### PR TITLE
Indirect Diffraction - Invalid parsing of run string containing C:/

### DIFF
--- a/scripts/Inelastic/IndirectReductionCommon.py
+++ b/scripts/Inelastic/IndirectReductionCommon.py
@@ -37,20 +37,17 @@ def create_file_range_parser(instrument):
     def parser(file_range):
         file_range = file_range.strip()
         # Check whether this is a range or single file
-        if '-' in file_range:
-            return [[instrument + str(run) for run in create_range_from(file_range, '-')]]
-        elif ':' in file_range:
-            try:
+        try:
+            if '-' in file_range:
+                return [[instrument + str(run) for run in create_range_from(file_range, '-')]]
+            elif ':' in file_range:
                 return [[instrument + str(run)] for run in create_range_from(file_range, ':')]
-            except ValueError:
-                return [[file_range]]
-        elif '+' in file_range:
-            return [[instrument + run for run in file_range.split('+')]]
-        else:
-            try:
+            elif '+' in file_range:
+                return [[instrument + run for run in file_range.split('+')]]
+            else:
                 return [[instrument + str(int(file_range))]]
-            except ValueError:
-                return [[file_range]]
+        except ValueError:
+            return [[file_range]]
 
     return parser
 

--- a/scripts/Inelastic/IndirectReductionCommon.py
+++ b/scripts/Inelastic/IndirectReductionCommon.py
@@ -40,7 +40,10 @@ def create_file_range_parser(instrument):
         if '-' in file_range:
             return [[instrument + str(run) for run in create_range_from(file_range, '-')]]
         elif ':' in file_range:
-            return [[instrument + str(run)] for run in create_range_from(file_range, ':')]
+            try:
+                return [[instrument + str(run)] for run in create_range_from(file_range, ':')]
+            except ValueError:
+                return [[file_range]]
         elif '+' in file_range:
             return [[instrument + run for run in file_range.split('+')]]
         else:


### PR DESCRIPTION
In the IndirectDiffractionReduction interface, entering a run string which contains 'C:/' produces an invalid int cast exception.
This occurs as a result of the \: being taken to specify a range.
This PR fixes this issue by taking the entire run string if both sides of \: aren't run numbers.

**To test:**
1. Navigate to Interfaces > Indirect > Diffraction
2. Use the browse button to select a RAW file in the file browser (test file provided below).
3. Click 'Run'.
4. Ensure the Diffraction algorithm runs without throwing an exception, on the correct file.

<!-- Instructions for testing. -->

Fixes #20970. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Test Files:**
[IRS26175.zip](https://github.com/mantidproject/mantid/files/1407232/IRS26175.zip)

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
