### PR TITLE
Change bankmin in MaskBTP for MANDI

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/MaskBTP.py
+++ b/Framework/PythonInterface/plugins/algorithms/MaskBTP.py
@@ -60,7 +60,7 @@ class MaskBTP(mantid.api.PythonAlgorithm):
             self.instname = self.instrument.getName()
 
         # special cases are defined, default value is in front
-        self.bankmin=defaultdict(lambda: 1, {"MANDI":10,"SEQUOIA":38,"TOPAZ":10})
+        self.bankmin=defaultdict(lambda: 1, {"MANDI":1,"SEQUOIA":38,"TOPAZ":10})
         self.bankmax={"ARCS":115,"CNCS":50,"CORELLI":91,"HYSPEC":20,"MANDI":59,"NOMAD":99,"POWGEN":300,"REF_M":1,
                       "SEQUOIA":150,"SNAP":18,"SXD":11,"TOPAZ":59,"WISH":10}
         tubemin=defaultdict(int, {"ARCS":1,"CNCS":1,"CORELLI":1,"HYSPEC":1,"NOMAD":1,"SEQUOIA":1,"WISH":1})


### PR DESCRIPTION
Description of work.

**To test:**
Make sure this error disappears:
LoadIsawPeaks started
Error in execution of algorithm MaskBTP:
Out of range index for MANDI instrument bank numbers
  at line 100 in '/opt/mantidnightly/plugins/python/algorithms/MaskBTP.py'
  caused by line 195 in '/opt/mantidnightly/plugins/python/algorithms/MaskBTP.py'
Can't execute MaskBTP algorithm
LoadIsawPeaks successful, Duration 6.00 seconds
```python
LoadIsawPeaks(Filename='MANDI_801.peaks', OutputWorkspace='peaks')
```
Fixes #20934 

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
