### PR TITLE
Raise exception if no test code in doctest

### DIFF
--- a/docs/sphinxext/mantiddoc/doctest.py
+++ b/docs/sphinxext/mantiddoc/doctest.py
@@ -310,7 +310,6 @@ class DocTestOutputParser(object):
           list: List of test cases in the document
         """
         fullname = self.__extract_fullname(results[0])
-
         if not results[1].startswith("-"):
             raise ValueError("Invalid second line of output: '%s'. "\
                              "Expected a title underline."

--- a/docs/sphinxext/mantiddoc/doctest.py
+++ b/docs/sphinxext/mantiddoc/doctest.py
@@ -140,6 +140,11 @@ TEST_FAILURE_TYPE = "UsageFailure"
 # Package name
 PACKAGE_NAME = "docs"
 
+# No Test found error message
+NO_TEST_ERROR = "\n*************************************************\n"\
+                "* No test code has been found in given file(s). * \n"\
+                "*************************************************"
+
 #-------------------------------------------------------------------------------
 # Define parts of lines that denote a document
 DOCTEST_DOCUMENT_BEGIN = "Document:"
@@ -283,7 +288,10 @@ class DocTestOutputParser(object):
                 continue
             if line.startswith(DOCTEST_SUMMARY_TITLE): # end of tests
                 in_doc = False
-                cases.extend(self.__parse_document(document_txt))
+                if document_txt:
+                    cases.extend(self.__parse_document(document_txt))
+                else:
+                    raise RuntimeError(NO_TEST_ERROR)
                 document_txt = None
             if in_doc and line != "":
                 document_txt.append(line)
@@ -302,6 +310,7 @@ class DocTestOutputParser(object):
           list: List of test cases in the document
         """
         fullname = self.__extract_fullname(results[0])
+
         if not results[1].startswith("-"):
             raise ValueError("Invalid second line of output: '%s'. "\
                              "Expected a title underline."


### PR DESCRIPTION
Added additional information if doctests are run but no test code has been found in the specified doc test. This exception should only be raised if **ALL** given doc tests do not contain test code. 

**To test:**

* Run the doc tests for an algorithm that contains a test.
* Remove the test code and rerun the algorithm (The `.. testcode::` part)
* Ensure you see the new error message included in the output:
   * ``` 
         ...
         Exception occurred:
         File "/home/osboxes/git/mantid/docs/sphinxext/mantiddoc/doctest.py", line 294, in __parse
         raise RuntimeError(NO_TEST_ERROR)
         RuntimeError: 
         *************************************************
         * No test code has been found in given file(s). * 
         *************************************************
        ...
     ```
* Try doing this with a combination of tests:
 * a set of tests where all tests have code - All should run fine
 * a set of tests where some have code and some don't - Only some of the tests should run (no error will be produced)
 * a set where no of the docs contain tests - Should produce same error as one test without test code. 

Fixes #20839

**Release Notes** 
*Internal change - not required in release notes*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
