### PR TITLE
Check for input string ISO8601 conformity in DateAndTime

### DIFF
--- a/Framework/API/src/DeprecatedAlgorithm.cpp
+++ b/Framework/API/src/DeprecatedAlgorithm.cpp
@@ -1,8 +1,7 @@
 #include "MantidAPI/DeprecatedAlgorithm.h"
 #include "MantidAPI/AlgorithmFactory.h"
-#include "MantidKernel/DateAndTimeHelpers.h"
-#include "MantidKernel/DateAndTimeHelpers.h"
 #include "MantidKernel/Logger.h"
+#include "MantidTypes/Core/DateAndTimeHelpers.h"
 #include <sstream>
 
 namespace Mantid {
@@ -43,7 +42,7 @@ void DeprecatedAlgorithm::deprecatedDate(const std::string &date) {
     // TODO warn people that it wasn't set
     return;
   }
-  if (!Kernel::DateAndTimeHelpers::stringIsISO8601(date)) {
+  if (!Types::Core::DateAndTimeHelpers::stringIsISO8601(date)) {
     // TODO warn people that it wasn't set
     return;
   }

--- a/Framework/DataHandling/src/LoadLog.cpp
+++ b/Framework/DataHandling/src/LoadLog.cpp
@@ -6,15 +6,14 @@
 #include "MantidAPI/FileProperty.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidKernel/ArrayProperty.h"
-#include "MantidKernel/DateAndTimeHelpers.h"
 #include "MantidKernel/Glob.h"
 #include "MantidKernel/LogParser.h"
 #include "MantidKernel/PropertyWithValue.h"
 #include "MantidKernel/Strings.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 #include "MantidKernel/make_unique.h"
+#include "MantidTypes/Core/DateAndTimeHelpers.h"
 
-#include <MantidKernel/DateAndTimeHelpers.h>
 #include <Poco/DateTimeFormat.h>
 #include <Poco/DateTimeParser.h>
 #include <Poco/DirectoryIterator.h>
@@ -469,13 +468,12 @@ bool LoadLog::isAscii(const std::string &filename) {
 }
 
 /**
- * Check if first 19 characters of a string is date-time string according to
- * yyyy-mm-ddThh:mm:ss
+ * Check if the string conforms to the ISO8601 standard.
  * @param str :: The string to test
  * @returns true if the strings format matched the expected date format
  */
 bool LoadLog::isDateTimeString(const std::string &str) const {
-  return DateAndTimeHelpers::stringIsISO8601(str.substr(0, 19));
+  return Types::Core::DateAndTimeHelpers::stringIsISO8601(str.substr(0, 19));
 }
 
 /**

--- a/Framework/ICat/src/CatalogSearchParam.cpp
+++ b/Framework/ICat/src/CatalogSearchParam.cpp
@@ -220,7 +220,7 @@ time_t CatalogSearchParam::getTimevalue(const std::string &inputDate) {
   boost::algorithm::split_regex(dateSegments, inputDate, boost::regex("/"));
   // Reorganise the date to be ISO format.
   std::string isoDate = dateSegments.at(2) + "-" + dateSegments.at(1) + "-" +
-                        dateSegments.at(0) + " 0:00:00.000";
+                        dateSegments.at(0) + " 00:00:00.000";
   // Return the date as time_t value.
   return Types::Core::DateAndTime(isoDate).to_time_t();
 }

--- a/Framework/Kernel/CMakeLists.txt
+++ b/Framework/Kernel/CMakeLists.txt
@@ -14,7 +14,7 @@ set ( SRC_FILES
 	src/ComputeResourceInfo.cpp
 	src/ConfigService.cpp
 	src/DateAndTime.cpp
-    	src/DataItem.cpp
+	src/DataItem.cpp
 	src/DateAndTimeHelpers.cpp
 	src/DateTimeValidator.cpp
 	src/DateValidator.cpp
@@ -129,14 +129,14 @@ set ( SRC_FILES
 )
 
 set ( SRC_UNITY_IGNORE_FILES src/Atom.cpp
-        src/NeutronAtom.cpp
-        src/FacilityInfo.cpp
-        src/FilterChannel.cpp
-        src/FileValidator.cpp
-        src/DirectoryValidator.cpp
-        src/PropertyManager.cpp
-        src/Unit.cpp
-        src/System.cpp
+	src/NeutronAtom.cpp
+	src/FacilityInfo.cpp
+	src/FilterChannel.cpp
+	src/FileValidator.cpp
+	src/DirectoryValidator.cpp
+	src/PropertyManager.cpp
+	src/Unit.cpp
+	src/System.cpp
 )
 
 set ( INC_FILES
@@ -286,7 +286,7 @@ set ( INC_FILES
 	inc/MantidKernel/ThreadSafeLogStream.h
 	inc/MantidKernel/ThreadScheduler.h
 	inc/MantidKernel/ThreadSchedulerMutexes.h
-    inc/MantidKernel/TimeSeriesProperty.h
+	inc/MantidKernel/TimeSeriesProperty.h
 	inc/MantidKernel/TimeSplitter.h
 	inc/MantidKernel/Timer.h
 	inc/MantidKernel/Tolerance.h
@@ -336,7 +336,7 @@ set ( TEST_FILES
 	ConfigServiceTest.h
 	CowPtrTest.h
 	DataServiceTest.h
-   	DateAndTimeHelpersTest.h
+	DateAndTimeHelpersTest.h
 	DateTimeValidatorTest.h
 	DateValidatorTest.h
 	DeltaEModeTest.h

--- a/Framework/Kernel/inc/MantidKernel/DateAndTimeHelpers.h
+++ b/Framework/Kernel/inc/MantidKernel/DateAndTimeHelpers.h
@@ -11,8 +11,6 @@ namespace DateAndTimeHelpers {
 MANTID_KERNEL_DLL Types::Core::DateAndTime
 createFromSanitizedISO8601(const std::string &date);
 
-MANTID_KERNEL_DLL bool stringIsISO8601(const std::string &date);
-
 MANTID_KERNEL_DLL std::string
 verifyAndSanitizeISO8601(const std::string &date, bool displayWarnings = true);
 

--- a/Framework/Kernel/src/DateAndTimeHelpers.cpp
+++ b/Framework/Kernel/src/DateAndTimeHelpers.cpp
@@ -34,18 +34,6 @@ Types::Core::DateAndTime createFromSanitizedISO8601(const std::string &date) {
   return Types::Core::DateAndTime(verifyAndSanitizeISO8601(date));
 }
 
-/** Check if a string is iso8601 format.
- *
- * @param date :: string to check
- * @return true if the string conforms to ISO 860I, false otherwise.
- */
-bool stringIsISO8601(const std::string &date) {
-  Poco::DateTime dt;
-  int tz_diff;
-  return Poco::DateTimeParser::tryParse(Poco::DateTimeFormat::ISO8601_FORMAT,
-                                        date, dt, tz_diff);
-}
-
 /** Verifies whether or not a string conforms to ISO8601. Corrects the string
  *if it does not and is of the ARGUS file date/time format.
  *e.g 2009-07- 8T10:23:50 becomes 2009-07-08T10:23:50.

--- a/Framework/Kernel/test/DateAndTimeHelpersTest.h
+++ b/Framework/Kernel/test/DateAndTimeHelpersTest.h
@@ -17,19 +17,6 @@ public:
   }
   static void destroySuite(DateAndTimeHelpersTest *suite) { delete suite; }
 
-  void test_stringIsISO8601() {
-    TS_ASSERT(stringIsISO8601("1990-01-02 03:04:02.000"));
-    TS_ASSERT(stringIsISO8601("1990-01-02T03:04:02.000"));
-    TS_ASSERT(stringIsISO8601("1990-01-02T03:04:02.000+05:30"));
-    TS_ASSERT(stringIsISO8601("1990-01-02 03:04"));
-    TS_ASSERT(stringIsISO8601("1990-01-02"));
-    TS_ASSERT(stringIsISO8601("1822-01-02"));
-
-    TS_ASSERT(!stringIsISO8601("January 1, 2345"));
-    TS_ASSERT(!stringIsISO8601("2010-31-56"));
-    TS_ASSERT(!stringIsISO8601("1990-01-02 45:92:22"));
-  }
-
   void test_verifyAndSanitizeISO8601() {
     TS_ASSERT_EQUALS(verifyAndSanitizeISO8601("1990- 1- 2T03:04:02.000"),
                      "1990-01-02T03:04:02.000");

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -283,8 +283,8 @@ public:
     log1->addValue("2016-03-17T01:30:00", 4);
     log1->addValue("2016-03-17T02:00:00", 5);
     TimeSeriesProperty<bool> *filter1 = new TimeSeriesProperty<bool>("filter");
-    filter1->addValue("2016-Mar-17T00:00:00", 1);
-    filter1->addValue("2016-Mar-17T01:00:00", 0);
+    filter1->addValue("2016-Mar-17 00:00:00", 1);
+    filter1->addValue("2016-Mar-17 01:00:00", 0);
     log1->filterWith(filter1);
 
     TimeSeriesProperty<int> *log2 = new TimeSeriesProperty<int>("count_rate");
@@ -293,8 +293,8 @@ public:
     log2->addValue("2016-03-17T05:00:00", 3);
     log2->addValue("2016-03-17T06:00:0", 4);
     TimeSeriesProperty<bool> *filter2 = new TimeSeriesProperty<bool>("filter");
-    filter2->addValue("2016-Mar-17T03:00:00", 1);
-    filter2->addValue("2016-Mar-17T05:00:00", 0);
+    filter2->addValue("2016-Mar-17 03:00:00", 1);
+    filter2->addValue("2016-Mar-17 05:00:00", 0);
     log2->filterWith(filter2);
 
     TS_ASSERT(!(*log1 == *log2));

--- a/Framework/Types/CMakeLists.txt
+++ b/Framework/Types/CMakeLists.txt
@@ -1,19 +1,20 @@
-# This is not a module, there are no source files. Types in this folder must be header-only!
-
 set ( SRC_FILES 
   src/Core/DateAndTime.cpp
+  src/Core/DateAndTimeHelpers.cpp
   src/Event/TofEvent.cpp
 )
 
 set ( INC_FILES
   inc/MantidTypes/Core/DateAndTime.h
-  inc/MantidTypes/SpectrumDefinition.h
+  inc/MantidTypes/Core/DateAndTimeHelpers.h
   inc/MantidTypes/Event/TofEvent.h
+  inc/MantidTypes/SpectrumDefinition.h
 )
 
 set ( TEST_FILES
-  SpectrumDefinitionTest.h
   DateAndTimeTest.h
+  DateAndTimeHelpersTest.h
+  SpectrumDefinitionTest.h
   TofEventTest.h
 )
 

--- a/Framework/Types/inc/MantidTypes/Core/DateAndTimeHelpers.h
+++ b/Framework/Types/inc/MantidTypes/Core/DateAndTimeHelpers.h
@@ -10,6 +10,7 @@ namespace Types {
 namespace Core {
 namespace DateAndTimeHelpers {
 MANTID_TYPES_DLL bool stringIsISO8601(const std::string &date);
+MANTID_TYPES_DLL bool stringIsPosix(const std::string &date);
 } // namespace DateAndTimeHelpers
 } // namespace Core
 } // namespace Types

--- a/Framework/Types/inc/MantidTypes/Core/DateAndTimeHelpers.h
+++ b/Framework/Types/inc/MantidTypes/Core/DateAndTimeHelpers.h
@@ -1,0 +1,18 @@
+#ifndef MANTID_TYPES_CORE_DATEANDTIMEHELPERS_H_
+#define MANTID_TYPES_CORE_DATEANDTIMEHELPERS_H_
+
+#include "MantidTypes/DllConfig.h"
+
+#include <string>
+
+namespace Mantid {
+namespace Types {
+namespace Core {
+namespace DateAndTimeHelpers {
+MANTID_TYPES_DLL bool stringIsISO8601(const std::string &date);
+} // namespace DateAndTimeHelpers
+} // namespace Core
+} // namespace Types
+} // namespace Mantid
+
+#endif /* MANTID_TYPES_CORE_DATEANDTIMEHELPERS_H_ */

--- a/Framework/Types/src/Core/DateAndTime.cpp
+++ b/Framework/Types/src/Core/DateAndTime.cpp
@@ -367,7 +367,8 @@ const DateAndTime &DateAndTime::defaultTime() {
  *               "yyyy-mm-ddThh:mm:ss[Z+-]tz:tz" or "yyy-MMM-dd hh:mm:ss.ssss"
  */
 void DateAndTime::setFromISO8601(const std::string &str) {
-  if (!DateAndTimeHelpers::stringIsISO8601(str) && !DateAndTimeHelpers::stringIsPosix(str)) {
+  if (!DateAndTimeHelpers::stringIsISO8601(str) &&
+      !DateAndTimeHelpers::stringIsPosix(str)) {
     throw std::invalid_argument("Error interpreting string '" + str +
                                 "' as a date/time.");
   }

--- a/Framework/Types/src/Core/DateAndTime.cpp
+++ b/Framework/Types/src/Core/DateAndTime.cpp
@@ -361,14 +361,15 @@ const DateAndTime &DateAndTime::defaultTime() {
 }
 
 //------------------------------------------------------------------------------------------------
-/** Sets the date and time using an ISO8601-formatted string
+/** Sets the date and time using an ISO8601 or Posix formatted string
  *
- * @param str :: ISO8601 format string: "yyyy-mm-ddThh:mm:ss[Z+-]tz:tz"
+ * @param str :: ISO8601 or posix format string:
+ *               "yyyy-mm-ddThh:mm:ss[Z+-]tz:tz" or "yyy-MMM-dd hh:mm:ss.ssss"
  */
 void DateAndTime::setFromISO8601(const std::string &str) {
-  if (!DateAndTimeHelpers::stringIsISO8601(str)) {
-    throw std::invalid_argument("The string '" + str +
-                                "' is not a valid ISO8601 time stamp.");
+  if (!DateAndTimeHelpers::stringIsISO8601(str) && !DateAndTimeHelpers::stringIsPosix(str)) {
+    throw std::invalid_argument("Error interpreting string '" + str +
+                                "' as a date/time.");
   }
   // Make a copy
   std::string time = str;

--- a/Framework/Types/src/Core/DateAndTime.cpp
+++ b/Framework/Types/src/Core/DateAndTime.cpp
@@ -1,5 +1,7 @@
 #include "MantidTypes/Core/DateAndTime.h"
 
+#include "MantidTypes/Core/DateAndTimeHelpers.h"
+
 namespace Mantid {
 namespace Types {
 namespace Core {
@@ -364,6 +366,10 @@ const DateAndTime &DateAndTime::defaultTime() {
  * @param str :: ISO8601 format string: "yyyy-mm-ddThh:mm:ss[Z+-]tz:tz"
  */
 void DateAndTime::setFromISO8601(const std::string &str) {
+  if (!DateAndTimeHelpers::stringIsISO8601(str)) {
+    throw std::invalid_argument("The string '" + str +
+                                "' is not a valid ISO8601 time stamp.");
+  }
   // Make a copy
   std::string time = str;
 

--- a/Framework/Types/src/Core/DateAndTimeHelpers.cpp
+++ b/Framework/Types/src/Core/DateAndTimeHelpers.cpp
@@ -13,7 +13,8 @@ namespace DateAndTimeHelpers {
  */
 bool stringIsISO8601(const std::string &date) {
   // On Ubuntu 14.04, std::regex seems to be broken, thus boost.
-  const boost::regex r(R"(^\d{4}-[01]\d-[0-3]\d([T\s][0-2]\d:[0-5]\d(:\d{2})?(.\d+)?(Z|[+-]\d{2}(:\d{2})?)?)?$)");
+  const boost::regex r(
+      R"(^\d{4}-[01]\d-[0-3]\d([T\s][0-2]\d:[0-5]\d(:\d{2})?(.\d+)?(Z|[+-]\d{2}(:\d{2})?)?)?$)");
   return boost::regex_match(date, r);
 }
 } // namespace DateAndTimeHelpers

--- a/Framework/Types/src/Core/DateAndTimeHelpers.cpp
+++ b/Framework/Types/src/Core/DateAndTimeHelpers.cpp
@@ -1,0 +1,22 @@
+#include "MantidTypes/Core/DateAndTimeHelpers.h"
+
+#include <boost/regex.hpp>
+
+namespace Mantid {
+namespace Types {
+namespace Core {
+namespace DateAndTimeHelpers {
+/** Check if a string is iso8601 format.
+ *
+ * @param date :: string to check
+ * @return true if the string conforms to ISO 860I, false otherwise.
+ */
+bool stringIsISO8601(const std::string &date) {
+  // On Ubuntu 14.04, std::regex seems to be broken, thus boost.
+  const boost::regex r(R"(^\d{4}-[01]\d-[0-3]\d([T\s][0-2]\d:[0-5]\d(:\d{2})?(.\d+)?(Z|[+-]\d{2}(:\d{2})?)?)?$)");
+  return boost::regex_match(date, r);
+}
+} // namespace DateAndTimeHelpers
+} // namespace Core
+} // namespace Types
+} // namespace Mantid

--- a/Framework/Types/src/Core/DateAndTimeHelpers.cpp
+++ b/Framework/Types/src/Core/DateAndTimeHelpers.cpp
@@ -6,16 +6,33 @@ namespace Mantid {
 namespace Types {
 namespace Core {
 namespace DateAndTimeHelpers {
-/** Check if a string is iso8601 format.
+/** Check if a string is in ISO8601 format.
  *
  * @param date :: string to check
- * @return true if the string conforms to ISO 860I, false otherwise.
+ * @return true if the string conforms to ISO 8601, false otherwise.
  */
 bool stringIsISO8601(const std::string &date) {
+  // Expecting most of Mantid's time stamp strings to be in the
+  // extended format --- check it first.
   // On Ubuntu 14.04, std::regex seems to be broken, thus boost.
-  const boost::regex r(
-      R"(^\d{4}-[01]\d-[0-3]\d([T\s][0-2]\d:[0-5]\d(:\d{2})?(.\d+)?(Z|[+-]\d{2}(:\d{2})?)?)?$)");
-  return boost::regex_match(date, r);
+  const boost::regex extendedFormat(
+      R"(^\d{4}-[01]\d-[0-3]\d([T\s][0-2]\d:[0-5]\d(:\d{2})?(.\d+)?(Z|[+-]\d{2}(:?\d{2})?)?)?$)");
+  if (!boost::regex_match(date, extendedFormat)) {
+    const boost::regex basicFormat(R"(^\d{4}[01]\d[0-3]\d([T\s][0-2]\d[0-5]\d(\d{2})?(.\d+)?(Z|[+-]\d{2}(:?\d{2})?)?)?$)");
+    return boost::regex_match(date, basicFormat);
+  }
+  return true;
+}
+
+/** Check if a string is in POSIX format.
+ *
+ * @param date :: string to check
+ * @return true if the string conforms to POSIX, false otherwise.
+ */
+bool stringIsPosix(const std::string &date) {
+  // Formatting taken from boost::to_simple_string.
+  const boost::regex format(R"(^\d{4}-[A-Z][a-z]{2}-[0-3]\d\s[0-2]\d:[0-5]\d:\d{2}(.\d+)?$)");
+  return boost::regex_match(date, format);
 }
 } // namespace DateAndTimeHelpers
 } // namespace Core

--- a/Framework/Types/src/Core/DateAndTimeHelpers.cpp
+++ b/Framework/Types/src/Core/DateAndTimeHelpers.cpp
@@ -18,7 +18,8 @@ bool stringIsISO8601(const std::string &date) {
   const boost::regex extendedFormat(
       R"(^\d{4}-[01]\d-[0-3]\d([T\s][0-2]\d:[0-5]\d(:\d{2})?(.\d+)?(Z|[+-]\d{2}(:?\d{2})?)?)?$)");
   if (!boost::regex_match(date, extendedFormat)) {
-    const boost::regex basicFormat(R"(^\d{4}[01]\d[0-3]\d([T\s][0-2]\d[0-5]\d(\d{2})?(.\d+)?(Z|[+-]\d{2}(:?\d{2})?)?)?$)");
+    const boost::regex basicFormat(
+        R"(^\d{4}[01]\d[0-3]\d([T\s][0-2]\d[0-5]\d(\d{2})?(.\d+)?(Z|[+-]\d{2}(:?\d{2})?)?)?$)");
     return boost::regex_match(date, basicFormat);
   }
   return true;
@@ -31,7 +32,8 @@ bool stringIsISO8601(const std::string &date) {
  */
 bool stringIsPosix(const std::string &date) {
   // Formatting taken from boost::to_simple_string.
-  const boost::regex format(R"(^\d{4}-[A-Z][a-z]{2}-[0-3]\d\s[0-2]\d:[0-5]\d:\d{2}(.\d+)?$)");
+  const boost::regex format(
+      R"(^\d{4}-[A-Z][a-z]{2}-[0-3]\d\s[0-2]\d:[0-5]\d:\d{2}(.\d+)?$)");
   return boost::regex_match(date, format);
 }
 } // namespace DateAndTimeHelpers

--- a/Framework/Types/test/DateAndTimeHelpersTest.h
+++ b/Framework/Types/test/DateAndTimeHelpersTest.h
@@ -15,10 +15,32 @@ public:
   }
   static void destroySuite(DateAndTimeHelpersTest *suite) { delete suite; }
 
-  void test_stringIsISO8601() {
+  void test_stringIsISO8601_basic_format() {
+    TS_ASSERT(stringIsISO8601("19900102 030402.000"));
+    TS_ASSERT(stringIsISO8601("19900102T030402.000"));
+    TS_ASSERT(stringIsISO8601("19900102T030402.000+05:30"));
+    TS_ASSERT(stringIsISO8601("19900102T030402.000+0530"));
+    TS_ASSERT(stringIsISO8601("19900102T030402.000+05"));
+    TS_ASSERT(stringIsISO8601("19900102 030402.000Z"))
+    TS_ASSERT(stringIsISO8601("19900102 030402Z"))
+    TS_ASSERT(stringIsISO8601("19900102 0304Z"))
+    TS_ASSERT(stringIsISO8601("19900102T0304Z"))
+    TS_ASSERT(stringIsISO8601("19900102 0304"));
+    TS_ASSERT(stringIsISO8601("19900102"));
+    TS_ASSERT(stringIsISO8601("18220102"));
+
+    TS_ASSERT(!stringIsISO8601("January 1, 2345"));
+    TS_ASSERT(!stringIsISO8601("20103156"));
+    TS_ASSERT(!stringIsISO8601("19900102 459222"));
+    TS_ASSERT(!stringIsISO8601("19900102 030402.000Z00:00"))
+  }
+
+  void test_stringIsISO8601_extended_format() {
     TS_ASSERT(stringIsISO8601("1990-01-02 03:04:02.000"));
     TS_ASSERT(stringIsISO8601("1990-01-02T03:04:02.000"));
     TS_ASSERT(stringIsISO8601("1990-01-02T03:04:02.000+05:30"));
+    TS_ASSERT(stringIsISO8601("1990-01-02T03:04:02.000+0530"));
+    TS_ASSERT(stringIsISO8601("1990-01-02T03:04:02.000+05"));
     TS_ASSERT(stringIsISO8601("1990-01-02 03:04:02.000Z"))
     TS_ASSERT(stringIsISO8601("1990-01-02 03:04:02Z"))
     TS_ASSERT(stringIsISO8601("1990-01-02 03:04Z"))
@@ -31,6 +53,21 @@ public:
     TS_ASSERT(!stringIsISO8601("2010-31-56"));
     TS_ASSERT(!stringIsISO8601("1990-01-02 45:92:22"));
     TS_ASSERT(!stringIsISO8601("1990-01-02 03:04:02.000Z00:00"))
+  }
+
+  void test_stringIsPosix() {
+    TS_ASSERT(stringIsPosix("1990-Jan-02 03:04:02.000"));
+    TS_ASSERT(stringIsPosix("1990-Jan-02 03:04:02"))
+
+    TS_ASSERT(!stringIsPosix("January 1, 2345"));
+    TS_ASSERT(!stringIsPosix("1990-01-02 03:04:02"))
+    TS_ASSERT(!stringIsPosix("1990-jan-01 02:04:02"))
+    TS_ASSERT(!stringIsPosix("2010-Jan-56"));
+    TS_ASSERT(!stringIsPosix("1990-Jan-02 45:92:22"));
+    TS_ASSERT(!stringIsPosix("1990-Jan-40 03:04:02"))
+    TS_ASSERT(!stringIsPosix("1990-Jan-01 30:04:02"))
+    TS_ASSERT(!stringIsPosix("1990-Jan-02 03:04:02.000Z"))
+    TS_ASSERT(!stringIsPosix("1990-Jan-40 03:04:02"))
   }
 };
 

--- a/Framework/Types/test/DateAndTimeHelpersTest.h
+++ b/Framework/Types/test/DateAndTimeHelpersTest.h
@@ -1,0 +1,37 @@
+#ifndef MANTID_TYPES_CORE_DATEANDTIMEHELPERSTEST_H_
+#define MANTID_TYPES_CORE_DATEANDTIMEHELPERSTEST_H_
+
+#include <cxxtest/TestSuite.h>
+#include "MantidTypes/Core/DateAndTimeHelpers.h"
+
+using namespace Mantid::Types::Core::DateAndTimeHelpers;
+
+class DateAndTimeHelpersTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static DateAndTimeHelpersTest *createSuite() {
+    return new DateAndTimeHelpersTest();
+  }
+  static void destroySuite(DateAndTimeHelpersTest *suite) { delete suite; }
+
+  void test_stringIsISO8601() {
+    TS_ASSERT(stringIsISO8601("1990-01-02 03:04:02.000"));
+    TS_ASSERT(stringIsISO8601("1990-01-02T03:04:02.000"));
+    TS_ASSERT(stringIsISO8601("1990-01-02T03:04:02.000+05:30"));
+    TS_ASSERT(stringIsISO8601("1990-01-02 03:04:02.000Z"))
+    TS_ASSERT(stringIsISO8601("1990-01-02 03:04:02Z"))
+    TS_ASSERT(stringIsISO8601("1990-01-02 03:04Z"))
+    TS_ASSERT(stringIsISO8601("1990-01-02T03:04Z"))
+    TS_ASSERT(stringIsISO8601("1990-01-02 03:04"));
+    TS_ASSERT(stringIsISO8601("1990-01-02"));
+    TS_ASSERT(stringIsISO8601("1822-01-02"));
+
+    TS_ASSERT(!stringIsISO8601("January 1, 2345"));
+    TS_ASSERT(!stringIsISO8601("2010-31-56"));
+    TS_ASSERT(!stringIsISO8601("1990-01-02 45:92:22"));
+    TS_ASSERT(!stringIsISO8601("1990-01-02 03:04:02.000Z00:00"))
+  }
+};
+
+#endif /* MANTID_TYPES_CORE_DATEANDTIMEHELPERSTEST_H_ */

--- a/docs/source/algorithms/ExportTimeSeriesLog-v1.rst
+++ b/docs/source/algorithms/ExportTimeSeriesLog-v1.rst
@@ -56,7 +56,7 @@ Usage
   for i in range(60):
       randsec = random.randint(0, 59)
       randval = random.random()*100.
-      timetemp = mk.DateAndTime("2012-01-01T00:%d:%d"%(i, randsec))
+      timetemp = mk.DateAndTime("2012-01-01T00:{:02}:{:02}".format(i, randsec))
       testprop.addValue(timetemp, randval)
   dataws.run().addProperty("Temp", testprop, True)
 
@@ -99,7 +99,7 @@ Output:
   for i in range(60):
       randsec = random.randint(0, 59)
       randval = random.random()*100.
-      timetemp = mk.DateAndTime("2012-01-01T00:%d:%d"%(i, randsec))
+      timetemp = mk.DateAndTime("2012-01-01T00:{:02}:{:02}".format(i, randsec))
       testprop.addValue(timetemp, randval)
   dataws.run().addProperty("Temp", testprop, True)
 

--- a/docs/source/release/v3.12.0/ui.rst
+++ b/docs/source/release/v3.12.0/ui.rst
@@ -15,6 +15,8 @@ Installation
 Workbench
 ---------
 
+- Fixed a bug where MantidPlot would crash if the sample log fields used for run start and end contained non-ISO8601 conforming values.
+
 SliceViewer and Vates Simple Interface
 --------------------------------------
 


### PR DESCRIPTION
This PR adds a check to `DateAndTime::setFomISO8601()` if the input string actually is ISO8601. This fixes a bug which could cause MantidPlot to crash.

As a part of this PR, `isStringISO8601()` was moved from the `Mantid::Kernel` namespace to `Mantid::Types` to gain access to it. The function was also rewritten to use `boost::regex` instead of the Poco library to not to introduce additional dependencies to `Mantid::Types`. Also, `isStringPosix` was added to the `Mantid::Types::Core::DateAndTimeHelpers` namespace since `DateAndTime::setFomISO8601()` should also handle Posix format strings.

**To test:**

Download the test data and follow the steps described in #20969.

Fixes #20969.

**Release Notes** 

The interface release notes were updated with a note about the bug fix.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
