### PR TITLE
Remove crash in debug build in LoadISISNexus

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadISISNexus2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadISISNexus2.h
@@ -147,6 +147,9 @@ private:
   void buildSpectraInd2SpectraNumMap(bool range_supplied, bool hasSpectraList,
                                      DataBlockComposite &dataBlockComposite);
 
+  /// Check if any of the spectra block ranges overlap
+  void checkOverlappingSpectraRange();
+
   /// The name and path of the input file
   std::string m_filename;
   /// The instrument name from Nexus

--- a/Framework/DataHandling/src/LoadISISNexus2.cpp
+++ b/Framework/DataHandling/src/LoadISISNexus2.cpp
@@ -696,18 +696,6 @@ void LoadISISNexus2::buildSpectraInd2SpectraNumMap(
   }
 }
 
-namespace {
-/// Compare two spectra blocks for ordering
-bool compareSpectraBlocks(const LoadISISNexus2::SpectraBlock &block1,
-                          const LoadISISNexus2::SpectraBlock &block2) {
-  bool res = block1.last < block2.first;
-  if (!res) {
-    assert(block2.last < block1.first);
-  }
-  return res;
-}
-}
-
 /**
 * Analyze the spectra ranges and prepare a list contiguous blocks. Each monitor
 * must be
@@ -738,7 +726,11 @@ LoadISISNexus2::prepareSpectraBlocks(std::map<int64_t, std::string> &monitors,
   // sort and check for overlapping
   if (m_spectraBlocks.size() > 1) {
     std::sort(m_spectraBlocks.begin(), m_spectraBlocks.end(),
-              compareSpectraBlocks);
+              [](const LoadISISNexus2::SpectraBlock &block1,
+                 const LoadISISNexus2::SpectraBlock &block2) {
+                return block1.last < block2.first;
+              });
+    checkOverlappingSpectraRange();
   }
 
   // Remove monitors that have been used.
@@ -765,14 +757,34 @@ LoadISISNexus2::prepareSpectraBlocks(std::map<int64_t, std::string> &monitors,
 }
 
 /**
-* Load a given period into the workspace
-* @param period :: The period number to load (starting from 1)
-* @param entry :: The opened root entry node for accessing the monitor and data
-* nodes
-* @param local_workspace :: The workspace to place the data in
-* @param update_spectra2det_mapping :: reset spectra-detector map to the one
-* calculated earlier. (Warning! -- this map has to be calculated correctly!)
-*/
+ * Check if any spectra block ranges overlap.
+ *
+ * Iterate over the sorted list of spectra blocks and check
+ * if the last element of the preceeding block is less than
+ * the first element of the next block.
+ */
+void LoadISISNexus2::checkOverlappingSpectraRange() {
+  for (size_t i = 1; i < m_spectraBlocks.size(); ++i) {
+    const auto &block1 = m_spectraBlocks[i - 1];
+    const auto &block2 = m_spectraBlocks[i];
+    if (block1.first > block1.last && block2.first > block2.last)
+      throw std::runtime_error("LoadISISNexus2: inconsistent spectra ranges");
+    if (block1.last >= block2.first) {
+      throw std::runtime_error(
+          "LoadISISNexus2: the range of SpectraBlocks must not overlap");
+    }
+  }
+}
+
+/**
+ * Load a given period into the workspace
+ * @param period :: The period number to load (starting from 1)
+ * @param entry :: The opened root entry node for accessing the monitor and data
+ * nodes
+ * @param local_workspace :: The workspace to place the data in
+ * @param update_spectra2det_mapping :: reset spectra-detector map to the one
+ * calculated earlier. (Warning! -- this map has to be calculated correctly!)
+ */
 void LoadISISNexus2::loadPeriodData(
     int64_t period, NXEntry &entry,
     DataObjects::Workspace2D_sptr &local_workspace,


### PR DESCRIPTION
This removes an assert statement that could be tripped depending on the implementation details of `std::sort`. 

**To test:**

See instructions in issue for how to reproduce. Data file is attached.
[PEARL00097532.nxs.zip](https://github.com/mantidproject/mantid/files/1441492/PEARL00097532.nxs.zip)


Fixes #21116 

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
