### PR TITLE
Add special case for 'EvaluateFunction'

### DIFF
--- a/Framework/PythonInterface/mantid/fitfunctions.py
+++ b/Framework/PythonInterface/mantid/fitfunctions.py
@@ -236,6 +236,15 @@ class FunctionWrapper(object):
     alg = AlgorithmManager.createUnmanaged(name)
     alg.setChild(True)
     alg.initialize()
+    # Python 3 treats **kwargs as an unordered list meaning it is possible
+    # to pass InputWorkspace into EvaluateFunction before Function.
+    # As a special case has been made for this. This case can be removed
+    # with ordered kwargs change in Python 3.6.
+    if name is 'EvaluateFunction':
+        alg.setProperty('Function', kwargs['Function'])
+        del kwargs['Function']
+        alg.setProperty('InputWorkspace', kwargs['InputWorkspace'])
+        del kwargs['InputWorkspace']
     for param in kwargs:
         alg.setProperty(param, kwargs[param])
     alg.setProperty('OutputWorkspace', 'none')


### PR DESCRIPTION
Due to kwargs being treated as an unorder list in Python3, it should be ensured that the Function parameter is always passed into Evaluate Function before the InputWorkspace parameter.

Python 3.6 and above will resolve this issue as kwargs will be treated as an ordered list see [PEP 468](https://www.python.org/dev/peps/pep-0468/)

**To test:**

Ensure that the unit test `FitFunctionTest` passes with Python 3. Might be best to run this several times locally to ensure this is the case as the failures are not consistent.

Fixes #20548

**Release Notes** 
*Internal changes to tests and does not need to be added to the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
