### PR TITLE
Fix FakeISISEventDAE for poco 1.8.0

### DIFF
--- a/instrument/Facilities.xml
+++ b/instrument/Facilities.xml
@@ -799,14 +799,14 @@
   <instrument name="ISIS_Histogram">
     <technique>Test Listener</technique>
     <livedata>
-      <connection name="histo" address="localhost:56789" listener="ISISHistoDataListener" />
+      <connection name="histo" address="127.0.0.1:56789" listener="ISISHistoDataListener" />
     </livedata>
   </instrument>
 
   <instrument name="ISIS_Event">
     <technique>Test Listener</technique>
     <livedata>
-      <connection name="event" address="localhost:59876" listener="ISISLiveEventDataListener" />
+      <connection name="event" address="127.0.0.1:59876" listener="ISISLiveEventDataListener" />
     </livedata>
   </instrument>
 


### PR DESCRIPTION
The` FakeISISEventDAE` doc-test currently fails with poco `1.8.0`:
```
01:05:57 Document: algorithms/FakeISISEventDAE-v1
01:05:57 ----------------------------------------
01:05:57 FakeISISEventDAE-[Notice] FakeISISEventDAE started
01:05:59 StartLiveData-[Notice] StartLiveData started
01:05:59 StartLiveData-[Error] Error in execution of algorithm StartLiveData:
01:05:59 StartLiveData-[Error] Unable to connect listener [ISISLiveEventDataListener] to [localhost:59876]: Exception
```

**To test:**
Update to poco `1.8.0` and see that the `FakeISISEventDAE` doc-test now passes


*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
