### PR TITLE
Indirect - OSIRIS Diffraction Reduction (diffonly) -  Incorrect output when supplying Manual D-Range

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReduction.py
@@ -160,6 +160,13 @@ class DRangeToWorkspaceMap(object):
         """
         return d_range in self._map
 
+    def __str__(self):
+        str_output = "{\n"
+
+        for d_range, workspaces in self._map.items():
+            str_output += str(d_range) + ": " + str(workspaces) + "\n"
+        return str_output + "}"
+
 
 def average_ws_list(ws_list):
     """
@@ -170,55 +177,54 @@ def average_ws_list(ws_list):
     :return:        The name of the workspace containing the average.
     """
     # Assert we have some ws in the list, and if there is only one then return it.
-    if len(ws_list) == 0:
+    num_workspaces = len(ws_list)
+
+    if num_workspaces == 0:
         raise RuntimeError("getAverageWs: Trying to take an average of nothing")
 
-    if len(ws_list) == 1:
+    if num_workspaces == 1:
         return ws_list[0]
-    
-    def do_binary_op(name,inputs):
-        alg=AlgorithmManager.createUnmanaged(name)
+
+    def do_binary_op(name, operands):
+        alg = AlgorithmManager.createUnmanaged(name)
         alg.initialize()
         alg.setChild(True)
-        for name,value in iteritems(inputs):
-            alg.setProperty(name,value)
-        alg.setProperty("OutputWorkspace","__unused__")
+        for prop_name, value in iteritems(operands):
+            alg.setProperty(prop_name, value)
+        alg.setProperty("OutputWorkspace", "__unused__")
         alg.execute()
         return alg.getProperty('OutputWorkspace').value
 
-    def localSum(ws_list):
-        sum = ws_list[0]
-        for j in range(1,len(ws_list)):
-            inputs={}
-            inputs["LHSWorkspace"]=sum
-            inputs["RHSWorkspace"]=ws_list[j]
-            sum=do_binary_op("Plus",inputs)
-        return sum
-    sum=localSum(ws_list)
-    inputs={}
-    inputs["InputWorkspace"]=localSum(ws_list)
-    inputs["Factor"]=1./float(len(ws_list))   
-    inputs["Operation"]="Multiply" 
-    logger.warning("RHS "+str(type(sum)))
-    logger.warning("LHS "+str(type(len(ws_list))))
-    return do_binary_op("Scale",inputs)
+    def local_sum(operand_list):
+        total = operand_list[0]
+        for j in range(1, num_workspaces):
+            operands = {"LHSWorkspace": total,
+                        "RHSWorkspace": operand_list[j]}
+            total = do_binary_op("Plus", operands)
+        return total
 
-def find_intersection_of_ranges(rangeA, rangeB):
-    if rangeA[0] >= rangeA[1] or rangeB[0] >= rangeB[1]:
+    inputs = {"InputWorkspace": local_sum(ws_list),
+              "Factor": 1. / float(num_workspaces),
+              "Operation": "Multiply"}
+    return do_binary_op("Scale", inputs)
+
+
+def find_intersection_of_ranges(range_a, range_b):
+    if range_a[0] >= range_a[1] or range_b[0] >= range_b[1]:
         raise RuntimeError("Malformed range")
 
-    if rangeA[0] <= rangeA[1] <= rangeB[0] <= rangeB[1]:
+    if range_a[0] <= range_a[1] <= range_b[0] <= range_b[1]:
         return
-    if rangeB[0] <= rangeB[1] <= rangeA[0] <= rangeA[1]:
+    if range_b[0] <= range_b[1] <= range_a[0] <= range_a[1]:
         return
-    if rangeA[0] <= rangeB[0] <= rangeB[1] <= rangeA[1]:
-        return rangeB
-    if rangeB[0] <= rangeA[0] <= rangeA[1] <= rangeB[1]:
-        return rangeA
-    if rangeA[0] <= rangeB[0] <= rangeA[1] <= rangeB[1]:
-        return [rangeB[0], rangeA[1]]
-    if rangeB[0] <= rangeA[0] <= rangeB[1] <= rangeA[1]:
-        return [rangeA[0], rangeB[1]]
+    if range_a[0] <= range_b[0] <= range_b[1] <= range_a[1]:
+        return range_b
+    if range_b[0] <= range_a[0] <= range_a[1] <= range_b[1]:
+        return range_a
+    if range_a[0] <= range_b[0] <= range_a[1] <= range_b[1]:
+        return [range_b[0], range_a[1]]
+    if range_b[0] <= range_a[0] <= range_b[1] <= range_a[1]:
+        return [range_a[0], range_b[1]]
 
     # Should never reach here
     raise RuntimeError()
@@ -404,17 +410,25 @@ class OSIRISDiffractionReduction(PythonAlgorithm):
         self._man_d_range = None
 
         if not self.getProperty("DetectDRange").value:
-            self._man_d_range = self.getProperty("DRange").value
+            self._man_d_range = self._parse_string_array(self.getProperty("DRange").value)
+            self._man_d_range = [x - 1 for x in self._man_d_range]
+            num_ranges = len(self._man_d_range)
+            num_runs = len(self._sample_runs)
+
+            if num_runs % num_ranges == 0:
+                self._man_d_range = list(itertools.repeat(self._man_d_range, (num_runs / num_ranges)))
+            elif num_runs != num_ranges:
+                raise ValueError("Less D-Ranges supplied than Sample Runs. Expected " + str(num_runs)
+                                 + ", Received " + str(num_ranges) + ".")
 
     def validateInputs(self):
-        self._get_properties()
+
         issues = dict()
 
         if self._man_d_range is not None:
             try:
-                self._man_d_range = self._parse_string_array(self._man_d_range)
-                self._man_d_range = [x - 1 for x in self._man_d_range]
-            except BaseException as exc:
+                self._get_properties()
+            except ValueError as exc:
                 issues['DRange'] = str(exc)
 
         num_samples = len(self._sample_runs)
@@ -609,7 +623,6 @@ class OSIRISDiffractionReduction(PythonAlgorithm):
             mtd.addOrReplace(sample_ws_name, sample_ws)
 
         if len(divided) > 1:
-            logger.warning("moo "+str(sample_ws_names))
             # Merge the sample files into one.
             merge_runs_alg = self.createChildAlgorithm("MergeRuns", enableLogging=False)
             merge_runs_alg.setProperty("InputWorkspaces", sample_ws_names)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReduction.py
@@ -609,7 +609,6 @@ class OSIRISDiffractionReduction(PythonAlgorithm):
             mtd.addOrReplace(sample_ws_name, sample_ws)
 
         if len(divided) > 1:
-            logger.warning("moo "+str(sample_ws_names))
             # Merge the sample files into one.
             merge_runs_alg = self.createChildAlgorithm("MergeRuns", enableLogging=False)
             merge_runs_alg.setProperty("InputWorkspaces", sample_ws_names)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReduction.py
@@ -416,7 +416,7 @@ class OSIRISDiffractionReduction(PythonAlgorithm):
             num_runs = len(self._sample_runs)
 
             if num_runs % num_ranges == 0:
-                self._man_d_range = list(itertools.repeat(self._man_d_range, (num_runs / num_ranges)))
+                self._man_d_range = list(self._man_d_range * (num_runs / num_ranges))
             elif num_runs != num_ranges:
                 raise ValueError("Less D-Ranges supplied than Sample Runs. Expected " + str(num_runs)
                                  + ", Received " + str(num_ranges) + ".")
@@ -430,7 +430,6 @@ class OSIRISDiffractionReduction(PythonAlgorithm):
                 self._get_properties()
             except ValueError as exc:
                 issues['DRange'] = str(exc)
-
         num_samples = len(self._sample_runs)
         num_vanadium = len(self._vanadium_runs)
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReduction.py
@@ -422,14 +422,15 @@ class OSIRISDiffractionReduction(PythonAlgorithm):
                                  + ", Received " + str(num_ranges) + ".")
 
     def validateInputs(self):
-
         issues = dict()
 
-        if self._man_d_range is not None:
-            try:
-                self._get_properties()
-            except ValueError as exc:
-                issues['DRange'] = str(exc)
+        try:
+            self._get_properties()
+        except ValueError as exc:
+            issues['DRange'] = str(exc)
+        except RuntimeError as exc:
+            issues['Sample'] = str(exc)
+
         num_samples = len(self._sample_runs)
         num_vanadium = len(self._vanadium_runs)
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReduction.py
@@ -416,7 +416,7 @@ class OSIRISDiffractionReduction(PythonAlgorithm):
             num_runs = len(self._sample_runs)
 
             if num_runs % num_ranges == 0:
-                self._man_d_range = list(self._man_d_range * (num_runs / num_ranges))
+                self._man_d_range = list(self._man_d_range * int(num_runs / num_ranges))
             elif num_runs != num_ranges:
                 raise ValueError("Less D-Ranges supplied than Sample Runs. Expected " + str(num_runs)
                                  + ", Received " + str(num_ranges) + ".")

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReductionTest.py
@@ -40,14 +40,14 @@ class OSIRISDiffractionReductionTest(unittest.TestCase):
         self.assertEqual(wks.getAxis(0).getUnit().unitID(), 'dSpacing')
         self.assertEqual(wks.getNumberHistograms(), 1)
 
-    def test_reduction_with_manual_range_list(self):
+    def test_reduction_with_manual_drange_list(self):
         """
         Test to ensure reduction with manual dRange list selection completes.
         The run here is for dRange 3-4.
         """
         wks = OSIRISDiffractionReduction(Sample=['OSI10203.raw', 'OSI10204.RAW'],
                                          CalFile='osiris_041_RES10.cal',
-                                         Vanadium=['OSI10156.raw', 'OSI10157.raw'],
+                                         Vanadium=['OSI10156.raw', 'OSI10157.RAW'],
                                          SpectraMin=3,
                                          SpectraMax=361,
                                          DetectDRange=False,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReductionTest.py
@@ -51,7 +51,7 @@ class OSIRISDiffractionReductionTest(unittest.TestCase):
                                          SpectraMin=3,
                                          SpectraMax=361,
                                          DetectDRange=False,
-                                         DRange="3-4")
+                                         DRange="1-2")
 
         self.assertTrue(isinstance(wks, MatrixWorkspace), 'Result workspace should be a matrix workspace.')
         self.assertEqual(wks.getAxis(0).getUnit().unitID(), 'dSpacing')

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReductionTest.py
@@ -45,7 +45,7 @@ class OSIRISDiffractionReductionTest(unittest.TestCase):
         Test to ensure reduction with manual dRange list selection completes.
         The run here is for dRange 3-4.
         """
-        wks = OSIRISDiffractionReduction(Sample=['OSI10203.raw', 'OSI10204.raw'],
+        wks = OSIRISDiffractionReduction(Sample=['OSI10203.raw', 'OSI10204.RAW'],
                                          CalFile='osiris_041_RES10.cal',
                                          Vanadium=['OSI10156.raw', 'OSI10157.raw'],
                                          SpectraMin=3,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReductionTest.py
@@ -51,7 +51,7 @@ class OSIRISDiffractionReductionTest(unittest.TestCase):
                                          SpectraMin=3,
                                          SpectraMax=361,
                                          DetectDRange=False,
-                                         DRange="1-2")
+                                         DRange="1,3")
 
         self.assertTrue(isinstance(wks, MatrixWorkspace), 'Result workspace should be a matrix workspace.')
         self.assertEqual(wks.getAxis(0).getUnit().unitID(), 'dSpacing')

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReductionTest.py
@@ -22,9 +22,9 @@ class OSIRISDiffractionReductionTest(unittest.TestCase):
         self.assertEqual(wks.getAxis(0).getUnit().unitID(), 'dSpacing')
         self.assertEqual(wks.getNumberHistograms(), 1)
 
-    def test_reduction_with_manual_drange_completes(self):
+    def test_reduction_with_single_manual_drange_completes(self):
         """
-        Test to ensure reduction with manual dRange selection completes.
+        Test to ensure reduction with single manual dRange selection completes.
         The run here is for dRange 3.
         """
 
@@ -35,6 +35,23 @@ class OSIRISDiffractionReductionTest(unittest.TestCase):
                                          SpectraMax=361,
                                          DetectDRange=False,
                                          DRange="3")
+
+        self.assertTrue(isinstance(wks, MatrixWorkspace), 'Result workspace should be a matrix workspace.')
+        self.assertEqual(wks.getAxis(0).getUnit().unitID(), 'dSpacing')
+        self.assertEqual(wks.getNumberHistograms(), 1)
+
+    def test_reduction_with_manual_range_list(self):
+        """
+        Test to ensure reduction with manual dRange list selection completes.
+        The run here is for dRange 3-4.
+        """
+        wks = OSIRISDiffractionReduction(Sample=['OSI10203.raw', 'OSI10204.raw'],
+                                         CalFile='osiris_041_RES10.cal',
+                                         Vanadium=['OSI10156.raw', 'OSI10157.raw'],
+                                         SpectraMin=3,
+                                         SpectraMax=361,
+                                         DetectDRange=False,
+                                         DRange="3-4")
 
         self.assertTrue(isinstance(wks, MatrixWorkspace), 'Result workspace should be a matrix workspace.')
         self.assertEqual(wks.getAxis(0).getUnit().unitID(), 'dSpacing')

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReductionTest.py
@@ -40,23 +40,6 @@ class OSIRISDiffractionReductionTest(unittest.TestCase):
         self.assertEqual(wks.getAxis(0).getUnit().unitID(), 'dSpacing')
         self.assertEqual(wks.getNumberHistograms(), 1)
 
-    def test_reduction_with_manual_drange_list(self):
-        """
-        Test to ensure reduction with manual dRange list selection completes.
-        The run here is for dRange 3-4.
-        """
-        wks = OSIRISDiffractionReduction(Sample=['OSI10203.raw', 'OSI10204.RAW'],
-                                         CalFile='osiris_041_RES10.cal',
-                                         Vanadium=['OSI10156.raw', 'OSI10157.RAW'],
-                                         SpectraMin=3,
-                                         SpectraMax=361,
-                                         DetectDRange=False,
-                                         DRange="1,3")
-
-        self.assertTrue(isinstance(wks, MatrixWorkspace), 'Result workspace should be a matrix workspace.')
-        self.assertEqual(wks.getAxis(0).getUnit().unitID(), 'dSpacing')
-        self.assertEqual(wks.getNumberHistograms(), 1)
-
     def test_reduction_with_can_subtraction(self):
         """
         Tests reduction after subtraction of an empty can.


### PR DESCRIPTION
The OSIRISDiffractionReduction algorithm was producing output data with only zero values, when a manual d-range was supplied. An error was also being displayed pertaining to the summing of workspaces using the 'sum' function in python.

**To test:**
1. Navigate to Interfaces > Indirect > Diffraction.
2. Ensure `OSIRIS` is selected as the instrument, and `diffonly` is set as the reflection mode.
3. Enter `119977-119988` into the 'Run Numbers' field.
4. Provide the supplied calibration file into the 'Cal File' field.
5. Enter `119963-119974` into the 'Vanadium Runs' field.
6. Check the 'Manual dRange (Vanadium)' checkbox.
7. Enter `1-12` into the 'Manual dRange (Vanadium)' text field.
8. Click Run.
9. Plot the created \*\_dRange workspace.
10. Ensure the output is not a flat line at 0 (i.e. the output contains non-zero values).

[osiris_041_RES10.zip](https://github.com/mantidproject/mantid/files/1356273/osiris_041_RES10.zip)

<!-- Instructions for testing. -->

Fixes #20763 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
