### PR TITLE
Python3 doctest compatibility: LoadIDFFromNexus to LoadLogPropertyTable

### DIFF
--- a/docs/source/algorithms/LoadIDFFromNexus-v1.rst
+++ b/docs/source/algorithms/LoadIDFFromNexus-v1.rst
@@ -52,12 +52,12 @@ Usage
    # This workspace had the IDF loaded into it, so getting component renamed to "the rings".
    inst1 = ws_1.getInstrument()
    comp1 = inst1.getComponentByName("the rings")
-   print "Modified component name =", comp1.getName()
+   print("Modified component name = {}".format(comp1.getName()))
 
    # This workspace had no IDF loaded into it, so still has component named to "both rings".
    inst2 = ws_2.getInstrument()
    comp2 = inst2.getComponentByName("both rings")
-   print "Unmodified component name =", comp2.getName()
+   print("Unmodified component name = {}".format(comp2.getName()))
    
 Output:
 

--- a/docs/source/algorithms/LoadILLReflectometry-v1.rst
+++ b/docs/source/algorithms/LoadILLReflectometry-v1.rst
@@ -158,7 +158,7 @@ Usage
    # Load ILL D17 data file (TOF mode) into a workspace 2D using default input options:
    ws1 = Load('ILL/D17/317370.nxs')
 
-   print("Workspace {} has {} dimensions and {} histograms.").format(ws1.name(), ws1.getNumDims(), ws1.getNumberHistograms())
+   print("Workspace {} has {} dimensions and {} histograms.".format(ws1.name(), ws1.getNumDims(), ws1.getNumberHistograms()))
 
 Output:
 
@@ -185,7 +185,7 @@ Output:
    # The Sample Log entry stheta will be the user defined angle of 30 degrees:
    angleBragg = ws2.getRun().getProperty("stheta").value * 180. / numpy.pi
 
-   print("The detector of workspace {} was rotated to {} degrees.").format(ws2.name(), 2. * angleBragg)
+   print("The detector of workspace {} was rotated to {:.1f} degrees.".format(ws2.name(), 2. * angleBragg))
    print("The nominal angle in the NeXus file was {:.2} degrees.".format(angleOrig))
 
 Output:

--- a/docs/source/algorithms/LoadILLSANS-v1.rst
+++ b/docs/source/algorithms/LoadILLSANS-v1.rst
@@ -25,7 +25,7 @@ Usage
    # Load ILL D33 data file into a workspace 2D.
    ws = Load('ILLD33_sample_001425.nxs')
 
-   print "This workspace has", ws.getNumDims(), "dimensions and has", ws.getNumberHistograms(), "histograms."
+   print("This workspace has {} dimensions and has {} histograms.".format(ws.getNumDims(), ws.getNumberHistograms()))
 
 Output:
 	

--- a/docs/source/algorithms/LoadISISNexus-v2.rst
+++ b/docs/source/algorithms/LoadISISNexus-v2.rst
@@ -152,7 +152,7 @@ Usage
    # Load LOQ histogram dataset
    ws = LoadISISNexus('LOQ49886.nxs')
 
-   print "The 1st x-value of the first spectrum is: " + str(ws.readX(0)[0])
+   print("The 1st x-value of the first spectrum is: {}".format(ws.readX(0)[0]))
 
 Output:
 
@@ -167,7 +167,7 @@ Output:
    # Load from LOQ data file spectrum 2 to 3.
    ws = LoadISISNexus('LOQ49886.nxs',SpectrumMin=2,SpectrumMax=3)
 
-   print "The number of histograms (spectra) is: " + str(ws.getNumberHistograms())
+   print("The number of histograms (spectra) is: {}".format(ws.getNumberHistograms()))
 
 Output:
 
@@ -182,7 +182,7 @@ Output:
    # Load first period of multiperiod POLREF data file
    ws = LoadISISNexus('POLREF00004699.nxs', EntryNumber=1)
 
-   print "The number of histograms (spectra) is: " + str(ws.getNumberHistograms())
+   print("The number of histograms (spectra) is: {}".format(ws.getNumberHistograms()))
 
 Output:
 

--- a/docs/source/algorithms/LoadInstrument-v1.rst
+++ b/docs/source/algorithms/LoadInstrument-v1.rst
@@ -37,14 +37,14 @@ Usage
    ws=CreateSampleWorkspace();
    inst0=ws.getInstrument();
 
-   print "Default workspace has instrument: {0} with {1} parameters".format(inst0.getName(),len(inst0.getParameterNames()));
+   print("Default workspace has instrument: {0} with {1} parameters".format(inst0.getName(),len(inst0.getParameterNames())))
 
    # load MARI
    det=LoadInstrument(ws,InstrumentName='MARI', RewriteSpectraMap=True)
    inst1=ws.getInstrument();
 
-   print "Modified workspace has instrument: {0} with {1} parameters".format(inst1.getName(),len(inst1.getParameterNames()));
-   print "Instrument {0} has the following detectors: ".format(inst1.getName()),det
+   print("Modified workspace has instrument: {0} with {1} parameters".format(inst1.getName(),len(inst1.getParameterNames())))
+   print("Instrument {0} has the following detectors:  {1}".format(inst1.getName(), det))
 
 
 **Output:**

--- a/docs/source/algorithms/LoadInstrumentFromNexus-v1.rst
+++ b/docs/source/algorithms/LoadInstrumentFromNexus-v1.rst
@@ -31,15 +31,15 @@ Usage
    inst = ws.getInstrument()
    source = inst.getSource()
 
-   print "The name of the instrument is \"%s\"." % inst.getName().strip()
-   print ("The source postion is at:  %s." % str(source.getPos()) )
+   print("The name of the instrument is '{}'.".format(inst.getName().strip()))
+   print("The source postion is at:  {}.".format(source.getPos()))
 
 
 Output:
 
 .. testoutput:: ExLoadMUSR
 
-   The name of the instrument is "MUSR".
+   The name of the instrument is 'MUSR'.
    The source postion is at:  [0,-10,0].
 
 .. categories::

--- a/docs/source/algorithms/LoadInstrumentFromRaw-v1.rst
+++ b/docs/source/algorithms/LoadInstrumentFromRaw-v1.rst
@@ -34,17 +34,17 @@ Usage
 
    inst = ws.getInstrument()
 
-   print "The name of the instrument is \"%s\"." % inst.getName().strip()
-   print "The position of the source is %s." % str(inst.getSource().getPos())
-   print "The position of detector 5 is %s." % str(inst.getDetector(5).getPos())
-   print "Is detector 1 a monitor? " + str(inst.getDetector(1).isMonitor())
-   print "Is detector 8 a monitor? " + str(inst.getDetector(8).isMonitor())
+   print("The name of the instrument is '{}'.".format(inst.getName().strip()))
+   print("The position of the source is {}.".format(inst.getSource().getPos()))
+   print("The position of detector 5 is {}.".format(inst.getDetector(5).getPos()))
+   print("Is detector 1 a monitor? {}".format(inst.getDetector(1).isMonitor()))
+   print("Is detector 8 a monitor? {}".format(inst.getDetector(8).isMonitor()))
 
 Output:
 
 .. testoutput:: Ex
 
-   The name of the instrument is "LOQ".
+   The name of the instrument is 'LOQ'.
    The position of the source is [0,0,-11].
    The position of detector 5 is [0,0,-11.15].
    Is detector 1 a monitor? True

--- a/docs/source/algorithms/LoadIsawDetCal-v1.rst
+++ b/docs/source/algorithms/LoadIsawDetCal-v1.rst
@@ -27,7 +27,7 @@ Usage
     iw = LoadEmptyInstrument(Filename="IDFs_for_UNIT_TESTING/MINITOPAZ_Definition.xml",)
     LoadIsawDetCal(InputWorkspace=iw,FileName=filename)
     bank = iw.getInstrument().getComponentByName("bank1")
-    print "Position after LoadDetCal :",bank.getPos()
+    print("Position after LoadDetCal : {}".format(bank.getPos()))
     
 .. testcleanup:: LoadIsawDetCal
     

--- a/docs/source/algorithms/LoadIsawPeaks-v1.rst
+++ b/docs/source/algorithms/LoadIsawPeaks-v1.rst
@@ -27,7 +27,7 @@ Usage
 .. testcode:: LoadIsawPeaksEx
 
     peaks = LoadIsawPeaks('TOPAZ_1204.peaks')
-    print "Number of peaks entries", peaks.getNumberPeaks()
+    print("Number of peaks entries {}".format(peaks.getNumberPeaks()))
 
 Output:
 

--- a/docs/source/algorithms/LoadIsawSpectrum-v1.rst
+++ b/docs/source/algorithms/LoadIsawSpectrum-v1.rst
@@ -43,8 +43,8 @@ Usage
     ow = LoadIsawSpectrum(SpectraFile=filename,InstrumentName="TOPAZ")
          
         #check the results 
-    print "x=",ow.readX(0) 
-    print "y=",ow.readY(0) 
+    print("x= {}".format(ow.readX(0)))
+    print("y= {}".format(ow.readY(0)))
     
 .. testcleanup:: LoadIsawSpectrum
 

--- a/docs/source/algorithms/LoadIsawUB-v1.rst
+++ b/docs/source/algorithms/LoadIsawUB-v1.rst
@@ -47,13 +47,13 @@ Usage
     
     #check the results
     ol=w.sample().getOrientedLattice()
-    print "a=",ol.a()
-    print "b=",ol.b()    
-    print "c=",ol.c()   
-    print "alpha=",ol.alpha()
-    print "beta=",ol.beta()
-    print "gamma=",ol.gamma() 
-    print "The following vectors are in the horizontal plane: ", ol.getuVector(),ol.getvVector()
+    print("a= {}".format(ol.a()))
+    print("b= {}".format(ol.b()))
+    print("c= {}".format(ol.c()))
+    print("alpha= {}".format(ol.alpha()))
+    print("beta= {}".format(ol.beta()))
+    print("gamma= {}".format(ol.gamma() ))
+    print("The following vectors are in the horizontal plane:  {} {}".format(ol.getuVector(), ol.getvVector()))
     
 .. testcleanup:: LoadIsawUB
 

--- a/docs/source/algorithms/LoadLLB-v1.rst
+++ b/docs/source/algorithms/LoadLLB-v1.rst
@@ -27,7 +27,7 @@ Usage
    # Load the MIBEMOL dataset into a workspace2D.
    ws = Load('LLB_d22418.nxs')
 
-   print "This workspace has", ws.getNumDims(), "dimensions and its title is:", ws.getTitle()
+   print("This workspace has {} dimensions and its title is: ".format(ws.getNumDims(), ws.getTitle()))
 
 Output:
 

--- a/docs/source/algorithms/LoadLog-v1.rst
+++ b/docs/source/algorithms/LoadLog-v1.rst
@@ -60,18 +60,18 @@ Usage
     #get the log data out of the Workspace's run object
     run = ws.getRun()
     logs= run.getLogData()
-    print "Logs before adding:"
+    print("Logs before adding:")
     for i in range(0,len(logs)):
-        print logs[i].name
+        print(logs[i].name)
     #ExampleForLog.log is taken from a NIMROD run
     LoadLog(ws,"ExampleForLog.log")
-    print ""
+    print("")
 
     run = ws.getRun()
     logs= run.getLogData()
-    print "Logs after adding:"
+    print("Logs after adding:")
     for i in range(0,len(logs)):
-        print logs[i].name
+        print(logs[i].name)
 
 Output:
 

--- a/docs/source/algorithms/LoadLogPropertyTable-v1.rst
+++ b/docs/source/algorithms/LoadLogPropertyTable-v1.rst
@@ -41,23 +41,21 @@ Usage
 .. testcode:: Exlogtable
     
         def print_table_workspace(wsOut):
-            for i in range(wsOut.columnCount()):
-                print wsOut.getColumnNames()[i],
-            print
+	    print(" ".join(wsOut.getColumnNames()[i]
+	          for i in range(wsOut.columnCount())))
 
             for rowIndex in range(wsOut.columnCount()):
-                for i in range(wsOut.columnCount()):
-                    print wsOut.column(i)[rowIndex],
-                print
+  	        print(" ".join(str(wsOut.column(i)[rowIndex])
+	              for i in range(wsOut.columnCount())))
 
         wsComment = LoadLogPropertyTable(FirstFile = "MUSR00015189.nxs", 
                     LastFile = "MUSR00015193.nxs", LogNames="comment")
-        print "The comments of all the files"
+        print("The comments of all the files")
         print_table_workspace(wsComment)
 
         wsMultiple = LoadLogPropertyTable(FirstFile = "MUSR00015189.nxs", 
                     LastFile = "MUSR00015193.nxs", LogNames="Temp_Sample,dur")
-        print "\nThe Temp_Sample and dur logs"
+        print("\nThe Temp_Sample and dur logs")
         print_table_workspace(wsMultiple)
 
 


### PR DESCRIPTION
## Description of work.
This PR is part of refactoring effort to bring Python3 compatiblity into the doctests.
See https://github.com/mantidproject/mantid/issues/20672 for details.

The following tests were refactored to be compatible :
```
LoadIDFFromNexus-v1
LoadILLDiffraction-v1
LoadILLIndirect-v2
LoadILLReflectometry-v1
LoadILLSANS-v1
LoadILLTOF-v2
LoadISISNexus-v2
LoadInstrument-v1
LoadInstrumentFromNexus-v1
LoadInstrumentFromRaw-v1
LoadIsawDetCal-v1
LoadIsawPeaks-v1
LoadIsawSpectrum-v1
LoadIsawUB-v1
LoadLLB-v1
LoadLog-v1
LoadLogPropertyTable-v1
```
## To test.

Code review.

Fixes #20789 
Internal change, no release notes