### PR TITLE
Python3 doctest compatibility: SavePDFGui to ScaleX

### DIFF
--- a/docs/source/algorithms/SavePDFGui-v1.rst
+++ b/docs/source/algorithms/SavePDFGui-v1.rst
@@ -35,7 +35,7 @@ Usage
    SavePDFGui(ws, path)
 
    # Check that the file exists
-   print os.path.isfile(path)
+   print(os.path.isfile(path))
 
 Output:
 

--- a/docs/source/algorithms/SavePHX-v1.rst
+++ b/docs/source/algorithms/SavePHX-v1.rst
@@ -56,13 +56,13 @@ Usage
    # import os funcions to work with folders
    import os
    # create sample workspace
-   ws=CreateSampleWorkspace();
+   ws=CreateSampleWorkspace()
    # test file name
    file_name = os.path.join(config["defaultsave.directory"], "TestSavePhx.phx")
     # save the file
    SavePHX(ws,Filename=file_name);
 
-   print "target file exists? {0}".format(os.path.exists(file_name));
+   print("target file exists? {0}".format(os.path.exists(file_name)))
 
 .. testcleanup:: exSavePHX
 

--- a/docs/source/algorithms/SaveParameterFile-v1.rst
+++ b/docs/source/algorithms/SaveParameterFile-v1.rst
@@ -37,7 +37,7 @@ Usage
 
   #Make sure the file was written successfully
   if os.path.isfile(filename):
-    print "Parameters written successfully."
+    print("Parameters written successfully.")
 
 .. testcleanup::
 

--- a/docs/source/algorithms/SavePlot1D-v1.rst
+++ b/docs/source/algorithms/SavePlot1D-v1.rst
@@ -72,7 +72,7 @@ Usage in autoreduction
     div = SavePlot1D(InputWorkspace='w1', OutputType='plotly')
     from postprocessing.publish_plot import publish_plot
     request = publish_plot('TESTINSTRUMENT', 12345, files={'file':div})
-    print "post returned %d" % request.status_code
+    print("post returned {}".format(request.status_code))
 
 To see what the result looks like on your local system, add the
 ``Filename`` argument (``.html`` extension) and change to

--- a/docs/source/algorithms/SaveRKH-v1.rst
+++ b/docs/source/algorithms/SaveRKH-v1.rst
@@ -38,7 +38,7 @@ Usage
    SaveRKH(out_ws, file_path)
    in_ws = LoadRKH(file_path)
 
-   print "Contents of the file  = " + str(in_ws.readY(0))
+   print("Contents of the file  = " + str(in_ws.readY(0)))
 
 .. testcleanup:: ExSimpleSavingRoundtrip
 

--- a/docs/source/algorithms/SaveSPE-v1.rst
+++ b/docs/source/algorithms/SaveSPE-v1.rst
@@ -104,7 +104,7 @@ Usage
     # perform the algorithm
     SaveSPE(InputWorkspace=ws1,Filename=savefile)
 
-    print "File Exists:", os.path.exists(savefile)
+    print("File Exists: {}".format(os.path.exists(savefile)))
 
 .. testcleanup:: ExSPESimple
 

--- a/docs/source/algorithms/SaveTBL-v1.rst
+++ b/docs/source/algorithms/SaveTBL-v1.rst
@@ -80,7 +80,7 @@ Usage
     # 13470,2.3,13463+13464,0.035,0.3,0.04,,0,
     # 13462,2.3,13463+13464,0.035,0.3,0.04,,1,ProcessingInstruction="1:2"
     # 13469,0.7,13463+13464,0.01,0.06,0.04,,1,
-    print "File Exists:", os.path.exists(savefile)
+    print("File Exists: {}".format(os.path.exists(savefile)))
 
 .. testcleanup:: ExTBLSimple
 

--- a/docs/source/algorithms/SaveVulcanGSS-v1.rst
+++ b/docs/source/algorithms/SaveVulcanGSS-v1.rst
@@ -38,10 +38,10 @@ Usage
   lines = gfile.readlines()
   gfile.close()
 
-  print "[GSAS File Start]"
+  print("[GSAS File Start]")
   for i in xrange(11):
-      print lines[i].rstrip()
-  print "... ..."
+      print(lines[i].rstrip())
+  print("... ...")
 
   
 .. testcleanup:: ExSaveVulcanGSAS

--- a/docs/source/algorithms/SaveVulcanGSS-v1.rst
+++ b/docs/source/algorithms/SaveVulcanGSS-v1.rst
@@ -39,7 +39,7 @@ Usage
   gfile.close()
 
   print("[GSAS File Start]")
-  for i in xrange(11):
+  for i in range(11):
       print(lines[i].rstrip())
   print("... ...")
 

--- a/docs/source/algorithms/SaveYDA-v1.rst
+++ b/docs/source/algorithms/SaveYDA-v1.rst
@@ -55,7 +55,7 @@ Usage
 
     with open(filename,'r') as f:
         for i in range(12):
-            print(f.readline())
+            print(f.readline(), end='')
 
 **Output:**
 

--- a/docs/source/algorithms/SaveYDA-v1.rst
+++ b/docs/source/algorithms/SaveYDA-v1.rst
@@ -53,10 +53,9 @@ Usage
     # save file
     SaveYDA(ws, filename)
 
-
     with open(filename,'r') as f:
         for i in range(12):
-            print f.readline(),
+            print(f.readline())
 
 **Output:**
 

--- a/docs/source/algorithms/SaveYDA-v1.rst
+++ b/docs/source/algorithms/SaveYDA-v1.rst
@@ -29,6 +29,7 @@ Usage
 
     import os
     import numpy as np
+    from sys import stdout
 
     # create x and y data
     dataX = np.arange(12).reshape(3, 4)
@@ -55,7 +56,7 @@ Usage
 
     with open(filename,'r') as f:
         for i in range(12):
-            print(f.readline(), end='')
+            stdout.write(f.readline())
 
 **Output:**
 

--- a/docs/source/algorithms/SaveZODS-v1.rst
+++ b/docs/source/algorithms/SaveZODS-v1.rst
@@ -87,7 +87,7 @@ using :ref:`CreateMDWorkspace <algm-CreateMDWorkspace>`.
     import os
     savefile = os.path.join(config["defaultsave.directory"], "ZODS.h5")
     SaveZODS(InputWorkspace=ws, FileName=savefile)
-    print "File created:", os.path.exists(savefile)
+    print("File created: {}".format(os.path.exists(savefile)))
 
 Output:
 

--- a/docs/source/algorithms/Scale-v1.rst
+++ b/docs/source/algorithms/Scale-v1.rst
@@ -23,18 +23,18 @@ Usage
 .. testcode:: ExOffsetScale
 
     ws = CreateSampleWorkspace(BankPixelWidth=1)
-    print "Every 10th bin value of " + ws.name()
-    print ws.readY(0)[0:100:10]
+    print("Every 10th bin value of " + ws.name())
+    print(ws.readY(0)[0:100:10])
 
     # Add 2 using scale
     wsOffset = Scale(ws,2,"Add")
-    print "Every 10th bin value of " + wsOffset.name()
-    print wsOffset.readY(0)[0:100:10]
+    print("Every 10th bin value of " + wsOffset.name())
+    print(wsOffset.readY(0)[0:100:10])
 
     # Add 2 using the workspace operator overloads
     wsOffset2 = ws + 2
-    print "Every 10th bin value of " + wsOffset2.name()
-    print wsOffset2.readY(0)[0:100:10]
+    print("Every 10th bin value of " + wsOffset2.name())
+    print(wsOffset2.readY(0)[0:100:10])
 
 Output:
 
@@ -52,18 +52,18 @@ Output:
 .. testcode:: ExOffsetScale
 
     ws = CreateSampleWorkspace(BankPixelWidth=1)
-    print "Every 10th bin value of " + ws.name()
-    print ws.readY(0)[0:100:10]
+    print("Every 10th bin value of " + ws.name())
+    print(ws.readY(0)[0:100:10])
 
     # Multiply by 10 using scale
     wsScaled = Scale(ws,10,"Multiply")
-    print "Every 10th bin value of " + wsScaled.name()
-    print wsScaled.readY(0)[0:100:10]
+    print("Every 10th bin value of " + wsScaled.name())
+    print(wsScaled.readY(0)[0:100:10])
 
     # Multiply by 10 using the workspace operator overloads
     wsScaled2 = ws * 10
-    print "Every 10th bin value of " + wsScaled2.name()
-    print wsScaled2.readY(0)[0:100:10]
+    print("Every 10th bin value of " + wsScaled2.name())
+    print(wsScaled2.readY(0)[0:100:10])
 
 Output:
 

--- a/docs/source/algorithms/ScaleX-v1.rst
+++ b/docs/source/algorithms/ScaleX-v1.rst
@@ -36,12 +36,12 @@ Usage
 
     # Center the Gaussian by shifting the X-axis, then find its average
     ws2 = ScaleX(ws, Factor=-mean, Operation='Add')
-    print 'mean=%.2f'%abs(np.sum( ws2.dataX(0) *ws2.dataY(0) ) / np.sum( ws2.dataY(0) ))
+    print('mean={:.2f}'.format(abs(np.sum( ws2.dataX(0) *ws2.dataY(0) ) / np.sum( ws2.dataY(0) ))))
 
     # Decrease the standard deviation of the Gaussian by half via shrinkage of the X-axis,
     # then find its standard deviation
     ws3 = ScaleX(ws2, Factor=0.5, Operation='Multiply')
-    print 'sigma=%.2f'%np.sqrt( np.sum( ws3.dataX(0)**2 *ws3.dataY(0) ) / np.sum( ws3.dataY(0) ) )
+    print('sigma={:.2f}'.format(np.sqrt( np.sum( ws3.dataX(0)**2 *ws3.dataY(0) ) / np.sum( ws3.dataY(0) ) )))
 
 Output:
 


### PR DESCRIPTION
Python3 doctest compatibility: algorithms <SavePDFGui to ScaleX>

## Description of work.
This PR is part of refactoring effort to bring Python3 compatiblity into the doctests.
See https://github.com/mantidproject/mantid/issues/20672 for details.

The following tests were refactored to be compatible :
```
SavePDFGui-v1
SavePHX-v1
SaveParameterFile-v1
SavePlot1D-v1
SavePlot1DAsJson-v1
SaveRKH-v1
SaveSESANS-v1
SaveSPE-v1
SaveTBL-v1
SaveToSNSHistogramNexus-v1
SaveVulcanGSS-v1
SaveYDA-v1
SaveZODS-v1
Scale-v1
ScaleX-v1
```

Code review.

Fixes #20827 .
Internal change, no release notes