### PR TITLE
Sample Transmission Calculator - Do not allow negative wavelengths in the spin boxes

### DIFF
--- a/qt/scientific_interfaces/General/SampleTransmission.ui
+++ b/qt/scientific_interfaces/General/SampleTransmission.ui
@@ -86,7 +86,7 @@
               <number>3</number>
              </property>
              <property name="minimum">
-              <double>-99.989999999999995</double>
+              <double>0.000000000000000</double>
              </property>
              <property name="singleStep">
               <double>0.100000000000000</double>
@@ -106,7 +106,7 @@
               <number>3</number>
              </property>
              <property name="minimum">
-              <double>-99.989999999999995</double>
+              <double>0.000000000000000</double>
              </property>
              <property name="singleStep">
               <double>0.100000000000000</double>
@@ -126,7 +126,7 @@
               <number>3</number>
              </property>
              <property name="minimum">
-              <double>-99.989999999999995</double>
+              <double>0.000000000000000</double>
              </property>
              <property name="singleStep">
               <double>0.100000000000000</double>


### PR DESCRIPTION
This is a simple change to set 0 as the minimum value in the wavelength spin boxes in the sample transmission claculator.

**To test:**

1. Open Mantid,
1. Interfaces-> General->Sample Transmission Calculator
1. Try to enter a negative value in the wavelength boxes.

Fixes #20706. 

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
