### PR TITLE
Fix modernize-deprecated-headers warnings

### DIFF
--- a/Framework/CurveFitting/src/FuncMinimizers/MoreSorensenMinimizer.cpp
+++ b/Framework/CurveFitting/src/FuncMinimizers/MoreSorensenMinimizer.cpp
@@ -4,9 +4,9 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidCurveFitting/FuncMinimizers/MoreSorensenMinimizer.h"
-#include "MantidCurveFitting/RalNlls/TrustRegion.h"
 #include "MantidAPI/FuncMinimizerFactory.h"
-#include <math.h>
+#include "MantidCurveFitting/RalNlls/TrustRegion.h"
+#include <cmath>
 
 namespace Mantid {
 namespace CurveFitting {

--- a/Framework/CurveFitting/src/FuncMinimizers/TrustRegionMinimizer.cpp
+++ b/Framework/CurveFitting/src/FuncMinimizers/TrustRegionMinimizer.cpp
@@ -6,7 +6,7 @@
 #include "MantidCurveFitting/FuncMinimizers/TrustRegionMinimizer.h"
 #include "MantidCurveFitting/RalNlls/TrustRegion.h"
 
-#include <math.h>
+#include <cmath>
 
 namespace Mantid {
 namespace CurveFitting {

--- a/Framework/CurveFitting/src/Functions/CrystalFieldPeakUtils.cpp
+++ b/Framework/CurveFitting/src/Functions/CrystalFieldPeakUtils.cpp
@@ -7,7 +7,7 @@
 #include "MantidKernel/make_unique.h"
 
 #include <algorithm>
-#include <math.h>
+#include <cmath>
 #include <iostream>
 
 namespace Mantid {

--- a/Framework/CurveFitting/src/RalNlls/TrustRegion.cpp
+++ b/Framework/CurveFitting/src/RalNlls/TrustRegion.cpp
@@ -10,9 +10,9 @@
 #include <limits>
 #include <string>
 
+#include <cmath>
 #include <gsl/gsl_blas.h>
 #include <gsl/gsl_linalg.h>
-#include <math.h>
 
 namespace Mantid {
 namespace CurveFitting {

--- a/qt/widgets/common/src/QtPropertyBrowser/ParameterPropertyManager.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/ParameterPropertyManager.cpp
@@ -1,8 +1,8 @@
 #include "MantidQtWidgets/Common/QtPropertyBrowser/ParameterPropertyManager.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/qtpropertymanager.h"
 
+#include <cmath>
 #include <stdexcept>
-#include <math.h>
 
 const QString ParameterPropertyManager::ERROR_TOOLTIP(" (Error)");
 


### PR DESCRIPTION
Take care of all the `clang-tidy` `modernize-deprecated-headers` warnings.

**To test:**

Code review and builds passing are all that is needed.

*There is no associated issue.*

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
