### PR TITLE
ISIS Powder HRPD extra TOF windows

### DIFF
--- a/docs/source/release/v3.12.0/diffraction.rst
+++ b/docs/source/release/v3.12.0/diffraction.rst
@@ -17,6 +17,7 @@ Powder Diffraction
 - New algorithm :ref:`algm-EstimateDivergence` estimates the beam divergence due to finite slit size
 - :ref:`PDCalibration <algm-PDCalibration>` returns three more diagnostic workspaces: one for the fitted peak heights, one for the fitted peak widths, and one for observed resolution.
 - :ref:`LoadILLDiffraction <algm-LoadILLDiffraction>` now supports D2B files with calibrated data.
+- ISIS Powder scripts for HRPD now support extra TOF windows 10-50 and 180-280
 
 Engineering Diffraction
 -----------------------

--- a/docs/source/techniques/ISISPowder-HRPD-v1.rst
+++ b/docs/source/techniques/ISISPowder-HRPD-v1.rst
@@ -529,6 +529,13 @@ On HRPD this is set to the following:
 
 .. code-block:: python
 
+  # window = "10-50"
+  focused_cropping_values = [
+        (1.2e4, 4.9e4),  # Bank 1
+        (1.2e4, 5.3e4),  # Bank 2
+        (1.1e4, 5.1e4),  # Bank 3
+  ]
+
   # window = "10-110"
   focused_cropping_values = [
         (1e4, 1.1e5),    # Bank 1
@@ -549,7 +556,14 @@ On HRPD this is set to the following:
         (9.6e4, 2.18e5),  # Bank 2
         (1e5, 2.11e5)     # Bank 3
   ]
-  
+
+  # window = "180-280"
+  focused_cropping_values = [
+        (1.8e5, 2.8e5),  # Bank 1
+        (1.8e5, 3.0e5),  # Bank 2
+        (1.7e5, 2.9e5),  # Bank 3
+  ]
+
 .. _grouping_file_name_hrpd_isis-powder-diffraction-ref:
   
 grouping_file_name
@@ -592,6 +606,9 @@ On HRPD this is set to the following:
 
 .. code-block:: python
 
+  # window = "10-50"
+  vanadium_tof_cropping = (1.1e4, 5e4)
+
   # window = "10-110"
   vanadium_tof_cropping = (1e4, 1.2e5)
 
@@ -600,6 +617,9 @@ On HRPD this is set to the following:
 
   # window = "100-200"
   vanadium_tof_cropping = (1e5, 2.15e5)
+
+  # window = "180-280"
+  vanadium_tof_cropping = (1.8e5, 2.8e5)
 
 Vanadium Sample details
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/techniques/ISISPowder-HRPD-v1.rst
+++ b/docs/source/techniques/ISISPowder-HRPD-v1.rst
@@ -531,9 +531,9 @@ On HRPD this is set to the following:
 
   # window = "10-50"
   focused_cropping_values = [
-        (1.2e4, 4.9e4),  # Bank 1
-        (1.2e4, 5.3e4),  # Bank 2
-        (1.1e4, 5.1e4),  # Bank 3
+        (1.2e4, 4.99e4),  # Bank 1
+        (1.2e4, 4.99e4),  # Bank 2
+        (1.2e4, 4.99e4),  # Bank 3
   ]
 
   # window = "10-110"
@@ -559,9 +559,9 @@ On HRPD this is set to the following:
 
   # window = "180-280"
   focused_cropping_values = [
-        (1.8e5, 2.8e5),  # Bank 1
-        (1.8e5, 3.0e5),  # Bank 2
-        (1.7e5, 2.9e5),  # Bank 3
+        (1.86e5, 2.8e5),   # Bank 1
+        (1.8e5, 2.798e5),  # Bank 2
+        (1.9e5, 2.795e5),  # Bank 3
   ]
 
 .. _grouping_file_name_hrpd_isis-powder-diffraction-ref:

--- a/scripts/Diffraction/isis_powder/hrpd_routines/hrpd_advanced_config.py
+++ b/scripts/Diffraction/isis_powder/hrpd_routines/hrpd_advanced_config.py
@@ -14,9 +14,9 @@ absorption_correction_params = {
 window_10_50_params = {
     "vanadium_tof_cropping": (1.1e4, 5e4),
     "focused_cropping_values": [
-        (1.2e4, 4.9e4),  # Bank 1
-        (1.2e4, 5.3e4),  # Bank 2
-        (1.1e4, 5.1e4),  # Bank 3
+        (1.2e4, 4.99e4),  # Bank 1
+        (1.2e4, 4.99e4),  # Bank 2
+        (1.2e4, 4.99e4),  # Bank 3
     ]
 }
 
@@ -51,9 +51,9 @@ window_100_200_params = {
 window_180_280_params = {
     "vanadium_tof_cropping": (1.8e5, 2.8e5),
     "focused_cropping_values": [
-        (1.8e5, 2.8e5),  # Bank 1
-        (1.8e5, 3.0e5),  # Bank 2
-        (1.7e5, 2.9e5),  # Bank 3
+        (1.86e5, 2.8e5),   # Bank 1
+        (1.8e5, 2.798e5),  # Bank 2
+        (1.9e5, 2.795e5),  # Bank 3
     ]
 }
 

--- a/scripts/Diffraction/isis_powder/hrpd_routines/hrpd_advanced_config.py
+++ b/scripts/Diffraction/isis_powder/hrpd_routines/hrpd_advanced_config.py
@@ -11,6 +11,15 @@ absorption_correction_params = {
 
 # Default cropping values are 5% off each end
 
+window_10_50_params = {
+    "vanadium_tof_cropping": (1e4, 5e4),
+    "focused_cropping_values": [
+        (1.08e4, 5e4),     # Bank 1
+        (1.03e4, 4.99e4),  # Bank 2
+        (1e4,    5e4),     # Bank 3
+    ]
+}
+
 window_10_110_params = {
     "vanadium_tof_cropping": (1e4, 1.2e5),
     "focused_cropping_values": [
@@ -38,6 +47,16 @@ window_100_200_params = {
     ]
 }
 
+
+window_180_280_params = {
+    "vanadium_tof_cropping": (1.8e5, 2.8e5),
+    "focused_cropping_values": [
+        (1.86e5, 2.8e5),    # Bank 1
+        (1.8e5,  2.8e5),    # Bank 2
+        (1.84e5, 2.795e5),  # Bank 3
+    ]
+}
+
 file_names = {
     "grouping_file_name": "hrpd_new_072_01_corr.cal"
 }
@@ -62,10 +81,14 @@ def get_all_adv_variables(tof_window=HRPD_TOF_WINDOWS.window_10_110):
 
 
 def get_tof_window_dict(tof_window):
+    if tof_window == HRPD_TOF_WINDOWS.window_10_50:
+        return window_10_50_params
     if tof_window == HRPD_TOF_WINDOWS.window_10_110:
         return window_10_110_params
     if tof_window == HRPD_TOF_WINDOWS.window_30_130:
         return window_30_130_params
     if tof_window == HRPD_TOF_WINDOWS.window_100_200:
         return window_100_200_params
+    if tof_window == HRPD_TOF_WINDOWS.window_180_280:
+        return window_180_280_params
     raise RuntimeError("Invalid time-of-flight window: {}".format(tof_window))

--- a/scripts/Diffraction/isis_powder/hrpd_routines/hrpd_advanced_config.py
+++ b/scripts/Diffraction/isis_powder/hrpd_routines/hrpd_advanced_config.py
@@ -12,11 +12,11 @@ absorption_correction_params = {
 # Default cropping values are 5% off each end
 
 window_10_50_params = {
-    "vanadium_tof_cropping": (1e4, 5e4),
+    "vanadium_tof_cropping": (1.1e4, 5e4),
     "focused_cropping_values": [
-        (1.08e4, 5e4),     # Bank 1
-        (1.03e4, 4.99e4),  # Bank 2
-        (1e4,    5e4),     # Bank 3
+        (1.2e4, 4.9e4),  # Bank 1
+        (1.2e4, 5.3e4),  # Bank 2
+        (1.1e4, 5.1e4),  # Bank 3
     ]
 }
 
@@ -25,7 +25,7 @@ window_10_110_params = {
     "focused_cropping_values": [
         (1.5e4, 1.08e5),  # Bank 1
         (1.5e4, 1.12e5),  # Bank 2
-        (1.5e4, 1e5)   # Bank 3
+        (1.5e4, 1e5)      # Bank 3
     ]
 }
 
@@ -51,9 +51,9 @@ window_100_200_params = {
 window_180_280_params = {
     "vanadium_tof_cropping": (1.8e5, 2.8e5),
     "focused_cropping_values": [
-        (1.86e5, 2.8e5),    # Bank 1
-        (1.8e5,  2.8e5),    # Bank 2
-        (1.84e5, 2.795e5),  # Bank 3
+        (1.8e5, 2.8e5),  # Bank 1
+        (1.8e5, 3.0e5),  # Bank 2
+        (1.7e5, 2.9e5),  # Bank 3
     ]
 }
 

--- a/scripts/Diffraction/isis_powder/hrpd_routines/hrpd_enums.py
+++ b/scripts/Diffraction/isis_powder/hrpd_routines/hrpd_enums.py
@@ -3,9 +3,11 @@ from __future__ import (absolute_import, division, print_function)
 
 class HRPD_TOF_WINDOWS(object):
     enum_friendly_name = "TOF windows"
+    window_10_50 = "10-50"
     window_10_110 = "10-110"
     window_30_130 = "30-130"
     window_100_200 = "100-200"
+    window_180_280 = "180-280"
 
 
 class HRPD_MODES(object):


### PR DESCRIPTION
Cropping values for two TOF windows which were missed off the original requirements for HRPD have been added to the `isis_powder` library. Scientists can now focus runs for TOF windows 10-50 and 180-280.

**To test:**

As with all `isis_powder` stuff, setting up your directories is a bit fiddly - give me a shout if you need a hand, but the scripts should bark at you if you miss something out.
Setup with this script:
```
from isis_powder import HRPD
user = "Test"
calib_dir = "path/to/hrpd/calibration/directory"
out_dir = "path/to/hrpd/output/directory"
mapping_file = "path/to/attached/mapping/file"

hrpd = HRPD(user_name=user, 
            calibration_directory=calib_dir,
            output_directory=out_dir,
            calibration_mapping_file=mapping_file)
```

Some files you'll need are [here](https://github.com/mantidproject/mantid/files/1475170/HRPD.zip).

```
hrpd.create_vanadium(first_cycle_run_no=68236, do_absorb_corrections=False, window="10-50")
```
Make sure the 3 workspaces in the group `VanSplineData` are cropped from 1e4 to 5e4.

```
hrpd.create_vanadium(first_cycle_run_no=68236, do_absorb_corrections=False, window="180-280")
```
Make sure the 3 workspaces in the group `VanSplineData` are cropped from 1.8e5 to 2.8e5.

```
hrpd.focus(run_number=68262, window="180-280", 
           vanadium_normalisation=True, do_absorb_corrections=False)
```
Make sure the first workspace in `68262.raw-Results-TOF-Grp` is cropped from 1.86e5 to 2.8e5, the second from 1.8e5 to 2.798e5 and the third from 1.9e5 to 2.795e5,

```
hrpd.focus(run_number=68254, window="10-50",
           vanadium_normalisation=True, do_absorb_corrections=False)
```

Make sure the workspaces in `68254.raw-Results-TOF-Grp` are cropped from 1.2e4 to 4.99e4.

Fixes #21149 
Address part of #21148 

**Release Notes** 
[Here](https://github.com/mantidproject/mantid/pull/21197/commits/fe9fd8874e7dbf7ed40058f6dd763ca289a0c928)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
