### PR TITLE
Update SwitchToSliceViewer in MultiSlice view to work with nonorthogonal axes.

### DIFF
--- a/docs/source/release/v3.12.0/ui.rst
+++ b/docs/source/release/v3.12.0/ui.rst
@@ -18,6 +18,7 @@ Workbench
 SliceViewer and Vates Simple Interface
 --------------------------------------
 
+- Update SwitchToSliceViewer (shift + click) in MultiSlice view to work with nonorthogonal axes.
 - Pressing alt while clicking an arrow in the MultiSlice view opens a text box where one may precisely enter the slice position.
 
 .. figure:: ../../images/VatesMultiSliceView.png

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/src/MultisliceView.cpp
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/src/MultisliceView.cpp
@@ -37,30 +37,6 @@ namespace Mantid {
 namespace Vates {
 namespace SimpleGui {
 
-static void GetOrientations(vtkSMSourceProxy *producer,
-                            vtkVector3d sliceNormals[3]) {
-  bool isvalid = false;
-  vtkTuple<double, 16> cobm =
-      pqModelTransformSupportBehavior::getChangeOfBasisMatrix(producer, 0,
-                                                              &isvalid);
-  if (isvalid) {
-    vtkNew<vtkMatrix4x4> changeOfBasisMatrix;
-    std::copy(&cobm[0], &cobm[0] + 16, &changeOfBasisMatrix->Element[0][0]);
-    vtkVector3d axisBases[3];
-    vtkPVChangeOfBasisHelper::GetBasisVectors(changeOfBasisMatrix.GetPointer(),
-                                              axisBases[0], axisBases[1],
-                                              axisBases[2]);
-    for (int cc = 0; cc < 3; cc++) {
-      sliceNormals[cc] = axisBases[(cc + 1) % 3].Cross(axisBases[(cc + 2) % 3]);
-      sliceNormals[cc].Normalize();
-    }
-  } else {
-    sliceNormals[0] = vtkVector3d(1, 0, 0);
-    sliceNormals[1] = vtkVector3d(0, 1, 0);
-    sliceNormals[2] = vtkVector3d(0, 0, 1);
-  }
-}
-
 MultiSliceView::MultiSliceView(QWidget *parent,
                                RebinnedSourcesManager *rebinnedSourcesManager,
                                bool createRenderProxy)

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/src/MultisliceView.cpp
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/src/MultisliceView.cpp
@@ -326,24 +326,20 @@ void MultiSliceView::showCutInSliceViewer(int axisIndex,
     }
   }
 
-  vtkVector3d sliceNormals[3];
-  GetOrientations(vtkSMSourceProxy::SafeDownCast(src1->getProxy()),
-                  sliceNormals);
-  vtkVector3d &orient = sliceNormals[axisIndex];
-
   // Construct origin vector from orientation vector
-  double origin[3];
-  origin[0] = sliceOffsetOnAxis * orient[0];
-  origin[1] = sliceOffsetOnAxis * orient[1];
-  origin[2] = sliceOffsetOnAxis * orient[2];
+  double origin[3] = {0.0, 0.0, 0.0};
+  origin[axisIndex] = sliceOffsetOnAxis;
+
+  vtkVector3d sliceNormalsInBasis[3] = {
+      {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}};
 
   // Create the XML holder
   VATES::VatesKnowledgeSerializer rks;
   rks.setWorkspaceName(wsName.toStdString());
   rks.setGeometryXML(geomXML);
 
-  rks.setImplicitFunction(
-      boost::make_shared<MDPlaneImplicitFunction>(3, orient.GetData(), origin));
+  rks.setImplicitFunction(boost::make_shared<MDPlaneImplicitFunction>(
+      3, sliceNormalsInBasis[axisIndex].GetData(), origin));
   QString titleAddition = "";
 
   // Use the WidgetFactory to create the slice viewer window


### PR DESCRIPTION
Description of work.

This updates the SwitchToSliceViewer function (accessible by pressing shift + left or right click in the MultiSlice view) to work with non-orthogonal axes. 

**To test:**

<!-- Instructions for testing. -->


1. Open the NaLaF<sub>4</sub> diffuse scattering dataset in the VSI.
2. Switch to the MultiSlice view
3. Move slices away from the 0.0 position.
4. Press shift while clicking on one of the axis arrows. Verify the Slice Viewer shows the correct slice.
5. Repeat step 4 with the other two axes.

There is no GitHub issue associated with this pull request.

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
