### PR TITLE
Restore crystal field parameters after attribute set.

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldFunction.h
@@ -216,6 +216,7 @@ private:
   void makeMapsMultiSiteMultiSpectrum() const;
   size_t makeMapsForFunction(const IFunction &fun, size_t iFirst,
                              const std::string &prefix) const;
+  void cacheSourceParameters() const;
 
   /// Function that creates the source function.
   mutable CrystalFieldControl m_control;
@@ -238,6 +239,8 @@ private:
   /// Map parameter/attribute prefixes to pointers to phys prop functions
   mutable std::unordered_map<std::string, API::IFunction_sptr>
       m_mapPrefixes2PhysProps;
+  /// Temporary cache for parameter values during source function resetting.
+  mutable std::vector<double> m_parameterResetCache;
 };
 
 } // namespace Functions

--- a/Framework/CurveFitting/src/Functions/CrystalFieldFunction.cpp
+++ b/Framework/CurveFitting/src/Functions/CrystalFieldFunction.cpp
@@ -488,6 +488,7 @@ void CrystalFieldFunction::setAttribute(const std::string &attName,
     // This will throw an exception because attribute doesn't exist
     IFunction::setAttribute(attName, attr);
   } else if (attRef.first == &m_control) {
+    cacheSourceParameters();
     m_source.reset();
   }
   attRef.first->setAttribute(attRef.second, attr);
@@ -627,6 +628,12 @@ void CrystalFieldFunction::buildSourceFunction() const {
   setSource(m_control.buildSource());
   m_nControlParams = m_control.nParams();
   m_nControlSourceParams = m_nControlParams + m_source->nParams();
+  if (!m_parameterResetCache.empty() && m_parameterResetCache.size() == m_source->nParams()) {
+    for(size_t i = 0; i < m_parameterResetCache.size(); ++i) {
+      m_source->setParameter(i, m_parameterResetCache[i]);
+    }
+  }
+  m_parameterResetCache.clear();
 }
 
 /// Update spectrum function if necessary.
@@ -1369,6 +1376,21 @@ void CrystalFieldFunction::makeMapsMultiSiteMultiSpectrum() const {
       prefix.append(std::to_string(ion)).append(".").append(physPropPrefix);
       i += makeMapsForFunction(*spectrum.getFunction(ion), i, prefix);
     }
+  }
+}
+
+/// Temporary cache parameter values of the source function if it's
+/// initialised
+void CrystalFieldFunction::cacheSourceParameters() const {
+  if (!m_source) {
+    // No function - nothing to cache
+    m_parameterResetCache.clear();
+    return;
+  }
+  auto np = m_source->nParams();
+  m_parameterResetCache.resize(np);
+  for(size_t i = 0; i < np; ++i) {
+    m_parameterResetCache[i] = m_source->getParameter(i);
   }
 }
 

--- a/Framework/CurveFitting/src/Functions/CrystalFieldFunction.cpp
+++ b/Framework/CurveFitting/src/Functions/CrystalFieldFunction.cpp
@@ -628,8 +628,9 @@ void CrystalFieldFunction::buildSourceFunction() const {
   setSource(m_control.buildSource());
   m_nControlParams = m_control.nParams();
   m_nControlSourceParams = m_nControlParams + m_source->nParams();
-  if (!m_parameterResetCache.empty() && m_parameterResetCache.size() == m_source->nParams()) {
-    for(size_t i = 0; i < m_parameterResetCache.size(); ++i) {
+  if (!m_parameterResetCache.empty() &&
+      m_parameterResetCache.size() == m_source->nParams()) {
+    for (size_t i = 0; i < m_parameterResetCache.size(); ++i) {
       m_source->setParameter(i, m_parameterResetCache[i]);
     }
   }
@@ -1389,7 +1390,7 @@ void CrystalFieldFunction::cacheSourceParameters() const {
   }
   auto np = m_source->nParams();
   m_parameterResetCache.resize(np);
-  for(size_t i = 0; i < np; ++i) {
+  for (size_t i = 0; i < np; ++i) {
     m_parameterResetCache[i] = m_source->getParameter(i);
   }
 }

--- a/Framework/CurveFitting/test/Functions/CrystalFieldFunctionTest.h
+++ b/Framework/CurveFitting/test/Functions/CrystalFieldFunctionTest.h
@@ -691,6 +691,19 @@ public:
     ads.clear();
   }
 
+  void test_setting_peak_shape_keeps_field_parameters() {
+    CrystalFieldFunction cf;
+    cf.setAttributeValue("Ions", "Ce, Yb");
+    cf.setAttributeValue("Symmetries", "C2v, D6h");
+    cf.setAttributeValue("Temperatures", std::vector<double>({44, 50}));
+    cf.setAttributeValue("FWHMs", std::vector<double>({1, 2}));
+    cf.setParameter("ion0.B20", 1.0);
+    cf.setParameter("ion1.B20", 2.0);
+    cf.setAttributeValue("PeakShape", "Lorentzian");
+    cf.setParameter("ion0.B20", 1.0);
+    cf.setParameter("ion1.B20", 2.0);
+  }
+
 private:
   MatrixWorkspace_sptr makeDataSS() {
     auto ws = create2DWorkspaceBinned(1, 100, 0.0, 0.5);

--- a/Framework/CurveFitting/test/Functions/CrystalFieldFunctionTest.h
+++ b/Framework/CurveFitting/test/Functions/CrystalFieldFunctionTest.h
@@ -699,9 +699,11 @@ public:
     cf.setAttributeValue("FWHMs", std::vector<double>({1, 2}));
     cf.setParameter("ion0.B20", 1.0);
     cf.setParameter("ion1.B20", 2.0);
+    TS_ASSERT_EQUALS(cf.getParameter("ion0.B20"), 1.0);
+    TS_ASSERT_EQUALS(cf.getParameter("ion1.B20"), 2.0);
     cf.setAttributeValue("PeakShape", "Lorentzian");
-    cf.setParameter("ion0.B20", 1.0);
-    cf.setParameter("ion1.B20", 2.0);
+    TS_ASSERT_EQUALS(cf.getParameter("ion0.B20"), 1.0);
+    TS_ASSERT_EQUALS(cf.getParameter("ion1.B20"), 2.0);
   }
 
 private:


### PR DESCRIPTION
Field parameters are saved and restored after setting an attribute that doesn't change the structure of the function (parameter number)

**To test:**

Run script form issue description.

Fixes #21104

**Release Notes** 

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [x] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
