### PR TITLE
Add naming parameter to TOSCA parameters file

### DIFF
--- a/instrument/TOSCA_graphite_002_Parameters.xml
+++ b/instrument/TOSCA_graphite_002_Parameters.xml
@@ -31,6 +31,10 @@
       <value val="0" />
     </parameter>
 
+    <parameter name="Workflow.NamingConvention" type="string">
+      <value val="RunTitle" />
+    </parameter>
+
   </component-link>
 
 </parameter-file>


### PR DESCRIPTION
Adds missing parameter to TOSCA graphite parameters file as loading a new file doesn't clear out the old parameters so when swapping between them any parameters loaded in a different file will persist. 

**To test:**

See issue for test instructions.

Fixes #20768

**Release Notes** 

*Minor bug. Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
