### PR TITLE
NormaliseToMonitor blocksize fix

### DIFF
--- a/Framework/API/src/WorkspaceOpOverloads.cpp
+++ b/Framework/API/src/WorkspaceOpOverloads.cpp
@@ -405,8 +405,9 @@ MatrixWorkspace_sptr operator/=(const MatrixWorkspace_sptr lhs,
  *  @return True if the bins match
  */
 bool WorkspaceHelpers::commonBoundaries(const MatrixWorkspace &WS) {
-  if (!WS.blocksize() || WS.getNumberHistograms() < 2)
+  if (WS.getNumberHistograms() < 2 || WS.size() == 0)
     return true;
+
   // Quickest check is to see if they are actually all the same vector
   if (sharedXData(WS))
     return true;

--- a/Framework/Algorithms/inc/MantidAlgorithms/ExtractSpectra.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ExtractSpectra.h
@@ -47,8 +47,8 @@ private:
   void execEvent();
 
   void checkProperties();
-  std::size_t getXMin(const int wsIndex = 0);
-  std::size_t getXMax(const int wsIndex = 0);
+  std::size_t getXMin(const size_t wsIndex = 0);
+  std::size_t getXMax(const size_t wsIndex = 0);
   void cropRagged(API::MatrixWorkspace_sptr outputWorkspace, int inIndex,
                   int outIndex);
 

--- a/Framework/Algorithms/src/ExtractSpectra.cpp
+++ b/Framework/Algorithms/src/ExtractSpectra.cpp
@@ -377,11 +377,12 @@ void ExtractSpectra::checkProperties() {
     m_workspaceIndexList = getProperty("WorkspaceIndexList");
 
     if (m_workspaceIndexList.empty()) {
-      int minSpec = getProperty("StartWorkspaceIndex");
-      const int numberOfSpectra =
-          static_cast<int>(m_inputWorkspace->getNumberHistograms());
-      int maxSpec = getProperty("EndWorkspaceIndex");
-      if (isEmpty(maxSpec))
+      int minSpec_i = getProperty("StartWorkspaceIndex");
+      size_t minSpec = static_cast<size_t>(minSpec_i);
+      const size_t numberOfSpectra = m_inputWorkspace->getNumberHistograms();
+      int maxSpec_i = getProperty("EndWorkspaceIndex");
+      size_t maxSpec = static_cast<size_t>(maxSpec_i);
+      if (isEmpty(maxSpec_i))
         maxSpec = numberOfSpectra - 1;
 
       // Check 'StartSpectrum' is in range 0-numberOfSpectra
@@ -409,7 +410,7 @@ void ExtractSpectra::checkProperties() {
   }
 
   // get the x-range from the used spectra
-  int spectrumIndex = 0; // default is just look at the initial spectrum
+  size_t spectrumIndex = 0; // default is just look at the initial spectrum
   if (!m_workspaceIndexList.empty())
     spectrumIndex =
         m_workspaceIndexList.front(); // or the first one being extracted
@@ -441,7 +442,7 @@ void ExtractSpectra::checkProperties() {
  *  @param  wsIndex The workspace index to check (default 0).
  *  @return The X index corresponding to the XMin value.
  */
-size_t ExtractSpectra::getXMin(const int wsIndex) {
+size_t ExtractSpectra::getXMin(const size_t wsIndex) {
   double minX_val = getProperty("XMin");
   size_t xIndex = 0;
   if (!isEmpty(minX_val)) { // A value has been passed to the algorithm, check
@@ -468,7 +469,7 @@ size_t ExtractSpectra::getXMin(const int wsIndex) {
  *  @param  wsIndex The workspace index to check (default 0).
  *  @return The X index corresponding to the XMax value.
  */
-size_t ExtractSpectra::getXMax(const int wsIndex) {
+size_t ExtractSpectra::getXMax(const size_t wsIndex) {
   const auto &X = m_inputWorkspace->x(wsIndex);
   size_t xIndex = X.size();
   // get the value that the user entered if they entered one at all

--- a/Framework/Algorithms/src/NormaliseToMonitor.cpp
+++ b/Framework/Algorithms/src/NormaliseToMonitor.cpp
@@ -570,7 +570,6 @@ void NormaliseToMonitor::normaliseBinByBin(
     this->normalisationFactor(monX, monY, monE);
 
   const size_t numHists = inputWorkspace->getNumberHistograms();
-  auto specLength = inputWorkspace->blocksize();
   // Flag set when a division by 0 is found
   bool hasZeroDivision = false;
   Progress prog(this, 0.0, 1.0, numHists);
@@ -585,6 +584,7 @@ void NormaliseToMonitor::normaliseBinByBin(
     // If not rebinning, just point to our monitor spectra, otherwise create new
     // vectors
 
+    const size_t specLength = inputWorkspace->y(i).size();
     auto Y = (m_commonBins ? monY : Counts(specLength));
     auto E = (m_commonBins ? monE : CountStandardDeviations(specLength));
 

--- a/docs/source/release/v3.12.0/framework.rst
+++ b/docs/source/release/v3.12.0/framework.rst
@@ -24,6 +24,7 @@ Algorithms
 
 - :ref:`CreateWorkspace <algm-CreateWorkspace>` will no longer create a default (and potentially wrong) mapping from spectra to detectors, unless a parent workspace is given. This change ensures that accidental bad mappings that could lead to corrupted data are not created silently anymore. This change does *not* affect the use of this algorithm if: (1) a parent workspace is given, or (2) no instrument is loaded into to workspace at a later point, or (3) an instrument is loaded at a later point but ``LoadInstrument`` is used with ``RewriteSpectraMapping=True``. See also the algorithm documentation for details.
 - :ref:`Fit <algm-Fit>` will now respect excluded ranges when ``CostFunction = 'Unweighted least squares'``.
+- :ref:`NormaliseToMonitor <algm-NormaliseToMonitor>` now supports non-constant number of bins.
 
 Core Functionality
 ------------------


### PR DESCRIPTION
It was discovered that for TOPAZ data that was just loaded, `NormaliseToMonitor` was raising an error:
```
ExtractSpectra-[Error] blocksize undefined because size of histograms is not equal
```
This PR addresses that issue.

**To test:**

Try running the following scripts without and with this PR.
```python
S=Load("TOPAZ_15629",LoadMonitors=True)
S=NormaliseToMonitor(InputWorkspace='S',MonitorWorkspace='S_monitors')
```

```python
S=Load("TOPAZ_15629",LoadMonitors=True)
S=NormaliseToMonitor(InputWorkspace='S',MonitorWorkspace='S_monitors',
      MonitorWorkspaceIndex=1)
```

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
