### PR TITLE
Python3 doctest compatibility: algorithms EQSANSAzimuthalAverage1D to ExtractUnmaskedSpectra

### DIFF
--- a/docs/source/algorithms/ElasticWindow-v1.rst
+++ b/docs/source/algorithms/ElasticWindow-v1.rst
@@ -47,8 +47,8 @@ Usage
   # Run the algorithm
   q, q2 = ElasticWindow(ws, -0.1, 0.1)
 
-  print q.getAxis(0).getUnit().caption()
-  print q2.getAxis(0).getUnit().caption()
+  print(q.getAxis(0).getUnit().caption())
+  print(q2.getAxis(0).getUnit().caption())
 
 .. testoutput:: exElasticWindowSimple
 

--- a/docs/source/algorithms/ElasticWindowMultiple-v1.rst
+++ b/docs/source/algorithms/ElasticWindowMultiple-v1.rst
@@ -72,9 +72,9 @@ Usage
     # Run the algorithm
     q, q2, elf = ElasticWindowMultiple(input, -0.1, 0.1)
 
-    print 'ELF X axis: %s' % elf.getAxis(0).getUnit().caption()
-    print 'ELF spectra count: %d' % elf.getNumberHistograms()
-    print 'ELF bin count: %d' % elf.blocksize()
+    print('ELF X axis: %s' % elf.getAxis(0).getUnit().caption())
+    print('ELF spectra count: %d' % elf.getNumberHistograms())
+    print('ELF bin count: %d' % elf.blocksize())
 
     # Reset the facility to the original setting
     config['default.facility'] = facility

--- a/docs/source/algorithms/EnggCalibrate-v1.rst
+++ b/docs/source/algorithms/EnggCalibrate-v1.rst
@@ -88,23 +88,23 @@ Usage
                                            difc=[difc1, difc2], tzero=[tzero1, tzero2])
 
    import math
-   print "DIFA1: {0}".format(difa1)
+   print("DIFA1: {0}".format(difa1))
    delta = 2
    approx_difc1 = 18267
    difc1_ok = abs(difc1 - approx_difc1) <= delta
-   print "DIFC1 is approximately (+/- {0}) {1}: {2}".format(delta, approx_difc1, difc1_ok)
+   print("DIFC1 is approximately (+/- {0}) {1}: {2}".format(delta, approx_difc1, difc1_ok))
    approx_tzero1 = 277
    tzero1_ok = abs(tzero1 - approx_tzero1) <= delta
-   print "TZERO1 is approximately (+/- {0}) {1}: {2}".format(delta, approx_tzero1, tzero1_ok)
+   print("TZERO1 is approximately (+/- {0}) {1}: {2}".format(delta, approx_tzero1, tzero1_ok))
    tbl = mtd[out_tbl_name]
 
    tbl_values_ok = (abs(tbl.cell(0,1) - approx_difc1) <= delta) and (abs(tbl.cell(0,2) - approx_tzero1) <= delta)
-   print "The output table has {0} row(s) and its values are as expected: {1}".format(tbl.rowCount(),
-                                                                                      tbl_values_ok)
+   print("The output table has {0} row(s) and its values are as expected: {1}".format(tbl.rowCount(),
+                                                                                      tbl_values_ok))
 
    import os
-   print "Output GSAS iparam file was written? {0}".format(os.path.exists(GSAS_iparm_fname))
-   print "Number of lines of the GSAS iparam file: {0}".format(sum(1 for line in open(GSAS_iparm_fname)))
+   print("Output GSAS iparam file was written? {0}".format(os.path.exists(GSAS_iparm_fname)))
+   print("Number of lines of the GSAS iparam file: {0}".format(sum(1 for line in open(GSAS_iparm_fname))))
 
 .. testcleanup:: ExampleCalib
 

--- a/docs/source/algorithms/EnggCalibrateFull-v1.rst
+++ b/docs/source/algorithms/EnggCalibrateFull-v1.rst
@@ -96,11 +96,11 @@ Usage
 
    det_id = pos_table.column(0)[0]
    cal_pos =  pos_table.column(2)[0]
-   print "Det ID:", det_id
-   print "Calibrated position: (%.3f,%.3f,%.3f)" % (cal_pos.getX(), cal_pos.getY(), cal_pos.getZ())
+   print("Det ID: {}".format(det_id))
+   print("Calibrated position: (%.3f,%.3f,%.3f)" % (cal_pos.getX(), cal_pos.getY(), cal_pos.getZ()))
    ws = mtd[ws_name]
    posInWSInst = ws.getInstrument().getDetector(det_id).getPos()
-   print "Is the detector position calibrated now in the original workspace instrument?", (cal_pos == posInWSInst)
+   print("Is the detector position calibrated now in the original workspace instrument? {}".format(cal_pos == posInWSInst))
 
 .. testcleanup:: ExCalFull
 
@@ -140,10 +140,10 @@ Output:
 
    det_id = pos_table.column(0)[0]
    pos =  pos_table.column(2)[0]
-   print "Det ID:", det_id
-   print "Calibrated position: ({0:.3f},{1:.3f},{2:.3f})".format(pos.getX(),pos.getY(),pos.getZ())
-   print "Got details on the peaks fitted for {0:d} detector(s)".format(peaks_info.rowCount())
-   print "Was the file created?", os.path.exists(pos_filename)
+   print("Det ID: {}".format(det_id))
+   print("Calibrated position: ({0:.3f},{1:.3f},{2:.3f})".format(pos.getX(),pos.getY(),pos.getZ()))
+   print("Got details on the peaks fitted for {0:d} detector(s)".format(peaks_info.rowCount()))
+   print("Was the file created? {}".format(os.path.exists(pos_filename)))
    with open(pos_filename) as csvf:
       reader = csv.reader(csvf, dialect='excel')
       reader.next()
@@ -154,7 +154,7 @@ Output:
                    (abs(float(row[5]) - cal_pos.getY()) < 1e-6) and\
                    (abs(float(row[6]) - cal_pos.getZ()) < 1e-6)
          if not calibOK: break
-   print "Does the calibration file have the expected values?", calibOK
+   print("Does the calibration file have the expected values? {}".format(calibOK))
 
 .. testcleanup:: ExCalFullWithOutputFile
 

--- a/docs/source/algorithms/EnggCalibrateFull-v1.rst
+++ b/docs/source/algorithms/EnggCalibrateFull-v1.rst
@@ -146,7 +146,7 @@ Output:
    print("Was the file created? {}".format(os.path.exists(pos_filename)))
    with open(pos_filename) as csvf:
       reader = csv.reader(csvf, dialect='excel')
-      reader.next()
+      next(reader)
       calibOK = True
       for i,row in enumerate(reader):
          cal_pos = pos_table.column(2)[i]

--- a/docs/source/algorithms/EnggFitDIFCFromPeaks-v1.rst
+++ b/docs/source/algorithms/EnggFitDIFCFromPeaks-v1.rst
@@ -76,17 +76,17 @@ Usage
    difa, difc, tzero = EnggFitDIFCFromPeaks(FittedPeaks=peaks_tbl, OutParametersTable=out_tbl_name)
 
    # Print the results
-   print "DIFA: %.1f" % difa
-   print "DIFC: %.0f" % round(difc,-1)
-   print "TZERO: %.0f" %round(tzero,-1)
+   print("DIFA: %.1f" % difa)
+   print("DIFC: %.0f" % round(difc,-1))
+   print("TZERO: %.0f" %round(tzero,-1))
    tbl = mtd[out_tbl_name]
-   print "The output table has %d row(s)" % tbl.rowCount()
-   print "Parameters from the table, DIFA: %.1f, DIFC: %.0f, TZERO: %.0f" % (tbl.cell(0,0), round(tbl.cell(0,1),-1), round(tbl.cell(0,2),-1))
-   print "Number of peaks fitted: {0}".format(peaks_tbl.rowCount())
-   print "First peak expected (dSpacing): {0}".format(peaks_tbl.column('dSpacing')[0])
-   print "First fitted peak center (ToF): {0:.1f}".format(peaks_tbl.column('X0')[0])
-   print "Second peak expected (dSpacing): {0}".format(peaks_tbl.column('dSpacing')[1])
-   print "Second fitted peak center (ToF): {0:.0f}".format(round(peaks_tbl.column('X0')[1],-1))
+   print("The output table has %d row(s)" % tbl.rowCount())
+   print("Parameters from the table, DIFA: %.1f, DIFC: %.0f, TZERO: %.0f" % (tbl.cell(0,0), round(tbl.cell(0,1),-1), round(tbl.cell(0,2),-1)))
+   print("Number of peaks fitted: {0}".format(peaks_tbl.rowCount()))
+   print("First peak expected (dSpacing): {0}".format(peaks_tbl.column('dSpacing')[0]))
+   print("First fitted peak center (ToF): {0:.1f}".format(peaks_tbl.column('X0')[0]))
+   print("Second peak expected (dSpacing): {0}".format(peaks_tbl.column('dSpacing')[1]))
+   print("Second fitted peak center (ToF): {0:.0f}".format(round(peaks_tbl.column('X0')[1],-1)))
 
 Output:
 

--- a/docs/source/algorithms/EnggFitPeaks-v1.rst
+++ b/docs/source/algorithms/EnggFitPeaks-v1.rst
@@ -80,11 +80,11 @@ Usage
 
 
    # Print the results
-   print "Number of peaks fitted: {0}".format(peaks_tbl.rowCount())
-   print "First peak expected (dSpacing): {0}".format(peaks_tbl.column('dSpacing')[0])
-   print "First fitted peak center (ToF): {0:.1f}".format(peaks_tbl.column('X0')[0])
-   print "Second peak expected (dSpacing): {0}".format(peaks_tbl.column('dSpacing')[1])
-   print "Second fitted peak center (ToF): {0:.0f}".format(round(peaks_tbl.column('X0')[1],-1))
+   print("Number of peaks fitted: {0}".format(peaks_tbl.rowCount()))
+   print("First peak expected (dSpacing): {0}".format(peaks_tbl.column('dSpacing')[0]))
+   print("First fitted peak center (ToF): {0:.1f}".format(peaks_tbl.column('X0')[0]))
+   print("Second peak expected (dSpacing): {0}".format(peaks_tbl.column('dSpacing')[1]))
+   print("Second fitted peak center (ToF): {0:.0f}".format(round(peaks_tbl.column('X0')[1],-1)))
 
 Output:
 

--- a/docs/source/algorithms/EnggFocus-v1.rst
+++ b/docs/source/algorithms/EnggFocus-v1.rst
@@ -65,12 +65,12 @@ Usage
                            Bank='1')
 
    # Should have one spectrum only
-   print "No. of spectra:", focussed_ws.getNumberHistograms()
+   print("No. of spectra: {}".format(focussed_ws.getNumberHistograms()))
 
    # Print a few arbitrary bins where higher intensities are expected
    fmt = "For TOF of {0:.3f} normalized intensity is {1:.3f}"
    for bin in [3169, 6037, 7124]:
-     print fmt.format(focussed_ws.readX(0)[bin], focussed_ws.readY(0)[bin])
+     print(fmt.format(focussed_ws.readX(0)[bin], focussed_ws.readY(0)[bin]))
 
 .. testcleanup:: ExSimpleFocussing
 

--- a/docs/source/algorithms/EnggVanadiumCorrections-v1.rst
+++ b/docs/source/algorithms/EnggVanadiumCorrections-v1.rst
@@ -111,7 +111,7 @@ Usage
                            CurvesWorkspace = curves_ws)
 
    # Should have one spectrum only
-   print "No. of spectra:", sample_ws.getNumberHistograms()
+   print("No. of spectra: {}".format(sample_ws.getNumberHistograms()))
 
    # Print a few arbitrary integrated spectra
    ws_idx = 400
@@ -120,7 +120,7 @@ Usage
                           EndWorkspaceIndex=ws_idx+idx_count)
    fmt = "For workspace index {0:d} the spectrum integration is {1:.3f}"
    for i in range(idx_count):
-      print fmt.format(ws_idx+i, integ_ws.readY(i)[0])
+      print(fmt.format(ws_idx+i, integ_ws.readY(i)[0]))
 
 .. testcleanup:: ExVanadiumCorr
 

--- a/docs/source/algorithms/EstimateMuonAsymmetryFromCounts-v1.rst
+++ b/docs/source/algorithms/EstimateMuonAsymmetryFromCounts-v1.rst
@@ -41,8 +41,8 @@ Usage
    run = input.getRun()
    run.addProperty("goodfrm","10","None",True)
    output,norm=EstimateMuonAsymmetryFromCounts(InputWorkspace=input,spectra=0,StartX=1,EndX=5)
-   print  "Asymmetry: ",['{0:.2f}'.format(value)  for value in output.readY(0)]
-   print "Normalization constant: {0:.2f}".format(norm[0])
+   print("Asymmetry:  {}".format(['{0:.2f}'.format(value) for value in output.readY(0)]))
+   print("Normalization constant: {0:.2f}".format(norm[0]))
    
 Output:
 
@@ -63,8 +63,8 @@ Output:
    run = input.getRun()
    run.addProperty("goodfrm","10","None",True)
    output,norm=EstimateMuonAsymmetryFromCounts(InputWorkspace=input,spectra=0,StartX=1,EndX=5,NormalizationIn=20.0)
-   print  "Asymmetry: ",['{0:.2f}'.format(value)  for value in output.readY(0)]
-   print "Normalization constant: {0:.2f}".format(norm[0])
+   print("Asymmetry:  {}".format(['{0:.2f}'.format(value)  for value in output.readY(0)]))
+   print("Normalization constant: {0:.2f}".format(norm[0]))
    
 Output:
 

--- a/docs/source/algorithms/EstimateResolutionDiffraction-v1.rst
+++ b/docs/source/algorithms/EstimateResolutionDiffraction-v1.rst
@@ -68,10 +68,10 @@ Usage
   EstimateResolutionDiffraction(InputWorkspace="PG3_2538", DeltaTOF=40.0, OutputWorkspace="PG3_Resolution")
   resws = mtd["PG3_Resolution"]
 
-  print "Size of workspace 'PG3_Resolution' = ", resws.getNumberHistograms()
-  print "Estimated resolution of detector of spectrum 0 = ", resws.readY(0)[0]
-  print "Estimated resolution of detector of spectrum 100 = ", resws.readY(100)[0]
-  print "Estimated resolution of detector of spectrum 999 = ", resws.readY(999)[0]
+  print("Size of workspace 'PG3_Resolution' =  {}".format(resws.getNumberHistograms()))
+  print("Estimated resolution of detector of spectrum 0 =  {}".format(resws.readY(0)[0]))
+  print("Estimated resolution of detector of spectrum 100 =  {}".format(resws.readY(100)[0]))
+  print("Estimated resolution of detector of spectrum 999 =  {}".format(resws.readY(999)[0]))
 
 .. testcleanup:: ExHistSimple
 

--- a/docs/source/algorithms/EstimateResolutionDiffraction-v1.rst
+++ b/docs/source/algorithms/EstimateResolutionDiffraction-v1.rst
@@ -69,9 +69,9 @@ Usage
   resws = mtd["PG3_Resolution"]
 
   print("Size of workspace 'PG3_Resolution' =  {}".format(resws.getNumberHistograms()))
-  print("Estimated resolution of detector of spectrum 0 =  {}".format(resws.readY(0)[0]))
-  print("Estimated resolution of detector of spectrum 100 =  {}".format(resws.readY(100)[0]))
-  print("Estimated resolution of detector of spectrum 999 =  {}".format(resws.readY(999)[0]))
+  print("Estimated resolution of detector of spectrum 0 =  {:.14f}".format(resws.readY(0)[0]))
+  print("Estimated resolution of detector of spectrum 100 =  {:.14f}".format(resws.readY(100)[0]))
+  print("Estimated resolution of detector of spectrum 999 =  {:.14f}".format(resws.readY(999)[0]))
 
 .. testcleanup:: ExHistSimple
 

--- a/docs/source/algorithms/EvaluateMDFunction-v1.rst
+++ b/docs/source/algorithms/EvaluateMDFunction-v1.rst
@@ -37,10 +37,10 @@ Usage
     out = EvaluateMDFunction(ws,function)
 
     # Check the result workspace
-    print out.getNumDims()
-    print out.getXDimension().name
-    print out.getYDimension().name
-    print out.getZDimension().name
+    print(out.getNumDims())
+    print(out.getXDimension().name)
+    print(out.getYDimension().name)
+    print(out.getZDimension().name)
     
     
 Output

--- a/docs/source/algorithms/ExaminePowderDiffProfile-v1.rst
+++ b/docs/source/algorithms/ExaminePowderDiffProfile-v1.rst
@@ -48,7 +48,7 @@ Usage
 
   # Output result
   ws = mtd['PG3_15035B3_Cal']
-  print 'Output workspace has %d spectra' % (ws.getNumberHistograms())
+  print('Output workspace has %d spectra' % (ws.getNumberHistograms()))
 
 .. testcleanup:: ExExaminePG3Profile
 

--- a/docs/source/algorithms/ExampleSaveAscii-v1.rst
+++ b/docs/source/algorithms/ExampleSaveAscii-v1.rst
@@ -40,9 +40,9 @@ Usage
     
     # Read and print first 3 lines from file
     with open(filepath, 'r') as f:
-        print f.readline()[:-1]
-        print f.readline()[:-1]
-        print f.readline()[:-1]
+        print(f.readline()[:-1])
+        print(f.readline()[:-1])
+        print(f.readline()[:-1])
     
     # Delete the test file
     os.remove(filepath)

--- a/docs/source/algorithms/Exponential-v1.rst
+++ b/docs/source/algorithms/Exponential-v1.rst
@@ -37,7 +37,7 @@ Usage
   # Use numpy array calculation to apply an exponential to all elements of array y
   yexp = np.exp(y)
   # Use numpy to check that all elements in two arrays are equal
-  print np.all( yexp == yres )
+  print(np.all( yexp == yres ))
 
 Output
 ######

--- a/docs/source/algorithms/ExponentialCorrection-v1.rst
+++ b/docs/source/algorithms/ExponentialCorrection-v1.rst
@@ -33,8 +33,8 @@ Usage
     ws_divide = ExponentialCorrection(InputWorkspace=ws,C0=2.0,C1=1.0,Operation="Divide")
     ws_multiply = ExponentialCorrection(InputWorkspace=ws,C0=2.0,C1=1.0,Operation="Multiply")
 
-    print("The first Y value after divide correction is: {}".format(ws_divide.dataY(0)[1]))
-    print("The first Y value after multiply correction is: {}".format(ws_multiply.dataY(0)[1]))
+    print("The first Y value after divide correction is: {:.11f}".format(ws_divide.dataY(0)[1]))
+    print("The first Y value after multiply correction is: {:.11f}".format(ws_multiply.dataY(0)[1]))
 
 Output:
 

--- a/docs/source/algorithms/ExponentialCorrection-v1.rst
+++ b/docs/source/algorithms/ExponentialCorrection-v1.rst
@@ -33,8 +33,8 @@ Usage
     ws_divide = ExponentialCorrection(InputWorkspace=ws,C0=2.0,C1=1.0,Operation="Divide")
     ws_multiply = ExponentialCorrection(InputWorkspace=ws,C0=2.0,C1=1.0,Operation="Multiply")
 
-    print("The first Y value after divide correction is: {:.11f}".format(ws_divide.dataY(0)[1]))
-    print("The first Y value after multiply correction is: {:.11f}".format(ws_multiply.dataY(0)[1]))
+    print("The first Y value after divide correction is: {:.11e}".format(ws_divide.dataY(0)[1]))
+    print("The first Y value after multiply correction is: {:.11e}".format(ws_multiply.dataY(0)[1]))
 
 Output:
 

--- a/docs/source/algorithms/ExponentialCorrection-v1.rst
+++ b/docs/source/algorithms/ExponentialCorrection-v1.rst
@@ -26,7 +26,7 @@ Usage
 
     ws = CreateSampleWorkspace()
 
-    print "The first Y value before correction is: " + str(ws.dataY(0)[1])
+    print("The first Y value before correction is: {}".format((ws.dataY(0)[1])))
 
     # By default, the Divide operation is used to correct the data.
     # The result is saved into another workspace, which can also be itself.

--- a/docs/source/algorithms/ExponentialCorrection-v1.rst
+++ b/docs/source/algorithms/ExponentialCorrection-v1.rst
@@ -33,8 +33,8 @@ Usage
     ws_divide = ExponentialCorrection(InputWorkspace=ws,C0=2.0,C1=1.0,Operation="Divide")
     ws_multiply = ExponentialCorrection(InputWorkspace=ws,C0=2.0,C1=1.0,Operation="Multiply")
 
-    print "The first Y value after divide correction is: " + str(ws_divide.dataY(0)[1])
-    print "The first Y value after multiply correction is: " + str(ws_multiply.dataY(0)[1])
+    print("The first Y value after divide correction is: {}".format(ws_divide.dataY(0)[1]))
+    print("The first Y value after multiply correction is: {}".format(ws_multiply.dataY(0)[1]))
 
 Output:
 

--- a/docs/source/algorithms/ExportExperimentLog-v1.rst
+++ b/docs/source/algorithms/ExportExperimentLog-v1.rst
@@ -114,14 +114,14 @@ Usage
       FileFormat = "tab",
       TimeZone = "America/New_York")
 
-  print "File is created = ", os.path.exists(savefile)
+  print("File is created =  {}".format(os.path.exists(savefile)))
   
   # Get lines of file
   sfile = open(savefile, 'r')
   slines = sfile.readlines()
   sfile.close()
 
-  print "Number of lines in File =", len(slines)
+  print("Number of lines in File = {}".format(len(slines)))
 
 .. testcleanup:: ExExportExpLogs
 

--- a/docs/source/algorithms/ExportGeometry-v1.rst
+++ b/docs/source/algorithms/ExportGeometry-v1.rst
@@ -30,7 +30,7 @@ Usage
                   Filename=filename)
    import os
    if os.path.isfile(filename):
-       print "File created: True"
+       print("File created: True")
 
 .. testcleanup:: ExportGeometry
 

--- a/docs/source/algorithms/ExportSampleLogsToCSVFile-v1.rst
+++ b/docs/source/algorithms/ExportSampleLogsToCSVFile-v1.rst
@@ -100,8 +100,8 @@ Usage
 
    headerfilename = os.path.join(defaultdir, "testphase4_header.txt")
 
-   print "File is created = ", os.path.exists(savefile)
-   print "Header file is created = ", os.path.exists(headerfilename)
+   print("File is created =  {}".format(os.path.exists(savefile)))
+   print("Header file is created =  {}".format(os.path.exists(headerfilename)))
 
    # Get the lines of both files
    sfile = open(savefile, 'r')
@@ -111,8 +111,8 @@ Usage
    hlines = hfile.readlines()
    hfile.close()
 
-   print "Number of lines in File =", len(slines)
-   print "Number of lines in Header file =", len(hlines)
+   print("Number of lines in File = {}".format(len(slines)))
+   print("Number of lines in Header file = {}".format(len(hlines)))
    
 .. testcleanup:: ExExportSampleToTSV
 

--- a/docs/source/algorithms/ExportTimeSeriesLog-v1.rst
+++ b/docs/source/algorithms/ExportTimeSeriesLog-v1.rst
@@ -51,7 +51,7 @@ Usage
   import mantid.kernel as mk
   testprop = mk.FloatTimeSeriesProperty("Temp")
 
-  import random
+  from numpy import random
   random.seed(10)
   for i in range(60):
       randsec = random.randint(0, 59)
@@ -79,10 +79,9 @@ Output:
 .. testoutput:: ExExpTempWS2D
 
   Length of X = 60, Length of Y = 60.
-  X[0]  = 26089826.0, Y[0]  = 42.88891
-  X[20] = 26091001.0, Y[20] = 22.42990
-  X[40] = 26092226.0, Y[40] = 39.05869
-
+  X[0]  = 26089801.0, Y[0]  = 29.87612
+  X[20] = 26091048.0, Y[20] = 61.19433
+  X[40] = 26092225.0, Y[40] = 63.79516
 
 **Example - export a float series to a EventWorkspace:**
 
@@ -122,7 +121,7 @@ Output:
 .. testoutput:: ExExpTempEvent
 
   Length of X = 2, Length of Y = 1.
-  X[0]  = 26089826000000.0, Y[0]  = 1702.58055
+  X[0]  = 26089828000000.0, Y[0]  = 2095.98009
   Number of events = 40
 
 .. categories::

--- a/docs/source/algorithms/ExportTimeSeriesLog-v1.rst
+++ b/docs/source/algorithms/ExportTimeSeriesLog-v1.rst
@@ -94,7 +94,7 @@ Output:
   # Create a new log
   testprop = mk.FloatTimeSeriesProperty("Temp")
 
-  import random
+  from numpy import random
   random.seed(10)
   for i in range(60):
       randsec = random.randint(0, 59)
@@ -121,7 +121,7 @@ Output:
 .. testoutput:: ExExpTempEvent
 
   Length of X = 2, Length of Y = 1.
-  X[0]  = 26089828000000.0, Y[0]  = 2095.98009
+  X[0]  = 26089801000000.0, Y[0]  = 1958.93574
   Number of events = 40
 
 .. categories::

--- a/docs/source/algorithms/ExportTimeSeriesLog-v1.rst
+++ b/docs/source/algorithms/ExportTimeSeriesLog-v1.rst
@@ -53,7 +53,7 @@ Usage
 
   import random
   random.seed(10)
-  for i in xrange(60):
+  for i in range(60):
       randsec = random.randint(0, 59)
       randval = random.random()*100.
       timetemp = mk.DateAndTime("2012-01-01T00:%d:%d"%(i, randsec))
@@ -65,9 +65,9 @@ Usage
 
   # Check
   print("Length of X = %d, Length of Y = %d." % (len(propws.readX(0)), len(propws.readY(0))))
-  print("X[0]  = %.1f, Y[0]  = %.5f" % (propws.readX(0)[0], propws.readY(0)[0]))
-  print("X[20] = %.1f, Y[20] = %.5f" % (propws.readX(0)[20], propws.readY(0)[20]))
-  print("X[40] = %.1f, Y[40] = %.5f" % (propws.readX(0)[40], propws.readY(0)[40]))
+  print("X[0]  = {:.1f}, Y[0]  = {:.5f}".format(propws.readX(0)[0], propws.readY(0)[0]))
+  print("X[20] = {:.1f}, Y[20] = {:.5f}".format(propws.readX(0)[20], propws.readY(0)[20]))
+  print("X[40] = {:.1f}, Y[40] = {:.5f}".format(propws.readX(0)[40], propws.readY(0)[40]))
 
 .. testcleanup:: ExExpTempWS2D
 
@@ -97,7 +97,7 @@ Output:
 
   import random
   random.seed(10)
-  for i in xrange(60):
+  for i in range(60):
       randsec = random.randint(0, 59)
       randval = random.random()*100.
       timetemp = mk.DateAndTime("2012-01-01T00:%d:%d"%(i, randsec))
@@ -108,9 +108,9 @@ Output:
   propws = ExportTimeSeriesLog(InputWorkspace=dataws, LogName="Temp", NumberEntriesExport=40, IsEventWorkspace=True)
 
   # Check
-  print("Length of X = %d, Length of Y = %d." % (len(propws.readX(0)), len(propws.readY(0))))
-  print("X[0]  = %.1f, Y[0]  = %.5f" % (propws.readX(0)[0], propws.readY(0)[0]))
-  print("Number of events = %d" % (propws.getNumberEvents()))
+  print("Length of X = {}, Length of Y = {}.".format(len(propws.readX(0)), len(propws.readY(0))))
+  print("X[0]  = {:.1f}, Y[0]  = {:.5f}".format(propws.readX(0)[0], propws.readY(0)[0]))
+  print("Number of events = {}".format(propws.getNumberEvents()))
 
 .. testcleanup:: ExExpTempEvent
 

--- a/docs/source/algorithms/ExportTimeSeriesLog-v1.rst
+++ b/docs/source/algorithms/ExportTimeSeriesLog-v1.rst
@@ -64,10 +64,10 @@ Usage
   propws = ExportTimeSeriesLog(InputWorkspace=dataws, LogName="Temp", IsEventWorkspace=False)
 
   # Check
-  print "Length of X = %d, Length of Y = %d." % (len(propws.readX(0)), len(propws.readY(0)))
-  print "X[0]  = %.1f, Y[0]  = %.5f" % (propws.readX(0)[0], propws.readY(0)[0])
-  print "X[20] = %.1f, Y[20] = %.5f" % (propws.readX(0)[20], propws.readY(0)[20])
-  print "X[40] = %.1f, Y[40] = %.5f" % (propws.readX(0)[40], propws.readY(0)[40])
+  print("Length of X = %d, Length of Y = %d." % (len(propws.readX(0)), len(propws.readY(0))))
+  print("X[0]  = %.1f, Y[0]  = %.5f" % (propws.readX(0)[0], propws.readY(0)[0]))
+  print("X[20] = %.1f, Y[20] = %.5f" % (propws.readX(0)[20], propws.readY(0)[20]))
+  print("X[40] = %.1f, Y[40] = %.5f" % (propws.readX(0)[40], propws.readY(0)[40]))
 
 .. testcleanup:: ExExpTempWS2D
 
@@ -108,9 +108,9 @@ Output:
   propws = ExportTimeSeriesLog(InputWorkspace=dataws, LogName="Temp", NumberEntriesExport=40, IsEventWorkspace=True)
 
   # Check
-  print "Length of X = %d, Length of Y = %d." % (len(propws.readX(0)), len(propws.readY(0)))
-  print "X[0]  = %.1f, Y[0]  = %.5f" % (propws.readX(0)[0], propws.readY(0)[0])
-  print "Number of events = %d" % (propws.getNumberEvents())
+  print("Length of X = %d, Length of Y = %d." % (len(propws.readX(0)), len(propws.readY(0))))
+  print("X[0]  = %.1f, Y[0]  = %.5f" % (propws.readX(0)[0], propws.readY(0)[0]))
+  print("Number of events = %d" % (propws.getNumberEvents()))
 
 .. testcleanup:: ExExpTempEvent
 

--- a/docs/source/algorithms/ExtractMask-v1.rst
+++ b/docs/source/algorithms/ExtractMask-v1.rst
@@ -39,10 +39,10 @@ Usage
     ws2 = CreateSampleWorkspace(NumBanks=1,BankPixelWidth=bankPixelWidth)
     MaskDetectors(ws2,MaskedWorkspace="wsMask")
 
-    print "Masked Detectors"
-    print "n ws    ws2"
+    print("Masked Detectors")
+    print("n ws    ws2")
     for i in range (ws.getNumberHistograms()):
-        print "%i %-5s %s" % (i, ws.getDetector(i).isMasked(), ws2.getDetector(i).isMasked())
+        print("%i %-5s %s" % (i, ws.getDetector(i).isMasked(), ws2.getDetector(i).isMasked()))
 
 Output:
 

--- a/docs/source/algorithms/ExtractMaskToTable-v1.rst
+++ b/docs/source/algorithms/ExtractMaskToTable-v1.rst
@@ -50,8 +50,8 @@ Usage
   outmaskws = ExtractMaskToTable(InputWorkspace=dataws, Xmin = 12300., Xmax = 24500.)
 
   # Output
-  print "Number of rows: ", outmaskws.rowCount()
-  print "Row 0: Xmin = %.5f, Xmax = %.5f, DetectorIDsList = %s." % (outmaskws.cell(0, 0), outmaskws.cell(0, 1), outmaskws.cell(0, 2))
+  print("Number of rows:  {}".format(outmaskws.rowCount()))
+  print("Row 0: Xmin = %.5f, Xmax = %.5f, DetectorIDsList = %s." % (outmaskws.cell(0, 0), outmaskws.cell(0, 1), outmaskws.cell(0, 2)))
 
 .. testcleanup:: ExHistSimple
 
@@ -88,10 +88,10 @@ Output:
   outmaskws = ExtractMaskToTable(InputWorkspace=dataws, MaskTableWorkspace=tws, Xmin = 12300., Xmax = 24500.)
 
   # Write some result
-  print "Number of rows: ", outmaskws.rowCount()
-  print "Row 0: Xmin = %.5f, Xmax = %.5f, DetectorIDsList = %s." % (outmaskws.cell(0, 0), outmaskws.cell(0, 1), outmaskws.cell(0, 2))
-  print "Row 1: Xmin = %.5f, Xmax = %.5f, DetectorIDsList = %s." % (outmaskws.cell(1, 0), outmaskws.cell(1, 1), outmaskws.cell(1, 2))
-  print "Row 2: Xmin = %.5f, Xmax = %.5f, DetectorIDsList = %s." % (outmaskws.cell(2, 0), outmaskws.cell(2, 1), outmaskws.cell(2, 2))
+  print("Number of rows:  {}".format(outmaskws.rowCount()))
+  print("Row 0: Xmin = %.5f, Xmax = %.5f, DetectorIDsList = %s." % (outmaskws.cell(0, 0), outmaskws.cell(0, 1), outmaskws.cell(0, 2)))
+  print("Row 1: Xmin = %.5f, Xmax = %.5f, DetectorIDsList = %s." % (outmaskws.cell(1, 0), outmaskws.cell(1, 1), outmaskws.cell(1, 2)))
+  print("Row 2: Xmin = %.5f, Xmax = %.5f, DetectorIDsList = %s." % (outmaskws.cell(2, 0), outmaskws.cell(2, 1), outmaskws.cell(2, 2)))
 
 .. testcleanup:: ExOptTable
 

--- a/docs/source/algorithms/ExtractMaskToTable-v1.rst
+++ b/docs/source/algorithms/ExtractMaskToTable-v1.rst
@@ -43,7 +43,7 @@ Usage
   dataws = LoadNexusProcessed(Filename="PG3_2538_2k.nxs")
 
   # mask some detectors
-  for i in xrange(100):
+  for i in range(100):
       dataws.maskDetectors(100+i)
 
   # Run algorithm
@@ -73,7 +73,7 @@ Output:
   dataws = LoadNexusProcessed(Filename="PG3_2538_2k.nxs")
 
   # mask some detectors
-  for i in xrange(100):
+  for i in range(100):
       dataws.maskDetectors(100+i)
 
   # create a mask table workspacetws =

--- a/docs/source/algorithms/ExtractMonitors-v1.rst
+++ b/docs/source/algorithms/ExtractMonitors-v1.rst
@@ -33,17 +33,17 @@ Usage
   monitor_ws = mtd['Monitors']
 
   # Detector histograms
-  print("Number of spectra in input workspace: {0}").format(ws.getNumberHistograms())
+  print("Number of spectra in input workspace: {0}".format(ws.getNumberHistograms()))
   # Detector histograms (spectra missing detectors generate warnings)
-  print("Number of spectra in detector workspace: {0}").format(detector_ws.getNumberHistograms())
+  print("Number of spectra in detector workspace: {0}".format(detector_ws.getNumberHistograms()))
   # Monitor histograms
-  print("Number of spectra in monitor workspace: {0}").format(monitor_ws.getNumberHistograms())
+  print("Number of spectra in monitor workspace: {0}".format(monitor_ws.getNumberHistograms()))
   # Check if the first spectrum in the detector workspace is a monitor
-  print("Detector workspace isMonitor for spectrum 0: {0}").format(detector_ws.getDetector(0).isMonitor())
+  print("Detector workspace isMonitor for spectrum 0: {0}".format(detector_ws.getDetector(0).isMonitor()))
   # Check if the first spectrum in the monitor workspace is a monitor
-  print("Monitor workspace isMonitor for spectrum 0: {0}").format(monitor_ws.getDetector(0).isMonitor())
+  print("Monitor workspace isMonitor for spectrum 0: {0}".format(monitor_ws.getDetector(0).isMonitor()))
   # See the monitor workspace is set
-  print("Name of monitor workspace: {0}").format(detector_ws.getMonitorWorkspace().name())
+  print("Name of monitor workspace: {0}".format(detector_ws.getMonitorWorkspace().name()))
 
 Output:
 

--- a/docs/source/algorithms/ExtractSingleSpectrum-v1.rst
+++ b/docs/source/algorithms/ExtractSingleSpectrum-v1.rst
@@ -20,16 +20,16 @@ Usage
 .. testcode:: ExExtractSingleSpectrum
 
     ws = CreateSampleWorkspace()
-    print "Workspace %s contains %i spectra" % (ws, ws.getNumberHistograms())
-    print "Counts for every 10th bin for workspace index 5"
-    print ws.readY(5)[0:100:10]
+    print("Workspace %s contains %i spectra" % (ws, ws.getNumberHistograms()))
+    print("Counts for every 10th bin for workspace index 5")
+    print(", ".join(["{:.1f}".format(y) for y in ws.readY(5)[0:100:10]]))
 
     wsOut = ExtractSingleSpectrum(ws,WorkspaceIndex=5)
-    print "After extracting one spectra at workspace index 5"
+    print("After extracting one spectra at workspace index 5")
 
-    print "Workspace %s contains %i spectra" % (wsOut, wsOut.getNumberHistograms())
-    print "Counts for every 10th bin for workspace index 0 (now it's 0 as wsOut only contains 1 spectra)"
-    print wsOut.readY(0)[0:100:10]
+    print("Workspace %s contains %i spectra" % (wsOut, wsOut.getNumberHistograms()))
+    print("Counts for every 10th bin for workspace index 0 (now it's 0 as wsOut only contains 1 spectra)")
+    print(", ".join(["{:.1f}".format(y) for y in wsOut.readY(0)[0:100:10]]))
 
 
 Output:
@@ -38,11 +38,11 @@ Output:
 
     Workspace ws contains 200 spectra
     Counts for every 10th bin for workspace index 5
-    [  0.3   0.3   0.3   0.3   0.3  10.3   0.3   0.3   0.3   0.3]
+    0.3, 0.3, 0.3, 0.3, 0.3, 10.3, 0.3, 0.3, 0.3, 0.3
     After extracting one spectra at workspace index 5
     Workspace wsOut contains 1 spectra
     Counts for every 10th bin for workspace index 0 (now it's 0 as wsOut only contains 1 spectra)
-    [  0.3   0.3   0.3   0.3   0.3  10.3   0.3   0.3   0.3   0.3]
+    0.3, 0.3, 0.3, 0.3, 0.3, 10.3, 0.3, 0.3, 0.3, 0.3
 
 .. categories::
 

--- a/docs/source/algorithms/ExtractSpectra-v1.rst
+++ b/docs/source/algorithms/ExtractSpectra-v1.rst
@@ -24,13 +24,13 @@ Usage
 
     # Create an input workspace
     ws = CreateSampleWorkspace()
-    print 'Input workspace has %s bins' % ws.blocksize()
-    print 'Input workspace has %s spectra' % ws.getNumberHistograms()
+    print('Input workspace has %s bins' % ws.blocksize())
+    print('Input workspace has %s spectra' % ws.getNumberHistograms())
 
     # Extract spectra 1,3 and 5 and crop the x-vector to interval 200 <= x <= 1300
     cropped = ExtractSpectra(ws,200,1300,WorkspaceIndexList=[1,3,5])
-    print 'Output workspace has %s bins' % cropped.blocksize()
-    print 'Output workspace has %s spectra' % cropped.getNumberHistograms()
+    print('Output workspace has %s bins' % cropped.blocksize())
+    print('Output workspace has %s spectra' % cropped.getNumberHistograms())
 
 Output:
 

--- a/docs/source/algorithms/ExtractUnmaskedSpectra-v1.rst
+++ b/docs/source/algorithms/ExtractUnmaskedSpectra-v1.rst
@@ -31,8 +31,8 @@ Usage
     ows = ExtractUnmaskedSpectra(ws)
 
     # Compare workspace sizes
-    print 'Number of spectra in original workspace', ws.getNumberHistograms()
-    print 'Number of spectra in cropped  workspace', ows.getNumberHistograms()
+    print('Number of spectra in original workspace {}'.format(ws.getNumberHistograms()))
+    print('Number of spectra in cropped  workspace {}'.format(ows.getNumberHistograms()))
 
 Output:
 


### PR DESCRIPTION
## Description of work.
This PR is part of refactoring effort to bring Python3 compatiblity into the doctests.
See https://github.com/mantidproject/mantid/issues/20672 for details.

The following tests were refactored to be compatible :
```
EQSANSAzimuthalAverage1D
EQSANSDarkCurrentSubtraction
EQSANSDirectBeamTransmission
EQSANSLoad
EQSANSMonitorTOF
EQSANSNormalise
EQSANSPatchSensitivity
EQSANSQ2D
EQSANSResolution
EQSANSTofStructure
EditInstrumentGeometry
ElasticWindow
ElasticWindowMultiple
EnergyWindowScan
EnggCalibrate
EnggCalibrateFull
EnggFitDIFCFromPeaks
EnggFitPeaks
EnggFocus
EnggVanadiumCorrections
EqualToMD
EstimateFitParameters
EstimateMuonAsymmetryFromCounts
EstimatePeakErrors
EstimateResolutionDiffraction
EvaluateFunction
EvaluateMDFunction
ExaminePowderDiffProfile
ExampleSaveAscii
Exponential
ExponentialCorrection
ExponentialMD
ExportExperimentLog
ExportGeometry
ExportSampleLogsToCSVFile
ExportSpectraMask
ExportTimeSeriesLog
ExtractFFTSpectrum
ExtractMask
ExtractMaskToTable
ExtractMonitorWorkspace
ExtractMonitors
ExtractSingleSpectrum
ExtractSpectra
ExtractUnmaskedSpectra
```
## To test.

Code review.

Fixes #20718 
Internal change, no release notes