### PR TITLE
ComponentInfo needs Component Names

### DIFF
--- a/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
@@ -9,6 +9,7 @@
 #include <utility>
 #include <cstddef>
 #include <Eigen/Geometry>
+#include <string>
 
 namespace Mantid {
 namespace Beamline {
@@ -54,6 +55,7 @@ private:
   Mantid::Kernel::cow_ptr<std::vector<Eigen::Quaterniond>> m_rotations;
   Mantid::Kernel::cow_ptr<std::vector<Eigen::Vector3d>> m_scaleFactors;
   Mantid::Kernel::cow_ptr<std::vector<bool>> m_isStructuredBank;
+  boost::shared_ptr<const std::vector<std::string>> m_names;
 
   const size_t m_size = 0;
   const int64_t m_sourceIndex = -1;
@@ -96,6 +98,7 @@ public:
                 boost::shared_ptr<std::vector<Eigen::Quaterniond>> rotations,
                 boost::shared_ptr<std::vector<Eigen::Vector3d>> scaleFactors,
                 boost::shared_ptr<std::vector<bool>> isStructuredBank,
+                boost::shared_ptr<const std::vector<std::string>> names,
                 int64_t sourceIndex, int64_t sampleIndex);
   /// Copy assignment not permitted because of the way DetectorInfo stored
   ComponentInfo &operator=(const ComponentInfo &other) = delete;
@@ -138,6 +141,8 @@ public:
   size_t sample() const;
   size_t root() const;
   double l1() const;
+  std::string name(const size_t componentIndex) const;
+  size_t indexOf(const std::string &name) const;
   Eigen::Vector3d scaleFactor(const size_t componentIndex) const;
   void setScaleFactor(const size_t componentIndex,
                       const Eigen::Vector3d &scaleFactor);

--- a/Framework/Beamline/src/ComponentInfo.cpp
+++ b/Framework/Beamline/src/ComponentInfo.cpp
@@ -508,13 +508,14 @@ std::string ComponentInfo::name(const size_t componentIndex) const {
 }
 
 size_t ComponentInfo::indexOf(const std::string &name) const {
-  auto it = std::find(m_names->begin(), m_names->end(), name);
-  if (it == m_names->end()) {
+  // Reverse iterate to hit top level components sooner
+  auto it = std::find(m_names->rbegin(), m_names->rend(), name);
+  if (it == m_names->rend()) {
     std::stringstream buffer;
     buffer << name << " does not exist";
     throw std::invalid_argument(buffer.str());
   }
-  return std::distance(m_names->begin(), it);
+  return std::distance(m_names->begin(), it.base() - 1);
 }
 
 void ComponentInfo::setScaleFactor(const size_t componentIndex,

--- a/Framework/Beamline/src/ComponentInfo.cpp
+++ b/Framework/Beamline/src/ComponentInfo.cpp
@@ -3,8 +3,11 @@
 #include "MantidKernel/make_cow.h"
 #include <boost/make_shared.hpp>
 #include <numeric>
+#include <algorithm>
 #include <utility>
 #include <vector>
+#include <sstream>
+#include <iterator>
 
 namespace Mantid {
 namespace Beamline {
@@ -39,8 +42,9 @@ ComponentInfo::ComponentInfo(
     boost::shared_ptr<std::vector<Eigen::Vector3d>> positions,
     boost::shared_ptr<std::vector<Eigen::Quaterniond>> rotations,
     boost::shared_ptr<std::vector<Eigen::Vector3d>> scaleFactors,
-    boost::shared_ptr<std::vector<bool>> isStructuredBank, int64_t sourceIndex,
-    int64_t sampleIndex)
+    boost::shared_ptr<std::vector<bool>> isStructuredBank,
+    boost::shared_ptr<const std::vector<std::string>> names,
+    int64_t sourceIndex, int64_t sampleIndex)
     : m_assemblySortedDetectorIndices(std::move(assemblySortedDetectorIndices)),
       m_assemblySortedComponentIndices(
           std::move(assemblySortedComponentIndices)),
@@ -50,6 +54,7 @@ ComponentInfo::ComponentInfo(
       m_positions(std::move(positions)), m_rotations(std::move(rotations)),
       m_scaleFactors(std::move(scaleFactors)),
       m_isStructuredBank(std::move(isStructuredBank)),
+      m_names(std::move(names)),
       m_size(m_assemblySortedDetectorIndices->size() +
              m_detectorRanges->size()),
       m_sourceIndex(sourceIndex), m_sampleIndex(sampleIndex),
@@ -82,6 +87,10 @@ ComponentInfo::ComponentInfo(
     throw std::invalid_argument("ComponentInfo should be provided same number "
                                 "of rectangular bank flags as number of "
                                 "non-detector components");
+  }
+  if (m_names->size() != m_size) {
+    throw std::invalid_argument("ComponentInfo should be provided same number "
+                                "of names as number of components");
   }
 }
 
@@ -492,6 +501,20 @@ ComponentInfo::componentRangeInSubtree(const size_t index) const {
 
 Eigen::Vector3d ComponentInfo::scaleFactor(const size_t componentIndex) const {
   return (*m_scaleFactors)[componentIndex];
+}
+
+std::string ComponentInfo::name(const size_t componentIndex) const {
+  return (*m_names)[componentIndex];
+}
+
+size_t ComponentInfo::indexOf(const std::string &name) const {
+  auto it = std::find(m_names->begin(), m_names->end(), name);
+  if (it == m_names->end()) {
+    std::stringstream buffer;
+    buffer << name << " does not exist";
+    throw std::invalid_argument(buffer.str());
+  }
+  return std::distance(m_names->begin(), it);
 }
 
 void ComponentInfo::setScaleFactor(const size_t componentIndex,

--- a/Framework/Beamline/test/ComponentInfoTest.h
+++ b/Framework/Beamline/test/ComponentInfoTest.h
@@ -749,14 +749,14 @@ public:
   }
 
   void test_name() {
-    auto infos = makeFlat(PosVec(1), RotVec(1));
+    auto infos = makeFlatTree(PosVec(1), RotVec(1));
     ComponentInfo &compInfo = *std::get<0>(infos);
     TS_ASSERT_EQUALS(compInfo.name(compInfo.root()), "root");
     TS_ASSERT_EQUALS(compInfo.name(0), "det0");
   }
 
   void test_indexOf_name_throws_when_name_invalid() {
-    auto infos = makeFlat(PosVec(1), RotVec(1));
+    auto infos = makeFlatTree(PosVec(1), RotVec(1));
     ComponentInfo &compInfo = *std::get<0>(infos);
     TSM_ASSERT_THROWS("Should throw, this name does not exist",
                       compInfo.indexOf("phantom"), std::invalid_argument &)
@@ -766,7 +766,7 @@ public:
   }
 
   void test_indexOf() {
-    auto infos = makeFlat(PosVec(1), RotVec(1));
+    auto infos = makeFlatTree(PosVec(1), RotVec(1));
     ComponentInfo &compInfo = *std::get<0>(infos);
     TS_ASSERT_EQUALS(compInfo.indexOf("det0"), 0);
     TS_ASSERT_EQUALS(compInfo.indexOf("root"), compInfo.root());

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
@@ -87,6 +87,7 @@ public:
   std::vector<size_t> componentsInSubtree(size_t componentIndex) const;
   size_t size() const;
   size_t indexOf(Geometry::IComponent *id) const;
+  size_t indexOf(const std::string &name) const;
   bool isDetector(const size_t componentIndex) const;
   Kernel::V3D position(const size_t componentIndex) const;
   Kernel::V3D position(const std::pair<size_t, size_t> index) const;
@@ -111,6 +112,7 @@ public:
   size_t sample() const;
   double l1() const;
   Kernel::V3D scaleFactor(const size_t componentIndex) const;
+  std::string name(const size_t componentIndex) const;
   void setScaleFactor(const size_t componentIndex,
                       const Kernel::V3D &scaleFactor);
   size_t root();

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentVisitor.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentVisitor.h
@@ -136,6 +136,9 @@ private:
   /// Structured bank flag
   boost::shared_ptr<std::vector<bool>> m_isStructuredBank;
 
+  /// Component names
+  boost::shared_ptr<std::vector<std::string>> m_names;
+
   void markAsSourceOrSample(Mantid::Geometry::IComponent *componentId,
                             const size_t componentIndex);
 

--- a/Framework/Geometry/src/Instrument/ComponentInfo.cpp
+++ b/Framework/Geometry/src/Instrument/ComponentInfo.cpp
@@ -111,6 +111,10 @@ size_t ComponentInfo::indexOf(Geometry::IComponent *id) const {
   return m_compIDToIndex->at(id);
 }
 
+size_t ComponentInfo::indexOf(const std::string &name) const {
+  return m_componentInfo->indexOf(name);
+}
+
 bool ComponentInfo::isDetector(const size_t componentIndex) const {
   return m_componentInfo->isDetector(componentIndex);
 }
@@ -205,6 +209,10 @@ const Object &ComponentInfo::shape(const size_t componentIndex) const {
 
 Kernel::V3D ComponentInfo::scaleFactor(const size_t componentIndex) const {
   return Kernel::toV3D(m_componentInfo->scaleFactor(componentIndex));
+}
+
+std::string ComponentInfo::name(const size_t componentIndex) const {
+  return m_componentInfo->name(componentIndex);
 }
 
 void ComponentInfo::setScaleFactor(const size_t componentIndex,

--- a/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
@@ -85,8 +85,9 @@ InstrumentVisitor::InstrumentVisitor(
           m_orderedDetectorIds->size(), m_nullShape)),
       m_scaleFactors(boost::make_shared<std::vector<Eigen::Vector3d>>(
           m_orderedDetectorIds->size(), Eigen::Vector3d{1, 1, 1})),
-      m_isStructuredBank(boost::make_shared<std::vector<bool>>()) {
-
+      m_isStructuredBank(boost::make_shared<std::vector<bool>>()),
+      m_names(boost::make_shared<std::vector<std::string>>(
+          m_orderedDetectorIds->size())) {
   if (m_instrument->isParametrized()) {
     m_pmap = m_instrument->getParameterMap().get();
   }
@@ -109,7 +110,6 @@ InstrumentVisitor::InstrumentVisitor(
   const auto nDetectors = m_orderedDetectorIds->size();
   m_assemblySortedDetectorIndices->reserve(nDetectors); // Exact
   m_componentIdToIndexMap->reserve(nDetectors);         // Approximation
-  m_shapes->reserve(nDetectors);                        // Approximation
 }
 
 void InstrumentVisitor::walkInstrument() {
@@ -160,6 +160,7 @@ InstrumentVisitor::registerComponentAssembly(const ICompAssembly &assembly) {
   m_shapes->emplace_back(m_nullShape);
   m_isStructuredBank->push_back(false);
   m_scaleFactors->emplace_back(Kernel::toVector3d(assembly.getScaleFactor()));
+  m_names->emplace_back(assembly.getName());
   clearLegacyParameters(m_pmap, assembly);
   return componentIndex;
 }
@@ -194,6 +195,7 @@ InstrumentVisitor::registerGenericComponent(const IComponent &component) {
   m_shapes->emplace_back(m_nullShape);
   m_isStructuredBank->push_back(false);
   m_scaleFactors->emplace_back(Kernel::toVector3d(component.getScaleFactor()));
+  m_names->emplace_back(component.getName());
   clearLegacyParameters(m_pmap, component);
   return componentIndex;
 }
@@ -261,6 +263,7 @@ size_t InstrumentVisitor::registerDetector(const IDetector &detector) {
   if (m_instrument->isMonitorViaIndex(detectorIndex)) {
     m_monitorIndices->push_back(detectorIndex);
   }
+  (*m_names)[detectorIndex] = detector.getName();
   clearLegacyParameters(m_pmap, detector);
 
   /* Note that positions and rotations for detectors are currently
@@ -314,7 +317,7 @@ InstrumentVisitor::componentInfo() const {
       m_assemblySortedDetectorIndices, m_detectorRanges,
       m_assemblySortedComponentIndices, m_componentRanges,
       m_parentComponentIndices, m_positions, m_rotations, m_scaleFactors,
-      m_isStructuredBank, m_sourceIndex, m_sampleIndex);
+      m_isStructuredBank, m_names, m_sourceIndex, m_sampleIndex);
 }
 
 std::unique_ptr<Beamline::DetectorInfo>

--- a/Framework/Geometry/test/ComponentInfoTest.h
+++ b/Framework/Geometry/test/ComponentInfoTest.h
@@ -104,11 +104,12 @@ std::unique_ptr<Beamline::ComponentInfo> makeSingleBeamlineComponentInfo(
       boost::make_shared<std::vector<Eigen::Quaterniond>>(1, rotation);
   auto scaleFactors =
       boost::make_shared<std::vector<Eigen::Vector3d>>(1, scaleFactor);
+  auto names = boost::make_shared<std::vector<std::string>>(1);
   auto isStructuredBank = boost::make_shared<std::vector<bool>>(1, false);
   return Kernel::make_unique<Beamline::ComponentInfo>(
       detectorIndices, detectorRanges, componentIndices, componentRanges,
-      parentIndices, positions, rotations, scaleFactors, isStructuredBank, -1,
-      -1);
+      parentIndices, positions, rotations, scaleFactors, isStructuredBank,
+      names, -1, -1);
 }
 }
 
@@ -146,10 +147,12 @@ public:
     auto positions = boost::make_shared<std::vector<Eigen::Vector3d>>(2);
     auto rotations = boost::make_shared<std::vector<Eigen::Quaterniond>>(2);
     auto scaleFactors = boost::make_shared<std::vector<Eigen::Vector3d>>(2);
+    auto names = boost::make_shared<std::vector<std::string>>(2);
     auto isRectBank = boost::make_shared<std::vector<bool>>(2);
     auto internalInfo = Kernel::make_unique<Beamline::ComponentInfo>(
         detectorIndices, detectorRanges, componentIndices, componentRanges,
-        parentIndices, positions, rotations, scaleFactors, isRectBank, -1, -1);
+        parentIndices, positions, rotations, scaleFactors, isRectBank, names,
+        -1, -1);
     Mantid::Geometry::ObjComponent comp1("component1");
     Mantid::Geometry::ObjComponent comp2("component2");
 

--- a/Framework/Geometry/test/InstrumentVisitorTest.h
+++ b/Framework/Geometry/test/InstrumentVisitorTest.h
@@ -384,6 +384,30 @@ public:
                       &componentInfo->shape(1 /*another detector*/));
   }
 
+  void test_names() {
+
+    const int nPixelsWide = 10; // Gives 10*10 detectors in total
+    auto instrument = ComponentCreationHelper::createTestInstrumentRectangular(
+        1 /*n banks*/, nPixelsWide, 1 /*sample-bank distance*/);
+
+    // Visit everything
+    auto wrappers =
+        InstrumentVisitor::makeWrappers(*instrument, nullptr /*parameter map*/);
+    auto componentInfo = std::move(std::get<0>(wrappers));
+
+    // Check root name
+    TS_ASSERT_EQUALS("basic_rect", componentInfo->name(componentInfo->root()));
+    // Backward check that we get the right index
+    TS_ASSERT_EQUALS(componentInfo->indexOf("basic_rect"),
+                     componentInfo->root());
+
+    // Check all names are the same in old instrument and component info
+    for (size_t index = 0; index < componentInfo->size(); ++index) {
+      TS_ASSERT_EQUALS(componentInfo->componentID(index)->getName(),
+                       componentInfo->name(index));
+    }
+  }
+
   void test_purge_scale_factors() {
 
     // Create a very basic instrument to visit


### PR DESCRIPTION
ComponentInfo needs ability to store and search via component names. fixes #21256 

**Tester**

Code review should be sufficient. No instances of `IComponent::getComponentByName` have been replaced here, so should not affect existing behaviour.

