### PR TITLE
ISIS_Powder PEARL create_vanadium giving incorrect data

### DIFF
--- a/scripts/Diffraction/isis_powder/pearl_routines/pearl_output.py
+++ b/scripts/Diffraction/isis_powder/pearl_routines/pearl_output.py
@@ -14,11 +14,11 @@ def generate_and_save_focus_output(instrument, processed_spectra, run_details, a
 
     if focus_mode == "all":
         processed_nexus_files = _focus_mode_all(output_file_paths=output_file_paths,
-                                                calibrated_spectra=processed_spectra,
+                                                processed_spectra=processed_spectra,
                                                 attenuation_filepath=attenuation_filepath)
     elif focus_mode == "groups":
         processed_nexus_files = _focus_mode_groups(output_file_paths=output_file_paths,
-                                                   calibrateded_spectra=processed_spectra)
+                                                   calibrated_spectra=processed_spectra)
     elif focus_mode == "trans":
         processed_nexus_files = _focus_mode_trans(output_file_paths=output_file_paths,
                                                   calibrated_spectra=processed_spectra,

--- a/scripts/Diffraction/isis_powder/routines/calibrate.py
+++ b/scripts/Diffraction/isis_powder/routines/calibrate.py
@@ -41,7 +41,7 @@ def create_van(instrument, run_details, absorb):
     focused_spectra = instrument._crop_van_to_expected_tof_range(focused_spectra)
 
     d_spacing_group, tof_group = instrument._output_focused_ws(processed_spectra=focused_spectra,
-                                                               run_details=run_details, output_mode="mods")
+                                                               run_details=run_details)
 
     _create_vanadium_splines(focused_spectra, instrument, run_details)
 


### PR DESCRIPTION
The PEARL routine for creating a vanadium was found to be giving the wrong values. In addition, the `focus_mode` parameter was found to be having no effect. This was pretty much just a matter of things being wired up incorrectly - `create_vanadium` now gives the same results as PEARL's old scripts.

**To test:**

`isis_powder` requires a relatively large amount of setup - come and see me if you take this on and I'll give you a hand setting up all the paths etc...
- As a mininum, a run with the following parameters should not fail:
```
pearl_focus.create_vanadium(run_in_cycle=99481, focus_mode="all", long_mode=False, 
                            tt_mode="tt88", do_absorb_corrections=False)
```
- Play around with some of the other parameters, especially `focus_mode` and see if anything goes bang that shouldn't
- Code review

Fixes #20866 

Doesn't need to be in the release notes, as it should have worked all along