### PR TITLE
Changed Both to All in batch_execution.py

### DIFF
--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -615,7 +615,7 @@ def set_properties_for_reduction_algorithm(reduction_alg, reduction_package, wor
     elif reduction_mode is ISISReductionMode.HAB:
         _set_output_name(reduction_alg, reduction_package, is_group, ISISReductionMode.HAB,
                          "OutputWorkspaceHAB", "reduced_hab_name", "reduced_hab_base_name")
-    elif reduction_mode is ISISReductionMode.Both:
+    elif reduction_mode is ISISReductionMode.All:
         _set_output_name(reduction_alg, reduction_package, is_group, ISISReductionMode.LAB,
                          "OutputWorkspaceLAB", "reduced_lab_name", "reduced_lab_base_name")
         _set_output_name(reduction_alg, reduction_package, is_group, ISISReductionMode.HAB,
@@ -636,7 +636,7 @@ def set_properties_for_reduction_algorithm(reduction_alg, reduction_package, wor
         _set_lab(reduction_alg, reduction_package, is_group)
     elif reduction_mode is ISISReductionMode.HAB:
         _set_hab(reduction_alg, reduction_package, is_group)
-    elif reduction_mode is ISISReductionMode.Both:
+    elif reduction_mode is ISISReductionMode.All:
         _set_lab(reduction_alg, reduction_package, is_group)
         _set_hab(reduction_alg, reduction_package, is_group)
     else:


### PR DESCRIPTION
Description of work.
When the SANS v2 GUi tries to do a reduction in mode All, it throws an error as it attempts to access ISISReductionMode.Both rather than ISISReductionMode.All
**To test:**
Grab some test data, for example from \olympic\Babylon5\Scratch\Matthew Andrew\GUI_TEST
Open the SANS v2 GUI
Load in a userfile and a batch file
In Settings->General-> switch the reduction mode to Both
Click Process
<!-- Instructions for testing. -->

Fixes #20613. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
No new release notes as just bug fix
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
