### PR TITLE
Add upstream ParaView and VTK contributions to the release notes

### DIFF
--- a/docs/source/release/v3.11.0/ui.rst
+++ b/docs/source/release/v3.11.0/ui.rst
@@ -47,9 +47,22 @@ VSI Improvements
    :class: screenshot
    :align: right
 
+- Upstream ParaView Contributions
+
+ - Fix scaling, orientation and position inputs when nonorthogonal axes are present.
+ - Speed up MultiSlice view by avoiding repeated allocating and freeing memory.
+ - Fix the resample to image mapper, which was failing when input contains cell data.
+ - Expose the SamplingDimensions property when using the resample to image mapper with vtkStructuredGrids.
+
+- Upstream VTK Contributions
+
+ - Improve surface filter performance using vtkSMPTools
+ - Refactor the vtkDataSetTriangleFilter for better performance.
+ - Refactor the threshold filter to take advantage of structured data.
+ - Minimize duplicate code in vtkDataArrayPrivate and parallelize range calculation.
+
 - Multislice view uses a custom `representation <https://www.paraview.org/ParaView/index.php/Views_And_Representations>`_ to speed up slicing by taking advantage of the consistent bin 
   sizes in a MDHistoWorkspace. Smooth interaction with typical data sizes (< 10 million cells) is now possible.
-
 
 Bugs Resolved
 -------------


### PR DESCRIPTION
Description of work.

This pull request adds a sentence about the patches we apply to VTK and ParaView and have submitted upstream. We should advertise the in our release notes.

**To test:**

<!-- Instructions for testing. -->

Review changes to the release notes.

There is no GitHub issue associated with this pull request

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
