### PR TITLE
Fix wrong graph axis being scaled on MacOS.

### DIFF
--- a/MantidPlot/src/ApplicationWindow.h
+++ b/MantidPlot/src/ApplicationWindow.h
@@ -1611,6 +1611,7 @@ private:
 
   friend class MantidUI;
   friend class ConfigDialog;
+  friend class Graph;
   QString m_nexusInputWSName;
 
   // Store initialized script environments

--- a/MantidPlot/src/Graph.cpp
+++ b/MantidPlot/src/Graph.cpp
@@ -3963,6 +3963,7 @@ void Graph::showAxisTitleMenu() {
 }
 
 void Graph::showAxisContextMenu(int axis) {
+  this->multiLayer()->applicationWindow()->setActiveWindow(this->multiLayer());
   QMenu menu(this);
 
   menu.addAction(getQPixmap("unzoom_xpm"), tr("&Rescale to show all"), this,

--- a/docs/source/release/v3.12.0/ui.rst
+++ b/docs/source/release/v3.12.0/ui.rst
@@ -17,7 +17,7 @@ Workbench
 
 - Fixed a bug where MantidPlot would crash if the sample log fields used for run start and end contained non-ISO8601 conforming values.
 - Fixed an issue where updating a workspace changes the number format from decimal to scientific notation if the workspace is being viewed.
-
+- Fixed a bug where on MacOS with multiple plots present the wrong axis was being scaled.
 
 SliceViewer and Vates Simple Interface
 --------------------------------------


### PR DESCRIPTION
Description of work.

On MacOS [right-clicks don't change the focus of the window](https://superuser.com/questions/292895/mac-os-focus-on-right-click), letting one right-click on one plot and modify the axes of another. This PR follows suggestions from @martyngigg and @mantid-roman to override this behavior.

**To test:**

<!-- Instructions for testing. -->

This is best tested on MacOS.
On Master:
1. Open or create a workspace where one can plot more than one spectra 
     i. I used `ExternalData/Testing/Data/UnitTest/IRS26173.RAW`
2. Right-click the workspace and use the "Plot Spectrum..." menu option to plot two spectra in separate windows.
3. Right click on the y-axis and click the option to scale axis.
4. Repeat step 3 with the other window and repeat until the axes change in the other (unclicked) window.

On this branch:
1. Repeat steps 1-3 above.
2. Repeat step 4 above, verifying that the modified axis matches the one clicked on.

This issue was reported by @mganeva. There is no GitHub issue associated with the pull request.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
