### PR TITLE
Ensure the correct generator is used for eigen & xmlrunner

### DIFF
--- a/buildconfig/CMake/Eigen.cmake
+++ b/buildconfig/CMake/Eigen.cmake
@@ -19,7 +19,7 @@ else()
   # for static libraries, object libraries, and executables without exports.
   cmake_policy(SET CMP0063 "OLD")
 
-  execute_process(COMMAND ${CMAKE_COMMAND} . WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/eigen-download )
+  execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" . WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/eigen-download )
   execute_process(COMMAND ${CMAKE_COMMAND} --build . WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/eigen-download )
 
   set(EIGEN3_INCLUDE_DIR "${CMAKE_BINARY_DIR}/eigen-src" CACHE PATH "Eigen include directory")

--- a/buildconfig/CMake/Python-xmlrunner.cmake
+++ b/buildconfig/CMake/Python-xmlrunner.cmake
@@ -14,10 +14,8 @@ else()
   set ( XMLRUNNER_DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/python-xmlrunner-download )
   configure_file(${CMAKE_SOURCE_DIR}/buildconfig/CMake/Python-xmlrunner.in ${XMLRUNNER_DOWNLOAD_DIR}/CMakeLists.txt)
 
-  execute_process(COMMAND ${CMAKE_COMMAND}
-    ARGS -G "${CMAKE_GENERATOR}" . WORKING_DIRECTORY ${XMLRUNNER_DOWNLOAD_DIR} )
-  execute_process(COMMAND ${CMAKE_COMMAND}
-    ARGS --build . WORKING_DIRECTORY ${XMLRUNNER_DOWNLOAD_DIR} )
+  execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" . WORKING_DIRECTORY ${XMLRUNNER_DOWNLOAD_DIR} )
+  execute_process(COMMAND ${CMAKE_COMMAND} --build . WORKING_DIRECTORY ${XMLRUNNER_DOWNLOAD_DIR} )
 
   set(PYTHON_XMLRUNNER_DIR "${CMAKE_BINARY_DIR}/python-xmlrunner-src" CACHE PATH "Location of xmlrunner package")
 

--- a/buildconfig/CMake/Python-xmlrunner.cmake
+++ b/buildconfig/CMake/Python-xmlrunner.cmake
@@ -14,8 +14,10 @@ else()
   set ( XMLRUNNER_DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/python-xmlrunner-download )
   configure_file(${CMAKE_SOURCE_DIR}/buildconfig/CMake/Python-xmlrunner.in ${XMLRUNNER_DOWNLOAD_DIR}/CMakeLists.txt)
 
-  execute_process(COMMAND ${CMAKE_COMMAND} . WORKING_DIRECTORY ${XMLRUNNER_DOWNLOAD_DIR} )
-  execute_process(COMMAND ${CMAKE_COMMAND} --build . WORKING_DIRECTORY ${XMLRUNNER_DOWNLOAD_DIR} )
+  execute_process(COMMAND ${CMAKE_COMMAND}
+    ARGS -G "${CMAKE_GENERATOR}" . WORKING_DIRECTORY ${XMLRUNNER_DOWNLOAD_DIR} )
+  execute_process(COMMAND ${CMAKE_COMMAND}
+    ARGS --build . WORKING_DIRECTORY ${XMLRUNNER_DOWNLOAD_DIR} )
 
   set(PYTHON_XMLRUNNER_DIR "${CMAKE_BINARY_DIR}/python-xmlrunner-src" CACHE PATH "Location of xmlrunner package")
 

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -74,7 +74,6 @@ if [[ ${PRBUILD} == true ]]; then
   fi
 fi
 
-
 ###############################################################################
 # Setup the build directory
 # For a clean build the entire thing is removed to guarantee it is clean. All
@@ -96,9 +95,20 @@ if [[ "$CLEANBUILD" == true ]]; then
 fi
 if [ -d $BUILD_DIR ]; then
   rm -rf $BUILD_DIR/bin $BUILD_DIR/ExternalData
+  ###############################################################################
+  # Temporary fix to clean build directories while
+  # https://github.com/mantidproject/mantid/pull/20617 is pushed through
+  ###############################################################################
+  _main_generator=$(grep "CMAKE_GENERATOR:INTERNAL" ${BUILD_DIR}/CMakeCache.txt)
+  _eigen_generator=$(grep "CMAKE_GENERATOR:INTERNAL"  ${BUILD_DIR}/eigen-download/CMakeCache.txt)
+  if [ "${_main_generator}" != "${_eigen_generator}" ]; then
+    echo "External project generator mismatch. Cleaning external projects"
+    CLEAN_EXTERNAL_PROJECTS=true
+  fi
   if [[ -n ${CLEAN_EXTERNAL_PROJECTS} && "${CLEAN_EXTERNAL_PROJECTS}" == true ]]; then
       rm -rf $BUILD_DIR/eigen-*
       rm -rf $BUILD_DIR/googletest-*
+      rm -fr $BUILD_DIR/python-xmlrunner-*
   fi
 else
   mkdir $BUILD_DIR

--- a/buildconfig/Jenkins/buildscript.bat
+++ b/buildconfig/Jenkins/buildscript.bat
@@ -14,6 +14,11 @@ call cmake.exe --version
 echo %sha1%
 set VS_VERSION=14
 
+:: Find the grep tool for later
+for /f "delims=" %%I in ('where git') do @set GIT_EXE_DIR=%%~dpI
+set GIT_ROOT_DIR=%GIT_EXE_DIR:~0,-4%
+set GREP_EXE=%GIT_ROOT_DIR%\usr\bin\grep.exe
+
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: Environment setup
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -75,6 +80,17 @@ if "!CLEANBUILD!" == "yes" (
 
 if EXIST %BUILD_DIR% (
   rmdir /S /Q %BUILD_DIR%\bin %BUILD_DIR%\ExternalData
+  call "%GREP_EXE%" CMAKE_GENERATOR:INTERNAL %BUILD_DIR%\eigen-download\CMakeCache.txt > eigen_generator.log
+  call "%GREP_EXE%" "%CM_GENERATOR%" eigen_generator.log
+  if ERRORLEVEL 1 (
+    echo External project generator mismatch. Cleaning external projects
+    set CLEAN_EXTERNAL_PROJECTS=true
+  )
+  if "!CLEAN_EXTERNAL_PROJECTS!" == "true" (
+    rmdir /S /Q %BUILD_DIR%\eigen-download %BUILD_DIR%\eigen-src
+    rmdir /S /Q %BUILD_DIR%\googletest-download %BUILD_DIR%\googletest-src
+    rmdir /S /Q %BUILD_DIR%\python-xmlrunner-download %BUILD_DIR%\python-xmlrunner-src
+  )
 ) else (
   md %BUILD_DIR%
 )


### PR DESCRIPTION
Description of work.

Passes the `-G ${CMAKE_GENERATOR}` argument to the `cmake` command that processes the external project configure commands for eigen and xmlrunner.

This is required on Windows where Visual Studio 2015 & 2017 are installed along with more cmake > 3.7. Without these changes the eigen & xmlrunner steps use the 2017 generator regardless of the generator chosen by the caller.

**To test:**

Code review.

*No issue*

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
