### PR TITLE
Fix RayTracerTesterTestPerformance indicated issues 

### DIFF
--- a/Framework/Algorithms/src/RayTracerTester.cpp
+++ b/Framework/Algorithms/src/RayTracerTester.cpp
@@ -55,6 +55,7 @@ void RayTracerTester::exec() {
   int NumAzimuth = getProperty("NumAzimuth");
   int NumZenith = getProperty("NumZenith");
   Progress prog(this, 0.3, 1.0, NumAzimuth);
+  InstrumentRayTracer tracker(ws->getInstrument());
   for (int iaz = 0; iaz < NumAzimuth; iaz++) {
     prog.report();
     double az = double(iaz) * M_PI * 2.0 / double(NumAzimuth);
@@ -66,7 +67,6 @@ void RayTracerTester::exec() {
       V3D beam(x, y, z);
 
       // Create a ray tracer
-      InstrumentRayTracer tracker(ws->getInstrument());
       tracker.traceFromSample(beam);
       IDetector_const_sptr det = tracker.getDetectorResult();
       if (det) {

--- a/Framework/Algorithms/test/RayTracerTesterTest.h
+++ b/Framework/Algorithms/test/RayTracerTesterTest.h
@@ -12,6 +12,18 @@ using namespace Mantid::API;
 
 // There are only performance tests here as this is not a real algorithm.
 // Functional tests disabled ec34e64616f34f1cf476b65f934272fdfda1212f
+// Unfortunately CxxTest/CTest gets confused if no functional test is present!
+// The following class does precicely nothing.
+class RayTracerTesterTest : public CxxTest::TestSuite {
+public:
+  static RayTracerTesterTest *createSuite() {
+    return new RayTracerTesterTest();
+  }
+  static void destroySuite(RayTracerTesterTest *suite) { delete suite; }
+  void test_dummy() {
+    // No tests. See comments above.
+  }
+};
 
 class RayTracerTesterTestPerformance : public CxxTest::TestSuite {
 public:

--- a/Framework/Algorithms/test/RayTracerTesterTest.h
+++ b/Framework/Algorithms/test/RayTracerTesterTest.h
@@ -4,38 +4,14 @@
 #include <cxxtest/TestSuite.h>
 #include "MantidKernel/Timer.h"
 #include "MantidKernel/System.h"
-
 #include "MantidAlgorithms/RayTracerTester.h"
 
 using namespace Mantid;
 using namespace Mantid::Algorithms;
 using namespace Mantid::API;
 
-class RayTracerTesterTest : public CxxTest::TestSuite {
-public:
-  // This pair of boilerplate methods prevent the suite being created statically
-  // This means the constructor isn't called when running other tests
-  static RayTracerTesterTest *createSuite() {
-    return new RayTracerTesterTest();
-  }
-  static void destroySuite(RayTracerTesterTest *suite) { delete suite; }
-
-  void test_Init() {
-    RayTracerTester alg;
-    TS_ASSERT_THROWS_NOTHING(alg.initialize())
-    TS_ASSERT(alg.isInitialized())
-  }
-
-  /** Disabled because this isn't a real algorithm, just a testing one */
-  void xtest_exec() {
-    RayTracerTester alg;
-    TS_ASSERT_THROWS_NOTHING(alg.initialize())
-    TS_ASSERT(alg.isInitialized())
-    alg.setPropertyValue("Filename", "CNCS_Definition.xml");
-    alg.setPropertyValue("OutputWorkspace", "cncs");
-    alg.exec();
-  }
-};
+// There are only performance tests here as this is not a real algorithm.
+// Functional tests disabled ec34e64616f34f1cf476b65f934272fdfda1212f
 
 class RayTracerTesterTestPerformance : public CxxTest::TestSuite {
 public:

--- a/Framework/Geometry/inc/MantidGeometry/Objects/InstrumentRayTracer.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/InstrumentRayTracer.h
@@ -4,14 +4,18 @@
 #include "MantidGeometry/IDetector.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Objects/Track.h"
+#include "MantidGeometry/Objects/BoundingBox.h"
+#include <boost/unordered_map.hpp>
 #include <deque>
 #include <list>
+#include <mutex>
 
 namespace Mantid {
 namespace Kernel {
 class V3D;
 }
 namespace Geometry {
+class IComponent;
 struct Link;
 class Track;
 /// Typedef for object intersections
@@ -71,6 +75,10 @@ private:
   /// Accumulate results in this Track object, aids performance. This is cleared
   /// when getResults is called.
   mutable Track m_resultsTrack;
+  /// Map of component id -> bounding box.
+  mutable boost::unordered_map<IComponent *, BoundingBox> m_boxCache;
+  /// Mutex to lock box cache
+  mutable std::mutex m_mutex;
 };
 }
 }


### PR DESCRIPTION
Fixes #20274

**Notes**

Implementation is similar to what `CompAssembly::getBoundingBox` did internally, but pushes the cache onto the client, InstrumentRayTracer in this case, including creation, locks, cache invalidation etc which we do not want to manage centrally.

I do not distinguish between any type of component when adding to the cache. Detectors etc also end up in the cache. Reduces the code, but let me know if you see this becoming a problem for other use-cases.

As further optimisations, that would help us keep away from Component level cache territory, we have discussed the possibility of recognising tubes for special treatment (`ComponentInfo::boundingBox`) based on top and bottom pixel calculations for whole-tube bounding box. We may also be able to do something with "eightpacks" based on the CNCS definition, which gives exactly the same object tree as `RecangularDetectors`, which we already optimise for. However, Mantid lacks a reliable way to identify tubes or eightpacks (type system not rich enough for this in current IComponent hierachy) so we are not implementing this now.

**Tester**
* Review code
* Maybe check `RayTracerTesterTestPeformance` too to ensure it won't time-out
