### PR TITLE
Fix excluded ranges in unweighted fitting

### DIFF
--- a/Framework/CurveFitting/src/CostFunctions/CostFuncUnweightedLeastSquares.cpp
+++ b/Framework/CurveFitting/src/CostFunctions/CostFuncUnweightedLeastSquares.cpp
@@ -44,7 +44,12 @@ void CostFuncUnweightedLeastSquares::calActiveCovarianceMatrix(GSLMatrix &covar,
 /// Return unit weights for all data points.
 std::vector<double> CostFuncUnweightedLeastSquares::getFitWeights(
     API::FunctionValues_sptr values) const {
-  return std::vector<double>(values->size(), 1.0);
+  std::vector<double> weights(values->size());
+  for (size_t i = 0; i < weights.size(); ++i) {
+    weights[i] = values->getFitWeight(i) != 0 ? 1 : 0;
+  }
+
+  return weights;
 }
 
 /// Calculates the residual variance from the internally stored FunctionValues.

--- a/Framework/CurveFitting/test/Algorithms/FitTest.h
+++ b/Framework/CurveFitting/test/Algorithms/FitTest.h
@@ -16,6 +16,7 @@
 #include "MantidCurveFitting/Functions/PawleyFunction.h"
 #include "MantidDataObjects/TableWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 
 #include "MantidTestHelpers/FunctionCreationHelper.h"
 #include "MantidTestHelpers/MultiDomainFunctionHelper.h"
@@ -2128,6 +2129,29 @@ public:
       TS_ASSERT_EQUALS(status, "success");
     }
 
+    AnalysisDataService::Instance().clear();
+  }
+
+  void test_exclude_ranges_with_unweighted_least_squares() {
+    HistogramData::Points points{-2, -1, 0, 1, 2};
+    HistogramData::Counts counts(points.size(), 0.0);
+    // This value should be excluded.
+    counts.mutableData()[2] = 10.0;
+    MatrixWorkspace_sptr ws(DataObjects::create<Workspace2D>(1, HistogramData::Histogram(points, counts)).release());
+    Fit fit;
+    fit.initialize();
+    fit.setRethrows(true);
+    TS_ASSERT_THROWS_NOTHING(fit.setProperty("Function", "name=FlatBackground,A0=0.1"))
+    TS_ASSERT_THROWS_NOTHING(fit.setProperty("InputWorkspace", ws))
+    TS_ASSERT_THROWS_NOTHING(fit.setPropertyValue("Exclude", "-0.5, 0.5"))
+    TS_ASSERT_THROWS_NOTHING(fit.setProperty("Minimizer", "Levenberg-MarquardtMD"))
+    TS_ASSERT_THROWS_NOTHING(fit.setProperty("CostFunction", "Unweighted least squares"))
+    TS_ASSERT_THROWS_NOTHING(fit.setProperty("Output", "fit_test_output"))
+    TS_ASSERT_THROWS_NOTHING(fit.execute())
+    const std::string status = fit.getProperty("OutputStatus");
+    TS_ASSERT_EQUALS(status, "success")
+    API::IFunction_sptr function = fit.getProperty("Function");
+    TS_ASSERT_DELTA(function->getParameter(0), 0.0, 1e-12)
     AnalysisDataService::Instance().clear();
   }
 

--- a/Framework/CurveFitting/test/Algorithms/FitTest.h
+++ b/Framework/CurveFitting/test/Algorithms/FitTest.h
@@ -2137,15 +2137,20 @@ public:
     HistogramData::Counts counts(points.size(), 0.0);
     // This value should be excluded.
     counts.mutableData()[2] = 10.0;
-    MatrixWorkspace_sptr ws(DataObjects::create<Workspace2D>(1, HistogramData::Histogram(points, counts)).release());
+    MatrixWorkspace_sptr ws(
+        DataObjects::create<Workspace2D>(
+            1, HistogramData::Histogram(points, counts)).release());
     Fit fit;
     fit.initialize();
     fit.setRethrows(true);
-    TS_ASSERT_THROWS_NOTHING(fit.setProperty("Function", "name=FlatBackground,A0=0.1"))
+    TS_ASSERT_THROWS_NOTHING(
+        fit.setProperty("Function", "name=FlatBackground,A0=0.1"))
     TS_ASSERT_THROWS_NOTHING(fit.setProperty("InputWorkspace", ws))
     TS_ASSERT_THROWS_NOTHING(fit.setPropertyValue("Exclude", "-0.5, 0.5"))
-    TS_ASSERT_THROWS_NOTHING(fit.setProperty("Minimizer", "Levenberg-MarquardtMD"))
-    TS_ASSERT_THROWS_NOTHING(fit.setProperty("CostFunction", "Unweighted least squares"))
+    TS_ASSERT_THROWS_NOTHING(
+        fit.setProperty("Minimizer", "Levenberg-MarquardtMD"))
+    TS_ASSERT_THROWS_NOTHING(
+        fit.setProperty("CostFunction", "Unweighted least squares"))
     TS_ASSERT_THROWS_NOTHING(fit.setProperty("Output", "fit_test_output"))
     TS_ASSERT_THROWS_NOTHING(fit.execute())
     const std::string status = fit.getProperty("OutputStatus");

--- a/Framework/CurveFitting/test/CostFunctions/CostFuncUnweightedLeastSquaresTest.h
+++ b/Framework/CurveFitting/test/CostFunctions/CostFuncUnweightedLeastSquaresTest.h
@@ -24,7 +24,9 @@ public:
   }
 
   void testGetFitWeights() {
-    /* The test makes sure that the returned weights are always 1.0 */
+    /* The test makes sure that the returned weights are always 1.0,
+     * except when the original weight was 0.
+     */
     FunctionDomain1DVector d1d(std::vector<double>(20, 1.0));
     FunctionValues_sptr values = boost::make_shared<FunctionValues>(d1d);
 
@@ -37,7 +39,8 @@ public:
     std::vector<double> weights = uwls.getFitWeights(values);
 
     TS_ASSERT_EQUALS(weights.size(), values->size());
-    for (size_t i = 0; i < weights.size(); ++i) {
+    TS_ASSERT_EQUALS(weights.front(), 0)
+    for (size_t i = 1; i < weights.size(); ++i) {
       TS_ASSERT_EQUALS(weights[i], 1.0);
     }
   }

--- a/docs/source/release/v3.12.0/framework.rst
+++ b/docs/source/release/v3.12.0/framework.rst
@@ -23,6 +23,7 @@ Algorithms
 ----------
 
 - :ref:`CreateWorkspace <algm-CreateWorkspace>` will no longer create a default (and potentially wrong) mapping from spectra to detectors, unless a parent workspace is given. This change ensures that accidental bad mappings that could lead to corrupted data are not created silently anymore. This change does *not* affect the use of this algorithm if: (1) a parent workspace is given, or (2) no instrument is loaded into to workspace at a later point, or (3) an instrument is loaded at a later point but ``LoadInstrument`` is used with ``RewriteSpectraMapping=True``. See also the algorithm documentation for details.
+- :ref:`Fit <algm-Fit>` will now respect excluded ranges when ``CostFunction = 'Unweighted least squares'``.
 
 Data Objects
 ------------


### PR DESCRIPTION
This PR fixes an issues where setting the `CostFunction` property to 'Unweighted least squares' would lead discarding the `Exclude` property.

**To test**

The following script should print something close to zero as the only non-zero number is excluded from the unweighted fit:
```python
import numpy

ys = numpy.array([0, 0, 0, 10, 0])
xs = numpy.array([0, 1, 2, 3, 4, 5])
ws = CreateWorkspace(DataX=xs, DataY=ys)
result = Fit('name=FlatBackground, A0=0.1', ws,
             Exclude=[3, 4],
             Minimizer='Levenberg-MarquardtMD',
             CostFunction='Unweighted least squares')
print(result.Function.A0)
```

Fixes #20949.

**Release Notes** 

The bug fix is mentioned in the Framework release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
