### PR TITLE
clang-tidy in cmake

### DIFF
--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -251,6 +251,23 @@ elseif ( ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang" )
 endif ()
 
 ###########################################################################
+# Configure clang-tidy if the tool is found
+###########################################################################
+
+if ( CMAKE_VERSION GREATER "3.5" )
+  find_program (CLANG_TIDY_EXE NAMES "clang-tidy")
+  if (CLANG_TIDY_EXE)
+    message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
+    set(ENABLE_CLANG_TIDY OFF CACHE BOOL "Add clang-tidy automatically to builds")
+    if (ENABLE_CLANG_TIDY)
+      set(CLANG_TIDY_CHECKS "-*,performance-for-range-copy,performance-unnecessary-copy-initialization,modernize-use-override,modernize-use-nullptr,modernize-loop-convert,modernize-use-bool-literals,modernize-deprecated-headers,misc-*")
+      set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE};-checks=${CLANG_TIDY_CHECKS};-header-filter='${SOURCE_DIR}/*'"
+        CACHE STRING "" FORCE)
+    endif()
+  endif()
+endif()
+
+###########################################################################
 # Setup cppcheck
 ###########################################################################
 include ( CppCheckSetup )

--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -263,6 +263,8 @@ if ( CMAKE_VERSION GREATER "3.5" )
       set(CLANG_TIDY_CHECKS "-*,performance-for-range-copy,performance-unnecessary-copy-initialization,modernize-use-override,modernize-use-nullptr,modernize-loop-convert,modernize-use-bool-literals,modernize-deprecated-headers,misc-*")
       set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE};-checks=${CLANG_TIDY_CHECKS};-header-filter='${SOURCE_DIR}/*'"
         CACHE STRING "" FORCE)
+    else()
+      set(CMAKE_CXX_CLANG_TIDY "" CACHE STRING "" FORCE) # delete it
     endif()
   endif()
 endif()


### PR DESCRIPTION
Add configuration to `cmake` to allow for running `clang-tidy` during every compile. The way that `cmake` configures the build scripts will have this run in parallel and the results of `clang-tidy` appear as compiler warnings to the IDE. This will also allow for simplifying the [clang-tidy build](http://builds.mantidproject.org/job/clang_tidy_framework/) and promote a consistent way for developers to run things.

The way this is implemented a developer must use a supported generator (e.g. `-G Ninja`), have `clang-tidy` installed, and opt-in by specifying `-DENABLE_CLANG_TIDY=On` and configuration time. Reconfiguring with `-DENABLE_CLANG_TIDY=Off` will turn it off. The only problem with changing the configuration is that it invalidates all of your compiled code.

**To test:**

1. create a new build area with `cmake -G Ninja -DENABLE_CLANG_TIDY=On ...`
2. `cmake --build . --target Kernel`
3. bask in the glow of ~500 new warnings

*There is no associated issue.*

*Does not need to be in the release notes* because it is directed at developers.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
