### PR TITLE
Add two more diagnostic workspaces to PDcalibration

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/PDCalibration.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PDCalibration.h
@@ -67,9 +67,12 @@ private:
                            const std::vector<double> &tof,
                            const std::vector<double> &height2, double &difc,
                            double &t0, double &difa);
+  API::ITableWorkspace_sptr sortTableWorkspace(API::ITableWorkspace_sptr &table);
   API::MatrixWorkspace_sptr m_uncalibratedWS;
   API::ITableWorkspace_sptr m_calibrationTable;
   API::ITableWorkspace_sptr m_peakPositionTable;
+  API::ITableWorkspace_sptr m_peakWidthTable;
+  API::ITableWorkspace_sptr m_peakHeightTable;
   std::vector<double> m_peaksInDspacing;
   std::map<detid_t, size_t> m_detidToRow;
   double m_tofMin{0.};

--- a/Framework/Algorithms/inc/MantidAlgorithms/PDCalibration.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PDCalibration.h
@@ -67,7 +67,8 @@ private:
                            const std::vector<double> &tof,
                            const std::vector<double> &height2, double &difc,
                            double &t0, double &difa);
-  API::ITableWorkspace_sptr sortTableWorkspace(API::ITableWorkspace_sptr &table);
+  API::ITableWorkspace_sptr
+  sortTableWorkspace(API::ITableWorkspace_sptr &table);
   API::MatrixWorkspace_sptr m_uncalibratedWS;
   API::ITableWorkspace_sptr m_calibrationTable;
   API::ITableWorkspace_sptr m_peakPositionTable;

--- a/Framework/Algorithms/src/PDCalibration.cpp
+++ b/Framework/Algorithms/src/PDCalibration.cpp
@@ -444,15 +444,19 @@ void PDCalibration::exec() {
     API::ITableWorkspace_sptr fittedTable = alg->getProperty("PeaksList");
 
     // includes peaks that aren't used in the fit
-    std::vector<double> tof_vec_full(m_peaksInDspacing.size(), std::nan(""));
+    const size_t numPeaks = m_peaksInDspacing.size();
+    std::vector<double> tof_vec_full(numPeaks, std::nan(""));
     std::vector<double> d_vec;
     std::vector<double> tof_vec;
+    std::vector<double> width_vec_full(numPeaks, std::nan(""));
+    std::vector<double> height_vec_full(numPeaks, std::nan(""));
     std::vector<double> height2; // the square of the peak height
     for (size_t i = 0; i < fittedTable->rowCount(); ++i) {
       // Get peak value
-      double centre = fittedTable->getRef<double>("centre", i);
-      double height = fittedTable->getRef<double>("height", i);
-      double chi2 = fittedTable->getRef<double>("chi2", i);
+      const double centre = fittedTable->getRef<double>("centre", i);
+      const double width = fittedTable->getRef<double>("width", i);
+      const double height = fittedTable->getRef<double>("height", i);
+      const double chi2 = fittedTable->getRef<double>("chi2", i);
 
       // check chi-square
       if (chi2 > maxChiSquared || chi2 < 0.) {
@@ -486,6 +490,8 @@ void PDCalibration::exec() {
       tof_vec.push_back(centre);
       height2.push_back(height * height);
       tof_vec_full[i + peaks.badPeakOffset] = centre;
+      width_vec_full[i + peaks.badPeakOffset] = width;
+      height_vec_full[i + peaks.badPeakOffset] = height;
     }
 
     if (d_vec.size() < 2) { // not enough peaks were found
@@ -499,18 +505,20 @@ void PDCalibration::exec() {
       double chisq = 0.;
       auto converter =
           Kernel::Diffraction::getTofToDConversionFunc(difc, difa, t0);
-      for (std::size_t i = 0; i < tof_vec_full.size(); ++i) {
+      for (std::size_t i = 0; i < numPeaks; ++i) {
         if (std::isnan(tof_vec_full[i]))
           continue;
         const double dspacing = converter(tof_vec_full[i]);
         const double temp = m_peaksInDspacing[i] - dspacing;
         chisq += (temp * temp);
         m_peakPositionTable->cell<double>(rowNum, i + 1) = dspacing;
+        m_peakWidthTable->cell<double>(rowNum, i + 1) = width_vec_full[i];
+        m_peakHeightTable->cell<double>(rowNum, i + 1) = height_vec_full[i];
       }
       m_peakPositionTable->cell<double>(rowNum, m_peaksInDspacing.size() + 1) =
           chisq;
       m_peakPositionTable->cell<double>(rowNum, m_peaksInDspacing.size() + 2) =
-          chisq / static_cast<double>(d_vec.size() - 1);
+          chisq / static_cast<double>(numPeaks - 1);
 
       setCalibrationValues(peaks.detid, difc, difa, t0);
     }
@@ -521,27 +529,13 @@ void PDCalibration::exec() {
   PARALLEL_CHECK_INTERUPT_REGION
 
   // sort the calibration workspaces
-  { // limit scope
-    auto alg = createChildAlgorithm("SortTableWorkspace");
-    alg->setLoggingOffset(1);
-    alg->setProperty("InputWorkspace", m_calibrationTable);
-    alg->setProperty("OutputWorkspace", m_calibrationTable);
-    alg->setProperty("Columns", "detid");
-    alg->executeAsChildAlg();
-    m_calibrationTable = alg->getProperty("OutputWorkspace");
-  }
+  m_calibrationTable = sortTableWorkspace(m_calibrationTable);
   setProperty("OutputCalibrationTable", m_calibrationTable);
 
   // fix-up the diagnostic workspaces
-  { // limit scope
-    auto alg = createChildAlgorithm("SortTableWorkspace");
-    alg->setLoggingOffset(1);
-    alg->setProperty("InputWorkspace", m_peakPositionTable);
-    alg->setProperty("OutputWorkspace", m_peakPositionTable);
-    alg->setProperty("Columns", "detid");
-    alg->executeAsChildAlg();
-    m_peakPositionTable = alg->getProperty("OutputWorkspace");
-  }
+  m_calibrationTable = sortTableWorkspace(m_peakPositionTable);
+  m_calibrationTable = sortTableWorkspace(m_peakWidthTable);
+  m_calibrationTable = sortTableWorkspace(m_peakHeightTable);
 
   // set the diagnostic workspaces out
   const std::string partials_prefix = getPropertyValue("DiagnosticWorkspaces");
@@ -549,6 +543,12 @@ void PDCalibration::exec() {
   API::AnalysisDataService::Instance().addOrReplace(
       partials_prefix + "_dspacing", m_peakPositionTable);
   diagnosticGroup->addWorkspace(m_peakPositionTable);
+  API::AnalysisDataService::Instance().addOrReplace(
+      partials_prefix + "_width", m_peakWidthTable);
+  diagnosticGroup->addWorkspace(m_peakWidthTable);
+  API::AnalysisDataService::Instance().addOrReplace(
+      partials_prefix + "_height", m_peakHeightTable);
+  diagnosticGroup->addWorkspace(m_peakHeightTable);
   setProperty("DiagnosticWorkspaces", diagnosticGroup);
 }
 
@@ -1015,14 +1015,23 @@ void PDCalibration::createNewCalTable() {
 void PDCalibration::createInformationWorkspaces() {
   // table for the fitted location of the various peaks
   m_peakPositionTable = boost::make_shared<DataObjects::TableWorkspace>();
+  m_peakWidthTable = boost::make_shared<DataObjects::TableWorkspace>();
+  m_peakHeightTable = boost::make_shared<DataObjects::TableWorkspace>();
+
   m_peakPositionTable->addColumn("int", "detid");
+  m_peakWidthTable->addColumn("int", "detid");
+  m_peakHeightTable->addColumn("int", "detid");
+
   for (double dSpacing : m_peaksInDspacing) {
     std::stringstream namess;
     namess << "@" << std::setprecision(5) << dSpacing;
     m_peakPositionTable->addColumn("double", namess.str());
+    m_peakWidthTable->addColumn("double", namess.str());
+    m_peakHeightTable->addColumn("double", namess.str());
   }
   m_peakPositionTable->addColumn("double", "chisq");
   m_peakPositionTable->addColumn("double", "normchisq");
+  // residuals aren't needed for FWHM or height
 
   // convert the map of m_detidToRow to be a vector of detector ids
   std::vector<detid_t> detIds(m_detidToRow.size());
@@ -1032,13 +1041,33 @@ void PDCalibration::createInformationWorkspaces() {
 
   // copy the detector ids from the main table and add lots of NaNs
   for (const auto &detId : detIds) {
-    API::TableRow newRow = m_peakPositionTable->appendRow();
-    newRow << detId;
+    API::TableRow newPosRow = m_peakPositionTable->appendRow();
+    API::TableRow newWidthRow = m_peakWidthTable->appendRow();
+    API::TableRow newHeightRow = m_peakHeightTable->appendRow();
+
+    newPosRow << detId;
+    newWidthRow << detId;
+    newHeightRow << detId;
+
     for (double dSpacing : m_peaksInDspacing) {
       UNUSED_ARG(dSpacing);
-      newRow << std::nan("");
+      newPosRow << std::nan("");
+      newWidthRow << std::nan("");
+      newHeightRow << std::nan("");
     }
   }
+}
+
+API::ITableWorkspace_sptr PDCalibration::sortTableWorkspace(API::ITableWorkspace_sptr &table) {
+  auto alg = createChildAlgorithm("SortTableWorkspace");
+  alg->setLoggingOffset(1);
+  alg->setProperty("InputWorkspace", table);
+  alg->setProperty("OutputWorkspace", table);
+  alg->setProperty("Columns", "detid");
+  alg->executeAsChildAlg();
+  table = alg->getProperty("OutputWorkspace");
+
+  return table;
 }
 
 } // namespace Algorithms

--- a/Framework/Algorithms/src/PDCalibration.cpp
+++ b/Framework/Algorithms/src/PDCalibration.cpp
@@ -543,11 +543,11 @@ void PDCalibration::exec() {
   API::AnalysisDataService::Instance().addOrReplace(
       partials_prefix + "_dspacing", m_peakPositionTable);
   diagnosticGroup->addWorkspace(m_peakPositionTable);
-  API::AnalysisDataService::Instance().addOrReplace(
-      partials_prefix + "_width", m_peakWidthTable);
+  API::AnalysisDataService::Instance().addOrReplace(partials_prefix + "_width",
+                                                    m_peakWidthTable);
   diagnosticGroup->addWorkspace(m_peakWidthTable);
-  API::AnalysisDataService::Instance().addOrReplace(
-      partials_prefix + "_height", m_peakHeightTable);
+  API::AnalysisDataService::Instance().addOrReplace(partials_prefix + "_height",
+                                                    m_peakHeightTable);
   diagnosticGroup->addWorkspace(m_peakHeightTable);
   setProperty("DiagnosticWorkspaces", diagnosticGroup);
 }
@@ -1058,7 +1058,8 @@ void PDCalibration::createInformationWorkspaces() {
   }
 }
 
-API::ITableWorkspace_sptr PDCalibration::sortTableWorkspace(API::ITableWorkspace_sptr &table) {
+API::ITableWorkspace_sptr
+PDCalibration::sortTableWorkspace(API::ITableWorkspace_sptr &table) {
   auto alg = createChildAlgorithm("SortTableWorkspace");
   alg->setLoggingOffset(1);
   alg->setProperty("InputWorkspace", table);

--- a/docs/source/algorithms/FindPeaks-v1.rst
+++ b/docs/source/algorithms/FindPeaks-v1.rst
@@ -17,10 +17,11 @@ is then searched for patterns consistent with the presence of a peak.
 The list of candidate peaks found is passed to a fitting routine and
 those that are successfully fitted are kept and returned in the output
 workspace (and logged at information level). The output
-`TableWorkspace <http://www.mantidproject.org/TableWorkspace>`_ contains the following columns,
-which reflect the fact that the peak has been fitted to a Gaussian atop
-a linear background: spectrum, centre, width, height,
-backgroundintercept & backgroundslope.
+`TableWorkspace <http://www.mantidproject.org/TableWorkspace>`_ contains columns,
+which reflect the fact that the peak has been fitted to a peak function atop
+a background: spectrum, centre, width, height, backgroundintercept and
+backgroundslope. Setting ``RawPeakParameters=True`` will give the actual
+peak fit parameters rather than this abstraction.
 
 Subalgorithms used
 ##################
@@ -80,6 +81,8 @@ observed data.
 
    #. If peak centre is restricted to given value, then the peak range will be from 1/6 to 5/6 of the given data points;
    #. If peak centre is set to observed value, then the 3 leftmost data points will be used for background.
+
+.. seealso:: The `peak shape functions <../fitfunctions/categories/Peak.html>`_ and `background functions </fitfunctions/categories/Background.html>`_ for details on the various functions. The `documentation for minimizers <../fitminimizers/>`_.
 
 References
 ----------

--- a/docs/source/algorithms/PDCalibration-v1.rst
+++ b/docs/source/algorithms/PDCalibration-v1.rst
@@ -29,7 +29,13 @@ with uncalibrated pixels masked.
 
 The resulting calibration table can be saved with
 :ref:`algm-SaveDiffCal`, loaded with :ref:`algm-LoadDiffCal` and
-applied to a workspace with :ref:`algm-AlignDetectors`.
+applied to a workspace with :ref:`algm-AlignDetectors`. There are also
+three workspaces placed in the ``DiagnosticWorkspace`` group. They
+contain the fitted positions in dspace, ``_dspacing``, peak widths,
+``_width``, and peak heights, ``_height``. Since multiple peak shapes
+can be used, see the documentation for the individual `fit
+functions <../fitfunctions/index.html>`_ to see how they relate to the effective
+values displayed in the diagnostic tables.
 
 Usage
 -----
@@ -53,7 +59,8 @@ Usage
                  TofBinning=[300,-.001,16666.7],
                  PreviousCalibration=oldCal,
                  PeakPositions=dvalues,
-                 OutputCalibrationTable='cal')
+                 OutputCalibrationTable='cal',
+                 DiagnosticWorkspaces='diag')
 
    # Print the result
    print("The calibrated difc at detid {detid} is {difc}".format(**mtd['cal'].row(40000)))
@@ -67,4 +74,3 @@ Output:
 .. categories::
 
 .. sourcelink::
-

--- a/docs/source/release/v3.12.0/diffraction.rst
+++ b/docs/source/release/v3.12.0/diffraction.rst
@@ -13,6 +13,7 @@ Powder Diffraction
 ------------------
 
 - The ``CalibrationFile`` is now optional in :ref:`SNSPowderReduction <algm-SNSPowderReduction>`. In this case time focussing will use :ref:`ConvertUnits <algm-ConvertUnits>` and the instrument geometry. Care must be taken to supply a ``GroupingFile`` otherwise all of the spectra will be kept separate.
+- :ref:`PDCalibration <algm-PDCalibration>` returns two more diagnostic workspaces: one for the fitted peak heights, one for the fitted peak widths.
 
 Engineering Diffraction
 -----------------------


### PR DESCRIPTION
The NOMAD and POWGEN teams are trying to further diagnose their calibration. This adds more diagnostic workspaces showing the other parameters from the individual peak fitting.

**To test:**

Run it and see two new workspaces.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
