### PR TITLE
Fix for instrument setting in new ISIS SANS GUI

### DIFF
--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -13,6 +13,7 @@ from PyQt4 import QtGui, QtCore
 
 from mantid.kernel import (Logger, config)
 from mantidqtpython import MantidQt
+
 try:
     from mantidplot import *
     canMantidPlot = True
@@ -235,6 +236,9 @@ class SANSDataProcessorGui(QtGui.QMainWindow, ui_sans_data_processor_window.Ui_S
         # Set the list of available instruments in the widget and the default instrument
         instrument_name = SANSInstrument.to_string(self._instrument)
         self.data_processor_table.setInstrumentList(SANSDataProcessorGui.INSTRUMENTS, instrument_name)
+
+        if instrument_name:
+            self._set_mantid_instrument(instrument_name)
 
         # The widget will emit a 'runAsPythonScript' signal to run python code
         self.data_processor_table.runAsPythonScript.connect(self._run_python_code)


### PR DESCRIPTION
This should fix an issue where the GUI setting of the instrument was not applied as the default instrument of Mantid at startup of the GUI

**To test:**

1. Start up Mantid and select the instrument to be SANS2D
1. Start up the ISIS SANS GUI and set the instrument to ZOOM
1. Close Mantid
1. Open Mantid and select the instrument to be SANS2D
1. Set the Mantid Path to the ZOOM test data
1. Open the ISIS SANS GUI
1. Set user file to the ZOOM user file
1. Set the `SampleScatter` to `423`
1. Press `Process`
  * Confirm that the reduction completes without issues


No release notes or issue number

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
