### PR TITLE
Fix slow update of slice viewer on refresh

### DIFF
--- a/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/SliceViewer.h
+++ b/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/SliceViewer.h
@@ -424,6 +424,8 @@ private:
   AspectRatioType m_lastRatioState;
   QwtScaleDrawNonOrthogonal *m_nonOrthAxis0;
   QwtScaleDrawNonOrthogonal *m_nonOrthAxis1;
+
+  bool m_holdDisplayUpdates;
 };
 
 } // namespace SliceViewer

--- a/qt/widgets/sliceviewer/src/SliceViewer.cpp
+++ b/qt/widgets/sliceviewer/src/SliceViewer.cpp
@@ -157,6 +157,16 @@ SliceViewer::SliceViewer(QWidget *parent)
   QObject::connect(m_algoRunner, SIGNAL(algorithmComplete(bool)), this,
                    SLOT(dynamicRebinComplete(bool)));
 
+  // disconnect and reconnect here
+  QObject::connect(this, SIGNAL(changedShownDim(size_t, size_t)), this,
+                   SLOT(checkForHKLDimension()));
+  QObject::connect(this, SIGNAL(changedShownDim(size_t, size_t)), this,
+                   SLOT(switchAxis()));
+  QObject::connect(ui.btnNonOrthogonalToggle, SIGNAL(toggled(bool)), this,
+                   SLOT(switchQWTRaster(bool)));
+  QObject::connect(ui.btnNonOrthogonalToggle, SIGNAL(toggled(bool)), this,
+                   SLOT(setNonOrthogonalbtn()));
+
   initMenus();
 
   loadSettings();
@@ -732,15 +742,6 @@ void SliceViewer::setWorkspace(Mantid::API::IMDWorkspace_sptr ws) {
   m_ws = ws;
 
   m_coordinateTransform = createCoordinateTransform(*ws, m_dimX, m_dimY);
-  // disconnect and reconnect here
-  QObject::connect(this, SIGNAL(changedShownDim(size_t, size_t)), this,
-                   SLOT(checkForHKLDimension()));
-  QObject::connect(this, SIGNAL(changedShownDim(size_t, size_t)), this,
-                   SLOT(switchAxis()));
-  QObject::connect(ui.btnNonOrthogonalToggle, SIGNAL(toggled(bool)), this,
-                   SLOT(switchQWTRaster(bool)));
-  QObject::connect(ui.btnNonOrthogonalToggle, SIGNAL(toggled(bool)), this,
-                   SLOT(setNonOrthogonalbtn()));
   m_firstNonOrthogonalWorkspaceOpen = true;
   m_data->setWorkspace(ws);
   m_plot->setWorkspace(ws);

--- a/qt/widgets/sliceviewer/src/SliceViewer.cpp
+++ b/qt/widgets/sliceviewer/src/SliceViewer.cpp
@@ -741,7 +741,7 @@ void SliceViewer::switchQWTRaster(bool useNonOrthogonal) {
 */
 void SliceViewer::setWorkspace(Mantid::API::IMDWorkspace_sptr ws) {
   struct ScopedFlag {
-    ScopedFlag(bool &b) : m_flag(b) { m_flag = true; }
+    explicit ScopedFlag(bool &b) : m_flag(b) { m_flag = true; }
     ~ScopedFlag() { m_flag = false; }
     bool &value() { return m_flag; }
     bool &m_flag;


### PR DESCRIPTION
**Description of work**

Avoids repeatedly calls to redraw the slice viewer widget when a workspace update occurs. 

**To test:**

Use the testing instructions in #20690 to compare the refresh performance before and after the fix.

Fixes #20690 and fixes #20717 


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
