### PR TITLE
Python3 doctest compatibility: LoadMD to LoadPreNexusMonitors

### DIFF
--- a/docs/source/algorithms/LoadMD-v1.rst
+++ b/docs/source/algorithms/LoadMD-v1.rst
@@ -40,8 +40,8 @@ Usage
    mdws = LoadMD('MAPS_MDEW.nxs');
     
    # Check results
-   print "Workspace type is:",mdws.id()
-   print "Workspace has:{0:2} dimensions and contains: {1:4} MD events".format(mdws.getNumDims(),mdws.getNEvents())
+   print("Workspace type is: {}".format(mdws.id()))
+   print("Workspace has:{0:2} dimensions and contains: {1:4} MD events".format(mdws.getNumDims(),mdws.getNEvents()))
   
 Output:
 

--- a/docs/source/algorithms/LoadMLZ-v1.rst
+++ b/docs/source/algorithms/LoadMLZ-v1.rst
@@ -29,8 +29,8 @@ Usage
 
    ws = LoadMLZ(Filename='TOFTOFTestdata.nxs')
 
-   print "Name of the instrument: ", ws.getInstrument().getName()
-   print "Number of spectra: ", ws.getNumberHistograms()
+   print("Name of the instrument:  {}".format(ws.getInstrument().getName()))
+   print("Number of spectra:  {}".format(ws.getNumberHistograms()))
    
 
 Output:

--- a/docs/source/algorithms/LoadMask-v1.rst
+++ b/docs/source/algorithms/LoadMask-v1.rst
@@ -89,11 +89,11 @@ Usage
     # ws.maskDetectors(MaskedWorkspace=mask)
 
     # Check some pixels
-    print "Is detector 0 masked:", ws.getDetector(0).isMasked()
-    print "Is detector 6245 masked:", ws.getDetector(6245).isMasked()
-    print "Is detector 11464 masked:", ws.getDetector(11464).isMasked()
-    print "Is detector 17578 masked:", ws.getDetector(17578).isMasked()
-    print "Is detector 20475 masked:", ws.getDetector(20475).isMasked()
+    print("Is detector 0 masked: {}".format(ws.getDetector(0).isMasked()))
+    print("Is detector 6245 masked: {}".format(ws.getDetector(6245).isMasked()))
+    print("Is detector 11464 masked: {}".format(ws.getDetector(11464).isMasked()))
+    print("Is detector 17578 masked: {}".format(ws.getDetector(17578).isMasked()))
+    print("Is detector 20475 masked: {}".format(ws.getDetector(20475).isMasked()))
 
 Output:
 
@@ -142,7 +142,7 @@ Output:
     MaskedDet1to1= []
     MaskedSp_R  = []
     MaskedDet_R= []
-    for ind in xrange(0,nhist):
+    for ind in range(0,nhist):
         try:
             det = rws.getDetector(ind)
             if det.isMasked():
@@ -160,25 +160,25 @@ Output:
                 MaskedDet_R.append(det.getID())
         except:
             pass
-    print "*** ************************************ **********************************************"
-    print ("*** Masked Spec. Id(s):  {0}".format(masked_list))
-    print "*** Initial workspace masking parameters **********************************************"
-    print "Masked Spectra Numbers: ",Sig0Masked
-    print "Masked Detector IDs   : ",Det0Masked
-    print "*** One to one mask workspace has masked the same spectra numbers but different detectors"
-    print "ws 1to1 Masked spectra: ",MaskedSp1to1
-    print "ws 1to1 Masked DedIDs : ",MaskedDet1to1
-    print "*** Real spectra-det-map workspace has masked different spectra numbers but the same detectors"
-    print "ws RSDM Masked spectra: ",MaskedSp_R
-    print "ws RSDM Masked DedIDs : ",MaskedDet_R
-    print "*** indeed the same:"
+    print("*** ************************************ **********************************************")
+    print("*** Masked Spec. Id(s):  {0}".format(masked_list))
+    print( "*** Initial workspace masking parameters **********************************************")
+    print("Masked Spectra Numbers:  {}".format(Sig0Masked))
+    print("Masked Detector IDs   :  {}".format(Det0Masked))
+    print("*** One to one mask workspace has masked the same spectra numbers but different detectors")
+    print("ws 1to1 Masked spectra:  {}".format(MaskedSp1to1))
+    print("ws 1to1 Masked DedIDs :  {}".format(MaskedDet1to1))
+    print("*** Real spectra-det-map workspace has masked different spectra numbers but the same detectors")
+    print("ws RSDM Masked spectra:  {}".format(MaskedSp_R))
+    print("ws RSDM Masked DedIDs :  {}".format(MaskedDet_R))
+    print("*** indeed the same:")
     Det0Masked.sort()
     MaskedDet_R.sort()
-    print "sorted initial DetIDs : ",Det0Masked
-    print "sorted RSDM    DedIDs : ",MaskedDet_R
-    print "*** ************************************ **********************************************"
-    print "*** note spectra with id 4 is a monitor, not present in the masking workspaces"
-    print "*** ************************************ **********************************************"
+    print("sorted initial DetIDs :  {}".format(Det0Masked))
+    print("sorted RSDM    DedIDs :  {}".format(MaskedDet_R))
+    print("*** ************************************ **********************************************")
+    print("*** note spectra with id 4 is a monitor, not present in the masking workspaces")
+    print("*** ************************************ **********************************************")
 
 Output:
 

--- a/docs/source/algorithms/LoadMcStas-v1.rst
+++ b/docs/source/algorithms/LoadMcStas-v1.rst
@@ -98,15 +98,15 @@ Usage
 
    # workspace group is first entry in tuple
    group = ws[0]
-   print "Number of entries in group: " + str(group.getNumberOfEntries())
+   print("Number of entries in group: {}".format(group.getNumberOfEntries()))
 
    eventData = ws[1]
-   print "Number of histograms in event data: " + str(eventData.getNumberHistograms())
-   print "Name of event data: " + str(eventData.getName())
+   print("Number of histograms in event data: {}".format(eventData.getNumberHistograms()))
+   print("Name of event data: {}".format(eventData.getName()))
 
    someHistogramData = ws[2]
-   print "Number of histograms in hist data: " + str(someHistogramData.getNumberHistograms())
-   print "Name of hist data: " + str(someHistogramData.getName())
+   print("Number of histograms in hist data: {}".format(someHistogramData.getNumberHistograms()))
+   print("Name of hist data: {}".format(someHistogramData.getName()))
 
 Output:
 

--- a/docs/source/algorithms/LoadMultipleGSS-v1.rst
+++ b/docs/source/algorithms/LoadMultipleGSS-v1.rst
@@ -22,10 +22,10 @@ Usage
     LoadMultipleGSS(FilePrefix="PG3",RunNumbers="11485,11486",Directory="")
     
     #quick test:
-    print "Found workspace PG3_11485",mtd.doesExist("PG3_11485")
-    print "It has",mtd["PG3_11485"].getNumberHistograms(),"histogram, with",mtd["PG3_11485"].blocksize(),"bins"
-    print "Found workspace PG3_11486",mtd.doesExist("PG3_11486")
-    print "It has",mtd["PG3_11486"].getNumberHistograms(),"histogram, with",mtd["PG3_11486"].blocksize(),"bins"
+    print("Found workspace PG3_11485 {}".format(mtd.doesExist("PG3_11485")))
+    print("It has {} histogram, with {} bins".format(mtd["PG3_11485"].getNumberHistograms(), mtd["PG3_11485"].blocksize()))
+    print("Found workspace PG3_11486 {}".format(mtd.doesExist("PG3_11486")))
+    print("It has {} histogram, with {} bins".format(mtd["PG3_11486"].getNumberHistograms(), mtd["PG3_11486"].blocksize()))
    
 .. testcleanup:: LoadMultipleGSS
 

--- a/docs/source/algorithms/LoadMuonLog-v1.rst
+++ b/docs/source/algorithms/LoadMuonLog-v1.rst
@@ -48,8 +48,8 @@ Usage
    # Extract a property from the log.
    time_series_prop = fake_musr_ws.run().getLogData("BEAMLOG_FREQ")
 
-   print "BEAMLOG_FREQ is a TimeSeriesProperty with %i entries." % time_series_prop.size()
-   print "The first entry is %f." % time_series_prop.firstValue()
+   print("BEAMLOG_FREQ is a TimeSeriesProperty with {} entries.".format(time_series_prop.size()))
+   print("The first entry is {:.6f}.".format(time_series_prop.firstValue()))
 
 Output:
 

--- a/docs/source/algorithms/LoadMuonNexus-v2.rst
+++ b/docs/source/algorithms/LoadMuonNexus-v2.rst
@@ -173,7 +173,7 @@ Usage
 
    # Load MUSR dataset
    ws = LoadMuonNexus(Filename="MUSR00015189.nxs",EntryNumber=1)
-   print "Workspace has ",  ws[0].getNumberHistograms(), " spectra"
+   print("Workspace has  {}  spectra".format(ws[0].getNumberHistograms()))
 
 Output:
 
@@ -187,7 +187,7 @@ Output:
 
    # Load some spectra
    ws = LoadMuonNexus(Filename="MUSR00015189.nxs",SpectrumMin=5,SpectrumMax=10,EntryNumber=1)
-   print "Workspace has ",  ws[0].getNumberHistograms(), " spectra"
+   print("Workspace has  {}  spectra".format(ws[0].getNumberHistograms()))
 
 Output:
 
@@ -203,18 +203,18 @@ Output:
    ws = LoadMuonNexus(Filename="emu00006473.nxs",SpectrumMin=5,SpectrumMax=10,DeadTimeTable="deadTimeTable")
    tab = mtd['deadTimeTable']
    for i in range(0,tab.rowCount()):
-       print tab.cell(i,0), tab.cell(i,1)
+       print("{} {:.12f}".format(tab.cell(i,0), tab.cell(i,1)))
 
 Output:
 
 .. testoutput:: ExLoadDeadTimeTable
 
-   5 0.00161112251226
-   6 0.00215016817674
-   7 0.0102171599865
-   8 0.00431686220691
-   9 0.00743605662137
-   10 0.00421147653833
+   5 0.001611122512
+   6 0.002150168177
+   7 0.010217159986
+   8 0.004316862207
+   9 0.007436056621
+   10 0.004211476538
 
 **Example - Load detector grouping into table:**
 
@@ -224,7 +224,7 @@ Output:
    ws = LoadMuonNexus(Filename="emu00006473.nxs",SpectrumList="1,16,17,32",DetectorGroupingTable="detectorTable")
    tab = mtd['detectorTable']
    for i in range(0,tab.rowCount()):
-       print tab.cell(i,0)
+       print(tab.cell(i,0))
 
 Output:
 

--- a/docs/source/algorithms/LoadNMoldyn3Ascii-v1.rst
+++ b/docs/source/algorithms/LoadNMoldyn3Ascii-v1.rst
@@ -30,7 +30,7 @@ Usage
                                      Functions=['Fqt-total', 'Sqw-total'])
 
     for ws_name in out_ws_group.getNames():
-      print ws_name
+      print(ws_name)
 
 Output:
 

--- a/docs/source/algorithms/LoadNMoldyn4Ascii-v1.rst
+++ b/docs/source/algorithms/LoadNMoldyn4Ascii-v1.rst
@@ -53,7 +53,7 @@ Usage
                              Functions=['sqf_total', 'iqt_total'])
 
     for ws in data:
-        print ws.name()
+        print(ws.name())
 
 Output:
 

--- a/docs/source/algorithms/LoadNMoldyn4Ascii1D-v1.rst
+++ b/docs/source/algorithms/LoadNMoldyn4Ascii1D-v1.rst
@@ -60,7 +60,7 @@ resolution convolution**
                                Functions=['dos_total', 'vacf_total'])
     
     for ws in data:
-        print ws.name()
+        print(ws.name())
 
 Output:
 

--- a/docs/source/algorithms/LoadNexus-v1.rst
+++ b/docs/source/algorithms/LoadNexus-v1.rst
@@ -53,7 +53,7 @@ Usage
    # Load LOQ histogram dataset
    ws = LoadNexus('LOQ49886.nxs')
 
-   print "The 1st x-value of the first spectrum is: " + str(ws.readX(0)[0])
+   print("The 1st x-value of the first spectrum is: {}".format(ws.readX(0)[0]))
 
 Output:
 
@@ -69,7 +69,7 @@ Output:
    # Load ISIS multiperiod muon MUSR dataset
    ws = LoadNexus('MUSR00015189.nxs')
 
-   print "The number of periods (entries) is: " + str(ws[0].getNumberOfEntries())
+   print("The number of periods (entries) is: {}".format(ws[0].getNumberOfEntries()))
 
 Output:
 
@@ -85,7 +85,7 @@ Output:
    # Load Mantid processed GEM data file
    ws = LoadNexus('focussed.nxs')
 
-   print "The number of histograms (spectra) is: " + str(ws.getNumberHistograms())
+   print("The number of histograms (spectra) is: {}".format(ws.getNumberHistograms()))
 
 Output:
 

--- a/docs/source/algorithms/LoadNexusLogs-v1.rst
+++ b/docs/source/algorithms/LoadNexusLogs-v1.rst
@@ -78,21 +78,21 @@ the logs.
 
     ws = LoadEventPreNexus("CNCS_7860_neutron_event.dat")
     # Five logs are already present
-    print "Number of original logs =", len(ws.getRun().keys())
+    print("Number of original logs = {}".format(len(ws.getRun().keys())))
     phase_log = "Phase1"
     # Try to get a log that doesn't exist yet
     try:
         log = ws.getRun().getLogData(phase_log)
     except RuntimeError:
-        print phase_log, "log does not exist!"
+        print("{} log does not exist!".format(phase_log))
     LoadNexusLogs(ws, "CNCS_7860_event.nxs")
-    print "Number of final logs =", len(ws.getRun().keys())
+    print("Number of final logs = {}".format(len(ws.getRun().keys())))
     # Try getting the log again
     try:
         log = ws.getRun().getLogData(phase_log)
-        print phase_log, "log size =", log.size()
+        print("{} log size = {}".format(phase_log, log.size()))
     except RuntimeError:
-        print phase_log, "log does not exist!"
+        print("{} log does not exist!".format(phase_log))
 
 Output:
 

--- a/docs/source/algorithms/LoadNexusMonitors-v1.rst
+++ b/docs/source/algorithms/LoadNexusMonitors-v1.rst
@@ -33,7 +33,7 @@ Usage
 
     ws = LoadNexusMonitors("CNCS_7860_event.nxs")
     # CNCS has 3 monitors
-    print "Number of monitors =", ws.getNumberHistograms()
+    print("Number of monitors = {}".format(ws.getNumberHistograms()))
 
 Output:
 

--- a/docs/source/algorithms/LoadNexusMonitors-v2.rst
+++ b/docs/source/algorithms/LoadNexusMonitors-v2.rst
@@ -71,7 +71,7 @@ Usage
 
     ws = LoadNexusMonitors("CNCS_7860_event.nxs")
     # CNCS has 3 monitors
-    print "Number of monitors =", ws.getNumberHistograms()
+    print("Number of monitors = {}".format(ws.getNumberHistograms()))
 
 Output:
 

--- a/docs/source/algorithms/LoadNexusProcessed-v1.rst
+++ b/docs/source/algorithms/LoadNexusProcessed-v1.rst
@@ -68,7 +68,7 @@ Usage
 
     wsOutput = LoadNexusProcessed(wsPath)
 
-    print CompareWorkspaces(ws,wsOutput, CheckInstrument=False)[0]
+    print(CompareWorkspaces(ws,wsOutput, CheckInstrument=False)[0])
 
     os.remove(wsPath)
 

--- a/docs/source/algorithms/LoadPreNexusMonitors-v1.rst
+++ b/docs/source/algorithms/LoadPreNexusMonitors-v1.rst
@@ -24,7 +24,7 @@ Usage
    # CNCS_7860_runinfo.xml references 3 beam monitor files.
    monitor_ws = LoadPreNexusMonitors("CNCS_7860_runinfo.xml")
 
-   print "The resulting workspace contains %i spectra -- one for each monitor." % monitor_ws.getNumberHistograms()
+   print("The resulting workspace contains {} spectra -- one for each monitor.".format(monitor_ws.getNumberHistograms()))
 
 Output:
 


### PR DESCRIPTION
Python3 doctest compatibility: algorithms <X to Y>

## Description of work.
This PR is part of refactoring effort to bring Python3 compatiblity into the doctests.
See https://github.com/mantidproject/mantid/issues/20672 for details.

The following tests were refactored to be compatible :
```
LoadMD-v1
LoadMLZ-v1
LoadMappingTable-v1
LoadMask-v1
LoadMcStas-v1
LoadMultipleGSS-v1
LoadMuonLog-v1
LoadMuonNexus-v2
LoadNMoldyn3Ascii-v1
LoadNMoldyn4Ascii-v1
LoadNMoldyn4Ascii1D-v1
LoadNXcanSAS-v1
LoadNexus-v1
LoadNexusLogs-v1
LoadNexusMonitors-v1
LoadNexusMonitors-v2
LoadNexusProcessed-v1
LoadParameterFile-v1
LoadPreNexusLive-v1
LoadPreNexusMonitors-v1
```

## To test.

Code review.

Fixes #20793 
Internal change, no release notes