### PR TITLE
Update build script to run clang-tidy

### DIFF
--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -121,6 +121,10 @@ if [[ $USE_CLANG ]]; then
   clang --version
   export CC=clang
   export CXX=clang++
+  # check if this is also a clang-tidy build
+  if [[ ${JOB_NAME} == *clang_tidy* ]]; then
+      CLANGTIDYVAR="-DENABLE_CLANG_TIDY=ON"
+  fi
   #check if CMakeCache.txt exists and if so that the cxx compiler is clang++
   #only needed with incremental builds. Clean builds delete this directory in a later step.
   if [[ -e $BUILD_DIR/CMakeCache.txt ]] && [[ ${JOB_NAME} != *clean* ]]; then
@@ -233,7 +237,7 @@ rm -f *.dmg *.rpm *.deb *.tar.gz
 ###############################################################################
 # CMake configuration
 ###############################################################################
-$SCL_ON_RHEL6 "cmake ${CMAKE_GENERATOR} -DCMAKE_BUILD_TYPE=${BUILD_CONFIG} -DENABLE_CPACK=ON -DMAKE_VATES=ON -DParaView_DIR=${PARAVIEW_DIR} -DMANTID_DATA_STORE=${MANTID_DATA_STORE} -DDOCS_HTML=ON -DENABLE_CONDA=ON -DENABLE_FILE_LOGGING=OFF ${DIST_FLAGS} ${PACKAGINGVARS} .."
+$SCL_ON_RHEL6 "cmake ${CMAKE_GENERATOR} -DCMAKE_BUILD_TYPE=${BUILD_CONFIG} -DENABLE_CPACK=ON -DMAKE_VATES=ON -DParaView_DIR=${PARAVIEW_DIR} -DMANTID_DATA_STORE=${MANTID_DATA_STORE} -DDOCS_HTML=ON -DENABLE_CONDA=ON -DENABLE_FILE_LOGGING=OFF ${DIST_FLAGS} ${PACKAGINGVARS} ${CLANGTIDYVAR} .."
 
 ###############################################################################
 # Coverity build should exit early
@@ -258,6 +262,14 @@ fi
 ###############################################################################
 $SCL_ON_RHEL6 "cmake --build . -- -j$BUILD_THREADS"
 $SCL_ON_RHEL6 "cmake --build . --target AllTests -- -j$BUILD_THREADS"
+
+###############################################################################
+# static analysis builds stop here
+###############################################################################
+if [[ $USE_CLANG ]] && [[ ${JOB_NAME} == *clang_tidy* ]]; then
+  exit 0
+fi
+
 
 ###############################################################################
 # Run the unit tests


### PR DESCRIPTION
Add support to the `buildscript` for running clang-tidy using `cmake`'s infrastructure.

**To test:**

A code review and builds passing while doing their normal thing in the PR build should be sufficient.

*There is no associated issue.*

*Does not need to be in the release notes* because it is moving functionality into the build script.

**Follow-on task**

Modify the builds to take advantage of this: rename `clang_tidy_framework` to be `clang_tidy` and just run the  normal buildscript and delete `clang_tidy_vates`.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
