### PR TITLE
Re #19126: Fixed LoadDialog crash by disabling ok button while updating dialog.

### DIFF
--- a/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/LoadDialog.h
+++ b/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/LoadDialog.h
@@ -59,8 +59,11 @@ namespace CustomDialogs {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
+class PreventLoadRequests;
+
 class LoadDialog : public API::AlgorithmDialog {
   Q_OBJECT
+  friend PreventLoadRequests;
 
 public:
   /// Default constructor

--- a/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/LoadDialog.h
+++ b/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/LoadDialog.h
@@ -98,15 +98,6 @@ private:
   void disableLoadRequests();
   /// Accept requests to load until they are disabled.
   void enableLoadRequests();
-
-  /// Perform an action ignoring any load requests which occur during it's
-  /// execution.
-  template <typename Action> auto protectedFromLoadRequests(Action action) {
-    disableLoadRequests();
-    action();
-    enableLoadRequests();
-  }
-
 private:
   /// Form
   Ui::LoadDialog m_form;

--- a/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/LoadDialog.h
+++ b/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/LoadDialog.h
@@ -94,7 +94,18 @@ private:
   /// Create the widgets for a given property
   int createWidgetsForProperty(const Mantid::Kernel::Property *prop,
                                QVBoxLayout *propertyLayout, QWidget *parent);
+  /// Ignore requests to load until they are re-enabled.
+  void disableLoadRequests();
+  /// Accept requests to load until they are disabled.
+  void enableLoadRequests();
 
+  /// Perform an action ignoring any load requests which occur during it's execution.
+  template<typename Action>
+  auto protectedFromLoadRequests(Action action) {
+    disableLoadRequests();
+    action();
+    enableLoadRequests();
+  }
 private:
   /// Form
   Ui::LoadDialog m_form;

--- a/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/LoadDialog.h
+++ b/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/LoadDialog.h
@@ -99,13 +99,14 @@ private:
   /// Accept requests to load until they are disabled.
   void enableLoadRequests();
 
-  /// Perform an action ignoring any load requests which occur during it's execution.
-  template<typename Action>
-  auto protectedFromLoadRequests(Action action) {
+  /// Perform an action ignoring any load requests which occur during it's
+  /// execution.
+  template <typename Action> auto protectedFromLoadRequests(Action action) {
     disableLoadRequests();
     action();
     enableLoadRequests();
   }
+
 private:
   /// Form
   Ui::LoadDialog m_form;

--- a/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/LoadDialog.h
+++ b/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/LoadDialog.h
@@ -98,6 +98,7 @@ private:
   void disableLoadRequests();
   /// Accept requests to load until they are disabled.
   void enableLoadRequests();
+
 private:
   /// Form
   Ui::LoadDialog m_form;

--- a/qt/widgets/plugins/algorithm_dialogs/src/LoadDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/LoadDialog.cpp
@@ -39,7 +39,7 @@ struct HoldFlag {
 // of it's lifetime.
 class PreventLoadRequests {
 public:
-  PreventLoadRequests(LoadDialog &dialog) : m_dialog(dialog) {
+  explicit PreventLoadRequests(LoadDialog &dialog) : m_dialog(dialog) {
     m_dialog.disableLoadRequests();
   }
 

--- a/qt/widgets/plugins/algorithm_dialogs/src/LoadDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/LoadDialog.cpp
@@ -123,20 +123,20 @@ void LoadDialog::accept() {
   // wasn't attempted for the new contents. Force one here.
   // The widget does nothing if the contents have not changed so it will be
   // quick for this case
-  protectedFromLoadRequests([this]() -> void {
-    m_form.fileWidget->findFiles();
-    while (m_form.fileWidget->isSearching() || m_populating)
-      QApplication::instance()->processEvents();
+  disableLoadRequests();
+  m_form.fileWidget->findFiles();
+  while (m_form.fileWidget->isSearching() || m_populating)
+    QApplication::instance()->processEvents();
 
-    // Check that the file still exists just incase it somehow got removed
-    std::string errMess =
-        getAlgorithm()->getPointerToProperty("Filename")->isValid();
-    if (!errMess.empty()) {
-      m_currentFiles = "";
-      createDynamicWidgets();
-    } else
-      AlgorithmDialog::accept();
-  });
+  // Check that the file still exists just incase it somehow got removed
+  std::string errMess =
+      getAlgorithm()->getPointerToProperty("Filename")->isValid();
+  if (!errMess.empty()) {
+    m_currentFiles = "";
+    createDynamicWidgets();
+  } else
+    AlgorithmDialog::accept();
+  enableLoadRequests();
 }
 
 //--------------------------------------------------------------------------


### PR DESCRIPTION
Disabled signals for the LoadDialog ok button while updating the ui.

Description of work.

**To test:**
1. Follow the instructions from the original issue and ensure that Mantid no longer crashes.
2. Ensure that the Load dialog still works as expected.
3. Code Review.

<!-- Instructions for testing. -->

Fixes #19126 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
