### PR TITLE
Python3 doctest compatibility: RetrieveRunInfo to SaveAscii-v2

### DIFF
--- a/docs/source/algorithms/RRFMuon-v1.rst
+++ b/docs/source/algorithms/RRFMuon-v1.rst
@@ -47,8 +47,8 @@ Usage
    input = CreateWorkspace(dataX=datax, dataY=datay,Nspec=2,UnitX="TOF")
    # Compute polarization in RRF
    output = RRFMuon(input,1.0,"MHz",0)
-   print("%.1f" % output.readY(0)[0])
-   print("%.1f" % output.readY(1)[0])
+   print("{:.1f}".format(output.readY(0)[0]))
+   print("{:.1f}".format(output.readY(1)[0]))
 
 Output:
 

--- a/docs/source/algorithms/RetrieveRunInfo-v1.rst
+++ b/docs/source/algorithms/RetrieveRunInfo-v1.rst
@@ -55,9 +55,9 @@ Usage
    info_table = RetrieveRunInfo(Runs="IRS21360,IRS26173")
 
    print("The table contains information about {} runs.".format(info_table.rowCount()))
-   print "The first has run number {}.".format(info_table.cell("run_number", 0)))
-   print "The second has run number {}.".format(info_table.cell("run_number", 1)))
-   print "The title of the second run is \"{}.\"".format(info_table.cell("run_title", 1).strip()))
+   print("The first has run number {}.".format(info_table.cell("run_number", 0)))
+   print("The second has run number {}.".format(info_table.cell("run_number", 1)))
+   print("The title of the second run is \"{}.\"".format(info_table.cell("run_title", 1).strip()))
 
 .. testcleanup:: ExSingleRun
 

--- a/docs/source/algorithms/RetrieveRunInfo-v1.rst
+++ b/docs/source/algorithms/RetrieveRunInfo-v1.rst
@@ -54,10 +54,10 @@ Usage
    # Get the information for IRIS runs 21360 and 26173.
    info_table = RetrieveRunInfo(Runs="IRS21360,IRS26173")
 
-   print "The table contains information about %i runs." % info_table.rowCount()
-   print "The first has run number %s." % info_table.cell("run_number", 0)
-   print "The second has run number %s." % info_table.cell("run_number", 1)
-   print "The title of the second run is \"%s.\"" % info_table.cell("run_title", 1).strip()
+   print("The table contains information about {} runs.".format(info_table.rowCount()))
+   print "The first has run number {}.".format(info_table.cell("run_number", 0)))
+   print "The second has run number {}.".format(info_table.cell("run_number", 1)))
+   print "The title of the second run is \"{}.\"".format(info_table.cell("run_title", 1).strip()))
 
 .. testcleanup:: ExSingleRun
 

--- a/docs/source/algorithms/RingProfile-v1.rst
+++ b/docs/source/algorithms/RingProfile-v1.rst
@@ -71,7 +71,7 @@ Usage
     ws = CreateSampleWorkspace("Histogram","Multiple Peaks")
     wsOut = RingProfile(ws,Centre=[0,5,10],MaxRadius=5)
 
-    print ("The RingProfile has been calculated with %i bins" % wsOut.blocksize())
+    print("The RingProfile has been calculated with {} bins".format(wsOut.blocksize()))
 
 Output:
 
@@ -86,7 +86,7 @@ Output:
     ws = CreateSampleWorkspace("Histogram","Multiple Peaks")
     wsOut = RingProfile(ws,Centre=[0,5,10],MinRadius=1,MaxRadius=5,NumBins=200)
 
-    print ("The RingProfile has been calculated with %i bins" % wsOut.blocksize())
+    print("The RingProfile has been calculated with {} bins".format(wsOut.blocksize()))
     
 Output:
 

--- a/docs/source/algorithms/RotateInstrumentComponent-v1.rst
+++ b/docs/source/algorithms/RotateInstrumentComponent-v1.rst
@@ -53,8 +53,8 @@ Example 1: Rotating a bank around the Y Axis
   print('Original positions of detectors 1 and 2')
   opos1 = ws.getInstrument().getDetector(1).getPos()
   opos2 = ws.getInstrument().getDetector(2).getPos()
-  print('Det 1: {0:.6f}'.format(pos3D_as_str(opos1)))
-  print('Det 2: {0:.6f}'.format(pos3D_as_str(opos2)))
+  print('Det 1: {0}'.format(pos3D_as_str(opos1)))
+  print('Det 2: {0}'.format(pos3D_as_str(opos2)))
 
   # Rotate bank 'back' around the Z axis by 90
   RotateInstrumentComponent( ws, ComponentName='back', X=0,Y=1,Z=0, Angle=90.0 )
@@ -62,8 +62,8 @@ Example 1: Rotating a bank around the Y Axis
   print('Positions of detectors 1 and 2 after rotation')
   pos1 = ws.getInstrument().getDetector(1).getPos()
   pos2 = ws.getInstrument().getDetector(2).getPos()
-  print('Det 1: {0:.6f}'.format(pos3D_as_str(pos1)))
-  print('Det 2: {0:.6f}'.format(pos3D_as_str(pos2)))
+  print('Det 1: {0}'.format(pos3D_as_str(pos1)))
+  print('Det 2: {0}'.format(pos3D_as_str(pos2)))
 
 
 Output
@@ -111,15 +111,15 @@ Example 2: Rotating a bank around the Z Axis
   print('Original positions of detectors 1 and 4')
   opos1 = ws.getInstrument().getDetector(1).getPos()
   opos4 = ws.getInstrument().getDetector(4).getPos()
-  print('Det 1: {0:.6f}'.format(pos3D_as_str(opos1)))
-  print('Det 4: {0:.6f}'.format(pos3D_as_str(opos4)))
+  print('Det 1: {0}'.format(pos3D_as_str(opos1)))
+  print('Det 4: {0}'.format(pos3D_as_str(opos4)))
 
   # Rotate bank 'back' around the Z axis by 3 detectors.
   RotateInstrumentComponent( ws, ComponentName='back', X=0,Y=0,Z=1, Angle=3*360.0 / 32 )
 
   print('Positions of detector 1 after rotation')
   pos1 = ws.getInstrument().getDetector(1).getPos()
-  print('Det 1: {0:.6f}'.format(pos3D_as_str(pos1)))
+  print('Det 1: {0}'.format(pos3D_as_str(pos1)))
   print('Detector 1 took place of detector 4')
 
 Output

--- a/docs/source/algorithms/RotateInstrumentComponent-v1.rst
+++ b/docs/source/algorithms/RotateInstrumentComponent-v1.rst
@@ -178,7 +178,7 @@ Example 3: Rotating a single detector
   # Take element by element difference of the solid angles
   diff = sa2 - sa1
   print(diff)
-  print('The non-zero difference {} is due to detector {}'.format(diff[32], ws.getDetector(32).getID()))
+  print('The non-zero difference {:.13f} is due to detector {}'.format(diff[32], ws.getDetector(32).getID()))
 
 Output
 ^^^^^^

--- a/docs/source/algorithms/RotateInstrumentComponent-v1.rst
+++ b/docs/source/algorithms/RotateInstrumentComponent-v1.rst
@@ -50,20 +50,20 @@ Example 1: Rotating a bank around the Y Axis
      result = format_str.format(nz(pos.getX()), nz(pos.getY()), nz(pos.getZ()))
      return result
 
-  print 'Original positions of detectors 1 and 2'
+  print('Original positions of detectors 1 and 2')
   opos1 = ws.getInstrument().getDetector(1).getPos()
   opos2 = ws.getInstrument().getDetector(2).getPos()
-  print 'Det 1: {0}'.format(pos3D_as_str(opos1))
-  print 'Det 2: {0}'.format(pos3D_as_str(opos2))
+  print('Det 1: {0}'.format(pos3D_as_str(opos1)))
+  print('Det 2: {0}'.format(pos3D_as_str(opos2)))
 
   # Rotate bank 'back' around the Z axis by 90
   RotateInstrumentComponent( ws, ComponentName='back', X=0,Y=1,Z=0, Angle=90.0 )
 
-  print 'Positions of detectors 1 and 2 after rotation'
+  print('Positions of detectors 1 and 2 after rotation')
   pos1 = ws.getInstrument().getDetector(1).getPos()
   pos2 = ws.getInstrument().getDetector(2).getPos()
-  print 'Det 1: {0}'.format(pos3D_as_str(pos1))
-  print 'Det 2: {0}'.format(pos3D_as_str(pos2))
+  print('Det 1: {0}'.format(pos3D_as_str(pos1)))
+  print('Det 2: {0}'.format(pos3D_as_str(pos2)))
 
 
 Output
@@ -108,19 +108,19 @@ Example 2: Rotating a bank around the Z Axis
      result = format_str.format(nz(pos.getX()), nz(pos.getY()), nz(pos.getZ()))
      return result
 
-  print 'Original positions of detectors 1 and 4'
+  print('Original positions of detectors 1 and 4')
   opos1 = ws.getInstrument().getDetector(1).getPos()
   opos4 = ws.getInstrument().getDetector(4).getPos()
-  print 'Det 1: {0}'.format(pos3D_as_str(opos1))
-  print 'Det 4: {0}'.format(pos3D_as_str(opos4))
+  print('Det 1: {0}'.format(pos3D_as_str(opos1)))
+  print('Det 4: {0}'.format(pos3D_as_str(opos4)))
 
   # Rotate bank 'back' around the Z axis by 3 detectors.
   RotateInstrumentComponent( ws, ComponentName='back', X=0,Y=0,Z=1, Angle=3*360.0 / 32 )
 
-  print 'Positions of detector 1 after rotation'
+  print('Positions of detector 1 after rotation')
   pos1 = ws.getInstrument().getDetector(1).getPos()
-  print 'Det 1: {0}'.format(pos3D_as_str(pos1))
-  print 'Detector 1 took place of detector 4'
+  print('Det 1: {0}'.format(pos3D_as_str(pos1)))
+  print('Detector 1 took place of detector 4')
 
 Output
 ^^^^^^
@@ -156,7 +156,7 @@ Example 3: Rotating a single detector
   # Rotating a detector doesn't change its position, just its orientation
 
   # Original position of detector 33
-  print ws.getInstrument().getDetector(33).getPos()
+  print(ws.getInstrument().getDetector(33).getPos())
 
   # Caclulate the solid angles for all detectors in the instrument
   # The result is a single-bin workspace with solid angles for all spectra in ws
@@ -169,7 +169,7 @@ Example 3: Rotating a single detector
   RotateInstrumentComponent( ws, DetectorID=33, X=0,Y=0,Z=1, Angle=90 )
 
   # Check the position of detector 33 stays unchanged
-  print ws.getInstrument().getDetector(33).getPos()
+  print(ws.getInstrument().getDetector(33).getPos())
 
   # Calculate the solid angles after rotation
   saws = SolidAngle( ws )
@@ -177,8 +177,8 @@ Example 3: Rotating a single detector
 
   # Take element by element difference of the solid angles
   diff = sa2 - sa1
-  print diff
-  print 'The non-zero difference',diff[32] ,'is due to detector', ws.getDetector(32).getID()
+  print(diff)
+  print('The non-zero difference {} is due to detector {}'.format(diff[32], ws.getDetector(32).getID()))
 
 Output
 ^^^^^^

--- a/docs/source/algorithms/RotateInstrumentComponent-v1.rst
+++ b/docs/source/algorithms/RotateInstrumentComponent-v1.rst
@@ -53,8 +53,8 @@ Example 1: Rotating a bank around the Y Axis
   print('Original positions of detectors 1 and 2')
   opos1 = ws.getInstrument().getDetector(1).getPos()
   opos2 = ws.getInstrument().getDetector(2).getPos()
-  print('Det 1: {0}'.format(pos3D_as_str(opos1)))
-  print('Det 2: {0}'.format(pos3D_as_str(opos2)))
+  print('Det 1: {0:.6f}'.format(pos3D_as_str(opos1)))
+  print('Det 2: {0:.6f}'.format(pos3D_as_str(opos2)))
 
   # Rotate bank 'back' around the Z axis by 90
   RotateInstrumentComponent( ws, ComponentName='back', X=0,Y=1,Z=0, Angle=90.0 )
@@ -62,8 +62,8 @@ Example 1: Rotating a bank around the Y Axis
   print('Positions of detectors 1 and 2 after rotation')
   pos1 = ws.getInstrument().getDetector(1).getPos()
   pos2 = ws.getInstrument().getDetector(2).getPos()
-  print('Det 1: {0}'.format(pos3D_as_str(pos1)))
-  print('Det 2: {0}'.format(pos3D_as_str(pos2)))
+  print('Det 1: {0:.6f}'.format(pos3D_as_str(pos1)))
+  print('Det 2: {0:.6f}'.format(pos3D_as_str(pos2)))
 
 
 Output
@@ -111,15 +111,15 @@ Example 2: Rotating a bank around the Z Axis
   print('Original positions of detectors 1 and 4')
   opos1 = ws.getInstrument().getDetector(1).getPos()
   opos4 = ws.getInstrument().getDetector(4).getPos()
-  print('Det 1: {0}'.format(pos3D_as_str(opos1)))
-  print('Det 4: {0}'.format(pos3D_as_str(opos4)))
+  print('Det 1: {0:.6f}'.format(pos3D_as_str(opos1)))
+  print('Det 4: {0:.6f}'.format(pos3D_as_str(opos4)))
 
   # Rotate bank 'back' around the Z axis by 3 detectors.
   RotateInstrumentComponent( ws, ComponentName='back', X=0,Y=0,Z=1, Angle=3*360.0 / 32 )
 
   print('Positions of detector 1 after rotation')
   pos1 = ws.getInstrument().getDetector(1).getPos()
-  print('Det 1: {0}'.format(pos3D_as_str(pos1)))
+  print('Det 1: {0:.6f}'.format(pos3D_as_str(pos1)))
   print('Detector 1 took place of detector 4')
 
 Output

--- a/docs/source/algorithms/RotateSource-v1.rst
+++ b/docs/source/algorithms/RotateSource-v1.rst
@@ -45,8 +45,8 @@ Usage
      result = format_str.format(nz(pos.getX()), nz(pos.getY()), nz(pos.getZ()))
      return result
 
-   print "Original position of the sample: {0}".format(pos3D_as_str(samplePos))
-   print "Original position of the source: {0}".format(pos3D_as_str(sourcePos))
+   print("Original position of the sample: {0}".format(pos3D_as_str(samplePos)))
+   print("Original position of the source: {0}".format(pos3D_as_str(sourcePos)))
 
    # Move (rotate) the source around X axis
    RotateSource(ws, -90)
@@ -54,8 +54,8 @@ Usage
    # New positions
    samplePos = ws.getInstrument().getSample().getPos()
    sourcePos = ws.getInstrument().getSource().getPos()
-   print "New position of the sample: {0}".format(pos3D_as_str(samplePos))
-   print "New position of the source: {0}".format(pos3D_as_str(sourcePos))
+   print("New position of the sample: {0}".format(pos3D_as_str(samplePos)))
+   print("New position of the source: {0}".format(pos3D_as_str(sourcePos)))
 
 Output:
 

--- a/docs/source/algorithms/RunPythonScript-v1.rst
+++ b/docs/source/algorithms/RunPythonScript-v1.rst
@@ -41,7 +41,7 @@ Usage
     RunPythonScript(InputWorkspace=ws,Code=script,OutputWorkspace="wsOut")
 
     wsOut = mtd["wsOut"]
-    print "The workspace contained a total of %i counts" % wsOut.readY(0)[0]
+    print("The workspace contained a total of {} counts".format(wsOut.readY(0)[0]))
 
 Output:
 

--- a/docs/source/algorithms/RunPythonScript-v1.rst
+++ b/docs/source/algorithms/RunPythonScript-v1.rst
@@ -41,7 +41,7 @@ Usage
     RunPythonScript(InputWorkspace=ws,Code=script,OutputWorkspace="wsOut")
 
     wsOut = mtd["wsOut"]
-    print("The workspace contained a total of {} counts".format(wsOut.readY(0)[0]))
+    print("The workspace contained a total of {:d} counts".format(wsOut.readY(0)[0]))
 
 Output:
 

--- a/docs/source/algorithms/RunPythonScript-v1.rst
+++ b/docs/source/algorithms/RunPythonScript-v1.rst
@@ -41,7 +41,7 @@ Usage
     RunPythonScript(InputWorkspace=ws,Code=script,OutputWorkspace="wsOut")
 
     wsOut = mtd["wsOut"]
-    print("The workspace contained a total of {:d} counts".format(wsOut.readY(0)[0]))
+    print("The workspace contained a total of {:d} counts".format(int(wsOut.readY(0)[0])))
 
 Output:
 

--- a/docs/source/algorithms/SANSBeamFluxCorrection-v1.rst
+++ b/docs/source/algorithms/SANSBeamFluxCorrection-v1.rst
@@ -41,8 +41,8 @@ Usage
    # Do the correction, dragging in the file which contains the reference flux spectrum.
    corrected = SANSBeamFluxCorrection(ws, InputMonitorWorkspace=monitor, ReferenceFluxFilename="SANSBeamFluxCorrectionMonitor.nxs")
 
-   print "The expected value of each bin should be %s." % (0.1/(49152*0.1)/(49152*0.1))
-   print "The actual value of the first bin is %s." % corrected[0].readY(0)[0]
+   print("The expected value of each bin should be {:.11e}.".format(0.1/(49152*0.1)/(49152*0.1)))
+   print("The actual value of the first bin is {:.11e}.".format(corrected[0].readY(0)[0]))
 
 Output:
 

--- a/docs/source/algorithms/SANSDarkRunBackgroundCorrection-v1.rst
+++ b/docs/source/algorithms/SANSDarkRunBackgroundCorrection-v1.rst
@@ -48,8 +48,8 @@ Usage
     in_y = ws_sample.dataY(0)
     out_y = out_ws.dataY(0)
 
-    print("The first bin of the first spectrum of the input was " + str(in_y[0]))
-    print("After the dark run correction it is " + str(out_y[0]))
+    print("The first bin of the first spectrum of the input was {:.1f}".format(in_y[0]))
+    print("After the dark run correction it is {:.2f}".format(out_y[0]))
 
 Output:
 

--- a/docs/source/algorithms/SANSDarkRunBackgroundCorrection-v1.rst
+++ b/docs/source/algorithms/SANSDarkRunBackgroundCorrection-v1.rst
@@ -48,8 +48,8 @@ Usage
     in_y = ws_sample.dataY(0)
     out_y = out_ws.dataY(0)
 
-    print "The first bin of the first spectrum of the input was " + str(in_y[0])
-    print "After the dark run correction it is " + str(out_y[0])
+    print("The first bin of the first spectrum of the input was " + str(in_y[0]))
+    print("After the dark run correction it is " + str(out_y[0]))
 
 Output:
 

--- a/docs/source/algorithms/SANSFitShiftScale-v1.rst
+++ b/docs/source/algorithms/SANSFitShiftScale-v1.rst
@@ -35,8 +35,8 @@ Usage
 
 	scale, shift = SANSFitShiftScale(HABWorkspace = hab_ws, LABWorkspace =lab_ws, Mode='ShiftOnly', ScaleFactor=1.0)
 
-	print(scale)
-	print(shift)
+	print("{:.1f}".format(scale))
+	print("{:.1f}".format(shift))
 
 Output:
    

--- a/docs/source/algorithms/SANSFitShiftScale-v1.rst
+++ b/docs/source/algorithms/SANSFitShiftScale-v1.rst
@@ -35,8 +35,8 @@ Usage
 
 	scale, shift = SANSFitShiftScale(HABWorkspace = hab_ws, LABWorkspace =lab_ws, Mode='ShiftOnly', ScaleFactor=1.0)
 
-	print scale
-	print shift
+	print(scale)
+	print(shift)
 
 Output:
    

--- a/docs/source/algorithms/SANSStitch-v1.rst
+++ b/docs/source/algorithms/SANSStitch-v1.rst
@@ -73,8 +73,8 @@ Usage
        LABNormSample=lab_norm, 
        Mode='ShiftOnly', ScaleFactor=1.0 )
 
-   print(scale)
-   print(shift)
+   print("{:.1f}".format(scale))
+   print("{:.1f}".format(shift))
 
 Output:
    

--- a/docs/source/algorithms/SANSStitch-v1.rst
+++ b/docs/source/algorithms/SANSStitch-v1.rst
@@ -73,8 +73,8 @@ Usage
        LABNormSample=lab_norm, 
        Mode='ShiftOnly', ScaleFactor=1.0 )
 
-   print scale
-   print shift
+   print(scale)
+   print(shift)
 
 Output:
    

--- a/docs/source/algorithms/SANSWideAngleCorrection-v1.rst
+++ b/docs/source/algorithms/SANSWideAngleCorrection-v1.rst
@@ -149,7 +149,7 @@ Usage
 
    corrected_data = SANSWideAngleCorrection(sample, transmission)
 
-   print("{:.6} was corrected to {:.6}.".format(sample.readY(19)[0], corrected_data.readY(19)[0]))
+   print("{:.6f} was corrected to {:.6f}.".format(sample.readY(19)[0], corrected_data.readY(19)[0]))
 
 Output:
 

--- a/docs/source/algorithms/SANSWideAngleCorrection-v1.rst
+++ b/docs/source/algorithms/SANSWideAngleCorrection-v1.rst
@@ -149,7 +149,7 @@ Usage
 
    corrected_data = SANSWideAngleCorrection(sample, transmission)
 
-   print("{} was corrected to {}.".format(sample.readY(19)[0], corrected_data.readY(19)[0]))
+   print("{:.6} was corrected to {:.6}.".format(sample.readY(19)[0], corrected_data.readY(19)[0]))
 
 Output:
 

--- a/docs/source/algorithms/SANSWideAngleCorrection-v1.rst
+++ b/docs/source/algorithms/SANSWideAngleCorrection-v1.rst
@@ -149,7 +149,7 @@ Usage
 
    corrected_data = SANSWideAngleCorrection(sample, transmission)
 
-   print "%f was corrected to %f." % (sample.readY(19)[0], corrected_data.readY(19)[0])
+   print("{} was corrected to {}.".format(sample.readY(19)[0], corrected_data.readY(19)[0]))
 
 Output:
 

--- a/docs/source/algorithms/SCDCalibratePanels-v1.rst
+++ b/docs/source/algorithms/SCDCalibratePanels-v1.rst
@@ -89,7 +89,7 @@ Usage
     det1 = mtd['MANDI_801_event_DetCal'].getInstrument().getDetector(327680)
     det2 = mtd['MANDI_801_event_xml'].getInstrument().getDetector(327680)
     if det1.getPos() == det2.getPos():
-        print "matches"
+        print("matches")
     
 .. testcleanup:: SCDCalibratePanels
 

--- a/docs/source/algorithms/SassenaFFT-v1.rst
+++ b/docs/source/algorithms/SassenaFFT-v1.rst
@@ -70,7 +70,7 @@ Usage
     ws = LoadSassena("loadSassenaExample.h5", TimeUnit=1.0)
     SassenaFFT(ws, FFTonlyRealPart=1, Temp=1000, DetailedBalance=1)
 
-    print('workspaces instantiated:  {}.format(', '.join(ws.getNames())))
+    print('workspaces instantiated:  {}.format(', '.join(ws.getNames()))
 
     sqt = ws[3] # S(Q,E)
     # I(Q,t) is a Gaussian, thus S(Q,E) is a Gaussian too (at high temperatures)

--- a/docs/source/algorithms/SassenaFFT-v1.rst
+++ b/docs/source/algorithms/SassenaFFT-v1.rst
@@ -70,7 +70,7 @@ Usage
     ws = LoadSassena("loadSassenaExample.h5", TimeUnit=1.0)
     SassenaFFT(ws, FFTonlyRealPart=1, Temp=1000, DetailedBalance=1)
 
-    print('workspaces instantiated:  {}.format(', '.join(ws.getNames()))
+    print('workspaces instantiated:  {}'.format(', '.join(ws.getNames())))
 
     sqt = ws[3] # S(Q,E)
     # I(Q,t) is a Gaussian, thus S(Q,E) is a Gaussian too (at high temperatures)

--- a/docs/source/algorithms/SassenaFFT-v1.rst
+++ b/docs/source/algorithms/SassenaFFT-v1.rst
@@ -70,7 +70,7 @@ Usage
     ws = LoadSassena("loadSassenaExample.h5", TimeUnit=1.0)
     SassenaFFT(ws, FFTonlyRealPart=1, Temp=1000, DetailedBalance=1)
 
-    print('workspaces instantiated: ', ', '.join(ws.getNames()))
+    print('workspaces instantiated:  {}.format(', '.join(ws.getNames())))
 
     sqt = ws[3] # S(Q,E)
     # I(Q,t) is a Gaussian, thus S(Q,E) is a Gaussian too (at high temperatures)
@@ -88,10 +88,10 @@ Usage
     paramTable = fit_output.OutputParameters  # table containing the optimal fit parameters
     fitWorkspace = fit_output.OutputWorkspace
 
-    print("The fit was: " + fit_output.OutputStatus)
-    print("Fitted Height value is: %.1f" % paramTable.column(1)[0])
-    print("Fitted centre value is: %.1f" % abs(paramTable.column(1)[1]))
-    print("Fitted sigma value is: %.4f" % paramTable.column(1)[2])
+    print("The fit was: " + str(fit_output.OutputStatus))
+    print("Fitted Height value is: {:.1f}".format(paramTable.column(1)[0]))
+    print("Fitted centre value is: {:.1f}".format(abs(paramTable.column(1)[1])))
+    print("Fitted sigma value is: {:.4f}".format(paramTable.column(1)[2]))
     # fitWorkspace contains the data, the calculated and the difference patterns
     print("Number of spectra in fitWorkspace is: " +  str(fitWorkspace.getNumberHistograms()))
 

--- a/docs/source/algorithms/SaveANSTOAscii-v1.rst
+++ b/docs/source/algorithms/SaveANSTOAscii-v1.rst
@@ -40,7 +40,7 @@ Usage
     # perform the algorithm
     SaveANSTOAscii(InputWorkspace=ws1,Filename=savefile)
 
-    print "File Exists:", os.path.exists(savefile)
+    print("File Exists: {}".format(os.path.exists(savefile)))
 
 .. testcleanup:: ExANSTOSimple
 

--- a/docs/source/algorithms/SaveAscii-v2.rst
+++ b/docs/source/algorithms/SaveAscii-v2.rst
@@ -44,7 +44,7 @@ Usage
     # perform the algorithm
     SaveAscii(InputWorkspace=ws1,Filename=savefile)
 
-    print "File Exists:", os.path.exists(savefile)
+    print("File Exists: {}".format(os.path.exists(savefile)))
 
 .. testcleanup:: ExSaveASCIISimple
 
@@ -77,7 +77,7 @@ Output:
     # perform the algorithm
     SaveAscii(InputWorkspace=ws1,Filename=savefile,Separator="Space")
 
-    print "File Exists:", os.path.exists(savefile)
+    print("File Exists: {}".format(os.path.exists(savefile)))
 
 .. testcleanup:: ExSaveASCIIDelimiter
 
@@ -112,7 +112,7 @@ Output:
     # CommentIndicator can be changed, but when read back in must be specified
     SaveAscii(InputWorkspace=ws1,Filename=savefile,CommentIndicator="!")
 
-    print "File Exists:", os.path.exists(savefile)
+    print("File Exists: {}".format(os.path.exists(savefile)))
 
 .. testcleanup:: ExSaveASCIIComment
 


### PR DESCRIPTION
Python3 doctest compatibility: algorithms <RetrieveRunInfo  to SaveAscii-v2>

## Description of work.
This PR is part of refactoring effort to bring Python3 compatiblity into the doctests.
See https://github.com/mantidproject/mantid/issues/20672 for details.

The following tests were refactored to be compatible :
```
RetrieveRunInfo-v1
RingProfile-v1
RotateInstrumentComponent-v1
RotateSource-v1
RunPythonScript-v1
SANSBeamFluxCorrection-v1
SANSConvertToWavelengthAndRebin-v1
SANSDarkRunBackgroundCorrection-v1
SANSFitShiftScale-v1
SANSStitch-v1
SANSWideAngleCorrection-v1
SCDCalibratePanels-v1
SassenaFFT-v1
SaveANSTOAscii-v1
SaveAscii-v2
```

Code review.

Fixes #20820 .
Internal change, no release notes
