### PR TITLE
Running muon and neutron data in fit benchmarking

### DIFF
--- a/scripts/CompareFitMinimizers/fitting_benchmarking.py
+++ b/scripts/CompareFitMinimizers/fitting_benchmarking.py
@@ -299,9 +299,9 @@ def do_fitting_benchmark_one_problem(prob, minimizers, use_errors=True,count=0,p
         fig.labels['title']=prob.name[:-4]+" "+str(count)
         fig.title_size=10
         fit_result= msapi.Fit(user_func, wks, Output='ws_fitting_test',
-                          Minimizer='Levenberg-Marquardt',
-                          CostFunction='Least squares',IgnoreInvalidData=True,
-                          StartX=prob.start_x, EndX=prob.end_x,MaxIterations=0)
+                              Minimizer='Levenberg-Marquardt',
+                              CostFunction='Least squares',IgnoreInvalidData=True,
+                              StartX=prob.start_x, EndX=prob.end_x,MaxIterations=0)
         tmp=msapi.ConvertToPointData(fit_result.OutputWorkspace)
         xData = tmp.readX(1)
         yData = tmp.readY(1)
@@ -356,10 +356,10 @@ def run_fit(wks, prob, function, minimizer='Levenberg-Marquardt', cost_function=
             ignore_invalid = False
 
         fit_result = msapi.Fit(function, wks, Output='ws_fitting_test',
-                           Minimizer=minimizer,
-                           CostFunction=cost_function,
-                           IgnoreInvalidData=ignore_invalid,
-                           StartX=prob.start_x, EndX=prob.end_x)
+                               Minimizer=minimizer,
+                               CostFunction=cost_function,
+                               IgnoreInvalidData=ignore_invalid,
+                               StartX=prob.start_x, EndX=prob.end_x)
 
         calc_chi2 = msapi.CalculateChiSquared(Function=function,
                                               InputWorkspace=wks, IgnoreInvalidData=ignore_invalid)

--- a/scripts/CompareFitMinimizers/fitting_benchmarking.py
+++ b/scripts/CompareFitMinimizers/fitting_benchmarking.py
@@ -229,7 +229,6 @@ def do_fitting_benchmark_one_problem(prob, minimizers, use_errors=True,count=0,p
 
     # Get function definitions for the problem - one for each starting point
     function_defs = get_function_definitions(prob)
-    print("WAAA", function_defs)
     # search for lowest chi2
     min_sum_err_sq = 1.e20
     # Loop over the different starting points
@@ -238,7 +237,6 @@ def do_fitting_benchmark_one_problem(prob, minimizers, use_errors=True,count=0,p
         for minimizer_name in minimizers:
             t_start = time.clock()
 
-            #status, chi2, fit_wks, params, errors = run_fit(wks, prob, function=user_func,
             status, chi2, fit_wks, params, errors = run_fit(wks, prob, function=user_func,
                                                             minimizer=minimizer_name,
                                                             cost_function=cost_function)
@@ -268,7 +266,6 @@ def do_fitting_benchmark_one_problem(prob, minimizers, use_errors=True,count=0,p
             result.errors = errors
             result.sum_err_sq = sum_err_sq
             # If the fit has failed, also set the runtime to NaN
-            #print ("mooo ",type(chi2))
             result.runtime = t_end - t_start if not np.isnan(chi2) else np.nan
             print("Result object: {0}".format(result))
             results_problem_start.append(result)
@@ -356,7 +353,6 @@ def run_fit(wks, prob, function, minimizer='Levenberg-Marquardt', cost_function=
                                                                 CostFunction=cost_function,
                                                                 IgnoreInvalidData=ignore_invalid,
                                                                 StartX=prob.start_x, EndX=prob.end_x)
-        print("mooo ",status)
 
         calc_chi2 = msapi.CalculateChiSquared(Function=function,
                                               InputWorkspace=wks, IgnoreInvalidData=ignore_invalid)

--- a/scripts/CompareFitMinimizers/fitting_benchmarking.py
+++ b/scripts/CompareFitMinimizers/fitting_benchmarking.py
@@ -298,11 +298,11 @@ def do_fitting_benchmark_one_problem(prob, minimizers, use_errors=True,count=0,p
         #fig.labels['y']="something "
         fig.labels['title']=prob.name[:-4]+" "+str(count)
         fig.title_size=10
-        status= msapi.Fit(user_func, wks, Output='ws_fitting_test',
+        fit_result= msapi.Fit(user_func, wks, Output='ws_fitting_test',
                           Minimizer='Levenberg-Marquardt',
                           CostFunction='Least squares',IgnoreInvalidData=True,
                           StartX=prob.start_x, EndX=prob.end_x,MaxIterations=0)
-        tmp=msapi.ConvertToPointData(status.OutputWorkspace)
+        tmp=msapi.ConvertToPointData(fit_result.OutputWorkspace)
         xData = tmp.readX(1)
         yData = tmp.readY(1)
         startData=data("Start Guess",xData,yData)
@@ -345,7 +345,7 @@ def run_fit(wks, prob, function, minimizer='Levenberg-Marquardt', cost_function=
 
     @returns the fitted parameter values and error estimates for these
     """
-    status = None
+    fit_result = None
     param_tbl = None
     try:
         # When using 'Least squares' (weighted by errors), ignore nans and zero errors, but don't
@@ -355,7 +355,7 @@ def run_fit(wks, prob, function, minimizer='Levenberg-Marquardt', cost_function=
         if 'WISH17701' in prob.name:
             ignore_invalid = False
 
-        status = msapi.Fit(function, wks, Output='ws_fitting_test',
+        fit_result = msapi.Fit(function, wks, Output='ws_fitting_test',
                            Minimizer=minimizer,
                            CostFunction=cost_function,
                            IgnoreInvalidData=ignore_invalid,
@@ -367,7 +367,7 @@ def run_fit(wks, prob, function, minimizer='Levenberg-Marquardt', cost_function=
 
     except RuntimeError as rerr:
         print("Warning, Fit probably failed. Going on. Error: {0}".format(str(rerr)))
-    param_tbl = status.OutputParameters
+    param_tbl = fit_result.OutputParameters
     if param_tbl:
         params = param_tbl.column(1)[:-1]
         errors = param_tbl.column(2)[:-1]
@@ -375,7 +375,7 @@ def run_fit(wks, prob, function, minimizer='Levenberg-Marquardt', cost_function=
         params = None
         errors = None
 
-    return status.OutputStatus, status.OutputChi2overDoF, status.OutputWorkspace, params, errors
+    return fit_result.OutputStatus, fit_result.OutputChi2overDoF, fit_result.OutputWorkspace, params, errors
 
 
 def prepare_wks_cost_function(prob, use_errors):

--- a/scripts/CompareFitMinimizers/fitting_benchmarking.py
+++ b/scripts/CompareFitMinimizers/fitting_benchmarking.py
@@ -101,7 +101,7 @@ def run_all_with_or_without_errors(base_problem_files_dir, use_errors, minimizer
 
 
 def do_fitting_benchmark(nist_group_dir=None, cutest_group_dir=None, neutron_data_group_dirs=None,
-                         minimizers=None, use_errors=True):
+                         muon_data_group_dir=None, minimizers=None, use_errors=True):
     """
     Run a fit minimizer benchmark against groups of fitting problems.
 
@@ -116,6 +116,7 @@ def do_fitting_benchmark(nist_group_dir=None, cutest_group_dir=None, neutron_dat
     @param nist_group_dir :: whether to try to load NIST problems
     @param cutest_group_dir :: whether to try to load CUTEst problems
     @param neutron_data_group_dirs :: base directory where fitting problems are located including NIST+CUTEst
+    @param muon_data_group_dir :: base directory where muon fitting problems are located
     @param minimizers :: list of minimizers to test
     @param use_errors :: whether to use observational errors as weights in the cost function
     """
@@ -134,6 +135,8 @@ def do_fitting_benchmark(nist_group_dir=None, cutest_group_dir=None, neutron_dat
 
     if neutron_data_group_dirs:
         problem_blocks.extend(get_data_groups(neutron_data_group_dirs))
+    if muon_data_group_dir:
+        problem_blocks.extend(get_data_groups(muon_data_group_dir))
 
     prob_results = [do_fitting_benchmark_group(block, minimizers, use_errors=use_errors) for
                     block in problem_blocks]
@@ -314,10 +317,15 @@ def do_fitting_benchmark_one_problem(prob, minimizers, use_errors=True,count=0,p
         start_fig.labels['y']="Arbitrary units"
         title=user_func[27:-1]
         title=splitByString(title,30)
-        start_fig.labels['title']=prob.name[:-4]+" "+str(count)+"\n"+title
+        run_ID = prob.name
+        k=-1
+        k=run_ID.rfind(".")
+        if k != -1:
+            run_ID=run_ID[:k]
+        start_fig.labels['title']=run_ID+" "+str(count)+"\n"+title
         start_fig.title_size=10
-        fig.make_scatter_plot("Fit for "+prob.name[:-4]+" "+str(count)+".pdf")
-        start_fig.make_scatter_plot("start for "+prob.name[:-4]+" "+str(count)+".pdf")
+        fig.make_scatter_plot("Fit for "+run_ID+" "+str(count)+".pdf")
+        start_fig.make_scatter_plot("start for "+run_ID+" "+str(count)+".pdf")
     return results_fit_problem
 
 
@@ -346,7 +354,6 @@ def run_fit(wks, prob, function, minimizer='Levenberg-Marquardt', cost_function=
         # Note the ugly adhoc exception. We need to reconsider these WISH problems:
         if 'WISH17701' in prob.name:
             ignore_invalid = False
-        #print("boo ", function,cost_function,prob.start_x,prob.end_x)
 
         status = msapi.Fit(function, wks, Output='ws_fitting_test',
                                                                 Minimizer=minimizer,

--- a/scripts/CompareFitMinimizers/fitting_benchmarking.py
+++ b/scripts/CompareFitMinimizers/fitting_benchmarking.py
@@ -317,11 +317,13 @@ def do_fitting_benchmark_one_problem(prob, minimizers, use_errors=True,count=0,p
         start_fig.labels['y']="Arbitrary units"
         title=user_func[27:-1]
         title=splitByString(title,30)
+        # remove the extension (e.g. .nxs) if there is one
         run_ID = prob.name
         k=-1
         k=run_ID.rfind(".")
         if k != -1:
             run_ID=run_ID[:k]
+
         start_fig.labels['title']=run_ID+" "+str(count)+"\n"+title
         start_fig.title_size=10
         fig.make_scatter_plot("Fit for "+run_ID+" "+str(count)+".pdf")

--- a/scripts/CompareFitMinimizers/fitting_benchmarking.py
+++ b/scripts/CompareFitMinimizers/fitting_benchmarking.py
@@ -299,9 +299,9 @@ def do_fitting_benchmark_one_problem(prob, minimizers, use_errors=True,count=0,p
         fig.labels['title']=prob.name[:-4]+" "+str(count)
         fig.title_size=10
         status= msapi.Fit(user_func, wks, Output='ws_fitting_test',
-                                                                Minimizer='Levenberg-Marquardt',
-                                                                CostFunction='Least squares',IgnoreInvalidData=True,
-                                                                StartX=prob.start_x, EndX=prob.end_x,MaxIterations=0)
+                          Minimizer='Levenberg-Marquardt',
+                          CostFunction='Least squares',IgnoreInvalidData=True,
+                          StartX=prob.start_x, EndX=prob.end_x,MaxIterations=0)
         tmp=msapi.ConvertToPointData(status.OutputWorkspace)
         xData = tmp.readX(1)
         yData = tmp.readY(1)
@@ -346,9 +346,7 @@ def run_fit(wks, prob, function, minimizer='Levenberg-Marquardt', cost_function=
     @returns the fitted parameter values and error estimates for these
     """
     status = None
-    chi2 = None
     param_tbl = None
-    fit_wks = None
     try:
         # When using 'Least squares' (weighted by errors), ignore nans and zero errors, but don't
         # ignore them when using 'Unweighted least squares' as that would ignore all values!
@@ -358,10 +356,10 @@ def run_fit(wks, prob, function, minimizer='Levenberg-Marquardt', cost_function=
             ignore_invalid = False
 
         status = msapi.Fit(function, wks, Output='ws_fitting_test',
-                                                                Minimizer=minimizer,
-                                                                CostFunction=cost_function,
-                                                                IgnoreInvalidData=ignore_invalid,
-                                                                StartX=prob.start_x, EndX=prob.end_x)
+                           Minimizer=minimizer,
+                           CostFunction=cost_function,
+                           IgnoreInvalidData=ignore_invalid,
+                           StartX=prob.start_x, EndX=prob.end_x)
 
         calc_chi2 = msapi.CalculateChiSquared(Function=function,
                                               InputWorkspace=wks, IgnoreInvalidData=ignore_invalid)

--- a/scripts/CompareFitMinimizers/input_parsing.py
+++ b/scripts/CompareFitMinimizers/input_parsing.py
@@ -220,9 +220,13 @@ def load_neutron_data_fitting_problem_file(fname):
     """
     with open(fname) as probf:
         entries = get_neutron_data_problem_entries(probf)
-
+        k=-1
+        prefix =""
+        k = fname.rfind("\\")
+        if k != -1:
+            prefix = fname[:k]+"\\data_files\\"
         prob = test_problem.FittingTestProblem()
-        get_fitting_neutron_data(entries['input_file'], prob)
+        get_fitting_neutron_data(prefix+entries['input_file'], prob)
         prob.name = entries['name']
         prob.equation = entries['function']
         prob.starting_values = None
@@ -263,7 +267,7 @@ def get_fitting_neutron_data(fname, prob):
     @param prob :: problem definition to populate with X-Y-E data.
     """
     import mantid.simpleapi as msapi
-
+    print("moooo ",fname)
     wks = msapi.Load(fname)
     prob.data_pattern_in = wks.readX(0)
     prob.data_pattern_out = wks.readY(0)

--- a/scripts/CompareFitMinimizers/input_parsing.py
+++ b/scripts/CompareFitMinimizers/input_parsing.py
@@ -220,6 +220,7 @@ def load_neutron_data_fitting_problem_file(fname):
     """
     with open(fname) as probf:
         entries = get_neutron_data_problem_entries(probf)
+        # get the path to the data
         k=-1
         prefix =""
         k = fname.rfind("\\")
@@ -267,7 +268,6 @@ def get_fitting_neutron_data(fname, prob):
     @param prob :: problem definition to populate with X-Y-E data.
     """
     import mantid.simpleapi as msapi
-    print("moooo ",fname)
     wks = msapi.Load(fname)
     prob.data_pattern_in = wks.readX(0)
     prob.data_pattern_out = wks.readY(0)

--- a/scripts/CompareFitMinimizers/plotHelper.py
+++ b/scripts/CompareFitMinimizers/plotHelper.py
@@ -156,8 +156,9 @@ class plot(data,insert):
         if save=="":
             plt.show()
         else:
-            print ("saving to "+save.replace(" ","_"))
-            plt.savefig(save.replace(" ","_"))
+            output_file = save.replace(",","")
+            print ("saving to "+output_file.replace(" ","_"))
+            plt.savefig(output_file.replace(" ","_"))
 
     # safe is used if the y values (strings) all have unique names
     def make_y_bar_plot(self,safe=True,save=""):


### PR DESCRIPTION
The fit bench marking should be able to use neutron and muon data. This required adding the full path to the load algorithm and making muon an acceptable argument.

There are few other changes to allow fit bench marking work with the new output from the fit algorithm. 

**To test:**

<!-- Instructions for testing. -->
Download the attached zip file: 

[FitMinimizerTesting.zip](https://github.com/mantidproject/mantid/files/1379578/FitMinimizerTesting.zip)



Unzip it

In the python scripting window open runScripts.py

Then on line 35 (run_data) you can choose what to run (muon, neutron or nist). Run each one in turn. 

Plots and summary tables should be produced in the mantidplot folder of your build. There will be 2 plots (start and best fit) for each test. 

Fixes #20865 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
