### PR TITLE
doctest.py Python3 compatibility

### DIFF
--- a/docs/sphinxext/mantiddoc/doctest.py
+++ b/docs/sphinxext/mantiddoc/doctest.py
@@ -171,12 +171,11 @@ class TestSuiteReport(object):
 
     @property
     def nfailed(self):
-        def sum_failure(fails, case):
+        fails = 0
+        for case in self.testcases:
             if case.failed:
-                return fails + 1
-            else:
-                return fails
-        return reduce(sum_failure, self.testcases, 0)
+                fails += 1
+        return fails
 
     @property
     def npassed(self):


### PR DESCRIPTION
This PR replaces the `reduce()` build-in function by a `for` loop in `doctest.py`. The function is removed from Python 3.

**To test:**

Check that the doctests run and report failures correctly under both Python2 and 3. To build Mantid under Python 3, see [here](http://www.mantidproject.org/Python_3). For instruction on how to run individual doctests, see [here](http://www.mantidproject.org/Documentation_Guide_For_Devs#Running_documentation_tests_locally).

Fixes #20773.

**Release Notes** 

Internal change. Does not need to be noted.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
