### PR TITLE
Fix ISIS SANS GUI failing to find file on UNIX

### DIFF
--- a/docs/source/release/v3.12.0/lowq.rst
+++ b/docs/source/release/v3.12.0/lowq.rst
@@ -14,5 +14,6 @@ Reflectometry
 
 Small Angle Scattering
 ----------------------
+- Fixed a bug in the old GUI where loading files on UNIX systems would not work unless the file name was in uppercase letters.
 
 :ref:`Release 3.12.0 <v3.12.0>`

--- a/scripts/SANS/isis_reduction_steps.py
+++ b/scripts/SANS/isis_reduction_steps.py
@@ -3888,7 +3888,6 @@ class UserFile(ReductionStep):
         @param arguments: the arguments of a QResolution line
         @param reducer: a reducer object
         '''
-        arguments = arguments.upper()
         if arguments.find('=') == -1:
             return self._read_q_resolution_line_on_off(arguments, reducer)
 
@@ -3897,7 +3896,7 @@ class UserFile(ReductionStep):
         arguments = [element.strip() for element in arguments]
 
         # Check if it is the moderator file name, if so add it and return
-        if arguments[0].startswith('MODERATOR'):
+        if arguments[0].upper().startswith('MODERATOR'):
             # pylint: disable=bare-except
             try:
                 reducer.to_Q.set_q_resolution_moderator(file_name=arguments[1])


### PR DESCRIPTION
The SANS GUI could not file a file it was looking for on UNIX systems because it was converting the file path to uppercase.

**To test:**
 - Reproduce the bug from the instructions in the issue.
 - Code review

Fixes #21037 

**Release Notes** 
[See here](https://github.com/mantidproject/mantid/blob/73e3ef6beacc889be29c0e733b77d91e3ed92ffc/docs/source/release/v3.12.0/lowq.rst)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
