### PR TITLE
Fix clang-tidy modernize-header issues

### DIFF
--- a/Framework/DataHandling/src/LoadRaw/isisraw.h
+++ b/Framework/DataHandling/src/LoadRaw/isisraw.h
@@ -11,9 +11,6 @@ struct ISISCRPT_STRUCT;
 #include "item_struct.h"
 #include <cstdlib>
 #include <cstring>
-#ifdef _WIN32 /* _WIN32 */
-#include <ctime>
-#endif
 #include "MantidKernel/System.h"
 
 /// Run header (80 bytes)

--- a/Framework/DataHandling/src/LoadRaw/isisraw.h
+++ b/Framework/DataHandling/src/LoadRaw/isisraw.h
@@ -12,7 +12,7 @@ struct ISISCRPT_STRUCT;
 #include <cstdlib>
 #include <cstring>
 #ifdef _WIN32 /* _WIN32 */
-#include <time.h>
+#include <ctime>
 #endif
 #include "MantidKernel/System.h"
 

--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -1,9 +1,6 @@
 #ifndef MANTID_DATAOBJECTS_EVENTLIST_H_
 #define MANTID_DATAOBJECTS_EVENTLIST_H_ 1
 
-#ifdef _WIN32 /* _WIN32 */
-#include <ctime>
-#endif
 #include "MantidAPI/IEventList.h"
 #include "MantidDataObjects/Events.h"
 #include "MantidKernel/MultiThreaded.h"

--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -2,7 +2,7 @@
 #define MANTID_DATAOBJECTS_EVENTLIST_H_ 1
 
 #ifdef _WIN32 /* _WIN32 */
-#include <time.h>
+#include <ctime>
 #endif
 #include "MantidAPI/IEventList.h"
 #include "MantidDataObjects/Events.h"

--- a/Framework/DataObjects/inc/MantidDataObjects/Events.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Events.h
@@ -2,7 +2,7 @@
 #define MANTID_DATAOBJECTS_EVENTS_H_
 
 #ifdef _WIN32 /* _WIN32 */
-#include <time.h>
+#include <ctime>
 #endif
 #include <cstddef>
 #include <iosfwd>

--- a/Framework/DataObjects/inc/MantidDataObjects/Events.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Events.h
@@ -1,9 +1,6 @@
 #ifndef MANTID_DATAOBJECTS_EVENTS_H_
 #define MANTID_DATAOBJECTS_EVENTS_H_
 
-#ifdef _WIN32 /* _WIN32 */
-#include <ctime>
-#endif
 #include <cstddef>
 #include <iosfwd>
 #include <vector>

--- a/Framework/ICat/src/ICat3/ICat3Helper.cpp
+++ b/Framework/ICat/src/ICat3/ICat3Helper.cpp
@@ -11,7 +11,7 @@ GCC_DIAG_OFF(literal-suffix)
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidKernel/Logger.h"
 #include <iomanip>
-#include <time.h>
+#include <ctime>
 #include <boost/lexical_cast.hpp>
 
 namespace Mantid {

--- a/Framework/Kernel/inc/MantidKernel/DateAndTime.h
+++ b/Framework/Kernel/inc/MantidKernel/DateAndTime.h
@@ -5,9 +5,9 @@
 #ifndef Q_MOC_RUN
 #include <boost/date_time/posix_time/posix_time.hpp>
 #endif
-#include <time.h>
+#include <cstdint>
+#include <ctime>
 #include <iosfwd>
-#include <stdint.h>
 #include <string>
 #include <vector>
 

--- a/Framework/Kernel/inc/MantidKernel/Timer.h
+++ b/Framework/Kernel/inc/MantidKernel/Timer.h
@@ -5,14 +5,12 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidKernel/DllConfig.h"
+#include <chrono>
 #include <iosfwd>
-
-#ifdef _WIN32
-#include <time.h>
-#else
-#include <sys/time.h>
-#endif
 #include <string>
+
+// forward declaration
+// class std::chrono::time_point;
 
 namespace Mantid {
 namespace Kernel {
@@ -53,12 +51,7 @@ public:
   void reset();
 
 private:
-// The type of this variable is different depending on the platform
-#ifdef _WIN32
-  clock_t
-#else
-  timeval
-#endif
+  std::chrono::time_point<std::chrono::high_resolution_clock>
       m_start; ///< The starting time (implementation dependent format)
 };
 

--- a/Framework/Kernel/inc/MantidKernel/Timer.h
+++ b/Framework/Kernel/inc/MantidKernel/Timer.h
@@ -9,9 +9,6 @@
 #include <iosfwd>
 #include <string>
 
-// forward declaration
-// class std::chrono::time_point;
-
 namespace Mantid {
 namespace Kernel {
 /** A simple class that provides a wall-clock (not processor time) timer.
@@ -52,7 +49,7 @@ public:
 
 private:
   std::chrono::time_point<std::chrono::high_resolution_clock>
-      m_start; ///< The starting time (implementation dependent format)
+      m_start; ///< The starting time
 };
 
 MANTID_KERNEL_DLL std::ostream &operator<<(std::ostream &, const Timer &);

--- a/Framework/Kernel/src/ArrayLengthValidator.cpp
+++ b/Framework/Kernel/src/ArrayLengthValidator.cpp
@@ -1,7 +1,7 @@
 #include "MantidKernel/ArrayLengthValidator.h"
 
 #include <boost/make_shared.hpp>
-#include <stdint.h>
+#include <cstdint>
 
 using namespace Mantid::Kernel;
 

--- a/Framework/Kernel/src/ArrayOrderedPairsValidator.cpp
+++ b/Framework/Kernel/src/ArrayOrderedPairsValidator.cpp
@@ -1,7 +1,7 @@
 #include "MantidKernel/ArrayOrderedPairsValidator.h"
 
 #include <boost/make_shared.hpp>
-#include <stdint.h>
+#include <cstdint>
 #include <sstream>
 
 namespace Mantid {

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -46,13 +46,13 @@
 #include <boost/regex.hpp>
 
 #include <algorithm>
+#include <cctype>
 #include <exception>
 #include <fstream>
 #include <functional>
 #include <iostream>
 #include <stdexcept>
 #include <utility>
-#include <ctype.h>
 
 #ifdef __APPLE__
 #include <mach-o/dyld.h>

--- a/Framework/Kernel/src/DateAndTime.cpp
+++ b/Framework/Kernel/src/DateAndTime.cpp
@@ -9,7 +9,7 @@
 #include <boost/date_time/time.hpp>
 #include <boost/date_time/date.hpp>
 
-#include <math.h>
+#include <cmath>
 #include <exception>
 #include <limits>
 #include <memory>

--- a/Framework/Kernel/src/DateValidator.cpp
+++ b/Framework/Kernel/src/DateValidator.cpp
@@ -1,7 +1,7 @@
 #include "MantidKernel/DateValidator.h"
 #include <boost/lexical_cast.hpp>
 #include <boost/make_shared.hpp>
-#include <time.h>
+#include <ctime>
 
 namespace Mantid {
 namespace Kernel {

--- a/Framework/Kernel/src/Memory.cpp
+++ b/Framework/Kernel/src/Memory.cpp
@@ -2,8 +2,8 @@
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/System.h"
 
+#include <cstdio>
 #include <sstream>
-#include <stdio.h>
 
 #ifdef __linux__
 #include <unistd.h>

--- a/Framework/Kernel/src/PropertyHistory.cpp
+++ b/Framework/Kernel/src/PropertyHistory.cpp
@@ -6,9 +6,9 @@
 #include "MantidKernel/Property.h"
 #include "MantidKernel/Strings.h"
 
-#include <boost/lexical_cast.hpp>
 #include <algorithm>
-#include <stdint.h>
+#include <boost/lexical_cast.hpp>
+#include <cstdint>
 #include <ostream>
 
 namespace Mantid {

--- a/Framework/Kernel/src/Timer.cpp
+++ b/Framework/Kernel/src/Timer.cpp
@@ -2,6 +2,7 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidKernel/Timer.h"
+#include <chrono>
 #include <ostream>
 #include <sstream>
 
@@ -11,13 +12,7 @@ namespace Kernel {
 /** Constructor.
  *  Instantiating the object starts the timer.
  */
-Timer::Timer() {
-#ifdef _WIN32
-  m_start = clock();
-#else /* linux & mac */
-  gettimeofday(&m_start, nullptr);
-#endif
-}
+Timer::Timer() { m_start = std::chrono::high_resolution_clock::now(); }
 
 /** Returns the wall-clock time elapsed in seconds since the Timer object's
  *creation, or the last call to elapsed
@@ -38,29 +33,14 @@ float Timer::elapsed(bool reset) {
  * @return time in seconds
  */
 float Timer::elapsed_no_reset() const {
-#ifdef _WIN32
-  clock_t now = clock();
-  const float retval = float(now - m_start) / CLOCKS_PER_SEC;
-#else /* linux & mac */
-  timeval now;
-  gettimeofday(&now, nullptr);
-  const float retval =
-      float(now.tv_sec - m_start.tv_sec) +
-      float(static_cast<float>(now.tv_usec - m_start.tv_usec) / 1e6);
-#endif
-  return retval;
+  const auto now = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<float> duration = now - m_start;
+
+  return duration.count();
 }
 
 /// Explicitly reset the timer.
-void Timer::reset() {
-#ifdef _WIN32
-  m_start = clock();
-#else /* linux & mac */
-  timeval now;
-  gettimeofday(&now, nullptr);
-  m_start = now;
-#endif
-}
+void Timer::reset() { m_start = std::chrono::high_resolution_clock::now(); }
 
 /// Convert the elapsed time (without reseting) to a string.
 std::string Timer::str() const {

--- a/Framework/Kernel/src/VMD.cpp
+++ b/Framework/Kernel/src/VMD.cpp
@@ -6,9 +6,9 @@
 #include "MantidKernel/V3D.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <iterator>
-#include <math.h>
 #include <sstream>
 #include <stdexcept>
 

--- a/Framework/Kernel/test/DateAndTimeTest.h
+++ b/Framework/Kernel/test/DateAndTimeTest.h
@@ -8,12 +8,12 @@
 #ifndef DATEANDTIMETEST_H_
 #define DATEANDTIMETEST_H_
 
-#include <cxxtest/TestSuite.h>
 #include "MantidKernel/DateAndTime.h"
 #include "MantidKernel/System.h"
-#include <sys/stat.h>
-#include <time.h>
+#include <ctime>
+#include <cxxtest/TestSuite.h>
 #include <sstream>
+#include <sys/stat.h>
 
 using namespace Mantid;
 using namespace Mantid::Kernel;

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -130,9 +130,9 @@
 #include "Mantid/InstrumentWidget/InstrumentWindow.h"
 #include "Mantid/RemoveErrorsDialog.h"
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <cassert>
+#include <cstdio>
+#include <cstdlib>
 #include <iostream>
 
 #include <qwt_scale_engine.h>

--- a/MantidPlot/src/AxesDialog.cpp
+++ b/MantidPlot/src/AxesDialog.cpp
@@ -26,22 +26,21 @@ Description          : General plot options dialog
 *   Boston, MA  02110-1301  USA                                           *
 *                                                                         *
 ***************************************************************************/
-#include "MantidQtWidgets/Common/qwt_compat.h"
 #include "AxesDialog.h"
 #include "ApplicationWindow.h"
-#include "TextDialog.h"
 #include "ColorBox.h"
+#include "ColorButton.h"
 #include "Graph.h"
 #include "Grid.h"
-#include "Plot.h"
-#include "MyParser.h"
-#include "ColorButton.h"
-#include "TextFormatButtons.h"
-#include "Table.h"
 #include "MantidQtWidgets/Common/DoubleSpinBox.h"
+#include "MantidQtWidgets/Common/qwt_compat.h"
+#include "MyParser.h"
+#include "Plot.h"
 #include "ScaleDraw.h"
-#include <float.h>
-
+#include "Table.h"
+#include "TextDialog.h"
+#include "TextFormatButtons.h"
+#include <cfloat>
 #include <cmath>
 
 #include "MantidKernel/Logger.h"

--- a/MantidPlot/src/Cone3D.cpp
+++ b/MantidPlot/src/Cone3D.cpp
@@ -27,11 +27,11 @@
  *   Boston, MA  02110-1301  USA                                           *
  *                                                                         *
  ***************************************************************************/
+#include "Cone3D.h"
 #include "MantidGeometry/Rendering/OpenGL_Headers.h"
-#include <math.h>
 #include "qwt3d_color.h"
 #include "qwt3d_plot.h"
-#include "Cone3D.h"
+#include <cmath>
 
 using namespace Qwt3D;
 

--- a/MantidPlot/src/FitDialog.cpp
+++ b/MantidPlot/src/FitDialog.cpp
@@ -61,7 +61,7 @@
 #include <QTableWidget>
 #include <QWidget>
 #include <QWidgetList>
-#include <stdio.h>
+#include <cstdio>
 
 #include <qwt_plot_curve.h>
 

--- a/MantidPlot/src/Graph.cpp
+++ b/MantidPlot/src/Graph.cpp
@@ -106,10 +106,10 @@
 #include <qwt_text_label.h>
 
 #include <climits>
-#include <math.h>
-#include <stddef.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cmath>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
 
 using namespace MantidQt::API;
 using CurveType = GraphOptions::CurveType;

--- a/MantidPlot/src/Mantid/AlgorithmHistoryWindow.cpp
+++ b/MantidPlot/src/Mantid/AlgorithmHistoryWindow.cpp
@@ -20,9 +20,9 @@
 #include <QTemporaryFile>
 #include <QTextStream>
 
-#include <numeric>
+#include <cstdio>
 #include <fstream>
-#include <stdio.h>
+#include <numeric>
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -72,8 +72,8 @@
 #include <QToolBar>
 
 #include <algorithm>
+#include <ctime>
 #include <qwt_plot_curve.h>
-#include <time.h>
 
 #ifdef _WIN32
 #include <windows.h>

--- a/MantidPlot/src/Matrix.cpp
+++ b/MantidPlot/src/Matrix.cpp
@@ -63,8 +63,8 @@
 
 #include <boost/algorithm/string.hpp>
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 #include <gsl/gsl_linalg.h>
 #include <gsl/gsl_math.h>

--- a/MantidPlot/src/MatrixModel.cpp
+++ b/MantidPlot/src/MatrixModel.cpp
@@ -44,8 +44,8 @@
 #include <gsl/gsl_linalg.h>
 #include <gsl/gsl_errno.h>
 
+#include <cstdlib>
 #include <qwt_color_map.h>
-#include <stdlib.h>
 
 MatrixModel::MatrixModel(QObject *parent)
     : QAbstractTableModel(parent), d_matrix(dynamic_cast<Matrix *>(parent)) {

--- a/MantidPlot/src/Spectrogram.cpp
+++ b/MantidPlot/src/Spectrogram.cpp
@@ -25,15 +25,15 @@
  *   Boston, MA  02110-1301  USA                                           *
  *                                                                         *
  ***************************************************************************/
-#include "MantidQtWidgets/Common/qwt_compat.h"
 #include "Spectrogram.h"
-#include <math.h>
-#include <QPen>
-#include <qwt_scale_widget.h>
+#include "MantidQtWidgets/Common/qwt_compat.h"
 #include <QColor>
+#include <QPainter>
+#include <QPen>
+#include <cmath>
 #include <qwt_painter.h>
 #include <qwt_scale_engine.h>
-#include <QPainter>
+#include <qwt_scale_widget.h>
 #include <qwt_symbol.h>
 
 #include "Mantid/MantidMatrix.h"

--- a/MantidPlot/src/analysis/fft2D.cpp
+++ b/MantidPlot/src/analysis/fft2D.cpp
@@ -29,8 +29,8 @@
 #include "fft2D.h"
 #include "../Matrix.h"
 //#define _USE_MATH_DEFINES
-#include <math.h>
 #include <QVarLengthArray>
+#include <cmath>
 void fft(double *x_int_re, double *x_int_im, int taille) {
   int size_2 = taille >> 1;
   double base = 2 * M_PI / taille;

--- a/MantidPlot/src/fit_gsl.cpp
+++ b/MantidPlot/src/fit_gsl.cpp
@@ -1,12 +1,12 @@
-#include <math.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <stddef.h>
-#include <qmessagebox.h>
-#include <gsl/gsl_blas.h>
-#include <gsl/gsl_math.h>
 #include "fit_gsl.h"
 #include "MyParser.h"
+#include <cmath>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
+#include <gsl/gsl_blas.h>
+#include <gsl/gsl_math.h>
+#include <qmessagebox.h>
 int expd3_f(const gsl_vector *x, void *params, gsl_vector *f) {
   size_t n = ((struct FitData *)params)->n;
   double *X = ((struct FitData *)params)->X;

--- a/MantidPlot/src/fit_gsl.h
+++ b/MantidPlot/src/fit_gsl.h
@@ -1,12 +1,15 @@
 #ifndef FIT_GSL_H
 #define FIT_GSL_H
 
+#include <cstddef>
+#include <gsl/gsl_matrix.h>
 #include <gsl/gsl_vector.h>
 
 //! Structure for fitting data
 struct FitData {
-  size_t n;  // number of points to be fitted (size of X, Y and sigma arrays)
-  size_t p;  // number of fit parameters
+  std::size_t
+      n; // number of points to be fitted (size of X, Y and sigma arrays)
+  std::size_t p; // number of fit parameters
   double *X; // the data to be fitted (abscissae)
   double *Y; // the data to be fitted (ordinates)
   double *sigma;        // the weighting data

--- a/MantidPlot/src/fit_gsl.h
+++ b/MantidPlot/src/fit_gsl.h
@@ -9,9 +9,9 @@
 struct FitData {
   std::size_t
       n; // number of points to be fitted (size of X, Y and sigma arrays)
-  std::size_t p; // number of fit parameters
-  double *X; // the data to be fitted (abscissae)
-  double *Y; // the data to be fitted (ordinates)
+  std::size_t p;        // number of fit parameters
+  double *X;            // the data to be fitted (abscissae)
+  double *Y;            // the data to be fitted (ordinates)
   double *sigma;        // the weighting data
   const char *function; // fit model (used only by the NonLinearFit class)
   const char *names; // names of the fit parameters separated by "," (used only

--- a/MantidPlot/src/lib/3rdparty/qtcolorpicker/src/qtcolorpicker.cpp
+++ b/MantidPlot/src/lib/3rdparty/qtcolorpicker/src/qtcolorpicker.cpp
@@ -44,25 +44,25 @@
 **
 ****************************************************************************/
 
-#include <QtGui/QApplication>
-#include <QtGui/QDesktopWidget>
-#include <QtGui/QPainter>
-#include <QtGui/QPushButton>
-#include <QtGui/QColorDialog>
 #include <QtCore/QMap>
-#include <QtGui/QLayout>
-#include <QtGui/QStyle>
-#include <QtGui/QLabel>
-#include <QtGui/QToolTip>
-#include <QtGui/QPixmap>
+#include <QtGui/QApplication>
+#include <QtGui/QColorDialog>
+#include <QtGui/QDesktopWidget>
 #include <QtGui/QFocusEvent>
-#include <QtGui/QPaintEvent>
 #include <QtGui/QGridLayout>
 #include <QtGui/QHideEvent>
 #include <QtGui/QKeyEvent>
-#include <QtGui/QShowEvent>
+#include <QtGui/QLabel>
+#include <QtGui/QLayout>
 #include <QtGui/QMouseEvent>
-#include <math.h>
+#include <QtGui/QPaintEvent>
+#include <QtGui/QPainter>
+#include <QtGui/QPixmap>
+#include <QtGui/QPushButton>
+#include <QtGui/QShowEvent>
+#include <QtGui/QStyle>
+#include <QtGui/QToolTip>
+#include <cmath>
 
 #include "qtcolorpicker.h"
 

--- a/MantidPlot/src/nrutil.cpp
+++ b/MantidPlot/src/nrutil.cpp
@@ -1,7 +1,7 @@
-#include <math.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <stddef.h>
+#include <cmath>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
 
 #include "nrutil.h"
 

--- a/MantidPlot/src/origin/OPJFile.cpp
+++ b/MantidPlot/src/origin/OPJFile.cpp
@@ -35,13 +35,13 @@
 #pragma warning disable 181
 #endif
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <limits.h>
-#include <math.h>
-#include <cstring>
-#include <algorithm> //required for std::swap
 #include "OPJFile.h"
+#include <algorithm> //required for std::swap
+#include <climits>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 using std::vector;
 using std::string;

--- a/Testing/Tools/cxxtest/cxxtest/XmlFormatter.h
+++ b/Testing/Tools/cxxtest/cxxtest/XmlFormatter.h
@@ -23,18 +23,18 @@
 #define CXXTEST_STACK_TRACE_FILELINE_PREFIX "\" location=\""
 #define CXXTEST_STACK_TRACE_FILELINE_SUFFIX ""
 
-#include <chrono>
-#include <cstring>
-#include <ctime>
-#include <cxxtest/ErrorFormatter.h>
-#include <cxxtest/StdHeaders.h>
-#include <cxxtest/TestListener.h>
 #include <cxxtest/TestRunner.h>
+#include <cxxtest/TestListener.h>
 #include <cxxtest/TestTracker.h>
 #include <cxxtest/ValueTraits.h>
+#include <cxxtest/ErrorFormatter.h>
+#include <cxxtest/StdHeaders.h>
+#include <chrono>
 #include <iostream>
 #include <sstream>
+#include <cstring>
 #include <stdexcept>
+
 
 namespace CxxTest
 {
@@ -137,16 +137,16 @@ namespace CxxTest
             std::map<std::string,std::string>::iterator curr=attribute.begin();
             std::map<std::string,std::string>::iterator end =attribute.end();
             while (curr != end) {
-              os << curr->first.c_str() << "=\"" << curr->second.c_str()
-                 << "\" ";
+              os << curr->first.c_str()
+                 << "=\"" << curr->second.c_str() << "\" ";
               curr++;
               }
             if (value.str().empty()) {
                 os << "/>";
             }
             else {
-              os << ">" << escape(value.str()).c_str() << "</" << name.c_str()
-                 << ">";
+                os << ">" << escape(value.str()).c_str()
+                   << "</" << name.c_str() << ">";
             }
             os.endl(os);
             }
@@ -256,28 +256,31 @@ namespace CxxTest
     class XmlFormatter : public TestListener
     {
         public:
-          XmlFormatter(OutputStream *o, OutputStream *ostr,
-                       std::ostringstream *os)
-              : cpuStartTime(0), cpuStopTime(0), _o(o), _ostr(ostr), _os(os),
-                stream_redirect(NULL) {}
+        XmlFormatter( OutputStream *o, OutputStream *ostr, std::ostringstream *os)
+           : cpuStartTime(0), cpuStopTime(0), _o(o), _ostr(ostr), _os(os), stream_redirect(NULL)
+        {}
 
-          virtual ~XmlFormatter() { delete _ostr; }
+        virtual ~XmlFormatter()
+        {
+          delete _ostr;
+        }
 
-          std::list<TestCaseInfo> info;
-          std::list<TestCaseInfo>::iterator testcase;
-          typedef std::list<ElementInfo>::iterator element_t;
-          std::string classname;
-          int ntests;
-          int nfail;
-          int nerror;
-          double totaltime;
-          std::chrono::time_point<std::chrono::high_resolution_clock>
-              testStartTime, testStopTime, testRunStartTime, testRunStopTime;
+        std::list<TestCaseInfo> info;
+        std::list<TestCaseInfo>::iterator testcase;
+        typedef std::list<ElementInfo>::iterator element_t;
+        std::string classname;
+        int ntests;
+        int nfail;
+        int nerror;
+        double totaltime;
+        std::chrono::time_point<std::chrono::high_resolution_clock>
+        testStartTime, testStopTime, testRunStartTime, testRunStopTime;
 
-          /// CPU time (for all processors)
-          clock_t cpuStartTime, cpuStopTime;
+        /// CPU time (for all processors)
+        clock_t cpuStartTime, cpuStopTime;
 
-          int run() {
+        int run()
+        {
             TestRunner::runAllTests( *this );
             return tracker().failedTests();
         }
@@ -294,7 +297,7 @@ namespace CxxTest
         {
             char s[WorldDescription::MAX_STRLEN_TOTAL_TESTS];
             const WorldDescription &wd = tracker().world();
-            o << wd.strTotalTests(s)
+            o << wd.strTotalTests( s )
               << (wd.numTotalTests() == 1 ? " test" : " tests");
         }
 
@@ -309,7 +312,7 @@ namespace CxxTest
                 while ( ! classname.empty() && classname[0] == '.' )
                    classname.erase(0,1);
 
-                // CXXTEST_STD(cout) << "HERE " << desc.file() << " "
+                //CXXTEST_STD(cout) << "HERE " << desc.file() << " "
                 //                  << classname << CXXTEST_STD(endl);
 
                 //classname=desc.suiteName();
@@ -340,19 +343,19 @@ namespace CxxTest
 
         void enterTest( const TestDescription & desc )
         {
-          testStartTime = std::chrono::high_resolution_clock::now();
-          testcase = info.insert(info.end(), TestCaseInfo());
-          testcase->testName = desc.testName();
-          testcase->className = classname;
-          std::ostringstream os;
-          os << desc.line();
-          testcase->line = os.str();
+           testStartTime = std::chrono::high_resolution_clock::now();
+           testcase = info.insert(info.end(), TestCaseInfo());
+           testcase->testName = desc.testName();
+           testcase->className = classname;
+           std::ostringstream os;
+           os << desc.line();
+           testcase->line = os.str();
 
-          if (stream_redirect)
-            CXXTEST_STD(cerr)
-                << "ERROR: The stream_redirect != NULL" << CXXTEST_STD(endl);
+           if ( stream_redirect )
+              CXXTEST_STD(cerr) << "ERROR: The stream_redirect != NULL"
+                                << CXXTEST_STD(endl);
 
-          stream_redirect =
+           stream_redirect =
               new TeeOutputStreams(CXXTEST_STD(cout), CXXTEST_STD(cerr));
         }
 
@@ -427,10 +430,11 @@ namespace CxxTest
           timeStream << totaltime;
                 (*_o) << "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>" << endl;
                 (*_o) << "<testsuite name=\"" << desc.worldName() << "\" ";
-                (*_o) << " tests=\"" << ntests << "\" errors=\"" << nerror
-                      << "\" failures=\"" << nfail << "\" package=\""
-                      << desc.worldName() << "\" time=\""
-                      << timeStream.str().c_str() << "\" >";
+                (*_o) << " tests=\"" << ntests
+                      << "\" errors=\"" << nerror
+                      << "\" failures=\"" << nfail
+                      << "\" package=\"" << desc.worldName()
+                      << "\" time=\"" << timeStream.str().c_str() << "\" >";
                 _o->endl(*_o);
                 (*_o) << _os->str().c_str();
                 _os->clear();
@@ -462,8 +466,8 @@ namespace CxxTest
 
         void failedAssert( const char *file, unsigned line, const char *expression )
         {
-          testFailure(file, line, "failedAssert")
-              << "Assertion failed: " << expression;
+            testFailure( file, line, "failedAssert" )
+               << "Assertion failed: " << expression;
         }
 
         void failedAssertEquals( const char *file, unsigned line,
@@ -480,10 +484,10 @@ namespace CxxTest
                                    const char *xStr, const char *yStr, const char *sizeStr,
                                    const void* /*x*/, const void* /*y*/, unsigned size )
         {
-          testFailure(file, line, "failedAssertSameData")
-              << "Error: Expected " << sizeStr << " (" << size
-              << ")  bytes to be equal at (" << xStr << ") and (" << yStr
-              << "), found";
+            testFailure( file, line, "failedAssertSameData")
+               << "Error: Expected " << sizeStr
+               << " (" << size << ")  bytes to be equal at ("
+               << xStr << ") and (" << yStr << "), found";
         }
 
         void failedAssertSameFiles( const char *file, unsigned line,
@@ -499,18 +503,21 @@ namespace CxxTest
                                 const char *xStr, const char *yStr, const char *dStr,
                                 const char *x, const char *y, const char *d )
         {
-          testFailure(file, line, "failedAssertDelta")
-              << "Error: Expected (" << xStr << " == " << yStr << ") up to "
-              << dStr << " (" << d << "), found (" << x << " != " << y << ")";
+            testFailure( file, line, "failedAssertDelta" )
+               << "Error: Expected ("
+               << xStr << " == " << yStr << ") up to " << dStr
+               << " (" << d << "), found ("
+               << x << " != " << y << ")";
         }
 
         void failedAssertDiffers( const char *file, unsigned line,
                                   const char *xStr, const char *yStr,
                                   const char *value )
         {
-          testFailure(file, line, "failedAssertDiffers")
-              << "Error: Expected (" << xStr << " != " << yStr << "), found ("
-              << value << ")";
+            testFailure( file, line, "failedAssertDiffers" )
+               << "Error: Expected ("
+               << xStr << " != " << yStr << "), found ("
+               << value << ")";
         }
 
         void failedAssertLessThan( const char *file, unsigned line,
@@ -537,9 +544,10 @@ namespace CxxTest
                                    const char *relation, const char *xStr, const char *yStr,
                                    const char *x, const char *y )
         {
-          testFailure(file, line, "failedAssertRelation")
-              << "Error: Expected " << relation << "( " << xStr << ", " << yStr
-              << " ), found !" << relation << "( " << x << ", " << y << " )";
+            testFailure( file, line, "failedAssertRelation" )
+               << "Error: Expected " << relation << "( " <<
+               xStr << ", " << yStr << " ), found !" << relation
+               << "( " << x << ", " << y << " )";
         }
 
         void failedAssertPredicate( const char *file, unsigned line,
@@ -554,17 +562,17 @@ namespace CxxTest
                                  const char *expression, const char *type,
                                  bool otherThrown )
         {
-          testFailure(file, line, "failedAssertThrows")
-              << "Error: Expected (" << expression << ") to throw (" << type
-              << ") but it "
-              << (otherThrown ? "threw something else" : "didn't throw");
+            testFailure( file, line, "failedAssertThrows" )
+               << "Error: Expected (" << expression << ") to throw ("  <<
+               type << ") but it "
+               << (otherThrown ? "threw something else" : "didn't throw");
         }
 
         void failedAssertThrowsNot( const char *file, unsigned line, const char *expression )
         {
-          testFailure(file, line, "failedAssertThrowsNot")
-              << "Error: Expected (" << expression
-              << ") not to throw, but it did";
+            testFailure( file, line, "failedAssertThrowsNot" )
+               << "Error: Expected (" << expression
+               << ") not to throw, but it did";
         }
 
     protected:

--- a/Testing/Tools/cxxtest/cxxtest/XmlFormatter.h
+++ b/Testing/Tools/cxxtest/cxxtest/XmlFormatter.h
@@ -23,25 +23,18 @@
 #define CXXTEST_STACK_TRACE_FILELINE_PREFIX "\" location=\""
 #define CXXTEST_STACK_TRACE_FILELINE_SUFFIX ""
 
-
-#include <cxxtest/TestRunner.h>
-#include <cxxtest/TestListener.h>
-#include <cxxtest/TestTracker.h>
-#include <cxxtest/ValueTraits.h>
+#include <chrono>
+#include <cstring>
+#include <ctime>
 #include <cxxtest/ErrorFormatter.h>
 #include <cxxtest/StdHeaders.h>
-#include <ctime>
-#ifdef _WIN32
-#include <time.h>
-#else
-#include <sys/time.h>
-#endif
-#include <time.h>
+#include <cxxtest/TestListener.h>
+#include <cxxtest/TestRunner.h>
+#include <cxxtest/TestTracker.h>
+#include <cxxtest/ValueTraits.h>
 #include <iostream>
 #include <sstream>
-#include <cstring>
 #include <stdexcept>
-
 
 namespace CxxTest
 {
@@ -144,16 +137,16 @@ namespace CxxTest
             std::map<std::string,std::string>::iterator curr=attribute.begin();
             std::map<std::string,std::string>::iterator end =attribute.end();
             while (curr != end) {
-              os << curr->first.c_str() 
-                 << "=\"" << curr->second.c_str() << "\" ";
+              os << curr->first.c_str() << "=\"" << curr->second.c_str()
+                 << "\" ";
               curr++;
               }
             if (value.str().empty()) {
                 os << "/>";
             }
             else {
-                os << ">" << escape(value.str()).c_str() 
-                   << "</" << name.c_str() << ">";
+              os << ">" << escape(value.str()).c_str() << "</" << name.c_str()
+                 << ">";
             }
             os.endl(os);
             }
@@ -263,36 +256,28 @@ namespace CxxTest
     class XmlFormatter : public TestListener
     {
         public:
-        XmlFormatter( OutputStream *o, OutputStream *ostr, std::ostringstream *os) 
-           : cpuStartTime(0), cpuStopTime(0), _o(o), _ostr(ostr), _os(os), stream_redirect(NULL)
-        {}
+          XmlFormatter(OutputStream *o, OutputStream *ostr,
+                       std::ostringstream *os)
+              : cpuStartTime(0), cpuStopTime(0), _o(o), _ostr(ostr), _os(os),
+                stream_redirect(NULL) {}
 
-        virtual ~XmlFormatter()
-        {
-          delete _ostr;
-        }
+          virtual ~XmlFormatter() { delete _ostr; }
 
-        std::list<TestCaseInfo> info;
-        std::list<TestCaseInfo>::iterator testcase;
-        typedef std::list<ElementInfo>::iterator element_t;
-        std::string classname;
-        int ntests;
-        int nfail;
-        int nerror;
-        double totaltime;
-        // The type of this variable is different depending on the platform
-      #ifdef _WIN32
-        clock_t
-      #else
-        timeval
-      #endif
-        testStartTime, testStopTime, testRunStartTime, testRunStopTime;
+          std::list<TestCaseInfo> info;
+          std::list<TestCaseInfo>::iterator testcase;
+          typedef std::list<ElementInfo>::iterator element_t;
+          std::string classname;
+          int ntests;
+          int nfail;
+          int nerror;
+          double totaltime;
+          std::chrono::time_point<std::chrono::high_resolution_clock>
+              testStartTime, testStopTime, testRunStartTime, testRunStopTime;
 
-        /// CPU time (for all processors)
-        clock_t cpuStartTime, cpuStopTime;
+          /// CPU time (for all processors)
+          clock_t cpuStartTime, cpuStopTime;
 
-        int run()
-        {
+          int run() {
             TestRunner::runAllTests( *this );
             return tracker().failedTests();
         }
@@ -309,7 +294,7 @@ namespace CxxTest
         {
             char s[WorldDescription::MAX_STRLEN_TOTAL_TESTS];
             const WorldDescription &wd = tracker().world();
-            o << wd.strTotalTests( s ) 
+            o << wd.strTotalTests(s)
               << (wd.numTotalTests() == 1 ? " test" : " tests");
         }
 
@@ -324,7 +309,7 @@ namespace CxxTest
                 while ( ! classname.empty() && classname[0] == '.' )
                    classname.erase(0,1);
 
-                //CXXTEST_STD(cout) << "HERE " << desc.file() << " " 
+                // CXXTEST_STD(cout) << "HERE " << desc.file() << " "
                 //                  << classname << CXXTEST_STD(endl);
 
                 //classname=desc.suiteName();
@@ -355,23 +340,19 @@ namespace CxxTest
 
         void enterTest( const TestDescription & desc )
         {
-            #ifdef _WIN32
-                testStartTime = clock();
-            #else
-                gettimeofday(&testStartTime, 0);
-            #endif
-                testcase = info.insert(info.end(),TestCaseInfo());
-                testcase->testName = desc.testName();
-                testcase->className = classname;
-                std::ostringstream os;
-                os << desc.line();
-                testcase->line = os.str();
+          testStartTime = std::chrono::high_resolution_clock::now();
+          testcase = info.insert(info.end(), TestCaseInfo());
+          testcase->testName = desc.testName();
+          testcase->className = classname;
+          std::ostringstream os;
+          os << desc.line();
+          testcase->line = os.str();
 
-           if ( stream_redirect )
-              CXXTEST_STD(cerr) << "ERROR: The stream_redirect != NULL" 
-                                << CXXTEST_STD(endl);
+          if (stream_redirect)
+            CXXTEST_STD(cerr)
+                << "ERROR: The stream_redirect != NULL" << CXXTEST_STD(endl);
 
-           stream_redirect = 
+          stream_redirect =
               new TeeOutputStreams(CXXTEST_STD(cout), CXXTEST_STD(cerr));
         }
 
@@ -384,11 +365,7 @@ namespace CxxTest
           cpuStartTime = clock();
 
           // Record the time now.
-          #ifdef _WIN32
-            testRunStartTime = clock();
-          #else
-            gettimeofday(&testRunStartTime, 0);
-          #endif
+          testRunStartTime = std::chrono::high_resolution_clock::now();
         }
 
         /** Call this method after the run() call, but before tearDown()
@@ -399,12 +376,7 @@ namespace CxxTest
           //Also CPU time.
           cpuStopTime = clock();
 
-          // Record the time now.
-          #ifdef _WIN32
-            testRunStopTime = clock();
-          #else
-            gettimeofday(&testRunStopTime, 0);
-          #endif
+          testRunStopTime = std::chrono::high_resolution_clock::now();
         }
 
         void leaveTest( const TestDescription & )
@@ -425,25 +397,20 @@ namespace CxxTest
                 stream_redirect = NULL;
            }
 
+           testStopTime = std::chrono::high_resolution_clock::now();
+           const std::chrono::duration<double> duration_total =
+               testStopTime - testStartTime;
+           const double testTime = duration_total.count();
 
-        #ifdef _WIN32
-           const double testTime = double(clock() - testStartTime)/CLOCKS_PER_SEC;
-           const double testRunTime = double(testRunStopTime - testRunStartTime)/CLOCKS_PER_SEC;
-        #else
-           gettimeofday(&testStopTime, 0);
-           double sec = double(testStopTime.tv_sec - testStartTime.tv_sec);
-           double usec = double(testStopTime.tv_usec - testStartTime.tv_usec);
-           double testTime = sec + (usec / 1000000.0);
-
-           sec = double(testRunStopTime.tv_sec - testRunStartTime.tv_sec);
-           usec = double(testRunStopTime.tv_usec - testRunStartTime.tv_usec);
-           double testRunTime = sec + (usec / 1000000.0);
-        #endif
+           const std::chrono::duration<double> duration_test =
+               testRunStopTime - testRunStartTime;
+           const double testRunTime = duration_test.count();
 
            // The CPU runtime, which on linux will be from all processors. Don't know about windows, think it's wall-clock time.
-           double cpuTime = double(cpuStopTime - cpuStartTime)/CLOCKS_PER_SEC;
+           const double cpuTime =
+               static_cast<double>(cpuStopTime - cpuStartTime) / CLOCKS_PER_SEC;
            // CPU fraction = what fraction of the CPU(s) was used.
-           double CPUFraction = cpuTime / testRunTime;
+           const double CPUFraction = cpuTime / testRunTime;
 
            // Changed: we show the run() time, EXCLUDING the setup time.
            // Set the run time for this test
@@ -460,11 +427,10 @@ namespace CxxTest
           timeStream << totaltime;
                 (*_o) << "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>" << endl;
                 (*_o) << "<testsuite name=\"" << desc.worldName() << "\" ";
-                (*_o) << " tests=\"" << ntests 
-                      << "\" errors=\"" << nerror 
-                      << "\" failures=\"" << nfail 
-                      << "\" package=\"" << desc.worldName()
-                      << "\" time=\"" << timeStream.str().c_str() << "\" >";
+                (*_o) << " tests=\"" << ntests << "\" errors=\"" << nerror
+                      << "\" failures=\"" << nfail << "\" package=\""
+                      << desc.worldName() << "\" time=\""
+                      << timeStream.str().c_str() << "\" >";
                 _o->endl(*_o);
                 (*_o) << _os->str().c_str();
                 _os->clear();
@@ -496,8 +462,8 @@ namespace CxxTest
 
         void failedAssert( const char *file, unsigned line, const char *expression )
         {
-            testFailure( file, line, "failedAssert" ) 
-               << "Assertion failed: " << expression;
+          testFailure(file, line, "failedAssert")
+              << "Assertion failed: " << expression;
         }
 
         void failedAssertEquals( const char *file, unsigned line,
@@ -514,10 +480,10 @@ namespace CxxTest
                                    const char *xStr, const char *yStr, const char *sizeStr,
                                    const void* /*x*/, const void* /*y*/, unsigned size )
         {
-            testFailure( file, line, "failedAssertSameData")
-               << "Error: Expected " << sizeStr 
-               << " (" << size << ")  bytes to be equal at ("
-               << xStr << ") and (" << yStr << "), found";
+          testFailure(file, line, "failedAssertSameData")
+              << "Error: Expected " << sizeStr << " (" << size
+              << ")  bytes to be equal at (" << xStr << ") and (" << yStr
+              << "), found";
         }
 
         void failedAssertSameFiles( const char *file, unsigned line,
@@ -533,21 +499,18 @@ namespace CxxTest
                                 const char *xStr, const char *yStr, const char *dStr,
                                 const char *x, const char *y, const char *d )
         {
-            testFailure( file, line, "failedAssertDelta" )
-               << "Error: Expected (" 
-               << xStr << " == " << yStr << ") up to " << dStr 
-               << " (" << d << "), found (" 
-               << x << " != " << y << ")";
+          testFailure(file, line, "failedAssertDelta")
+              << "Error: Expected (" << xStr << " == " << yStr << ") up to "
+              << dStr << " (" << d << "), found (" << x << " != " << y << ")";
         }
 
         void failedAssertDiffers( const char *file, unsigned line,
                                   const char *xStr, const char *yStr,
                                   const char *value )
         {
-            testFailure( file, line, "failedAssertDiffers" )
-               << "Error: Expected (" 
-               << xStr << " != " << yStr << "), found (" 
-               << value << ")";
+          testFailure(file, line, "failedAssertDiffers")
+              << "Error: Expected (" << xStr << " != " << yStr << "), found ("
+              << value << ")";
         }
 
         void failedAssertLessThan( const char *file, unsigned line,
@@ -574,10 +537,9 @@ namespace CxxTest
                                    const char *relation, const char *xStr, const char *yStr,
                                    const char *x, const char *y )
         {
-            testFailure( file, line, "failedAssertRelation" )
-               << "Error: Expected " << relation << "( " <<
-               xStr << ", " << yStr << " ), found !" << relation 
-               << "( " << x << ", " << y << " )";
+          testFailure(file, line, "failedAssertRelation")
+              << "Error: Expected " << relation << "( " << xStr << ", " << yStr
+              << " ), found !" << relation << "( " << x << ", " << y << " )";
         }
 
         void failedAssertPredicate( const char *file, unsigned line,
@@ -592,17 +554,17 @@ namespace CxxTest
                                  const char *expression, const char *type,
                                  bool otherThrown )
         {
-            testFailure( file, line, "failedAssertThrows" )
-               << "Error: Expected (" << expression << ") to throw ("  <<
-               type << ") but it " 
-               << (otherThrown ? "threw something else" : "didn't throw");
+          testFailure(file, line, "failedAssertThrows")
+              << "Error: Expected (" << expression << ") to throw (" << type
+              << ") but it "
+              << (otherThrown ? "threw something else" : "didn't throw");
         }
 
         void failedAssertThrowsNot( const char *file, unsigned line, const char *expression )
         {
-            testFailure( file, line, "failedAssertThrowsNot" )
-               << "Error: Expected (" << expression 
-               << ") not to throw, but it did";
+          testFailure(file, line, "failedAssertThrowsNot")
+              << "Error: Expected (" << expression
+              << ") not to throw, but it did";
         }
 
     protected:
@@ -684,4 +646,3 @@ namespace CxxTest
 // Copyright 2008 Sandia Corporation. Under the terms of Contract
 // DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
 // retains certain rights in this software.
-

--- a/qt/widgets/common/src/DoubleSpinBox.cpp
+++ b/qt/widgets/common/src/DoubleSpinBox.cpp
@@ -29,11 +29,11 @@
 #include "MantidQtWidgets/Common/DoubleSpinBox.h"
 
 //#include <MyParser.h>
-#include <QLineEdit>
-#include <QHBoxLayout>
 #include <QCloseEvent>
-#include <float.h>
-#include <math.h>
+#include <QHBoxLayout>
+#include <QLineEdit>
+#include <cfloat>
+#include <cmath>
 
 DoubleSpinBox::DoubleSpinBox(const char format, QWidget *parent)
     : QAbstractSpinBox(parent), d_format(format), d_min_val(-DBL_MAX),

--- a/qt/widgets/common/src/MantidWSIndexDialog.cpp
+++ b/qt/widgets/common/src/MantidWSIndexDialog.cpp
@@ -5,14 +5,14 @@
 #include "MantidAPI/Run.h"
 #include "MantidAPI/SpectraDetectorTypes.h"
 
+#include <QMessageBox>
 #include <QPalette>
 #include <QPushButton>
 #include <QRegExp>
 #include <QtAlgorithms>
-#include <QMessageBox>
 #include <boost/lexical_cast.hpp>
+#include <cstdlib>
 #include <exception>
-#include <stdlib.h>
 
 namespace MantidQt {
 namespace MantidWidgets {

--- a/qt/widgets/common/src/QtPropertyBrowser/qtpropertymanager.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtpropertymanager.cpp
@@ -100,9 +100,9 @@
 #include <QtGui/QPainter>
 #include <QtGui/QLabel>
 
-#include <limits.h>
-#include <float.h>
-#include <math.h>
+#include <cfloat>
+#include <climits>
+#include <cmath>
 
 #if defined(Q_CC_MSVC)
 #pragma warning(                                                               \

--- a/qt/widgets/common/src/QwtRasterDataMD.cpp
+++ b/qt/widgets/common/src/QwtRasterDataMD.cpp
@@ -1,9 +1,9 @@
 #include "MantidQtWidgets/Common/QwtRasterDataMD.h"
-#include <math.h>
-#include "MantidGeometry/MDGeometry/MDTypes.h"
-#include "MantidGeometry/MDGeometry/IMDDimension.h"
 #include "MantidAPI/IMDWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidGeometry/MDGeometry/IMDDimension.h"
+#include "MantidGeometry/MDGeometry/MDTypes.h"
+#include <cmath>
 
 namespace MantidQt {
 namespace API {

--- a/qt/widgets/common/src/ScaleEngine.cpp
+++ b/qt/widgets/common/src/ScaleEngine.cpp
@@ -30,7 +30,7 @@
 #include "MantidQtWidgets/Common/ScaleEngine.h"
 #include "MantidQtWidgets/Common/PowerScaleEngine.h"
 #include "MantidQtWidgets/Common/qwt_compat.h"
-#include <limits.h>
+#include <climits>
 
 QwtScaleTransformation *ScaleEngine::transformation() const {
   return new ScaleTransformation(this);

--- a/qt/widgets/common/src/SlitCalculator.cpp
+++ b/qt/widgets/common/src/SlitCalculator.cpp
@@ -5,7 +5,7 @@
 #include "MantidKernel/Strings.h"
 #include "MantidGeometry/Instrument/InstrumentDefinitionParser.h"
 
-#include <math.h>
+#include <cmath>
 
 namespace MantidQt {
 namespace MantidWidgets {

--- a/qt/widgets/instrumentview/src/GLActorCollection.cpp
+++ b/qt/widgets/instrumentview/src/GLActorCollection.cpp
@@ -4,10 +4,10 @@
 
 #include "MantidKernel/Exception.h"
 
-#include <stdexcept>
-#include <functional>
 #include <algorithm>
-#include <float.h>
+#include <cfloat>
+#include <functional>
+#include <stdexcept>
 
 namespace MantidQt {
 namespace MantidWidgets {

--- a/qt/widgets/instrumentview/src/Viewport.cpp
+++ b/qt/widgets/instrumentview/src/Viewport.cpp
@@ -1,9 +1,9 @@
 #include "MantidQtWidgets/InstrumentView/Viewport.h"
-#include "MantidQtWidgets/Common/TSVSerialiser.h"
-#include <math.h>
 #include "MantidGeometry/Rendering/OpenGL_Headers.h"
 #include "MantidKernel/V3D.h"
+#include "MantidQtWidgets/Common/TSVSerialiser.h"
 #include "MantidQtWidgets/InstrumentView/OpenGLError.h"
+#include <cmath>
 #include <limits>
 
 namespace MantidQt {

--- a/qt/widgets/spectrumviewer/src/ArrayDataSource.cpp
+++ b/qt/widgets/spectrumviewer/src/ArrayDataSource.cpp
@@ -1,5 +1,5 @@
 
-#include <math.h>
+#include <cmath>
 
 #include "MantidQtWidgets/SpectrumViewer/ArrayDataSource.h"
 #include "MantidQtWidgets/SpectrumViewer/SVUtils.h"

--- a/qt/widgets/spectrumviewer/src/ColorMaps.cpp
+++ b/qt/widgets/spectrumviewer/src/ColorMaps.cpp
@@ -1,6 +1,6 @@
 
+#include <cmath>
 #include <sstream>
-#include <math.h>
 
 #include "MantidQtWidgets/SpectrumViewer/ColorMaps.h"
 

--- a/qt/widgets/spectrumviewer/src/DataArray.cpp
+++ b/qt/widgets/spectrumviewer/src/DataArray.cpp
@@ -2,7 +2,7 @@
  * File DataArray.cpp
  */
 
-#include <math.h>
+#include <cmath>
 
 #include "MantidQtWidgets/SpectrumViewer/DataArray.h"
 

--- a/qt/widgets/spectrumviewer/src/MatrixWSDataSource.cpp
+++ b/qt/widgets/spectrumviewer/src/MatrixWSDataSource.cpp
@@ -3,8 +3,8 @@
  */
 
 #include <boost/lexical_cast.hpp>
+#include <cmath>
 #include <sstream>
-#include <math.h>
 
 #include <QThread>
 

--- a/qt/widgets/spectrumviewer/src/SVUtils.cpp
+++ b/qt/widgets/spectrumviewer/src/SVUtils.cpp
@@ -1,6 +1,6 @@
+#include <cmath>
 #include <iostream>
 #include <sstream>
-#include <math.h>
 
 #include "MantidQtWidgets/SpectrumViewer/SVUtils.h"
 

--- a/qt/widgets/spectrumviewer/src/SpectrumDataSource.cpp
+++ b/qt/widgets/spectrumviewer/src/SpectrumDataSource.cpp
@@ -1,5 +1,5 @@
 
-#include <math.h>
+#include <cmath>
 
 #include "MantidQtWidgets/SpectrumViewer/SpectrumDataSource.h"
 


### PR DESCRIPTION
Also redo `Timer.cpp` and `XMLFormatter.h` to use c++11 constructs.

**To test:**

If the builds pass, it should be good.

*There is no associated issue.*

*Does not need to be in the release notes* because it is just cleaning up implementation.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
