### PR TITLE
Import mantid in testhelper.testrunner

### DIFF
--- a/Framework/PythonInterface/test/testhelpers/testrunner.py
+++ b/Framework/PythonInterface/test/testhelpers/testrunner.py
@@ -8,10 +8,10 @@ from __future__ import (absolute_import, division, print_function)
 import imp
 import os
 import sys
-from xmlrunner import XMLTestRunner
-from xmlrunner.result import _TestInfo, _XMLTestResult, safe_unicode
 import unittest
 
+from xmlrunner import XMLTestRunner
+from xmlrunner.result import _TestInfo, _XMLTestResult, safe_unicode
 
 class GroupedNameTestInfo(_TestInfo):
     """
@@ -128,4 +128,8 @@ def result_class(pathname):
 
 
 if __name__ == "__main__":
+    # Import mantid so that it sets up the additional paths to scripts etc
+    # It would be good to try & remove this to soften the impact on tests
+    # that don't require importing mantid at all
+    import mantid  # noqa
     main(sys.argv)

--- a/scripts/test/CrystalFieldMultiSiteTest.py
+++ b/scripts/test/CrystalFieldMultiSiteTest.py
@@ -1,7 +1,6 @@
 import numpy as np
 import unittest
 
-import mantid # noqa
 from CrystalField.CrystalFieldMultiSite import CrystalFieldMultiSite
 
 c_mbsr = 79.5774715459  # Conversion from barn to mb/sr

--- a/scripts/test/Muon/FFTModel_test.py
+++ b/scripts/test/Muon/FFTModel_test.py
@@ -1,6 +1,5 @@
 import sys
 
-import mantid #noqa
 from  Muon import fft_model
 
 import unittest

--- a/scripts/test/Muon/FFTPresenter_test.py
+++ b/scripts/test/Muon/FFTPresenter_test.py
@@ -1,6 +1,5 @@
 import sys
 
-import mantid #noqa
 from  Muon import load_utils
 from  Muon import fft_presenter
 from  Muon import fft_view

--- a/scripts/test/Muon/MaxEntPresenter_test.py
+++ b/scripts/test/Muon/MaxEntPresenter_test.py
@@ -2,7 +2,6 @@ from __future__ import (absolute_import, division, print_function)
 
 import sys
 
-import mantid #noqa
 from  Muon import load_utils
 from  Muon import maxent_presenter
 from  Muon import maxent_view

--- a/scripts/test/SANS/common/enums_test.py
+++ b/scripts/test/SANS/common/enums_test.py
@@ -1,7 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 import unittest
 
-import mantid #noqa
 from sans.common.enums import serializable_enum, string_convertible
 
 


### PR DESCRIPTION
Description of work.

Several python tests are [failing](http://builds.mantidproject.org/job/pull_requests-rhel7/17462/consoleFull) as they cannot find appropriate modules that used to be imported at the start. This reverts part of the functional change from `https://github.com/mantidproject/mantid/commit/de4509594bb25437538b5581973969c52f91ce62#diff-a2d6a01451724b0fc156cafdc10b3539` as a high priority fix for tests on `master`.

**To test:**

* Code reveiew
* Run `ctest -R PythonSANS`


**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
