### PR TITLE
Fix clang-tidy modernize-use-override issues

### DIFF
--- a/MantidPlot/src/lib/3rdparty/qtcolorpicker/src/qtcolorpicker.cpp
+++ b/MantidPlot/src/lib/3rdparty/qtcolorpicker/src/qtcolorpicker.cpp
@@ -170,7 +170,7 @@ public:
   ColorPickerItem(const QColor &color = Qt::white,
                   const QString &text = QString::null,
                   QWidget *parent = nullptr);
-  ~ColorPickerItem();
+  ~ColorPickerItem() override;
 
   QColor color() const;
   QString text() const;
@@ -204,7 +204,7 @@ class ColorPickerPopup : public QFrame {
 
 public:
   ColorPickerPopup(int width, bool withColorDialog, QWidget *parent = nullptr);
-  ~ColorPickerPopup();
+  ~ColorPickerPopup() override;
 
   void insertColor(const QColor &col, const QString &text, int index);
   void exec();

--- a/qt/widgets/plugins/algorithm_dialogs/src/StartLiveDataDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/StartLiveDataDialog.cpp
@@ -30,7 +30,7 @@ class LiveDataAlgInputHistoryImpl : public AbstractAlgorithmInputHistory {
 private:
   LiveDataAlgInputHistoryImpl()
       : AbstractAlgorithmInputHistory("LiveDataAlgorithms") {}
-  ~LiveDataAlgInputHistoryImpl() {}
+  ~LiveDataAlgInputHistoryImpl() override {}
 
 private:
   friend struct Mantid::Kernel::CreateUsingNew<LiveDataAlgInputHistoryImpl>;
@@ -49,7 +49,7 @@ class LiveDataPostProcessingAlgInputHistoryImpl
 private:
   LiveDataPostProcessingAlgInputHistoryImpl()
       : AbstractAlgorithmInputHistory("LiveDataPostProcessingAlgorithms") {}
-  ~LiveDataPostProcessingAlgInputHistoryImpl() {}
+  ~LiveDataPostProcessingAlgInputHistoryImpl() override {}
 
 private:
   friend struct Mantid::Kernel::CreateUsingNew<


### PR DESCRIPTION
This uses the -fix option on clang-tidy to automatically fix all
the cases not using override that have crept into Mantid.

This was an easy one.

**To test:**

 - Build passes
 - Code review

There is no issue associated with this PR

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
