### PR TITLE
Bug in MultidomainFunction python wrapper

### DIFF
--- a/Framework/PythonInterface/mantid/fitfunctions.py
+++ b/Framework/PythonInterface/mantid/fitfunctions.py
@@ -1,377 +1,383 @@
 from mantid.api import FunctionFactory, Workspace, AlgorithmManager
- 
+
+
 class FunctionWrapper(object):
-  """ Wrapper class for Fitting Function 
-  """
-  def __init__ (self, name, **kwargs):
-    """ 
-    Called when creating an instance
-    :param name: name of fitting function to create or 
-    an Ifunction object to wrap.
-    :param **kwargs: standard argument for __init__ function
+    """ Wrapper class for Fitting Function
     """
-    if not isinstance(name, str):
-       self.fun = name
-    else:
-       self.fun = FunctionFactory.createFunction(name)
-       # Deal with attributes first
-       for key in kwargs:
-          if key == "attributes":
-             atts = kwargs[key]
-             for keya in atts:
-               self.fun.setAttributeValue(keya, atts[keya])
-          elif self.fun.hasAttribute(key):
-             self.fun.setAttributeValue(key, kwargs[key])
-           
-       # Then deal with parameters        
-       for key in kwargs:
-          if key != "attributes" and not self.fun.hasAttribute(key):
-             self.fun.setParameter(key, kwargs[key])
+    def __init__ (self, name, **kwargs):
+        """
+        Called when creating an instance
+        :param name: name of fitting function to create or
+        an Ifunction object to wrap.
+        :param **kwargs: standard argument for __init__ function
+        """
+        if not isinstance(name, str):
+            self.fun = name
+        else:
+            self.fun = FunctionFactory.createFunction(name)
+        self._init_paramgeters_and_attributes(**kwargs)
+
+    def _init_paramgeters_and_attributes(self, **kwargs):
+        # Deal with attributes first
+        for key in kwargs:
+            if key == "attributes":
+                atts = kwargs[key]
+                for keya in atts:
+                    self.fun.setAttributeValue(keya, atts[keya])
+            elif self.fun.hasAttribute(key):
+                 self.fun.setAttributeValue(key, kwargs[key])
+
+        # Then deal with parameters
+        for key in kwargs:
+            if key != "attributes" and not self.fun.hasAttribute(key):
+                self.fun.setParameter(key, kwargs[key])
+
+    def __getattr__(self, item):
+        """
+        __getattr__ invoked when attribute item not found in the instance,
+        nor in the class, nor its superclasses.
+        :param item: named attribute
+        :return: attribute of self.fun instance, or any of the fitting
+        parameters or function attributes
+        """
+        if 'fun' in self.__dict__:
+            if hasattr(self.fun, item):
+                return getattr(self.fun, item)
+            else:
+                return self.__getitem__(item)
+
+    def __setattr__(self, key, value):
+        """
+        __setattr__ invoked when attribute key not found in the instance,
+        nor in the class, nor its superclasses.
+        Enables direct access to the attributes of self.fun instance, and
+        also to its fitting parameters and function attributes
+        :param key: named attribute
+        :param value: new value for the named attribute
+        """
+        if key == 'fun':
+            self.__dict__['fun'] = value  # initialize self.fun
+        elif 'fun' in self.__dict__ and hasattr(self.fun, key):
+            setattr(self.fun, key, value)  # key is attribute of instance self.fun
+        elif 'fun' in self.__dict__ and self.fun.hasAttribute(key):
+            self.fun.setAttributeValue(key, value)  # key is function attribute
+        elif 'fun' in self.__dict__ and self.fun.hasParameter(key):
+            self.fun.setParameter(key, value)  # key is fitting parameter
+        else:
+            self.__dict__[key] = value  # initialize self.key
  
-  def __getattr__(self, item):
-      """
-      __getattr__ invoked when attribute item not found in the instance,
-      nor in the class, nor its superclasses.
-      :param item: named attribute
-      :return: attribute of self.fun instance, or any of the fitting
-       parameters or function attributes
-      """
-      if 'fun' in self.__dict__:
-          if hasattr(self.fun, item):
-              return getattr(self.fun, item)
-          else:
-              return self.__getitem__(item)
- 
-  def __setattr__(self, key, value):
-      """
-      __setattr__ invoked when attribute key not found in the instance,
-      nor in the class, nor its superclasses.
-      Enables direct access to the attributes of self.fun instance, and
-      also to its fitting parameters and function attributes
-      :param key: named attribute 
-      :param value: new value for the named attribute
-      """
-      if key == 'fun':
-          self.__dict__['fun'] = value  # initialize self.fun
-      elif 'fun' in self.__dict__ and hasattr(self.fun, key):
-          setattr(self.fun, key, value)  # key is attribute of instance self.fun
-      elif 'fun' in self.__dict__ and self.fun.hasAttribute(key):
-          self.fun.setAttributeValue(key, value)  # key is function attribute
-      elif 'fun' in self.__dict__ and self.fun.hasParameter(key):
-          self.fun.setParameter(key, value)  # key is fitting parameter
-      else:
-          self.__dict__[key] = value  # initialize self.key
- 
-  def __getitem__ (self, name):
-      """ Called from array-like access on RHS
-          It should not be called directly.
-          :param name: name that appears in the []
-      """
-      if type(name) == type('string') and self.fun.hasAttribute(name):
-         return self.fun.getAttributeValue(name)
-      else:
-         return self.fun.getParameterValue(name)
-       
-  def __setitem__ (self, name, value):
-      """ Called from array-like access on LHS
-          It should not be called directly.
-       
-          :param name: name that appears in the []
-          :param value: new value of this item
-      """
-      if type(name) == type('string') and self.fun.hasAttribute(name):
-         self.fun.setAttributeValue(name, value)
-      else:
-         self.fun.setParameter(name, value)
-       
-  def __str__ (self):
-      """ Return string giving contents of function.
+    def __getitem__ (self, name):
+        """ Called from array-like access on RHS
+        It should not be called directly.
+        :param name: name that appears in the []
+        """
+        if type(name) == type('string') and self.fun.hasAttribute(name):
+            return self.fun.getAttributeValue(name)
+        else:
+            return self.fun.getParameterValue(name)
+
+    def __setitem__ (self, name, value):
+        """ Called from array-like access on LHS
+        It should not be called directly.
+
+        :param name: name that appears in the []
+        :param value: new value of this item
+        """
+        if type(name) == type('string') and self.fun.hasAttribute(name):
+            self.fun.setAttributeValue(name, value)
+        else:
+            self.fun.setParameter(name, value)
+
+    def __str__ (self):
+        """ Return string giving contents of function.
           Used in unit tests.
-      """
-      return self.fun.__str__()
+        """
+        return str(self.fun)
  
-  def __add__ (self, other):
-      """ Implement + operator for composite function
-       
-          :param other: functionWrapper to be added to self
-      """
-      sum = CompositeFunctionWrapper(self, other)
-      if sum.pureAddition:
-         sum = sum.flatten()
-      return sum    
-         
-  def __mul__ (self, other):
-      """ Implement * operator for product function
-       
-          :param other: functionWrapper to multiply self by
-      """
-      prod = ProductFunctionWrapper(self, other)
-      if prod.pureMultiplication:
-         prod = prod.flatten()
-      return prod
-      
-  def __call__(self, x, *params):
-      """ Implement function evaluation, such that
-          func(args) is equivalent func.__call__(args)
-           
-          :param x: x value or list of x values
-          :param *params list of parameter values
-      """
-      import numpy as np
-      
-      if isinstance(x, Workspace):
-          # If the input is a workspace, simply return the output workspace.
-          return self._execute_algorithm('EvaluateFunction', Function=self.fun, InputWorkspace=x)
-       
-      list_input =  isinstance(x, list)
-      numpy_input = isinstance(x, np.ndarray)      
-      if numpy_input:
-          # If the input is a numpy array reshape into 1D array, saving
-          # original shape to reshape output back to it.
-          x_list = x.reshape(-1, order='C')
-          x_shape = x.shape         
-      elif list_input:
-          # If the input isn't a list, wrap it in one so we can iterate easily
-          x_list = x
-      else:
-          x_list = [x]
-      
-      for i in range(len(params)):
-          self.fun.setParameter(i, params[i])
-      y = x_list[:]
-      ws = self._execute_algorithm('CreateWorkspace', DataX=x_list, DataY=y)
-      out = self._execute_algorithm('EvaluateFunction', Function=self.fun, InputWorkspace=ws)
-      # Create a copy of the calculated spectrum
-      output_array = np.array(out.readY(1))
-      if numpy_input:
-         return output_array.reshape(x_shape, order='C')
+    def __add__ (self, other):
+        """ Implement + operator for composite function
 
-      if list_input:
-        return output_array
-      else:
-        return output_array[0]
-        
-  def plot(self, **kwargs):
-      """ Plot the function
-      
-          :param workspace=ws: workspace upon whose x values 
+        :param other: functionWrapper to be added to self
+        """
+        sum = CompositeFunctionWrapper(self, other)
+        if sum.pureAddition:
+            sum = sum.flatten()
+        return sum
+
+    def __mul__ (self, other):
+        """ Implement * operator for product function
+
+        :param other: functionWrapper to multiply self by
+        """
+        prod = ProductFunctionWrapper(self, other)
+        if prod.pureMultiplication:
+            prod = prod.flatten()
+        return prod
+
+    def __call__(self, x, *params):
+        """ Implement function evaluation, such that
+        func(args) is equivalent func.__call__(args)
+
+        :param x: x value or list of x values
+        :param *params list of parameter values
+        """
+        import numpy as np
+
+        if isinstance(x, Workspace):
+            # If the input is a workspace, simply return the output workspace.
+            return self._execute_algorithm('EvaluateFunction', Function=self.fun, InputWorkspace=x)
+
+        list_input =  isinstance(x, list)
+        numpy_input = isinstance(x, np.ndarray)
+        if numpy_input:
+            # If the input is a numpy array reshape into 1D array, saving
+            # original shape to reshape output back to it.
+            x_list = x.reshape(-1, order='C')
+            x_shape = x.shape
+        elif list_input:
+            # If the input isn't a list, wrap it in one so we can iterate easily
+            x_list = x
+        else:
+            x_list = [x]
+
+        for i in range(len(params)):
+            self.fun.setParameter(i, params[i])
+        y = x_list[:]
+        ws = self._execute_algorithm('CreateWorkspace', DataX=x_list, DataY=y)
+        out = self._execute_algorithm('EvaluateFunction', Function=self.fun, InputWorkspace=ws)
+        # Create a copy of the calculated spectrum
+        output_array = np.array(out.readY(1))
+        if numpy_input:
+            return output_array.reshape(x_shape, order='C')
+
+        if list_input:
+            return output_array
+        else:
+            return output_array[0]
+
+    def plot(self, **kwargs):
+        """ Plot the function
+
+          :param workspace=ws: workspace upon whose x values
           the function is plotted.
-      """
-      from mantid import mtd
-      try:
-          from mantidplot import plot 
-      except:
-          raise RuntimeError("mantidplot must be importable to plot functions.")
-      from mantid.simpleapi import CreateWorkspace
-      import numpy as np
+        """
+        from mantid import mtd
+        try:
+            from mantidplot import plot
+        except:
+            raise RuntimeError("mantidplot must be importable to plot functions.")
+        from mantid.simpleapi import CreateWorkspace
+        import numpy as np
+
+        isWorkspace = False
+        extractSpectrum = False
+        workspaceIndex = 0
+        haveXValues = False
+        haveStartX = False
+        haveEndX = False
+        nSteps = 20
+        plotName = self.name
       
-      isWorkspace = False
-      extractSpectrum = False
-      workspaceIndex = 0
-      haveXValues = False
-      haveStartX = False
-      haveEndX = False
-      nSteps = 20
-      plotName = self.name
-      
-      def inRange(x):
-         return x >= xMin and x <= xMax
+        def inRange(x):
+            return x >= xMin and x <= xMax
 
-      for key in kwargs:
-        if key == "workspace":
-           isWorkspace = True
-           ws = kwargs[key]
-           if type(ws) == type('string'):
-              ws = mtd[ws]
-        if key == "workspaceIndex":
-           workspaceIndex = kwargs[key]
-           if workspaceIndex > 0:
-              extractSpectrum = True
-        if key == "xValues":
-           xvals = kwargs[key]
-           haveXValues = True
-        if key == "startX":
-           xMin = kwargs[key]
-           haveStartX = True
-        if key == "endX":
-           xMax = kwargs[key]
-           haveEndX = True
-        if key == "nSteps":
-           nSteps = kwargs[key]
-           if nSteps < 1:
-              raise RuntimeError("nSteps must be at least 1")
-        if key == "name":
-           plotName = kwargs[key]
-           
-      if haveStartX and haveEndX:
-          if xMin >= xMax:
-             raise RuntimeError("startX must be less than EndX")
+        for key in kwargs:
+            if key == "workspace":
+                isWorkspace = True
+                ws = kwargs[key]
+                if type(ws) == type('string'):
+                    ws = mtd[ws]
+            if key == "workspaceIndex":
+                 workspaceIndex = kwargs[key]
+                 if workspaceIndex > 0:
+                     extractSpectrum = True
+            if key == "xValues":
+                 xvals = kwargs[key]
+                 haveXValues = True
+            if key == "startX":
+                 xMin = kwargs[key]
+                 haveStartX = True
+            if key == "endX":
+                 xMax = kwargs[key]
+                 haveEndX = True
+            if key == "nSteps":
+                 nSteps = kwargs[key]
+                 if nSteps < 1:
+                    raise RuntimeError("nSteps must be at least 1")
+            if key == "name":
+                 plotName = kwargs[key]
 
-      if haveXValues:
-          spectrumWs = self._execute_algorithm('CreateWorkspace', DataX=xvals, DataY=xvals)
-      elif isWorkspace:
-          xvals = ws.readX(workspaceIndex)
-          if haveStartX and haveEndX:
-              xvals = filter(inRange, xvals)
-          if extractSpectrum or (haveStartX and haveEndX):
-              spectrumWs = self._execute_algorithm('CreateWorkspace', DataX=xvals, DataY=xvals)
-          else:
-              spectrumWs = ws           
-      elif haveStartX and haveEndX:
-          xvals = np.linspace(start=xMin, stop=xMax, num=nSteps)
-          spectrumWs = self._execute_algorithm('CreateWorkspace', DataX=xvals, DataY=xvals)
-      else:
-          if not haveStartX:
-             raise RuntimeError("startX must be defined if no workspace or xValues are defined.") 
-          if not haveEndX:
-             raise RuntimeError("endX must be defined if no workspace or xValues are defined.")
-          else:
-             raise RuntimeError("insufficient plotting arguments") # Should not occur.
+        if haveStartX and haveEndX:
+            if xMin >= xMax:
+                raise RuntimeError("startX must be less than EndX")
 
-      outWs = self(spectrumWs)
-      vals = outWs.readY(1)
-      function = CreateWorkspace( DataX=xvals, DataY=vals, OutputWorkspace=plotName)
-      plot(plotName,0)
+        if haveXValues:
+            spectrumWs = self._execute_algorithm('CreateWorkspace', DataX=xvals, DataY=xvals)
+        elif isWorkspace:
+            xvals = ws.readX(workspaceIndex)
+            if haveStartX and haveEndX:
+                xvals = filter(inRange, xvals)
+            if extractSpectrum or (haveStartX and haveEndX):
+                spectrumWs = self._execute_algorithm('CreateWorkspace', DataX=xvals, DataY=xvals)
+            else:
+                spectrumWs = ws
+        elif haveStartX and haveEndX:
+            xvals = np.linspace(start=xMin, stop=xMax, num=nSteps)
+            spectrumWs = self._execute_algorithm('CreateWorkspace', DataX=xvals, DataY=xvals)
+        else:
+            if not haveStartX:
+                raise RuntimeError("startX must be defined if no workspace or xValues are defined.")
+            if not haveEndX:
+                raise RuntimeError("endX must be defined if no workspace or xValues are defined.")
+            else:
+                raise RuntimeError("insufficient plotting arguments") # Should not occur.
+
+        outWs = self(spectrumWs)
+        vals = outWs.readY(1)
+        function = CreateWorkspace( DataX=xvals, DataY=vals, OutputWorkspace=plotName)
+        plot(plotName,0)
          
-  def tie (self, *args, **kwargs):
-    """ Add ties.
-        :param *args: one or more dictionaries of ties
-        :param **kwargs: one or more ties
-    """
-    for a in args:
-        if isinstance(a, dict):
-          for key in a:
-            self.fun.tie(key, str(a[key]))
- 
-    for key in kwargs:
-        self.fun.tie(key, str(kwargs[key]))
-         
-  def fix(self, name):
-      """ Fix a parameter.
-       
+    def tie (self, *args, **kwargs):
+        """ Add ties.
+            :param *args: one or more dictionaries of ties
+            :param **kwargs: one or more ties
+        """
+        for a in args:
+            if isinstance(a, dict):
+                for key in a:
+                    self.fun.tie(key, str(a[key]))
+
+        for key in kwargs:
+            self.fun.tie(key, str(kwargs[key]))
+
+    def fix(self, name):
+        """ Fix a parameter.
+
           :param name: name of parameter to be fixed
-      """
-      self.fun.fixParameter(name)
+        """
+        self.fun.fixParameter(name)
        
-  def fixAllParameters(self):
-       """ Fix all parameters.
-       """
-       self.fun.fixAll()
+    def fixAllParameters(self):
+        """ Fix all parameters.
+        """
+        self.fun.fixAll()
        
-  def untie(self, name):
-      """ Remove tie from parameter.
-       
-          :param name: name of parameter to be untied
-      """
-      self.fun.removeTie(name)
-       
-  def untieAllParameters(self):
-      """ Remove ties from all parameters.
-      """
-      for i in range(0, self.fun.numParams()):  
-          self.fun.removeTie(self.getParameterName(i))  
- 
-           
-  def constrain(self, expressions):
-      """ Add constraints
-       
-          :param expressions: string of tie expressions      
-      """
-      self.fun.addConstraints( expressions )
-       
-  def unconstrain(self, name):
-      """ Remove constraints from a parameter
-       
-          :param name: name of parameter to be unconstrained
-      """
-      self.fun.removeConstraint(name)
-            
-  def free(self, name):
-      """ Free a parameter from tie or constraint
-       
-          :param name: name of parameter to be freed
-      """
-      self.fun.removeTie(name)
-      self.fun.removeConstraint(name)
-       
-  def getParameterName(self, index):
-      """ Get the name of the parameter of given index
-       
-          :param index: index of parameter
-      """
-      return self.fun.getParamName(index)
-        
-  @property
-  def function(self):
-      """ Return the underlying IFunction object
-      """      
-      return self.fun
- 
-  @property
-  def name(self):
-      """ Return the name of the function
-      """
-      return self.fun.name()
+    def untie(self, name):
+        """ Remove tie from parameter.
 
-  def _execute_algorithm(self, name, **kwargs):
-    alg = AlgorithmManager.createUnmanaged(name)
-    alg.setChild(True)
-    alg.initialize()
-    # Python 3 treats **kwargs as an unordered list meaning it is possible
-    # to pass InputWorkspace into EvaluateFunction before Function.
-    # As a special case has been made for this. This case can be removed
-    # with ordered kwargs change in Python 3.6.
-    if name is 'EvaluateFunction':
-        alg.setProperty('Function', kwargs['Function'])
-        del kwargs['Function']
-        alg.setProperty('InputWorkspace', kwargs['InputWorkspace'])
-        del kwargs['InputWorkspace']
-    for param in kwargs:
-        alg.setProperty(param, kwargs[param])
-    alg.setProperty('OutputWorkspace', 'none')
-    alg.execute()
-    return alg.getProperty("OutputWorkspace").value
+          :param name: name of parameter to be untied
+        """
+        self.fun.removeTie(name)
+       
+    def untieAllParameters(self):
+        """ Remove ties from all parameters.
+        """
+        for i in range(0, self.fun.numParams()):
+            self.fun.removeTie(self.getParameterName(i))
+ 
+
+    def constrain(self, expressions):
+        """ Add constraints
+
+          :param expressions: string of tie expressions
+        """
+        self.fun.addConstraints( expressions )
+       
+    def unconstrain(self, name):
+        """ Remove constraints from a parameter
+
+          :param name: name of parameter to be unconstrained
+        """
+        self.fun.removeConstraint(name)
+            
+    def free(self, name):
+        """ Free a parameter from tie or constraint
+
+          :param name: name of parameter to be freed
+        """
+        self.fun.removeTie(name)
+        self.fun.removeConstraint(name)
+       
+    def getParameterName(self, index):
+        """ Get the name of the parameter of given index
+
+          :param index: index of parameter
+        """
+        return self.fun.getParamName(index)
+        
+    @property
+    def function(self):
+        """ Return the underlying IFunction object
+        """
+        return self.fun
+ 
+    @property
+    def name(self):
+        """ Return the name of the function
+        """
+        return self.fun.name()
+
+    def _execute_algorithm(self, name, **kwargs):
+        alg = AlgorithmManager.createUnmanaged(name)
+        alg.setChild(True)
+        alg.initialize()
+        # Python 3 treats **kwargs as an unordered list meaning it is possible
+        # to pass InputWorkspace into EvaluateFunction before Function.
+        # As a special case has been made for this. This case can be removed
+        # with ordered kwargs change in Python 3.6.
+        if name is 'EvaluateFunction':
+            alg.setProperty('Function', kwargs['Function'])
+            del kwargs['Function']
+            alg.setProperty('InputWorkspace', kwargs['InputWorkspace'])
+            del kwargs['InputWorkspace']
+        for param in kwargs:
+            alg.setProperty(param, kwargs[param])
+        alg.setProperty('OutputWorkspace', 'none')
+        alg.execute()
+        return alg.getProperty("OutputWorkspace").value
 
        
 class CompositeFunctionWrapper(FunctionWrapper):
     """ Wrapper class for Composite Fitting Function
     """
     def __init__ (self, *args):
-       """ Called when creating an instance
+        """ Called when creating an instance
            It should not be called directly
            :param *args: names of functions in composite function
-       """
-       self.pureAddition = True
-       self.pureMultiplication = False
-       return self.initByName("CompositeFunction", *args)
+        """
+        self.pureAddition = True
+        self.pureMultiplication = False
+        self.initByName("CompositeFunction", *args)
  
-    def initByName(self, name, *args):
-       """ intialise composite function of named type.
+    def initByName(self, name, *args, **kwargs):
+        """ intialise composite function of named type.
            E.g. "ProductFunction"
            This function would be protected in c++
            and should not be called directly except
            by __init__ functions of this class and
            subclasses.
-            
+
           :param name: name of class calling this.
           :param *args: names of functions in composite function
-       """
-       if len(args) == 1 and  not isinstance(args[0], FunctionWrapper):
-          # We have a composite function to wrap
-          self.fun = args[0]
-       else:
-          self.fun = FunctionFactory.createCompositeFunction(name)
+          :param kwargs: any parameters or attributs that must be passed to the
+            composite function itself.
+        """
+        if len(args) == 1 and  not isinstance(args[0], FunctionWrapper):
+            # We have a composite function to wrap
+            self.fun = args[0]
+        else:
+            self.fun = FunctionFactory.createCompositeFunction(name)
     
-          #Add the functions, checking for Composite & Product functions
-          for a in args:
-             if not isinstance(a, int):
-                if isinstance(a, CompositeFunctionWrapper):
-                   if self.pureAddition:
-                      self.pureAddition = a.pureAddition
-                   if self.pureMultiplication:
-                      self.pureMultiplication = a.pureMultiplication
-                functionToAdd = FunctionFactory.createInitialized( a.fun.__str__() )             
-                self.fun.add(functionToAdd)    
+            # Add the functions, checking for Composite & Product functions
+            for a in args:
+                if not isinstance(a, int):
+                    if isinstance(a, CompositeFunctionWrapper):
+                        if self.pureAddition:
+                            self.pureAddition = a.pureAddition
+                        if self.pureMultiplication:
+                            self.pureMultiplication = a.pureMultiplication
+                    functionToAdd = FunctionFactory.createInitialized( a.fun.__str__() )
+                    self.fun.add(functionToAdd)
        
     def getParameter(self, name):
         """ get value of parameter of specified name
@@ -398,25 +404,25 @@ class CompositeFunctionWrapper(FunctionWrapper):
          
         delimiter = " "
         if name.count(delimiter) == 0:
-           fname = name
-           occurrence = 0
+            fname = name
+            occurrence = 0
         else:
-           fname, n = name.split(delimiter)
-           occurrence = int(n)
+            fname, n = name.split(delimiter)
+            occurrence = int(n)
             
         index = 0
         count = 0
         for f in self:
-           if f.fun.name() == fname:
-              if( count == occurrence):
-                 return index
-              else:
-                 count += 1
-           index += 1
+            if f.fun.name() == fname:
+                if count == occurrence:
+                    return index
+                else:
+                    count += 1
+            index += 1
           
         raise RuntimeError("Specified function not found.")
          
-    def f (self, name):
+    def f(self, name):
         """ get function specified by name,
             such as "LinearBackground" for the only
             LinearBackground function or
@@ -438,15 +444,15 @@ class CompositeFunctionWrapper(FunctionWrapper):
         comp = self.fun
         item = comp[nameorindex]
         if isinstance(item, float):
-           return  item
+            return  item
         elif item.name() == "CompositeFunction":
-           return CompositeFunctionWrapper(item)
+            return CompositeFunctionWrapper(item)
         elif item.name() == "ProductFunction":
-           return ProductFunctionWrapper(item)
+            return ProductFunctionWrapper(item)
         elif item.name() == "Convolution":
-           return ConvolutionWrapper(item)
+            return ConvolutionWrapper(item)
         else:       
-           return FunctionWrapper(item)
+            return FunctionWrapper(item)
  
     def __setitem__ (self, name, newValue):
         """ Called from array-like access on LHS
@@ -457,18 +463,18 @@ class CompositeFunctionWrapper(FunctionWrapper):
         """
         comp = self.fun
         if isinstance( newValue, FunctionWrapper):
-           comp[name] = newValue.fun
+            comp[name] = newValue.fun
         else:
-           comp[name] = newValue
+            comp[name] = newValue
                      
     def __iadd__ (self, other):
-       """ Implement += operator.
+        """ Implement += operator.
            It should not be called directly.
             
            :param other: object to add
-       """
-       self.fun.add(other.fun)
-       return self
+        """
+        self.fun.add(other.fun)
+        return self
         
     def __delitem__ (self, index):
        """ Delete item of given index from composite function.
@@ -479,74 +485,72 @@ class CompositeFunctionWrapper(FunctionWrapper):
        self.fun.__delitem__(index)
         
     def __len__ (self):
-       """ Return number of items in composite function.
+        """ Return number of items in composite function.
            Implement len() function.
            It should not be called directly.
-       """
+        """
  
-       composite = self.fun
-       return composite.__len__()
+        composite = self.fun
+        return composite.__len__()
 
-        
-    def tieAll (self, name):
-       """ For each member function, tie the parameter of the given name 
+    def tieAll(self, name):
+        """ For each member function, tie the parameter of the given name
            to the parameter of that name in the first member function.
            The named parameter must occur in all the member functions.
             
            :param name: name of parameter
-       """
-       expr = self.getCompositeParameterName(name, 0)
-       self.tie({self.getCompositeParameterName(name, i): expr for i in range(1,len(self)) }) 
+        """
+        expr = self.getCompositeParameterName(name, 0)
+        self.tie({self.getCompositeParameterName(name, i): expr for i in range(1,len(self)) })
            
     def fixAll (self, name):
-       """ Fix all parameters with the given local name.
+        """ Fix all parameters with the given local name.
            Every member function must have a parameter of this name.
             
            :param name: name of parameter
-       """
-       for f in self:
-         f.fix(name)
- 
+        """
+        for f in self:
+            f.fix(name)
            
     def constrainAll (self, expressions):
-       """ Constrain all parameters according local names in expressions.
+        """ Constrain all parameters according local names in expressions.
                    
            :param expressions: string of expressions
-       """
-       for i in range(0, len(self)):
-          if isinstance( self[i], CompositeFunctionWrapper ):
-             self[i].constrainAll(expressions)
-          else:
-             try:
-                self[i].constrain(expressions)
-             except:
-                pass
+        """
+        for i in range(0, len(self)):
+            if isinstance(self[i], CompositeFunctionWrapper):
+                self[i].constrainAll(expressions)
+            else:
+                try:
+                    self[i].constrain(expressions)
+                except:
+                    pass
            
     def unconstrainAll (self, name):
-       """ Unconstrain all parameters of given local name.
+        """ Unconstrain all parameters of given local name.
             
            :param name: local name of parameter
-       """
-       for i in range(0, len(self)):
-          if isinstance( self[i], CompositeFunctionWrapper ):
-             self[i].unconstrainAll(name)
-          else:
-             try:
-                self[i].unconstrain(name)
-             except:
-                pass
+        """
+        for i in range(0, len(self)):
+            if isinstance( self[i], CompositeFunctionWrapper ):
+                self[i].unconstrainAll(name)
+            else:
+                try:
+                    self[i].unconstrain(name)
+                except:
+                    pass
            
     def untieAll (self, name):
-       """ Untie all parameters with the given local name.
+        """ Untie all parameters with the given local name.
            Every member function must have a parameter of this name.
             
            :param name: local name of parameter
-       """
-       for i in range(0, len(self)):
-          self.untie(self.getCompositeParameterName(name, i))
+        """
+        for i in range(0, len(self)):
+            self.untie(self.getCompositeParameterName(name, i))
  
     def flatten (self):
-       """ Return composite function, equal to self, but with 
+        """ Return composite function, equal to self, but with
            every composite function within replaced by
            its list of functions, so having a pure list of functions.
            This makes it possible to index and iterate all the functions
@@ -555,56 +559,59 @@ class CompositeFunctionWrapper(FunctionWrapper):
            composite functions, because the arithmetic 
            may no longer be correct.
            The return value is not independent of self.
-       """
-       # If there are no composite functions, do nothing
-       needToFlatten = False
-       for i in range(0, len(self)):
-          if not needToFlatten and isinstance(self[i],CompositeFunctionWrapper):
-             needToFlatten = True
-              
-       if not needToFlatten :
-          return self
-        
-       # Now we know there is a composite function.
-       if isinstance(self,ProductFunctionWrapper):
-          flatSelf = ProductFunctionWrapper()
-       else:
-          flatSelf = CompositeFunctionWrapper()
-           
-       for i in range(0, len(self)):
-          if isinstance(self[i],CompositeFunctionWrapper):
-             currentFunction = self[i].flatten()
-             for j in range(0, len(currentFunction)):
-                flatSelf.fun.add(currentFunction[j].fun)
-          else:
-             flatSelf.fun.add(self[i].fun)
-              
-       return flatSelf          
-  
+        """
+        # If there are no composite functions, do nothing
+        needToFlatten = False
+        for i in range(0, len(self)):
+            if not needToFlatten and isinstance(self[i],CompositeFunctionWrapper):
+                needToFlatten = True
+
+        if not needToFlatten:
+            return self
+
+        # Now we know there is a composite function.
+        if isinstance(self,ProductFunctionWrapper):
+            flatSelf = ProductFunctionWrapper()
+        else:
+            flatSelf = CompositeFunctionWrapper()
+
+        for i in range(0, len(self)):
+            if isinstance(self[i],CompositeFunctionWrapper):
+                currentFunction = self[i].flatten()
+                for j in range(0, len(currentFunction)):
+                    flatSelf.fun.add(currentFunction[j].fun)
+            else:
+                flatSelf.fun.add(self[i].fun)
+
+        return flatSelf
+
+
 class ProductFunctionWrapper(CompositeFunctionWrapper):
     """ Wrapper class for Product Fitting Function
     """
     def __init__ (self, *args):
-       """ Called when creating an instance
+        """ Called when creating an instance
            It should not be called directly.
            :param *args: names of functions in composite function
-       """
-       self.pureAddition = False
-       self.pureMultiplication = True
-       return self.initByName("ProductFunction", *args)
-        
+        """
+        self.pureAddition = False
+        self.pureMultiplication = True
+        return self.initByName("ProductFunction", *args)
+
+
 class ConvolutionWrapper(CompositeFunctionWrapper):
     """ Wrapper class for Convolution Fitting Function
     """
     def __init__ (self, *args):
-       """ Called when creating an instance
+        """ Called when creating an instance
            It should not be called directly.
            :param *args: names of functions in composite function
-       """
-       self.pureAddition = False
-       self.pureMultiplication = False
-       return self.initByName("Convolution", *args)
-        
+        """
+        self.pureAddition = False
+        self.pureMultiplication = False
+        return self.initByName("Convolution", *args)
+
+
 class MultiDomainFunctionWrapper(CompositeFunctionWrapper):
     """ Wrapper class for Multidomain Fitting Function
     """
@@ -617,13 +624,17 @@ class MultiDomainFunctionWrapper(CompositeFunctionWrapper):
         self.pureAddition = False
         self.pureMultiplication = False
 
+        global_parameters = []
+        if 'Global' in kwargs:
+            global_parameters = kwargs['Global']
+            del kwargs['Global']
+
         # Create and populate with copied functions
-        self.initByName("MultiDomainFunction", *args)
+        self.initByName("MultiDomainFunction", *args, **kwargs)
 
         # Tie the global parameters
-        if 'Global' in kwargs:
-            for name in kwargs['Global']:
-                self.tieAll(name)
+        for name in global_parameters:
+            self.tieAll(name)
 
         # Set domain indices: 1 to 1
         for i in range(0, len(self)):
@@ -662,4 +673,4 @@ def _create_wrapper_function(name):
  
 fnames = FunctionFactory.getFunctionNames()
 for i, val in enumerate(fnames):
-   _create_wrapper_function(val)
+    _create_wrapper_function(val)

--- a/Framework/PythonInterface/mantid/fitfunctions.py
+++ b/Framework/PythonInterface/mantid/fitfunctions.py
@@ -15,9 +15,9 @@ class FunctionWrapper(object):
             self.fun = name
         else:
             self.fun = FunctionFactory.createFunction(name)
-        self._init_paramgeters_and_attributes(**kwargs)
+        self.init_paramgeters_and_attributes(**kwargs)
 
-    def _init_paramgeters_and_attributes(self, **kwargs):
+    def init_paramgeters_and_attributes(self, **kwargs):
         # Deal with attributes first
         for key in kwargs:
             if key == "attributes":
@@ -340,14 +340,16 @@ class FunctionWrapper(object):
 class CompositeFunctionWrapper(FunctionWrapper):
     """ Wrapper class for Composite Fitting Function
     """
-    def __init__ (self, *args):
+    def __init__ (self, *args, **kwargs):
         """ Called when creating an instance
            It should not be called directly
            :param *args: names of functions in composite function
+           :param kwargs: any parameters or attributes that must be passed to the
+            composite function itself.
         """
         self.pureAddition = True
         self.pureMultiplication = False
-        self.initByName("CompositeFunction", *args)
+        self.initByName("CompositeFunction", *args, **kwargs)
  
     def initByName(self, name, *args, **kwargs):
         """ intialise composite function of named type.
@@ -359,7 +361,7 @@ class CompositeFunctionWrapper(FunctionWrapper):
 
           :param name: name of class calling this.
           :param *args: names of functions in composite function
-          :param kwargs: any parameters or attributs that must be passed to the
+          :param kwargs: any parameters or attributes that must be passed to the
             composite function itself.
         """
         if len(args) == 1 and  not isinstance(args[0], FunctionWrapper):
@@ -376,8 +378,9 @@ class CompositeFunctionWrapper(FunctionWrapper):
                             self.pureAddition = a.pureAddition
                         if self.pureMultiplication:
                             self.pureMultiplication = a.pureMultiplication
-                    functionToAdd = FunctionFactory.createInitialized( a.fun.__str__() )
+                    functionToAdd = FunctionFactory.createInitialized(a.fun.__str__())
                     self.fun.add(functionToAdd)
+        self.init_paramgeters_and_attributes(**kwargs)
        
     def getParameter(self, name):
         """ get value of parameter of specified name
@@ -589,27 +592,31 @@ class CompositeFunctionWrapper(FunctionWrapper):
 class ProductFunctionWrapper(CompositeFunctionWrapper):
     """ Wrapper class for Product Fitting Function
     """
-    def __init__ (self, *args):
+    def __init__ (self, *args, **kwargs):
         """ Called when creating an instance
-           It should not be called directly.
-           :param *args: names of functions in composite function
+            It should not be called directly.
+            :param *args: names of functions in composite function
+            :param kwargs: any parameters or attributes that must be passed to the
+            composite function itself.
         """
         self.pureAddition = False
         self.pureMultiplication = True
-        return self.initByName("ProductFunction", *args)
+        self.initByName("ProductFunction", *args, **kwargs)
 
 
 class ConvolutionWrapper(CompositeFunctionWrapper):
     """ Wrapper class for Convolution Fitting Function
     """
-    def __init__ (self, *args):
+    def __init__ (self, *args, **kwargs):
         """ Called when creating an instance
            It should not be called directly.
            :param *args: names of functions in composite function
+           :param kwargs: any parameters or attributes that must be passed to the
+            composite function itself.
         """
         self.pureAddition = False
         self.pureMultiplication = False
-        return self.initByName("Convolution", *args)
+        self.initByName("Convolution", *args, **kwargs)
 
 
 class MultiDomainFunctionWrapper(CompositeFunctionWrapper):
@@ -619,6 +626,8 @@ class MultiDomainFunctionWrapper(CompositeFunctionWrapper):
         """ Called when creating an instance
            It should not be called directly
            :param *args: names of functions in composite function
+           :param kwargs: any parameters or attributes that must be passed to the
+            composite function itself.
         """
         # Assume it's not safe to flatten
         self.pureAddition = False
@@ -664,11 +673,10 @@ def _create_wrapper_function(name):
         # constructor is FunctionWrapper if the name is not in the registry.
         if name in name_to_constructor:
             return name_to_constructor[name](*args, **kwargs)
-        return  FunctionWrapper(name, *args, **kwargs)
+        return FunctionWrapper(name, **kwargs)
  
     # ------------------------------------------------------------------------------------------------
     wrapper_function.__name__ = name
-    # _replace_signature(fake_function, ("", ""))
     globals()[name] = wrapper_function
  
 fnames = FunctionFactory.getFunctionNames()

--- a/Framework/PythonInterface/mantid/fitfunctions.py
+++ b/Framework/PythonInterface/mantid/fitfunctions.py
@@ -606,37 +606,36 @@ class ConvolutionWrapper(CompositeFunctionWrapper):
        return self.initByName("Convolution", *args)
         
 class MultiDomainFunctionWrapper(CompositeFunctionWrapper):
-    """ Wrapper class for Product Fitting Function
+    """ Wrapper class for Multidomain Fitting Function
     """
     def __init__ (self, *args, **kwargs):
-       """ Called when creating an instance
+        """ Called when creating an instance
            It should not be called directly
            :param *args: names of functions in composite function
-       """
-       # Assume it's not safe to flatten
-       self.pureAddition = False
-       self.pureMultiplication = False
-        
-       # Create and populate with copied functions
-       self.initByName("MultiDomainFunction", *args)
-                
-       # Tie the global parameters
-       if 'Global' in kwargs:
-          list = kwargs['Global']
-          for name in list:
-             self.tieAll(name)
-        
-       # Set domain indices: 1 to 1       
-       for i in range(0, len(self)):
-          self.fun.setDomainIndex(i, i)
-     
-    @property     
+        """
+        # Assume it's not safe to flatten
+        self.pureAddition = False
+        self.pureMultiplication = False
+
+        # Create and populate with copied functions
+        self.initByName("MultiDomainFunction", *args)
+
+        # Tie the global parameters
+        if 'Global' in kwargs:
+            for name in kwargs['Global']:
+                self.tieAll(name)
+
+        # Set domain indices: 1 to 1
+        for i in range(0, len(self)):
+            self.fun.setDomainIndex(i, i)
+
+    @property
     def nDomains (self):
-       """ Return number of domains 
-       """
-       return self.fun.nDomains()
-      
- 
+        """ Return number of domains
+        """
+        return self.fun.nDomains()
+
+
 def _create_wrapper_function(name):
     """Create fake functions for the given name
        It should not be called directly
@@ -652,8 +651,9 @@ def _create_wrapper_function(name):
             'MultiDomainFunction': MultiDomainFunctionWrapper,
             }
         # constructor is FunctionWrapper if the name is not in the registry.
-        constructor = name_to_constructor.get(name, FunctionWrapper)  
-        return  constructor(name, *args, **kwargs)
+        if name in name_to_constructor:
+            return name_to_constructor[name](*args, **kwargs)
+        return  FunctionWrapper(name, *args, **kwargs)
  
     # ------------------------------------------------------------------------------------------------
     wrapper_function.__name__ = name

--- a/Framework/PythonInterface/test/python/mantid/FitFunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/FitFunctionsTest.py
@@ -8,10 +8,12 @@ import testhelpers
 import platform
 from mantid.simpleapi import CreateWorkspace, EvaluateFunction, Fit, FitDialog 
 from mantid.simpleapi import FunctionWrapper, CompositeFunctionWrapper, ProductFunctionWrapper, ConvolutionWrapper, MultiDomainFunctionWrapper 
-from mantid.simpleapi import Gaussian, LinearBackground, Polynomial, MultiDomainFunction, Convolution, ProductFunction
+from mantid.simpleapi import Gaussian, LinearBackground, Polynomial, MultiDomainFunction, Convolution, ProductFunction,\
+    CompositeFunction
 from mantid.api import mtd, MatrixWorkspace, ITableWorkspace
 import numpy as np
 from testhelpers import run_algorithm
+
 
 class FitFunctionsTest(unittest.TestCase):
 
@@ -654,10 +656,31 @@ class FitFunctionsTest(unittest.TestCase):
 
     def test_evaluation_with_parameters_set(self):
         p = Polynomial(n=2)
-        result = p([0,1,2],0.0,0.5,0.5)   
-        self.assertAlmostEqual(result[0],0.0)
-        self.assertAlmostEqual(result[1],1.0)
-        self.assertAlmostEqual(result[2],3.0)         
-       
+        result = p([0, 1, 2], 0.0, 0.5, 0.5)
+        self.assertAlmostEqual(result[0], 0.0)
+        self.assertAlmostEqual(result[1], 1.0)
+        self.assertAlmostEqual(result[2], 3.0)
+
+    def test_attributes_passed_to_composite_functions(self):
+        cf = Gaussian() + LinearBackground()
+        self.assertEqual(cf.getAttributeValue('NumDeriv'), False)
+        cf = CompositeFunction(Gaussian(), LinearBackground(), NumDeriv=True)
+        self.assertEqual(cf.getAttributeValue('NumDeriv'), True)
+
+    def test_attributes_passed_to_convolution(self):
+        cf = Convolution(Gaussian(), Gaussian(), NumDeriv=True)
+        self.assertEqual(cf.getAttributeValue('NumDeriv'), True)
+
+    def test_attributes_passed_to_product_functions(self):
+        pf = Gaussian() * LinearBackground()
+        self.assertEqual(pf.getAttributeValue('NumDeriv'), False)
+        pf = ProductFunction(Gaussian(), LinearBackground(), NumDeriv=True)
+        self.assertEqual(pf.getAttributeValue('NumDeriv'), True)
+
+    def test_attributes_passed_to_multidomain_function(self):
+        cf = MultiDomainFunction(Gaussian(), Gaussian(), NumDeriv=True)
+        self.assertEqual(cf.getAttributeValue('NumDeriv'), True)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/Framework/PythonInterface/test/python/mantid/FitFunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/FitFunctionsTest.py
@@ -497,7 +497,7 @@ class FitFunctionsTest(unittest.TestCase):
         g1 = FunctionWrapper( "Gaussian", Height=8.5, Sigma=1.2, PeakCentre=11)
         testhelpers.assertRaisesNothing(self, ProductFunctionWrapper, g0, g1)
 
-    def test_productfunction_creation_1(self):
+    def test_productfunction_creation_by_name(self):
         g0 = Gaussian(Height=7.5, Sigma=1.2, PeakCentre=10)
         g1 = Gaussian(Height=8.5, Sigma=1.2, PeakCentre=11)
         testhelpers.assertRaisesNothing(self, ProductFunction, g0, g1)
@@ -532,7 +532,7 @@ class FitFunctionsTest(unittest.TestCase):
         g1 = FunctionWrapper( "Gaussian", Height=8.5, Sigma=1.2, PeakCentre=11)
         testhelpers.assertRaisesNothing(self, ConvolutionWrapper, g0, g1)
 
-    def test_convolution_creation_1(self):
+    def test_convolution_creation_by_name(self):
         g0 = Gaussian(Height=7.5, Sigma=1.2, PeakCentre=10)
         g1 = Gaussian(Height=8.5, Sigma=1.2, PeakCentre=11)
         testhelpers.assertRaisesNothing(self, Convolution, g0, g1)
@@ -547,7 +547,7 @@ class FitFunctionsTest(unittest.TestCase):
         self.assertEqual( m_str.count("ties"),1)
         self.assertEqual( m_str.count("Height"),4) # 2 in functions 2 in ties
 
-    def test_multidomainfunction_creation_1(self):
+    def test_multidomainfunction_creation_by_name(self):
         g0 = Gaussian(Height=7.5, Sigma=1.2, PeakCentre=10)
         g1 = Gaussian(Height=8.5, Sigma=1.2, PeakCentre=11)
         m = MultiDomainFunction( g0, g1, Global=["Height"])

--- a/Framework/PythonInterface/test/python/mantid/FitFunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/FitFunctionsTest.py
@@ -8,7 +8,7 @@ import testhelpers
 import platform
 from mantid.simpleapi import CreateWorkspace, EvaluateFunction, Fit, FitDialog 
 from mantid.simpleapi import FunctionWrapper, CompositeFunctionWrapper, ProductFunctionWrapper, ConvolutionWrapper, MultiDomainFunctionWrapper 
-from mantid.simpleapi import Gaussian, LinearBackground, Polynomial
+from mantid.simpleapi import Gaussian, LinearBackground, Polynomial, MultiDomainFunction, Convolution, ProductFunction
 from mantid.api import mtd, MatrixWorkspace, ITableWorkspace
 import numpy as np
 from testhelpers import run_algorithm
@@ -491,11 +491,16 @@ class FitFunctionsTest(unittest.TestCase):
         for f in c:
            count += 1
         self.assertEqual( count, 3)
-        
+
     def test_productfunction_creation(self):
         g0 = FunctionWrapper( "Gaussian", Height=7.5, Sigma=1.2, PeakCentre=10)
         g1 = FunctionWrapper( "Gaussian", Height=8.5, Sigma=1.2, PeakCentre=11)
         testhelpers.assertRaisesNothing(self, ProductFunctionWrapper, g0, g1)
+
+    def test_productfunction_creation_1(self):
+        g0 = Gaussian(Height=7.5, Sigma=1.2, PeakCentre=10)
+        g1 = Gaussian(Height=8.5, Sigma=1.2, PeakCentre=11)
+        testhelpers.assertRaisesNothing(self, ProductFunction, g0, g1)
 
     def test_mul(self):
         g0 = FunctionWrapper( "Gaussian", Height=7.5, Sigma=1.2, PeakCentre=10)  
@@ -520,13 +525,18 @@ class FitFunctionsTest(unittest.TestCase):
         
         g1_str = str(g1)
         p2_str = str(p[2])
-        self.assertEqual(p2_str, g1_str)   
+        self.assertEqual(p2_str, g1_str)
 
     def test_convolution_creation(self):
         g0 = FunctionWrapper( "Gaussian", Height=7.5, Sigma=1.2, PeakCentre=10)
         g1 = FunctionWrapper( "Gaussian", Height=8.5, Sigma=1.2, PeakCentre=11)
         testhelpers.assertRaisesNothing(self, ConvolutionWrapper, g0, g1)
-        
+
+    def test_convolution_creation_1(self):
+        g0 = Gaussian(Height=7.5, Sigma=1.2, PeakCentre=10)
+        g1 = Gaussian(Height=8.5, Sigma=1.2, PeakCentre=11)
+        testhelpers.assertRaisesNothing(self, Convolution, g0, g1)
+
     def test_multidomainfunction_creation(self):
         g0 = FunctionWrapper( "Gaussian", Height=7.5, Sigma=1.2, PeakCentre=10)
         g1 = FunctionWrapper( "Gaussian", Height=8.5, Sigma=1.2, PeakCentre=11)
@@ -536,7 +546,16 @@ class FitFunctionsTest(unittest.TestCase):
         m_str = str(m)
         self.assertEqual( m_str.count("ties"),1)
         self.assertEqual( m_str.count("Height"),4) # 2 in functions 2 in ties
-        
+
+    def test_multidomainfunction_creation_1(self):
+        g0 = Gaussian(Height=7.5, Sigma=1.2, PeakCentre=10)
+        g1 = Gaussian(Height=8.5, Sigma=1.2, PeakCentre=11)
+        m = MultiDomainFunction( g0, g1, Global=["Height"])
+        self.assertEqual( m.nDomains, 2)
+        m_str = str(m)
+        self.assertEqual( m_str.count("ties"),1)
+        self.assertEqual( m_str.count("Height"),4) # 2 in functions 2 in ties
+
     def test_generatedfunction(self):
         testhelpers.assertRaisesNothing(self, Gaussian, Height=7.5, Sigma=1.2, PeakCentre=10)
         lb = LinearBackground()

--- a/docs/source/concepts/FitFunctionsInPython.rst
+++ b/docs/source/concepts/FitFunctionsInPython.rst
@@ -100,7 +100,7 @@ Multi-Domain functions can be constructed like this:
 
 .. code:: python
 
-    md_fun = MultiDomainFunction(Gaussian(PeakCentre=1, Sigma=0.1), Gaussian(PeakCentre=1, Sigma=0.2), ..., global=['Height'])
+    md_fun = MultiDomainFunction(Gaussian(PeakCentre=1, Sigma=0.1), Gaussian(PeakCentre=1, Sigma=0.2), ..., Global=['Height'])
 
 Setting Ties
 ------------


### PR DESCRIPTION
Generic function that creates fit function wrappers for composite functions uses correct arguments now.

**To test:**

* Use the script form the issue description. Print out the created fit function to see that the global parameters are tied to each other.
* Run the code from @AnthonyLim23's comment. Gradient 1 and Gradient 2 must be both equal to 3.5

Fixes #21102

**Release Notes** 

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [x] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
