### PR TITLE
Check SplittersWorkspace before running algorithm

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/FilterEvents.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FilterEvents.h
@@ -72,6 +72,7 @@ public:
   const std::string category() const override {
     return "Events\\EventFiltering";
   }
+  std::map<std::string, std::string> validateInputs() override;
 
 private:
   // Implement abstract Algorithm methods


### PR DESCRIPTION
Move the workspace type checking into `validateInputs()`.

**To test:**

See that normal usage still works and try supplying other random workspaces as the `SplitterWorkspace`.

*This has no associated issue.*

*Does not need to be in the release notes* because it is moving type checking.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
