### PR TITLE
Python3 doctest compatibility: SaveCSV to SaveISISNexus

### DIFF
--- a/docs/source/algorithms/SaveCanSAS1D-v1.rst
+++ b/docs/source/algorithms/SaveCanSAS1D-v1.rst
@@ -54,7 +54,7 @@ Usage
    SaveCanSAS1D(out_ws, file_path, Version=1)
    in_ws = LoadCanSAS1D(file_path)
 
-   print "Contents of the file = " + str(in_ws.readY(0)) + "."
+   print("Contents of the file = " + str(in_ws.readY(0)) + ".")
 
 .. testcleanup:: ExSimpleSavingRoundtrip
 

--- a/docs/source/algorithms/SaveCanSAS1D-v2.rst
+++ b/docs/source/algorithms/SaveCanSAS1D-v2.rst
@@ -54,7 +54,7 @@ Usage
    SaveCanSAS1D(out_ws, file_path)
    in_ws = LoadCanSAS1D(file_path)
 
-   print "Contents of the file = " + str(in_ws.readY(0)) + "."
+   print("Contents of the file = " + str(in_ws.readY(0)) + ".")
 
 .. testcleanup:: ExSimpleSavingRoundtrip
 

--- a/docs/source/algorithms/SaveDaveGrp-v1.rst
+++ b/docs/source/algorithms/SaveDaveGrp-v1.rst
@@ -27,17 +27,17 @@ a contrived example will be created.
     ws = ConvertUnits(ws, Target="DeltaE", EMode="Direct", EFixed=3.0)
     ws = Rebin(ws, Params=[-3,0.01,3], PreserveEvents=False)
     ws = SofQW(ws, QAxisBinning=[0.2,0.2,3], EMode="Direct", EFixed=3.0)
-    print "Workspace size = (", ws.getNumberHistograms(), ",", ws.blocksize(), ")"
+    print("Workspace size = ( {} , {} )".format(ws.getNumberHistograms(), ws.blocksize()))
     import os
     savefile = os.path.join(config["default.savedirectory"], "CNCS_7860_sqw.grp")
     SaveDaveGrp(ws, Filename=savefile)
-    print "File created:", os.path.exists(savefile)
+    print("File created: {}".format(os.path.exists(savefile)))
     ifile = open(savefile, 'r')
     lines = ifile.readlines()
     ifile.close()
     # Number of lines = header(4) + Q axis spec(1 + 14) + E axis spec(1 + 600)
     #                   + data(14 * 601)
-    print "Number of lines =", len(lines)
+    print("Number of lines = {}".format(len(lines)))
 
 Output:
 

--- a/docs/source/algorithms/SaveDetectorsGrouping-v1.rst
+++ b/docs/source/algorithms/SaveDetectorsGrouping-v1.rst
@@ -40,7 +40,7 @@ Usage
    SaveDetectorsGrouping(grouping, save_path)
 
    with open(save_path, 'r') as f:
-     print f.read().replace('\t', '  ').strip()
+     print(f.read().replace('\t', '  ').strip())
 
 Output:
 

--- a/docs/source/algorithms/SaveDiffFittingAscii-v1.rst
+++ b/docs/source/algorithms/SaveDiffFittingAscii-v1.rst
@@ -103,7 +103,7 @@ Usage
     SaveDiffFittingAscii(InputWorkspace = ws, Filename=savefile, RunNumber="21344", Bank = "1",
     OutMode = "AppendToExistingFile")
 
-    print "File Exists:", os.path.exists(savefile)
+    print("File Exists: {}".format(os.path.exists(savefile)))
 
 Output:
 

--- a/docs/source/algorithms/SaveDspacemap-v1.rst
+++ b/docs/source/algorithms/SaveDspacemap-v1.rst
@@ -30,7 +30,7 @@ Usage
   LoadCalFile(InputWorkspace=ws,CalFilename=r'PG3_golden.cal',MakeGroupingWorkspace='0',MakeMaskWorkspace='0',WorkspaceName='PG3_gold')
   SaveDspacemap(InputWorkspace="PG3_gold_offsets", DspacemapFile=savefilename)
 
-  print("File created = {} , file size =  {}".format(os.path.exists(savefilename),  os.path.getsize(savefilename)))
+  print("File created =  {} , file size =  {}".format(os.path.exists(savefilename),  os.path.getsize(savefilename)))
 
 .. testcleanup:: ExSavePG3Dmap
 

--- a/docs/source/algorithms/SaveDspacemap-v1.rst
+++ b/docs/source/algorithms/SaveDspacemap-v1.rst
@@ -30,7 +30,7 @@ Usage
   LoadCalFile(InputWorkspace=ws,CalFilename=r'PG3_golden.cal',MakeGroupingWorkspace='0',MakeMaskWorkspace='0',WorkspaceName='PG3_gold')
   SaveDspacemap(InputWorkspace="PG3_gold_offsets", DspacemapFile=savefilename)
 
-  print "File created = ", os.path.exists(savefilename), ", file size = ", os.path.getsize(savefilename)
+  print("File created = {} , file size =  {}".format(os.path.exists(savefilename),  os.path.getsize(savefilename)))
 
 .. testcleanup:: ExSavePG3Dmap
 

--- a/docs/source/algorithms/SaveFITS-v1.rst
+++ b/docs/source/algorithms/SaveFITS-v1.rst
@@ -79,7 +79,7 @@ Usage
         print("Could not find the keywords '{}' and '{}' in this FITS file".format(axis1_log, axis2_log))
 
     pos_x, pos_y = 22, 33
-    print("Pixel value at coordinates ({0},{1}), first image: {2}, second image: {3}".
+    print("Pixel value at coordinates ({0},{1}), first image: {2:.1f}, second image: {3:.1f}".
            format(pos_x, pos_y, ws.readY(pos_y)[pos_x], ws_reload.readY(pos_y)[pos_x]))
                 
 .. testcleanup:: LoadSaveLoadFITS

--- a/docs/source/algorithms/SaveFITS-v1.rst
+++ b/docs/source/algorithms/SaveFITS-v1.rst
@@ -60,26 +60,26 @@ Usage
     bpp_log = 'BITPIX'
     try:
         log = ws.getRun().getLogData(bpp_log).value
-        print "Bits per pixel in first image: {0}".format(int(log))
+        print("Bits per pixel in first image: {0}".format(int(log)))
         log_reload = ws.getRun().getLogData(bpp_log).value
-        print "Bits per pixel in second image: {0}".format(int(log_reload))
+        print("Bits per pixel in second image: {0}".format(int(log_reload)))
     except RuntimeError:
-        print "Could not find the keyword '{0}' in the FITS file" % bpp_log
+        print("Could not find the keyword '{0}' in the FITS file".format(bpp_log))
 
     axis1_log = 'NAXIS1'
     axis2_log = 'NAXIS2'
     try:
         log1 = ws.getRun().getLogData(axis1_log).value
         log2 = ws.getRun().getLogData(axis2_log).value
-        print "Image size in first image: {0} x {1} pixels".format(int(log1), int(log2))
+        print("Image size in first image: {0} x {1} pixels".format(int(log1), int(log2)))
         log1_reload = ws_reload.getRun().getLogData(axis1_log).value
         log2_reload = ws_reload.getRun().getLogData(axis2_log).value
-        print "Image size in second image: {0} x {1} pixels".format(int(log1_reload), int(log2_reload))
+        print("Image size in second image: {0} x {1} pixels".format(int(log1_reload), int(log2_reload)))
     except RuntimeError:
-        print "Could not find the keywords '%s' and '%s' in this FITS file" % (axis1_log, axis2_log)
+        print("Could not find the keywords '{}' and '{}' in this FITS file".format(axis1_log, axis2_log))
 
     pos_x, pos_y = 22, 33
-    print ("Pixel value at coordinates ({0},{1}), first image: {2}, second image: {3}".
+    print("Pixel value at coordinates ({0},{1}), first image: {2}, second image: {3}".
            format(pos_x, pos_y, ws.readY(pos_y)[pos_x], ws_reload.readY(pos_y)[pos_x]))
                 
 .. testcleanup:: LoadSaveLoadFITS

--- a/docs/source/algorithms/SaveFocusedXYE-v1.rst
+++ b/docs/source/algorithms/SaveFocusedXYE-v1.rst
@@ -44,7 +44,7 @@ Usage
     
     SaveFocusedXYE(ws, path)
     path = os.path.join(os.path.expanduser("~"), "myworkspace-0.ascii")
-    print os.path.isfile(path)
+    print(os.path.isfile(path))
 
 Output:
 
@@ -78,7 +78,7 @@ Output:
     path = os.path.join(os.path.expanduser("~"), file_name)
 
     SaveFocusedXYE(ws, path, SplitFiles=False, IncludeHeader=True, Format='MAUD')
-    print os.path.isfile(path)
+    print(os.path.isfile(path))
 
 
 Output:

--- a/docs/source/algorithms/SaveGSASInstrumentFile-v1.rst
+++ b/docs/source/algorithms/SaveGSASInstrumentFile-v1.rst
@@ -86,7 +86,7 @@ Usage
   gfile.close()
 
   # Print out some result
-  print("Number of lines in GSAS instrument file:  {}".format(len(lines))
+  print("Number of lines in GSAS instrument file:  {}".format(len(lines)))
   print("Line 0:  {}".format(lines[0].strip()))
   print("Line 1:  {}".format(lines[1].strip()))
   print("Line 2:  {}".format(lines[2].strip()))

--- a/docs/source/algorithms/SaveGSASInstrumentFile-v1.rst
+++ b/docs/source/algorithms/SaveGSASInstrumentFile-v1.rst
@@ -86,12 +86,12 @@ Usage
   gfile.close()
 
   # Print out some result
-  print "Number of lines in GSAS instrument file: ", len(lines)
-  print "Line 0: ", lines[0].strip()
-  print "Line 1: ", lines[1].strip()
-  print "Line 2: ", lines[2].strip()
-  print "Line 3: ", lines[3].strip()
-  print "Line 305: ", lines[305].strip()
+  print("Number of lines in GSAS instrument file:  {}".format(len(lines))
+  print("Line 0:  {}".format(lines[0].strip()))
+  print("Line 1:  {}".format(lines[1].strip()))
+  print("Line 2:  {}".format(lines[2].strip()))
+  print("Line 3:  {}".format(lines[3].strip()))
+  print("Line 305:  {}".format(lines[305].strip()))
 
 .. testcleanup:: ExHistSimple
 

--- a/docs/source/algorithms/SaveGSS-v1.rst
+++ b/docs/source/algorithms/SaveGSS-v1.rst
@@ -55,7 +55,7 @@ Usage
 
     # Does the file exist
     path = os.path.join(os.path.expanduser("~"), file_name)
-    print os.path.isfile(path)
+    print(os.path.isfile(path))
 
 Output:
 
@@ -93,7 +93,7 @@ Output:
     path = os.path.join(os.path.expanduser("~"), file_name)
     SaveGSS(ws, path, SplitFiles=False, ExtendedHeader=True, UseSpectrumNumberAsBankID=True)
 
-    print os.path.isfile(path)
+    print(os.path.isfile(path))
         
 Output:
 

--- a/docs/source/algorithms/SaveHKL-v1.rst
+++ b/docs/source/algorithms/SaveHKL-v1.rst
@@ -57,7 +57,7 @@ Usage
     peaks = LoadIsawPeaks(Filename=r'Peaks5637.integrate')
     SaveHKL(peaks, path)
 
-    print os.path.isfile(path)
+    print(os.path.isfile(path))
 
 Output:
 
@@ -86,13 +86,13 @@ Output:
 
     #load a peaks workspace from file
     peaks = LoadIsawPeaks(Filename=r'Peaks5637.integrate')
-    print "Number of peaks in table %d" % peaks.rowCount()
+    print("Number of peaks in table {}".format(peaks.rowCount()))
     
     path = os.path.join(os.path.expanduser("~"), "MyPeaks.hkl")
     SaveHKL(peaks, path, MinWavelength=0.5, MaxWavelength=2,MinDSpacing=0.2, SortBy='Bank')
 
     peaks = LoadHKL(path)
-    print "Number of peaks in table %d" % peaks.rowCount()
+    print("Number of peaks in table {}".format(peaks.rowCount()))
 
 Output:
 

--- a/docs/source/algorithms/SaveILLCosmosAscii-v1.rst
+++ b/docs/source/algorithms/SaveILLCosmosAscii-v1.rst
@@ -40,7 +40,7 @@ Usage
     # perform the algorithm
     SaveILLCosmosAscii(InputWorkspace=ws1,Filename=savefile)
 
-    print("File Exists: {}".format(os.path.exists(savefile))
+    print("File Exists: {}".format(os.path.exists(savefile)))
 
 .. testcleanup:: ExILLCosmosSimple
 

--- a/docs/source/algorithms/SaveILLCosmosAscii-v1.rst
+++ b/docs/source/algorithms/SaveILLCosmosAscii-v1.rst
@@ -40,7 +40,7 @@ Usage
     # perform the algorithm
     SaveILLCosmosAscii(InputWorkspace=ws1,Filename=savefile)
 
-    print "File Exists:", os.path.exists(savefile)
+    print("File Exists: {}".format(os.path.exists(savefile))
 
 .. testcleanup:: ExILLCosmosSimple
 


### PR DESCRIPTION
Python3 doctest compatibility: algorithms <SaveCSV to SaveISISNexus>

## Description of work.
This PR is part of refactoring effort to bring Python3 compatiblity into the doctests.
See https://github.com/mantidproject/mantid/issues/20672 for details.

The following tests were refactored to be compatible :
```
SaveCSV-v1
SaveCanSAS1D-v1
SaveCanSAS1D-v2
SaveDaveGrp-v1
SaveDetectorsGrouping-v1
SaveDiffFittingAscii-v1
SaveDspacemap-v1
SaveFITS-v1
SaveFocusedXYE-v1
SaveFullprofResolution-v1
SaveGSASInstrumentFile-v1
SaveGSS-v1
SaveHKL-v1
SaveILLCosmosAscii-v1
SaveISISNexus-v1
```

Code review.

Fixes #20823.
Internal change, no release notes