### PR TITLE
Refactor CropToComponent to use the new instrument API

### DIFF
--- a/Framework/Algorithms/src/CropToComponent.cpp
+++ b/Framework/Algorithms/src/CropToComponent.cpp
@@ -2,7 +2,6 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/SpectrumInfo.h"
 #include "MantidAlgorithms/CropToComponent.h"
-#include "MantidGeometry/IDetector.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"

--- a/Framework/Algorithms/src/CropToComponent.cpp
+++ b/Framework/Algorithms/src/CropToComponent.cpp
@@ -43,6 +43,9 @@ getWorkspaceIndices(const Mantid::API::MatrixWorkspace &workspace,
                                "-- spectrum in MatrixWorkspace maps to more "
                                "than 1 detector.");
   }
+  if (detectorIndices.size() != spectrumIndices.size())
+    throw std::runtime_error(
+        "Some of the requested detectors do not have a corresponding spectrum");
   return spectrumIndices;
 }
 }

--- a/Framework/Algorithms/src/CropToComponent.cpp
+++ b/Framework/Algorithms/src/CropToComponent.cpp
@@ -35,8 +35,8 @@ getWorkspaceIndices(const Mantid::API::MatrixWorkspace &workspace,
   std::vector<size_t> spectrumIndices;
   for (size_t i = 0; i < spectrumInfo.size(); ++i) {
     const auto &spectrumDefinition = spectrumInfo.spectrumDefinition(i);
-    const auto detectorIndex = spectrumDefinition[0].first;
-    if (spectrumDefinition.size() == 1 && detectorMap[detectorIndex])
+    if (spectrumDefinition.size() == 1 &&
+        detectorMap[spectrumDefinition[0].first])
       spectrumIndices.push_back(i);
     if (spectrumDefinition.size() > 1)
       throw std::runtime_error("Cannot map from detector ID to workspace index "

--- a/Framework/Indexing/CMakeLists.txt
+++ b/Framework/Indexing/CMakeLists.txt
@@ -9,6 +9,7 @@ set ( SRC_FILES
 )
 
 set ( INC_FILES
+	inc/MantidIndexing/Conversion.h
 	inc/MantidIndexing/DetectorID.h
 	inc/MantidIndexing/DllConfig.h
 	inc/MantidIndexing/Extract.h
@@ -27,6 +28,7 @@ set ( INC_FILES
 )
 
 set ( TEST_FILES
+	ConversionTest.h
 	DetectorIDTest.h
 	ExtractTest.h
 	GlobalSpectrumIndexTest.h

--- a/Framework/Indexing/inc/MantidIndexing/Conversion.h
+++ b/Framework/Indexing/inc/MantidIndexing/Conversion.h
@@ -1,0 +1,79 @@
+#ifndef MANTID_INDEXING_CONVERSION_H_
+#define MANTID_INDEXING_CONVERSION_H_
+
+#include "MantidIndexing/DllConfig.h"
+#include "MantidIndexing/GlobalSpectrumIndex.h"
+#include "MantidIndexing/SpectrumNumber.h"
+
+namespace Mantid {
+namespace Indexing {
+
+/** Conversion helpers from and to (vectors of) integer types such as
+  SpectrumNumber and GlobalSpectrumIndex.
+
+  @author Simon Heybrock
+  @date 2016
+
+  Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+
+/** Convert std::vector<In> to std::vector<Out> by static-casting all elements.
+ *
+ * `In` must be an integral type and `Out` can be any type inheriting
+ * Indexing::IndexType, such as SpectrumNumber or GlobalSpectrumIndex. The
+ * conversion is done using static_cast without any range check. It is the
+ * responsibility of the caller to not pass any vectors containing elements that
+ * suffer from loss of data in a static_cast. */
+template <
+    class Out, class In,
+    typename std::enable_if<std::is_integral<In>::value>::type * = nullptr>
+std::vector<Out> castVector(const std::vector<In> &indices) {
+  std::vector<Out> converted;
+  converted.reserve(indices.size());
+  for (const auto index : indices)
+    converted.push_back(static_cast<typename Out::underlying_type>(index));
+  return converted;
+}
+
+/** Convert std::vector<In> to std::vector<Out> by static-casting all elements.
+ *
+ * `Out` must be an integral type and `In` can be any type inheriting
+ * Indexing::IndexType, such as SpectrumNumber or GlobalSpectrumIndex. The
+ * conversion is done using static_cast without any range check. It is the
+ * responsibility of the caller to not pass any vectors containing elements that
+ * suffer from loss of data in a static_cast. */
+template <
+    class Out, class In,
+    typename std::enable_if<!std::is_integral<In>::value>::type * = nullptr>
+std::vector<Out> castVector(const std::vector<In> &indices) {
+  std::vector<Out> converted;
+  converted.reserve(indices.size());
+  for (const auto index : indices)
+    converted.push_back(
+        static_cast<Out>(static_cast<typename In::underlying_type>(index)));
+  return converted;
+}
+
+} // namespace Indexing
+} // namespace Mantid
+
+#endif /* MANTID_INDEXING_CONVERSION_H_ */

--- a/Framework/Indexing/inc/MantidIndexing/Conversion.h
+++ b/Framework/Indexing/inc/MantidIndexing/Conversion.h
@@ -12,7 +12,7 @@ namespace Indexing {
   SpectrumNumber and GlobalSpectrumIndex.
 
   @author Simon Heybrock
-  @date 2016
+  @date 2017
 
   Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
   National Laboratory & European Spallation Source

--- a/Framework/Indexing/inc/MantidIndexing/IndexInfo.h
+++ b/Framework/Indexing/inc/MantidIndexing/IndexInfo.h
@@ -114,6 +114,9 @@ public:
   SpectrumIndexSet
   makeIndexSet(const std::vector<GlobalSpectrumIndex> &globalIndices) const;
 
+  std::vector<GlobalSpectrumIndex> globalSpectrumIndicesFromDetectorIndices(
+      const std::vector<size_t> &detectorIndices) const;
+
   bool isOnThisPartition(GlobalSpectrumIndex globalIndex) const;
 
   Parallel::StorageMode storageMode() const;

--- a/Framework/Indexing/inc/MantidIndexing/IndexType.h
+++ b/Framework/Indexing/inc/MantidIndexing/IndexType.h
@@ -37,6 +37,7 @@ template <class Derived, class Int,
           class = typename std::enable_if<std::is_integral<Int>::value>::type>
 class IndexType {
 public:
+  using underlying_type = Int;
   IndexType() noexcept : m_data(0) {}
   IndexType(Int data) noexcept : m_data(data) {}
   explicit operator Int() const noexcept { return m_data; }

--- a/Framework/Indexing/src/IndexInfo.cpp
+++ b/Framework/Indexing/src/IndexInfo.cpp
@@ -232,7 +232,7 @@ IndexInfo::globalSpectrumIndicesFromDetectorIndices(
       }
     }
     if (spectrumDefinition.size() > 1)
-      throw std::runtime_error("SpectrumDefinition containes multiple entries. "
+      throw std::runtime_error("SpectrumDefinition contains multiple entries. "
                                "No unique mapping from detector to spectrum "
                                "possible");
   }

--- a/Framework/Indexing/src/IndexInfo.cpp
+++ b/Framework/Indexing/src/IndexInfo.cpp
@@ -193,6 +193,44 @@ SpectrumIndexSet IndexInfo::makeIndexSet(
   return m_spectrumNumberTranslator->makeIndexSet(globalIndices);
 }
 
+/** Map a vector of detector indices to a vector of global spectrum indices.
+ *
+ * The mapping is based on the held spectrum definitions. Throws if any spectrum
+ * maps to more than one detectors. Throws if there is no 1:1 mapping from
+ * detectors to spectra, such as when some of the detectors have no matching
+ * spectrum. */
+std::vector<GlobalSpectrumIndex>
+IndexInfo::globalSpectrumIndicesFromDetectorIndices(
+    const std::vector<size_t> &detectorIndices) const {
+  std::vector<bool> detectorMap;
+  for (const auto &index : detectorIndices) {
+    // IndexInfo has no knowledge of the maximum detector index so we workaround
+    // this knowledge gap by assuming below that any index beyond the end of the
+    // map is `false`.
+    if (index >= detectorMap.size())
+      detectorMap.resize(index + 1, false);
+    detectorMap[index] = true;
+  }
+
+  std::vector<GlobalSpectrumIndex> spectrumIndices;
+  for (size_t i = 0; i < size(); ++i) {
+    const auto &spectrumDefinition = m_spectrumDefinitions->operator[](i);
+    if (spectrumDefinition.size() == 1) {
+      const auto detectorIndex = spectrumDefinition[0].first;
+      if (detectorMap.size() > detectorIndex && detectorMap[detectorIndex])
+        spectrumIndices.push_back(i);
+    }
+    if (spectrumDefinition.size() > 1)
+      throw std::runtime_error("SpectrumDefinition containes multiple entries. "
+                               "No unique mapping from detector to spectrum "
+                               "possible.");
+  }
+  if (detectorIndices.size() != spectrumIndices.size())
+    throw std::runtime_error(
+        "Some of the requested detectors do not have a corresponding spectrum");
+  return spectrumIndices;
+}
+
 /// Returns true if the given global index is on this partition.
 bool IndexInfo::isOnThisPartition(GlobalSpectrumIndex globalIndex) const {
   // A map from global index to partition might be faster, consider adding this

--- a/Framework/Indexing/test/ConversionTest.h
+++ b/Framework/Indexing/test/ConversionTest.h
@@ -1,0 +1,57 @@
+#ifndef MANTID_INDEXING_CONVERSIONTEST_H_
+#define MANTID_INDEXING_CONVERSIONTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidIndexing/Conversion.h"
+#include "MantidIndexing/GlobalSpectrumIndex.h"
+#include "MantidIndexing/SpectrumNumber.h"
+
+using namespace Mantid::Indexing;
+
+class ConversionTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static ConversionTest *createSuite() { return new ConversionTest(); }
+  static void destroySuite(ConversionTest *suite) { delete suite; }
+
+  void test_just_a_static_cast() {
+    std::vector<SpectrumNumber> in{-1};
+    TS_ASSERT_EQUALS(castVector<size_t>(in),
+                     (std::vector<size_t>{18446744073709551615ul}));
+  }
+
+  void test_GlobalSpectrumIndex() {
+    std::vector<GlobalSpectrumIndex> in{0, 1, 2};
+    TS_ASSERT_EQUALS(castVector<size_t>(in), (std::vector<size_t>{0, 1, 2}));
+    TS_ASSERT_EQUALS(castVector<int64_t>(in), (std::vector<int64_t>{0, 1, 2}));
+    TS_ASSERT_EQUALS(castVector<int32_t>(in), (std::vector<int32_t>{0, 1, 2}));
+  }
+
+  void test_to_GlobalSpectrumIndex() {
+    std::vector<int64_t> in{0, 1, 2};
+    TS_ASSERT_EQUALS(castVector<GlobalSpectrumIndex>(in),
+                     (std::vector<GlobalSpectrumIndex>{0, 1, 2}));
+    std::vector<size_t> in2{0, 1, 2};
+    TS_ASSERT_EQUALS(castVector<GlobalSpectrumIndex>(in2),
+                     (std::vector<GlobalSpectrumIndex>{0, 1, 2}));
+  }
+
+  void test_SpectrumNumber() {
+    std::vector<SpectrumNumber> in{-1, 1, 2};
+    TS_ASSERT_EQUALS(castVector<int64_t>(in), (std::vector<int64_t>{-1, 1, 2}));
+    TS_ASSERT_EQUALS(castVector<int32_t>(in), (std::vector<int32_t>{-1, 1, 2}));
+  }
+
+  void test_to_SpectrumNumber() {
+    std::vector<int32_t> in{-1, 1, 2};
+    TS_ASSERT_EQUALS(castVector<SpectrumNumber>(in),
+                     (std::vector<SpectrumNumber>{-1, 1, 2}));
+    std::vector<int64_t> in2{-1, 1, 2};
+    TS_ASSERT_EQUALS(castVector<SpectrumNumber>(in2),
+                     (std::vector<SpectrumNumber>{-1, 1, 2}));
+  }
+};
+
+#endif /* MANTID_INDEXING_CONVERSIONTEST_H_ */

--- a/Framework/Indexing/test/IndexInfoTest.h
+++ b/Framework/Indexing/test/IndexInfoTest.h
@@ -187,6 +187,90 @@ public:
     TS_ASSERT_EQUALS(info.spectrumDefinitions().get(), defs.get());
   }
 
+  void test_globalSpectrumIndicesFromDetectorIndices_fails_without_spec_defs() {
+    IndexInfo info(3);
+    std::vector<size_t> detectorIndices{6, 8};
+    TS_ASSERT_THROWS_EQUALS(
+        info.globalSpectrumIndicesFromDetectorIndices(detectorIndices),
+        const std::runtime_error &e, std::string(e.what()),
+        "IndexInfo::globalSpectrumIndicesFromDetectorIndices -- no spectrum "
+        "definitions available");
+  }
+
+  void test_globalSpectrumIndicesFromDetectorIndices_fails_multiple() {
+    IndexInfo info(3);
+    std::vector<size_t> detectorIndices{6, 8};
+    std::vector<SpectrumDefinition> specDefs(3);
+    specDefs[0].add(6);
+    specDefs[1].add(7);
+    specDefs[1].add(77);
+    specDefs[2].add(8);
+    info.setSpectrumDefinitions(specDefs);
+    TS_ASSERT_THROWS_EQUALS(
+        info.globalSpectrumIndicesFromDetectorIndices(detectorIndices),
+        const std::runtime_error &e, std::string(e.what()),
+        "SpectrumDefinition containes multiple entries. No unique mapping from "
+        "detector to spectrum possible");
+  }
+
+  void test_globalSpectrumIndicesFromDetectorIndices_fails_missing() {
+    IndexInfo info(3);
+    std::vector<size_t> detectorIndices{6, 8};
+    std::vector<SpectrumDefinition> specDefs(3);
+    // Nothing maps to 8
+    specDefs[0].add(6);
+    specDefs[1].add(7);
+    info.setSpectrumDefinitions(specDefs);
+    TS_ASSERT_THROWS_EQUALS(
+        info.globalSpectrumIndicesFromDetectorIndices(detectorIndices),
+        const std::runtime_error &e, std::string(e.what()),
+        "Some of the requested detectors do not have a corresponding spectrum");
+  }
+
+  void test_globalSpectrumIndicesFromDetectorIndices_fails_conflict() {
+    IndexInfo info(3);
+    std::vector<size_t> detectorIndices{6, 8};
+    std::vector<SpectrumDefinition> specDefs(3);
+    // Two indices map to same detector.
+    specDefs[0].add(6);
+    specDefs[1].add(6);
+    specDefs[2].add(8);
+    info.setSpectrumDefinitions(specDefs);
+    TS_ASSERT_THROWS_EQUALS(
+        info.globalSpectrumIndicesFromDetectorIndices(detectorIndices),
+        const std::runtime_error &e, std::string(e.what()),
+        "Multiple spectra correspond to the same detector");
+  }
+
+  void test_globalSpectrumIndicesFromDetectorIndices_fails_conflict_miss() {
+    IndexInfo info(3);
+    std::vector<size_t> detectorIndices{6, 8};
+    std::vector<SpectrumDefinition> specDefs(3);
+    // Two indices map to same detector, but additionally one is missing.
+    specDefs[0].add(6);
+    specDefs[1].add(6);
+    info.setSpectrumDefinitions(specDefs);
+    TS_ASSERT_THROWS_EQUALS(
+        info.globalSpectrumIndicesFromDetectorIndices(detectorIndices),
+        const std::runtime_error &e, std::string(e.what()),
+        "Multiple spectra correspond to the same detector");
+  }
+
+  void test_globalSpectrumIndicesFromDetectorIndices() {
+    IndexInfo info(3);
+    std::vector<size_t> detectorIndices{6, 8};
+    std::vector<SpectrumDefinition> specDefs(3);
+    specDefs[0].add(6);
+    specDefs[1].add(7);
+    specDefs[2].add(8);
+    info.setSpectrumDefinitions(specDefs);
+    const auto &indices =
+        info.globalSpectrumIndicesFromDetectorIndices(detectorIndices);
+    TS_ASSERT_EQUALS(indices.size(), detectorIndices.size());
+    TS_ASSERT_EQUALS(indices[0], 0);
+    TS_ASSERT_EQUALS(indices[1], 2);
+  }
+
   void test_StorageMode_Cloned() {
     runParallel(run_StorageMode_Cloned);
     // Trivial: Run with one partition.

--- a/Framework/Indexing/test/IndexInfoTest.h
+++ b/Framework/Indexing/test/IndexInfoTest.h
@@ -209,7 +209,7 @@ public:
     TS_ASSERT_THROWS_EQUALS(
         info.globalSpectrumIndicesFromDetectorIndices(detectorIndices),
         const std::runtime_error &e, std::string(e.what()),
-        "SpectrumDefinition containes multiple entries. No unique mapping from "
+        "SpectrumDefinition contains multiple entries. No unique mapping from "
         "detector to spectrum possible");
   }
 

--- a/docs/source/release/v3.12.0/framework.rst
+++ b/docs/source/release/v3.12.0/framework.rst
@@ -38,6 +38,7 @@ Performance
 -----------
 
 - Improved performance for second and consecutive loads of instrument geometry, particularly for instruments with many detector pixels. This affects :ref:`LoadEmptyInstrument <algm-LoadEmptyInstrument>` and load algorithms that are using it.
+- Up to 30% performance improvement for :ref:`CropToComponent <algm-CropToComponent>` based on ongoing work on Instrument-2.0.
 
 Python
 ------


### PR DESCRIPTION
Refactor `CropToComponent` to use the new instrument API. This also serves as a preparation for adding MPI support in the next step.

Note that the code for doing the mapping from detectors to spectra is likely to be absorbed into some lower-level abstraction like `IndexInfo` in the future.

I observed a speedup from 0.7 seconds to 0.4 seconds when extracting a single bank from a 4-bank instrument with 160k pixels per bank.

**To test:**

Code review. Existing unit tests look quite reasonable and should hopefully catch any issues.
No related issue.

Release notes updated with performance improvement.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
