### PR TITLE
Colour Fill plots of ragged workspaces.

### DIFF
--- a/MantidPlot/src/Spectrogram.cpp
+++ b/MantidPlot/src/Spectrogram.cpp
@@ -250,10 +250,10 @@ MantidQt::API::QwtRasterDataMD *Spectrogram::dataFromWorkspace(
          ++iHisto) {
       auto &x = matrixWorkspace->x(iHisto);
       if (x.front() < minX) {
-        minX = x.front();
+        minX = static_cast<Mantid::coord_t>(x.front());
       }
       if (x.back() > maxX) {
-        maxX = x.back();
+        maxX = static_cast<Mantid::coord_t>(x.back());
       }
     }
   }

--- a/MantidPlot/src/Spectrogram.cpp
+++ b/MantidPlot/src/Spectrogram.cpp
@@ -211,15 +211,19 @@ void Spectrogram::updateData(
 }
 
 /**
- * Check all histograms in a matrix workspace to make sure that minX and maxX cover all x -values.
+ * Check all histograms in a matrix workspace to make sure that minX and maxX
+ * cover all x -values.
  * @param workspace :: A workspace being plotted.
- * @param minX :: The minimum value on the Spectrogram's x axis. Updated if workspace is ragged.
- * @param maxX :: The maximum value on the Spectrogram's x axis. Updated if workspace is ragged.
+ * @param minX :: The minimum value on the Spectrogram's x axis. Updated if
+ * workspace is ragged.
+ * @param maxX :: The maximum value on the Spectrogram's x axis. Updated if
+ * workspace is ragged.
  */
-void Spectrogram::checkRaggedMatrixWorkspace(const Mantid::API::Workspace* workspace, Mantid::coord_t& minX, Mantid::coord_t& maxX) {
+void Spectrogram::checkRaggedMatrixWorkspace(
+    const Mantid::API::Workspace *workspace, Mantid::coord_t &minX,
+    Mantid::coord_t &maxX) {
   auto matrixWorkspace =
-      dynamic_cast<const Mantid::API::MatrixWorkspace*>(
-          workspace);
+      dynamic_cast<const Mantid::API::MatrixWorkspace *>(workspace);
   if (matrixWorkspace) {
     for (size_t iHisto = 0; iHisto < matrixWorkspace->getNumberHistograms();
          ++iHisto) {

--- a/MantidPlot/src/Spectrogram.cpp
+++ b/MantidPlot/src/Spectrogram.cpp
@@ -211,6 +211,30 @@ void Spectrogram::updateData(
 }
 
 /**
+ * Check all histograms in a matrix workspace to make sure that minX and maxX cover all x -values.
+ * @param workspace :: A workspace being plotted.
+ * @param minX :: The minimum value on the Spectrogram's x axis. Updated if workspace is ragged.
+ * @param maxX :: The maximum value on the Spectrogram's x axis. Updated if workspace is ragged.
+ */
+void Spectrogram::checkRaggedMatrixWorkspace(const Mantid::API::Workspace* workspace, Mantid::coord_t& minX, Mantid::coord_t& maxX) {
+  auto matrixWorkspace =
+      dynamic_cast<const Mantid::API::MatrixWorkspace*>(
+          workspace);
+  if (matrixWorkspace) {
+    for (size_t iHisto = 0; iHisto < matrixWorkspace->getNumberHistograms();
+         ++iHisto) {
+      auto &x = matrixWorkspace->x(iHisto);
+      if (x.front() < minX) {
+        minX = static_cast<Mantid::coord_t>(x.front());
+      }
+      if (x.back() > maxX) {
+        maxX = static_cast<Mantid::coord_t>(x.back());
+      }
+    }
+  }
+}
+
+/**
  * Extracts data from workspace
  * @param workspace :: [input] Pointer to workspace
  * @param range :: [input] (optional) Data range - set null for full range
@@ -242,21 +266,7 @@ MantidQt::API::QwtRasterDataMD *Spectrogram::dataFromWorkspace(
 
   // A MatrixWorkspace can be ragged. Make sure the x axis covers all
   // histograms.
-  auto matrixWorkspace =
-      boost::dynamic_pointer_cast<const Mantid::API::MatrixWorkspace>(
-          workspace);
-  if (matrixWorkspace) {
-    for (size_t iHisto = 0; iHisto < matrixWorkspace->getNumberHistograms();
-         ++iHisto) {
-      auto &x = matrixWorkspace->x(iHisto);
-      if (x.front() < minX) {
-        minX = static_cast<Mantid::coord_t>(x.front());
-      }
-      if (x.back() > maxX) {
-        maxX = static_cast<Mantid::coord_t>(x.back());
-      }
-    }
-  }
+  checkRaggedMatrixWorkspace(workspace.get(), minX, maxX);
 
   Mantid::coord_t dx(dim0->getBinWidth()), dy(dim1->getBinWidth());
   const Mantid::coord_t width = (maxX - minX) + dx;

--- a/MantidPlot/src/Spectrogram.cpp
+++ b/MantidPlot/src/Spectrogram.cpp
@@ -240,10 +240,14 @@ MantidQt::API::QwtRasterDataMD *Spectrogram::dataFromWorkspace(
   Mantid::coord_t minX(dim0->getMinimum()), maxX(dim0->getMaximum()),
       minY(dim1->getMinimum()), maxY(dim1->getMaximum());
 
-  // A MatrixWorkspace can be ragged. Make sure the x axis covers all histograms.
-  auto matrixWorkspace = boost::dynamic_pointer_cast<const Mantid::API::MatrixWorkspace>(workspace);
+  // A MatrixWorkspace can be ragged. Make sure the x axis covers all
+  // histograms.
+  auto matrixWorkspace =
+      boost::dynamic_pointer_cast<const Mantid::API::MatrixWorkspace>(
+          workspace);
   if (matrixWorkspace) {
-    for (size_t iHisto = 0; iHisto < matrixWorkspace->getNumberHistograms(); ++iHisto) {
+    for (size_t iHisto = 0; iHisto < matrixWorkspace->getNumberHistograms();
+         ++iHisto) {
       auto &x = matrixWorkspace->x(iHisto);
       if (x.front() < minX) {
         minX = x.front();

--- a/MantidPlot/src/Spectrogram.cpp
+++ b/MantidPlot/src/Spectrogram.cpp
@@ -227,7 +227,7 @@ void Spectrogram::checkRaggedMatrixWorkspace(
   if (matrixWorkspace) {
     for (size_t iHisto = 0; iHisto < matrixWorkspace->getNumberHistograms();
          ++iHisto) {
-      auto &x = matrixWorkspace->x(iHisto);
+      const auto &x = matrixWorkspace->x(iHisto);
       if (x.front() < minX) {
         minX = static_cast<Mantid::coord_t>(x.front());
       }

--- a/MantidPlot/src/Spectrogram.h
+++ b/MantidPlot/src/Spectrogram.h
@@ -190,6 +190,7 @@ protected:
                     const QwtScaleMap &yMap,
                     const QwtRasterData::ContourLines &lines) const;
   void createLabels();
+  void checkRaggedMatrixWorkspace(const Mantid::API::Workspace* workspace, Mantid::coord_t& minX, Mantid::coord_t& maxX);
 
   //! Pointer to the source data matrix
   Matrix *d_matrix;

--- a/MantidPlot/src/Spectrogram.h
+++ b/MantidPlot/src/Spectrogram.h
@@ -190,7 +190,8 @@ protected:
                     const QwtScaleMap &yMap,
                     const QwtRasterData::ContourLines &lines) const;
   void createLabels();
-  void checkRaggedMatrixWorkspace(const Mantid::API::Workspace* workspace, Mantid::coord_t& minX, Mantid::coord_t& maxX);
+  void checkRaggedMatrixWorkspace(const Mantid::API::Workspace *workspace,
+                                  Mantid::coord_t &minX, Mantid::coord_t &maxX);
 
   //! Pointer to the source data matrix
   Matrix *d_matrix;


### PR DESCRIPTION
Check x axes of all histograms before setting the x scale.

**To test:**

Create a workspace with this script:
```
w=CreateWorkspace(DataX='1,2,3,4, 2,3,5,9, 3,4,7,11, 1,2,3,4', DataY='1,5,2,1,2,3,1,2,3,1,2,3', NSpec=4)
```
Then open a Colour Fill plot. It should show the data correctly.

Fixes #20685

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
