### PR TITLE
TOFTOF GUI refactoring

### DIFF
--- a/instrument/TOFTOF_Parameters.xml
+++ b/instrument/TOFTOF_Parameters.xml
@@ -25,6 +25,30 @@
 			<value val="sqrt(e/25.3)" />
 		</parameter>
 
+                <!-- parameters to merge sample logs by MergeRuns algorithm -->
+                <parameter name="sample_logs_sum" type="string">
+                    <value val="monitor_counts, duration" />
+                </parameter>
+                <parameter name="sample_logs_time_series" type="string">
+                    <value val="temperature" />
+                </parameter>
+                <parameter name="sample_logs_list" type="string">
+                    <value val="run_number,run_start,run_end" />
+                </parameter>
+                <parameter name="sample_logs_warn" type="string">
+                    <value val="temperature, run_title" />
+                </parameter>
+                <parameter name="sample_logs_warn_tolerances" type="string">
+                    <value val="1.0, 0" />
+                </parameter>
+                <parameter name="sample_logs_fail" type="string">
+                    <value val="chopper_speed, channel_width, chopper_ratio, Ei, wavelength, full_channels, EPP" />
+                </parameter>
+                <parameter name="sample_logs_fail_tolerances" type="string">
+                    <value val="10, 0.01, 0.01, 0.0001, 0.001, 0.1, 0.1" />
+                </parameter>
+
+
           
 	</component-link>
 

--- a/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
+++ b/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
@@ -482,7 +482,7 @@ class TOFTOFScriptElement(BaseScriptElement):
               .format(self.prefix))
         if self.binQon:
             l("for ws in {}:" .format(gDataBinQ))
-            l("    RenameWorkspace(ws, OutputWorkspace='{}_SQW_' + ws.getComment())"
+            l("    RenameWorkspace(ws, OutputWorkspace='{}_' + ws.getComment() + '_sqw')"
               .format(self.prefix))
 
         return script[0]

--- a/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
+++ b/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
@@ -339,7 +339,7 @@ class TOFTOFScriptElement(BaseScriptElement):
         self.l("# save {}".format(wsgroup))
         self.l("for ws in {}:".format(wsgroup))
         self.l("    name = ws.getComment() + {}".format(suffix))
-        if self.saveNXSPE:
+        if self.saveNXSPE and self.binEon:
             self.l("    SaveNXSPE(ws, join('{}', name + '.nxspe'), Efixed=Ei)".format(self.saveDir))
         if self.saveNexus:
             self.l("    SaveNexus(ws, join('{}', name + '.nxs'))".format(self.saveDir))

--- a/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
+++ b/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
@@ -46,6 +46,13 @@ class TOFTOFScriptElement(BaseScriptElement):
     DEF_normalise  = NORM_NONE
     DEF_correctTof = CORR_TOF_NONE
 
+    DEF_saveDir    = ''
+    DEF_saveSofQW  = False
+    DEF_saveSofTW  = False
+    DEF_saveNXSPE  = False
+    DEF_saveNexus  = False
+    DEF_saveAscii  = False
+
     XML_TAG = 'TOFTOFReduction'
 
     def reset(self):
@@ -90,6 +97,14 @@ class TOFTOFScriptElement(BaseScriptElement):
         self.createDiff    = self.DEF_createDiff
         self.keepSteps     = self.DEF_keepSteps
 
+        # save data
+        self.saveDir      = self.DEF_saveDir
+        self.saveSofQW    = self.DEF_saveSofQW
+        self.saveSofTW    = self.DEF_saveSofTW
+        self.saveNXSPE    = self.DEF_saveNXSPE
+        self.saveNexus    = self.DEF_saveNexus
+        self.saveAscii    = self.DEF_saveAscii
+
     def to_xml(self):
         res = ['']
 
@@ -127,6 +142,13 @@ class TOFTOFScriptElement(BaseScriptElement):
         put('replace_nans',   self.replaceNaNs)
         put('create_diff',    self.createDiff)
         put('keep_steps',     self.keepSteps)
+
+        put('save_dir',      self.saveDir)
+        put('save_sofqw',    self.saveSofQW)
+        put('save_softw',    self.saveSofTW)
+        put('save_nxspe',    self.saveNXSPE)
+        put('save_nexus',    self.saveNexus)
+        put('save_ascii',    self.saveAscii)
 
         return '<{0}>\n{1}</{0}>\n'.format(self.XML_TAG, res[0])
 
@@ -187,6 +209,13 @@ class TOFTOFScriptElement(BaseScriptElement):
             self.createDiff    = get_bol('create_diff',    self.DEF_createDiff)
             self.keepSteps     = get_bol('keep_steps',     self.DEF_keepSteps)
 
+            self.saveDir     = get_str('save_dir',     self.DEF_saveDir)
+            self.saveSofQW   = get_bol('save_sofqw',   self.DEF_saveSofQW)
+            self.saveSofTW   = get_bol('save_softw',   self.DEF_saveSofTW)
+            self.saveNXSPE   = get_bol('save_nxspe',   self.DEF_saveNXSPE)
+            self.saveNexus   = get_bol('save_nexus',   self.DEF_saveNexus)
+            self.saveAscii   = get_bol('save_ascii',   self.DEF_saveAscii)
+
     def to_script(self):
 
         def error(message):
@@ -223,6 +252,15 @@ class TOFTOFScriptElement(BaseScriptElement):
         # must have a comment for runs
         if self.vanRuns and not self.vanCmnt:
             error('missing vanadium comment')
+
+        # saving settings must be consistent
+        if self.saveNXSPE or self.saveNexus or self.saveAscii:
+            if not self.saveDir:
+                error('missing directory to save the data')
+            elif not (self.saveSofQW or self.saveSofTW):
+                error('you must select workspaces to save')
+        elif self.saveDir or self.saveSofQW or self.saveSofTW:
+            error('missing data format to save')
 
         # generated script
         script = ['']

--- a/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
+++ b/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
@@ -40,6 +40,7 @@ class TOFTOFScriptElement(BaseScriptElement):
     DEF_binQend    = 0.0
 
     DEF_subECVan   = False
+    DEF_replaceNaNs   = False
     DEF_normalise  = NORM_NONE
     DEF_correctTof = CORR_TOF_NONE
 
@@ -83,6 +84,7 @@ class TOFTOFScriptElement(BaseScriptElement):
         self.subtractECVan = self.DEF_subECVan
         self.normalise     = self.DEF_normalise
         self.correctTof    = self.DEF_correctTof
+        self.replaceNaNs   = self.DEF_replaceNaNs
 
     def to_xml(self):
         res = ['']
@@ -118,6 +120,7 @@ class TOFTOFScriptElement(BaseScriptElement):
         put('subtract_ecvan', self.subtractECVan)
         put('normalise',      self.normalise)
         put('correct_tof',    self.correctTof)
+        put('replace_nans', self.replaceNaNs)
 
         return '<{0}>\n{1}</{0}>\n'.format(self.XML_TAG, res[0])
 
@@ -174,6 +177,7 @@ class TOFTOFScriptElement(BaseScriptElement):
             self.subtractECVan = get_bol('subtract_ecvan', self.DEF_subECVan)
             self.normalise     = get_int('normalise',      self.DEF_normalise)
             self.correctTof    = get_int('correct_tof',    self.DEF_correctTof)
+            self.replaceNaNs   = get_bol('replace_nans', self.DEF_replaceNaNs)
 
     def to_script(self):
 
@@ -464,8 +468,8 @@ class TOFTOFScriptElement(BaseScriptElement):
             l("# calculate momentum transfer Q for sample data")
             l("rebinQ = '{:.3f}, {:.3f}, {:.3f}'"
               .format(self.binQstart, self.binQstep, self.binQend))
-            l("{} = SofQW3({}, QAxisBinning=rebinQ, EMode='Direct', EFixed=Ei)"
-              .format(gDataBinQ, gLast))
+            l("{} = SofQW3({}, QAxisBinning=rebinQ, EMode='Direct', EFixed=Ei, ReplaceNaNs={})"
+              .format(gDataBinQ, gLast, self.replaceNaNs))
             l()
 
         l("# make nice workspace names")

--- a/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
+++ b/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
@@ -393,7 +393,7 @@ class TOFTOFScriptElement(BaseScriptElement):
         if self.CORR_TOF_VAN == self.correctTof:
             self.l("# apply vanadium TOF correction")
             self.l("{} = CorrectTOF({}, {})".format(gData2, gDataCleanFrame, eppTable))
-            self.delete_workspaces([gDataCleanFrame, eppTable])
+            self.delete_workspaces([gDataCleanFrame, gData, eppTable])
             return True
 
         elif self.CORR_TOF_SAMPLE == self.correctTof:
@@ -401,11 +401,11 @@ class TOFTOFScriptElement(BaseScriptElement):
             self.l("# apply sample TOF correction")
             self.l("{} = FindEPP({})".format(eppTables, gData))
             self.l("{} = CorrectTOF({}, {})".format(gData2, gDataCleanFrame, eppTables))
-            self.delete_workspaces([gDataCleanFrame, eppTables])
+            self.delete_workspaces([gDataCleanFrame, gData, eppTables])
             return True
 
         if self.vanRuns:
-            self.delete_workspaces([eppTable])
+            self.delete_workspaces([eppTable, gData])
         else:
             self.delete_workspaces([gData])
         return False
@@ -532,6 +532,8 @@ class TOFTOFScriptElement(BaseScriptElement):
                .format(gDataCleanFrame, gDataCorr))
         if self.vanRuns:
             self.delete_workspaces([gDataCorr])
+        if self.ecRuns:
+            self.delete_workspaces([gDataSubEC])
 
         tof_corrected = self.correct_tof(gData)
         gData2 = gData + 'TofCorr' if tof_corrected else gDataCleanFrame

--- a/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
@@ -409,7 +409,9 @@ class TOFTOFSetupWidget(BaseWidget):
         if not onVal:
             self.chkNxspe.setChecked(False)
             self.chkReplaceNaNs.setChecked(False)
-        for widget in (self.binEstart, self.binEstep, self.binEend, self.chkCreateDiff, self.chkNxspe, self.chkReplaceNaNs):
+            self.binQon.setChecked(False)
+        for widget in (self.binEstart, self.binEstep, self.binEend, self.chkCreateDiff, self.chkNxspe, self.binQon,
+                       self.binQstart, self.binQstep, self.binQend, self.chkReplaceNaNs, self.chkSofQW):
             widget.setEnabled(onVal)
 
     def _onBinQon(self, onVal):

--- a/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
@@ -168,7 +168,8 @@ class TOFTOFSetupWidget(BaseWidget):
     TIP_dataRunsView = ''
 
     TIP_chkSubtractECVan = ''
-    TIP_chkReplaceNaNs = ''
+    TIP_chkReplaceNaNs = 'Replace NaNs with 0'
+    TIP_chkCreateDiff = ''
 
     TIP_rbtNormaliseNone = ''
     TIP_rbtNormaliseMonitor = ''
@@ -237,6 +238,7 @@ class TOFTOFSetupWidget(BaseWidget):
 
         self.chkSubtractECVan    = tip(QCheckBox('Subtract empty can from vanadium'), self.TIP_chkSubtractECVan)
         self.chkReplaceNaNs      = tip(QCheckBox('Replace special values in S(Q,W) with 0'), self.TIP_chkReplaceNaNs)
+        self.chkCreateDiff       = tip(QCheckBox('Create diffractograms'), self.TIP_chkCreateDiff)
 
         self.rbtNormaliseNone    = tip(QRadioButton('none'), self.TIP_rbtNormaliseNone)
         self.rbtNormaliseMonitor = tip(QRadioButton('to monitor'), self.TIP_rbtNormaliseMonitor)
@@ -297,6 +299,7 @@ class TOFTOFSetupWidget(BaseWidget):
         grid.addWidget(self.rbtCorrectTOFVan,   2, 2)
         grid.addWidget(self.rbtCorrectTOFSample,2, 3)
         grid.addWidget(self.chkReplaceNaNs,   3, 0, 1, 4)
+        grid.addWidget(self.chkCreateDiff,   4, 0, 1, 4)
         grid.setColumnStretch(4, 1)
 
         gbOptions.setLayout(grid)
@@ -362,11 +365,11 @@ class TOFTOFSetupWidget(BaseWidget):
             self.dataDir.setText(dirname)
 
     def _onBinEon(self, onVal):
-        for widget in (self.binEstart, self.binEstep, self.binEend):
+        for widget in (self.binEstart, self.binEstep, self.binEend, self.chkCreateDiff):
             widget.setEnabled(onVal)
 
     def _onBinQon(self, onVal):
-        for widget in (self.binQstart, self.binQstep, self.binQend):
+        for widget in (self.binQstart, self.binQstep, self.binQend, self.chkReplaceNaNs):
             widget.setEnabled(onVal)
 
     def _onSelectedCell(self, index):
@@ -407,6 +410,7 @@ class TOFTOFSetupWidget(BaseWidget):
 
         elem.subtractECVan = self.chkSubtractECVan.isChecked()
         elem.replaceNaNs   = self.chkReplaceNaNs.isChecked()
+        elem.createDiff   = self.chkCreateDiff.isChecked()
 
         elem.normalise     = elem.NORM_MONITOR    if self.rbtNormaliseMonitor.isChecked() else \
             elem.NORM_TIME       if self.rbtNormaliseTime.isChecked()    else \
@@ -451,6 +455,7 @@ class TOFTOFSetupWidget(BaseWidget):
 
         self.chkSubtractECVan.setChecked(elem.subtractECVan)
         self.chkReplaceNaNs.setChecked(elem.replaceNaNs)
+        self.chkCreateDiff.setChecked(elem.createDiff)
 
         if elem.normalise == elem.NORM_MONITOR:
             self.rbtNormaliseMonitor.setChecked(True)

--- a/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
@@ -302,7 +302,7 @@ class TOFTOFSetupWidget(BaseWidget):
         self._layout.addLayout(box)
 
         box.addLayout(hbox((gbDataDir, gbPrefix)))
-        box.addLayout(hbox((vbox((gbInputs, gbBinning, gbOptions, gbSave, 1)), gbData)))
+        box.addLayout(hbox((vbox((gbInputs, gbBinning, gbOptions, 1)), vbox((gbData, gbSave)))))
 
         gbDataDir.setLayout(hbox((self.dataDir, self.btnDataDir)))
         gbPrefix.setLayout(hbox((self.prefix,)))

--- a/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
@@ -236,7 +236,7 @@ class TOFTOFSetupWidget(BaseWidget):
         self.btnDataDir          = tip(QPushButton('Browse'), self.TIP_btnDataDir)
 
         self.chkSubtractECVan    = tip(QCheckBox('Subtract empty can from vanadium'), self.TIP_chkSubtractECVan)
-        self.chkReplaceNaNs      = tip(QCheckBox('Replace special values in S(Q,W)'), self.TIP_chkReplaceNaNs)
+        self.chkReplaceNaNs      = tip(QCheckBox('Replace special values in S(Q,W) with 0'), self.TIP_chkReplaceNaNs)
 
         self.rbtNormaliseNone    = tip(QRadioButton('none'), self.TIP_rbtNormaliseNone)
         self.rbtNormaliseMonitor = tip(QRadioButton('to monitor'), self.TIP_rbtNormaliseMonitor)

--- a/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
@@ -406,7 +406,9 @@ class TOFTOFSetupWidget(BaseWidget):
             self.saveDir.setText(dirname)
 
     def _onBinEon(self, onVal):
-        for widget in (self.binEstart, self.binEstep, self.binEend, self.chkCreateDiff):
+        if not onVal:
+            self.chkNxspe.setChecked(False)
+        for widget in (self.binEstart, self.binEstep, self.binEend, self.chkCreateDiff, self.chkNxspe):
             widget.setEnabled(onVal)
 
     def _onBinQon(self, onVal):

--- a/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
@@ -168,6 +168,7 @@ class TOFTOFSetupWidget(BaseWidget):
     TIP_dataRunsView = ''
 
     TIP_chkSubtractECVan = ''
+    TIP_chkReplaceNaNs = ''
 
     TIP_rbtNormaliseNone = ''
     TIP_rbtNormaliseMonitor = ''
@@ -235,6 +236,7 @@ class TOFTOFSetupWidget(BaseWidget):
         self.btnDataDir          = tip(QPushButton('Browse'), self.TIP_btnDataDir)
 
         self.chkSubtractECVan    = tip(QCheckBox('Subtract empty can from vanadium'), self.TIP_chkSubtractECVan)
+        self.chkReplaceNaNs      = tip(QCheckBox('Replace special values in S(Q,W)'), self.TIP_chkReplaceNaNs)
 
         self.rbtNormaliseNone    = tip(QRadioButton('none'), self.TIP_rbtNormaliseNone)
         self.rbtNormaliseMonitor = tip(QRadioButton('to monitor'), self.TIP_rbtNormaliseMonitor)
@@ -294,6 +296,7 @@ class TOFTOFSetupWidget(BaseWidget):
         grid.addWidget(self.rbtCorrectTOFNone,  2, 1)
         grid.addWidget(self.rbtCorrectTOFVan,   2, 2)
         grid.addWidget(self.rbtCorrectTOFSample,2, 3)
+        grid.addWidget(self.chkReplaceNaNs,   3, 0, 1, 4)
         grid.setColumnStretch(4, 1)
 
         gbOptions.setLayout(grid)
@@ -403,6 +406,7 @@ class TOFTOFSetupWidget(BaseWidget):
         elem.maskDetectors = line_text(self.maskDetectors)
 
         elem.subtractECVan = self.chkSubtractECVan.isChecked()
+        elem.replaceNaNs   = self.chkReplaceNaNs.isChecked()
 
         elem.normalise     = elem.NORM_MONITOR    if self.rbtNormaliseMonitor.isChecked() else \
             elem.NORM_TIME       if self.rbtNormaliseTime.isChecked()    else \
@@ -446,6 +450,7 @@ class TOFTOFSetupWidget(BaseWidget):
         self.maskDetectors.setText(elem.maskDetectors)
 
         self.chkSubtractECVan.setChecked(elem.subtractECVan)
+        self.chkReplaceNaNs.setChecked(elem.replaceNaNs)
 
         if elem.normalise == elem.NORM_MONITOR:
             self.rbtNormaliseMonitor.setChecked(True)

--- a/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
@@ -454,6 +454,7 @@ class TOFTOFSetupWidget(BaseWidget):
         elem.createDiff    = self.chkCreateDiff.isChecked()
         elem.keepSteps     = self.chkKeepSteps.isChecked()
 
+        elem.saveDir       = line_text(self.saveDir)
         elem.saveSofQW     = self.chkSofQW.isChecked()
         elem.saveSofTW     = self.chkSofTW.isChecked()
         elem.saveNXSPE     = self.chkNxspe.isChecked()

--- a/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
@@ -170,6 +170,7 @@ class TOFTOFSetupWidget(BaseWidget):
     TIP_chkSubtractECVan = ''
     TIP_chkReplaceNaNs = 'Replace NaNs with 0'
     TIP_chkCreateDiff = ''
+    TIP_chkKeepSteps = ''
 
     TIP_rbtNormaliseNone = ''
     TIP_rbtNormaliseMonitor = ''
@@ -239,6 +240,7 @@ class TOFTOFSetupWidget(BaseWidget):
         self.chkSubtractECVan    = tip(QCheckBox('Subtract empty can from vanadium'), self.TIP_chkSubtractECVan)
         self.chkReplaceNaNs      = tip(QCheckBox('Replace special values in S(Q,W) with 0'), self.TIP_chkReplaceNaNs)
         self.chkCreateDiff       = tip(QCheckBox('Create diffractograms'), self.TIP_chkCreateDiff)
+        self.chkKeepSteps        = tip(QCheckBox('Keep intermediate steps'), self.TIP_chkKeepSteps)
 
         self.rbtNormaliseNone    = tip(QRadioButton('none'), self.TIP_rbtNormaliseNone)
         self.rbtNormaliseMonitor = tip(QRadioButton('to monitor'), self.TIP_rbtNormaliseMonitor)
@@ -299,7 +301,8 @@ class TOFTOFSetupWidget(BaseWidget):
         grid.addWidget(self.rbtCorrectTOFVan,   2, 2)
         grid.addWidget(self.rbtCorrectTOFSample,2, 3)
         grid.addWidget(self.chkReplaceNaNs,   3, 0, 1, 4)
-        grid.addWidget(self.chkCreateDiff,   4, 0, 1, 4)
+        grid.addWidget(self.chkCreateDiff,    4, 0, 1, 4)
+        grid.addWidget(self.chkKeepSteps,     5, 0, 1, 4)
         grid.setColumnStretch(4, 1)
 
         gbOptions.setLayout(grid)
@@ -410,7 +413,8 @@ class TOFTOFSetupWidget(BaseWidget):
 
         elem.subtractECVan = self.chkSubtractECVan.isChecked()
         elem.replaceNaNs   = self.chkReplaceNaNs.isChecked()
-        elem.createDiff   = self.chkCreateDiff.isChecked()
+        elem.createDiff    = self.chkCreateDiff.isChecked()
+        elem.keepSteps     = self.chkKeepSteps.isChecked()
 
         elem.normalise     = elem.NORM_MONITOR    if self.rbtNormaliseMonitor.isChecked() else \
             elem.NORM_TIME       if self.rbtNormaliseTime.isChecked()    else \
@@ -456,6 +460,7 @@ class TOFTOFSetupWidget(BaseWidget):
         self.chkSubtractECVan.setChecked(elem.subtractECVan)
         self.chkReplaceNaNs.setChecked(elem.replaceNaNs)
         self.chkCreateDiff.setChecked(elem.createDiff)
+        self.chkKeepSteps.setChecked(elem.keepSteps)
 
         if elem.normalise == elem.NORM_MONITOR:
             self.rbtNormaliseMonitor.setChecked(True)

--- a/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
@@ -408,7 +408,8 @@ class TOFTOFSetupWidget(BaseWidget):
     def _onBinEon(self, onVal):
         if not onVal:
             self.chkNxspe.setChecked(False)
-        for widget in (self.binEstart, self.binEstep, self.binEend, self.chkCreateDiff, self.chkNxspe):
+            self.chkReplaceNaNs.setChecked(False)
+        for widget in (self.binEstart, self.binEstep, self.binEend, self.chkCreateDiff, self.chkNxspe, self.chkReplaceNaNs):
             widget.setEnabled(onVal)
 
     def _onBinQon(self, onVal):


### PR DESCRIPTION
This PR:
1. adds to TOFTOF GUI features requested by instrument scientist
2. switches the data reduction workflow to MergeRuns instead of TOFTOFMergeRuns (TOFTOFMergeRuns can be deprecated in the next release)
3. reduces number of flake8 warnings in the toftof_reduction script (#20508).

**To test:**
Download the test data 
[testdata.zip](https://github.com/mantidproject/mantid/files/1329808/testdata.zip)

Start the TOFTOF data reduction GUI: Interfaces->Direct->DGS Reduction and choose facility MLZ and instrument TOFTOF.

Test that the GUI works at different settings and that the consistent Python script is generated with 'Export' button.

<!-- Instructions for testing. -->

Fixes #20535. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
