### PR TITLE
Reformat see also sections in sphinx

### DIFF
--- a/docs/source/algorithms/AppendSpectra-v1.rst
+++ b/docs/source/algorithms/AppendSpectra-v1.rst
@@ -41,12 +41,7 @@ If there is an overlap in the spectrum numbers of both inputs, then the
 output workspace will have its spectrum numbers reset starting at 0 and
 increasing by 1 for each spectrum.
 
-See Also
-########
-
--  :ref:`algm-ConjoinWorkspaces` for joining parts of the
-   same workspace.
-
+.. seealso:: :ref:`algm-ConjoinWorkspaces` for joining parts of the same workspace.
 
 Usage
 -----

--- a/docs/source/algorithms/ChangeLogTime-v1.rst
+++ b/docs/source/algorithms/ChangeLogTime-v1.rst
@@ -9,8 +9,10 @@
 Description
 -----------
 
-Adds a constant to the times for the requested log. 
-See also :ref:`ShiftLogTime <algm-ShiftLogTime>` and :ref:`CorrectLogTimes <algm-CorrectLogTimes>`
+Adds a constant to the times for the requested log.
+
+
+.. seealso:: :ref:`ShiftLogTime <algm-ShiftLogTime>` and :ref:`CorrectLogTimes <algm-CorrectLogTimes>`
 
 Usage
 -----
@@ -18,7 +20,7 @@ Usage
 .. include:: ../usagedata-note.txt
 
 .. testcode:: ChangeLogTime
-    
+
     #Load a workspace
     w=Load('CNCS_7860')
     #get the log times for a particular variable
@@ -40,7 +42,7 @@ Usage
 Output:
 
 .. testoutput:: ChangeLogTime
-   
+
     OriginalTimes:  [2010-Mar-25 16:09:27.780000000,2010-Mar-25 16:10:01.560998229,2010-Mar-25 16:10:31.514001159,2010-Mar-25 16:11:25.498002319]
     ModifiedTimes:  [2010-Mar-25 16:09:37.780000000,2010-Mar-25 16:10:11.560998229,2010-Mar-25 16:10:41.514001159,2010-Mar-25 16:11:35.498002319]
 

--- a/docs/source/algorithms/CorrectLogTimes-v1.rst
+++ b/docs/source/algorithms/CorrectLogTimes-v1.rst
@@ -14,7 +14,7 @@ experimental log values are not synchronized. This algorithm attempts to
 make all (some) time series property logs start at the same time as the
 first time in the proton charge log. It uses :ref:`ChangeLogTime <algm-ChangeLogTime>`.
 
-See also :ref:`ShiftLogTime <algm-ShiftLogTime>` and :ref:`ChangeLogTime <algm-ChangeLogTime>`.
+.. seealso:: :ref:`ShiftLogTime <algm-ShiftLogTime>` and :ref:`ChangeLogTime <algm-ChangeLogTime>`.
 
 
 Usage
@@ -23,7 +23,7 @@ Usage
 .. include:: ../usagedata-note.txt
 
 .. testcode:: CorrectLogTimes
-    
+
     w=Load('CNCS_7860')
     print("Original start time for 'proton_charge': {}".format(w.getRun()['proton_charge'].times[0]).strip())
     print("Original start time for 'Speed5': {}".format(w.getRun()['Speed5'].times[0]).strip())
@@ -42,9 +42,9 @@ Output:
 
 .. testoutput:: CorrectLogTimes
 
-    Original start time for 'proton_charge': 2010-03-25T16:08:37 
-    Original start time for 'Speed5': 2010-03-25T16:09:27.780000000 
-    Corrected start time for 'Speed5': 2010-03-25T16:08:37 
+    Original start time for 'proton_charge': 2010-03-25T16:08:37
+    Original start time for 'Speed5': 2010-03-25T16:09:27.780000000
+    Corrected start time for 'Speed5': 2010-03-25T16:08:37
 
 .. categories::
 

--- a/docs/source/algorithms/DetectorEfficiencyCor-v1.rst
+++ b/docs/source/algorithms/DetectorEfficiencyCor-v1.rst
@@ -14,16 +14,16 @@ The probability of neutron detection by each detector in the
 energy, angle between their path and the detector axis, detector gas
 pressure, radius and wall thickness. The detectors must be cylindrical
 and their :sup:`3`\ He partial pressure, wall thickness and radius
-are attached to the instrument stored in the input workspace, 
-The first parameter is in atmospheres and the last two in metres. 
+are attached to the instrument stored in the input workspace,
+The first parameter is in atmospheres and the last two in metres.
 That workspace then needs to be converted so that its
 X-values are in :ref:`units <Unit Factory>` of energy transfer, e.g. using
 the :ref:`algm-ConvertUnits` algorithm.
 
 To estimate the true number of neutrons that entered the detector the
 counts in each bin are divided by the detector efficiency of that
-detector at that energy. The efficiency iteslef is calculated from 
-the forumula, tabulated within the algorithm. 
+detector at that energy. The efficiency iteslef is calculated from
+the forumula, tabulated within the algorithm.
 
 The numbers of counts are then multiplied by the value of
 :math:`k_i/k_f` for each bin. In that formula :math:`k_i` is the
@@ -41,8 +41,8 @@ Note: it is not possible to use this :ref:`algorithm <algorithm>` to
 correct for the detector efficiency alone. One solution to this is to
 divide the output of the algorithm by :math:`k_i/k_f` calculated as above.
 
-See also :ref:`algm-DetectorEfficiencyCorUser` algorithm, which may provide
-more instrument specific efficiency corrections.
+.. seealso:: :ref:`algm-DetectorEfficiencyCorUser` algorithm, which may provide
+             more instrument specific efficiency corrections.
 
 Usage
 -----
@@ -54,9 +54,9 @@ Usage
     # Simulates Load of a workspace with all necessary parameters #################
     detWS = CreateSimulationWorkspace(Instrument='MAR',BinParams=[-50,2,50],UnitX='DeltaE')
     detWS.dataE(0)[range(0,50)]=1
-    AddSampleLog(detWS,LogName='Ei',LogText='52.',LogType='Number');    
-    
-    # Correct detectors efficiency 
+    AddSampleLog(detWS,LogName='Ei',LogText='52.',LogType='Number');
+
+    # Correct detectors efficiency
     corWS = DetectorEfficiencyCor(detWS)
     corWS = CorrectKiKf(corWS,EMode='Direct')
 
@@ -71,7 +71,7 @@ Usage
 .. testcleanup:: ExDetectorEfficiencyCorr
 
    DeleteWorkspace(detWS)
-   DeleteWorkspace(corWS)   
+   DeleteWorkspace(corWS)
 
 **Output:**
 

--- a/docs/source/algorithms/EnggFitPeaks-v1.rst
+++ b/docs/source/algorithms/EnggFitPeaks-v1.rst
@@ -32,8 +32,9 @@ Mantid algorithm :ref:`AlignDetectors <algm-AlignDetectors>`
 (following GSAS equations) if the workspace is focused (single
 spectrum) and has a log entry named "difc", where the GSAS DIFC
 parameter is expected. Otherwise the conversion of units is done as in
-the Mantid :ref:`ConvertUnits <algm-ConvertUnits>`. See also
-:ref:`EnggFitDIFCFromPeaks <algm-EnggFitDIFCFromPeaks>`.
+the Mantid :ref:`ConvertUnits <algm-ConvertUnits>`.
+
+.. seealso:: :ref:`EnggFitDIFCFromPeaks <algm-EnggFitDIFCFromPeaks>`.
 
 This algorithm currently fits (single) peaks of type
 :ref:`Back2BackExponential <func-BackToBackExponential>`. Other

--- a/docs/source/algorithms/GSASIIRefineFitPeaks-v1.rst
+++ b/docs/source/algorithms/GSASIIRefineFitPeaks-v1.rst
@@ -106,11 +106,10 @@ table give the parameters fitted, similarly to the information found
 in the "Peaks List" window of the GSAS-II GUI. These results are
 printed in the log messages as well.
 
-For fitting single peaks, one at a time, see also :ref:`EnggFitPeaks
-<algm-EnggFitPeaks>`. For other algorithms that implement different
-variants of whole diffraction pattern refinement and fitting see also
-:ref:`PawleyFit <algm-PawleyFit>` and :ref:`LeBailFit
-<algm-LeBailFit>`.
+.. seealso:: For fitting single peaks, one at a time, :ref:`EnggFitPeaks
+             <algm-EnggFitPeaks>`. For other algorithms that implement different
+             variants of whole diffraction pattern refinement and fitting by
+             :ref:`PawleyFit <algm-PawleyFit>` and :ref:`LeBailFit <algm-LeBailFit>`.
 
 
 *References*:

--- a/docs/source/algorithms/MergeMD-v1.rst
+++ b/docs/source/algorithms/MergeMD-v1.rst
@@ -21,8 +21,8 @@ The output workspace is created with these dimensions and the box
 parameters specified above. Then the events from each input workspace
 are appended to the output.
 
-See also: :ref:`algm-MergeMDFiles`, for merging when system
-memory is too small to keep the entire workspace in memory.
+.. seealso:: :ref:`algm-MergeMDFiles`, for merging when system
+             memory is too small to keep the entire workspace.
 
 Usage
 -----
@@ -32,16 +32,16 @@ Usage
 .. testcode:: ExMergeMD
 
    from mantid.api import IMDEventWorkspace
-   # Create sample inelastic workspace for MARI instrument containing 1 at all spectra 
+   # Create sample inelastic workspace for MARI instrument containing 1 at all spectra
    ws1=CreateSimulationWorkspace(Instrument='MAR',BinParams='-10,1,10',UnitX='DeltaE')
    AddSampleLog(ws1,'Ei','12.','Number')
    # get first MD workspace;
-   mdWs1 =ConvertToMD(InputWorkspace=ws1,QDimensions='|Q|',QConversionScales='Q in A^-1',MinValues='0,-10',MaxValues='5,10')   
+   mdWs1 =ConvertToMD(InputWorkspace=ws1,QDimensions='|Q|',QConversionScales='Q in A^-1',MinValues='0,-10',MaxValues='5,10')
    # Create another inelastic workspace
    ws1=CreateSimulationWorkspace(Instrument='MAR',BinParams='-5,1,15',UnitX='DeltaE')
    AddSampleLog(ws1,'Ei','20.','Number')
    # get second MD workspace;
-   mdWs2 =ConvertToMD(InputWorkspace=ws1,QDimensions='|Q|',QConversionScales='Q in A^-1',MinValues='0,-5',MaxValues='10,15')   
+   mdWs2 =ConvertToMD(InputWorkspace=ws1,QDimensions='|Q|',QConversionScales='Q in A^-1',MinValues='0,-5',MaxValues='10,15')
 
    # Merge MD workspaces
    SumWS=MergeMD(InputWorkspaces='mdWs1,mdWs2',SplitInto='100,100')
@@ -63,7 +63,7 @@ Usage
    print('with d1 min_max={0}:{1}, d2 min_max={2}:{3}'.format(d1.getMinimum(),d1.getMaximum(),d2.getMinimum(),d2.getMaximum()))
    print('****************************************************************')
 
-   
+
 **Output:**
 
 .. testoutput:: ExMergeMD

--- a/docs/source/algorithms/MergeMDFiles-v1.rst
+++ b/docs/source/algorithms/MergeMDFiles-v1.rst
@@ -33,8 +33,8 @@ algorithm avoids excessive memory use by only keeping the events from
 ONE box from ALL the files in memory at once to further process and
 refine it. This is why it requires a common box structure.
 
-See also: :ref:`algm-MergeMD`, for merging any MDWorkspaces in system
-memory (faster, but needs more memory).
+.. seealso:: :ref:`algm-MergeMD`, for merging any MDWorkspaces in system
+             memory (faster, but needs more memory).
 
 .. categories::
 

--- a/docs/source/algorithms/ResizeRectangularDetector-v1.rst
+++ b/docs/source/algorithms/ResizeRectangularDetector-v1.rst
@@ -30,14 +30,14 @@ individual pixels. This means that algorithms based on solid angle
 calculations might be off. Ray-tracing (e.g. peak finding) are
 unaffected.
 
-See also :ref:`algm-MoveInstrumentComponent` and
-:ref:`algm-RotateInstrumentComponent` for other ways
-to move components.
+.. seealso:: :ref:`algm-MoveInstrumentComponent` and
+             :ref:`algm-RotateInstrumentComponent` for other ways
+             to move components.
 
 Usage
 -----
 
-**Example - Resize bank 1:**  
+**Example - Resize bank 1:**
 
 .. testcode:: ExScaleBank1
 
@@ -56,7 +56,7 @@ Usage
 Output:
 
 .. testoutput:: ExScaleBank1
-   
+
 	bank 1 was scaled and is now 0.16 by 0.04
 	bank 2 was not scaled and remains 0.08 by 0.08
 

--- a/docs/source/algorithms/SaveFITS-v1.rst
+++ b/docs/source/algorithms/SaveFITS-v1.rst
@@ -34,7 +34,7 @@ files include the following basic standard headers: SIMPLE, BITPIX,
 NAXIS, (NAXIS1 and NAXIS2), EXTEND, and a COMMENT header with the
 format description.
 
-See also :ref:`algm-LoadFITS`.
+.. seealso:: :ref:`algm-LoadFITS`.
 
 
 Usage
@@ -81,11 +81,11 @@ Usage
     pos_x, pos_y = 22, 33
     print("Pixel value at coordinates ({0},{1}), first image: {2:.1f}, second image: {3:.1f}".
            format(pos_x, pos_y, ws.readY(pos_y)[pos_x], ws_reload.readY(pos_y)[pos_x]))
-                
+
 .. testcleanup:: LoadSaveLoadFITS
 
     import os
-                 
+
     DeleteWorkspace(wsg_name)
     DeleteWorkspace(wsg_reload_name)
     os.remove(save_name)

--- a/docs/source/algorithms/ShiftLogTime-v1.rst
+++ b/docs/source/algorithms/ShiftLogTime-v1.rst
@@ -9,7 +9,9 @@
 Description
 -----------
 
-The algorithm is similar to :ref:`ChangeLogTime <algm-ChangeLogTime>`, but instead of a defined time shift of the logs, one gets a shift in the indexes of the specified logs. This will make the log shorter by the specified shift. See also :ref:`ChangeLogTime <algm-ChangeLogTime>` and :ref:`CorrectLogTimes <algm-CorrectLogTimes>`
+The algorithm is similar to :ref:`ChangeLogTime <algm-ChangeLogTime>`, but instead of a defined time shift of the logs, one gets a shift in the indexes of the specified logs. This will make the log shorter by the specified shift.
+
+.. seealso:: :ref:`ChangeLogTime <algm-ChangeLogTime>` and :ref:`CorrectLogTimes <algm-CorrectLogTimes>`
 
 Usage
 -----
@@ -17,7 +19,7 @@ Usage
 .. include:: ../usagedata-note.txt
 
 .. testcode:: ShiftLogTime
-    
+
     #Load a workspace
     w = Load('CNCS_7860')
     #get the log times for a particular variable
@@ -39,11 +41,11 @@ Usage
 Output:
 
 .. testoutput:: ShiftLogTime
-   
+
     OriginalTimes:  [2010-Mar-25 16:09:27.780000000,2010-Mar-25 16:10:01.560998229,2010-Mar-25 16:10:31.514001159,2010-Mar-25 16:11:25.498002319]
     ModifiedTimes:  [2010-Mar-25 16:10:31.514001159,2010-Mar-25 16:11:25.498002319]
-    
-    
+
+
 .. categories::
 
 .. sourcelink::

--- a/docs/source/concepts/MDWorkspace.rst
+++ b/docs/source/concepts/MDWorkspace.rst
@@ -9,8 +9,9 @@ MD Workspace
 
 The MD Workspace [MDWorkspace] (short for "Multi-Dimensional" Workspace) is a generic
 data structure holdings points (MDEvents) that are defined by their
-position in several dimensions. See also
-:ref:`MDHistoWorkspace <MDHistoWorkspace>`.
+position in several dimensions.
+
+.. seealso:: :ref:`MDHistoWorkspace <MDHistoWorkspace>`
 
 Description of MDWorkspace
 --------------------------
@@ -47,7 +48,7 @@ contain too many events, it will be split into smaller boxes.
    :alt: MDWorkspace_structure.png
 
    MDWorkspace\_structure.png
-   
+
 The threshold for splitting is defined in
 :ref:`CreateMDWorkspace <algm-CreateMDWorkspace>` as the SplitThreshold
 parameter. Each parent box will get split into N sub-boxes in each
@@ -225,7 +226,7 @@ To access the data of an MDWorkspace you need to convert it to a regular grid, o
 
 .. testcode:: MDWorkspaceConvertToHisto
 
-   # Setup 
+   # Setup
    mdWS = CreateMDWorkspace(Dimensions=4, Extents=[-1,1,-1,1,-1,1,-10,10], Names="H,K,L,E", Units="U,U,U,V")
    FakeMDEventData(InputWorkspace=mdWS, PeakParams='500000,0,0,0,0,3')
 

--- a/docs/source/concepts/NexusFile.rst
+++ b/docs/source/concepts/NexusFile.rst
@@ -18,9 +18,9 @@ The general structure of NEXUS files is explained in http://download.nexusformat
 
 Here are some specific details:
 
-ISIS uses NEXUS files for both histrogram and event data and SNS uses NEXUS for event data only. 
-Also both ISIS and SNS use the same structure for event data. 
-Hence there are two principal types of NEXUS files loaded by Mantid 
+ISIS uses NEXUS files for both histrogram and event data and SNS uses NEXUS for event data only.
+Also both ISIS and SNS use the same structure for event data.
+Hence there are two principal types of NEXUS files loaded by Mantid
 
  - ISIS histogram Nexus file, which is loaded by :ref:`LoadISISNexus <algm-LoadISISNexus>` and
  - Event Nexus file, which is loaded by :ref:`LoadEventNexus <algm-LoadEventNexus>`.
@@ -31,16 +31,11 @@ ISIS uses two versions of Nexus files for muon histogram data:
  - Muon Nexus file v2, which is loaded by :ref:`LoadEventNexus v2<algm-LoadMuonNexus-v2>`.
 
 
-As well as Nexus files loaded by Mantid, there is a kind of Nexus file, 
+As well as Nexus files loaded by Mantid, there is a kind of Nexus file,
 which is produced by Mantid, when it saves a workspace
-to Nexus, which is called a Processed Nexus file and is saved by 
+to Nexus, which is called a Processed Nexus file and is saved by
 :ref:`SaveNexusProcessed <algm-SaveNexusProcessed>`.
 
-See also
---------
-
-:ref:`RAW File <RAW File>` an older data file format.
-
-
+.. seealso:: :ref:`RAW File <RAW File>` an older data file format.
 
 .. categories:: Concepts

--- a/docs/source/concepts/Project.rst
+++ b/docs/source/concepts/Project.rst
@@ -14,11 +14,6 @@ A project consists of a .mantid file and a collection of :ref:`Nexus
 files <Nexus file>` it refers to. For this reason, a project is put
 into its own folder when saved.
 
-See Also
---------
-
-MantidPlot:_The_File_Menu for how to save or load a project
-
-
+.. seealso:: MantidPlot:_The_File_Menu for how to save or load a project
 
 .. categories:: Concepts

--- a/docs/source/concepts/RAWFile.rst
+++ b/docs/source/concepts/RAWFile.rst
@@ -56,7 +56,7 @@ least for RAW files.
 ::
 
     notepad2.exe SANS2D00000799.raw:checksum
-    more < SANS2D00000799.raw:checksum 
+    more < SANS2D00000799.raw:checksum
 
 If a file with an alternate data stream is copied to an FAT file system
 the alternate data stream is lost. It has been reported that if a file
@@ -75,11 +75,6 @@ More information about Alternate Data Streams
 -  `Practical Guide to Alternative Data Streams in
    NTFS <http://www.irongeek.com/i.php?page=security/altds>`__
 
-See also
-~~~~~~~~
-
-:ref:`Nexus file <Nexus file>` a newer type of data file
-
-
+.. seealso:: :ref:`Nexus file <Nexus file>` a newer type of data file
 
 .. categories:: Concepts


### PR DESCRIPTION
Several places used "See also" which sphinx has a markup for. Switch them to use it.

**To test:**

Build the documentation and look things over.

*There is no associated issue.*
*Does not need to be in the release notes* because it is a change in markup.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
