### PR TITLE
Python3 doctest compatibility: algorithms beginning with F

### DIFF
--- a/docs/source/algorithms/FFT-v1.rst
+++ b/docs/source/algorithms/FFT-v1.rst
@@ -208,11 +208,10 @@ Usage
    #apply the FFT algorithm - note output is point data
    outworkspace = FFT(InputWorkspace = ws, Transform = 'Backward')
 
-   #print statements
-   print "DataX(0)[1] equals DataX(0)[99]? : " + str((round(abs(outworkspace.dataX(0)[1]), 3)) == (round(outworkspace.dataX(0)[99], 3)))
-   print "DataX(0)[10] equals DataX(0)[90]? : " + str((round(abs(outworkspace.dataX(0)[10]), 3)) == (round(outworkspace.dataX(0)[90], 3)))
-   print "DataX((0)[50] equals 0? : " + str((round(abs(outworkspace.dataX(0)[50]), 3)) == 0)
-   print "DataY(0)[40] equals DataY(0)[60]? : " + str((round(abs(outworkspace.dataY(0)[40]), 5)) == (round(outworkspace.dataY(0)[60], 5)))
+   print("DataX(0)[1] equals DataX(0)[99]? : " + str((round(abs(outworkspace.dataX(0)[1]), 3)) == (round(outworkspace.dataX(0)[99], 3))))
+   print("DataX(0)[10] equals DataX(0)[90]? : " + str((round(abs(outworkspace.dataX(0)[10]), 3)) == (round(outworkspace.dataX(0)[90], 3))))
+   print("DataX((0)[50] equals 0? : " + str((round(abs(outworkspace.dataX(0)[50]), 3)) == 0))
+   print("DataY(0)[40] equals DataY(0)[60]? : " + str((round(abs(outworkspace.dataY(0)[40]), 5)) == (round(outworkspace.dataY(0)[60], 5))))
 
 Output:
 

--- a/docs/source/algorithms/FFTDerivative-v1.rst
+++ b/docs/source/algorithms/FFTDerivative-v1.rst
@@ -23,9 +23,9 @@ Usage
     wsOrder2 = FFTDerivative(wsOriginal,Order=2)
     wsOrder3 = FFTDerivative(wsOriginal,Order=3)
 
-    print "bin Orig  1st    2nd   3rd"
+    print("bin Orig  1st    2nd   3rd")
     for i in range (41,67,5):
-        print "%i  %.2f  %.2f  %.2f  %.2f" % (i, wsOriginal.readY(0)[i], wsOrder1.readY(0)[i], wsOrder2.readY(0)[i], wsOrder3.readY(0)[i])
+        print("{}  {:.2f}  {:.2f}  {:.2f}  {:.2f}".format(i, wsOriginal.readY(0)[i], wsOrder1.readY(0)[i], wsOrder2.readY(0)[i], wsOrder3.readY(0)[i]))
 
 .. figure:: /images/FFTDerivativeExample.png
     :align: right
@@ -54,8 +54,8 @@ Output:
 
     wsOrder2Test = FFTDerivative(wsOrder1,Order=1)
 
-    print "The direct 2nd order derivative and the derivative of a derivative should match"
-    print CompareWorkspaces(wsOrder2,wsOrder2Test,CheckAllData=True,Tolerance=1e10)[0]
+    print("The direct 2nd order derivative and the derivative of a derivative should match")
+    print(CompareWorkspaces(wsOrder2,wsOrder2Test,CheckAllData=True,Tolerance=1e10)[0])
 
 Output:
 

--- a/docs/source/algorithms/FFTSmooth-v1.rst
+++ b/docs/source/algorithms/FFTSmooth-v1.rst
@@ -46,9 +46,9 @@ Usage
 
     wsSmooth = FFTSmooth(ws, Params='2', Version=1)
 
-    print "bin Orig  Smoothed"
+    print("bin Orig  Smoothed")
     for i in range (0,100,10):
-        print "%i  %.2f  %.2f" % (i, ws.readY(0)[i], wsSmooth.readY(0)[i])
+        print("{}  {:.2f}  {:.2f}".format(i, ws.readY(0)[i], wsSmooth.readY(0)[i]))
 
 
 .. figure:: /images/FFTSmoothZeroing.png

--- a/docs/source/algorithms/FFTSmooth-v2.rst
+++ b/docs/source/algorithms/FFTSmooth-v2.rst
@@ -67,9 +67,9 @@ Usage
 
     wsSmooth = FFTSmooth(ws, Params='2')
 
-    print "bin Orig  Smoothed"
+    print("bin Orig  Smoothed")
     for i in range (0,100,10):
-        print "%i  %.2f  %.2f" % (i, ws.readY(0)[i], wsSmooth.readY(0)[i])
+        print("{}  {:.2f}  {:.2f}".format(i, ws.readY(0)[i], wsSmooth.readY(0)[i]))
 
 
 .. figure:: /images/FFTSmoothZeroing.png
@@ -114,9 +114,9 @@ Output:
     wsButter5_2 = FFTSmooth(ws, Filter="Butterworth", Params='5,2', AllSpectra=True)
     wsButter20_2 = FFTSmooth(ws, Filter="Butterworth", Params='20,2', AllSpectra=True)
 
-    print "bin Orig  2_2   5_2   20_2"
+    print("bin Orig  2_2   5_2   20_2")
     for i in range (0,100,10):
-        print "%i  %.2f  %.2f  %.2f  %.2f" % (i, ws.readY(0)[i], wsButter2_2.readY(0)[i], wsButter5_2.readY(0)[i], wsButter20_2.readY(0)[i])
+        print("{}  {:.2f}  {:.2f}  {:.2f}  {:.2f}".format(i, ws.readY(0)[i], wsButter2_2.readY(0)[i], wsButter5_2.readY(0)[i], wsButter20_2.readY(0)[i]))
 
 
 .. figure:: /images/FFTSmoothZeroingButter.png

--- a/docs/source/algorithms/FakeISISEventDAE-v1.rst
+++ b/docs/source/algorithms/FakeISISEventDAE-v1.rst
@@ -67,7 +67,7 @@ Usage
 
     try:
         captureLive()
-    except Exception, exc:
+    except:
         print("Error occurred starting live data")
     finally:
         thread.join() # this must get hit

--- a/docs/source/algorithms/FakeISISEventDAE-v1.rst
+++ b/docs/source/algorithms/FakeISISEventDAE-v1.rst
@@ -68,7 +68,7 @@ Usage
     try:
         captureLive()
     except Exception, exc:
-        print "Error occurred starting live data"
+        print("Error occurred starting live data")
     finally:
         thread.join() # this must get hit
 
@@ -77,7 +77,7 @@ Usage
 
     #get the ouput workspace
     wsOut = mtd["wsOut"]
-    print "The workspace contains %i events" % wsOut.getNumberEvents()
+    print("The workspace contains %i events" % wsOut.getNumberEvents())
 
 Output:
 

--- a/docs/source/algorithms/FakeISISHistoDAE-v1.rst
+++ b/docs/source/algorithms/FakeISISHistoDAE-v1.rst
@@ -62,7 +62,7 @@ Usage
     try:
         captureLive()
     except Exception, exc:
-        print "Error occurred starting live data"
+        print("Error occurred starting live data")
     finally:
         thread.join() # this must get hit
 
@@ -71,7 +71,7 @@ Usage
 
     #get the ouput workspace
     wsOut = mtd["wsOut"]
-    print "The workspace contains %i histograms" % wsOut.getNumberHistograms()
+    print("The workspace contains %i histograms" % wsOut.getNumberHistograms())
 
 Output:
 

--- a/docs/source/algorithms/FakeISISHistoDAE-v1.rst
+++ b/docs/source/algorithms/FakeISISHistoDAE-v1.rst
@@ -61,7 +61,7 @@ Usage
 
     try:
         captureLive()
-    except Exception, exc:
+    except:
         print("Error occurred starting live data")
     finally:
         thread.join() # this must get hit

--- a/docs/source/algorithms/FakeMDEventData-v1.rst
+++ b/docs/source/algorithms/FakeMDEventData-v1.rst
@@ -28,7 +28,7 @@ using :ref:`CreateMDWorkspace <algm-CreateMDWorkspace>`.
     ws = CreateMDWorkspace(Dimensions='2', EventType='MDEvent', Extents='-10,10,-10,10',
                            Names='Q_lab_x,Q_lab_y', Units='A,B')
     FakeMDEventData(ws, UniformParams="1000000")
-    print "Number of events =", ws.getNEvents()
+    print("Number of events = {}".format(ws.getNEvents()))
 
 Output:
 
@@ -54,7 +54,7 @@ Creates 3 peaks in (H,K,L) at (0,0,0), (1,1,0) and (1,1,1).
     FakeMDEventData(ws, PeakParams='10000,1,1,1,0.1', RandomSeed='63759', RandomizeSignal='1')
     FakeMDEventData(ws, PeakParams='100000,0,0,0,0.1', RandomSeed='63759', RandomizeSignal='1')
     FakeMDEventData(ws, PeakParams='40000,1,1,0,0.1', RandomSeed='63759', RandomizeSignal='1')
-    print "Number of events =", ws.getNEvents()
+    print("Number of events = {}".format(ws.getNEvents()))
 
 Output:
 
@@ -85,7 +85,7 @@ Creates a peak at (H,K,L) of (0,0,0) around T=5K.
     ws = CreateMDWorkspace(Dimensions='4', Extents='-1,1,-1,1,-1,1,0,10', Names='H,K,L,T', Units='rlu,rlu,rlu,K',
                            SplitInto='2', SplitThreshold='50')
     FakeMDEventData(ws, PeakParams='1e+06,0,0,0,5,0.2', RandomSeed='3873875')
-    print "Number of events =", ws.getNEvents()
+    print("Number of events = {}".format(ws.getNEvents()))
 
 Output:
 

--- a/docs/source/algorithms/FilterBadPulses-v1.rst
+++ b/docs/source/algorithms/FilterBadPulses-v1.rst
@@ -33,8 +33,8 @@ Usage
     AddSampleLog(ws,"gd_prtn_chrg", "1e6", "Number")
     wsFiltered = FilterBadPulses(ws)
 
-    print ("The number of events that remain: %i" % wsFiltered.getNumberEvents())
-    print ("compared to the number in the unfiltered workspace: %i" % ws.getNumberEvents())
+    print("The number of events that remain: %i" % wsFiltered.getNumberEvents())
+    print("compared to the number in the unfiltered workspace: %i" % ws.getNumberEvents())
 
 Output:
 

--- a/docs/source/algorithms/FilterByLogValue-v1.rst
+++ b/docs/source/algorithms/FilterByLogValue-v1.rst
@@ -97,11 +97,11 @@ Usage
    AddTimeSeriesLog(ws, Name="proton_charge", Time="2010-01-01T00:40:00", Value=15)
    AddTimeSeriesLog(ws, Name="proton_charge", Time="2010-01-01T00:50:00", Value=100)
 
-   print "The unfiltered workspace %s has %i events and a peak value of %.2f" % (ws, ws.getNumberEvents(),ws.readY(0)[50])
+   print("The unfiltered workspace {} has {} events and a peak value of {:.2f}".format(ws, ws.getNumberEvents(),ws.readY(0)[50]))
 
    wsOut = FilterByLogValue(ws,"proton_charge",MinimumValue=75, MaximumValue=150)
 
-   print "The filtered workspace %s has %i events and a peak value of %.2f" % (wsOut, wsOut.getNumberEvents(),wsOut.readY(0)[50])
+   print("The filtered workspace {} has {} events and a peak value of {:.2f}".format(wsOut, wsOut.getNumberEvents(),wsOut.readY(0)[50]))
 
 
 Output:

--- a/docs/source/algorithms/FilterByTime-v1.rst
+++ b/docs/source/algorithms/FilterByTime-v1.rst
@@ -53,9 +53,9 @@ Usage
         AbsoluteStartTime="2010-01-01T00:10:00",
         AbsoluteStopTime="2010-01-01T00:20:00")
 
-    print ("The number of events within the relative Filter: %i" % wsFiltered.getNumberEvents())
-    print ("The number of events within the Aboslute Filter: %i" % wsFilteredAbs.getNumberEvents())
-    print ("Compared to the number in the unfiltered workspace: %i" % ws.getNumberEvents())
+    print("The number of events within the relative Filter: %i" % wsFiltered.getNumberEvents())
+    print("The number of events within the Aboslute Filter: %i" % wsFilteredAbs.getNumberEvents())
+    print("Compared to the number in the unfiltered workspace: %i" % ws.getNumberEvents())
 
 Output:
 

--- a/docs/source/algorithms/FilterByXValue-v1.rst
+++ b/docs/source/algorithms/FilterByXValue-v1.rst
@@ -26,9 +26,9 @@ Usage
 .. testcode:: ExFilterTofByMax
 
     ws = CreateSampleWorkspace("Event",BankPixelWidth=1)
-    print "%i events before filtering" % ws.getNumberEvents()
+    print("%i events before filtering" % ws.getNumberEvents())
     wsOut = FilterByXValue(ws,XMax=15000)
-    print "%i events after filtering" % wsOut.getNumberEvents()
+    print("%i events after filtering" % wsOut.getNumberEvents())
 
 
 Output:
@@ -44,9 +44,9 @@ Output:
 
     ws = CreateSampleWorkspace("Event",BankPixelWidth=1)
     ws = ConvertUnits(ws,"Wavelength")
-    print "%i events before filtering" % ws.getNumberEvents()
+    print("%i events before filtering" % ws.getNumberEvents())
     wsOut = FilterByXValue(ws,XMin=1,XMax=3)
-    print "%i events after filtering" % wsOut.getNumberEvents()
+    print("%i events after filtering" % wsOut.getNumberEvents())
 
 
 Output:

--- a/docs/source/algorithms/FilterEvents-v1.rst
+++ b/docs/source/algorithms/FilterEvents-v1.rst
@@ -162,7 +162,7 @@ Usage
     wsnames = wsgroup.getNames()
     for name in sorted(wsnames):
         tmpws = mtd[name]
-        print "workspace %s has %d events" % (name, tmpws.getNumberEvents())
+        print("workspace %s has %d events" % (name, tmpws.getNumberEvents()))
 
 
 Output:
@@ -207,9 +207,9 @@ Output:
     wsnames = wsgroup.getNames()
     for name in sorted(wsnames):
         tmpws = mtd[name]
-        print "workspace %s has %d events" % (name, tmpws.getNumberEvents())
+        print("workspace %s has %d events" % (name, tmpws.getNumberEvents()))
         split_log = tmpws.run().getProperty('splitter')
-        print 'event splitter log: entry 0 and entry 1 are {0} and {1}.'.format(split_log.times[0], split_log.times[1])
+        print('event splitter log: entry 0 and entry 1 are {0} and {1}.'.format(split_log.times[0], split_log.times[1]))
 
 
 Output:
@@ -251,7 +251,7 @@ Output:
     wsnames = wsgroup.getNames()
     for name in sorted(wsnames):
         tmpws = mtd[name]
-        print "workspace %s has %d events" % (name, tmpws.getNumberEvents())
+        print("workspace %s has %d events" % (name, tmpws.getNumberEvents()))
 
 
 Output:
@@ -290,7 +290,7 @@ Output:
     wsnames = wsgroup.getNames()
     for name in sorted(wsnames):
         tmpws = mtd[name]
-        print "workspace %s has %d events" % (name, tmpws.getNumberEvents())
+        print("workspace %s has %d events" % (name, tmpws.getNumberEvents()))
 
 
 Output:

--- a/docs/source/algorithms/FilterLogByTime-v1.rst
+++ b/docs/source/algorithms/FilterLogByTime-v1.rst
@@ -40,26 +40,26 @@ Usage
     AddTimeSeriesLog(ws, Name="proton_charge", Time="2010-01-01T00:40:00", Value=15)
     AddTimeSeriesLog(ws, Name="proton_charge", Time="2010-01-01T00:50:00", Value=100)
 
-    print ("Without a StartTime or EndTime all of the values are included")
+    print("Without a StartTime or EndTime all of the values are included")
     (filtered_result,stat_result) = FilterLogByTime(ws,LogName="proton_charge")
-    print ("The default statistic is mean: %i" % stat_result)
-    print ("The filtered result is")
-    print (filtered_result)
+    print("The default statistic is mean: %i" % stat_result)
+    print("The filtered result is")
+    print(filtered_result)
 
     (filtered_result,stat_result) = FilterLogByTime(ws,LogName="proton_charge", Method="max")
-    print ("The max is: %i" % stat_result)
+    print("The max is: %i" % stat_result)
     (filtered_result,stat_result) = FilterLogByTime(ws,LogName="proton_charge", Method="min")
-    print ("The min is: %i" % stat_result)
+    print("The min is: %i" % stat_result)
     (filtered_result,stat_result) = FilterLogByTime(ws,LogName="proton_charge", Method="median")
-    print ("The median is: %i" % stat_result)
-    print 
+    print("The median is: %i" % stat_result)
+    print("") 
 
     print("Adding a start time and optionally an end time allows you to filter the values")
     (filtered_result,stat_result) = FilterLogByTime(ws,LogName="proton_charge",
         StartTime=580,EndTime = 1800)
-    print ("The filtered mean is: %i" % stat_result)
-    print ("The filtered result is")
-    print (filtered_result)
+    print("The filtered mean is: %i" % stat_result)
+    print("The filtered result is")
+    print(filtered_result)
  
 
 Output:

--- a/docs/source/algorithms/FindDeadDetectors-v1.rst
+++ b/docs/source/algorithms/FindDeadDetectors-v1.rst
@@ -43,17 +43,17 @@ Usage
     str_data=[0.4,5.0,0.001,0.0,0.0,0.0,0.0,0.0,1.0,1.0]
     ws.setY(20,np.array(str_data))
 
-    print "With no range will find very dead"
+    print("With no range will find very dead")
     (wsOut,detList) = FindDeadDetectors(ws)
-    print str(detList)
+    print(detList)
 
-    print "\nwith a lower range will find very dead and drop off"
+    print("\nwith a lower range will find very dead and drop off")
     (wsOut,detList) = FindDeadDetectors(ws,RangeLower=8e3)
-    print str(detList)
+    print(detList)
 
-    print "\nwith a lower range and upper range will find all three"
+    print("\nwith a lower range and upper range will find all three")
     (wsOut,detList) = FindDeadDetectors(ws,RangeLower=8e3, rangeUpper=1.6e4)
-    print str(detList)
+    print(detList)
 
 Output:
 

--- a/docs/source/algorithms/FindDetectorsInShape-v1.rst
+++ b/docs/source/algorithms/FindDetectorsInShape-v1.rst
@@ -53,8 +53,8 @@ Usage
    no_detectors = FindDetectorsInShape(musr_inst_ws, narrow_cylinder)
    all_detectors = FindDetectorsInShape(musr_inst_ws, wide_cylinder)
 
-   print "The narrow cylinder contains %i of the detectors." % len(no_detectors)
-   print "The wide cylinder contains %i of the detectors." % len(all_detectors)
+   print("The narrow cylinder contains %i of the detectors." % len(no_detectors))
+   print("The wide cylinder contains %i of the detectors." % len(all_detectors))
 
 Output:
 

--- a/docs/source/algorithms/FindDetectorsOutsideLimits-v1.rst
+++ b/docs/source/algorithms/FindDetectorsOutsideLimits-v1.rst
@@ -43,13 +43,13 @@ Usage
 
     print("With just the default LowThreshold of 0")
     (wsOut,NumberOfFailures)=FindDetectorsOutsideLimits(ws)
-    print("%i spectra were outside the limits." % NumberOfFailures)
+    print("{} spectra were outside the limits.".format(NumberOfFailures))
     print("")
 
-    print("With a High and LowThreshold, as well as restricting the XRange to consider")
+    print("With a High and LowThreshold, as well as restricting the range to consider")
     (wsOut2,NumberOfFailures)=FindDetectorsOutsideLimits(ws, HighThreshold=1000, 
         LowThreshold=0, RangeLower=200, RangeUpper=10000)
-    print("%i spectra were outside the limits." % NumberOfFailures)
+    print("{} spectra were outside the limits.".format(NumberOfFailures))
 
     mtd.clear()
 
@@ -61,7 +61,7 @@ Output:
     With just the default LowThreshold of 0
     20 spectra were outside the limits.
 
-    With a High and LowThreshold, as well as restricting the XRange to consider
+    With a High and LowThreshold, as well as restricting the range to consider
     40 spectra were outside the limits.
 
 **Example:**
@@ -70,7 +70,7 @@ Output:
 
     ws = CreateSimulationWorkspace('MARI','0,1,10')
     nh = ws.getNumberHistograms()
-    for ind in xrange(nh):
+    for ind in range(nh):
         y = ws.dataY(ind)    
         if ind>=100 and ind < 300:
             y.fill(100)
@@ -80,7 +80,7 @@ Output:
     mws1,nMasked1 = FindDetectorsOutsideLimits(ws,100)
     mws2,nMasked2 = FindDetectorsOutsideLimits(ws,100,startWorkspaceIndex = 200)
 
-    print "****************************************"
+    print("****************************************")
     print("full mask ws has {0} masked detectors".format(nMasked1))
     print("part mask ws  has {0} masked detectors".format(nMasked2))
     print("****************************************")

--- a/docs/source/algorithms/FindDetectorsOutsideLimits-v1.rst
+++ b/docs/source/algorithms/FindDetectorsOutsideLimits-v1.rst
@@ -41,15 +41,15 @@ Usage
         ws.setY(i,np.array(deadDetArray))
         ws.setY(i+1,np.array(noisyDetArray))
 
-    print "With just the default LowThreshold of 0"
+    print("With just the default LowThreshold of 0")
     (wsOut,NumberOfFailures)=FindDetectorsOutsideLimits(ws)
-    print "%i spectra were outside the limits." % NumberOfFailures
-    print
+    print("%i spectra were outside the limits." % NumberOfFailures)
+    print("")
 
-    print "With a High and LowThreshold, as well as restricting the XRange to consider"
+    print("With a High and LowThreshold, as well as restricting the XRange to consider")
     (wsOut2,NumberOfFailures)=FindDetectorsOutsideLimits(ws, HighThreshold=1000, 
         LowThreshold=0, RangeLower=200, RangeUpper=10000)
-    print "%i spectra were outside the limits." % NumberOfFailures
+    print("%i spectra were outside the limits." % NumberOfFailures)
 
     mtd.clear()
 
@@ -81,14 +81,14 @@ Output:
     mws2,nMasked2 = FindDetectorsOutsideLimits(ws,100,startWorkspaceIndex = 200)
 
     print "****************************************"
-    print "full mask ws has {0} masked detectors".format(nMasked1)
-    print "part mask ws  has {0} masked detectors".format(nMasked2)
-    print "****************************************"
+    print("full mask ws has {0} masked detectors".format(nMasked1))
+    print("part mask ws  has {0} masked detectors".format(nMasked2))
+    print("****************************************")
     selected_spec = [99,100,199,200,299,300]
     for spec in selected_spec:
-        print "full mask ws Spec N{0} is masked: {1}".format(spec,mws1.readY(spec)[0]>0.5)
-        print "part mask ws Spec N{0} is masked: {1}".format(spec,mws2.readY(spec)[0]>0.5) 
-    print "****************************************"
+        print("full mask ws Spec N{0} is masked: {1}".format(spec,mws1.readY(spec)[0]>0.5))
+        print("part mask ws Spec N{0} is masked: {1}".format(spec,mws2.readY(spec)[0]>0.5) )
+    print("****************************************")
 
 Output:
 

--- a/docs/source/algorithms/FindDetectorsPar-v1.rst
+++ b/docs/source/algorithms/FindDetectorsPar-v1.rst
@@ -81,9 +81,9 @@ Usage
     # Output workspace is None if OutputParTable is not used)
     pars = FindDetectorsPar(ws, OutputParTable="pars")
     # pars is a TableWorkspace
-    print "Workspace type =", pars.id()
+    print("Workspace type = {}".format(pars.id()))
     # Show width column headers
-    print "Width headers = (", pars.getColumnNames()[3], ",", pars.getColumnNames()[4], ")"
+    print("Width headers = ( {} , {} )".format(pars.getColumnNames()[3], pars.getColumnNames()[4]))
 
 Output:
 
@@ -100,9 +100,9 @@ Output:
     # Output workspace is None if OutputParTable is not used)
     pars = FindDetectorsPar(ws, ReturnLinearRanges=True, OutputParTable="pars")
     # pars is a TableWorkspace
-    print "Workspace type =", pars.id()
+    print("Workspace type = {}".format(pars.id()))
     # Show width column headers
-    print "Width headers = (", pars.getColumnNames()[3], ",", pars.getColumnNames()[4], ")"
+    print("Width headers = ( {} , {} )".format(pars.getColumnNames()[3], pars.getColumnNames()[4]))
 
 Output:
 

--- a/docs/source/algorithms/FindEPP-v1.rst
+++ b/docs/source/algorithms/FindEPP-v1.rst
@@ -31,9 +31,9 @@ Usage
     table = FindEPP(ws, Version=1)
 
     # print some results
-    print "The fit status is", table.row(0)['FitStatus']
-    print "The peak centre is at", round(table.row(0)['PeakCentre'], 2), "microseconds"
-    print "The peak height is", round(table.row(0)['Height'],2)
+    print("The fit status is {}".format(table.row(0)['FitStatus']))
+    print("The peak centre is at {} microseconds".format(round(table.row(0)['PeakCentre'], 2)))
+    print("The peak height is {}".format(round(table.row(0)['Height'],2)))
 
 Output:
 

--- a/docs/source/algorithms/FindEPP-v2.rst
+++ b/docs/source/algorithms/FindEPP-v2.rst
@@ -40,9 +40,9 @@ Usage
     table = FindEPP(ws)
 
     # print some results
-    print "The fit status is", table.row(0)['FitStatus']
-    print "The peak centre is at", round(table.row(0)['PeakCentre'], 2), "microseconds"
-    print "The peak height is", round(table.row(0)['Height'],2)
+    print("The fit status is {}".format(table.row(0)['FitStatus']))
+    print("The peak centre is at {} microseconds".format(round(table.row(0)['PeakCentre'], 2)))
+    print("The peak height is {}".format(round(table.row(0)['Height'],2)))
 
 Output:
 

--- a/docs/source/algorithms/FindPeaks-v1.rst
+++ b/docs/source/algorithms/FindPeaks-v1.rst
@@ -100,8 +100,7 @@ Usage
 
    row = table.row(0)
 
-   #print row
-   print "Peak 1 {Centre: %.3f, width: %.3f, height: %.3f }" % ( row["centre"],  row["width"], row["height"])
+   print("Peak 1 {Centre: %.3f, width: %.3f, height: %.3f }" % ( row["centre"],  row["width"], row["height"]))
 
 
 Output:

--- a/docs/source/algorithms/FindPeaksMD-v1.rst
+++ b/docs/source/algorithms/FindPeaksMD-v1.rst
@@ -76,18 +76,18 @@ file is availible in `Mantid system tests repository <https://github.com/mantidp
        for name in tab_names:
            if len(name)>8:
               name= name[0:8];
-           print "| {0:8} ".format(name),
-       print "|\n",
+           print("| {0:8} ".format(name))
+       print("|\n")
    
        for i in xrange(0,nRows):
            for name in tab_names:
                  col = pTWS.column(name);
                  data2pr=col[i]
                  if type(data2pr) is float:
-                      print "| {0:>8.2f} ".format(data2pr),
+                      print("| {0:>8.2f} ".format(data2pr))
                  else:
-                     print "| {0:>8} ".format(data2pr),   
-           print "|\n",
+                     print("| {0:>8} ".format(data2pr))
+           print("|\n")
        
     
    # load test workspace

--- a/docs/source/algorithms/FindReflectometryLines-v1.rst
+++ b/docs/source/algorithms/FindReflectometryLines-v1.rst
@@ -36,7 +36,7 @@ Usage
     wsOut = FindReflectometryLines(ws)
 
     for i in range(wsOut.columnCount()):
-        print wsOut.getColumnNames()[i], wsOut.column(i)[0]
+        print("{} {}".format(wsOut.getColumnNames()[i], wsOut.column(i)[0]))
     
 Output:
 

--- a/docs/source/algorithms/FindSXPeaks-v1.rst
+++ b/docs/source/algorithms/FindSXPeaks-v1.rst
@@ -73,7 +73,7 @@ Usage
    
    wsPeaks = FindSXPeaks(ws)
 
-   print "Peaks found: " + str(wsPeaks.getNumberPeaks())
+   print("Peaks found: {}".format(wsPeaks.getNumberPeaks()))
 
 Output:
 

--- a/docs/source/algorithms/FindUBUsingFFT-v1.rst
+++ b/docs/source/algorithms/FindUBUsingFFT-v1.rst
@@ -46,12 +46,12 @@ Usage
 .. testcode:: ExFindUBUsingFFT
 
     ws=LoadIsawPeaks("TOPAZ_3007.peaks")
-    print "After LoadIsawPeaks does the workspace have an orientedLattice: %s" % ws.sample().hasOrientedLattice()
+    print("After LoadIsawPeaks does the workspace have an orientedLattice: %s" % ws.sample().hasOrientedLattice())
 
     FindUBUsingFFT(ws,MinD=8.0,MaxD=13.0)
-    print "After FindUBUsingFFT does the workspace have an orientedLattice: %s" % ws.sample().hasOrientedLattice()
+    print("After FindUBUsingFFT does the workspace have an orientedLattice: %s" % ws.sample().hasOrientedLattice())
 
-    print ws.sample().getOrientedLattice().getUB()
+    print(ws.sample().getOrientedLattice().getUB())
 
 
 Output:

--- a/docs/source/algorithms/FindUBUsingIndexedPeaks-v1.rst
+++ b/docs/source/algorithms/FindUBUsingIndexedPeaks-v1.rst
@@ -27,12 +27,12 @@ Usage
 .. testcode:: ExFindUBUsingIndexedPeaks
 
     ws=LoadIsawPeaks("TOPAZ_3007.peaks")
-    print "After LoadIsawPeaks does the workspace have an orientedLattice: %s" % ws.sample().hasOrientedLattice()
+    print("After LoadIsawPeaks does the workspace have an orientedLattice: %s" % ws.sample().hasOrientedLattice())
 
     FindUBUsingIndexedPeaks(ws)
-    print "After FindUBUsingIndexedPeaks does the workspace have an orientedLattice: %s" % ws.sample().hasOrientedLattice()
+    print("After FindUBUsingIndexedPeaks does the workspace have an orientedLattice: %s" % ws.sample().hasOrientedLattice())
 
-    print ws.sample().getOrientedLattice().getUB()
+    print(ws.sample().getOrientedLattice().getUB())
 
 
 Output:

--- a/docs/source/algorithms/FindUBUsingLatticeParameters-v1.rst
+++ b/docs/source/algorithms/FindUBUsingLatticeParameters-v1.rst
@@ -49,10 +49,10 @@ Usage
 .. testcode:: ExFindUBUsingLatticeParameters
 
     ws=LoadIsawPeaks("TOPAZ_3007.peaks")
-    print("After LoadIsawPeaks does the workspace have an orientedLattice: %s" % ws.sample().hasOrientedLattice())
+    print("After LoadIsawPeaks does the workspace have an orientedLattice: {}".format(ws.sample().hasOrientedLattice()))
 
     FindUBUsingLatticeParameters(ws,a=14.131,b=19.247,c=8.606,alpha=90.0,beta=105.071,gamma=90.0,NumInitial=15)
-    print "After FindUBUsingLatticeParameters does the workspace have an orientedLattice: %s" % ws.sample().hasOrientedLattice()
+    print("After FindUBUsingLatticeParameters does the workspace have an orientedLattice: {}".format(ws.sample().hasOrientedLattice()))
 
     print(ws.sample().getOrientedLattice().getUB())
 

--- a/docs/source/algorithms/FindUBUsingLatticeParameters-v1.rst
+++ b/docs/source/algorithms/FindUBUsingLatticeParameters-v1.rst
@@ -49,12 +49,12 @@ Usage
 .. testcode:: ExFindUBUsingLatticeParameters
 
     ws=LoadIsawPeaks("TOPAZ_3007.peaks")
-    print "After LoadIsawPeaks does the workspace have an orientedLattice: %s" % ws.sample().hasOrientedLattice()
+    print("After LoadIsawPeaks does the workspace have an orientedLattice: %s" % ws.sample().hasOrientedLattice())
 
     FindUBUsingLatticeParameters(ws,a=14.131,b=19.247,c=8.606,alpha=90.0,beta=105.071,gamma=90.0,NumInitial=15)
     print "After FindUBUsingLatticeParameters does the workspace have an orientedLattice: %s" % ws.sample().hasOrientedLattice()
 
-    print ws.sample().getOrientedLattice().getUB()
+    print(ws.sample().getOrientedLattice().getUB())
 
 
 Output:

--- a/docs/source/algorithms/FindUBUsingMinMaxD-v1.rst
+++ b/docs/source/algorithms/FindUBUsingMinMaxD-v1.rst
@@ -34,12 +34,12 @@ Usage
 .. testcode:: ExFindUBUsingMinMaxD
 
     ws=LoadIsawPeaks("TOPAZ_3007.peaks")
-    print "After LoadIsawPeaks does the workspace have an orientedLattice: %s" % ws.sample().hasOrientedLattice()
+    print("After LoadIsawPeaks does the workspace have an orientedLattice: %s" % ws.sample().hasOrientedLattice())
 
     FindUBUsingMinMaxD(ws,MinD=8.0,MaxD=13.0)
-    print "After FindUBUsingMinMaxD does the workspace have an orientedLattice: %s" % ws.sample().hasOrientedLattice()
+    print("After FindUBUsingMinMaxD does the workspace have an orientedLattice: %s" % ws.sample().hasOrientedLattice())
 
-    print ws.sample().getOrientedLattice().getUB()
+    print(ws.sample().getOrientedLattice().getUB())
 
 
 Output:

--- a/docs/source/algorithms/Fit-v1.rst
+++ b/docs/source/algorithms/Fit-v1.rst
@@ -382,7 +382,6 @@ Usage
 
 .. testcode:: ExFitPeak
 
-   from __future__ import print_function
    # create a workspace with a gaussian peak sitting on top of a linear (here flat) background
    ws = CreateSampleWorkspace(Function="User Defined", UserDefinedFunction="name=LinearBackground, \
       A0=0.3;name=Gaussian, PeakCentre=5, Height=10, Sigma=0.7", NumBanks=1, BankPixelWidth=1, XMin=0, XMax=10, BinWidth=0.1)
@@ -406,14 +405,14 @@ Usage
    paramTable = fit_output.OutputParameters  # table containing the optimal fit parameters
    fitWorkspace = fit_output.OutputWorkspace
 
-   print("The fit was: " + fit_output.OutputStatus)
-   print("chi-squared of fit is: %.2f" % fit_output.OutputChi2overDoF)
-   print("Fitted Height value is: %.2f" % paramTable.column(1)[0])
-   print("Fitted centre value is: %.2f" % paramTable.column(1)[1])
-   print("Fitted sigma value is: %.2f" % paramTable.column(1)[2])
+   print("The fit was: {}".format(fit_output.OutputStatus))
+   print("chi-squared of fit is: {:.2f}".format(fit_output.OutputChi2overDoF))
+   print("Fitted Height value is: {:.2f}".format(paramTable.column(1)[0]))
+   print("Fitted centre value is: {:.2f}".format(paramTable.column(1)[1]))
+   print("Fitted sigma value is: {:.2f}".format(paramTable.column(1)[2]))
    # fitWorkspace contains the data, the calculated and the difference patterns
-   print("Number of spectra in fitWorkspace is: " +  str(fitWorkspace.getNumberHistograms()))
-   print("The 20th y-value of the calculated pattern: %.4f" % fitWorkspace.readY(1)[19])
+   print("Number of spectra in fitWorkspace is: {}".format(fitWorkspace.getNumberHistograms()))
+   print("The 20th y-value of the calculated pattern: {:.4f}".format(fitWorkspace.readY(1)[19]))
 
 Output:
 
@@ -431,7 +430,6 @@ Output:
 
 .. testcode:: simFit
 
-    from __future__ import print_function
     import math
     import numpy as np
 
@@ -470,7 +468,6 @@ Output:
 
 .. testcode:: shareFit
 
-    from __future__ import print_function
     import math
     import numpy as np
 
@@ -508,7 +505,6 @@ Output:
 
 .. testcode:: shareFit2
 
-    from __future__ import print_function
     import math
     import numpy as np
 

--- a/docs/source/algorithms/FitGaussian-v1.rst
+++ b/docs/source/algorithms/FitGaussian-v1.rst
@@ -45,9 +45,9 @@ Usage
    # attempt the fit
    fitResult = FitGaussian(wspace,0)
    if (0.0,0.0) == fitResult:
-      print "the fit was not successful"
+      print("the fit was not successful")
    else:
-      print "the fitted peak: centre=%.2f, sigma=%.2f" % fitResult
+      print("the fitted peak: centre={:.2f}, sigma={:.2f}".format(fitResult[0], fitResult[1]))
 
 .. testcleanup:: ExFitPeak
 

--- a/docs/source/algorithms/FitPeak-v1.rst
+++ b/docs/source/algorithms/FitPeak-v1.rst
@@ -147,7 +147,7 @@ Usage
   peakheight = tbws.cell(2, 1)
   peakcentre = tbws.cell(3, 1)
   sigma = tbws.cell(4, 1)
-  print "Chi-square = %.5f: Peak centre = %.5f, Height = %.2f, Sigma = %.5f" % (chi2, peakcentre, peakheight, sigma)
+  print("Chi-square = {:.5f}: Peak centre = {:.5f}, Height = {:.2f}, Sigma = {:.5f}".format(chi2, peakcentre, peakheight, sigma))
 
 
 .. testcleanup:: ExFitPeak

--- a/docs/source/algorithms/FitPowderDiffPeaks-v1.rst
+++ b/docs/source/algorithms/FitPowderDiffPeaks-v1.rst
@@ -139,7 +139,7 @@ Usage
 
   # Print result
   resultws = mtd["BraggPeakParameterTable2_P"]
-  for i in xrange(10):
+  for i in range(10):
       print("Peak @ d = {:.5f}, TOF_0 = {:.5f}, A = {:.5f}, B = {:.5f}, Sigma = {:.5f}".
             format(resultws.readX(0)[i], resultws.readY(0)[i], resultws.readY(1)[i], resultws.readY(2)[i], resultws.readY(3)[i]))
 

--- a/docs/source/algorithms/FitPowderDiffPeaks-v1.rst
+++ b/docs/source/algorithms/FitPowderDiffPeaks-v1.rst
@@ -140,8 +140,8 @@ Usage
   # Print result
   resultws = mtd["BraggPeakParameterTable2_P"]
   for i in xrange(10):
-      print "Peak @ d = %.5f, TOF_0 = %.5f, A = %.5f, B = %.5f, Sigma = %.5f" % (resultws.readX(0)[i], 
-          resultws.readY(0)[i], resultws.readY(1)[i], resultws.readY(2)[i], resultws.readY(3)[i])
+      print("Peak @ d = {:.5f}, TOF_0 = {:.5f}, A = {:.5f}, B = {:.5f}, Sigma = {:.5f}".
+            format(resultws.readX(0)[i], resultws.readY(0)[i], resultws.readY(1)[i], resultws.readY(2)[i], resultws.readY(3)[i]))
 
 .. testcleanup:: ExFitSingleDiffPeaks
 

--- a/docs/source/algorithms/FixGSASInstrumentFile-v1.rst
+++ b/docs/source/algorithms/FixGSASInstrumentFile-v1.rst
@@ -41,7 +41,7 @@ Usage
         numlinefewer80b += 1
 
   # Print out result
-  print "Corrected File: Number of lines that are not equal to 80 characters = ", numlinefewer80b
+  print("Corrected File: Number of lines that are not equal to 80 characters =  {}".format(numlinefewer80b))
 
 .. testcleanup:: ExHistSimple
 

--- a/docs/source/algorithms/FlatPlateAbsorption-v1.rst
+++ b/docs/source/algorithms/FlatPlateAbsorption-v1.rst
@@ -44,7 +44,7 @@ Usage
 
     wsOut = FlatPlateAbsorption(ws, SampleHeight=1, SampleWidth=0.5, SampleThickness=0.5)
 
-    print "The created workspace has one entry for each spectra: %i" % wsOut.getNumberHistograms()
+    print("The created workspace has one entry for each spectra: %i" % wsOut.getNumberHistograms())
 
 Output:
 

--- a/docs/source/algorithms/FlatPlatePaalmanPingsCorrection-v1.rst
+++ b/docs/source/algorithms/FlatPlatePaalmanPingsCorrection-v1.rst
@@ -68,7 +68,7 @@ Usage
                                            Emode='Indirect',
                                            Efixed=1.845)
 
-    print 'Correction workspaces: %s' % (', '.join(corr.getNames()))
+    print('Correction workspaces: %s' % (', '.join(corr.getNames())))
 
 Output:
 


### PR DESCRIPTION
## Description of work.
This PR is part of refactoring effort to bring Python3 compatiblity into the doctests.
See https://github.com/mantidproject/mantid/issues/20672 for details.

The following tests were refactored to be compatible :
```
FFT
FFTDerivative
FFTSmooth
FakeISISEventDAE
FakeISISHistoDAE
FakeMDEventData
FilterBadPulses
FilterByLogValue
FilterByTime
FilterByXValue
FilterEvents
FilterEventsByLogValuePreNexus
FilterLogByTime
FilterPeaks
FindCenterOfMassPosition
FindClusterFaces
FindDeadDetectors
FindDetectorsInShape
FindDetectorsOutsideLimits
FindDetectorsPar
FindEPP
FindPeakBackground
FindPeaks
FindPeaksMD
FindReflectometryLines
FindSXPeaks
FindUBUsingFFT
FindUBUsingIndexedPeaks
FindUBUsingLatticeParameters
FindUBUsingMinMaxD
Fit
FitGaussian
FitPeak
FitPowderDiffPeaks
FitResolutionConvolvedModel
FixGSASInstrumentFile
FlatPlateAbsorption
FlatPlatePaalmanPingsCorrection
```
## To test.

Code review.

Fixes #20726 
Internal change, no release notes
