### PR TITLE
Python3 doctest compatibility: MaskWorkspaceToCalFile to Minus

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/MergeCalFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/MergeCalFiles.py
@@ -96,7 +96,7 @@ class MergeCalFiles(PythonAlgorithm):
 
     #add any lines at the end
         for UDET in updateDict.keys():
-            (offset,select,group)=updateDict.pop(UDET)
+            (offset,select,group)=updateDict[UDET]
             lastNumber += 1
             outputFile.write(self.FormatLine(lastNumber,UDET,offset,select,group))
             linesAdded += 1

--- a/docs/source/algorithms/MaskWorkspaceToCalFile-v1.rst
+++ b/docs/source/algorithms/MaskWorkspaceToCalFile-v1.rst
@@ -40,7 +40,7 @@ Usage
 
   # Print out first 10 lines of the file
   for line in calFile[:10]:
-    print line
+    print(line)
 
 Output
 ######

--- a/docs/source/algorithms/MatchPeaks-v1.rst
+++ b/docs/source/algorithms/MatchPeaks-v1.rst
@@ -39,7 +39,7 @@ Usage
 
   output_ws = MatchPeaks(InputWorkspace=ws)
 
-  print('Peak height at center: {}').format(output_ws.readY(0)[ws.blocksize() / 2])
+  print('Peak height at center: {:.11f}'.format(output_ws.readY(0)[ws.blocksize() / 2]))
 
 Output
 ######

--- a/docs/source/algorithms/MatchPeaks-v1.rst
+++ b/docs/source/algorithms/MatchPeaks-v1.rst
@@ -39,7 +39,7 @@ Usage
 
   output_ws = MatchPeaks(InputWorkspace=ws)
 
-  print('Peak height at center: {:.11f}'.format(output_ws.readY(0)[ws.blocksize() / 2]))
+  print('Peak height at center: {:.11f}'.format(output_ws.readY(0)[ws.blocksize() // 2]))
 
 Output
 ######

--- a/docs/source/algorithms/Max-v1.rst
+++ b/docs/source/algorithms/Max-v1.rst
@@ -23,17 +23,17 @@ Usage
   max_ws = Max(ws)
 
   # Check the returned values
-  print 'Maximum found at bin [',max_ws.readX(0)[0],',',max_ws.readX(0)[1],'], value',max_ws.readY(0)[0]
-  print 'In original workspace'
-  print 'Bounds of bin 30     [',ws.readX(0)[30],',',ws.readX(0)[31],'], value',ws.readY(0)[30]
+  print('Maximum found at bin [ {} , {} ], value {}'.format(max_ws.readX(0)[0], max_ws.readX(0)[1], max_ws.readY(0)[0]))
+  print('In original workspace')
+  print('Bounds of bin 30     [ {} , {} ], value {}'.format(ws.readX(0)[30], ws.readX(0)[31], ws.readY(0)[30]))
 
   # Find another peak
   max_ws = Max(ws,RangeLower = 7000)
 
   # Check the returned values
-  print 'Maximum found at bin [',max_ws.readX(0)[0],',',max_ws.readX(0)[1],'], value',max_ws.readY(0)[0]
-  print 'In original workspace'
-  print 'Bounds of bin 60     [',ws.readX(0)[60],',',ws.readX(0)[61],'], value',ws.readY(0)[60]
+  print('Maximum found at bin [ {} , {} ], value {}'.format(max_ws.readX(0)[0], max_ws.readX(0)[1], max_ws.readY(0)[0]))
+  print('In original workspace')
+  print('Bounds of bin 60     [ {} , {} ], value {}'.format(ws.readX(0)[60], ws.readX(0)[61], ws.readY(0)[60]))
 
 Output
 ######

--- a/docs/source/algorithms/MaxEnt-v1.rst
+++ b/docs/source/algorithms/MaxEnt-v1.rst
@@ -157,11 +157,11 @@ and the reconstructed image, i.e. Fourier transform (right).
    CreateWorkspace(OutputWorkspace='inputws',DataX=X,DataY=Y,DataE=E,NSpec=1)
    evolChi, evolAngle, image, data = MaxEnt(InputWorkspace='inputws', chiTarget=N, A=0.0001)
 
-   print "First  reconstructed coefficient: %.3f" % data.readY(0)[5]
-   print "Second reconstructed coefficient: %.3f" % data.readY(0)[10]
-   print "Third  reconstructed coefficient: %.3f" % data.readY(0)[20]
-   print "Fourth reconstructed coefficient: %.3f" % data.readY(0)[12]
-   print "Fifth  reconstructed coefficient: %.3f" % data.readY(0)[14]
+   print("First  reconstructed coefficient: {:.3f}".format(data.readY(0)[5]))
+   print("Second reconstructed coefficient: {:.3f}".format(data.readY(0)[10]))
+   print("Third  reconstructed coefficient: {:.3f}".format(data.readY(0)[20]))
+   print("Fourth reconstructed coefficient: {:.3f}".format(data.readY(0)[12]))
+   print("Fifth  reconstructed coefficient: {:.3f}".format(data.readY(0)[14]))
 
 Output:
 
@@ -193,9 +193,9 @@ and :ref:`algm-FFT` (right).
    # Compare MaxEnt to FFT
    imageFFT = FFT(InputWorkspace='MUSR00022725')
 
-   print "Image at %.3f: %.3f" % (image.readX(0)[44], image.readY(0)[44])
-   print "Image at %.3f: %.3f" % (image.readX(0)[46], image.readY(0)[46])
-   print "Image at %.3f: %.3f" % (image.readX(0)[48], image.readY(0)[48])
+   print("Image at {:.3f}: {:.3f}".format(image.readX(0)[44], image.readY(0)[44]))
+   print("Image at {:.3f}: {:.3f}".format(image.readX(0)[46], image.readY(0)[46]))
+   print("Image at {:.3f}: {:.3f}".format(image.readX(0)[48], image.readY(0)[48]))
 
 Output:
 
@@ -222,12 +222,12 @@ and its imaginary part (right).
    # Compare MaxEnt to FFT
    imageFFT = FFT(InputWorkspace='EMU00020884')
 
-   print "Image (real part) at %.3f: %.3f" % (image.readX(0)[129], image.readY(0)[129])
-   print "Image (real part) at  %.3f:  %.3f" % (image.readX(0)[135], image.readY(0)[135])
-   print "Image (real part) at  %.3f: %.3f" % (image.readX(0)[141], image.readY(0)[141])
-   print "Image (imaginary part) at %.3f: %.3f" % (image.readX(0)[129], image.readY(0)[129])
-   print "Image (imaginary part) at  %.3f:  %.3f" % (image.readX(0)[135], image.readY(0)[135])
-   print "Image (imaginary part) at  %.3f: %.3f" % (image.readX(0)[141], image.readY(0)[141])
+   print("Image (real part) at {:.3f}: {:.3f}".format(image.readX(0)[129], image.readY(0)[129]))
+   print("Image (real part) at  {:.3f}:  {:.3f}".format(image.readX(0)[135], image.readY(0)[135]))
+   print("Image (real part) at  {:.3f}: {:.3f}".format(image.readX(0)[141], image.readY(0)[141]))
+   print("Image (imaginary part) at {:.3f}: {:.3f}".format(image.readX(0)[129], image.readY(0)[129]))
+   print("Image (imaginary part) at  {:.3f}:  {:.3f}".format(image.readX(0)[135], image.readY(0)[135]))
+   print("Image (imaginary part) at  {:.3f}: {:.3f}".format(image.readX(0)[141], image.readY(0)[141]))
 
 Output:
 
@@ -268,9 +268,9 @@ the original and reconstructed data (left), and the reconstructed image (right).
    CreateWorkspace(OutputWorkspace='ws',DataX=X+X,DataY=YRe+YIm,DataE=E+E,NSpec=2)
    evolChi, evolAngle, image, data = MaxEnt(InputWorkspace='ws', ComplexData=True, chiTarget=2*N, A=0.001)
 
-   print "Image (real part) at %.3f: %.3f" % (image.readX(0)[102], image.readY(0)[102])
-   print "Image (real part) at %.3f: %.3f" % (image.readX(0)[103], image.readY(0)[103])
-   print "Image (real part) at %.3f: %.3f" % (image.readX(0)[104], image.readY(0)[104])
+   print("Image (real part) at {:.3f}: {:.3f}".format(image.readX(0)[102], image.readY(0)[102]))
+   print("Image (real part) at {:.3f}: {:.3f}".format(image.readX(0)[103], image.readY(0)[103]))
+   print("Image (real part) at {:.3f}: {:.3f}".format(image.readX(0)[104], image.readY(0)[104]))
 
 Output:
 
@@ -320,9 +320,9 @@ image in order to obtain smooth results).
    evolChi, evolAngle, image, data = MaxEnt(InputWorkspace='ws', ComplexData=True, chiTarget=2*N, A=0.001, PositiveImage=False)
    evolChiP, evolAngleP, imageP, dataP = MaxEnt(InputWorkspace='ws', ComplexData=True, chiTarget=2*N, A=0.001, PositiveImage=True)
 
-   print "Image at %.3f: %.3f (PositiveImage=False), %.3f (PositiveImage=True)" % (image.readX(0)[102], image.readY(0)[102], imageP.readY(0)[102])
-   print "Image at %.3f: %.3f (PositiveImage=False), %.3f (PositiveImage=True)" % (image.readX(0)[103], image.readY(0)[103], imageP.readY(0)[103])
-   print "Image at %.3f: %.3f (PositiveImage=False), %.3f (PositiveImage=True)" % (image.readX(0)[104], image.readY(0)[104], imageP.readY(0)[102])
+   print("Image at {:.3f}: {:.3f} (PositiveImage=False), {:.3f} (PositiveImage=True)".format(image.readX(0)[102], image.readY(0)[102], imageP.readY(0)[102]))
+   print("Image at {:.3f}: {:.3f} (PositiveImage=False), {:.3f} (PositiveImage=True)".format(image.readX(0)[103], image.readY(0)[103], imageP.readY(0)[103]))
+   print("Image at {:.3f}: {:.3f} (PositiveImage=False), {:.3f} (PositiveImage=True)".format(image.readX(0)[104], image.readY(0)[104], imageP.readY(0)[102]))
 
 Output:
 
@@ -367,8 +367,8 @@ the reconstructed data is twice the size of the original (experimental) data.
    evolChi1, evolAngle1, image1, data1 = MaxEnt(InputWorkspace='ws', A=0.0001, ChiTarget=300, MaxIterations=2500, ResolutionFactor=1)
    evolChi2, evolAngle2, image2, data2 = MaxEnt(InputWorkspace='ws', A=0.0001, ChiTarget=300, MaxIterations=5000, ResolutionFactor=2)
 
-   print "Image at %.3f: %.3f (ResolutionFactor=1)" % (image1.readX(0)[135], image1.readY(0)[135])
-   print "Image at %.3f: %.3f (ResolutionFactor=2)" % (image2.readX(0)[270], image2.readY(0)[270])
+   print("Image at {:.3f}: {:.3f} (ResolutionFactor=1)".format(image1.readX(0)[135], image1.readY(0)[135]))
+   print("Image at {:.3f}: {:.3f} (ResolutionFactor=2)".format(image2.readX(0)[270], image2.readY(0)[270]))
 
 Output:
 

--- a/docs/source/algorithms/MaxMin-v1.rst
+++ b/docs/source/algorithms/MaxMin-v1.rst
@@ -30,9 +30,9 @@ Usage
    # Run algorithm
    wsMax = MaxMin (ws)
 
-   print "Maximum of each spectrum"
+   print("Maximum of each spectrum")
    for i in range(9):
-      print wsMax.readY(i)
+      print(wsMax.readY(i))
 
 Output:
 
@@ -60,9 +60,9 @@ Output:
    # Run algorithm
    wsMax = MaxMin (ws, ShowMin=True)
 
-   print "Minimum of each spectrum"
+   print("Minimum of each spectrum")
    for i in range(9):
-      print wsMax.readY(i)
+      print(wsMax.readY(i))
 
 Output:
 

--- a/docs/source/algorithms/MayersSampleCorrection-v1.rst
+++ b/docs/source/algorithms/MayersSampleCorrection-v1.rst
@@ -81,8 +81,8 @@ Usage
                                              MultipleScattering=True)
 
    # Print a bin
-   print "Uncorrected signal: {0:.4f}".format(sample_ws.readY(0)[25])
-   print "Corrected signal: {0:.4f}".format(corrected_sample.readY(0)[25])
+   print("Uncorrected signal: {0:.4f}".format(sample_ws.readY(0)[25]))
+   print("Corrected signal: {0:.4f}".format(corrected_sample.readY(0)[25]))
 
 Output:
 

--- a/docs/source/algorithms/Mean-v1.rst
+++ b/docs/source/algorithms/Mean-v1.rst
@@ -41,8 +41,8 @@ Usage:
    ws_2 = CreateWorkspace(dataX, dataY, NSpec=2)
 
    result = Mean("ws_1, ws_2") # note the comma-separate strings
-   print "Mean of y values in first spectrum:", result.readY(0)
-   print "Mean of y values in second spectrum:", result.readY(1)
+   print("Mean of y values in first spectrum: {}".format(result.readY(0)))
+   print("Mean of y values in second spectrum: {}".format(result.readY(1)))
 
 Output:
 

--- a/docs/source/algorithms/MergeCalFiles-v1.rst
+++ b/docs/source/algorithms/MergeCalFiles-v1.rst
@@ -57,9 +57,9 @@ Usage
         MergeGroups = True)
 
     #Load and print the resulting file
-    print "The result file has been updated with 0 for group, select and offset\nwhere the detector id's match"
+    print("The result file has been updated with 0 for group, select and offset\nwhere the detector id's match")
     with open(output_file, "r") as file:
-        print file.read().rstrip()
+        print(file.read().rstrip())
 
     #cleanup
     os.remove(calFile_master)
@@ -119,9 +119,9 @@ Output:
         MergeGroups = False)
 
     #Load and print the resulting file
-    print "Any additional rows in the update file will be added,\nset the Merge options to False if you don't want to affect existing values"
+    print("Any additional rows in the update file will be added,\nset the Merge options to False if you don't want to affect existing values")
     with open(output_file, "r") as file:
-        print file.read().rstrip()
+        print(file.read().rstrip())
 
     #cleanup
     os.remove(calFile_master)

--- a/docs/source/algorithms/MergeLogs-v1.rst
+++ b/docs/source/algorithms/MergeLogs-v1.rst
@@ -32,13 +32,13 @@ Usage
   prop1 = ws.run().getProperty("Phase1")
   prop2 = ws.run().getProperty("Phase2")
   
-  print "Phase 1's size = %d, Phase 2's size = %d, Merged size = %d." % (prop1.size(), prop2.size(), newprop.size())
-  for i in xrange(5):
-      print "Phase1              Time[%d] = %s." % (i, prop1.nthTime(i))
-  for i in xrange(5):
-      print "Phase2              Time[%d] = %s." % (i, prop2.nthTime(i))
-  for i in xrange(5):
-      print "Mixed Phase 1 and 2 Time[%d] = %s." % (i, newprop.nthTime(i))
+  print("Phase 1's size = {}, Phase 2's size = {}, Merged size = {}.".format(prop1.size(), prop2.size(), newprop.size()))
+  for i in range(5):
+      print("Phase1              Time[{}] = {}.".format(i, prop1.nthTime(i)))
+  for i in range(5):
+      print("Phase2              Time[{}] = {}.".format(i, prop2.nthTime(i)))
+  for i in range(5):
+      print("Mixed Phase 1 and 2 Time[{}] = {}.".format(i, newprop.nthTime(i)))
 
 .. testcleanup:: ExMerge2Logs
 

--- a/docs/source/algorithms/MergeMD-v1.rst
+++ b/docs/source/algorithms/MergeMD-v1.rst
@@ -47,21 +47,21 @@ Usage
    SumWS=MergeMD(InputWorkspaces='mdWs1,mdWs2',SplitInto='100,100')
 
     # check it looks like the one we wanted
-   print 'merged workspace of type: {0}\n'.format(SumWS.id()),
+   print('merged workspace of type: {0}'.format(SumWS.id()))
    # this is how you would check whether it is a general MDEventWorkspace
-   print 'it is a type of MDEventWorkspace: {0}\n'.format(isinstance(SumWS, IMDEventWorkspace)),
-   print '****************************************************************'   
-   print 'workspace 1 has {0} dimensions with {1} points and {2} events'.format(mdWs1.getNumDims(),mdWs1.getNPoints(),mdWs1.getNEvents());
+   print('it is a type of MDEventWorkspace: {0}'.format(isinstance(SumWS, IMDEventWorkspace)))
+   print('****************************************************************')
+   print('workspace 1 has {0} dimensions with {1} points and {2} events'.format(mdWs1.getNumDims(),mdWs1.getNPoints(),mdWs1.getNEvents()))
    d1=mdWs1.getDimension(0);d2=mdWs1.getDimension(1)
-   print 'with d1 min_max={0}:{1}, d2 min_max={2}:{3}'.format(d1.getMinimum(),d1.getMaximum(),d2.getMinimum(),d2.getMaximum())
-   print 'workspace 2 has {0} dimensions with {1} points and {2} events'.format(mdWs2.getNumDims(),mdWs2.getNPoints(),mdWs2.getNEvents());   
+   print('with d1 min_max={0}:{1}, d2 min_max={2}:{3}'.format(d1.getMinimum(),d1.getMaximum(),d2.getMinimum(),d2.getMaximum()))
+   print('workspace 2 has {0} dimensions with {1} points and {2} events'.format(mdWs2.getNumDims(),mdWs2.getNPoints(),mdWs2.getNEvents()))
    d1=mdWs2.getDimension(0);d2=mdWs2.getDimension(1)
-   print 'with d1 min_max={0}:{1}, d2 min_max={2}:{3}'.format(d1.getMinimum(),d1.getMaximum(),d2.getMinimum(),d2.getMaximum())
-   print '****************************************************************'
-   print 'Merged WS has   {0} dimensions with {1} points and {2} events'.format(SumWS.getNumDims(),SumWS.getNPoints(),SumWS.getNEvents());
+   print('with d1 min_max={0}:{1}, d2 min_max={2}:{3}'.format(d1.getMinimum(),d1.getMaximum(),d2.getMinimum(),d2.getMaximum()))
+   print('****************************************************************')
+   print('Merged WS has   {0} dimensions with {1} points and {2} events'.format(SumWS.getNumDims(),SumWS.getNPoints(),SumWS.getNEvents()))
    d1=SumWS.getDimension(0);d2=SumWS.getDimension(1)
-   print 'with d1 min_max={0}:{1}, d2 min_max={2}:{3}'.format(d1.getMinimum(),d1.getMaximum(),d2.getMinimum(),d2.getMaximum())
-   print '****************************************************************'   
+   print('with d1 min_max={0}:{1}, d2 min_max={2}:{3}'.format(d1.getMinimum(),d1.getMaximum(),d2.getMinimum(),d2.getMaximum()))
+   print('****************************************************************')
 
    
 **Output:**

--- a/docs/source/algorithms/MergeRuns-v1.rst
+++ b/docs/source/algorithms/MergeRuns-v1.rst
@@ -147,9 +147,9 @@ Usage
 
    merged = MergeRuns(InputWorkspaces="a, b")
 
-   print "a      = " + str(a.readY(0))
-   print "b      = " + str(b.readY(0))
-   print "merged = " + str(merged.readY(0))
+   print("a      = {}".format(a.readY(0)))
+   print("b      = {}".format(b.readY(0)))
+   print("merged = {}".format(merged.readY(0)))
 
 Output:
 
@@ -176,13 +176,13 @@ Output:
 
    merged = MergeRuns(InputWorkspaces="group_1, group_2")
 
-   print "group_1 = [" + str(group_1[0].readY(0)) + ","
-   print "           " + str(group_1[1].readY(0)) + "]"
+   print("group_1 = [{},".format(group_1[0].readY(0)))
+   print("           {}]".format(group_1[1].readY(0)))
+	      
+   print("group_2 = [{},".format(group_2[0].readY(0)))
+   print("           {}]".format(group_2[1].readY(0)))
 
-   print "group_2 = [" + str(group_2[0].readY(0)) + ","
-   print "           " + str(group_2[1].readY(0)) + "]"
-
-   print "merged   = " + str(merged.readY(0))
+   print("merged   = {}".format(merged.readY(0)))
 
 Output:
 

--- a/docs/source/algorithms/Min-v1.rst
+++ b/docs/source/algorithms/Min-v1.rst
@@ -20,12 +20,16 @@ Usage
     
     #Find minima
     minim=Min(InputWorkspace='w2')
-    print "Minima for spectrum 0 is Y = ",minim.dataY(0)[0]," and it occurs at X between ", minim.dataX(0)[0], " and ", minim.dataX(0)[1]
-    print "Minima for spectrum 1 is Y = ",minim.dataY(1)[0]," and it occurs at X between ", minim.dataX(1)[0], " and ", minim.dataX(1)[1]
+    print("Minima for spectrum 0 is Y =  {}  and it occurs at X between  {}  and  {}".
+           format(minim.dataY(0)[0], minim.dataX(0)[0], minim.dataX(0)[1]))
+    print("Minima for spectrum 1 is Y =  {}  and it occurs at X between  {}  and  {}".
+          format(minim.dataY(1)[0], minim.dataX(1)[0], minim.dataX(1)[1]))
     
     #Find minima with extra parameters
     minim=Min(InputWorkspace='w2',RangeLower=0,RangeUpper=3,StartWorkspaceIndex =1,EndWorkspaceIndex=1)
-    print "The new output workspace has ",minim.getNumberHistograms()," histogram, with the minimum Y = ",minim.dataY(0)[0]," and it occurs at X between ", minim.dataX(0)[0], " and ", minim.dataX(0)[1]
+    print("The new output workspace has  {}  histogram, with the minimum Y =  {}  " \
+          "and it occurs at X between  {}  and  {}".
+          format(minim.getNumberHistograms(), minim.dataY(0)[0], minim.dataX(0)[0], minim.dataX(0)[1]))
     
 .. testcleanup:: Min
 

--- a/docs/source/algorithms/Minus-v1.rst
+++ b/docs/source/algorithms/Minus-v1.rst
@@ -41,9 +41,9 @@ Usage
     # perform the algorithm
     ws = Minus(ws1, ws2)
 
-    print "The X values are: " + str(ws.readX(0))
-    print "The Y values are: " + str(ws.readY(0))
-    print "The updated Error values are: " + str(ws.readE(0))
+    print("The X values are: {}".format(ws.readX(0)))
+    print("The Y values are: {}".format(ws.readY(0)))
+    print("The updated Error values are: {}".format(ws.readE(0)))
 
 Output:
 
@@ -71,9 +71,9 @@ Output:
     # perform the algorithm
     ws = ws1 - ws2
 
-    print "The X values are: " + str(ws.readX(0))
-    print "The Y values are: " + str(ws.readY(0))
-    print "The updated Error values are: " + str(ws.readE(0))
+    print("The X values are: {}".format(ws.readX(0)))
+    print("The Y values are: {}".format(ws.readY(0)))
+    print("The updated Error values are: {}".format(ws.readE(0)))
 
 Output:
 
@@ -101,9 +101,9 @@ Output:
     # perform the algorithm
     ws -= ws1
 
-    print "The X values are: " + str(ws.readX(0))
-    print "The Y values are: " + str(ws.readY(0))
-    print "The updated Error values are: " + str(ws.readE(0))
+    print("The X values are: {}".format(ws.readX(0)))
+    print("The Y values are: {}".format(ws.readY(0)))
+    print("The updated Error values are: {}".format(ws.readE(0)))
 
 Output:
 
@@ -127,9 +127,9 @@ Output:
     # perform the algorithm
     ws = ws1 - 2.5
 
-    print "The X values are: " + str(ws.readX(0))
-    print "The Y values are: " + str(ws.readY(0))
-    print "The updated Error values are: " + str(ws.readE(0))
+    print("The X values are: {}".format(ws.readX(0)))
+    print("The Y values are: {}".format(ws.readY(0)))
+    print("The updated Error values are: {}".format(ws.readE(0)))
 
 Output:
 


### PR DESCRIPTION
## Description of work.
This PR is part of refactoring effort to bring Python3 compatiblity into the doctests.
See https://github.com/mantidproject/mantid/issues/20672 for details.

*Note*: in this PR, a small change was also made to the algorithm `MergeCalFiles`, as there was a conflict with the new dictionary behaviour in Python3

The following tests were refactored to be compatible :

```
MaskWorkspaceToCalFile-v1
MatchPeaks-v1
Max-v1
MaxEnt-v1
MaxMin-v1
MayersSampleCorrection-v1
Mean-v1
MedianBinWidth-v1
MergeCalFiles-v1
MergeLogs-v1
MergeMD-v1
MergeRuns-v1
Min-v1
Minus-v1
```

## To test.
Code review.

Fixes <your issue>.
Internal change, no release notes