### PR TITLE
Python3 doctest compatibility: PredictPeaks to Regroup

### DIFF
--- a/docs/source/algorithms/PredictPeaks-v1.rst
+++ b/docs/source/algorithms/PredictPeaks-v1.rst
@@ -56,18 +56,18 @@ which can currently be achieved as in the following example:
                              MinDSpacing=0.5,
                              WavelengthMin=0.9, WavelengthMax=6.0)
 
-    print 'There are', predicted.getNumberPeaks(), 'detectable peaks.'
+    print('There are {} detectable peaks.'.format(predicted.getNumberPeaks()))
 
     intensities = np.array(predicted.column('Intens'))
     maxIntensity = np.max(intensities)
     relativeIntensities = intensities / maxIntensity
 
-    print 'Maximum intensity: {0:.2f}'.format(maxIntensity)
-    print 'Peaks with relative intensity < 1%:', len([x for x in relativeIntensities if x < 0.01])
+    print('Maximum intensity: {0:.2f}'.format(maxIntensity))
+    print('Peaks with relative intensity < 1%: {}'.format(len([x for x in relativeIntensities if x < 0.01])))
 
     absences = [i for i, x in enumerate(intensities) if x < 1e-9]
-    print 'Number of absences:', len(absences)
-    print 'Absent HKLs:', [predicted.getPeak(i).getHKL() for i in absences]
+    print('Number of absences: {}'.format(len(absences)))
+    print('Absent HKLs: {}'.format([predicted.getPeak(i).getHKL() for i in absences]))
 
 The script provides some information about the predicted peaks and
 their structure factors. Additionally it prints out the HKL of peaks

--- a/docs/source/algorithms/PreprocessDetectorsToMD-v1.rst
+++ b/docs/source/algorithms/PreprocessDetectorsToMD-v1.rst
@@ -64,12 +64,12 @@ Usage
     # 
     preprDetWS = PreprocessDetectorsToMD(InputWorkspace=detWS,GetMaskState=1,GetEFixed=1)
     # Look at sample results:       
-    print "The resulting table has the following columns:"
-    print preprDetWS.keys()
-    print "The number of rows in the workspace is : ",len(preprDetWS.column('L2'))
+    print("The resulting table has the following columns:")
+    print(preprDetWS.keys())
+    print("The number of rows in the workspace is :  {}".format(len(preprDetWS.column('L2'))))
     polar = preprDetWS.column('TwoTheta')
-    print "The polar angle for detector N {0} is {1:5f} rad".format(10,polar[10])
-    print "The table workspace logs (properties) are currently not availible from python"
+    print("The polar angle for detector N {0} is {1:5f} rad".format(10,polar[10]))
+    print("The table workspace logs (properties) are currently not available from python")
     
     
 .. testcleanup:: ExPreprocessDetectoresToMD
@@ -85,7 +85,7 @@ Usage
    ['DetDirections', 'L2', 'TwoTheta', 'Azimuthal', 'DetectorID', 'detIDMap', 'spec2detMap', 'detMask', 'eFixed']
    The number of rows in the workspace is :  918
    The polar angle for detector N 10 is 0.314159 rad
-   The table workspace logs (properties) are currently not availible from python
+   The table workspace logs (properties) are currently not available from python
 
 
 

--- a/docs/source/algorithms/ProcessBackground-v1.rst
+++ b/docs/source/algorithms/ProcessBackground-v1.rst
@@ -194,13 +194,13 @@ Usage
 
   tbws = outputs[2]
 
-  print "Number of output workspace = %d, Number of selected background points = %d" %( len(outputs),  len(outputs[0].readX(0)))
-  print "Fitted background function: A0 = %.5e, A1 = %.5e, A2 = %.5e ..." % (tbws.cell(1, 1), tbws.cell(2, 1), tbws.cell(3,1))
+  print("Number of output workspace = {}, Number of selected background points = {}".format(len(outputs), len(outputs[0].readX(0))))
+  print("Fitted background function: A0 = {:.5e}, A1 = {:.5e}, A2 = {:.5e} ...".format(tbws.cell(1, 1), tbws.cell(2, 1), tbws.cell(3,1)))
 
 .. testcleanup:: testSelectBkgd
 
   DeleteWorkspace(Workspace='PG3_15035-3')
-  for i in xrange(3):
+  for i in range(3):
     DeleteWorkspace(Workspace=outputs[i])
 
 Output:
@@ -226,7 +226,7 @@ Output:
   dx = 0.01
 
   random.seed(1)
-  for i in xrange(1000):
+  for i in range(1000):
     x = x0 + float(i) * dx
     vecx.append(x)
     y = (random.random() - 0.5) * 2.0 + 2.0 + math.exp(-(x-4.0)**2/0.1)
@@ -242,13 +242,14 @@ Output:
         LowerBound = 3.0, UpperBound = 5.0, ReferenceWorkspace = ws2)
 
   for i in [200, 400, 450, 500, 700]:
-    print "X = %.5f, Input Y[%d] = %.5f, Reference Y[%d] = %.5f, Output Y[%d] = %.5f" % (vecx[i], i, ws1.readY(0)[i], i, ws2.readY(0)[i], i, outputs[0].readY(0)[i])
+      print("X = {0:.5f}, Input Y[{1}] = {2:.5f}, Reference Y[{1}] = {3:.5f}, Output Y[{1}] = {4:.5f}".format(
+             vecx[i], i, ws1.readY(0)[i], ws2.readY(0)[i], outputs[0].readY(0)[i]))
 
 .. testcleanup:: testAddRegion
 
   DeleteWorkspace(Workspace=ws1)
   DeleteWorkspace(Workspace=ws2)
-  for i in xrange(3):
+  for i in range(3):
     DeleteWorkspace(Workspace=outputs[i])
 
 Output:
@@ -276,7 +277,7 @@ Output:
   dx = 0.01
 
   random.seed(1)
-  for i in xrange(1000):
+  for i in range(1000):
     x = x0 + float(i) * dx
     vecx.append(x)
     y = (random.random() - 0.5) * 2.0 + 2.0 + math.exp(-(x-4.0)**2/0.1)
@@ -289,12 +290,12 @@ Output:
   outputs = ProcessBackground(InputWorkspace=ws1, WorkspaceIndex=0, OutputWorkspace="ws2", Options="DeleteRegion",
         LowerBound = 3.0, UpperBound = 5.0)
 
-  print "Input has %d data points; Output has %d data points." % ( len(ws1.readX(0)), len(outputs[0].readX(0)) )
+  print("Input has {} data points; Output has {} data points.".format(len(ws1.readX(0)), len(outputs[0].readX(0))))
 
 .. testcleanup:: testDelRegion
 
   DeleteWorkspace(Workspace=ws1)
-  for i in xrange(3):
+  for i in range(3):
     DeleteWorkspace(Workspace=outputs[i])
 
 Output:
@@ -318,7 +319,7 @@ Output:
   dx = 0.01
 
   random.seed(1)
-  for i in xrange(1000):
+  for i in range(1000):
     x = float(i)*dx
     y = 5 + (random.random() - 1)*2. + 10*math.exp( -(x-2.0)**2/0.1**2 ) + 20*math.exp( -(x-7.5)**2/0.05**2 )
     e = math.sqrt(y)
@@ -340,13 +341,13 @@ Output:
       OutputNormalisedCovarianceMatrix='background_NormalisedCovarianceMatrix', OutputParameters='background_Parameters', OutputWorkspace='background_Workspace')
 
   outparws = mtd["background_Parameters"]
-  print "Input workspace has %d data points; Output workspace has %d data points." % (len(ws.readX(0)), len(outputs[0].readX(0)))
-  print "Fitted background parameters: A0 = %.5e, A1 = %.5e, Chi-square = %.5f" % (outparws.cell(0, 1), outparws.cell(1,1), outparws.cell(2,1))
+  print("Input workspace has {} data points; Output workspace has {} data points.".format(len(ws.readX(0)), len(outputs[0].readX(0))))
+  print("Fitted background parameters: A0 = {:.5e}, A1 = {:.5e}, Chi-square = {:.5f}".format(outparws.cell(0, 1), outparws.cell(1,1), outparws.cell(2,1)))
 
 .. testcleanup:: testRmPeaks
 
   DeleteWorkspace(Workspace=ws)
-  for i in xrange(3):
+  for i in range(3):
       DeleteWorkspace(Workspace=outputs[i])
   DeleteWorkspace(Workspace="background_NormalisedCovarianceMatrix")
   DeleteWorkspace(Workspace="background_Parameters")

--- a/docs/source/algorithms/ProcessIndirectFitParameters-v1.rst
+++ b/docs/source/algorithms/ProcessIndirectFitParameters-v1.rst
@@ -48,8 +48,8 @@ Usage
    wsOut = mtd[wsName]
 
    # Print the result
-   print "%s is a %s and the Y values are:" % (wsOut, wsOut.id())
-   print wsOut.readY(0)
+   print("{} is a {} and the Y values are:".format(wsOut, wsOut.id()))
+   print(wsOut.readY(0))
    
 Output:
 

--- a/docs/source/algorithms/ProjectMD-v1.rst
+++ b/docs/source/algorithms/ProjectMD-v1.rst
@@ -38,11 +38,11 @@ Usage
 
     def outputMDDimensions(ws):
         num_dims = ws.getNumDims()
-        print "Name   Bins   Min     Max"
+        print("Name   Bins   Min     Max")
         for dim_index in range(num_dims):
             dim = ws.getDimension(dim_index)
-            print "%s      %i      %.2f   %.2f" % (dim.name,
-                 dim.getNBins(), dim.getMinimum(), dim.getMaximum())   
+            print("{}      {}      {:.2f}   {:.2f}".format(
+	          dim.name, dim.getNBins(), dim.getMinimum(), dim.getMaximum()))
 
     #create a test MD event workspace
     mdew = CreateMDWorkspace(Dimensions=3, Extents=[-1,1,-5,5,-9,10], 
@@ -54,15 +54,15 @@ Usage
         AlignedDim1='B,-5,5,5',
         AlignedDim2='C,-9,10,9')
 
-    print "The original workspace"
+    print("The original workspace")
     outputMDDimensions(wsHisto)
 
     wsProjected1 = ProjectMD(wsHisto,ProjectDirection="Z")
-    print "\nAfter the workspace has been summed in the Z direction"
+    print("\nAfter the workspace has been summed in the Z direction")
     outputMDDimensions(wsProjected1)
 
     wsProjected2 = ProjectMD(wsProjected1,ProjectDirection="X")
-    print "\nAfter the workspace has been also been summed in the X direction"
+    print("\nAfter the workspace has been also been summed in the X direction")
     outputMDDimensions(wsProjected2)
 
 .. testoutput:: ProjectMD

--- a/docs/source/algorithms/QueryMDWorkspace-v1.rst
+++ b/docs/source/algorithms/QueryMDWorkspace-v1.rst
@@ -45,15 +45,11 @@ Usage
    print("Table contains {0} rows".format(nRows))
    print("first 11 of them are:")
    print("--------------------------------------------------------------------------------------------------------------")
-   for name in col_names:
-      print('| {0:19} '.format(name), end='')
-   print('|')
+   print(' '.join('| {0:19}'.format(name) for name in col_names) + ' |')
+	      
    print("--------------------------------------------------------------------------------------------------------------")
    for i in range(0,11):
-     for name in col_names:
-        col = table.column(name);
-        print('| {0:>19.4f} '.format(col[i]), end='')
-     print('|')
+      print(' '.join('| {0:>19.4f}'.format(table.column(name)[i]) for name in col_names) + ' |')
     
     
 **Output:**

--- a/docs/source/algorithms/QueryMDWorkspace-v1.rst
+++ b/docs/source/algorithms/QueryMDWorkspace-v1.rst
@@ -42,18 +42,18 @@ Usage
    col_names=table.keys();
    name0=col_names[0];
    nRows = len(table.column(name0));
-   print "Table contains {0} rows".format(nRows)
-   print "first 11 of them are:"
-   print '{0}'.format("--------------------------------------------------------------------------------------------------------------")
+   print("Table contains {0} rows".format(nRows))
+   print("first 11 of them are:")
+   print("--------------------------------------------------------------------------------------------------------------")
    for name in col_names:
-      print '| {0:19}'.format(name),
-   print '|'
-   print '{0}'.format("--------------------------------------------------------------------------------------------------------------")
-   for i in xrange(0,11):
+      print('| {0:19} '.format(name), end='')
+   print('|')
+   print("--------------------------------------------------------------------------------------------------------------")
+   for i in range(0,11):
      for name in col_names:
         col = table.column(name);
-        print '| {0:>19.4f}'.format(col[i]),
-     print '|'
+        print('| {0:>19.4f} '.format(col[i]), end='')
+     print('|')
     
     
 **Output:**

--- a/docs/source/algorithms/QueryMDWorkspace-v1.rst
+++ b/docs/source/algorithms/QueryMDWorkspace-v1.rst
@@ -29,18 +29,18 @@ Usage
 .. testcode:: ExQueryMDWorkspace
 
    # create sample inelastic workspace for MARI instrument containing 1 at all spectra 
-   ws1=CreateSimulationWorkspace(Instrument='MAR',BinParams='-10,1,10',UnitX='DeltaE')
-   AddSampleLog(ws1,'Ei','12.','Number')
-   ws2=ws1*2;
+   ws1 = CreateSimulationWorkspace(Instrument='MAR', BinParams='-10,1,10', UnitX='DeltaE')
+   AddSampleLog(ws1, 'Ei', '12.', 'Number')
+   ws2 = ws1 * 2;
    # Convert to MD
-   mdWs1 =ConvertToMD(InputWorkspace=ws1,QDimensions='|Q|',QConversionScales='Q in A^-1',SplitInto='10,10',MaxRecursionDepth='1')
+   mdWs1 = ConvertToMD(InputWorkspace=ws1, QDimensions='|Q|', QConversionScales='Q in A^-1', SplitInto='10,10', MaxRecursionDepth='1')
 
    # get the query
    table = QueryMDWorkspace(InputWorkspace=mdWs1)
    
    # look at the output:
-   col_names=table.keys();
-   name0=col_names[0];
+   col_names = table.keys();
+   name0 = col_names[0];
    nRows = len(table.column(name0));
    print("Table contains {0} rows".format(nRows))
    print("first 11 of them are:")

--- a/docs/source/algorithms/RRFMuon-v1.rst
+++ b/docs/source/algorithms/RRFMuon-v1.rst
@@ -47,8 +47,8 @@ Usage
    input = CreateWorkspace(dataX=datax, dataY=datay,Nspec=2,UnitX="TOF")
    # Compute polarization in RRF
    output = RRFMuon(input,1.0,"MHz",0)
-   print("%.1f" % output.readY(0)[0])
-   print("%.1f" % output.readY(1)[0])
+   print("{:.1f}".format(output.readY(0)[0]))
+   print("{:.1f}".format(output.readY(1)[0]))
 
 Output:
 

--- a/docs/source/algorithms/ReadGroupsFromFile-v1.rst
+++ b/docs/source/algorithms/ReadGroupsFromFile-v1.rst
@@ -36,8 +36,8 @@ Usage
    ws2 = ReadGroupsFromFile( ws1, "INES_example.cal")
 
    # Print the value of selected sprectra. Each corresponds to the group of the corresponding detector.
-   for i in [0,1,2,3,4,5,6,7,8]:
-      print ws2.readY(16*i), ws2.readY(16*i+5), ws2.readY(16*i+10), ws2.readY(16*i+15)
+   for i in range(9):
+       print(" ".join(str(ws2.readY(16 * i + j)) for j in range(0, 20, 5)))
 
 Output:
 

--- a/docs/source/algorithms/RealFFT-v1.rst
+++ b/docs/source/algorithms/RealFFT-v1.rst
@@ -46,14 +46,17 @@ Usage
   # Check the outputs
 
   # Check the sizes
-  print 'Number of bins in the input workspace   ',ws.blocksize()
-  print 'Number of bins in the forward transform ',transform.blocksize()
-  print 'Number of bins in the backward transform',ws_back.blocksize()
+  print('Number of bins in the input workspace    {}'.format(ws.blocksize()))
+  print('Number of bins in the forward transform  {}'.format(transform.blocksize()))
+  print('Number of bins in the backward transform {}'.format(ws_back.blocksize()))
 
   # Check the X axes
-  print 'Input starts at',ws.readX(10)[0],', ends at',ws.readX(10)[-1],', the width is',ws.readX(10)[-1] - ws.readX(10)[0]
-  print 'Forward starts at ',transform.readX(0)[0],', ends at',transform.readX(0)[-1],', the width is',transform.readX(0)[-1] - transform.readX(0)[0]
-  print 'Backward starts at',ws_back.readX(0)[0],', ends at',ws_back.readX(0)[-1],', the width is',ws_back.readX(0)[-1] - ws_back.readX(0)[0]
+  print('Input starts at {:.1f} , ends at {:.1f} , the width is {:.1f}'.format(
+        ws.readX(10)[0], ws.readX(10)[-1], ws.readX(10)[-1] - ws.readX(10)[0]))
+  print('Forward starts at  {:.1f} , ends at {:.2f} , the width is {:.2f}'.format(
+        transform.readX(0)[0], transform.readX(0)[-1], transform.readX(0)[-1] - transform.readX(0)[0]))
+  print('Backward starts at {:.1f} , ends at {:.1f} , the width is {:.1f}'.format(
+        ws_back.readX(0)[0], ws_back.readX(0)[-1], ws_back.readX(0)[-1] - ws_back.readX(0)[0]))
 
   # Check that the backward transform restores the original data.
   # The input spetrum values
@@ -62,9 +65,9 @@ Usage
   y_back = ws_back.readY(0)
   # Check that they are almost equal.
   # Using numpy array calculations show that all elements of arrays y_back and y10 are very close
-  print np.all( np.abs(y_back - y10) < 1e-15 )
+  print(np.all(np.abs(y_back - y10) < 1e-15))
   # but not equal
-  print np.all( y_back == y10 )
+  print(np.all(y_back == y10))
 
 
 Output

--- a/docs/source/algorithms/Rebin-v1.rst
+++ b/docs/source/algorithms/Rebin-v1.rst
@@ -97,8 +97,8 @@ Usage
    # rebin from min to max with size bin = 2
    ws = Rebin(ws, 2)
 
-   print "The rebinned X values are: " + str(ws.readX(0))
-   print "The rebinned Y values are: " + str(ws.readY(0))
+   print("The rebinned X values are: {}".format(ws.readX(0)))
+   print("The rebinned Y values are: {}".format(ws.readY(0)))
 
 Output:
 
@@ -119,7 +119,7 @@ Output:
    # rebin from min to max with logarithmic bins of 0.5
    ws = Rebin(ws, -0.5)
 
-   print "The 2nd and 3rd rebinned X values are: " + str(ws.readX(0)[1:3])
+   print("The 2nd and 3rd rebinned X values are: {}".format(ws.readX(0)[1:3]))
 
 Output:
 
@@ -139,7 +139,7 @@ Output:
    # rebin from 0 to 3 in steps of 2 and from 3 to 9 in steps of 3
    ws = Rebin(ws, "1,2,3,3,9")
 
-   print "The rebinned X values are: " + str(ws.readX(0))
+   print("The rebinned X values are: {}".format(ws.readX(0)))
 
 Output:
 
@@ -159,8 +159,8 @@ Output:
    # rebin from min to max with size bin = 2
    ws = Rebin(ws, 2, FullBinsOnly=True)
 
-   print "The rebinned X values are: " + str(ws.readX(0))
-   print "The rebinned Y values are: " + str(ws.readY(0))
+   print("The rebinned X values are: {}".format(ws.readX(0)))
+   print("The rebinned Y values are: {}".format(ws.readY(0)))
 
 Output:
 
@@ -176,13 +176,13 @@ Output:
    # create some event workspace
    ws = CreateSampleWorkspace(WorkspaceType="Event")
 
-   print "What type is the workspace before 1st rebin: " + ws.id()
+   print("What type is the workspace before 1st rebin: {}".format(ws.id()))
    # rebin from min to max with size bin = 2 preserving event workspace (default behaviour)
    ws = Rebin(ws, 2)
-   print "What type is the workspace after 1st rebin: " + ws.id()
+   print("What type is the workspace after 1st rebin: {}".format(ws.id()))
    ws = Rebin(ws, 2, PreserveEvents=False)
-   print "What type is the workspace after 2nd rebin: " + ws.id()
-   # note you can also check the type of a workspace using: print isinstance(ws, IEventWorkspace)
+   print("What type is the workspace after 2nd rebin: {}".format(ws.id()))
+   # note you can also check the type of a workspace using: print(isinstance(ws, IEventWorkspace))
 
 Output:
 

--- a/docs/source/algorithms/Rebin2D-v1.rst
+++ b/docs/source/algorithms/Rebin2D-v1.rst
@@ -36,8 +36,8 @@ Usage
     wsc = ConvertSpectrumAxis(ws,"theta")
 
     rb = Rebin2D(wsc,[0,100,20000],[0,0.01,1.2],UseFractionalArea=True)
-    print ("Bins in the X axis: %i" % rb.blocksize())
-    print ("Bins in the Y axis: %i" % rb.getNumberHistograms())
+    print("Bins in the X axis: {}".format(rb.blocksize()))
+    print("Bins in the Y axis: {}".format(rb.getNumberHistograms()))
 
 Output:
 
@@ -55,8 +55,8 @@ Output:
     wsc = ConvertSpectrumAxis(ws,"theta")
 
     rb = Rebin2D(wsc,[0,100,20000],[0,0.01,1.2],Transpose=True)
-    print ("Bins in the X axis: %i" % rb.blocksize())
-    print ("Bins in the Y axis: %i" % rb.getNumberHistograms())
+    print("Bins in the X axis: {}".format(rb.blocksize()))
+    print("Bins in the Y axis: {}".format(rb.getNumberHistograms()))
     
 Output:
 

--- a/docs/source/algorithms/RebinByPulseTimes-v1.rst
+++ b/docs/source/algorithms/RebinByPulseTimes-v1.rst
@@ -64,9 +64,9 @@ Input workspace has raw events
    # Perform the rebin
    pulse_t_ws = RebinByPulseTimes(InputWorkspace=event_ws, Params=[start_time_in_seconds, time_step_in_seconds, end_time_in_seconds])
 
-   print "Events are rebinned into: ",  pulse_t_ws.blocksize(), "bins per histogram"
-   print "X-axis relative start time in seconds: ", pulse_t_ws.readX(0)[0] 
-   print "X-axis relative end time in seconds: ", pulse_t_ws.readX(0)[-1] 
+   print("Events are rebinned into:  {} bins per histogram".format(pulse_t_ws.blocksize()))
+   print("X-axis relative start time in seconds:  {}".format(pulse_t_ws.readX(0)[0] ))
+   print("X-axis relative end time in seconds:  {}".format(pulse_t_ws.readX(0)[-1] ))
 
 Output:
    

--- a/docs/source/algorithms/Rebunch-v1.rst
+++ b/docs/source/algorithms/Rebunch-v1.rst
@@ -28,7 +28,7 @@ Usage
   print('Input workspace bin width       {:.1f}'.format(ws.readX(0)[1] - ws.readX(0)[0]))
   print('"Rebunched" workspace bin width {:.1f}'.format(rebunched.readX(0)[1] - rebunched.readX(0)[0]))
   print('Input workspace values          {:.1f} {:.1f} {:.1f}'.format(ws.readY(0)[0], ws.readY(0)[50], ws.readY(0)[70]))
-  print('"Rebunched" workspace values    {:.1f} {:.1f} {:.1f}'.format(rebunched.readY(0)[0], rebunched.readY(0)[50/3], rebunched.readY(0)[70/3]))
+  print('"Rebunched" workspace values    {:.1f} {:.1f} {:.1f}'.format(rebunched.readY(0)[0], rebunched.readY(0)[50//3], rebunched.readY(0)[70//3]))
 
 Output
 ######

--- a/docs/source/algorithms/Rebunch-v1.rst
+++ b/docs/source/algorithms/Rebunch-v1.rst
@@ -23,24 +23,24 @@ Usage
   rebunched = Rebunch( ws, 3 )
 
   # Check the result
-  print 'Input workspace has      ',ws.blocksize(),'bins'
-  print '"Rebunched" workspace has',rebunched.blocksize(),'bins'
-  print 'Input workspace bin width      ',ws.readX(0)[1] - ws.readX(0)[0]
-  print '"Rebunched" workspace bin width',rebunched.readX(0)[1] - rebunched.readX(0)[0]
-  print 'Input workspace values      ',ws.readY(0)[0],ws.readY(0)[50],ws.readY(0)[70]
-  print '"Rebunched" workspace values',rebunched.readY(0)[0],rebunched.readY(0)[50/3],rebunched.readY(0)[70/3]
+  print('Input workspace has             {} bins'.format(ws.blocksize()))
+  print('"Rebunched" workspace has       {} bins'.format(rebunched.blocksize()))
+  print('Input workspace bin width       {:.1f}'.format(ws.readX(0)[1] - ws.readX(0)[0]))
+  print('"Rebunched" workspace bin width {:.1f}'.format(rebunched.readX(0)[1] - rebunched.readX(0)[0]))
+  print('Input workspace values          {:.1f} {:.1f} {:.1f}'.format(ws.readY(0)[0], ws.readY(0)[50], ws.readY(0)[70]))
+  print('"Rebunched" workspace values    {:.1f} {:.1f} {:.1f}'.format(rebunched.readY(0)[0], rebunched.readY(0)[50/3], rebunched.readY(0)[70/3]))
 
 Output
 ######
 
 .. testoutput::
 
-  Input workspace has       100 bins
-  "Rebunched" workspace has 34 bins
+  Input workspace has             100 bins
+  "Rebunched" workspace has       34 bins
   Input workspace bin width       200.0
   "Rebunched" workspace bin width 600.0
-  Input workspace values       0.3 10.3 0.3
-  "Rebunched" workspace values 0.9 10.9 0.9
+  Input workspace values          0.3 10.3 0.3
+  "Rebunched" workspace values    0.9 10.9 0.9
 
 .. categories::
 

--- a/docs/source/algorithms/RecordPythonScript-v1.rst
+++ b/docs/source/algorithms/RecordPythonScript-v1.rst
@@ -53,9 +53,9 @@ Usage
     thread.join()
 
     #Load and print the resulting file
-    print "The result file has the following python recorded"
+    print("The result file has the following python recorded")
     with open(outputFile, "r") as file:
-        print file.read().rstrip()
+        print(file.read().rstrip())
 
     #cleanup
     os.remove(outputFile)

--- a/docs/source/algorithms/ReflectometryReductionOne-v1.rst
+++ b/docs/source/algorithms/ReflectometryReductionOne-v1.rst
@@ -227,9 +227,11 @@ Usage
    MonitorBackgroundWavelengthMin=15.0, MonitorBackgroundWavelengthMax=17.0,
    MonitorIntegrationWavelengthMin=4.0, MonitorIntegrationWavelengthMax=10.0, Version=1)
 
-   print "The first four IvsLam Y values are: [ %.4e, %.4e, %.4e, %.4e ]" % (IvsLam.readY(0)[0], IvsLam.readY(0)[1], IvsLam.readY(0)[2], IvsLam.readY(0)[3])
-   print "The first four IvsQ Y values are: [ %.4e, %.4e, %.4e, %.4e ]" % (IvsQ.readY(0)[0], IvsQ.readY(0)[1], IvsQ.readY(0)[2], IvsQ.readY(0)[3])
-   print "Theta out is the same as theta in:",thetaOut
+   print("The first four IvsLam Y values are: [ {:.4e}, {:.4e}, {:.4e}, {:.4e} ]".format(
+	  IvsLam.readY(0)[0], IvsLam.readY(0)[1], IvsLam.readY(0)[2], IvsLam.readY(0)[3]))
+   print("The first four IvsQ Y values are: [ {:.4e}, {:.4e}, {:.4e}, {:.4e} ]".format(
+          IvsQ.readY(0)[0], IvsQ.readY(0)[1], IvsQ.readY(0)[2], IvsQ.readY(0)[3]))
+   print("Theta out is the same as theta in: {}".format(thetaOut))
 
 
 Output:

--- a/docs/source/algorithms/ReflectometryReductionOne-v2.rst
+++ b/docs/source/algorithms/ReflectometryReductionOne-v2.rst
@@ -208,10 +208,10 @@ Usage
                                             MonitorIntegrationWavelengthMin=4.0,
                                             MonitorIntegrationWavelengthMax=10.0)
 
-   print "%.4f" % (IvsLam.readY(0)[533])
-   print "%.4f" % (IvsLam.readY(0)[534])
-   print "%.4f" % (IvsQ.readY(0)[327])
-   print "%.4f" % (IvsQ.readY(0)[328])
+   print("{:.4f}".format(IvsLam.readY(0)[533]))
+   print("{:.4f}".format(IvsLam.readY(0)[534]))
+   print("{:.4f}".format(IvsQ.readY(0)[327]))
+   print("{:.4f}".format(IvsQ.readY(0)[328]))
 
 
 Output:
@@ -244,10 +244,10 @@ Output:
 					    FirstTransmissionRun=trans1,
 					    SecondTransmissionRun=trans2)
 
-   print "%.4f" % (IvsLam.readY(0)[480])
-   print "%.4f" % (IvsLam.readY(0)[481])
-   print "%.4f" % (IvsQ.readY(0)[107])
-   print "%.4f" % (IvsQ.readY(0)[108])
+   print("{:.4f}".format(IvsLam.readY(0)[480]))
+   print("{:.4f}".format(IvsLam.readY(0)[481]))
+   print("{:.4f}".format(IvsQ.readY(0)[107]))
+   print("{:.4f}".format(IvsQ.readY(0)[108]))
 
 
 Output:

--- a/docs/source/algorithms/ReflectometryReductionOneAuto-v1.rst
+++ b/docs/source/algorithms/ReflectometryReductionOneAuto-v1.rst
@@ -72,9 +72,11 @@ Usage
     # Basic reduction with no transmission run
     IvsQ, IvsLam, thetaOut = ReflectometryReductionOneAuto(InputWorkspace=run, ThetaIn=0.7, Version=1)
 
-    print "The first four IvsLam Y values are: [ %.4e, %.4e, %.4e, %.4e ]" % (IvsLam.readY(0)[0], IvsLam.readY(0)[1], IvsLam.readY(0)[2], IvsLam.readY(0)[3])
-    print "The first four IvsQ Y values are: [ %.4e, %.4e, %.4e, %.4e ]" % (IvsQ.readY(0)[0], IvsQ.readY(0)[1], IvsQ.readY(0)[2], IvsQ.readY(0)[3])
-    print "Theta out is the same as theta in:",thetaOut
+    print("The first four IvsLam Y values are: [ {:.4e}, {:.4e}, {:.4e}, {:.4e} ]".format(
+  	   IvsLam.readY(0)[0], IvsLam.readY(0)[1], IvsLam.readY(0)[2], IvsLam.readY(0)[3]))
+    print("The first four IvsQ Y values are: [ {:.4e}, {:.4e}, {:.4e}, {:.4e} ]".format(
+	   IvsQ.readY(0)[0], IvsQ.readY(0)[1], IvsQ.readY(0)[2], IvsQ.readY(0)[3]))
+    print("Theta out is the same as theta in: {}".format(thetaOut))
 
 Output:
 
@@ -93,9 +95,11 @@ Output:
     # Basic reduction with a transmission run
     IvsQ, IvsLam, thetaOut = ReflectometryReductionOneAuto(InputWorkspace=run, FirstTransmissionRun=trans, ThetaIn=0.7, Version=1)
 
-    print "The first four IvsLam Y values are: [ %.4e, %.4e, %.4e, %.4e ]" % (IvsLam.readY(0)[0], IvsLam.readY(0)[1], IvsLam.readY(0)[2], IvsLam.readY(0)[3])
-    print "The first four IvsQ Y values are: [ %.4e, %.4e, %.4e, %.4e ]" % (IvsQ.readY(0)[0], IvsQ.readY(0)[1], IvsQ.readY(0)[2], IvsQ.readY(0)[3])
-    print "Theta out is the same as theta in:",thetaOut
+    print("The first four IvsLam Y values are: [ {:.4e}, {:.4e}, {:.4e}, {:.4e} ]".format(
+  	   IvsLam.readY(0)[0], IvsLam.readY(0)[1], IvsLam.readY(0)[2], IvsLam.readY(0)[3]))
+    print("The first four IvsQ Y values are: [ {:.4e}, {:.4e}, {:.4e}, {:.4e} ]".format(
+	   IvsQ.readY(0)[0], IvsQ.readY(0)[1], IvsQ.readY(0)[2], IvsQ.readY(0)[3]))
+    print("Theta out is the same as theta in: {}".format(thetaOut))
 
 Output:
 
@@ -113,9 +117,11 @@ Output:
     # Reduction overriding the default values for MonitorBackgroundWavelengthMin and MonitorBackgroundWavelengthMax which would otherwise be retirieved from the workspace
     IvsQ, IvsLam, thetaOut = ReflectometryReductionOneAuto(InputWorkspace=run, ThetaIn=0.7, MonitorBackgroundWavelengthMin=0.0, MonitorBackgroundWavelengthMax=1.0, Version=1)
 
-    print "The first four IvsLam Y values are: [ %.4e, %.4e, %.4e, %.4e ]" % (IvsLam.readY(0)[0], IvsLam.readY(0)[1], IvsLam.readY(0)[2], IvsLam.readY(0)[3])
-    print "The first four IvsQ Y values are: [ %.4e, %.4e, %.4e, %.4e ]" % (IvsQ.readY(0)[0], IvsQ.readY(0)[1], IvsQ.readY(0)[2], IvsQ.readY(0)[3])
-    print "Theta out is the same as theta in:",thetaOut
+    print("The first four IvsLam Y values are: [ {:.4e}, {:.4e}, {:.4e}, {:.4e} ]".format(
+  	   IvsLam.readY(0)[0], IvsLam.readY(0)[1], IvsLam.readY(0)[2], IvsLam.readY(0)[3]))
+    print("The first four IvsQ Y values are: [ {:.4e}, {:.4e}, {:.4e}, {:.4e} ]".format(
+	   IvsQ.readY(0)[0], IvsQ.readY(0)[1], IvsQ.readY(0)[2], IvsQ.readY(0)[3]))
+    print("Theta out is the same as theta in: {}".format(thetaOut))
 
 Output:
 
@@ -137,7 +143,7 @@ Output:
     IvsQ, IvsLam, thetaOut = ReflectometryReductionOneAuto(InputWorkspace=run, ThetaIn=0.7, Version=1)
 
     def findByName(histories, name):
-        return filter(lambda x: x.name() == name, histories)[0]
+        return next(x for x in histories if x.name() == name)
 
     # Find the PolynomialCorrection entry in the workspace's history
     algHist = IvsLam.getHistory()
@@ -147,7 +153,7 @@ Output:
 
     coefProp = findByName(polyCorHist.getProperties(), "Coefficients")
 
-    print "Coefficients: '" + coefProp.value() + "'"
+    print("Coefficients: '{}'".format(coefProp.value()))
 
 Output:
 

--- a/docs/source/algorithms/ReflectometryReductionOneAuto-v2.rst
+++ b/docs/source/algorithms/ReflectometryReductionOneAuto-v2.rst
@@ -134,12 +134,12 @@ Usage
     run = Load(Filename='INTER00013460.nxs')
     IvsQ, IvsQ_unbinned, IvsLam = ReflectometryReductionOneAuto(InputWorkspace=run, ThetaIn=0.7)
 
-    print "%.5f" % (IvsLam.readY(0)[175])
-    print "%.5f" % (IvsLam.readY(0)[176])
-    print "%.5f" % (IvsQ_unbinned.readY(0)[106])
-    print "%.5f" % (IvsQ_unbinned.readY(0)[107])
-    print "%.5f" % (IvsQ.readY(0)[13])
-    print "%.5f" % (IvsQ.readY(0)[14])
+    print("{:.5f}".format(IvsLam.readY(0)[175]))
+    print("{:.5f}".format(IvsLam.readY(0)[176]))
+    print("{:.5f}".format(IvsQ_unbinned.readY(0)[106]))
+    print("{:.5f}".format(IvsQ_unbinned.readY(0)[107]))
+    print("{:.5f}".format(IvsQ.readY(0)[13]))
+    print("{:.5f}".format(IvsQ.readY(0)[14]))
 
 Output:
 
@@ -160,12 +160,12 @@ Output:
     trans = Load(Filename='INTER00013463.nxs')
     IvsQ, IvsQ_unbinned, IvsLam = ReflectometryReductionOneAuto(InputWorkspace=run, FirstTransmissionRun=trans, ThetaIn=0.7)
 
-    print "%.5f" % (IvsLam.readY(0)[164])
-    print "%.5f" % (IvsLam.readY(0)[164])
-    print "%.5f" % (IvsQ_unbinned.readY(0)[96])
-    print "%.5f" % (IvsQ_unbinned.readY(0)[97])
-    print "%.5f" % (IvsQ.readY(0)[5])
-    print "%.5f" % (IvsQ.readY(0)[6])
+    print("{:.5f}".format(IvsLam.readY(0)[164]))
+    print("{:.5f}".format(IvsLam.readY(0)[164]))
+    print("{:.5f}".format(IvsQ_unbinned.readY(0)[96]))
+    print("{:.5f}".format(IvsQ_unbinned.readY(0)[97]))
+    print("{:.5f}".format(IvsQ.readY(0)[5]))
+    print("{:.5f}".format(IvsQ.readY(0)[6]))
 
 Output:
 
@@ -185,12 +185,12 @@ Output:
     run = Load(Filename='INTER00013460.nxs')
     IvsQ, IvsQ_unbinned, IvsLam = ReflectometryReductionOneAuto(InputWorkspace=run, ThetaIn=0.7, DetectorCorrectionType="RotateAroundSample", MonitorBackgroundWavelengthMin=0.0, MonitorBackgroundWavelengthMax=1.0)
 
-    print "%.5f" % (IvsLam.readY(0)[175])
-    print "%.5f" % (IvsLam.readY(0)[176])
-    print "%.5f" % (IvsQ_unbinned.readY(0)[106])
-    print "%.5f" % (IvsQ_unbinned.readY(0)[107])
-    print "%.5f" % (IvsQ.readY(0)[5])
-    print "%.5f" % (IvsQ.readY(0)[6])
+    print("{:.5f}".format(IvsLam.readY(0)[175]))
+    print("{:.5f}".format(IvsLam.readY(0)[176]))
+    print("{:.5f}".format(IvsQ_unbinned.readY(0)[106]))
+    print("{:.5f}".format(IvsQ_unbinned.readY(0)[107]))
+    print("{:.5f}".format(IvsQ.readY(0)[5]))
+    print("{:.5f}".format(IvsQ.readY(0)[6]))
 
 Output:
 

--- a/docs/source/algorithms/Regroup-v1.rst
+++ b/docs/source/algorithms/Regroup-v1.rst
@@ -38,8 +38,8 @@ Usage
   rgws = Regroup(ws, [0,300,20000])
 
   # Check the result
-  print 'Bin width in ws   is',ws.readX(0)[1]-ws.readX(0)[0]
-  print 'Bin width in rgws is',rgws.readX(0)[1]-rgws.readX(0)[0]
+  print('Bin width in ws   is {}'.format(ws.readX(0)[1] - ws.readX(0)[0]))
+  print('Bin width in rgws is {}'.format(rgws.readX(0)[1] - rgws.readX(0)[0]))
 
   # Using numpy array calculations check that all  bins in the regrouped workspace
   # are wider than 300
@@ -53,7 +53,7 @@ Usage
   widths = x[1:] - x[:-1]
 
   # Check that all elements in widths are greater than 300
-  print np.all( widths >= 300 )
+  print(np.all(widths >= 300))
 
 Output
 ######


### PR DESCRIPTION
## Description of work.
This PR is part of refactoring effort to bring Python3 compatiblity into the doctests.
See https://github.com/mantidproject/mantid/issues/20672 for details.

The following tests were refactored to be compatible:
```
PredictPeaks-v1
PreprocessDetectorsToMD-v1
ProcessBackground-v1
ProcessIndirectFitParameters-v1
ProjectMD-v1
QueryMDWorkspace-v1
RRFMuon-v1
RayTracerTester-v1
ReadGroupsFromFile-v1
RealFFT-v1
Rebin-v1
Rebin2D-v1
RebinByPulseTimes-v1
Rebunch-v1
RecordPythonScript-v1
ReflectometryReductionOne-v1
ReflectometryReductionOne-v2
ReflectometryReductionOneAuto-v1
ReflectometryReductionOneAuto-v2
Regroup-v1
```
## To test.

Code review.

Fixes #20816 
Internal change, no release notes