### PR TITLE
Removed duplication of functions in muon analysis

### DIFF
--- a/qt/scientific_interfaces/Muon/MuonAnalysisFitFunctionPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisFitFunctionPresenter.cpp
@@ -43,8 +43,6 @@ void MuonAnalysisFitFunctionPresenter::doConnect() {
     connect(fitBrowser, SIGNAL(errorsEnabled(bool)), this,
             SLOT(handleErrorsEnabled(bool)));
     connect(fitBrowser, SIGNAL(fitUndone()), this, SLOT(handleFitFinished()));
-    connect(fitBrowser, SIGNAL(functionLoaded(const QString &)), this,
-            SLOT(handleFunctionLoaded(const QString &)));
     connect(fitBrowser, SIGNAL(workspacesToFitChanged(int)), this,
             SLOT(updateNumberOfDatasets(int)));
     connect(fitBrowser, SIGNAL(userChangedDatasetIndex(int)), this,
@@ -174,16 +172,6 @@ void MuonAnalysisFitFunctionPresenter::handleErrorsEnabled(bool enabled) {
   m_funcBrowser->setErrorsEnabled(enabled);
 }
 
-/**
- * Called when a saved setup is loaded into the fit property browser.
- * Update the function browser with this loaded function.
- * @param funcString :: [input] Loaded function as a string
- */
-void MuonAnalysisFitFunctionPresenter::handleFunctionLoaded(
-    const QString &funcString) {
-  m_funcBrowser->clear();
-  m_funcBrowser->setFunction(funcString);
-}
 
 /**
  * Called when the number of datasets to fit is changed in the model.

--- a/qt/scientific_interfaces/Muon/MuonAnalysisFitFunctionPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisFitFunctionPresenter.cpp
@@ -172,7 +172,6 @@ void MuonAnalysisFitFunctionPresenter::handleErrorsEnabled(bool enabled) {
   m_funcBrowser->setErrorsEnabled(enabled);
 }
 
-
 /**
  * Called when the number of datasets to fit is changed in the model.
  * Update the view with the new number of datasets.

--- a/qt/scientific_interfaces/Muon/MuonAnalysisFitFunctionPresenter.h
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisFitFunctionPresenter.h
@@ -64,8 +64,6 @@ public slots:
   void handleModelCleared();
   /// Pass show/hide parameter errors to function browser
   void handleErrorsEnabled(bool enabled);
-  /// When a saved setup is loaded, update the function browser
-  void handleFunctionLoaded(const QString &funcString);
   /// When number of datasets to fit changes, update function browser
   void updateNumberOfDatasets(int nDatasets);
   /// When "edit local parameter" button is clicked, launch dialog

--- a/qt/scientific_interfaces/test/MuonAnalysisFitFunctionPresenterTest.h
+++ b/qt/scientific_interfaces/test/MuonAnalysisFitFunctionPresenterTest.h
@@ -194,13 +194,6 @@ public:
     m_presenter->handleErrorsEnabled(false);
   }
 
-  void test_handleFunctionLoaded() {
-    const QString funcString("some function string");
-    EXPECT_CALL(*m_funcBrowser, clear()).Times(1);
-    EXPECT_CALL(*m_funcBrowser, setFunction(funcString)).Times(1);
-    m_presenter->handleFunctionLoaded(funcString);
-  }
-
   void test_updateNumberOfDatasets() {
     const int nDatasets(21);
     EXPECT_CALL(*m_funcBrowser, clearErrors()).Times(1);


### PR DESCRIPTION
This is to remove the duplication of functions in the function browser of muon analysis (when a custom setup is loaded). 

**To test:**
0. Open muon analysis and load some data
1. Got to data analysis
2. select the setup menu, custom setup and then some setup (it doesn't matter which)
3. Observe that the function only appears once (in master it is added twice)
<!-- Instructions for testing. -->

Fixes #20550. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
