### PR TITLE
Change from setting PYTHONPATH to using .pth files

### DIFF
--- a/buildconfig/CMake/LinuxPackageScripts.cmake
+++ b/buildconfig/CMake/LinuxPackageScripts.cmake
@@ -39,9 +39,8 @@ file ( WRITE ${CMAKE_CURRENT_BINARY_DIR}/mantid.sh
   "MANTIDPATH=${CMAKE_INSTALL_PREFIX}/${BIN_DIR}\n"
   "PV_PLUGIN_PATH=${CMAKE_INSTALL_PREFIX}/${PVPLUGINS_DIR}/${PVPLUGINS_DIR}\n"
   "PATH=$PATH:$MANTIDPATH\n"
-  "PYTHONPATH=$MANTIDPATH:$PYTHONPATH\n"
 
-  "export MANTIDPATH PV_PLUGIN_PATH PATH PYTHONPATH\n"
+  "export MANTIDPATH PV_PLUGIN_PATH PATH\n"
 )
 
 # c-shell
@@ -50,17 +49,26 @@ file ( WRITE ${CMAKE_CURRENT_BINARY_DIR}/mantid.csh
   "setenv MANTIDPATH \"${CMAKE_INSTALL_PREFIX}/${BIN_DIR}\"\n"
   "setenv PV_PLUGIN_PATH \"${CMAKE_INSTALL_PREFIX}/${PVPLUGINS_DIR}/${PVPLUGINS_DIR}\"\n"
   "setenv PATH \"\${PATH}:\${MANTIDPATH}\"\n"
-
-  "if ($?PYTHONPATH) then\n"
-  "  setenv PYTHONPATH \"\${MANTIDPATH}:\${PYTHONPATH}\"\n"
-  "else\n"
-  "  setenv PYTHONPATH \"\${MANTIDPATH}\"\n"
-  "endif\n"
 )
 
 install ( PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/mantid.sh
   ${CMAKE_CURRENT_BINARY_DIR}/mantid.csh
+  ${CMAKE_CURRENT_BINARY_DIR}/mantid.pth
   DESTINATION ${ETC_DIR}
+)
+
+###########################################################################
+# Find python site-packages dir and create mantid.pth
+###########################################################################
+execute_process(
+  COMMAND "${PYTHON_EXECUTABLE}" -c "if True:
+    from distutils import sysconfig as sc
+    print(sc.get_python_lib(plat_specific=True))"
+  OUTPUT_VARIABLE PYTHON_SITE
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+file ( WRITE ${CMAKE_CURRENT_BINARY_DIR}/mantid.pth
+  "${CMAKE_INSTALL_PREFIX}/${BIN_DIR}\n"
 )
 
 ############################################################################

--- a/buildconfig/CMake/LinuxPackageScripts.cmake
+++ b/buildconfig/CMake/LinuxPackageScripts.cmake
@@ -24,7 +24,10 @@ if ( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
 endif()
 
 # We are only generating Qt4 packages at the moment
-set ( CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${LIB_DIR};${CMAKE_INSTALL_PREFIX}/${PLUGINS_DIR}/qt4 )
+set ( CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${LIB_DIR};${CMAKE_INSTALL_PREFIX}/${PLUGINS_DIR};${CMAKE_INSTALL_PREFIX}/${PLUGINS_DIR}/qt4; )
+if ( MAKE_VATES )
+  list ( APPEND CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${LIB_DIR}/paraview-${ParaView_VERSION_MAJOR}.${ParaView_VERSION_MINOR} )
+endif ()
 
 # Tell rpm that this package does not own /opt /usr/share/{applications,pixmaps}
 # Required for Fedora >= 18 and RHEL >= 7
@@ -61,9 +64,8 @@ install ( PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/mantid.sh
 # Find python site-packages dir and create mantid.pth
 ###########################################################################
 execute_process(
-  COMMAND "${PYTHON_EXECUTABLE}" -c "if True:
-    from distutils import sysconfig as sc
-    print(sc.get_python_lib(plat_specific=True))"
+  COMMAND "${PYTHON_EXECUTABLE}" -c "from distutils import sysconfig as sc
+print(sc.get_python_lib(plat_specific=True))"
   OUTPUT_VARIABLE PYTHON_SITE
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 
@@ -162,6 +164,11 @@ configure_file ( ${CMAKE_MODULE_PATH}/Packaging/mantidpython.in
                  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/mantidpython @ONLY )
 # Needs to be executable
 execute_process ( COMMAND "chmod" "+x" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/mantidpython"
+                  OUTPUT_QUIET ERROR_QUIET )
+configure_file ( ${CMAKE_MODULE_PATH}/Packaging/AddPythonPath.py.in
+                 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/AddPythonPath.py @ONLY )
+# Needs to be executable
+execute_process ( COMMAND "chmod" "+x" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/AddPythonPath.py"
                   OUTPUT_QUIET ERROR_QUIET )
 
 # Package version

--- a/buildconfig/CMake/Packaging/AddPythonPath.py.in
+++ b/buildconfig/CMake/Packaging/AddPythonPath.py.in
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+"""This will create a mantid.pth file in your current python
+environment pointing to this build of mantid
+"""
+
+from __future__ import print_function
+from distutils import sysconfig as sc
+import os
+import sys
+
+# get location of mantid this was run with
+mantidpath = "@CMAKE_RUNTIME_OUTPUT_DIRECTORY@"
+
+# check mantid can be loaded in this python
+sys.path.append(mantidpath)
+try:
+    import mantid
+except ImportError as e:
+    print("Can't import mantid: {}".format(e))
+    exit(1)
+
+# check that trailing `/` is there
+if not mantidpath.endswith(os.sep):
+    mantidpath += os.sep
+
+# where path file should go
+pathfile = os.path.join(sc.get_python_lib(plat_specific=True), 'mantid.pth')
+
+print('writing', mantidpath, 'to', pathfile)
+with open(pathfile, 'w') as f:
+    f.write(mantidpath)
+    f.write('\n')

--- a/buildconfig/CMake/Packaging/deb/scripts/deb_post_inst.in
+++ b/buildconfig/CMake/Packaging/deb/scripts/deb_post_inst.in
@@ -43,6 +43,7 @@ case "$1" in
 	# Link profiles to /etc/profile.d
 	ln -s @CMAKE_INSTALL_PREFIX@/@ETC_DIR@/mantid.sh /etc/profile.d/mantid.sh
 	ln -s @CMAKE_INSTALL_PREFIX@/@ETC_DIR@/mantid.csh /etc/profile.d/mantid.csh
+	ln -s @CMAKE_INSTALL_PREFIX@/@ETC_DIR@/mantid.pth @PYTHON_SITE@/mantid.pth
     fi
   ;;
 

--- a/buildconfig/CMake/Packaging/deb/scripts/deb_pre_inst.in
+++ b/buildconfig/CMake/Packaging/deb/scripts/deb_pre_inst.in
@@ -37,6 +37,9 @@ case "$1" in
 	    if [ -h /etc/profile.d/mantid.csh ]; then
 		rm /etc/profile.d/mantid.csh
 	    fi
+	    if [ -h @PYTHON_SITE@/mantid.pth ]; then
+		rm @PYTHON_SITE@/mantid.pth
+	    fi
 	fi
 	;;
 

--- a/buildconfig/CMake/Packaging/deb/scripts/deb_pre_rm.in
+++ b/buildconfig/CMake/Packaging/deb/scripts/deb_pre_rm.in
@@ -36,6 +36,9 @@ case "$1" in
 	    if [ -h /etc/profile.d/mantid.csh ]; then
 		rm /etc/profile.d/mantid.csh
 	    fi
+	    if [ -h @PYTHON_SITE@/mantid.pth ]; then
+		rm @PYTHON_SITE@/mantid.pth
+	    fi
 	fi
 	;;
     

--- a/buildconfig/CMake/Packaging/rpm/scripts/rpm_post_install.sh.in
+++ b/buildconfig/CMake/Packaging/rpm/scripts/rpm_post_install.sh.in
@@ -22,6 +22,7 @@ if [ ${ENVVARS_ON_INSTALL} -eq 1 ]; then
     # Link profiles to /etc/profile.d
     ln -s $RPM_INSTALL_PREFIX0/@ETC_DIR@/mantid.sh /etc/profile.d/mantid.sh
     ln -s $RPM_INSTALL_PREFIX0/@ETC_DIR@/mantid.csh /etc/profile.d/mantid.csh
+    ln -s $RPM_INSTALL_PREFIX0/@ETC_DIR@/mantid.pth @PYTHON_SITE@/mantid.pth
 else
     # Create symbolic links in world's path
     if [ ! -L /usr/bin/mantidplot@CPACK_PACKAGE_SUFFIX@ ]; then

--- a/buildconfig/CMake/Packaging/rpm/scripts/rpm_post_uninstall.sh.in
+++ b/buildconfig/CMake/Packaging/rpm/scripts/rpm_post_uninstall.sh.in
@@ -20,6 +20,9 @@ if [ ! -e $RPM_INSTALL_PREFIX0/@BIN_DIR@/launch_mantidplot.sh  ]; then
 	if [ -h /etc/profile.d/mantid.csh ]; then
 	    rm /etc/profile.d/mantid.csh
 	fi
+	if [ -h @PYTHON_SITE@/mantid.pth ]; then
+	    rm @PYTHON_SITE@/mantid.pth
+	fi
     fi
 
     if [ -L /usr/bin/mantidplot@CPACK_PACKAGE_SUFFIX@ ]; then

--- a/buildconfig/CMake/Packaging/rpm/scripts/rpm_pre_install.sh.in
+++ b/buildconfig/CMake/Packaging/rpm/scripts/rpm_pre_install.sh.in
@@ -22,4 +22,7 @@ if [ ${ENVVARS_ON_INSTALL} -eq 1 ]; then
   if [ -h /etc/profile.d/mantid.csh ]; then
       rm /etc/profile.d/mantid.csh
   fi
+  if [ -h @PYTHON_SITE@/mantid.pth ]; then
+      rm @PYTHON_SITE@/mantid.pth
+  fi
 fi


### PR DESCRIPTION
This will allow both python 2 and 3 packages to be installed and imported into native python correctly

At the moment if you try to import python 2 mantid into python 3 you get:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/Mantid/bin/mantid/__init__.py", line 25, in <module>
    from . import pyversion
  File "/opt/Mantid/bin/mantid/pyversion.py", line 18, in <module>
    raise ImportError(message % (TARGET_VERSION, _running_vers))
ImportError: Python version mismatch, cannot continue.
Mantid was built against version '2.7' but you are running version '3.6'. These versions
must match.
```
So we should not be using `PYTHONPATH`

**To test:**
Build release packages for python 2 and 3, install and test importing into python 2 and 3

**Does not need to be in the release notes.**

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
