### PR TITLE
Indirect Data Analysis: Suppress warning on missing optional output 

### DIFF
--- a/qt/scientific_interfaces/Indirect/Elwin.cpp
+++ b/qt/scientific_interfaces/Indirect/Elwin.cpp
@@ -493,7 +493,7 @@ void Elwin::plotClicked() {
     plotSpectrum(workspaceBaseName + "_elf");
 
   if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_elt").toStdString(),
-                                   true))
+                                   true, false))
     plotSpectrum(workspaceBaseName + "_elt");
 }
 

--- a/qt/scientific_interfaces/Indirect/Elwin.cpp
+++ b/qt/scientific_interfaces/Indirect/Elwin.cpp
@@ -518,7 +518,7 @@ void Elwin::saveClicked() {
     addSaveWorkspaceToQueue(workspaceBaseName + "_elf");
 
   if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_elt").toStdString(),
-                                   false))
+                                   false, false))
     addSaveWorkspaceToQueue(workspaceBaseName + "_elt");
 
   m_batchAlgoRunner->executeBatchAsync();

--- a/qt/scientific_interfaces/Indirect/IndirectTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTab.cpp
@@ -620,20 +620,19 @@ QString IndirectTab::runPythonCode(QString code, bool no_output) {
  * @return False if no workspace found, True if workspace found
  */
 bool IndirectTab::checkADSForPlotSaveWorkspace(const std::string &workspaceName,
-                                               const bool &plotting) {
+                                               const bool plotting,
+                                               const bool warn) {
   const auto workspaceExists =
       AnalysisDataService::Instance().doesExist(workspaceName);
-  if (workspaceExists) {
-    return true;
-  } else {
+  if (warn && !workspaceExists) {
     const std::string plotSave = plotting ? "plotting" : "saving";
     const auto errorMessage = "Error while " + plotSave +
                               ":\nThe workspace \"" + workspaceName +
                               "\" could not be found.";
     const char *textMessage = errorMessage.c_str();
-    QMessageBox::warning(NULL, tr("Workspace not found"), tr(textMessage));
-    return false;
+    QMessageBox::warning(nullptr, tr("Indirect "), tr(textMessage));
   }
+  return workspaceExists;
 }
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectTab.h
@@ -161,7 +161,8 @@ protected:
   /// Checks the ADS for a workspace named `workspaceName`,
   /// opens a warning box for plotting/saving if none found
   bool checkADSForPlotSaveWorkspace(const std::string &workspaceName,
-                                    const bool &plotting);
+                                    const bool plotting,
+                                    const bool warn = true);
 
   /// Parent QWidget (if applicable)
   QWidget *m_parentWidget;


### PR DESCRIPTION
Description of work.

**To test:**

See the test instructions in the original issue. The missing `_elt` workspace should now not produce a warning. To produce the `_elt` workspace first use the Indirect Data Reduction interface to reduce a newer file such as `IRIS00073585` and save the result. Load this into the data analysis interface, click "Normalise to Lowest Temperature" and click run. The `_elt` workspace should now appear and plotting should show all 4 plots.

Fixes #20610 

**Release Notes** 

*Feature introduced this cycle. Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
