### PR TITLE
Correctly handle units in parallel event loader

### DIFF
--- a/Framework/Parallel/inc/MantidParallel/IO/EventLoaderHelpers.h
+++ b/Framework/Parallel/inc/MantidParallel/IO/EventLoaderHelpers.h
@@ -81,6 +81,7 @@ void load(const Chunker &chunker, NXEventDataSource<TimeOffsetType> &dataSource,
       dataSink.wait();
     if (static_cast<int64_t>(range.bankIndex) != previousBank) {
       dataSink.setEventDataPartitioner(std::move(partitioner));
+      dataSink.setEventTimeOffsetUnit(dataSource.readEventTimeOffsetUnit());
       previousBank = range.bankIndex;
     }
     dataSink.startAsync(event_id.data() + bufferOffset,

--- a/Framework/Parallel/inc/MantidParallel/IO/NXEventDataLoader.h
+++ b/Framework/Parallel/inc/MantidParallel/IO/NXEventDataLoader.h
@@ -56,6 +56,7 @@ public:
                    size_t count) const override;
   void readEventTimeOffset(TimeOffsetType *event_time_offset, size_t start,
                            size_t count) const override;
+  std::string readEventTimeOffsetUnit() const override;
 
 private:
   const int m_numWorkers;
@@ -212,6 +213,13 @@ void NXEventDataLoader<TimeOffsetType>::readEventTimeOffset(
     TimeOffsetType *buffer, size_t start, size_t count) const {
   detail::read<TimeOffsetType>(buffer, m_group, "event_time_offset", start,
                                count);
+}
+
+/// Read and return the `units` attribute from event_time_offset.
+template <class TimeOffsetType>
+std::string NXEventDataLoader<TimeOffsetType>::readEventTimeOffsetUnit() const {
+  const auto timeOffset = m_group.openDataSet("event_time_offset");
+  return detail::readAttribute(timeOffset, "units");
 }
 
 } // namespace IO

--- a/Framework/Parallel/inc/MantidParallel/IO/NXEventDataLoader.h
+++ b/Framework/Parallel/inc/MantidParallel/IO/NXEventDataLoader.h
@@ -116,6 +116,7 @@ makeEventDataPartitioner(const H5::Group &group, const int numWorkers) {
       numWorkers, PulseTimeGenerator<IndexType, TimeZeroType>{
                       detail::read<IndexType>(group, "event_index"),
                       detail::read<TimeZeroType>(group, "event_time_zero"),
+                      "",
                       time_zero_offset});
 }
 

--- a/Framework/Parallel/inc/MantidParallel/IO/NXEventDataSource.h
+++ b/Framework/Parallel/inc/MantidParallel/IO/NXEventDataSource.h
@@ -49,6 +49,7 @@ public:
                            size_t count) const = 0;
   virtual void readEventTimeOffset(TimeOffsetType *event_time_offset,
                                    size_t start, size_t count) const = 0;
+  virtual std::string readEventTimeOffsetUnit() const = 0;
 };
 
 } // namespace IO

--- a/Framework/Parallel/test/EventDataPartitionerTest.h
+++ b/Framework/Parallel/test/EventDataPartitionerTest.h
@@ -37,8 +37,8 @@ public:
   void test_empty_range() {
     for (const auto workers : {1, 2, 3}) {
       EventDataPartitioner<int32_t, int64_t, double> partitioner(
-          workers,
-          PulseTimeGenerator<int32_t, int64_t>({0, 2, 2, 3}, {2, 4, 6, 8}, 0));
+          workers, PulseTimeGenerator<int32_t, int64_t>(
+                       {0, 2, 2, 3}, {2, 4, 6, 8}, "nanosecond", 0));
       size_t count = 0;
       std::vector<std::vector<Event>> data;
       partitioner.partition(data, nullptr, nullptr, {0, 1, count});
@@ -51,7 +51,8 @@ public:
 
   void test_partition_1_worker() {
     EventDataPartitioner<int32_t, int64_t, double> partitioner(
-        1, PulseTimeGenerator<int32_t, int64_t>({0, 2, 2, 3}, {2, 4, 6, 8}, 0));
+        1, PulseTimeGenerator<int32_t, int64_t>({0, 2, 2, 3}, {2, 4, 6, 8},
+                                                "nanosecond", 0));
     std::vector<std::vector<Event>> data;
     std::vector<int32_t> index{5, 1, 4};
     std::vector<double> tof{1.1, 2.2, 3.3};
@@ -73,7 +74,8 @@ public:
 
   void test_partition_2_workers() {
     EventDataPartitioner<int32_t, int64_t, double> partitioner(
-        2, PulseTimeGenerator<int32_t, int64_t>({0, 2, 2, 3}, {2, 4, 6, 8}, 0));
+        2, PulseTimeGenerator<int32_t, int64_t>({0, 2, 2, 3}, {2, 4, 6, 8},
+                                                "nanosecond", 0));
     std::vector<std::vector<Event>> data;
     std::vector<int32_t> index{5, 1, 4, 1};
     std::vector<double> tof{1.1, 2.2, 3.3, 4.4};
@@ -101,7 +103,8 @@ public:
 
   void test_partition_3_workers() {
     EventDataPartitioner<int32_t, int64_t, double> partitioner(
-        3, PulseTimeGenerator<int32_t, int64_t>({0, 2, 2, 3}, {2, 4, 6, 8}, 0));
+        3, PulseTimeGenerator<int32_t, int64_t>({0, 2, 2, 3}, {2, 4, 6, 8},
+                                                "nanosecond", 0));
     std::vector<std::vector<Event>> data;
     std::vector<int32_t> index{5, 1, 4, 1};
     std::vector<double> tof{1.1, 2.2, 3.3, 4.4};

--- a/Framework/Parallel/test/EventLoaderTest.h
+++ b/Framework/Parallel/test/EventLoaderTest.h
@@ -54,8 +54,8 @@ public:
     int64_t time_zero_offset = 123456789 + 1000000 * m_bank;
 
     return Kernel::make_unique<EventDataPartitioner<int64_t, int64_t, int32_t>>(
-        m_numWorkers, PulseTimeGenerator<int64_t, int64_t>{index, time_zero,
-                                                           time_zero_offset});
+        m_numWorkers, PulseTimeGenerator<int64_t, int64_t>{
+                          index, time_zero, "nanosecond", time_zero_offset});
   }
 
   void readEventID(int32_t *event_id, size_t start,

--- a/Framework/Parallel/test/EventParserTest.h
+++ b/Framework/Parallel/test/EventParserTest.h
@@ -139,17 +139,6 @@ public:
   static EventParserTest *createSuite() { return new EventParserTest(); }
   static void destroySuite(EventParserTest *suite) { delete suite; }
 
-  void test_conversion_to_time_of_flight() {
-    using detail::microseconds;
-    double tof{1.2345678987654321};
-    TS_ASSERT_EQUALS(microseconds(tof), tof);
-    TS_ASSERT_DELTA(microseconds(static_cast<float>(tof)), tof, 1e-7);
-    TS_ASSERT_EQUALS(microseconds(static_cast<int32_t>(1500)), double{1.5});
-    TS_ASSERT_EQUALS(microseconds(static_cast<int64_t>(1500)), double{1.5});
-    TS_ASSERT_EQUALS(microseconds(static_cast<uint32_t>(1500)), double{1.5});
-    TS_ASSERT_EQUALS(microseconds(static_cast<uint64_t>(1500)), double{1.5});
-  }
-
   void testConstruct() {
     std::vector<std::vector<int>> rankGroups;
     std::vector<int32_t> bankOffsets{1, 2, 3, 4};
@@ -226,6 +215,7 @@ public:
         Kernel::make_unique<EventDataPartitioner<int32_t, int32_t, double>>(
             1, PulseTimeGenerator<int32_t, int32_t>{
                    gen.eventIndex(0), gen.eventTimeZero(), "nanosecond", 0}));
+    parser->setEventTimeOffsetUnit("microsecond");
     auto event_id = gen.eventId(0);
     auto event_time_offset = gen.eventTimeOffset(0);
 
@@ -243,6 +233,7 @@ public:
         Kernel::make_unique<EventDataPartitioner<int32_t, int64_t, float>>(
             1, PulseTimeGenerator<int32_t, int64_t>{
                    gen.eventIndex(0), gen.eventTimeZero(), "nanosecond", 0}));
+    parser->setEventTimeOffsetUnit("microsecond");
     auto event_id = gen.eventId(0);
     auto event_time_offset = gen.eventTimeOffset(0);
 
@@ -264,6 +255,7 @@ public:
           Kernel::make_unique<EventDataPartitioner<int32_t, int64_t, double>>(
               1, PulseTimeGenerator<int32_t, int64_t>{
                      gen.eventIndex(i), gen.eventTimeZero(), "nanosecond", 0}));
+      parser->setEventTimeOffsetUnit("microsecond");
       auto event_id = gen.eventId(i);
       auto event_time_offset = gen.eventTimeOffset(i);
 
@@ -281,6 +273,7 @@ public:
         Kernel::make_unique<EventDataPartitioner<int32_t, int64_t, double>>(
             1, PulseTimeGenerator<int32_t, int64_t>{
                    gen.eventIndex(0), gen.eventTimeZero(), "nanosecond", 0}));
+    parser->setEventTimeOffsetUnit("microsecond");
     auto event_id = gen.eventId(0);
     auto event_time_offset = gen.eventTimeOffset(0);
 
@@ -313,6 +306,7 @@ public:
               1, PulseTimeGenerator<int32_t, int64_t>{gen.eventIndex(bank),
                                                       gen.eventTimeZero(),
                                                       "nanosecond", 0}));
+      parser->setEventTimeOffsetUnit("microsecond");
       auto event_id = gen.eventId(bank);
       auto event_time_offset = gen.eventTimeOffset(bank);
 
@@ -333,6 +327,52 @@ public:
       }
     }
     gen.checkEventLists();
+  }
+
+  void test_setEventTimeOffsetUnit() {
+    std::vector<std::vector<int>> rankGroups;
+    std::vector<int32_t> bankOffsets{0};
+    std::vector<TofEvent> eventList;
+    std::vector<std::vector<TofEvent> *> eventLists{&eventList};
+    Parallel::Communicator comm;
+    EventParser<double> parser(comm, rankGroups, bankOffsets, eventLists);
+    PulseTimeGenerator<int32_t, int32_t> pulseTimes({0}, {0}, "nanosecond", 0);
+
+    parser.setEventDataPartitioner(
+        Kernel::make_unique<EventDataPartitioner<int32_t, int32_t, double>>(
+            1, std::move(pulseTimes)));
+
+    int32_t event_id{0};
+    const double event_time_offset{1.5};
+    const Chunker::LoadRange range{0, 0, 1};
+
+    parser.startAsync(&event_id, &event_time_offset, range);
+    parser.wait();
+    TS_ASSERT_EQUALS(eventList.size(), 1);
+    TS_ASSERT_EQUALS(eventList[0].tof(), 0.0);
+
+    parser.setEventTimeOffsetUnit("second");
+    parser.startAsync(&event_id, &event_time_offset, range);
+    parser.wait();
+    TS_ASSERT_EQUALS(eventList.size(), 2);
+    TS_ASSERT_EQUALS(eventList[1].tof(), 1.5e6);
+
+    parser.setEventTimeOffsetUnit("microsecond");
+    parser.startAsync(&event_id, &event_time_offset, range);
+    parser.wait();
+    TS_ASSERT_EQUALS(eventList.size(), 3);
+    TS_ASSERT_EQUALS(eventList[2].tof(), 1.5);
+
+    parser.setEventTimeOffsetUnit("nanosecond");
+    parser.startAsync(&event_id, &event_time_offset, range);
+    parser.wait();
+    TS_ASSERT_EQUALS(eventList.size(), 4);
+    TS_ASSERT_EQUALS(eventList[3].tof(), 1.5e-3);
+
+    TS_ASSERT_THROWS_EQUALS(
+        parser.setEventTimeOffsetUnit("millisecond"),
+        const std::runtime_error &e, std::string(e.what()),
+        "EventParser: unsupported unit `millisecond` for event_time_offset");
   }
 
 private:
@@ -383,6 +423,7 @@ public:
           Kernel::make_unique<EventDataPartitioner<int32_t, int64_t, double>>(
               1, PulseTimeGenerator<int32_t, int64_t>{
                      gen.eventIndex(i), gen.eventTimeZero(), "nanosecond", 0}));
+      parser->setEventTimeOffsetUnit("microsecond");
       parser->startAsync(event_ids[i].data(), event_time_offsets[i].data(),
                          gen.generateBasicRange(i));
       parser->wait();
@@ -397,10 +438,6 @@ public:
                             event_time_offsets[bank].data(),
                             gen.generateBasicRange(bank));
     }
-  }
-
-  void testPopulateEventListsPerformance() {
-    detail::populateEventLists(rankData[0], m_eventListPtrs);
   }
 
 private:

--- a/Framework/Parallel/test/EventParserTest.h
+++ b/Framework/Parallel/test/EventParserTest.h
@@ -184,7 +184,7 @@ public:
     std::vector<std::vector<EventParser<double>::Event>> rankData;
     // event_id now contains spectrum indices
     EventDataPartitioner<int32_t, int64_t, double> partitioner(
-        1, {gen.eventIndex(0), gen.eventTimeZero(), 0});
+        1, {gen.eventIndex(0), gen.eventTimeZero(), "nanosecond", 0});
     partitioner.partition(rankData, event_id.data(),
                           event_time_offset.data() + range.eventOffset, range);
 
@@ -206,7 +206,7 @@ public:
     std::vector<std::vector<EventParser<double>::Event>> rankData;
     // event_id now contains spectrum indices
     EventDataPartitioner<int32_t, int64_t, double> partitioner(
-        1, {gen.eventIndex(0), gen.eventTimeZero(), 0});
+        1, {gen.eventIndex(0), gen.eventTimeZero(), "nanosecond", 0});
     partitioner.partition(rankData, event_id.data(),
                           event_time_offset.data() + range.eventOffset, range);
 
@@ -224,8 +224,8 @@ public:
     auto parser = gen.generateTestParser();
     parser->setEventDataPartitioner(
         Kernel::make_unique<EventDataPartitioner<int32_t, int32_t, double>>(
-            1, PulseTimeGenerator<int32_t, int32_t>{gen.eventIndex(0),
-                                                    gen.eventTimeZero(), 0}));
+            1, PulseTimeGenerator<int32_t, int32_t>{
+                   gen.eventIndex(0), gen.eventTimeZero(), "nanosecond", 0}));
     auto event_id = gen.eventId(0);
     auto event_time_offset = gen.eventTimeOffset(0);
 
@@ -241,8 +241,8 @@ public:
     auto parser = gen.generateTestParser();
     parser->setEventDataPartitioner(
         Kernel::make_unique<EventDataPartitioner<int32_t, int64_t, float>>(
-            1, PulseTimeGenerator<int32_t, int64_t>{gen.eventIndex(0),
-                                                    gen.eventTimeZero(), 0}));
+            1, PulseTimeGenerator<int32_t, int64_t>{
+                   gen.eventIndex(0), gen.eventTimeZero(), "nanosecond", 0}));
     auto event_id = gen.eventId(0);
     auto event_time_offset = gen.eventTimeOffset(0);
 
@@ -262,8 +262,8 @@ public:
     for (int i = 0; i < numBanks; i++) {
       parser->setEventDataPartitioner(
           Kernel::make_unique<EventDataPartitioner<int32_t, int64_t, double>>(
-              1, PulseTimeGenerator<int32_t, int64_t>{gen.eventIndex(i),
-                                                      gen.eventTimeZero(), 0}));
+              1, PulseTimeGenerator<int32_t, int64_t>{
+                     gen.eventIndex(i), gen.eventTimeZero(), "nanosecond", 0}));
       auto event_id = gen.eventId(i);
       auto event_time_offset = gen.eventTimeOffset(i);
 
@@ -279,8 +279,8 @@ public:
     auto parser = gen.generateTestParser();
     parser->setEventDataPartitioner(
         Kernel::make_unique<EventDataPartitioner<int32_t, int64_t, double>>(
-            1, PulseTimeGenerator<int32_t, int64_t>{gen.eventIndex(0),
-                                                    gen.eventTimeZero(), 0}));
+            1, PulseTimeGenerator<int32_t, int64_t>{
+                   gen.eventIndex(0), gen.eventTimeZero(), "nanosecond", 0}));
     auto event_id = gen.eventId(0);
     auto event_time_offset = gen.eventTimeOffset(0);
 
@@ -311,7 +311,8 @@ public:
       parser->setEventDataPartitioner(
           Kernel::make_unique<EventDataPartitioner<int32_t, int64_t, double>>(
               1, PulseTimeGenerator<int32_t, int64_t>{gen.eventIndex(bank),
-                                                      gen.eventTimeZero(), 0}));
+                                                      gen.eventTimeZero(),
+                                                      "nanosecond", 0}));
       auto event_id = gen.eventId(bank);
       auto event_time_offset = gen.eventTimeOffset(bank);
 
@@ -343,7 +344,7 @@ private:
                                                     TimeOffsetType> &gen,
                  const Chunker::LoadRange &range) {
     PulseTimeGenerator<IndexType, TimeZeroType> pulseTimes(
-        gen.eventIndex(0), gen.eventTimeZero(), 0);
+        gen.eventIndex(0), gen.eventTimeZero(), "nanosecond", 0);
     pulseTimes.seek(range.eventOffset);
     TS_ASSERT_EQUALS(rankData[0].size(), range.eventCount);
     for (const auto &item : rankData[0]) {
@@ -380,8 +381,8 @@ public:
     for (size_t i = 0; i < NUM_BANKS; ++i) {
       parser->setEventDataPartitioner(
           Kernel::make_unique<EventDataPartitioner<int32_t, int64_t, double>>(
-              1, PulseTimeGenerator<int32_t, int64_t>{gen.eventIndex(i),
-                                                      gen.eventTimeZero(), 0}));
+              1, PulseTimeGenerator<int32_t, int64_t>{
+                     gen.eventIndex(i), gen.eventTimeZero(), "nanosecond", 0}));
       parser->startAsync(event_ids[i].data(), event_time_offsets[i].data(),
                          gen.generateBasicRange(i));
       parser->wait();
@@ -391,7 +392,7 @@ public:
   void testExtractEventsPerformance() {
     for (size_t bank = 0; bank < NUM_BANKS; bank++) {
       EventDataPartitioner<int32_t, int64_t, double> partitioner(
-          1, {gen.eventIndex(bank), gen.eventTimeZero(), 0});
+          1, {gen.eventIndex(bank), gen.eventTimeZero(), "nanosecond", 0});
       partitioner.partition(rankData, event_ids[bank].data(),
                             event_time_offsets[bank].data(),
                             gen.generateBasicRange(bank));

--- a/Framework/Parallel/test/PulseTimeGeneratorTest.h
+++ b/Framework/Parallel/test/PulseTimeGeneratorTest.h
@@ -3,10 +3,14 @@
 
 #include <cxxtest/TestSuite.h>
 
+#include <type_traits>
+
 #include "MantidParallel/IO/PulseTimeGenerator.h"
 
 using PulseTimeGenerator =
     Mantid::Parallel::IO::PulseTimeGenerator<int32_t, int32_t>;
+using Mantid::Parallel::IO::detail::scaleFromUnit;
+using Mantid::Parallel::IO::detail::IntOrFloat64Bit;
 
 class PulseTimeGeneratorTest : public CxxTest::TestSuite {
 public:
@@ -17,21 +21,66 @@ public:
   }
   static void destroySuite(PulseTimeGeneratorTest *suite) { delete suite; }
 
+  void test_scaleFromUnit_integer_converted_to_nanoseconds() {
+    // DateAndTime expects int64_t to be in nanoseconds so if unit does not
+    // match there must be an appropriate conversion factor.
+    TS_ASSERT_EQUALS(scaleFromUnit<int32_t>("nanosecond"), 1);
+    TS_ASSERT_EQUALS(scaleFromUnit<uint32_t>("nanosecond"), 1);
+    TS_ASSERT_EQUALS(scaleFromUnit<int64_t>("nanosecond"), 1);
+    TS_ASSERT_EQUALS(scaleFromUnit<uint64_t>("nanosecond"), 1);
+    // Would supporting anything by `second` make sense for integers?
+    TS_ASSERT_THROWS_EQUALS(
+        scaleFromUnit<int64_t>("second"), const std::runtime_error &e,
+        std::string(e.what()),
+        "PulseTimeGenerator: unsupported unit `second` for event_time_zero");
+  }
+
+  void test_scaleFromUnit_float_converted_to_microseconds() {
+    // DateAndTime expects double to be in seconds so if unit does not match
+    // there must be an appropriate conversion factor.
+    TS_ASSERT_EQUALS(scaleFromUnit<float>("second"), 1.0);
+    TS_ASSERT_EQUALS(scaleFromUnit<double>("second"), 1.0);
+    TS_ASSERT_EQUALS(scaleFromUnit<float>("microsecond"), 1e-6);
+    TS_ASSERT_EQUALS(scaleFromUnit<double>("microsecond"), 1e-6);
+    TS_ASSERT_EQUALS(scaleFromUnit<float>("nanosecond"), 1e-9);
+    TS_ASSERT_EQUALS(scaleFromUnit<double>("nanosecond"), 1e-9);
+    // Currently not supported (but in principle we could).
+    TS_ASSERT_THROWS_EQUALS(scaleFromUnit<float>("millisecond"),
+                            const std::runtime_error &e, std::string(e.what()),
+                            "PulseTimeGenerator: unsupported unit "
+                            "`millisecond` for event_time_zero");
+  }
+
+  void test_scaleFromUnit_does_not_lose_precision() {
+    // Return type should be double, even if input is float
+    TS_ASSERT_DIFFERS(scaleFromUnit<float>("nanosecond"),
+                      static_cast<float>(1e-9));
+  }
+
+  void test_IntOrFloat64Bit() {
+    TS_ASSERT((std::is_same<IntOrFloat64Bit<int32_t>::type, int64_t>::value));
+    TS_ASSERT((std::is_same<IntOrFloat64Bit<uint32_t>::type, int64_t>::value));
+    TS_ASSERT((std::is_same<IntOrFloat64Bit<int64_t>::type, int64_t>::value));
+    TS_ASSERT((std::is_same<IntOrFloat64Bit<uint64_t>::type, int64_t>::value));
+    TS_ASSERT((std::is_same<IntOrFloat64Bit<float>::type, double>::value));
+    TS_ASSERT((std::is_same<IntOrFloat64Bit<double>::type, double>::value));
+  }
+
   void test_empty() {
-    PulseTimeGenerator pulseTimes({}, {}, 1000);
+    PulseTimeGenerator pulseTimes({}, {}, "nanosecond", 1000);
     TS_ASSERT_THROWS_EQUALS(pulseTimes.seek(0), const std::runtime_error &e,
                             std::string(e.what()),
                             "Empty event index in PulseTimeGenerator");
   }
 
   void test_no_seek() {
-    PulseTimeGenerator pulseTimes({0}, {17}, 1000);
+    PulseTimeGenerator pulseTimes({0}, {17}, "nanosecond", 1000);
     // seek() must always called before the first next() call
     TS_ASSERT_EQUALS(pulseTimes.next().totalNanoseconds(), 0);
   }
 
   void test_size_1() {
-    PulseTimeGenerator pulseTimes({0}, {17}, 1000);
+    PulseTimeGenerator pulseTimes({0}, {17}, "nanosecond", 1000);
     pulseTimes.seek(0);
     TS_ASSERT_EQUALS(pulseTimes.next().totalNanoseconds(), 1017);
     TS_ASSERT_EQUALS(pulseTimes.next().totalNanoseconds(), 1017);
@@ -39,7 +88,7 @@ public:
   }
 
   void test_size_2() {
-    PulseTimeGenerator pulseTimes({0, 2}, {4, 8}, 1000);
+    PulseTimeGenerator pulseTimes({0, 2}, {4, 8}, "nanosecond", 1000);
     pulseTimes.seek(0);
     TS_ASSERT_EQUALS(pulseTimes.next().totalNanoseconds(), 1004);
     TS_ASSERT_EQUALS(pulseTimes.next().totalNanoseconds(), 1004);
@@ -48,7 +97,7 @@ public:
   }
 
   void test_empty_pulse_at_start() {
-    PulseTimeGenerator pulseTimes({0, 0, 2}, {4, 8, 12}, 1000);
+    PulseTimeGenerator pulseTimes({0, 0, 2}, {4, 8, 12}, "nanosecond", 1000);
     pulseTimes.seek(0);
     TS_ASSERT_EQUALS(pulseTimes.next().totalNanoseconds(), 1008);
     TS_ASSERT_EQUALS(pulseTimes.next().totalNanoseconds(), 1008);
@@ -57,7 +106,8 @@ public:
   }
 
   void test_empty_pulse() {
-    PulseTimeGenerator pulseTimes({0, 2, 2, 3}, {4, 8, 12, 16}, 1000);
+    PulseTimeGenerator pulseTimes({0, 2, 2, 3}, {4, 8, 12, 16}, "nanosecond",
+                                  1000);
     pulseTimes.seek(0);
     TS_ASSERT_EQUALS(pulseTimes.next().totalNanoseconds(), 1004);
     TS_ASSERT_EQUALS(pulseTimes.next().totalNanoseconds(), 1004);
@@ -67,7 +117,7 @@ public:
   }
 
   void test_empty_pulse_at_end() {
-    PulseTimeGenerator pulseTimes({0, 2, 2}, {4, 8, 12}, 1000);
+    PulseTimeGenerator pulseTimes({0, 2, 2}, {4, 8, 12}, "nanosecond", 1000);
     pulseTimes.seek(0);
     TS_ASSERT_EQUALS(pulseTimes.next().totalNanoseconds(), 1004);
     TS_ASSERT_EQUALS(pulseTimes.next().totalNanoseconds(), 1004);
@@ -76,28 +126,30 @@ public:
   }
 
   void test_seek_to_pulse() {
-    PulseTimeGenerator pulseTimes({0, 2}, {4, 8}, 1000);
+    PulseTimeGenerator pulseTimes({0, 2}, {4, 8}, "nanosecond", 1000);
     pulseTimes.seek(2);
     TS_ASSERT_EQUALS(pulseTimes.next().totalNanoseconds(), 1008);
     TS_ASSERT_EQUALS(pulseTimes.next().totalNanoseconds(), 1008);
   }
 
   void test_seek_into_pulse() {
-    PulseTimeGenerator pulseTimes({0, 2}, {4, 8}, 1000);
+    PulseTimeGenerator pulseTimes({0, 2}, {4, 8}, "nanosecond", 1000);
     pulseTimes.seek(1);
     TS_ASSERT_EQUALS(pulseTimes.next().totalNanoseconds(), 1004);
     TS_ASSERT_EQUALS(pulseTimes.next().totalNanoseconds(), 1008);
   }
 
   void test_seek_with_empty_pulse() {
-    PulseTimeGenerator pulseTimes({0, 2, 2, 3}, {4, 8, 12, 16}, 1000);
+    PulseTimeGenerator pulseTimes({0, 2, 2, 3}, {4, 8, 12, 16}, "nanosecond",
+                                  1000);
     pulseTimes.seek(2);
     TS_ASSERT_EQUALS(pulseTimes.next().totalNanoseconds(), 1012);
     TS_ASSERT_EQUALS(pulseTimes.next().totalNanoseconds(), 1016);
   }
 
   void test_seek_multiple_times() {
-    PulseTimeGenerator pulseTimes({0, 2, 2, 3}, {4, 8, 12, 16}, 1000);
+    PulseTimeGenerator pulseTimes({0, 2, 2, 3}, {4, 8, 12, 16}, "nanosecond",
+                                  1000);
     pulseTimes.seek(1);
     TS_ASSERT_EQUALS(pulseTimes.next().totalNanoseconds(), 1004);
     pulseTimes.seek(3);
@@ -105,13 +157,21 @@ public:
   }
 
   void test_seek_backwards() {
-    PulseTimeGenerator pulseTimes({0, 2, 2, 3}, {4, 8, 12, 16}, 1000);
+    PulseTimeGenerator pulseTimes({0, 2, 2, 3}, {4, 8, 12, 16}, "nanosecond",
+                                  1000);
     pulseTimes.seek(1);
     TS_ASSERT_EQUALS(pulseTimes.next().totalNanoseconds(), 1004);
     TS_ASSERT_EQUALS(pulseTimes.next().totalNanoseconds(), 1012);
     pulseTimes.seek(1);
     TS_ASSERT_EQUALS(pulseTimes.next().totalNanoseconds(), 1004);
     TS_ASSERT_EQUALS(pulseTimes.next().totalNanoseconds(), 1012);
+  }
+
+  void test_event_time_zero_type_conversion() {
+    Mantid::Parallel::IO::PulseTimeGenerator<int32_t, float> pulseTimes(
+        {0}, {1.5}, "microsecond", 10000);
+    pulseTimes.seek(0);
+    TS_ASSERT_EQUALS(pulseTimes.next().totalNanoseconds(), 11500);
   }
 };
 


### PR DESCRIPTION
Previously this made assumptions about default units, now they are read from the `units` attribute defined by the Nexus standard.

**To test:**

Code review.

Fixes #21015.

No release notes since this is not used in anything public.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
