### PR TITLE
Fix #20910 Error when processing single transmission run from settings tab

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/ReflSettingsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflSettingsPresenter.cpp
@@ -286,8 +286,7 @@ std::string ReflSettingsPresenter::getTransmissionRuns(bool loadRuns) const {
     return "";
 
   std::vector<std::string> transmissionRuns;
-  boost::split(transmissionRuns, transmissionRunsString,
-               boost::is_any_of(","));
+  boost::split(transmissionRuns, transmissionRunsString, boost::is_any_of(","));
 
   if (loadRuns)
     loadTransmissionRuns(transmissionRuns);

--- a/qt/scientific_interfaces/ISISReflectometry/ReflSettingsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflSettingsPresenter.h
@@ -60,8 +60,11 @@ public:
   // Loads the runs with the names/run numbers specified by the vector.
   void
   loadTransmissionRuns(std::vector<std::string> const &transmissionRuns) const;
-  std::string firstTransmissionRunLabelled(std::vector<std::string> const& runNumber) const;
-  std::string secondTransmissionRunLabelled(std::vector<std::string> const& runNumber) const;
+  std::string
+  firstTransmissionRunLabelled(std::vector<std::string> const &runNumber) const;
+  std::string secondTransmissionRunLabelled(
+      std::vector<std::string> const &runNumber) const;
+
 private:
   void createStitchHints();
   void getExpDefaults();

--- a/qt/scientific_interfaces/ISISReflectometry/ReflSettingsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflSettingsPresenter.h
@@ -1,10 +1,11 @@
 #ifndef MANTID_ISISREFLECTOMETRY_REFLSETTINGSPRESENTER_H
 #define MANTID_ISISREFLECTOMETRY_REFLSETTINGSPRESENTER_H
 
-#include "MantidAPI/IAlgorithm_fwd.h"
-#include "MantidGeometry/Instrument_fwd.h"
 #include "DllConfig.h"
 #include "IReflSettingsPresenter.h"
+#include "MantidAPI/IAlgorithm_fwd.h"
+#include "MantidGeometry/Instrument_fwd.h"
+#include <vector>
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -56,7 +57,11 @@ public:
   std::string getReductionOptions() const override;
   /// Returns global options for 'Stitch1DMany'
   std::string getStitchOptions() const override;
-
+  // Loads the runs with the names/run numbers specified by the vector.
+  void
+  loadTransmissionRuns(std::vector<std::string> const &transmissionRuns) const;
+  std::string firstTransmissionRunLabelled(std::vector<std::string> const& runNumber) const;
+  std::string secondTransmissionRunLabelled(std::vector<std::string> const& runNumber) const;
 private:
   void createStitchHints();
   void getExpDefaults();


### PR DESCRIPTION
Fixes #20910 by checking the size of the parsed list of run numbers rather than the run string.

**To test:**
1. Follow the instructions in the original issue and check that the UI no longer crashes and instead processes the data with the transition run.

2. Try entering `13463,13462` and check that the UI processes the the data with both transition runs correctly.

Fixes #20910. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
