### PR TITLE
Fix Qt5 build on Visual Studio

### DIFF
--- a/MantidPlot/CMakeLists.txt
+++ b/MantidPlot/CMakeLists.txt
@@ -690,6 +690,9 @@ find_package ( QScintillaQt4 REQUIRED )
 add_definitions ( -DSCRIPTING_MUPARSER )
 add_definitions ( -DSCRIPTING_PYTHON )
 add_definitions ( -DQSCINTILLA_DLL )     # Will only have an effect on Windows (as is desired)
+if ( MSVC )
+  add_definitions ( -DQ_COMPILER_INITIALIZER_LISTS )
+endif ()
 
 ###########################################################################
 # Application icon files

--- a/MantidPlot/src/Mantid/MantidMatrixModel.cpp
+++ b/MantidPlot/src/Mantid/MantidMatrixModel.cpp
@@ -8,10 +8,15 @@
 #include "MantidAPI/TextAxis.h"
 #include "MantidKernel/ReadLock.h"
 
+#include "MantidQtWidgets/Common/QStringUtils.h"
+
 #include <QApplication>
 #include <QObject>
 #include <QPalette>
 #include <QVariant>
+
+using MantidQt::API::toQStringInternal;
+
 // ----------   MantidMatrixModel   ------------------ //
 
 /**   MantidMatrixModel constructor.
@@ -132,7 +137,7 @@ QVariant MantidMatrixModel::headerData(int section, Qt::Orientation orientation,
       }
     }
 
-    QString unit = QString::fromStdWString(axis->unit()->label().utf8());
+    QString unit = toQStringInternal(axis->unit()->label().utf8());
 
     // Handle RefAxis for X axis
     Mantid::API::RefAxis *refAxis = dynamic_cast<Mantid::API::RefAxis *>(axis);

--- a/MantidPlot/src/main.cpp
+++ b/MantidPlot/src/main.cpp
@@ -173,7 +173,7 @@ int main(int argc, char **argv) {
       ApplicationWindow::about();
       exit(0);
     } else if (str == "-h" || str == "--help") {
-      QString s = "\nUsage: ";
+      std::string s = "\nUsage: ";
       s += "MantidPlot [options] [filename]\n\n";
       s += "Valid options are:\n";
       s += "-a or --about: show about dialog and exit\n";
@@ -188,7 +188,7 @@ int main(int argc, char **argv) {
            "and then exit MantidPlot\n\n";
       s += "'filename' can be any of .qti, qti.gz, .opj, .ogm, .ogw, .ogg, .py "
            "or ASCII file\n\n";
-      std::wcout << s.toStdWString();
+      std::cout << s;
 
       exit(0);
     }

--- a/buildconfig/CMake/Bootstrap.cmake
+++ b/buildconfig/CMake/Bootstrap.cmake
@@ -10,7 +10,7 @@ if( MSVC )
   include ( ExternalProject )
   set( EXTERNAL_ROOT ${PROJECT_SOURCE_DIR}/external CACHE PATH "Location to clone third party dependencies to" )
   set( THIRD_PARTY_GIT_URL "https://github.com/mantidproject/thirdparty-msvc2015.git" )
-  set ( THIRD_PARTY_GIT_SHA1 ef72b6d824ff2df21cca80c87b565136cc4020aa )
+  set ( THIRD_PARTY_GIT_SHA1 3b4620fd3ab80d48182861f5a5cba1bc96ab17e4 )
   set ( THIRD_PARTY_DIR ${EXTERNAL_ROOT}/src/ThirdParty )
   # Generates a script to do the clone/update in tmp
   set ( _project_name ThirdParty )
@@ -67,7 +67,7 @@ if( MSVC )
   # Print out where we are looking for 3rd party stuff
   set ( PYTHON_MAJOR_VERSION 2 )
   set ( PYTHON_MINOR_VERSION 7 )
-  set ( THIRD_PARTY_BIN "${THIRD_PARTY_DIR}/bin;${THIRD_PARTY_DIR}/lib/qt4/bin;${THIRD_PARTY_DIR}/lib/python${PYTHON_MAJOR_VERSION}.${PYTHON_MINOR_VERSION}" )
+  set ( THIRD_PARTY_BIN "${THIRD_PARTY_DIR}/bin;${THIRD_PARTY_DIR}/lib/qt4/bin;${THIRD_PARTY_DIR}/lib/qt5/bin;${THIRD_PARTY_DIR}/lib/python${PYTHON_MAJOR_VERSION}.${PYTHON_MINOR_VERSION}" )
   message ( STATUS "Third party dependencies are in ${THIRD_PARTY_DIR}" )
   # Add to the path so that cmake can configure correctly without the user having to do it
   set ( ENV{PATH} "${THIRD_PARTY_BIN};$ENV{PATH}" )

--- a/buildconfig/CMake/MSVCSetup.cmake
+++ b/buildconfig/CMake/MSVCSetup.cmake
@@ -13,10 +13,6 @@ add_definitions ( -D_USE_MATH_DEFINES -DNOMINMAX )
 add_definitions ( -DGSL_DLL -DJSON_DLL )
 add_definitions ( -DPOCO_NO_UNWINDOWS )
 add_definitions ( -D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS )
-# Workaround Qt compiler detection
-#https://forum.qt.io/topic/43778/error-when-initializing-qstringlist-using-initializer-list/3
-#https://bugreports.qt.io/browse/QTBUG-39142
-add_definitions ( -DQ_COMPILER_INITIALIZER_LISTS )
 
 ##########################################################################
 # Additional compiler flags

--- a/buildconfig/CMake/MSVCSetup.cmake
+++ b/buildconfig/CMake/MSVCSetup.cmake
@@ -19,9 +19,7 @@ add_definitions ( -D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS )
 ##########################################################################
 # /MP     - Compile .cpp files in parallel
 # /W3     - Warning Level 3 (This is also the default)
-# /Zc:wchar_t- - Do not treat wchar_t as a builtin type. Required for Qt to
-#           work with wstring
-set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /W3 /Zc:wchar_t-" )
+set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /W3" )
 
 # Set PCH heap limit, the default does not work when running msbuild from the commandline for some reason
 # Any other value lower or higher seems to work but not the default. It it is fine without this when compiling

--- a/buildconfig/CMake/MSVCSetup.cmake
+++ b/buildconfig/CMake/MSVCSetup.cmake
@@ -41,6 +41,11 @@ set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zm${VISUALSTUDIO_COMPILERHEAPLIMIT}" 
 endif()
 
 ###########################################################################
+# Qt5 is always in the same place
+###########################################################################
+set ( Qt5_DIR ${THIRD_PARTY_DIR}/lib/qt5/lib/cmake/Qt5 )
+
+###########################################################################
 # On Windows we want to bundle Python.
 ###########################################################################
 set ( PYTHON_DIR ${THIRD_PARTY_DIR}/lib/python${PYTHON_MAJOR_VERSION}.${PYTHON_MINOR_VERSION} )

--- a/buildconfig/CMake/QScintillaFindImpl.cmake
+++ b/buildconfig/CMake/QScintillaFindImpl.cmake
@@ -36,6 +36,11 @@ function (find_qscintilla qt_version)
       qt5scintilla2
       libqscintilla2-qt5.dylib
     )
+    if ( MSVC )
+      set ( _qsci_lib_paths
+        ${THIRD_PARTY_DIR}/lib/qt5/lib
+      )
+    endif()
     set ( _qsci_include_paths
       ${Qt5Core_INCLUDE_DIRS}
     )

--- a/buildconfig/CMake/QtTargetFunctions.cmake
+++ b/buildconfig/CMake/QtTargetFunctions.cmake
@@ -100,6 +100,10 @@ function (mtd_add_qt_target)
   set (CMAKE_CURRENT_BINARY_DIR ${_ui_dir})
   set ( _all_defines ${PARSED_DEFS};${PARSED_QT${PARSED_QT_VERSION}_DEFS} )
   if (PARSED_QT_VERSION EQUAL 4)
+    # Workaround Qt compiler detection
+    # https://forum.qt.io/topic/43778/error-when-initializing-qstringlist-using-initializer-list/3
+    # https://bugreports.qt.io/browse/QTBUG-39142
+    list ( APPEND _all_defines Q_COMPILER_INITIALIZER_LISTS )
     qt4_wrap_ui (UI_HEADERS ${PARSED_UI})
     _internal_qt_wrap_cpp ( 4 MOC_GENERATED DEFS ${_all_defines} INFILES ${PARSED_MOC})
     set (ALL_SRC ${PARSED_SRC} ${PARSED_QT4_SRC} ${MOC_GENERATED})

--- a/buildconfig/CMake/QtTargetFunctions.cmake
+++ b/buildconfig/CMake/QtTargetFunctions.cmake
@@ -256,11 +256,17 @@ function (mtd_add_qt_test_executable)
   # libraries
   set (_link_libs ${PARSED_LINK_LIBS} ${_mtd_qt_libs} )
   if (PARSED_QT_VERSION EQUAL 4)
-   set (_link_libs Qt4::QtGui ${PARSED_QT4_LINK_LIBS} ${_link_libs})
+    set (_link_libs Qt4::QtGui ${PARSED_QT4_LINK_LIBS} ${_link_libs})
+    # Workaround Qt compiler detection
+    # https://forum.qt.io/topic/43778/error-when-initializing-qstringlist-using-initializer-list/3
+    # https://bugreports.qt.io/browse/QTBUG-39142
+    set_target_properties ( ${_target_name} PROPERTIES 
+      COMPILE_DEFINITIONS Q_COMPILER_INITIALIZER_LISTS
+    )
   elseif (PARSED_QT_VERSION EQUAL 5)
-   set (_link_libs Qt5::Widgets ${PARSED_QT5_LINK_LIBS} ${_link_libs})
+    set (_link_libs Qt5::Widgets ${PARSED_QT5_LINK_LIBS} ${_link_libs})
   else ()
-   message (FATAL_ERROR "Unknown Qt version. Please specify only the major version.")
+    message (FATAL_ERROR "Unknown Qt version. Please specify only the major version.")
   endif()
   _append_qt_suffix (VERSION ${PARSED_QT_VERSION} OUTPUT_VARIABLE _mtd_qt_libs
                      ${PARSED_MTD_QT_LINK_LIBS})

--- a/buildconfig/Jenkins/buildscript.bat
+++ b/buildconfig/Jenkins/buildscript.bat
@@ -29,6 +29,20 @@ set CM_GENERATOR=Visual Studio 14 2015 Win64
 set PARAVIEW_DIR=%PARAVIEW_NEXT_DIR%
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: Pre-processing steps on the workspace itself
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: If the third party repo exists ensure it is in a clean state
+:: as updating errors on previous builds can leave it in a state that
+:: cmake is unable to cope with
+if EXIST %WORKSPACE%\external\src\ThirdParty\.git (
+  cd %WORKSPACE%\external\src\ThirdParty
+  git reset --hard HEAD
+  git clean -fdx
+  cd %WORKSPACE%
+)
+
+
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: Set up the location for local object store outside of the build and source
 :: tree, which can be shared by multiple builds.
 :: It defaults to a MantidExternalData directory within the USERPROFILE

--- a/qt/paraview_ext/CMakeLists.txt
+++ b/qt/paraview_ext/CMakeLists.txt
@@ -12,6 +12,13 @@ if( ParaView_FOUND AND USE_PARAVIEW )
   include( ${PARAVIEW_USE_FILE} )
 
   function (set_pvplugin_properties target QT_VERSION vers)
+    # Workaround Qt compiler detection
+    # https://forum.qt.io/topic/43778/error-when-initializing-qstringlist-using-initializer-list/3
+    # https://bugreports.qt.io/browse/QTBUG-39142
+    # This is only required for Qt4
+    if ( vers EQUAL 4 )
+      set_target_properties ( ${_target} PROPERTIES COMPILE_DEFINITIONS Q_COMPILER_INITIALIZER_LISTS )
+    endif()
     set_target_properties ( ${target} PROPERTIES
       LIBRARY_OUTPUT_DIRECTORY ${PVPLUGINS_LIBRARY_OUTPUT_DIRECTORY}/qt${vers}
       RUNTIME_OUTPUT_DIRECTORY ${PVPLUGINS_LIBRARY_OUTPUT_DIRECTORY}/qt${vers}

--- a/qt/paraview_ext/PVPlugins/CMakeLists.txt
+++ b/qt/paraview_ext/PVPlugins/CMakeLists.txt
@@ -18,7 +18,7 @@ set ( _plugin_filename ${CMAKE_SHARED_LIBRARY_PREFIX}NonOrthogonalSource${CMAKE_
 if (CMAKE_GENERATOR MATCHES "Visual Studio")
   set ( _pv_library_output_dir ${ParaView_DIR}/bin )
   # add_custom_command doesn't support generator expressions for the OUTPUT argument
-  string ( REPLACE "<CONFIG>" "\${CMAKE_CFG_INTDIR}" _plugin_library_output ${PVPLUGINS_LIBRARY_OUTPUT_DIRECTORY} )
+  string ( REPLACE "$<CONFIG>" "${CMAKE_CFG_INTDIR}" _plugin_library_output ${PVPLUGINS_LIBRARY_OUTPUT_DIRECTORY} )
 else ()
   set ( _pv_library_output_dir ${ParaView_DIR}/lib )
   set ( _plugin_library_output ${PVPLUGINS_LIBRARY_OUTPUT_DIRECTORY} )

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -266,6 +266,7 @@ set ( INC_FILES
 	inc/MantidQtWidgets/Common/PythonSystemHeader.h
 	inc/MantidQtWidgets/Common/PythonThreading.h
 	inc/MantidQtWidgets/Common/QScienceSpinBox.h
+	inc/MantidQtWidgets/Common/QStringUtils.h
 	inc/MantidQtWidgets/Common/ScriptRepositoryView.h
 	inc/MantidQtWidgets/Common/SelectionNotificationService.h
 	inc/MantidQtWidgets/Common/SignalBlocker.h

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QStringUtils.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QStringUtils.h
@@ -1,0 +1,41 @@
+#ifndef MANTIDQT_API_QSTRINGUTILS_H
+#define MANTIDQT_API_QSTRINGUTILS_H
+
+#include <QString>
+#include <string>
+
+namespace MantidQt {
+namespace API {
+/**
+* Internal version of QString::fromStdWString. On MSVC Qt4 rquired
+* /Z:wchar_t- but Qt5 does not. For simplicity we
+* remove the /Z:wchar_t- compiler option and
+* define the functionality interally.
+* @param str A pointer to the raw wchar_t string
+*/
+inline QString toQStringInternal(const wchar_t *str) {
+  return sizeof(wchar_t) == sizeof(QChar)
+             ? QString::fromUtf16(reinterpret_cast<const ushort *>(str),
+                                  static_cast<int>(wcslen(str)))
+             : QString::fromUcs4(reinterpret_cast<const uint *>(str),
+                                 static_cast<int>(wcslen(str)));
+}
+
+/**
+* Internal version of QString::fromStdWString. On MSVC Qt4 rquired
+* /Z:wchar_t- but Qt5 does not. For simplicity we
+* remove the /Z:wchar_t- compiler option and
+* define the functionality interally.
+* @param str A std::wstring object
+*/
+inline QString toQStringInternal(const std::wstring &str) {
+  return sizeof(wchar_t) == sizeof(QChar)
+             ? QString::fromUtf16(reinterpret_cast<const ushort *>(str.data()),
+                                  static_cast<int>(str.size()))
+             : QString::fromUcs4(reinterpret_cast<const uint *>(str.data()),
+                                 static_cast<int>(str.size()));
+}
+}
+}
+
+#endif // MANTIDQT_API_QSTRINGUTILS_H

--- a/qt/widgets/common/src/PlotAxis.cpp
+++ b/qt/widgets/common/src/PlotAxis.cpp
@@ -1,4 +1,5 @@
 #include "MantidQtWidgets/Common/PlotAxis.h"
+#include "MantidQtWidgets/Common/QStringUtils.h"
 
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/MatrixWorkspace.h"
@@ -72,7 +73,7 @@ void PlotAxis::titleFromDimension(const Mantid::Geometry::IMDDimension &dim) {
   if (!m_title.isEmpty()) {
     auto unitLbl = dim.getUnits();
     if (!unitLbl.utf8().empty()) {
-      m_title += " (" + QString::fromStdWString(unitLbl.utf8()) + ")";
+      m_title += " (" + toQStringInternal(unitLbl.utf8()) + ")";
     } else if (!unitLbl.ascii().empty()) {
       m_title += " (" + QString::fromStdString(unitLbl.ascii()) + ")";
     }
@@ -103,8 +104,8 @@ void PlotAxis::titleFromYData(const Mantid::API::MatrixWorkspace &workspace,
       const auto xunit = workspace.getAxis(0)->unit();
       const auto lbl = xunit->label();
       if (!lbl.utf8().empty()) {
-        m_title += " (" + QString::fromStdWString(lbl.utf8()) + ")" +
-                   QString::fromWCharArray(L"\u207b\u00b9");
+        m_title += " (" + toQStringInternal(lbl.utf8()) + ")" +
+                   toQStringInternal(L"\u207b\u00b9");
       }
     }
   } else {

--- a/qt/widgets/common/test/PlotAxisTest.h
+++ b/qt/widgets/common/test/PlotAxisTest.h
@@ -4,6 +4,7 @@
 #include <cxxtest/TestSuite.h>
 
 #include "MantidQtWidgets/Common/PlotAxis.h"
+#include "MantidQtWidgets/Common/QStringUtils.h"
 #include "MantidAPI/NumericAxis.h"
 #include "MantidAPI/SpectraAxis.h"
 #include "MantidGeometry/MDGeometry/MDHistoDimension.h"
@@ -80,7 +81,8 @@ public:
     ws->getAxis(0)->setUnit("TOF");
     ws->replaceAxis(1, new Mantid::API::NumericAxis(1));
     ws->getAxis(1)->setUnit("TOF");
-    QString expected = QString::fromWCharArray(L"Time-of-flight (\u03bcs)");
+    QString expected =
+        MantidQt::API::toQStringInternal(L"Time-of-flight (\u03bcs)");
     TS_ASSERT_EQUALS(expected, PlotAxis(*ws, 0).title());
     TS_ASSERT_EQUALS(expected, PlotAxis(*ws, 1).title());
   }
@@ -94,8 +96,8 @@ public:
     const auto lbl = xunit->label();
     // the Y unit should be (<x_unit_label>)^-1 when plotting as distribution
     // instead of (<x_unit_label>^-1).
-    TS_ASSERT_EQUALS(" (" + QString::fromStdWString(lbl.utf8()) + ")" +
-                         QString::fromWCharArray(L"\u207b\u00b9"),
+    TS_ASSERT_EQUALS(" (" + MantidQt::API::toQStringInternal(lbl.utf8()) + ")" +
+                         MantidQt::API::toQStringInternal(L"\u207b\u00b9"),
                      PlotAxis(true, *ws).title());
   }
 
@@ -139,7 +141,7 @@ public:
         Mantid::Geometry::GeneralFrame::GeneralFrameTOF,
         UnitLabel("us", L"\u03bcs", "\\mu s"));
     MDHistoDimension dim("tof", "dimx", frame, 0.0f, 1.0f, 10);
-    QString expected = QString::fromWCharArray(L"tof (\u03bcs)");
+    QString expected = MantidQt::API::toQStringInternal(L"tof (\u03bcs)");
     TS_ASSERT_EQUALS(expected, PlotAxis(dim).title());
   }
 

--- a/qt/widgets/legacyqwt/src/MantidQwtIMDWorkspaceData.cpp
+++ b/qt/widgets/legacyqwt/src/MantidQwtIMDWorkspaceData.cpp
@@ -1,3 +1,5 @@
+#include "MantidQtWidgets/LegacyQwt/MantidQwtIMDWorkspaceData.h"
+#include "MantidQtWidgets/Common/QStringUtils.h"
 #include "MantidAPI/CoordTransform.h"
 #include "MantidAPI/IMDEventWorkspace.h"
 #include "MantidAPI/IMDHistoWorkspace.h"
@@ -6,9 +8,9 @@
 #include "MantidAPI/NullCoordTransform.h"
 #include "MantidGeometry/MDGeometry/IMDDimension.h"
 #include "MantidGeometry/MDGeometry/MDTypes.h"
-#include "MantidQtWidgets/LegacyQwt/MantidQwtIMDWorkspaceData.h"
 #include <QStringBuilder>
 
+using MantidQt::API::toQStringInternal;
 using namespace Mantid::Kernel;
 using namespace Mantid::Geometry;
 using Mantid::API::NullCoordTransform;
@@ -365,7 +367,7 @@ QString MantidQwtIMDWorkspaceData::getXAxisLabel() const {
     IMDDimension_const_sptr dim =
         m_originalWorkspace.lock()->getDimension(m_currentPlotAxis);
     xLabel = QString::fromStdString(dim->getName()) + " (" +
-             QString::fromStdWString(dim->getUnits().utf8()) + ")";
+             toQStringInternal(dim->getUnits().utf8()) + ")";
   } else {
     // Distance
     // Distance, or not set.

--- a/qt/widgets/sliceviewer/src/DimensionSliceWidget.cpp
+++ b/qt/widgets/sliceviewer/src/DimensionSliceWidget.cpp
@@ -1,9 +1,11 @@
 #include "MantidQtWidgets/SliceViewer/DimensionSliceWidget.h"
+#include "MantidQtWidgets/Common/QStringUtils.h"
 #include "MantidKernel/UnitLabel.h"
 #include <iosfwd>
 #include <QLayout>
 
 namespace MantidQt {
+using API::toQStringInternal;
 namespace SliceViewer {
 
 DimensionSliceWidget::DimensionSliceWidget(QWidget *parent)
@@ -151,7 +153,7 @@ void DimensionSliceWidget::setMinMax(double min, double max) {
   if (!m_dim)
     return;
   ui.lblName->setText(QString::fromStdString(m_dim->getName()));
-  ui.lblUnits->setText(QString::fromStdWString(m_dim->getUnits().utf8()));
+  ui.lblUnits->setText(toQStringInternal(m_dim->getUnits().utf8()));
 
   ui.horizontalSlider->setRange(min, max, m_dim->getBinWidth());
 

--- a/qt/widgets/sliceviewer/src/XYLimitsDialog.cpp
+++ b/qt/widgets/sliceviewer/src/XYLimitsDialog.cpp
@@ -1,6 +1,9 @@
 #include "MantidQtWidgets/SliceViewer/XYLimitsDialog.h"
+#include "MantidQtWidgets/Common/QStringUtils.h"
 #include "MantidKernel/UnitLabel.h"
 #include <QIntValidator>
+
+using MantidQt::API::toQStringInternal;
 
 XYLimitsDialog::XYLimitsDialog(QWidget *parent) : QDialog(parent) {
   ui.setupUi(this);
@@ -20,14 +23,14 @@ XYLimitsDialog::~XYLimitsDialog() {}
  * @param dim : IMDDimension */
 void XYLimitsDialog::setXDim(Mantid::Geometry::IMDDimension_const_sptr dim) {
   ui.lblXName->setText(QString::fromStdString(dim->getName()));
-  ui.lblXUnits->setText(QString::fromStdWString(dim->getUnits().utf8()));
+  ui.lblXUnits->setText(toQStringInternal(dim->getUnits().utf8()));
 }
 
 /** Set the labels for the Y dimensions
  * @param dim : IMDDimension */
 void XYLimitsDialog::setYDim(Mantid::Geometry::IMDDimension_const_sptr dim) {
   ui.lblYName->setText(QString::fromStdString(dim->getName()));
-  ui.lblYUnits->setText(QString::fromStdWString(dim->getUnits().utf8()));
+  ui.lblYUnits->setText(toQStringInternal(dim->getUnits().utf8()));
 }
 
 //------------------------------------------------------------------------------------------


### PR DESCRIPTION
Description of work.

Adds QScintilla for Qt5 and applies some additional fixes for Visual Studio.

**To test:**

* Checkout the code and set the `ENABLE_WORKBENCH` option in cmake.
* Build all
* A workbench executable should now exist in bin\[Release,Debug]
* Run this.

Fixes #20381

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
