### PR TITLE
sequential fit bug

### DIFF
--- a/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
@@ -973,19 +973,11 @@ Muon::DatasetParams parseWorkspaceName(const std::string &wsName) {
  */
 void parseRunLabel(const std::string &label, std::string &instrument,
                    std::vector<int> &runNumbers) {
-  size_t path = label.find_last_of("/");
-  if (path == std::string::npos) {
-	  size_t path = label.find_last_of('\\');
-  }
-  std::string useThisLabel = label;
-  if (path != std::string::npos) {
-	  useThisLabel = label.substr(0, path);
-  }
-  const size_t instPos = useThisLabel.find_first_of("0123456789");
-  instrument = useThisLabel.substr(0, instPos);
-  const size_t numPos = useThisLabel.find_first_not_of('0', instPos);
+  const size_t instPos = label.find_first_of("0123456789");
+  instrument = label.substr(0, instPos);
+  const size_t numPos = label.find_first_not_of('0', instPos);
   if (numPos != std::string::npos) {
-    std::string runString = useThisLabel.substr(numPos, useThisLabel.size());
+    std::string runString = label.substr(numPos, label.size());
     // sets of continuous ranges
     Mantid::Kernel::StringTokenizer rangeTokenizer(
         runString, ",", Mantid::Kernel::StringTokenizer::TOK_TRIM);

--- a/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
@@ -973,11 +973,19 @@ Muon::DatasetParams parseWorkspaceName(const std::string &wsName) {
  */
 void parseRunLabel(const std::string &label, std::string &instrument,
                    std::vector<int> &runNumbers) {
-  const size_t instPos = label.find_first_of("0123456789");
-  instrument = label.substr(0, instPos);
-  const size_t numPos = label.find_first_not_of('0', instPos);
+  size_t path = label.find_last_of("/");
+  if (path == std::string::npos) {
+	  size_t path = label.find_last_of('\\');
+  }
+  std::string useThisLabel = label;
+  if (path != std::string::npos) {
+	  useThisLabel = label.substr(0, path);
+  }
+  const size_t instPos = useThisLabel.find_first_of("0123456789");
+  instrument = useThisLabel.substr(0, instPos);
+  const size_t numPos = useThisLabel.find_first_not_of('0', instPos);
   if (numPos != std::string::npos) {
-    std::string runString = label.substr(numPos, label.size());
+    std::string runString = useThisLabel.substr(numPos, useThisLabel.size());
     // sets of continuous ranges
     Mantid::Kernel::StringTokenizer rangeTokenizer(
         runString, ",", Mantid::Kernel::StringTokenizer::TOK_TRIM);

--- a/qt/scientific_interfaces/Muon/MuonSequentialFitDialog.cpp
+++ b/qt/scientific_interfaces/Muon/MuonSequentialFitDialog.cpp
@@ -20,6 +20,23 @@ using MantidQt::MantidWidgets::MuonFitPropertyBrowser;
 
 namespace {
 Logger g_log("MuonSequentialFitDialog");
+std::string removePath(const std::string &labelIn) {
+	size_t path = labelIn.find_last_of("/");
+	if (path == std::string::npos) {
+		 path = labelIn.find_last_of('\\');
+		
+	}
+	std::string useThisLabel = labelIn;
+	if (path != std::string::npos) {
+		path = path + 1;
+		size_t end = labelIn.find_last_of(".");
+		useThisLabel = labelIn.substr(path);
+		useThisLabel = useThisLabel.substr(0, end - path);
+		auto test = useThisLabel;
+	}
+	return useThisLabel;
+}
+
 }
 const std::string MuonSequentialFitDialog::SEQUENTIAL_PREFIX("MuonSeqFit_");
 
@@ -328,7 +345,7 @@ void MuonSequentialFitDialog::continueFit() {
   // Get names of workspaces to fit
   const auto wsNames = m_dataPresenter->generateWorkspaceNames(
       m_ui.runs->getInstrumentOverride().toStdString(),
-      m_ui.runs->getText().toStdString(), false);
+      removePath(m_ui.runs->getText().toStdString()), false);
   if (wsNames.size() == 0) {
     QMessageBox::critical(
         this, "No data to fit",

--- a/qt/scientific_interfaces/Muon/MuonSequentialFitDialog.cpp
+++ b/qt/scientific_interfaces/Muon/MuonSequentialFitDialog.cpp
@@ -21,22 +21,20 @@ using MantidQt::MantidWidgets::MuonFitPropertyBrowser;
 namespace {
 Logger g_log("MuonSequentialFitDialog");
 std::string removePath(const std::string &labelIn) {
-	size_t path = labelIn.find_last_of("/");
-	if (path == std::string::npos) {
-		 path = labelIn.find_last_of('\\');
-		
-	}
-	std::string useThisLabel = labelIn;
-	if (path != std::string::npos) {
-		path = path + 1;
-		size_t end = labelIn.find_last_of(".");
-		useThisLabel = labelIn.substr(path);
-		useThisLabel = useThisLabel.substr(0, end - path);
-		auto test = useThisLabel;
-	}
-	return useThisLabel;
+  size_t path = labelIn.find_last_of("/");
+  if (path == std::string::npos) {
+    path = labelIn.find_last_of('\\');
+  }
+  std::string useThisLabel = labelIn;
+  if (path != std::string::npos) {
+    path = path + 1;
+    size_t end = labelIn.find_last_of(".");
+    useThisLabel = labelIn.substr(path);
+    useThisLabel = useThisLabel.substr(0, end - path);
+    auto test = useThisLabel;
+  }
+  return useThisLabel;
 }
-
 }
 const std::string MuonSequentialFitDialog::SEQUENTIAL_PREFIX("MuonSeqFit_");
 


### PR DESCRIPTION
The sequential fitting in muon analysis would crash Mantid if a user used the browse button. This was fixed by trimming the path to give just the file name.

**To test:**
1. open Muon Analysis
2. Load some data (doesn't matter which)
3. Go to the data analysis tab and add a fitting function
4. Go to fit -> sequential fit. A new window should appear
5. Click browse and select a muon file from your machine
6. Click start - Mantid should throw an error about not having the data in the ADS, but will not crash. 
7. Go to the home tab in muon analysis and load some data from you machine
8. Go back to the data analysis tab and open the sequential fit window 
9. Select the file via browse and click run. It should work this time.
10. Double check that sequential fit still works if you put run numbers in (if they are not in the ADS it will load them)


<!-- Instructions for testing. -->

Fixes #20844 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
