### PR TITLE
 Reconnect VSI Peaks Table to onSortPeaks.

### DIFF
--- a/docs/source/release/v3.12.0/ui.rst
+++ b/docs/source/release/v3.12.0/ui.rst
@@ -23,6 +23,7 @@ SliceViewer and Vates Simple Interface
 - Users can now sort by the I/sigma and energy columns in the SliceViewer when viewing a peaks workspace.
 - Fixed bug which would cause slice viewer to crash when deleting an overlaid peaks workspace.
 - Fixed a bug where overwriting peaks workspaces with overlaid in the slice viewer with peak backgrounds shown cause Mantid to crash.
+- Fixed an issue preventing sorting of the VSI peaks table.
 
 .. figure:: ../../images/VatesMultiSliceView.png
    :class: screenshot

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/CompositePeaksPresenterVsi.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/CompositePeaksPresenterVsi.h
@@ -39,7 +39,7 @@ public:
   void sortPeaksWorkspace(const std::string &, const bool) override {}
   void sortPeaksWorkspace(const std::string &columnToSortBy,
                           const bool sortedAscending,
-                          const Mantid::API::IPeaksWorkspace *peaksWS);
+                          const Mantid::API::IPeaksWorkspace_sptr peaksWS);
   bool hasPeaks();
 
 private:

--- a/qt/paraview_ext/VatesAPI/src/CompositePeaksPresenterVsi.cpp
+++ b/qt/paraview_ext/VatesAPI/src/CompositePeaksPresenterVsi.cpp
@@ -162,9 +162,9 @@ bool CompositePeaksPresenterVsi::hasPeaks() {
  */
 void CompositePeaksPresenterVsi::sortPeaksWorkspace(
     const std::string &columnToSortBy, const bool sortedAscending,
-    const Mantid::API::IPeaksWorkspace *peaksWS) {
+    const Mantid::API::IPeaksWorkspace_sptr peaksWS) {
   for (const auto &presenter : m_peaksPresenters) {
-    if (presenter->getPeaksWorkspace().get() == peaksWS) {
+    if (presenter->getPeaksWorkspace() == peaksWS) {
       presenter->sortPeaksWorkspace(columnToSortBy, sortedAscending);
     }
   }

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/PeaksTableControllerVsi.h
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/PeaksTableControllerVsi.h
@@ -43,7 +43,7 @@ public slots:
   void onZoomToPeak(Mantid::API::IPeaksWorkspace_sptr peaksWorkspace, int row);
   void onPeaksSorted(const std::string &columnToSortBy,
                      const bool sortAscending,
-                     const Mantid::API::IPeaksWorkspace *ws);
+                     const Mantid::API::IPeaksWorkspace_sptr ws);
   void destroySinglePeakSource();
   void onPeakMarkerDestroyed();
 

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/src/PeaksTableControllerVsi.cpp
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/src/PeaksTableControllerVsi.cpp
@@ -604,7 +604,7 @@ void PeaksTableControllerVsi::updatePeaksWorkspaces(
  */
 void PeaksTableControllerVsi::onPeaksSorted(
     const std::string &columnToSortBy, const bool sortAscending,
-    const Mantid::API::IPeaksWorkspace *ws) {
+    const Mantid::API::IPeaksWorkspace_sptr ws) {
   // Invoke the ording command on the presenters
   m_presenter->sortPeaksWorkspace(columnToSortBy, sortAscending, ws);
   // Update the tabs


### PR DESCRIPTION
Description of work.

Noticed a disconnected signal/slot when opening the peaks table in the VSI SplatterPlotView. This changes signature of onPeaksSorted and other classes to match the signal.

**To test:**

<!-- Instructions for testing. -->

1. Open a MDEventWorkspace and a PeaksWorkspace in MantidPlot.
2. View the MDEventWorkspace in the VSI SplatterPlotView and drag the PeaksWorkspace into the window.
3. Open the peaks table, try sorting by several different columns and verify there are no warnings from Qt.

There is no GitHub issue associated with this pull request.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
