### PR TITLE
Fix clang-tidy modernize-use-bool-literals issues

### DIFF
--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -463,7 +463,7 @@ void LogManager::clearOutdatedTimeSeriesLogValues() {
  */
 void LogManager::saveNexus(::NeXus::File *file, const std::string &group,
                            bool keepOpen) const {
-  file->makeGroup(group, "NXgroup", 1);
+  file->makeGroup(group, "NXgroup", true);
   file->putAttr("version", 1);
 
   // Save all the properties as NXlog

--- a/Framework/API/src/Run.cpp
+++ b/Framework/API/src/Run.cpp
@@ -348,7 +348,7 @@ void Run::saveNexus(::NeXus::File *file, const std::string &group,
 
   // write the histogram bins, if there are any
   if (!m_histoBins.empty()) {
-    file->makeGroup(HISTO_BINS_LOG_NAME, "NXdata", 1);
+    file->makeGroup(HISTO_BINS_LOG_NAME, "NXdata", true);
     file->writeData("value", m_histoBins);
     file->closeGroup();
   }
@@ -356,12 +356,12 @@ void Run::saveNexus(::NeXus::File *file, const std::string &group,
     const std::vector<double> &values =
         this->getPropertyValueAsType<std::vector<double>>("PeakRadius");
 
-    file->makeGroup(PEAK_RADIUS_GROUP, "NXdata", 1);
+    file->makeGroup(PEAK_RADIUS_GROUP, "NXdata", true);
     file->writeData("value", values);
     file->closeGroup();
   }
   if (this->hasProperty("BackgroundInnerRadius")) {
-    file->makeGroup(INNER_BKG_RADIUS_GROUP, "NXdata", 1);
+    file->makeGroup(INNER_BKG_RADIUS_GROUP, "NXdata", true);
     const std::vector<double> &values =
         this->getPropertyValueAsType<std::vector<double>>(
             "BackgroundInnerRadius");
@@ -369,7 +369,7 @@ void Run::saveNexus(::NeXus::File *file, const std::string &group,
     file->closeGroup();
   }
   if (this->hasProperty("BackgroundOuterRadius")) {
-    file->makeGroup(OUTER_BKG_RADIUS_GROUP, "NXdata", 1);
+    file->makeGroup(OUTER_BKG_RADIUS_GROUP, "NXdata", true);
     const std::vector<double> &values =
         this->getPropertyValueAsType<std::vector<double>>(
             "BackgroundOuterRadius");

--- a/Framework/API/src/Sample.cpp
+++ b/Framework/API/src/Sample.cpp
@@ -288,7 +288,7 @@ void Sample::addSample(boost::shared_ptr<Sample> childSample) {
  * @param group :: name of the group to create
  */
 void Sample::saveNexus(::NeXus::File *file, const std::string &group) const {
-  file->makeGroup(group, "NXsample", 1);
+  file->makeGroup(group, "NXsample", true);
   file->putAttr("name", m_name);
   file->putAttr("version", 1);
   file->putAttr("shape_xml", m_shape.getShapeXML());

--- a/Framework/Crystal/src/AnvredCorrection.cpp
+++ b/Framework/Crystal/src/AnvredCorrection.cpp
@@ -237,7 +237,7 @@ void AnvredCorrection::exec() {
   API::Run &run = correctionFactors->mutableRun();
   run.addProperty<double>("Radius", m_radius, true);
   if (!m_onlySphericalAbsorption && !m_returnTransmissionOnly)
-    run.addProperty<bool>("LorentzCorrection", 1, true);
+    run.addProperty<bool>("LorentzCorrection", true, true);
   setProperty("OutputWorkspace", correctionFactors);
 }
 
@@ -330,7 +330,7 @@ void AnvredCorrection::execEvent() {
   API::Run &run = correctionFactors->mutableRun();
   run.addProperty<double>("Radius", m_radius, true);
   if (!m_onlySphericalAbsorption && !m_returnTransmissionOnly)
-    run.addProperty<bool>("LorentzCorrection", 1, true);
+    run.addProperty<bool>("LorentzCorrection", true, true);
   setProperty("OutputWorkspace", std::move(correctionFactors));
 
   // Now do some cleaning-up since destructor may not be called immediately

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -635,7 +635,7 @@ LoadEventNexus::LoadEventNexus()
       filter_tof_max(0), m_specList(), m_specMin(0), m_specMax(0),
       filter_time_start(), filter_time_stop(), chunk(0), totalChunks(0),
       firstChunkForBank(0), eventsPerChunk(0), m_tofMutex(), longest_tof(0),
-      shortest_tof(0), bad_tofs(0), discarded_events(0), precount(0),
+      shortest_tof(0), bad_tofs(0), discarded_events(0), precount(false),
       compressTolerance(0), eventVectors(), m_eventVectorMutex(),
       eventid_max(0), pixelID_to_wi_vector(), pixelID_to_wi_offset(),
       m_bankPulseTimes(), m_allBanksPulseTimes(), m_top_entry_name(),

--- a/Framework/DataHandling/src/LoadMappingTable.cpp
+++ b/Framework/DataHandling/src/LoadMappingTable.cpp
@@ -35,7 +35,7 @@ void LoadMappingTable::exec() {
   /// ISISRAW class instance which does raw file reading.
   auto iraw = Kernel::make_unique<ISISRAW2>();
 
-  if (iraw->readFromFile(m_filename.c_str(), 0) !=
+  if (iraw->readFromFile(m_filename.c_str(), false) !=
       0) // ReadFrom File with no data
   {
     g_log.error("Unable to open file " + m_filename);

--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -874,7 +874,7 @@ API::Workspace_sptr LoadNexusProcessed::loadTableEntry(NXEntry &entry) {
 
     columnNumber++;
 
-  } while (1);
+  } while (true);
 
   return boost::static_pointer_cast<API::Workspace>(workspace);
 }
@@ -996,7 +996,7 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(NXEntry &entry) {
 
     columnNumber++;
 
-  } while (1);
+  } while (true);
 
   // Get information from all but data group
   std::string parameterStr;

--- a/Framework/DataHandling/src/SaveNexusProcessed.cpp
+++ b/Framework/DataHandling/src/SaveNexusProcessed.cpp
@@ -547,7 +547,7 @@ void SaveNexusProcessed::saveSpectraMapNexus(
   }
 
   // Start the detector group
-  file->makeGroup("detector", "NXdetector", 1);
+  file->makeGroup("detector", "NXdetector", true);
   file->putAttr("version", 1);
 
   int numberSpec = int(spec.size());

--- a/Framework/Geometry/src/Crystal/OrientedLattice.cpp
+++ b/Framework/Geometry/src/Crystal/OrientedLattice.cpp
@@ -220,7 +220,7 @@ const DblMatrix &OrientedLattice::setUFromVectors(const V3D &u, const V3D &v) {
  */
 void OrientedLattice::saveNexus(::NeXus::File *file,
                                 const std::string &group) const {
-  file->makeGroup(group, "NXcrystal", 1);
+  file->makeGroup(group, "NXcrystal", true);
   file->writeData("unit_cell_a", this->a());
   file->writeData("unit_cell_b", this->b());
   file->writeData("unit_cell_c", this->c());

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -991,7 +991,7 @@ const std::string &Instrument::getXmlText() const {
  */
 void Instrument::saveNexus(::NeXus::File *file,
                            const std::string &group) const {
-  file->makeGroup(group, "NXinstrument", 1);
+  file->makeGroup(group, "NXinstrument", true);
   file->putAttr("version", 1);
 
   file->writeData("name", getName());

--- a/Framework/Geometry/src/Instrument/Goniometer.cpp
+++ b/Framework/Geometry/src/Instrument/Goniometer.cpp
@@ -248,7 +248,7 @@ void Goniometer::recalculateR() {
  */
 void Goniometer::saveNexus(::NeXus::File *file,
                            const std::string &group) const {
-  file->makeGroup(group, "NXpositioner", 1);
+  file->makeGroup(group, "NXpositioner", true);
   file->putAttr("version", 1);
   // Because the order of the axes is very important, they have to be written
   // and read out in the same order

--- a/Framework/Kernel/src/Material.cpp
+++ b/Framework/Kernel/src/Material.cpp
@@ -384,7 +384,7 @@ double Material::totalScatterLengthSqrd(const double lambda) const {
  * @param group :: name of the group to create
  */
 void Material::saveNexus(::NeXus::File *file, const std::string &group) const {
-  file->makeGroup(group, "NXdata", 1);
+  file->makeGroup(group, "NXdata", true);
   file->putAttr("version", 2);
   file->putAttr("name", m_name);
 

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -2237,7 +2237,7 @@ void TimeSeriesProperty<std::string>::saveProperty(::NeXus::File *file) {
   std::vector<std::string> values = this->valuesAsVector();
   if (values.empty())
     return;
-  file->makeGroup(this->name(), "NXlog", 1);
+  file->makeGroup(this->name(), "NXlog", true);
 
   // Find the max length of any string
   auto max_it =
@@ -2275,7 +2275,7 @@ template <> void TimeSeriesProperty<bool>::saveProperty(::NeXus::File *file) {
   if (value.empty())
     return;
   std::vector<uint8_t> asUint(value.begin(), value.end());
-  file->makeGroup(this->name(), "NXlog", 1);
+  file->makeGroup(this->name(), "NXlog", true);
   file->writeData("value", asUint);
   file->putAttr("boolean", "1");
   saveTimeVector(file);

--- a/Framework/TestHelpers/src/NexusTestHelper.cpp
+++ b/Framework/TestHelpers/src/NexusTestHelper.cpp
@@ -40,7 +40,7 @@ void NexusTestHelper::createFile(std::string barefilename) {
   if (Poco::File(filename).exists())
     Poco::File(filename).remove();
   file = new ::NeXus::File(filename, NXACC_CREATE5);
-  file->makeGroup("test_entry", "NXentry", 1);
+  file->makeGroup("test_entry", "NXentry", true);
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/TestHelpers/src/SANSInstrumentCreationHelper.cpp
+++ b/Framework/TestHelpers/src/SANSInstrumentCreationHelper.cpp
@@ -42,7 +42,7 @@ Workspace2D_sptr SANSInstrumentCreationHelper::createSANSInstrumentWorkspace(
   // Create a test workspace with test data with a well defined peak
   // The test instrument has two monitor channels
   Workspace2D_sptr ws = WorkspaceCreationHelper::create2DWorkspace123(
-      nBins * nBins + nMonitors, 1, 1);
+      nBins * nBins + nMonitors, 1, true);
   AnalysisDataService::Instance().addOrReplace(workspace, ws);
   ws->getAxis(0)->unit() =
       Mantid::Kernel::UnitFactory::Instance().create("Wavelength");

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -6566,7 +6566,7 @@ void ApplicationWindow::exportASCII(const QString &tableName,
   if (!fname.isEmpty()) {
     QFileInfo fi(fname);
     QString baseName = fi.fileName();
-    if (baseName.contains(".") == false)
+    if (!baseName.contains("."))
       fname.append(selectedFilter.remove("*"));
 
     asciiDirPath = fi.absolutePath();

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -6566,7 +6566,7 @@ void ApplicationWindow::exportASCII(const QString &tableName,
   if (!fname.isEmpty()) {
     QFileInfo fi(fname);
     QString baseName = fi.fileName();
-    if (baseName.contains(".") == 0)
+    if (baseName.contains(".") == false)
       fname.append(selectedFilter.remove("*"));
 
     asciiDirPath = fi.absolutePath();
@@ -8305,7 +8305,7 @@ void ApplicationWindow::drawArrow() {
 
   Graph *g = dynamic_cast<Graph *>(plot->activeGraph());
   if (g) {
-    g->drawLine(true, 1);
+    g->drawLine(true, true);
     emit modified();
   }
 }

--- a/MantidPlot/src/ConfigDialog.cpp
+++ b/MantidPlot/src/ConfigDialog.cpp
@@ -2465,7 +2465,7 @@ void ConfigDialog::apply() {
   sep.replace(tr("SPACE"), " ");
   sep.replace("\\s", " ");
 
-  if (sep.contains(QRegExp("[0-9.eE+-]")) != false) {
+  if (sep.contains(QRegExp("[0-9.eE+-]"))) {
     QMessageBox::warning(nullptr, tr("MantidPlot - Import options error"),
                          tr("The separator must not contain the following "
                             "characters: 0-9eE.+-"));

--- a/MantidPlot/src/ConfigDialog.cpp
+++ b/MantidPlot/src/ConfigDialog.cpp
@@ -2465,7 +2465,7 @@ void ConfigDialog::apply() {
   sep.replace(tr("SPACE"), " ");
   sep.replace("\\s", " ");
 
-  if (sep.contains(QRegExp("[0-9.eE+-]")) != 0) {
+  if (sep.contains(QRegExp("[0-9.eE+-]")) != false) {
     QMessageBox::warning(nullptr, tr("MantidPlot - Import options error"),
                          tr("The separator must not contain the following "
                             "characters: 0-9eE.+-"));

--- a/MantidPlot/src/Graph.cpp
+++ b/MantidPlot/src/Graph.cpp
@@ -2754,7 +2754,7 @@ PlotCurve *Graph::insertCurve(Table *w, const QString &xColName,
     if (!xval.isEmpty() && !yval.isEmpty()) {
       bool valid_data = true;
       if (xColType == Table::Text) {
-        if (xLabels.contains(xval) == 0)
+        if (xLabels.contains(xval) == false)
           xLabels << xval;
         X[size] = (double)(xLabels.indexOf(xval) + 1);
       } else if (xColType == Table::Time) {

--- a/MantidPlot/src/Graph.cpp
+++ b/MantidPlot/src/Graph.cpp
@@ -2754,7 +2754,7 @@ PlotCurve *Graph::insertCurve(Table *w, const QString &xColName,
     if (!xval.isEmpty() && !yval.isEmpty()) {
       bool valid_data = true;
       if (xColType == Table::Text) {
-        if (xLabels.contains(xval) == false)
+        if (!xLabels.contains(xval))
           xLabels << xval;
         X[size] = (double)(xLabels.indexOf(xval) + 1);
       } else if (xColType == Table::Time) {

--- a/MantidPlot/src/Mantid/AlgorithmHistoryWindow.cpp
+++ b/MantidPlot/src/Mantid/AlgorithmHistoryWindow.cpp
@@ -45,7 +45,7 @@ AlgExecSummaryGrpBox::AlgExecSummaryGrpBox(QString title, QWidget *w)
 
   m_execDurationEdit = new QLineEdit("", this);
   if (m_execDurationEdit)
-    m_execDurationEdit->setReadOnly(1);
+    m_execDurationEdit->setReadOnly(true);
   m_execDurationlabel = new QLabel("Duration:", this);
   if (m_execDurationlabel)
     m_execDurationlabel->setBuddy(m_execDurationEdit);
@@ -53,7 +53,7 @@ AlgExecSummaryGrpBox::AlgExecSummaryGrpBox(QString title, QWidget *w)
   QDateTime datetime(QDate(0, 0, 0), QTime(0, 0, 0), Qt::LocalTime);
   m_execDateTimeEdit = new QLineEdit("", this);
   if (m_execDateTimeEdit)
-    m_execDateTimeEdit->setReadOnly(1);
+    m_execDateTimeEdit->setReadOnly(true);
   m_Datelabel = new QLabel("Date:", this);
   if (m_Datelabel)
     m_Datelabel->setBuddy(m_execDateTimeEdit);
@@ -124,7 +124,7 @@ AlgEnvHistoryGrpBox::AlgEnvHistoryGrpBox(QString title, QWidget *w)
   // OS Name Label & Edit Box
   m_osNameEdit = new QLineEdit("", this);
   if (m_osNameEdit) {
-    m_osNameEdit->setReadOnly(1);
+    m_osNameEdit->setReadOnly(true);
   }
   m_osNameLabel = new QLabel("OS Name:", this);
   if (m_osNameLabel)
@@ -133,7 +133,7 @@ AlgEnvHistoryGrpBox::AlgEnvHistoryGrpBox(QString title, QWidget *w)
   // OS Version Label & Edit Box
   m_osVersionEdit = new QLineEdit("", this);
   if (m_osVersionEdit) {
-    m_osVersionEdit->setReadOnly(1);
+    m_osVersionEdit->setReadOnly(true);
     m_osVersionLabel = new QLabel("OS Version:", this);
   }
   if (m_osVersionLabel)
@@ -142,7 +142,7 @@ AlgEnvHistoryGrpBox::AlgEnvHistoryGrpBox(QString title, QWidget *w)
   // Mantid Framework Version Label & Edit Box
   m_frmwkVersnEdit = new QLineEdit("", this);
   if (m_frmwkVersnEdit)
-    m_frmwkVersnEdit->setReadOnly(1);
+    m_frmwkVersnEdit->setReadOnly(true);
   m_frmworkVersionLabel = new QLabel("Framework Version:", this);
   if (m_frmworkVersionLabel)
     m_frmworkVersionLabel->setBuddy(m_frmwkVersnEdit);

--- a/MantidPlot/src/Mantid/MantidSampleLogDialog.cpp
+++ b/MantidPlot/src/Mantid/MantidSampleLogDialog.cpp
@@ -72,7 +72,7 @@ MantidSampleLogDialog::MantidSampleLogDialog(const QString &wsname,
   for (size_t i = 0; i < NUM_STATS; i++) {
     statLabels[i] = new QLabel(stats[i].c_str());
     statValues[i] = new QLineEdit("");
-    statValues[i]->setReadOnly(1);
+    statValues[i]->setReadOnly(true);
     statsBoxLayout->addRow(statLabels[i], statValues[i]);
   }
   statsBox->setLayout(statsBoxLayout);

--- a/MantidPlot/src/importOPJ.cpp
+++ b/MantidPlot/src/importOPJ.cpp
@@ -1045,8 +1045,8 @@ bool ImportOPJ::importGraphs(const OPJFile &opj) {
                    translateOrigin2QtiplotLineStyle(grids[3].style))));
 
       grid->setAxis(2, 0);
-      grid->enableZeroLineX(0);
-      grid->enableZeroLineY(0);
+      grid->enableZeroLineX(false);
+      grid->enableZeroLineY(false);
 
       vector<graphAxisFormat> formats = opj.layerAxisFormat(g, l);
       vector<graphAxisTick> ticks = opj.layerAxisTickLabels(g, l);

--- a/MantidPlot/src/origin/OPJFile.cpp
+++ b/MantidPlot/src/origin/OPJFile.cpp
@@ -1260,7 +1260,7 @@ int OPJFile::ParseFormatNew() {
   //////////////////////// OBJECT INFOS //////////////////////////////////////
   POS += 0xB;
   CHECKED_FSEEK(debug, f, POS, SEEK_SET);
-  while (1) {
+  while (true) {
 
     fprintf(debug, "     reading Header\n");
     fflush(debug);
@@ -1311,7 +1311,7 @@ int OPJFile::ParseFormatNew() {
     CHECKED_FREAD(debug, &c, 1, 1, f);
   }
   CHECKED_FSEEK(debug, f, 1 + 5, SEEK_CUR);
-  while (1) {
+  while (true) {
     // fseek(f,5+0x40+1,SEEK_CUR);
     int size;
     CHECKED_FREAD(debug, &size, 4, 1, f);
@@ -1444,7 +1444,7 @@ void OPJFile::readSpreadInfo(FILE *f, int file_size, FILE *debug) {
     // possible sections: column formulas, __WIPR, __WIOTN, __LayerInfoStorage
     // etc
     // section name(column name in formula case) starts with 0x46 position
-    while (1) {
+    while (true) {
       int sec_size;
       // section_header_size=0x6F(4 bytes) + '\n'
       LAYER += 0x5;
@@ -1523,7 +1523,7 @@ void OPJFile::readSpreadInfo(FILE *f, int file_size, FILE *debug) {
   fprintf(debug, "     Spreadsheet has %zu columns\n",
           SPREADSHEET[spread].column.size());
 
-  while (1) {
+  while (true) {
     LAYER += 0x5;
     CHECKED_FSEEK(debug, f, LAYER + 0x12, SEEK_SET);
     CHECKED_FREAD(debug, &name, 12, 1, f);
@@ -1683,7 +1683,7 @@ void OPJFile::readExcelInfo(FILE *f, int file_size, FILE *debug) {
   LAYER += headersize + 0x1;
   int sec_size;
   int isheet = 0;
-  while (1) // multisheet loop
+  while (true) // multisheet loop
   {
     // LAYER section
     LAYER += 0x5 /* length of block = 0x12D + '\n'*/ + 0x12D + 0x1;
@@ -1694,7 +1694,7 @@ void OPJFile::readExcelInfo(FILE *f, int file_size, FILE *debug) {
     // possible sections: column formulas, __WIPR, __WIOTN, __LayerInfoStorage
     // etc
     // section name(column name in formula case) starts with 0x46 position
-    while (1) {
+    while (true) {
       // section_header_size=0x6F(4 bytes) + '\n'
       LAYER += 0x5;
 
@@ -1769,7 +1769,7 @@ void OPJFile::readExcelInfo(FILE *f, int file_size, FILE *debug) {
     fprintf(debug, "     Excel sheet %d has %zu columns\n", isheet,
             EXCEL[iexcel].sheet[isheet].column.size());
 
-    while (1) {
+    while (true) {
       LAYER += 0x5;
       CHECKED_FSEEK(debug, f, LAYER + 0x12, SEEK_SET);
       CHECKED_FREAD(debug, &name, 12, 1, f);
@@ -1990,7 +1990,7 @@ void OPJFile::readMatrixInfo(FILE *f, int file_size, FILE *debug) {
   // section_body_2 + '\n'
   // possible sections: column formulas, __WIPR, __WIOTN, __LayerInfoStorage
   // section name(column name in formula case) starts with 0x46 position
-  while (1) {
+  while (true) {
     // section_header_size=0x6F(4 bytes) + '\n'
     LAYER += 0x5;
 
@@ -2053,7 +2053,7 @@ void OPJFile::readMatrixInfo(FILE *f, int file_size, FILE *debug) {
   }
   LAYER += 0x5;
 
-  while (1) {
+  while (true) {
     LAYER += 0x5;
 
     short width = 0;
@@ -2140,7 +2140,7 @@ void OPJFile::readGraphInfo(FILE *f, int file_size, FILE *debug) {
   int LAYER = POS;
   LAYER += headersize + 0x1;
   int sec_size;
-  while (1) // multilayer loop
+  while (true) // multilayer loop
   {
     GRAPH.back().layer.push_back(graphLayer());
     // LAYER section
@@ -2206,7 +2206,7 @@ void OPJFile::readGraphInfo(FILE *f, int file_size, FILE *debug) {
     // possible sections: axes, legend, __BC02, _202, _231, _232,
     // __LayerInfoStorage etc
     // section name starts with 0x46 position
-    while (1) {
+    while (true) {
       // section_header_size=0x6F(4 bytes) + '\n'
       LAYER += 0x5;
 
@@ -2505,7 +2505,7 @@ void OPJFile::readGraphInfo(FILE *f, int file_size, FILE *debug) {
       SwapBytes(sec_size);
     if (sec_size == 0x1E7) // check layer is not empty
     {
-      while (1) {
+      while (true) {
         LAYER += 0x5;
 
         graphCurve curve;
@@ -2784,7 +2784,7 @@ void OPJFile::readGraphInfo(FILE *f, int file_size, FILE *debug) {
 
     LAYER += 0x5;
     // read axis breaks
-    while (1) {
+    while (true) {
       CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
       CHECKED_FREAD(debug, &sec_size, 4, 1, f);
       if (IsBigEndian())
@@ -2902,7 +2902,7 @@ void OPJFile::skipObjectInfo(FILE *f, FILE *fdebug) {
   int LAYER = POS;
   LAYER += headersize + 0x1;
   int sec_size;
-  while (1) // multilayer loop
+  while (true) // multilayer loop
   {
     // LAYER section
     LAYER += 0x5 /* length of block = 0x12D + '\n'*/ + 0x12D + 0x1;
@@ -2912,7 +2912,7 @@ void OPJFile::skipObjectInfo(FILE *f, FILE *fdebug) {
     // section_body_2 + '\n'
     // possible sections: column formulas, __WIPR, __WIOTN, __LayerInfoStorage
     // section name(column name in formula case) starts with 0x46 position
-    while (1) {
+    while (true) {
       // section_header_size=0x6F(4 bytes) + '\n'
       LAYER += 0x5;
 
@@ -2962,7 +2962,7 @@ void OPJFile::skipObjectInfo(FILE *f, FILE *fdebug) {
     }
     LAYER += 0x5;
 
-    while (1) {
+    while (true) {
       LAYER += 0x5;
 
       LAYER += 0x1E7 + 0x1;


### PR DESCRIPTION
This uses the -fix option on clang-tidy to automatically fix all
the cases not using bool literals that have crept into Mantid.

**To test:**

 - Build passes
 - Code review

There is no issue associated with this PR

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
