### PR TITLE
Add missing bracket in Python print statement in ISIS SANS GUI

### DIFF
--- a/qt/scientific_interfaces/ISISSANS/SANSRunWindow.cpp
+++ b/qt/scientific_interfaces/ISISSANS/SANSRunWindow.cpp
@@ -2784,7 +2784,7 @@ void SANSRunWindow::handleRunFindCentre() {
   } else {
     coordinates_python_code =
         "print(i.ReductionSingleton().get_beam_center('front')[0]);print("
-        "i.ReductionSingleton().get_beam_center('front')[1]";
+        "i.ReductionSingleton().get_beam_center('front')[1])";
     m_uiForm.detbank_sel->setCurrentIndex(
         1); // FRONT selected -> detbank_sel <- FRONT
     beam_x = m_uiForm.front_beam_x;


### PR DESCRIPTION
During the maintenance work for the Python2 to Python3 conversion a closing bracket on a print statement was forgotten. This becomes a problem when running the beam center finder for the front detector.

**To test:**

Please find test data here: \\olympic\Babylon5\Scratch\Anton\LOQ_Prompt_Peak_Fix

1. Add the path of the test data to the Mantid search directories
2. Open the old ISIS SANS GUI
3. Select LOQ as the instrument
4. Load the User file:  MASKLOQ_MAN_133E_Hornqvist_6mm_Furnace_MERGED.txt
5. Set `front_38` as the sample scatter data
6. Go to the Geometry tab
7. On the left hand side in the beam centre section set the detector to `HAB`; set `Max iterations` to 20.
8. Press run
  * Confirm that after a while the beam center finder stops (at most 20 iterations)
  * Confirm that there is no pop up with an error message

No issue number

**Release Notes** 

Not required


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
