### PR TITLE
Fix crash in peaks viewer when deleting workspaces

### DIFF
--- a/docs/source/release/v3.12.0/ui.rst
+++ b/docs/source/release/v3.12.0/ui.rst
@@ -20,6 +20,7 @@ SliceViewer and Vates Simple Interface
 
 - Update SwitchToSliceViewer (shift + click) in MultiSlice view to work with nonorthogonal axes.
 - Pressing alt while clicking an arrow in the MultiSlice view opens a text box where one may precisely enter the slice position.
+- Fixed bug which would cause slice viewer to crash when deleting an overlaid peaks workspace.
 
 .. figure:: ../../images/VatesMultiSliceView.png
    :class: screenshot

--- a/qt/widgets/sliceviewer/src/CompositePeaksPresenter.cpp
+++ b/qt/widgets/sliceviewer/src/CompositePeaksPresenter.cpp
@@ -337,7 +337,11 @@ void CompositePeaksPresenter::setShown(
     return m_default->setShown(shown);
   }
   auto iterator = getPresenterIteratorFromWorkspace(peaksWS);
-  (*iterator)->setShown(shown);
+  // Need to check if the iterator exists as the workspace
+  // might have just been deleted.
+  if (*iterator) {
+    (*iterator)->setShown(shown);
+  }
 }
 
 /**

--- a/qt/widgets/sliceviewer/src/CompositePeaksPresenter.cpp
+++ b/qt/widgets/sliceviewer/src/CompositePeaksPresenter.cpp
@@ -337,11 +337,11 @@ void CompositePeaksPresenter::setShown(
     return m_default->setShown(shown);
   }
   auto iterator = getPresenterIteratorFromWorkspace(peaksWS);
-  if(iterator == m_subjects.end())
+  if (iterator == m_subjects.end())
     return;
 
   auto presenter = *iterator;
-  if(presenter)
+  if (presenter)
     presenter->setShown(shown);
 }
 

--- a/qt/widgets/sliceviewer/src/CompositePeaksPresenter.cpp
+++ b/qt/widgets/sliceviewer/src/CompositePeaksPresenter.cpp
@@ -337,11 +337,12 @@ void CompositePeaksPresenter::setShown(
     return m_default->setShown(shown);
   }
   auto iterator = getPresenterIteratorFromWorkspace(peaksWS);
-  // Need to check if the iterator exists as the workspace
-  // might have just been deleted.
-  if (*iterator) {
-    (*iterator)->setShown(shown);
-  }
+  if(iterator == m_subjects.end())
+    return;
+
+  auto presenter = *iterator;
+  if(presenter)
+    presenter->setShown(shown);
 }
 
 /**


### PR DESCRIPTION
Spotted while doing something else. I can make the peaks viewer crash Mantid by deleting all the workspaces while the slicer viewer is open and a peaks workspace is overlaid.

**To test:**

To reproduce:
 - Run the attached script
 - Right click on the `md` workspace
 - "Show slice viewer"
 - Drag and drop the `spherical_integration` peaks workspace over the slice viewer
 - Click on the row of the table that appears.
 - Now highlight and delete all the workspaces.
 - Mantid crashes.

Now apply changes and repeat. It should no longer crash

```python
import numpy as np

region_radius = 3.0
background = True

ws = LoadEmptyInstrument("/Users/samueljackson/git/mantid-main/instrument/IDFs_for_UNIT_TESTING/MINITOPAZ_Definition.xml")
ws.getAxis(0).setUnit("TOF")
ws = Rebin(ws, "0,1,1000")

conv = np.array([[.1, .0, .0],
                          [.0, .1, .0],
                          [.0, .0, 10.]])
peak_events = np.random.multivariate_normal((50,50,500), conv, 100000)

H, bins = np.histogramdd(peak_events, bins=(range(101), range(101), range(1001)))
d = H.reshape(10000, 1000)
b = np.random.normal(10, 1.0, size=(10000, 1000))
for i in range(ws.getNumberHistograms()):
    spec = d[i] 
    if background:
        spec += b[i]
    ws.setY(i, spec)

peaks = FindSXPeaks(ws, Resolution=1.0, PeakFindingStrategy='AllPeaks')
peak = peaks.getPeak(0)
peak.setHKL(1,1,1)

SetUB(ws, 1., 1, 1, 90, 90, 90)
SetUB(peaks, 1., 1, 1, 90, 90, 90)

md = ConvertToDiffractionMDWorkspace(ws, OneEventPerBin=False, extents=[-50,50, -50, 50, -50, 50])
ws = ConvertUnits(ws, Target='Wavelength')
peak_size = 0.8
bkg_inner = 1.0
bkg_outer = 2.0
region_radius = bkg_outer
spherical_integration = IntegratePeaksMD(md, peaks, peak_size, CorrectIfOnEdge=False, IntegrateIfOnEdge=True, BackgroundInnerRadius=bkg_inner, BackgroundOuterRadius=bkg_outer)

```

There's no issue associated with this PR

**Release Notes** 
[See here](https://github.com/mantidproject/mantid/pull/21090/commits/df477bad29540716d5f3dbed73f45094d26f49c4)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
