### PR TITLE
 Use correct length from MatrixWorkspace in RefAxis.

### DIFF
--- a/Framework/API/inc/MantidAPI/RefAxis.h
+++ b/Framework/API/inc/MantidAPI/RefAxis.h
@@ -1,9 +1,6 @@
 #ifndef MANTID_API_REFAXIS_H_
 #define MANTID_API_REFAXIS_H_
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
 #include "MantidAPI/NumericAxis.h"
 
 namespace Mantid {
@@ -41,13 +38,12 @@ namespace API {
 */
 class MANTID_API_DLL RefAxis : public NumericAxis {
 public:
-  RefAxis(const std::size_t &length,
-          const MatrixWorkspace *const parentWorkspace);
+  RefAxis(const MatrixWorkspace *const parentWorkspace);
 
   Axis *clone(const MatrixWorkspace *const parentWorkspace) override;
   Axis *clone(const std::size_t length,
               const MatrixWorkspace *const parentWorkspace) override;
-  std::size_t length() const override { return m_size; }
+  std::size_t length() const override;
   /// Get a value at the specified index
   double operator()(const std::size_t &index,
                     const std::size_t &verticalIndex) const override;
@@ -72,8 +68,6 @@ private:
 
   /// A pointer to the workspace holding the axis
   const MatrixWorkspace *const m_parentWS;
-  /// Length of the axis
-  std::size_t m_size;
 };
 
 } // namespace API

--- a/Framework/API/src/RefAxis.cpp
+++ b/Framework/API/src/RefAxis.cpp
@@ -1,6 +1,3 @@
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
 #include "MantidAPI/RefAxis.h"
 #include "MantidAPI/MatrixWorkspace.h"
 
@@ -8,14 +5,12 @@ namespace Mantid {
 namespace API {
 
 /** Constructor
- *  @param length :: The length of this axis
  *  @param parentWorkspace :: A pointer to the workspace that holds this axis
  */
 // NumericAxis is set to length 0 since we do not need its internal storage. We
 // override public functions of NumericAxis that would access it.
-RefAxis::RefAxis(const std::size_t &length,
-                 const MatrixWorkspace *const parentWorkspace)
-    : NumericAxis(0), m_parentWS(parentWorkspace), m_size(length) {}
+RefAxis::RefAxis(const MatrixWorkspace *const parentWorkspace)
+    : NumericAxis(0), m_parentWS(parentWorkspace) {}
 
 /** Private, specialised copy constructor. Needed because it's necessary to pass
  * in
@@ -27,7 +22,7 @@ RefAxis::RefAxis(const std::size_t &length,
  */
 RefAxis::RefAxis(const RefAxis &right,
                  const MatrixWorkspace *const parentWorkspace)
-    : NumericAxis(right), m_parentWS(parentWorkspace), m_size(right.m_size) {}
+    : NumericAxis(right), m_parentWS(parentWorkspace) {}
 
 /** Virtual constructor
  *  @param parentWorkspace :: A pointer to the workspace that will hold the new
@@ -40,10 +35,11 @@ Axis *RefAxis::clone(const MatrixWorkspace *const parentWorkspace) {
 
 Axis *RefAxis::clone(const std::size_t length,
                      const MatrixWorkspace *const parentWorkspace) {
-  auto newAxis = new RefAxis(*this, parentWorkspace);
-  newAxis->m_size = length;
-  return newAxis;
+  static_cast<void>(length);
+  return clone(parentWorkspace);
 }
+
+std::size_t RefAxis::length() const { return m_parentWS->x(0).size(); }
 
 /** Get the axis value at the position given. In this case, the values are held
  * in the
@@ -57,12 +53,12 @@ Axis *RefAxis::clone(const std::size_t length,
  */
 double RefAxis::operator()(const std::size_t &index,
                            const std::size_t &verticalIndex) const {
-  if (index >= m_size) {
-    throw Kernel::Exception::IndexError(index, m_size - 1,
+  const auto &x = m_parentWS->x(verticalIndex);
+  if (index >= x.size()) {
+    throw Kernel::Exception::IndexError(index, x.size() - 1,
                                         "Axis: Index out of range.");
   }
-
-  return m_parentWS->dataX(verticalIndex)[index];
+  return x[index];
 }
 
 /** Method not available for RefAxis. Will always throw.

--- a/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Framework/DataObjects/src/EventWorkspace.cpp
@@ -80,7 +80,8 @@ bool EventWorkspace::threadSafe() const {
 void EventWorkspace::init(const std::size_t &NVectors,
                           const std::size_t &XLength,
                           const std::size_t &YLength) {
-  (void)YLength; // Avoid compiler warning
+  static_cast<void>(XLength);
+  static_cast<void>(YLength);
 
   // Check validity of arguments
   if (NVectors <= 0) {
@@ -106,7 +107,7 @@ void EventWorkspace::init(const std::size_t &NVectors,
 
   // Create axes.
   m_axes.resize(2);
-  m_axes[0] = new API::RefAxis(XLength, this);
+  m_axes[0] = new API::RefAxis(this);
   m_axes[1] = new API::SpectraAxis(this);
 }
 
@@ -129,7 +130,7 @@ void EventWorkspace::init(const HistogramData::Histogram &histogram) {
   }
 
   m_axes.resize(2);
-  m_axes[0] = new API::RefAxis(histogram.x().size(), this);
+  m_axes[0] = new API::RefAxis(this);
   m_axes[1] = new API::SpectraAxis(this);
 }
 

--- a/Framework/DataObjects/src/Workspace2D.cpp
+++ b/Framework/DataObjects/src/Workspace2D.cpp
@@ -86,7 +86,7 @@ void Workspace2D::init(const std::size_t &NVectors, const std::size_t &XLength,
 
   // Add axes that reference the data
   m_axes.resize(2);
-  m_axes[0] = new API::RefAxis(XLength, this);
+  m_axes[0] = new API::RefAxis(this);
   m_axes[1] = new API::SpectraAxis(this);
 }
 
@@ -113,7 +113,7 @@ void Workspace2D::init(const HistogramData::Histogram &histogram) {
 
   // Add axes that reference the data
   m_axes.resize(2);
-  m_axes[0] = new API::RefAxis(initializedHistogram.x().size(), this);
+  m_axes[0] = new API::RefAxis(this);
   m_axes[1] = new API::SpectraAxis(this);
 }
 

--- a/Framework/DataObjects/test/RefAxisTest.h
+++ b/Framework/DataObjects/test/RefAxisTest.h
@@ -43,7 +43,7 @@ public:
     delete[] b;
 
     // Create the axis that the tests will be performed on
-    refAxis = new RefAxis(5, space);
+    refAxis = new RefAxis(space);
     refAxis->title() = "test axis";
     refAxis->unit() = UnitFactory::Instance().create("TOF");
   }

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
@@ -207,7 +207,7 @@ protected:
 
     // Put an 'empty' axis in to test the getAxis method
     m_axes.resize(2);
-    m_axes[0] = new Mantid::API::RefAxis(j, this);
+    m_axes[0] = new Mantid::API::RefAxis(this);
     m_axes[1] = new Mantid::API::SpectraAxis(this);
   }
   void init(const Mantid::HistogramData::Histogram &histogram) override {
@@ -215,7 +215,7 @@ protected:
 
     // Put an 'empty' axis in to test the getAxis method
     m_axes.resize(2);
-    m_axes[0] = new Mantid::API::RefAxis(histogram.x().size(), this);
+    m_axes[0] = new Mantid::API::RefAxis(this);
     m_axes[1] = new Mantid::API::SpectraAxis(this);
   }
 


### PR DESCRIPTION
Avoid truncating or reading out of bounds by using correct length in `RefAxis`. This is relevant only if the length of X changes in a workspace after initialization. See issue for details and example.

**To test:**

Code review.
Fixes #21162.
No one complained, so probably not worth mentioning? Could potentially have been the reason for some crashes or ununderstood issues?

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
