### PR TITLE
Fix *IsoRotDiff doc-tests for scipy 1.0.0

### DIFF
--- a/docs/source/fitfunctions/ElasticIsoRotDiff.rst
+++ b/docs/source/fitfunctions/ElasticIsoRotDiff.rst
@@ -56,7 +56,12 @@ following model:
 .. testcode:: ExampleElasticIsoRotDiff
 
     import numpy as np
-    from scipy.special import sph_jn
+    try:
+        from scipy.special import spherical_jn
+        def sjn(n, z): return spherical_jn(range(n+1), z)
+    except ImportError:
+        from scipy.special import sph_jn
+        def sjn(n, z): return sph_jn(n, z)[0]
     """Generate resolution function with the following properties:
     1. Normal distribution along the energy axis, same for all Q-values
     2. FWHM = 0.005 meV
@@ -90,7 +95,7 @@ following model:
         noise = dataY*np.random.random(nE)*0.1 # noise is up to 10% of the elastic signal
         background = np.random.random()+np.random.random()*dataX  # linear background
         background = (0.01*H*max(dataY)) * (background/max(np.abs(background))) # up to 1% of H
-        j0 = sph_jn(0,Q*R)[0][0]
+        j0 = sjn(0,Q*R)[0]
         qdataY=np.append(qdataY, H*j0**2*(dataY+noise) + background)
     # Create data workspace
     data=CreateWorkspace(np.tile(dataX,nQ), qdataY, NSpec=nQ, UnitX="deltaE",

--- a/docs/source/fitfunctions/InelasticIsoRotDiff.rst
+++ b/docs/source/fitfunctions/InelasticIsoRotDiff.rst
@@ -60,7 +60,12 @@ and the overal intensity of the signal with a fit to the following model:
 .. testcode:: ExampleInelasticIsoRotDiff
 
     import numpy as np
-    from scipy.special import sph_jn
+    try:
+        from scipy.special import spherical_jn
+        def sjn(n, z): return spherical_jn(range(n+1), z)
+    except ImportError:
+        from scipy.special import sph_jn
+        def sjn(n, z): return sph_jn(n, z)[0]
     """Generate resolution function with the following properties:
     1. Gaussian in Energy
     2. Dynamic range = [-0.1, 0.1] meV with spacing 0.0004 meV
@@ -87,7 +92,7 @@ and the overal intensity of the signal with a fit to the following model:
     for Q in Qs:
         centre=dE*np.random.random()  # some shift along the energy axis
         dataY=np.zeros(nE)  # holds the inelastic signal for this Q-value
-        js=sph_jn(N,Q*R)[0]  # spherical bessel functions from L=0 to L=N
+        js=sjn(N,Q*R)  # spherical bessel functions from L=0 to L=N
         for L in range(1,N+1):
             HWHM = L*(L+1)*hbar/tau; aL=(2*L+1)*js[L]**2
             dataY += H*aL/np.pi * HWHM/(HWHM**2+(dataX-centre)**2)  # add component

--- a/docs/source/fitfunctions/IsoRotDiff.rst
+++ b/docs/source/fitfunctions/IsoRotDiff.rst
@@ -59,7 +59,12 @@ and the overal intensity of the signal with a fit to the following model:
 .. testcode:: ExampleIsoRotDiff
 
     import numpy as np
-    from scipy.special import sph_jn
+    try:
+        from scipy.special import spherical_jn
+        def sjn(n, z): return spherical_jn(range(n+1), z)
+    except ImportError:
+        from scipy.special import sph_jn
+        def sjn(n, z): return sph_jn(n, z)[0]
     """Generate resolution function with the following properties:
     1. Gaussian in Energy
     2. Dynamic range = [-0.1, 0.1] meV with spacing 0.0004 meV
@@ -90,7 +95,7 @@ and the overal intensity of the signal with a fit to the following model:
     for Q in Qs:
         centre=0  # some shift along the energy axis
         dataY=np.zeros(nE)
-        js=sph_jn(N,Q*R)[0]  # spherical bessel functions from L=0 to L=N
+        js=sjn(N,Q*R) # spherical bessel functions from L=0 to L=N
         for L in range(1,N+1):
             HWHM = L*(L+1)*hbar/tau
             aL = (2*L+1)*js[L]**2


### PR DESCRIPTION
`scipy.special.sph_jn` was deprecated in scipy 0.18.0 and removed in 1.0.0, see [here](https://docs.scipy.org/doc/scipy-0.18.0/reference/generated/scipy.special.sph_jn.html). Arch LInux currently [fails on these tests](http://builds.mantidproject.org/job/master_clean-archlinux/1012/testReport/). Use `scipy.special.spherical_jn` instead, note that the new function has a different signature, see [here](https://docs.scipy.org/doc/scipy-0.18.0/reference/generated/scipy.special.spherical_jn.html)
 
Related #18988

**To test:**
Code review, tests should still pass


**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
