### PR TITLE
Python3 doctest compatibility: algorithms CopyDetectorMapping to CreateWorkspace

### DIFF
--- a/docs/source/algorithms/CopyDetectorMapping-v1.rst
+++ b/docs/source/algorithms/CopyDetectorMapping-v1.rst
@@ -39,14 +39,14 @@ Usage:
     to_match = GroupDetectors(InputWorkspace=to_match, PreserveEvents=False,
                               CopyGroupingFromWorkspace='grouping_ws')
 
-    print 'Spectrum 0 detectors before copy: ' + str(to_remap.getSpectrum(0).getDetectorIDs())
+    print('Spectrum 0 detectors before copy: {}'.format(to_remap.getSpectrum(0).getDetectorIDs()))
 
     # Copy the grouping to another workspace
     CopyDetectorMapping(WorkspaceToMatch='to_match',
                         WorkspaceToRemap='to_remap',
                         IndexBySpectrumNumber=True)
 
-    print 'Spectrum 0 detectors after copy: ' + str(to_remap.getSpectrum(0).getDetectorIDs())
+    print('Spectrum 0 detectors after copy: {}'.format(to_remap.getSpectrum(0).getDetectorIDs()))
 
 
 Output:

--- a/docs/source/algorithms/CopyInstrumentParameters-v1.rst
+++ b/docs/source/algorithms/CopyInstrumentParameters-v1.rst
@@ -42,8 +42,8 @@ Usage
    # Show positions in 1st workspace
    for i in spectra:
         det = ws1.getDetector(i)
-        print "Position of Detector ID=%i in 1st workspace: %.0f,%.0f,%.0f" % (det.getID(), 
-                det.getPos().X(), det.getPos().Y(), det.getPos().Z())
+        print("Position of Detector ID={} in 1st workspace: {:.0f},{:.0f},{:.0f}". 
+               format(det.getID(), det.getPos().X(), det.getPos().Y(), det.getPos().Z()))
                 
    # Show positions in 2nd workspace before CopyInstrumrentParameters
    for i in spectra:
@@ -59,8 +59,8 @@ Usage
    # Show positions in 2nd workspace after CopyInstrumrentParameters
    for i in spectra:
         det = ws2.getDetector(i)
-        print "Position of Detector ID=%i in 2nd workspace after CopyInstrumentParameters: %.0f,%.0f,%.0f" % (det.getID(), 
-                det.getPos().X(), det.getPos().Y(), det.getPos().Z())
+        print("Position of Detector ID={} in 2nd workspace after CopyInstrumentParameters: {:.0f},{:.0f},{:.0f}".
+              format(det.getID(), det.getPos().X(), det.getPos().Y(), det.getPos().Z()))
 
 Output:
 

--- a/docs/source/algorithms/CopyInstrumentParameters-v1.rst
+++ b/docs/source/algorithms/CopyInstrumentParameters-v1.rst
@@ -48,8 +48,8 @@ Usage
    # Show positions in 2nd workspace before CopyInstrumrentParameters
    for i in spectra:
         det = ws2.getDetector(i)
-        print "Position of Detector ID=%i in 2nd workspace before CopyInstrumentParameters: %.0f,%.0f,%.0f" % (det.getID(), 
-                det.getPos().X(), det.getPos().Y(), det.getPos().Z())
+        print("Position of Detector ID=%i in 2nd workspace before CopyInstrumentParameters: %.0f,%.0f,%.0f" % (det.getID(), 
+                det.getPos().X(), det.getPos().Y(), det.getPos().Z()))
   
   
    # Copy paremeters from 1st workspace to 2nd workspace

--- a/docs/source/algorithms/CopyLogs-v1.rst
+++ b/docs/source/algorithms/CopyLogs-v1.rst
@@ -54,9 +54,9 @@ Usage
    log_w = run2.getLogData('w')
 
    # Print the log values
-   print "Before CopyLog"
-   print "1st workspace log values x =",log_x1.value,", y =", log_y.value,", z =", log_z.value 
-   print "2nd workspace log values x =",log_x2.value,", w =", log_w.value
+   print("Before CopyLog")
+   print("1st workspace log values x = {} , y = {} , z = {}".format(log_x1.value, log_y.value, log_z.value))
+   print("2nd workspace log values x = {} , w = {}".format(log_x2.value, log_w.value ))
 
    # Copy logs of 1st workspace to 2nd workspace 
    CopyLogs( demo_ws1, demo_ws2)
@@ -73,9 +73,9 @@ Usage
    log_z2 = run2.getLogData('z')
 
    # Print the log values
-   print "After CopyLog"
-   print "1st workspace log values x =",log_x1.value,", y =", log_y.value,", z =", log_z.value 
-   print "2nd workspace log values x =",log_x2.value,", w =", log_w.value,", y =", log_y2.value,", z =", log_z2.value 
+   print("After CopyLog")
+   print("1st workspace log values x = {} , y = {} , z = {}".format(log_x1.value, log_y.value, log_z.value))
+   print("2nd workspace log values x = {} , w = {} , y = {} , z = {}".format(log_x2.value, log_w.value, log_y2.value, log_z2.value))
 
 Output:
 
@@ -116,9 +116,9 @@ Output:
    log_w = run2.getLogData('w')
 
    # Print the log values
-   print "Before CopyLog"
-   print "1st workspace log values x =",log_x1.value,", y =", log_y.value,", z =", log_z.value 
-   print "2nd workspace log values x =",log_x2.value,", w =", log_w.value
+   print("Before CopyLog")
+   print("1st workspace log values x = {} , y = {} , z = {}".format(log_x1.value, log_y.value, log_z.value))
+   print("2nd workspace log values x = {} , w = {}".format(log_x2.value, log_w.value))
 
    # Copy logs of 1st workspace to 2nd workspace 
    CopyLogs( demo_ws1, demo_ws2, MergeStrategy='MergeKeepExisting')
@@ -135,9 +135,9 @@ Output:
    log_z2 = run2.getLogData('z')
 
    # Print the log values
-   print "After CopyLog"
-   print "1st workspace log values x =",log_x1.value,", y =", log_y.value,", z =", log_z.value 
-   print "2nd workspace log values x =",log_x2.value,", w =", log_w.value,", y =", log_y2.value,", z =", log_z2.value 
+   print("After CopyLog")
+   print("1st workspace log values x = {} , y = {} , z = {}".format(log_x1.value, log_y.value, log_z.value))
+   print("2nd workspace log values x = {} , w = {} , y = {} , z = {}".format(log_x2.value, log_w.value, log_y2.value, log_z2.value))
 
 Output:
 
@@ -178,9 +178,9 @@ Output:
    log_w = run2.getLogData('w')
 
    # Print the log values
-   print "Before CopyLog"
-   print "1st workspace log values x =",log_x1.value,", y =", log_y.value,", z =", log_z.value
-   print "2nd workspace log values x =",log_x2.value,", w =", log_w.value
+   print("Before CopyLog")
+   print("1st workspace log values x = {} , y = {} , z = {}".format(log_x1.value, log_y.value, log_z.value))
+   print("2nd workspace log values x = {} , w = {}".format(log_x2.value, log_w.value))
 
    # Copy logs of 1st workspace to 2nd workspace
    CopyLogs( demo_ws1, demo_ws2, MergeStrategy='WipeExisting')
@@ -196,9 +196,9 @@ Output:
    log_z2 = run2.getLogData('z')
 
    # Print the log values
-   print "After CopyLog"
-   print "1st workspace log values x =",log_x1.value,", y =", log_y.value,", z =", log_z.value
-   print "2nd workspace log values x =",log_x2.value,", y =", log_y2.value,", z =", log_z2.value
+   print("After CopyLog")
+   print("1st workspace log values x = {} , y = {} , z = {}".format(log_x1.value, log_y.value, log_z.value))
+   print("2nd workspace log values x = {} , y = {} , z = {}".format(log_x2.value, log_y2.value, log_z2.value))
 
 
 Output:

--- a/docs/source/algorithms/CopySample-v1.rst
+++ b/docs/source/algorithms/CopySample-v1.rst
@@ -46,7 +46,8 @@ Usage
 
     #do a quick check
     ol=data.sample().getOrientedLattice()
-    print "Data lattice parameters are:",ol.a(),ol.b(),ol.c(),ol.alpha(),ol.beta(),ol.gamma()
+    print("Data lattice parameters are: {} {} {} {} {} {}".format(
+	   ol.a(), ol.b(), ol.c(), ol.alpha(), ol.beta(), ol.gamma()))
     
 .. testcleanup:: CopySample
 

--- a/docs/source/algorithms/CorelliCrossCorrelate-v1.rst
+++ b/docs/source/algorithms/CorelliCrossCorrelate-v1.rst
@@ -36,9 +36,9 @@ Usage
     # Run the cross-correlation. This is using a TDC timing offset of 56000ns.
     wsOut = CorelliCrossCorrelate(ws, 56000)
 
-    print 'The detector 172305 has ' + str(ws.getSpectrum(172305).getNumberEvents()) + ' events.'
-    print 'The event weights before cross-correlation are ' + str(ws.getSpectrum(172305).getWeights())
-    print 'The event weights after  cross-correlation are ' + str(wsOut.getSpectrum(172305).getWeights())
+    print('The detector 172305 has {} events.'.format(ws.getSpectrum(172305).getNumberEvents()))
+    print('The event weights before cross-correlation are {}'.format(ws.getSpectrum(172305).getWeights()))
+    print('The event weights after  cross-correlation are {}'.format(wsOut.getSpectrum(172305).getWeights()))
 
 Output:
 

--- a/docs/source/algorithms/CorrectKiKf-v1.rst
+++ b/docs/source/algorithms/CorrectKiKf-v1.rst
@@ -32,8 +32,8 @@ Usage
     
     wsOut = CorrectKiKf(ws, EMode="Direct", EFixed=7.5)
 
-    print ("First five bins:")
-    print ("index  orig  corrected")
+    print("First five bins:")
+    print("index  orig  corrected")
     for i in range(5):
         print("  %i    %.2f  %.2f" % 
             (i,ws.readY(0)[i],wsOut.readY(0)[i]))

--- a/docs/source/algorithms/CorrectLogTimes-v1.rst
+++ b/docs/source/algorithms/CorrectLogTimes-v1.rst
@@ -25,12 +25,12 @@ Usage
 .. testcode:: CorrectLogTimes
     
     w=Load('CNCS_7860')
-    print "Original start time for 'proton_charge':", str(w.getRun()['proton_charge'].times[0]).strip()
-    print "Original start time for 'Speed5':", str(w.getRun()['Speed5'].times[0]).strip()
+    print("Original start time for 'proton_charge': {}".format(w.getRun()['proton_charge'].times[0]).strip())
+    print("Original start time for 'Speed5': {}".format(w.getRun()['Speed5'].times[0]).strip())
     #Change the log times
     CorrectLogTimes(w)
     #there should be almost 10 seconds different than before
-    print "Corrected start time for 'Speed5':", str(w.getRun()['Speed5'].times[0]).strip()
+    print("Corrected start time for 'Speed5': {}".format(w.getRun()['Speed5'].times[0]).strip())
 
 
 .. testcleanup:: CorrectLogTimes

--- a/docs/source/algorithms/CorrectTOF-v1.rst
+++ b/docs/source/algorithms/CorrectTOF-v1.rst
@@ -63,7 +63,7 @@ Usage
     # apply correction
     wscorr = CorrectTOF(ws, table)
 
-    print("Correction term dt = t_el - t_table =  {}".format(8190.02 - 8128.59, 2))
+    print("Correction term dt = t_el - t_table =  {:.2f}".format(8190.02 - 8128.59, 2))
     difference = wscorr.readX(0) - ws.readX(0)
     print("Difference between input and corrected workspaces:  {}".format(round(difference[10],2)))
 

--- a/docs/source/algorithms/CorrectTOF-v1.rst
+++ b/docs/source/algorithms/CorrectTOF-v1.rst
@@ -63,9 +63,9 @@ Usage
     # apply correction
     wscorr = CorrectTOF(ws, table)
 
-    print "Correction term dt = t_el - t_table = ", round(8190.02 - 8128.59, 2)
+    print("Correction term dt = t_el - t_table =  {}".format(8190.02 - 8128.59, 2))
     difference = wscorr.readX(0) - ws.readX(0)
-    print "Difference between input and corrected workspaces: ", round(difference[10],2)
+    print("Difference between input and corrected workspaces:  {}".format(round(difference[10],2)))
 
 Output:
 
@@ -94,9 +94,9 @@ Output:
     ws_dE = ConvertUnits(ws_tof_corr, Target='DeltaE', EMode='Direct', EFixed=2.27)
     ConvertToDistribution(ws_dE)
 
-    print "5 X values of raw data: ", numpy.round(ws_tof.readX(200)[580:585],2)
-    print "5 X values corrected data: ", numpy.round(ws_tof_corr.readX(200)[580:585],2)
-    print "5 X values after units conversion: ", numpy.round(ws_dE.readX(200)[580:585], 2)
+    print("5 X values of raw data:  {}".format(numpy.round(ws_tof.readX(200)[580:585],2)))
+    print("5 X values corrected data:  {}".format(numpy.round(ws_tof_corr.readX(200)[580:585],2)))
+    print("5 X values after units conversion:  {}".format(numpy.round(ws_dE.readX(200)[580:585], 2)))
 
 Output:
 

--- a/docs/source/algorithms/CountReflections-v1.rst
+++ b/docs/source/algorithms/CountReflections-v1.rst
@@ -62,12 +62,12 @@ data, because some intensities in the input file are 0, so these reflections are
                                                                   LatticeCentering='Robv', MinDSpacing=0.205,
                                                                   MaxDSpacing=2.08, MissingReflectionsWorkspace='')
 
-    print 'Data set statistics:'
-    print '             Peaks: {0}'.format(peaks.getNumberPeaks())
-    print '            Unique: {0}'.format(unique)
-    print '      Completeness: {0}%'.format(round(completeness * 100, 2))
-    print '        Redundancy: {0}'.format(round(redundancy, 2))
-    print ' Multiply observed: {0}%'.format(round(multiple*100, 2))
+    print('Data set statistics:')
+    print('             Peaks: {0}'.format(peaks.getNumberPeaks()))
+    print('            Unique: {0}'.format(unique))
+    print('      Completeness: {0}%'.format(round(completeness * 100, 2)))
+    print('        Redundancy: {0}'.format(round(redundancy, 2)))
+    print(' Multiply observed: {0}%'.format(round(multiple*100, 2)))
 
 Output:
 

--- a/docs/source/algorithms/CreateCalFileByNames-v1.rst
+++ b/docs/source/algorithms/CreateCalFileByNames-v1.rst
@@ -53,7 +53,7 @@ Usage
 
 
    # Check the output file
-   print "File Exists:", os.path.exists(newFile)
+   print("File Exists: {}".format(os.path.exists(newFile)))
 
 Output:
 

--- a/docs/source/algorithms/CreateChunkingFromInstrument-v1.rst
+++ b/docs/source/algorithms/CreateChunkingFromInstrument-v1.rst
@@ -28,7 +28,7 @@ Usage
 
    pg3 = LoadEmptyInstrument(Filename="POWGEN_Definition_2015-08-01.xml")
    ws = CreateChunkingFromInstrument(InputWorkspace=pg3, ChunkBy="Group")
-   print "Created %i Chunks" % ws.rowCount()
+   print("Created {} Chunks".format(ws.rowCount()))
 
 Output:
 
@@ -41,7 +41,7 @@ Output:
 .. testcode:: ExSnap
 
    ws = CreateChunkingFromInstrument(InstrumentName="snap", ChunkNames="East,West", MaxBankNumber=20)
-   print "Created %i Chunks" % ws.rowCount()
+   print("Created {} Chunks".format(ws.rowCount()))
 
 Output:
 

--- a/docs/source/algorithms/CreateDummyCalFile-v1.rst
+++ b/docs/source/algorithms/CreateDummyCalFile-v1.rst
@@ -45,7 +45,7 @@ Usage
    CreateDummyCalFile(ws_1,newFile)
 
    # Check the output file
-   print "File Exists:", os.path.exists(newFile)
+   print("File Exists: {}".format(os.path.exists(newFile)))
 
    f = open( newFile, 'r' )
    file = f.read().split('\n')
@@ -54,7 +54,7 @@ Usage
    for line in file[0:6]:
        # print the line truncating before system dependent line break can take effect
        # also stripping off any trailing spaces
-       print line[0:89].rstrip()
+       print(line[0:89].rstrip())
 
 Output:
 

--- a/docs/source/algorithms/CreateEPP-v1.rst
+++ b/docs/source/algorithms/CreateEPP-v1.rst
@@ -77,9 +77,9 @@ Usage
     findEPPWS = FindEPP(InputWorkspace='exWS')
     
     epp1 = createEPPWS.cell('PeakCentre', 0)
-    print('CreateEPP gives {0} as the first elastic peak position.'.format(epp1))
+    print('CreateEPP gives {0:.8f} as the first elastic peak position.'.format(epp1))
     epp2 = findEPPWS.cell('PeakCentre', 0)
-    print('FindEPP gives {0}.'.format(epp2))
+    print('FindEPP gives {0:.8f}.'.format(epp2))
 
 Output:
 

--- a/docs/source/algorithms/CreateEmptyTableWorkspace-v1.rst
+++ b/docs/source/algorithms/CreateEmptyTableWorkspace-v1.rst
@@ -35,10 +35,10 @@ Usage
    my_table.addRow(["IRIS", 8465])
    my_table.addRow(["SANS2D", 20462])
 
-   print "The run number for IRIS is " + str(my_table.cell("Run Number", 1)) + "."
-   print "The number of rows is " + str(my_table.rowCount()) + "."
-   print "The title of the table is " + my_table.getTitle() + "."
-   print "Remember, the table is a workspace.  It's name is \"" + my_table.name() + "\"."
+   print("The run number for IRIS is {}.".format(my_table.cell("Run Number", 1)))
+   print("The number of rows is {}.".format(my_table.rowCount()))
+   print("The title of the table is {}.".format(my_table.getTitle()))
+   print("Remember, the table is a workspace.  It's name is \"{}\".".format(my_table.name()))
 
 Output:
 

--- a/docs/source/algorithms/CreateFlatEventWorkspace-v1.rst
+++ b/docs/source/algorithms/CreateFlatEventWorkspace-v1.rst
@@ -26,10 +26,10 @@ Usage
     #to compare we need to match the bins
     wsOut=RebinToWorkspace(wsOut,ws,PreserveEvents=True)
 
-    print "The values for every 10th bin."
-    print "bin\tws\twsOut"
+    print("The values for every 10th bin.")
+    print("bin\tws\twsOut")
     for i in range (0,ws.blocksize(),10):
-        print "%i\t%.2f\t%.2f" % (i,ws.readY(0)[i],wsOut.readY(0)[i])
+        print("{}\t{:.2f}\t{:.2f}".format(i,ws.readY(0)[i],wsOut.readY(0)[i]))
 
 Output:
 

--- a/docs/source/algorithms/CreateGroupingWorkspace-v1.rst
+++ b/docs/source/algorithms/CreateGroupingWorkspace-v1.rst
@@ -49,7 +49,7 @@ Usage
    grouping = result[0]
    inst1 = grouping.getInstrument()
    comp1 = inst1.getComponentByName("MUSR")
-   print "Instrument name =", comp1.getName()
+   print("Instrument name = {}".format(comp1.getName()))
 
 Output:
 
@@ -73,7 +73,7 @@ Output:
    grouping = result[0]
    inst1 = grouping.getInstrument()
    comp1 = inst1.getComponentByName("MUSR")
-   print "Instrument name =", comp1.getName() 
+   print("Instrument name = {}".format(comp1.getName()))
 
 Output:
 
@@ -92,7 +92,7 @@ Output:
    grouping = result[0]
    inst1 = grouping.getInstrument()
    comp1 = inst1.getComponentByName("GEM")
-   print "Instrument name =", comp1.getName()
+   print("Instrument name = {}".format(comp1.getName()))
 
 Output:
 
@@ -106,8 +106,8 @@ Output:
 
    grouping_ws, spectra_count, group_count = CreateGroupingWorkspace(InstrumentName='IRIS', ComponentName='graphite', FixedGroupCount=5)
   
-   print "Number of grouped spectra:",spectra_count
-   print "Number of groups:",group_count
+   print("Number of grouped spectra: {}".format(spectra_count))
+   print("Number of groups: {}".format(group_count))
 
 Output:
 

--- a/docs/source/algorithms/CreateLeBailFitInput-v1.rst
+++ b/docs/source/algorithms/CreateLeBailFitInput-v1.rst
@@ -60,7 +60,7 @@ Usage
   # Examine 
   partablews = mtd["PG3_Bank3_ParTable"]
   braggtablews = mtd["LaB6_HKL_Table"]
-  print "Number Bragg peaks from .hkl file is %d.  Number of peak profile parameters is %d." % (braggtablews.rowCount(), partablews.rowCount())
+  print("Number Bragg peaks from .hkl file is {}.  Number of peak profile parameters is {}.".format(braggtablews.rowCount(), partablews.rowCount()))
 
 
 .. testcleanup:: ExCreateLBInputs

--- a/docs/source/algorithms/CreateLogPropertyTable-v1.rst
+++ b/docs/source/algorithms/CreateLogPropertyTable-v1.rst
@@ -76,8 +76,8 @@ Usage
     tab=CreateLogPropertyTable(InputWorkspaces='a,b,c',LogPropertyNames='run_title,ImportantParameter')
 
     #do some tests
-    print "Column names are: ",tab.getColumnNames()
-    print "The values of the ImportantParameter are:",tab.column(1)
+    print("Column names are:  {}".format(tab.getColumnNames()))
+    print("The values of the ImportantParameter are: {}".format(tab.column(1)))
 
 .. testcleanup:: CreateLogPropertyTable
 

--- a/docs/source/algorithms/CreateLogTimeCorrection-v1.rst
+++ b/docs/source/algorithms/CreateLogTimeCorrection-v1.rst
@@ -33,24 +33,24 @@ Usage
   cfile.close()
 
   # Print out partial result
-  print "From output TableWorkspace:"
-  print "detector (ID: %d) correction = %-.6f" % (corrws.cell(0, 0), corrws.cell(0, 1))
-  print "detector (ID: %d) correction = %-.6f" % (corrws.cell(10, 0), corrws.cell(10, 1))
-  print "detector (ID: %d) correction = %-.6f" % (corrws.cell(100, 0), corrws.cell(100, 1))
-  print "detector (ID: %d) correction = %-.6f" % (corrws.cell(1000, 0), corrws.cell(1000, 1))
-  print "detector (ID: %d) correction = %-.6f" % (corrws.cell(10000, 0), corrws.cell(1000, 1))
+  print("From output TableWorkspace:")
+  print("detector (ID: {}) correction = {:.6f}".format(corrws.cell(0, 0), corrws.cell(0, 1)))
+  print("detector (ID: {}) correction = {:.6f}".format(corrws.cell(10, 0), corrws.cell(10, 1)))
+  print("detector (ID: {}) correction = {:.6f}".format(corrws.cell(100, 0), corrws.cell(100, 1)))
+  print("detector (ID: {}) correction = {:.6f}".format(corrws.cell(1000, 0), corrws.cell(1000, 1)))
+  print("detector (ID: {}) correction = {:.6f}".format(corrws.cell(10000, 0), corrws.cell(1000, 1)))
 
-  print "\nFrom output file:"
+  print("\nFrom output file:")
   terms = lines[0].split()
-  print "detector (ID: %s) correction = %s" % (terms[0], terms[1])
+  print("detector (ID: {}) correction = {}".format(terms[0], terms[1]))
   terms = lines[10].split()
-  print "detector (ID: %s) correction = %s" % (terms[0], terms[1])
+  print("detector (ID: {}) correction = {}".format(terms[0], terms[1]))
   terms = lines[100].split()
-  print "detector (ID: %s) correction = %s" % (terms[0], terms[1])
+  print("detector (ID: {}) correction = {}".format(terms[0], terms[1]))
   terms = lines[1000].split()
-  print "detector (ID: %s) correction = %s" % (terms[0], terms[1])
+  print("detector (ID: {}) correction = {}".format(terms[0], terms[1]))
   terms = lines[10000].split()
-  print "detector (ID: %s) correction = %s" % (terms[0], terms[1])
+  print("detector (ID: {}) correction = {}".format(terms[0], terms[1]))
 
 .. testcleanup:: ExHistSimple
 

--- a/docs/source/algorithms/CreateMD-v1.rst
+++ b/docs/source/algorithms/CreateMD-v1.rst
@@ -80,7 +80,7 @@ Workflow
    ndims = new_mdew.getNumDims()
    for i in range(ndims):
        dim = new_mdew.getDimension(i)
-       print dim.getName()
+       print(dim.getName())
   
 Output
 ^^^^^^
@@ -116,7 +116,7 @@ Output
    ndims = new_merged.getNumDims()
    for i in range(ndims):
        dim = new_merged.getDimension(i)
-       print dim.getName()
+       print(dim.getName())
 
 Output
 ^^^^^^
@@ -152,7 +152,7 @@ Output
    ndims = new_merged.getNumDims()
    for i in range(ndims):
        dim = new_merged.getDimension(i)
-       print dim.getName()
+       print(dim.getName())
 
 Output
 ^^^^^^

--- a/docs/source/algorithms/CreateMDHistoWorkspace-v1.rst
+++ b/docs/source/algorithms/CreateMDHistoWorkspace-v1.rst
@@ -51,14 +51,15 @@ Usage
                               NumberOfBins='10,10',Names='Dim1,Dim2',Units='MomentumTransfer,EnergyTransfer')
 
    # check it looks like the one we wanted
-   print 'created workspace is of type: {0}\n'.format(ws.id()),
-   print 'and has {0} dimensions with {1} points and {2} events'.format(ws.getNumDims(),ws.getNPoints(),ws.getNEvents());
+   print('created workspace is of type: {0}'.format(ws.id()))
+   print('and has {0} dimensions with {1} points and {2} events'.
+	 format(ws.getNumDims(),ws.getNPoints(),ws.getNEvents()))
    d1=ws.getDimension(0)
-   print 'dimension 0 has ID: {0}; nBins={1}; min: {2}; max: {3} in units of: {4}\n'.format(d1.getDimensionId(),d1.getNBins(),\
-          d1.getMinimum(),d1.getMaximum(),d1.getUnits()),
+   print('dimension 0 has ID: {0}; nBins={1}; min: {2}; max: {3} in units of: {4}'.
+         format(d1.getDimensionId(), d1.getNBins(), d1.getMinimum(), d1.getMaximum(),d1.getUnits()))
    d1=ws.getDimension(1)   
-   print 'dimension 1 has ID: {0}; nBins={1}; min: {2}; max: {3} in units of: {4}\n'.format(d1.getDimensionId(),d1.getNBins(),\
-          d1.getMinimum(),d1.getMaximum(),d1.getUnits()),   
+   print('dimension 1 has ID: {0}; nBins={1}; min: {2}; max: {3} in units of: {4}'.
+         format(d1.getDimensionId(), d1.getNBins(), d1.getMinimum(), d1.getMaximum(), d1.getUnits()))
 
   
 **Output:**

--- a/docs/source/algorithms/CreateMDWorkspace-v1.rst
+++ b/docs/source/algorithms/CreateMDWorkspace-v1.rst
@@ -35,10 +35,10 @@ Usage
 
     mdws = CreateMDWorkspace(Dimensions=3, Extents='-10,10,-10,10,-10,10', Names='A,B,C', Units='U,U,U')
     
-    print "mdws is a " + mdws.id()
-    print "with {0} dimensions:".format(mdws.getNumDims())
+    print("mdws is a " + mdws.id())
+    print("with {0} dimensions:".format(mdws.getNumDims()))
     for i in range (mdws.getNumDims()):
-        print mdws.getDimension(i).name
+        print(mdws.getDimension(i).name)
 
 Output:
 

--- a/docs/source/algorithms/CreatePSDBleedMask-v1.rst
+++ b/docs/source/algorithms/CreatePSDBleedMask-v1.rst
@@ -72,7 +72,7 @@ Usage
     ws.setY(50,noisyY)
     (wsOut, numFailures) = CreatePSDBleedMask(ws,MaxTubeFramerate=10, NIgnoredCentralPixels=2)
 
-    print "%i spectra have been masked in wsOut" % numFailures
+    print("{} spectra have been masked in wsOut".format(numFailures))
 
 
 Output:

--- a/docs/source/algorithms/CreatePeaksWorkspace-v1.rst
+++ b/docs/source/algorithms/CreatePeaksWorkspace-v1.rst
@@ -25,7 +25,7 @@ Usage
 .. testcode:: ExEmptyTable
 
     ws = CreatePeaksWorkspace()
-    print "Created a %s with %i rows" % (ws.id(), ws.rowCount())
+    print("Created a {} with {} rows".format(ws.id(), ws.rowCount()))
 
 Output:
 
@@ -39,7 +39,7 @@ Output:
 
     sampleWs = CreateSampleWorkspace()
     ws = CreatePeaksWorkspace(InstrumentWorkspace=sampleWs,NumberOfPeaks=3)
-    print "Created a %s with %i rows" % (ws.id(), ws.rowCount())
+    print("Created a {} with {} rows".format(ws.id(), ws.rowCount()))
 
 Output:
 

--- a/docs/source/algorithms/CreateSampleWorkspace-v1.rst
+++ b/docs/source/algorithms/CreateSampleWorkspace-v1.rst
@@ -73,10 +73,9 @@ Usage
    # create histogram workspace
    ws = CreateSampleWorkspace()
 
-   print "Number of spectra: " +  str(ws.getNumberHistograms())
-   print "Number of bins: " +  str(ws.blocksize())
-   print "Each spectra has a level backgound of " + str(ws.readY(0)[0]) + \
-    " counts and a peak in the centre of " + str(ws.readY(0)[50]) + " counts."
+   print("Number of spectra: {}".format(ws.getNumberHistograms()))
+   print("Number of bins: {}".format(ws.blocksize()))
+   print("Each spectra has a level backgound of {} counts and a peak in the centre of {} counts.".format(ws.readY(0)[0], ws.readY(0)[50]))
 
 Output:
 
@@ -93,13 +92,12 @@ Output:
    # create event workspace
    ws = CreateSampleWorkspace("Event")
 
-   print "Number of spectra: " +  str(ws.getNumberHistograms())
-   print "Number of bins: " +  str(ws.blocksize())
-   print "Number of events: " +  str(ws.getNumberEvents())
-   print "Event Workspaces come with bins set by default to a bin width of " + str(ws.readX(0)[1]-ws.readX(0)[0])
+   print("Number of spectra: {}".format(ws.getNumberHistograms()))
+   print("Number of bins: {}".format(ws.blocksize()))
+   print("Number of events: {}".format(ws.getNumberEvents()))
+   print("Event Workspaces come with bins set by default to a bin width of {}".format(ws.readX(0)[1]-ws.readX(0)[0]))
    #The data itensity of an EventWorkspce is scaled by the number of events used, so the values differ from the histogram above.
-   print "Each spectra has a level backgound of " + str(ws.readY(0)[0]) + \
-   	" counts and a peak in the centre of " + str(ws.readY(0)[50]) + " counts."
+   print("Each spectra has a level backgound of {} counts and a peak in the centre of {} counts.".format(ws.readY(0)[0], ws.readY(0)[50]))
 
 Output:
 
@@ -117,16 +115,16 @@ Output:
 
    # create a workspace with Flat Background
    wsFlat = CreateSampleWorkspace("Histogram","Flat background")
-   print "Flat background has a constant value of " + str(wsFlat.readY(0)[0]) + " counts."
+   print("Flat background has a constant value of {} counts.".format(wsFlat.readY(0)[0]))
 
    # create a workspace with multiple peaks
    wsMulti = CreateSampleWorkspace("Histogram","Multiple Peaks")
-   print "Multiple Peaks has a level backgound of " + str(wsMulti.readY(0)[0]),
-   print "counts and two gaussian peaks, the largest of which is " + str(wsMulti.readY(0)[60]) + " counts."
+   print("Multiple Peaks has a level backgound of {} counts and two gaussian peaks, the largest of which is {} counts.".
+         format(wsMulti.readY(0)[0], wsMulti.readY(0)[60]))
 
    # create a workspace with Exponential Decay
    wsExp = CreateSampleWorkspace("Histogram","Exp Decay")
-   print ("Exp Decay starts high and drops rapidly to %.2f counts at 8,000 us (with the default binning)." % wsExp.readY(0)[40])
+   print("Exp Decay starts high and drops rapidly to {:.2f} counts at 8,000 us (with the default binning).".format(wsExp.readY(0)[40]))
 
 Output:
 
@@ -145,9 +143,9 @@ Output:
 
    ws = CreateSampleWorkspace("Histogram","User Defined",myFunc)
 
-   print "My function defined a background of "+ str(ws.readY(0)[0]) + " counts."
-   print "With a peak reaching "+ str(ws.readY(0)[5]) + " counts at 1,000 us,"
-   print "and another reaching "+ str(ws.readY(0)[50]) + " counts at 10,000 us."
+   print("My function defined a background of {} counts.".format(ws.readY(0)[0]))
+   print("With a peak reaching {} counts at 1,000 us,".format(ws.readY(0)[5]))
+   print("and another reaching {} counts at 10,000 us.".format(ws.readY(0)[50]))
 
 Output:
 
@@ -167,8 +165,8 @@ Output:
                             XMax=0.5,
                             BinWidth=0.01)
 
-   print "Number of spectra: " +  str(ws.getNumberHistograms())
-   print "Number of bins: " +  str(ws.blocksize())
+   print("Number of spectra: {}".format(ws.getNumberHistograms()))
+   print("Number of bins: {}".format(ws.blocksize()))
 
 Output:
 
@@ -184,8 +182,8 @@ Output:
    #Random adds a little random noise to the data function
    ws=CreateSampleWorkspace(WorkspaceType="Event",Function="One Peak",NumBanks=4,NumMonitors=3,BankPixelWidth=5,NumEvents=500,Random=True,XUnit="tof",XMin=0, XMax=8000, BinWidth=100)
 
-   print "Number of spectra: " +  str(ws.getNumberHistograms())
-   print "Number of bins: " +  str(ws.blocksize())
+   print("Number of spectra: {}".format(ws.getNumberHistograms()))
+   print("Number of bins: {}".format(ws.blocksize()))
 
 Output:
 

--- a/docs/source/algorithms/CreateSingleValuedWorkspace-v1.rst
+++ b/docs/source/algorithms/CreateSingleValuedWorkspace-v1.rst
@@ -27,13 +27,13 @@ Usage
 
    five = CreateSingleValuedWorkspace(5)
 
-   print "Number of histograms:",five.getNumberHistograms()
-   print "Length of y array:",len(five.readY(0))
-   print "Length of e array:",len(five.readE(0))
-   print "Length of x array:",len(five.readX(0))
+   print("Number of histograms: {}".format(five.getNumberHistograms()))
+   print("Length of y array: {}".format(len(five.readY(0))))
+   print("Length of e array: {}".format(len(five.readE(0))))
+   print("Length of x array: {}".format(len(five.readX(0))))
 
-   print "y value:",five.readY(0)
-   print "e value:",five.readE(0)
+   print("y value: {}".format(five.readY(0)))
+   print("e value: {}".format(five.readE(0)))
 
 Output:
 
@@ -52,13 +52,13 @@ Output:
 
    five = CreateSingleValuedWorkspace(5, 0.1)
 
-   print "Number of histograms:",five.getNumberHistograms()
-   print "Length of y array:",len(five.readY(0))
-   print "Length of e array:",len(five.readE(0))
-   print "Length of x array:",len(five.readX(0))
+   print("Number of histograms: {}".format(five.getNumberHistograms()))
+   print("Length of y array: {}".format(len(five.readY(0))))
+   print("Length of e array: {}".format(len(five.readE(0))))
+   print("Length of x array: {}".format(len(five.readX(0))))
 
-   print "y value:",five.readY(0)
-   print "e value:",five.readE(0)
+   print("y value: {}".format(five.readY(0)))
+   print("e value: {}".format(five.readE(0)))
 
 Output:
 

--- a/docs/source/algorithms/CreateTransmissionWorkspace-v1.rst
+++ b/docs/source/algorithms/CreateTransmissionWorkspace-v1.rst
@@ -55,7 +55,7 @@ Usage
 
     print("The first four transWS Y values are:")
     for i in range (4):
-        print("%.4f" % transWS.readY(0)[i])
+        print("{:.4f}".format(transWS.readY(0)[i]))
 
 Output:
 
@@ -91,7 +91,7 @@ Output:
 
     print("The first four transWS Y values are:")
     for i in range (4):
-        print("%.4f" % transWS.readY(0)[i])
+        print("{:.4f}".format(transWS.readY(0)[i]))
 
 Output:
 

--- a/docs/source/algorithms/CreateTransmissionWorkspace-v1.rst
+++ b/docs/source/algorithms/CreateTransmissionWorkspace-v1.rst
@@ -53,9 +53,9 @@ Usage
       MonitorIntegrationWavelengthMax = 10,
       Version=1)
 
-    print "The first four transWS Y values are:"
+    print("The first four transWS Y values are:")
     for i in range (4):
-        print "%.4f" % transWS.readY(0)[i]
+        print("%.4f" % transWS.readY(0)[i])
 
 Output:
 
@@ -89,9 +89,9 @@ Output:
       MonitorIntegrationWavelengthMax = 10,
       Version=1)
 
-    print "The first four transWS Y values are:"
+    print("The first four transWS Y values are:")
     for i in range (4):
-        print "%.4f" % transWS.readY(0)[i]
+        print("%.4f" % transWS.readY(0)[i])
 
 Output:
 

--- a/docs/source/algorithms/CreateTransmissionWorkspace-v2.rst
+++ b/docs/source/algorithms/CreateTransmissionWorkspace-v2.rst
@@ -73,7 +73,7 @@ Usage
 
     print("The first four transWS Y values are:")
     for i in range (4):
-        print("%.4f" % transWS.readY(0)[i])
+        print("{:.4f}".format(transWS.readY(0)[i]))
 
 Output:
 
@@ -107,7 +107,7 @@ Output:
 
     print("The first four transWS Y values are:")
     for i in range (4):
-        print("%.4f" % transWS.readY(0)[i])
+        print("{:.4f}".format(transWS.readY(0)[i]))
 
 Output:
 

--- a/docs/source/algorithms/CreateTransmissionWorkspace-v2.rst
+++ b/docs/source/algorithms/CreateTransmissionWorkspace-v2.rst
@@ -71,9 +71,9 @@ Usage
                                           MonitorIntegrationWavelengthMin = 4,
                                           MonitorIntegrationWavelengthMax = 10)
 
-    print "The first four transWS Y values are:"
+    print("The first four transWS Y values are:")
     for i in range (4):
-        print "%.4f" % transWS.readY(0)[i]
+        print("%.4f" % transWS.readY(0)[i])
 
 Output:
 
@@ -105,9 +105,9 @@ Output:
                                           MonitorIntegrationWavelengthMin = 4,
                                           MonitorIntegrationWavelengthMax = 10)
 
-    print "The first four transWS Y values are:"
+    print("The first four transWS Y values are:")
     for i in range (4):
-        print "%.4f" % transWS.readY(0)[i]
+        print("%.4f" % transWS.readY(0)[i])
 
 Output:
 

--- a/docs/source/algorithms/CreateTransmissionWorkspaceAuto-v1.rst
+++ b/docs/source/algorithms/CreateTransmissionWorkspaceAuto-v1.rst
@@ -33,9 +33,9 @@ Usage
     # Reduction overriding the default values for MonitorBackgroundWavelengthMin and MonitorBackgroundWavelengthMax which would otherwise be retirieved from the workspace
     transWS = CreateTransmissionWorkspaceAuto(FirstTransmissionRun=trans, Version=1)
 
-    print "The first four transWS Y values are:"
+    print("The first four transWS Y values are:")
     for i in range (4):
-        print "%.4f" % transWS.readY(0)[i]
+        print("%.4f" % transWS.readY(0)[i])
 
 
 Output:
@@ -57,9 +57,9 @@ Output:
     # Reduction overriding the default values for MonitorBackgroundWavelengthMin and MonitorBackgroundWavelengthMax which would otherwise be retirieved from the workspace
     transWS = CreateTransmissionWorkspaceAuto(FirstTransmissionRun=trans, MonitorBackgroundWavelengthMin=0.0, MonitorBackgroundWavelengthMax=1.0, Version=1)
 
-    print "The first four transWS Y values are:"
+    print("The first four transWS Y values are:")
     for i in range (4):
-        print "%.4f" % transWS.readY(0)[i]
+        print("%.4f" % transWS.readY(0)[i])
 
 Output:
 
@@ -81,9 +81,9 @@ Output:
     # Reduction overriding the default values for MonitorBackgroundWavelengthMin and MonitorBackgroundWavelengthMax which would otherwise be retirieved from the workspace
     transWS = CreateTransmissionWorkspaceAuto(FirstTransmissionRun=trans1, SecondTransmissionRun=trans2, Params=[1.5,0.02,17], StartOverlap=10.0, EndOverlap=12.0, Version=1)
 
-    print "The first four transWS Y values are:"
+    print("The first four transWS Y values are:")
     for i in range (4):
-        print "%.4f" % transWS.readY(0)[i]
+        print("%.4f" % transWS.readY(0)[i])
 
 Output:
 

--- a/docs/source/algorithms/CreateTransmissionWorkspaceAuto-v1.rst
+++ b/docs/source/algorithms/CreateTransmissionWorkspaceAuto-v1.rst
@@ -35,7 +35,7 @@ Usage
 
     print("The first four transWS Y values are:")
     for i in range (4):
-        print("%.4f" % transWS.readY(0)[i])
+        print("{:.4f}".format(transWS.readY(0)[i]))
 
 
 Output:
@@ -59,7 +59,7 @@ Output:
 
     print("The first four transWS Y values are:")
     for i in range (4):
-        print("%.4f" % transWS.readY(0)[i])
+        print("{:.4f}".format(transWS.readY(0)[i]))
 
 Output:
 
@@ -83,7 +83,7 @@ Output:
 
     print("The first four transWS Y values are:")
     for i in range (4):
-        print("%.4f" % transWS.readY(0)[i])
+        print("{:.4f}".format(transWS.readY(0)[i]))
 
 Output:
 

--- a/docs/source/algorithms/CreateTransmissionWorkspaceAuto-v2.rst
+++ b/docs/source/algorithms/CreateTransmissionWorkspaceAuto-v2.rst
@@ -49,10 +49,10 @@ Usage
     trans = Load(Filename='INTER00013463.nxs')
     transWS = CreateTransmissionWorkspaceAuto(FirstTransmissionRun=trans)
 
-    print("%.4f" % (transWS.readY(0)[26]))
-    print("%.4f" % (transWS.readY(0)[27]))
-    print("%.4f" % (transWS.readY(0)[28]))
-    print("%.4f" % (transWS.readY(0)[29]))
+    print("{:.4f}".format(transWS.readY(0)[26]))
+    print("{:.4f}".format(transWS.readY(0)[27]))
+    print("{:.4f}".format(transWS.readY(0)[28]))
+    print("{:.4f}".format(transWS.readY(0)[29]))
 
 Output:
 
@@ -72,10 +72,10 @@ Output:
     trans = Load(Filename='INTER00013463.nxs')
     transWS = CreateTransmissionWorkspaceAuto(FirstTransmissionRun=trans, MonitorBackgroundWavelengthMin=0.0, MonitorBackgroundWavelengthMax=1.0)
 
-    print("%.3f" % (transWS.readY(0)[26]))
-    print("%.3f" % (transWS.readY(0)[27]))
-    print("%.3f" % (transWS.readY(0)[28]))
-    print("%.3f" % (transWS.readY(0)[29]))
+    print("{:.3f}".format(transWS.readY(0)[26]))
+    print("{:.3f}".format(transWS.readY(0)[27]))
+    print("{:.3f}".format(transWS.readY(0)[28]))
+    print("{:.3f}".format(transWS.readY(0)[29]))
 
 Output:
 
@@ -95,10 +95,10 @@ Output:
     trans2 = Load(Filename='INTER00013464.nxs')
     transWS = CreateTransmissionWorkspaceAuto(FirstTransmissionRun=trans1, SecondTransmissionRun=trans2, Params=[1.5,0.02,17], StartOverlap=10.0, EndOverlap=12.0)
 
-    print("%.4f" % (transWS.readY(0)[26]))
-    print("%.4f" % (transWS.readY(0)[27]))
-    print("%.4f" % (transWS.readY(0)[28]))
-    print("%.4f" % (transWS.readY(0)[29]))
+    print("{:.4f}".format(transWS.readY(0)[26]))
+    print("{:.4f}".format(transWS.readY(0)[27]))
+    print("{:.4f}".format(transWS.readY(0)[28]))
+    print("{:.4f}".format(transWS.readY(0)[29]))
 
 Output:
 

--- a/docs/source/algorithms/CreateTransmissionWorkspaceAuto-v2.rst
+++ b/docs/source/algorithms/CreateTransmissionWorkspaceAuto-v2.rst
@@ -49,10 +49,10 @@ Usage
     trans = Load(Filename='INTER00013463.nxs')
     transWS = CreateTransmissionWorkspaceAuto(FirstTransmissionRun=trans)
 
-    print "%.4f" % (transWS.readY(0)[26])
-    print "%.4f" % (transWS.readY(0)[27])
-    print "%.4f" % (transWS.readY(0)[28])
-    print "%.4f" % (transWS.readY(0)[29])
+    print("%.4f" % (transWS.readY(0)[26]))
+    print("%.4f" % (transWS.readY(0)[27]))
+    print("%.4f" % (transWS.readY(0)[28]))
+    print("%.4f" % (transWS.readY(0)[29]))
 
 Output:
 
@@ -72,10 +72,10 @@ Output:
     trans = Load(Filename='INTER00013463.nxs')
     transWS = CreateTransmissionWorkspaceAuto(FirstTransmissionRun=trans, MonitorBackgroundWavelengthMin=0.0, MonitorBackgroundWavelengthMax=1.0)
 
-    print "%.3f" % (transWS.readY(0)[26])
-    print "%.3f" % (transWS.readY(0)[27])
-    print "%.3f" % (transWS.readY(0)[28])
-    print "%.3f" % (transWS.readY(0)[29])
+    print("%.3f" % (transWS.readY(0)[26]))
+    print("%.3f" % (transWS.readY(0)[27]))
+    print("%.3f" % (transWS.readY(0)[28]))
+    print("%.3f" % (transWS.readY(0)[29]))
 
 Output:
 
@@ -95,10 +95,10 @@ Output:
     trans2 = Load(Filename='INTER00013464.nxs')
     transWS = CreateTransmissionWorkspaceAuto(FirstTransmissionRun=trans1, SecondTransmissionRun=trans2, Params=[1.5,0.02,17], StartOverlap=10.0, EndOverlap=12.0)
 
-    print "%.4f" % (transWS.readY(0)[26])
-    print "%.4f" % (transWS.readY(0)[27])
-    print "%.4f" % (transWS.readY(0)[28])
-    print "%.4f" % (transWS.readY(0)[29])
+    print("%.4f" % (transWS.readY(0)[26]))
+    print("%.4f" % (transWS.readY(0)[27]))
+    print("%.4f" % (transWS.readY(0)[28]))
+    print("%.4f" % (transWS.readY(0)[29]))
 
 Output:
 

--- a/docs/source/algorithms/CreateUserDefinedBackground-v1.rst
+++ b/docs/source/algorithms/CreateUserDefinedBackground-v1.rst
@@ -58,7 +58,7 @@ Usage
    # Check that workspace matches expected peak
    expected = CreateWorkspace(dataX, peak)
    result, messages = CompareWorkspaces(peakWS, expected)
-   print "Workspaces match:", result
+   print("Workspaces match: {}".format(result))
 
 
 Output:


### PR DESCRIPTION

## Description of work.
This PR is part of refactoring effort to bring Python3 compatiblity into the doctests.
See https://github.com/mantidproject/mantid/issues/20672 for details.

The following tests were refactored to be compatible :
```
CopyDetectorMapping
CopyInstrumentParameters
CopyLogs
CopySample
CorelliCrossCorrelate
CorrectKiKf
CorrectLogTimes
CorrectTOF
CorrectTOFAxis
CorrectToFile
CountReflections
CreateCacheFilename
CreateCalFileByNames
CreateChopperModel
CreateChunkingFromInstrument
CreateDummyCalFile
CreateEPP
CreateEmptyTableWorkspace
CreateFlatEventWorkspace
CreateGroupingWorkspace
CreateLeBailFitInput
CreateLogPropertyTable
CreateLogTimeCorrection
CreateMD
CreateMDHistoWorkspace
CreateMDWorkspace
CreateModeratorModel
CreatePSDBleedMask
CreatePeaksWorkspace
CreateSampleShape
CreateSampleWorkspace
CreateSimulationWorkspace
CreateSingleValuedWorkspace
CreateTransmissionWorkspace
CreateTransmissionWorkspaceAuto
CreateUserDefinedBackground
CreateWorkspace
```
## To test.

Code review.

Fixes #20712 .
Internal change, no release notes