### PR TITLE
CalMuonDetectorPhases

### DIFF
--- a/Framework/Algorithms/src/CalMuonDetectorPhases.cpp
+++ b/Framework/Algorithms/src/CalMuonDetectorPhases.cpp
@@ -203,22 +203,22 @@ void CalMuonDetectorPhases::extractDetectorInfo(
   double asym = paramTab->Double(0, 1);
   double phase = paramTab->Double(2, 1);
   // If asym<0, take the absolute value and add \pi to phase
-  // f(x) = A * sin( w * x + p) = -A * sin( w * x + p + PI)
+  // f(x) = A * cos( w * x + p) = -A * cos( w * x + p - PI)
   if (asym < 0) {
     asym = -asym;
-    phase = phase + M_PI;
+    phase = phase - M_PI;
   }
   // Now convert phases to interval [0, 2PI)
-  int factor = static_cast<int>(floor(phase / 2 / M_PI));
+  int factor = static_cast<int>(floor(phase / (2.* M_PI)));
   if (factor) {
-    phase = phase - factor * 2 * M_PI;
+    phase = phase - factor * 2. * M_PI;
   }
   // Copy parameters to new row in results table
   API::TableRow row = resultsTab->appendRow();
   row << static_cast<int>(spectrumNumber) << asym << phase;
 }
 
-/** Creates the fitting function f(x) = A * sin( w*x + p) + B as string
+/** Creates the fitting function f(x) = A * cos( w*x + p) + B as string
 * Two modes:
 * 1) Fixed frequency, no background - for main sequential fit
 * 2) Varying frequency, flat background - for finding frequency from asymmetry
@@ -235,10 +235,10 @@ std::string CalMuonDetectorPhases::createFittingFunction(double freq,
   ss << "name=UserFunction,";
   if (fixFreq) {
     // no background
-    ss << "Formula=A*sin(w*x+p),";
+    ss << "Formula=A*cos(w*x+p),";
   } else {
     // flat background
-    ss << "Formula=A*sin(w*x+p)+B,";
+    ss << "Formula=A*cos(w*x+p)+B,";
     ss << "B=0.5,";
   }
   ss << "A=0.5,";

--- a/Framework/Algorithms/src/CalMuonDetectorPhases.cpp
+++ b/Framework/Algorithms/src/CalMuonDetectorPhases.cpp
@@ -209,7 +209,7 @@ void CalMuonDetectorPhases::extractDetectorInfo(
     phase = phase - M_PI;
   }
   // Now convert phases to interval [0, 2PI)
-  int factor = static_cast<int>(floor(phase / (2.* M_PI)));
+  int factor = static_cast<int>(floor(phase / (2. * M_PI)));
   if (factor) {
     phase = phase - factor * 2. * M_PI;
   }

--- a/Framework/Algorithms/test/CalMuonDetectorPhasesTest.h
+++ b/Framework/Algorithms/test/CalMuonDetectorPhasesTest.h
@@ -211,10 +211,10 @@ private:
     TS_ASSERT_DELTA(tab->Double(2, 1), 0.100, 0.001);
     TS_ASSERT_DELTA(tab->Double(3, 1), 0.100, 0.001);
     // Test phases
-    TS_ASSERT_DELTA(tab->Double(0, 2), 6.278, 0.001);
-    TS_ASSERT_DELTA(tab->Double(1, 2), 0.781, 0.001);
-    TS_ASSERT_DELTA(tab->Double(2, 2), 1.566, 0.001);
-    TS_ASSERT_DELTA(tab->Double(3, 2), 2.350, 0.001);
+    TS_ASSERT_DELTA(tab->Double(0, 2), 4.707, 0.001);
+    TS_ASSERT_DELTA(tab->Double(1, 2), 5.494, 0.001);
+    TS_ASSERT_DELTA(tab->Double(2, 2), 6.278, 0.001);
+    TS_ASSERT_DELTA(tab->Double(3, 2), 0.779, 0.001);
   }
 };
 

--- a/docs/source/algorithms/CalMuonDetectorPhases-v1.rst
+++ b/docs/source/algorithms/CalMuonDetectorPhases-v1.rst
@@ -64,7 +64,7 @@ Output:
 
 .. testoutput:: CalMuonDetectorPhasesExample
 
-  Detector 1 has phase 5.332568 and amplitude 0.133113
+  Detector 1 has phase 5.332568 and amplitude 0.133112
   Detector 2 has phase 5.111274 and amplitude 0.134679
   Detector 3 has phase 4.926346 and amplitude 0.149430
   Detector 4 has phase 4.798584 and amplitude 0.152869

--- a/docs/source/algorithms/CalMuonDetectorPhases-v1.rst
+++ b/docs/source/algorithms/CalMuonDetectorPhases-v1.rst
@@ -13,7 +13,7 @@ Description
 Calculates detector asymmetries and phases from a reference dataset. The algorithm fits each of
 the spectra in the input workspace to:
 
-.. math:: f_i(t) = A_i \sin\left(\omega t + \phi_i\right)
+.. math:: f_i(t) = A_i \cos\left(\omega t + \phi_i\right)
 
 where :math:`\omega` is shared across spectra and :math:`A_i` and :math:`\phi_i` are
 detector-dependent.
@@ -64,10 +64,10 @@ Output:
 
 .. testoutput:: CalMuonDetectorPhasesExample
 
-  Detector 1 has phase 0.620299 and amplitude 0.133113
-  Detector 2 has phase 0.399003 and amplitude 0.134679
-  Detector 3 has phase 0.214079 and amplitude 0.149431
-  Detector 4 has phase 0.086315 and amplitude 0.152870
+  Detector 1 has phase 5.332568 and amplitude 0.133113
+  Detector 2 has phase 5.111274 and amplitude 0.134679
+  Detector 3 has phase 4.926346 and amplitude 0.149430
+  Detector 4 has phase 4.798584 and amplitude 0.152869
 
 .. categories::
 

--- a/docs/source/release/v3.11.0/framework.rst
+++ b/docs/source/release/v3.11.0/framework.rst
@@ -61,6 +61,11 @@ Improved
 - :ref:`algm-LineProfile`: Fixed a bug which could cause crashes when the line extended over the right or bottom edge of a workspace.
 - :ref:`algm-LoadLiveData`: Fixed a bug affecting Live Data Processing in "Replace" mode. The bug meant that changes to Instrument position/rotation were overwitten by defaults on every load. Now fixed so that Instrument state is persistent across loads.
 
+Bugfixes
+########
+
+- :ref:`CalMuonDetectorPhasees <algm-CalMuonDetectorPhases-v1>` now fits a cos instead of a sin function.
+
 Performance
 -----------
 - Performance of UB indexing routines addressed. `:ref:`FindUBUsingLatticeParameters` running 2x faster than before.


### PR DESCRIPTION
There was a bug in the code that meant it was fitting using a sin instead of a cosine. So all of the phases were out by pi/2. 

**To test:**

<!-- Instructions for testing. -->
If you load some data into muon analysis (Musr 62642)

Then run CalMuonDetectorPhases on the MuonAnalysis workspace (frequency = 5.6)

The run PaddingandApodization (with padding =1, negative padding true, apodization function = Lorentz and decay constant 2.4) on the output.

Then take the result and put it into FFT (set the output to be the real and imaginary ws, set real to 0 and Im to 1). Run. The plot should have a peak at -5.6 MHz (see #20742 will fix the minus sign)


Fixes #20727 
**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [x] Are the unit tests small and test the class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
