### PR TITLE
MuonAnalysis plotting crashes

### DIFF
--- a/docs/source/release/v3.11.0/muon.rst
+++ b/docs/source/release/v3.11.0/muon.rst
@@ -24,6 +24,7 @@ Fit Functions
 Bug Fixes
 ---------
 - Mantid would crash when multiple period data was used in single fits (in muon analysis). This has been fixed. 
+- Fixed crash when loading data into MuonAnalysis after using Add/Remove curves.
 
 
 |

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -1701,7 +1701,7 @@ void MuonAnalysis::plotSpectrum(const QString &wsName, bool logScale) {
   s << "  layer = window.activeLayer()";
   s << "  if layer is not None:";
   s << "    kept_fits = 0";
-  s << "    for i in range(layer.numCurves() - 1, -1, -1):"; // reversed
+  s << "    for i in range(layer.numCurves() - 1, 0, -1):"; // reversed
   s << "      title = layer.curveTitle(i)";
   s << "      if title == \"CompositeFunction\":";
   s << "        continue"; // keep all guesses
@@ -1764,8 +1764,15 @@ void MuonAnalysis::plotSpectrum(const QString &wsName, bool logScale) {
   // Plot the data!
   s << "win = get_window('%WSNAME%', '%PREV%', %USEPREV%)";
   s << "if %FITSTOKEEP% != -1:";
+  // leave the 0th layer -> layer is not empty
   s << "  remove_data(win, %FITSTOKEEP%)";
   s << "g = plot_data('%WSNAME%', %ERRORS%, %CONNECT%, win)";
+  // if there is more than one layer delete the oldest one manually 
+  s << "if %FITSTOKEEP% != -1:";
+  s << "  layer = win.activeLayer()";
+  s << "  if layer.numCurves()>1:";
+  s << "     layer.removeCurve(0)";
+
   s << "format_graph(g, '%WSNAME%', %LOGSCALE%, %YAUTO%, '%YMIN%', '%YMAX%')";
 
   QString pyS;

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -1767,7 +1767,7 @@ void MuonAnalysis::plotSpectrum(const QString &wsName, bool logScale) {
   // leave the 0th layer -> layer is not empty
   s << "  remove_data(win, %FITSTOKEEP%)";
   s << "g = plot_data('%WSNAME%', %ERRORS%, %CONNECT%, win)";
-  // if there is more than one layer delete the oldest one manually 
+  // if there is more than one layer delete the oldest one manually
   s << "if %FITSTOKEEP% != -1:";
   s << "  layer = win.activeLayer()";
   s << "  if layer.numCurves()>1:";


### PR DESCRIPTION
Muon analysis would crash after using the add/remove plots and then attempting to load data into MuonAnalysis. 

**To test:**

<!-- Instructions for testing. -->
1. Open Muon Analysis
2. Load the HiFi current run
3. In the Workspaces pane right click on Muon Analysis and do Sample Logs. 
4. Export two different logs (e.g. "Beamlog_Good_Frames_Total" and "Beamlog_Raw_Frames_Total")
5. Overlay the two log curves in one plot. 
6.Go back to Muon Analysis and reload Current Run. 
7. It should not crash 

Fixes #20546. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
