### PR TITLE
Python3 doctest compatibility: NMoldyn4Interpolation to PDLoadCharacterizations

### DIFF
--- a/docs/source/algorithms/NMoldyn4Interpolation-v1.rst
+++ b/docs/source/algorithms/NMoldyn4Interpolation-v1.rst
@@ -38,9 +38,9 @@ set**
     osiris = Rebin(osiris, [-0.6, 0.02, 0.6])
     #interpolate the two workspaces
     interpolated_ws = NMoldyn4Interpolation(sim_ws, osiris)
-    print 'No. of Q-values in simulation = ' + str(sim_ws.getNumberHistograms())
-    print 'No. of Q-values in reference = ' + str(osiris.getNumberHistograms())
-    print 'No. of Q-values in interpolated set = '+ str(interpolated_ws.getNumberHistograms())
+    print('No. of Q-values in simulation = {}'.format(sim_ws.getNumberHistograms()))
+    print('No. of Q-values in reference = {}'.format(osiris.getNumberHistograms()))
+    print('No. of Q-values in interpolated set = {}'.format(interpolated_ws.getNumberHistograms()))
 
 Output:
 

--- a/docs/source/algorithms/NRCalculateSlitResolution-v1.rst
+++ b/docs/source/algorithms/NRCalculateSlitResolution-v1.rst
@@ -50,7 +50,7 @@ Usage
 
   ws = Load('INTER00013460')
   res = NRCalculateSlitResolution(Workspace = ws, TwoTheta = 0.7 * 2)
-  print("Resolution: %.4f" % res)
+  print("Resolution: {:.4f}".format(res))
 
 .. testoutput::
 

--- a/docs/source/algorithms/NormaliseByCurrent-v1.rst
+++ b/docs/source/algorithms/NormaliseByCurrent-v1.rst
@@ -55,16 +55,16 @@ Usage
    log_p = run1.getLogData('gd_prtn_chrg')
 
    # Print the log value
-   print "Good Proton Charge =",log_p.value
+   print("Good Proton Charge = {}".format(log_p.value))
 
    #Run the Algorithm
    wsN = NormaliseByCurrent(ws)
    norm_factor = wsN.getRun().getLogData('NormalizationFactor').value
 
    #Print results
-   print "Before normalisation", ws.readY(0);
-   print "After normalisation ", wsN.readY(0);
-   print "Normalisation factor", norm_factor;
+   print("Before normalisation {}".format(ws.readY(0)))
+   print("After normalisation  {}".format(wsN.readY(0)))
+   print("Normalisation factor {}".format(norm_factor))
 
 
 Output:

--- a/docs/source/algorithms/NormaliseByDetector-v1.rst
+++ b/docs/source/algorithms/NormaliseByDetector-v1.rst
@@ -200,10 +200,10 @@ Usage
   #Now we are ready to run the correction
   wsCorrected = NormaliseByDetector(ws)
 
-  print ("The correction will divide the data by an increasing linear function.")
-  print ("f(x) = 2x + 1")
+  print("The correction will divide the data by an increasing linear function.")
+  print("f(x) = 2x + 1")
   for i in range(0,wsCorrected.blocksize(),10):
-    print ("The correct value in bin %i is %.2f compared to %.2f" % (i,wsCorrected.readY(0)[i],ws.readY(0)[i]))
+    print("The correct value in bin {} is {:.2f} compared to {:.2f}".format(i,wsCorrected.readY(0)[i],ws.readY(0)[i]))
 
   #clean up the file
   if os.path.exists(param_file_path):

--- a/docs/source/algorithms/NormaliseByPeakArea-v1.rst
+++ b/docs/source/algorithms/NormaliseByPeakArea-v1.rst
@@ -55,10 +55,10 @@ Usage
     normalised, yspace, fitted, symmetrised = \
       NormaliseByPeakArea(InputWorkspace=tof_ws, Mass=1.0079,Sum=False)
 
-    print "Number of normalised spectra is: %d" % normalised.getNumberHistograms()
-    print "Number of Y-space spectra is: %d" % yspace.getNumberHistograms()
-    print "Number of fitted spectra is: %d" % fitted.getNumberHistograms()
-    print "Number of symmetrised spectra is: %d" % symmetrised.getNumberHistograms()
+    print("Number of normalised spectra is: {}".format(normalised.getNumberHistograms()))
+    print("Number of Y-space spectra is: {}".format(yspace.getNumberHistograms()))
+    print("Number of fitted spectra is: {}".format(fitted.getNumberHistograms()))
+    print("Number of symmetrised spectra is: {}".format(symmetrised.getNumberHistograms()))
 
 .. testoutput:: NormaliseNoSumOutput
 
@@ -87,10 +87,10 @@ Usage
     normalised, yspace, fitted, symmetrised = \
       NormaliseByPeakArea(InputWorkspace=tof_ws, Mass=1.0079,Sum=True)
 
-    print "Number of normalised spectra is: %d" % normalised.getNumberHistograms()
-    print "Number of Y-space spectra is: %d" % yspace.getNumberHistograms()
-    print "Number of fitted spectra is: %d" % fitted.getNumberHistograms()
-    print "Number of symmetrised spectra is: %d" % symmetrised.getNumberHistograms()
+    print("Number of normalised spectra is: {}".format(normalised.getNumberHistograms()))
+    print("Number of Y-space spectra is: {}".format(yspace.getNumberHistograms()))
+    print("Number of fitted spectra is: {}".format(fitted.getNumberHistograms()))
+    print("Number of symmetrised spectra is: {}".format(symmetrised.getNumberHistograms()))
 
 .. testoutput:: NormaliseWithSummedOutput
 

--- a/docs/source/algorithms/NormaliseByThickness-v1.rst
+++ b/docs/source/algorithms/NormaliseByThickness-v1.rst
@@ -24,11 +24,11 @@ Usage
     norm=NormaliseByThickness(raw,SampleThickness=10)
 
     #do a quick check
-    print norm[1]
-    print "Min(raw)=",raw.dataY(0).min()
-    print "Min(norm)=",norm[0].dataY(0).min()
-    print "Max(raw)=",raw.dataY(0).max()
-    print "Max(norm)=",norm[0].dataY(0).max()   
+    print(norm[1])
+    print("Min(raw)= {}".format(raw.dataY(0).min()))
+    print("Min(norm)= {}".format(norm[0].dataY(0).min()))
+    print("Max(raw)= {}".format(raw.dataY(0).max()))
+    print("Max(norm)= {}".format(norm[0].dataY(0).max()))
     
     
 .. testcleanup:: NormaliseByThicness

--- a/docs/source/algorithms/NormaliseSpectra-v1.rst
+++ b/docs/source/algorithms/NormaliseSpectra-v1.rst
@@ -32,7 +32,7 @@ Usage
   out_ws = NormaliseSpectra(InputWorkspace=ws)
   
   # Print resulting y values
-  print out_ws.readY(0)
+  print(out_ws.readY(0))
 
 Output:  
   

--- a/docs/source/algorithms/NormaliseToMonitor-v1.rst
+++ b/docs/source/algorithms/NormaliseToMonitor-v1.rst
@@ -81,13 +81,13 @@ Usage
 
    wsN = NormaliseToMonitor( ws, MonitorID=1 )
 
-   print "Without normalisation"
-   print "Monitor ID=1 %.3f, %.3f" % ( ws.readY(0)[0], ws.readY(0)[1] )
-   print "Selected data %.6f, %.6f" % ( ws.readY(6)[0], ws.readY(3)[1] )
+   print("Without normalisation")
+   print("Monitor ID=1 {:.3f}, {:.3f}".format(ws.readY(0)[0], ws.readY(0)[1]))
+   print("Selected data {:.6f}, {:.6f}".format(ws.readY(6)[0], ws.readY(3)[1]))
 
-   print "With Normalisation"
-   print "Monitor ID=1 %.3f, %.3f" % ( wsN.readY(0)[0], wsN.readY(0)[1] )
-   print "Selected data %.6f, %.6f" % ( wsN.readY(6)[0], wsN.readY(3)[1] )
+   print("With Normalisation")
+   print("Monitor ID=1 {:.3f}, {:.3f}".format(wsN.readY(0)[0], wsN.readY(0)[1]))
+   print("Selected data {:.6f}, {:.6f}".format(wsN.readY(6)[0], wsN.readY(3)[1]))
 
 Output:
 

--- a/docs/source/algorithms/NormaliseToUnity-v1.rst
+++ b/docs/source/algorithms/NormaliseToUnity-v1.rst
@@ -29,20 +29,21 @@ Usage
    # Run algorithm
    wsNorm = NormaliseToUnity (ws)
 
-   print "Normalised Workspace"
+   print("Normalised Workspace")
    for i in range(4):
-      print "[ %.4f,%.4f,%.4f, %.4f, %.4f ]" % (wsNorm.readY(i)[0], wsNorm.readY(i)[1], 
-      wsNorm.readY(i)[2], wsNorm.readY(i)[3], wsNorm.readY(i)[4],)
+      print("[ {:.4f}, {:.4f}, {:.4f}, {:.4f}, {:.4f} ]".format(
+            wsNorm.readY(i)[0], wsNorm.readY(i)[1], wsNorm.readY(i)[2],
+            wsNorm.readY(i)[3], wsNorm.readY(i)[4]))
 
 Output:
 
 .. testoutput:: ExNormaliseToUnitySimple
 
    Normalised Workspace
-   [ 0.2239,0.0065,0.0065, 0.0065, 0.0065 ]
-   [ 0.2239,0.0065,0.0065, 0.0065, 0.0065 ]
-   [ 0.2239,0.0065,0.0065, 0.0065, 0.0065 ]
-   [ 0.2239,0.0065,0.0065, 0.0065, 0.0065 ]
+   [ 0.2239, 0.0065, 0.0065, 0.0065, 0.0065 ]
+   [ 0.2239, 0.0065, 0.0065, 0.0065, 0.0065 ]
+   [ 0.2239, 0.0065, 0.0065, 0.0065, 0.0065 ]
+   [ 0.2239, 0.0065, 0.0065, 0.0065, 0.0065 ]
 
 .. categories::
 

--- a/docs/source/algorithms/NormaliseVanadium-v1.rst
+++ b/docs/source/algorithms/NormaliseVanadium-v1.rst
@@ -23,7 +23,7 @@ Usage
     inst = LoadEmptyInstrument(Filename='IDFs_for_UNIT_TESTING/MINITOPAZ_Definition.xml')
     vanadium = CreateWorkspace(DataX='0,0.5,1,1.5,2,2.5,3,3.5,4,4.5,5', DataY='10.574151,10.873,11.07348,11.22903,11.42286,11.47365,11.37375,11.112,10.512181,10.653397', UnitX='wavelength', ParentWorkspace=inst)
     norm_van = NormaliseVanadium(InputWorkspace=vanadium)
-    print "Wavelength = ", norm_van.readX(0)[2], " Y = ", norm_van.readY(0)[2]
+    print("Wavelength =  {}  Y =  {:.11f}".format(norm_van.readX(0)[2], norm_van.readY(0)[2]))
     
 Output:
 

--- a/docs/source/algorithms/OSIRISDiffractionReduction-v1.rst
+++ b/docs/source/algorithms/OSIRISDiffractionReduction-v1.rst
@@ -67,7 +67,7 @@ Usage
     vanadium = [os.path.join(os.path.expanduser("~"), van  + ".nxs") for van in vanadium]
     ws = OSIRISDiffractionReduction(Sample=','.join(samples), Vanadium=','.join(vanadium), CalFile="osiris_041_RES10.cal")
 
-    print "Number of Spectra: %d, Number of bins: %d" % (ws.getNumberHistograms(), ws.blocksize())
+    print("Number of Spectra: {}, Number of bins: {}".format(ws.getNumberHistograms(), ws.blocksize()))
 
 Output:
 

--- a/docs/source/algorithms/OneMinusExponentialCor-v1.rst
+++ b/docs/source/algorithms/OneMinusExponentialCor-v1.rst
@@ -31,13 +31,13 @@ Usage
 .. testcode:: ExOneMinusExp
 
     ws=CreateWorkspace([1,2,3],[1,1,1])
-    print "You can divide the data by the factor"
+    print("You can divide the data by the factor")
     wsOut=OneMinusExponentialCor(ws,2,3,"Divide")
-    print wsOut.readY(0)
+    print(wsOut.readY(0))
 
-    print "Or multiply"
+    print("Or multiply")
     wsOut=OneMinusExponentialCor(ws,2,3,"Multiply")
-    print wsOut.readY(0)
+    print(wsOut.readY(0))
 
 
 Output:

--- a/docs/source/algorithms/OptimizeCrystalPlacement-v1.rst
+++ b/docs/source/algorithms/OptimizeCrystalPlacement-v1.rst
@@ -56,7 +56,7 @@ Usage
     LoadIsawUB(ws,"ls5637.mat")
     wsd = OptimizeCrystalPlacement(ws)
     (wsPeakOut,fitInfoTable,chi2overDoF,nPeaks,nParams,nIndexed,covrianceInfoTable) = OptimizeCrystalPlacement(ws)
-    print "Chi2: %.4f" % chi2overDoF
+    print("Chi2: {:.4f}".format(chi2overDoF))
 
 Output:
 

--- a/docs/source/algorithms/OptimizeLatticeForCellType-v1.rst
+++ b/docs/source/algorithms/OptimizeLatticeForCellType-v1.rst
@@ -29,11 +29,11 @@ Usage
 
     ws=LoadIsawPeaks("TOPAZ_3007.peaks")
     FindUBUsingFFT(ws,MinD=8.0,MaxD=13.0)
-    print "Before Optimization:"
-    print ws.sample().getOrientedLattice().getUB()
+    print("Before Optimization:")
+    print(ws.sample().getOrientedLattice().getUB())
     OptimizeLatticeForCellType(ws,CellType="Monoclinic")
-    print "\nAfter Optimization:"
-    print ws.sample().getOrientedLattice().getUB()
+    print("\nAfter Optimization:")
+    print(ws.sample().getOrientedLattice().getUB())
 
 
 Output:

--- a/docs/source/algorithms/PDFFourierTransform-v1.rst
+++ b/docs/source/algorithms/PDFFourierTransform-v1.rst
@@ -144,17 +144,17 @@ Usage
 
 .. testcode:: ExPDFFouurierTransform
 
-    # Simulates Load of a workspace with all necessary parameters #################
+    # Simulates Load of a workspace with all necessary parameters
     import numpy as np;
-    xx= np.array(range(0,100))*0.1
-    yy = np.exp(-((xx)/.5)**2)
-    ws=CreateWorkspace(DataX=xx,DataY=yy,UnitX='MomentumTransfer')
-    Rt= PDFFourierTransform(ws,InputSofQType='S(Q)',PDFType='g(r)');   
-    #
+    xx = np.array(range(0,100))*0.1
+    yy = np.exp(-(2.0 * xx)**2)
+    ws = CreateWorkspace(DataX=xx, DataY=yy, UnitX='MomentumTransfer')
+    Rt = PDFFourierTransform(ws, InputSofQType='S(Q)', PDFType='g(r)')   
+
     # Look at sample results:
-    print 'part of S(Q) and its correlation function'
-    for i in xrange(0,10): 
-       print '! {0:4.2f} ! {1:5f} ! {2:f} ! {3:5f} !'.format(xx[i],yy[i],Rt.readX(0)[i],Rt.readY(0)[i])
+    print('part of S(Q) and its correlation function')
+    for i in range(10): 
+       print('! {0:4.2f} ! {1:5f} ! {2:f} ! {3:5f} !'.format(xx[i], yy[i], Rt.readX(0)[i], Rt.readY(0)[i]))
 
 
 


### PR DESCRIPTION
## Description of work.
This PR is part of refactoring effort to bring Python3 compatiblity into the doctests.
See https://github.com/mantidproject/mantid/issues/20672 for details.

The following tests were refactored to be compatible :
```
NMoldyn4Interpolation-v1
NRCalculateSlitResolution-v1
NormaliseByCurrent-v1
NormaliseByDetector-v1
NormaliseByPeakArea-v1
NormaliseByThickness-v1
NormaliseSpectra-v1
NormaliseToMonitor-v1
NormaliseToUnity-v1
NormaliseVanadium-v1
OSIRISDiffractionReduction-v1
OneMinusExponentialCor-v1
OptimizeCrystalPlacement-v1
OptimizeLatticeForCellType-v1
PDCalibration-v1
PDFFourierTransform-v1
PDLoadCharacterizations-v1
```
## To test.

Code review.

Fixes #20808
Internal change, no release notes