### PR TITLE
Python exceptions do not propagate into c++ in sans gui

### DIFF
--- a/qt/python/mantidqtpython/mantidqt.sip
+++ b/qt/python/mantidqtpython/mantidqt.sip
@@ -1565,6 +1565,7 @@ void setCell(const QString &, int, int, int parentRow = 0, int parentColumn = 0)
 QString getCell(int, int, int parentRow = 0, int parentColumn = 0);
 int getNumberOfRows();
 void clearTable();
+void skipProcessing();
 
 signals:
 void runPythonCode(const QString &);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/DataProcessorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/DataProcessorPresenter.h
@@ -105,6 +105,8 @@ public:
                               int parentColumn) = 0;
   virtual int getNumberOfRows() = 0;
   virtual void clearTable() = 0;
+
+  virtual void skipProcessing() = 0;
 };
 }
 }

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/DataProcessorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/DataProcessorView.h
@@ -113,6 +113,10 @@ public:
   // Methods to emit signals
   virtual void emitProcessClicked() = 0;
   virtual void emitProcessingFinished() = 0;
+
+  //
+  virtual void skipProcessing() = 0;
+
 };
 }
 }

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GenericDataProcessorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GenericDataProcessorPresenter.h
@@ -143,6 +143,8 @@ public:
   bool isProcessing() const override;
   void setForcedReProcessing(bool forceReProcessing) override;
 
+  void skipProcessing() override;
+
 protected:
   template <typename T> using QOrderedSet = QMap<T, std::nullptr_t>;
   // The table view we're managing
@@ -303,6 +305,7 @@ private:
   bool isProcessed(int position) const;
   bool isProcessed(int position, int parent) const;
   bool m_forceProcessing = false;
+  bool m_skipProcessing = false;
 
   // List of workspaces the user can open
   QSet<QString> m_workspaceList;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/MockObjects.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/MockObjects.h
@@ -67,6 +67,7 @@ public:
 
   // Processing options
   MOCK_METHOD1(setForcedReProcessing, void(bool));
+  MOCK_METHOD0(skipProcessing, void());
 
   // Accessor
   MOCK_CONST_METHOD0(getCurrentInstrument, QString());
@@ -144,6 +145,7 @@ public:
   MOCK_CONST_METHOD2(giveUserWarning,
                      void(const QString &prompt, const QString &title));
   MOCK_METHOD0(publishCommandsMocked, void());
+  MOCK_METHOD0(skipProcessing, void());
   MOCK_METHOD1(setForcedReProcessing, void(bool));
 
 private:

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/QDataProcessorWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/QDataProcessorWidget.h
@@ -157,6 +157,8 @@ public:
 
   void emitProcessingFinished() override { emit processingFinished(); }
 
+  void skipProcessing() override;
+
 signals:
   void processButtonClicked();
   void processingFinished();

--- a/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -300,7 +300,7 @@ Process selected data
 void GenericDataProcessorPresenter::process() {
   // Emit a signal hat the process is starting
   m_view->emitProcessClicked();
-  
+  if (GenericDataProcessorPresenter::m_skipProcessing) { m_skipProcessing = false; return; }
   m_selectedData = m_manager->selectedData(m_promptUser);
 
   // Don't continue if there are no items selected

--- a/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -300,7 +300,7 @@ Process selected data
 void GenericDataProcessorPresenter::process() {
   // Emit a signal hat the process is starting
   m_view->emitProcessClicked();
-
+  
   m_selectedData = m_manager->selectedData(m_promptUser);
 
   // Don't continue if there are no items selected
@@ -1810,6 +1810,13 @@ int GenericDataProcessorPresenter::getNumberOfRows() {
   * Clear the table
  **/
 void GenericDataProcessorPresenter::clearTable() { m_manager->deleteRow(); }
+
+/**
+  * Flag used to stop processing
+**/
+void GenericDataProcessorPresenter::skipProcessing() {
+	m_skipProcessing = true;
+}
 
 }
 }

--- a/qt/widgets/common/src/DataProcessorUI/QDataProcessorWidget.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/QDataProcessorWidget.cpp
@@ -686,6 +686,9 @@ QString QDataProcessorWidget::getCurrentInstrument() const {
   return ui.comboProcessInstrument->currentText();
 }
 
+void QDataProcessorWidget::skipProcessing() {
+	m_presenter->skipProcessing();
+}
 } // namespace DataProcessor
 } // namespace MantidWidgets
 } // namespace Mantid

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -505,6 +505,9 @@ class SANSDataProcessorGui(QtGui.QMainWindow, ui_sans_data_processor_window.Ui_S
         else:
             gui_element.addItem(element)
 
+    def halt_process_flag(self):
+        self.data_processor_table.skipProcessing();
+
     @staticmethod
     def _set_enum_as_element_in_combo_box(gui_element, element, expected_type):
         value_as_string = expected_type.to_string(element)

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -506,7 +506,7 @@ class SANSDataProcessorGui(QtGui.QMainWindow, ui_sans_data_processor_window.Ui_S
             gui_element.addItem(element)
 
     def halt_process_flag(self):
-        self.data_processor_table.skipProcessing();
+        self.data_processor_table.skipProcessing()
 
     @staticmethod
     def _set_enum_as_element_in_combo_box(gui_element, element, expected_type):

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -241,6 +241,7 @@ class RunTabPresenter(object):
         # 1. Set up the states and convert them into property managers
         states = self.get_states()
         if not states:
+            self._view.halt_process_flag()
             raise RuntimeError("There seems to have been an issue with setting the states. Make sure that a user file"
                                "has been loaded")
         property_manager_service = PropertyManagerService()
@@ -342,6 +343,7 @@ class RunTabPresenter(object):
             if not self.is_empty_row(row):
                 sample_scatter = self._view.get_cell(row, 0)
                 if not sample_scatter:
+                    self._view.halt_process_flag()
                     raise RuntimeError("Row {} has not SampleScatter specified. Please correct this.".format(row))
 
     def get_processing_options(self):
@@ -841,6 +843,7 @@ class RunTabPresenter(object):
                     self.sans_logger.error("There was a bad entry for row {}. Ensure that the path to your files has "
                                            "been added to the Mantid search directories! See here for more "
                                            "details: {}".format(row, str(e)))
+                    self._view.halt_process_flag();
                     raise RuntimeError("There was a bad entry for row {}. Ensure that the path to your files has "
                                        "been added to the Mantid search directories! See here for more "
                                        "details: {}".format(row, str(e)))

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -843,7 +843,7 @@ class RunTabPresenter(object):
                     self.sans_logger.error("There was a bad entry for row {}. Ensure that the path to your files has "
                                            "been added to the Mantid search directories! See here for more "
                                            "details: {}".format(row, str(e)))
-                    self._view.halt_process_flag();
+                    self._view.halt_process_flag()
                     raise RuntimeError("There was a bad entry for row {}. Ensure that the path to your files has "
                                        "been added to the Mantid search directories! See here for more "
                                        "details: {}".format(row, str(e)))

--- a/scripts/SANS/sans/test_helper/mock_objects.py
+++ b/scripts/SANS/sans/test_helper/mock_objects.py
@@ -79,6 +79,7 @@ def create_mock_view(user_file_path, batch_file_path=None):
     masking_table = create_mock_masking_table()
     view.masking_table = masking_table
 
+    view.halt_process_flag = mock.MagicMock();
     # ---------------------
     # Mocking properties
     # ---------------------
@@ -170,7 +171,6 @@ def create_mock_view2(user_file_path, batch_file_path=None):
     type(view).output_mode = _output_mode
 
     return view
-
 
 class FakeState(object):
     dummy_state = "dummy_state"

--- a/scripts/SANS/sans/test_helper/mock_objects.py
+++ b/scripts/SANS/sans/test_helper/mock_objects.py
@@ -79,7 +79,7 @@ def create_mock_view(user_file_path, batch_file_path=None):
     masking_table = create_mock_masking_table()
     view.masking_table = masking_table
 
-    view.halt_process_flag = mock.MagicMock();
+    view.halt_process_flag = mock.MagicMock()
     # ---------------------
     # Mocking properties
     # ---------------------
@@ -171,6 +171,7 @@ def create_mock_view2(user_file_path, batch_file_path=None):
     type(view).output_mode = _output_mode
 
     return view
+
 
 class FakeState(object):
     dummy_state = "dummy_state"

--- a/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
@@ -270,6 +270,67 @@ class RunTabPresenterTest(unittest.TestCase):
 
         self._clear_property_manager_data_service()
 
+    def test_that_calls_halt_process_flag_if_user_file_has_not_been_loaded_and_process_is_run(self):
+        # Arrange
+        self._clear_property_manager_data_service()
+        batch_file_path, user_file_path, presenter, view = self._get_files_and_mock_presenter(BATCH_FILE_TEST_CONTENT_2)
+
+        with self.assertRaises(RuntimeError):
+            presenter.on_processed_clicked()
+
+        # Assert
+        # We should have raised an exception and called halt process flag
+        self.assertTrue(view.halt_process_flag.call_count == 1)
+        # clean up
+        self._remove_files(user_file_path=user_file_path, batch_file_path=batch_file_path)
+
+        self._clear_property_manager_data_service()
+
+    def test_that_calls_halt_process_flag_if_state_are_invalid_and_process_is_run(self):
+        # Arrange
+        self._clear_property_manager_data_service()
+        batch_file_path, user_file_path, presenter, view = self._get_files_and_mock_presenter(BATCH_FILE_TEST_CONTENT_2)
+
+        presenter.on_batch_file_load()
+        presenter.on_user_file_load()
+
+        #Set invalid state
+        presenter._state_model.event_slices = 'Hello'
+
+        with self.assertRaises(RuntimeError):
+            presenter.on_processed_clicked()
+
+        # Assert
+        # We should have raised an exception and called halt process flag
+        self.assertTrue(view.halt_process_flag.call_count == 1)
+        #self.assertTrue(has_raised)
+        # clean up
+        self._remove_files(user_file_path=user_file_path, batch_file_path=batch_file_path)
+
+        self._clear_property_manager_data_service()
+
+    def test_that_calls_halt_process_flag_if_states_are_not_retrievable_and_process_is_run(self):
+        # Arrange
+        self._clear_property_manager_data_service()
+        batch_file_path, user_file_path, presenter, view = self._get_files_and_mock_presenter(BATCH_FILE_TEST_CONTENT_2)
+
+        presenter.on_batch_file_load()
+        presenter.on_user_file_load()
+
+        presenter.get_states = mock.MagicMock(return_value='')
+
+        with self.assertRaises(RuntimeError):
+            presenter.on_processed_clicked()
+
+        # Assert
+        # We should have raised an exception and called halt process flag
+        self.assertTrue(view.halt_process_flag.call_count == 1)
+        #self.assertTrue(has_raised)
+        # clean up
+        self._remove_files(user_file_path=user_file_path, batch_file_path=batch_file_path)
+
+        self._clear_property_manager_data_service()
+
     def test_that_can_add_new_masks(self):
         # Arrange
         self._clear_property_manager_data_service()

--- a/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
@@ -4,12 +4,11 @@ from __future__ import (absolute_import, division, print_function)
 import unittest
 import sys
 
-import mantid
 from mantid.kernel import config
 from mantid.kernel import PropertyManagerDataService
 
 from sans.gui_logic.presenter.run_tab_presenter import RunTabPresenter
-from sans.common.enums import (SANSFacility, ReductionDimensionality, SaveType, OutputMode, ISISReductionMode,
+from sans.common.enums import (SANSFacility, ReductionDimensionality, SaveType, ISISReductionMode,
                                RangeStepType, FitType)
 from sans.test_helper.user_file_test_helper import (create_user_file, sample_user_file)
 from sans.test_helper.mock_objects import (create_mock_view)


### PR DESCRIPTION
Description of work.

In the SANS GUI version 2 when the python code threw an exception during processing it's execution was stopped but the algorithm was still run as the exception did not cross over into C++. 

**To test:**
Get the data from \olympic\Babylon5\Scratch\Matthew Andrew\GUI_TEST
Open SANS gui v2 and load in the userfile USER_SANS2D_154E_2p4_4m_M3_Xpress_8mm_SampleChanger_FRONT
Load the batch file batch_file
In settings->General type Hello into the Event slice box.
Click Process
<!-- Instructions for testing. -->

Fixes #20640 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
No release noted needed as bugfix
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
