### PR TITLE
Expand deprecated macro to include clang

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/System.h
+++ b/Framework/Kernel/inc/MantidKernel/System.h
@@ -81,7 +81,7 @@
 /**
  * A Macro to mark a function as deprecated.
  */
-#ifdef __GNUC__
+#if (defined(__GNUC__) || defined(__clang__))
 #define DEPRECATED(func) func __attribute__((deprecated))
 #elif defined(_MSC_VER)
 #define DEPRECATED(func) __declspec(deprecated) func


### PR DESCRIPTION
Since the magic is the same for clang, expand the macro to do the same thing for gcc and clang.

**To test:**

Just a code review.

*There is no associated issue.*

*Does not need to be in the release notes* since it is just for development.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
