### PR TITLE
isis_powder - add beam parameters

### DIFF
--- a/docs/source/release/v3.12.0/diffraction.rst
+++ b/docs/source/release/v3.12.0/diffraction.rst
@@ -24,7 +24,7 @@ Powder Diffraction
 - New algorithm :ref:`algm-SumOverlappingTubes` combines a detector scan for D2B into a single workspace.
 - ISIS Powder scripts for HRPD now support extra TOF windows 10-50 and 180-280
 - After calling create_vanadium and focus in ISIS Powder scripts on POLARIS, the output workspaces always contain the sample material if it is set using set_sample_material. (To view the sample material, right click the workspace and click 'Sample Material...')
-
+- It is now possible to set beam parameters (height and width) using instrument_object.set_beam_parameters(height=123, width=456).
 
 Engineering Diffraction
 -----------------------
@@ -42,7 +42,7 @@ Single Crystal Diffraction
 
 - HB3A reduction interface has been enhanced.  A child window is added to it for users to pre-process scans and save the processed and merged data to NeXus files in order to save time when they start to reduce and visualize the data. A record file is generated along with processed scans to record the calibration information. During data reduction, scans that have been processed in pre-processing will be loaded automatically from corresponding MD files.
 
-- In HB3A reduction intervace, section for downloading experimental data via http server has been removed from main UI.
+- In HB3A reduction interface, section for downloading experimental data via http server has been removed from main UI.
 
 - :ref:`IntegratePeaksMDHKL <algm-IntegratePeaksMDHKL>` now has option to specify background shell instead of using default background determination.
 

--- a/docs/source/techniques/ISISPowder-Tutorials.rst
+++ b/docs/source/techniques/ISISPowder-Tutorials.rst
@@ -832,6 +832,20 @@ advanced properties and chemical properties)
     # Now allowed as object does not have a chemical formula associated
     my_sample.set_material(...)
 
+.. _set_beam_parameters-ref:
+
+Setting beam parameters
+-----------------------
+
+The beam width and height can be set for the instrument.
+These are then used for total scattering corrections.
+
+.. code-block:: python
+
+ from isis_powder import Polaris
+ polaris_obj = Polaris(...)
+ polaris.obj.set_beam_parameters(height=1.23, width=4,56)
+
 .. _instrument_advanced_properties_isis-powder-diffraction-ref:
 
 Instrument advanced properties

--- a/scripts/Diffraction/isis_powder/abstract_inst.py
+++ b/scripts/Diffraction/isis_powder/abstract_inst.py
@@ -23,6 +23,7 @@ class AbstractInst(object):
         self._inst_prefix = inst_prefix
         self._output_dir = output_dir
         self._is_vanadium = None
+        self._beam_parameters = None
 
     @property
     def calibration_dir(self):
@@ -59,6 +60,20 @@ class AbstractInst(object):
         self._is_vanadium = False
         return focus.focus(run_number_string=run_number_string, perform_vanadium_norm=do_van_normalisation,
                            instrument=self, absorb=do_absorb_corrections, sample_details=sample_details)
+
+    def set_beam_parameters(self, height, width):
+        """
+        Set the height and width of the beam. Currently only supports rectangular (or square) beam shapes.
+        Implementation should be common across all instruments so no need for overriding in instrument classes.
+        :param height: Height of the beam (mm).
+        :param width: Width of the beam (mm).
+        :return:
+        """
+        if height <= 0 or width <= 0:
+            raise ValueError("Beam height and width must be more than 0.")
+        else:
+            self._beam_parameters = {'height': height,
+                                     'width': width}
 
     # Mandatory overrides
 

--- a/scripts/Diffraction/isis_powder/abstract_inst.py
+++ b/scripts/Diffraction/isis_powder/abstract_inst.py
@@ -69,6 +69,11 @@ class AbstractInst(object):
         :param width: Width of the beam (mm).
         :return:
         """
+        try:
+            height = float(height)
+            width = float(width)
+        except ValueError:
+                raise ValueError("Beam height and width must be numbers.")
         if height <= 0 or width <= 0:
             raise ValueError("Beam height and width must be more than 0.")
         else:

--- a/scripts/test/ISISPowderAbstractInstrumentTest.py
+++ b/scripts/test/ISISPowderAbstractInstrumentTest.py
@@ -84,6 +84,10 @@ class ISISPowderAbstractInstrumentTest(unittest.TestCase):
         self.assertRaises(ValueError, mock_inst.set_beam_parameters, height=-1.234, width=2)
         self.assertRaises(ValueError, mock_inst.set_beam_parameters, height=-1.234, width=-2)
 
+        # Test non-numerical input
+        self.assertRaises(ValueError, mock_inst.set_beam_parameters, height='height', width=-2)
+        self.assertRaises(ValueError, mock_inst.set_beam_parameters, height=-1.234, width=True)
+
 
 class _MockInst(AbstractInst):
 

--- a/scripts/test/ISISPowderAbstractInstrumentTest.py
+++ b/scripts/test/ISISPowderAbstractInstrumentTest.py
@@ -62,6 +62,28 @@ class ISISPowderAbstractInstrumentTest(unittest.TestCase):
                                              "MOCK15-suf.nxs")
         self.assertEquals(output_paths["nxs_filename"], expected_nxs_filename)
 
+    def test_set_valid_beam_parameters(self):
+        # Setup basic instrument mock
+        cal_dir = self._create_temp_dir()
+        out_dir = self._create_temp_dir()
+        mock_inst = self._setup_mock_inst(calibration_dir=cal_dir, output_dir=out_dir)
+
+        # Test valid parameters are retained
+        mock_inst.set_beam_parameters(height=1.234, width=2)
+        self.assertEqual(mock_inst._beam_parameters['height'], 1.234)
+        self.assertEqual(mock_inst._beam_parameters['width'], 2)
+
+    def test_set_invalid_beam_parameters(self):
+        # Setup basic instrument mock
+        cal_dir = self._create_temp_dir()
+        out_dir = self._create_temp_dir()
+        mock_inst = self._setup_mock_inst(calibration_dir=cal_dir, output_dir=out_dir)
+
+        # Test combination of positive / negative raise exceptions
+        self.assertRaises(ValueError, mock_inst.set_beam_parameters, height=1.234, width=-2)
+        self.assertRaises(ValueError, mock_inst.set_beam_parameters, height=-1.234, width=2)
+        self.assertRaises(ValueError, mock_inst.set_beam_parameters, height=-1.234, width=-2)
+
 
 class _MockInst(AbstractInst):
 


### PR DESCRIPTION
Added the ability to set beam height and width in the isis_powder instruments. This is not yet being used, but will be used for total scattering corrections and may need to be taken into account for other isis_powder instruments at a later stage. Documentation has been updated.

**To test:**
* Run the below script and check the output of `print(polaris._beam_parameters)` to ensure the beam parameters are updated correctly. Try to force errors with different input (negative numbers, strings, etc.)
* Ensure the unit new tests pass locally and on the build servers
```
from isis_powder import Polaris
# set up POLARIS instrument
polaris = Polaris(user_name="test",
                      calibration_mapping_file='test',
                      calibration_directory='test',
                      output_directory='test')
polaris.set_beam_parameters(height=1.0, width=2.0)
print(polaris._beam_parameters)
```

Fixes #21268 and Fixes #20892

[**Release Notes**](https://github.com/mantidproject/mantid/blob/5611210cf6b607d480d0757aa19c27ebfe497de3/docs/source/release/v3.12.0/diffraction.rst)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
