### PR TITLE
Use fixed Windows SDK Version on builders

### DIFF
--- a/buildconfig/Jenkins/buildscript.bat
+++ b/buildconfig/Jenkins/buildscript.bat
@@ -12,7 +12,6 @@ setlocal enableextensions enabledelayedexpansion
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 call cmake.exe --version
 echo %sha1%
-set VS_VERSION=14
 
 :: Find the grep tool for later
 for /f "delims=" %%I in ('where git') do @set GIT_EXE_DIR=%%~dpI
@@ -24,7 +23,11 @@ set GREP_EXE=%GIT_ROOT_DIR%\usr\bin\grep.exe
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: Source the VS setup script
 set VS_VERSION=14
-call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" amd64
+:: 8.1 is backwards compatible with Windows 7. It allows us to target Windows 7
+:: when building on newer versions of Windows. This value must be supplied
+:: externally and cannot be supplied in the cmake configuration
+set SDK_VERSION=8.1
+call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" amd64 %SDK_VERSION%
 set CM_GENERATOR=Visual Studio 14 2015 Win64
 set PARAVIEW_DIR=%PARAVIEW_NEXT_DIR%
 
@@ -127,7 +130,7 @@ if not "%JOB_NAME%"=="%JOB_NAME:debug=%" (
 ) else (
   set VATES_OPT_VAL=ON
 )
-call cmake.exe -G "%CM_GENERATOR%" -DCONSOLE=OFF -DENABLE_CPACK=ON -DMAKE_VATES=%VATES_OPT_VAL% -DParaView_DIR=%PARAVIEW_DIR% -DMANTID_DATA_STORE=!MANTID_DATA_STORE! -DUSE_PRECOMPILED_HEADERS=ON -DENABLE_FILE_LOGGING=OFF %PACKAGE_OPTS% ..
+call cmake.exe -G "%CM_GENERATOR%" -DCMAKE_SYSTEM_VERSION=%SDK_VERSION% -DCONSOLE=OFF -DENABLE_CPACK=ON -DMAKE_VATES=%VATES_OPT_VAL% -DParaView_DIR=%PARAVIEW_DIR% -DMANTID_DATA_STORE=!MANTID_DATA_STORE! -DUSE_PRECOMPILED_HEADERS=ON -DENABLE_FILE_LOGGING=OFF %PACKAGE_OPTS% ..
 if ERRORLEVEL 1 exit /B %ERRORLEVEL%
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
Description of work.

Ensures that all Windows builders target the same version of the platform SDK. This will allow us to build on Windows 10 but still guarantee and app that runs on Windows 7.

**To test:**

* Code review as the changes are to the build server script alone. The default value cannot be
specified with CMake itself.
* You can simulate this locally by running (from the command line as it is not available in the GUI)

`cmake -DCMAKE_SYSTEM_VERSION=8.1`

from the build directory. When the generation has complete:

* open VS
* select a target, say Kernel
* right-click on it and select properties
* check that the "Target Platform Version" matches 8.1


**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
