### PR TITLE
Turn off clang-tidy warning in cxxtestgen

### DIFF
--- a/Testing/Tools/cxxtest/python/cxxtest/cxxtestgen.py
+++ b/Testing/Tools/cxxtest/python/cxxtest/cxxtestgen.py
@@ -387,7 +387,7 @@ def writeTestDescription( output, suite, test ):
     if not options.noStaticInit:
         output.write( ' %s() : CxxTest::RealTestDescription( %s, %s, %s, "%s" ) {}\n' %
                       (test['class'], suite['tlist'], suite['dobject'], test['line'], test['name']) )
-    output.write( ' void runTest() override final { %s }\n' % runBody( suite, test ) )
+    output.write( ' void runTest() override final { %s } // NOLINT\n' % runBody( suite, test ) )
     output.write( '} %s;\n\n' % test['object'] )
 
 def runBody( suite, test ):


### PR DESCRIPTION
Since the warning is not going to get fixed and it is templated code, just turn it off.

**To test:**

Code review is good enough.

*There is no associated issue.*

*Does not need to be in the release notes* because it is a change for static analysis only.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
