### PR TITLE
Fix missing indirect reduction tabs

### DIFF
--- a/qt/scientific_interfaces/Indirect/IndirectDataReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReduction.cpp
@@ -9,6 +9,7 @@
 #include "MantidGeometry/IComponent.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/ConfigService.h"
+#include "MantidKernel/FacilityInfo.h"
 #include "MantidQtWidgets/Common/HelpWindow.h"
 #include "MantidQtWidgets/Common/ManageUserDirectories.h"
 #include "IndirectMoments.h"
@@ -143,9 +144,8 @@ void IndirectDataReduction::initLayout() {
   // Update the instrument configuration across the UI
   m_uiForm.iicInstrumentConfiguration->newInstrumentConfiguration();
 
-  std::string facility =
-      Mantid::Kernel::ConfigService::Instance().getString("default.facility");
-  filterUiForFacility(QString::fromStdString(facility));
+  auto facility = Mantid::Kernel::ConfigService::Instance().getFacility();
+  filterUiForFacility(QString::fromStdString(facility.name()));
   emit newInstrumentConfiguration();
 }
 
@@ -463,7 +463,6 @@ void IndirectDataReduction::saveSettings() {
 void IndirectDataReduction::filterUiForFacility(QString facility) {
   g_log.information() << "Facility selected: " << facility.toStdString()
                       << '\n';
-
   QStringList enabledTabs;
   QStringList disabledInstruments;
 


### PR DESCRIPTION
Description of work.

The indirect reduction tabs were checking for the facility but were not checking whether the returned string was empty. This lead to missing tabs if the facility was not set correctly.

**To test:**

Before merging, check

* start MantidPlot
* in IPython type `config['default.facility] = ""`
* start `Interfaces->Indirect->Data Reduction`
* see that tabs are missing

after merging perform the same check and see that ISIS tabs are present.

*No issue*

**Release Notes** 

*Introduced in this cycle so it does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
