### PR TITLE
Add additional options to FilterPeaks

### DIFF
--- a/Framework/Crystal/inc/MantidCrystal/FilterPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/FilterPeaks.h
@@ -71,17 +71,17 @@ private:
    * @param filterValue :: the value to compare the filter variable against
    */
   template <typename Comparator>
-  void filterPeaks(Mantid::API::IPeaksWorkspace_const_sptr inputWS,
-                   Mantid::API::IPeaksWorkspace_sptr filteredWS,
+  void filterPeaks(const Mantid::API::IPeaksWorkspace &inputWS,
+                   Mantid::API::IPeaksWorkspace &filteredWS,
                    const FilterFunction &filterFunction,
                    const double filterValue) {
     Comparator operatorFunc;
-    for (int i = 0; i < inputWS->getNumberPeaks(); ++i) {
-      const Geometry::IPeak &currentPeak = inputWS->getPeak(i);
+    for (int i = 0; i < inputWS.getNumberPeaks(); ++i) {
+      const Geometry::IPeak &currentPeak = inputWS.getPeak(i);
       const auto currentValue = filterFunction(currentPeak);
 
       if (operatorFunc(currentValue, filterValue))
-        filteredWS->addPeak(currentPeak);
+        filteredWS.addPeak(currentPeak);
     }
   }
 };

--- a/Framework/Crystal/inc/MantidCrystal/FilterPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/FilterPeaks.h
@@ -1,8 +1,9 @@
 #ifndef MANTID_CRYSTAL_FILTERPEAKS_H_
 #define MANTID_CRYSTAL_FILTERPEAKS_H_
 
-#include "MantidKernel/System.h"
 #include "MantidAPI/Algorithm.h"
+#include "MantidAPI/IPeaksWorkspace.h"
+#include "MantidKernel/System.h"
 
 namespace Mantid {
 namespace Crystal {
@@ -44,8 +45,45 @@ public:
   const std::string category() const override;
 
 private:
+  /// Typedef for the function to get the variable we're filtering against
+  typedef std::function<double(const Geometry::IPeak &)> FilterFunction;
+
+  /// Override for algorithm init
   void init() override;
+  /// Override for algorithm exec
   void exec() override;
+
+  /// Get a function to filter peaks by
+  FilterFunction
+  getFilterVariableFunction(const std::string &filterVariable) const;
+
+  /** Filter the input peaks workspace using a comparator and a value selection
+   * function
+   *
+   * The template parameter is a comparator function such as std::less to use to
+   * compare the filterValue against the corresponding value of the peak.
+   *
+   * @param inputWS :: the input peaks workspace containing peaks to be filtered
+   * @param filteredWS :: the output peaks workspace which will contain a subset
+   * of the inputWS
+   * @param filterFunction :: function extracting the value to filter on from
+   * the peak object
+   * @param filterValue :: the value to compare the filter variable against
+   */
+  template <typename Comparator>
+  void filterPeaks(Mantid::API::IPeaksWorkspace_const_sptr inputWS,
+                   Mantid::API::IPeaksWorkspace_sptr filteredWS,
+                   const FilterFunction &filterFunction,
+                   const double filterValue) {
+    Comparator operatorFunc;
+    for (int i = 0; i < inputWS->getNumberPeaks(); ++i) {
+      const Geometry::IPeak &currentPeak = inputWS->getPeak(i);
+      const auto currentValue = filterFunction(currentPeak);
+
+      if (operatorFunc(currentValue, filterValue))
+        filteredWS->addPeak(currentPeak);
+    }
+  }
 };
 
 } // namespace Crystal

--- a/Framework/Crystal/src/FilterPeaks.cpp
+++ b/Framework/Crystal/src/FilterPeaks.cpp
@@ -104,7 +104,7 @@ void FilterPeaks::exec() {
   else
     throw std::invalid_argument("Unknown FilterVariable: " + filterVariable);
 
-  const double FilterValue = getProperty("FilterValue");
+  const double filterValue = getProperty("FilterValue");
   const std::string Operator = getProperty("Operator");
 
   for (int i = 0; i < inputWS->getNumberPeaks(); ++i) {
@@ -114,15 +114,15 @@ void FilterPeaks::exec() {
         filterFunction(currentPeak); // filterFunction pointer set above
 
     if (Operator == "<")
-      pass = (currentValue < FilterValue);
+      pass = (currentValue < filterValue);
     else if (Operator == ">")
-      pass = (currentValue > FilterValue);
+      pass = (currentValue > filterValue);
     else if (Operator == "=")
-      pass = (currentValue == FilterValue);
+      pass = (currentValue == filterValue);
     else if (Operator == "<=")
-      pass = (currentValue <= FilterValue);
+      pass = (currentValue <= filterValue);
     else if (Operator == ">=")
-      pass = (currentValue >= FilterValue);
+      pass = (currentValue >= filterValue);
 
     if (pass)
       filteredWS->addPeak(currentPeak);

--- a/Framework/Crystal/src/FilterPeaks.cpp
+++ b/Framework/Crystal/src/FilterPeaks.cpp
@@ -69,7 +69,7 @@ void FilterPeaks::init() {
                   boost::make_shared<MandatoryValidator<double>>(),
                   "The value of the FilterVariable to compare each peak to");
 
-  std::vector<std::string> operation{"<", ">", "=", "<=", ">="};
+  std::vector<std::string> operation{"<", ">", "=", "!=", "<=", ">="};
   declareProperty("Operator", "<",
                   boost::make_shared<StringListValidator>(operation), "");
 }
@@ -99,6 +99,9 @@ void FilterPeaks::exec() {
   else if (Operator == "=")
     filterPeaks<std::equal_to<double>>(inputWS, filteredWS, filterFunction,
                                        filterValue);
+  else if (Operator == "!=")
+    filterPeaks<std::not_equal_to<double>>(inputWS, filteredWS, filterFunction,
+                                           filterValue);
   else if (Operator == "<=")
     filterPeaks<std::less_equal<double>>(inputWS, filteredWS, filterFunction,
                                          filterValue);

--- a/Framework/Crystal/src/FilterPeaks.cpp
+++ b/Framework/Crystal/src/FilterPeaks.cpp
@@ -5,6 +5,12 @@
 #include "MantidDataObjects/PeaksWorkspace.h"
 
 namespace {
+
+double intensity(const Mantid::Geometry::IPeak &p) { return p.getIntensity(); }
+double wavelength(const Mantid::Geometry::IPeak &p) { return p.getWavelength(); }
+double dspacing(const Mantid::Geometry::IPeak &p) { return p.getDSpacing(); }
+double tof(const Mantid::Geometry::IPeak &p) { return p.getTOF(); }
+
 double HKLSum(const Mantid::Geometry::IPeak &p) {
   return p.getH() + p.getK() + p.getL();
 }
@@ -17,11 +23,10 @@ double QMOD(const Mantid::Geometry::IPeak &p) {
   return p.getQSampleFrame().norm();
 }
 
-double intensity(const Mantid::Geometry::IPeak &p) { return p.getIntensity(); }
-
 double SN(const Mantid::Geometry::IPeak &p) {
   return p.getIntensity() / p.getSigmaIntensity();
 }
+
 }
 
 namespace Mantid {
@@ -53,7 +58,7 @@ void FilterPeaks::init() {
                   "The filtered workspace");
 
   std::vector<std::string> filters{"h+k+l", "h^2+k^2+l^2", "Intensity",
-                                   "Signal/Noise", "QMod"};
+                                   "Signal/Noise", "QMod", "Wavelength", "DSpacing", "TOF"};
   declareProperty("FilterVariable", "",
                   boost::make_shared<StringListValidator>(filters),
                   "The variable on which to filter the peaks");
@@ -84,6 +89,12 @@ void FilterPeaks::exec() {
     filterFunction = &HKL2;
   else if (FilterVariable == "Intensity")
     filterFunction = &intensity;
+  else if (FilterVariable == "Wavelength")
+    filterFunction = &wavelength;
+  else if (FilterVariable == "DSpacing")
+    filterFunction = &dspacing;
+  else if (FilterVariable == "TOF")
+    filterFunction = &tof;
   else if (FilterVariable == "Signal/Noise")
     filterFunction = &SN;
   else if (FilterVariable == "QMod")

--- a/Framework/Crystal/src/FilterPeaks.cpp
+++ b/Framework/Crystal/src/FilterPeaks.cpp
@@ -83,26 +83,26 @@ void FilterPeaks::exec() {
   // Copy over ExperimentInfo from input workspace
   filteredWS->copyExperimentInfoFrom(inputWS.get());
 
-  const std::string FilterVariable = getProperty("FilterVariable");
+  const std::string filterVariable = getProperty("FilterVariable");
   double (*filterFunction)(const Mantid::Geometry::IPeak &) = nullptr;
-  if (FilterVariable == "h+k+l")
+  if (filterVariable == "h+k+l")
     filterFunction = &HKLSum;
-  else if (FilterVariable == "h^2+k^2+l^2")
+  else if (filterVariable == "h^2+k^2+l^2")
     filterFunction = &HKL2;
-  else if (FilterVariable == "Intensity")
+  else if (filterVariable == "Intensity")
     filterFunction = &intensity;
-  else if (FilterVariable == "Wavelength")
+  else if (filterVariable == "Wavelength")
     filterFunction = &wavelength;
-  else if (FilterVariable == "DSpacing")
+  else if (filterVariable == "DSpacing")
     filterFunction = &dspacing;
-  else if (FilterVariable == "TOF")
+  else if (filterVariable == "TOF")
     filterFunction = &tof;
-  else if (FilterVariable == "Signal/Noise")
+  else if (filterVariable == "Signal/Noise")
     filterFunction = &SN;
-  else if (FilterVariable == "QMod")
+  else if (filterVariable == "QMod")
     filterFunction = &QMOD;
   else
-    throw std::invalid_argument("Unknown FilterVariable: " + FilterVariable);
+    throw std::invalid_argument("Unknown FilterVariable: " + filterVariable);
 
   const double FilterValue = getProperty("FilterValue");
   const std::string Operator = getProperty("Operator");

--- a/Framework/Crystal/src/FilterPeaks.cpp
+++ b/Framework/Crystal/src/FilterPeaks.cpp
@@ -91,23 +91,23 @@ void FilterPeaks::exec() {
 
   // Choose which version of the function to use based on the operator
   if (Operator == "<")
-    filterPeaks<std::less<double>>(inputWS, filteredWS, filterFunction,
+    filterPeaks<std::less<double>>(*inputWS, *filteredWS, filterFunction,
                                    filterValue);
   else if (Operator == ">")
-    filterPeaks<std::greater<double>>(inputWS, filteredWS, filterFunction,
+    filterPeaks<std::greater<double>>(*inputWS, *filteredWS, filterFunction,
                                       filterValue);
   else if (Operator == "=")
-    filterPeaks<std::equal_to<double>>(inputWS, filteredWS, filterFunction,
+    filterPeaks<std::equal_to<double>>(*inputWS, *filteredWS, filterFunction,
                                        filterValue);
   else if (Operator == "!=")
-    filterPeaks<std::not_equal_to<double>>(inputWS, filteredWS, filterFunction,
-                                           filterValue);
+    filterPeaks<std::not_equal_to<double>>(*inputWS, *filteredWS,
+                                           filterFunction, filterValue);
   else if (Operator == "<=")
-    filterPeaks<std::less_equal<double>>(inputWS, filteredWS, filterFunction,
+    filterPeaks<std::less_equal<double>>(*inputWS, *filteredWS, filterFunction,
                                          filterValue);
   else if (Operator == ">=")
-    filterPeaks<std::greater_equal<double>>(inputWS, filteredWS, filterFunction,
-                                            filterValue);
+    filterPeaks<std::greater_equal<double>>(*inputWS, *filteredWS,
+                                            filterFunction, filterValue);
   else
     throw std::invalid_argument("Unknown Operator " + Operator);
 

--- a/Framework/Crystal/src/FilterPeaks.cpp
+++ b/Framework/Crystal/src/FilterPeaks.cpp
@@ -7,7 +7,9 @@
 namespace {
 
 double intensity(const Mantid::Geometry::IPeak &p) { return p.getIntensity(); }
-double wavelength(const Mantid::Geometry::IPeak &p) { return p.getWavelength(); }
+double wavelength(const Mantid::Geometry::IPeak &p) {
+  return p.getWavelength();
+}
 double dspacing(const Mantid::Geometry::IPeak &p) { return p.getDSpacing(); }
 double tof(const Mantid::Geometry::IPeak &p) { return p.getTOF(); }
 
@@ -26,7 +28,6 @@ double QMOD(const Mantid::Geometry::IPeak &p) {
 double SN(const Mantid::Geometry::IPeak &p) {
   return p.getIntensity() / p.getSigmaIntensity();
 }
-
 }
 
 namespace Mantid {
@@ -57,8 +58,9 @@ void FilterPeaks::init() {
                       "OutputWorkspace", "", Direction::Output),
                   "The filtered workspace");
 
-  std::vector<std::string> filters{"h+k+l", "h^2+k^2+l^2", "Intensity",
-                                   "Signal/Noise", "QMod", "Wavelength", "DSpacing", "TOF"};
+  std::vector<std::string> filters{"h+k+l",        "h^2+k^2+l^2", "Intensity",
+                                   "Signal/Noise", "QMod",        "Wavelength",
+                                   "DSpacing",     "TOF"};
   declareProperty("FilterVariable", "",
                   boost::make_shared<StringListValidator>(filters),
                   "The variable on which to filter the peaks");

--- a/Framework/Crystal/test/FilterPeaksTest.h
+++ b/Framework/Crystal/test/FilterPeaksTest.h
@@ -2,6 +2,7 @@
 #define MANTID_CRYSTAL_FILTERPEAKSTEST_H_
 
 #include <cxxtest/TestSuite.h>
+#include <iostream>
 
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidCrystal/FilterPeaks.h"
@@ -178,6 +179,87 @@ public:
     TS_ASSERT_EQUALS(1, outWS->getNumberPeaks());
 
     outWS = runAlgorithm(inWS, "Intensity", intensity, "<=");
+    TS_ASSERT_EQUALS(1, outWS->getNumberPeaks());
+
+    AnalysisDataService::Instance().remove(outWS->getName());
+    AnalysisDataService::Instance().remove(inWS->getName());
+  }
+
+  void test_filter_by_wavelength() {
+    const double h = 1;
+    const double k = 1;
+    const double l = 1;
+
+    auto inWS = createInputWorkspace(h, k, l);
+    const auto wavelength = inWS->getPeak(0).getWavelength();
+
+    auto outWS = runAlgorithm(inWS, "Wavelength", wavelength, "<");
+    TS_ASSERT_EQUALS(0, outWS->getNumberPeaks());
+
+    outWS = runAlgorithm(inWS, "Wavelength", wavelength, ">");
+    TS_ASSERT_EQUALS(0, outWS->getNumberPeaks());
+
+    outWS = runAlgorithm(inWS, "Wavelength", wavelength, "=");
+    TS_ASSERT_EQUALS(1, outWS->getNumberPeaks());
+
+    outWS = runAlgorithm(inWS, "Wavelength", wavelength, ">=");
+    TS_ASSERT_EQUALS(1, outWS->getNumberPeaks());
+
+    outWS = runAlgorithm(inWS, "Wavelength", wavelength, "<=");
+    TS_ASSERT_EQUALS(1, outWS->getNumberPeaks());
+
+    AnalysisDataService::Instance().remove(outWS->getName());
+    AnalysisDataService::Instance().remove(inWS->getName());
+  }
+
+  void test_filter_by_tof() {
+    const double h = 1;
+    const double k = 1;
+    const double l = 1;
+
+    auto inWS = createInputWorkspace(h, k, l);
+    const auto tof = inWS->getPeak(0).getTOF();
+
+    auto outWS = runAlgorithm(inWS, "TOF", tof, "<");
+    TS_ASSERT_EQUALS(0, outWS->getNumberPeaks());
+
+    outWS = runAlgorithm(inWS, "TOF", tof, ">");
+    TS_ASSERT_EQUALS(0, outWS->getNumberPeaks());
+
+    outWS = runAlgorithm(inWS, "TOF", tof, "=");
+    TS_ASSERT_EQUALS(1, outWS->getNumberPeaks());
+
+    outWS = runAlgorithm(inWS, "TOF", tof, ">=");
+    TS_ASSERT_EQUALS(1, outWS->getNumberPeaks());
+
+    outWS = runAlgorithm(inWS, "TOF", tof, "<=");
+    TS_ASSERT_EQUALS(1, outWS->getNumberPeaks());
+
+    AnalysisDataService::Instance().remove(outWS->getName());
+    AnalysisDataService::Instance().remove(inWS->getName());
+  }
+
+  void test_filter_by_d_spacing() {
+    const double h = 1;
+    const double k = 1;
+    const double l = 1;
+
+    auto inWS = createInputWorkspace(h, k, l);
+    const auto dspacing = inWS->getPeak(0).getDSpacing();
+
+    auto outWS = runAlgorithm(inWS, "DSpacing", dspacing, "<");
+    TS_ASSERT_EQUALS(0, outWS->getNumberPeaks());
+
+    outWS = runAlgorithm(inWS, "DSpacing", dspacing, ">");
+    TS_ASSERT_EQUALS(0, outWS->getNumberPeaks());
+
+    outWS = runAlgorithm(inWS, "DSpacing", dspacing, "=");
+    TS_ASSERT_EQUALS(1, outWS->getNumberPeaks());
+
+    outWS = runAlgorithm(inWS, "DSpacing", dspacing, ">=");
+    TS_ASSERT_EQUALS(1, outWS->getNumberPeaks());
+
+    outWS = runAlgorithm(inWS, "DSpacing", dspacing, "<=");
     TS_ASSERT_EQUALS(1, outWS->getNumberPeaks());
 
     AnalysisDataService::Instance().remove(outWS->getName());

--- a/Framework/Crystal/test/FilterPeaksTest.h
+++ b/Framework/Crystal/test/FilterPeaksTest.h
@@ -119,6 +119,9 @@ public:
     outWS = runAlgorithm(inWS, "h+k+l", h + k + l, ">");
     TS_ASSERT_EQUALS(0, outWS->getNumberPeaks());
 
+    outWS = runAlgorithm(inWS, "h+k+l", h + k + l, "!=");
+    TS_ASSERT_EQUALS(0, outWS->getNumberPeaks());
+
     outWS = runAlgorithm(inWS, "h+k+l", h + k + l, "=");
     TS_ASSERT_EQUALS(1, outWS->getNumberPeaks());
 
@@ -143,6 +146,9 @@ public:
     TS_ASSERT_EQUALS(0, outWS->getNumberPeaks());
 
     outWS = runAlgorithm(inWS, "h^2+k^2+l^2", h * h + k * k + l * l, ">");
+    TS_ASSERT_EQUALS(0, outWS->getNumberPeaks());
+
+    outWS = runAlgorithm(inWS, "h^2+k^2+l^2", h * h + k * k + l * l, "!=");
     TS_ASSERT_EQUALS(0, outWS->getNumberPeaks());
 
     outWS = runAlgorithm(inWS, "h^2+k^2+l^2", h * h + k * k + l * l, "=");
@@ -172,6 +178,9 @@ public:
     outWS = runAlgorithm(inWS, "Intensity", intensity, ">");
     TS_ASSERT_EQUALS(0, outWS->getNumberPeaks());
 
+    outWS = runAlgorithm(inWS, "Intensity", intensity, "!=");
+    TS_ASSERT_EQUALS(0, outWS->getNumberPeaks());
+
     outWS = runAlgorithm(inWS, "Intensity", intensity, "=");
     TS_ASSERT_EQUALS(1, outWS->getNumberPeaks());
 
@@ -197,6 +206,9 @@ public:
     TS_ASSERT_EQUALS(0, outWS->getNumberPeaks());
 
     outWS = runAlgorithm(inWS, "Wavelength", wavelength, ">");
+    TS_ASSERT_EQUALS(0, outWS->getNumberPeaks());
+
+    outWS = runAlgorithm(inWS, "Wavelength", wavelength, "!=");
     TS_ASSERT_EQUALS(0, outWS->getNumberPeaks());
 
     outWS = runAlgorithm(inWS, "Wavelength", wavelength, "=");
@@ -226,6 +238,9 @@ public:
     outWS = runAlgorithm(inWS, "TOF", tof, ">");
     TS_ASSERT_EQUALS(0, outWS->getNumberPeaks());
 
+    outWS = runAlgorithm(inWS, "TOF", tof, "!=");
+    TS_ASSERT_EQUALS(0, outWS->getNumberPeaks());
+
     outWS = runAlgorithm(inWS, "TOF", tof, "=");
     TS_ASSERT_EQUALS(1, outWS->getNumberPeaks());
 
@@ -251,6 +266,9 @@ public:
     TS_ASSERT_EQUALS(0, outWS->getNumberPeaks());
 
     outWS = runAlgorithm(inWS, "DSpacing", dspacing, ">");
+    TS_ASSERT_EQUALS(0, outWS->getNumberPeaks());
+
+    outWS = runAlgorithm(inWS, "DSpacing", dspacing, "!=");
     TS_ASSERT_EQUALS(0, outWS->getNumberPeaks());
 
     outWS = runAlgorithm(inWS, "DSpacing", dspacing, "=");
@@ -280,6 +298,9 @@ public:
     TS_ASSERT_EQUALS(0, outWS->getNumberPeaks());
 
     outWS = runAlgorithm(inWS, "Signal/Noise", ratio, ">");
+    TS_ASSERT_EQUALS(0, outWS->getNumberPeaks());
+
+    outWS = runAlgorithm(inWS, "Signal/Noise", ratio, "!=");
     TS_ASSERT_EQUALS(0, outWS->getNumberPeaks());
 
     outWS = runAlgorithm(inWS, "Signal/Noise", ratio, "=");

--- a/docs/source/release/v3.12.0/diffraction.rst
+++ b/docs/source/release/v3.12.0/diffraction.rst
@@ -17,6 +17,7 @@ Engineering Diffraction
 
 Single Crystal Diffraction
 --------------------------
+- :ref:`FilterPeaks <algm-FilterPeaks>` now supports filtering peaks by TOF, d-spacing, and wavelength.
 
 Imaging
 -------


### PR DESCRIPTION
This adds a couple of extra options that I've seen creep into user scripts to filter by wavelength, d-spacing, and tof. 

**To test:**
Play around with the new options for `FilterVariable`. Here's and example script and peaks workspace to get you started:

```python
peaks = Load('nacl_peaks.nxs')
filtered = FilterPeaks(peaks, "Wavelength", 1.0, "<")

print "Original number of peaks: {}".format(peaks.getNumberPeaks())
print "Filtered number of peaks: {}".format(filtered.getNumberPeaks())
assert filtered.getNumberPeaks() < peaks.getNumberPeaks()
```

[nacl_peaks.nxs.zip](https://github.com/mantidproject/mantid/files/1388399/nacl_peaks.nxs.zip)

Fixes #20929 

**Release Notes** 

See [here](https://github.com/mantidproject/mantid/pull/20931/commits/6ea92ea6ffd52fe04007010074a62cc147791082)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
