### PR TITLE
Tie bug that stopped parameters being untied

### DIFF
--- a/docs/source/release/v3.11.0/framework.rst
+++ b/docs/source/release/v3.11.0/framework.rst
@@ -90,6 +90,7 @@ Bug fixes
 
 - :ref:`CubicSpline <func-CubicSpline>` is fixed to sort the y-values and x-values correctly.
 - Fix displayed type name for optional boolean properties.
+- Fix parameters that are tied to functions can now be untied correctly. 
 
 Improved
 ########

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyHandler.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyHandler.h
@@ -167,6 +167,7 @@ public:
 
   void addTie(const QString &tieStr);
   void fix(const QString &parName);
+  void removeTie(QtProperty *prop, std::string globalName);
   void removeTie(QtProperty *prop);
   void removeTie(const QString &propName);
   void addConstraint(QtProperty *parProp, bool lo, bool up, double loBound,
@@ -195,6 +196,8 @@ public:
 
   /// Update high-level structure tooltip and return it
   QString updateStructureTooltip();
+
+  QMap<QString, QtProperty *> getTies() { return m_ties; };
 
 protected slots:
 

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -2076,10 +2076,17 @@ void FitPropertyBrowser::deleteTie() {
   PropertyHandler *h = getHandler()->findHandler(paramProp);
   if (!h)
     return;
-  // get name from composite function
-  if (ci->property()->propertyName() == "Tie") {
+  // get name of parent property (i.e. function)
+  if (paramProp->propertyName() != "Tie") {
+	  auto parameterMap = h->getTies();
+	  auto match = parameterMap.find(paramProp->propertyName());
+	  if (match != parameterMap.end()) {
+		  paramProp = match.value();
+	  }
+  }
+  if (paramProp->propertyName() == "Tie") {
 	  auto ties = h->getTies();
-	  QString qParName = ties.key(ci->property(), "");
+	  QString qParName = ties.key(paramProp, "");
 	  std::string parName = qParName.toStdString();
 	  QStringList functionNames;
 	  // ithParameter = -1 => not found
@@ -2111,7 +2118,7 @@ void FitPropertyBrowser::deleteTie() {
 	  else{
 	  QString tieExpr =
 		  QString::fromStdString(m_compositeFunction->parameterName(ithParameter));
-	  h->removeTie(ci->property(), tieExpr.toStdString());}
+	  h->removeTie(paramProp, tieExpr.toStdString());}
   }
   else {
 	  h->removeTie(ci->property()->propertyName());

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -2079,40 +2079,39 @@ void FitPropertyBrowser::deleteTie() {
   // get name from composite function
   if (ci->property()->propertyName() == "Tie") {
 	  auto ties = h->getTies();
-	  QString QparName = ties.key(ci->property(), "");
-	  std::string parName = QparName.toStdString();
-	  QStringList fnNames;
-
-	  int iPar = -1;
+	  QString qParName = ties.key(ci->property(), "");
+	  std::string parName = qParName.toStdString();
+	  QStringList functionNames;
+	  // ithParameter = -1 => not found
+	  int ithParameter = -1;
 	  for (size_t i = 0; i < m_compositeFunction->nParams(); i++) {
-		  Mantid::API::ParameterReference ref(m_compositeFunction.get(), i);
-		  Mantid::API::IFunction *fun = ref.getLocalFunction();
+		  Mantid::API::ParameterReference parameterRef(m_compositeFunction.get(), i);
+		  Mantid::API::IFunction *function = parameterRef.getLocalFunction();
 
 		  // Pick out parameters with the same name as the one we're tying from
-		  if (fun->parameterName(static_cast<int>(ref.getLocalIndex())) == parName) {
-			  if (iPar == -1 &&
-				  fun ==
+		  if (function->parameterName(static_cast<int>(parameterRef.getLocalIndex())) == parName) {
+			  if (ithParameter == -1 &&
+				  function ==
 				  h->function()
 				  .get()) // If this is the 'tied from' parameter, remember it
 			  {
-				  iPar = (int)i;
+				  ithParameter = static_cast<int>(i);
 			  }
 			  else // Otherwise add it to the list of potential 'tyees'
 			  {
-				  fnNames << QString::fromStdString(
+				  functionNames << QString::fromStdString(
 					  m_compositeFunction->parameterName(i));
 			  }
 		  }
 	  }
-	  if (fnNames.empty() || iPar < 0) {
+	  if (functionNames.empty() || ithParameter < 0) {
 		  QMessageBox::information(this, "Mantid - information",
 			  "Cannot find a parameter with this tie");
-		  return;
 	  }
-
+	  else{
 	  QString tieExpr =
-		  QString::fromStdString(m_compositeFunction->parameterName(iPar));
-	  h->removeTie(ci->property(), tieExpr.toStdString());
+		  QString::fromStdString(m_compositeFunction->parameterName(ithParameter));
+	  h->removeTie(ci->property(), tieExpr.toStdString());}
   }
   else {
 	  h->removeTie(ci->property()->propertyName());

--- a/qt/widgets/common/src/PropertyHandler.cpp
+++ b/qt/widgets/common/src/PropertyHandler.cpp
@@ -6,6 +6,7 @@
 #include "MantidAPI/IBackgroundFunction.h"
 #include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/ParameterTie.h"
+#include "MantidAPI/ParameterReference.h"
 #include "MantidAPI/IConstraint.h"
 #include "MantidAPI/ConstraintFactory.h"
 #include "MantidAPI/AlgorithmManager.h"
@@ -1079,23 +1080,49 @@ void PropertyHandler::fix(const QString &parName) {
 }
 
 /**
- * Remove the tie.
- * @param prop :: The tie property to remove
- */
-void PropertyHandler::removeTie(QtProperty *prop) {
-  QString parName = m_ties.key(prop, "");
-  if (parName.isEmpty())
-    return;
+* Remove the tie.
+* @param prop :: The tie property to remove
+* @param globalName :: Name of the parameter in compoite function
+* (e.g. f1.omega)
+*/
+void PropertyHandler::removeTie(QtProperty *prop, std::string globalName) {
+	QString parName = m_ties.key(prop, "");
+	if (parName.isEmpty())
+		return;
 
-  QtProperty *parProp = getParameterProperty(parName);
-  if (parProp) {
-    m_browser->m_changeSlotsEnabled = false;
-    m_fun->removeTie(parName.toStdString());
-    parProp->removeSubProperty(prop);
-    m_ties.remove(parName);
-    m_browser->m_changeSlotsEnabled = true;
-    parProp->setEnabled(true);
-  }
+	QtProperty *parProp = getParameterProperty(parName);
+	if (parProp) {
+		m_browser->m_changeSlotsEnabled = false;
+		auto tom = parName.toStdString();
+		auto &cfun = *m_browser->compositeFunction();
+		auto index = cfun.parameterIndex(globalName);
+		cfun.removeTie(index);
+		parProp->removeSubProperty(prop);
+		m_ties.remove(QString::fromStdString(globalName));
+		m_ties.remove(parName);
+		m_browser->m_changeSlotsEnabled = true;
+		parProp->setEnabled(true);
+	}
+}
+/**
+* Remove the tie.
+* @param prop :: The tie property to remove
+*/
+void PropertyHandler::removeTie(QtProperty *prop) {
+	QString parName = m_ties.key(prop, "");
+	if (parName.isEmpty())
+		return;
+
+	QtProperty *parProp = getParameterProperty(parName);
+	if (parProp) {
+		m_browser->m_changeSlotsEnabled = false;
+		auto tom = parName.toStdString();
+		m_fun->removeTie(parName.toStdString());
+		parProp->removeSubProperty(prop);
+		m_ties.remove(parName);
+		m_browser->m_changeSlotsEnabled = true;
+		parProp->setEnabled(true);
+	}
 }
 
 /**

--- a/qt/widgets/common/src/PropertyHandler.cpp
+++ b/qt/widgets/common/src/PropertyHandler.cpp
@@ -1093,10 +1093,9 @@ void PropertyHandler::removeTie(QtProperty *prop, std::string globalName) {
 	QtProperty *parProp = getParameterProperty(parName);
 	if (parProp) {
 		m_browser->m_changeSlotsEnabled = false;
-		auto tom = parName.toStdString();
-		auto &cfun = *m_browser->compositeFunction();
-		auto index = cfun.parameterIndex(globalName);
-		cfun.removeTie(index);
+		auto &compositeFunction = *m_browser->compositeFunction();
+		auto index = compositeFunction.parameterIndex(globalName);
+		compositeFunction.removeTie(index);
 		parProp->removeSubProperty(prop);
 		m_ties.remove(QString::fromStdString(globalName));
 		m_ties.remove(parName);
@@ -1114,7 +1113,7 @@ void PropertyHandler::removeTie(QtProperty *prop) {
 		return;
 
 	QtProperty *parProp = getParameterProperty(parName);
-	if (parProp) {
+	if (parProp != nullptr) {
 		m_browser->m_changeSlotsEnabled = false;
 		auto tom = parName.toStdString();
 		m_fun->removeTie(parName.toStdString());


### PR DESCRIPTION
This fixes a bug in Mantid that stopped parameters being untied correctly. 

**To test:**
0. Add 2 of the same function to the fit property browser 
1. Do a fit is done. 
2. Then tie one of the parameters to a function. 
3. Do another fit. 
4. Then untie the parameter (it use to crash here)

Also check that fixes etc still work correctly. 
<!-- Instructions fting. -->

Fixes #20552. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
