### PR TITLE
Blocksize show data

### DIFF
--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -172,12 +172,13 @@ const std::string MatrixWorkspace::toString() const {
   std::ostringstream os;
   os << id() << "\n"
      << "Title: " << getTitle() << "\n"
-     << "Histograms: " << getNumberHistograms() << "\n";
+     << "Histograms: " << getNumberHistograms() << "\n"
+     << "Bins: ";
 
   try {
-    os << "Bins: " << blocksize() << "\n";
+    os << blocksize() << "\n";
   } catch (std::length_error &) {
-    os << "Bins: variable\n"; // TODO shouldn't use try/catch
+    os << "variable\n"; // TODO shouldn't use try/catch
   }
 
   if (isHistogramData())

--- a/MantidPlot/src/Mantid/MantidMatrix.cpp
+++ b/MantidPlot/src/Mantid/MantidMatrix.cpp
@@ -539,35 +539,39 @@ void MantidMatrix::goToColumn(int col) {
 }
 
 double MantidMatrix::dataX(int row, int col) const {
-  const auto &x = m_workspace->x(row + m_startRow);
-  if (!m_workspace || row >= numRows() || col >= static_cast<int>(x.size()))
+  if (!m_workspace || row >= numRows() || col >= numCols())
     return 0.;
-  double res = x[col];
-  return res;
+  const auto &x = m_workspace->x(row + m_startRow);
+  if (col >= static_cast<int>(x.size()))
+    return 0.;
+  return x[col];
 }
 
 double MantidMatrix::dataY(int row, int col) const {
-  const auto &y = m_workspace->y(row + m_startRow);
   if (!m_workspace || row >= numRows() || col >= numCols())
     return 0.;
-  double res = y[col];
-  return res;
+  const auto &y = m_workspace->y(row + m_startRow);
+  if (col >= static_cast<int>(y.size()))
+    return 0.;
+  return y[col];
 }
 
 double MantidMatrix::dataE(int row, int col) const {
-  const auto &e = m_workspace->e(row + m_startRow);
   if (!m_workspace || row >= numRows() || col >= numCols())
     return 0.;
-  double res = e[col];
-  return res;
+  const auto &e = m_workspace->e(row + m_startRow);
+  if (col >= static_cast<int>(e.size()))
+    return 0.;
+  return e[col];
 }
 
 double MantidMatrix::dataDx(int row, int col) const {
-  const auto &dx = m_workspace->dx(row + m_startRow);
   if (!m_workspace || row >= numRows() || col >= numCols())
     return 0.;
-  double res = dx[col];
-  return res;
+  const auto &dx = m_workspace->dx(row + m_startRow);
+  if (col >= static_cast<int>(dx.size()))
+    return 0.;
+  return dx[col];
 }
 
 QString MantidMatrix::workspaceName() const {

--- a/MantidPlot/src/Mantid/MantidMatrixModel.cpp
+++ b/MantidPlot/src/Mantid/MantidMatrixModel.cpp
@@ -60,19 +60,25 @@ void MantidMatrixModel::setup(const Mantid::API::MatrixWorkspace *ws, int rows,
 double MantidMatrixModel::data(int row, int col) const {
   Mantid::Kernel::ReadLock _lock(*m_workspace);
 
-  double val;
+  const size_t workspaceIndex = static_cast<size_t>(row + m_startRow);
+
+  double val = 0.; // default value
   switch (m_type) {
   case X:
-    val = m_workspace->x(row + m_startRow)[col];
+    if (col < static_cast<int>(m_workspace->x(workspaceIndex).size()))
+      val = m_workspace->x(workspaceIndex)[col];
     break;
   case Y:
-    val = m_workspace->y(row + m_startRow)[col];
+    if (col < static_cast<int>(m_workspace->y(workspaceIndex).size()))
+      val = m_workspace->y(workspaceIndex)[col];
     break;
   case E:
-    val = m_workspace->e(row + m_startRow)[col];
+    if (col < static_cast<int>(m_workspace->e(workspaceIndex).size()))
+      val = m_workspace->e(workspaceIndex)[col];
     break;
   default:
-    val = m_workspace->dx(row + m_startRow)[col];
+    if (col < static_cast<int>(m_workspace->dx(workspaceIndex).size()))
+      val = m_workspace->dx(workspaceIndex)[col];
     break;
   }
   return val;

--- a/MantidPlot/src/Mantid/MantidMatrixModel.cpp
+++ b/MantidPlot/src/Mantid/MantidMatrixModel.cpp
@@ -44,10 +44,17 @@ void MantidMatrixModel::setup(const Mantid::API::MatrixWorkspace *ws, int rows,
   m_mask_color =
       QApplication::palette().color(QPalette::Disabled, QPalette::Background);
 
-  if (ws->blocksize() != 0)
-    m_colNumCorr = ws->isHistogramData() ? 1 : 0;
-  else
-    m_colNumCorr = 0;
+  m_colNumCorr = 0;
+  const size_t numHist = ws->getNumberHistograms();
+  for (size_t i = 0; i < numHist; ++i) {
+    // anything being non-empty means check it
+    // checking x-means EventWorkspaces aren't
+    // histogramed as part of the check
+    if (!ws->x(i).empty()) {
+      m_colNumCorr = ws->isHistogramData() ? 1 : 0;
+      break;
+    }
+  }
 }
 
 double MantidMatrixModel::data(int row, int col) const {

--- a/qt/widgets/common/src/QwtHelper.cpp
+++ b/qt/widgets/common/src/QwtHelper.cpp
@@ -22,7 +22,7 @@ boost::shared_ptr<QwtData> curveDataFromWs(MatrixWorkspace_const_sptr ws,
                                            size_t wsIndex) {
   const double *x = &ws->x(wsIndex)[0];
   const double *y = &ws->y(wsIndex)[0];
-  size_t size = ws->blocksize();
+  size_t size = ws->y(wsIndex).size();
 
   return boost::make_shared<QwtArrayData>(x, y, size);
 }

--- a/qt/widgets/common/src/WorkspacePresenter/QWorkspaceDockView.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/QWorkspaceDockView.cpp
@@ -915,9 +915,21 @@ void QWorkspaceDockView::addMatrixWorkspaceMenuItems(
   menu->addAction(m_plotAdvanced);
 
   // Don't plot a spectrum if only one X value
-  m_plotSpec->setEnabled(matrixWS->blocksize() > 1);
-  m_plotSpecErr->setEnabled(matrixWS->blocksize() > 1);
-  m_plotAdvanced->setEnabled(matrixWS->blocksize() > 1);
+  bool multipleBins = false;
+  try {
+    multipleBins = (matrixWS->blocksize() > 1);
+  } catch (...) {
+    const size_t numHist = matrixWS->getNumberHistograms();
+    for (size_t i = 0; i < numHist; ++i) {
+      if (matrixWS->y(i).size() > 1) {
+        multipleBins = true;
+        break;
+      }
+    }
+  }
+  m_plotSpec->setEnabled(multipleBins);
+  m_plotSpecErr->setEnabled(multipleBins);
+  m_plotAdvanced->setEnabled(multipleBins);
 
   menu->addAction(m_showSpectrumViewer); // The 2D spectrum viewer
 

--- a/qt/widgets/plugins/algorithm_dialogs/src/FitDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/FitDialog.cpp
@@ -216,8 +216,8 @@ MWPropertiesWidget::MWPropertiesWidget(InputWorkspaceWidget *parent)
     if (ws) {
       m_workspaceIndex->setRange(0,
                                  static_cast<int>(ws->getNumberHistograms()));
-      if (ws->blocksize() > 0) {
-        const Mantid::MantidVec &x = ws->readX(0);
+      const Mantid::MantidVec &x = ws->readX(0);
+      if (!x.empty()) {
         m_startX->setText(QString::number(x.front()));
         m_endX->setText(QString::number(x.back()));
       }


### PR DESCRIPTION
There was a bug in getting the right click menu working and showing the data in a table.

**To test:**

1. `LoadNeXusMonitors(Filename='TOPAZ_24989', OutputWorkspace='TOPAZ_24989')`
2. The right click menu should not crash mantid
3. "Show Data" should show a nice table

Spectrum 1 should have 30001 data points, Spectrum 2 should have 200002 data points.

*There is no associated issue.*

*Does not need to be in the release notes* because it is fixing a bug that was only recently introduced.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
