### PR TITLE
Fix clang-tidy performance-unnecessary-copy-initialization issues.

### DIFF
--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -1010,7 +1010,7 @@ ExperimentInfo::getInstrumentFilename(const std::string &instrumentName,
       if (!filePath.isFile())
         continue;
 
-      std::string l_filenamePart = filePath.getFileName();
+      const std::string &l_filenamePart = filePath.getFileName();
       if (regex_match(l_filenamePart, regex)) {
         const auto &pathName = filePath.toString();
         g_log.debug() << "Found file: '" << pathName << "'\n";

--- a/Framework/Algorithms/src/Bin2DPowderDiffraction.cpp
+++ b/Framework/Algorithms/src/Bin2DPowderDiffraction.cpp
@@ -360,7 +360,7 @@ size_t Bin2DPowderDiffraction::UnifyXBins(
 
 void Bin2DPowderDiffraction::normalizeToBinArea(MatrixWorkspace_sptr outWS) {
   NumericAxis *verticalAxis = dynamic_cast<NumericAxis *>(outWS->getAxis(1));
-  const std::vector<double> yValues = verticalAxis->getValues();
+  const std::vector<double> &yValues = verticalAxis->getValues();
   auto nhist = outWS->getNumberHistograms();
   g_log.debug() << "Number of hists: " << nhist
                 << " Length of YAxis: " << verticalAxis->length() << std::endl;

--- a/Framework/Algorithms/src/CopyLogs.cpp
+++ b/Framework/Algorithms/src/CopyLogs.cpp
@@ -56,7 +56,7 @@ void CopyLogs::exec() {
 
   // get logs from input workspace
   Run &inputRun = inputWs->mutableRun();
-  auto inputLogs = inputRun.getLogData();
+  const auto &inputLogs = inputRun.getLogData();
 
   // get run from output workspace
   Run &outputRun = outputWs->mutableRun();

--- a/Framework/Algorithms/src/FilterEvents.cpp
+++ b/Framework/Algorithms/src/FilterEvents.cpp
@@ -1894,7 +1894,7 @@ std::vector<std::string> FilterEvents::getTimeSeriesLogNames() {
 
     // append to vector if it is either double TimeSeries or int TimeSeries
     if (dbltimeprop || inttimeprop || booltimeprop) {
-      std::string pname = ip->name();
+      const std::string &pname = ip->name();
       lognames.push_back(pname);
     }
   }

--- a/Framework/Algorithms/src/FilterEvents.cpp
+++ b/Framework/Algorithms/src/FilterEvents.cpp
@@ -1505,7 +1505,7 @@ void FilterEvents::setupCustomizedTOFCorrection() {
       // If there are more than 1 spectrum, it is very likely to have problem
       // with correction factor
       const DataObjects::EventList events = m_eventWS->getSpectrum(i);
-      auto detids = events.getDetectorIDs();
+      const auto &detids = events.getDetectorIDs();
       if (detids.size() != 1) {
         // Check whether there are more than 1 detector per spectra.
         stringstream errss;

--- a/Framework/Algorithms/src/MagFormFactorCorrection.cpp
+++ b/Framework/Algorithms/src/MagFormFactorCorrection.cpp
@@ -80,7 +80,7 @@ void MagFormFactorCorrection::exec() {
   }
 
   // Parses the ion name and get handle to MagneticIon object
-  const MagneticIon ion = getMagneticIon(ionNameStr);
+  const MagneticIon &ion = getMagneticIon(ionNameStr);
   // Gets the vector of form factor values
   std::vector<double> FF;
   FF.reserve(Qvals.size());

--- a/Framework/Algorithms/src/NormaliseByDetector.cpp
+++ b/Framework/Algorithms/src/NormaliseByDetector.cpp
@@ -105,7 +105,7 @@ void NormaliseByDetector::processHistogram(size_t wsIndex,
   const Geometry::FitParameter &foundFittingParam =
       tryParseFunctionParameter(foundParam, det);
 
-  std::string fitFunctionName = foundFittingParam.getFunction();
+  const std::string &fitFunctionName = foundFittingParam.getFunction();
   IFunction_sptr function =
       FunctionFactory::Instance().createFunction(fitFunctionName);
   typedef std::vector<std::string> ParamNames;
@@ -122,7 +122,7 @@ void NormaliseByDetector::processHistogram(size_t wsIndex,
       throw std::runtime_error(
           "A Forumla has not been provided for a fit function");
     } else {
-      std::string resultUnitStr = fitParam.getResultUnit();
+      const std::string &resultUnitStr = fitParam.getResultUnit();
       if (!resultUnitStr.empty() && resultUnitStr != "Wavelength") {
         throw std::runtime_error(
             "Units for function parameters must be in Wavelength");

--- a/Framework/Algorithms/src/PDCalibration.cpp
+++ b/Framework/Algorithms/src/PDCalibration.cpp
@@ -61,7 +61,7 @@ public:
 
     // convert workspace index into detector id
     const auto &spectrum = wksp->getSpectrum(wkspIndex);
-    const auto detIds = spectrum.getDetectorIDs();
+    const auto &detIds = spectrum.getDetectorIDs();
     if (detIds.size() != 1) {
       throw std::runtime_error("Summed pixels is not currently supported");
     }

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmHistory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmHistory.cpp
@@ -40,7 +40,7 @@ getChildrenAsList(boost::shared_ptr<AlgorithmHistory> self) {
  */
 boost::python::object getPropertiesAsList(AlgorithmHistory &self) {
   boost::python::list names;
-  const auto histories = self.getProperties();
+  const auto &histories = self.getProperties();
   for (const auto &historie : histories) {
     names.append(historie);
   }

--- a/Framework/PythonInterface/mantid/api/src/Exports/BinaryOperations.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/BinaryOperations.cpp
@@ -156,7 +156,7 @@ ResultType performBinaryOpWithDouble(const LHSType inputWS, const double value,
                                      const std::string &op,
                                      const std::string &name, bool inplace,
                                      bool reverse) {
-  std::string algoName = op;
+  const std::string &algoName = op;
 
   // Create the single valued workspace first so that it is run as a top-level
   // algorithm

--- a/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceHistory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceHistory.cpp
@@ -25,7 +25,7 @@ GET_POINTER_SPECIALIZATION(WorkspaceHistory)
  */
 boost::python::object getHistoriesAsList(WorkspaceHistory &self) {
   boost::python::list names;
-  const auto histories = self.getAlgorithmHistories();
+  const auto &histories = self.getAlgorithmHistories();
   for (const auto &historie : histories) {
     names.append(historie);
   }

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/UnitLabel.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/UnitLabel.cpp
@@ -42,7 +42,7 @@ createLabel(const object &ascii, const object &utf8, const object &latex) {
  * @return A new Python unicode string with the contents of the utf8 label
  */
 PyObject *utf8ToUnicode(UnitLabel &self) {
-  const auto label = self.utf8();
+  const auto &label = self.utf8();
   return PyUnicode_FromWideChar(label.c_str(), label.size());
 }
 }

--- a/MantidPlot/src/Folder.cpp
+++ b/MantidPlot/src/Folder.cpp
@@ -143,7 +143,7 @@ MdiSubWindow *Folder::findWindow(const QString &s, bool windowNames,
       else if (caseSensitive && name == s)
         return w;
       else {
-        QString text = s;
+        const QString &text = s;
         if (name == text.toLower())
           return w;
       }
@@ -156,7 +156,7 @@ MdiSubWindow *Folder::findWindow(const QString &s, bool windowNames,
       else if (caseSensitive && label == s)
         return w;
       else {
-        QString text = s;
+        const QString &text = s;
         if (label == text.toLower())
           return w;
       }

--- a/MantidPlot/src/Graph.cpp
+++ b/MantidPlot/src/Graph.cpp
@@ -1006,7 +1006,7 @@ void Graph::initScaleLimits() { // We call this function the first time we add
       continue;
 
     const QwtPlotCurve *c = dynamic_cast<const QwtPlotCurve *>(item);
-    const QwtSymbol s = c->symbol();
+    const QwtSymbol &s = c->symbol();
     if (s.style() != QwtSymbol::NoSymbol && s.size().width() >= maxSymbolSize)
       maxSymbolSize = s.size().width();
 
@@ -1845,7 +1845,7 @@ void Graph::updateCurvesData(Table *w, const QString &yColName) {
 
 QColor Graph::canvasFrameColor() {
   QwtPlotCanvas *canvas = (QwtPlotCanvas *)d_plot->canvas();
-  QPalette pal = canvas->palette();
+  const QPalette &pal = canvas->palette();
   return pal.color(QPalette::Active, QPalette::Foreground);
 }
 
@@ -1988,7 +1988,7 @@ QString Graph::saveCurveLayout(int index) {
     s += QString::number(c->pen().style() - 1) + "\t";
     s += QString::number(c->pen().widthF()) + "\t";
 
-    const QwtSymbol symbol = c->symbol();
+    const QwtSymbol &symbol = c->symbol();
     s += QString::number(symbol.size().width()) + "\t";
     s += QString::number(SymbolBox::symbolIndex(symbol.style())) + "\t";
     s += QString::number(ColorBox::colorIndex(symbol.pen().color())) + "\t";
@@ -4619,7 +4619,7 @@ void Graph::guessUniqueCurveLayout(int &colorIndex, int &symbolIndex) {
     if (c) {
       colorIndex = std::max(ColorBox::colorIndex(c->pen().color()), colorIndex);
 
-      QwtSymbol symb = c->symbol();
+      const QwtSymbol &symb = c->symbol();
       symbolIndex = std::max(SymbolBox::symbolIndex(symb.style()), symbolIndex);
     }
   }

--- a/MantidPlot/src/Mantid/InputHistory.cpp
+++ b/MantidPlot/src/Mantid/InputHistory.cpp
@@ -132,7 +132,7 @@ QString InputHistoryImpl::getDirectoryFromFilePath(const QString &filePath) {
 }
 
 QString InputHistoryImpl::getNameOnlyFromFilePath(const QString &filePath) {
-  QString s = filePath;
+  const QString &s = filePath;
   int i = s.lastIndexOf('\\');
   if (i < 0)
     i = s.lastIndexOf('/');

--- a/MantidPlot/src/Mantid/MantidMatrixModel.cpp
+++ b/MantidPlot/src/Mantid/MantidMatrixModel.cpp
@@ -174,7 +174,7 @@ QVariant MantidMatrixModel::headerData(int section, Qt::Orientation orientation,
     Mantid::API::BinEdgeAxis *binEdgeAxis =
         dynamic_cast<Mantid::API::BinEdgeAxis *>(axis);
     if (binEdgeAxis && axisIndex == 1) {
-      const Mantid::MantidVec axisBinEdges = binEdgeAxis->getValues();
+      const Mantid::MantidVec &axisBinEdges = binEdgeAxis->getValues();
       double binCentreValue =
           (axisBinEdges[section] + axisBinEdges[section + 1]) / 2.0;
 

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -734,7 +734,7 @@ MantidUI::plotMDList(const QStringList &wsNames, const int plotAxis,
                      const bool showErrors, MultiLayer *plotWindow,
                      bool clearWindow) {
   ScopedOverrideCursor waitCursor;
-  auto firstName = wsNames.at(0);
+  const auto &firstName = wsNames.at(0);
 
   bool isGraphNew = false;
   MultiLayer *ml = appWindow()->prepareMultiLayer(isGraphNew, plotWindow,
@@ -744,7 +744,7 @@ MantidUI::plotMDList(const QStringList &wsNames, const int plotAxis,
   try {
     for (int i = 0; i < wsNames.size(); ++i) {
       // Create the curve with defaults
-      auto wsName = wsNames.at(i);
+      const auto &wsName = wsNames.at(i);
       MantidMDCurve *curve = new MantidMDCurve(wsName, g, showErrors);
       MantidQwtIMDWorkspaceData *data = curve->mantidData();
 

--- a/MantidPlot/src/Plot.cpp
+++ b/MantidPlot/src/Plot.cpp
@@ -263,19 +263,19 @@ void Plot::drawInwardTicks(QPainter *painter, const QRect &rect,
   int y2 = rect.bottom();
 
   QPalette pal = axisWidget(axis)->palette();
-  QColor color = pal.color(QPalette::Active, QPalette::Foreground);
+  const QColor &color = pal.color(QPalette::Active, QPalette::Foreground);
 
   painter->save();
   painter->setPen(QPen(color, axesLinewidth(), Qt::SolidLine));
 
   const QwtScaleDiv *scDiv = (const QwtScaleDiv *)axisScaleDiv(axis);
-  const QwtValueList minTickList = scDiv->ticks(QwtScaleDiv::MinorTick);
+  const QwtValueList &minTickList = scDiv->ticks(QwtScaleDiv::MinorTick);
   int minTicks = (int)minTickList.count();
 
-  const QwtValueList medTickList = scDiv->ticks(QwtScaleDiv::MediumTick);
+  const QwtValueList &medTickList = scDiv->ticks(QwtScaleDiv::MediumTick);
   int medTicks = (int)medTickList.count();
 
-  const QwtValueList majTickList = scDiv->ticks(QwtScaleDiv::MajorTick);
+  const QwtValueList &majTickList = scDiv->ticks(QwtScaleDiv::MajorTick);
   int majTicks = (int)majTickList.count();
 
   int j, x, y, low, high;

--- a/MantidPlot/src/PythonScripting.cpp
+++ b/MantidPlot/src/PythonScripting.cpp
@@ -291,7 +291,7 @@ PyObject *PythonScripting::toPyList(const QStringList &items) {
   Py_ssize_t length = static_cast<Py_ssize_t>(items.length());
   PyObject *pylist = PyList_New((length));
   for (Py_ssize_t i = 0; i < length; ++i) {
-    QString item = items.at(static_cast<int>(i));
+    const QString &item = items.at(static_cast<int>(i));
     PyList_SetItem(pylist, i, FROM_CSTRING(item.toAscii()));
   }
   return pylist;

--- a/MantidPlot/src/ScaleDetails.cpp
+++ b/MantidPlot/src/ScaleDetails.cpp
@@ -378,7 +378,7 @@ void ScaleDetails::initWidgets() {
       m_grpAxesBreaks->setEnabled(false);
     }
 
-    QwtValueList lst = scDiv->ticks(QwtScaleDiv::MajorTick);
+    const QwtValueList &lst = scDiv->ticks(QwtScaleDiv::MajorTick);
     m_spnMajorValue->setValue(lst.count());
 
     checkstep();

--- a/MantidPlot/src/ScaleDraw.cpp
+++ b/MantidPlot/src/ScaleDraw.cpp
@@ -370,15 +370,15 @@ ScaleEngine *sc_engine =dynamic_cast< ScaleEngine*>(qwtsc_engine);
   }
   //}
   QwtScaleDiv scDiv = scaleDiv();
-  QwtValueList majTicks = scDiv.ticks(QwtScaleDiv::MajorTick);
+  const QwtValueList &majTicks = scDiv.ticks(QwtScaleDiv::MajorTick);
   if (majTicks.contains(value) && (d_majTicks == In || d_majTicks == None))
     return;
 
-  QwtValueList medTicks = scDiv.ticks(QwtScaleDiv::MediumTick);
+  const QwtValueList &medTicks = scDiv.ticks(QwtScaleDiv::MediumTick);
   if (medTicks.contains(value) && (d_minTicks == In || d_minTicks == None))
     return;
 
-  QwtValueList minTicks = scDiv.ticks(QwtScaleDiv::MinorTick);
+  const QwtValueList &minTicks = scDiv.ticks(QwtScaleDiv::MinorTick);
   if (minTicks.contains(value) && (d_minTicks == In || d_minTicks == None))
     return;
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -1705,7 +1705,7 @@ void EnggDiffFittingPresenter::setDefaultBank(
   // can be assigned to text-field when number is given
   else if (!m_view->getFittingRunNumVec().empty()) {
     auto firstDir = m_view->getFittingRunNumVec().at(0);
-    auto intialDir = firstDir;
+    const auto &intialDir = firstDir;
     m_view->setFittingRunNo(intialDir);
   }
   // if nothing found related to text-field input

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -869,7 +869,7 @@ void EnggDiffractionPresenter::parseCalibrateFilename(const std::string &path,
   ceriaNo = "";
 
   Poco::Path fullPath(path);
-  const std::string filename = fullPath.getFileName();
+  const std::string &filename = fullPath.getFileName();
   if (filename.empty()) {
     return;
   }

--- a/qt/scientific_interfaces/General/deltaECalc.cpp
+++ b/qt/scientific_interfaces/General/deltaECalc.cpp
@@ -88,8 +88,8 @@ void deltaECalc::createProcessingScript(const QStringList &runFiles,
       (motorName.isEmpty()) ? "None" : QString("r'" + motorName + "'");
 
   QString None = "None";
-  auto rebin = None;
-  auto map_file = None;
+  const auto &rebin = None;
+  const auto &map_file = None;
   pyCode += "mono_sample.prop_man.motor_name = " + pyMotorName + "\n";
   pyCode += "mono_sample.prop_man.motor_offset = " + pySeOffset + "\n";
 

--- a/qt/scientific_interfaces/ISISSANS/SANSAddFiles.cpp
+++ b/qt/scientific_interfaces/ISISSANS/SANSAddFiles.cpp
@@ -191,7 +191,7 @@ void SANSAddFiles::add2Runs2Add() {
   // split comma separated file names or run numbers into a list
   ArrayProperty<std::string> commaSep(
       "unusedName", m_SANSForm->new2Add_edit->text().toStdString());
-  const std::vector<std::string> nam = commaSep;
+  const std::vector<std::string> &nam = commaSep;
 
   for (std::vector<std::string>::const_iterator i = nam.begin(); i != nam.end();
        ++i) { // each comma separated item could be a range of run numbers

--- a/qt/scientific_interfaces/Indirect/JumpFit.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFit.cpp
@@ -197,7 +197,7 @@ void JumpFit::fitAlgDone(bool error) {
     m_uiForm.ckPlotGuess->setChecked(false);
   }
   for (auto it = m_properties.begin(); it != m_properties.end(); ++it) {
-    QString propName(it.key());
+    const QString &propName(it.key());
     if (propName.startsWith("parameter_")) {
       size_t row(0), col(0);
       paramTable->find(propName.split("_")[1].toStdString(), row, col);

--- a/qt/scientific_interfaces/Muon/MuonAnalysisResultTableTab.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisResultTableTab.cpp
@@ -576,7 +576,7 @@ void MuonAnalysisResultTableTab::populateLogsAndValues(
        ++logIt) {
     for (auto wsIt = m_logValues.constBegin(); wsIt != m_logValues.constEnd();
          ++wsIt) {
-      auto wsLogValues = wsIt.value();
+      const auto &wsLogValues = wsIt.value();
       if (!wsLogValues.contains(*logIt)) {
         toRemove.insert(*logIt);
         break;

--- a/qt/widgets/common/src/AlgorithmPropertiesWidget.cpp
+++ b/qt/widgets/common/src/AlgorithmPropertiesWidget.cpp
@@ -378,7 +378,7 @@ void AlgorithmPropertiesWidget::hideOrDisableProperties() {
   for (auto pitr = m_propWidgets.begin(); pitr != m_propWidgets.end(); ++pitr) {
     PropertyWidget *widget = pitr.value();
     Mantid::Kernel::Property *prop = widget->getProperty();
-    QString propName = pitr.key();
+    const QString &propName = pitr.key();
     IPropertySettings *settings = prop->getSettings();
 
     // Set the enabled and visible flags based on what the validators say.
@@ -441,7 +441,7 @@ void AlgorithmPropertiesWidget::saveInput() {
     for (auto pitr = m_propWidgets.begin(); pitr != m_propWidgets.end();
          ++pitr) {
       PropertyWidget *widget = pitr.value();
-      QString propName = pitr.key();
+      const QString &propName = pitr.key();
       QString value = widget->getValue();
       //        Mantid::Kernel::Property *prop = widget->getProperty();
       //        if (!prop || prop->remember())

--- a/qt/widgets/common/src/DataProcessorUI/GenerateNotebook.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/GenerateNotebook.cpp
@@ -363,7 +363,7 @@ QString getReducedWorkspaceName(const RowData &data, const WhiteList &whitelist,
     // Do we want to use this column to generate the name of the output ws?
     if (whitelist.showValue(col)) {
       // Get what's in the column
-      const QString valueStr = data.at(col);
+      const QString &valueStr = data.at(col);
       if (!valueStr.isEmpty()) {
         // But we may have things like '1+2' which we want to replace with '1_2'
         auto value = valueStr.split(QRegExp("[+,]"), QString::SkipEmptyParts);
@@ -433,13 +433,13 @@ reduceRowString(const RowData &data, const QString &instrument,
       // instructions
 
       // Get the runs
-      const QString runStr = data.at(col);
+      const QString &runStr = data.at(col);
 
       if (!runStr.isEmpty()) {
         // Some runs were given for pre-processing
 
         // The pre-processing alg
-        const PreprocessingAlgorithm preprocessor = preprocessMap.at(colName);
+        const PreprocessingAlgorithm &preprocessor = preprocessMap.at(colName);
         // The pre-processing options
         const QString options = preprocessingOptionsMap.count(colName) > 0
                                     ? preprocessingOptionsMap.at(colName)
@@ -457,7 +457,7 @@ reduceRowString(const RowData &data, const QString &instrument,
       // No pre-processing
 
       // Just read the property value from the table
-      const QString propStr = data.at(col);
+      const QString &propStr = data.at(col);
 
       if (!propStr.isEmpty()) {
         // If it was not empty, we used it as an input property to the reduction
@@ -469,14 +469,14 @@ reduceRowString(const RowData &data, const QString &instrument,
 
   auto options = parseKeyValueString(processingOptions.toStdString());
 
-  const auto hiddenOptionsStr = data.back();
+  const auto &hiddenOptionsStr = data.back();
   // Parse and set any user-specified options
   auto hiddenOptionsMap = parseKeyValueString(hiddenOptionsStr.toStdString());
   // Options specified via 'Hidden Options' column will be preferred
   addProperties(algProperties, hiddenOptionsMap);
 
   // 'Options' specified either via 'Options' column or HintinLineEdit
-  const auto optionsStr = data.at(ncols - 2);
+  const auto &optionsStr = data.at(ncols - 2);
   // Parse and set any user-specified options
   auto optionsMap = parseKeyValueString(optionsStr.toStdString());
   // Options specified via 'Options' column will be preferred

--- a/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -762,7 +762,7 @@ GenericDataProcessorPresenter::getReducedWorkspaceName(const QStringList &data,
     if (m_whitelist.showValue(col)) {
 
       // Get what's in the column
-      auto const valueStr = data.at(col);
+      auto const &valueStr = data.at(col);
 
       // If it's not empty, use it
       if (!valueStr.isEmpty()) {
@@ -983,7 +983,7 @@ void GenericDataProcessorPresenter::reduceRow(RowData *data) {
                            runWS->getName());
     } else {
       // No pre-processing needed
-      auto propertyValue = data->at(i);
+      const auto &propertyValue = data->at(i);
       if (!propertyValue.isEmpty())
         alg->setPropertyValue(propertyName.toStdString(),
                               propertyValue.toStdString());

--- a/qt/widgets/common/src/DisplayCurveFit.cpp
+++ b/qt/widgets/common/src/DisplayCurveFit.cpp
@@ -115,7 +115,7 @@ QPair<double, double> DisplayCurveFit::getCurveRange(
 void DisplayCurveFit::addSpectrum(
     const curveType &aType, const Mantid::API::MatrixWorkspace_sptr workspace,
     const size_t specIndex) {
-  const QString curveName{m_curveTypeToQString.at(aType)};
+  const QString &curveName{m_curveTypeToQString.at(aType)};
   const QColor curveColor(m_curveTypeToColor.at(aType));
   m_plotPanel.at(aType)
       ->addSpectrum(curveName, workspace, specIndex, curveColor);
@@ -149,7 +149,7 @@ bool DisplayCurveFit::hasCurve(const curveType &aType) {
 void DisplayCurveFit::addRangeSelector(const dcRange &adcRange,
                                        RangeSelector::SelectType aType) {
   if (m_rangeSelector.find(adcRange) == m_rangeSelector.end()) {
-    const QString dcRangeName(m_dcRangeToQString.at(adcRange));
+    const QString &dcRangeName(m_dcRangeToQString.at(adcRange));
     m_rangeSelector.emplace(
         adcRange, m_uiForm.fitPlot->addRangeSelector(dcRangeName, aType));
     switch (adcRange) {

--- a/qt/widgets/common/src/FileDialogHandler.cpp
+++ b/qt/widgets/common/src/FileDialogHandler.cpp
@@ -156,7 +156,7 @@ QString getCaption(const std::string &dialogName,
   // generate the dialog title
   auto dialogTitle = QString::fromStdString(dialogName);
   if (bool(prop)) {
-    const auto name = prop->name();
+    const auto &name = prop->name();
     if (name != "Filename" && prop->name() != "Directory" &&
         prop->name() != "Dir") {
       dialogTitle.append(" - ");

--- a/qt/widgets/common/src/MantidWSIndexDialog.cpp
+++ b/qt/widgets/common/src/MantidWSIndexDialog.cpp
@@ -122,7 +122,7 @@ int MantidWSIndexWidget::getPlotIndex() const {
   if (!userInput.empty()) {
     const auto indexList = userInput.values();
     if (!indexList.empty()) {
-      const auto spectrumIndexes = indexList.at(0);
+      const auto &spectrumIndexes = indexList.at(0);
       if (!spectrumIndexes.empty()) {
         spectrumIndex = *spectrumIndexes.begin();
       }
@@ -634,7 +634,7 @@ void MantidWSIndexWidget::populateLogComboBox() {
         // If this is a single-value numeric log, add it to the list of counts
         if (dynamic_cast<Mantid::Kernel::PropertyWithValue<int> *>(log) ||
             dynamic_cast<Mantid::Kernel::PropertyWithValue<double> *>(log)) {
-          const std::string name = log->name();
+          const std::string &name = log->name();
           if (logCounts.find(name) != logCounts.end()) {
             logCounts[name]++;
           } else {
@@ -1182,7 +1182,7 @@ void IntervalList::addIntervals(QString intervals) {
 }
 
 void IntervalList::addIntervalList(const IntervalList &intervals) {
-  const QList<Interval> list = intervals.getList();
+  const QList<Interval> &list = intervals.getList();
 
   QList<Interval>::const_iterator it = list.constBegin();
 

--- a/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
@@ -1099,7 +1099,7 @@ void MuonFitPropertyBrowser::finishAfterSimultaneousFit(
 
   // Group output together
   std::string groupName = fitAlg->getPropertyValue("Output");
-  std::string baseName = groupName;
+  const std::string &baseName = groupName;
   if (ads.doesExist(groupName)) {
     ads.deepRemoveGroup(groupName);
   }
@@ -1527,7 +1527,7 @@ void MuonFitPropertyBrowser::setChosenPeriods(
   for (auto selected : chosenPeriods) {
     for (auto iter = m_periodBoxes.constBegin();
          iter != m_periodBoxes.constEnd(); ++iter) {
-      auto tmp = iter.key();
+      const auto &tmp = iter.key();
       if (iter.key() == selected) {
         m_boolManager->setValue(iter.value(), true);
       }
@@ -1542,7 +1542,7 @@ void MuonFitPropertyBrowser::setChosenPeriods(const QString &period) {
   clearChosenPeriods();
   for (auto iter = m_periodBoxes.constBegin(); iter != m_periodBoxes.constEnd();
        ++iter) {
-    auto tmp = iter.key();
+    const auto &tmp = iter.key();
     if (iter.key() == period) {
       m_boolManager->setValue(iter.value(), true);
     }

--- a/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
@@ -1527,7 +1527,6 @@ void MuonFitPropertyBrowser::setChosenPeriods(
   for (auto selected : chosenPeriods) {
     for (auto iter = m_periodBoxes.constBegin();
          iter != m_periodBoxes.constEnd(); ++iter) {
-      const auto &tmp = iter.key();
       if (iter.key() == selected) {
         m_boolManager->setValue(iter.value(), true);
       }
@@ -1542,7 +1541,6 @@ void MuonFitPropertyBrowser::setChosenPeriods(const QString &period) {
   clearChosenPeriods();
   for (auto iter = m_periodBoxes.constBegin(); iter != m_periodBoxes.constEnd();
        ++iter) {
-    const auto &tmp = iter.key();
     if (iter.key() == period) {
       m_boolManager->setValue(iter.value(), true);
     }

--- a/qt/widgets/common/src/PreviewPlot.cpp
+++ b/qt/widgets/common/src/PreviewPlot.cpp
@@ -839,7 +839,7 @@ void PreviewPlot::handleAxisTypeSelect() {
   // Hide range selectors on X axis when X axis scale is X^2
   bool xIsSquared = xAxisType == "Squared";
   for (auto it = m_rangeSelectors.begin(); it != m_rangeSelectors.end(); ++it) {
-    QString rsName = it.key();
+    const QString &rsName = it.key();
     RangeSelector *rs = it.value();
     RangeSelector::SelectType type = rs->getType();
 

--- a/qt/widgets/common/src/QtPropertyBrowser/qtpropertybrowser.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtpropertybrowser.cpp
@@ -1306,7 +1306,7 @@ void QtAbstractPropertyBrowserPrivate::createBrowserIndexes(
     if (it == m_propertyToIndexes.constEnd())
       return;
 
-    QList<QtBrowserItem *> indexes = it.value();
+    const QList<QtBrowserItem *> &indexes = it.value();
     QListIterator<QtBrowserItem *> itIndex(indexes);
     while (itIndex.hasNext()) {
       QtBrowserItem *idx = itIndex.next();
@@ -1322,7 +1322,7 @@ void QtAbstractPropertyBrowserPrivate::createBrowserIndexes(
     if (it == m_propertyToIndexes.constEnd())
       return;
 
-    QList<QtBrowserItem *> indexes = it.value();
+    const QList<QtBrowserItem *> &indexes = it.value();
     QListIterator<QtBrowserItem *> itIndex(indexes);
     while (itIndex.hasNext()) {
       QtBrowserItem *idx = itIndex.next();
@@ -1373,7 +1373,7 @@ void QtAbstractPropertyBrowserPrivate::removeBrowserIndexes(
   if (it == m_propertyToIndexes.constEnd())
     return;
 
-  QList<QtBrowserItem *> indexes = it.value();
+  const QList<QtBrowserItem *> &indexes = it.value();
   QListIterator<QtBrowserItem *> itIndex(indexes);
   while (itIndex.hasNext()) {
     QtBrowserItem *idx = itIndex.next();
@@ -1462,7 +1462,7 @@ void QtAbstractPropertyBrowserPrivate::slotPropertyDataChanged(
   if (it == m_propertyToIndexes.constEnd())
     return;
 
-  QList<QtBrowserItem *> indexes = it.value();
+  const QList<QtBrowserItem *> &indexes = it.value();
   QListIterator<QtBrowserItem *> itIndex(indexes);
   while (itIndex.hasNext()) {
     QtBrowserItem *idx = itIndex.next();

--- a/qt/widgets/common/src/QtPropertyBrowser/qtpropertymanager.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtpropertymanager.cpp
@@ -2448,7 +2448,7 @@ QString QtLocalePropertyManager::valueText(const QtProperty *property) const {
   if (it == d_ptr->m_values.constEnd())
     return QString();
 
-  QLocale loc = it.value();
+  const QLocale &loc = it.value();
 
   int langIdx = 0;
   int countryIdx = 0;

--- a/qt/widgets/common/src/RepoModel.cpp
+++ b/qt/widgets/common/src/RepoModel.cpp
@@ -214,7 +214,7 @@ QVariant RepoModel::data(const QModelIndex &index, int role) const {
     return QVariant();
   RepoItem *item = static_cast<RepoItem *>(index.internalPointer());
   try {
-    QString path = item->path();
+    const QString &path = item->path();
     Mantid::API::ScriptInfo inf;
     Mantid::API::SCRIPTSTATUS status;
     // return the data for the display role

--- a/qt/widgets/instrumentview/src/OneCurvePlot.cpp
+++ b/qt/widgets/instrumentview/src/OneCurvePlot.cpp
@@ -23,7 +23,7 @@ namespace MantidWidgets {
 
 OneCurvePlot::OneCurvePlot(QWidget *parent)
     : QwtPlot(parent), m_curve(nullptr), m_xUnits("") {
-  QFont font = parent->font();
+  const QFont &font = parent->font();
   setAxisFont(QwtPlot::xBottom, font);
   setAxisFont(QwtPlot::yLeft, font);
   QwtText dummyText;

--- a/qt/widgets/sliceviewer/src/PeakViewFactory.cpp
+++ b/qt/widgets/sliceviewer/src/PeakViewFactory.cpp
@@ -168,9 +168,11 @@ PeakRepresentation_sptr PeakViewFactory::createPeakRepresentationEllipsoid(
       dynamic_cast<const Mantid::DataObjects::PeakShapeEllipsoid &>(shape);
 
   // Ellipsoidd paramters
-  const auto abcRadii = ellipsoidShape.abcRadii();
-  const auto abcRadiiBackgroundInner = ellipsoidShape.abcRadiiBackgroundInner();
-  const auto abcRadiiBackgroundOuter = ellipsoidShape.abcRadiiBackgroundOuter();
+  const auto &abcRadii = ellipsoidShape.abcRadii();
+  const auto &abcRadiiBackgroundInner =
+      ellipsoidShape.abcRadiiBackgroundInner();
+  const auto &abcRadiiBackgroundOuter =
+      ellipsoidShape.abcRadiiBackgroundOuter();
 
   // Extract directions for the displayed frame
   const auto dimension0 = m_mdWS->getDimension(0);


### PR DESCRIPTION
This uses the -fix option on clang-tidy to automatically fix all
the cases where we make an extra copy on initialization.

**To test:**
- Build pass.
 - Code review

There is no issue associated with this PR.

**Release Notes** 
*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
