### PR TITLE
Add support for unicode property names

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertyManager.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertyManager.cpp
@@ -7,6 +7,7 @@
 
 #include <boost/python/class.hpp>
 #include <boost/python/copy_const_reference.hpp>
+#include <boost/python/dict.hpp>
 #include <boost/python/iterator.hpp>
 #include <boost/python/list.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
@@ -20,6 +21,27 @@ using namespace boost::python;
 GET_POINTER_SPECIALIZATION(IPropertyManager)
 
 namespace {
+
+/**
+ * Convert a python object to a string or throw an exception. This will convert
+ * unicode strings in python2 via utf8.
+ */
+std::string pyObjToStr(const boost::python::object &value) {
+  extract<std::string> extractor(value);
+
+  std::string valuestr;
+  if (extractor.check()) {
+    valuestr = extractor();
+#if PY_VERSION_HEX < 0x03000000
+  } else if (PyUnicode_Check(value.ptr())) {
+    valuestr = extract<std::string>(str(value).encode("utf-8"))();
+#endif
+  } else {
+    throw std::invalid_argument("Failed to convert python object a string");
+  }
+  return valuestr;
+}
+
 /**
  * Set the value of a property from the value within the
  * boost::python object
@@ -28,26 +50,41 @@ namespace {
  * @param name :: The name of the property
  * @param value :: The value of the property as a bpl object
  */
-void setProperty(IPropertyManager &self, const std::string &name,
+void setProperty(IPropertyManager &self, const boost::python::object &name,
                  const boost::python::object &value) {
-  extract<std::string> cppstr(value);
+  std::string namestr;
+  try {
+    namestr = pyObjToStr(name);
+  } catch (std::invalid_argument &e) {
+    throw std::invalid_argument("Failed to convert property name to a string");
+  }
 
-  if (cppstr.check()) {
-    self.setPropertyValue(name, cppstr());
+  extract<std::string> valuecpp(value);
+  if (valuecpp.check()) {
+    self.setPropertyValue(namestr, valuecpp());
 #if PY_VERSION_HEX < 0x03000000
   } else if (PyUnicode_Check(value.ptr())) {
-    self.setPropertyValue(name,
+    self.setPropertyValue(namestr,
                           extract<std::string>(str(value).encode("utf-8"))());
 #endif
   } else {
     try {
-      Property *p = self.getProperty(name);
+      Property *p = self.getProperty(namestr);
       const auto &entry = Registry::TypeRegistry::retrieve(*(p->type_info()));
-      entry.set(&self, name, value);
+      entry.set(&self, namestr, value);
     } catch (std::invalid_argument &e) {
-      throw std::invalid_argument("When converting parameter \"" + name +
+      throw std::invalid_argument("When converting parameter \"" + namestr +
                                   "\": " + e.what());
     }
+  }
+}
+
+void setProperties(IPropertyManager &self, const boost::python::dict &kwargs) {
+  const boost::python::list keys = kwargs.keys();
+  const size_t numItems = boost::python::len(keys);
+  for (size_t i = 0; i < numItems; ++i) {
+    const boost::python::object value = kwargs[keys[i]];
+    setProperty(self, keys[i], value);
   }
 }
 
@@ -58,10 +95,11 @@ void setProperty(IPropertyManager &self, const std::string &name,
  * @param name :: The name of the property
  * @param value :: The value of the property as a bpl object
  */
-void declareProperty(IPropertyManager &self, const std::string &name,
+void declareProperty(IPropertyManager &self, const boost::python::object &name,
                      boost::python::object value) {
+  std::string nameStr = pyObjToStr(name);
   auto p = std::unique_ptr<Property>(
-      Registry::PropertyWithValueFactory::create(name, value, 0));
+      Registry::PropertyWithValueFactory::create(nameStr, value, 0));
   self.declareProperty(std::move(p));
 }
 
@@ -73,9 +111,11 @@ void declareProperty(IPropertyManager &self, const std::string &name,
  * @param name :: The name of the property
  * @param value :: The value of the property as a bpl object
  */
-void declareOrSetProperty(IPropertyManager &self, const std::string &name,
+void declareOrSetProperty(IPropertyManager &self,
+                          const boost::python::object &name,
                           boost::python::object value) {
-  bool propExists = self.existsProperty(name);
+  std::string nameStr = pyObjToStr(name);
+  bool propExists = self.existsProperty(nameStr);
   if (propExists) {
     setProperty(self, name, value);
   } else {
@@ -134,7 +174,7 @@ Property *get(IPropertyManager &self, const std::string &name,
               const boost::python::object &value) {
   try {
     return self.getPointerToProperty(name);
-  } catch (Exception::NotFoundError) {
+  } catch (Exception::NotFoundError &) {
     return Registry::PropertyWithValueFactory::create(name, value, 0).release();
   }
 }
@@ -171,6 +211,8 @@ void export_IPropertyManager() {
       .def("setProperty", &setProperty,
            (arg("self"), arg("name"), arg("value")),
            "Set the value of the named property")
+      .def("setProperties", &setProperties, (arg("self"), arg("kwargs")),
+           "Set a collection of properties from a dict")
 
       .def("setPropertySettings", &setPropertySettings,
            (arg("self"), arg("name"), arg("settingsManager")),

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertyManager.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertyManager.cpp
@@ -55,7 +55,7 @@ void setProperty(IPropertyManager &self, const boost::python::object &name,
   std::string namestr;
   try {
     namestr = pyObjToStr(name);
-  } catch (std::invalid_argument &e) {
+  } catch (std::invalid_argument &) {
     throw std::invalid_argument("Failed to convert property name to a string");
   }
 

--- a/Framework/PythonInterface/test/python/mantid/api/AlgorithmTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/AlgorithmTest.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 import six
 
 import unittest
+import json
 from mantid.api import AlgorithmID, AlgorithmManager
 from testhelpers import run_algorithm
 
@@ -56,13 +57,17 @@ class AlgorithmTest(unittest.TestCase):
 
     def test_execute_succeeds_with_unicode_props(self):
         data = [1.0,2.0,3.0]
+        kwargs = {'child':True}
         unitx = 'Wavelength'
         if six.PY2:
             # force a property value to be unicode to assert conversion happens correctly
             # this is only an issue in python2
-            unitx = unicode(unitx)
+            kwargs[unicode('UnitX')] = unicode(unitx)
+        else:
+            kwargs['UnitX'] = unitx
 
-        alg = run_algorithm('CreateWorkspace',DataX=data,DataY=data,NSpec=1,UnitX=unitx,child=True)
+
+        alg = run_algorithm('CreateWorkspace',DataX=data,DataY=data,NSpec=1,**kwargs)
         self.assertEquals(alg.isExecuted(), True)
         self.assertEquals(alg.isRunning(), False)
         self.assertEquals(alg.getProperty('NSpec').value, 1)
@@ -74,6 +79,10 @@ class AlgorithmTest(unittest.TestCase):
         as_str = str(alg)
         self.assertEquals(as_str, '{"name":"CreateWorkspace","properties":{"DataX":"1,2,3","DataY":"1,2,3",'
                           '"OutputWorkspace":"UNUSED_NAME_FOR_CHILD","UnitX":"Wavelength"},"version":1}\n')
+
+    def test_execute_succeeds_with_unicode_kwargs(self):
+        props = json.loads('{"DryRun":true}') # this is always unicode
+        alg = run_algorithm('Segfault', **props)
 
     def test_getAlgorithmID_returns_AlgorithmID_object(self):
         alg = AlgorithmManager.createUnmanaged('Load')

--- a/Framework/PythonInterface/test/testhelpers/__init__.py
+++ b/Framework/PythonInterface/test/testhelpers/__init__.py
@@ -58,8 +58,7 @@ def create_algorithm(name, **kwargs):
     if 'rethrow' in kwargs:
         alg.setRethrows(True)
         del kwargs['rethrow']
-    for key, value in iteritems(kwargs):
-        alg.setProperty(key, value)
+    alg.setProperties(kwargs)
     return alg
 
 

--- a/docs/source/release/v3.12.0/framework.rst
+++ b/docs/source/release/v3.12.0/framework.rst
@@ -52,4 +52,13 @@ In `mantid.simpleapi`, a keyword has been implemented for function-like algorith
 - The standard Python operators, e.g. ``+``, ``+=``, etc., now work also with workspaces not in the ADS.
 - The ``isDefault`` attribute for workspace properties now works correctly with workspaces not in the ADS.
 
+Support for unicode property names has been added to python. This means that one can run the following in python2 or python3.
+
+.. code-block:: python
+
+   from mantid.simpleapi import Segfault
+   import json
+   props = json.loads('{"DryRun":true}')
+   Segfault(**props)
+
 :ref:`Release 3.12.0 <v3.12.0>`


### PR DESCRIPTION
This needs to be tested against python2 since all strings are unicode in python3.

**To test:**

A code review and running the test that is in the release notes should be sufficient.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
