### PR TITLE
Fix Mantid log warnings with 'docs-html' target under Python3

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/plugins.py
+++ b/Framework/PythonInterface/mantid/kernel/plugins.py
@@ -242,7 +242,8 @@ def contains_algorithm(filename):
     #endif
     alg_found = True
     try:
-        with open(filename,'r') as plugin_file:
+        from io import open
+        with open(filename,'r', encoding='UTF-8') as plugin_file:
             for line in readlines_reversed(plugin_file):
                 if 'AlgorithmFactory.subscribe' in line:
                     alg_found = True


### PR DESCRIPTION
This PR adds Python3 compatible utf-8 encoding file opening to Python algorithm source parser.

**To test:**

Build the 'docs-html' target under Python 3 (see [here](http://www.mantidproject.org/Python_3) how to switch to Python 3) and check that no warnings like the one in the issue appear.

Resolves #20723.

**Release Notes** 

Internal fix, doesn't need to be in the release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
