### PR TITLE
Add workaround for symbol visiblity issue with boost python 1.64/1.65

### DIFF
--- a/Framework/PythonInterface/CMakeLists.txt
+++ b/Framework/PythonInterface/CMakeLists.txt
@@ -49,6 +49,13 @@ include_directories ( SYSTEM ${PYTHON_NUMPY_INCLUDE_DIR} )
 set ( HEADER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/inc/MantidPythonInterface )
 include_directories ( inc )
 add_definitions ( -DBOOST_PYTHON_NO_LIB -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION )
+if ( CMAKE_COMPILER_IS_GNUCXX AND Boost_MAJOR_VERSION EQUAL "1" AND
+     Boost_MINOR_VERSION GREATER "63" AND Boost_MINOR_VERSION LESS "66" )
+  # Several bugs in boost 1.64-1.65 prevent python modues from loading on gcc without
+  # this definition:   https://github.com/boostorg/python/issues/131
+  add_definitions ( -DBOOST_PYTHON_USE_GCC_SYMBOL_VISIBILITY )
+endif ()
+
 set ( PYTHON_DEPS ${MPI_CXX_LIBRARIES} )
 
 ####################################################################################


### PR DESCRIPTION
Description of work.

**To test:**

- use a Linux distro with boost 1.64 (Fedora 27 or daily build of Ubuntu 18.04)
- build the `Framework` and `PythonInterface` targets
- try importing mantid into Python.
- before this fix you would get an error that no `init__kernel` symbol could be found.

*No issue*

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
