### PR TITLE
Fix for crash when UserSubWindow is closed while Python script is running

### DIFF
--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -15104,10 +15104,7 @@ bool ApplicationWindow::runPythonScript(const QString &code, bool async,
 /**
  * Aborts a running Python script.
  */
-void ApplicationWindow::abortRunningPythonScript() {
-  m_iface_script->abort();
-}
-
+void ApplicationWindow::abortRunningPythonScript() { m_iface_script->abort(); }
 
 bool ApplicationWindow::validFor2DPlot(Table *table) {
   if (!table->selectedYColumns().count()) {
@@ -15676,9 +15673,10 @@ void ApplicationWindow::performCustomAction(QAction *action) {
       connect(user_interface, SIGNAL(runAsPythonScript(const QString &, bool)),
               this, SLOT(runPythonScript(const QString &, bool)),
               Qt::DirectConnection);
-      // Connect the ability to stop a running Python script from the UserSubWindow
-      connect(user_interface, SIGNAL(abortRunningPythonScript()),
-              this, SLOT(abortRunningPythonScript()));
+      // Connect the ability to stop a running Python script from the
+      // UserSubWindow
+      connect(user_interface, SIGNAL(abortRunningPythonScript()), this,
+              SLOT(abortRunningPythonScript()));
       // Update the used fit property browser
       connect(user_interface,
               SIGNAL(setFitPropertyBrowser(

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -15101,6 +15101,14 @@ bool ApplicationWindow::runPythonScript(const QString &code, bool async,
   return success;
 }
 
+/**
+ * Aborts a running Python script.
+ */
+void ApplicationWindow::abortRunningPythonScript() {
+  m_iface_script->abort();
+}
+
+
 bool ApplicationWindow::validFor2DPlot(Table *table) {
   if (!table->selectedYColumns().count()) {
     QMessageBox::warning(this, tr("MantidPlot - Error"),
@@ -15668,6 +15676,9 @@ void ApplicationWindow::performCustomAction(QAction *action) {
       connect(user_interface, SIGNAL(runAsPythonScript(const QString &, bool)),
               this, SLOT(runPythonScript(const QString &, bool)),
               Qt::DirectConnection);
+      // Connect the ability to stop a running Python script from the UserSubWindow
+      connect(user_interface, SIGNAL(abortRunningPythonScript()),
+              this, SLOT(abortRunningPythonScript()));
       // Update the used fit property browser
       connect(user_interface,
               SIGNAL(setFitPropertyBrowser(

--- a/MantidPlot/src/ApplicationWindow.h
+++ b/MantidPlot/src/ApplicationWindow.h
@@ -259,6 +259,9 @@ public slots:
   bool runPythonScript(const QString &code, bool async = false,
                        bool quiet = false, bool redirect = true);
 
+  /// Abort a running Python script
+  void abortRunningPythonScript();
+
   QList<MdiSubWindow *> windowsList() const;
   QList<MdiSubWindow *> getAllWindows() const;
   void updateWindowLists(MdiSubWindow *w);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/UserSubWindow.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/UserSubWindow.h
@@ -91,6 +91,9 @@ public:
 public:
   /// DefaultConstructor
   UserSubWindow(QWidget *parent = nullptr);
+  /// Desctructor
+  ~UserSubWindow();
+
   /// Create the layout of the widget. Can only be called once.
   void initializeLayout();
   /// Run local Python init code. Calls overridable function in specialized
@@ -104,6 +107,9 @@ public:
 signals:
   /// Emitted to start a (generally small) script running
   void runAsPythonScript(const QString &code, bool);
+
+  /// Abort a running Python script
+  void abortRunningPythonScript();
 
   /// Thrown when used fit property browser should be changed to given one
   void
@@ -126,6 +132,10 @@ protected:
   QString runPythonCode(const QString &code, bool no_output = false);
   QString openFileDialog(const bool save, const QStringList &exts);
   QLabel *newValidator(QWidget *parent);
+  void closeEvent(QCloseEvent *event) override;
+
+  /// Python script lock
+  bool m_pythonScriptLock = false;
 
 private:
   // This is so that it can set the name

--- a/qt/widgets/common/src/UserSubWindow.cpp
+++ b/qt/widgets/common/src/UserSubWindow.cpp
@@ -13,24 +13,17 @@
 #include <QTemporaryFile>
 #include <QTextStream>
 
-
 namespace {
 
 struct PythonScriptLockGuard {
-  PythonScriptLockGuard(bool& lock) : m_lock(lock) {
-    m_lock = true;
-  }
+  PythonScriptLockGuard(bool &lock) : m_lock(lock) { m_lock = true; }
 
-  ~PythonScriptLockGuard() {
-    m_lock = false;
-  }
+  ~PythonScriptLockGuard() { m_lock = false; }
 
 private:
-  bool& m_lock;
+  bool &m_lock;
 };
-
 }
-
 
 using namespace MantidQt::API;
 
@@ -51,10 +44,7 @@ UserSubWindow::UserSubWindow(QWidget *parent)
           this, SIGNAL(runAsPythonScript(const QString &, bool)));
 }
 
-
-UserSubWindow::~UserSubWindow() {
-  emit abortRunningPythonScript();
-}
+UserSubWindow::~UserSubWindow() { emit abortRunningPythonScript(); }
 
 /**
  * Create the layout for this dialog.
@@ -182,7 +172,8 @@ QLabel *UserSubWindow::newValidator(QWidget *parent) {
 }
 
 /**
- * Overrides the closeEvent handler. We want to ensure that we only close the window if
+ * Overrides the closeEvent handler. We want to ensure that we only close the
+ * window if
  * python script execution has completed.
  * @param event the event
  */
@@ -193,7 +184,6 @@ void UserSubWindow::closeEvent(QCloseEvent *event) {
     event->accept();
   }
 }
-
 
 //--------------------------------------
 // Private member functions


### PR DESCRIPTION
Mantid would crash when a `UserSubWindow` was closed while a Python script was executing.  Here we ignore the `closeEvent` of a `UserSubWindow` when a script is running. In addition we send an abort request to the script runner.

This should be tested on instances of the `UserSubWindow` that can have a long running Python script execution, e.g. SANS (where it was discovered), but maybe also Muon

**To test:**

1. Open the old ISIS SANS GUI and load a user file which takes a long time to load, e.g. something with a calibration file (newer SANS2D reductions should do)
2. While it is loading, close the ISIS SANS GUI. 
  * Confirm that it cannot be closed and you get a pop up which says that the Window cannot be closed



No issue number or release notes

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
