### PR TITLE
Fix for Mantid freezing when handling Engineering Diffraction

### DIFF
--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -133,13 +133,13 @@ void EnggDiffractionViewQtGUI::doSetupTabCalib() {
   if (m_uiTabCalib.MWRunFiles_new_vanadium_num->getUserInput()
           .toString()
           .isEmpty()) {
-    m_uiTabCalib.MWRunFiles_new_vanadium_num->setUserInput(
+    m_uiTabCalib.MWRunFiles_new_vanadium_num->setFileTextWithoutSearch(
         QString::fromStdString(vanadiumRun));
   }
   if (m_uiTabCalib.MWRunFiles_new_ceria_num->getUserInput()
           .toString()
           .isEmpty()) {
-    m_uiTabCalib.MWRunFiles_new_ceria_num->setUserInput(
+    m_uiTabCalib.MWRunFiles_new_ceria_num->setFileTextWithoutSearch(
         QString::fromStdString(ceriaRun));
   }
 

--- a/qt/widgets/common/src/MWRunFiles.cpp
+++ b/qt/widgets/common/src/MWRunFiles.cpp
@@ -267,22 +267,9 @@ MWRunFiles::MWRunFiles(QWidget *parent)
 MWRunFiles::~MWRunFiles() {
   // Before destruction, make sure the file finding thread has stopped running.
   // Wait if necessary. This can freeze up Mantid.
-  try {
-    QEventLoop eventLoop(QApplication::instance());
-    QTimer timer;
-    connect(&timer, SIGNAL(timeout()), &eventLoop, SLOT(quit()));
-    if (m_thread->isRunning()) {
-        m_thread->exit(-1);
-        // While the thread is quiting keep the application responsive
-        while (m_thread->isRunning()) {
-          timer.start(50);
-          eventLoop.exec();
-          timer.stop();
-        }
-    }
-  } catch(...) {
-    g_log.error("There seems to have been an expection when closing the MWRunFiles instance.");
-  }
+
+  m_thread->exit(-1);
+  m_thread->wait(50);
 }
 
 /**

--- a/qt/widgets/common/src/MWRunFiles.cpp
+++ b/qt/widgets/common/src/MWRunFiles.cpp
@@ -3,7 +3,6 @@
 
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/FacilityInfo.h"
-#include "MantidKernel/Logger.h"
 #include "MantidKernel/VectorHelper.h"
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/FileFinder.h"
@@ -26,9 +25,6 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/regex.hpp>
 
-namespace {
-  Mantid::Kernel::Logger g_log("MWRunFiles");
-}
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;

--- a/qt/widgets/common/src/MWRunFiles.cpp
+++ b/qt/widgets/common/src/MWRunFiles.cpp
@@ -17,7 +17,6 @@
 #include <QDropEvent>
 #include <QDragEnterEvent>
 #include <QMimeData>
-#include <QTimer>
 #include <QUrl>
 #include <QtConcurrentRun>
 #include <Poco/File.h>

--- a/qt/widgets/common/src/MWRunFiles.cpp
+++ b/qt/widgets/common/src/MWRunFiles.cpp
@@ -25,7 +25,6 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/regex.hpp>
 
-
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
 using namespace MantidQt::API;
@@ -709,14 +708,14 @@ void MWRunFiles::findFiles() {
     QTimer timer;
     connect(&timer, SIGNAL(timeout()), &eventLoop, SLOT(quit()));
     if (m_thread->isRunning()) {
-        // Quit the thread
-        m_thread->exit(-1);
-        // While the thread is quiting keep the application responsive
-        while (m_thread->isRunning()) {
-          timer.start(50);
-          eventLoop.exec();
-          timer.stop();
-        }
+      // Quit the thread
+      m_thread->exit(-1);
+      // While the thread is quiting keep the application responsive
+      while (m_thread->isRunning()) {
+        timer.start(50);
+        eventLoop.exec();
+        timer.stop();
+      }
     }
 
     emit findingFiles();

--- a/qt/widgets/common/src/MWRunFiles.cpp
+++ b/qt/widgets/common/src/MWRunFiles.cpp
@@ -262,7 +262,6 @@ MWRunFiles::MWRunFiles(QWidget *parent)
 MWRunFiles::~MWRunFiles() {
   // Before destruction, make sure the file finding thread has stopped running.
   // Wait if necessary. This can freeze up Mantid.
-
   m_thread->exit(-1);
   m_thread->wait(50);
 }
@@ -704,18 +703,9 @@ void MWRunFiles::findFiles() {
     m_uiForm.fileEditor->setModified(false);
 
     // If the thread is running, cancel it.
-    QEventLoop eventLoop(QApplication::instance());
-    QTimer timer;
-    connect(&timer, SIGNAL(timeout()), &eventLoop, SLOT(quit()));
     if (m_thread->isRunning()) {
-      // Quit the thread
       m_thread->exit(-1);
-      // While the thread is quiting keep the application responsive
-      while (m_thread->isRunning()) {
-        timer.start(50);
-        eventLoop.exec();
-        timer.stop();
-      }
+      m_thread->wait();
     }
 
     emit findingFiles();
@@ -820,7 +810,6 @@ void MWRunFiles::inspectThreadResult() {
 void MWRunFiles::readSettings(const QString &group) {
   QSettings settings;
   settings.beginGroup(group);
-
   m_lastDir = settings.value("last_directory", "").toString();
 
   if (m_lastDir == "") {


### PR DESCRIPTION
Fixes #20836

The fixes stop the GUI freezing up (However quitting the thread is still taking ages. Maybe somebody should look into this). 

**To test:**

* Open MantidPlot
* Open Interfaces > Diffraction > Engineerig Diffraction
  * Confirm that it does not freeze up Mantid and starts quickly
* Close the interface
  * Confirm that not freeze up Mantid when shutting down
* Close the Mantid
  * Confirm that there are not error messages

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
