### PR TITLE
Indirect - Elwin - Add check in case of invalid value within IPF file

### DIFF
--- a/qt/scientific_interfaces/Indirect/Elwin.cpp
+++ b/qt/scientific_interfaces/Indirect/Elwin.cpp
@@ -293,7 +293,7 @@ void Elwin::setDefaultResolution(Mantid::API::MatrixWorkspace_const_sptr ws,
       auto params = comp->getNumberParameter("resolution", true);
 
       // set the default instrument resolution
-      if (params.size() > 0) {
+      if (!params.empty()) {
         double res = params[0];
         m_dblManager->setValue(m_properties["IntegrationStart"], -res);
         m_dblManager->setValue(m_properties["IntegrationEnd"], res);

--- a/qt/scientific_interfaces/Indirect/Elwin.cpp
+++ b/qt/scientific_interfaces/Indirect/Elwin.cpp
@@ -288,19 +288,24 @@ void Elwin::setDefaultResolution(Mantid::API::MatrixWorkspace_const_sptr ws,
 
   if (analyser.size() > 0) {
     auto comp = inst->getComponentByName(analyser[0]);
-    auto params = comp->getNumberParameter("resolution", true);
 
-    // set the default instrument resolution
-    if (params.size() > 0) {
-      double res = params[0];
-      m_dblManager->setValue(m_properties["IntegrationStart"], -res);
-      m_dblManager->setValue(m_properties["IntegrationEnd"], res);
+    if(comp) {
+      auto params = comp->getNumberParameter("resolution", true);
 
-      m_dblManager->setValue(m_properties["BackgroundStart"], -10 * res);
-      m_dblManager->setValue(m_properties["BackgroundEnd"], -9 * res);
+      // set the default instrument resolution
+      if (params.size() > 0) {
+        double res = params[0];
+        m_dblManager->setValue(m_properties["IntegrationStart"], -res);
+        m_dblManager->setValue(m_properties["IntegrationEnd"], res);
+
+        m_dblManager->setValue(m_properties["BackgroundStart"], -10 * res);
+        m_dblManager->setValue(m_properties["BackgroundEnd"], -9 * res);
+      } else {
+        m_dblManager->setValue(m_properties["IntegrationStart"], range.first);
+        m_dblManager->setValue(m_properties["IntegrationEnd"], range.second);
+      }
     } else {
-      m_dblManager->setValue(m_properties["IntegrationStart"], range.first);
-      m_dblManager->setValue(m_properties["IntegrationEnd"], range.second);
+      showMessageBox("Warning: The instrument definition file for the input workspace is invalid.");
     }
   }
 }

--- a/qt/scientific_interfaces/Indirect/Elwin.cpp
+++ b/qt/scientific_interfaces/Indirect/Elwin.cpp
@@ -289,7 +289,7 @@ void Elwin::setDefaultResolution(Mantid::API::MatrixWorkspace_const_sptr ws,
   if (analyser.size() > 0) {
     auto comp = inst->getComponentByName(analyser[0]);
 
-    if(comp) {
+    if (comp) {
       auto params = comp->getNumberParameter("resolution", true);
 
       // set the default instrument resolution
@@ -305,7 +305,8 @@ void Elwin::setDefaultResolution(Mantid::API::MatrixWorkspace_const_sptr ws,
         m_dblManager->setValue(m_properties["IntegrationEnd"], range.second);
       }
     } else {
-      showMessageBox("Warning: The instrument definition file for the input workspace is invalid.");
+      showMessageBox("Warning: The instrument definition file for the input "
+                     "workspace contains an invalid value.");
     }
   }
 }


### PR DESCRIPTION
In the Elwin interface (Elwin.cpp), it is possible to crash Mantid, when there is an attempt to load an IPF file which contains an invalid value.

This PR adds a check for when this condition occurs and provides a warning message to the user.

**To test:**
1. Add the \*\_Parameters file to your instrument parameters directory.
2. Navigate to Interfaces > Indirect > Data Analysis Elwin.
3. Supply the \*\_red file as the input.
4. Run the Elwin interface and ensure Mantid does not crash and an error message is displayed.

**Test Files:**
[elwin-ipf-test-files.zip](https://github.com/mantidproject/mantid/files/1422106/elwin-ipf-test-files.zip)

<!-- Instructions for testing. -->

Fixes #20858. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
