### PR TITLE
Rounding errors in tables

### DIFF
--- a/MantidPlot/src/Mantid/MantidTable.cpp
+++ b/MantidPlot/src/Mantid/MantidTable.cpp
@@ -1,3 +1,6 @@
+#include <iomanip>
+#include <limits>
+
 #include "MantidTable.h"
 #include "../ApplicationWindow.h"
 #include "../Mantid/MantidUI.h"
@@ -312,7 +315,7 @@ void MantidTable::cellEdited(int row, int col) {
     // Put it back in the stream and let the column deduce the correct
     // type of the number.
     std::stringstream textStream;
-    textStream << number;
+    textStream << std::setprecision(std::numeric_limits<long double>::digits10 + 1)<<number;
     std::istringstream stream(textStream.str());
     c->read(index, stream);
   }

--- a/MantidPlot/src/Mantid/MantidTable.cpp
+++ b/MantidPlot/src/Mantid/MantidTable.cpp
@@ -315,7 +315,8 @@ void MantidTable::cellEdited(int row, int col) {
     // Put it back in the stream and let the column deduce the correct
     // type of the number.
     std::stringstream textStream;
-    textStream << std::setprecision(std::numeric_limits<long double>::digits10 + 1)<<number;
+    textStream << std::setprecision(std::numeric_limits<long double>::digits10 +
+                                    1) << number;
     std::istringstream stream(textStream.str());
     c->read(index, stream);
   }

--- a/docs/source/release/v3.11.0/framework.rst
+++ b/docs/source/release/v3.11.0/framework.rst
@@ -98,7 +98,8 @@ Bug fixes
 
 - :ref:`CubicSpline <func-CubicSpline>` is fixed to sort the y-values and x-values correctly.
 - Fix displayed type name for optional boolean properties.
-- Fix parameters that are tied to functions can now be untied correctly. 
+- Fix parameters that are tied to functions can now be untied correctly.
+- Table workspaces do not have the values changed by viewing them (no rounding).
 
 Improved
 ########


### PR DESCRIPTION
If a user makes a table with a large number in it. Then opens the table to look at the data (it will look ok), all of the data would have been rounded. This is to stop rounding errors. 

**To test:**
In the script window run the following code:

```
tab = CreateEmptyTableWorkspace()
tab.addColumn('double', 'Asymmetry')
tab.addColumn('double', 'Phase')
tab.addColumn('double', 'DeadTime')
for i in range(0,16):
   #tab.addRow([1, 50.0, 0.00, 0])
   tab.addRow([123456789, 50.0, 1.57])
```
If you then open the table by double clicking it, it will look ok. Close the table and reopen it (on the release branch there will be some rounding of the values). 

You can check the value in the table (without opening it) by using this script:
```

table = mtd["tab"]
print table.row(0)
```

<!-- Instructions for testing. -->

Fixes #20661. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->
Added to release notes
---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
