### PR TITLE
Switch default package suffix to unstable for Linuxes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ if( DATA_TARGETS_ONLY )
   return()
 endif()
 
-set ( CPACK_PACKAGE_SUFFIX "" CACHE STRING "suffix used to determine the deployment type")
+set ( CPACK_PACKAGE_SUFFIX "unstable" CACHE STRING "suffix used to determine the deployment type")
 set_property(CACHE CPACK_PACKAGE_SUFFIX PROPERTY STRINGS nightly unstable "") #empty string and release are treated as the same thing
 
 #Set package name here

--- a/buildconfig/CMake/CPackLinuxSetup.cmake
+++ b/buildconfig/CMake/CPackLinuxSetup.cmake
@@ -13,7 +13,6 @@ if (CMAKE_BINARY_DIR MATCHES "^${CMAKE_SOURCE_DIR}/.+")
   string (REGEX REPLACE "^${CMAKE_SOURCE_DIR}/([^\\/]+)(.*)\$" "/\\1/" _ignore_dir "${CMAKE_BINARY_DIR}")
   set (CPACK_SOURCE_IGNORE_FILES "${CPACK_SOURCE_IGNORE_FILES};${_ignore_dir}")
 endif ()
-message("CPACK_SOURCE_IGNORE_FILES = ${CPACK_SOURCE_IGNORE_FILES}")
 
 include (DetermineLinuxDistro)
 

--- a/buildconfig/CMake/LinuxPackageScripts.cmake
+++ b/buildconfig/CMake/LinuxPackageScripts.cmake
@@ -17,7 +17,7 @@ set ( PVPLUGINS_DIR pvplugins )
 set ( PVPLUGINS_SUBDIR pvplugins ) # Need to tidy these things up!
 
 if ( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
-  set ( CMAKE_INSTALL_PREFIX /opt/Mantid CACHE PATH "Install path" FORCE )
+  set ( CMAKE_INSTALL_PREFIX /opt/mantid${CPACK_PACKAGE_SUFFIX} CACHE PATH "Install path" FORCE )
 endif()
 
 set ( CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${LIB_DIR};${CMAKE_INSTALL_PREFIX}/${PLUGINS_DIR};${CMAKE_INSTALL_PREFIX}/${PVPLUGINS_DIR} )
@@ -64,15 +64,12 @@ install ( PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/mantid.sh
 # These are very different depending on the distribution so are contained
 # in the Packaging/*/scripts directory as CMake templates
 ############################################################################
-if ( NOT MPI_BUILD )
-  set ( ENVVARS_ON_INSTALL ON CACHE BOOL
-        "Whether to include the scripts in /etc/profile.d to set the MANTIDPATH variable and add it to PATH. Turning this off allows installing locally without being root." )
-endif()
+# We only manipulate the environment for  nprefixed non-MPI package builds
 # for shell maintainer scripts as ENVVARS_ON_INSTALL could have ON, OFF, True, False etc
-if ( ENVVARS_ON_INSTALL )
-  set ( ENVVARS_ON_INSTALL_INT 1 )
-else ()
+if ( MPI_BUILD OR CPACK_PACKAGE_SUFFIX )
   set ( ENVVARS_ON_INSTALL_INT 0 )
+else ()
+  set ( ENVVARS_ON_INSTALL_INT 1 )
 endif()
 
 # Common filenames to hold maintainer scripts

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -188,7 +188,9 @@ if [[ "$BUILDPKG" == true ]]; then
   # Set some variables relating to the linux packages
   if [[ ${ON_MACOS} != true ]]; then
     # Use different suffix for linux builds
-    if [[ ${JOB_NAME} == *master* ]]; then
+    if [[ ${JOB_NAME} == *release* ]]; then
+       PACKAGE_SUFFIX=""
+    elif [[ ${JOB_NAME} == *master* ]]; then
       PACKAGE_SUFFIX="nightly"
     elif [[ ${JOB_NAME} == *pvnext* ]]; then
       PACKAGE_SUFFIX="mantidunstable-pvnext"
@@ -200,6 +202,7 @@ if [[ "$BUILDPKG" == true ]]; then
       # Add '-python3' to package name and install path
       PACKAGE_SUFFIX=${PACKAGE_SUFFIX}-python3
     fi
+
     if [[ ${JOB_NAME} == *release* ]] && [[ ${PY2_BUILD} == true ]]; then
       # No suffix and traditional install path for python 2 release build
       PACKAGINGVARS="${PACKAGINGVARS} -DCMAKE_INSTALL_PREFIX=/opt/Mantid -DCPACK_PACKAGE_SUFFIX="

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -183,9 +183,7 @@ if [[ "$BUILDPKG" == true ]]; then
   # Set some variables relating to the linux packages
   if [[ ${ON_MACOS} != true ]]; then
     # Use different suffix for linux builds
-    if [[ ${JOB_NAME} == *release* ]]; then
-      echo "Performing release build" # do nothing
-    elif [[ ${JOB_NAME} == *master* ]]; then
+    if [[ ${JOB_NAME} == *master* ]]; then
       PACKAGE_SUFFIX="nightly"
     elif [[ ${JOB_NAME} == *pvnext* ]]; then
       PACKAGE_SUFFIX="mantidunstable-pvnext"
@@ -193,19 +191,14 @@ if [[ "$BUILDPKG" == true ]]; then
       PACKAGE_SUFFIX="unstable"
     fi
 
-    # Add '-python3' to package name and install path
-    if [[ ${JOB_NAME} == *python3* ]]; then
-	PACKAGE_SUFFIX=${PACKAGE_SUFFIX}-python3
-    fi
-
-    # Only unsuffixed release builds create envvars scripts
-    if [[ ${JOB_NAME} == *release* && -z "$PACKAGE_SUFFIX" ]]; then
-      PACKAGINGVARS="${PACKAGINGVARS} -DENVVARS_ON_INSTALL=True -DCPACK_SET_DESTDIR=ON"
+    if [[ ${JOB_NAME} == *release* ]]; then
+      # No suffix and traditional install path
+      PACKAGINGVARS="${PACKAGINGVARS} -DCMAKE_INSTALL_PREFIX=/opt/Mantid -DCPACK_PACKAGE_SUFFIX="
     else
-      PACKAGINGVARS="${PACKAGINGVARS} -DENVVARS_ON_INSTALL=False -DCPACK_SET_DESTDIR=OFF"
-    fi
-
-    if [ ! -z "$PACKAGE_SUFFIX" ]; then
+      if [[ ${JOB_NAME} == *python3* ]]; then
+        # Add '-python3' to package name and install path
+        PACKAGE_SUFFIX=${PACKAGE_SUFFIX}-python3
+      fi
       PACKAGINGVARS="${PACKAGINGVARS} -DCMAKE_INSTALL_PREFIX=/opt/mantid${PACKAGE_SUFFIX} -DCPACK_PACKAGE_SUFFIX=${PACKAGE_SUFFIX}"
     fi
   fi

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -169,10 +169,15 @@ fi
 ###############################################################################
 # Check if this is a Python 3 build and set CMake arguments.
 ###############################################################################
+PY2_BUILD=false
+PY3_BUILD=false
 if [[ ${JOB_NAME} == *python3* ]]; then
+  PY3_BUILD=true
   PYTHON3_EXECUTABLE=`which python3`
   DIST_FLAGS="${DIST_FLAGS} -DPYTHON_EXECUTABLE=$PYTHON3_EXECUTABLE"
   PARAVIEW_DIR="${PARAVIEW_DIR}-python3"
+else
+  PY2_BUILD=true
 fi
 
 ###############################################################################
@@ -191,14 +196,15 @@ if [[ "$BUILDPKG" == true ]]; then
       PACKAGE_SUFFIX="unstable"
     fi
 
-    if [[ ${JOB_NAME} == *release* ]]; then
-      # No suffix and traditional install path
+    if [[ ${PY3_BUILD} == true ]]; then
+      # Add '-python3' to package name and install path
+      PACKAGE_SUFFIX=${PACKAGE_SUFFIX}-python3
+    fi
+    if [[ ${JOB_NAME} == *release* ]] && [[ ${PY2_BUILD} == true ]]; then
+      # No suffix and traditional install path for python 2 release build
       PACKAGINGVARS="${PACKAGINGVARS} -DCMAKE_INSTALL_PREFIX=/opt/Mantid -DCPACK_PACKAGE_SUFFIX="
     else
-      if [[ ${JOB_NAME} == *python3* ]]; then
-        # Add '-python3' to package name and install path
-        PACKAGE_SUFFIX=${PACKAGE_SUFFIX}-python3
-      fi
+      # everything else uses lower-case values
       PACKAGINGVARS="${PACKAGINGVARS} -DCMAKE_INSTALL_PREFIX=/opt/mantid${PACKAGE_SUFFIX} -DCPACK_PACKAGE_SUFFIX=${PACKAGE_SUFFIX}"
     fi
   fi


### PR DESCRIPTION
Description of work.

Sets the default package suffix for linux builds to `unstable`.

**To test:**

Code review. Pay close attention to the buildscript changes.

Run cmake with `ENABLE_CPACK=ON` with a clean build to examine the effect of the changes. Check the package installation scripts have the ENVVARS_ON_INSTALL set as expected.

*No issue*

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
