### PR TITLE
Fix performance regression in MaxEnt performance test

### DIFF
--- a/Framework/Algorithms/src/MaxEnt.cpp
+++ b/Framework/Algorithms/src/MaxEnt.cpp
@@ -224,7 +224,7 @@ void MaxEnt::exec() {
   size_t nspec = inWS->getNumberHistograms();
   // Number of data points - assumed to be constant between spectra or
   // this will throw an exception
-  size_t npoints = inWS->y(0).blocksize() * resolutionFactor;
+  size_t npoints = inWS->blocksize() * resolutionFactor;
   // Number of X bins
   const size_t npointsX = inWS->isHistogramData() ? npoints + 1 : npoints;
 

--- a/Framework/Algorithms/src/MaxEnt.cpp
+++ b/Framework/Algorithms/src/MaxEnt.cpp
@@ -19,13 +19,8 @@
 namespace Mantid {
 namespace Algorithms {
 
-using Mantid::Kernel::Direction;
-using Mantid::API::WorkspaceProperty;
-using Mantid::HistogramData::Points;
-using Mantid::HistogramData::BinEdges;
-using Mantid::HistogramData::Counts;
-using Mantid::HistogramData::CountStandardDeviations;
 using Mantid::HistogramData::LinearGenerator;
+using Mantid::HistogramData::Points;
 
 using namespace API;
 using namespace Kernel;
@@ -227,8 +222,8 @@ void MaxEnt::exec() {
   MatrixWorkspace_const_sptr inWS = getProperty("InputWorkspace");
   // Number of spectra
   size_t nspec = inWS->getNumberHistograms();
-  // Number of data points
-  size_t npoints = inWS->blocksize() * resolutionFactor;
+  // Number of data points - assumed to be constant between spectra
+  size_t npoints = inWS->y(0).size() * resolutionFactor;
   // Number of X bins
   const size_t npointsX = inWS->isHistogramData() ? npoints + 1 : npoints;
 
@@ -378,7 +373,7 @@ void MaxEnt::exec() {
 */
 std::vector<double> MaxEnt::toComplex(API::MatrixWorkspace_const_sptr &inWS,
                                       size_t spec, bool errors) {
-  const size_t numBins = inWS->blocksize();
+  const size_t numBins = inWS->y(0).size();
   std::vector<double> result(numBins * 2);
 
   if (inWS->getNumberHistograms() % 2)
@@ -687,11 +682,11 @@ void MaxEnt::populateImageWS(MatrixWorkspace_const_sptr &inWS, size_t spec,
   double dx = dataPoints[1] - x0;
 
   double delta = 1. / dx / npoints;
-  int isOdd = (inWS->blocksize() % 2) ? 1 : 0;
+  const int isOdd = (inWS->y(0).size() % 2) ? 1 : 0;
 
-  double shift = x0 * 2 * M_PI;
+  double shift = x0 * 2. * M_PI;
   if (!autoShift)
-    shift = 0;
+    shift = 0.;
 
   // X values
   for (int i = 0; i < npoints; i++) {

--- a/Framework/Algorithms/src/MaxEnt.cpp
+++ b/Framework/Algorithms/src/MaxEnt.cpp
@@ -222,8 +222,9 @@ void MaxEnt::exec() {
   MatrixWorkspace_const_sptr inWS = getProperty("InputWorkspace");
   // Number of spectra
   size_t nspec = inWS->getNumberHistograms();
-  // Number of data points - assumed to be constant between spectra
-  size_t npoints = inWS->y(0).size() * resolutionFactor;
+  // Number of data points - assumed to be constant between spectra or
+  // this will throw an exception
+  size_t npoints = inWS->y(0).blocksize() * resolutionFactor;
   // Number of X bins
   const size_t npointsX = inWS->isHistogramData() ? npoints + 1 : npoints;
 


### PR DESCRIPTION
There was a [regression in performance of `MaxEnt`](http://builds.mantidproject.org/job/master_performancetests2/Master_branch_performance_tests/AlgorithmsTest.MaxEntTestPerformance.testExecReal.htm) that was introduced by the `blocksize()` changes of #20451. This addresses that.

**To test:**

`ctest -R MaxEntTest` a few times before and after the change and marvel at how much faster it is now.

*There is no associated issue.*

*Does not need to be in the release notes* because it fixes a performance issue that was recently introduced and shouldn't have been seen by users of stable releases.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
