### PR TITLE
Fix file downloading issue with HFIR PD GUI 

### DIFF
--- a/scripts/HFIRPowderReduction/HfirPDReductionGUI.py
+++ b/scripts/HFIRPowderReduction/HfirPDReductionGUI.py
@@ -614,6 +614,7 @@ class MainWindow(QtGui.QMainWindow):
                 mqt.MantidQt.API.MantidDesktopServices.openUrl(QtCore.QUrl(self.externalUrl))
         return
 
+    # flake8: noqa
     def doLoadData(self, exp=None, scan=None):
         """ Load and reduce data
         It does not support for tab 'Advanced Setup'

--- a/scripts/HFIRPowderReduction/HfirPDReductionGUI.py
+++ b/scripts/HFIRPowderReduction/HfirPDReductionGUI.py
@@ -407,14 +407,14 @@ class MainWindow(QtGui.QMainWindow):
         cache_dir = str(self.ui.lineEdit_cache.text()).strip()
         if len(cache_dir) == 0 or os.path.exists(cache_dir) is False:
             invalid_cache = cache_dir
-            if False:
-                cache_dir = os.path.expanduser('~')
-            else:
-                cache_dir = os.getcwd()
+            cache_dir = os.path.expanduser('~')
             self.ui.lineEdit_cache.setText(cache_dir)
-            self._logWarning("Cache directory %s is not valid. "
-                             "Using current workspace directory %s as cache." %
-                             (invalid_cache, cache_dir))
+            if len(invalid_cache) == 0:
+                warning_msg = 'Cache directory is not set. '
+            else:
+                warning_msg = 'Cache directory {0} does not exist. '.format(invalid_cache)
+            warning_msg += 'Using {0} for caching dowloaded file instead.'.format(cache_dir)
+            print ('[WARNING] {0}'.format(warning_msg))
 
         # Get on hold of raw data file
         useserver = self.ui.radioButton_useServer.isChecked()
@@ -2141,7 +2141,7 @@ class MainWindow(QtGui.QMainWindow):
 
             filename = '%s_exp%04d_scan%04d.dat' % (self._instrument.upper(), exp, scan)
             srcFileName = os.path.join(cachedir, filename)
-            status, errmsg = urllib.downloadFile(fullurl, srcFileName)
+            status, errmsg = HfirPDReductionControl.downloadFile(fullurl, srcFileName)
             if status is False:
                 self._logError(errmsg)
                 srcFileName = None

--- a/scripts/HFIRPowderReduction/HfirPDReductionGUI.py
+++ b/scripts/HFIRPowderReduction/HfirPDReductionGUI.py
@@ -1,4 +1,4 @@
-#pylint: disable=invalid-name, relative-import, too-many-lines,too-many-instance-attributes,too-many-arguments
+#pylint: disable=invalid-name, relative-import, too-many-lines,too-many-instance-attributes,too-many-arguments,C901
 ################################################################################
 # Main class for HFIR powder reduction GUI
 # Key word for future developing: FUTURE, NEXT, REFACTOR, RELEASE 2.0


### PR DESCRIPTION
Fixed the wrong import of urllib in HFIR Powder Diffraction interface.

**To test:**

Try Exp 596 Scan 11.  File shall be downloaded.

<!-- Instructions for testing. -->

Fixes #20889. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
