### PR TITLE
Fix LoadLogs loading thowing an error on rubbish log files

### DIFF
--- a/Framework/DataHandling/src/LoadLog.cpp
+++ b/Framework/DataHandling/src/LoadLog.cpp
@@ -209,7 +209,7 @@ void LoadLog::loadThreeColumnLogFile(std::ifstream &logFileStream,
   }
 
   while (Mantid::Kernel::Strings::extractToEOL(logFileStream, str)) {
-    if (!isDateTimeString(str)) {
+    if (!isDateTimeString(str) && !str.empty()) {
       throw std::invalid_argument("File" + logFileName +
                                   " is not a standard ISIS log file. Expected "
                                   "to be a file starting with DateTime String "
@@ -217,8 +217,8 @@ void LoadLog::loadThreeColumnLogFile(std::ifstream &logFileStream,
     }
 
     if (!Kernel::TimeSeriesProperty<double>::isTimeString(str) ||
-        (str[0] ==
-         '#')) { // if the line doesn't start with a time read the next line
+        (str.empty() || str[0] == '#')) {
+      // if the line doesn't start with a time read the next line
       continue;
     }
 
@@ -229,6 +229,9 @@ void LoadLog::loadThreeColumnLogFile(std::ifstream &logFileStream,
     std::string blockcolumn;
     line >> blockcolumn;
     l_kind = classify(blockcolumn);
+
+    if (LoadLog::empty == l_kind)
+      continue;
 
     if (LoadLog::string != l_kind) {
       throw std::invalid_argument(
@@ -404,9 +407,16 @@ LoadLog::kind LoadLog::classify(const std::string &s) const {
 
   if (letters.find_first_of(s) != string::npos) {
     return LoadLog::string;
-  } else {
-    return LoadLog::number;
   }
+
+  const auto isNumber = [](const std::string& str) {
+    // try and get stringstream to parse a number out of the string
+    // if this fails it will not set the eof character
+    long double ld;
+    return ((std::istringstream(str) >> ld >> std::ws).eof());
+  };
+
+  return (isNumber(s)) ? LoadLog::number : LoadLog::empty;
 }
 
 /**

--- a/Framework/DataHandling/src/LoadLog.cpp
+++ b/Framework/DataHandling/src/LoadLog.cpp
@@ -416,6 +416,7 @@ LoadLog::kind LoadLog::classify(const std::string &s) const {
     // try and get stold to parse a number out of the string
     // if this throws then we don't have a number
     try {
+      // cppcheck-suppress ignoredReturnValue
       std::stold(str);
       return true;
     } catch (const std::invalid_argument &e) {

--- a/Framework/DataHandling/src/LoadLog.cpp
+++ b/Framework/DataHandling/src/LoadLog.cpp
@@ -409,7 +409,7 @@ LoadLog::kind LoadLog::classify(const std::string &s) const {
     return LoadLog::string;
   }
 
-  const auto isNumber = [](const std::string& str) {
+  const auto isNumber = [](const std::string &str) {
     // try and get stringstream to parse a number out of the string
     // if this fails it will not set the eof character
     long double ld;

--- a/Framework/DataHandling/src/LoadLog.cpp
+++ b/Framework/DataHandling/src/LoadLog.cpp
@@ -230,8 +230,11 @@ void LoadLog::loadThreeColumnLogFile(std::ifstream &logFileStream,
     line >> blockcolumn;
     l_kind = classify(blockcolumn);
 
-    if (LoadLog::empty == l_kind)
+    if (LoadLog::empty == l_kind) {
+      g_log.warning() << "Failed to parse line in log file: " << timecolumn
+                      << "\t" << blockcolumn;
       continue;
+    }
 
     if (LoadLog::string != l_kind) {
       throw std::invalid_argument(

--- a/Framework/DataHandling/src/LoadLog.cpp
+++ b/Framework/DataHandling/src/LoadLog.cpp
@@ -410,10 +410,16 @@ LoadLog::kind LoadLog::classify(const std::string &s) const {
   }
 
   const auto isNumber = [](const std::string &str) {
-    // try and get stringstream to parse a number out of the string
-    // if this fails it will not set the eof character
-    long double ld;
-    return ((std::istringstream(str) >> ld >> std::ws).eof());
+    // try and get stold to parse a number out of the string
+    // if this throws then we don't have a number
+    try {
+      std::stold(str);
+      return true;
+    } catch (const std::invalid_argument &e) {
+      return false;
+    } catch (const std::out_of_range &e) {
+      return false;
+    }
   };
 
   return (isNumber(s)) ? LoadLog::number : LoadLog::empty;

--- a/Framework/DataHandling/test/LoadLogTest.h
+++ b/Framework/DataHandling/test/LoadLogTest.h
@@ -223,6 +223,20 @@ public:
     TS_ASSERT_EQUALS(tsp->size(), 33);
   }
 
+  void test_ISISTextFile_withRubbishLogFileInput_fails() {
+    auto ws = WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
+
+    LoadLog alg;
+    alg.initialize();
+    alg.setPropertyValue("Filename", "ENGINX00275776_ICPputlog.txt");
+    alg.setProperty("Workspace", ws);
+
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+
+    const auto props = ws->run().getProperties();
+    TS_ASSERT_EQUALS(props.size(), 2);
+  };
+
   void test_SNSTextFile_noNames_fails() { do_test_SNSTextFile("", "", true); }
 
   void test_SNSTextFile_tooFewNames_fails() {

--- a/Testing/Data/UnitTest/ENGINX00275776_ICPputlog.txt.md5
+++ b/Testing/Data/UnitTest/ENGINX00275776_ICPputlog.txt.md5
@@ -1,0 +1,1 @@
+ade333d2cf33b2432b425ecb6288a3ff


### PR DESCRIPTION
This changes the LoadLog routine to fix the issue that @FreddieAkeroyd was seeing. Mantid now appears to load the raw file cleanly.

**To test:**
 - Go to the archive and grab everything for run ENGINX0000275776
 - Try loading the raw file with `LoadLogs = true`
 - Before these changes you should see an error
   - Afterwards you should see none
 - Code review.

Fixes #20515 

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
