### PR TITLE
Python 3 Vesuvio system test failures

### DIFF
--- a/scripts/Inelastic/vesuvio/commands.py
+++ b/scripts/Inelastic/vesuvio/commands.py
@@ -143,6 +143,7 @@ def fit_tof_iteration(sample_data, container_data, runs, flags):
              final fit parameters, chi^2 values)
     """
     # Transform inputs into something the algorithm can understand
+    print("In TOF iteration")
     if isinstance(flags['masses'][0], list):
         mass_values, _, all_mass_values, _ = \
             _create_profile_strs_and_mass_list(copy.deepcopy(flags['masses'][0]))
@@ -570,10 +571,15 @@ def _create_profile_strs_and_mass_list(profile_flags):
     material_builder = MaterialBuilder()
     mass_values, profiles = [], []
     all_mass_values, all_profiles = [], []
-
     for idx, mass_prop in enumerate(profile_flags):
         function_props = ["{0}={1}".format(key, value) for key, value in mass_prop.items()]
-        function_props = ','.join(function_props)
+        # Ensure function_props starts with "function=...,"
+        function_index = [index for index, val in enumerate(function_props) if 'function' in val]
+        if len(function_index) != 1:
+            raise ValueError("Only one function can be defined per mass profile. Found %d functions."
+                             % len(function_index))
+        function_name = function_props.pop(function_index[0])
+        function_props = ("%s,%s" % (function_name, (','.join(function_props))))
 
         mass_value = mass_prop.pop('value', None)
         if mass_value is None:

--- a/scripts/Inelastic/vesuvio/commands.py
+++ b/scripts/Inelastic/vesuvio/commands.py
@@ -571,13 +571,8 @@ def _create_profile_strs_and_mass_list(profile_flags):
     mass_values, profiles = [], []
     all_mass_values, all_profiles = [], []
     for idx, mass_prop in enumerate(profile_flags):
+        function_name = ("function=%s," % mass_prop.pop('function'))
         function_props = ["{0}={1}".format(key, value) for key, value in mass_prop.items()]
-        # Ensure function_props starts with "function=...,"
-        function_index = [index for index, val in enumerate(function_props) if 'function' in val]
-        if len(function_index) != 1:
-            raise ValueError("Only one function can be defined per mass profile. Found %d functions."
-                             % len(function_index))
-        function_name = function_props.pop(function_index[0])
         function_props = ("%s,%s" % (function_name, (','.join(function_props))))
 
         mass_value = mass_prop.pop('value', None)

--- a/scripts/Inelastic/vesuvio/commands.py
+++ b/scripts/Inelastic/vesuvio/commands.py
@@ -143,7 +143,6 @@ def fit_tof_iteration(sample_data, container_data, runs, flags):
              final fit parameters, chi^2 values)
     """
     # Transform inputs into something the algorithm can understand
-    print("In TOF iteration")
     if isinstance(flags['masses'][0], list):
         mass_values, _, all_mass_values, _ = \
             _create_profile_strs_and_mass_list(copy.deepcopy(flags['masses'][0]))


### PR DESCRIPTION
The reliance on the order of the dictionary in Vesuvio commands script has been removed. This was causing failures on the Python 3 build servers as the `function=...` was not at the head of the function string (as expected by algorithms that are run later in the workflow).

**To test:**

* Build changes in this branch on a Python 3 Mantid.
* Run Vesuvio system tests
```
cd mantid/build/dir
./systemtest -R VesuvioCommandsTest
```
* It could be worth running these a couple of times to ensure the fix works as the test can randomly pass if the dict order happens to be correct. **Warning: These tests take some time to execute**

**No issue has been created for this PR**


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
