### PR TITLE
Fix Mantid library dependencies for OSX.

### DIFF
--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -342,6 +342,11 @@ h5py_patterns.each do |pattern|
   end
 end
 
+# ---------------------------------------------
+# Fix imports for Mantid Scientific Interfaces
+# ---------------------------------------------
+`install_name_tool -add_rpath @loader_path/../../../plugins/qtplugins/mantid ./plugins/qtplugins/mantid/libMantidScientificInterfacesEnggDiffraction.dylib`
+# ---------------------------------------------
 
 files = ["gnureadline.so","readline.py","pyparsing.py","mistune.py"]
 files.each do |file|


### PR DESCRIPTION
**Requires an OSX reviewer.**

When Mantid starts up on OSX I get the following error. Originally reported by Jon:

```
Could not open library /Applications/MantidPlot.app/plugins/qtplugins/mantid//libMantidScientificInterfacesEnggDiffraction.dylib: dlopen(/Applications/MantidPlot.app/plugins/qtplugins/mantid//libMantidScientificInterfacesEnggDiffraction.dylib, 10): Library not loaded: @rpath/libMantidScientificInterfacesMuon.dylib
Referenced from: /Applications/MantidPlot.app/plugins/qtplugins/mantid//libMantidScientificInterfacesEnggDiffraction.dylib
Reason: image not found
```

Some of the Mantid Scientific Interfaces have dependencies on each other. These need to be reflected in the package install script. The true fix is to factor out the common code, but for now this should fix the missing dependencies on OSX.

**To test:**

 - Build the OSX package. Instructions are [here](http://www.mantidproject.org/Building_with_CMake#Building_the_installer_package).
 - Install the package and check you no longer the the error on startup.

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
