### PR TITLE
PropertyManager::asJson should not serialize properties that are not enabled

### DIFF
--- a/Framework/Kernel/src/PropertyManager.cpp
+++ b/Framework/Kernel/src/PropertyManager.cpp
@@ -502,7 +502,7 @@ std::string PropertyManager::asString(bool withDefaultValues) const {
   for (size_t i = 0; i < count; ++i) {
     Property *p = getPointerToPropertyOrdinal(static_cast<int>(i));
     if (p->isValueSerializable() && (withDefaultValues || !p->isDefault()) &&
-            p->getSettings()->isEnabled(this) ) {
+        p->getSettings()->isEnabled(this)) {
       jsonMap[p->name()] = p->value();
     }
   }

--- a/Framework/Kernel/src/PropertyManager.cpp
+++ b/Framework/Kernel/src/PropertyManager.cpp
@@ -501,8 +501,11 @@ std::string PropertyManager::asString(bool withDefaultValues) const {
   const size_t count = propertyCount();
   for (size_t i = 0; i < count; ++i) {
     Property *p = getPointerToPropertyOrdinal(static_cast<int>(i));
-    if (p->isValueSerializable() && (withDefaultValues || !p->isDefault()) &&
-        p->getSettings()->isEnabled(this)) {
+    bool is_enabled = true;
+    if (p->getSettings()) {
+      is_enabled = p->getSettings()->isEnabled(this);
+    }
+    if (p->isValueSerializable() && (withDefaultValues || !p->isDefault()) && is_enabled) {
       jsonMap[p->name()] = p->value();
     }
   }

--- a/Framework/Kernel/src/PropertyManager.cpp
+++ b/Framework/Kernel/src/PropertyManager.cpp
@@ -505,7 +505,8 @@ std::string PropertyManager::asString(bool withDefaultValues) const {
     if (p->getSettings()) {
       is_enabled = p->getSettings()->isEnabled(this);
     }
-    if (p->isValueSerializable() && (withDefaultValues || !p->isDefault()) && is_enabled) {
+    if (p->isValueSerializable() && (withDefaultValues || !p->isDefault()) &&
+        is_enabled) {
       jsonMap[p->name()] = p->value();
     }
   }

--- a/Framework/Kernel/src/PropertyManager.cpp
+++ b/Framework/Kernel/src/PropertyManager.cpp
@@ -498,9 +498,9 @@ std::string PropertyManager::asString(bool withDefaultValues) const {
  */
 ::Json::Value PropertyManager::asJson(bool withDefaultValues) const {
   ::Json::Value jsonMap;
-  const size_t count = propertyCount();
-  for (size_t i = 0; i < count; ++i) {
-    Property *p = getPointerToPropertyOrdinal(static_cast<int>(i));
+  const int count = static_cast<int>(propertyCount());
+  for (int i = 0; i < count; ++i) {
+    Property *p = getPointerToPropertyOrdinal(i);
     bool is_enabled = true;
     if (p->getSettings()) {
       is_enabled = p->getSettings()->isEnabled(this);

--- a/Framework/Kernel/src/PropertyManager.cpp
+++ b/Framework/Kernel/src/PropertyManager.cpp
@@ -4,6 +4,7 @@
 #include "MantidKernel/PropertyManager.h"
 #include "MantidKernel/FilteredTimeSeriesProperty.h"
 #include "MantidKernel/StringTokenizer.h"
+#include "MantidKernel/IPropertySettings.h"
 
 #include <json/json.h>
 
@@ -500,7 +501,8 @@ std::string PropertyManager::asString(bool withDefaultValues) const {
   const size_t count = propertyCount();
   for (size_t i = 0; i < count; ++i) {
     Property *p = getPointerToPropertyOrdinal(static_cast<int>(i));
-    if (p->isValueSerializable() && (withDefaultValues || !p->isDefault())) {
+    if (p->isValueSerializable() && (withDefaultValues || !p->isDefault()) &&
+            p->getSettings()->isEnabled(this) ) {
       jsonMap[p->name()] = p->value();
     }
   }

--- a/Framework/Kernel/test/PropertyManagerTest.h
+++ b/Framework/Kernel/test/PropertyManagerTest.h
@@ -5,11 +5,13 @@
 
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/PropertyManager.h"
+#include "MantidKernel/EnabledWhenProperty.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/MandatoryValidator.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 #include "MantidKernel/FilteredTimeSeriesProperty.h"
 #include "MantidKernel/OptionalBool.h"
+#include "../inc/MantidKernel/EnabledWhenProperty.h"
 
 #include <boost/scoped_ptr.hpp>
 #include <json/json.h>
@@ -397,6 +399,20 @@ public:
     TS_ASSERT_EQUALS(mgr.propertyCount(), 0);
   }
 
+  void test_asStringWithNotEnabledProperty(){
+    PropertyManagerHelper mgr;
+    TS_ASSERT_THROWS_NOTHING(mgr.declareProperty("Prop1", 42));
+    TS_ASSERT_THROWS_NOTHING(mgr.declareProperty("Prop2", true));
+    mgr.setPropertySettings("Prop1", make_unique<EnabledWhenProperty>("Prop2",
+        Mantid::Kernel::ePropertyCriterion::IS_DEFAULT));
+
+    TSM_ASSERT_EQUALS("Show the default", mgr.asString(true),
+                      "{\"Prop1\":\"42\",\"Prop2\":\"1\"}\n");
+    mgr.setProperty("Prop2", false);
+    TSM_ASSERT_EQUALS("Hide not enabled", mgr.asString(true),
+                      "{\"Prop2\":\"0\"}\n");
+  }
+
   void test_asString() {
     PropertyManagerHelper mgr;
     TS_ASSERT_THROWS_NOTHING(mgr.declareProperty("Prop1", 10));
@@ -458,7 +474,7 @@ public:
     using namespace Mantid::Kernel;
     PropertyManagerHelper mgr;
     TS_ASSERT_THROWS_NOTHING(mgr.declareProperty(
-        make_unique<MockNonSerializableProperty>("PropertyName", 0)));
+        make_unique<MockNonSerializableProperty>("PropdertyName", 0)));
     TS_ASSERT_EQUALS(mgr.asString(true), "null\n")
     TS_ASSERT_EQUALS(mgr.asString(false), "null\n")
     // Set to non-default value.

--- a/Framework/Kernel/test/PropertyManagerTest.h
+++ b/Framework/Kernel/test/PropertyManagerTest.h
@@ -401,17 +401,17 @@ public:
 
   void test_asStringWithNotEnabledProperty() {
     PropertyManagerHelper mgr;
-    TS_ASSERT_THROWS_NOTHING(mgr.declareProperty("Prop1", 42));
-    TS_ASSERT_THROWS_NOTHING(mgr.declareProperty("Prop2", true));
+    TS_ASSERT_THROWS_NOTHING(mgr.declareProperty("Semaphor", true));
+    TS_ASSERT_THROWS_NOTHING(mgr.declareProperty("Crossing", 42));
     mgr.setPropertySettings(
-        "Prop1", make_unique<EnabledWhenProperty>(
-                     "Prop2", Mantid::Kernel::ePropertyCriterion::IS_DEFAULT));
+        "Crossing", make_unique<EnabledWhenProperty>(
+                     "Semaphor", Mantid::Kernel::ePropertyCriterion::IS_DEFAULT));
 
     TSM_ASSERT_EQUALS("Show the default", mgr.asString(true),
-                      "{\"Prop1\":\"42\",\"Prop2\":\"1\"}\n");
-    mgr.setProperty("Prop2", false);
+                      "{\"Crossing\":\"42\",\"Semaphor\":\"1\"}\n");
+    mgr.setProperty("Semaphor", false);
     TSM_ASSERT_EQUALS("Hide not enabled", mgr.asString(true),
-                      "{\"Prop2\":\"0\"}\n");
+                      "{\"Semaphor\":\"0\"}\n");
   }
 
   void test_asString() {

--- a/Framework/Kernel/test/PropertyManagerTest.h
+++ b/Framework/Kernel/test/PropertyManagerTest.h
@@ -11,7 +11,6 @@
 #include "MantidKernel/TimeSeriesProperty.h"
 #include "MantidKernel/FilteredTimeSeriesProperty.h"
 #include "MantidKernel/OptionalBool.h"
-#include "../inc/MantidKernel/EnabledWhenProperty.h"
 
 #include <boost/scoped_ptr.hpp>
 #include <json/json.h>

--- a/Framework/Kernel/test/PropertyManagerTest.h
+++ b/Framework/Kernel/test/PropertyManagerTest.h
@@ -404,8 +404,9 @@ public:
     TS_ASSERT_THROWS_NOTHING(mgr.declareProperty("Semaphor", true));
     TS_ASSERT_THROWS_NOTHING(mgr.declareProperty("Crossing", 42));
     mgr.setPropertySettings(
-        "Crossing", make_unique<EnabledWhenProperty>(
-                     "Semaphor", Mantid::Kernel::ePropertyCriterion::IS_DEFAULT));
+        "Crossing",
+        make_unique<EnabledWhenProperty>(
+            "Semaphor", Mantid::Kernel::ePropertyCriterion::IS_DEFAULT));
 
     TSM_ASSERT_EQUALS("Show the default", mgr.asString(true),
                       "{\"Crossing\":\"42\",\"Semaphor\":\"1\"}\n");

--- a/Framework/Kernel/test/PropertyManagerTest.h
+++ b/Framework/Kernel/test/PropertyManagerTest.h
@@ -399,12 +399,13 @@ public:
     TS_ASSERT_EQUALS(mgr.propertyCount(), 0);
   }
 
-  void test_asStringWithNotEnabledProperty(){
+  void test_asStringWithNotEnabledProperty() {
     PropertyManagerHelper mgr;
     TS_ASSERT_THROWS_NOTHING(mgr.declareProperty("Prop1", 42));
     TS_ASSERT_THROWS_NOTHING(mgr.declareProperty("Prop2", true));
-    mgr.setPropertySettings("Prop1", make_unique<EnabledWhenProperty>("Prop2",
-        Mantid::Kernel::ePropertyCriterion::IS_DEFAULT));
+    mgr.setPropertySettings(
+        "Prop1", make_unique<EnabledWhenProperty>(
+                     "Prop2", Mantid::Kernel::ePropertyCriterion::IS_DEFAULT));
 
     TSM_ASSERT_EQUALS("Show the default", mgr.asString(true),
                       "{\"Prop1\":\"42\",\"Prop2\":\"1\"}\n");

--- a/Framework/Kernel/test/PropertyManagerTest.h
+++ b/Framework/Kernel/test/PropertyManagerTest.h
@@ -476,7 +476,7 @@ public:
     using namespace Mantid::Kernel;
     PropertyManagerHelper mgr;
     TS_ASSERT_THROWS_NOTHING(mgr.declareProperty(
-        make_unique<MockNonSerializableProperty>("PropdertyName", 0)));
+        make_unique<MockNonSerializableProperty>("PropertyName", 0)));
     TS_ASSERT_EQUALS(mgr.asString(true), "null\n")
     TS_ASSERT_EQUALS(mgr.asString(false), "null\n")
     // Set to non-default value.

--- a/docs/source/release/v3.12.0/framework.rst
+++ b/docs/source/release/v3.12.0/framework.rst
@@ -37,6 +37,7 @@ Core Functionality
 
 - Fixed an issue where certain isotopes could not be accessed using the `Atom` classes, e.g Si28.
 - Added new functionality to ``datasearch.searcharchive`` :ref:`property <Properties File>` to only search the default facility
+- Condition to check if a property is enabled when serializing.
 
 Performance
 -----------


### PR DESCRIPTION
- Included a condition to check if property is enabled
- unit test

**To test:**
Run the following algorithm declaration in MantidPlot's python window:
```
from __future__ import print_function
class Hello(PythonAlgorithm):
    def __init__(self):
        PythonAlgorithm.__init__(self)
    def name(self):
        return 'Hello'
    def category(self):
        return "General"
    def PyInit(self):
        self.declareProperty('Greet', True, direction=Direction.Input,
                             doc='Do I personally greet you?')
        ifGreet = EnabledWhenProperty('Greet', PropertyCriterion.IsDefault)
        self.declareProperty('Name', '', 'Enter a name')
        self.setPropertySettings('Name', ifGreet)
    def PyExec(self):
        print(self)
AlgorithmFactory.subscribe(Hello)
```
Now execute `Hello` from MantidPlot with some value for `Name`, first with `Greet` option enabled  and then with `Greet` disabled. The  output shown in the log widget for the first case should be:

```
{"name":"Hello","properties":{"Name":"Horace"},"version":1}
```

(I chose "Horace" for `Name`), and for the second case:

```
{"name":"Hello","properties":{"Greet":"0"},"version":1
```

"Horace" is not printed because of disabled `Greet`.

Deserialization:

```
import json
for json_str in ('{"name":"Hello","properties":{"Name": "Horace"},"version":1}',
                 '{"name":"Hello","properties":{"Greet":"0"},"version":1}'):
    x = json.loads(json_str)
    alg = AlgorithmManager.create('Hello')
    alg.initialize()
    for name,value in x['properties'].items():
        alg.setProperty(str(name), value)
    alg.execute()
```

Should result in the following output:

```
{"name":"Hello","properties":{"Name":"Horace"},"version":1}

{"name":"Hello","properties":{"Greet":"0"},"version":1}
```

Fixes #21321

[Release Notes ](https://github.com/mantidproject/mantid/blob/a9c794d35de2a5966c8b37876ea1216d653f83a1/docs/source/release/v3.12.0/framework.rst#core-functionality)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
