### PR TITLE
Python3 doctest compatibility: ModeratorTzero to MuscatSofQW

### DIFF
--- a/docs/source/algorithms/ModifyDetectorDotDatFile-v1.rst
+++ b/docs/source/algorithms/ModifyDetectorDotDatFile-v1.rst
@@ -53,7 +53,7 @@ Usage
    ModifyDetectorDotDatFile(ws_1, "detector_1.dat", newFile)
 
    # Check the output file
-   print "File Exists:", os.path.exists(newFile)
+   print("File Exists: {}".format(os.path.exists(newFile)))
 
    f = open( newFile, 'r' )
    file = f.read().split('\n')
@@ -62,7 +62,7 @@ Usage
    for line in file[0:4]:
         # print the line truncating before system dependent line break can take effect
         # also stripping off any trailing spaces
-        print line[0:89].rstrip()
+        print(line[0:89].rstrip())
         
 Output:
 

--- a/docs/source/algorithms/MolDyn-v1.rst
+++ b/docs/source/algorithms/MolDyn-v1.rst
@@ -42,7 +42,7 @@ Usage
                           Functions=['Fqt-total', 'Sqw-total'])
 
     for ws_name in out_ws_group.getNames():
-      print ws_name
+      print(ws_name)
 
 Output:
 

--- a/docs/source/algorithms/MonitorEfficiencyCorUser-v1.rst
+++ b/docs/source/algorithms/MonitorEfficiencyCorUser-v1.rst
@@ -39,17 +39,17 @@ Usage
     wsSample = LoadMLZ(Filename='TOFTOFTestdata.nxs')
     wsNorm = MonitorEfficiencyCorUser(wsSample )
     # Input and output workspaces have the same structure
-    print 'Number of histograms of the input and output workspaces:'
-    print wsSample.getNumberHistograms(), wsNorm.getNumberHistograms()
-    print 'Number of time channels of the input an output workspaces:'
-    print wsSample.blocksize(), wsNorm.blocksize()
+    print('Number of histograms of the input and output workspaces:')
+    print('{} {}'.format(wsSample.getNumberHistograms(), wsNorm.getNumberHistograms()))
+    print('Number of time channels of the input an output workspaces:')
+    print('{} {}'.format( wsSample.blocksize(), wsNorm.blocksize()))
     # Check calculation of normalisation coefficient between input and output workspaces
     wsCheck = Divide(wsSample,wsNorm)
-    print "Coefficient of proportionality between Input and Output of MonitorEfficiencyCorUser algorithm: %5.3f" % wsCheck.readY(102)[1]
+    print("Coefficient of proportionality between Input and Output of MonitorEfficiencyCorUser algorithm: {:.3f}".format(wsCheck.readY(102)[1]))
     # Read the values of the incident energy and of the monitor counts from the SampleLogs of wsSample
     monitor_counts = float(mtd['wsSample'].getRun().getLogData('monitor_counts').value)
     Ei = float(mtd['wsSample'].getRun().getLogData('Ei').value)
-    print "Coefficient from theoretical formula = monitor_counts * sqrt(Ei/25.3): %5.3f" % (monitor_counts*np.sqrt(Ei/25.3))
+    print("Coefficient from theoretical formula = monitor_counts * sqrt(Ei/25.3): {:.3f}".format(monitor_counts*np.sqrt(Ei/25.3)))
  
  
 Output:

--- a/docs/source/algorithms/MoveInstrumentComponent-v1.rst
+++ b/docs/source/algorithms/MoveInstrumentComponent-v1.rst
@@ -42,25 +42,25 @@ Example 1: Move a component by name
   ws = CreateSampleWorkspace()
 
   # Original position of instrument component 'bank1'
-  print ws.getInstrument().getComponentByName('bank1').getPos()
+  print(ws.getInstrument().getComponentByName('bank1').getPos())
 
   # Move 'bank1' by vector (1,0,0) relative to its original position
   MoveInstrumentComponent( ws, 'bank1', X=1,Y=0,Z=0 )
 
   # Check the new position of 'bank1'
-  print ws.getInstrument().getComponentByName('bank1').getPos()
+  print(ws.getInstrument().getComponentByName('bank1').getPos())
 
   # Move the same bank again by vector (2,0,0)
   MoveInstrumentComponent( ws, 'bank1', X=2,Y=0,Z=0 )
 
   # Check the new position of 'bank1'
-  print ws.getInstrument().getComponentByName('bank1').getPos()
+  print(ws.getInstrument().getComponentByName('bank1').getPos())
 
   # Move 'bank1' to a new absolute position (1,2,3)
   MoveInstrumentComponent( ws, 'bank1', X=1,Y=2,Z=3, RelativePosition=False )
 
   # Check the new position of 'bank1'
-  print ws.getInstrument().getComponentByName('bank1').getPos()
+  print(ws.getInstrument().getComponentByName('bank1').getPos())
 
 Output
 ^^^^^^
@@ -93,13 +93,13 @@ Example 2: Move a detector by ID
   ws = mtd['musr_1']
 
   # Original position of detector 33
-  print ws.getInstrument().getDetector(33).getPos()
+  print(ws.getInstrument().getDetector(33).getPos())
 
   # Move detector 33 by vector (1,0,0) relative to its original position
   MoveInstrumentComponent( ws, DetectorID=33, X=1,Y=0,Z=0 )
 
   # Check the new position of detector 33
-  print ws.getInstrument().getDetector(33).getPos()
+  print(ws.getInstrument().getDetector(33).getPos())
 
 Output
 ^^^^^^

--- a/docs/source/algorithms/MultipleScatteringCylinderAbsorption-v1.rst
+++ b/docs/source/algorithms/MultipleScatteringCylinderAbsorption-v1.rst
@@ -51,7 +51,7 @@ Usage
     #restrict the number of wavelength points to speed up the example
     wsOut = MultipleScatteringCylinderAbsorption(ws,CylinderSampleRadius=0.2)
 
-    print "Output: ", wsOut.readY(0)
+    print("Output:  {}".format(wsOut.readY(0)))
 
 Output:
 

--- a/docs/source/algorithms/Multiply-v1.rst
+++ b/docs/source/algorithms/Multiply-v1.rst
@@ -39,9 +39,9 @@ Usage
     # perform the algorithm
     ws = Multiply(ws1, ws2)
 
-    print "The X values are: " + str(ws.readX(0))
-    print "The Y values are: " + str(ws.readY(0))
-    print "The updated Error values are: " + str(ws.readE(0))
+    print("The X values are: {}".format(ws.readX(0)))
+    print("The Y values are: {}".format(ws.readY(0)))
+    print("The updated Error values are: {}".format(ws.readE(0)))
 
 Output:
 
@@ -69,9 +69,9 @@ Output:
     # perform the algorithm
     ws = ws1 * ws2
 
-    print "The X values are: " + str(ws.readX(0))
-    print "The Y values are: " + str(ws.readY(0))
-    print "The updated Error values are: " + str(ws.readE(0))
+    print("The X values are: {}".format(ws.readX(0)))
+    print("The Y values are: {}".format(ws.readY(0)))
+    print("The updated Error values are: {}".format(ws.readE(0)))
 
 Output:
 
@@ -99,9 +99,9 @@ Output:
     # perform the algorithm
     ws *= ws1
 
-    print "The X values are: " + str(ws.readX(0))
-    print "The Y values are: " + str(ws.readY(0))
-    print "The updated Error values are: " + str(ws.readE(0))
+    print("The X values are: {}".format(ws.readX(0)))
+    print("The Y values are: {}".format(ws.readY(0)))
+    print("The updated Error values are: {}".format(ws.readE(0)))
 
 Output:
 
@@ -125,9 +125,9 @@ Output:
     # perform the algorithm
     ws = ws1 * 2.5
 
-    print "The X values are: " + str(ws.readX(0))
-    print "The Y values are: " + str(ws.readY(0))
-    print "The updated Error values are: " + str(ws.readE(0))
+    print("The X values are: {}".format(ws.readX(0)))
+    print("The Y values are: {}".format(ws.readY(0)))
+    print("The updated Error values are: {}".format(ws.readE(0)))
 
 Output:
 

--- a/docs/source/algorithms/MultiplyRange-v1.rst
+++ b/docs/source/algorithms/MultiplyRange-v1.rst
@@ -27,9 +27,9 @@ Usage
   yres = res.readY(0)
 
   # Print out the ratios yres[i] / y[i] for bins with indices 20 to 30
-  print yres[20:30] / y[20:30]
+  print(yres[20:30] / y[20:30])
   # Print out the ratios yres[i] / y[i] for bins with indices 70 to 80
-  print yres[70:80] / y[70:80]
+  print(yres[70:80] / y[70:80])
 
 Output
 ######

--- a/docs/source/algorithms/MuonGroupDetectors-v1.rst
+++ b/docs/source/algorithms/MuonGroupDetectors-v1.rst
@@ -45,10 +45,10 @@ Usage
 
    grouped = MuonGroupDetectors('ws', 'grouping')
 
-   print 'No. of spectra in grouped workspace:', grouped.getNumberHistograms()
-   print 'Detectors grouped in spectra 0:', list(grouped.getSpectrum(0).getDetectorIDs())
-   print 'Detectors grouped in spectra 1:', list(grouped.getSpectrum(1).getDetectorIDs())
-   print 'Detectors grouped in spectra 2:', list(grouped.getSpectrum(2).getDetectorIDs())
+   print('No. of spectra in grouped workspace: {}'.format(grouped.getNumberHistograms()))
+   print('Detectors grouped in spectra 0: {}'.format(list(grouped.getSpectrum(0).getDetectorIDs())))
+   print('Detectors grouped in spectra 1: {}'.format(list(grouped.getSpectrum(1).getDetectorIDs())))
+   print('Detectors grouped in spectra 2: {}'.format(list(grouped.getSpectrum(2).getDetectorIDs())))
 
 Output:
 
@@ -73,9 +73,9 @@ Output:
    # Use grouping from one file to group data from different file
    grouped = MuonGroupDetectors('ws', 'grouping')
 
-   print 'No. of periods loaded:', grouped.size()
-   print 'No. of grouped spectra in first period:', grouped.getItem(0).getNumberHistograms()
-   print 'No. of grouped spectra in second period:', grouped.getItem(1).getNumberHistograms()
+   print('No. of periods loaded: {}'.format(grouped.size()))
+   print('No. of grouped spectra in first period: {}'.format(grouped.getItem(0).getNumberHistograms()))
+   print('No. of grouped spectra in second period: {}'.format(grouped.getItem(1).getNumberHistograms()))
 
 Output:
 

--- a/docs/source/algorithms/MuonProcess-v1.rst
+++ b/docs/source/algorithms/MuonProcess-v1.rst
@@ -99,7 +99,7 @@ Usage
    processed = mtd['MuonProcess_output']
    output_int = Integration(processed)
 
-   print 'Integrated asymmetry for the run: {0:.3f}'.format(output_int.readY(0)[0])
+   print('Integrated asymmetry for the run: {0:.3f}'.format(output_int.readY(0)[0]))
 
 Output:
 
@@ -132,7 +132,7 @@ Output:
 			PairSecondIndex = 0,
 			Alpha = 0.5)
    
-   print 'Output:', output.readY(0)
+   print('Output: {}'.format(output.readY(0)))
 
 Output:
 
@@ -172,7 +172,7 @@ Output:
 			OutputType = 'GroupAsymmetry',
 			GroupIndex = 0,Xmin=0,Xmax=4)
 
-   print 'Output:', output.readY(0)
+   print('Output: {}'.format(output.readY(0)))
 
 Output:
 

--- a/docs/source/algorithms/MuscatSofQW-v1.rst
+++ b/docs/source/algorithms/MuscatSofQW-v1.rst
@@ -44,9 +44,9 @@ Usage
                       ResolutionWorkspace=resolution,
                       ParameterWorkspace=parameters)
 
-    print 'S(Q, w) workspace is intensity as a function of {0} and {1}'.format(
+    print('S(Q, w) workspace is intensity as a function of {0} and {1}'.format(
           sqw.getAxis(0).getUnit().unitID(),
-          sqw.getAxis(1).getUnit().unitID())
+          sqw.getAxis(1).getUnit().unitID()))
 
 Output:
 


### PR DESCRIPTION
## Description of work.
This PR is part of refactoring effort to bring Python3 compatiblity into the doctests.
See https://github.com/mantidproject/mantid/issues/20672 for details.

The following tests were refactored to be compatible :

```
ModeratorTzero-v1
ModeratorTzeroLinear-v1
ModifyDetectorDotDatFile-v1
MolDyn-v1
MonitorEfficiencyCorUser-v1
MonteCarloAbsorption-v1
MoveInstrumentComponent-v1
MultipleScatteringCylinderAbsorption-v1
Multiply-v1
MultiplyRange-v1
MuonGroupDetectors-v1
MuonProcess-v1
MuscatData-v1
MuscatFunc-v1
MuscatSofQW-v1
```

## To test.

Code review.

Fixes #20806
Internal change, no release notes