### PR TITLE
Corrected restricted list check in data processor widget

### DIFF
--- a/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -956,7 +956,7 @@ void GenericDataProcessorPresenter::reduceRow(RowData *data) {
   auto isUnrestrictedProperty =
       [&restrictedProps](QString const &propertyName) -> bool {
         return std::find(restrictedProps.begin(), restrictedProps.end(),
-                         propertyName) != restrictedProps.end();
+                         propertyName) == restrictedProps.end();
       };
 
   // Parse and set any user-specified options


### PR DESCRIPTION
Description of work.
This switches a comparison operator so that options not on the restricted list are read in not vise versa.
**To test:**
- In the sans GUI run a reduction with use optimizations ticked, confirm that the transmission work spaces are left on the ADS.
-  In the sans GUI run a reduction with use optimizations not ticked, confirm that the transmission work spaces are removed from the ADS.
- Check that the reflectometry GUI still works and in particular that the right options are propagated through.
<!-- Instructions for testing. -->

Fixes #21235. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
No release notes needed.
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
