### PR TITLE
Revert "Fix for Mantid freezing when handling Engineering Diffraction"

### DIFF
--- a/docs/source/release/v3.11.0/diffraction.rst
+++ b/docs/source/release/v3.11.0/diffraction.rst
@@ -37,6 +37,11 @@ Single Crystal Diffraction
 - :ref:`SCDCalibratePanels <algm-SCDCalibratePanels>` has CalibrateSnapPanels option to calibrate 3X3 banks of SNAP instrument for single crystal data.
 - :ref:`LoadIsawDetCal <algm-LoadIsawDetCal>` has not correctly aligned the detectors for SNAP since release 3.9. This bug that only impacted SNAP has been fixed.
 
+Engineering Diffraction
+-----------------------
+ 
+- The ISIS engineering diffraction interface has temporarily been disabled due to an issue with file search freezing Mantid when opening the interface.
+
 Imaging
 -------
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -133,13 +133,13 @@ void EnggDiffractionViewQtGUI::doSetupTabCalib() {
   if (m_uiTabCalib.MWRunFiles_new_vanadium_num->getUserInput()
           .toString()
           .isEmpty()) {
-    m_uiTabCalib.MWRunFiles_new_vanadium_num->setFileTextWithoutSearch(
+    m_uiTabCalib.MWRunFiles_new_vanadium_num->setUserInput(
         QString::fromStdString(vanadiumRun));
   }
   if (m_uiTabCalib.MWRunFiles_new_ceria_num->getUserInput()
           .toString()
           .isEmpty()) {
-    m_uiTabCalib.MWRunFiles_new_ceria_num->setFileTextWithoutSearch(
+    m_uiTabCalib.MWRunFiles_new_ceria_num->setUserInput(
         QString::fromStdString(ceriaRun));
   }
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -22,7 +22,8 @@ namespace MantidQt {
 namespace CustomInterfaces {
 
 // Add this class to the list of specialised dialogs in this namespace
-DECLARE_SUBWINDOW(EnggDiffractionViewQtGUI)
+// Temporarily disabled to prevent freezing when opening the file dialog.
+// DECLARE_SUBWINDOW(EnggDiffractionViewQtGUI)
 
 const double EnggDiffractionViewQtGUI::g_defaultRebinWidth = -0.0005;
 

--- a/qt/widgets/common/src/MWRunFiles.cpp
+++ b/qt/widgets/common/src/MWRunFiles.cpp
@@ -260,9 +260,9 @@ MWRunFiles::MWRunFiles(QWidget *parent)
 
 MWRunFiles::~MWRunFiles() {
   // Before destruction, make sure the file finding thread has stopped running.
-  // Wait if necessary. This can freeze up Mantid.
+  // Wait if necessary.
   m_thread->exit(-1);
-  m_thread->wait(50);
+  m_thread->wait();
 }
 
 /**
@@ -809,6 +809,7 @@ void MWRunFiles::inspectThreadResult() {
 void MWRunFiles::readSettings(const QString &group) {
   QSettings settings;
   settings.beginGroup(group);
+
   m_lastDir = settings.value("last_directory", "").toString();
 
   if (m_lastDir == "") {


### PR DESCRIPTION
Reverts mantidproject/mantid#20847

This has caused an issue where Mantid is now crashing when closing the interface.