### PR TITLE
Fix LoadILLPolarizationFactors performance test.

### DIFF
--- a/Framework/DataHandling/test/LoadILLPolarizationFactorsTest.h
+++ b/Framework/DataHandling/test/LoadILLPolarizationFactorsTest.h
@@ -202,7 +202,7 @@ private:
 class LoadILLPolarizationFactorsTestPerformance : public CxxTest::TestSuite {
 public:
   void test_loadingLargeHistogram() {
-    const size_t nBins = 100000000;
+    const size_t nBins = 1000000;
     const std::vector<double> y(nBins, 1.0);
     Mantid::HistogramData::Counts counts(y);
     std::vector<double> x(nBins + 1);
@@ -211,14 +211,16 @@ public:
     const Mantid::HistogramData::Histogram h(edges, counts);
     Mantid::API::MatrixWorkspace_sptr ws =
         Mantid::DataObjects::create<Mantid::DataObjects::Workspace2D>(1, h);
-    LoadILLPolarizationFactors alg;
-    alg.setRethrows(true);
-    alg.setChild(true);
-    alg.initialize();
-    alg.setProperty("Filename", "ILL/D17/PolarizationFactors.txt");
-    alg.setProperty("OutputWorkspace", "LoadILLPolarizationFactorsTest");
-    alg.setProperty("WavelengthReference", ws);
-    alg.execute();
+    for (size_t i = 0; i < 100; ++i) {
+      LoadILLPolarizationFactors alg;
+      alg.setRethrows(true);
+      alg.setChild(true);
+      alg.initialize();
+      alg.setProperty("Filename", "ILL/D17/PolarizationFactors.txt");
+      alg.setProperty("OutputWorkspace", "LoadILLPolarizationFactorsTest");
+      alg.setProperty("WavelengthReference", ws);
+      alg.execute();
+    }
   }
 };
 


### PR DESCRIPTION
This PR tries to fix the failing `LoadILLPolarizationFactors` performance test by decreasing the amount of memory the test reserves.

**To test:**

Build with performance tests enabled (`-DCXXTEST_ADD_PERFORMANCE=TRUE`) and check that the test passes.

Fixes #21346.

**Release Notes** 

This change does not affect the release in any way.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
