### PR TITLE
Muon Analysis bug fixes

### DIFF
--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -2193,6 +2193,7 @@ void MuonAnalysis::handleGroupBox() {
     updateLabels(names[0]);
   }
   m_fitDataPresenter->handleSelectedDataChanged(true);
+  m_dataSelector->checkForMultiGroupPeriodSelection();
 }
 /**
 * Handle"periods" selected/deselected

--- a/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
@@ -1178,8 +1178,6 @@ std::string MuonFitPropertyBrowser::outputName() const {
 void MuonFitPropertyBrowser::setMultiFittingMode(bool enabled) {
   // First, clear whatever model is currently set
   this->clear();
-  modifyFitMenu(m_fitActionEvaluate, !enabled);
-  modifyFitMenu(m_fitActionSeqFit, !enabled);
   // set default selection (all groups)
   if (enabled) {
     setAllGroups();


### PR DESCRIPTION
This is a simple set of changes to fix some bugs in Muon Analysis. The first bug is that in multiple fitting mode the label box is not editable when there are multiple groups/pairs/periods for a single run. The second bug is that the fit menu was missing some options. 

**To test:**
1. Open muon analysis and load the current run
2. Go to the settings tab and make sure that the multiple fitting is unticked
3. Go to data analysis and add a fitting function (the function does not matter)
4. Look at the fit menu and see that it includes; evaluate and sequential fit
5. Go to the settings tab and tick the multiple fitting box
6. Go to data analysis and add a fitting function
7. Look in the fit menu and see that it include; evaluate and sequential fit

8. Change the group selection to custom and make sure only one group/pair is selected. If periods are available do the same. 
9. See that the simultaneous label has been disabled. 
10. Change the group/pair selection to all groups
11. See that the simultaneous label is now enabled. 

<!-- Instructions for testing. -->

Fixes #20467 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->
Does not need to be in release notes (not reported by users) 
---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
