### PR TITLE
Remove check for patchVersion!=0 when forming URL

### DIFF
--- a/Framework/Kernel/src/MantidVersion.cpp.in
+++ b/Framework/Kernel/src/MantidVersion.cpp.in
@@ -39,13 +39,13 @@ std::string MantidVersion::releaseNotes()
   // for now the code assumes that the next main release version number will be one minor version higher
 
   std::stringstream versionLabel;
-  
-  if(( patchVersion < 100 ) && ( patchVersion != 0 )) {
+
+  if ( patchVersion < 100 ) {
     versionLabel << versionShort();
     versionLabel << "." << patchVersion;
   }
   else {
-  	const unsigned int minorVersion = static_cast<unsigned int>(@VERSION_MINOR@);
+    const unsigned int minorVersion = static_cast<unsigned int>(@VERSION_MINOR@);
     versionLabel << "@VERSION_MAJOR@." << minorVersion + 1  << "." << "0";
   }
 


### PR DESCRIPTION
Description of work.

Fixes the link to the current release notes for an official build.

**To test:**

Build this branch and click Release Notes on the first time setup screen. It should point to a valid document.

Fixes #20837 

**Release Notes**

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
