### PR TITLE
Refactor index handling in LoadEventNexus

### DIFF
--- a/Framework/DataHandling/CMakeLists.txt
+++ b/Framework/DataHandling/CMakeLists.txt
@@ -45,6 +45,7 @@ set ( SRC_FILES
 	src/LoadDspacemap.cpp
 	src/LoadEmptyInstrument.cpp
 	src/LoadEventNexus.cpp
+	src/LoadEventNexusIndexSetup.cpp
 	src/LoadEventPreNexus2.cpp
 	src/LoadFITS.cpp
 	src/LoadFullprofResolution.cpp
@@ -221,6 +222,7 @@ set ( INC_FILES
 	inc/MantidDataHandling/LoadDspacemap.h
 	inc/MantidDataHandling/LoadEmptyInstrument.h
 	inc/MantidDataHandling/LoadEventNexus.h
+	inc/MantidDataHandling/LoadEventNexusIndexSetup.h
 	inc/MantidDataHandling/LoadEventPreNexus2.h
 	inc/MantidDataHandling/LoadFITS.h
 	inc/MantidDataHandling/LoadFullprofResolution.h
@@ -390,6 +392,7 @@ set ( TEST_FILES
 	LoadDiffCalTest.h
 	LoadDspacemapTest.h
 	LoadEmptyInstrumentTest.h
+	LoadEventNexusIndexSetupTest.h
 	LoadEventNexusTest.h
 	LoadEventPreNexus2Test.h
 	LoadFITSTest.h

--- a/Framework/DataHandling/inc/MantidDataHandling/DefaultEventLoader.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/DefaultEventLoader.h
@@ -11,7 +11,7 @@ namespace Mantid {
 namespace DataHandling {
 class LoadEventNexus;
 
-/** Code extracted from LoadEventNexus that is specific to the current default
+/** Helper class for LoadEventNexus that is specific to the current default
   loading code for NXevent_data entries in Nexus files, in particular
   LoadBankFromDiskTask and ProcessBankData.
 

--- a/Framework/DataHandling/inc/MantidDataHandling/EventWorkspaceCollection.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/EventWorkspaceCollection.h
@@ -13,6 +13,9 @@
 #include <memory>
 
 namespace Mantid {
+namespace Indexing {
+class IndexInfo;
+}
 namespace DataHandling {
 
 /** EventWorkspaceCollection : Collection of EventWorspaces to give
@@ -98,6 +101,7 @@ public:
   size_t getNumberEvents() const;
   void resizeTo(const size_t size);
   void padSpectra(const std::vector<int32_t> &padding);
+  void setIndexInfo(const Indexing::IndexInfo &indexInfo);
   void setInstrument(const Geometry::Instrument_const_sptr &inst);
   void
   setMonitorWorkspace(const boost::shared_ptr<API::MatrixWorkspace> &monitorWS);

--- a/Framework/DataHandling/inc/MantidDataHandling/EventWorkspaceCollection.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/EventWorkspaceCollection.h
@@ -99,8 +99,6 @@ public:
   Kernel::DateAndTime getFirstPulseTime() const;
   void setAllX(const HistogramData::BinEdges &x);
   size_t getNumberEvents() const;
-  void resizeTo(const size_t size);
-  void padSpectra(const std::vector<int32_t> &padding);
   void setIndexInfo(const Indexing::IndexInfo &indexInfo);
   void setInstrument(const Geometry::Instrument_const_sptr &inst);
   void

--- a/Framework/DataHandling/inc/MantidDataHandling/EventWorkspaceCollection.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/EventWorkspaceCollection.h
@@ -102,7 +102,6 @@ public:
   void
   setMonitorWorkspace(const boost::shared_ptr<API::MatrixWorkspace> &monitorWS);
   void updateSpectraUsing(const API::SpectrumDetectorMapping &map);
-  void populateInstrumentParameters();
   void setTitle(std::string title);
   void applyFilter(boost::function<void(API::MatrixWorkspace_sptr)> func);
   virtual bool threadSafe() const;

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -208,7 +208,7 @@ private:
   template <typename T> void filterDuringPause(T workspace);
 
   // Validate the optional spectra input properties and initialize m_specList
-  void createSpectraList(int32_t min, int32_t max);
+  Indexing::IndexInfo createSpectraList(const Indexing::IndexInfo &indexInfo);
 
   /// Set the top entry field name
   void setTopEntryName();

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -208,8 +208,6 @@ private:
                             size_t end_wi = 0);
   template <typename T> void filterDuringPause(T workspace);
 
-  Indexing::IndexInfo filterIndexInfo(const Indexing::IndexInfo &indexInfo);
-
   /// Set the top entry field name
   void setTopEntryName();
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -207,8 +207,7 @@ private:
                             size_t end_wi = 0);
   template <typename T> void filterDuringPause(T workspace);
 
-  // Validate the optional spectra input properties and initialize m_specList
-  Indexing::IndexInfo createSpectraList(const Indexing::IndexInfo &indexInfo);
+  Indexing::IndexInfo filterIndexInfo(const Indexing::IndexInfo &indexInfo);
 
   /// Set the top entry field name
   void setTopEntryName();

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -192,9 +192,10 @@ private:
   void setTimeFilters(const bool monitors);
 
   /// Load a spectra mapping from the given file
-  bool loadISISVMSSpectraMapping(const std::string &filename,
-                                 const bool monitorsOnly,
-                                 const std::string &entry_name);
+  std::unique_ptr<std::pair<std::vector<int32_t>, std::vector<int32_t>>>
+  loadISISVMSSpectraMapping(const std::string &filename,
+                            const bool monitorsOnly,
+                            const std::string &entry_name);
 
   /// ISIS specific methods for dealing with wide events
   void loadTimeOfFlight(EventWorkspaceCollection_sptr WS,

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -193,9 +193,7 @@ private:
 
   /// Load a spectra mapping from the given file
   std::unique_ptr<std::pair<std::vector<int32_t>, std::vector<int32_t>>>
-  loadISISVMSSpectraMapping(const std::string &filename,
-                            const bool monitorsOnly,
-                            const std::string &entry_name);
+  loadISISVMSSpectraMapping(const std::string &entry_name);
 
   /// ISIS specific methods for dealing with wide events
   void loadTimeOfFlight(EventWorkspaceCollection_sptr WS,

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -134,8 +134,6 @@ public:
   /// Filter by a maximum time-of-flight
   double filter_tof_max;
 
-  /// Spectra list to load
-  std::vector<int32_t> m_specList;
   /// Minimum spectrum to load
   int32_t m_specMin;
   /// Maximum spectrum to load

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexusIndexSetup.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexusIndexSetup.h
@@ -11,6 +11,13 @@ namespace DataHandling {
 /** Helper for LoadEventNexus dealing with setting up indices (spectrum numbers
   an detector ID mapping) for workspaces.
 
+  Filters set via `min`, `max`, and `range` are used by LoadEventNexus for
+  selecting from the `event_id` entry in Nexus files. This may either correspond
+  to a spectrum number (ISIS) or a detector ID. Throughout this class IndexInfo
+  is used for filtering and thus the spectrum number is set to the requested
+  event_id ranges. The final returned IndexInfo will however have spectrum
+  numbers that, in general, are not the event_ids (except for ISIS).
+
   Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
   National Laboratory & European Spallation Source
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexusIndexSetup.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexusIndexSetup.h
@@ -1,0 +1,62 @@
+#ifndef MANTID_DATAHANDLING_LOADEVENTNEXUSINDEXSETUP_H_
+#define MANTID_DATAHANDLING_LOADEVENTNEXUSINDEXSETUP_H_
+
+#include "MantidDataHandling/DllConfig.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidIndexing/IndexInfo.h"
+
+namespace Mantid {
+namespace DataHandling {
+
+/** Helper for LoadEventNexus dealing with setting up indices (spectrum numbers
+  an detector ID mapping) for workspaces.
+
+  Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class MANTID_DATAHANDLING_DLL LoadEventNexusIndexSetup {
+public:
+  LoadEventNexusIndexSetup(API::MatrixWorkspace_const_sptr instrumentWorkspace,
+                           const int32_t min, const int32_t max,
+                           const std::vector<int32_t> range);
+
+  std::pair<int32_t, int32_t> eventIDLimits() const;
+
+  Indexing::IndexInfo makeIndexInfo();
+  Indexing::IndexInfo makeIndexInfo(const std::vector<std::string> &bankNames);
+  Indexing::IndexInfo
+  makeIndexInfo(const std::pair<std::vector<int32_t>, std::vector<int32_t>> &
+                    spectrumDetectorMapping,
+                const bool monitorsOnly);
+
+private:
+  Indexing::IndexInfo filterIndexInfo(const Indexing::IndexInfo &indexInfo);
+
+  const API::MatrixWorkspace_const_sptr m_instrumentWorkspace;
+  int32_t m_min;
+  int32_t m_max;
+  std::vector<int32_t> m_range;
+};
+
+} // namespace DataHandling
+} // namespace Mantid
+
+#endif /* MANTID_DATAHANDLING_LOADEVENTNEXUSINDEXSETUP_H_ */

--- a/Framework/DataHandling/src/EventWorkspaceCollection.cpp
+++ b/Framework/DataHandling/src/EventWorkspaceCollection.cpp
@@ -1,11 +1,13 @@
 #include "MantidDataHandling/EventWorkspaceCollection.h"
 #include "MantidDataObjects/EventWorkspace.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidKernel/UnitFactory.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/Sample.h"
 #include "MantidAPI/WorkspaceFactory.h"
+#include "MantidIndexing/IndexInfo.h"
 
 #include <vector>
 #include <set>
@@ -252,6 +254,12 @@ void EventWorkspaceCollection::padSpectra(const std::vector<int32_t> &padding) {
       }
     }
   }
+}
+
+void EventWorkspaceCollection::setIndexInfo(
+    const Indexing::IndexInfo &indexInfo) {
+  for (auto &ws : m_WsVec)
+    ws = create<EventWorkspace>(*ws, indexInfo, HistogramData::BinEdges(2));
 }
 
 void EventWorkspaceCollection::setInstrument(

--- a/Framework/DataHandling/src/EventWorkspaceCollection.cpp
+++ b/Framework/DataHandling/src/EventWorkspaceCollection.cpp
@@ -274,12 +274,6 @@ void EventWorkspaceCollection::updateSpectraUsing(
   }
 }
 
-void EventWorkspaceCollection::populateInstrumentParameters() {
-  for (auto &ws : m_WsVec) {
-    ws->populateInstrumentParameters();
-  }
-}
-
 void EventWorkspaceCollection::setGeometryFlag(const int flag) {
   for (auto &ws : m_WsVec) {
     ws->mutableSample().setGeometryFlag(flag);

--- a/Framework/DataHandling/src/EventWorkspaceCollection.cpp
+++ b/Framework/DataHandling/src/EventWorkspaceCollection.cpp
@@ -226,36 +226,6 @@ size_t EventWorkspaceCollection::getNumberEvents() const {
   return m_WsVec[0]->getNumberEvents(); // Should be the sum across all periods?
 }
 
-void EventWorkspaceCollection::resizeTo(const size_t size) {
-  for (auto &ws : m_WsVec) {
-    auto tmp = createWorkspace<DataObjects::EventWorkspace>(size, 2, 1);
-    WorkspaceFactory::Instance().initializeFromParent(*ws, *tmp, true);
-    ws = std::move(tmp);
-    for (size_t i = 0; i < ws->getNumberHistograms(); ++i)
-      ws->getSpectrum(i).setSpectrumNo(static_cast<specnum_t>(i + 1));
-  }
-}
-
-void EventWorkspaceCollection::padSpectra(const std::vector<int32_t> &padding) {
-  if (padding.empty()) {
-    const std::vector<detid_t> pixelIDs = getInstrument()->getDetectorIDs(true);
-    resizeTo(pixelIDs.size());
-    for (auto &ws : m_WsVec)
-      for (size_t i = 0; i < pixelIDs.size(); ++i)
-        ws->getSpectrum(i).setDetectorID(pixelIDs[i]);
-  } else {
-    resizeTo(padding.size());
-    for (auto &ws : m_WsVec) {
-      for (size_t i = 0; i < padding.size(); ++i) {
-        // specList ranges from 1, ..., N
-        // detector ranges from 0, ..., N-1
-        ws->getSpectrum(i).setDetectorID(padding[i] - 1);
-        ws->getSpectrum(i).setSpectrumNo(padding[i]);
-      }
-    }
-  }
-}
-
 void EventWorkspaceCollection::setIndexInfo(
     const Indexing::IndexInfo &indexInfo) {
   for (auto &ws : m_WsVec)

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -1101,16 +1101,14 @@ void LoadEventNexus::createSpectraMapping(
                                  " Try unchecking SingleBankPixelsOnly.");
       allDets.insert(allDets.end(), dets.begin(), dets.end());
     }
-    if (!allDets.empty()) {
-      m_ws->resizeTo(allDets.size());
-      // Make an event list for each.
-      for (size_t wi = 0; wi < allDets.size(); wi++) {
-        const detid_t detID = allDets[wi]->getID();
-        m_ws->setDetectorIdsForAllPeriods(wi, detID);
-      }
-      spectramap = true;
-      g_log.debug() << "Populated spectra map for select banks\n";
+    m_ws->resizeTo(allDets.size());
+    // Make an event list for each.
+    for (size_t wi = 0; wi < allDets.size(); wi++) {
+      const detid_t detID = allDets[wi]->getID();
+      m_ws->setDetectorIdsForAllPeriods(wi, detID);
     }
+    spectramap = true;
+    g_log.debug() << "Populated spectra map for select banks\n";
 
   } else {
     spectramap =

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -1087,6 +1087,8 @@ void LoadEventNexus::createSpectraMapping(
       getProperty("SpectrumMax"), getProperty("SpectrumList"));
   if (!monitorsOnly && !bankNames.empty()) {
     m_ws->setIndexInfo(indexSetup.makeIndexInfo(bankNames));
+    g_log.notice()
+        << "Selecting banks will ignore spectrum min/max/list selection\n";
     g_log.debug() << "Populated spectra map for select banks\n";
   } else if (auto mapping = loadISISVMSSpectraMapping(m_top_entry_name)) {
     if (monitorsOnly) {

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -1693,9 +1693,6 @@ void LoadEventNexus::loadSampleDataISIScompatibility(
  * Parallel::StorageMode of `indexInfo` is `Cloned`. */
 Indexing::IndexInfo
 LoadEventNexus::filterIndexInfo(const Indexing::IndexInfo &indexInfo) {
-  // Spectrum numbers in indexInfo must be sorted.
-  // StorageMode must be cloned
-
   if (m_specMin != EMPTY_INT() || m_specMax != EMPTY_INT()) {
     // check if range [SpectrumMin, SpectrumMax] was supplied
     if (m_specMax == EMPTY_INT())

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -10,6 +10,7 @@
 #include "MantidAPI/SpectrumDetectorMapping.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/ComponentInfo.h"
+#include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidGeometry/Instrument/Goniometer.h"
 #include "MantidGeometry/Instrument/RectangularDetector.h"
 #include "MantidKernel/ArrayProperty.h"
@@ -19,6 +20,7 @@
 #include "MantidKernel/Timer.h"
 #include "MantidKernel/UnitFactory.h"
 #include "MantidKernel/VisibleWhenProperty.h"
+#include "MantidIndexing/Extract.h"
 #include "MantidIndexing/IndexInfo.h"
 #include "MantidTypes/SpectrumDefinition.h"
 
@@ -1127,12 +1129,16 @@ void LoadEventNexus::createSpectraMapping(
   if (!spectramap) {
     g_log.debug() << "No custom spectra mapping found, continuing with default "
                      "1:1 mapping of spectrum:detectorID\n";
-    auto specList = m_ws->getInstrument()->getDetectorIDs(true);
-    createSpectraList(*std::min_element(specList.begin(), specList.end()),
-                      *std::max_element(specList.begin(), specList.end()));
     // The default 1:1 will suffice but exclude the monitors as they are always
     // in a separate workspace
-    m_ws->padSpectra(m_specList);
+    auto detIDs = m_ws->getInstrument()->getDetectorIDs(true);
+    const auto &detectorInfo = m_ws->getSingleHeldWorkspace()->detectorInfo();
+    std::vector<SpectrumDefinition> specDefs;
+    for (const auto detID : detIDs)
+      specDefs.emplace_back(detectorInfo.indexOf(detID));
+    Indexing::IndexInfo indexInfo(detIDs.size());
+    indexInfo.setSpectrumDefinitions(specDefs);
+    m_ws->setIndexInfo(createSpectraList(indexInfo));
     g_log.debug() << "Populated 1:1 spectra map for the whole instrument \n";
   }
 }
@@ -1393,34 +1399,21 @@ bool LoadEventNexus::loadISISVMSSpectraMapping(const std::string &filename,
   } else {
     g_log.debug() << "Loading only detector spectra from " << filename << "\n";
 
-    // If optional spectra are provided, if so, m_specList is initialized. spec
-    // is used if necessary
-    createSpectraList(*std::min_element(spec.begin(), spec.end()),
-                      *std::max_element(spec.begin(), spec.end()));
-
-    if (!m_specList.empty()) {
-      int i = 0;
-      std::vector<int32_t> spec_temp, udet_temp;
-      for (auto &element : spec) {
-        if (find(m_specList.begin(), m_specList.end(), element) !=
-            m_specList.end()) // spec element *it is not in spec_list
-        {
-          spec_temp.push_back(element);
-          udet_temp.push_back(udet.at(i));
-        }
-        i++;
-      }
-      spec = spec_temp;
-      udet = udet_temp;
-    }
-
     SpectrumDetectorMapping mapping(spec, udet, monitors);
-    m_ws->resizeTo(mapping.getMapping().size());
-    // Make sure spectrum numbers are correct
     auto uniqueSpectra = mapping.getSpectrumNumbers();
-    m_ws->setSpectrumNumbersFromUniqueSpectra(uniqueSpectra);
-    // Fill detectors based on this mapping
-    m_ws->updateSpectraUsing(mapping);
+    Indexing::IndexInfo indexInfo(std::vector<Indexing::SpectrumNumber>(
+        uniqueSpectra.begin(), uniqueSpectra.end()));
+    std::vector<SpectrumDefinition> spectrumDefinitions;
+    const auto &detectorInfo = m_ws->getSingleHeldWorkspace()->detectorInfo();
+    for (const auto spec : uniqueSpectra) {
+      spectrumDefinitions.emplace_back();
+      for (const auto detID : mapping.getDetectorIDsForSpectrumNo(spec)) {
+        spectrumDefinitions.back().add(detectorInfo.indexOf(detID));
+      }
+    }
+    indexInfo.setSpectrumDefinitions(std::move(spectrumDefinitions));
+
+    m_ws->setIndexInfo(createSpectraList(indexInfo));
   }
   return true;
 }
@@ -1706,70 +1699,43 @@ void LoadEventNexus::loadSampleDataISIScompatibility(
 * @param max :: The maximum spectrum number read from file
 */
 
-void LoadEventNexus::createSpectraList(int32_t min, int32_t max) {
+Indexing::IndexInfo
+LoadEventNexus::createSpectraList(const Indexing::IndexInfo &indexInfo) {
+  // Spectrum numbers in indexInfo must be sorted.
+  // StorageMode must be cloned
 
-  // check if range [SpectrumMin, SpectrumMax] was supplied
   if (m_specMin != EMPTY_INT() || m_specMax != EMPTY_INT()) {
-    if (m_specMax == EMPTY_INT()) {
-      m_specMax = max;
-    }
-    if (m_specMin == EMPTY_INT()) {
-      m_specMin = min;
-    }
-
-    if (m_specMax > max) {
-      throw std::invalid_argument("Inconsistent range property: SpectrumMax is "
-                                  "larger than maximum spectrum found in "
-                                  "file.");
-    }
-
-    // Sanity checks for min/max
-    if (m_specMin > m_specMax) {
-      throw std::invalid_argument("Inconsistent range property: SpectrumMin is "
-                                  "larger than SpectrumMax.");
-    }
-
-    // Populate spec_list
+    // check if range [SpectrumMin, SpectrumMax] was supplied
+    if (m_specMax == EMPTY_INT())
+      m_specMax = static_cast<specnum_t>(
+          indexInfo.spectrumNumber(indexInfo.size() - 1));
+    if (m_specMin == EMPTY_INT())
+      m_specMin = static_cast<specnum_t>(indexInfo.spectrumNumber(0));
     for (int32_t i = m_specMin; i <= m_specMax; i++)
       m_specList.push_back(i);
-  } else {
-    // Check if SpectrumList was supplied
-
-    if (!m_specList.empty()) {
-      // Check no negative/zero numbers have been passed
-      auto itr = std::find_if(m_specList.begin(), m_specList.end(),
-                              std::bind2nd(std::less<int32_t>(), 1));
-      if (itr != m_specList.end()) {
-        throw std::invalid_argument(
-            "Negative/Zero SpectraList property encountered.");
-      }
-
-      // Check range and set m_specMax to maximum value in m_specList
-      if ((m_specMax =
-               *std::max_element(m_specList.begin(), m_specList.end())) >
-          *std::max_element(m_specList.begin(), m_specList.end())) {
-        throw std::invalid_argument("Inconsistent range property: SpectrumMax "
-                                    "is larger than number of spectra.");
-      }
-
-      // Set m_specMin to minimum value in m_specList
-      m_specMin = *std::min_element(m_specList.begin(), m_specList.end());
-    }
   }
-
   if (!m_specList.empty()) {
-
+    // Check if SpectrumList was supplied (or filled via min/max above)
+    const auto indices =
+        indexInfo.makeIndexSet(std::vector<Indexing::SpectrumNumber>(
+            m_specList.begin(), m_specList.end()));
+    m_specMin =
+        static_cast<specnum_t>(indexInfo.spectrumNumber(*indices.begin()));
+    m_specMax =
+        static_cast<specnum_t>(indexInfo.spectrumNumber(*(indices.end() - 1)));
+    const auto filteredIndexInfo = Indexing::extract(indexInfo, indices);
     // Check that spectra supplied by user do not correspond to monitors
-    auto nmonitors = m_ws->getInstrument()->getMonitors().size();
-
-    for (size_t i = 0; i < nmonitors; ++i) {
-      if (std::find(m_specList.begin(), m_specList.end(), i + 1) !=
-          m_specList.end()) {
-        throw std::invalid_argument("Inconsistent range property: some of the "
-                                    "selected spectra correspond to monitors.");
-      }
+    const auto &detectorInfo = m_ws->getSingleHeldWorkspace()->detectorInfo();
+    for (const auto &specDef : *filteredIndexInfo.spectrumDefinitions()) {
+      for (const auto &det : specDef)
+        if (detectorInfo.isMonitor(det))
+          throw std::invalid_argument(
+              "Inconsistent range property: some of the "
+              "selected spectra correspond to monitors.");
     }
+    return filteredIndexInfo;
   }
+  return indexInfo;
 }
 
 /**

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -1378,11 +1378,9 @@ bool LoadEventNexus::loadISISVMSSpectraMapping(const std::string &filename,
     std::vector<Indexing::SpectrumNumber> spectrumNumbers;
     std::vector<SpectrumDefinition> spectrumDefinitions;
     // Find the det_ids in the udet array.
-    for (size_t i = 0; i < monitors.size(); ++i) {
+    for (const auto id : monitors) {
       // Find the index in the udet array
-      const detid_t &id = monitors[i];
-      std::vector<int32_t>::const_iterator it =
-          std::find(udet.begin(), udet.end(), id);
+      auto it = std::find(udet.begin(), udet.end(), id);
       if (it != udet.end()) {
         const specnum_t &specNo = spec[it - udet.begin()];
         spectrumNumbers.emplace_back(specNo);

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -1086,9 +1086,11 @@ void LoadEventNexus::createSpectraMapping(
       m_ws->getSingleHeldWorkspace(), getProperty("SpectrumMin"),
       getProperty("SpectrumMax"), getProperty("SpectrumList"));
   if (!monitorsOnly && !bankNames.empty()) {
+    if (!isDefault("SpectrumMin") || !isDefault("SpectrumMax") ||
+        !isDefault("SpectrumList"))
+      g_log.warning() << "Spectrum min/max/list selection ignored when "
+                         "`SingleBankPixelsOnly` is enabled\n";
     m_ws->setIndexInfo(indexSetup.makeIndexInfo(bankNames));
-    g_log.notice()
-        << "Selecting banks will ignore spectrum min/max/list selection\n";
     g_log.debug() << "Populated spectra map for select banks\n";
   } else if (auto mapping = loadISISVMSSpectraMapping(m_top_entry_name)) {
     if (monitorsOnly) {

--- a/Framework/DataHandling/src/LoadEventNexusIndexSetup.cpp
+++ b/Framework/DataHandling/src/LoadEventNexusIndexSetup.cpp
@@ -132,10 +132,10 @@ LoadEventNexusIndexSetup::filterIndexInfo(const IndexInfo &indexInfo) {
   if (m_min != EMPTY_INT() || m_max != EMPTY_INT()) {
     // check if range [SpectrumMin, SpectrumMax] was supplied
     if (m_max == EMPTY_INT())
-      m_max = static_cast<specnum_t>(
-          indexInfo.spectrumNumber(indexInfo.size() - 1));
+      m_max =
+          static_cast<int32_t>(indexInfo.spectrumNumber(indexInfo.size() - 1));
     if (m_min == EMPTY_INT())
-      m_min = static_cast<specnum_t>(indexInfo.spectrumNumber(0));
+      m_min = static_cast<int32_t>(indexInfo.spectrumNumber(0));
     // Avoid adding non-existing indices (can happen if instrument has gaps in
     // its detector IDs). IndexInfo does the filtering for use.
     const auto indices = indexInfo.makeIndexSet(m_min, m_max);
@@ -146,9 +146,9 @@ LoadEventNexusIndexSetup::filterIndexInfo(const IndexInfo &indexInfo) {
     // Check if SpectrumList was supplied (or filled via min/max above)
     const auto indices = indexInfo.makeIndexSet(
         std::vector<Indexing::SpectrumNumber>(m_range.begin(), m_range.end()));
-    m_min = static_cast<specnum_t>(indexInfo.spectrumNumber(*indices.begin()));
+    m_min = static_cast<int32_t>(indexInfo.spectrumNumber(*indices.begin()));
     m_max =
-        static_cast<specnum_t>(indexInfo.spectrumNumber(*(indices.end() - 1)));
+        static_cast<int32_t>(indexInfo.spectrumNumber(*(indices.end() - 1)));
     const auto filteredIndexInfo = Indexing::extract(indexInfo, indices);
     // Check that spectra supplied by user do not correspond to monitors
     const auto &detectorInfo = m_instrumentWorkspace->detectorInfo();

--- a/Framework/DataHandling/src/LoadEventNexusIndexSetup.cpp
+++ b/Framework/DataHandling/src/LoadEventNexusIndexSetup.cpp
@@ -44,13 +44,14 @@ IndexInfo LoadEventNexusIndexSetup::makeIndexInfo() {
   // If there is no actual filter, spectrum numbers are contiguous and start at
   // 1. Otherwise spectrum numbers are detector IDs. This is legacy behavior
   // adopted from EventWorkspaceCollection.
-  if(filtered.size() == indexInfo.size())
-    filtered.setSpectrumNumbers(1, filtered.size());
+  if (filtered.size() == indexInfo.size())
+    filtered.setSpectrumNumbers(1, static_cast<int32_t>(filtered.size()));
 
   return filtered;
 }
 
-IndexInfo LoadEventNexusIndexSetup::makeIndexInfo(const std::vector<std::string> &bankNames) {
+IndexInfo LoadEventNexusIndexSetup::makeIndexInfo(
+    const std::vector<std::string> &bankNames) {
   const auto &componentInfo = m_instrumentWorkspace->componentInfo();
   std::vector<SpectrumDefinition> spectrumDefinitions;
   const auto &instrument = m_instrumentWorkspace->getInstrument();
@@ -121,6 +122,11 @@ IndexInfo LoadEventNexusIndexSetup::makeIndexInfo(
   }
 }
 
+/** Filter IndexInfo based on optional spectrum range/list provided.
+ *
+ * Checks the validity of user provided spectrum range/list. This method assumes
+ * that spectrum numbers in `indexInfo` argument are sorted and that the
+ * Parallel::StorageMode of `indexInfo` is `Cloned`. */
 IndexInfo
 LoadEventNexusIndexSetup::filterIndexInfo(const IndexInfo &indexInfo) {
   if (m_min != EMPTY_INT() || m_max != EMPTY_INT()) {
@@ -154,7 +160,6 @@ LoadEventNexusIndexSetup::filterIndexInfo(const IndexInfo &indexInfo) {
   }
   return indexInfo;
 }
-  
 
 } // namespace DataHandling
 } // namespace Mantid

--- a/Framework/DataHandling/src/LoadEventNexusIndexSetup.cpp
+++ b/Framework/DataHandling/src/LoadEventNexusIndexSetup.cpp
@@ -72,6 +72,10 @@ IndexInfo LoadEventNexusIndexSetup::makeIndexInfo(
   }
   Indexing::IndexInfo indexInfo(spectrumDefinitions.size());
   indexInfo.setSpectrumDefinitions(std::move(spectrumDefinitions));
+  // Filters are ignored when selecting bank names. Reset min/max to avoid
+  // unintended dropping of events in the loader.
+  m_min = EMPTY_INT();
+  m_max = EMPTY_INT();
   return indexInfo;
 }
 

--- a/Framework/DataHandling/src/LoadEventNexusIndexSetup.cpp
+++ b/Framework/DataHandling/src/LoadEventNexusIndexSetup.cpp
@@ -142,7 +142,7 @@ IndexInfo LoadEventNexusIndexSetup::makeIndexInfo(
       for (const auto detID : mapping.getDetectorIDsForSpectrumNo(spec)) {
         try {
           spectrumDefinitions.back().add(detectorInfo.indexOf(detID));
-        } catch (std::out_of_range &e) {
+        } catch (std::out_of_range &) {
           // Discarding detector IDs that do not exist in the instrument.
         }
       }

--- a/Framework/DataHandling/src/LoadEventNexusIndexSetup.cpp
+++ b/Framework/DataHandling/src/LoadEventNexusIndexSetup.cpp
@@ -1,0 +1,160 @@
+#include "MantidDataHandling/LoadEventNexusIndexSetup.h"
+#include "MantidGeometry/Instrument.h"
+#include "MantidGeometry/Instrument/ComponentInfo.h"
+#include "MantidGeometry/Instrument/DetectorInfo.h"
+#include "MantidAPI/SpectrumDetectorMapping.h"
+#include "MantidIndexing/Extract.h"
+#include "MantidIndexing/SpectrumIndexSet.h"
+#include "MantidIndexing/SpectrumNumber.h"
+#include "MantidTypes/SpectrumDefinition.h"
+
+using namespace Mantid::API;
+using namespace Mantid::Indexing;
+
+namespace Mantid {
+namespace DataHandling {
+
+LoadEventNexusIndexSetup::LoadEventNexusIndexSetup(
+    MatrixWorkspace_const_sptr instrumentWorkspace, const int32_t min,
+    const int32_t max, const std::vector<int32_t> range)
+    : m_instrumentWorkspace(instrumentWorkspace), m_min(min), m_max(max),
+      m_range(range) {}
+
+std::pair<int32_t, int32_t> LoadEventNexusIndexSetup::eventIDLimits() const {
+  return {m_min, m_max};
+}
+
+IndexInfo LoadEventNexusIndexSetup::makeIndexInfo() {
+  // The default 1:1 will suffice but exclude the monitors as they are always in
+  // a separate workspace
+  auto detIDs = m_instrumentWorkspace->getInstrument()->getDetectorIDs(true);
+  const auto &detectorInfo = m_instrumentWorkspace->detectorInfo();
+  std::vector<SpectrumDefinition> specDefs;
+  for (const auto detID : detIDs)
+    specDefs.emplace_back(detectorInfo.indexOf(detID));
+  // We need to filter based on detector IDs, but use IndexInfo for filtering
+  // for a unified filtering mechanism. Thus we set detector IDs as (temporary)
+  // spectrum numbers.
+  IndexInfo indexInfo(
+      std::vector<SpectrumNumber>(detIDs.begin(), detIDs.end()));
+  indexInfo.setSpectrumDefinitions(specDefs);
+
+  auto filtered = filterIndexInfo(indexInfo);
+
+  // If there is no actual filter, spectrum numbers are contiguous and start at
+  // 1. Otherwise spectrum numbers are detector IDs. This is legacy behavior
+  // adopted from EventWorkspaceCollection.
+  if(filtered.size() == indexInfo.size())
+    filtered.setSpectrumNumbers(1, filtered.size());
+
+  return filtered;
+}
+
+IndexInfo LoadEventNexusIndexSetup::makeIndexInfo(const std::vector<std::string> &bankNames) {
+  const auto &componentInfo = m_instrumentWorkspace->componentInfo();
+  std::vector<SpectrumDefinition> spectrumDefinitions;
+  const auto &instrument = m_instrumentWorkspace->getInstrument();
+  for (const auto &bankName : bankNames) {
+    const auto &bank = instrument->getComponentByName(bankName);
+    std::vector<size_t> dets;
+    if (bank) {
+      const auto bankIndex = componentInfo.indexOf(bank->getComponentID());
+      dets = componentInfo.detectorsInSubtree(bankIndex);
+      for (const auto detIndex : dets)
+        spectrumDefinitions.emplace_back(detIndex);
+    }
+    if (dets.empty())
+      throw std::runtime_error("Could not find the bank named '" + bankName +
+                               "' as a component assembly in the instrument "
+                               "tree; or it did not contain any detectors. Try "
+                               "unchecking SingleBankPixelsOnly.");
+  }
+  Indexing::IndexInfo indexInfo(spectrumDefinitions.size());
+  indexInfo.setSpectrumDefinitions(std::move(spectrumDefinitions));
+  return indexInfo;
+}
+
+IndexInfo LoadEventNexusIndexSetup::makeIndexInfo(
+    const std::pair<std::vector<int32_t>, std::vector<int32_t>> &
+        spectrumDetectorMapping,
+    const bool monitorsOnly) {
+  const auto &spec = spectrumDetectorMapping.first;
+  const auto &udet = spectrumDetectorMapping.second;
+
+  const std::vector<detid_t> monitors =
+      m_instrumentWorkspace->getInstrument()->getMonitors();
+  const auto &detectorInfo = m_instrumentWorkspace->detectorInfo();
+  if (monitorsOnly) {
+    std::vector<Indexing::SpectrumNumber> spectrumNumbers;
+    std::vector<SpectrumDefinition> spectrumDefinitions;
+    // Find the det_ids in the udet array.
+    for (const auto id : monitors) {
+      // Find the index in the udet array
+      auto it = std::find(udet.begin(), udet.end(), id);
+      if (it != udet.end()) {
+        const specnum_t &specNo = spec[it - udet.begin()];
+        spectrumNumbers.emplace_back(specNo);
+        spectrumDefinitions.emplace_back(detectorInfo.indexOf(id));
+      }
+    }
+    Indexing::IndexInfo indexInfo(spectrumNumbers);
+    indexInfo.setSpectrumDefinitions(std::move(spectrumDefinitions));
+    return indexInfo;
+  } else {
+    SpectrumDetectorMapping mapping(spec, udet, monitors);
+    auto uniqueSpectra = mapping.getSpectrumNumbers();
+    std::vector<SpectrumDefinition> spectrumDefinitions;
+    for (const auto spec : uniqueSpectra) {
+      spectrumDefinitions.emplace_back();
+      for (const auto detID : mapping.getDetectorIDsForSpectrumNo(spec)) {
+        try {
+          spectrumDefinitions.back().add(detectorInfo.indexOf(detID));
+        } catch (std::out_of_range &e) {
+          // Discarding detector IDs that do not exist in the instrument.
+        }
+      }
+    }
+    Indexing::IndexInfo indexInfo(std::vector<Indexing::SpectrumNumber>(
+        uniqueSpectra.begin(), uniqueSpectra.end()));
+    indexInfo.setSpectrumDefinitions(std::move(spectrumDefinitions));
+    return filterIndexInfo(indexInfo);
+  }
+}
+
+IndexInfo
+LoadEventNexusIndexSetup::filterIndexInfo(const IndexInfo &indexInfo) {
+  if (m_min != EMPTY_INT() || m_max != EMPTY_INT()) {
+    // check if range [SpectrumMin, SpectrumMax] was supplied
+    if (m_max == EMPTY_INT())
+      m_max = static_cast<specnum_t>(
+          indexInfo.spectrumNumber(indexInfo.size() - 1));
+    if (m_min == EMPTY_INT())
+      m_min = static_cast<specnum_t>(indexInfo.spectrumNumber(0));
+    for (int32_t i = m_min; i <= m_max; i++)
+      m_range.push_back(i);
+  }
+  if (!m_range.empty()) {
+    // Check if SpectrumList was supplied (or filled via min/max above)
+    const auto indices = indexInfo.makeIndexSet(
+        std::vector<Indexing::SpectrumNumber>(m_range.begin(), m_range.end()));
+    m_min = static_cast<specnum_t>(indexInfo.spectrumNumber(*indices.begin()));
+    m_max =
+        static_cast<specnum_t>(indexInfo.spectrumNumber(*(indices.end() - 1)));
+    const auto filteredIndexInfo = Indexing::extract(indexInfo, indices);
+    // Check that spectra supplied by user do not correspond to monitors
+    const auto &detectorInfo = m_instrumentWorkspace->detectorInfo();
+    for (const auto &specDef : *filteredIndexInfo.spectrumDefinitions()) {
+      for (const auto &det : specDef)
+        if (detectorInfo.isMonitor(det))
+          throw std::invalid_argument(
+              "Inconsistent range property: some of the "
+              "selected spectra correspond to monitors.");
+    }
+    return filteredIndexInfo;
+  }
+  return indexInfo;
+}
+  
+
+} // namespace DataHandling
+} // namespace Mantid

--- a/Framework/DataHandling/src/LoadEventNexusIndexSetup.cpp
+++ b/Framework/DataHandling/src/LoadEventNexusIndexSetup.cpp
@@ -136,8 +136,11 @@ LoadEventNexusIndexSetup::filterIndexInfo(const IndexInfo &indexInfo) {
           indexInfo.spectrumNumber(indexInfo.size() - 1));
     if (m_min == EMPTY_INT())
       m_min = static_cast<specnum_t>(indexInfo.spectrumNumber(0));
-    for (int32_t i = m_min; i <= m_max; i++)
-      m_range.push_back(i);
+    // Avoid adding non-existing indices (can happen if instrument has gaps in
+    // its detector IDs). IndexInfo does the filtering for use.
+    const auto indices = indexInfo.makeIndexSet(m_min, m_max);
+    for (const auto &index : indices)
+      m_range.push_back(static_cast<int32_t>(indexInfo.spectrumNumber(index)));
   }
   if (!m_range.empty()) {
     // Check if SpectrumList was supplied (or filled via min/max above)

--- a/Framework/DataHandling/test/LoadEventNexusIndexSetupTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusIndexSetupTest.h
@@ -97,12 +97,8 @@ public:
     TS_ASSERT_EQUALS(indexSetup.eventIDLimits().first, 11);
     TS_ASSERT_EQUALS(indexSetup.eventIDLimits().second, 12);
     TS_ASSERT_EQUALS(indexInfo.size(), 2);
-    // Note that spectrum numbers are now detector IDs. This is not consistent
-    // with the load without filter, but it is the behavior of the old index
-    // setup code. This should probably be changed to give spectrum numbers
-    // consistent with loading the full range, namely 3 and 4.
-    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(0), SpectrumNumber(11));
-    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(12));
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(0), SpectrumNumber(3));
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(4));
     const auto specDefs = indexInfo.spectrumDefinitions();
     // Old behavior would have given detector indices 1 and 2 (instead of 2 and
     // 3), mapping to detector IDs 2 and 11, instead of the requested 11 and 12.
@@ -119,9 +115,8 @@ public:
     // contrary to the behavior of the old index setup code.
     TS_ASSERT_EQUALS(indexInfo.size(), 3);
     TS_ASSERT_EQUALS(indexInfo.spectrumNumber(0), SpectrumNumber(2));
-    // Should be 3 and 4 if inconsistent legacy behavior is fixed.
-    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(11));
-    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(2), SpectrumNumber(12));
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(3));
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(2), SpectrumNumber(4));
     const auto specDefs = indexInfo.spectrumDefinitions();
     TS_ASSERT_EQUALS(specDefs->at(0), SpectrumDefinition(1));
     TS_ASSERT_EQUALS(specDefs->at(1), SpectrumDefinition(2));
@@ -135,8 +130,7 @@ public:
     TS_ASSERT_EQUALS(indexSetup.eventIDLimits().second, 11);
     TS_ASSERT_EQUALS(indexInfo.size(), 2);
     TS_ASSERT_EQUALS(indexInfo.spectrumNumber(0), SpectrumNumber(2));
-    // Should be 3 if inconsistent legacy behavior is fixed.
-    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(11));
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(3));
     const auto specDefs = indexInfo.spectrumDefinitions();
     TS_ASSERT_EQUALS(specDefs->at(0), SpectrumDefinition(1));
     TS_ASSERT_EQUALS(specDefs->at(1), SpectrumDefinition(2));
@@ -150,8 +144,7 @@ public:
     TS_ASSERT_EQUALS(indexSetup.eventIDLimits().second, 11);
     TS_ASSERT_EQUALS(indexInfo.size(), 2);
     TS_ASSERT_EQUALS(indexInfo.spectrumNumber(0), SpectrumNumber(2));
-    // Should be 3 if inconsistent legacy behavior is fixed.
-    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(11));
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(3));
     const auto specDefs = indexInfo.spectrumDefinitions();
     TS_ASSERT_EQUALS(specDefs->at(0), SpectrumDefinition(1));
     TS_ASSERT_EQUALS(specDefs->at(1), SpectrumDefinition(2));
@@ -164,9 +157,8 @@ public:
     TS_ASSERT_EQUALS(indexSetup.eventIDLimits().second, 12);
     TS_ASSERT_EQUALS(indexInfo.size(), 3);
     TS_ASSERT_EQUALS(indexInfo.spectrumNumber(0), SpectrumNumber(1));
-    // Should be 3 and 4 if inconsistent legacy behavior is fixed.
-    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(11));
-    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(2), SpectrumNumber(12));
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(3));
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(2), SpectrumNumber(4));
     const auto specDefs = indexInfo.spectrumDefinitions();
     TS_ASSERT_EQUALS(specDefs->at(0), SpectrumDefinition(0));
     TS_ASSERT_EQUALS(specDefs->at(1), SpectrumDefinition(2));
@@ -181,8 +173,7 @@ public:
     TS_ASSERT_EQUALS(indexInfo.size(), 3);
     TS_ASSERT_EQUALS(indexInfo.spectrumNumber(0), SpectrumNumber(1));
     TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(2));
-    // Should be 3 if inconsistent legacy behavior is fixed.
-    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(2), SpectrumNumber(11));
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(2), SpectrumNumber(3));
     const auto specDefs = indexInfo.spectrumDefinitions();
     TS_ASSERT_EQUALS(specDefs->at(0), SpectrumDefinition(0));
     TS_ASSERT_EQUALS(specDefs->at(1), SpectrumDefinition(1));
@@ -195,11 +186,8 @@ public:
     TS_ASSERT_EQUALS(indexSetup.eventIDLimits().first, EMPTY_INT());
     TS_ASSERT_EQUALS(indexSetup.eventIDLimits().second, EMPTY_INT());
     TS_ASSERT_EQUALS(indexInfo.size(), 2);
-    // Note that spectrum numbers are simply starting at 1, i.e., are not the
-    // same as without bank-filtering. To be consistent with the load without
-    // bank filter this should be 2 and 4 when fixing legacy behavior.
-    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(0), SpectrumNumber(1));
-    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(2));
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(0), SpectrumNumber(2));
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(4));
     const auto specDefs = indexInfo.spectrumDefinitions();
     TS_ASSERT_EQUALS(specDefs->at(0), SpectrumDefinition(1));
     TS_ASSERT_EQUALS(specDefs->at(1), SpectrumDefinition(3));
@@ -216,9 +204,8 @@ public:
     TS_ASSERT_EQUALS(indexSetup.eventIDLimits().first, EMPTY_INT());
     TS_ASSERT_EQUALS(indexSetup.eventIDLimits().second, EMPTY_INT());
     TS_ASSERT_EQUALS(indexInfo.size(), 2);
-    // Should be 2 and 4 if inconsistent legacy behavior is fixed.
-    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(0), SpectrumNumber(1));
-    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(2));
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(0), SpectrumNumber(2));
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(4));
     const auto specDefs = indexInfo.spectrumDefinitions();
     TS_ASSERT_EQUALS(specDefs->at(0), SpectrumDefinition(1));
     TS_ASSERT_EQUALS(specDefs->at(1), SpectrumDefinition(3));

--- a/Framework/DataHandling/test/LoadEventNexusIndexSetupTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusIndexSetupTest.h
@@ -98,8 +98,9 @@ public:
     TS_ASSERT_EQUALS(indexSetup.eventIDLimits().second, 12);
     TS_ASSERT_EQUALS(indexInfo.size(), 2);
     // Note that spectrum numbers are now detector IDs. This is not consistent
-    // with the load without filter, but it is the old behavior. Can we change
-    // this to be more sensible?
+    // with the load without filter, but it is the behavior of the old index
+    // setup code. This should probably be changed to give spectrum numbers
+    // consistent with loading the full range, namely 3 and 4.
     TS_ASSERT_EQUALS(indexInfo.spectrumNumber(0), SpectrumNumber(11));
     TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(12));
     const auto specDefs = indexInfo.spectrumDefinitions();
@@ -115,9 +116,10 @@ public:
     TS_ASSERT_EQUALS(indexSetup.eventIDLimits().first, 2);
     TS_ASSERT_EQUALS(indexSetup.eventIDLimits().second, 12);
     // Note that we are NOT creating spectra for the gap between IDs 2 and 11,
-    // contrary to the old behavior.
+    // contrary to the behavior of the old index setup code.
     TS_ASSERT_EQUALS(indexInfo.size(), 3);
     TS_ASSERT_EQUALS(indexInfo.spectrumNumber(0), SpectrumNumber(2));
+    // Should be 3 and 4 if inconsistent legacy behavior is fixed.
     TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(11));
     TS_ASSERT_EQUALS(indexInfo.spectrumNumber(2), SpectrumNumber(12));
     const auto specDefs = indexInfo.spectrumDefinitions();
@@ -133,6 +135,7 @@ public:
     TS_ASSERT_EQUALS(indexSetup.eventIDLimits().second, 11);
     TS_ASSERT_EQUALS(indexInfo.size(), 2);
     TS_ASSERT_EQUALS(indexInfo.spectrumNumber(0), SpectrumNumber(2));
+    // Should be 3 if inconsistent legacy behavior is fixed.
     TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(11));
     const auto specDefs = indexInfo.spectrumDefinitions();
     TS_ASSERT_EQUALS(specDefs->at(0), SpectrumDefinition(1));
@@ -147,6 +150,7 @@ public:
     TS_ASSERT_EQUALS(indexSetup.eventIDLimits().second, 11);
     TS_ASSERT_EQUALS(indexInfo.size(), 2);
     TS_ASSERT_EQUALS(indexInfo.spectrumNumber(0), SpectrumNumber(2));
+    // Should be 3 if inconsistent legacy behavior is fixed.
     TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(11));
     const auto specDefs = indexInfo.spectrumDefinitions();
     TS_ASSERT_EQUALS(specDefs->at(0), SpectrumDefinition(1));
@@ -160,6 +164,7 @@ public:
     TS_ASSERT_EQUALS(indexSetup.eventIDLimits().second, 12);
     TS_ASSERT_EQUALS(indexInfo.size(), 3);
     TS_ASSERT_EQUALS(indexInfo.spectrumNumber(0), SpectrumNumber(1));
+    // Should be 3 and 4 if inconsistent legacy behavior is fixed.
     TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(11));
     TS_ASSERT_EQUALS(indexInfo.spectrumNumber(2), SpectrumNumber(12));
     const auto specDefs = indexInfo.spectrumDefinitions();
@@ -176,6 +181,7 @@ public:
     TS_ASSERT_EQUALS(indexInfo.size(), 3);
     TS_ASSERT_EQUALS(indexInfo.spectrumNumber(0), SpectrumNumber(1));
     TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(2));
+    // Should be 3 if inconsistent legacy behavior is fixed.
     TS_ASSERT_EQUALS(indexInfo.spectrumNumber(2), SpectrumNumber(11));
     const auto specDefs = indexInfo.spectrumDefinitions();
     TS_ASSERT_EQUALS(specDefs->at(0), SpectrumDefinition(0));
@@ -190,7 +196,8 @@ public:
     TS_ASSERT_EQUALS(indexSetup.eventIDLimits().second, EMPTY_INT());
     TS_ASSERT_EQUALS(indexInfo.size(), 2);
     // Note that spectrum numbers are simply starting at 1, i.e., are not the
-    // same as without bank-filtering. This is consistent with the old behavior.
+    // same as without bank-filtering. To be consistent with the load without
+    // bank filter this should be 2 and 4 when fixing legacy behavior.
     TS_ASSERT_EQUALS(indexInfo.spectrumNumber(0), SpectrumNumber(1));
     TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(2));
     const auto specDefs = indexInfo.spectrumDefinitions();
@@ -205,9 +212,11 @@ public:
     // apply when loading actual events in ProcessBankData (range is still
     // ignored though).
     const auto indexInfo = indexSetup.makeIndexInfo({"det-2", "det-12"});
-    TS_ASSERT_EQUALS(indexSetup.eventIDLimits().first, 12);
+    // Filter ignored, make sure also limits are set correctly.
+    TS_ASSERT_EQUALS(indexSetup.eventIDLimits().first, EMPTY_INT());
     TS_ASSERT_EQUALS(indexSetup.eventIDLimits().second, EMPTY_INT());
     TS_ASSERT_EQUALS(indexInfo.size(), 2);
+    // Should be 2 and 4 if inconsistent legacy behavior is fixed.
     TS_ASSERT_EQUALS(indexInfo.spectrumNumber(0), SpectrumNumber(1));
     TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(2));
     const auto specDefs = indexInfo.spectrumDefinitions();

--- a/Framework/DataHandling/test/LoadEventNexusIndexSetupTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusIndexSetupTest.h
@@ -206,6 +206,120 @@ public:
     TS_ASSERT_EQUALS(specDefs->at(1), SpectrumDefinition(3));
   }
 
+  void test_makeIndexInfo_from_isis_spec_udet() {
+    LoadEventNexusIndexSetup indexSetup(m_ws, EMPTY_INT(), EMPTY_INT(), {});
+    auto spec = {4, 3, 2, 1};
+    auto udet = {2, 1, 12, 11};
+    const auto indexInfo = indexSetup.makeIndexInfo({spec, udet}, false);
+    TS_ASSERT_EQUALS(indexSetup.eventIDLimits().first, EMPTY_INT());
+    TS_ASSERT_EQUALS(indexSetup.eventIDLimits().second, EMPTY_INT());
+    TS_ASSERT_EQUALS(indexInfo.size(), 4);
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(0), SpectrumNumber(1));
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(2));
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(2), SpectrumNumber(3));
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(3), SpectrumNumber(4));
+    const auto specDefs = indexInfo.spectrumDefinitions();
+    TS_ASSERT_EQUALS(specDefs->at(0), SpectrumDefinition(2));
+    TS_ASSERT_EQUALS(specDefs->at(1), SpectrumDefinition(3));
+    TS_ASSERT_EQUALS(specDefs->at(2), SpectrumDefinition(0));
+    TS_ASSERT_EQUALS(specDefs->at(3), SpectrumDefinition(1));
+  }
+
+  void test_makeIndexInfo_from_isis_spec_udet_grouped() {
+    LoadEventNexusIndexSetup indexSetup(m_ws, EMPTY_INT(), EMPTY_INT(), {});
+    auto spec = {1, 2, 1, 2};
+    auto udet = {1, 2, 11, 12};
+    const auto indexInfo = indexSetup.makeIndexInfo({spec, udet}, false);
+    TS_ASSERT_EQUALS(indexSetup.eventIDLimits().first, EMPTY_INT());
+    TS_ASSERT_EQUALS(indexSetup.eventIDLimits().second, EMPTY_INT());
+    TS_ASSERT_EQUALS(indexInfo.size(), 2);
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(0), SpectrumNumber(1));
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(2));
+    const auto specDefs = indexInfo.spectrumDefinitions();
+    SpectrumDefinition group_1_11;
+    group_1_11.add(0);
+    group_1_11.add(2);
+    TS_ASSERT_EQUALS(specDefs->at(0), group_1_11);
+    SpectrumDefinition group_2_12;
+    group_2_12.add(1);
+    group_2_12.add(3);
+    TS_ASSERT_EQUALS(specDefs->at(1), group_2_12);
+  }
+
+  void test_makeIndexInfo_from_isis_spec_udet_unknown_detector_ids() {
+    LoadEventNexusIndexSetup indexSetup(m_ws, EMPTY_INT(), EMPTY_INT(), {});
+    auto spec = {1, 2};
+    auto udet = {1, 100};
+    const auto indexInfo = indexSetup.makeIndexInfo({spec, udet}, false);
+    TS_ASSERT_EQUALS(indexSetup.eventIDLimits().first, EMPTY_INT());
+    TS_ASSERT_EQUALS(indexSetup.eventIDLimits().second, EMPTY_INT());
+    TS_ASSERT_EQUALS(indexInfo.size(), 2);
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(0), SpectrumNumber(1));
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(2));
+    const auto specDefs = indexInfo.spectrumDefinitions();
+    TS_ASSERT_EQUALS(specDefs->at(0), SpectrumDefinition(0));
+    // ID 100 does not exist so SpectrumDefinition is empty
+    TS_ASSERT_EQUALS(specDefs->at(1), SpectrumDefinition());
+  }
+
+  void test_makeIndexInfo_from_isis_spec_udet_min() {
+    LoadEventNexusIndexSetup indexSetup(m_ws, 3, EMPTY_INT(), {});
+    auto spec = {4, 3, 2, 1};
+    auto udet = {2, 1, 12, 11};
+    const auto indexInfo = indexSetup.makeIndexInfo({spec, udet}, false);
+    TS_ASSERT_EQUALS(indexSetup.eventIDLimits().first, 3);
+    TS_ASSERT_EQUALS(indexSetup.eventIDLimits().second, 4);
+    TS_ASSERT_EQUALS(indexInfo.size(), 2);
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(0), SpectrumNumber(3));
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(4));
+    const auto specDefs = indexInfo.spectrumDefinitions();
+    TS_ASSERT_EQUALS(specDefs->at(0), SpectrumDefinition(0));
+    TS_ASSERT_EQUALS(specDefs->at(1), SpectrumDefinition(1));
+  }
+
+  void test_makeIndexInfo_from_isis_spec_udet_min_max() {
+    LoadEventNexusIndexSetup indexSetup(m_ws, 2, 3, {});
+    auto spec = {4, 3, 2, 1};
+    auto udet = {2, 1, 12, 11};
+    const auto indexInfo = indexSetup.makeIndexInfo({spec, udet}, false);
+    TS_ASSERT_EQUALS(indexSetup.eventIDLimits().first, 2);
+    TS_ASSERT_EQUALS(indexSetup.eventIDLimits().second, 3);
+    TS_ASSERT_EQUALS(indexInfo.size(), 2);
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(0), SpectrumNumber(2));
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(3));
+    const auto specDefs = indexInfo.spectrumDefinitions();
+    TS_ASSERT_EQUALS(specDefs->at(0), SpectrumDefinition(3));
+    TS_ASSERT_EQUALS(specDefs->at(1), SpectrumDefinition(0));
+  }
+
+  void test_makeIndexInfo_from_isis_spec_udet_range() {
+    LoadEventNexusIndexSetup indexSetup(m_ws, EMPTY_INT(), EMPTY_INT(), {1});
+    auto spec = {4, 3, 2, 1};
+    auto udet = {2, 1, 12, 11};
+    const auto indexInfo = indexSetup.makeIndexInfo({spec, udet}, false);
+    TS_ASSERT_EQUALS(indexSetup.eventIDLimits().first, 1);
+    TS_ASSERT_EQUALS(indexSetup.eventIDLimits().second, 1);
+    TS_ASSERT_EQUALS(indexInfo.size(), 1);
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(0), SpectrumNumber(1));
+    const auto specDefs = indexInfo.spectrumDefinitions();
+    TS_ASSERT_EQUALS(specDefs->at(0), SpectrumDefinition(2));
+  }
+
+  void test_makeIndexInfo_from_isis_spec_udet_min_max_range() {
+    LoadEventNexusIndexSetup indexSetup(m_ws, 2, 2, {1});
+    auto spec = {4, 3, 2, 1};
+    auto udet = {2, 1, 12, 11};
+    const auto indexInfo = indexSetup.makeIndexInfo({spec, udet}, false);
+    TS_ASSERT_EQUALS(indexSetup.eventIDLimits().first, 1);
+    TS_ASSERT_EQUALS(indexSetup.eventIDLimits().second, 2);
+    TS_ASSERT_EQUALS(indexInfo.size(), 2);
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(0), SpectrumNumber(1));
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(2));
+    const auto specDefs = indexInfo.spectrumDefinitions();
+    TS_ASSERT_EQUALS(specDefs->at(0), SpectrumDefinition(2));
+    TS_ASSERT_EQUALS(specDefs->at(1), SpectrumDefinition(3));
+  }
+
 private:
   MatrixWorkspace_sptr m_ws;
 };

--- a/Framework/DataHandling/test/LoadEventNexusIndexSetupTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusIndexSetupTest.h
@@ -1,0 +1,27 @@
+#ifndef MANTID_DATAHANDLING_LOADEVENTNEXUSINDEXSETUPTEST_H_
+#define MANTID_DATAHANDLING_LOADEVENTNEXUSINDEXSETUPTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidDataHandling/LoadEventNexusIndexSetup.h"
+
+using Mantid::DataHandling::LoadEventNexusIndexSetup;
+
+class LoadEventNexusIndexSetupTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static LoadEventNexusIndexSetupTest *createSuite() { return new LoadEventNexusIndexSetupTest(); }
+  static void destroySuite( LoadEventNexusIndexSetupTest *suite ) { delete suite; }
+
+
+  void test_Something()
+  {
+    TS_FAIL( "You forgot to write a test!");
+  }
+
+
+};
+
+
+#endif /* MANTID_DATAHANDLING_LOADEVENTNEXUSINDEXSETUPTEST_H_ */

--- a/Framework/DataHandling/test/LoadEventNexusTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusTest.h
@@ -357,8 +357,8 @@ public:
     auto outWs2 =
         AnalysisDataService::Instance().retrieveWS<EventWorkspace>(wsName2);
 
-    TSM_ASSERT("The number of spectra in the workspace should be 12",
-               outWs->getNumberHistograms() == 12);
+    TSM_ASSERT_EQUALS("The number of spectra in the workspace should be 12",
+                      outWs->getNumberHistograms(), 12);
 
     TSM_ASSERT_EQUALS("The number of events in the precount and not precount "
                       "workspaces do not match",

--- a/Framework/DataHandling/test/LoadEventNexusTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusTest.h
@@ -246,14 +246,12 @@ public:
     TSM_ASSERT("The number of spectra in the workspace should be equal to the "
                "spectra filtered",
                outWs->getNumberHistograms() == specList.size());
-    TSM_ASSERT("Some spectra were not found in the workspace",
-               outWs->getSpectrum(0).getSpectrumNo() == 13);
-    TSM_ASSERT("Some spectra were not found in the workspace",
-               outWs->getSpectrum(1).getSpectrumNo() == 16);
-    TSM_ASSERT("Some spectra were not found in the workspace",
-               outWs->getSpectrum(2).getSpectrumNo() == 21);
-    TSM_ASSERT("Some spectra were not found in the workspace",
-               outWs->getSpectrum(3).getSpectrumNo() == 28);
+    // Spectrum numbers match those that same detector would have in unfiltered
+    // load, in this case detID + 1 since IDs in instrument start at 0.
+    TS_ASSERT_EQUALS(outWs->getSpectrum(0).getSpectrumNo(), 14);
+    TS_ASSERT_EQUALS(outWs->getSpectrum(1).getSpectrumNo(), 17);
+    TS_ASSERT_EQUALS(outWs->getSpectrum(2).getSpectrumNo(), 22);
+    TS_ASSERT_EQUALS(outWs->getSpectrum(3).getSpectrumNo(), 29);
 
     // B) test SpectrumMin and SpectrumMax
     wsName = "test_partial_spectra_loading_SpectrumMin_SpectrumMax";
@@ -274,9 +272,11 @@ public:
     // check number and indices of spectra
     const size_t numSpecs = specMax - specMin + 1;
     TS_ASSERT_EQUALS(outWs->getNumberHistograms(), numSpecs);
+    // Spectrum numbers match those that same detector would have in unfiltered
+    // load, in this case detID + 1 since IDs in instrument start at 0.
     for (size_t specIdx = 0; specIdx < numSpecs; specIdx++) {
       TS_ASSERT_EQUALS(outWs->getSpectrum(specIdx).getSpectrumNo(),
-                       static_cast<int>(specMin + specIdx));
+                       static_cast<int>(specMin + specIdx + 1));
     }
 
     // C) test SpectrumList + SpectrumMin and SpectrumMax
@@ -310,12 +310,14 @@ public:
     // check number and indices of spectra
     const size_t n = sMax - sMin + 1; // this n is the 20...22, excluding '17'
     TS_ASSERT_EQUALS(outWs->getNumberHistograms(), n + 1); // +1 is the '17'
-    // 17 should come from SpectrumList
-    TS_ASSERT_EQUALS(outWs->getSpectrum(0).getSpectrumNo(), 17);
+    // Spectrum numbers match those that same detector would have in unfiltered
+    // load, in this case detID + 1 since IDs in instrument start at 0.
+    // 18 should come from SpectrumList
+    TS_ASSERT_EQUALS(outWs->getSpectrum(0).getSpectrumNo(), 18);
     // and then sMin(20)...sMax(22)
     for (size_t specIdx = 0; specIdx < n; specIdx++) {
       TS_ASSERT_EQUALS(outWs->getSpectrum(specIdx + 1).getSpectrumNo(),
-                       static_cast<int>(sMin + specIdx));
+                       static_cast<int>(sMin + specIdx + 1));
     }
   }
 

--- a/Framework/Indexing/inc/MantidIndexing/Extract.h
+++ b/Framework/Indexing/inc/MantidIndexing/Extract.h
@@ -8,6 +8,7 @@
 namespace Mantid {
 namespace Indexing {
 class IndexInfo;
+class SpectrumIndexSet;
 
 /** Functions for extracting spectra. A new IndexInfo with the desired spectra
   is created based on an existing one.
@@ -36,6 +37,8 @@ class IndexInfo;
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
+MANTID_INDEXING_DLL IndexInfo
+extract(const IndexInfo &source, const SpectrumIndexSet &indices);
 MANTID_INDEXING_DLL IndexInfo
 extract(const IndexInfo &source, const std::vector<size_t> &indices);
 MANTID_INDEXING_DLL IndexInfo

--- a/Framework/Indexing/src/Extract.cpp
+++ b/Framework/Indexing/src/Extract.cpp
@@ -1,9 +1,16 @@
 #include "MantidIndexing/Extract.h"
 #include "MantidIndexing/IndexInfo.h"
+#include "MantidIndexing/SpectrumIndexSet.h"
 #include "MantidTypes/SpectrumDefinition.h"
 
 namespace Mantid {
 namespace Indexing {
+
+/// Extracts IndexInfo from source IndexInfo, extracting data for all indices
+/// specified by index set.
+IndexInfo extract(const IndexInfo &source, const SpectrumIndexSet &indices) {
+  return extract(source, std::vector<size_t>(indices.begin(), indices.end()));
+}
 
 /// Extracts IndexInfo from source IndexInfo, extracting data for all indices
 /// specified by vector.

--- a/Framework/Indexing/test/ExtractTest.h
+++ b/Framework/Indexing/test/ExtractTest.h
@@ -41,7 +41,7 @@ public:
     specDefs[1].add(20);
     specDefs[2].add(30);
     source.setSpectrumDefinitions(specDefs);
-    std::vector<SpectrumNumber> indices{{0, 2}};
+    std::vector<SpectrumNumber> indices{{1, 3}};
     const auto indexSet = source.makeIndexSet(indices);
     auto result = extract(source, indexSet);
     TS_ASSERT_EQUALS(result.size(), 2);

--- a/Framework/Indexing/test/ExtractTest.h
+++ b/Framework/Indexing/test/ExtractTest.h
@@ -5,6 +5,7 @@
 
 #include "MantidIndexing/Extract.h"
 #include "MantidIndexing/IndexInfo.h"
+#include "MantidIndexing/SpectrumIndexSet.h"
 #include "MantidTypes/SpectrumDefinition.h"
 
 using namespace Mantid;
@@ -26,6 +27,23 @@ public:
     source.setSpectrumDefinitions(specDefs);
     std::vector<size_t> indices{{0, 2}};
     auto result = extract(source, indices);
+    TS_ASSERT_EQUALS(result.size(), 2);
+    TS_ASSERT_EQUALS(result.spectrumNumber(0), 1);
+    TS_ASSERT_EQUALS(result.spectrumNumber(1), 3);
+    TS_ASSERT_EQUALS((*result.spectrumDefinitions())[0], specDefs[0]);
+    TS_ASSERT_EQUALS((*result.spectrumDefinitions())[1], specDefs[2]);
+  }
+
+  void test_extract_SpectrumIndexSet() {
+    IndexInfo source({1, 2, 3});
+    std::vector<SpectrumDefinition> specDefs(3);
+    specDefs[0].add(10);
+    specDefs[1].add(20);
+    specDefs[2].add(30);
+    source.setSpectrumDefinitions(specDefs);
+    std::vector<SpectrumNumber> indices{{0, 2}};
+    const auto indexSet = source.makeIndexSet(indices);
+    auto result = extract(source, indexSet);
     TS_ASSERT_EQUALS(result.size(), 2);
     TS_ASSERT_EQUALS(result.spectrumNumber(0), 1);
     TS_ASSERT_EQUALS(result.spectrumNumber(1), 3);

--- a/Framework/Types/inc/MantidTypes/SpectrumDefinition.h
+++ b/Framework/Types/inc/MantidTypes/SpectrumDefinition.h
@@ -41,6 +41,10 @@ namespace Mantid {
 */
 class SpectrumDefinition {
 public:
+  SpectrumDefinition() = default;
+  explicit SpectrumDefinition(const size_t detectorIndex,
+                              const size_t timeIndex = 0)
+      : m_data{{detectorIndex, timeIndex}} {}
   /// Returns the size of the SpectrumDefinition, i.e., the number of detectors
   /// (or rather detector positions) that the spectrum comprises.
   size_t size() const { return m_data.size(); }

--- a/Framework/Types/test/SpectrumDefinitionTest.h
+++ b/Framework/Types/test/SpectrumDefinitionTest.h
@@ -16,6 +16,23 @@ public:
   }
   static void destroySuite(SpectrumDefinitionTest *suite) { delete suite; }
 
+  void test_default_construct() {
+    SpectrumDefinition def;
+    TS_ASSERT_EQUALS(def.size(), 0);
+  }
+
+  void test_construct_no_time() {
+    SpectrumDefinition def(42);
+    TS_ASSERT_EQUALS(def.size(), 1);
+    TS_ASSERT_EQUALS(def[0], (std::pair<size_t, size_t>(42, 0)));
+  }
+
+  void test_construct() {
+    SpectrumDefinition def(42, 7);
+    TS_ASSERT_EQUALS(def.size(), 1);
+    TS_ASSERT_EQUALS(def[0], (std::pair<size_t, size_t>(42, 7)));
+  }
+
   void test_size() {
     SpectrumDefinition def;
     TS_ASSERT_EQUALS(def.size(), 0);


### PR DESCRIPTION
Refactor index handling in `LoadEventNexus` to use `IndexInfo`, making it ready for introducing MPI support.

**The following subtleties are important and should be addressed/confirmed by the reviewer**

*Fixed*
1. `EventWorkspaceCollection::padSpectra` used to set `ws->getSpectrum(i).setDetectorID(padding[i] - 1);` (only in the non-empty case), but as far as I understand the calling code passed detector IDs in `padding`, so the first ID is dropped, an unwanted one is added. This happens only for non-ISIS files. I think this is wrong and this PR should fix it.
2. The monitor range-check in `LoadEventNexus::createSpectraList` was based on spectrum numbers and effectively prevent loading the first couple of spectra (in the case of provides spectrum range/list). I think this is wrong and this PR should fix it.
3. The range check in `LoadEventNexus::createSpectraList` for `m_specMax` looks broken in the original, should be fixed.
4. In `LoadEventNexus::createSpectraList`, if both min/max *and* list of spectra is provided, any sanity check for the *list*-part seems to be skipped in the original, and the corresponding events are not loaded. However, spectra for the list of spectra are nevertheless created in the non-ISIS case. Should be fixed in this PR, validating and loading spectra from the list as well.
5. If the detector IDs in the instrument have a gap and min/max for spectra selection is used, empty spectra are created for all non-existing detector IDs falling in the range between min and max. This happens only for non-ISIS files. I think this is wrong and this PR should fix it.
6. If a bank is selected and `SingleBankPixelsOnly` is checked, min/max/range are not validated and ignored when creating spectra (i.e., spectra for all pixels in the bank are created). But then min and max (but not range!) are still used to select which events are actually being loaded from the file. This PR will now emit a warning if min/max/range are set in this case and ignore the limits, i.e., events for all pixels in the bank are loaded.
7. For non-ISIS files, spectrum numbers usually start from 1 and are contiguous. Exception: If min/max/range property is set, the spectrum numbers are the detector IDs, i.e., loading a range of spectra will create a workspace whose spectrum numbers do not match the corresponding spectra of the same file loaded fully. Fixed to be consistented (had to modify a couple of unit tests in `LoadEventNexus`).

*Currently not fixed*

1. If a bank is selected for loading the ISIS spectra mapping from the file is ignored, probably leading to a complete mess being loaded since for such files `event_id` is the spectrum number, whereas in "bank"-mode `event_id` is interpreted as detector ID.


**To test:**

Really careful code review.

Fixes #20500.

**Release Notes** 
Some bugs are fixed, changing the behavior, but when I previously reported the issues they were closed, so I do not know if this is relevant?

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
