### PR TITLE
Cleanup Run sharing in ExperimentInfo

### DIFF
--- a/Framework/API/inc/MantidAPI/ExperimentInfo.h
+++ b/Framework/API/inc/MantidAPI/ExperimentInfo.h
@@ -104,6 +104,8 @@ public:
   const Run &run() const;
   /// Writable version of the run object
   Run &mutableRun();
+  void setSharedRun(Kernel::cow_ptr<Run> run);
+
   /// Access a log for this experiment.
   Kernel::Property *getLog(const std::string &log) const;
   /// Access a single value from a log for this experiment.
@@ -187,10 +189,6 @@ protected:
   boost::shared_ptr<ModeratorModel> m_moderatorModel;
   /// Description of the choppers for this experiment.
   std::list<boost::shared_ptr<ChopperModel>> m_choppers;
-  /// The information on the sample environment
-  boost::shared_ptr<Sample> m_sample;
-  /// The run information
-  boost::shared_ptr<Run> m_run;
   /// Parameters modifying the base instrument
   boost::shared_ptr<Geometry::ParameterMap> m_parmap;
   /// The base (unparametrized) instrument
@@ -218,6 +216,12 @@ private:
 
   // Loads the xml from an instrument file with some basic error handling
   std::string loadInstrumentXML(const std::string &filename);
+
+  /// The information on the sample environment
+  Kernel::cow_ptr<Sample> m_sample;
+  /// The run information
+  Kernel::cow_ptr<Run> m_run;
+
   /// Detector grouping information
   mutable std::unordered_map<detid_t, size_t> m_det2group;
   void cacheDefaultDetectorGrouping() const; // Not thread-safe

--- a/Framework/API/inc/MantidAPI/ExperimentInfo.h
+++ b/Framework/API/inc/MantidAPI/ExperimentInfo.h
@@ -228,9 +228,6 @@ private:
   void invalidateAllSpectrumDefinitions();
   mutable std::once_flag m_defaultDetectorGroupingCached;
 
-  /// Mutex to protect against cow_ptr copying
-  mutable std::recursive_mutex m_mutex;
-
   mutable std::unique_ptr<Beamline::SpectrumInfo> m_spectrumInfo;
   mutable std::unique_ptr<SpectrumInfo> m_spectrumInfoWrapper;
   mutable std::mutex m_spectrumInfoMutex;

--- a/Framework/API/inc/MantidAPI/WorkspaceFactory.h
+++ b/Framework/API/inc/MantidAPI/WorkspaceFactory.h
@@ -82,10 +82,6 @@ public:
                             MatrixWorkspace &child,
                             const bool differentSize) const;
 
-  void initializeFromParentWithoutLogs(const MatrixWorkspace &parent,
-                                       MatrixWorkspace &child,
-                                       const bool differentSize) const;
-
   /// Create a ITableWorkspace
   boost::shared_ptr<ITableWorkspace>
   createTable(const std::string &className = "TableWorkspace") const;

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -66,8 +66,7 @@ Kernel::Logger g_log("ExperimentInfo");
 /** Constructor
  */
 ExperimentInfo::ExperimentInfo()
-    : m_moderatorModel(), m_choppers(), m_sample(new Sample()),
-      m_run(new Run()), m_parmap(new ParameterMap()),
+    : m_moderatorModel(), m_choppers(), m_parmap(new ParameterMap()),
       sptr_instrument(new Instrument()) {
   m_parmap->setInstrument(sptr_instrument.get());
 }
@@ -91,7 +90,7 @@ ExperimentInfo::~ExperimentInfo() = default;
  */
 void ExperimentInfo::copyExperimentInfoFrom(const ExperimentInfo *other) {
   m_sample = other->m_sample;
-  m_run = other->m_run->clone();
+  m_run = other->m_run;
   this->setInstrument(other->getInstrument());
   if (other->m_moderatorModel)
     m_moderatorModel = other->m_moderatorModel->clone();
@@ -602,30 +601,17 @@ ChopperModel &ExperimentInfo::chopperModel(const size_t index) const {
 */
 const Sample &ExperimentInfo::sample() const {
   populateIfNotLoaded();
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   return *m_sample;
 }
 
 /** Get a reference to the Sample associated with this workspace.
 *  This non-const method will copy the sample if it is shared between
 *  more than one workspace, and the reference returned will be to the copy.
-*  Can ONLY be taken by reference!
 * @return reference to sample object
 */
 Sample &ExperimentInfo::mutableSample() {
   populateIfNotLoaded();
-  // Use a double-check for sharing so that we only
-  // enter the critical region if absolutely necessary
-  if (!m_sample.unique()) {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    // Check again because another thread may have taken copy
-    // and dropped reference count since previous check
-    if (!m_sample.unique()) {
-      boost::shared_ptr<Sample> oldData = m_sample;
-      m_sample = boost::make_shared<Sample>(*oldData);
-    }
-  }
-  return *m_sample;
+  return m_sample.access();
 }
 
 /** Get a constant reference to the Run object associated with this workspace.
@@ -633,30 +619,22 @@ Sample &ExperimentInfo::mutableSample() {
 */
 const Run &ExperimentInfo::run() const {
   populateIfNotLoaded();
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   return *m_run;
 }
 
 /** Get a reference to the Run object associated with this workspace.
 *  This non-const method will copy the Run object if it is shared between
 *  more than one workspace, and the reference returned will be to the copy.
-*  Can ONLY be taken by reference!
 * @return reference to Run object
 */
 Run &ExperimentInfo::mutableRun() {
   populateIfNotLoaded();
-  // Use a double-check for sharing so that we only
-  // enter the critical region if absolutely necessary
-  if (!m_run.unique()) {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    // Check again because another thread may have taken copy
-    // and dropped reference count since previous check
-    if (!m_run.unique()) {
-      boost::shared_ptr<Run> oldData = m_run;
-      m_run = boost::make_shared<Run>(*oldData);
-    }
-  }
-  return *m_run;
+  return m_run.access();
+}
+
+/// Set the run object. Use in particular to clear run without copying old run.
+void ExperimentInfo::setSharedRun(Kernel::cow_ptr<Run> run) {
+  m_run = std::move(run);
 }
 
 /**

--- a/Framework/API/src/WorkspaceFactory.cpp
+++ b/Framework/API/src/WorkspaceFactory.cpp
@@ -93,14 +93,7 @@ void WorkspaceFactoryImpl::initializeFromParentWithoutLogs(
     const bool differentSize) const {
   child.setTitle(parent.getTitle());
   child.setComment(parent.getComment());
-  child.setInstrument(parent.getInstrument()); // This call also copies the
-                                               // SHARED POINTER to the
-                                               // parameter map
-
-  // This call will (should) perform a COPY of the parameter map.
-  child.instrumentParameters();
-  child.m_sample = parent.m_sample;
-  child.m_run = boost::make_shared<API::Run>();
+  child.copyExperimentInfoFrom(&parent);
   child.setYUnit(parent.m_YUnit);
   child.setYUnitLabel(parent.m_YUnitLabel);
   child.setDistribution(parent.isDistribution());
@@ -157,7 +150,6 @@ void WorkspaceFactoryImpl::initializeFromParent(
     const MatrixWorkspace &parent, MatrixWorkspace &child,
     const bool differentSize) const {
   initializeFromParentWithoutLogs(parent, child, differentSize);
-  child.m_run = parent.m_run;
 }
 
 /** Creates a new instance of the class with the given name, and allocates

--- a/Framework/API/src/WorkspaceFactory.cpp
+++ b/Framework/API/src/WorkspaceFactory.cpp
@@ -78,17 +78,15 @@ WorkspaceFactoryImpl::create(const MatrixWorkspace_const_sptr &parent,
 }
 
 /** Initialize a workspace from its parent
- * This sets values such as instrument, units, sample, spectramap.
+ * This sets values such as title, instrument, units, sample, spectramap.
  * This does NOT copy any data.
- * This does NOT copy any sample logs, i.e., Run object of the workspace won't
- * be copied
- * from its parent.
- * @brief WorkspaceFactoryImpl::initializeFromParentWithoutLogs
- * @param parent
- * @param child
- * @param differentSize
+ *
+ * @param parent :: the parent workspace
+ * @param child :: the child workspace
+ * @param differentSize :: A flag to indicate if the two workspace will be
+ *different sizes
  */
-void WorkspaceFactoryImpl::initializeFromParentWithoutLogs(
+void WorkspaceFactoryImpl::initializeFromParent(
     const MatrixWorkspace &parent, MatrixWorkspace &child,
     const bool differentSize) const {
   child.setTitle(parent.getTitle());
@@ -135,21 +133,6 @@ void WorkspaceFactoryImpl::initializeFromParentWithoutLogs(
       }
     }
   }
-}
-
-/** Initialize a workspace from its parent
- * This sets values such as title, instrument, units, sample, spectramap.
- * This does NOT copy any data.
- *
- * @param parent :: the parent workspace
- * @param child :: the child workspace
- * @param differentSize :: A flag to indicate if the two workspace will be
- *different sizes
- */
-void WorkspaceFactoryImpl::initializeFromParent(
-    const MatrixWorkspace &parent, MatrixWorkspace &child,
-    const bool differentSize) const {
-  initializeFromParentWithoutLogs(parent, child, differentSize);
 }
 
 /** Creates a new instance of the class with the given name, and allocates

--- a/Framework/Algorithms/src/FilterEvents.cpp
+++ b/Framework/Algorithms/src/FilterEvents.cpp
@@ -1092,7 +1092,9 @@ void FilterEvents::createOutputWorkspaces() {
     }
 
     boost::shared_ptr<EventWorkspace> optws =
-        createWithoutLogs<DataObjects::EventWorkspace>(*m_eventWS);
+        create<EventWorkspace>(*m_eventWS);
+    // Clear Run without copying first.
+    optws->setSharedRun(Kernel::make_cow<Run>());
     m_outputWorkspacesMap.emplace(wsgroup, optws);
 
     // Add information, including title and comment, to output workspace

--- a/Framework/Algorithms/src/FilterEvents.cpp
+++ b/Framework/Algorithms/src/FilterEvents.cpp
@@ -1204,7 +1204,9 @@ void FilterEvents::createOutputWorkspacesMatrixCase() {
     // create new workspace from input EventWorkspace and all the sample logs
     // are copied to the new one
     boost::shared_ptr<EventWorkspace> optws =
-        createWithoutLogs<DataObjects::EventWorkspace>(*m_eventWS);
+        create<EventWorkspace>(*m_eventWS);
+    // Clear Run without copying first.
+    optws->setSharedRun(Kernel::make_cow<Run>());
     m_outputWorkspacesMap.emplace(wsgroup, optws);
 
     // TODO/ISSUE/NOW - How about comment and info similar to
@@ -1294,7 +1296,9 @@ void FilterEvents::createOutputWorkspacesTableSplitterCase() {
 
     // create new workspace
     boost::shared_ptr<EventWorkspace> optws =
-        createWithoutLogs<DataObjects::EventWorkspace>(*m_eventWS);
+        create<EventWorkspace>(*m_eventWS);
+    // Clear Run without copying first.
+    optws->setSharedRun(Kernel::make_cow<Run>());
     m_outputWorkspacesMap.emplace(wsgroup, optws);
 
     // TODO/NOW/ISSUE -- How about comment and info?

--- a/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
@@ -283,11 +283,6 @@ private:
 
   /// Coordinates
   Kernel::SpecialCoordinateSystem m_coordSystem;
-
-  // adapter for logs() function, which create reference to this class itself
-  // and does not allow to delete the shared pointers,
-  // returned by logs() function when they go out of scope
-  API::LogManager_sptr m_logCash;
 };
 
 /// Typedef for a shared pointer to a peaks workspace.

--- a/Framework/DataObjects/inc/MantidDataObjects/WorkspaceCreation.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/WorkspaceCreation.h
@@ -145,10 +145,6 @@ fixDistributionFlag(API::MatrixWorkspace &workspace,
 MANTID_DATAOBJECTS_DLL void
 initializeFromParent(const API::MatrixWorkspace &parent,
                      API::MatrixWorkspace &ws);
-
-MANTID_DATAOBJECTS_DLL void
-initializeFromParentWithoutLogs(const API::MatrixWorkspace &parent,
-                                API::MatrixWorkspace &ws);
 }
 
 /** This is the create() method that all the other create() methods call.
@@ -193,46 +189,6 @@ std::unique_ptr<T> create(const P &parent, const IndexArg &indexArg,
   return ws;
 }
 
-/** create a new workspace with empty run, i.e., without logs
- *  this is for initializeFromParentWithoutLogs
- */
-template <class T, class P, class IndexArg, class HistArg,
-          class = typename std::enable_if<
-              std::is_base_of<API::MatrixWorkspace, P>::value>::type>
-std::unique_ptr<T> createWithoutLogs(const P &parent, const IndexArg &indexArg,
-                                     const HistArg &histArg) {
-  // Figure out (dynamic) target type:
-  // - Type is same as parent if T is base of parent
-  // - If T is not base of parent, conversion may occur. Currently only
-  //   supported for EventWorkspace
-  std::unique_ptr<T> ws;
-  if (std::is_base_of<API::HistoWorkspace, T>::value &&
-      parent.id() == "EventWorkspace") {
-    // Drop events, create Workspace2D or T whichever is more derived.
-    ws = detail::createHelper<T>();
-  } else {
-    try {
-      // If parent is more derived than T: create type(parent)
-      ws = dynamic_cast<const T &>(parent).cloneEmpty();
-    } catch (std::bad_cast &) {
-      // If T is more derived than parent: create T
-      ws = detail::createConcreteHelper<T>();
-    }
-  }
-
-  // The instrument is also copied by initializeFromParentWithoutLogs,
-  // but if indexArg is
-  // IndexInfo and contains non-empty spectrum definitions the initialize call
-  // will fail due to invalid indices in the spectrum definitions. Therefore, we
-  // copy the instrument first. This should be cleaned up once we figure out the
-  // future of WorkspaceFactory.
-  ws->setInstrument(parent.getInstrument());
-  ws->initialize(indexArg, HistogramData::Histogram(histArg));
-  detail::initializeFromParentWithoutLogs(parent, *ws);
-  detail::fixDistributionFlag(*ws, histArg);
-  return ws;
-}
-
 template <class T, class IndexArg, class HistArg,
           typename std::enable_if<
               !std::is_base_of<API::MatrixWorkspace, IndexArg>::value>::type * =
@@ -263,19 +219,6 @@ std::unique_ptr<T> create(const P &parent) {
   const auto numHistograms = parent.getNumberHistograms();
   auto ws =
       create<T>(parent, numHistograms, detail::stripData(parent.histogram(0)));
-  for (size_t i = 0; i < numHistograms; ++i) {
-    ws->setSharedX(i, parent.sharedX(i));
-  }
-  return ws;
-}
-
-template <class T, class P,
-          typename std::enable_if<std::is_base_of<API::MatrixWorkspace,
-                                                  P>::value>::type * = nullptr>
-std::unique_ptr<T> createWithoutLogs(const P &parent) {
-  const auto numHistograms = parent.getNumberHistograms();
-  auto ws = createWithoutLogs<T>(parent, numHistograms,
-                                 detail::stripData(parent.histogram(0)));
   for (size_t i = 0; i < numHistograms; ++i) {
     ws->setSharedX(i, parent.sharedX(i));
   }

--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -877,15 +877,9 @@ PeaksWorkspace::getSpecialCoordinateSystem() const {
 struct NullDeleter {
   template <typename T> void operator()(T *) {}
 };
-/**Get access to shared pointer containing workspace porperties, cashes the
- shared pointer
- into internal class variable to not allow shared pointer being deleted */
+/**Get access to shared pointer containing workspace porperties */
 API::LogManager_sptr PeaksWorkspace::logs() {
-  if (m_logCash)
-    return m_logCash;
-
-  m_logCash = API::LogManager_sptr(&(this->mutableRun()), NullDeleter());
-  return m_logCash;
+  return API::LogManager_sptr(&(this->mutableRun()), NullDeleter());
 }
 
 /** Get constant access to shared pointer containing workspace porperties;

--- a/Framework/DataObjects/src/WorkspaceCreation.cpp
+++ b/Framework/DataObjects/src/WorkspaceCreation.cpp
@@ -52,24 +52,6 @@ void initializeFromParent(const API::MatrixWorkspace &parent,
   static_cast<void>(ws.mutableX(0));
 }
 
-/** Initialize a MatrixWorkspace from its parent including instrument, unit,
- * number of spectra but without Run (i.e., logs)
- * @brief initializeFromParentWithoutLogs
- * @param parent
- * @param ws
- */
-void initializeFromParentWithoutLogs(const API::MatrixWorkspace &parent,
-                                     API::MatrixWorkspace &ws) {
-  bool differentSize = (parent.x(0).size() != ws.x(0).size()) ||
-                       (parent.y(0).size() != ws.y(0).size());
-  API::WorkspaceFactory::Instance().initializeFromParentWithoutLogs(
-      parent, ws, differentSize);
-  // For EventWorkspace, `ws.y(0)` put entry 0 in the MRU. However, clients
-  // would typically expect an empty MRU and fail to clear it. This dummy call
-  // removes the entry from the MRU.
-  static_cast<void>(ws.mutableX(0));
-}
-
 template <>
 void fixDistributionFlag(API::MatrixWorkspace &workspace,
                          const HistogramData::Histogram &histArg) {

--- a/Framework/DataObjects/test/WorkspaceCreationTest.h
+++ b/Framework/DataObjects/test/WorkspaceCreationTest.h
@@ -265,7 +265,8 @@ public:
     const std::string &name1 = "Log4";
     const std::string &value1 = "6.4a";
     parent->mutableRun().addProperty(name1, value1);
-    const auto ws = createWithoutLogs<Workspace2D>(*parent);
+    const auto ws = create<Workspace2D>(*parent);
+    ws->setSharedRun(Kernel::make_cow<Run>());
     check_indices(*ws);
     check_zeroed_data(*ws);
     check_instrument(*ws);

--- a/Framework/DataObjects/test/WorkspaceCreationTest.h
+++ b/Framework/DataObjects/test/WorkspaceCreationTest.h
@@ -266,6 +266,7 @@ public:
     const std::string &value1 = "6.4a";
     parent->mutableRun().addProperty(name1, value1);
     const auto ws = create<Workspace2D>(*parent);
+    TS_ASSERT_EQUALS(&parent->run(), &ws->run());
     ws->setSharedRun(Kernel::make_cow<Run>());
     check_indices(*ws);
     check_zeroed_data(*ws);


### PR DESCRIPTION
`WorkspaceFactory` shares the `Run` in a workspace, whereas the copy constructor of `ExperimentInfo` makes a clone (the copy constructor would be called, e.g., when cloning a workspace, without use of the factory).

Changes:
- `ExperimentInfo` now shares the run when copies are made.
- Use `cow_ptr` instead of hand-written copy-on-write based on `shared_ptr`.
- Add `Experiment::setSharedRun` to avoid code duplication, which apparently was added because SNS had trouble with large runs being copied. @wdzhou  you should have a look if this still works for you as expected.
- Workspace factory now also copies `ExperimentInfo::m_moderatorModel` and `ExperimentInfo::m_choppers` from the parent. I believe these have been previously overlooked in the implementation?

**To test:**

Code review.
No issue, no release notes (potentially there might be performance improvements for certain cases, but I cannot name any).

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
