### PR TITLE
PDCalibration resolution

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/PDCalibration.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PDCalibration.h
@@ -67,6 +67,8 @@ private:
                            const std::vector<double> &tof,
                            const std::vector<double> &height2, double &difc,
                            double &t0, double &difa);
+  API::MatrixWorkspace_sptr calculateResolutionTable();
+
   API::ITableWorkspace_sptr
   sortTableWorkspace(API::ITableWorkspace_sptr &table);
   API::MatrixWorkspace_sptr m_uncalibratedWS;

--- a/docs/source/algorithms/PDCalibration-v1.rst
+++ b/docs/source/algorithms/PDCalibration-v1.rst
@@ -31,11 +31,15 @@ The resulting calibration table can be saved with
 :ref:`algm-SaveDiffCal`, loaded with :ref:`algm-LoadDiffCal` and
 applied to a workspace with :ref:`algm-AlignDetectors`. There are also
 three workspaces placed in the ``DiagnosticWorkspace`` group. They
-contain the fitted positions in dspace, ``_dspacing``, peak widths,
-``_width``, and peak heights, ``_height``. Since multiple peak shapes
-can be used, see the documentation for the individual `fit
-functions <../fitfunctions/index.html>`_ to see how they relate to the effective
-values displayed in the diagnostic tables.
+contain the fitted positions in dspace( ``_dspacing``), peak widths
+(``_width``), peak heights (``_height``), and instrument resolution
+(delta-d/d ``_resolution``). Since multiple peak shapes can be used,
+see the documentation for the individual `fit functions
+<../fitfunctions/index.html>`_ to see how they relate to the effective
+values displayed in the diagnostic tables. For ``Gaussian`` and
+``Lorentzian``, the widths and resolution are converted to values that
+can be directly compared with the results of
+:ref:`algm-EstimateResolutionDiffraction`.
 
 Usage
 -----

--- a/docs/source/release/v3.12.0/diffraction.rst
+++ b/docs/source/release/v3.12.0/diffraction.rst
@@ -15,7 +15,7 @@ Powder Diffraction
 - Some new functionality for POLARIS in the ISIS Powder scripts. Adjusted some default parameters and output unsplined vanadium workspace by default
 - The ``CalibrationFile`` is now optional in :ref:`SNSPowderReduction <algm-SNSPowderReduction>`. In this case time focussing will use :ref:`ConvertUnits <algm-ConvertUnits>` and the instrument geometry. Care must be taken to supply a ``GroupingFile`` otherwise all of the spectra will be kept separate.
 - New algorithm :ref:`algm-EstimateDivergence` estimates the beam divergence due to finite slit size
-- :ref:`PDCalibration <algm-PDCalibration>` returns two more diagnostic workspaces: one for the fitted peak heights, one for the fitted peak widths.
+- :ref:`PDCalibration <algm-PDCalibration>` returns three more diagnostic workspaces: one for the fitted peak heights, one for the fitted peak widths, and one for observed resolution.
 
 Engineering Diffraction
 -----------------------


### PR DESCRIPTION
Add a new diangostic workspace that gives the "observed" resolution of each pixel that is calibrated.

**To test:**

The script I've been running is
```python
LoadEventNexus(Filename='PG3_37861', OutputWorkspace='PG3_37861') #/SNS/PG3/IPTS-2767/nexus/PG3_37659.nxs.h5', OutputWorkspace='PG3_37659')
PDCalibration(SignalWorkspace='PG3_37861', TofBinning='300,-0.0005,16667',
              PeakPositions='2.06,1.2615,1.0758,0.892,0.8186,0.7283,0.6867,0.6307,0.5947,0.5642,0.5441,0.515,0.4996,0.4768,0.4645,0.4205,0.3916,0.3499,0.3257,0.3117',
              PeakWindow=0.02, Tolerance=2, MinGuessedPeakWidth=4, MaxGuessedPeakWidth=14,
              MinimumPeakHeight=10, MaxChiSq=50, TZEROrange='0,10', OutputCalibrationTable='PDCalib', DiagnosticWorkspaces='diag')
```
The results can be compared to
```python
EstimateResolutionDiffraction(InputWorkspace='PG3_37861',
                              OutputWorkspace='resolution',
                              DeltaTOF=10,
                              PartialResolutionWorkspaces='partial')
```


*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
