### PR TITLE
Histogram slicing

### DIFF
--- a/Framework/HistogramData/CMakeLists.txt
+++ b/Framework/HistogramData/CMakeLists.txt
@@ -13,6 +13,7 @@ set ( SRC_FILES
 	src/Interpolate.cpp
 	src/Points.cpp
 	src/Rebin.cpp
+	src/Slice.cpp
 )
 
 set ( INC_FILES
@@ -45,6 +46,7 @@ set ( INC_FILES
 	inc/MantidHistogramData/Points.h
 	inc/MantidHistogramData/Rebin.h
 	inc/MantidHistogramData/Scalable.h
+	inc/MantidHistogramData/Slice.h
 	inc/MantidHistogramData/StandardDeviationVectorOf.h
 	inc/MantidHistogramData/Validation.h
 	inc/MantidHistogramData/VarianceVectorOf.h
@@ -82,6 +84,7 @@ set ( TEST_FILES
 	PointsTest.h
 	RebinTest.h
 	ScalableTest.h
+	SliceTest.h
 	StandardDeviationVectorOfTest.h
 	VarianceVectorOfTest.h
 	VectorOfTest.h

--- a/Framework/HistogramData/inc/MantidHistogramData/Histogram.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/Histogram.h
@@ -139,7 +139,7 @@ public:
 
   /// Returns the size of the histogram, i.e., the number of Y data points.
   size_t size() const {
-    if (xMode() == XMode::BinEdges)
+    if (!m_x->empty() && xMode() == XMode::BinEdges)
       return m_x->size() - 1;
     return m_x->size();
   }

--- a/Framework/HistogramData/inc/MantidHistogramData/Slice.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/Slice.h
@@ -1,0 +1,42 @@
+#ifndef MANTID_HISTOGRAMDATA_SLICE_H_
+#define MANTID_HISTOGRAMDATA_SLICE_H_
+
+#include "MantidHistogramData/DllConfig.h"
+#include "MantidHistogramData/Histogram.h"
+
+namespace Mantid {
+namespace HistogramData {
+
+/** Slicing function for Histogram.
+
+  @author Simon Heybrock
+  @date 2017
+
+  Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+MANTID_HISTOGRAMDATA_DLL Histogram
+slice(const Histogram &histogram, const size_t begin, const size_t end);
+
+} // namespace HistogramData
+} // namespace Mantid
+
+#endif /* MANTID_HISTOGRAMDATA_SLICE_H_ */

--- a/Framework/HistogramData/src/Histogram.cpp
+++ b/Framework/HistogramData/src/Histogram.cpp
@@ -267,7 +267,7 @@ template <> void Histogram::checkSize(const BinEdges &binEdges) const {
   std::vector::resize which either truncates the current values
   or applies zero padding. */
 void Histogram::resize(size_t n) {
-  auto newXSize = xMode() == XMode::Points ? n : n + 1;
+  auto newXSize = (xMode() == XMode::Points || n == 0) ? n : n + 1;
 
   m_x.access().mutableRawData().resize(newXSize);
   if (m_y) {

--- a/Framework/HistogramData/src/Slice.cpp
+++ b/Framework/HistogramData/src/Slice.cpp
@@ -1,0 +1,38 @@
+#include "MantidHistogramData/Slice.h"
+
+namespace Mantid {
+namespace HistogramData {
+
+/// Returns a slice of histogram between given begin and end indices.
+Histogram slice(const Histogram &histogram, const size_t begin,
+                const size_t end) {
+  if (begin > end)
+    throw std::out_of_range(
+        "Histogram slice: begin must not be greater than end");
+  if (end > histogram.size())
+    throw std::out_of_range(
+        "Histogram slice: end may not be larger than the histogram size");
+  auto sliced(histogram);
+  if (begin == 0 && end == histogram.size())
+    return sliced;
+  sliced.resize(end - begin);
+  if (end - begin == 0)
+    return sliced;
+
+  auto xEnd = histogram.xMode() == Histogram::XMode::Points ? end : end + 1;
+  sliced.mutableX().assign(histogram.x().begin() + begin,
+                           histogram.x().begin() + xEnd);
+  if (sliced.sharedY())
+    sliced.mutableY().assign(histogram.y().begin() + begin,
+                             histogram.y().begin() + end);
+  if (sliced.sharedE())
+    sliced.mutableE().assign(histogram.e().begin() + begin,
+                             histogram.e().begin() + end);
+  if (sliced.sharedDx())
+    sliced.mutableDx().assign(histogram.dx().begin() + begin,
+                              histogram.dx().begin() + end);
+  return sliced;
+}
+
+} // namespace HistogramData
+} // namespace Mantid

--- a/Framework/HistogramData/test/HistogramTest.h
+++ b/Framework/HistogramData/test/HistogramTest.h
@@ -152,6 +152,47 @@ public:
     TS_ASSERT_EQUALS(dest.xMode(), Histogram::XMode::Points);
   }
 
+  void test_size() {
+    TS_ASSERT_EQUALS(Histogram(BinEdges(0)).size(), 0);
+    TS_ASSERT_EQUALS(Histogram(BinEdges(2)).size(), 1);
+    TS_ASSERT_EQUALS(Histogram(BinEdges(3)).size(), 2);
+    TS_ASSERT_EQUALS(Histogram(Points(0)).size(), 0);
+    TS_ASSERT_EQUALS(Histogram(Points(1)).size(), 1);
+    TS_ASSERT_EQUALS(Histogram(Points(2)).size(), 2);
+  }
+
+  void test_resize_point_data() {
+    Histogram histogram(Points(3), Counts(3));
+    histogram.resize(2);
+    TS_ASSERT_EQUALS(histogram.size(), 2);
+    TS_ASSERT_EQUALS(histogram.x().size(), 2);
+    TS_ASSERT_EQUALS(histogram.y().size(), 2);
+    histogram.resize(1);
+    TS_ASSERT_EQUALS(histogram.size(), 1);
+    TS_ASSERT_EQUALS(histogram.x().size(), 1);
+    TS_ASSERT_EQUALS(histogram.y().size(), 1);
+    histogram.resize(0);
+    TS_ASSERT_EQUALS(histogram.size(), 0);
+    TS_ASSERT_EQUALS(histogram.x().size(), 0);
+    TS_ASSERT_EQUALS(histogram.y().size(), 0);
+  }
+
+  void test_resize_histogram() {
+    Histogram histogram(BinEdges(4), Counts(3));
+    histogram.resize(2);
+    TS_ASSERT_EQUALS(histogram.size(), 2);
+    TS_ASSERT_EQUALS(histogram.x().size(), 3);
+    TS_ASSERT_EQUALS(histogram.y().size(), 2);
+    histogram.resize(1);
+    TS_ASSERT_EQUALS(histogram.size(), 1);
+    TS_ASSERT_EQUALS(histogram.x().size(), 2);
+    TS_ASSERT_EQUALS(histogram.y().size(), 1);
+    histogram.resize(0);
+    TS_ASSERT_EQUALS(histogram.size(), 0);
+    TS_ASSERT_EQUALS(histogram.x().size(), 0);
+    TS_ASSERT_EQUALS(histogram.y().size(), 0);
+  }
+
   void test_xMode() {
     Histogram hist1(Histogram::XMode::Points, Histogram::YMode::Counts);
     TS_ASSERT_EQUALS(hist1.xMode(), Histogram::XMode::Points);

--- a/Framework/HistogramData/test/SliceTest.h
+++ b/Framework/HistogramData/test/SliceTest.h
@@ -1,0 +1,157 @@
+#ifndef MANTID_HISTOGRAMDATA_SLICETEST_H_
+#define MANTID_HISTOGRAMDATA_SLICETEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidHistogramData/Slice.h"
+#include "MantidTestHelpers/HistogramDataTestHelper.h"
+
+using namespace Mantid::HistogramData;
+
+class SliceTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static SliceTest *createSuite() { return new SliceTest(); }
+  static void destroySuite(SliceTest *suite) { delete suite; }
+
+  void test_out_of_range() {
+    const Histogram histogram(BinEdges{1, 2, 3});
+    TS_ASSERT_THROWS_EQUALS(
+        slice(histogram, 1, 0), const std::out_of_range &e,
+        std::string(e.what()),
+        "Histogram slice: begin must not be greater than end");
+    TS_ASSERT_THROWS_EQUALS(
+        slice(histogram, 0, 3), const std::out_of_range &e,
+        std::string(e.what()),
+        "Histogram slice: end may not be larger than the histogram size");
+  }
+
+  void test_empty_slice() {
+    const Histogram histogram(BinEdges{1, 2, 3});
+    auto sliced = slice(histogram, 1, 1);
+    TS_ASSERT_EQUALS(sliced.size(), 0);
+    TS_ASSERT_EQUALS(sliced.x().size(), 0);
+  }
+
+  void test_empty_slice_point_data() {
+    const Histogram histogram(Points{1, 2});
+    auto sliced = slice(histogram, 1, 1);
+    TS_ASSERT_EQUALS(sliced.size(), 0);
+    TS_ASSERT_EQUALS(sliced.x().size(), 0);
+  }
+
+  void test_full_range_sharing_maintained() {
+    const Histogram histogram(BinEdges{1, 2, 3}, Counts{4, 9});
+    auto sliced = slice(histogram, 0, 2);
+    TS_ASSERT_EQUALS(sliced.sharedX(), histogram.sharedX());
+    TS_ASSERT_EQUALS(sliced.sharedY(), histogram.sharedY());
+    TS_ASSERT_EQUALS(sliced.sharedE(), histogram.sharedE());
+    TS_ASSERT(!sliced.sharedDx());
+  }
+
+  void test_slices_dx() {
+    Histogram histogram(BinEdges{1, 2, 3}, Counts{4, 9});
+    histogram.setPointStandardDeviations(2);
+    auto sliced = slice(histogram, 0, 2);
+    TS_ASSERT_EQUALS(sliced.dx(), histogram.dx());
+  }
+
+  void test_slice_single_bin_at_start() {
+    const Histogram histogram(BinEdges{1, 2, 3, 4}, Counts{4, 9, 16});
+    auto sliced = slice(histogram, 0, 1);
+    TS_ASSERT_EQUALS(sliced.x(), HistogramX({1, 2}));
+    TS_ASSERT_EQUALS(sliced.y(), HistogramY({4}));
+    TS_ASSERT_EQUALS(sliced.e(), HistogramE({2}));
+  }
+
+  void test_slice_single_bin() {
+    const Histogram histogram(BinEdges{1, 2, 3, 4}, Counts{4, 9, 16});
+    auto sliced = slice(histogram, 1, 2);
+    TS_ASSERT_EQUALS(sliced.x(), HistogramX({2, 3}));
+    TS_ASSERT_EQUALS(sliced.y(), HistogramY({9}));
+    TS_ASSERT_EQUALS(sliced.e(), HistogramE({3}));
+  }
+
+  void test_slice_single_bin_at_end() {
+    const Histogram histogram(BinEdges{1, 2, 3, 4}, Counts{4, 9, 16});
+    auto sliced = slice(histogram, 2, 3);
+    TS_ASSERT_EQUALS(sliced.x(), HistogramX({3, 4}));
+    TS_ASSERT_EQUALS(sliced.y(), HistogramY({16}));
+    TS_ASSERT_EQUALS(sliced.e(), HistogramE({4}));
+  }
+
+  void test_points_slice_single_bin_at_start() {
+    const Histogram histogram(Points{1, 2, 3}, Counts{4, 9, 16});
+    auto sliced = slice(histogram, 0, 1);
+    TS_ASSERT_EQUALS(sliced.x(), HistogramX({1}));
+    TS_ASSERT_EQUALS(sliced.y(), HistogramY({4}));
+    TS_ASSERT_EQUALS(sliced.e(), HistogramE({2}));
+  }
+
+  void test_points_slice_single_bin() {
+    const Histogram histogram(Points{1, 2, 3}, Counts{4, 9, 16});
+    auto sliced = slice(histogram, 1, 2);
+    TS_ASSERT_EQUALS(sliced.x(), HistogramX({2}));
+    TS_ASSERT_EQUALS(sliced.y(), HistogramY({9}));
+    TS_ASSERT_EQUALS(sliced.e(), HistogramE({3}));
+  }
+
+  void test_points_slice_single_bin_at_end() {
+    const Histogram histogram(Points{1, 2, 3}, Counts{4, 9, 16});
+    auto sliced = slice(histogram, 2, 3);
+    TS_ASSERT_EQUALS(sliced.x(), HistogramX({3}));
+    TS_ASSERT_EQUALS(sliced.y(), HistogramY({16}));
+    TS_ASSERT_EQUALS(sliced.e(), HistogramE({4}));
+  }
+
+  void test_slice_two_bins_at_start() {
+    const Histogram histogram(BinEdges{1, 2, 3, 4, 5}, Counts{1, 4, 9, 16});
+    auto sliced = slice(histogram, 0, 2);
+    TS_ASSERT_EQUALS(sliced.x(), HistogramX({1, 2, 3}));
+    TS_ASSERT_EQUALS(sliced.y(), HistogramY({1, 4}));
+    TS_ASSERT_EQUALS(sliced.e(), HistogramE({1, 2}));
+  }
+
+  void test_slice_two_bins() {
+    const Histogram histogram(BinEdges{1, 2, 3, 4, 5}, Counts{1, 4, 9, 16});
+    auto sliced = slice(histogram, 1, 3);
+    TS_ASSERT_EQUALS(sliced.x(), HistogramX({2, 3, 4}));
+    TS_ASSERT_EQUALS(sliced.y(), HistogramY({4, 9}));
+    TS_ASSERT_EQUALS(sliced.e(), HistogramE({2, 3}));
+  }
+
+  void test_slice_two_bins_at_end() {
+    const Histogram histogram(BinEdges{1, 2, 3, 4, 5}, Counts{1, 4, 9, 16});
+    auto sliced = slice(histogram, 2, 4);
+    TS_ASSERT_EQUALS(sliced.x(), HistogramX({3, 4, 5}));
+    TS_ASSERT_EQUALS(sliced.y(), HistogramY({9, 16}));
+    TS_ASSERT_EQUALS(sliced.e(), HistogramE({3, 4}));
+  }
+
+  void test_points_slice_two_bins_at_start() {
+    const Histogram histogram(Points{1, 2, 3, 4}, Counts{1, 4, 9, 16});
+    auto sliced = slice(histogram, 0, 2);
+    TS_ASSERT_EQUALS(sliced.x(), HistogramX({1, 2}));
+    TS_ASSERT_EQUALS(sliced.y(), HistogramY({1, 4}));
+    TS_ASSERT_EQUALS(sliced.e(), HistogramE({1, 2}));
+  }
+
+  void test_points_slice_two_bins() {
+    const Histogram histogram(Points{1, 2, 3, 4}, Counts{1, 4, 9, 16});
+    auto sliced = slice(histogram, 1, 3);
+    TS_ASSERT_EQUALS(sliced.x(), HistogramX({2, 3}));
+    TS_ASSERT_EQUALS(sliced.y(), HistogramY({4, 9}));
+    TS_ASSERT_EQUALS(sliced.e(), HistogramE({2, 3}));
+  }
+
+  void test_points_slice_two_bins_at_end() {
+    const Histogram histogram(Points{1, 2, 3, 4}, Counts{1, 4, 9, 16});
+    auto sliced = slice(histogram, 2, 4);
+    TS_ASSERT_EQUALS(sliced.x(), HistogramX({3, 4}));
+    TS_ASSERT_EQUALS(sliced.y(), HistogramY({9, 16}));
+    TS_ASSERT_EQUALS(sliced.e(), HistogramE({3, 4}));
+  }
+};
+
+#endif /* MANTID_HISTOGRAMDATA_SLICETEST_H_ */


### PR DESCRIPTION
Adds slicing for `Histogram`, similar to (but more limited than) list slicing in Python.

Also fixes the issues with `Histogram::size()` and `resize`.

**To test:**

Code review.
No related issue. No release notes, internal addition.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
