### PR TITLE
More efficient iteration over a python dict

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertyManager.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertyManager.cpp
@@ -83,7 +83,7 @@ void setProperty(IPropertyManager &self, const boost::python::object &name,
 void setProperties(IPropertyManager &self, const boost::python::dict &kwargs) {
 #if PY_MAJOR_VERSION >= 3
   const object view = kwargs.attr("items");
-  const object objectItems = itemIter(handle<>(PyObject_GetIter(view.ptr())));
+  const object objectItems(handle<>(PyObject_GetIter(view.ptr())));
 #else
   const object objectItems = kwargs.iteritems();
 #endif

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertyManager.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertyManager.cpp
@@ -82,7 +82,7 @@ void setProperty(IPropertyManager &self, const boost::python::object &name,
 
 void setProperties(IPropertyManager &self, const boost::python::dict &kwargs) {
 #if PY_MAJOR_VERSION >= 3
-  const object view = kwargs.attr("items");
+  const object view = kwargs.attr("items")();
   const object objectItems(handle<>(PyObject_GetIter(view.ptr())));
 #else
   const object objectItems = kwargs.iteritems();

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertyManager.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertyManager.cpp
@@ -12,6 +12,7 @@
 #include <boost/python/list.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
 #include <boost/python/return_internal_reference.hpp>
+#include <boost/python/stl_iterator.hpp>
 #include <boost/python/str.hpp>
 
 using namespace Mantid::Kernel;
@@ -80,11 +81,16 @@ void setProperty(IPropertyManager &self, const boost::python::object &name,
 }
 
 void setProperties(IPropertyManager &self, const boost::python::dict &kwargs) {
-  const boost::python::list keys = kwargs.keys();
-  const size_t numItems = boost::python::len(keys);
-  for (size_t i = 0; i < numItems; ++i) {
-    const boost::python::object value = kwargs[keys[i]];
-    setProperty(self, keys[i], value);
+#if PY_MAJOR_VERSION >= 3
+  const object view = kwargs.attr("items");
+  const object objectItems = itemIter(handle<>(PyObject_GetIter(view.ptr())));
+#else
+  const object objectItems = kwargs.iteritems();
+#endif
+  auto begin = stl_input_iterator<object>(objectItems);
+  auto end = stl_input_iterator<object>();
+  for (auto it = begin; it != end; ++it) {
+    setProperty(self, (*it)[0], (*it)[1]);
   }
 }
 


### PR DESCRIPTION
Description of work.

This is an improvement to #21359 that more efficiently iterates over a python dict and avoids creating a separate list of keys and searching for the value in each iteration.

It borrows code from [createPropertyManager](https://github.com/mantidproject/mantid/blob/master/Framework/PythonInterface/mantid/kernel/src/Registry/PropertyManagerFactory.cpp), suggesting a refactoring opportunity not in this PR.

**To test:**

<!-- Instructions for testing. -->

There is no GitHub issue associated with this pull request

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
