### PR TITLE
Reflectivity fixes for REFM

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LRPeakSelection.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRPeakSelection.py
@@ -140,12 +140,16 @@ class PeakFinderDerivation(object):
         _std_deviation_counts_firstderi = self.std_deviation_counts_firstderi
 
         px_offset = 0
-        while abs(_counts[int(_deri_min_pixel_value - px_offset)]) > _std_deviation_counts_firstderi:
+        while int(_deri_min_pixel_value - px_offset) < len(_counts) \
+            and int(_deri_min_pixel_value - px_offset) > 0 \
+            and abs(_counts[int(_deri_min_pixel_value - px_offset)]) > _std_deviation_counts_firstderi:
             px_offset += 1
         _peak_min_final_value = _pixel[int(_deri_min_pixel_value - px_offset)]
 
         px_offset = 0
-        while abs(_counts[int(round(_deri_max_pixel_value + px_offset))]) > _std_deviation_counts_firstderi:
+        while int(round(_deri_max_pixel_value + px_offset)) < len(_counts)-1 \
+            and int(round(_deri_max_pixel_value + px_offset)) >= 0 \
+            and abs(_counts[int(round(_deri_max_pixel_value + px_offset))]) > _std_deviation_counts_firstderi:
             px_offset += 1
         _peak_max_final_value = _pixel[int(round(_deri_max_pixel_value + px_offset))]
 
@@ -235,17 +239,16 @@ class LRPeakSelection(PythonAlgorithm):
         # Get the full range
         pf = PeakFinderDerivation(workspace, back_offset=0)
         [left_max, right_min] = pf.low_res
-
         # Process left-end data
         pf.ydata = workspace.dataY(0)[0: left_max]
         pf.xdata = np.arange(len(pf.ydata))
         pf.compute()
-        left_clocking = pf.calculate_low_res_range()[0]
+        left_clocking = pf.low_resolution_range()[0]
 
         pf.ydata = workspace.dataY(0)[right_min: -1]
         pf.xdata = np.arange(len(pf.ydata))
         pf.compute()
-        right_clocking = pf.calculate_low_res_range()[1]
+        right_clocking = pf.low_resolution_range()[1]+right_min
 
         return [left_clocking, right_clocking]
 

--- a/Framework/PythonInterface/plugins/algorithms/LRPeakSelection.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRPeakSelection.py
@@ -141,15 +141,15 @@ class PeakFinderDerivation(object):
 
         px_offset = 0
         while int(_deri_min_pixel_value - px_offset) < len(_counts) \
-            and int(_deri_min_pixel_value - px_offset) > 0 \
-            and abs(_counts[int(_deri_min_pixel_value - px_offset)]) > _std_deviation_counts_firstderi:
+                and int(_deri_min_pixel_value - px_offset) > 0 \
+                and abs(_counts[int(_deri_min_pixel_value - px_offset)]) > _std_deviation_counts_firstderi:
             px_offset += 1
         _peak_min_final_value = _pixel[int(_deri_min_pixel_value - px_offset)]
 
         px_offset = 0
         while int(round(_deri_max_pixel_value + px_offset)) < len(_counts)-1 \
-            and int(round(_deri_max_pixel_value + px_offset)) >= 0 \
-            and abs(_counts[int(round(_deri_max_pixel_value + px_offset))]) > _std_deviation_counts_firstderi:
+                and int(round(_deri_max_pixel_value + px_offset)) >= 0 \
+                and abs(_counts[int(round(_deri_max_pixel_value + px_offset))]) > _std_deviation_counts_firstderi:
             px_offset += 1
         _peak_max_final_value = _pixel[int(round(_deri_max_pixel_value + px_offset))]
 

--- a/Framework/PythonInterface/plugins/algorithms/MagnetismReflectometryReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/MagnetismReflectometryReduction.py
@@ -40,6 +40,9 @@ class MagnetismReflectometryReduction(PythonAlgorithm):
     def PyInit(self):
         """ Initialization """
         self.declareProperty(StringArrayProperty("RunNumbers"), "List of run numbers to process")
+        self.declareProperty(WorkspaceProperty("InputWorkspace", "",
+                                               Direction.Input, PropertyMode.Optional),
+                             "Optionally, we can provide a workspace directly")
         self.declareProperty("NormalizationRunNumber", 0, "Run number of the normalization run to use")
         self.declareProperty(IntArrayProperty("SignalPeakPixelRange", [123, 137],
                                               IntArrayLengthValidator(2), direction=Direction.Input),
@@ -96,7 +99,6 @@ class MagnetismReflectometryReduction(PythonAlgorithm):
     def PyExec(self):
         """ Main execution """
         # DATA
-        dataRunNumbers = self.getProperty("RunNumbers").value
         dataPeakRange = self.getProperty("SignalPeakPixelRange").value
         dataBackRange = self.getProperty("SignalBackgroundPixelRange").value
 
@@ -105,21 +107,8 @@ class MagnetismReflectometryReduction(PythonAlgorithm):
         normBackRange = self.getProperty("NormBackgroundPixelRange").value
         normPeakRange = self.getProperty("NormPeakPixelRange").value
 
-        # If we have multiple files, add them
-        file_list = []
-        for item in dataRunNumbers:
-            # The standard mode of operation is to give a run number as input
-            try:
-                data_file = FileFinder.findRuns("%s%s" % (INSTRUMENT_NAME, item))[0]
-            except RuntimeError:
-                # Allow for a file name or file path as input
-                data_file = FileFinder.findRuns(item)[0]
-            file_list.append(data_file)
-        runs = functools.reduce((lambda x, y: '%s+%s' % (x, y)), file_list)
-
-        entry_name = self.getProperty("EntryName").value
-        ws_event_data = LoadEventNexus(Filename=runs, NXentryName=entry_name,
-                                       OutputWorkspace="%s_%s" % (INSTRUMENT_NAME, dataRunNumbers[0]))
+        # Load the data
+        ws_event_data = self.load_data()
 
         # Number of pixels in each direction
         self.number_of_pixels_x = int(ws_event_data.getInstrument().getNumberParameter("number-of-x-pixels")[0])
@@ -187,6 +176,33 @@ class MagnetismReflectometryReduction(PythonAlgorithm):
         AnalysisDataService.remove(str(normalized_data))
 
         self.setProperty('OutputWorkspace', q_rebin)
+
+    def load_data(self):
+        """
+            Load the data. We can either load it from the specified
+            run numbers, or use the input workspace if no runs are specified.
+        """
+        dataRunNumbers = self.getProperty("RunNumbers").value
+        ws_event_data = self.getProperty("InputWorkspace").value
+
+        if len(dataRunNumbers) > 0:
+            # If we have multiple files, add them
+            file_list = []
+            for item in dataRunNumbers:
+                # The standard mode of operation is to give a run number as input
+                try:
+                    data_file = FileFinder.findRuns("%s%s" % (INSTRUMENT_NAME, item))[0]
+                except RuntimeError:
+                    # Allow for a file name or file path as input
+                    data_file = FileFinder.findRuns(item)[0]
+                file_list.append(data_file)
+            runs = reduce((lambda x, y: '%s+%s' % (x, y)), file_list)
+            entry_name = self.getProperty("EntryName").value
+            ws_event_data = LoadEventNexus(Filename=runs, NXentryName=entry_name,
+                                           OutputWorkspace="%s_%s" % (INSTRUMENT_NAME, dataRunNumbers[0]))
+        elif ws_event_data is None:
+            raise RuntimeError("No input data was specified")
+        return ws_event_data
 
     def load_direct_beam(self, normalizationRunNumber):
         """

--- a/Framework/PythonInterface/plugins/algorithms/MagnetismReflectometryReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/MagnetismReflectometryReduction.py
@@ -4,7 +4,6 @@
 """
 from __future__ import (absolute_import, division, print_function)
 import math
-import functools
 import numpy as np
 from mantid.api import *
 from mantid.simpleapi import *

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
@@ -53,6 +53,7 @@ set ( TEST_PY_FILES
   LoadNMoldyn3AsciiTest.py
   LoadNMoldyn4Ascii1DTest.py
   LoadNMoldyn4AsciiTest.py
+  LRPeakSelectionTest.py
   MaskAngleTest.py
   MaskBTPTest.py
   MaskWorkspaceToCalFileTest.py

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LRPeakSelectionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LRPeakSelectionTest.py
@@ -1,0 +1,68 @@
+from __future__ import (absolute_import, division, print_function)
+
+import unittest
+from mantid.simpleapi import LRPeakSelection, CreateSampleWorkspace, DeleteWorkspace
+import logging
+
+class LRPeakSelectionTest(unittest.TestCase):
+    def setUp(self):
+        self.ws = None
+
+    def tearDown(self):
+        if self.ws is not None: DeleteWorkspace(self.ws)
+
+    def _workspace(self,userFun):
+        if self.ws is not None: DeleteWorkspace(self.ws)
+
+        self.ws = CreateSampleWorkspace(OutputWorkspace="out",
+            Function="User Defined",UserDefinedFunction=userFun,
+            NumBanks=1, BankPixelWidth=1, XMin=0, XMax=300, BinWidth=1.0)
+
+    def _gaussianWorkspace(self,peakCentre,height,sigma):
+        self._workspace("name=Gaussian,PeakCentre=%s,Height=%s,Sigma=%s" %(peakCentre,height,sigma))
+
+    def test_peaks(self):
+        """
+            Test that a reflectivity peak is found to match a generated Gaussian.
+        """
+        peak_center = 150.0
+        sigma = 25.0
+        self._gaussianWorkspace(peak_center, 1000, sigma)
+        peak, low_res, _ = LRPeakSelection(self.ws)
+
+        # Require a close relative match between given and fitted values.
+        # The width of the fitted peak should be about twice the sigma.
+        position = (peak[0] + peak[1]) / 2.0
+        width = abs(peak[1] - peak[0]) / 4.0
+        diff_peak_centre = abs((position - peak_center) / peak_center)
+        diff_sigma = abs((width - sigma) / sigma)
+
+        self.assertTrue(diff_peak_centre < 0.03)
+        self.assertTrue(diff_sigma < 0.05)
+
+    def test_primary_range(self):
+        """
+            Test that a reflectivity peak is found to match a generated Gaussian,
+            with the primary range turned on.
+        """
+        peak_center = 150.0
+        sigma = 25.0
+        self._gaussianWorkspace(peak_center, 1000, sigma)
+        peak, low_res, primary_range = LRPeakSelection(self.ws, ComputePrimaryRange=True)
+
+        # Require a close relative match between given and fitted values.
+        # The width of the fitted peak should be about twice the sigma.
+        position = (peak[0] + peak[1]) / 2.0
+        width = abs(peak[1] - peak[0]) / 4.0
+        diff_peak_centre = abs((position - peak_center) / peak_center)
+        diff_sigma = abs((width - sigma) / sigma)
+
+        self.assertTrue(diff_peak_centre < 0.03)
+        self.assertTrue(diff_sigma < 0.05)
+
+        # The low resolution range should fit within the primary range
+        self.assertTrue(primary_range[0] < low_res[0])
+        self.assertTrue(primary_range[1] > low_res[1])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This is part of REFM work. The MagnetismReflectometryReduction algorithm needs to be able to take in a workspace instead of a file path. The LRPeakSelection algorithm has a bug and crashes when setting ComputePrimaryRange=True.

**To test:**
- Make sure all tests pass.
- Inspect the code.

There is no 'issue' fir this PR. All the information is here.

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
