### PR TITLE
Python3 doctest compatibility: LoadRKH to LoadVulcanCalFile

### DIFF
--- a/docs/source/algorithms/LoadRKH-v1.rst
+++ b/docs/source/algorithms/LoadRKH-v1.rst
@@ -38,7 +38,7 @@ Usage
    SaveRKH(out_ws, file_path)
    in_ws = LoadRKH(file_path)
 
-   print "Contents of the file  = " + str(in_ws.readY(0))
+   print("Contents of the file  = {}".format(in_ws.readY(0)))
 
 .. testcleanup:: ExSimpleSavingRoundtrip
 

--- a/docs/source/algorithms/LoadRaw-v3.rst
+++ b/docs/source/algorithms/LoadRaw-v3.rst
@@ -82,15 +82,15 @@ Example 1: using defaults
 
   # Load a RAW file using all defaults
   ws = Load('HRP39180.RAW')
-  print 'Workspace has',ws.getNumberHistograms(),'spectra'
+  print('Workspace has {} spectra'.format(ws.getNumberHistograms()))
   # Get a detector in histogram 1024 of the workspace
   detid = ws.getSpectrum(1024).getDetectorIDs()[0]
-  print 'Is detector',detid,'a monitor?',ws.getInstrument().getDetector(detid).isMonitor()
+  print('Is detector {} a monitor? {}'.format(detid, ws.getInstrument().getDetector(detid).isMonitor()))
 
   # Get the Run object
   run = ws.run()
-  print 'Workspace contains',len(run.keys()),'logs'
-  print 'Workspace has property INT1:',run.hasProperty('INT1')
+  print('Workspace contains {} logs'.format(len(run.keys())))
+  print('Workspace has property INT1: {}'.format(run.hasProperty('INT1')))
 
 Output
 ^^^^^^
@@ -110,15 +110,15 @@ Example 2: load without the logs
 
   # Load a RAW file without the logs
   ws = Load('HRP39180.RAW',LoadLogFiles=False)
-  print 'Workspace has',ws.getNumberHistograms(),'spectra'
+  print('Workspace has {} spectra'.format(ws.getNumberHistograms()))
   # Get a detector in histogram 1024 of the workspace
   detid = ws.getSpectrum(1024).getDetectorIDs()[0]
-  print 'Is detector',detid,'a monitor?',ws.getInstrument().getDetector(detid).isMonitor()
+  print('Is detector {} a monitor? {}'.format(detid, ws.getInstrument().getDetector(detid).isMonitor()))
 
   # Get the Run object
   run = ws.run()
-  print 'Workspace contains',len(run.keys()),'logs'
-  print 'Workspace has property INT1:',run.hasProperty('INT1')
+  print('Workspace contains {} logs'.format(len(run.keys())))
+  print('Workspace has property INT1: {}'.format(run.hasProperty('INT1')))
 
 Output
 ^^^^^^
@@ -137,15 +137,15 @@ Example 3: exclude monitors
 
   # Load a RAW file without the monitors
   ws = Load('HRP39180.RAW',LoadMonitors='Exclude')
-  print 'Workspace has',ws.getNumberHistograms(),'spectra'
+  print('Workspace has {} spectra'.format(ws.getNumberHistograms()))
   # Get a detector in histogram 1024 of the workspace
   detid = ws.getSpectrum(1024).getDetectorIDs()[0]
-  print 'Is detector',detid,'a monitor?',ws.getInstrument().getDetector(detid).isMonitor()
+  print('Is detector {} a monitor? {}'.format(detid, ws.getInstrument().getDetector(detid).isMonitor()))
 
   # Get the Run object
   run = ws.run()
-  print 'Workspace contains',len(run.keys()),'logs'
-  print 'Workspace has property INT1:',run.hasProperty('INT1')
+  print('Workspace contains {} logs'.format(len(run.keys())))
+  print('Workspace has property INT1: {}'.format(run.hasProperty('INT1')))
 
 Output
 ^^^^^^
@@ -164,16 +164,16 @@ Example 4: load monitors separately
 
   # Load a RAW file, load the monitors into a separate workspace
   dataws,monitorws = Load('HRP39180.RAW',LoadMonitors='Separate')
-  print 'Data workspace has',dataws.getNumberHistograms(),'spectra'
+  print('Data workspace has {} spectra'.format(dataws.getNumberHistograms()))
 
-  print 'Monitor workspace has',monitorws.getNumberHistograms(),'spectra'
+  print('Monitor workspace has {} spectra'.format(monitorws.getNumberHistograms()))
   # Check that the detector in the first histogram of the monitor workspace is a monitor
   detid = monitorws.getSpectrum(0).getDetectorIDs()[0]
-  print 'Is detector',detid,'a monitor?',monitorws.getInstrument().getDetector(detid).isMonitor()
+  print('Is detector {} a monitor? {}'.format(detid, monitorws.getInstrument().getDetector(detid).isMonitor()))
 
   # Check that the detector in the second histogram of the monitor workspace is a monitor
   detid = monitorws.getSpectrum(1).getDetectorIDs()[0]
-  print 'Is detector',detid,'a monitor?',monitorws.getInstrument().getDetector(detid).isMonitor()
+  print('Is detector {} a monitor? {}'.format(detid, monitorws.getInstrument().getDetector(detid).isMonitor()))
 
 Output
 ^^^^^^

--- a/docs/source/algorithms/LoadRawBin0-v1.rst
+++ b/docs/source/algorithms/LoadRawBin0-v1.rst
@@ -25,7 +25,7 @@ Usage
    bin_zeroes = LoadRawBin0("IRS21360.raw")
    total = SumSpectra(bin_zeroes)
 
-   print "Bin0 contained %i counts." % total.readY(0)[0]
+   print("Bin0 contained {:.0f} counts.".format(total.readY(0)[0]))
 
 Output:
 

--- a/docs/source/algorithms/LoadRawSpectrum0-v1.rst
+++ b/docs/source/algorithms/LoadRawSpectrum0-v1.rst
@@ -25,7 +25,7 @@ Usage
     wsOut = LoadRawSpectrum0('HRP39180.RAW')
 
     wsIntegral = Integration(wsOut)
-    print ("Spectrum0 contained %i counts" % wsIntegral.readY(0)[0])
+    print("Spectrum0 contained {:.0f} counts".format(wsIntegral.readY(0)[0]))
 
 Output:
 

--- a/docs/source/algorithms/LoadSESANS-v1.rst
+++ b/docs/source/algorithms/LoadSESANS-v1.rst
@@ -40,7 +40,7 @@ Usage
    
    # Retrieve loaded workspace from ADS
    in_ws = mtd["in_ws"]
-   print("Y values of loaded workspace = " + str(in_ws.readY(0)))
+   print("Y values of loaded workspace = {}".format(in_ws.readY(0)))
    
 .. testcleanup:: LoadSESANSRoundTrip
 

--- a/docs/source/algorithms/LoadSINQ-v1.rst
+++ b/docs/source/algorithms/LoadSINQ-v1.rst
@@ -27,7 +27,7 @@ The following usage example loads a POLDI data file using the instrument name, y
 
     poldi_data = LoadSINQ(Instrument = "POLDI", Year = 2013, Numor = 6904)
     
-    print "Poldi sample 6904 has", poldi_data.getNumberHistograms(), "histograms."
+    print("Poldi sample 6904 has {} histograms.".format(poldi_data.getNumberHistograms()))
 
 Output:
     

--- a/docs/source/algorithms/LoadSINQFile-v1.rst
+++ b/docs/source/algorithms/LoadSINQFile-v1.rst
@@ -24,7 +24,7 @@ Usage
 
     poldi_data = LoadSINQFile(Filename = "poldi2013n006904.hdf", Instrument = "POLDI")
 
-    print "Poldi sample 6904 has", poldi_data.getNumberHistograms(), "histograms."
+    print("Poldi sample 6904 has {} histograms.".format(poldi_data.getNumberHistograms()))
 
 Output:
 

--- a/docs/source/algorithms/LoadSINQFocus-v1.rst
+++ b/docs/source/algorithms/LoadSINQFocus-v1.rst
@@ -28,8 +28,8 @@ The following example script loads a data file obtained at the FOCUS instrument 
     focus_2906 = LoadSINQFocus('focus2014n002906.hdf')
     
     # Print out some information
-    print "Sample title:", focus_2906.getTitle()
-    print "Number of spectra:", focus_2906.getNumberHistograms()
+    print("Sample title: {}".format(focus_2906.getTitle()))
+    print("Number of spectra: {}".format(focus_2906.getNumberHistograms()))
     
 Output:
 

--- a/docs/source/algorithms/LoadSPE-v1.rst
+++ b/docs/source/algorithms/LoadSPE-v1.rst
@@ -27,8 +27,8 @@ Usage
    #If it's in your managed user directories there's no need for an absolute path
    ws1 = LoadSPE("Example.spe")
 
-   print "Number of Spectra:", ws1.getNumberHistograms()
-   print "Number of Bins:", ws1.blocksize()
+   print("Number of Spectra: {}".format(ws1.getNumberHistograms()))
+   print("Number of Bins: {}".format(ws1.blocksize()))
 
 Output:
 

--- a/docs/source/algorithms/LoadSQW-v1.rst
+++ b/docs/source/algorithms/LoadSQW-v1.rst
@@ -180,8 +180,8 @@ Usage
    mdws = LoadSQW('test_horace_reader.sqw');
    
    # Check results
-   print "Workspace type is: ",mdws.id()
-   print "Workspace has:{0:2} dimensions and contains: {1:4} MD events".format(mdws.getNumDims(),mdws.getNEvents())
+   print("Workspace type is:  {}".format(mdws.id()))
+   print("Workspace has:{0:2} dimensions and contains: {1:4} MD events".format(mdws.getNumDims(),mdws.getNEvents()))
    
 Output:
 

--- a/docs/source/algorithms/LoadSampleDetailsFromRaw-v1.rst
+++ b/docs/source/algorithms/LoadSampleDetailsFromRaw-v1.rst
@@ -39,8 +39,8 @@ Usage
     LoadSampleDetailsFromRaw(ws,filename)
 
     s = ws.sample()
-    print "Geometry flag %.0f" % s.getGeometryFlag()
-    print "Dimensions H,W,D %.0f,%.0f,%.0f" % (s.getHeight(),s.getWidth(),s.getThickness())
+    print("Geometry flag {:.0f}".format(s.getGeometryFlag()))
+    print("Dimensions H,W,D {:.0f},{:.0f},{:.0f}".format(s.getHeight(),s.getWidth(),s.getThickness()))
 
 Output:
 

--- a/docs/source/algorithms/LoadSassena-v1.rst
+++ b/docs/source/algorithms/LoadSassena-v1.rst
@@ -56,7 +56,7 @@ Usage
 
     from __future__ import print_function
     ws = LoadSassena("loadSassenaExample.h5", TimeUnit=1.0)
-    print('workspaces instantiated: ', ', '.join(ws.getNames()))
+    print('workspaces instantiated:  {}'.format(', '.join(ws.getNames())))
     fqtReal = ws[1] # Real part of F(Q,t)
     # Let's fit it to a Gaussian. We start with an initial guess
     intensity = 0.5
@@ -71,13 +71,13 @@ Usage
     paramTable = fit_output.OutputParameters  # table containing the optimal fit parameters
     fitWorkspace = fit_output.OutputWorkspace
 
-    print("The fit was: " + fit_output.OutputStatus)
-    print("Fitted Height value is: %.2f" % paramTable.column(1)[0])
-    print("Fitted centre value is: %.2f" % abs(paramTable.column(1)[1]))
-    print("Fitted sigma value is: %.1f" % paramTable.column(1)[2])
+    print("The fit was: {}".format(fit_output.OutputStatus))
+    print("Fitted Height value is: {:.2f}".format(paramTable.column(1)[0]))
+    print("Fitted centre value is: {:.2f}".format(abs(paramTable.column(1)[1])))
+    print("Fitted sigma value is: {:.1f}".format(paramTable.column(1)[2]))
     # fitWorkspace contains the data, the calculated and the difference patterns
-    print("Number of spectra in fitWorkspace is: " +  str(fitWorkspace.getNumberHistograms()))
-    print("The 989th y-value of the fitted curve: %.3f" % fitWorkspace.readY(1)[989])
+    print("Number of spectra in fitWorkspace is: {}".format(fitWorkspace.getNumberHistograms()))
+    print("The 989th y-value of the fitted curve: {:.3f}".format(fitWorkspace.readY(1)[989]))
 
 Output:
 

--- a/docs/source/algorithms/LoadSpiceAscii-v1.rst
+++ b/docs/source/algorithms/LoadSpiceAscii-v1.rst
@@ -53,15 +53,16 @@ Usage
   datatbws = mtd['HB2A_0231_0001_Data'] 
   infows = mtd['HB2A_0231_Info']
 
-  print "Number of measuring points = %d" % (datatbws.rowCount())
-  print "Number of columns in data workspace = %d" % (datatbws.columnCount())
+  print("Number of measuring points = {}".format(datatbws.rowCount()))
+  print("Number of columns in data workspace = {}".format(datatbws.columnCount()))
   propertylist = infows.getRun().getProperties()
-  print "Number of run information = %d" % (len(propertylist))
-  for i in xrange(len(propertylist)):
-      print "Property %d: Name = %-20s." % (i, propertylist[i].name)
-  print "Sum of Counts = %d" % (infows.getRun().getProperty("Sum of Counts").value)
-  print "Center of Mass = %.5f +/- %.5f" % (infows.getRun().getProperty("Center of Mass").value, 
-      infows.getRun().getProperty("Center of Mass.error").value)
+  print("Number of run information = {}".format(len(propertylist)))
+  for i in range(len(propertylist)):
+      print("Property {}: Name = {}".format(i, propertylist[i].name))
+  print("Sum of Counts = {}".format(infows.getRun().getProperty("Sum of Counts").value))
+  print("Center of Mass = {:.5f} +/- {:.5f}".format(
+         infows.getRun().getProperty("Center of Mass").value, 
+         infows.getRun().getProperty("Center of Mass.error").value))
 
 .. testcleanup:: ExLoadHB2AData
 
@@ -75,41 +76,41 @@ Output:
   Number of measuring points = 61
   Number of columns in data workspace = 70
   Number of run information = 35
-  Property 0: Name = Center of Mass      .
-  Property 1: Name = Center of Mass.error.
-  Property 2: Name = Full Width Half-Maximum.
-  Property 3: Name = Full Width Half-Maximum.error.
-  Property 4: Name = Sum of Counts       .
-  Property 5: Name = analyzer            .
-  Property 6: Name = builtin_command     .
-  Property 7: Name = col_headers         .
-  Property 8: Name = collimation         .
-  Property 9: Name = command             .
-  Property 10: Name = date                .
-  Property 11: Name = def_x               .
-  Property 12: Name = def_y               .
-  Property 13: Name = experiment          .
-  Property 14: Name = experiment_number   .
-  Property 15: Name = latticeconstants    .
-  Property 16: Name = local_contact       .
-  Property 17: Name = mode                .
-  Property 18: Name = monochromator       .
-  Property 19: Name = preset_channel      .
-  Property 20: Name = preset_type         .
-  Property 21: Name = preset_value        .
-  Property 22: Name = proposal            .
-  Property 23: Name = runend              .
-  Property 24: Name = samplemosaic        .
-  Property 25: Name = samplename          .
-  Property 26: Name = sampletype          .
-  Property 27: Name = scan                .
-  Property 28: Name = scan_title          .
-  Property 29: Name = sense               .
-  Property 30: Name = time                .
-  Property 31: Name = ubconf              .
-  Property 32: Name = ubmatrix            .
-  Property 33: Name = users               .
-  Property 34: Name = run_start           .
+  Property 0: Name = Center of Mass
+  Property 1: Name = Center of Mass.error
+  Property 2: Name = Full Width Half-Maximum
+  Property 3: Name = Full Width Half-Maximum.error
+  Property 4: Name = Sum of Counts
+  Property 5: Name = analyzer
+  Property 6: Name = builtin_command
+  Property 7: Name = col_headers
+  Property 8: Name = collimation
+  Property 9: Name = command
+  Property 10: Name = date
+  Property 11: Name = def_x
+  Property 12: Name = def_y
+  Property 13: Name = experiment
+  Property 14: Name = experiment_number
+  Property 15: Name = latticeconstants
+  Property 16: Name = local_contact
+  Property 17: Name = mode
+  Property 18: Name = monochromator
+  Property 19: Name = preset_channel
+  Property 20: Name = preset_type
+  Property 21: Name = preset_value
+  Property 22: Name = proposal
+  Property 23: Name = runend
+  Property 24: Name = samplemosaic
+  Property 25: Name = samplename
+  Property 26: Name = sampletype
+  Property 27: Name = scan
+  Property 28: Name = scan_title
+  Property 29: Name = sense
+  Property 30: Name = time
+  Property 31: Name = ubconf
+  Property 32: Name = ubmatrix
+  Property 33: Name = users
+  Property 34: Name = run_start
   Sum of Counts = 1944923
   Center of Mass = 9.00076 +/- 0.00921
 

--- a/docs/source/algorithms/LoadSpiceXML2DDet-v1.rst
+++ b/docs/source/algorithms/LoadSpiceXML2DDet-v1.rst
@@ -100,9 +100,9 @@ Usage
   # Access output workspace and print out some result
   ws = mtd["s0001_0522"]
 
-  print "Number of spectrum = %d." % (ws.getNumberHistograms())
+  print("Number of spectrum = {}.".format(ws.getNumberHistograms()))
   for i, j in [(0, 0), (255, 255), (136, 140), (143, 140)]:
-      print "Y[%-3d, %-3d] = %.5f" % (i, j, ws.readY(i)[j])
+      print("Y[{:<3}, {:<3}] = {:.5f}".format(i, j, ws.readY(i)[j]))
 
 .. testcleanup:: ExLoadHB3AXMLData
 

--- a/docs/source/algorithms/LoadVesuvio-v1.rst
+++ b/docs/source/algorithms/LoadVesuvio-v1.rst
@@ -103,7 +103,7 @@ Usage
 
    tof = LoadVesuvio("14188",SpectrumList=135)
 
-   print "Number of spectra:", tof.getNumberHistograms()
+   print("Number of spectra: {}".format(tof.getNumberHistograms()))
 
 Output::
 
@@ -115,7 +115,7 @@ Output::
 
    tof = LoadVesuvio("14188-14193",SpectrumList=135)
 
-   print "Number of spectra:", tof.getNumberHistograms()
+   print("Number of spectra: {}".format(tof.getNumberHistograms()))
 
 Output::
 
@@ -127,7 +127,7 @@ Output::
 
    tof = LoadVesuvio("14188-14193",SpectrumList="135-142")
 
-   print "Number of spectra:", tof.getNumberHistograms()
+   print("Number of spectra: {}".format(tof.getNumberHistograms()))
 
 Output::
 
@@ -139,7 +139,7 @@ Output::
 
    tof = LoadVesuvio("14188-14193",SpectrumList="135-142", SumSpectra=True)
 
-   print "Number of spectra:", tof.getNumberHistograms()
+   print("Number of spectra: {}".format(tof.getNumberHistograms()))
 
 Output::
 
@@ -152,7 +152,7 @@ Output::
    tof = LoadVesuvio("14188-14193",SpectrumList="135-142", SumSpectra=True,
                      Mode="SingleDifference")
 
-   print "Number of spectra:", tof.getNumberHistograms()
+   print("Number of spectra: {}".format(tof.getNumberHistograms()))
 
 Output::
 

--- a/docs/source/algorithms/LoadVisionElasticBS-v1.rst
+++ b/docs/source/algorithms/LoadVisionElasticBS-v1.rst
@@ -21,7 +21,7 @@ Usage
 
    w1 = LoadVisionElasticBS("VIS_19351.nxs.h5")
 
-   print "Number of spectra:", w1.getNumberHistograms()
+   print("Number of spectra: {}".format(w1.getNumberHistograms()))
 
 .. testoutput::
 
@@ -33,7 +33,7 @@ Usage
 
    w1 = LoadVisionElasticBS("VIS_19351.nxs.h5",Banks="bank20")
 
-   print "Number of spectra:", w1.getNumberHistograms()
+   print("Number of spectra: {}".format(w1.getNumberHistograms()))
 
 .. testoutput::
 

--- a/docs/source/algorithms/LoadVisionElasticEQ-v1.rst
+++ b/docs/source/algorithms/LoadVisionElasticEQ-v1.rst
@@ -21,7 +21,7 @@ Usage
 
    w1 = LoadVisionElasticEQ("VIS_19351.nxs.h5")
 
-   print "Number of spectra:", w1.getNumberHistograms()
+   print("Number of spectra: {}".format(w1.getNumberHistograms()))
 
 .. testoutput::
 
@@ -33,7 +33,7 @@ Usage
 
    w1 = LoadVisionElasticEQ("VIS_19351.nxs.h5",Banks="bank29")
 
-   print "Number of spectra:", w1.getNumberHistograms()
+   print("Number of spectra: {}".format(w1.getNumberHistograms()))
 
 .. testoutput::
 

--- a/docs/source/algorithms/LoadVisionInelastic-v1.rst
+++ b/docs/source/algorithms/LoadVisionInelastic-v1.rst
@@ -21,7 +21,7 @@ Usage
 
    w1 = LoadVisionInelastic("VIS_19351.nxs.h5")
 
-   print "Number of spectra:", w1.getNumberHistograms()
+   print("Number of spectra: {}".format(w1.getNumberHistograms()))
 
 .. testoutput:: 
 
@@ -33,7 +33,7 @@ Usage
 
    w1 = LoadVisionInelastic("VIS_19351.nxs.h5",Banks="forward")
 
-   print "Number of spectra:", w1.getNumberHistograms()
+   print("Number of spectra: {}".format(w1.getNumberHistograms()))
 
 .. testoutput::
 
@@ -45,7 +45,7 @@ Usage
 
    w1 = LoadVisionInelastic("VIS_19351.nxs.h5",Banks="backward,bank3")
 
-   print "Number of spectra:", w1.getNumberHistograms()
+   print("Number of spectra: {}".format(w1.getNumberHistograms()))
 
 .. testoutput::
 

--- a/docs/source/algorithms/LoadVulcanCalFile-v1.rst
+++ b/docs/source/algorithms/LoadVulcanCalFile-v1.rst
@@ -90,9 +90,9 @@ Usage
   offsetws = mtd["Vulcan_idl_offsets"]
   groupws = mtd["Vulcan_idl_group"]
   for iws in [0, 100, 1000, 3500, 7000]:
-    print "Spectrum %-5d Offset = %.5f of Group %d" % (iws, offsetws.readY(iws)[0], groupws.readY(iws)[0])
+    print("Spectrum {:<5} Offset = {:.5f} of Group {:.0f}".format(iws, offsetws.readY(iws)[0], groupws.readY(iws)[0]))
   maskws = mtd["Vulcan_idl_mask"]
-  print "Size of mask workspace = %d" % (maskws.getNumberHistograms())
+  print("Size of mask workspace = {}".format(maskws.getNumberHistograms()))
 
 .. testcleanup::
 


### PR DESCRIPTION
## Description of work.
This PR is part of refactoring effort to bring Python3 compatiblity into the doctests.
See https://github.com/mantidproject/mantid/issues/20672 for details.

The following tests were refactored to be compatible :
```
LoadRKH-v1
LoadRaw-v3
LoadRawBin0-v1
LoadRawSpectrum0-v1
LoadSESANS-v1
LoadSINQ-v1
LoadSINQFile-v1
LoadSINQFocus-v1
LoadSPE-v1
LoadSQW-v1
LoadSampleDetailsFromRaw-v1
LoadSassena-v1
LoadSpiceAscii-v1
LoadSpiceXML2DDet-v1
LoadVTK-v1
LoadVesuvio-v1
LoadVisionElasticBS-v1
LoadVisionElasticEQ-v1
LoadVisionInelastic-v1
LoadVulcanCalFile-v1
```
## To test.

Code review.

Fixes #20800 
Internal change, no release notes