### PR TITLE
LoadEventNexus MPI support

### DIFF
--- a/Framework/API/CMakeLists.txt
+++ b/Framework/API/CMakeLists.txt
@@ -135,6 +135,7 @@ set ( SRC_FILES
 	src/TableRow.cpp
 	src/TextAxis.cpp
 	src/TransformScaleFactory.cpp
+	src/TriviallyParallelAlgorithm.cpp
 	src/Workspace.cpp
 	src/WorkspaceFactory.cpp
 	src/WorkspaceGroup.cpp
@@ -330,6 +331,7 @@ set ( INC_FILES
 	inc/MantidAPI/TableRow.h
 	inc/MantidAPI/TextAxis.h
 	inc/MantidAPI/TransformScaleFactory.h
+	inc/MantidAPI/TriviallyParallelAlgorithm.h
 	inc/MantidAPI/VectorParameter.h
 	inc/MantidAPI/VectorParameterParser.h
 	inc/MantidAPI/Workspace.h
@@ -352,10 +354,10 @@ set ( TEST_FILES
 	AlgorithmFactoryTest.h
 	AlgorithmHasPropertyTest.h
 	AlgorithmHistoryTest.h
+	AlgorithmMPITest.h
 	AlgorithmManagerTest.h
 	AlgorithmPropertyTest.h
 	AlgorithmProxyTest.h
-	AlgorithmMPITest.h
 	AlgorithmTest.h
 	AnalysisDataServiceTest.h
 	AsynchronousTest.h

--- a/Framework/API/inc/MantidAPI/TriviallyParallelAlgorithm.h
+++ b/Framework/API/inc/MantidAPI/TriviallyParallelAlgorithm.h
@@ -1,0 +1,56 @@
+#ifndef MANTID_API_TRIVIALLYPARALLELALGORITHM_H_
+#define MANTID_API_TRIVIALLYPARALLELALGORITHM_H_
+
+#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/DllConfig.h"
+
+namespace Mantid {
+namespace API {
+
+/** Base class for algorithms that treat all spectra independently, i.e., we can
+  trivially parallelize over the spectra without changes. The assumption is that
+  we have one input and one output workspace. The storage mode is just
+  propagated from input to output. When a specific algorithm is determined to be
+  trivially parallel (this is a manual process), the only required change to add
+  MPI support is to inherit from this class instead of Algorithm. Inheriting
+  from TriviallyParallelAlgorithm instead of from Algorithm provides the
+  necessary overriden method(s) to allow running an algorithm with MPI. This
+  works under the following conditions:
+  1. The algorithm must have a single input and a single output workspace.
+  2. No output files may be written since filenames would clash.
+
+  @author Simon Heybrock
+  @date 2017
+
+  Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class MANTID_API_DLL TriviallyParallelAlgorithm : public Algorithm {
+protected:
+  Parallel::ExecutionMode getParallelExecutionMode(
+      const std::map<std::string, Parallel::StorageMode> &storageModes)
+      const override;
+};
+
+} // namespace API
+} // namespace Mantid
+
+#endif /* MANTID_API_TRIVIALLYPARALLELALGORITHM_H_ */

--- a/Framework/API/src/TriviallyParallelAlgorithm.cpp
+++ b/Framework/API/src/TriviallyParallelAlgorithm.cpp
@@ -1,0 +1,12 @@
+#include "MantidAPI/TriviallyParallelAlgorithm.h"
+
+namespace Mantid {
+namespace API {
+
+Parallel::ExecutionMode TriviallyParallelAlgorithm::getParallelExecutionMode(
+    const std::map<std::string, Parallel::StorageMode> &storageModes) const {
+  return Parallel::getCorrespondingExecutionMode(storageModes.begin()->second);
+}
+
+} // namespace API
+} // namespace Mantid

--- a/Framework/Algorithms/inc/MantidAlgorithms/Rebin.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/Rebin.h
@@ -1,10 +1,8 @@
 #ifndef MANTID_ALGORITHMS_REBIN_H_
 #define MANTID_ALGORITHMS_REBIN_H_
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/TriviallyParallelAlgorithm.h"
+
 namespace Mantid {
 namespace Algorithms {
 /** Takes a workspace as input and rebins the data according to the input rebin
@@ -52,7 +50,7 @@ namespace Algorithms {
     File change history is stored at: <https://github.com/mantidproject/mantid>
     Code Documentation is available at: <http://doxygen.mantidproject.org>
  */
-class DLLExport Rebin : public API::Algorithm {
+class DLLExport Rebin : public API::TriviallyParallelAlgorithm {
 public:
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "Rebin"; }
@@ -90,10 +88,6 @@ protected:
 
   void propagateMasks(API::MatrixWorkspace_const_sptr inputWS,
                       API::MatrixWorkspace_sptr outputWS, int hist);
-
-  Parallel::ExecutionMode getParallelExecutionMode(
-      const std::map<std::string, Parallel::StorageMode> &storageModes)
-      const override;
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/src/Rebin.cpp
+++ b/Framework/Algorithms/src/Rebin.cpp
@@ -355,10 +355,5 @@ void Rebin::propagateMasks(API::MatrixWorkspace_const_sptr inputWS,
   }
 }
 
-Parallel::ExecutionMode Rebin::getParallelExecutionMode(
-    const std::map<std::string, Parallel::StorageMode> &storageModes) const {
-  return Parallel::getCorrespondingExecutionMode(storageModes.begin()->second);
-}
-
 } // namespace Algorithm
 } // namespace Mantid

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -168,6 +168,11 @@ public:
   std::string m_top_entry_name;
   ::NeXus::File *m_file;
 
+protected:
+  Parallel::ExecutionMode getParallelExecutionMode(
+      const std::map<std::string, Parallel::StorageMode> &storageModes)
+      const override;
+
 private:
   /// Intialisation code
   void init() override;

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexusIndexSetup.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexusIndexSetup.h
@@ -4,6 +4,7 @@
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidIndexing/IndexInfo.h"
+#include "MantidParallel/Communicator.h"
 
 namespace Mantid {
 namespace DataHandling {
@@ -41,9 +42,10 @@ namespace DataHandling {
 */
 class MANTID_DATAHANDLING_DLL LoadEventNexusIndexSetup {
 public:
-  LoadEventNexusIndexSetup(API::MatrixWorkspace_const_sptr instrumentWorkspace,
-                           const int32_t min, const int32_t max,
-                           const std::vector<int32_t> range);
+  LoadEventNexusIndexSetup(
+      API::MatrixWorkspace_const_sptr instrumentWorkspace, const int32_t min,
+      const int32_t max, const std::vector<int32_t> range,
+      const Parallel::Communicator &communicator = Parallel::Communicator());
 
   std::pair<int32_t, int32_t> eventIDLimits() const;
 
@@ -61,6 +63,7 @@ private:
   int32_t m_min;
   int32_t m_max;
   std::vector<int32_t> m_range;
+  const Parallel::Communicator m_communicator;
 };
 
 } // namespace DataHandling

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadInstrument.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadInstrument.h
@@ -1,17 +1,11 @@
 #ifndef MANTID_DATAHANDLING_LOADINSTRUMENT_H_
 #define MANTID_DATAHANDLING_LOADINSTRUMENT_H_
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
-#include "MantidAPI/Algorithm.h"
 #include "MantidAPI/ExperimentInfo.h"
+#include "MantidAPI/TriviallyParallelAlgorithm.h"
 
 #include <mutex>
 
-//----------------------------------------------------------------------
-// Forward declarations
-//----------------------------------------------------------------------
 /// @cond Exclude from doxygen documentation
 namespace Poco {
 namespace XML {
@@ -75,10 +69,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 File change history is stored at: <https://github.com/mantidproject/mantid>
 */
-class DLLExport LoadInstrument : public API::Algorithm {
+class DLLExport LoadInstrument : public API::TriviallyParallelAlgorithm {
 public:
-  /// Default constructor
-  LoadInstrument();
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "LoadInstrument"; };
   /// Summary of algorithms purpose

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNexusLogs.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNexusLogs.h
@@ -1,16 +1,10 @@
 #ifndef MANTID_DATAHANDLING_LOADNEXUSLOGS_H_
 #define MANTID_DATAHANDLING_LOADNEXUSLOGS_H_
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/TriviallyParallelAlgorithm.h"
 #include <nexus/NeXusFile.hpp>
 
 namespace Mantid {
-//----------------------------------------------------------------------
-// Forward declaration
-//----------------------------------------------------------------------
 namespace Kernel {
 class Property;
 }
@@ -54,7 +48,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 File change history is stored at: <https://github.com/mantidproject/mantid>.
 Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport LoadNexusLogs : public API::Algorithm {
+class DLLExport LoadNexusLogs : public API::TriviallyParallelAlgorithm {
 public:
   /// Default constructor
   LoadNexusLogs();

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadParameterFile.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadParameterFile.h
@@ -1,14 +1,8 @@
 #ifndef MANTID_DATAHANDLING_LOADPARAMETERFILE_H_
 #define MANTID_DATAHANDLING_LOADPARAMETERFILE_H_
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/TriviallyParallelAlgorithm.h"
 
-//----------------------------------------------------------------------
-// Forward declaration
-//----------------------------------------------------------------------
 /// @cond Exclude from doxygen documentation
 namespace Poco {
 namespace XML {
@@ -68,10 +62,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 File change history is stored at: <https://github.com/mantidproject/mantid>
 */
-class DLLExport LoadParameterFile : public API::Algorithm {
+class DLLExport LoadParameterFile : public API::TriviallyParallelAlgorithm {
 public:
-  /// Default constructor
-  LoadParameterFile();
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "LoadParameterFile"; };
   /// Summary of algorithms purpose

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -1642,5 +1642,11 @@ void LoadEventNexus::safeOpenFile(const std::string fname) {
   }
 }
 
+Parallel::ExecutionMode LoadEventNexus::getParallelExecutionMode(
+    const std::map<std::string, Parallel::StorageMode> &storageModes) const {
+  static_cast<void>(storageModes);
+  return Parallel::ExecutionMode::Distributed;
+}
+
 } // namespace DataHandling
 } // namespace Mantid

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -1084,7 +1084,7 @@ void LoadEventNexus::createSpectraMapping(
     const std::vector<std::string> &bankNames) {
   LoadEventNexusIndexSetup indexSetup(
       m_ws->getSingleHeldWorkspace(), getProperty("SpectrumMin"),
-      getProperty("SpectrumMax"), getProperty("SpectrumList"));
+      getProperty("SpectrumMax"), getProperty("SpectrumList"), communicator());
   if (!monitorsOnly && !bankNames.empty()) {
     if (!isDefault("SpectrumMin") || !isDefault("SpectrumMax") ||
         !isDefault("SpectrumList"))

--- a/Framework/DataHandling/src/LoadInstrument.cpp
+++ b/Framework/DataHandling/src/LoadInstrument.cpp
@@ -192,16 +192,17 @@ void LoadInstrument::exec() {
       // Add to data service for later retrieval
       InstrumentDataService::Instance().add(instrumentNameMangled, instrument);
     }
+    m_workspace->setInstrument(instrument);
+
+    // populate parameter map of workspace
+    m_workspace->populateInstrumentParameters();
+
+    // LoadParameterFile modifies the base instrument stored in the IDS so this
+    // must also be protected by the lock until LoadParameterFile is fixed.
+    // check if default parameter file is also present, unless loading from
+    if (!m_filename.empty())
+      runLoadParameterFile();
   }
-  // Add the instrument to the workspace
-  m_workspace->setInstrument(instrument);
-
-  // populate parameter map of workspace
-  m_workspace->populateInstrumentParameters();
-
-  // check if default parameter file is also present, unless loading from
-  if (!m_filename.empty())
-    runLoadParameterFile();
 
   // Set the monitors output property
   setProperty("MonitorList", instrument->getMonitors());

--- a/Framework/DataHandling/src/LoadInstrument.cpp
+++ b/Framework/DataHandling/src/LoadInstrument.cpp
@@ -42,10 +42,6 @@ using namespace Geometry;
 
 std::recursive_mutex LoadInstrument::m_mutex;
 
-/// Empty default constructor
-LoadInstrument::LoadInstrument() : Algorithm() {}
-
-//------------------------------------------------------------------------------------------------------------------------------
 /// Initialisation method.
 void LoadInstrument::init() {
   // When used as a Child Algorithm the workspace name is not used - hence the

--- a/Framework/DataHandling/src/LoadParameterFile.cpp
+++ b/Framework/DataHandling/src/LoadParameterFile.cpp
@@ -36,9 +36,6 @@ using namespace API;
 using Geometry::Instrument;
 using Geometry::Instrument_sptr;
 
-/// Empty default constructor
-LoadParameterFile::LoadParameterFile() : Algorithm() {}
-
 /// Initialisation method.
 void LoadParameterFile::init() {
   // When used as a Child Algorithm the workspace name is not used - hence the

--- a/Framework/DataHandling/test/CMakeLists.txt
+++ b/Framework/DataHandling/test/CMakeLists.txt
@@ -12,6 +12,7 @@ if ( CXXTEST_FOUND )
                         ../../TestHelpers/src/TearDownWorld.cpp
                         ../../TestHelpers/src/WorkspaceCreationHelper.cpp
                         ../../TestHelpers/src/NexusTestHelper.cpp
+                        ../../TestHelpers/src/ParallelRunner.cpp
                         NXcanSASTestHelper.cpp
       )
 

--- a/Framework/DataHandling/test/LoadEventNexusTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusTest.h
@@ -90,7 +90,8 @@ void run_MPI_load(const Parallel::Communicator &comm) {
   std::vector<size_t> compared;
   Parallel::gather(comm, localCompared, compared, 0);
   if (comm.rank() == 0) {
-    TS_ASSERT_EQUALS(std::accumulate(compared.begin(), compared.end(), 0),
+    TS_ASSERT_EQUALS(std::accumulate(compared.begin(), compared.end(),
+                                     static_cast<size_t>(0)),
                      reference->getNumberHistograms());
   }
 }

--- a/Framework/DataHandling/test/LoadEventNexusTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusTest.h
@@ -65,11 +65,13 @@ void run_MPI_load(const Parallel::Communicator &comm) {
   Parallel::gather(comm, localSize, localSizes, 0);
   Parallel::gather(comm, localEventCount, localEventCounts, 0);
   if (comm.rank() == 0) {
-    TS_ASSERT_EQUALS(std::accumulate(localSizes.begin(), localSizes.end(), 0),
+    TS_ASSERT_EQUALS(std::accumulate(localSizes.begin(), localSizes.end(),
+                                     static_cast<size_t>(0)),
                      static_cast<size_t>(51200));
-    TS_ASSERT_EQUALS(
-        std::accumulate(localEventCounts.begin(), localEventCounts.end(), 0),
-        static_cast<size_t>(112266));
+    TS_ASSERT_EQUALS(std::accumulate(localEventCounts.begin(),
+                                     localEventCounts.end(),
+                                     static_cast<size_t>(0)),
+                     static_cast<size_t>(112266));
   }
 
   const auto &reference = load_reference_workspace(filename);

--- a/Framework/DataHandling/test/LoadEventNexusTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusTest.h
@@ -781,9 +781,7 @@ public:
     }
   }
 
-  void test_MPI_load() {
-    ParallelTestHelpers::runParallel(run_MPI_load);
-  }
+  void test_MPI_load() { ParallelTestHelpers::runParallel(run_MPI_load); }
 
 private:
   std::string wsSpecFilterAndEventMonitors;

--- a/Framework/DataHandling/test/LoadEventNexusTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusTest.h
@@ -54,6 +54,9 @@ void run_MPI_load(const Parallel::Communicator &comm) {
   TS_ASSERT_THROWS_NOTHING(alg->execute());
   TS_ASSERT(alg->isExecuted());
   Workspace_const_sptr out = alg->getProperty("OutputWorkspace");
+  if (comm.size() != 1) {
+    TS_ASSERT_EQUALS(out->storageMode(), Parallel::StorageMode::Distributed);
+  }
   const auto eventWS = boost::dynamic_pointer_cast<const EventWorkspace>(out);
   const size_t localSize = eventWS->getNumberHistograms();
   auto localEventCount = eventWS->getNumberEvents();

--- a/Framework/DataHandling/test/LoadEventNexusTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusTest.h
@@ -63,10 +63,10 @@ void run_MPI_load(const Parallel::Communicator &comm) {
   Parallel::gather(comm, localEventCount, localEventCounts, 0);
   if (comm.rank() == 0) {
     TS_ASSERT_EQUALS(std::accumulate(localSizes.begin(), localSizes.end(), 0),
-                     51200);
+                     static_cast<size_t>(51200));
     TS_ASSERT_EQUALS(
         std::accumulate(localEventCounts.begin(), localEventCounts.end(), 0),
-        112266);
+        static_cast<size_t>(112266));
   }
 
   const auto &reference = load_reference_workspace(filename);

--- a/Framework/Indexing/CMakeLists.txt
+++ b/Framework/Indexing/CMakeLists.txt
@@ -5,6 +5,7 @@ set ( SRC_FILES
 	src/LegacyConversion.cpp
 	src/Partitioner.cpp
 	src/RoundRobinPartitioner.cpp
+	src/Scatter.cpp
 	src/SpectrumNumberTranslator.cpp
 )
 
@@ -21,6 +22,7 @@ set ( INC_FILES
 	inc/MantidIndexing/PartitionIndex.h
 	inc/MantidIndexing/Partitioner.h
 	inc/MantidIndexing/RoundRobinPartitioner.h
+	inc/MantidIndexing/Scatter.h
 	inc/MantidIndexing/SpectrumIndexSet.h
 	inc/MantidIndexing/SpectrumNumber.h
 	inc/MantidIndexing/SpectrumNumberTranslator.h
@@ -38,6 +40,7 @@ set ( TEST_FILES
 	PartitionIndexTest.h
 	PartitionerTest.h
 	RoundRobinPartitionerTest.h
+	ScatterTest.h
 	SpectrumIndexSetTest.h
 	SpectrumNumberTest.h
 	SpectrumNumberTranslatorTest.h

--- a/Framework/Indexing/inc/MantidIndexing/Scatter.h
+++ b/Framework/Indexing/inc/MantidIndexing/Scatter.h
@@ -1,0 +1,39 @@
+#ifndef MANTID_INDEXING_SCATTER_H_
+#define MANTID_INDEXING_SCATTER_H_
+
+#include "MantidIndexing/DllConfig.h"
+
+namespace Mantid {
+namespace Indexing {
+class IndexInfo;
+
+/** Scattering for IndexInfo, in particular changing its storage mode to
+  Parallel::StorageMode::Distributed.
+
+  Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+MANTID_INDEXING_DLL IndexInfo scatter(const IndexInfo &indexInfo);
+
+} // namespace Indexing
+} // namespace Mantid
+
+#endif /* MANTID_INDEXING_SCATTER_H_ */

--- a/Framework/Indexing/inc/MantidIndexing/Scatter.h
+++ b/Framework/Indexing/inc/MantidIndexing/Scatter.h
@@ -10,6 +10,9 @@ class IndexInfo;
 /** Scattering for IndexInfo, in particular changing its storage mode to
   Parallel::StorageMode::Distributed.
 
+  @author Simon Heybrock
+  @date 2017
+
   Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
   National Laboratory & European Spallation Source
 

--- a/Framework/Indexing/src/Scatter.cpp
+++ b/Framework/Indexing/src/Scatter.cpp
@@ -1,0 +1,36 @@
+#include "MantidIndexing/IndexInfo.h"
+#include "MantidIndexing/GlobalSpectrumIndex.h"
+#include "MantidIndexing/Scatter.h"
+#include "MantidIndexing/SpectrumNumber.h"
+#include "MantidParallel/Communicator.h"
+#include "MantidTypes/SpectrumDefinition.h"
+
+namespace Mantid {
+namespace Indexing {
+
+IndexInfo scatter(const Indexing::IndexInfo &indexInfo) {
+  using namespace Parallel;
+  if (indexInfo.communicator().size() == 1 ||
+      indexInfo.storageMode() == Parallel::StorageMode::Distributed)
+    return indexInfo;
+  if (indexInfo.storageMode() == Parallel::StorageMode::MasterOnly)
+    throw std::runtime_error(
+        "Cannot scatter IndexInfo with unsupported storage mode " +
+        toString(StorageMode::MasterOnly));
+
+  std::vector<SpectrumNumber> spectrumNumbers;
+  for (size_t i = 0; i < indexInfo.size(); ++i)
+    spectrumNumbers.push_back(indexInfo.spectrumNumber(i));
+  IndexInfo scattered(spectrumNumbers, Parallel::StorageMode::Distributed,
+                      indexInfo.communicator());
+  const auto &globalSpectrumDefinitions = indexInfo.spectrumDefinitions();
+  std::vector<SpectrumDefinition> spectrumDefinitions;
+  for (size_t i = 0; i < indexInfo.size(); ++i)
+    if (scattered.isOnThisPartition(static_cast<GlobalSpectrumIndex>(i)))
+      spectrumDefinitions.emplace_back((*globalSpectrumDefinitions)[i]);
+  scattered.setSpectrumDefinitions(spectrumDefinitions);
+  return scattered;
+}
+
+} // namespace Indexing
+} // namespace Mantid

--- a/Framework/Indexing/src/Scatter.cpp
+++ b/Framework/Indexing/src/Scatter.cpp
@@ -8,6 +8,7 @@
 namespace Mantid {
 namespace Indexing {
 
+/// Returns a scattered copy of `indexInfo` with storage mode `Distributed`.
 IndexInfo scatter(const Indexing::IndexInfo &indexInfo) {
   using namespace Parallel;
   if (indexInfo.communicator().size() == 1 ||

--- a/Framework/Indexing/test/ScatterTest.h
+++ b/Framework/Indexing/test/ScatterTest.h
@@ -1,0 +1,89 @@
+#ifndef MANTID_INDEXING_SCATTERTEST_H_
+#define MANTID_INDEXING_SCATTERTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidIndexing/IndexInfo.h"
+#include "MantidIndexing/Scatter.h"
+#include "MantidIndexing/SpectrumIndexSet.h"
+#include "MantidParallel/Communicator.h"
+#include "MantidTypes/SpectrumDefinition.h"
+
+#include "MantidTestHelpers/ParallelRunner.h"
+
+using namespace Mantid;
+using namespace Mantid::Indexing;
+using namespace Mantid::Parallel;
+using namespace ParallelTestHelpers;
+
+namespace {
+IndexInfo makeIndexInfo(const Communicator &comm = Communicator()) {
+  IndexInfo indexInfo(7, StorageMode::Cloned, comm);
+  std::vector<SpectrumDefinition> specDefs;
+  specDefs.emplace_back(1);
+  specDefs.emplace_back(2);
+  specDefs.emplace_back(4);
+  specDefs.emplace_back(8);
+  specDefs.emplace_back();
+  specDefs.emplace_back();
+  specDefs.emplace_back();
+  indexInfo.setSpectrumDefinitions(std::move(specDefs));
+  return indexInfo;
+}
+
+void run_StorageMode_Cloned(const Communicator &comm) {
+  const auto indexInfo = makeIndexInfo(comm);
+  if (comm.size() == 1) {
+    TS_ASSERT_THROWS_NOTHING(scatter(indexInfo));
+  } else {
+    const auto result = scatter(indexInfo);
+    TS_ASSERT_EQUALS(result.storageMode(), StorageMode::Distributed);
+    TS_ASSERT_EQUALS(result.globalSize(), indexInfo.size());
+    // Assuming round-robin partitioning
+    TS_ASSERT_EQUALS(result.size(),
+                     (indexInfo.size() + comm.size() - 1 - comm.rank()) /
+                         comm.size());
+    const auto resultSpecDefs = result.spectrumDefinitions();
+    const auto specDefs = indexInfo.spectrumDefinitions();
+    const auto indices = result.makeIndexSet();
+    size_t current = 0;
+    for (size_t i = 0; i < specDefs->size(); ++i) {
+      if (static_cast<int>(i) % comm.size() == comm.rank()) {
+        TS_ASSERT_EQUALS(result.spectrumNumber(indices[current]),
+                         indexInfo.spectrumNumber(i));
+        TS_ASSERT_EQUALS(resultSpecDefs->at(indices[current]), specDefs->at(i));
+        ++current;
+      }
+    }
+  }
+}
+}
+
+class ScatterTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static ScatterTest *createSuite() { return new ScatterTest(); }
+  static void destroySuite(ScatterTest *suite) { delete suite; }
+
+  void test_1_rank() {
+    const auto indexInfo = makeIndexInfo();
+    const auto result = scatter(indexInfo);
+    TS_ASSERT_EQUALS(result.storageMode(), StorageMode::Cloned);
+    TS_ASSERT_EQUALS(result.globalSize(), indexInfo.size());
+    TS_ASSERT_EQUALS(result.size(), indexInfo.size());
+    TS_ASSERT_EQUALS(result.spectrumDefinitions(),
+                     indexInfo.spectrumDefinitions());
+    TS_ASSERT_EQUALS(result.spectrumNumber(0), indexInfo.spectrumNumber(0));
+    TS_ASSERT_EQUALS(result.spectrumNumber(1), indexInfo.spectrumNumber(1));
+    TS_ASSERT_EQUALS(result.spectrumNumber(2), indexInfo.spectrumNumber(2));
+    TS_ASSERT_EQUALS(result.spectrumNumber(3), indexInfo.spectrumNumber(3));
+    TS_ASSERT_EQUALS(result.spectrumNumber(4), indexInfo.spectrumNumber(4));
+    TS_ASSERT_EQUALS(result.spectrumNumber(5), indexInfo.spectrumNumber(5));
+    TS_ASSERT_EQUALS(result.spectrumNumber(6), indexInfo.spectrumNumber(6));
+  }
+
+  void test_StorageMode_Cloned() { runParallel(run_StorageMode_Cloned); }
+};
+
+#endif /* MANTID_INDEXING_SCATTERTEST_H_ */

--- a/Framework/Parallel/inc/MantidParallel/ThreadingBackend.h
+++ b/Framework/Parallel/inc/MantidParallel/ThreadingBackend.h
@@ -113,10 +113,8 @@ void ThreadingBackend::recv(int dest, int source, int tag, T &&... args) {
     break;
   }
   std::istream is(buf.get());
-  {
-    boost::archive::binary_iarchive ia(is);
-    ia.operator>>(std::forward<T>(args)...);
-  }
+  boost::archive::binary_iarchive ia(is);
+  ia.operator>>(std::forward<T>(args)...);
 }
 
 template <typename... T>

--- a/Framework/Parallel/inc/MantidParallel/ThreadingBackend.h
+++ b/Framework/Parallel/inc/MantidParallel/ThreadingBackend.h
@@ -113,8 +113,10 @@ void ThreadingBackend::recv(int dest, int source, int tag, T &&... args) {
     break;
   }
   std::istream is(buf.get());
-  boost::archive::binary_iarchive ia(is);
-  ia.operator>>(std::forward<T>(args)...);
+  {
+    boost::archive::binary_iarchive ia(is);
+    ia.operator>>(std::forward<T>(args)...);
+  }
 }
 
 template <typename... T>

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -458,7 +458,7 @@ CreateWorkspace   all
 LoadEventNexus    Distributed     storage mode of output cannot be changed via a parameter currently, min and max bin boundary are not globally the same
 LoadInstrument    all
 LoadNexusLogs     all
-LoadParameterFile all             has issues when used in unit tests with MPI threading backend due to `#9365 <https://github.com/mantidproject/mantid/issues/9365>`_, normal use should be ok
+LoadParameterFile all             segfaults when used in unit tests with MPI threading backend due to `#9365 <https://github.com/mantidproject/mantid/issues/9365>`_, normal use should be ok
 Rebin             all             min and max bin boundaries must be given explicitly
 ================= =============== ========
 

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -266,6 +266,10 @@ In that case the execution mode can simply be determined from the input workspac
 Here the helper ``Parallel::getCorrespondingExecutionMode`` is used to obtain the 'natural' execution mode from a storage mode, i.e., ``ExecutionMode::Identical`` for ``StorageMode::Cloned``, ``ExecutionMode::Distributed`` for ``StorageMode::Distributed``, and ``ExecutionMode::MasterOnly`` for ``StorageMode::MasterOnly``.
 More complex algorithms may require more complex decision mechanism, e.g., when there is more than one input workspace.
 
+For many algorithms the base class ``API::TriviallyParallelAlgorithm`` provides a sufficient default implementation of ``Algorithm::getParallelExecutionMode()``.
+MPI support can simply be enabled by inheriting from ``TriviallyParallelAlgorithm`` instead of from ``Algorithm``.
+Generally this works only for algorithms with a single input and a single output that either process only non-spectrum data or process all spectra independently.
+
 If none of the other virtual methods listed above is implemented, ``Algorithm`` will run the normal ``exec()`` method on all MPI ranks.
 The exception are non-master ranks if the execution mode is ``ExecutionMode::MasterOnly`` -- in that case creating a dummy workspace is attempted.
 This is discussed in more detail in the subsections below.
@@ -447,12 +451,16 @@ Potential limitations must be described in the comments.
 Supported Algorithms
 ####################
 
-=============== =============== ========
-Algorithm       Supported modes Comments
-=============== =============== ========
-CreateWorkspace all
-Rebin           all             min and max bin boundaries must be given explicitly
-=============== =============== ========
+================= =============== ========
+Algorithm         Supported modes Comments
+================= =============== ========
+CreateWorkspace   all
+LoadEventNexus    Distributed     storage mode of output cannot be changed via a parameter currently
+LoadInstrument    all
+LoadNexusLogs     all
+LoadParameterFile all
+Rebin             all             min and max bin boundaries must be given explicitly
+================= =============== ========
 
 .. rubric:: Footnotes
 

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -458,7 +458,7 @@ CreateWorkspace   all
 LoadEventNexus    Distributed     storage mode of output cannot be changed via a parameter currently, min and max bin boundary are not globally the same
 LoadInstrument    all
 LoadNexusLogs     all
-LoadParameterFile all
+LoadParameterFile all             has issues when used in unit tests with MPI threading backend due to `#9365 <https://github.com/mantidproject/mantid/issues/9365>`_, normal use should be ok
 Rebin             all             min and max bin boundaries must be given explicitly
 ================= =============== ========
 

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -455,7 +455,7 @@ Supported Algorithms
 Algorithm         Supported modes Comments
 ================= =============== ========
 CreateWorkspace   all
-LoadEventNexus    Distributed     storage mode of output cannot be changed via a parameter currently
+LoadEventNexus    Distributed     storage mode of output cannot be changed via a parameter currently, min and max bin boundary are not globally the same
 LoadInstrument    all
 LoadNexusLogs     all
 LoadParameterFile all


### PR DESCRIPTION
Adds MPI support for `LoadEventNexus`. The implementation is not particularly efficient and not meant for production. An actual parallel loader will be added later.

Depends on https://github.com/mantidproject/mantid/pull/20511 (merged).

Note that `LoadInstrument` is now working around #9365: `LoadParameterFile` causes segfaults in MPI related unit tests since it is modifying the base instrument and is thus not thread safe. This should not be an issue in an actuall MPI run.

**To test:**

Code review.

Fixes #20555.

No release notes, MPI is not officially supported yet.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
