### PR TITLE
BASISReduction: Flip NoMonitorNorm option

### DIFF
--- a/docs/source/release/v3.12.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.12.0/indirect_inelastic.rst
@@ -14,7 +14,8 @@ New
 Improved
 ########
 
-- BASISReduction now permits the user to exclude a contiguous time segment from the reduction process
+- BASISReduction now permits the user to exclude a contiguous time segment from the reduction process.
+- BASISReduction option noMonitorNorm changed to MonitorNorm.
 
 Vesuvio
 -------


### PR DESCRIPTION
Description of work.

**To test:**
Save, unzip, and load [sqw.nxs.zip](https://github.com/mantidproject/mantid/files/1506562/sqw.nxs.zip), onto workspace `sqw`. This workspace corresponds to reduction of run `76223` with algoritm BASISReduction of the master branch.

Now reduce the corresponding run with the modified algorithm:

```
BASISReduction(RunNumbers='76223',
               MonitorNorm=True,
               EnergyBins=[-120, 0.4, 120],
               MomentumTransferBins=[0.3,0.2,1.9])
```
Now plot a few histograms of created workspace `BSS_76223_sqw` against those  of `sqw`. They should be equal.

Fixes #21272

[**Release Notes** ](https://github.com/mantidproject/mantid/blob/1f9806100e6cd2846de2d60583ba4dae7e7bcd3d/docs/source/release/v3.12.0/indirect_inelastic.rst#id16)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
