### PR TITLE
Fix crash in slice viewer when replacing overlaid peaks workspace.

### DIFF
--- a/docs/source/release/v3.12.0/ui.rst
+++ b/docs/source/release/v3.12.0/ui.rst
@@ -24,6 +24,7 @@ SliceViewer and Vates Simple Interface
 
 - Update SwitchToSliceViewer (shift + click) in MultiSlice view to work with nonorthogonal axes.
 - Pressing alt while clicking an arrow in the MultiSlice view opens a text box where one may precisely enter the slice position.
+- Fixed a bug where overwriting peaks workspaces with overlaid in the slice viewer with peak backgrounds shown cause Mantid to crash.
 
 .. figure:: ../../images/VatesMultiSliceView.png
    :class: screenshot

--- a/qt/widgets/sliceviewer/src/PeakRepresentationSphere.cpp
+++ b/qt/widgets/sliceviewer/src/PeakRepresentationSphere.cpp
@@ -138,8 +138,10 @@ std::shared_ptr<PeakPrimitives> PeakRepresentationSphere::getDrawingInformation(
   drawingInformation->peakInnerRadiusX = scaleX * m_peakRadiusAtDistance.get();
   drawingInformation->peakInnerRadiusY = scaleY * m_peakRadiusAtDistance.get();
 
-  // If the outer radius is selected, then add the outer radius
-  if (this->m_showBackgroundRadius) {
+  // If the outer radius is selected, and we actually have an integrated
+  // background radius, then add the outer radius
+  if (this->m_showBackgroundRadius && m_backgroundInnerRadiusAtDistance &&
+      m_backgroundOuterRadiusAtDistance) {
     drawingInformation->backgroundOuterRadiusX =
         scaleX * m_backgroundOuterRadiusAtDistance.get();
     drawingInformation->backgroundOuterRadiusY =


### PR DESCRIPTION
While playing with the peaks viewer in the slice viewer I found I could crash Mantid under some circumstances when the peaks workspace gets replaced. 

With these changes it also seems to no longer plot the peaks overlay correctly after replacement. I have created [another issue](https://github.com/mantidproject/mantid/issues/21101) to look into this, but I feel it's more important to get the fix for the crash in now.

**To test:**

To reproduce:
 - Run the script below
 - Open slice viewer on the `md` workspace
 - Drag the `spherical_integration` workspace over the slice viewer and drop it.
 - Click the first peak
 - Toggle `show background`
 - Rerun the script with the slice viewer still open
 - Change the axes being plotted.

Apply the changes and you should find Mantid no longer crashes. 

Script for testing:
```python
import numpy as np

region_radius = 3.0
background = True

ws = LoadEmptyInstrument("/Users/samueljackson/git/mantid-main/instrument/IDFs_for_UNIT_TESTING/MINITOPAZ_Definition.xml")
ws.getAxis(0).setUnit("TOF")
ws = Rebin(ws, "0,1,1000")

conv = np.array([[.1, .0, .0],
                          [.0, .1, .0],
                          [.0, .0, 10.]])
peak_events = np.random.multivariate_normal((50,50,500), conv, 100000)

H, bins = np.histogramdd(peak_events, bins=(range(101), range(101), range(1001)))
d = H.reshape(10000, 1000)
b = np.random.normal(10, 1.0, size=(10000, 1000))
for i in range(ws.getNumberHistograms()):
    spec = d[i] 
    if background:
        spec += b[i]
    ws.setY(i, spec)

peaks = FindSXPeaks(ws, Resolution=1.0, PeakFindingStrategy='AllPeaks')
peak = peaks.getPeak(0)
peak.setHKL(1,1,1)

SetUB(ws, 1., 1, 1, 90, 90, 90)
SetUB(peaks, 1., 1, 1, 90, 90, 90)

md = ConvertToDiffractionMDWorkspace(ws, OneEventPerBin=False, extents=[-50,50, -50, 50, -50, 50])
ws = ConvertUnits(ws, Target='Wavelength')
peak_size = 5.0
bkg_inner = .0
bkg_outer = .0
region_radius = bkg_outer
spherical_integration = IntegratePeaksMD(md, peaks, peak_size, CorrectIfOnEdge=False, IntegrateIfOnEdge=True, BackgroundInnerRadius=bkg_inner, BackgroundOuterRadius=bkg_outer)
```

*There is no issue associated with this PR.*

**Release Notes** 
[See here](https://github.com/mantidproject/mantid/pull/21100/commits/05f688e7068aaa589db776f40d87b2ef77a5d72d)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
