### PR TITLE
Fix python3 test

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/ComputeIncoherentDOSTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ComputeIncoherentDOSTest.py
@@ -55,8 +55,8 @@ class ComputeIncoherentDOSTest(unittest.TestCase):
         self.assertEquals(ws_DOS.getAxis(0).getUnit().unitID(), 'DeltaE_inWavenumber')
         self.assertEquals(ws_DOS.blocksize(), 200)
         # Checks that the Bose factor correction is ok.
-        dos_eplus = np.max(ws_DOS.readY(0)[range(100,200)])
-        dos_eminus = np.max(ws_DOS.readY(0)[range(0,100)])
+        dos_eplus = np.max(ws_DOS.readY(0)[100:200])
+        dos_eminus = np.max(ws_DOS.readY(0)[:100])
         self.assertAlmostEqual(dos_eplus, dos_eminus, places=1)
         # Check that unit conversion from cm^-1 to meV works and also that conversion to states/meV is done
         ws = self.convertToWavenumber(ws)


### PR DESCRIPTION
Replace range in indices with slicing. The test failed in http://builds.mantidproject.org/job/master_clean-ubuntu-python3/504/ Test should now pass on both python 2 and 3 builds.

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [x] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
