### PR TITLE
Fix simple flake 8 warnings

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/Mean.py
+++ b/Framework/PythonInterface/plugins/algorithms/Mean.py
@@ -44,7 +44,7 @@ class Mean(PythonAlgorithm):
                 # cannot run the next test if this fails
                 return issues
             for spectra in range(0,nSpectra):
-                if numpy.allclose(ws1.readX(spectra) ,ws2.readX(spectra)) ==False:
+                if numpy.allclose(ws1.readX(spectra) ,ws2.readX(spectra)) is False:
                     issues["Workspaces"] = "The data should have the same order for x values. Sort your data first"
         return issues
 

--- a/Framework/PythonInterface/plugins/algorithms/Mean.py
+++ b/Framework/PythonInterface/plugins/algorithms/Mean.py
@@ -44,7 +44,7 @@ class Mean(PythonAlgorithm):
                 # cannot run the next test if this fails
                 return issues
             for spectra in range(0,nSpectra):
-                if numpy.allclose(ws1.readX(spectra) ,ws2.readX(spectra)) is False:
+                if not numpy.allclose(ws1.readX(spectra) ,ws2.readX(spectra)):
                     issues["Workspaces"] = "The data should have the same order for x values. Sort your data first"
         return issues
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
@@ -384,6 +384,6 @@ class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
             if mtd.doesExist(workspace_name + "_mon"):
                 DeleteWorkspace(workspace_name + '_mon')
 
-# ------------------------------------------------------------------------------
 
+# ------------------------------------------------------------------------------
 AlgorithmFactory.subscribe(ISISIndirectDiffractionReduction)

--- a/tools/release_generator/release.py
+++ b/tools/release_generator/release.py
@@ -47,9 +47,12 @@ Citation
 
 Please cite any usage of Mantid as follows: **TODO update with current version doi**
 
-- *Mantid {version}: Manipulation and Analysis Toolkit for Instrument Data.; Mantid Project*. `doi: 10.5286/SOFTWARE/MANTID{version} <http://dx.doi.org/10.5286/SOFTWARE/MANTID{version}>`_
+- *Mantid {version}: Manipulation and Analysis Toolkit for Instrument Data.; Mantid Project*. `doi: 10.5286/SOFTWARE/MANTID{version}
+   <http://dx.doi.org/10.5286/SOFTWARE/MANTID{version}>`_
 
-- Arnold, O. et al. *Mantid-Data Analysis and Visualization Package for Neutron Scattering and mu-SR Experiments.* Nuclear Instruments and Methods in Physics Research Section A: Accelerators, Spectrometers, Detectors and Associated Equipment 764 (2014): 156-166 `doi: 10.1016/j.nima.2014.07.029 <https://doi.org/10.1016/j.nima.2014.07.029>`_
+- Arnold, O. et al. *Mantid-Data Analysis and Visualization Package for Neutron Scattering and mu-SR Experiments.* Nuclear Instruments
+  and Methods in Physics Research Section A: Accelerators, Spectrometers, Detectors and Associated Equipment 764 (2014): 156-166
+  `doi: 10.1016/j.nima.2014.07.029 <https://doi.org/10.1016/j.nima.2014.07.029>`_
 
 
 Changes


### PR DESCRIPTION
This is a fix of simple flake 8 warnings. The Muon warnings are fixed in #20890 and Reflectometry are fixed in 20663.

The remaining warnings are about the complexity of the functions. 

**To test:**
Code review and check that the Mean algorithm works. 

<!-- Instructions for testing. -->

Fixes #20908. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
Does not need to be in release notes 
#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
