### PR TITLE
Frequency Domain Analysis was not opening on Windows 7 or 8

### DIFF
--- a/scripts/Muon/table_utils.py
+++ b/scripts/Muon/table_utils.py
@@ -53,8 +53,8 @@ def setTableHeaders(table):
         if os.name != "nt":
             return
         version=QtCore.QSysInfo.WindowsVersion
-        windows10=QtCore.QSysInfo.WindowsVersion
-        if(version==windows10):
+        WINDOWS_10=160
+        if(version==WINDOWS_10):
             styleSheet= \
                 "QHeaderView::section{"\
                 +"border-top:0px solid #D8D8D8;"\

--- a/scripts/Muon/table_utils.py
+++ b/scripts/Muon/table_utils.py
@@ -72,4 +72,5 @@ def setTableHeaders(table):
                 +"background-color:white;"\
                 +"}"
             table.setStyleSheet(styleSheet)
-        return styleSheet
+            return styleSheet
+        return 

--- a/scripts/Muon/table_utils.py
+++ b/scripts/Muon/table_utils.py
@@ -53,7 +53,7 @@ def setTableHeaders(table):
         if os.name != "nt":
             return
         version=QtCore.QSysInfo.WindowsVersion
-        windows10=160 # version code?
+        windows10=QtCore.QSysInfo.WindowsVersion
         if(version==windows10):
             styleSheet= \
                 "QHeaderView::section{"\


### PR DESCRIPTION
Fixed an oversight that meant windows 7 and 8 would fail. 
**To test:**

<!-- Instructions for testing. -->
Open the Frequency Domain Analysis Gui on windows 7 and/or 8

Fixes #20835. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
Does not need to be in release notes. 
#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
