### PR TITLE
Remove legacy bounding box code

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
@@ -18,7 +18,6 @@ namespace Kernel {
 template <class KEYTYPE, class VALUETYPE> class Cache;
 }
 namespace Geometry {
-class BoundingBox;
 class ComponentInfo;
 class DetectorInfo;
 class Instrument;
@@ -318,11 +317,6 @@ public:
                          const Kernel::Quat &rotation) const;
   /// Attempts to retrieve a rotation from the rotation cache
   bool getCachedRotation(const IComponent *comp, Kernel::Quat &rotation) const;
-  /// Sets a cached bounding box
-  void setCachedBoundingBox(const IComponent *comp,
-                            const BoundingBox &box) const;
-  /// Attempts to retrieve a bounding box from the cache
-  bool getCachedBoundingBox(const IComponent *comp, BoundingBox &box) const;
   /// Persist a representation of the Parameter map to the open Nexus file
   void saveNexus(::NeXus::File *file, const std::string &group) const;
   /// Copy pairs (oldComp->id,Parameter) to the m_map assigning the new
@@ -377,9 +371,6 @@ private:
   std::unique_ptr<Kernel::Cache<const ComponentID, Kernel::V3D>> m_cacheLocMap;
   /// internal cache map instance for cached rotation values
   std::unique_ptr<Kernel::Cache<const ComponentID, Kernel::Quat>> m_cacheRotMap;
-  /// internal cache map for cached bounding boxes
-  std::unique_ptr<Kernel::Cache<const ComponentID, BoundingBox>>
-      m_boundingBoxMap;
 
   /// Pointer to the DetectorInfo wrapper. NULL unless the instrument is
   /// associated with an ExperimentInfo object.

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -830,9 +830,6 @@ void Instrument::getBoundingBox(BoundingBox &assemblyBox) const {
       return;
     }
 
-    if (m_map->getCachedBoundingBox(this, assemblyBox)) {
-      return;
-    }
     // Loop over the children and define a box large enough for all of them
     ComponentID sourceID = getSource()->getComponentID();
     assemblyBox =
@@ -846,9 +843,6 @@ void Instrument::getBoundingBox(BoundingBox &assemblyBox) const {
         assemblyBox.grow(compBox);
       }
     }
-    // Set the cache
-    m_map->setCachedBoundingBox(this, assemblyBox);
-
   } else {
 
     if (!m_cachedBoundingBox) {

--- a/Framework/Geometry/src/Instrument/CompAssembly.cpp
+++ b/Framework/Geometry/src/Instrument/CompAssembly.cpp
@@ -363,11 +363,6 @@ void CompAssembly::getBoundingBox(BoundingBox &assemblyBox) const {
       return;
     }
 
-    // Check cache for assembly, inside the ParameterMap
-    if (m_map->getCachedBoundingBox(this, assemblyBox)) {
-      return;
-    }
-
     // Loop over the children and define a box large enough for all of them
     assemblyBox = BoundingBox(); // this makes assembly box always axis alighned
     int nchildren = nelements();
@@ -377,8 +372,6 @@ void CompAssembly::getBoundingBox(BoundingBox &assemblyBox) const {
       comp->getBoundingBox(compBox);
       assemblyBox.grow(compBox);
     }
-    // Set the cache
-    m_map->setCachedBoundingBox(this, assemblyBox);
   }
 
   else {

--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -2,7 +2,6 @@
 #include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidGeometry/Instrument/ParComponentFactory.h"
-#include "MantidGeometry/Objects/BoundingBox.h"
 #include "MantidGeometry/IDetector.h"
 #include "MantidKernel/Cache.h"
 #include "MantidKernel/MultiThreaded.h"
@@ -60,9 +59,7 @@ ParameterMap::ParameterMap()
     : m_cacheLocMap(
           Kernel::make_unique<Kernel::Cache<const ComponentID, Kernel::V3D>>()),
       m_cacheRotMap(Kernel::make_unique<
-          Kernel::Cache<const ComponentID, Kernel::Quat>>()),
-      m_boundingBoxMap(Kernel::make_unique<
-          Kernel::Cache<const ComponentID, BoundingBox>>()) {}
+          Kernel::Cache<const ComponentID, Kernel::Quat>>()) {}
 
 ParameterMap::ParameterMap(const ParameterMap &other)
     : m_parameterFileNames(other.m_parameterFileNames), m_map(other.m_map),
@@ -72,9 +69,6 @@ ParameterMap::ParameterMap(const ParameterMap &other)
       m_cacheRotMap(
           Kernel::make_unique<Kernel::Cache<const ComponentID, Kernel::Quat>>(
               *other.m_cacheRotMap)),
-      m_boundingBoxMap(
-          Kernel::make_unique<Kernel::Cache<const ComponentID, BoundingBox>>(
-              *other.m_boundingBoxMap)),
       m_instrument(other.m_instrument) {
   if (m_instrument)
     std::tie(m_componentInfo, m_detectorInfo) =
@@ -1036,7 +1030,6 @@ std::string ParameterMap::asString() const {
 void ParameterMap::clearPositionSensitiveCaches() {
   m_cacheLocMap->clear();
   m_cacheRotMap->clear();
-  m_boundingBoxMap->clear();
 }
 
 /// Sets a cached location on the location cache
@@ -1071,23 +1064,6 @@ void ParameterMap::setCachedRotation(const IComponent *comp,
 bool ParameterMap::getCachedRotation(const IComponent *comp,
                                      Quat &rotation) const {
   return m_cacheRotMap->getCache(comp->getComponentID(), rotation);
-}
-
-/// Sets a cached bounding box
-/// @param comp :: The Component to set the rotation of
-/// @param box :: A reference to the bounding box
-void ParameterMap::setCachedBoundingBox(const IComponent *comp,
-                                        const BoundingBox &box) const {
-  m_boundingBoxMap->setCache(comp->getComponentID(), box);
-}
-
-/// Attempts to retrieve a bounding box from the cache
-/// @param comp :: The Component to find the bounding box of
-/// @param box :: If the bounding box is found it's value will be set here
-/// @returns true if the bounding is in the map, otherwise false
-bool ParameterMap::getCachedBoundingBox(const IComponent *comp,
-                                        BoundingBox &box) const {
-  return m_boundingBoxMap->getCache(comp->getComponentID(), box);
 }
 
 /**


### PR DESCRIPTION
fixes #20848 by deleting unused code from `ParameterMap` and removing all code that used it. The same thing can be done for `m_cacheLocMap` and `m_cacheRotMap` easily now since we use `ComponentInfo` for all of this now. I am going to do that in a separate PR as I want to double check the performance effects of these changes via the master run of the performance tests first.

**Tester**
A code review will be sufficient 