### PR TITLE
Remove workaround for broken macdeployqt on macOS

### DIFF
--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -47,19 +47,6 @@ def findQScintilla2(lib_dir)
     end
 end
 
-# Find the qt folder. This is different depending on
-# what tap you're using in homebrew
-def findQtFolder()
-    if Dir.exist?("/usr/local/opt/qt@4")
-        return '/usr/local/opt/qt@4'
-    elsif Dir.exist?("/usr/local/opt/qt")
-        return '/usr/local/opt/qt'
-    else
-        p 'Could not find the qt folder'
-        exit 1
-    end
-end
-
 lib_dir = Pathname.new("/usr/local/lib")
 openssl_dir = Pathname.new("/usr/local/opt/openssl/lib")
 ParaView_dir = Pathname.new("@ParaView_DIR@")
@@ -243,13 +230,6 @@ if( "@MAKE_VATES@" == "ON" )
    end
 end
 
-qt_folder = findQtFolder()
-if not Dir.exist?("#{qt_folder}/plugins")
-    p "Cannot find the Qt4 plugins folder"
-    p "You probably need to simlink the plugins folder in #{qt_folder}/lib/qt/plugins to #{qt_folder}/plugins"
-    exit 1
-end
-
 `macdeployqt ../MantidPlot.app #{Qt_Executables}`
 
 if Dir.exist?("Contents/PlugIns")
@@ -305,7 +285,7 @@ end
 pyqt4_patterns = ["**/PyQt4/*.so"]
 change_id(pyqt4_patterns, "Contents/MacOS/PyQt4/")
 
-QtLinkingDir = find_linking_directories(pyqt4_patterns, 'Qt.*.framework/Versions/\d/Qt.*',"#{qt_folder}/lib")
+QtLinkingDir = find_linking_directories(pyqt4_patterns, 'Qt.*.framework/Versions/\d/Qt.*',"/usr/local/opt/qt@4/lib")
 
 if QtLinkingDir.uniq != [QtLinkingDir[0]]
   p "Error updating PyQt4 dynamic linking!"


### PR DESCRIPTION
The package has been fixed upstream so the workaround is not necessary.

Description of work.

**To test:**

* Make sure you have the latest qt@4 version from homebrew (`4.8.7_3`)
* Build the package and it should complete successfully.

*No issue number*

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
