### PR TITLE
Add links to our privacy pollicy

### DIFF
--- a/MantidPlot/src/Mantid/FirstTimeSetup.cpp
+++ b/MantidPlot/src/Mantid/FirstTimeSetup.cpp
@@ -138,15 +138,16 @@ void FirstTimeSetup::allowUsageDataStateChanged(int checkedState) {
     msgBox.setWindowTitle("Mantid: Report Usage Data ");
     msgBox.setTextFormat(Qt::RichText); // this is what makes the links
                                         // clickable
-    msgBox.setText("Are you sure you want to disable reporting <a "
-                   "href='http://reports.mantidproject.org'>usage data</a>?");
+    msgBox.setText("Are you sure you want to disable reporting of <a "
+                   "href='http://reports.mantidproject.org'>usage data</a>?"
+                   "\t(full details in our <a href='http://www.mantidproject.org/MantidProject:Privacy_policy#Usage_Data_recorded_in_Mantid'>Privacy Policy</a>)");
     msgBox.setInformativeText(
-        "All usage data is anonymous and untraceable.\n"
-        "We use the usage data to inform the future development of Mantid.\n"
-        "If you click \"Yes\" aspects you need risk being deprecated in "
-        "future versions if we think they are not used.\n\n"
-        "Are you sure you still want to disable reporting usage data?\n"
-        "Please click \"No\".");
+      "All usage data is anonymous and untraceable.\n"
+      "We use the usage data to inform the future development of Mantid.\n"
+      "If you click \"Yes\" aspects you need risk being deprecated in "
+      "future versions if we think they are not used.\n\n"
+      "Are you sure you still want to disable reporting usage data?\n"
+      "Please click \"No\".");
     msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
     msgBox.setDefaultButton(QMessageBox::No);
     msgBox.setEscapeButton(QMessageBox::No);

--- a/MantidPlot/src/Mantid/FirstTimeSetup.cpp
+++ b/MantidPlot/src/Mantid/FirstTimeSetup.cpp
@@ -140,14 +140,17 @@ void FirstTimeSetup::allowUsageDataStateChanged(int checkedState) {
                                         // clickable
     msgBox.setText("Are you sure you want to disable reporting of <a "
                    "href='http://reports.mantidproject.org'>usage data</a>?"
-                   "\t(full details in our <a href='http://www.mantidproject.org/MantidProject:Privacy_policy#Usage_Data_recorded_in_Mantid'>Privacy Policy</a>)");
+                   "\t(full details in our <a "
+                   "href='http://www.mantidproject.org/"
+                   "MantidProject:Privacy_policy#Usage_Data_recorded_in_Mantid'"
+                   ">Privacy Policy</a>)");
     msgBox.setInformativeText(
-      "All usage data is anonymous and untraceable.\n"
-      "We use the usage data to inform the future development of Mantid.\n"
-      "If you click \"Yes\" aspects you need risk being deprecated in "
-      "future versions if we think they are not used.\n\n"
-      "Are you sure you still want to disable reporting usage data?\n"
-      "Please click \"No\".");
+        "All usage data is anonymous and untraceable.\n"
+        "We use the usage data to inform the future development of Mantid.\n"
+        "If you click \"Yes\" aspects you need risk being deprecated in "
+        "future versions if we think they are not used.\n\n"
+        "Are you sure you still want to disable reporting usage data?\n"
+        "Please click \"No\".");
     msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
     msgBox.setDefaultButton(QMessageBox::No);
     msgBox.setEscapeButton(QMessageBox::No);

--- a/MantidPlot/src/Mantid/FirstTimeSetup.ui
+++ b/MantidPlot/src/Mantid/FirstTimeSetup.ui
@@ -566,25 +566,6 @@ background-color: qlineargradient(spread:pad, x1:0, y1:1, x2:0, y2:0, stop:0 rgb
                 </property>
                </widget>
               </item>
-              <item row="3" column="1">
-               <widget class="QCheckBox" name="chkAllowUsageData">
-                <property name="styleSheet">
-                 <string notr="true">padding: 4px;</string>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="iconSize">
-                 <size>
-                  <width>16</width>
-                  <height>16</height>
-                 </size>
-                </property>
-                <property name="checked">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
               <item row="3" column="0">
                <widget class="QLabel" name="lblAllowUsageData">
                 <property name="font">
@@ -603,6 +584,67 @@ background-color: qlineargradient(spread:pad, x1:0, y1:1, x2:0, y2:0, stop:0 rgb
                  <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
                 </property>
                </widget>
+              </item>
+              <item row="3" column="1">
+               <layout class="QHBoxLayout" name="horizontalLayout_8">
+                <property name="sizeConstraint">
+                 <enum>QLayout::SetDefaultConstraint</enum>
+                </property>
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QCheckBox" name="chkAllowUsageData">
+                  <property name="toolTip">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">padding: 4px;</string>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                  <property name="iconSize">
+                   <size>
+                    <width>16</width>
+                    <height>16</height>
+                   </size>
+                  </property>
+                  <property name="checked">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_4">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QLabel" name="lblPrivacyPolicy">
+                  <property name="text">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;http://www.mantidproject.org/MantidProject:Privacy_policy#Usage_Data_recorded_in_Mantid&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Privacy Policy&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <property name="textFormat">
+                   <enum>Qt::RichText</enum>
+                  </property>
+                  <property name="openExternalLinks">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
               </item>
              </layout>
             </item>
@@ -832,7 +874,6 @@ color: rgb(25,125,25);</string>
   <tabstop>cbFacility</tabstop>
   <tabstop>cbInstrument</tabstop>
   <tabstop>pbMUD</tabstop>
-  <tabstop>chkAllowUsageData</tabstop>
   <tabstop>pbCancel</tabstop>
   <tabstop>pbConfirm</tabstop>
  </tabstops>


### PR DESCRIPTION
Expanded our privacy policy to have details of our data retention for usage data and potential crash reporting.
Added links to the first time setup screen to point to the privacy policy

**To test:**

1. Start Mantid
1. On the first time setup screen you should have a link to our privacy policy next to the usage reporting checkbox.
1. If you unselect the box you should have another link in the dialog box that appears.
1. Read that section of the privacy policy record errors as bugs on this PR.

Yes the link to reports.mantidproject.org does not work, that is another issue.

Fixes #21074

**Release Notes** 
*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
