### PR TITLE
Port some algorithms for MPI

### DIFF
--- a/Framework/API/inc/MantidAPI/Algorithm.h
+++ b/Framework/API/inc/MantidAPI/Algorithm.h
@@ -403,13 +403,13 @@ protected:
   /// versions
   bool m_usingBaseProcessGroups = false;
 
-  template <typename T, typename... WSPropArgs,
+  template <typename T, const int AllowedIndexTypes = IndexType::WorkspaceIndex,
+            typename... WSPropArgs,
             typename = typename std::enable_if<
                 std::is_convertible<T *, MatrixWorkspace *>::value>::type>
-  void declareWorkspaceInputProperties(
-      const std::string &propertyName, WSPropArgs... wsPropArgs,
-      const int allowedIndexTypes = IndexType::WorkspaceIndex,
-      const std::string &doc = "");
+  void declareWorkspaceInputProperties(const std::string &propertyName,
+                                       const std::string &doc,
+                                       WSPropArgs &&... wsPropArgs);
 
 private:
   template <typename T1, typename T2, typename WsType>

--- a/Framework/API/inc/MantidAPI/Algorithm.h
+++ b/Framework/API/inc/MantidAPI/Algorithm.h
@@ -403,13 +403,13 @@ protected:
   /// versions
   bool m_usingBaseProcessGroups = false;
 
-  template <typename T, typename = typename std::enable_if<std::is_convertible<
-                            T *, MatrixWorkspace *>::value>::type>
+  template <typename T, typename... WSPropArgs,
+            typename = typename std::enable_if<
+                std::is_convertible<T *, MatrixWorkspace *>::value>::type>
   void declareWorkspaceInputProperties(
-      const std::string &propertyName,
+      const std::string &propertyName, WSPropArgs... wsPropArgs,
       const int allowedIndexTypes = IndexType::WorkspaceIndex,
-      PropertyMode::Type optional = PropertyMode::Type::Mandatory,
-      LockMode::Type lock = LockMode::Type::Lock, const std::string &doc = "");
+      const std::string &doc = "");
 
 private:
   template <typename T1, typename T2, typename WsType>

--- a/Framework/API/inc/MantidAPI/Algorithm.tcc
+++ b/Framework/API/inc/MantidAPI/Algorithm.tcc
@@ -1,3 +1,6 @@
+#ifndef MANTID_API_ALGORITHM_TCC_
+#define MANTID_API_ALGORITHM_TCC_
+
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/IndexProperty.h"
 #include "MantidAPI/WorkspaceProperty.h"
@@ -46,11 +49,19 @@ void Algorithm::declareWorkspaceInputProperties(const std::string &propertyName,
       indexTypePropName, AllowedIndexTypes);
   const auto &indexTypePropRef = *indexTypeProp;
 
-  declareProperty(std::move(indexTypeProp));
+  declareProperty(std::move(indexTypeProp),
+                  "The type of indices in the optional index set; For optimal "
+                  "performance WorkspaceIndex should be preferred;");
 
   auto indexPropName = IndexProperty::generatePropertyName(propertyName);
   declareProperty(Kernel::make_unique<IndexProperty>(indexPropName, wsPropRef,
-                                                     indexTypePropRef));
+                                                     indexTypePropRef),
+                  "An optional set of spectra that will be processed by the "
+                  "algorithm; If not set, all spectra will be processed; The "
+                  "indices in this list can be workspace indices or possibly "
+                  "spectrum numbers, depending on the selection made for the "
+                  "index type; Indices are entered as a comma-separated list "
+                  "of values, and/or ranges; For example, '4,6,10-20,1000';");
 
   m_reservedList.push_back(propertyName);
   m_reservedList.push_back(indexTypePropName);
@@ -145,3 +156,5 @@ Algorithm::getWorkspaceAndIndices(const std::string &name) const {
 }
 } // namespace API
 } // namespace Mantid
+
+#endif /*MANTID_API_ALGORITHM_TCC_*/

--- a/Framework/API/inc/MantidAPI/Algorithm.tcc
+++ b/Framework/API/inc/MantidAPI/Algorithm.tcc
@@ -25,20 +25,17 @@ namespace API {
 @param propertyName Name of property which will be reserved
 @param allowedIndexTypes combination of allowed index types. Default
 IndexType::WorkspaceIndex
-@param optional Determines if workspace property is optional. Default
-PropertyMode::Type::Mandatory
-@param lock Determines whether or not the workspace is locked. Default
-LockMode::Type::Lock
+@param wsPropArgs a parameter pack of arguments forwarded to WorkspaceProperty.
+Can contain PropertyMode, LockMode, and validators.
 @param doc Property documentation string.
 */
-template <typename T, typename>
+template <typename T, typename... WSPropArgs, typename>
 void Algorithm::declareWorkspaceInputProperties(const std::string &propertyName,
+                                                WSPropArgs... wsPropArgs,
                                                 const int allowedIndexTypes,
-                                                PropertyMode::Type optional,
-                                                LockMode::Type lock,
                                                 const std::string &doc) {
   auto wsProp = Kernel::make_unique<WorkspaceProperty<T>>(
-      propertyName, "", Kernel::Direction::Input, optional, lock);
+      propertyName, "", Kernel::Direction::Input, wsPropArgs...);
   const auto &wsPropRef = *wsProp;
   declareProperty(std::move(wsProp), doc);
 

--- a/Framework/API/inc/MantidAPI/Algorithm.tcc
+++ b/Framework/API/inc/MantidAPI/Algorithm.tcc
@@ -29,20 +29,21 @@ IndexType::WorkspaceIndex
 Can contain PropertyMode, LockMode, and validators.
 @param doc Property documentation string.
 */
-template <typename T, typename... WSPropArgs, typename>
+template <typename T, const int AllowedIndexTypes, typename... WSPropArgs,
+          typename>
 void Algorithm::declareWorkspaceInputProperties(const std::string &propertyName,
-                                                WSPropArgs... wsPropArgs,
-                                                const int allowedIndexTypes,
-                                                const std::string &doc) {
+                                                const std::string &doc,
+                                                WSPropArgs &&... wsPropArgs) {
   auto wsProp = Kernel::make_unique<WorkspaceProperty<T>>(
-      propertyName, "", Kernel::Direction::Input, wsPropArgs...);
+      propertyName, "", Kernel::Direction::Input,
+      std::forward<WSPropArgs>(wsPropArgs)...);
   const auto &wsPropRef = *wsProp;
   declareProperty(std::move(wsProp), doc);
 
   auto indexTypePropName =
       IndexTypeProperty::generatePropertyName(propertyName);
   auto indexTypeProp = Kernel::make_unique<IndexTypeProperty>(
-      indexTypePropName, allowedIndexTypes);
+      indexTypePropName, AllowedIndexTypes);
   const auto &indexTypePropRef = *indexTypeProp;
 
   declareProperty(std::move(indexTypeProp));

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -2015,7 +2015,28 @@ namespace API {
 template DLLExport void
 Algorithm::declareWorkspaceInputProperties<MatrixWorkspace>(
     const std::string &propertyName, const int allowedIndexTypes,
-    PropertyMode::Type optional, LockMode::Type lock, const std::string &doc);
+    const std::string &doc);
+
+template DLLExport void Algorithm::declareWorkspaceInputProperties<
+    MatrixWorkspace, Kernel::IValidator_sptr>(const std::string &propertyName,
+                                              Kernel::IValidator_sptr validator,
+                                              const int allowedIndexTypes,
+                                              const std::string &doc);
+
+template DLLExport void
+Algorithm::declareWorkspaceInputProperties<MatrixWorkspace, PropertyMode::Type,
+                                           Kernel::IValidator_sptr>(
+    const std::string &propertyName, PropertyMode::Type optional,
+    Kernel::IValidator_sptr validator, const int allowedIndexTypes,
+    const std::string &doc);
+
+template DLLExport void Algorithm::declareWorkspaceInputProperties<
+    MatrixWorkspace, PropertyMode::Type, LockMode::Type,
+    Kernel::IValidator_sptr>(const std::string &propertyName,
+                             PropertyMode::Type optional, LockMode::Type lock,
+                             Kernel::IValidator_sptr validator,
+                             const int allowedIndexTypes,
+                             const std::string &doc);
 
 template DLLExport void
 Algorithm::setWorkspaceInputProperties<MatrixWorkspace, std::vector<int>>(

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -1,5 +1,5 @@
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidAPI/Algorithm.tcc"
+#include "MantidAPI/Algorithm.h"
 #include "MantidAPI/BinEdgeAxis.h"
 #include "MantidAPI/MatrixWorkspaceMDIterator.h"
 #include "MantidAPI/NumericAxis.h"
@@ -2008,61 +2008,6 @@ void MatrixWorkspace::rebuildDetectorIDGroupings() {
 
 } // namespace API
 } // Namespace Mantid
-
-// Explicit Instantiations of IndexProperty Methods in Algorithm
-namespace Mantid {
-namespace API {
-template DLLExport void
-Algorithm::declareWorkspaceInputProperties<MatrixWorkspace>(
-    const std::string &propertyName, const int allowedIndexTypes,
-    const std::string &doc);
-
-template DLLExport void Algorithm::declareWorkspaceInputProperties<
-    MatrixWorkspace, Kernel::IValidator_sptr>(const std::string &propertyName,
-                                              Kernel::IValidator_sptr validator,
-                                              const int allowedIndexTypes,
-                                              const std::string &doc);
-
-template DLLExport void
-Algorithm::declareWorkspaceInputProperties<MatrixWorkspace, PropertyMode::Type,
-                                           Kernel::IValidator_sptr>(
-    const std::string &propertyName, PropertyMode::Type optional,
-    Kernel::IValidator_sptr validator, const int allowedIndexTypes,
-    const std::string &doc);
-
-template DLLExport void Algorithm::declareWorkspaceInputProperties<
-    MatrixWorkspace, PropertyMode::Type, LockMode::Type,
-    Kernel::IValidator_sptr>(const std::string &propertyName,
-                             PropertyMode::Type optional, LockMode::Type lock,
-                             Kernel::IValidator_sptr validator,
-                             const int allowedIndexTypes,
-                             const std::string &doc);
-
-template DLLExport void
-Algorithm::setWorkspaceInputProperties<MatrixWorkspace, std::vector<int>>(
-    const std::string &name, const MatrixWorkspace_sptr &wksp, IndexType type,
-    const std::vector<int> &list);
-
-template DLLExport void
-Algorithm::setWorkspaceInputProperties<MatrixWorkspace, std::string>(
-    const std::string &name, const MatrixWorkspace_sptr &wksp, IndexType type,
-    const std::string &list);
-
-template DLLExport void
-Algorithm::setWorkspaceInputProperties<MatrixWorkspace, std::vector<int>>(
-    const std::string &name, const std::string &wsName, IndexType type,
-    const std::vector<int> &list);
-
-template DLLExport void
-Algorithm::setWorkspaceInputProperties<MatrixWorkspace, std::string>(
-    const std::string &name, const std::string &wsName, IndexType type,
-    const std::string &list);
-
-template DLLExport
-    std::tuple<boost::shared_ptr<MatrixWorkspace>, Indexing::SpectrumIndexSet>
-    Algorithm::getWorkspaceAndIndices(const std::string &name) const;
-} // namespace API
-} // namespace Mantid
 
 ///\cond TEMPLATE
 namespace Mantid {

--- a/Framework/API/test/AlgorithmTest.h
+++ b/Framework/API/test/AlgorithmTest.h
@@ -4,9 +4,10 @@
 #include <cxxtest/TestSuite.h>
 
 #include "FakeAlgorithms.h"
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/Algorithm.tcc"
 #include "MantidAPI/AlgorithmFactory.h"
 #include "MantidAPI/FrameworkManager.h"
+#include "MantidAPI/HistogramValidator.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidAPI/WorkspaceProperty.h"
@@ -171,10 +172,16 @@ public:
   static const std::string FAIL_MSG;
 
   void init() override {
-    declareWorkspaceInputProperties<MatrixWorkspace>("InputWorkspace");
+    declareWorkspaceInputProperties<MatrixWorkspace>("InputWorkspace", "");
     declareProperty(
         Mantid::Kernel::make_unique<WorkspaceProperty<MatrixWorkspace>>(
             "InputWorkspace2", "", Mantid::Kernel::Direction::Input));
+    declareWorkspaceInputProperties<
+        MatrixWorkspace, IndexType::SpectrumNum | IndexType::WorkspaceIndex>(
+        "InputWorkspace3", "");
+    declareWorkspaceInputProperties<
+        MatrixWorkspace, IndexType::SpectrumNum | IndexType::WorkspaceIndex>(
+        "InputWorkspace4", "", boost::make_shared<HistogramValidator>());
   }
 
   void exec() override {}

--- a/Framework/Algorithms/inc/MantidAlgorithms/FilterBadPulses.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FilterBadPulses.h
@@ -1,11 +1,8 @@
 #ifndef MANTID_ALGORITHMS_FILTERBADPULSES_H_
 #define MANTID_ALGORITHMS_FILTERBADPULSES_H_
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
 #include "MantidKernel/System.h"
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/TriviallyParallelAlgorithm.h"
 #include "MantidDataObjects/EventWorkspace.h"
 
 namespace Mantid {
@@ -49,7 +46,7 @@ namespace Algorithms {
     File change history is stored at: <https://github.com/mantidproject/mantid>.
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport FilterBadPulses : public API::Algorithm {
+class DLLExport FilterBadPulses : public API::TriviallyParallelAlgorithm {
 public:
   const std::string name() const override;
   /// Summary of algorithms purpose

--- a/Framework/Algorithms/inc/MantidAlgorithms/FilterBadPulses.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FilterBadPulses.h
@@ -2,7 +2,7 @@
 #define MANTID_ALGORITHMS_FILTERBADPULSES_H_
 
 #include "MantidKernel/System.h"
-#include "MantidAPI/TriviallyParallelAlgorithm.h"
+#include "MantidAPI/ParallelAlgorithm.h"
 #include "MantidDataObjects/EventWorkspace.h"
 
 namespace Mantid {
@@ -46,7 +46,7 @@ namespace Algorithms {
     File change history is stored at: <https://github.com/mantidproject/mantid>.
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport FilterBadPulses : public API::TriviallyParallelAlgorithm {
+class DLLExport FilterBadPulses : public API::ParallelAlgorithm {
 public:
   const std::string name() const override;
   /// Summary of algorithms purpose

--- a/Framework/Algorithms/inc/MantidAlgorithms/FilterByLogValue.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FilterByLogValue.h
@@ -1,11 +1,8 @@
 #ifndef MANTID_ALGORITHMS_FILTERBYLOGVALUE_H_
 #define MANTID_ALGORITHMS_FILTERBYLOGVALUE_H_
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
 #include "MantidKernel/System.h"
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/TriviallyParallelAlgorithm.h"
 #include "MantidDataObjects/EventWorkspace.h"
 
 namespace Mantid {
@@ -33,7 +30,7 @@ namespace Algorithms {
     File change history is stored at: <https://github.com/mantidproject/mantid>.
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport FilterByLogValue : public API::Algorithm {
+class DLLExport FilterByLogValue : public API::TriviallyParallelAlgorithm {
 public:
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "FilterByLogValue"; };

--- a/Framework/Algorithms/inc/MantidAlgorithms/FilterByLogValue.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FilterByLogValue.h
@@ -2,7 +2,7 @@
 #define MANTID_ALGORITHMS_FILTERBYLOGVALUE_H_
 
 #include "MantidKernel/System.h"
-#include "MantidAPI/TriviallyParallelAlgorithm.h"
+#include "MantidAPI/ParallelAlgorithm.h"
 #include "MantidDataObjects/EventWorkspace.h"
 
 namespace Mantid {
@@ -30,7 +30,7 @@ namespace Algorithms {
     File change history is stored at: <https://github.com/mantidproject/mantid>.
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport FilterByLogValue : public API::TriviallyParallelAlgorithm {
+class DLLExport FilterByLogValue : public API::ParallelAlgorithm {
 public:
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "FilterByLogValue"; };

--- a/Framework/Algorithms/inc/MantidAlgorithms/MaskBins.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/MaskBins.h
@@ -1,9 +1,6 @@
 #ifndef MANTID_ALGORITHMS_MASKBINS_H_
 #define MANTID_ALGORITHMS_MASKBINS_H_
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
 #include "MantidAPI/Algorithm.h"
 #include "MantidDataObjects/EventList.h"
 #include "MantidDataObjects/EventWorkspace.h"
@@ -57,8 +54,6 @@ namespace Algorithms {
  */
 class DLLExport MaskBins : public API::Algorithm {
 public:
-  /// Constructor
-  MaskBins();
   /// Algorithm's name
   const std::string name() const override { return "MaskBins"; }
   /// Summary of algorithms purpose
@@ -82,10 +77,10 @@ private:
                    MantidVec::difference_type &startBin,
                    MantidVec::difference_type &endBin);
 
-  double m_startX; ///< The range start point
-  double m_endX;   ///< The range end point
-  std::vector<int>
-      spectra_list; ///<the list of Spectra (workspace index) to load
+  double m_startX{0.0}; ///< The range start point
+  double m_endX{0.0};   ///< The range end point
+  Indexing::SpectrumIndexSet
+      indexSet; ///<the list of Spectra (workspace index) to load
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/MaskBins.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/MaskBins.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_ALGORITHMS_MASKBINS_H_
 #define MANTID_ALGORITHMS_MASKBINS_H_
 
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/TriviallyParallelAlgorithm.h"
 #include "MantidDataObjects/EventList.h"
 #include "MantidDataObjects/EventWorkspace.h"
 
@@ -52,7 +52,7 @@ namespace Algorithms {
     File change history is stored at: <https://github.com/mantidproject/mantid>
     Code Documentation is available at: <http://doxygen.mantidproject.org>
  */
-class DLLExport MaskBins : public API::Algorithm {
+class DLLExport MaskBins : public API::TriviallyParallelAlgorithm {
 public:
   /// Algorithm's name
   const std::string name() const override { return "MaskBins"; }

--- a/Framework/Algorithms/inc/MantidAlgorithms/MaskBins.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/MaskBins.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_ALGORITHMS_MASKBINS_H_
 #define MANTID_ALGORITHMS_MASKBINS_H_
 
-#include "MantidAPI/TriviallyParallelAlgorithm.h"
+#include "MantidAPI/ParallelAlgorithm.h"
 #include "MantidDataObjects/EventList.h"
 #include "MantidDataObjects/EventWorkspace.h"
 
@@ -52,7 +52,7 @@ namespace Algorithms {
     File change history is stored at: <https://github.com/mantidproject/mantid>
     Code Documentation is available at: <http://doxygen.mantidproject.org>
  */
-class DLLExport MaskBins : public API::TriviallyParallelAlgorithm {
+class DLLExport MaskBins : public API::ParallelAlgorithm {
 public:
   /// Algorithm's name
   const std::string name() const override { return "MaskBins"; }

--- a/Framework/Algorithms/inc/MantidAlgorithms/RemovePromptPulse.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/RemovePromptPulse.h
@@ -2,7 +2,7 @@
 #define MANTID_ALGORITHMS_REMOVEPROMPTPULSE_H_
 
 #include "MantidKernel/System.h"
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/TriviallyParallelAlgorithm.h"
 #include "MantidAPI/Run.h"
 
 namespace Mantid {
@@ -34,7 +34,7 @@ namespace Algorithms {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport RemovePromptPulse : public API::Algorithm {
+class DLLExport RemovePromptPulse : public API::TriviallyParallelAlgorithm {
 public:
   /// Algorithm's name for identification
   const std::string name() const override;

--- a/Framework/Algorithms/inc/MantidAlgorithms/RemovePromptPulse.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/RemovePromptPulse.h
@@ -2,7 +2,7 @@
 #define MANTID_ALGORITHMS_REMOVEPROMPTPULSE_H_
 
 #include "MantidKernel/System.h"
-#include "MantidAPI/TriviallyParallelAlgorithm.h"
+#include "MantidAPI/ParallelAlgorithm.h"
 #include "MantidAPI/Run.h"
 
 namespace Mantid {
@@ -34,7 +34,7 @@ namespace Algorithms {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport RemovePromptPulse : public API::TriviallyParallelAlgorithm {
+class DLLExport RemovePromptPulse : public API::ParallelAlgorithm {
 public:
   /// Algorithm's name for identification
   const std::string name() const override;

--- a/Framework/Algorithms/inc/MantidAlgorithms/SortEvents.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SortEvents.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_ALGORITHMS_SORTEVENTS_H_
 #define MANTID_ALGORITHMS_SORTEVENTS_H_
 
-#include "MantidAPI/TriviallyParallelAlgorithm.h"
+#include "MantidAPI/ParallelAlgorithm.h"
 
 namespace Mantid {
 namespace Algorithms {
@@ -39,7 +39,7 @@ namespace Algorithms {
     File change history is stored at: <https://github.com/mantidproject/mantid>
     Code Documentation is available at: <http://doxygen.mantidproject.org>
  */
-class DLLExport SortEvents : public API::TriviallyParallelAlgorithm {
+class DLLExport SortEvents : public API::ParallelAlgorithm {
 public:
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "SortEvents"; }

--- a/Framework/Algorithms/inc/MantidAlgorithms/SortEvents.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SortEvents.h
@@ -1,10 +1,7 @@
 #ifndef MANTID_ALGORITHMS_SORTEVENTS_H_
 #define MANTID_ALGORITHMS_SORTEVENTS_H_
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/TriviallyParallelAlgorithm.h"
 
 namespace Mantid {
 namespace Algorithms {
@@ -42,7 +39,7 @@ namespace Algorithms {
     File change history is stored at: <https://github.com/mantidproject/mantid>
     Code Documentation is available at: <http://doxygen.mantidproject.org>
  */
-class DLLExport SortEvents : public API::Algorithm {
+class DLLExport SortEvents : public API::TriviallyParallelAlgorithm {
 public:
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "SortEvents"; }

--- a/Framework/Algorithms/src/ChangePulsetime2.cpp
+++ b/Framework/Algorithms/src/ChangePulsetime2.cpp
@@ -1,4 +1,5 @@
 #include "MantidAlgorithms/ChangePulsetime2.h"
+#include "MantidAPI/Algorithm.tcc"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidKernel/ArrayProperty.h"
@@ -19,7 +20,8 @@ using std::size_t;
 /** Initialize the algorithm's properties.
  */
 void ChangePulsetime2::init() {
-  declareWorkspaceInputProperties<EventWorkspace>("InputWorkspace");
+  declareWorkspaceInputProperties<EventWorkspace>("InputWorkspace",
+                                                  "An input event workspace.");
   declareProperty(
       make_unique<PropertyWithValue<double>>("TimeOffset", Direction::Input),
       "Number of seconds (a float) to add to each event's pulse "

--- a/Framework/Algorithms/src/MaskBins.cpp
+++ b/Framework/Algorithms/src/MaskBins.cpp
@@ -64,6 +64,9 @@ void MaskBins::exec() {
   // Copy indices from legacy property
   std::vector<int> spectraList = this->getProperty("SpectraList");
   if (!spectraList.empty()) {
+    if (!isDefault("InputWorkspaceIndexSet"))
+      throw std::runtime_error("Cannot provide both InputWorkspaceIndexSet and "
+                               "SpectraList at the same time.");
     setProperty("InputWorkspaceIndexSet", spectraList);
     g_log.warning("The 'SpectraList' property is deprecated. Use "
                   "'InputWorkspaceIndexSet' instead.");

--- a/Framework/Algorithms/src/MaskBins.cpp
+++ b/Framework/Algorithms/src/MaskBins.cpp
@@ -93,8 +93,7 @@ void MaskBins::exec() {
       this->findIndices(X, startBin, endBin);
     }
 
-    const int numHists = static_cast<int>(indexSet.size());
-    Progress progress(this, 0.0, 1.0, numHists);
+    Progress progress(this, 0.0, 1.0, indexSet.size());
     // Parallel running has problems with a race condition, leading to
     // occaisional test failures and crashes
 
@@ -119,14 +118,10 @@ void MaskBins::execEvent() {
   MatrixWorkspace_sptr outputMatrixWS = getProperty("OutputWorkspace");
   auto outputWS = boost::dynamic_pointer_cast<EventWorkspace>(outputMatrixWS);
 
-  // set up the progress bar
-  const size_t numHists = outputWS->getNumberHistograms();
-  Progress progress(this, 0.0, 1.0, numHists * 2);
+  Progress progress(this, 0.0, 1.0, outputWS->getNumberHistograms() * 2);
 
-  // sort the events
   outputWS->sortAll(Mantid::DataObjects::TOF_SORT, &progress);
 
-  // Go through all histograms
   PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS))
   for (int i = 0; i < static_cast<int>(indexSet.size()); // NOLINT
        ++i) {

--- a/Framework/Algorithms/src/MaskBins.cpp
+++ b/Framework/Algorithms/src/MaskBins.cpp
@@ -1,11 +1,9 @@
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
 #include "MantidAlgorithms/MaskBins.h"
 #include "MantidAPI/HistogramValidator.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/BoundedValidator.h"
+#include "MantidAPI/Algorithm.tcc"
 
 #include <limits>
 #include <sstream>
@@ -20,19 +18,15 @@ DECLARE_ALGORITHM(MaskBins)
 
 using namespace Kernel;
 using namespace API;
-using namespace Mantid;
-using Mantid::DataObjects::EventWorkspace;
-using Mantid::DataObjects::EventWorkspace_sptr;
-using Mantid::DataObjects::EventWorkspace_const_sptr;
-
-MaskBins::MaskBins() : API::Algorithm(), m_startX(0.0), m_endX(0.0) {}
+using DataObjects::EventWorkspace;
+using DataObjects::EventWorkspace_sptr;
+using DataObjects::EventWorkspace_const_sptr;
 
 void MaskBins::init() {
-  declareProperty(
-      make_unique<WorkspaceProperty<>>(
-          "InputWorkspace", "", Direction::Input,
-          boost::make_shared<HistogramValidator>()),
-      "The name of the input workspace. Must contain histogram data.");
+  declareWorkspaceInputProperties<MatrixWorkspace>(
+      "InputWorkspace",
+      "The name of the input workspace. Must contain histogram data.",
+      boost::make_shared<HistogramValidator>());
   declareProperty(make_unique<WorkspaceProperty<>>("OutputWorkspace", "",
                                                    Direction::Output),
                   "The name of the Workspace containing the masked bins.");
@@ -47,22 +41,14 @@ void MaskBins::init() {
   declareProperty("XMax", std::numeric_limits<double>::max(), required,
                   "The value to end masking at.");
 
-  // which pixels to load
   this->declareProperty(make_unique<ArrayProperty<int>>("SpectraList"),
-                        "Optional: A list of individual which spectra to mask "
-                        "(specified using the workspace index). If not set, "
-                        "all spectra are masked. Can be entered as a "
-                        "comma-seperated list of values, or a range (such as "
-                        "'a-b' which will include spectra with workspace index "
-                        "of a to b inclusively).");
+                        "Deprecated, use InputWorkspaceIndexSet.");
 }
 
 /** Execution code.
  *  @throw std::invalid_argument If XMax is less than XMin
  */
 void MaskBins::exec() {
-  MatrixWorkspace_const_sptr inputWS = getProperty("InputWorkspace");
-
   // Check for valid X limits
   m_startX = getProperty("XMin");
   m_endX = getProperty("XMax");
@@ -75,22 +61,17 @@ void MaskBins::exec() {
     throw std::invalid_argument(msg.str());
   }
 
-  //---------------------------------------------------------------------------------
-  // what spectra (workspace indices) to load. Optional.
-  this->spectra_list = this->getProperty("SpectraList");
-  if (!this->spectra_list.empty()) {
-    const int numHist = static_cast<int>(inputWS->getNumberHistograms());
-    //--- Validate spectra list ---
-    for (auto wi : this->spectra_list) {
-      if ((wi < 0) || (wi >= numHist)) {
-        std::ostringstream oss;
-        oss << "One of the workspace indices specified, " << wi
-            << " is above the number of spectra in the workspace (" << numHist
-            << ").";
-        throw std::invalid_argument(oss.str());
-      }
-    }
+  // Copy indices from legacy property
+  std::vector<int> spectraList = this->getProperty("SpectraList");
+  if (!spectraList.empty()) {
+    setProperty("InputWorkspaceIndexSet", spectraList);
+    g_log.warning("The 'SpectraList' property is deprecated. Use "
+                  "'InputWorkspaceIndexSet' instead.");
   }
+
+  MatrixWorkspace_sptr inputWS;
+  std::tie(inputWS, indexSet) =
+      getWorkspaceAndIndices<MatrixWorkspace>("InputWorkspace");
 
   // Only create the output workspace if it's different to the input one
   MatrixWorkspace_sptr outputWS = getProperty("OutputWorkspace");
@@ -99,16 +80,9 @@ void MaskBins::exec() {
     setProperty("OutputWorkspace", outputWS);
   }
 
-  //---------------------------------------------------------------------------------
-  // Now, determine if the input workspace is actually an EventWorkspace
-  EventWorkspace_const_sptr eventW =
-      boost::dynamic_pointer_cast<const EventWorkspace>(inputWS);
-
-  if (eventW != nullptr) {
-    //------- EventWorkspace ---------------------------
+  if (boost::dynamic_pointer_cast<const EventWorkspace>(inputWS)) {
     this->execEvent();
   } else {
-    //------- MatrixWorkspace of another kind -------------
     MantidVec::difference_type startBin(0), endBin(0);
 
     // If the binning is the same throughout, we only need to find the index
@@ -119,27 +93,12 @@ void MaskBins::exec() {
       this->findIndices(X, startBin, endBin);
     }
 
-    const int numHists = static_cast<int>(inputWS->getNumberHistograms());
+    const int numHists = static_cast<int>(indexSet.size());
     Progress progress(this, 0.0, 1.0, numHists);
     // Parallel running has problems with a race condition, leading to
     // occaisional test failures and crashes
 
-    bool useSpectraList = (!this->spectra_list.empty());
-
-    // Alter the for loop ending based on what we are looping on
-    int for_end = numHists;
-    if (useSpectraList)
-      for_end = static_cast<int>(this->spectra_list.size());
-
-    for (int i = 0; i < for_end; ++i) {
-      // Find the workspace index, either based on the spectra list or all
-      // spectra
-      int wi;
-      if (useSpectraList)
-        wi = this->spectra_list[i];
-      else
-        wi = i;
-
+    for (const auto wi : indexSet) {
       MantidVec::difference_type startBinLoop(startBin), endBinLoop(endBin);
       if (!commonBins)
         this->findIndices(outputWS->binEdges(wi), startBinLoop, endBinLoop);
@@ -150,9 +109,8 @@ void MaskBins::exec() {
         outputWS->maskBin(wi, j);
       }
       progress.report();
-
-    } // ENDFOR(i)
-  }   // ENDIFELSE(eventworkspace?)
+    }
+  }
 }
 
 /** Execution code for EventWorkspaces
@@ -169,30 +127,16 @@ void MaskBins::execEvent() {
   outputWS->sortAll(Mantid::DataObjects::TOF_SORT, &progress);
 
   // Go through all histograms
-  if (!this->spectra_list.empty()) {
-    // Specific spectra were specified
-    PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS))
-    for (int i = 0; i < static_cast<int>(this->spectra_list.size()); // NOLINT
-         ++i) {
-      PARALLEL_START_INTERUPT_REGION
-      outputWS->getSpectrum(this->spectra_list[i]).maskTof(m_startX, m_endX);
-      progress.report();
-      PARALLEL_END_INTERUPT_REGION
-    }
-    PARALLEL_CHECK_INTERUPT_REGION
-  } else {
-    // Do all spectra!
-    PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS))
-    for (int64_t i = 0; i < int64_t(numHists); ++i) {
-      PARALLEL_START_INTERUPT_REGION
-      outputWS->getSpectrum(i).maskTof(m_startX, m_endX);
-      progress.report();
-      PARALLEL_END_INTERUPT_REGION
-    }
-    PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS))
+  for (int i = 0; i < static_cast<int>(indexSet.size()); // NOLINT
+       ++i) {
+    PARALLEL_START_INTERUPT_REGION
+    outputWS->getSpectrum(indexSet[i]).maskTof(m_startX, m_endX);
+    progress.report();
+    PARALLEL_END_INTERUPT_REGION
   }
+  PARALLEL_CHECK_INTERUPT_REGION
 
-  // Clear the MRU
   outputWS->clearMRU();
 }
 

--- a/Framework/Algorithms/test/ChangePulsetime2Test.h
+++ b/Framework/Algorithms/test/ChangePulsetime2Test.h
@@ -5,6 +5,7 @@
 #include "MantidKernel/Timer.h"
 #include <cxxtest/TestSuite.h>
 
+#include "MantidAPI/Algorithm.tcc"
 #include "MantidAlgorithms/ChangePulsetime2.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"

--- a/Framework/DataHandling/inc/MantidDataHandling/CompressEvents.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/CompressEvents.h
@@ -1,10 +1,7 @@
 #ifndef MANTID_DATAHANDLING_COMPRESSEVENTS_H_
 #define MANTID_DATAHANDLING_COMPRESSEVENTS_H_
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/TriviallyParallelAlgorithm.h"
 
 namespace Mantid {
 namespace DataHandling {
@@ -43,7 +40,7 @@ namespace DataHandling {
     File change history is stored at: <https://github.com/mantidproject/mantid>.
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport CompressEvents : public API::Algorithm {
+class DLLExport CompressEvents : public API::TriviallyParallelAlgorithm {
 public:
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "CompressEvents"; };

--- a/Framework/DataHandling/inc/MantidDataHandling/CompressEvents.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/CompressEvents.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_DATAHANDLING_COMPRESSEVENTS_H_
 #define MANTID_DATAHANDLING_COMPRESSEVENTS_H_
 
-#include "MantidAPI/TriviallyParallelAlgorithm.h"
+#include "MantidAPI/ParallelAlgorithm.h"
 
 namespace Mantid {
 namespace DataHandling {
@@ -40,7 +40,7 @@ namespace DataHandling {
     File change history is stored at: <https://github.com/mantidproject/mantid>.
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport CompressEvents : public API::TriviallyParallelAlgorithm {
+class DLLExport CompressEvents : public API::ParallelAlgorithm {
 public:
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "CompressEvents"; };

--- a/Framework/DataHandling/src/CompressEvents.cpp
+++ b/Framework/DataHandling/src/CompressEvents.cpp
@@ -1,6 +1,7 @@
 #include "MantidDataHandling/CompressEvents.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidDataObjects/EventWorkspace.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/BoundedValidator.h"
 
@@ -56,13 +57,7 @@ void CompressEvents::exec() {
 
   // Are we making a copy of the input workspace?
   if (!inplace) {
-    // Make a brand new EventWorkspace
-    outputWS = boost::dynamic_pointer_cast<EventWorkspace>(
-        API::WorkspaceFactory::Instance().create(
-            "EventWorkspace", inputWS->getNumberHistograms(), 2, 1));
-    // Copy geometry over.
-    API::WorkspaceFactory::Instance().initializeFromParent(*inputWS, *outputWS,
-                                                           false);
+    outputWS = create<EventWorkspace>(*inputWS, HistogramData::BinEdges(2));
     // We DONT copy the data though
     // Loop over the histograms (detector spectra)
     tbb::parallel_for(tbb::blocked_range<size_t>(0, noSpectra),

--- a/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Framework/DataObjects/src/EventWorkspace.cpp
@@ -1,4 +1,5 @@
 #include "MantidDataObjects/EventWorkspace.h"
+#include "MantidAPI/Algorithm.h"
 #include "MantidAPI/ISpectrum.h"
 #include "MantidAPI/Progress.h"
 #include "MantidAPI/RefAxis.h"
@@ -17,7 +18,6 @@
 #include "MantidKernel/MultiThreaded.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 
-#include "MantidAPI/Algorithm.tcc"
 #include "tbb/parallel_for.h"
 #include <limits>
 #include <numeric>
@@ -672,65 +672,6 @@ void EventWorkspace::getIntegratedSpectra(std::vector<double> &out,
 }
 
 } // namespace DataObjects
-} // namespace Mantid
-
-// Explicit Instantiations of IndexProperty Methods in Algorithm
-namespace Mantid {
-namespace API {
-template DLLExport void
-Algorithm::declareWorkspaceInputProperties<DataObjects::EventWorkspace>(
-    const std::string &propertyName, const int allowedIndexTypes,
-    const std::string &doc);
-
-template DLLExport void
-Algorithm::declareWorkspaceInputProperties<DataObjects::EventWorkspace,
-                                           Kernel::IValidator_sptr>(
-    const std::string &propertyName, Kernel::IValidator_sptr validator,
-    const int allowedIndexTypes, const std::string &doc);
-
-template DLLExport void Algorithm::declareWorkspaceInputProperties<
-    DataObjects::EventWorkspace, PropertyMode::Type, Kernel::IValidator_sptr>(
-    const std::string &propertyName, PropertyMode::Type optional,
-    Kernel::IValidator_sptr validator, const int allowedIndexTypes,
-    const std::string &doc);
-
-template DLLExport void Algorithm::declareWorkspaceInputProperties<
-    DataObjects::EventWorkspace, PropertyMode::Type, LockMode::Type,
-    Kernel::IValidator_sptr>(const std::string &propertyName,
-                             PropertyMode::Type optional, LockMode::Type lock,
-                             Kernel::IValidator_sptr validator,
-                             const int allowedIndexTypes,
-                             const std::string &doc);
-
-template DLLExport void
-Algorithm::setWorkspaceInputProperties<DataObjects::EventWorkspace,
-                                       std::vector<int>>(
-    const std::string &name, const DataObjects::EventWorkspace_sptr &wksp,
-    IndexType type, const std::vector<int> &list);
-
-template DLLExport void
-Algorithm::setWorkspaceInputProperties<DataObjects::EventWorkspace,
-                                       std::string>(
-    const std::string &name, const DataObjects::EventWorkspace_sptr &wksp,
-    IndexType type, const std::string &list);
-
-template DLLExport void
-Algorithm::setWorkspaceInputProperties<DataObjects::EventWorkspace,
-                                       std::vector<int>>(
-    const std::string &name, const std::string &wsName, IndexType type,
-    const std::vector<int> &list);
-
-template DLLExport void
-Algorithm::setWorkspaceInputProperties<DataObjects::EventWorkspace,
-                                       std::string>(const std::string &name,
-                                                    const std::string &wsName,
-                                                    IndexType type,
-                                                    const std::string &list);
-
-template DLLExport std::tuple<boost::shared_ptr<DataObjects::EventWorkspace>,
-                              Indexing::SpectrumIndexSet>
-Algorithm::getWorkspaceAndIndices(const std::string &name) const;
-} // namespace API
 } // namespace Mantid
 
 namespace Mantid {

--- a/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Framework/DataObjects/src/EventWorkspace.cpp
@@ -680,7 +680,27 @@ namespace API {
 template DLLExport void
 Algorithm::declareWorkspaceInputProperties<DataObjects::EventWorkspace>(
     const std::string &propertyName, const int allowedIndexTypes,
-    PropertyMode::Type optional, LockMode::Type lock, const std::string &doc);
+    const std::string &doc);
+
+template DLLExport void
+Algorithm::declareWorkspaceInputProperties<DataObjects::EventWorkspace,
+                                           Kernel::IValidator_sptr>(
+    const std::string &propertyName, Kernel::IValidator_sptr validator,
+    const int allowedIndexTypes, const std::string &doc);
+
+template DLLExport void Algorithm::declareWorkspaceInputProperties<
+    DataObjects::EventWorkspace, PropertyMode::Type, Kernel::IValidator_sptr>(
+    const std::string &propertyName, PropertyMode::Type optional,
+    Kernel::IValidator_sptr validator, const int allowedIndexTypes,
+    const std::string &doc);
+
+template DLLExport void Algorithm::declareWorkspaceInputProperties<
+    DataObjects::EventWorkspace, PropertyMode::Type, LockMode::Type,
+    Kernel::IValidator_sptr>(const std::string &propertyName,
+                             PropertyMode::Type optional, LockMode::Type lock,
+                             Kernel::IValidator_sptr validator,
+                             const int allowedIndexTypes,
+                             const std::string &doc);
 
 template DLLExport void
 Algorithm::setWorkspaceInputProperties<DataObjects::EventWorkspace,

--- a/docs/source/concepts/IndexProperty.rst
+++ b/docs/source/concepts/IndexProperty.rst
@@ -43,17 +43,21 @@ with maintaining these properties on their own. There are few special methods in
 Property declaration is as shown below: 
 
 .. code-block:: cpp
+  #include "MantidAPI/Algorithm.tcc"
 
   // Declare property with default settings
   // IndexType::WorkspaceIndex is default
-  declareWorkspaceInputProperties<MatrixWorkspace>("InputWorkspace");
-  
-  // Declare all arguments
   declareWorkspaceInputProperties<MatrixWorkspace>(
-      "InputWorkspace", /* optional PropertyMode, LockMode, and validator
-                           forwarded to WorkspaceProperty */
-      IndexType::SpectrumNum | IndexType::WorkspaceIndex,
+      "InputWorkspace",
       "This is an input workspace with associated index handling");
+
+  // Declare all arguments
+  declareWorkspaceInputProperties<MatrixWorkspace,
+                                  IndexType::SpectrumNum | IndexType::WorkspaceIndex>(
+      "InputWorkspace",
+      "This is an input workspace with associated index handling"
+      /* optional PropertyMode, LockMode, and validator forwarded to WorkspaceProperty */);
+
 
 Internally, a ``WorkspaceProperty`` is created along with an ``IndexTypeProperty`` for
 managing the workspace and the type of user-defined input index list respectively. Their names are

--- a/docs/source/concepts/IndexProperty.rst
+++ b/docs/source/concepts/IndexProperty.rst
@@ -44,14 +44,16 @@ Property declaration is as shown below:
 
 .. code-block:: cpp
 
-  //Declare property with default settings
+  // Declare property with default settings
   // IndexType::WorkspaceIndex is default
   declareWorkspaceInputProperties<MatrixWorkspace>("InputWorkspace");
   
-  //Declare all arguments
-  declareWorkspaceInputProperties<MatrixWorkspace>("InputWorkspace", 
-    IndexType::SpectrumNum|IndexType::WorkspaceIndex, PropertyMode::Type::Mandatory, 
-    LockMode::Type::Lock, "This is an input workspace with associated index handling")
+  // Declare all arguments
+  declareWorkspaceInputProperties<MatrixWorkspace>(
+      "InputWorkspace", /* optional PropertyMode, LockMode, and validator
+                           forwarded to WorkspaceProperty */
+      IndexType::SpectrumNum | IndexType::WorkspaceIndex,
+      "This is an input workspace with associated index handling");
 
 Internally, a ``WorkspaceProperty`` is created along with an ``IndexTypeProperty`` for
 managing the workspace and the type of user-defined input index list respectively. Their names are

--- a/docs/source/concepts/IndexProperty.rst
+++ b/docs/source/concepts/IndexProperty.rst
@@ -43,6 +43,7 @@ with maintaining these properties on their own. There are few special methods in
 Property declaration is as shown below: 
 
 .. code-block:: cpp
+
   #include "MantidAPI/Algorithm.tcc"
 
   // Declare property with default settings

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -454,6 +454,7 @@ Supported Algorithms
 ================= =============== ========
 Algorithm         Supported modes Comments
 ================= =============== ========
+CompressEvents    all
 CreateWorkspace   all
 FilterBadPulses   all
 FilterByLogValue  all
@@ -464,6 +465,7 @@ LoadParameterFile all             segfaults when used in unit tests with MPI thr
 MaskBins          all
 Rebin             all             min and max bin boundaries must be given explicitly
 RemovePromptPulse all
+SortEvents        all
 ================= =============== ========
 
 .. rubric:: Footnotes

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -461,6 +461,7 @@ LoadEventNexus    Distributed     storage mode of output cannot be changed via a
 LoadInstrument    all
 LoadNexusLogs     all
 LoadParameterFile all             segfaults when used in unit tests with MPI threading backend due to `#9365 <https://github.com/mantidproject/mantid/issues/9365>`_, normal use should be ok
+MaskBins          all
 Rebin             all             min and max bin boundaries must be given explicitly
 ================= =============== ========
 

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -463,6 +463,7 @@ LoadNexusLogs     all
 LoadParameterFile all             segfaults when used in unit tests with MPI threading backend due to `#9365 <https://github.com/mantidproject/mantid/issues/9365>`_, normal use should be ok
 MaskBins          all
 Rebin             all             min and max bin boundaries must be given explicitly
+RemovePromptPulse all
 ================= =============== ========
 
 .. rubric:: Footnotes

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -455,6 +455,8 @@ Supported Algorithms
 Algorithm         Supported modes Comments
 ================= =============== ========
 CreateWorkspace   all
+FilterBadPulses   all
+FilterByLogValue  all
 LoadEventNexus    Distributed     storage mode of output cannot be changed via a parameter currently, min and max bin boundary are not globally the same
 LoadInstrument    all
 LoadNexusLogs     all

--- a/docs/source/release/v3.12.0/framework.rst
+++ b/docs/source/release/v3.12.0/framework.rst
@@ -27,6 +27,7 @@ Algorithms
 - :ref:`ConjoinWorkspaces <algm-ConjoinWorkspaces>` now supports non-constant bins.
 - :ref:`Fit <algm-Fit>` will now respect excluded ranges when ``CostFunction = 'Unweighted least squares'``.
 - :ref:`NormaliseToMonitor <algm-NormaliseToMonitor>` now supports non-constant number of bins.
+- :ref:`MaskBins <algm-MaskBins>` now uses a modernized and standardized way for providing a list of workspace indices. For compatibility reasons the previous ``SpectraList`` property is still supported.
 
 Core Functionality
 ------------------


### PR DESCRIPTION
Adds MPI support for a couple of algorithms, all of which are trivial (after some minor modifications), i.e., do not actually require any MPI communication.

Notable changes:
- `MaskBins` now uses `WorkspacePropertyWithIndex`, which is required for MPI support. For compatibility with legacy scripts the old index input field has been kept and forwards to the new one (logging a deprecation warning).
- `WorkspacePropertyWithIndex` now works with workspace validators.

**To test:**

Fixes #21032.
MPI not supported publicly.
Release notes have been updated with non-breaking property change of `MaskBins`.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
