### PR TITLE
Output multidataset fit parameters in columns

### DIFF
--- a/docs/source/release/v3.12.0/ui.rst
+++ b/docs/source/release/v3.12.0/ui.rst
@@ -31,4 +31,10 @@ SliceViewer and Vates Simple Interface
    :class: screenshot
    :align: right
 
+MultiDataset Fitting Interface
+------------------------------
+
+- After a simultaneous fit the parameters are saved in a TableWorkspace made to simplify plotting their values against the datasets.
+  The parameters are organised into columns and each row corresponds to a dataset.
+
 :ref:`Release 3.12.0 <v3.12.0>`

--- a/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.cpp
+++ b/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.cpp
@@ -33,6 +33,16 @@ Mantid::Kernel::Logger g_log("MultiDatasetFit");
 /// plotting them against a dataset index.
 void formatParametersForPlotting(const Mantid::API::IFunction &function,
                                  const std::string &parametersPropertyName) {
+
+  const auto nDomains = function.getNumberDomains();
+
+  if (nDomains < 2) {
+    // Single domain fit: nothing to plot.
+    return;
+  }
+
+  // function must be MultiDomainFunction by the logic of the interface.
+  // If it's not the cast error will tell us about it.
   const auto &mdFunction =
       dynamic_cast<const Mantid::API::MultiDomainFunction &>(function);
 
@@ -42,13 +52,12 @@ void formatParametersForPlotting(const Mantid::API::IFunction &function,
     return;
   }
 
+  assert(nDomains == mdFunction.nFunctions());
+
   auto table =
       Mantid::API::WorkspaceFactory::Instance().createTable("TableWorkspace");
   auto col = table->addColumn("double", "Dataset");
   col->setPlotType(1); // X-values inplots
-
-  auto nDomains = mdFunction.getNumberDomains();
-  assert(nDomains == mdFunction.nFunctions());
 
   // Add columns for parameters and their errors
   const auto &fun = *mdFunction.getFunction(0);

--- a/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.cpp
+++ b/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.cpp
@@ -31,8 +31,10 @@ Mantid::Kernel::Logger g_log("MultiDatasetFit");
 
 /// Copy parameter values into a table workspace that is ready for
 /// plotting them against a dataset index.
-void formatParametersForPlotting(const Mantid::API::IFunction& function, const std::string& parametersPropertyName) {
-  const auto &mdFunction = dynamic_cast<const Mantid::API::MultiDomainFunction&>(function);
+void formatParametersForPlotting(const Mantid::API::IFunction &function,
+                                 const std::string &parametersPropertyName) {
+  const auto &mdFunction =
+      dynamic_cast<const Mantid::API::MultiDomainFunction &>(function);
 
   if (mdFunction.nFunctions() == 0) {
     // Fit button was hit by mistake? Nothing to do here.
@@ -40,7 +42,8 @@ void formatParametersForPlotting(const Mantid::API::IFunction& function, const s
     return;
   }
 
-  auto table = Mantid::API::WorkspaceFactory::Instance().createTable("TableWorkspace");
+  auto table =
+      Mantid::API::WorkspaceFactory::Instance().createTable("TableWorkspace");
   auto col = table->addColumn("double", "Dataset");
   col->setPlotType(1); // X-values inplots
 
@@ -48,26 +51,26 @@ void formatParametersForPlotting(const Mantid::API::IFunction& function, const s
   assert(nDomains == mdFunction.nFunctions());
 
   // Add columns for parameters and their errors
-  const auto& fun = *mdFunction.getFunction(0);
+  const auto &fun = *mdFunction.getFunction(0);
   for (size_t iPar = 0; iPar < fun.nParams(); ++iPar) {
     table->addColumn("double", fun.parameterName(iPar));
     table->addColumn("double", fun.parameterName(iPar) + "_Err");
   }
 
   // Fill in the columns
-  for(size_t iData = 0; iData < nDomains; ++iData) {
+  for (size_t iData = 0; iData < nDomains; ++iData) {
     Mantid::API::TableRow row = table->appendRow();
     row << static_cast<double>(iData);
-    const auto& fun = *mdFunction.getFunction(iData);
+    const auto &fun = *mdFunction.getFunction(iData);
     for (size_t iPar = 0; iPar < fun.nParams(); ++iPar) {
       row << fun.getParameter(iPar) << fun.getError(iPar);
     }
   }
 
   // Store the table in the ADS
-  Mantid::API::AnalysisDataService::Instance().addOrReplace(parametersPropertyName + "_vs_dataset", table);
+  Mantid::API::AnalysisDataService::Instance().addOrReplace(
+      parametersPropertyName + "_vs_dataset", table);
 }
-
 }
 
 namespace MantidQt {
@@ -492,7 +495,8 @@ void MultiDatasetFit::finishFit(bool error) {
       auto chiSquared = QString::fromStdString(
           algorithm->getPropertyValue("OutputChi2overDoF"));
       setFitStatusInfo(status, chiSquared);
-      formatParametersForPlotting(*fun, algorithm->getPropertyValue("OutputParameters"));
+      formatParametersForPlotting(
+          *fun, algorithm->getPropertyValue("OutputParameters"));
     } else {
       // After a sequential fit
       auto paramsWSName =
@@ -796,7 +800,6 @@ void MultiDatasetFit::updateGuessFunction(const QString &, const QString &) {
 /// Log a warning
 /// @param msg :: A warning message to log.
 void MultiDatasetFit::logWarning(const std::string &msg) { g_log.warning(msg); }
-
 
 } // CustomInterfaces
 } // MantidQt

--- a/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.cpp
+++ b/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.cpp
@@ -67,8 +67,9 @@ void formatParametersForPlotting(const Mantid::API::IFunction &function,
   }
 
   // Fill in the columns
+  table->setRowCount(nDomains);
   for (size_t iData = 0; iData < nDomains; ++iData) {
-    Mantid::API::TableRow row = table->appendRow();
+    Mantid::API::TableRow row = table->getRow(iData);
     row << static_cast<double>(iData);
     const auto &fun = *mdFunction.getFunction(iData);
     for (size_t iPar = 0; iPar < fun.nParams(); ++iPar) {


### PR DESCRIPTION
After a simultaneous fit the MultiDatasetFit interface creates a table workspace with parameter values put into columns. It's easier to plot.

**To test:**

Do a simultaneous fit using the MultiDatasetFit interface. It must create a TableWorkspace with a name ending on `_vs_dataset`. Open the workspace and plot some columns.

Fixes #21173 


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
