### PR TITLE
Allow monitor workspaces not in the ADS to be used with NormaliseToMonitor

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/NormaliseToMonitor.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/NormaliseToMonitor.h
@@ -97,6 +97,7 @@ private:
   // Overridden Algorithm methods
   void init() override;
   void exec() override;
+  std::map<std::string, std::string> validateInputs() override;
 
 protected: // for testing
   void checkProperties(const API::MatrixWorkspace_sptr &inputWorkspace);

--- a/Framework/Algorithms/src/NormaliseToMonitor.cpp
+++ b/Framework/Algorithms/src/NormaliseToMonitor.cpp
@@ -36,7 +36,6 @@ bool MonIDPropChanger::isEnabled(const IPropertyManager *algo) const {
     return false;
   } else {
     is_enabled = true;
-    ;
   }
 
   // is there the ws property, which describes monitors ws. It also disables the
@@ -57,16 +56,12 @@ bool MonIDPropChanger::isConditionChanged(const IPropertyManager *algo) const {
   // is enabled is based on other properties:
   if (!is_enabled)
     return false;
-
   // read monitors list from the input workspace
   API::MatrixWorkspace_const_sptr inputWS = algo->getProperty(hostWSname);
   bool monitors_changed = monitorIdReader(inputWS);
-
-  //       std::cout << "MonIDPropChanger::isConditionChanged() called  ";
-  //       std::cout << monitors_changed << '\n';
-
   return monitors_changed;
 }
+
 // function which modifies the allowed values for the list of monitors.
 void MonIDPropChanger::applyChanges(const IPropertyManager *algo,
                                     Kernel::Property *const pProp) {
@@ -76,12 +71,13 @@ void MonIDPropChanger::applyChanges(const IPropertyManager *algo,
     throw(std::invalid_argument(
         "modify allowed value has been called on wrong property"));
   }
-  //
+
   if (iExistingAllowedValues.empty()) {
     API::MatrixWorkspace_const_sptr inputWS = algo->getProperty(hostWSname);
     int spectra_max(-1);
-    if (inputWS) { // let's assume that detectors IDs correspond to spectraID --
-                   // not always the case but often. TODO: should be fixed
+    if (inputWS) {
+      // let's assume that detectors IDs correspond to spectraID --
+      // not always the case but often. TODO: should be fixed
       spectra_max = static_cast<int>(inputWS->getNumberHistograms()) + 1;
     }
     piProp->replaceValidator(
@@ -170,18 +166,11 @@ void NormaliseToMonitor::init() {
                                        val),
       "Name of the input workspace. Must be a non-distribution histogram.");
 
-  //
-  // declareProperty("NofmalizeByAnySpectra",false,
-  //   "Allows you to normalize the workspace by any spectra, not just by the
-  //   monitor one");
-  // Can either set a spectrum within the workspace to be the monitor
-  // spectrum.....
   declareProperty(make_unique<WorkspaceProperty<>>("OutputWorkspace", "",
                                                    Direction::Output),
                   "Name to use for the output workspace");
   // should be any spectrum number, but named this property MonitorSpectrum to
-  // keep
-  // compatibility with previous scripts
+  // keep compatibility with previous scripts
   // Can either set a spectrum within the workspace to be the monitor
   // spectrum.....
   declareProperty("MonitorSpectrum", -1,
@@ -255,7 +244,7 @@ void NormaliseToMonitor::exec() {
   // Get the input workspace
   const MatrixWorkspace_sptr inputWS = getProperty("InputWorkspace");
   MatrixWorkspace_sptr outputWS = getProperty("OutputWorkspace");
-  // First check the inputs, throws std::runtime_error if a property is invalid
+  // First check the inputs
   this->checkProperties(inputWS);
 
   // See if the normalization with integration properties are set,
@@ -620,13 +609,11 @@ void NormaliseToMonitor::normaliseBinByBin(
     }
 
     if (inputEvent) {
-      // ----------------------------------- EventWorkspace
-      // ---------------------------------------
+      // --- EventWorkspace ---
       EventList &outEL = outputEvent->getSpectrum(i);
       outEL.divide(X.rawData(), Y.mutableRawData(), E.mutableRawData());
     } else {
-      // ----------------------------------- Workspace2D
-      // ---------------------------------------
+      // --- Workspace2D ---
       auto &YOut = outputWorkspace->mutableY(i);
       auto &EOut = outputWorkspace->mutableE(i);
       const auto &inY = inputWorkspace->y(i);
@@ -644,8 +631,7 @@ void NormaliseToMonitor::normaliseBinByBin(
         }
 
         // Calculate result and store in local variable to avoid overwriting
-        // original data if
-        // output workspace is same as one of the input ones
+        // original data if output workspace is same as one of the input ones
         const double newY = leftY / rightY;
 
         if (fabs(rightY) > 1.0e-12 && fabs(newY) > 1.0e-12) {

--- a/Framework/Algorithms/src/NormaliseToMonitor.cpp
+++ b/Framework/Algorithms/src/NormaliseToMonitor.cpp
@@ -303,14 +303,18 @@ std::map<std::string, std::string> NormaliseToMonitor::validateInputs() {
     if (monIndex < 0) {
       issues["MonitorWorkspaceIndex"] = "A workspace index cannot be negative.";
     } else if (monWS->getNumberHistograms() <= static_cast<size_t>(monIndex)) {
-      issues["MonitorWorkspaceIndex"] = "The MonitorWorkspace must contain the MonitorWorkspaceIndex.";
+      issues["MonitorWorkspaceIndex"] =
+          "The MonitorWorkspace must contain the MonitorWorkspaceIndex.";
     }
     MatrixWorkspace_const_sptr inWS = getProperty("InputWorkspace");
     if (monWS->getInstrument()->getName() != inWS->getInstrument()->getName()) {
-      issues["MonitorWorkspace"] = "The Input and Monitor workspaces must come from the same instrument.";
+      issues["MonitorWorkspace"] = "The Input and Monitor workspaces must come "
+                                   "from the same instrument.";
     }
-    if (monWS->getAxis(0)->unit()->unitID() != inWS->getAxis(0)->unit()->unitID()) {
-      issues["MonitorWorkspace"] = "The Input and Monitor workspaces must have the same unit";
+    if (monWS->getAxis(0)->unit()->unitID() !=
+        inWS->getAxis(0)->unit()->unitID()) {
+      issues["MonitorWorkspace"] =
+          "The Input and Monitor workspaces must have the same unit";
     }
   }
 

--- a/Framework/Algorithms/src/NormaliseToMonitor.cpp
+++ b/Framework/Algorithms/src/NormaliseToMonitor.cpp
@@ -247,8 +247,7 @@ void NormaliseToMonitor::exec() {
   // First check the inputs
   this->checkProperties(inputWS);
 
-  // See if the normalization with integration properties are set,
-  // throws std::runtime_error if a property is invalid
+  // See if the normalization with integration properties are set.
   const bool integrate = this->setIntegrationProps();
 
   if (integrate) {
@@ -294,12 +293,22 @@ std::map<std::string, std::string> NormaliseToMonitor::validateInputs() {
     issues["MonitorID"] = mess;
     issues["MonitorWorkspace"] = mess;
   }
+
+  const double intMin = getProperty("IntegrationRangeMin");
+  const double intMax = getProperty("IntegrationRangeMax");
+  if (!isEmpty(intMin) && !isEmpty(intMax)) {
+    if (intMin > intMax) {
+      issues["IntegrationRangeMin"] =
+          "Integration minimum set to larger value than maximum.";
+    }
+  }
+
+
   return issues;
 }
 
 /** Makes sure that the input properties are set correctly
  *  @param inputWorkspace The input workspace
- *  @throw std::runtime_error If the properties are invalid
  */
 void NormaliseToMonitor::checkProperties(
     const API::MatrixWorkspace_sptr &inputWorkspace) {
@@ -475,7 +484,6 @@ NormaliseToMonitor::extractMonitorSpectrum(const API::MatrixWorkspace_sptr &WS,
 /** Sets the maximum and minimum X values of the monitor spectrum to use for
  * integration
  *  @return True if the maximum or minimum values are set
- *  @throw std::runtime_error If the minimum was set higher than the maximum
  */
 bool NormaliseToMonitor::setIntegrationProps() {
   m_integrationMin = getProperty("IntegrationRangeMin");
@@ -489,14 +497,6 @@ bool NormaliseToMonitor::setIntegrationProps() {
     return false;
   }
   // Yes integration is going to be used...
-
-  // There is only one set of values that is unacceptable let's check for that
-  if (!isEmpty(m_integrationMin) && !isEmpty(m_integrationMax)) {
-    if (m_integrationMin > m_integrationMax) {
-      throw std::runtime_error(
-          "Integration minimum set to larger value than maximum!");
-    }
-  }
 
   // Now check the end X values are within the X value range of the workspace
   if (isEmpty(m_integrationMin) || m_integrationMin < m_monitor->x(0).front()) {

--- a/Framework/Algorithms/src/NormaliseToMonitor.cpp
+++ b/Framework/Algorithms/src/NormaliseToMonitor.cpp
@@ -294,11 +294,13 @@ std::map<std::string, std::string> NormaliseToMonitor::validateInputs() {
   if (!isEmpty(intMin) && !isEmpty(intMax)) {
     if (intMin > intMax) {
       issues["IntegrationRangeMin"] =
-          "Integration minimum set to larger value than maximum.";
+          "Range minimum set to a larger value than maximum.";
+      issues["IntegrationRangeMax"] =
+          "Range maximum set to a smaller value than minimum.";
     }
   }
 
-  if (monWS) {
+  if (monWS && monSpecProp->isDefault()) {
     const int monIndex = getProperty("MonitorWorkspaceIndex");
     if (monIndex < 0) {
       issues["MonitorWorkspaceIndex"] = "A workspace index cannot be negative.";

--- a/Framework/Algorithms/test/NormaliseToMonitorTest.h
+++ b/Framework/Algorithms/test/NormaliseToMonitorTest.h
@@ -1,14 +1,17 @@
 #ifndef NORMALISETOMONITORTEST_H_
 #define NORMALISETOMONITORTEST_H_
 
-#include "MantidTestHelpers/WorkspaceCreationHelper.h"
 #include <cxxtest/TestSuite.h>
 
+#include "MantidAlgorithms/NormaliseToMonitor.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/FrameworkManager.h"
-#include "MantidAlgorithms/NormaliseToMonitor.h"
 #include "MantidGeometry/Instrument.h"
+#include "MantidHistogramData/BinEdges.h"
+#include "MantidHistogramData/Counts.h"
 #include "MantidKernel/UnitFactory.h"
+#include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
@@ -353,6 +356,7 @@ public:
     TS_ASSERT(!pID->isEnabled(&norm5));
     TS_ASSERT(!pID->isConditionChanged(&norm5));
   }
+
   void testIsConditionChanged() {
     NormaliseToMonitor norm6;
     norm6.initialize();
@@ -368,6 +372,7 @@ public:
     // and second time the monitons should be the same so no changes
     TS_ASSERT(!pID->isConditionChanged(&norm6));
   }
+
   void testAlgoConditionChanged() {
     NormaliseToMonitor norm6;
     norm6.initialize();
@@ -412,6 +417,25 @@ public:
     // it should return the list of allowed monitor ID-s
     monitors = monSpec->allowedValues();
     TS_ASSERT(monitors.empty());
+  }
+
+  void testMonitorWorkspaceNotInADSWorks() {
+    using namespace Mantid::DataObjects;
+    using namespace Mantid::HistogramData;
+    BinEdges xs{-1.0, 1.0};
+    Counts ys{1.0};
+    Histogram h(xs, ys);
+    MatrixWorkspace_sptr monitors = create<Workspace2D>(1, h);
+    NormaliseToMonitor alg;
+    alg.setRethrows(true);
+    alg.setChild(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", monitors))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("OutputWorkspace", "unused_because_child"))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("MonitorWorkspace", monitors))
+    TS_ASSERT_THROWS_NOTHING(alg.execute())
+    TS_ASSERT(alg.isExecuted())
   }
 };
 

--- a/Framework/Algorithms/test/NormaliseToMonitorTest.h
+++ b/Framework/Algorithms/test/NormaliseToMonitorTest.h
@@ -432,7 +432,8 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", monitors))
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("OutputWorkspace", "unused_because_child"))
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setProperty("OutputWorkspace", "unused_because_child"))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("MonitorWorkspace", monitors))
     TS_ASSERT_THROWS_NOTHING(alg.execute())
     TS_ASSERT(alg.isExecuted())


### PR DESCRIPTION
[`NormaliseToMonitor`](http://docs.mantidproject.org/nightly/algorithms/NormaliseToMonitor-v1.html) was testing if the *MonitorWorkspace* property was set by using `Property::isDefault()`. This method does not work as expected if *MonitorWorkspace* is set to a workspace not in the ADS thus preventing the usage of `NormaliseToMonitor` in some scenarios. This PR fixes the bug, as well as improves input property validation in general by moving validation previously scattered around the class methods into the standard `validateInputs()` method.

**To test:**

The following, otherwise valid script will fail if these changes are not applied.
```python
# Prepare a workspace.
createWS = AlgorithmManager.createUnmanaged('CreateSampleWorkspace')
createWS.setChild(True)
createWS.initialize()
createWS.setProperty('OutputWorkspace', 'not-in-ADS-because-child')
createWS.setProperty('NumMonitors', 1)
createWS.execute()
ws = createWS.getProperty('OutputWorkspace').value
# Put monitors into a separate workspace.
separate = AlgorithmManager.createUnmanaged('ExtractMonitors')
separate.setChild(True)
separate.initialize()
separate.setProperty('InputWorkspace', ws)
separate.setProperty('DetectorWorkspace', 'dets-not-in-ADS')
separate.setProperty('MonitorWorkspace', 'mons-not-in-ADS')
separate.execute()
detWS = separate.getProperty('DetectorWorkspace').value
monWS = separate.getProperty('MonitorWorkspace').value
# Run NormaliseToMonitor with a monitor workspace which is not in the ADS.
normalise = AlgorithmManager.createUnmanaged('NormaliseToMonitor')
normalise.setChild(True)
normalise.initialize()
normalise.setProperty('InputWorkspace', detWS)
normalise.setProperty('OutputWorkspace', 'not-in-ADS')
normalise.setProperty('MonitorWorkspace', monWS)
normalise.execute()
ws = normalise.getProperty('OutputWorkspace').value
mtd.addOrReplace('final-product', ws)
```

Fixes #20540.

**Release Notes** 

At the moment, there are no release notes for 3.12.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [x] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
