### PR TITLE
Fix packaging of Vates/ParaView plugins on OSX 

### DIFF
--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -159,12 +159,13 @@ if( "@MAKE_VATES@" == "ON" )
 
   `mkdir Contents/Libraries`
   `cp #{ParaView_dir}/lib/*Python.so Contents/Libraries`
+  `cp #{ParaView_dir}/lib/libNonOrthogonalSource.dylib plugins/paraview/qt4/`
   vatesfiles = ["Contents/MacOS/MantidPlot",
                 "Contents/MacOS/libMantidQtWidgetsCommonQt4.dylib",
                 "Contents/MacOS/libMantidVatesAPI.dylib",
                 "plugins/libMantidVatesAlgorithms.dylib",
-                "plugins/qt4/libMantidVatesSimpleGuiViewWidgets.dylib"]
-  vatesfiles += Dir["Contents/Libraries/*Python.so"] + Dir["plugins/paraview/*.dylib"]
+                "plugins/qt4/libMantidVatesSimpleGuiViewWidgetsQt4.dylib"]
+  vatesfiles += Dir["Contents/Libraries/*Python.so"] + Dir["plugins/paraview/qt4/*.dylib"]
   vatesfiles.each do |file|
     add_ParaView_Libraries(file)
   end
@@ -196,7 +197,7 @@ if( "@MAKE_VATES@" == "ON" )
     break if issues_found == 0
   end
   #fix libNonOrthogonalSource.dylib
-  `install_name_tool -id @rpath/libNonOrthogonalSource.dylib plugins/paraview/libNonOrthogonalSource.dylib`
+  `install_name_tool -id @rpath/libNonOrthogonalSource.dylib plugins/paraview/qt4/libNonOrthogonalSource.dylib`
 end
 
 #use install_name_tool to change dependencies from /usr/local to libraries in the package.


### PR DESCRIPTION
**Description of work**

The OSX packaging is currently broken after the code shuffle in #21073.

**To test:**

* On OSX build a package with `MAKE_VATES=ON` and it should complete successfully.

*No issue number*

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
