### PR TITLE
Mantid crash when using qt help system

### DIFF
--- a/qt/widgets/common/src/pqHelpWindow.cxx
+++ b/qt/widgets/common/src/pqHelpWindow.cxx
@@ -270,10 +270,10 @@ pqHelpWindow::pqHelpWindow(QHelpEngine *engine, QWidget *parentObject,
 
 // setup the content pane
 #if defined(USE_QTWEBKIT)
+  m_browser = new QWebView(this);
   QNetworkAccessManager *oldManager = m_browser->page()->networkAccessManager();
   pqNetworkAccessManager *newManager =
       new pqNetworkAccessManager(m_helpEngine, oldManager, this);
-  m_browser = new QWebView(this);
   m_browser->page()->setLinkDelegationPolicy(QWebPage::DelegateAllLinks);
   m_browser->page()->setNetworkAccessManager(newManager);
   m_browser->page()->setForwardUnsupportedContent(false);


### PR DESCRIPTION
A pointer wasn't initialised before use.

**To test:**

Start mantid and click on release notes link on the welcome screen or try accessing algorithm help pages.

Fixes #21300.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
