### PR TITLE
IFunction::fixAll fails if there are ties

### DIFF
--- a/Framework/API/CMakeLists.txt
+++ b/Framework/API/CMakeLists.txt
@@ -394,6 +394,7 @@ set ( TEST_FILES
 	IFunction1DSpectrumTest.h
 	IFunction1DTest.h
 	IFunctionMDTest.h
+	IFunctionTest.h
 	ILatticeFunctionTest.h
 	IMDWorkspaceTest.h
 	ISpectrumTest.h

--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -1397,14 +1397,18 @@ void IFunction::unfixParameter(const std::string &name) {
 /// @param isDefault :: If true fix them by default
 void IFunction::fixAll(bool isDefault) {
   for (size_t i = 0; i < nParams(); ++i) {
-    fix(i, isDefault);
+    if (isActive(i)) {
+      fix(i, isDefault);
+    }
   }
 }
 
 /// Free all parameters
 void IFunction::unfixAll() {
   for (size_t i = 0; i < nParams(); ++i) {
-    unfix(i);
+    if (isFixed(i)) {
+      unfix(i);
+    }
   }
 }
 

--- a/Framework/API/test/IFunctionTest.h
+++ b/Framework/API/test/IFunctionTest.h
@@ -1,0 +1,119 @@
+#ifndef MANTID_API_IFUNCTIONTEST_H_
+#define MANTID_API_IFUNCTIONTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAPI/IFunction.h"
+
+using namespace Mantid::API;
+
+class MockFunction: public IFunction {
+public:
+  MockFunction() : IFunction(), m_parameterValues(4),
+    m_parameterIndexes{{"A", 0}, {"B", 1}, {"C", 2}, {"D", 3}},
+    m_parameterNames{{0, "A"}, {1, "B"}, {2, "C"}, {3, "D"}},
+    m_parameterStatus{Active, Active, Active, Active}
+    {}
+  std::string name() const {return "MockFunction";}
+  void function(const Mantid::API::FunctionDomain &,Mantid::API::FunctionValues &) const {}
+  void setParameter(const std::string &parName, const double &value, bool = true) {m_parameterValues[m_parameterIndexes.find(parName)->second] = value;}
+  void setParameter(std::size_t index,const double &value, bool = true) {m_parameterValues[index] = value;}
+  void setParameterDescription(const std::string &,const std::string &) {}
+  void setParameterDescription(std::size_t,const std::string &) {}
+  double getParameter(const std::string &parName) const {return m_parameterValues[m_parameterIndexes.find(parName)->second];}
+  double getParameter(std::size_t index) const {return m_parameterValues[index];}
+  bool hasParameter(const std::string &parName) const {return m_parameterIndexes.count(parName) > 0; }
+  size_t nParams() const {return m_parameterValues.size();}
+  size_t parameterIndex(const std::string &parName) const {return m_parameterIndexes.find(parName)->second;}
+  std::string parameterName(std::size_t index) const {return m_parameterNames.find(index)->second;}
+  std::string parameterDescription(std::size_t) const {return "";}
+  bool isExplicitlySet(std::size_t) const {return true;}
+  double getError(std::size_t) const {return 0.0;}
+  void setError(std::size_t,double) {}
+  size_t getParameterIndex(const Mantid::API::ParameterReference &ref) const {
+    if (ref.getLocalFunction() == this && ref.getLocalIndex() < nParams()) {
+      return ref.getLocalIndex();
+    }
+    return nParams();
+  }
+  void setParameterStatus(std::size_t index, ParameterStatus status) {m_parameterStatus[index] = status;}
+  ParameterStatus getParameterStatus(std::size_t index) const {return m_parameterStatus[index];}
+  void declareParameter(const std::string &,double,const std::string &) {}
+private:
+  std::vector<double> m_parameterValues;
+  std::map<std::string, size_t> m_parameterIndexes;
+  std::map<size_t, std::string> m_parameterNames;
+  std::vector<ParameterStatus> m_parameterStatus;
+};
+
+class IFunctionTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static IFunctionTest *createSuite() {
+    return new IFunctionTest();
+  }
+  static void destroySuite(IFunctionTest *suite) { delete suite; }
+
+  void testTie() {
+    MockFunction fun;
+    fun.tie("A", "2*B");
+    auto aTie = fun.getTie(0);
+    TS_ASSERT(aTie);
+    TS_ASSERT(!fun.isActive(0));
+    TS_ASSERT(!fun.isFixed(0));
+
+    fun.tie("C", "3");
+    auto cTie = fun.getTie(2);
+    TS_ASSERT(!cTie);
+    TS_ASSERT(!fun.isActive(2));
+    TS_ASSERT(fun.isFixed(2));
+    TS_ASSERT_EQUALS(fun.getParameter(2), 3.0);
+
+    fun.setParameter("B", 4.0);
+    TS_ASSERT_EQUALS(fun.getParameter("A"), 0.0);
+    fun.applyTies();
+    TS_ASSERT_EQUALS(fun.getParameter("A"), 8.0);
+    TS_ASSERT_EQUALS(fun.getParameter("B"), 4.0);
+    TS_ASSERT_EQUALS(fun.getParameter("C"), 3.0);
+    TS_ASSERT_EQUALS(fun.getParameter("D"), 0.0);
+  }
+
+  void testFixAll() {
+    MockFunction fun;
+    fun.tie("A", "2*B");
+    fun.setParameter("B", 4.0);
+    fun.fixAll();
+    TS_ASSERT(!fun.isFixed(0));
+    TS_ASSERT(!fun.isActive(0));
+    TS_ASSERT(fun.isFixed(1));
+    TS_ASSERT(fun.isFixed(2));
+    TS_ASSERT(fun.isFixed(3));
+    fun.applyTies();
+    TS_ASSERT_EQUALS(fun.getParameter("A"), 8.0);
+    TS_ASSERT_EQUALS(fun.getParameter("B"), 4.0);
+    TS_ASSERT_EQUALS(fun.getParameter("C"), 0.0);
+    TS_ASSERT_EQUALS(fun.getParameter("D"), 0.0);
+  }
+
+  void testUnfixAll() {
+    MockFunction fun;
+    fun.tie("A", "2*B");
+    fun.setParameter("B", 4.0);
+    fun.fixAll();
+    fun.unfixAll();
+    TS_ASSERT(!fun.isFixed(0));
+    TS_ASSERT(!fun.isActive(0));
+    TS_ASSERT(!fun.isFixed(1));
+    TS_ASSERT(!fun.isFixed(2));
+    TS_ASSERT(!fun.isFixed(3));
+    fun.applyTies();
+    TS_ASSERT_EQUALS(fun.getParameter("A"), 8.0);
+    TS_ASSERT_EQUALS(fun.getParameter("B"), 4.0);
+    TS_ASSERT_EQUALS(fun.getParameter("C"), 0.0);
+    TS_ASSERT_EQUALS(fun.getParameter("D"), 0.0);
+  }
+
+};
+
+#endif /* MANTID_API_IFUNCTIONTEST_H_*/

--- a/Framework/API/test/IFunctionTest.h
+++ b/Framework/API/test/IFunctionTest.h
@@ -14,51 +14,55 @@ public:
         m_parameterIndexes{{"A", 0}, {"B", 1}, {"C", 2}, {"D", 3}},
         m_parameterNames{{0, "A"}, {1, "B"}, {2, "C"}, {3, "D"}},
         m_parameterStatus{Active, Active, Active, Active} {}
-  std::string name() const { return "MockFunction"; }
+  std::string name() const override { return "MockFunction"; }
   void function(const Mantid::API::FunctionDomain &,
-                Mantid::API::FunctionValues &) const {}
+                Mantid::API::FunctionValues &) const override {}
   void setParameter(const std::string &parName, const double &value,
-                    bool = true) {
+                    bool = true) override {
     m_parameterValues[m_parameterIndexes.find(parName)->second] = value;
   }
-  void setParameter(std::size_t index, const double &value, bool = true) {
+  void setParameter(std::size_t index, const double &value,
+                    bool = true) override {
     m_parameterValues[index] = value;
   }
-  void setParameterDescription(const std::string &, const std::string &) {}
-  void setParameterDescription(std::size_t, const std::string &) {}
-  double getParameter(const std::string &parName) const {
+  void setParameterDescription(const std::string &,
+                               const std::string &) override {}
+  void setParameterDescription(std::size_t, const std::string &) override {}
+  double getParameter(const std::string &parName) const override {
     return m_parameterValues[m_parameterIndexes.find(parName)->second];
   }
-  double getParameter(std::size_t index) const {
+  double getParameter(std::size_t index) const override {
     return m_parameterValues[index];
   }
-  bool hasParameter(const std::string &parName) const {
+  bool hasParameter(const std::string &parName) const override {
     return m_parameterIndexes.count(parName) > 0;
   }
-  size_t nParams() const { return m_parameterValues.size(); }
-  size_t parameterIndex(const std::string &parName) const {
+  size_t nParams() const override { return m_parameterValues.size(); }
+  size_t parameterIndex(const std::string &parName) const override {
     return m_parameterIndexes.find(parName)->second;
   }
-  std::string parameterName(std::size_t index) const {
+  std::string parameterName(std::size_t index) const override {
     return m_parameterNames.find(index)->second;
   }
-  std::string parameterDescription(std::size_t) const { return ""; }
-  bool isExplicitlySet(std::size_t) const { return true; }
-  double getError(std::size_t) const { return 0.0; }
-  void setError(std::size_t, double) {}
-  size_t getParameterIndex(const Mantid::API::ParameterReference &ref) const {
+  std::string parameterDescription(std::size_t) const override { return ""; }
+  bool isExplicitlySet(std::size_t) const override { return true; }
+  double getError(std::size_t) const override { return 0.0; }
+  void setError(std::size_t, double) override {}
+  size_t
+  getParameterIndex(const Mantid::API::ParameterReference &ref) const override {
     if (ref.getLocalFunction() == this && ref.getLocalIndex() < nParams()) {
       return ref.getLocalIndex();
     }
     return nParams();
   }
-  void setParameterStatus(std::size_t index, ParameterStatus status) {
+  void setParameterStatus(std::size_t index, ParameterStatus status) override {
     m_parameterStatus[index] = status;
   }
-  ParameterStatus getParameterStatus(std::size_t index) const {
+  ParameterStatus getParameterStatus(std::size_t index) const override {
     return m_parameterStatus[index];
   }
-  void declareParameter(const std::string &, double, const std::string &) {}
+  void declareParameter(const std::string &, double,
+                        const std::string &) override {}
 
 private:
   std::vector<double> m_parameterValues;

--- a/Framework/API/test/IFunctionTest.h
+++ b/Framework/API/test/IFunctionTest.h
@@ -7,38 +7,59 @@
 
 using namespace Mantid::API;
 
-class MockFunction: public IFunction {
+class MockFunction : public IFunction {
 public:
-  MockFunction() : IFunction(), m_parameterValues(4),
-    m_parameterIndexes{{"A", 0}, {"B", 1}, {"C", 2}, {"D", 3}},
-    m_parameterNames{{0, "A"}, {1, "B"}, {2, "C"}, {3, "D"}},
-    m_parameterStatus{Active, Active, Active, Active}
-    {}
-  std::string name() const {return "MockFunction";}
-  void function(const Mantid::API::FunctionDomain &,Mantid::API::FunctionValues &) const {}
-  void setParameter(const std::string &parName, const double &value, bool = true) {m_parameterValues[m_parameterIndexes.find(parName)->second] = value;}
-  void setParameter(std::size_t index,const double &value, bool = true) {m_parameterValues[index] = value;}
-  void setParameterDescription(const std::string &,const std::string &) {}
-  void setParameterDescription(std::size_t,const std::string &) {}
-  double getParameter(const std::string &parName) const {return m_parameterValues[m_parameterIndexes.find(parName)->second];}
-  double getParameter(std::size_t index) const {return m_parameterValues[index];}
-  bool hasParameter(const std::string &parName) const {return m_parameterIndexes.count(parName) > 0; }
-  size_t nParams() const {return m_parameterValues.size();}
-  size_t parameterIndex(const std::string &parName) const {return m_parameterIndexes.find(parName)->second;}
-  std::string parameterName(std::size_t index) const {return m_parameterNames.find(index)->second;}
-  std::string parameterDescription(std::size_t) const {return "";}
-  bool isExplicitlySet(std::size_t) const {return true;}
-  double getError(std::size_t) const {return 0.0;}
-  void setError(std::size_t,double) {}
+  MockFunction()
+      : IFunction(), m_parameterValues(4),
+        m_parameterIndexes{{"A", 0}, {"B", 1}, {"C", 2}, {"D", 3}},
+        m_parameterNames{{0, "A"}, {1, "B"}, {2, "C"}, {3, "D"}},
+        m_parameterStatus{Active, Active, Active, Active} {}
+  std::string name() const { return "MockFunction"; }
+  void function(const Mantid::API::FunctionDomain &,
+                Mantid::API::FunctionValues &) const {}
+  void setParameter(const std::string &parName, const double &value,
+                    bool = true) {
+    m_parameterValues[m_parameterIndexes.find(parName)->second] = value;
+  }
+  void setParameter(std::size_t index, const double &value, bool = true) {
+    m_parameterValues[index] = value;
+  }
+  void setParameterDescription(const std::string &, const std::string &) {}
+  void setParameterDescription(std::size_t, const std::string &) {}
+  double getParameter(const std::string &parName) const {
+    return m_parameterValues[m_parameterIndexes.find(parName)->second];
+  }
+  double getParameter(std::size_t index) const {
+    return m_parameterValues[index];
+  }
+  bool hasParameter(const std::string &parName) const {
+    return m_parameterIndexes.count(parName) > 0;
+  }
+  size_t nParams() const { return m_parameterValues.size(); }
+  size_t parameterIndex(const std::string &parName) const {
+    return m_parameterIndexes.find(parName)->second;
+  }
+  std::string parameterName(std::size_t index) const {
+    return m_parameterNames.find(index)->second;
+  }
+  std::string parameterDescription(std::size_t) const { return ""; }
+  bool isExplicitlySet(std::size_t) const { return true; }
+  double getError(std::size_t) const { return 0.0; }
+  void setError(std::size_t, double) {}
   size_t getParameterIndex(const Mantid::API::ParameterReference &ref) const {
     if (ref.getLocalFunction() == this && ref.getLocalIndex() < nParams()) {
       return ref.getLocalIndex();
     }
     return nParams();
   }
-  void setParameterStatus(std::size_t index, ParameterStatus status) {m_parameterStatus[index] = status;}
-  ParameterStatus getParameterStatus(std::size_t index) const {return m_parameterStatus[index];}
-  void declareParameter(const std::string &,double,const std::string &) {}
+  void setParameterStatus(std::size_t index, ParameterStatus status) {
+    m_parameterStatus[index] = status;
+  }
+  ParameterStatus getParameterStatus(std::size_t index) const {
+    return m_parameterStatus[index];
+  }
+  void declareParameter(const std::string &, double, const std::string &) {}
+
 private:
   std::vector<double> m_parameterValues;
   std::map<std::string, size_t> m_parameterIndexes;
@@ -50,9 +71,7 @@ class IFunctionTest : public CxxTest::TestSuite {
 public:
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests
-  static IFunctionTest *createSuite() {
-    return new IFunctionTest();
-  }
+  static IFunctionTest *createSuite() { return new IFunctionTest(); }
   static void destroySuite(IFunctionTest *suite) { delete suite; }
 
   void testTie() {
@@ -113,7 +132,6 @@ public:
     TS_ASSERT_EQUALS(fun.getParameter("C"), 0.0);
     TS_ASSERT_EQUALS(fun.getParameter("D"), 0.0);
   }
-
 };
 
 #endif /* MANTID_API_IFUNCTIONTEST_H_*/

--- a/Framework/PythonInterface/mantid/fitfunctions.py
+++ b/Framework/PythonInterface/mantid/fitfunctions.py
@@ -256,8 +256,7 @@ class FunctionWrapper(object):
   def fixAllParameters(self):
        """ Fix all parameters.
        """
-       for i in range(0, self.fun.numParams()):
-          self.fix(self.getParameterName(i))
+       self.fun.fixAll()
        
   def untie(self, name):
       """ Remove tie from parameter.

--- a/Framework/PythonInterface/test/python/mantid/FitFunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/FitFunctionsTest.py
@@ -187,7 +187,24 @@ class FitFunctionsTest(unittest.TestCase):
         c.untieAllParameters()
         cz_str = str(c)
         self.assertEqual(cz_str.count("ties="),0)
-    
+
+    def test_fix_all_parameters_with_ties(self):
+        g0 = FunctionWrapper( "Gaussian", Height=7.5, Sigma=1.2, PeakCentre=10)
+        g1 = FunctionWrapper( "Gaussian", Height=7.5, Sigma=1.2, PeakCentre=10)
+        c = CompositeFunctionWrapper(g0, g1)
+        c.tie({"f1.Sigma":"f0.Sigma"})
+
+        c.fixAllParameters()
+        c_str = str(c)
+        self.assertEqual(c_str.count("ties="),3)
+        self.assertEqual(c_str.count("ties=(Height=7.5,PeakCentre=10,Sigma=1.2)"),1)
+        self.assertEqual(c_str.count("ties=(Height=7.5,PeakCentre=10)"),1)
+        self.assertEqual(c_str.count("ties=(f1.Sigma=f0.Sigma)"),1)
+
+        c.untieAllParameters()
+        cz_str = str(c)
+        self.assertEqual(cz_str.count("ties="),0)
+
 
     def test_tie(self):
         g = FunctionWrapper( "Gaussian", Height=8.5, Sigma=1.2, PeakCentre=15)


### PR DESCRIPTION
When fixing all parameters skip ones that are already tied.

**To test:**

Run this.

```
p = Polynomial(n=4)
p.tie(A0='A1')
p.fixAllParameters()
```

Fixes #20974.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
