### PR TITLE
Enabled config file in ISIS Powder scripts HRPD

### DIFF
--- a/scripts/Diffraction/isis_powder/hrpd_routines/hrpd_param_mapping.py
+++ b/scripts/Diffraction/isis_powder/hrpd_routines/hrpd_param_mapping.py
@@ -7,6 +7,7 @@ attr_mapping = \
     [
         ParamMapEntry(ext_name="calibration_directory",     int_name="calibration_dir"),
         ParamMapEntry(ext_name="calibration_mapping_file",  int_name="cal_mapping_path"),
+        ParamMapEntry(ext_name="config_file",               int_name="config_file_name"),
         ParamMapEntry(ext_name="do_absorb_corrections",     int_name="do_absorb_corrections"),
         ParamMapEntry(ext_name="file_ext",                  int_name="file_extension", optional=True),
         ParamMapEntry(ext_name="focused_bin_widths",        int_name="focused_bin_widths"),


### PR DESCRIPTION
The `config_file` parameter of an instrument in `isis_powder` was exposed to HRPD, meaning the instrument object can be initialised with a yaml file instead of passing in all the required config as parameters.

**To test:**
Create a file called `config.yaml` somewhere with the following contents:
```
user_name: "Polly"
```
Running the following script should raise `AttributeError: The parameter with name: 'calibration_directory' is required but was not set or passed.`. This means that the config file was found by HRPD but is missing some parameters (which is fine, because it is).

```
from isis_powder import HRPD
hrpd = HRPD(config_file="path/to/config.yaml")
```

Fixes #21142 
Addresses part of #21148 

**Release Notes** 
Does not need to be in the release notes, as should have worked all along

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
