### PR TITLE
Fix Mantid build with Xcode generator.

### DIFF
--- a/qt/paraview_ext/PVPlugins/CMakeLists.txt
+++ b/qt/paraview_ext/PVPlugins/CMakeLists.txt
@@ -19,15 +19,29 @@ if (CMAKE_GENERATOR MATCHES "Visual Studio")
   set ( _pv_library_output_dir ${ParaView_DIR}/bin )
   # add_custom_command doesn't support generator expressions for the OUTPUT argument
   string ( REPLACE "$<CONFIG>" "${CMAKE_CFG_INTDIR}" _plugin_library_output ${PVPLUGINS_LIBRARY_OUTPUT_DIRECTORY} )
+elseif (CMAKE_GENERATOR MATCHES "Xcode")
+  set ( _pv_library_output_dir ${ParaView_DIR}/lib )
+  # add_custom_command doesn't support generator expressions for the OUTPUT argument
+  string ( REPLACE "$<CONFIG>" "${CMAKE_CFG_INTDIR}" _plugin_library_output ${PVPLUGINS_LIBRARY_OUTPUT_DIRECTORY} )
 else ()
   set ( _pv_library_output_dir ${ParaView_DIR}/lib )
   set ( _plugin_library_output ${PVPLUGINS_LIBRARY_OUTPUT_DIRECTORY} )
 endif()
-add_custom_command ( OUTPUT ${_plugin_library_output}/qt4/${_plugin_filename}
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different
-  ${_pv_library_output_dir}/${CMAKE_CFG_INTDIR}/${_plugin_filename}
-  ${_plugin_library_output}/qt4/${_plugin_filename}
-)
+
+if (CMAKE_GENERATOR MATCHES "Xcode")
+  # assume ParaView was built with Makefile or Ninja generator.
+  add_custom_command ( OUTPUT ${_plugin_library_output}/qt4/${_plugin_filename}
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    ${_pv_library_output_dir}/${_plugin_filename}
+    ${_plugin_library_output}/qt4/${_plugin_filename}
+  )
+else ()
+  add_custom_command ( OUTPUT ${_plugin_library_output}/qt4/${_plugin_filename}
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    ${_pv_library_output_dir}/${CMAKE_CFG_INTDIR}/${_plugin_filename}
+    ${_plugin_library_output}/qt4/${_plugin_filename}
+  )
+endif()
 add_custom_target ( copy_nonorthogonal_plugin DEPENDS ${_plugin_library_output}/qt4/${_plugin_filename} )
 add_dependencies ( MantidParaViewMDEWSourceSMPlugin copy_nonorthogonal_plugin )
 


### PR DESCRIPTION
Description of work.

This adjusts the cmake script to work when using ParaView configured with `Makefiles` or `Ninja` and Mantid configured with `Xcode`.

**To test:**

<!-- Instructions for testing. -->

* Code review and checking the build servers may be sufficient.
* Configure mantid on MacOS with the `Xcode` generator and `MAKE_VATES=ON`.

There is no GitHub issue associated with this pull request.

**Release Notes** 

*Does not need to be in the release notes.* Changes were made during this release and build system changes are rarely of interest to users.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
