### PR TITLE
c and c++ compiler version may be different and hence their allowed compiler options

### DIFF
--- a/buildconfig/CMake/GNUSetup.cmake
+++ b/buildconfig/CMake/GNUSetup.cmake
@@ -17,8 +17,15 @@ endif()
 
 # Set our own compiler version flag from the cmake one and export it globally
 if ( CMAKE_COMPILER_IS_GNUCXX )
-  set( GCC_COMPILER_VERSION ${CMAKE_CXX_COMPILER_VERSION} CACHE INTERNAL "")
-  message( STATUS "gcc version: ${GCC_COMPILER_VERSION}" )
+  set( GCC_C_COMPILER_VERSION ${CMAKE_C_COMPILER_VERSION} CACHE INTERNAL "")
+  message( STATUS "gcc version: ${GCC_C_COMPILER_VERSION}" )
+  set( GCC_CXX_COMPILER_VERSION ${CMAKE_CXX_COMPILER_VERSION} CACHE INTERNAL "")
+  message( STATUS "g++ version: ${GCC_CXX_COMPILER_VERSION}" )
+  if ( GCC_COMPILER_VERSION VERSION_GREATER GCC_CXX_COMPILER_VERSION )
+    set( GCC_C_COMPILER_VERSION GCC_CXX_COMPILER_VERSION )
+  endif()
+  message( STATUS "using the lowest version number (${GCC_C_COMPILER_VERSION}) for compiler options" )
+
   if ( GCC_COMPILER_VERSION VERSION_LESS "5.1.0" )
     # Add an option to use the old C++ ABI if gcc is 5 series
     option ( USE_CXX98_ABI "If enabled, sets the _GLIBCXX_USE_CXX11_ABI=0 compiler flag" OFF)

--- a/buildconfig/CMake/GNUSetup.cmake
+++ b/buildconfig/CMake/GNUSetup.cmake
@@ -17,15 +17,11 @@ endif()
 
 # Set our own compiler version flag from the cmake one and export it globally
 if ( CMAKE_COMPILER_IS_GNUCXX )
-  set( GCC_C_COMPILER_VERSION ${CMAKE_C_COMPILER_VERSION} CACHE INTERNAL "")
-  message( STATUS "gcc version: ${GCC_C_COMPILER_VERSION}" )
-  set( GCC_CXX_COMPILER_VERSION ${CMAKE_CXX_COMPILER_VERSION} CACHE INTERNAL "")
-  message( STATUS "g++ version: ${GCC_CXX_COMPILER_VERSION}" )
-  if ( GCC_COMPILER_VERSION VERSION_GREATER GCC_CXX_COMPILER_VERSION )
-    set( GCC_C_COMPILER_VERSION GCC_CXX_COMPILER_VERSION )
+  if ( NOT CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL CMAKE_C_COMPILER_VERSION )
+      message( FATAL_ERROR "gcc/g++ compiler version mismatch ( found gcc=${CMAKE_C_COMPILER_VERSION}, g++=${CMAKE_CXX_COMPILER_VERSION} ). Please ensure you use the same version of gcc and g++." )
   endif()
-  message( STATUS "using the lowest version number (${GCC_C_COMPILER_VERSION}) for compiler options" )
-
+  set( GCC_COMPILER_VERSION ${CMAKE_CXX_COMPILER_VERSION} CACHE INTERNAL "")
+  message( STATUS "gcc version: ${GCC_COMPILER_VERSION}" )
   if ( GCC_COMPILER_VERSION VERSION_LESS "5.1.0" )
     # Add an option to use the old C++ ABI if gcc is 5 series
     option ( USE_CXX98_ABI "If enabled, sets the _GLIBCXX_USE_CXX11_ABI=0 compiler flag" OFF)


### PR DESCRIPTION
Introduces a test in cmake's code-configuring step that takes the most conservative choice for compiler options, as the c version and c++ compiler options may be different.

In the particular case gcc was 6.4 and g++ 7.2 which leads to compilation failure since the "-Wimplicit-fallthrough" option is unknown to gcc-6.

**To test:**

<!-- cmake; make. -->

Fixes #21329. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
