### PR TITLE
Re #21011 Fix missaligned ticks on 2D plots

### DIFF
--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -7557,7 +7557,7 @@ void ApplicationWindow::zoomIn() {
   QList<Graph *> layers = plot->layersList();
   foreach (Graph *g, layers) {
     if (!g->isPiePlot())
-      g->zoom(true);
+      g->zoomMode(true);
   }
 }
 

--- a/MantidPlot/src/Graph.cpp
+++ b/MantidPlot/src/Graph.cpp
@@ -62,8 +62,8 @@
 #include "Mantid/ErrorBarSettings.h"
 #include "Mantid/MantidMDCurve.h"
 #include "Mantid/MantidMatrixCurve.h"
-#include "MantidKernel/Strings.h"
 #include "MantidAPI/AnalysisDataService.h"
+#include "MantidKernel/Strings.h"
 #include "MantidQtWidgets/Common/PlotAxis.h"
 #include "MantidQtWidgets/Common/QwtRasterDataMD.h"
 #include "MantidQtWidgets/Common/QwtWorkspaceSpectrumData.h"
@@ -187,7 +187,7 @@ Graph::Graph(int x, int y, int width, int height, QWidget *parent, Qt::WFlags f)
       new QwtPlotZoomer(QwtPlot::xTop, QwtPlot::yRight,
                         QwtPicker::DragSelection | QwtPicker::CornerToCorner,
                         QwtPicker::AlwaysOff, d_plot->canvas());
-  zoom(false);
+  zoomMode(false);
 
   c_type = QVector<int>();
   c_keys = QVector<int>();
@@ -3357,14 +3357,20 @@ bool Graph::zoomOn() {
   return (d_zoomer[0]->isEnabled() || d_zoomer[1]->isEnabled());
 }
 
-void Graph::zoomed(const QwtDoubleRect &) { emit modifiedGraph(); }
+void Graph::zoomed(const QwtDoubleRect &) {
+  updateSecondaryAxis(QwtPlot::xTop);
+  updateSecondaryAxis(QwtPlot::yRight);
+  d_plot->replot();
+  emit modifiedGraph();
+}
+
 bool Graph::hasActiveTool() {
   return (zoomOn() || drawLineActive() || d_active_tool || d_peak_fit_tool ||
           d_magnifier || d_panner ||
           (d_range_selector && d_range_selector->isVisible()));
 }
 
-void Graph::zoom(bool on) {
+void Graph::zoomMode(bool on) {
   d_zoomer[0]->setEnabled(on);
   d_zoomer[1]->setEnabled(false);
   for (int i = 0; i < n_curves; i++) {
@@ -4566,7 +4572,7 @@ void Graph::setActiveTool(PlotToolInterface *tool) {
 
 void Graph::disableTools() {
   if (zoomOn())
-    zoom(false);
+    zoomMode(false);
   enablePanningMagnifier(false);
   if (drawLineActive())
     drawLine(false);

--- a/MantidPlot/src/Graph.h
+++ b/MantidPlot/src/Graph.h
@@ -448,7 +448,7 @@ public slots:
   //! \name Zoom
   //@{
   void zoomed(const QwtDoubleRect &);
-  void zoom(bool on);
+  void zoomMode(bool on);
   void zoomOut();
   bool zoomOn();
   //@}


### PR DESCRIPTION
Fixes #21011 by updating the secondary axes and re-plotting after a zoom.

Additionally this PR reduces tidies up some of the code in `Plot.cpp` - originally thought to be the cause of the bug.

**To test:**
1. Open a 2D plot
2. Zoom into an area of the plot.
3. Ensure that the markers on the top axes line up with the markers on the bottom and the same for the left and right axes.

- I am not sure if the changes to `Graph.cpp` have other undesirable effects on other plots.
- I am not sure if the contents of `PlotTick.cpp/.h` should be split into more, separate files. 

*Please sanity check this PR*

Fixes #21011 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
