### PR TITLE
Fix a hang when a UI startup script throws an error

### DIFF
--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -420,8 +420,7 @@ void MantidUI::shutdown() {
 
   // If any python objects need to be cleared away then the GIL needs to be
   // held.
-  PythonGIL gil;
-  ScopedPythonGIL lock(gil);
+  ScopedPythonGIL lock;
   // Relevant notifications are connected to signals that will close all
   // dependent windows
   Mantid::API::FrameworkManager::Instance().shutdown();
@@ -2218,8 +2217,7 @@ void MantidUI::clearAllMemory(const bool prompt) {
   // If any python objects need to be cleared away then the GIL needs to be
   // held. This doesn't feel like
   // it is in the right place but it will do no harm
-  PythonGIL gil;
-  ScopedPythonGIL lock(gil);
+  ScopedPythonGIL lock;
   // Relevant notifications are connected to signals that will close all
   // dependent windows
   Mantid::API::FrameworkManager::Instance().clear();

--- a/MantidPlot/src/PythonScript.cpp
+++ b/MantidPlot/src/PythonScript.cpp
@@ -81,7 +81,7 @@ PythonScript::PythonScript(PythonScripting *env, const QString &name,
     : Script(env, name, interact, context), m_interp(env), localDict(NULL),
       stdoutSave(NULL), stderrSave(NULL), m_codeFileObject(NULL),
       m_threadID(-1), isFunction(false), m_isInitialized(false),
-      m_pathHolder(name, *this), m_recursiveAsyncGIL() {
+      m_pathHolder(name), m_recursiveAsyncGIL() {
   initialize(name, context);
 }
 

--- a/MantidPlot/src/PythonScript.cpp
+++ b/MantidPlot/src/PythonScript.cpp
@@ -81,7 +81,7 @@ PythonScript::PythonScript(PythonScripting *env, const QString &name,
     : Script(env, name, interact, context), m_interp(env), localDict(NULL),
       stdoutSave(NULL), stderrSave(NULL), m_codeFileObject(NULL),
       m_threadID(-1), isFunction(false), m_isInitialized(false),
-      m_pathHolder(name, *this), m_workspaceHandles() {
+      m_pathHolder(name, *this), m_recursiveAsyncGIL() {
   initialize(name, context);
 }
 
@@ -89,7 +89,7 @@ PythonScript::PythonScript(PythonScripting *env, const QString &name,
  * Destructor
  */
 PythonScript::~PythonScript() {
-  ScopedPythonGIL lock(gil());
+  ScopedPythonGIL lock;
   this->abort();
   observeAdd(false);
   observeAfterReplace(false);
@@ -142,7 +142,7 @@ PyObject *PythonScript::createSipInstanceFromMe() {
  */
 bool PythonScript::compilesToCompleteStatement(const QString &code) const {
   bool result(false);
-  ScopedPythonGIL lock(gil());
+  ScopedPythonGIL lock;
   PyObject *compiledCode = Py_CompileString(code.toAscii(), "", Py_file_input);
   if (PyObject *exception = PyErr_Occurred()) {
     // Certain exceptions still mean the code is complete
@@ -186,7 +186,7 @@ void PythonScript::sendLineChangeSignal(int lineNo, bool error) {
  * Create a list autocomplete keywords
  */
 void PythonScript::generateAutoCompleteList() {
-  ScopedPythonGIL lock(gil());
+  ScopedPythonGIL lock;
   PyObject *keywords = PyObject_CallFunctionObjArgs(
       PyDict_GetItemString(m_interp->globalDict(),
                            "_ScopeInspector_GetFunctionAttributes"),
@@ -206,7 +206,7 @@ void PythonScript::generateAutoCompleteList() {
  */
 void PythonScript::emit_error() {
   // gil is necessary so other things don't continue
-  ScopedPythonGIL lock(gil());
+  ScopedPythonGIL lock;
 
   // return early if nothing happened
   if (!PyErr_Occurred()) {
@@ -380,7 +380,7 @@ void PythonScript::setContext(QObject *context) {
  * the dictionary context back to the default set
  */
 void PythonScript::clearLocals() {
-  ScopedPythonGIL lock(gil());
+  ScopedPythonGIL lock;
 
   PyObject *mainModule = PyImport_AddModule("__main__");
   PyObject *cleanLocals = PyDict_Copy(PyModule_GetDict(mainModule));
@@ -398,12 +398,6 @@ void PythonScript::clearLocals() {
 }
 
 /**
- * @brief PythonScript::gil
- * @return A reference to the global lock
- */
-PythonGIL &PythonScript::gil() const { return interp()->gil(); }
-
-/**
  * Sets the context for the script and if name points to a file then
  * sets the __file__ variable
  * @param name A string identifier for the script
@@ -412,7 +406,7 @@ PythonGIL &PythonScript::gil() const { return interp()->gil(); }
 void PythonScript::initialize(const QString &name, QObject *context) {
   clearLocals(); // holds and releases GIL
 
-  ScopedPythonGIL lock(gil());
+  ScopedPythonGIL lock;
   PythonScript::setIdentifier(name);
   setContext(context);
 
@@ -460,8 +454,8 @@ void PythonScript::endStdoutRedirect() {
  * @return True if the lock was released by this call, false otherwise
  */
 bool PythonScript::recursiveAsyncSetup() {
-  if (gil().locked()) {
-    gil().release();
+  if (PythonGIL::locked()) {
+    m_recursiveAsyncGIL.release();
     return true;
   }
   return false;
@@ -475,7 +469,7 @@ bool PythonScript::recursiveAsyncSetup() {
  */
 void PythonScript::recursiveAsyncTeardown(bool relock) {
   if (relock) {
-    gil().acquire();
+    m_recursiveAsyncGIL.acquire();
   }
 }
 
@@ -495,7 +489,7 @@ bool PythonScript::compileImpl() {
  * @return
  */
 QVariant PythonScript::evaluateImpl() {
-  ScopedPythonGIL lock(gil());
+  ScopedPythonGIL lock;
   PyObject *compiledCode = this->compileToByteCode(true);
   if (!compiledCode) {
     return QVariant("");
@@ -621,7 +615,7 @@ void PythonScript::abortImpl() {
   // hasn't implemented cancel() checking so that when control returns the
   // Python the
   // interrupt should be picked up.
-  ScopedPythonGIL lock(gil());
+  ScopedPythonGIL lock;
   m_interp->raiseAsyncException(m_threadID, PyExc_KeyboardInterrupt);
   PyObject *curAlg =
       PyObject_CallFunction(m_algorithmInThread, STR_LITERAL("l"), m_threadID);
@@ -636,7 +630,7 @@ void PythonScript::abortImpl() {
  * @return A long int giving a unique ID for the thread
  */
 long PythonScript::getThreadID() {
-  ScopedPythonGIL lock(gil());
+  ScopedPythonGIL lock;
   return PyThreadState_Get()->thread_id;
 }
 
@@ -644,7 +638,7 @@ long PythonScript::getThreadID() {
 bool PythonScript::executeString() {
   emit started(MSG_STARTED);
   bool success(false);
-  ScopedPythonGIL lock(gil());
+  ScopedPythonGIL lock;
 
   PyObject *compiledCode = compileToByteCode(false);
   PyObject *result(NULL);

--- a/MantidPlot/src/PythonScript.h
+++ b/MantidPlot/src/PythonScript.h
@@ -126,14 +126,14 @@ private:
     }
 
     void appendPath(const QString &path) {
-      ScopedPythonGIL lock(m_script.gil());
+      ScopedPythonGIL lock;
       QString code = "if r'%1' not in sys.path:\n"
                      "    sys.path.append(r'%1')";
       code = code.arg(path);
       PyRun_SimpleString(code.toAscii().constData());
     }
     void removePath(const QString &path) {
-      ScopedPythonGIL lock(m_script.gil());
+      ScopedPythonGIL lock;
       QString code = "if r'%1' in sys.path:\n"
                      "    sys.path.remove(r'%1')";
       code = code.arg(path);
@@ -208,8 +208,9 @@ private:
   QString fileName;
   bool m_isInitialized;
   PythonPathHolder m_pathHolder;
-  /// Set of current python variables that point to workspace handles
-  std::set<std::string> m_workspaceHandles;
+  /// This must only be used by the recursiveAsync* methods
+  /// as they need to store state between calls.
+  PythonGIL m_recursiveAsyncGIL;
 };
 
 #endif

--- a/MantidPlot/src/PythonScript.h
+++ b/MantidPlot/src/PythonScript.h
@@ -105,8 +105,7 @@ private:
   /// Helper class to ensure the sys.path variable is updated correctly
   struct PythonPathHolder {
     /// Update the path with the given entry
-    explicit PythonPathHolder(const QString &entry, const PythonScript &script)
-        : m_path(entry), m_script(script) {
+    explicit PythonPathHolder(const QString &entry) : m_path(entry) {
       const QFileInfo filePath(m_path);
       if (filePath.exists()) {
         QDir directory = filePath.absoluteDir();
@@ -142,7 +141,6 @@ private:
 
   private:
     QString m_path;
-    const PythonScript &m_script;
   };
 
   inline PythonScripting *interp() const { return m_interp; }

--- a/MantidPlot/src/PythonScripting.cpp
+++ b/MantidPlot/src/PythonScripting.cpp
@@ -69,7 +69,7 @@ ScriptingEnv *PythonScripting::constructor(ApplicationWindow *parent) {
 /** Constructor */
 PythonScripting::PythonScripting(ApplicationWindow *parent)
     : ScriptingEnv(parent, "Python"), m_globals(NULL), m_math(NULL),
-      m_sys(NULL), m_mainThreadState(NULL), m_gil() {}
+      m_sys(NULL), m_mainThreadState(NULL) {}
 
 PythonScripting::~PythonScripting() {}
 
@@ -77,7 +77,7 @@ PythonScripting::~PythonScripting() {}
  * @param args A list of strings that denoting command line arguments
  */
 void PythonScripting::setSysArgs(const QStringList &args) {
-  ScopedPythonGIL lock(gil());
+  ScopedPythonGIL lock;
   PyObject *argv = toPyList(args);
   if (argv && m_sys) {
     PyDict_SetItemString(m_sys, "argv", argv);
@@ -138,7 +138,7 @@ bool PythonScripting::start() {
   PyImport_AppendInittab("_qti", &init_qti);
 #endif
   PythonInterpreter::initialize();
-  ScopedPythonGIL lock(gil());
+  ScopedPythonGIL lock;
 
   // Keep a hold of the globals, math and sys dictionary objects
   PyObject *mainmod = PyImport_AddModule("__main__");

--- a/MantidPlot/src/PythonScripting.h
+++ b/MantidPlot/src/PythonScripting.h
@@ -113,8 +113,6 @@ public:
   PyObject *globalDict() { return m_globals; }
   /// Return the sys dictionary for this environment
   PyObject *sysDict() { return m_sys; }
-  /// Return a reference to the global lock
-  PythonGIL &gil() { return m_gil; }
 
 private:
   /// Constructor

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/PythonThreading.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/PythonThreading.h
@@ -39,46 +39,23 @@ private:
 };
 
 //------------------------------------------------------------------------------
-// RecursiveGlobalInterpreterLock
-//------------------------------------------------------------------------------
-
-/**
- * A thread can call acquire multiple times and will only be unlocked
- * when a corresponding number of release calls are made.
- */
-class EXPORT_OPT_MANTIDQT_COMMON RecursivePythonGIL {
-public:
-  RecursivePythonGIL();
-
-  void acquire();
-  void release();
-
-private:
-  int m_count;
-  PythonGIL m_lock;
-};
-
-//------------------------------------------------------------------------------
 // ScopedInterpreterLock
 //------------------------------------------------------------------------------
 
 /**
   * Acquires a lock in the constructor and releases it in the destructor.
-  * Modelled on std::lock_guard
   * @tparam T Templated on the lock type
   */
 template <typename T> class ScopedGIL {
 public:
-  ScopedGIL(T &l) : m_lock(l) { m_lock.acquire(); }
+  ScopedGIL() : m_lock() { m_lock.acquire(); }
   ~ScopedGIL() { m_lock.release(); }
 
 private:
-  T &m_lock;
+  T m_lock;
 };
 
 /// Typedef for scoped lock
 typedef ScopedGIL<PythonGIL> ScopedPythonGIL;
-/// Typedef for scoped recursive lock
-typedef ScopedGIL<RecursivePythonGIL> ScopedRecursivePythonGIL;
 
 #endif /* PYTHONTHREADING_H_ */

--- a/qt/widgets/common/src/PythonThreading.cpp
+++ b/qt/widgets/common/src/PythonThreading.cpp
@@ -55,25 +55,3 @@ void PythonGIL::acquire() { m_state = PyGILState_Ensure(); }
  * Calls PyGILState_Release
  */
 void PythonGIL::release() { PyGILState_Release(m_state); }
-
-//------------------------------------------------------------------------------
-// RecursivePythonGIL public members
-//------------------------------------------------------------------------------
-/**
- * Leaves the lock unlocked. You are strongly encouraged to use
- * the ScopedRecursiveInterpreterLock class to control this
- */
-RecursivePythonGIL::RecursivePythonGIL() : m_count(0), m_lock() {}
-
-void RecursivePythonGIL::acquire() {
-  if (m_count == 0) {
-    m_lock.acquire();
-  }
-  m_count += 1;
-}
-
-void RecursivePythonGIL::release() {
-  if (--m_count == 0) {
-    m_lock.release();
-  }
-}


### PR DESCRIPTION
This fixes an issue where if a Python GUI startup script raised an error then any subsequent attempts to run a script in the script window would hang MantidPlot.

**To test:**

1. try out the above scenario
2. try the test instructions in #20464 
3. attempt to break the scripting by testing combinations of scripts in the script window that
flick between the serialised and asynchronous modes and also scripts that
  * run successfully
  * produce a syntax error
  * produce a runtime error  

*No issue number*

**Release Notes** 
*Issue introduced in this cycle so it does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
