### PR TITLE
Removed duplicate names error in doctests

### DIFF
--- a/docs/source/algorithms/Transpose-v1.rst
+++ b/docs/source/algorithms/Transpose-v1.rst
@@ -47,4 +47,4 @@ Output:
 .. categories::
 
 .. sourcelink::
-      :h: /Framework/Algorithms/inc/MantidAlgorithms/Transpose.h
+      :h: Framework/Algorithms/inc/MantidAlgorithms/Transpose.h

--- a/docs/source/algorithms/Transpose-v1.rst
+++ b/docs/source/algorithms/Transpose-v1.rst
@@ -46,5 +46,5 @@ Output:
 
 .. categories::
 
-.. sourcelink:
+.. sourcelink::
       :h: /Framework/Algorithms/inc/MantidAlgorithms/Transpose.h

--- a/docs/source/algorithms/Transpose-v1.rst
+++ b/docs/source/algorithms/Transpose-v1.rst
@@ -46,4 +46,5 @@ Output:
 
 .. categories::
 
-.. sourcelink::
+.. sourcelink:
+      :h: /Framework/Algorithms/inc/MantidAlgorithms/Transpose.h


### PR DESCRIPTION
Previously the `runsphinx_doctest.py` script failed on Ubuntu when reading sources with the following error:
```
Exception occurred:
  File "~/mantid/docs/sphinxext/mantiddoc/doctest.py", line 520, in doctest_to_xunit
    raise exception
SourceLinkError: Found multiple possibilities for Transpose.h
Possible matches[u'~/mantid/Framework/Algorithms/inc/MantidAlgorithms/Transpose.h', u'~/eigen-src/Eigen/src/Core/Transpose.h']
Specify one using the h option
e.g. 
.. sourcelink:
      :h: /Framework/Algorithms/inc/MantidAlgorithms/Transpose.h
```
The recommended flag has now been added to `Transpose.h` and the name conflict no longer occurs.

**To test:**
Make sure all doctests still pass without worry.

Fixes #20687 

**Release Notes** 
*Does not need to be in the release notes - internal change.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
