### PR TITLE
Launch algorithm dialogs with correct window flags

### DIFF
--- a/qt/widgets/common/src/InterfaceManager.cpp
+++ b/qt/widgets/common/src/InterfaceManager.cpp
@@ -74,7 +74,7 @@ AlgorithmDialog *InterfaceManager::createDialog(
 
   // Set the QDialog window flags to ensure the dialog ends up on top
   Qt::WindowFlags flags = nullptr;
-  flags |= Qt::Window;
+  flags |= Qt::Dialog;
   flags |= Qt::WindowCloseButtonHint;
 #ifdef Q_OS_MAC
   // Work around to ensure that floating windows remain on top of the main


### PR DESCRIPTION
Correct window flags for algorithm dialogs. Algorithm dialogs should either be `Qt::Dialog` or `Qt::Tool`, `Tool` seems more appropriate for the sake of being on top of the main window (see http://doc.qt.io/qt-4.8/qt.html#WindowType-enum).

**To test:**

Should be tested on Windows and Linux to make sure existing behavior is unchanged.

- Open algorithm dialogs, make sure they open as expected

Fixes #20537.

**Release Notes** 

I doubt enough people come across this problem to mention it.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
