### PR TITLE
StartLiveData in Replace mode resets changes to Instrument

### DIFF
--- a/Framework/LiveData/src/LoadLiveData.cpp
+++ b/Framework/LiveData/src/LoadLiveData.cpp
@@ -20,6 +20,38 @@ using namespace Mantid::DataObjects;
 namespace Mantid {
 namespace LiveData {
 
+namespace {
+
+/**
+ * Copy the Instrument from source workspace to target workspace if possible
+ *
+ * Handles cases where source does not exist, or are not forms of
+ *ExperimentInfo.
+ * Expects source and target workspaces to be the same type and size (if
+ *workspace group)
+ *
+ * @param source : Source workspace containing instrument
+ * @param target : Target workspace to write instrument to
+ */
+void copyInstrument(const API::Workspace *source, API::Workspace &target) {
+
+  // Special handling for Worspace Groups.
+  if (auto *sourceGroup = dynamic_cast<const API::WorkspaceGroup *>(source)) {
+    auto &targetGroup = dynamic_cast<API::WorkspaceGroup &>(target);
+    for (size_t index = 0; index < sourceGroup->size(); ++index) {
+      copyInstrument(sourceGroup->getItem(index).get(),
+                     *targetGroup.getItem(index));
+    }
+  } else {
+    if (auto *sourceExpInfo =
+            dynamic_cast<const API::ExperimentInfo *>(source)) {
+      dynamic_cast<API::ExperimentInfo &>(target)
+          .setInstrument(sourceExpInfo->getInstrument());
+    }
+  }
+}
+}
+
 // Register the algorithm into the AlgorithmFactory
 DECLARE_ALGORITHM(LoadLiveData)
 
@@ -273,9 +305,14 @@ void LoadLiveData::addMatrixWSChunk(const std::string &algoName,
  * @param chunkWS :: processed live data chunk workspace
  */
 void LoadLiveData::replaceChunk(Mantid::API::Workspace_sptr chunkWS) {
+  // We keep a temporary to the orignal workspace containing the instrument
+  auto instrumentWS = m_accumWS;
   // When the algorithm exits the chunk workspace will be renamed
   // and overwrite the old one
   m_accumWS = chunkWS;
+  // Put the original instrument back. Otherwise geometry changes will not be
+  // persistent
+  copyInstrument(instrumentWS.get(), *m_accumWS);
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/LiveData/src/LoadLiveData.cpp
+++ b/Framework/LiveData/src/LoadLiveData.cpp
@@ -38,7 +38,8 @@ void copyInstrument(const API::Workspace *source, API::Workspace &target) {
   // Special handling for Worspace Groups.
   if (auto *sourceGroup = dynamic_cast<const API::WorkspaceGroup *>(source)) {
     auto &targetGroup = dynamic_cast<API::WorkspaceGroup &>(target);
-    for (size_t index = 0; index < sourceGroup->size(); ++index) {
+    for (size_t index = 0;
+         index < std::min(sourceGroup->size(), targetGroup.size()); ++index) {
       copyInstrument(sourceGroup->getItem(index).get(),
                      *targetGroup.getItem(index));
     }

--- a/Framework/LiveData/test/LoadLiveDataTest.h
+++ b/Framework/LiveData/test/LoadLiveDataTest.h
@@ -134,24 +134,6 @@ public:
                       ws2CompInfo.position(ws2CompInfo.sample()));
   }
 
-  void test_replace_keeps_original_instrument() {
-    auto ws1 = doExec<EventWorkspace>("Replace");
-    auto &ws1CompInfo = ws1->mutableComponentInfo();
-    // Put the sample somewhere else prior to the next replace
-    const Kernel::V3D newSamplePosition =
-        ws1CompInfo.position(ws1CompInfo.sample()) + V3D(1, 1, 1);
-    ws1CompInfo.setPosition(ws1CompInfo.sample(), newSamplePosition);
-
-    // Second Run of replace
-    auto ws2 = doExec<EventWorkspace>("Replace");
-    const auto &ws2CompInfo = ws2->componentInfo();
-    // Check the sample is where I put it. i.e. Instrument should NOT be
-    // overwritten.
-    TSM_ASSERT_EQUALS("Instrument should NOT have been overwritten",
-                      newSamplePosition,
-                      ws2CompInfo.position(ws2CompInfo.sample()));
-  }
-
   //--------------------------------------------------------------------------------------------
   void test_append() {
     EventWorkspace_sptr ws1, ws2;

--- a/Framework/LiveData/test/LoadLiveDataTest.h
+++ b/Framework/LiveData/test/LoadLiveDataTest.h
@@ -3,6 +3,7 @@
 
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/LiveListenerFactory.h"
+#include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidKernel/ConfigService.h"
@@ -112,6 +113,43 @@ public:
     TS_ASSERT_EQUALS(ws2->getNumberEvents(), 200);
     TSM_ASSERT("Workspace changed when replaced", ws1 != ws2);
     TS_ASSERT_EQUALS(AnalysisDataService::Instance().size(), 1);
+  }
+
+  //--------------------------------------------------------------------------------------------
+  void test_replace_keeps_original_instrument() {
+    auto ws1 = doExec<EventWorkspace>("Replace");
+    auto &ws1CompInfo = ws1->mutableComponentInfo();
+    // Put the sample somewhere else prior to the next replace
+    const Kernel::V3D newSamplePosition =
+        ws1CompInfo.position(ws1CompInfo.sample()) + V3D(1, 1, 1);
+    ws1CompInfo.setPosition(ws1CompInfo.sample(), newSamplePosition);
+
+    // Second Run of replace
+    auto ws2 = doExec<EventWorkspace>("Replace");
+    const auto &ws2CompInfo = ws2->componentInfo();
+    // Check the sample is where I put it. i.e. Instrument should NOT be
+    // overwritten.
+    TSM_ASSERT_EQUALS("Instrument should NOT have been overwritten",
+                      newSamplePosition,
+                      ws2CompInfo.position(ws2CompInfo.sample()));
+  }
+
+  void test_replace_keeps_original_instrument() {
+    auto ws1 = doExec<EventWorkspace>("Replace");
+    auto &ws1CompInfo = ws1->mutableComponentInfo();
+    // Put the sample somewhere else prior to the next replace
+    const Kernel::V3D newSamplePosition =
+        ws1CompInfo.position(ws1CompInfo.sample()) + V3D(1, 1, 1);
+    ws1CompInfo.setPosition(ws1CompInfo.sample(), newSamplePosition);
+
+    // Second Run of replace
+    auto ws2 = doExec<EventWorkspace>("Replace");
+    const auto &ws2CompInfo = ws2->componentInfo();
+    // Check the sample is where I put it. i.e. Instrument should NOT be
+    // overwritten.
+    TSM_ASSERT_EQUALS("Instrument should NOT have been overwritten",
+                      newSamplePosition,
+                      ws2CompInfo.position(ws2CompInfo.sample()));
   }
 
   //--------------------------------------------------------------------------------------------

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -6,6 +6,7 @@ Release Notes
    :maxdepth: 1
    :titlesonly:
 
+   v3.12.0 <v3.11.0/index>
    v3.11.0 <v3.11.0/index>
    v3.10.1 <v3.10.1/index>
    v3.10.0 <v3.10.0/index>

--- a/docs/source/release/v3.12.0/framework.rst
+++ b/docs/source/release/v3.12.0/framework.rst
@@ -1,0 +1,66 @@
+=================
+Framework Changes
+=================
+
+.. contents:: Table of Contents
+   :local:
+
+Concepts
+--------
+
+Properties
+----------
+
+Algorithms
+----------
+
+New
+###
+
+Fixed
+#####
+- :ref:`algm-LoadLiveData`: Fixed a bug in Replace mode which reset changes to Instrument Geometry.
+
+Deprecated
+##########
+
+MD Algorithms (VATES CLI)
+#########################
+
+Performance
+-----------
+
+Core Framework Changes
+----------------------
+
+CurveFitting
+------------
+
+New
+###
+
+Bug fixes
+#########
+
+Improved
+########
+
+Python
+------
+
+Python Algorithms
+#################
+
+Bugfixes
+########
+
+Python Fit Functions
+####################
+
+|
+
+Full list of
+`Framework <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.11%22+is%3Amerged+label%3A%22Component%3A+Framework%22>`__
+and
+`Python <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.11%22+is%3Amerged+label%3A%22Component%3A+Python%22>`__
+changes on GitHub

--- a/docs/source/release/v3.12.0/index.rst
+++ b/docs/source/release/v3.12.0/index.rst
@@ -1,0 +1,34 @@
+.. _v3.12.0:
+
+===========================
+Mantid 3.12.0 Release Notes
+===========================
+
+
+Citation
+--------
+
+Please cite any usage of Mantid as follows:
+
+- *Mantid 3.11: Manipulation and Analysis Toolkit for Instrument Data.; Mantid Project*. doi: http://dx.doi.org/10.5286/SOFTWARE/MANTID3.11
+
+Changes
+-------
+
+.. toctree::
+   :titlesonly:
+
+   Framework <framework>
+
+Full Change Listings
+--------------------
+
+For a full list of all issues addressed during this release please see the `GitHub milestone`_.
+
+.. _download page: http://download.mantidproject.org
+
+.. _forum: http://forum.mantidproject.org
+
+.. _GitHub milestone: http://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A%22Release+3.11%22+is%3Aclosed
+
+.. _GitHub release page: https://github.com/mantidproject/mantid/releases/tag/v3.11.0


### PR DESCRIPTION
Copy the instrument from old workspace to new, to prevent loosing geometry changes. Fixes #20517. See there for manual testing instructions.

**To test:**

* Code review
* Ensure new unit test passes
* Run manual tests according to issue

