### PR TITLE
Fix the Python package bundled with the Windows installer

### DIFF
--- a/Framework/PythonInterface/mantid/BundlePython.cmake
+++ b/Framework/PythonInterface/mantid/BundlePython.cmake
@@ -23,6 +23,7 @@ if( MSVC )
                                                                           PATTERN "*_d.pyd" EXCLUDE PATTERN "*_d.dll" EXCLUDE )
   install ( DIRECTORY ${PYTHON_DIR}/Lib DESTINATION bin PATTERN ".svn" EXCLUDE PATTERN ".git" EXCLUDE PATTERN "*_d.pyd" EXCLUDE )
   install ( DIRECTORY ${PYTHON_DIR}/Scripts DESTINATION bin PATTERN ".svn" EXCLUDE PATTERN ".git" EXCLUDE PATTERN "*_d.py" EXCLUDE )
+  install ( DIRECTORY ${PYTHON_DIR}/tcl DESTINATION bin PATTERN ".svn" EXCLUDE PATTERN ".git" EXCLUDE )
   install ( FILES ${PYTHON_DIR}/python27.dll ${PYTHON_EXECUTABLE} ${PYTHONW_EXECUTABLE} DESTINATION bin )
 
 endif()


### PR DESCRIPTION
When the Windows installer is built, the Python package that gets bundled with the installer is stripped down to a bare minimum of files to slim down the installer. This process is too aggressive, as it drops the `tcl` directory which holds files needed by the `Tkinter` Python module. This PR adds the missing directory to the installer thus fixing the bundled Python.

**To test:**

This has to be tested on Windows.

1. Install Mantid using the installer.
2. Check that the `tcl` directory and its contents are installed.
3. Make sure no `PYTHONPATH`s or `PYTHONHOME`s or other spurious environment variables are defined.
4. Check that the following script runs without errors:
```python
import Tkinter
t = Tkinter.Tk()
```

Fixes #21283.

**Release Notes** 

Internal change, no need for release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
