### PR TITLE
Remove a cppcheck error

### DIFF
--- a/Framework/ICat/src/CatalogDownloadDataFiles.cpp
+++ b/Framework/ICat/src/CatalogDownloadDataFiles.cpp
@@ -164,10 +164,8 @@ std::string CatalogDownloadDataFiles::doDownloadandSavetoLocalDrive(
         nullptr, certificateHandler, context);
 
     // Session takes ownership of socket
-    Poco::Net::SecureStreamSocket *socket =
-        new Poco::Net::SecureStreamSocket(context);
+    auto socket = Kernel::make_unique<Poco::Net::SecureStreamSocket>(context);
     Poco::Net::HTTPSClientSession session(*socket);
-    socket = nullptr;
     session.setHost(uri.getHost());
     session.setPort(uri.getPort());
 

--- a/Framework/ICat/src/CatalogDownloadDataFiles.cpp
+++ b/Framework/ICat/src/CatalogDownloadDataFiles.cpp
@@ -164,8 +164,8 @@ std::string CatalogDownloadDataFiles::doDownloadandSavetoLocalDrive(
         nullptr, certificateHandler, context);
 
     // Session takes ownership of socket
-    auto socket = Kernel::make_unique<Poco::Net::SecureStreamSocket>(context);
-    Poco::Net::HTTPSClientSession session(*socket);
+    Poco::Net::SecureStreamSocket socket{context};
+    Poco::Net::HTTPSClientSession session{socket};
     session.setHost(uri.getHost());
     session.setPort(uri.getPort());
 
@@ -213,12 +213,6 @@ std::string CatalogDownloadDataFiles::doDownloadandSavetoLocalDrive(
   // I have opted to catch the exception and do nothing as this allows the
   // load/download functionality to work.
   // However, the port the user used to download the file will be left open.
-  //
-  // In addition, there's a crash when destructing SecureSocketImpl (internal to
-  // SecureSocketStream, which is
-  // created and destroyed by HTTPSClientSession). We avoid that crash by
-  // instantiating SecureSocketStream
-  // ourselves and passing it to the HTTPSClientSession, which takes ownership.
   catch (Poco::Exception &error) {
     throw std::runtime_error(error.displayText());
   }


### PR DESCRIPTION
Remove the single cppcheck error on the build servers. This error was left in because of a bug in Poco 1.3 that we could not work around. Since we are now on version 1.4 it should be safe fix this.

After this is merged it should be safe to take the accepted error tolerance on the cppcheck build down to zero.

**To test:**
 - Apply changes 
 - Login to ICAT
 - Search for an investigation of your choice
 - Attempt to download some files and check you do not get an exception.
 - Code review

This PR has no associated issue.

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
