### PR TITLE
Added suffix in Merged or All reduction

### DIFF
--- a/docs/source/release/v3.12.0/lowq.rst
+++ b/docs/source/release/v3.12.0/lowq.rst
@@ -16,6 +16,6 @@ Small Angle Scattering
 ----------------------
 - Fixed a bug where specifying fit range was not working for merged reductions. Previously the user specified range was being ignored.
 - Fixed a bug in the old GUI where loading files on UNIX systems would not work unless the file name was in uppercase letters.
-
+- Fixed an issue where merged or all reductions were overwriting each other as they were beng given the same name.
 
 :ref:`Release 3.12.0 <v3.12.0>`

--- a/scripts/SANS/sans/common/general_functions.py
+++ b/scripts/SANS/sans/common/general_functions.py
@@ -607,6 +607,11 @@ def get_output_name(state, reduction_mode, is_group, suffix=""):
     user_specified_output_name_suffix = save_info.user_specified_output_name_suffix
     use_reduction_mode_as_suffix = save_info.use_reduction_mode_as_suffix
 
+    # This adds a reduction mode suffix in merged or all reductions so the workspaces do not overwrite each other.
+    if (state.reduction.reduction_mode == ISISReductionMode.Merged or state.reduction.reduction_mode == ISISReductionMode.All) \
+            and user_specified_output_name:
+        use_reduction_mode_as_suffix = True
+
     # An output name requires special attention when the workspace is part of a multi-period reduction
     # or slice event scan
     # If user specified output name is not none then we use it for the base name


### PR DESCRIPTION
See Issue #21196

**To test:**
- Get the data from _\\olympic\Babylon5\Scratch\Matthew Andrew\GUI_TEST_
- Open the sans GUI V2
- Load the user file _USER_SANS2D_154E_2p4_4m_M3_Xpress_8mm_SampleChanger_REAR_
- Load the Batch file _batch\_file_
- In the settings tab change the reduction mode to merged.
- Click process.
Confirm that three work-spaces are output to the ADS, with suffix's front, rear and merged.
<!-- Instructions for testing. -->

Fixes #21196. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
Have added to release notes.
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
