### PR TITLE
Python3 doctest compatibility: algorithms Load to LoadHKL

### DIFF
--- a/docs/source/algorithms/Load-v1.rst
+++ b/docs/source/algorithms/Load-v1.rst
@@ -65,7 +65,7 @@ Usage
    # Load ISIS LOQ histogram dataset
    ws = Load('LOQ49886.nxs')
 
-   print "The 1st x-value of the first spectrum is: " + str(ws.readX(0)[0])
+   print("The 1st x-value of the first spectrum is: {}".format(ws.readX(0)[0]))
 
 Output:
 
@@ -81,7 +81,7 @@ Output:
    # Load SNS HYS event dataset
    ws = Load('HYS_11092_event.nxs')
 
-   print "The number of histograms (spectra) is: " + str(ws.getNumberHistograms())
+   print("The number of histograms (spectra) is: {}".format(ws.getNumberHistograms()))
 
 Output:
 
@@ -97,7 +97,7 @@ Output:
    # Load ISIS multiperiod muon MUSR dataset
    ws = Load('MUSR00015189.nxs')
 
-   print "The number of periods (entries) is: " + str(ws[0].getNumberOfEntries())
+   print("The number of periods (entries) is: {}".format(ws[0].getNumberOfEntries()))
 
 Output:
 
@@ -113,7 +113,7 @@ Output:
    # Load Mantid processed GEM data file
    ws = Load('focussed.nxs')
 
-   print "The number of histograms (spectra) is: " + str(ws.getNumberHistograms())
+   print("The number of histograms (spectra) is: {}".format(ws.getNumberHistograms()))
 
 Output:
 

--- a/docs/source/algorithms/LoadAscii-v2.rst
+++ b/docs/source/algorithms/LoadAscii-v2.rst
@@ -67,7 +67,7 @@ Usage
     #Load it again - Load would work just as well as LoadAscii
     wsOutput = LoadAscii(savefile,Unit="Label")
 
-    print CompareWorkspaces(ws1,wsOutput)[0]
+    print(CompareWorkspaces(ws1,wsOutput)[0])
 
     #clean up the file I saved
     os.remove(savefile)

--- a/docs/source/algorithms/LoadBBY-v1.rst
+++ b/docs/source/algorithms/LoadBBY-v1.rst
@@ -26,7 +26,7 @@ Usage
 
    ws = LoadBBY('BBY0000014.tar');
 
-   print "Number of spectra:", ws.getNumberHistograms()
+   print("Number of spectra: {}".format(ws.getNumberHistograms()))
 
 Output:
 

--- a/docs/source/algorithms/LoadCIF-v1.rst
+++ b/docs/source/algorithms/LoadCIF-v1.rst
@@ -73,7 +73,7 @@ The following script loads a CIF-file and prints the space group of the crystal 
     # Get the space group from the crystal structure that was loaded
     crystal_structure = sample_ws.sample().getCrystalStructure()
 
-    print 'Space group:', crystal_structure.getSpaceGroup().getHMSymbol()
+    print('Space group: {}'.format(crystal_structure.getSpaceGroup().getHMSymbol()))
 
 The output is:
 

--- a/docs/source/algorithms/LoadCalFile-v1.rst
+++ b/docs/source/algorithms/LoadCalFile-v1.rst
@@ -33,11 +33,11 @@ create the necessary workspaces.
     # WorkspaceName parameter is required inspite of docs not saying so.
     ws = LoadCalFile(InstrumentName="GEM", CalFilename="offsets_2006_cycle064.cal",
                      WorkspaceName="ws")
-    print "Total number of workspaces =", len(ws)
-    print "Workspace 1 type =", ws[0].id()
-    print "Workspace 2 type =", ws[1].id()
-    print "Workspace 3 type =", ws[2].id()
-    print "Workspace 4 type =", ws[3].id()
+    print("Total number of workspaces = {}".format(len(ws)))
+    print("Workspace 1 type = {}".format(ws[0].id()))
+    print("Workspace 2 type = {}".format(ws[1].id()))
+    print("Workspace 3 type = {}".format(ws[2].id()))
+    print("Workspace 4 type = {}".format(ws[3].id()))
 
 Output:
 

--- a/docs/source/algorithms/LoadCanSAS1D-v1.rst
+++ b/docs/source/algorithms/LoadCanSAS1D-v1.rst
@@ -40,7 +40,7 @@ Usage
    SaveCanSAS1D(out_ws, file_path, Version=1)
    in_ws = LoadCanSAS1D(file_path, Version=1)
 
-   print "Contents of the file = " + str(in_ws.readY(0)) + "."
+   print("Contents of the file = {}.".format(in_ws.readY(0)))
 
 .. testcleanup:: ExSimpleSavingRoundtrip
 

--- a/docs/source/algorithms/LoadCanSAS1D-v2.rst
+++ b/docs/source/algorithms/LoadCanSAS1D-v2.rst
@@ -39,7 +39,7 @@ Usage
    SaveCanSAS1D(out_ws, file_path)
    in_ws = LoadCanSAS1D(file_path)
 
-   print "Contents of the file = " + str(in_ws.readY(0)) + "."
+   print("Contents of the file = {}.".format(in_ws.readY(0)))
 
 .. testcleanup:: ExSimpleSavingRoundtrip
 

--- a/docs/source/algorithms/LoadDNSLegacy-v1.rst
+++ b/docs/source/algorithms/LoadDNSLegacy-v1.rst
@@ -67,7 +67,7 @@ Usage
    # Load dataset
    ws = LoadDNSLegacy(datafile, Normalization='monitor')
 
-   print "This workspace has", ws.getNumDims(), "dimensions and has", ws.getNumberHistograms(), "histograms."
+   print("This workspace has {} dimensions and has {} histograms.".format(ws.getNumDims(), ws.getNumberHistograms()))
 
 Output:
 

--- a/docs/source/algorithms/LoadDetectorInfo-v1.rst
+++ b/docs/source/algorithms/LoadDetectorInfo-v1.rst
@@ -283,11 +283,11 @@ that the first three detectors (monitors) were not touched and the next three we
    def write_detectors(instr_type,instr,ndet):
        ''' print first ndet detectors from given instrument '''
 
-       print "{0} {1} instrument".format(instr_type, instr.getName())
-       print  'det ID | monitor? | polar angle| position X | position Y | position Z |  Pressure  | Wall thick |'
+       print("{0} {1} instrument".format(instr_type, instr.getName()))
+       print('det ID | monitor? | polar angle| position X | position Y | position Z |  Pressure  | Wall thick |')
        
        # get first nder detectors using detector ID    
-       for i in xrange(0,ndet):
+       for i in range(0,ndet):
          if i<3:
              detBase = 1
          else:
@@ -297,9 +297,9 @@ that the first three detectors (monitors) were not touched and the next three we
          pos = det1.getPos();
          pressure = det1.getNumberParameter('TubePressure');
          thickness = det1.getNumberParameter('TubeThickness');
-         print ' {0:5} | {1:8} | {2:10.3f} | {3:>10.3f} | {4:>10.3f} | {5:>10.3f} | {6:10} | {7:10} |\n'.format(\
-                detID,det1.isMonitor(),(det1.getPhi()*(180/math.pi)),pos.X(),pos.Y(),pos.Z(),pressure[0],thickness[0]),
-       print '*********************************************************************************'
+         print(' {0:5} | {1:8} | {2:10.3f} | {3:>10.3f} | {4:>10.3f} | {5:>10.3f} | {6:10} | {7:10} |'.format(\
+                detID,det1.isMonitor(),(det1.getPhi()*(180/math.pi)),pos.X(),pos.Y(),pos.Z(),pressure[0],thickness[0]))
+       print('*********************************************************************************')
    # 
    def prepare_test_detector(ind):
         """  prepare modified detector with random test values  """
@@ -347,7 +347,7 @@ that the first three detectors (monitors) were not touched and the next three we
       f.write("{0}    14\n".format(ndet))
       f.write("det no.  offset    l2     code     theta        phi         w_x         w_y         w_z         f_x         f_y         f_z         a_x         a_y         a_z        det_1       det_2       det_3       det4\n");
    
-      for i in xrange(0,ndet):
+      for i in range(0,ndet):
          detBase,offset,l2,code,theta,phi,w_xyz,f_xyz,a_xyz,det1,det2,det3,det4=prepare_test_detector(i);
          detID = detBase+i
          f.write("{0:>9} {1:>7} {2: >8f} {3:>5} {4:>11f} {5:>11f} {6:>11f} {7:>11f} {8:>11f} {9:>11f} {10:>11f} {11:>11f} {12:>11f} {13:>11f} {14:>11f} {15:>11f} {16:>11f} {17:>11f} {18:>11f} {19:>11f}\n".format(\

--- a/docs/source/algorithms/LoadDetectorsGroupingFile-v1.rst
+++ b/docs/source/algorithms/LoadDetectorsGroupingFile-v1.rst
@@ -162,19 +162,18 @@ Usage
     ws=LoadDetectorsGroupingFile("test.xml")
 
     #check some values
+    format_string = "Detector {}, with ID {}, in spectrum {} belongs to group {:.0f}"
+	      
     sid=0
-    print "Detector "+ws.getDetector(sid).getName()+", with ID "+\
-        str(ws.getDetector(sid).getID())+ ", in spectrum "+str(sid)+\
-        " belongs to group "+str(int(ws.dataY(sid)[0]))
+    print(format_string.format(ws.getDetector(sid).getName(), ws.getDetector(sid).getID(),
+	  sid, ws.dataY(sid)[0]))
     sid=2500
-    print "Detector "+ws.getDetector(sid).getName()+", with ID "+\
-	    str(ws.getDetector(sid).getID())+ ", in spectrum "+str(sid)+\
-	    " belongs to group "+str(int(ws.dataY(sid)[0]))
+    print(format_string.format(ws.getDetector(sid).getName(), ws.getDetector(sid).getID(),
+	  sid, ws.dataY(sid)[0]))
     sid=5000
-    print "Detector "+ws.getDetector(sid).getName()+", with ID "+\
-	    str(ws.getDetector(sid).getID())+ ", in spectrum "+str(sid)+\
-	    " belongs to group "+str(int(ws.dataY(sid)[0]))
-
+    print(format_string.format(ws.getDetector(sid).getName(), ws.getDetector(sid).getID(),
+	  sid, ws.dataY(sid)[0]))
+    
 .. testcleanup:: LoadDetectorsGroupingFile
 
    DeleteWorkspace(ws)
@@ -214,9 +213,9 @@ Output:
     ws=LoadDetectorsGroupingFile("test.map")
 
     #check some values
-    print "Spectrum 0 belongs to group", ws.readY(0)[0]
-    print "Spectrum 65 belongs to group", ws.readY(65)[0]
-    print "Spectrum 125 belongs to group", ws.readY(125)[0]
+    print("Spectrum 0 belongs to group {}".format(ws.readY(0)[0]))
+    print("Spectrum 65 belongs to group {}".format(ws.readY(65)[0]))
+    print("Spectrum 125 belongs to group {}".format(ws.readY(125)[0]))
 
 .. testcleanup:: LoadDetectorsGroupingFileMap
 

--- a/docs/source/algorithms/LoadDspacemap-v1.rst
+++ b/docs/source/algorithms/LoadDspacemap-v1.rst
@@ -26,7 +26,7 @@ This algorithm is SNS specific in its use.
 
     ws = LoadDspacemap(InstrumentName="VULCAN", Filename="pid_offset_vulcan_new.dat",
                        FileType="VULCAN-ASCII")
-    print "Workspace type =", ws.id()
+    print("Workspace type = {}".format(ws.id()))
 
 Output:
 

--- a/docs/source/algorithms/LoadEmptyInstrument-v1.rst
+++ b/docs/source/algorithms/LoadEmptyInstrument-v1.rst
@@ -30,7 +30,7 @@ Usage
 
     wsOut = LoadEmptyInstrument(inesPath)
 
-    print "The workspace contains %i spectra" % wsOut.getNumberHistograms()
+    print("The workspace contains {} spectra".format(wsOut.getNumberHistograms()))
 
 Output:
 

--- a/docs/source/algorithms/LoadEmptyVesuvio-v1.rst
+++ b/docs/source/algorithms/LoadEmptyVesuvio-v1.rst
@@ -32,7 +32,7 @@ Usage
 
     b_det_1_l1 = sample.getPos().distance(b_det_1.getPos())
 
-    print "First backscattering detector L1 = %.5fm" % (b_det_1_l1)
+    print("First backscattering detector L1 = {:.5f}m".format(b_det_1_l1))
 
 Output:
 
@@ -53,7 +53,7 @@ Output:
 
     b_det_1_l1 = sample.getPos().distance(b_det_1.getPos())
 
-    print "First backscattering detector L1 = %.5fm" % (b_det_1_l1)
+    print("First backscattering detector L1 = {:.5f}m".format(b_det_1_l1))
 
 Output:
 

--- a/docs/source/algorithms/LoadEventAndCompress-v1.rst
+++ b/docs/source/algorithms/LoadEventAndCompress-v1.rst
@@ -60,7 +60,7 @@ Create a python driver script called test_mpi.py
         mpiSize = 1 # simplify if clauses
 
     wksp = LoadEventAndCompress(Filename="PG3_2538_event.nxs")
-    print "Rank = ", mpiRank, "Number of Events = ", wksp.getNumberEvents()
+    print("Rank =  {} Number of Events =  {}".format(mpiRank, wksp.getNumberEvents()))
     if mpiRank == 0:
         reduce = AlignAndFocusPowder(InputWorkspace=wksp, CalFileName='PG3_calibrate_d2538_2014_05_13.cal', Params='0.5,0.01,2')
         SaveNexus(reduce,Filename=str(mpiSize)+"tasks.nxs")

--- a/docs/source/algorithms/LoadEventNexus-v1.rst
+++ b/docs/source/algorithms/LoadEventNexus-v1.rst
@@ -131,7 +131,7 @@ Usage
    # Load SNS HYS event dataset
    ws = LoadEventNexus('HYS_11092_event.nxs')
 
-   print "The number of histograms (spectra) is: " + str(ws.getNumberHistograms())
+   print("The number of histograms (spectra) is: {}".format(ws.getNumberHistograms()))
 
 Output:
 
@@ -146,7 +146,7 @@ Output:
    # Load SNS CNCS event dataset between 10 and 20 minutes
    ws = LoadEventNexus('CNCS_7860_event.nxs', FilterByTimeStart=600, FilterByTimeStop=1200)
 
-   print "The number of events: " + str(ws.getNumberEvents())
+   print("The number of events: {}".format(ws.getNumberEvents()))
 
 Output:
 

--- a/docs/source/algorithms/LoadFITS-v1.rst
+++ b/docs/source/algorithms/LoadFITS-v1.rst
@@ -89,19 +89,19 @@ Example 1: loading one spectrum per image row
     bpp_log = 'BITPIX'
     try:
         log = ws.getRun().getLogData(bpp_log).value
-        print "Bits per pixel: %s" % int(log)
+        print("Bits per pixel: {}".format(log))
     except RuntimeError:
-        print "Could not find the keyword '%s' in this FITS file" % bpp_log
+        print("Could not find the keyword '{}' in this FITS file".format(bpp_log))
 
     axis1_log = 'NAXIS1'
     axis2_log = 'NAXIS2'
     try:
         log1 = ws.getRun().getLogData(axis1_log).value
         log2 = ws.getRun().getLogData(axis2_log).value
-        print "FITS image size: %s x %s pixels" % (int(log1), int(log2))
-        print "Number of spectra in the output workspace: %d" % ws.getNumberHistograms()
+        print("FITS image size: {} x {} pixels".format(log1, log2))
+        print("Number of spectra in the output workspace: {}".format(ws.getNumberHistograms()))
     except RuntimeError:
-        print "Could not find the keywords '%s' and '%s' in this FITS file" % (axis1_log, axis2_log)
+        print("Could not find the keywords '{}' and '{}' in this FITS file".format(axis1_log, axis2_log))
 
 .. testcleanup:: LoadFITS1SpectrumPerRow
 
@@ -128,19 +128,19 @@ Example 2: loading one spectrum per pixel
     bpp_log = 'BITPIX'
     try:
         log = ws.getRun().getLogData(bpp_log).value
-        print "Bits per pixel: %s" % int(log)
+        print("Bits per pixel: {}".format(int(log)))
     except RuntimeError:
-        print "Could not find the keyword '%s' in this FITS file" % bpp_log
+        print("Could not find the keyword '{}' in this FITS file".format(bpp_log))
 
     axis1_log = 'NAXIS1'
     axis2_log = 'NAXIS2'
     try:
         log1 = ws.getRun().getLogData(axis1_log).value
         log2 = ws.getRun().getLogData(axis2_log).value
-        print "FITS image size: %s x %s pixels" % (int(log1), int(log2))
-        print "Number of spectra in the output workspace: %d" % ws.getNumberHistograms()
+        print("FITS image size: {} x {} pixels".format(log1, log2))
+        print("Number of spectra in the output workspace: {}".format(ws.getNumberHistograms()))
     except RuntimeError:
-        print "Could not find the keywords '%s' and '%s' in this FITS file" % (axis1_log, axis2_log)
+        print("Could not find the keywords '{}' and '{}' in this FITS file".format(axis1_log, axis2_log))
 
 .. testcleanup:: LoadFITSManySpectra
 

--- a/docs/source/algorithms/LoadFlexiNexus-v1.rst
+++ b/docs/source/algorithms/LoadFlexiNexus-v1.rst
@@ -69,12 +69,12 @@ Usage
         Dictionary=os.path.join(dictionary_path, 'amor.dic'))
 
     num_dims = wsOut.getNumDims()
-    print "This has loaded a MD Workspace with %i dimensions" % num_dims
-    print "Name   Bins   Min     Max"
+    print("This has loaded a MD Workspace with {} dimensions".format(num_dims))
+    print("Name   Bins   Min     Max")
     for dim_index in range(num_dims):
         dim = wsOut.getDimension(dim_index)
-        print "%s      %i    %.2f  %.2f" % (dim.name,
-             dim.getNBins(), dim.getMinimum(), dim.getMaximum())
+        print("{}      {}    {:.2f}  {:.2f}".format(dim.name,
+             dim.getNBins(), dim.getMinimum(), dim.getMaximum()))
 
 Output:
 

--- a/docs/source/algorithms/LoadFullprofFile-v1.rst
+++ b/docs/source/algorithms/LoadFullprofFile-v1.rst
@@ -58,10 +58,10 @@ Usage
   infotablews = mtd["LaB6_InfoTable"]
   dataws = mtd["PG3_LaB6_Bank3"]
 
-  print "LaB6: A = B = C = %.5f, Alpha = Beta = Gamma = %.5f" % (infotablews.cell(0, 1), infotablews.cell(5, 1))
+  print("LaB6: A = B = C = {:.5f}, Alpha = Beta = Gamma = {:.5f}".format(infotablews.cell(0, 1), infotablews.cell(5, 1)))
 
   maxy = max(dataws.readY(1))
-  print "Maximum peak value (calculated) = %.5f" % (maxy)
+  print("Maximum peak value (calculated) = {:.5f}".format(maxy))
 
 
 .. testcleanup:: ExLoadPrf
@@ -89,15 +89,15 @@ Output:
   fakedataws = mtd["Fake"]
   reftablews = mtd["LaB6_Ref_Table"]
   
-  print "Reflection table imported %d peaks.  Faked data workspace contains %d data points." % (
-      reftablews.rowCount(), len(fakedataws.readX(0)))
+  print("Reflection table imported {} peaks.  Faked data workspace contains {} data points.".format(
+      reftablews.rowCount(), len(fakedataws.readX(0))))
   
   index = 0
-  print "Peak %d of (%d, %d, %d): Alpha = %.5f, Beta = %.5f, FWHM = %.5f" % (index, reftablews.cell(index, 0), 
-      reftablews.cell(index, 1), reftablews.cell(index, 2), reftablews.cell(index, 3), reftablews.cell(index, 4), reftablews.cell(index, 7))
+  print("Peak {} of ({}, {}, {}): Alpha = {:.5f}, Beta = {:.5f}, FWHM = {:.5f}".format(index, reftablews.cell(index, 0), 
+      reftablews.cell(index, 1), reftablews.cell(index, 2), reftablews.cell(index, 3), reftablews.cell(index, 4), reftablews.cell(index, 7)))
   index = 75
-  print "Peak %d of (%d, %d, %d): Alpha = %.5f, Beta = %.5f, FWHM = %.5f" % (index, reftablews.cell(index, 0), 
-      reftablews.cell(index, 1), reftablews.cell(index, 2), reftablews.cell(index, 3), reftablews.cell(index, 4), reftablews.cell(index, 7))
+  print("Peak {} of ({}, {}, {}): Alpha = {:.5f}, Beta = {:.5f}, FWHM = {:.5f}".format(index, reftablews.cell(index, 0), 
+      reftablews.cell(index, 1), reftablews.cell(index, 2), reftablews.cell(index, 3), reftablews.cell(index, 4), reftablews.cell(index, 7)))
 
 
 .. testcleanup:: ExLoadIrf

--- a/docs/source/algorithms/LoadFullprofResolution-v1.rst
+++ b/docs/source/algorithms/LoadFullprofResolution-v1.rst
@@ -46,7 +46,7 @@ Usage
    print("First 4 rows of OutputTableWorkspace")
    for i in [0,1,2,3]:
       row = tws.row(i)
-      print("\{'Name': '{}', 'Value_3': {:.2f}, 'Value_5': {:.2f}\}".format(row["Name"], row["Value_3"], row["Value_5"]))
+      print("{{'Name': '{}', 'Value_3': {:.2f}, 'Value_5': {:.2f}}}".format(row["Name"], row["Value_3"], row["Value_5"]))
 
    # Get the instrument with the parameters
    inst = ws[0][0].getInstrument()

--- a/docs/source/algorithms/LoadFullprofResolution-v1.rst
+++ b/docs/source/algorithms/LoadFullprofResolution-v1.rst
@@ -43,19 +43,19 @@ Usage
    tws = LoadFullprofResolution("MUSR_01.irf",Banks="3,5", Workspace="ws")
 
    #Print first four rows of output table workspace
-   print "First 4 rows of OutputTableWorkspace"
+   print("First 4 rows of OutputTableWorkspace")
    for i in [0,1,2,3]:
       row = tws.row(i)
-      print "{'Name': '%s', 'Value_3': %.2f, 'Value_5': %.2f}" % (  row["Name"], row["Value_3"], row["Value_5"] )
+      print("\{'Name': '{}', 'Value_3': {:.2f}, 'Value_5': {:.2f}\}".format(row["Name"], row["Value_3"], row["Value_5"]))
 
    # Get the instrument with the parameters
    inst = ws[0][0].getInstrument()
 
    # demonstrate that the type of parameters saved are fitting parameters
-   print "Type of 3 parameters got from instrument in workspace"
-   print "Alpha0 type =", inst.getParameterType('Alpha0')
-   print "Beta0 type =", inst.getParameterType('Beta0')
-   print "SigmaSquared type =", inst.getParameterType('SigmaSquared')
+   print("Type of 3 parameters got from instrument in workspace")
+   print("Alpha0 type = {}".format(inst.getParameterType('Alpha0')))
+   print("Beta0 type = {}".format(inst.getParameterType('Beta0')))
+   print("SigmaSquared type = {}".format(inst.getParameterType('SigmaSquared')))
 
    # As of the time of writing, 
    # fitting instrument parameters cannot be 

--- a/docs/source/algorithms/LoadGSASInstrumentFile-v1.rst
+++ b/docs/source/algorithms/LoadGSASInstrumentFile-v1.rst
@@ -30,7 +30,7 @@ Usage
    #Print first four rows
    for i in [0,1,2,3]:
       row = tws.row(i)
-      print("\{'Name': '{}','Value_1': {:.2f}, 'Value_2': {:.2f}\}".format(row["Name"], row["Value_1"],  row["Value_2"] ))
+      print("{{'Name': '{}','Value_1': {:.2f}, 'Value_2': {:.2f}}}".format(row["Name"], row["Value_1"],  row["Value_2"] ))
 
 Output:
 

--- a/docs/source/algorithms/LoadGSASInstrumentFile-v1.rst
+++ b/docs/source/algorithms/LoadGSASInstrumentFile-v1.rst
@@ -30,7 +30,7 @@ Usage
    #Print first four rows
    for i in [0,1,2,3]:
       row = tws.row(i)
-      print "{'Name': '%s','Value_1': %.2f, 'Value_2': %.2f}" % ( row["Name"], row["Value_1"],  row["Value_2"] )
+      print("\{'Name': '{}','Value_1': {:.2f}, 'Value_2': {:.2f}\}".format(row["Name"], row["Value_1"],  row["Value_2"] ))
 
 Output:
 
@@ -56,19 +56,19 @@ Output:
 
    # ...and check they do not exist
    instrument = groupWs.getItem(0).getInstrument()
-   print "Alpha0 parameter exists: ",  instrument.hasParameter("Alpha0")
-   print "Beta0 parameter exists: ", instrument.hasParameter("Beta0")
-   print "SigmaSquared parameter exists: " , instrument.hasParameter("SigmaSquared")
+   print("Alpha0 parameter exists:  {}".format(instrument.hasParameter("Alpha0")))
+   print("Beta0 parameter exists:  {}".format(instrument.hasParameter("Beta0")))
+   print("SigmaSquared parameter exists:  {}".format(instrument.hasParameter("SigmaSquared")))
 
    # Now we load a GSAS Instrument file with 2 Banks into the workspace...
-   print "\nLoading parameters from GSAS\n"
+   print("\nLoading parameters from GSAS\n")
    tws = LoadGSASInstrumentFile(Filename="GSAS_2bank.prm",UseBankIDsInFile=True,Workspace=groupWs,Banks=[1,2])
 
    # ...and check parameters are there again
    instrument = groupWs.getItem(0).getInstrument()
-   print "Alpha0 parameter exists: ",  instrument.hasParameter("Alpha0")
-   print "Beta0 parameter exists: ", instrument.hasParameter("Beta0")
-   print "SigmaSquared parameter exists: " , instrument.hasParameter("SigmaSquared")
+   print("Alpha0 parameter exists:  {}".format(instrument.hasParameter("Alpha0")))
+   print("Beta0 parameter exists:  {}".format(instrument.hasParameter("Beta0")))
+   print("SigmaSquared parameter exists:  {}".format(instrument.hasParameter("SigmaSquared")))
 
 Output:
 


### PR DESCRIPTION
## Description of work.
This PR is part of refactoring effort to bring Python3 compatiblity into the doctests.
See https://github.com/mantidproject/mantid/issues/20672 for details.

The following tests were refactored to be compatible :
```
Load-v1
LoadAscii-v2
LoadBBY-v1
LoadCIF-v1
LoadCalFile-v1
LoadCanSAS1D-v1
LoadCanSAS1D-v2
LoadDNSLegacy-v1
LoadDetectorInfo-v1
LoadDetectorsGroupingFile-v1
LoadDspacemap-v1
LoadEmptyInstrument-v1
LoadEmptyVesuvio-v1
LoadEventAndCompress-v1
LoadEventNexus-v1
LoadFITS-v1
LoadFlexiNexus-v1
LoadFullprofFile-v1
LoadFullprofResolution-v1
LoadGSASInstrumentFile-v1
LoadHKL-v1
```
## To test.

Code review.

Fixes #20786 
Internal change, no release notes