### PR TITLE
BASISReduction: exclude one time period from the reduction

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
@@ -362,6 +362,7 @@ class BASISReduction(PythonAlgorithm):
                 sapi.DeleteWorkspace('splitted_unfiltered')
                 sapi.DeleteWorkspace('splitter')
                 sapi.DeleteWorkspace('TOFCorrectWS')
+
     def _getRuns(self, rlist, doIndiv=True):
         """
         Create sets of run numbers for analysis. A semicolon indicates a

--- a/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
@@ -358,7 +358,10 @@ class BASISReduction(PythonAlgorithm):
                 sapi.DeleteWorkspace(self._normWs)  # Delete vanadium S(Q)
                 if self._normalizationType == "by Q slice":
                     sapi.DeleteWorkspace(normWs)  # Delete vanadium events file
-
+            if self.getProperty("ExcludeTimeSegment").value:
+                sapi.DeleteWorkspace('splitted_unfiltered')
+                sapi.DeleteWorkspace('splitter')
+                sapi.DeleteWorkspace('TOFCorrectWS')
     def _getRuns(self, rlist, doIndiv=True):
         """
         Create sets of run numbers for analysis. A semicolon indicates a
@@ -603,7 +606,7 @@ class BASISReduction(PythonAlgorithm):
         ws_name : str
             name of the workspace to filter
         """
-        for run_fragment in self.getProperty("ExcludeTimeSegment").value.split(','):
+        for run_fragment in self.getProperty("ExcludeTimeSegment").value.split(';'):
             if run+':' in run_fragment:
                 self.generateSplitterWorkspace(run_fragment.split(':')[1])
                 sapi.FilterEvents(InputWorkspace=ws_name,
@@ -615,9 +618,6 @@ class BASISReduction(PythonAlgorithm):
                 sapi.UnGroupWorkspace('splitted')
                 sapi.RenameWorkspace(InputWorkspace='splitted_0',
                                      OutputWorkspace=ws_name)
-                sapi.DeleteWorkspace('splitted_unfiltered')
-                sapi.DeleteWorkspace('splitter')
-                sapi.DeleteWorkspace('TOFCorrectWS')
                 break
 
 # Register algorithm with Mantid.

--- a/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
@@ -11,7 +11,6 @@ from mantid.kernel import IntArrayProperty, StringListValidator,\
     FloatArrayLengthValidator, Direction, PropertyCriterion
 from mantid import config
 from os.path import join as pjoin
-import sys
 
 TEMPERATURE_SENSOR = "SensorA"
 DEFAULT_RANGE = [6.24, 6.30]
@@ -106,16 +105,16 @@ class BASISReduction(PythonAlgorithm):
         self.declareProperty("NoMonitorNorm", False,
                              "Stop monitor normalization")
         self.declareProperty('ExcludeTimeSegment', '',
-                             'Exclude a contigous time segment; '+\
-                             'Examples: "71546:0-60" filter run 71546 from '+\
-                             'start to 60 seconds, "71546:300-600", '+\
+                             'Exclude a contigous time segment; '+
+                             'Examples: "71546:0-60" filter run 71546 from '+
+                             'start to 60 seconds, "71546:300-600", '+
                              '"71546:120-end" from 120s to the end of the run')
         grouping_type = ["None", "Low-Resolution", "By-Tube"]
         self.declareProperty("GroupDetectors", "None",
                              StringListValidator(grouping_type),
                              "Switch for grouping detectors")
-        self.declareProperty("NormalizeToFirst", False, "Normalize spectra \
-        to intensity of spectrum with lowest Q?")
+        self.declareProperty('NormalizeToFirst', False, 'Normalize spectra '+
+                             'to intensity of spectrum with lowest Q?')
 
         # Properties affected by the reflection selected
         titleReflection = "Reflection Selector"
@@ -421,7 +420,7 @@ class BASISReduction(PythonAlgorithm):
             sapi.LoadEventNexus(Filename=run_file,
                                 OutputWorkspace=ws_name, **kwargs)
             if str(run)+':' in self.getProperty("ExcludeTimeSegment").value:
-                 self._filterEvents(str(run), ws_name)
+                self._filterEvents(str(run), ws_name)
 
             if not self._noMonNorm:
                 sapi.LoadNexusMonitors(Filename=run_file,
@@ -593,7 +592,7 @@ class BASISReduction(PythonAlgorithm):
         else:
             splitter.addRow([0, a, '0'])
             splitter.addRow([b, inf, '0'])
- 
+
     def _filterEvents(self, run, ws_name):
         r"""Filter out ExcludeTimeSegment if applicable
 

--- a/docs/source/algorithms/BASISReduction-v1.rst
+++ b/docs/source/algorithms/BASISReduction-v1.rst
@@ -27,6 +27,17 @@ Examples:
 If *DoIndividual* is checked, then each run number is reduced separately
 from the rest. The semicolon symbol is ignored.
 
+**ExcludeTimeSegment**:
+Events happening in a time segment with no proton charge are most likely
+noise. Those events can be filtered out of the reduction process.
+
+Example:
+
+- "71465:0-500;71466:900-2100;71467:4000-end" will filter out events
+happening between the start of the run and 500 seconds for run 71465, then
+between 900 and 2100 seconds for run 71466 and between 4000 seconds and the
+end of the run for 71467. Only one time segment can be excluded per run number.
+
 **Momentum transfer binning scheme**: Three values are required, the
 center of the bin with the minimum momentum, the bin width, and the
 center of the bin with the maximum momentum.

--- a/docs/source/algorithms/BASISReduction-v1.rst
+++ b/docs/source/algorithms/BASISReduction-v1.rst
@@ -34,9 +34,9 @@ noise. Those events can be filtered out of the reduction process.
 Example:
 
 - "71465:0-500;71466:900-2100;71467:4000-end" will filter out events
-happening between the start of the run and 500 seconds for run 71465, then
-between 900 and 2100 seconds for run 71466 and between 4000 seconds and the
-end of the run for 71467. Only one time segment can be excluded per run number.
+  happening between the start of the run and 500 seconds for run 71465, then
+  between 900 and 2100 seconds for run 71466 and between 4000 seconds and the
+  end of the run for 71467. Only one time segment can be excluded per run number.
 
 **Momentum transfer binning scheme**: Three values are required, the
 center of the bin with the minimum momentum, the bin width, and the
@@ -143,4 +143,3 @@ Workflow
 --------
 
 .. diagram:: BASISReduction-v1_wkflw.dot
-

--- a/docs/source/release/v3.12.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.12.0/indirect_inelastic.rst
@@ -14,6 +14,8 @@ New
 Improved
 ########
 
+- BASISReduction now permits the user to exclude a contigous time segment from the reduction process
+
 Vesuvio
 -------
 

--- a/docs/source/release/v3.12.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.12.0/indirect_inelastic.rst
@@ -14,7 +14,7 @@ New
 Improved
 ########
 
-- BASISReduction now permits the user to exclude a contigous time segment from the reduction process
+- BASISReduction now permits the user to exclude a contiguous time segment from the reduction process
 
 Vesuvio
 -------


### PR DESCRIPTION
Description of work.

**To test:**
Edit the reduction script `BASISReduction.py` in MantidPlot's script window and in line 59 set ` _debugMode = True`. This prevents removal of workspaces intermediate in the reduction process, which will be necessary for this test. Then `Execute All` to load the changes. After this, run the reduction:

```
BASISReduction(RunNumbers='76149', ExcludeTimeSegment='76149:500-2100')
```
Plot the `proton_charge` log for workspaces `BSS_76149` and` splitted_unfiltered`. The first should contain no charge in between 500 and 2100 seconds. The missing charge should show up in the `proton_charge` log of `splitted_unfiltered`.

Fixes #21178

[Release Notes](https://github.com/mantidproject/mantid/blob/34cb3a158cd137b47bef8ccb1fd4cb4c458f0c90/docs/source/release/v3.12.0/indirect_inelastic.rst#improved)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
