### PR TITLE
simpleapi and fitfunctions sphinx docs

### DIFF
--- a/Framework/PythonInterface/mantid/fitfunctions.py
+++ b/Framework/PythonInterface/mantid/fitfunctions.py
@@ -7,8 +7,9 @@ class FunctionWrapper(object):
     def __init__ (self, name, **kwargs):
         """
         Called when creating an instance
+
         :param name: name of fitting function to create or
-        an Ifunction object to wrap.
+                     an Ifunction object to wrap.
         :param **kwargs: standard argument for __init__ function
         """
         if not isinstance(name, str):
@@ -36,6 +37,7 @@ class FunctionWrapper(object):
         """
         __getattr__ invoked when attribute item not found in the instance,
         nor in the class, nor its superclasses.
+
         :param item: named attribute
         :return: attribute of self.fun instance, or any of the fitting
         parameters or function attributes
@@ -52,6 +54,7 @@ class FunctionWrapper(object):
         nor in the class, nor its superclasses.
         Enables direct access to the attributes of self.fun instance, and
         also to its fitting parameters and function attributes
+
         :param key: named attribute
         :param value: new value for the named attribute
         """
@@ -65,10 +68,12 @@ class FunctionWrapper(object):
             self.fun.setParameter(key, value)  # key is fitting parameter
         else:
             self.__dict__[key] = value  # initialize self.key
- 
+
     def __getitem__ (self, name):
         """ Called from array-like access on RHS
-        It should not be called directly.
+
+        **It should not be called directly.**
+
         :param name: name that appears in the []
         """
         if type(name) == type('string') and self.fun.hasAttribute(name):
@@ -78,7 +83,8 @@ class FunctionWrapper(object):
 
     def __setitem__ (self, name, value):
         """ Called from array-like access on LHS
-        It should not be called directly.
+
+        **It should not be called directly.**
 
         :param name: name that appears in the []
         :param value: new value of this item
@@ -93,7 +99,7 @@ class FunctionWrapper(object):
           Used in unit tests.
         """
         return str(self.fun)
- 
+
     def __add__ (self, other):
         """ Implement + operator for composite function
 
@@ -177,7 +183,7 @@ class FunctionWrapper(object):
         haveEndX = False
         nSteps = 20
         plotName = self.name
-      
+
         def inRange(x):
             return x >= xMin and x <= xMax
 
@@ -236,9 +242,10 @@ class FunctionWrapper(object):
         vals = outWs.readY(1)
         function = CreateWorkspace( DataX=xvals, DataY=vals, OutputWorkspace=plotName)
         plot(plotName,0)
-         
+
     def tie (self, *args, **kwargs):
         """ Add ties.
+
             :param *args: one or more dictionaries of ties
             :param **kwargs: one or more ties
         """
@@ -256,25 +263,25 @@ class FunctionWrapper(object):
           :param name: name of parameter to be fixed
         """
         self.fun.fixParameter(name)
-       
+
     def fixAllParameters(self):
         """ Fix all parameters.
         """
         self.fun.fixAll()
-       
+
     def untie(self, name):
         """ Remove tie from parameter.
 
           :param name: name of parameter to be untied
         """
         self.fun.removeTie(name)
-       
+
     def untieAllParameters(self):
         """ Remove ties from all parameters.
         """
         for i in range(0, self.fun.numParams()):
             self.fun.removeTie(self.getParameterName(i))
- 
+
 
     def constrain(self, expressions):
         """ Add constraints
@@ -282,14 +289,14 @@ class FunctionWrapper(object):
           :param expressions: string of tie expressions
         """
         self.fun.addConstraints( expressions )
-       
+
     def unconstrain(self, name):
         """ Remove constraints from a parameter
 
           :param name: name of parameter to be unconstrained
         """
         self.fun.removeConstraint(name)
-            
+
     def free(self, name):
         """ Free a parameter from tie or constraint
 
@@ -297,20 +304,20 @@ class FunctionWrapper(object):
         """
         self.fun.removeTie(name)
         self.fun.removeConstraint(name)
-       
+
     def getParameterName(self, index):
         """ Get the name of the parameter of given index
 
           :param index: index of parameter
         """
         return self.fun.getParamName(index)
-        
+
     @property
     def function(self):
         """ Return the underlying IFunction object
         """
         return self.fun
- 
+
     @property
     def name(self):
         """ Return the name of the function
@@ -336,21 +343,23 @@ class FunctionWrapper(object):
         alg.execute()
         return alg.getProperty("OutputWorkspace").value
 
-       
+
 class CompositeFunctionWrapper(FunctionWrapper):
     """ Wrapper class for Composite Fitting Function
     """
     def __init__ (self, *args, **kwargs):
         """ Called when creating an instance
-           It should not be called directly
-           :param *args: names of functions in composite function
+
+           **It should not be called directly**
+
+           :param *args:  names of functions in composite function
            :param kwargs: any parameters or attributes that must be passed to the
-            composite function itself.
+                          composite function itself.
         """
         self.pureAddition = True
         self.pureMultiplication = False
         self.initByName("CompositeFunction", *args, **kwargs)
- 
+
     def initByName(self, name, *args, **kwargs):
         """ intialise composite function of named type.
            E.g. "ProductFunction"
@@ -362,14 +371,14 @@ class CompositeFunctionWrapper(FunctionWrapper):
           :param name: name of class calling this.
           :param *args: names of functions in composite function
           :param kwargs: any parameters or attributes that must be passed to the
-            composite function itself.
+                         composite function itself.
         """
         if len(args) == 1 and  not isinstance(args[0], FunctionWrapper):
             # We have a composite function to wrap
             self.fun = args[0]
         else:
             self.fun = FunctionFactory.createCompositeFunction(name)
-    
+
             # Add the functions, checking for Composite & Product functions
             for a in args:
                 if not isinstance(a, int):
@@ -381,30 +390,30 @@ class CompositeFunctionWrapper(FunctionWrapper):
                     functionToAdd = FunctionFactory.createInitialized(a.fun.__str__())
                     self.fun.add(functionToAdd)
         self.init_paramgeters_and_attributes(**kwargs)
-       
+
     def getParameter(self, name):
         """ get value of parameter of specified name
-       
+
             :param name: name of parameter
         """
         return self.fun.getParameterValue(name)
-         
+
     def getCompositeParameterName(self, name, index):
-        """ get composite parameter name of parameter of 
+        """ get composite parameter name of parameter of
             given name of member function of given index
         """
         return "f"+str(index)+"."+name
-         
+
     def getIndexOfFunction (self, name):
         """ get index of function specified by name,
             such as "LinearBackground" for the only
             LinearBackground function or
             "Gaussian1" for the second Gaussian function.
-       
+
             :param name: name specifying the function
         """
         # Only a shallow search is done.
-         
+
         delimiter = " "
         if name.count(delimiter) == 0:
             fname = name
@@ -412,7 +421,7 @@ class CompositeFunctionWrapper(FunctionWrapper):
         else:
             fname, n = name.split(delimiter)
             occurrence = int(n)
-            
+
         index = 0
         count = 0
         for f in self:
@@ -422,28 +431,29 @@ class CompositeFunctionWrapper(FunctionWrapper):
                 else:
                     count += 1
             index += 1
-          
+
         raise RuntimeError("Specified function not found.")
-         
+
     def f(self, name):
         """ get function specified by name,
             such as "LinearBackground" for the only
             LinearBackground function or
             "Gaussian1" for the second Gaussian function.
-       
+
             :param name: name specifying the function
         """
         index = self.getIndexOfFunction(name)
         return self[index]
- 
+
     def __getitem__ (self, nameorindex):
         """ get function of specified index or parameter of specified name
             called for array-like access on RHS.
-            It should not be called directly.
-       
+
+            **It should not be called directly.**
+
             :param name: name or index in the []
         """
- 
+
         comp = self.fun
         item = comp[nameorindex]
         if isinstance(item, float):
@@ -454,13 +464,14 @@ class CompositeFunctionWrapper(FunctionWrapper):
             return ProductFunctionWrapper(item)
         elif item.name() == "Convolution":
             return ConvolutionWrapper(item)
-        else:       
+        else:
             return FunctionWrapper(item)
- 
+
     def __setitem__ (self, name, newValue):
         """ Called from array-like access on LHS
-            It should not be called directly.
-       
+
+            **It should not be called directly.**
+
             :param name: name or index in the []
             :param newValue: new value for item
         """
@@ -469,30 +480,33 @@ class CompositeFunctionWrapper(FunctionWrapper):
             comp[name] = newValue.fun
         else:
             comp[name] = newValue
-                     
+
     def __iadd__ (self, other):
         """ Implement += operator.
-           It should not be called directly.
-            
+
+           **It should not be called directly.**
+
            :param other: object to add
         """
         self.fun.add(other.fun)
         return self
-        
+
     def __delitem__ (self, index):
        """ Delete item of given index from composite function.
-           It should not be called directly.
-            
+
+           **It should not be called directly.**
+
            :param index: index of item
        """
        self.fun.__delitem__(index)
-        
+
     def __len__ (self):
         """ Return number of items in composite function.
            Implement len() function.
-           It should not be called directly.
+
+           **It should not be called directly.**
         """
- 
+
         composite = self.fun
         return composite.__len__()
 
@@ -500,24 +514,24 @@ class CompositeFunctionWrapper(FunctionWrapper):
         """ For each member function, tie the parameter of the given name
            to the parameter of that name in the first member function.
            The named parameter must occur in all the member functions.
-            
+
            :param name: name of parameter
         """
         expr = self.getCompositeParameterName(name, 0)
         self.tie({self.getCompositeParameterName(name, i): expr for i in range(1,len(self)) })
-           
+
     def fixAll (self, name):
         """ Fix all parameters with the given local name.
            Every member function must have a parameter of this name.
-            
+
            :param name: name of parameter
         """
         for f in self:
             f.fix(name)
-           
+
     def constrainAll (self, expressions):
         """ Constrain all parameters according local names in expressions.
-                   
+
            :param expressions: string of expressions
         """
         for i in range(0, len(self)):
@@ -528,10 +542,10 @@ class CompositeFunctionWrapper(FunctionWrapper):
                     self[i].constrain(expressions)
                 except:
                     pass
-           
+
     def unconstrainAll (self, name):
         """ Unconstrain all parameters of given local name.
-            
+
            :param name: local name of parameter
         """
         for i in range(0, len(self)):
@@ -542,24 +556,24 @@ class CompositeFunctionWrapper(FunctionWrapper):
                     self[i].unconstrain(name)
                 except:
                     pass
-           
+
     def untieAll (self, name):
         """ Untie all parameters with the given local name.
            Every member function must have a parameter of this name.
-            
+
            :param name: local name of parameter
         """
         for i in range(0, len(self)):
             self.untie(self.getCompositeParameterName(name, i))
- 
+
     def flatten (self):
         """ Return composite function, equal to self, but with
            every composite function within replaced by
            its list of functions, so having a pure list of functions.
            This makes it possible to index and iterate all the functions
            and use tieAll() and untieAll().
-           Not to be used with a mixture of product and sum 
-           composite functions, because the arithmetic 
+           Not to be used with a mixture of product and sum
+           composite functions, because the arithmetic
            may no longer be correct.
            The return value is not independent of self.
         """
@@ -594,10 +608,12 @@ class ProductFunctionWrapper(CompositeFunctionWrapper):
     """
     def __init__ (self, *args, **kwargs):
         """ Called when creating an instance
-            It should not be called directly.
+
+            **It should not be called directly.**
+
             :param *args: names of functions in composite function
             :param kwargs: any parameters or attributes that must be passed to the
-            composite function itself.
+                           composite function itself.
         """
         self.pureAddition = False
         self.pureMultiplication = True
@@ -609,10 +625,12 @@ class ConvolutionWrapper(CompositeFunctionWrapper):
     """
     def __init__ (self, *args, **kwargs):
         """ Called when creating an instance
-           It should not be called directly.
+
+           **It should not be called directly.**
+
            :param *args: names of functions in composite function
            :param kwargs: any parameters or attributes that must be passed to the
-            composite function itself.
+                          composite function itself.
         """
         self.pureAddition = False
         self.pureMultiplication = False
@@ -624,10 +642,12 @@ class MultiDomainFunctionWrapper(CompositeFunctionWrapper):
     """
     def __init__ (self, *args, **kwargs):
         """ Called when creating an instance
-           It should not be called directly
+
+           **It should not be called directly**
+
            :param *args: names of functions in composite function
            :param kwargs: any parameters or attributes that must be passed to the
-            composite function itself.
+                          composite function itself.
         """
         # Assume it's not safe to flatten
         self.pureAddition = False
@@ -658,8 +678,9 @@ class MultiDomainFunctionWrapper(CompositeFunctionWrapper):
 
 def _create_wrapper_function(name):
     """Create fake functions for the given name
-       It should not be called directly
-                   
+
+       **It should not be called directly**
+
        :param name: name of fake function
     """
     # ------------------------------------------------------------------------------------------------
@@ -674,11 +695,11 @@ def _create_wrapper_function(name):
         if name in name_to_constructor:
             return name_to_constructor[name](*args, **kwargs)
         return FunctionWrapper(name, **kwargs)
- 
+
     # ------------------------------------------------------------------------------------------------
     wrapper_function.__name__ = name
     globals()[name] = wrapper_function
- 
+
 fnames = FunctionFactory.getFunctionNames()
 for i, val in enumerate(fnames):
     _create_wrapper_function(val)

--- a/Framework/PythonInterface/mantid/fitfunctions.py
+++ b/Framework/PythonInterface/mantid/fitfunctions.py
@@ -2,15 +2,17 @@ from mantid.api import FunctionFactory, Workspace, AlgorithmManager
 
 
 class FunctionWrapper(object):
-    """ Wrapper class for Fitting Function
+    """
+    Wrapper class for Fitting Function
     """
     def __init__ (self, name, **kwargs):
         """
         Called when creating an instance
 
-        :param name: name of fitting function to create or
-                     an Ifunction object to wrap.
-        :param **kwargs: standard argument for __init__ function
+        :param name:   name of fitting function to create or
+                       an Ifunction object to wrap.
+        :param kwargs: standard argument for initializing fit
+                       function
         """
         if not isinstance(name, str):
             self.fun = name
@@ -70,7 +72,8 @@ class FunctionWrapper(object):
             self.__dict__[key] = value  # initialize self.key
 
     def __getitem__ (self, name):
-        """ Called from array-like access on RHS
+        """
+        Called from array-like access on RHS
 
         **It should not be called directly.**
 
@@ -82,7 +85,8 @@ class FunctionWrapper(object):
             return self.fun.getParameterValue(name)
 
     def __setitem__ (self, name, value):
-        """ Called from array-like access on LHS
+        """
+        Called from array-like access on LHS
 
         **It should not be called directly.**
 
@@ -95,13 +99,15 @@ class FunctionWrapper(object):
             self.fun.setParameter(name, value)
 
     def __str__ (self):
-        """ Return string giving contents of function.
-          Used in unit tests.
+        """
+        Return string giving contents of function.
+        Used in unit tests.
         """
         return str(self.fun)
 
     def __add__ (self, other):
-        """ Implement + operator for composite function
+        """
+        Implement + operator for composite function
 
         :param other: functionWrapper to be added to self
         """
@@ -111,7 +117,8 @@ class FunctionWrapper(object):
         return sum
 
     def __mul__ (self, other):
-        """ Implement * operator for product function
+        """
+        Implement * operator for product function
 
         :param other: functionWrapper to multiply self by
         """
@@ -121,11 +128,12 @@ class FunctionWrapper(object):
         return prod
 
     def __call__(self, x, *params):
-        """ Implement function evaluation, such that
+        """
+        Implement function evaluation, such that
         func(args) is equivalent func.__call__(args)
 
-        :param x: x value or list of x values
-        :param *params list of parameter values
+        :param x:      x value or list of x values
+        :param params: list of parameter values
         """
         import numpy as np
 
@@ -162,10 +170,11 @@ class FunctionWrapper(object):
             return output_array[0]
 
     def plot(self, **kwargs):
-        """ Plot the function
+        """
+        Plot the function
 
-          :param workspace=ws: workspace upon whose x values
-          the function is plotted.
+        :param workspace: workspace upon whose x values
+                          the function is plotted.
         """
         from mantid import mtd
         try:
@@ -244,10 +253,11 @@ class FunctionWrapper(object):
         plot(plotName,0)
 
     def tie (self, *args, **kwargs):
-        """ Add ties.
+        """
+        Add ties.
 
-            :param *args: one or more dictionaries of ties
-            :param **kwargs: one or more ties
+        :param args: one or more dictionaries of ties
+        :param kwargs: one or more ties
         """
         for a in args:
             if isinstance(a, dict):
@@ -258,69 +268,79 @@ class FunctionWrapper(object):
             self.fun.tie(key, str(kwargs[key]))
 
     def fix(self, name):
-        """ Fix a parameter.
+        """
+        Fix a parameter.
 
-          :param name: name of parameter to be fixed
+        :param name: name of parameter to be fixed
         """
         self.fun.fixParameter(name)
 
     def fixAllParameters(self):
-        """ Fix all parameters.
+        """
+        Fix all parameters.
         """
         self.fun.fixAll()
 
     def untie(self, name):
-        """ Remove tie from parameter.
+        """
+        Remove tie from parameter.
 
-          :param name: name of parameter to be untied
+        :param name: name of parameter to be untied
         """
         self.fun.removeTie(name)
 
     def untieAllParameters(self):
-        """ Remove ties from all parameters.
+        """
+        Remove ties from all parameters.
         """
         for i in range(0, self.fun.numParams()):
             self.fun.removeTie(self.getParameterName(i))
 
 
     def constrain(self, expressions):
-        """ Add constraints
+        """
+        Add constraints
 
-          :param expressions: string of tie expressions
+        :param expressions: string of tie expressions
         """
         self.fun.addConstraints( expressions )
 
     def unconstrain(self, name):
-        """ Remove constraints from a parameter
+        """
+        Remove constraints from a parameter
 
-          :param name: name of parameter to be unconstrained
+        :param name: name of parameter to be unconstrained
         """
         self.fun.removeConstraint(name)
 
     def free(self, name):
-        """ Free a parameter from tie or constraint
+        """
+        Free a parameter from tie or constraint
 
-          :param name: name of parameter to be freed
+        :param name: name of parameter to be freed
         """
         self.fun.removeTie(name)
         self.fun.removeConstraint(name)
 
     def getParameterName(self, index):
-        """ Get the name of the parameter of given index
+        """
+        Get the name of the parameter of given index
 
-          :param index: index of parameter
+        :param index: index of parameter
         """
         return self.fun.getParamName(index)
 
     @property
     def function(self):
-        """ Return the underlying IFunction object
+        """
+        Return the underlying IFunction object
         """
         return self.fun
 
     @property
     def name(self):
-        """ Return the name of the function
+        """
+        Return the name of the function
         """
         return self.fun.name()
 
@@ -345,33 +365,36 @@ class FunctionWrapper(object):
 
 
 class CompositeFunctionWrapper(FunctionWrapper):
-    """ Wrapper class for Composite Fitting Function
+    """
+    Wrapper class for Composite Fitting Function
     """
     def __init__ (self, *args, **kwargs):
-        """ Called when creating an instance
+        """
+        Called when creating an instance
 
-           **It should not be called directly**
+        **It should not be called directly**
 
-           :param *args:  names of functions in composite function
-           :param kwargs: any parameters or attributes that must be passed to the
-                          composite function itself.
+        :param args:   names of functions in composite function
+        :param kwargs: any parameters or attributes that must be passed to the
+                       composite function itself.
         """
         self.pureAddition = True
         self.pureMultiplication = False
         self.initByName("CompositeFunction", *args, **kwargs)
 
     def initByName(self, name, *args, **kwargs):
-        """ intialise composite function of named type.
-           E.g. "ProductFunction"
-           This function would be protected in c++
-           and should not be called directly except
-           by __init__ functions of this class and
-           subclasses.
+        """
+        intialise composite function of named type.
+        E.g. "ProductFunction"
+        This function would be protected in c++
+        and should not be called directly except
+        by :meth:`__init__` functions of this class
+        and subclasses.
 
-          :param name: name of class calling this.
-          :param *args: names of functions in composite function
-          :param kwargs: any parameters or attributes that must be passed to the
-                         composite function itself.
+        :param name:   name of class calling this.
+        :param args:   names of functions in composite function
+        :param kwargs: any parameters or attributes that must be passed to the
+                       composite function itself.
         """
         if len(args) == 1 and  not isinstance(args[0], FunctionWrapper):
             # We have a composite function to wrap
@@ -392,25 +415,28 @@ class CompositeFunctionWrapper(FunctionWrapper):
         self.init_paramgeters_and_attributes(**kwargs)
 
     def getParameter(self, name):
-        """ get value of parameter of specified name
+        """
+        get value of parameter of specified name
 
-            :param name: name of parameter
+        :param name: name of parameter
         """
         return self.fun.getParameterValue(name)
 
     def getCompositeParameterName(self, name, index):
-        """ get composite parameter name of parameter of
-            given name of member function of given index
+        """
+        get composite parameter name of parameter of
+        given name of member function of given index
         """
         return "f"+str(index)+"."+name
 
     def getIndexOfFunction (self, name):
-        """ get index of function specified by name,
-            such as "LinearBackground" for the only
-            LinearBackground function or
-            "Gaussian1" for the second Gaussian function.
+        """
+        get index of function specified by name,
+        such as "LinearBackground" for the only
+        LinearBackground function or
+        "Gaussian1" for the second Gaussian function.
 
-            :param name: name specifying the function
+        :param name: name specifying the function
         """
         # Only a shallow search is done.
 
@@ -435,23 +461,25 @@ class CompositeFunctionWrapper(FunctionWrapper):
         raise RuntimeError("Specified function not found.")
 
     def f(self, name):
-        """ get function specified by name,
-            such as "LinearBackground" for the only
-            LinearBackground function or
-            "Gaussian1" for the second Gaussian function.
+        """
+        get function specified by name,
+        such as "LinearBackground" for the only
+        LinearBackground function or
+        "Gaussian1" for the second Gaussian function.
 
-            :param name: name specifying the function
+        :param name: name specifying the function
         """
         index = self.getIndexOfFunction(name)
         return self[index]
 
     def __getitem__ (self, nameorindex):
-        """ get function of specified index or parameter of specified name
-            called for array-like access on RHS.
+        """
+        get function of specified index or parameter of specified name
+        called for array-like access on RHS.
 
-            **It should not be called directly.**
+        **It should not be called directly.**
 
-            :param name: name or index in the []
+        :param name: name or index in the []
         """
 
         comp = self.fun
@@ -468,12 +496,13 @@ class CompositeFunctionWrapper(FunctionWrapper):
             return FunctionWrapper(item)
 
     def __setitem__ (self, name, newValue):
-        """ Called from array-like access on LHS
+        """
+        Called from array-like access on LHS
 
-            **It should not be called directly.**
+        **It should not be called directly.**
 
-            :param name: name or index in the []
-            :param newValue: new value for item
+        :param name: name or index in the []
+        :param newValue: new value for item
         """
         comp = self.fun
         if isinstance( newValue, FunctionWrapper):
@@ -482,57 +511,63 @@ class CompositeFunctionWrapper(FunctionWrapper):
             comp[name] = newValue
 
     def __iadd__ (self, other):
-        """ Implement += operator.
+        """
+        Implement += operator.
 
-           **It should not be called directly.**
+        **It should not be called directly.**
 
-           :param other: object to add
+        :param other: object to add
         """
         self.fun.add(other.fun)
         return self
 
     def __delitem__ (self, index):
-       """ Delete item of given index from composite function.
+       """
+       Delete item of given index from composite function.
 
-           **It should not be called directly.**
+       **It should not be called directly.**
 
-           :param index: index of item
+       :param index: index of item
        """
        self.fun.__delitem__(index)
 
     def __len__ (self):
-        """ Return number of items in composite function.
-           Implement len() function.
+        """
+        Return number of items in composite function.
+        Implement len() function.
 
-           **It should not be called directly.**
+        **It should not be called directly.**
         """
 
         composite = self.fun
         return composite.__len__()
 
     def tieAll(self, name):
-        """ For each member function, tie the parameter of the given name
-           to the parameter of that name in the first member function.
-           The named parameter must occur in all the member functions.
+        """
+        For each member function, tie the parameter of the given name
+        to the parameter of that name in the first member function.
+        The named parameter must occur in all the member functions.
 
-           :param name: name of parameter
+        :param name: name of parameter
         """
         expr = self.getCompositeParameterName(name, 0)
         self.tie({self.getCompositeParameterName(name, i): expr for i in range(1,len(self)) })
 
     def fixAll (self, name):
-        """ Fix all parameters with the given local name.
-           Every member function must have a parameter of this name.
+        """
+        Fix all parameters with the given local name.
+        Every member function must have a parameter of this name.
 
-           :param name: name of parameter
+        :param name: name of parameter
         """
         for f in self:
             f.fix(name)
 
     def constrainAll (self, expressions):
-        """ Constrain all parameters according local names in expressions.
+        """
+        Constrain all parameters according local names in expressions.
 
-           :param expressions: string of expressions
+        :param expressions: string of expressions
         """
         for i in range(0, len(self)):
             if isinstance(self[i], CompositeFunctionWrapper):
@@ -544,9 +579,10 @@ class CompositeFunctionWrapper(FunctionWrapper):
                     pass
 
     def unconstrainAll (self, name):
-        """ Unconstrain all parameters of given local name.
+        """
+        Unconstrain all parameters of given local name.
 
-           :param name: local name of parameter
+        :param name: local name of parameter
         """
         for i in range(0, len(self)):
             if isinstance( self[i], CompositeFunctionWrapper ):
@@ -558,24 +594,26 @@ class CompositeFunctionWrapper(FunctionWrapper):
                     pass
 
     def untieAll (self, name):
-        """ Untie all parameters with the given local name.
-           Every member function must have a parameter of this name.
+        """
+        Untie all parameters with the given local name.
+        Every member function must have a parameter of this name.
 
-           :param name: local name of parameter
+        :param name: local name of parameter
         """
         for i in range(0, len(self)):
             self.untie(self.getCompositeParameterName(name, i))
 
     def flatten (self):
-        """ Return composite function, equal to self, but with
-           every composite function within replaced by
-           its list of functions, so having a pure list of functions.
-           This makes it possible to index and iterate all the functions
-           and use tieAll() and untieAll().
-           Not to be used with a mixture of product and sum
-           composite functions, because the arithmetic
-           may no longer be correct.
-           The return value is not independent of self.
+        """
+        Return composite function, equal to self, but with
+        every composite function within replaced by
+        its list of functions, so having a pure list of functions.
+        This makes it possible to index and iterate all the functions
+        and use :meth:`tieAll` and :meth:`untieAll`.
+        Not to be used with a mixture of product and sum
+        composite functions, because the arithmetic
+        may no longer be correct.
+        The return value is not independent of self.
         """
         # If there are no composite functions, do nothing
         needToFlatten = False
@@ -604,16 +642,18 @@ class CompositeFunctionWrapper(FunctionWrapper):
 
 
 class ProductFunctionWrapper(CompositeFunctionWrapper):
-    """ Wrapper class for Product Fitting Function
+    """
+    Wrapper class for Product Fitting Function
     """
     def __init__ (self, *args, **kwargs):
-        """ Called when creating an instance
+        """
+        Called when creating an instance
 
-            **It should not be called directly.**
+        **It should not be called directly.**
 
-            :param *args: names of functions in composite function
-            :param kwargs: any parameters or attributes that must be passed to the
-                           composite function itself.
+        :param args:   names of functions in composite function
+        :param kwargs: any parameters or attributes that must be passed to the
+                       composite function itself.
         """
         self.pureAddition = False
         self.pureMultiplication = True
@@ -621,16 +661,18 @@ class ProductFunctionWrapper(CompositeFunctionWrapper):
 
 
 class ConvolutionWrapper(CompositeFunctionWrapper):
-    """ Wrapper class for Convolution Fitting Function
+    """
+    Wrapper class for Convolution Fitting Function
     """
     def __init__ (self, *args, **kwargs):
-        """ Called when creating an instance
+        """
+        Called when creating an instance
 
-           **It should not be called directly.**
+        **It should not be called directly.**
 
-           :param *args: names of functions in composite function
-           :param kwargs: any parameters or attributes that must be passed to the
-                          composite function itself.
+        :param args:   names of functions in composite function
+        :param kwargs: any parameters or attributes that must be passed to the
+                       composite function itself.
         """
         self.pureAddition = False
         self.pureMultiplication = False
@@ -638,16 +680,18 @@ class ConvolutionWrapper(CompositeFunctionWrapper):
 
 
 class MultiDomainFunctionWrapper(CompositeFunctionWrapper):
-    """ Wrapper class for Multidomain Fitting Function
+    """
+    Wrapper class for Multidomain Fitting Function
     """
     def __init__ (self, *args, **kwargs):
-        """ Called when creating an instance
+        """
+        Called when creating an instance
 
-           **It should not be called directly**
+        **It should not be called directly**
 
-           :param *args: names of functions in composite function
-           :param kwargs: any parameters or attributes that must be passed to the
-                          composite function itself.
+        :param args:   names of functions in composite function
+        :param kwargs: any parameters or attributes that must be passed to the
+                       composite function itself.
         """
         # Assume it's not safe to flatten
         self.pureAddition = False
@@ -671,17 +715,19 @@ class MultiDomainFunctionWrapper(CompositeFunctionWrapper):
 
     @property
     def nDomains (self):
-        """ Return number of domains
+        """
+        Return number of domains
         """
         return self.fun.nDomains()
 
 
 def _create_wrapper_function(name):
-    """Create fake functions for the given name
+    """
+    Create fake functions for the given name
 
-       **It should not be called directly**
+    **It should not be called directly**
 
-       :param name: name of fake function
+    :param name: name of fake function
     """
     # ------------------------------------------------------------------------------------------------
     def wrapper_function(*args, **kwargs):

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -8,7 +8,7 @@
 
     The Rebin algorithm is mapped to this Python function:
 
-        Rebin(InputWorkspace, OutputWorkspace, Params, PreserveEvents=None, Version=1)
+       Rebin(InputWorkspace, OutputWorkspace, Params, PreserveEvents=None, Version=1)
 
     It returns the output workspace and this workspace has the same name as
     the variable it is assigned to, i.e.

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -1,23 +1,22 @@
 """
-    This module defines a simple function-style API for running Mantid
-    algorithms. Each algorithm within Mantid is mapped to a Python
-    function of the same name with the parameters of the algorithm becoming
-    arguments to the function.
+This module defines a simple function-style API for running Mantid
+algorithms. Each algorithm within Mantid is mapped to a Python
+function of the same name with the parameters of the algorithm becoming
+arguments to the function.
 
-    For example:
+For example:
 
-    The Rebin algorithm is mapped to this Python function:
+The Rebin algorithm is mapped to this Python function:
 
-       Rebin(InputWorkspace, OutputWorkspace, Params, PreserveEvents=None, Version=1)
+   Rebin(InputWorkspace, OutputWorkspace, Params, PreserveEvents=None, Version=1)
 
-    It returns the output workspace and this workspace has the same name as
-    the variable it is assigned to, i.e.
+It returns the output workspace and this workspace has the same name as
+the variable it is assigned to, i.e.
 
-       rebinned = Rebin(input, Params = '0.1,0.05,10')
+   rebinned = Rebin(input, Params = '0.1,0.05,10')
 
-    would call Rebin with the given parameters and create a workspace called 'rebinned'
-    and assign it to the rebinned variable
-
+would call Rebin with the given parameters and create a workspace called 'rebinned'
+and assign it to the rebinned variable
 """
 from __future__ import (absolute_import, division,
                         print_function)

--- a/docs/source/api/python/mantid/fitfunctions.rst
+++ b/docs/source/api/python/mantid/fitfunctions.rst
@@ -1,0 +1,9 @@
+=============================================================================
+ :mod:`mantid.fitfunctions` --- Wrapper class for composite fitting function
+=============================================================================
+
+Fuller discussion of how this works with the :ref:`fitting frameworks
+<Fitting>` is described :ref:`here <FitFunctionsInPython>`.
+
+.. automodule:: mantid.fitfunctions
+   :members:

--- a/docs/source/api/python/mantid/index.rst
+++ b/docs/source/api/python/mantid/index.rst
@@ -23,3 +23,5 @@ Submodules
    kernel/index
    geometry/index
    api/index
+   simpleapi
+   fitfunctions

--- a/docs/source/api/python/mantid/simpleapi.rst
+++ b/docs/source/api/python/mantid/simpleapi.rst
@@ -1,0 +1,7 @@
+==========================================================================
+ :mod:`mantid.simpleapi` --- Simple functions calls for mantid algorithms
+==========================================================================
+
+.. automodule:: mantid.simpleapi
+
+See the :ref:`full list of algorithms <Algorithms List>` for information on what is available.


### PR DESCRIPTION
I discovered that `mantid.simpleapi` and `mantid.fitfunctions` were not in the sphinx site. This adds them in. Since `simpleapi` is full of internals and is meant as a easy way to get the algorithms into python, that page is just a link to the normal list of algorithms.

**To test:**

Build the docs and look at `api/python/mantid` and see links to two new pages.

*There is no associated issue.*

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
