### PR TITLE
Improve precision of the aligned cutter.

### DIFF
--- a/qt/paraview_ext/PVPlugins/Representations/AlignedCutter.cxx
+++ b/qt/paraview_ext/PVPlugins/Representations/AlignedCutter.cxx
@@ -33,6 +33,21 @@ AlignedCutter::AlignedCutter(vtkImplicitFunction *cf) : vtkCutter(cf) {}
 //----------------------------------------------------------------------------
 AlignedCutter::~AlignedCutter() = default;
 
+namespace {
+std::array<double, 3> getOffset(vtkDataArray *input, int64_t lastPos,
+                                double celldim) {
+  double first[3], last[3];
+  std::array<double, 3> offset;
+  input->GetTuple(0, first);
+  input->GetTuple(lastPos, last);
+  double prefactor = 0.5 / celldim;
+  for (size_t i = 0; i < 3; ++i) {
+    offset[i] = prefactor * (last[i] - first[i]);
+  }
+  return offset;
+}
+}
+
 //----------------------------------------------------------------------------
 void AlignedCutter::AlignedStructuredGridCutter(vtkDataSet *dataSetInput,
                                                 vtkPolyData *thisOutput) {
@@ -79,12 +94,8 @@ void AlignedCutter::AlignedStructuredGridCutter(vtkDataSet *dataSetInput,
   {
     double value = this->ContourValues->GetValue(i);
     if (AxisNumber == 0) {
-      double first[3], last[3], offset[3];
-      dataArrayInput->GetTuple(0,first);
-      dataArrayInput->GetTuple(celldims[0], last);
-      for(size_t i = 0 ; i < 3; ++i) {
-        offset[i] = 0.5 * (last[i] - first[i]) / celldims[0];
-      }
+      std::array<double, 3> offset =
+          getOffset(dataArrayInput, celldims[0], celldims[0]);
       cutScalars->SetNumberOfTuples(dims[0]);
       for(vtkIdType i = 0; i < dims[0]; ++i) {
         double x[3];
@@ -96,12 +107,8 @@ void AlignedCutter::AlignedStructuredGridCutter(vtkDataSet *dataSetInput,
         cutScalars->SetTypedComponent(i, 0, std::abs(FuncVal - value));
       }
     } else if (AxisNumber == 1) {
-      double first[3], last[3], offset[3];
-      dataArrayInput->GetTuple(0,first);
-      dataArrayInput->GetTuple(d01 - dims[0], last);
-      for(size_t i = 0 ; i < 3; ++i) {
-        offset[i] = 0.5 * (last[i] - first[i]) / celldims[1];
-      }
+      std::array<double, 3> offset =
+          getOffset(dataArrayInput, d01 - dims[0], celldims[1]);
       cutScalars->SetNumberOfTuples(dims[1]);
       for (vtkIdType i = 0, j = 0; i < d01; i = i + dims[0], ++j) {
         double x[3];
@@ -113,12 +120,8 @@ void AlignedCutter::AlignedStructuredGridCutter(vtkDataSet *dataSetInput,
         cutScalars->SetTypedComponent(j, 0, std::abs(FuncVal - value));
       }
     } else if (AxisNumber == 2) {
-      double first[3], last[3], offset[3];
-      dataArrayInput->GetTuple(0,first);
-      dataArrayInput->GetTuple(numPts - d01, last);
-      for(size_t i = 0 ; i < 3; ++i) {
-        offset[i] = 0.5 * (last[i] - first[i]) / celldims[2];
-      }
+      std::array<double, 3> offset =
+          getOffset(dataArrayInput, numPts - d01, celldims[2]);
       cutScalars->SetNumberOfTuples(dims[2]);
       for (vtkIdType i = 0, j = 0; i < numPts; i = i + d01, ++j) {
         double x[3];

--- a/qt/paraview_ext/PVPlugins/Representations/AlignedCutter.cxx
+++ b/qt/paraview_ext/PVPlugins/Representations/AlignedCutter.cxx
@@ -64,7 +64,7 @@ void AlignedCutter::AlignedStructuredGridCutter(vtkDataSet *dataSetInput,
   vtkNew<vtkPoints> outPts;
   vtkPoints *inPts = input->GetPoints();
   ids->SetNumberOfIds(4);
-    
+
   vtkIdType NumberOfContours = this->ContourValues->GetNumberOfContours();
   if (AxisNumber == 0) {
     outPts->Allocate(4 * celldims[1] * celldims[2]*NumberOfContours);
@@ -74,31 +74,58 @@ void AlignedCutter::AlignedStructuredGridCutter(vtkDataSet *dataSetInput,
     outPts->Allocate(4 * celldims[0] * celldims[1]*NumberOfContours);
   }
   vtkIdType outCellId = 0;
-    
+
   for(int i = 0; i != NumberOfContours; ++i)
   {
     double value = this->ContourValues->GetValue(i);
     if (AxisNumber == 0) {
+      double first[3], last[3], offset[3];
+      dataArrayInput->GetTuple(0,first);
+      dataArrayInput->GetTuple(celldims[0], last);
+      for(size_t i = 0 ; i < 3; ++i) {
+        offset[i] = 0.5 * (last[i] - first[i]) / celldims[0];
+      }
       cutScalars->SetNumberOfTuples(dims[0]);
       for(vtkIdType i = 0; i < dims[0]; ++i) {
         double x[3];
         dataArrayInput->GetTuple(i, x);
+        for(size_t i = 0 ; i < 3; ++i) {
+          x[i] += offset[i];
+        }
         double FuncVal = this->CutFunction->EvaluateFunction(x);
         cutScalars->SetTypedComponent(i, 0, std::abs(FuncVal - value));
       }
     } else if (AxisNumber == 1) {
+      double first[3], last[3], offset[3];
+      dataArrayInput->GetTuple(0,first);
+      dataArrayInput->GetTuple(d01 - dims[0], last);
+      for(size_t i = 0 ; i < 3; ++i) {
+        offset[i] = 0.5 * (last[i] - first[i]) / celldims[1];
+      }
       cutScalars->SetNumberOfTuples(dims[1]);
       for (vtkIdType i = 0, j = 0; i < d01; i = i + dims[0], ++j) {
         double x[3];
         dataArrayInput->GetTuple(i, x);
+        for(size_t i = 0 ; i < 3; ++i) {
+          x[i] += offset[i];
+        }
         double FuncVal = this->CutFunction->EvaluateFunction(x);
         cutScalars->SetTypedComponent(j, 0, std::abs(FuncVal - value));
       }
     } else if (AxisNumber == 2) {
+      double first[3], last[3], offset[3];
+      dataArrayInput->GetTuple(0,first);
+      dataArrayInput->GetTuple(numPts - d01, last);
+      for(size_t i = 0 ; i < 3; ++i) {
+        offset[i] = 0.5 * (last[i] - first[i]) / celldims[2];
+      }
       cutScalars->SetNumberOfTuples(dims[2]);
       for (vtkIdType i = 0, j = 0; i < numPts; i = i + d01, ++j) {
         double x[3];
         dataArrayInput->GetTuple(i, x);
+        for(size_t i = 0 ; i < 3; ++i) {
+          x[i] += offset[i];
+        }
         double FuncVal = this->CutFunction->EvaluateFunction(x);
         cutScalars->SetTypedComponent(j, 0, std::abs(FuncVal - value));
       }

--- a/qt/paraview_ext/PVPlugins/Representations/AlignedCutter.cxx
+++ b/qt/paraview_ext/PVPlugins/Representations/AlignedCutter.cxx
@@ -26,6 +26,8 @@
 #include "vtkRectilinearGrid.h"
 #include "vtkStructuredGrid.h"
 
+#include <array>
+
 vtkStandardNewMacro(AlignedCutter);
 
 AlignedCutter::AlignedCutter(vtkImplicitFunction *cf) : vtkCutter(cf) {}

--- a/qt/paraview_ext/PVPlugins/Representations/AlignedCutter.cxx
+++ b/qt/paraview_ext/PVPlugins/Representations/AlignedCutter.cxx
@@ -37,10 +37,10 @@ namespace {
 std::array<double, 3> getOffset(vtkDataArray *input, int64_t lastPos,
                                 double celldim) {
   double first[3], last[3];
-  std::array<double, 3> offset;
   input->GetTuple(0, first);
   input->GetTuple(lastPos, last);
   double prefactor = 0.5 / celldim;
+  std::array<double, 3> offset;
   for (size_t i = 0; i < 3; ++i) {
     offset[i] = prefactor * (last[i] - first[i]);
   }


### PR DESCRIPTION
Description of work.

This improves the aligned cutter by evaluating the plane equation at the cell center instead of a corner point. Historically the sliders were weren't precise enough for this to be issue, but since #20905 the exact position may now be entered.

**To test:**

<!-- Instructions for testing. -->

1. Open the NaLaF<sub>4</sub> diffuse scattering dataset in the VSI.
2. Verify that diffuse scattering now appears at half-integer positions.

There is no GitHub issue associated with this pull request.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
