### PR TITLE
Python3 doctest compatibility: SaveIsawPeaks to SavePAR

### DIFF
--- a/docs/source/algorithms/SaveIsawPeaks-v1.rst
+++ b/docs/source/algorithms/SaveIsawPeaks-v1.rst
@@ -44,10 +44,10 @@ Usage
   # different on different systems and breaks tests
   for line in file[:9]:
       # print the line stripping any ending white spaces
-      print line.rstrip()
+      print(line.rstrip())
   for line in file[10:12]:
       # print the line stripping any ending white spaces
-      print line.rstrip()
+      print(line.rstrip())
 
 Output
 ######

--- a/docs/source/algorithms/SaveIsawUB-v1.rst
+++ b/docs/source/algorithms/SaveIsawUB-v1.rst
@@ -37,13 +37,13 @@ Usage
     f=open(filename,"r")
     x,y,z=map(float,f.readline().split())
     if (x==0) and (y==0.5) and (z==0):
-        print "The first line is 0 0.5 0"
+        print("The first line is 0 0.5 0")
     x,y,z=map(float,f.readline().split())
     if (x==0) and (y==0) and (z==0.25):
-        print "The second line is 0 0 0.25"
+        print("The second line is 0 0 0.25")
     x,y,z=map(float,f.readline().split())
     if (x==0.2) and (y==0) and (z==0):
-        print "The third line is 0.2 0 0"
+        print("The third line is 0.2 0 0")
     f.close()
   
 

--- a/docs/source/algorithms/SaveIsawUB-v1.rst
+++ b/docs/source/algorithms/SaveIsawUB-v1.rst
@@ -26,22 +26,22 @@ Usage
 .. testcode:: SaveIsawUB
 
     #A workspace with some UB matrix    
-    w=CreateSingleValuedWorkspace()
-    SetUB(w,2,4,5,90,90,90,"0,0,1","1,0,0")
+    w = CreateSingleValuedWorkspace()
+    SetUB(w, 2, 4, 5, 90, 90, 90, "0,0,1", "1,0,0")
     #run the algorithm
     import mantid   
-    filename=mantid.config.getString("defaultsave.directory")+"saveIsawUBTest.mat"  
-    SaveIsawUB(w,filename)
+    filename = mantid.config.getString("defaultsave.directory") + "saveIsawUBTest.mat"  
+    SaveIsawUB(w, filename)
     
     #check if the correct results are written in the file
-    f=open(filename,"r")
-    x,y,z=map(float,f.readline().split())
+    f = open(filename, "r")
+    x, y, z = map(float, f.readline().split())
     if (x==0) and (y==0.5) and (z==0):
         print("The first line is 0 0.5 0")
-    x,y,z=map(float,f.readline().split())
+    x, y, z = map(float, f.readline().split())
     if (x==0) and (y==0) and (z==0.25):
         print("The second line is 0 0 0.25")
-    x,y,z=map(float,f.readline().split())
+    x, y, z = map(float, f.readline().split())
     if (x==0.2) and (y==0) and (z==0):
         print("The third line is 0.2 0 0")
     f.close()

--- a/docs/source/algorithms/SaveLauenorm-v1.rst
+++ b/docs/source/algorithms/SaveLauenorm-v1.rst
@@ -75,7 +75,7 @@ Output:
     ifile = open(finalfile, 'r')
     lines = ifile.readlines()
     ifile.close()
-    print("Number of peaks in table {}".format(len(lines))
+    print("Number of peaks in table {}".format(len(lines)))
 
 Output:
 

--- a/docs/source/algorithms/SaveLauenorm-v1.rst
+++ b/docs/source/algorithms/SaveLauenorm-v1.rst
@@ -37,7 +37,7 @@ Usage
     SaveLauenorm(InputWorkspace=peaks, Filename=prefix)
 
     firstfile = prefix + "001"
-    print "File was saved:", os.path.isfile(firstfile)
+    print("File was saved: {}".format(os.path.isfile(firstfile)))
 
 Output:
 
@@ -66,7 +66,7 @@ Output:
 
     #load a peaks workspace from file
     peaks = LoadIsawPeaks(Filename=r'Peaks5637.integrate')
-    print "Number of peaks in table %d" % peaks.rowCount()
+    print("Number of peaks in table {}".format(peaks.rowCount()))
 
     prefix = os.path.expanduser("~/MyPeaks")
     SaveLauenorm(InputWorkspace=peaks, Filename=prefix, MinWavelength=0.5, MaxWavelength=2,MinDSpacing=0.2, SortFilesBy='Bank')
@@ -75,7 +75,7 @@ Output:
     ifile = open(finalfile, 'r')
     lines = ifile.readlines()
     ifile.close()
-    print "Number of peaks in table %d" % len(lines)
+    print("Number of peaks in table {}".format(len(lines))
 
 Output:
 

--- a/docs/source/algorithms/SaveMD-v1.rst
+++ b/docs/source/algorithms/SaveMD-v1.rst
@@ -31,7 +31,7 @@ Usage
     import os
     savefile = os.path.join(config["default.savedirectory"], "mdhws.nxs")
     SaveMD(ws, Filename=savefile, Version=1)
-    print "File created:", os.path.exists(savefile)
+    print("File created: {}".format(os.path.exists(savefile)))
 
 Output:
 

--- a/docs/source/algorithms/SaveMD-v2.rst
+++ b/docs/source/algorithms/SaveMD-v2.rst
@@ -31,7 +31,7 @@ Usage
     import os
     savefile = os.path.join(config["default.savedirectory"], "mdhws.nxs")
     SaveMD(ws, Filename=savefile)
-    print "File created:", os.path.exists(savefile)
+    print("File created: {}".format(os.path.exists(savefile)))
 
 Output:
 

--- a/docs/source/algorithms/SaveMDWorkspaceToVTK-v1.rst
+++ b/docs/source/algorithms/SaveMDWorkspaceToVTK-v1.rst
@@ -37,7 +37,7 @@ Usage
     savefile = os.path.join(config["defaultsave.directory"], "mdhws.vts")
     SaveMDWorkspaceToVTK(InputWorkspace = ws, Filename = savefile)
 
-    print "File created:", os.path.exists(savefile)
+    print("File created: {}".format(os.path.exists(savefile)))
 
 .. testoutput:: SaveMDWorkspaceToVTK
 

--- a/docs/source/algorithms/SaveNISTDAT-v1.rst
+++ b/docs/source/algorithms/SaveNISTDAT-v1.rst
@@ -34,7 +34,7 @@ Usage
 
    # Load it back in and inspect what we have.
    reloaded_data = LoadAscii(file_path)
-   print "The data read back in is " + str(reloaded_data.readY(0))
+   print("The data read back in is " + str(reloaded_data.readY(0)))
 
 .. testcleanup:: ExSaveRoundtrip
 

--- a/docs/source/algorithms/SaveNXSPE-v1.rst
+++ b/docs/source/algorithms/SaveNXSPE-v1.rst
@@ -57,7 +57,7 @@ Usage
    print("Contents of the first spectrum = " + str(in_ws.readY(0)) + ".")
    print("Initial and loaded workspaces comparison is: {}".format(str(ws_comparison_rez[0])))
    run = in_ws.getRun();
-   print("Loaded workspace has attached incident energy Ei={0:5} and rotation angle Psi={1:5}deg".format(run.getLogData('Ei').value,run.getLogData('psi').value))
+   print("Loaded workspace has attached incident energy Ei={0:.1f} and rotation angle Psi={1:.1f}deg".format(run.getLogData('Ei').value,run.getLogData('psi').value))
    
 
 .. testcleanup:: ExSimpleSavingRoundtrip

--- a/docs/source/algorithms/SaveNXSPE-v1.rst
+++ b/docs/source/algorithms/SaveNXSPE-v1.rst
@@ -48,13 +48,13 @@ Usage
    # By desigghn, SaveMXSPE does not store detector's ID-s. LoadNXSPE sets detector's ID-s to defaults.
    # To compare loaded and saved workspaces here, one needs to set-up default detector's ID-s to the source workspace.
    nSpec = out_ws.getNumberHistograms()
-   for i in xrange(0,nSpec):
+   for i in range(0,nSpec):
        sp=out_ws.getSpectrum(i);
        sp.setDetectorID(i+1);
    in_ws = LoadNXSPE(file_path)
    
    ws_comparison_rez = CompareWorkspaces(out_ws,in_ws,1.e-9,CheckInstrument=False)
-   print("Contents of the first spectrum = " + str(in_ws.readY(0)) + ".")
+   print("Contents of the first spectrum = {}.".format(in_ws.readY(0)))
    print("Initial and loaded workspaces comparison is: {}".format(str(ws_comparison_rez[0])))
    run = in_ws.getRun();
    print("Loaded workspace has attached incident energy Ei={0:.1f} and rotation angle Psi={1:.1f}deg".format(run.getLogData('Ei').value,run.getLogData('psi').value))

--- a/docs/source/algorithms/SaveNXSPE-v1.rst
+++ b/docs/source/algorithms/SaveNXSPE-v1.rst
@@ -57,7 +57,7 @@ Usage
    print("Contents of the first spectrum = {}.".format(in_ws.readY(0)))
    print("Initial and loaded workspaces comparison is: {}".format(str(ws_comparison_rez[0])))
    run = in_ws.getRun();
-   print("Loaded workspace has attached incident energy Ei={0:.1f} and rotation angle Psi={1:.1f}deg".format(run.getLogData('Ei').value,run.getLogData('psi').value))
+   print("Loaded workspace has attached incident energy Ei={0:.1f} and rotation angle Psi= {1:.1f}deg".format(run.getLogData('Ei').value,run.getLogData('psi').value))
    
 
 .. testcleanup:: ExSimpleSavingRoundtrip

--- a/docs/source/algorithms/SaveNXSPE-v1.rst
+++ b/docs/source/algorithms/SaveNXSPE-v1.rst
@@ -54,10 +54,10 @@ Usage
    in_ws = LoadNXSPE(file_path)
    
    ws_comparison_rez = CompareWorkspaces(out_ws,in_ws,1.e-9,CheckInstrument=False)
-   print "Contents of the first spectrum = " + str(in_ws.readY(0)) + "."
-   print "Initial and loaded workspaces comparison is:",str(ws_comparison_rez[0])
+   print("Contents of the first spectrum = " + str(in_ws.readY(0)) + ".")
+   print("Initial and loaded workspaces comparison is: {}".format(str(ws_comparison_rez[0])))
    run = in_ws.getRun();
-   print "Loaded workspace has attached incident energy Ei={0:5} and rotation angle Psi={1:5}deg".format(run.getLogData('Ei').value,run.getLogData('psi').value)
+   print("Loaded workspace has attached incident energy Ei={0:5} and rotation angle Psi={1:5}deg".format(run.getLogData('Ei').value,run.getLogData('psi').value))
    
 
 .. testcleanup:: ExSimpleSavingRoundtrip

--- a/docs/source/algorithms/SaveNexusProcessed-v1.rst
+++ b/docs/source/algorithms/SaveNexusProcessed-v1.rst
@@ -91,10 +91,10 @@ Output:
     path = os.path.join(os.path.expanduser("~"), file_name)
     SaveNexusProcessed(ws, path, Title="MyWorkspace", WorkspaceIndexMin=0, WorkspaceIndexMax=9)
 
-    print os.path.isfile(path)
+    print(os.path.isfile(path))
 
     ws = Load(path)
-    print "Saved workspace has %d spectra" % ws.getNumberHistograms()
+    print("Saved workspace has {} spectra".format(ws.getNumberHistograms()))
 
 Output:
 
@@ -127,10 +127,10 @@ Output:
     path = os.path.join(os.path.expanduser("~"), file_name)
     SaveNexusProcessed(ws, path, CompressNexus=True, PreserveEvents=True)
 
-    print os.path.isfile(path)
+    print(os.path.isfile(path))
 
     ws = Load(path)
-    print "Saved workspace has %d spectra" % ws.getNumberHistograms()
+    print("Saved workspace has {} spectra".format(ws.getNumberHistograms()))
     
 Output:
 

--- a/docs/source/algorithms/SaveNexusProcessed-v1.rst
+++ b/docs/source/algorithms/SaveNexusProcessed-v1.rst
@@ -58,7 +58,7 @@ Usage
     path = os.path.join(os.path.expanduser("~"), file_name)
     SaveNexusProcessed(ws, path)
 
-    print os.path.isfile(path)
+    print(os.path.isfile(path))
 
 Output:
 

--- a/docs/source/algorithms/SaveOpenGenieAscii-v1.rst
+++ b/docs/source/algorithms/SaveOpenGenieAscii-v1.rst
@@ -41,7 +41,7 @@ Usage
     SaveOpenGenieAscii(ws, path)
 
     path = os.path.join(os.path.expanduser("~"), "myworkspace.ascii")
-    print os.path.isfile(path)
+    print(os.path.isfile(path))
 
 
 Output:

--- a/docs/source/algorithms/SavePAR-v1.rst
+++ b/docs/source/algorithms/SavePAR-v1.rst
@@ -50,13 +50,13 @@ Usage
    # import os funcions to work with folders
    import os
    # create sample workspace
-   ws=CreateSampleWorkspace();
+   ws = CreateSampleWorkspace()
    # test file name
    file_name = os.path.join(config["defaultsave.directory"], "TestSavePar.par")
-    # save the file
+   # save the file
    SavePAR(ws,Filename=file_name);
 
-   print "target file exists? {0}".format(os.path.exists(file_name));
+   print("target file exists? {0}".format(os.path.exists(file_name)))
 
 .. testcleanup:: exSavePAR
 


### PR DESCRIPTION
Python3 doctest compatibility: algorithms <SaveIsawPeaks to SavePAR>

## Description of work.
This PR is part of refactoring effort to bring Python3 compatiblity into the doctests.
See https://github.com/mantidproject/mantid/issues/20672 for details.

The following tests were refactored to be compatible :
```
SaveIsawPeaks-v1
SaveIsawUB-v1
SaveLauenorm-v1
SaveMD-v1
SaveMD-v2
SaveMDWorkspaceToVTK-v1
SaveMask-v1
SaveNISTDAT-v1
SaveNXSPE-v1
SaveNXTomo-v1
SaveNXcanSAS-v1
SaveNexus-v1
SaveNexusProcessed-v1
SaveOpenGenieAscii-v1
SavePAR-v1
```

Code review.

Fixes #20825 .
Internal change, no release notes