### PR TITLE
Engineering Diffraction GUI allow runs to be removed from the fitting list

### DIFF
--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.cpp
@@ -32,7 +32,7 @@ bool runMapContains(const int runNumber, const size_t bank,
 }
 
 template <typename T, size_t S>
-const T& getFromRunMap(const int runNumber, const size_t bank,
+const T &getFromRunMap(const int runNumber, const size_t bank,
                        const RunMap<S, T> &map) {
   if (bank < 1 || bank > map.size()) {
     throw std::invalid_argument("Tried to access invalid bank: " +
@@ -70,7 +70,7 @@ void EnggDiffFittingModel::addFitResults(
   addToRunMap(runNumber, bank, m_fitParamsMap, ws);
 }
 
-const std::string&
+const std::string &
 EnggDiffFittingModel::getWorkspaceFilename(const int runNumber,
                                            const size_t bank) const {
   return getFromRunMap(runNumber, bank, m_wsFilenameMap);

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.cpp
@@ -84,7 +84,7 @@ EnggDiffFittingModel::getFitResults(const int runNumber,
 
 namespace {
 
-template<size_t S, typename T>
+template <size_t S, typename T>
 void removeFromRunMapAndADS(const int runNumber, const size_t bank,
                             RunMap<S, T> &map,
                             Mantid::API::AnalysisDataServiceImpl &ADS) {
@@ -99,7 +99,7 @@ void removeFromRunMapAndADS(const int runNumber, const size_t bank,
 
 } // anonymous namespace
 
-void EnggDiffFittingModel::removeRun(const int runNumber, const size_t bank){
+void EnggDiffFittingModel::removeRun(const int runNumber, const size_t bank) {
   m_wsFilenameMap[bank - 1].erase(runNumber);
 
   auto &ADS = Mantid::API::AnalysisDataService::Instance();

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.cpp
@@ -26,13 +26,19 @@ bool isDigit(const std::string &text) {
 }
 
 template <typename T, size_t S>
+bool runMapContains(const int runNumber, const size_t bank,
+                    const RunMap<S, T> &map) {
+  return map[bank - 1].find(runNumber) != map[bank - 1].end();
+}
+
+template <typename T, size_t S>
 T getFromRunMap(const int runNumber, const size_t bank,
-                const RunMap<S, T> map) {
+                const RunMap<S, T> &map) {
   if (bank < 1 || bank > map.size()) {
     throw std::invalid_argument("Tried to access invalid bank: " +
                                 std::to_string(bank));
   }
-  if (map[bank - 1].find(runNumber) == map[bank - 1].end()) {
+  if (!runMapContains(runNumber, bank, map)) {
     throw std::invalid_argument("Tried to access invalid run number " +
                                 std::to_string(runNumber) + " for bank " +
                                 std::to_string(bank));
@@ -76,12 +82,31 @@ EnggDiffFittingModel::getFitResults(const int runNumber,
   return getFromRunMap(runNumber, bank, m_fitParamsMap);
 }
 
+namespace {
+
+template<size_t S, typename T>
+void removeFromRunMapAndADS(const int runNumber, const size_t bank,
+                            RunMap<S, T> &map,
+                            Mantid::API::AnalysisDataServiceImpl &ADS) {
+  if (runMapContains(runNumber, bank, map)) {
+    const auto name = getFromRunMap(runNumber, bank, map)->getName();
+    map[bank - 1].erase(runNumber);
+    if (ADS.doesExist(name)) {
+      ADS.remove(name);
+    }
+  }
+}
+
+} // anonymous namespace
+
 void EnggDiffFittingModel::removeRun(const int runNumber, const size_t bank){
   m_wsFilenameMap[bank - 1].erase(runNumber);
-  m_focusedWorkspaceMap[bank - 1].erase(runNumber);
-  m_fitParamsMap[bank - 1].erase(runNumber);
-  m_fittedPeaksMap[bank - 1].erase(runNumber);
-  m_alignedWorkspaceMap[bank - 1].erase(runNumber);
+
+  auto &ADS = Mantid::API::AnalysisDataService::Instance();
+  removeFromRunMapAndADS(runNumber, bank, m_focusedWorkspaceMap, ADS);
+  removeFromRunMapAndADS(runNumber, bank, m_fittedPeaksMap, ADS);
+  removeFromRunMapAndADS(runNumber, bank, m_alignedWorkspaceMap, ADS);
+  removeFromRunMapAndADS(runNumber, bank, m_fitParamsMap, ADS);
 }
 
 void EnggDiffFittingModel::setDifcTzero(

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.cpp
@@ -76,6 +76,14 @@ EnggDiffFittingModel::getFitResults(const int runNumber,
   return getFromRunMap(runNumber, bank, m_fitParamsMap);
 }
 
+void EnggDiffFittingModel::removeRun(const int runNumber, const size_t bank){
+  m_wsFilenameMap[bank - 1].erase(runNumber);
+  m_focusedWorkspaceMap[bank - 1].erase(runNumber);
+  m_fitParamsMap[bank - 1].erase(runNumber);
+  m_fittedPeaksMap[bank - 1].erase(runNumber);
+  m_alignedWorkspaceMap[bank - 1].erase(runNumber);
+}
+
 void EnggDiffFittingModel::setDifcTzero(
     const int runNumber, const size_t bank,
     const std::vector<GSASCalibrationParms> &calibParams) {

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.cpp
@@ -32,8 +32,8 @@ bool runMapContains(const int runNumber, const size_t bank,
 }
 
 template <typename T, size_t S>
-const T& getFromRunMap(const int runNumber, const size_t bank,
-                       const RunMap<S, T>& map) {
+T getFromRunMap(const int runNumber, const size_t bank,
+                const RunMap<S, T> &map) {
   if (bank < 1 || bank > map.size()) {
     throw std::invalid_argument("Tried to access invalid bank: " +
                                 std::to_string(bank));
@@ -70,13 +70,13 @@ void EnggDiffFittingModel::addFitResults(
   addToRunMap(runNumber, bank, m_fitParamsMap, ws);
 }
 
-const std::string&
+std::string
 EnggDiffFittingModel::getWorkspaceFilename(const int runNumber,
                                            const size_t bank) const {
   return getFromRunMap(runNumber, bank, m_wsFilenameMap);
 }
 
-const Mantid::API::ITableWorkspace_sptr&
+Mantid::API::ITableWorkspace_sptr
 EnggDiffFittingModel::getFitResults(const int runNumber,
                                     const size_t bank) const {
   return getFromRunMap(runNumber, bank, m_fitParamsMap);
@@ -245,13 +245,13 @@ bool EnggDiffFittingModel::hasFittedPeaksForRun(const int runNumber,
          m_fittedPeaksMap[bank - 1].end();
 }
 
-const Mantid::API::MatrixWorkspace_sptr&
+Mantid::API::MatrixWorkspace_sptr
 EnggDiffFittingModel::getAlignedWorkspace(const int runNumber,
                                           const size_t bank) const {
   return getFromRunMap(runNumber, bank, m_alignedWorkspaceMap);
 }
 
-const Mantid::API::MatrixWorkspace_sptr&
+Mantid::API::MatrixWorkspace_sptr
 EnggDiffFittingModel::getFittedPeaksWS(const int runNumber,
                                        const size_t bank) const {
   return getFromRunMap(runNumber, bank, m_fittedPeaksMap);
@@ -429,7 +429,7 @@ void EnggDiffFittingModel::groupWorkspaces(
   groupAlg->execute();
 }
 
-const API::MatrixWorkspace_sptr&
+API::MatrixWorkspace_sptr
 EnggDiffFittingModel::getFocusedWorkspace(const int runNumber,
                                           const size_t bank) const {
   return getFromRunMap(runNumber, bank, m_focusedWorkspaceMap);

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.cpp
@@ -32,8 +32,8 @@ bool runMapContains(const int runNumber, const size_t bank,
 }
 
 template <typename T, size_t S>
-T getFromRunMap(const int runNumber, const size_t bank,
-                const RunMap<S, T> &map) {
+const T& getFromRunMap(const int runNumber, const size_t bank,
+                       const RunMap<S, T> &map) {
   if (bank < 1 || bank > map.size()) {
     throw std::invalid_argument("Tried to access invalid bank: " +
                                 std::to_string(bank));
@@ -70,7 +70,7 @@ void EnggDiffFittingModel::addFitResults(
   addToRunMap(runNumber, bank, m_fitParamsMap, ws);
 }
 
-std::string
+const std::string&
 EnggDiffFittingModel::getWorkspaceFilename(const int runNumber,
                                            const size_t bank) const {
   return getFromRunMap(runNumber, bank, m_wsFilenameMap);
@@ -89,7 +89,7 @@ void removeFromRunMapAndADS(const int runNumber, const size_t bank,
                             RunMap<S, T> &map,
                             Mantid::API::AnalysisDataServiceImpl &ADS) {
   if (runMapContains(runNumber, bank, map)) {
-    const auto name = getFromRunMap(runNumber, bank, map)->getName();
+    const auto &name = getFromRunMap(runNumber, bank, map)->getName();
     map[bank - 1].erase(runNumber);
     if (ADS.doesExist(name)) {
       ADS.remove(name);

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.cpp
@@ -32,8 +32,8 @@ bool runMapContains(const int runNumber, const size_t bank,
 }
 
 template <typename T, size_t S>
-T getFromRunMap(const int runNumber, const size_t bank,
-                const RunMap<S, T> &map) {
+const T& getFromRunMap(const int runNumber, const size_t bank,
+                       const RunMap<S, T>& map) {
   if (bank < 1 || bank > map.size()) {
     throw std::invalid_argument("Tried to access invalid bank: " +
                                 std::to_string(bank));
@@ -70,13 +70,13 @@ void EnggDiffFittingModel::addFitResults(
   addToRunMap(runNumber, bank, m_fitParamsMap, ws);
 }
 
-std::string
+const std::string&
 EnggDiffFittingModel::getWorkspaceFilename(const int runNumber,
                                            const size_t bank) const {
   return getFromRunMap(runNumber, bank, m_wsFilenameMap);
 }
 
-Mantid::API::ITableWorkspace_sptr
+const Mantid::API::ITableWorkspace_sptr&
 EnggDiffFittingModel::getFitResults(const int runNumber,
                                     const size_t bank) const {
   return getFromRunMap(runNumber, bank, m_fitParamsMap);
@@ -245,13 +245,13 @@ bool EnggDiffFittingModel::hasFittedPeaksForRun(const int runNumber,
          m_fittedPeaksMap[bank - 1].end();
 }
 
-Mantid::API::MatrixWorkspace_sptr
+const Mantid::API::MatrixWorkspace_sptr&
 EnggDiffFittingModel::getAlignedWorkspace(const int runNumber,
                                           const size_t bank) const {
   return getFromRunMap(runNumber, bank, m_alignedWorkspaceMap);
 }
 
-Mantid::API::MatrixWorkspace_sptr
+const Mantid::API::MatrixWorkspace_sptr&
 EnggDiffFittingModel::getFittedPeaksWS(const int runNumber,
                                        const size_t bank) const {
   return getFromRunMap(runNumber, bank, m_fittedPeaksMap);
@@ -429,7 +429,7 @@ void EnggDiffFittingModel::groupWorkspaces(
   groupAlg->execute();
 }
 
-API::MatrixWorkspace_sptr
+const API::MatrixWorkspace_sptr&
 EnggDiffFittingModel::getFocusedWorkspace(const int runNumber,
                                           const size_t bank) const {
   return getFromRunMap(runNumber, bank, m_focusedWorkspaceMap);

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.h
@@ -30,8 +30,8 @@ public:
   Mantid::API::ITableWorkspace_sptr
   getFitResults(const int runNumber, const size_t bank) const override;
 
-  std::string getWorkspaceFilename(const int runNumber,
-                                   const size_t bank) const override;
+  const std::string &getWorkspaceFilename(const int runNumber,
+                                          const size_t bank) const override;
 
   void removeRun(const int runNumber, const size_t bank) override;
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.h
@@ -18,20 +18,20 @@ class MANTIDQT_ENGGDIFFRACTION_DLL EnggDiffFittingModel
     : public IEnggDiffFittingModel {
 
 public:
-  Mantid::API::MatrixWorkspace_sptr
+  const Mantid::API::MatrixWorkspace_sptr&
   getFocusedWorkspace(const int runNumber, const size_t bank) const override;
 
-  Mantid::API::MatrixWorkspace_sptr
+  const Mantid::API::MatrixWorkspace_sptr&
   getAlignedWorkspace(const int runNumber, const size_t bank) const override;
 
-  Mantid::API::MatrixWorkspace_sptr
+  const Mantid::API::MatrixWorkspace_sptr&
   getFittedPeaksWS(const int runNumber, const size_t bank) const override;
 
-  Mantid::API::ITableWorkspace_sptr
+  const Mantid::API::ITableWorkspace_sptr&
   getFitResults(const int runNumber, const size_t bank) const override;
 
-  std::string getWorkspaceFilename(const int runNumber,
-                                   const size_t bank) const override;
+  const std::string &getWorkspaceFilename(const int runNumber,
+                                          const size_t bank) const override;
 
   void removeRun(const int runNumber, const size_t bank) override;
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.h
@@ -33,6 +33,8 @@ public:
   std::string getWorkspaceFilename(const int runNumber,
                                    const size_t bank) const override;
 
+  void removeRun(const int runNumber, const size_t bank) override;
+
   void loadWorkspaces(const std::string &filenames) override;
 
   std::vector<std::pair<int, size_t>> getRunNumbersAndBankIDs() const override;

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.h
@@ -18,20 +18,20 @@ class MANTIDQT_ENGGDIFFRACTION_DLL EnggDiffFittingModel
     : public IEnggDiffFittingModel {
 
 public:
-  const Mantid::API::MatrixWorkspace_sptr&
+  Mantid::API::MatrixWorkspace_sptr
   getFocusedWorkspace(const int runNumber, const size_t bank) const override;
 
-  const Mantid::API::MatrixWorkspace_sptr&
+  Mantid::API::MatrixWorkspace_sptr
   getAlignedWorkspace(const int runNumber, const size_t bank) const override;
 
-  const Mantid::API::MatrixWorkspace_sptr&
+  Mantid::API::MatrixWorkspace_sptr
   getFittedPeaksWS(const int runNumber, const size_t bank) const override;
 
-  const Mantid::API::ITableWorkspace_sptr&
+  Mantid::API::ITableWorkspace_sptr
   getFitResults(const int runNumber, const size_t bank) const override;
 
-  const std::string &getWorkspaceFilename(const int runNumber,
-                                          const size_t bank) const override;
+  std::string getWorkspaceFilename(const int runNumber,
+                                   const size_t bank) const override;
 
   void removeRun(const int runNumber, const size_t bank) override;
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -177,6 +177,10 @@ void EnggDiffFittingPresenter::notify(
   case IEnggDiffFittingPresenter::selectRun:
     processSelectRun();
     break;
+
+  case IEnggDiffFittingPresenter::removeRun:
+    processRemoveRun();
+    break;
   }
 }
 
@@ -328,10 +332,7 @@ void EnggDiffFittingPresenter::processLoad() {
                                                               pair.second);
                  });
   m_view->enableFittingListWidget(true);
-  m_view->clearFittingListWidget();
-  std::for_each(
-      listWidgetLabels.begin(), listWidgetLabels.end(),
-      [&](const std::string &listLabel) { m_view->addRunNoItem(listLabel); });
+  m_view->updateFittingListWidget(listWidgetLabels);
 
   m_view->enableFitAllButton(m_model->getNumFocusedWorkspaces() > 1);
 }
@@ -346,6 +347,31 @@ void EnggDiffFittingPresenter::processLogMsg() {
   std::vector<std::string> msgs = m_view->logMsgs();
   for (size_t i = 0; i < msgs.size(); i++) {
     g_log.information() << msgs[i] << '\n';
+  }
+}
+
+void EnggDiffFittingPresenter::processRemoveRun(){
+  const auto workspaceLabel = m_view->getFittingListWidgetCurrentValue();
+
+  if (workspaceLabel) {
+    const auto runBankPair = runAndBankNumberFromListWidgetLabel(*workspaceLabel);
+    const auto bank = runBankPair.first;
+    const auto runNumber = runBankPair.second;
+    m_model->removeRun(bank, runNumber);
+
+    const auto runNoBankPairs = m_model->getRunNumbersAndBankIDs();
+    std::vector<std::string> listWidgetLabels;
+    std::transform(runNoBankPairs.begin(), runNoBankPairs.end(),
+                 std::back_inserter(listWidgetLabels),
+                 [](const std::pair<int, size_t> &pair) {
+                   return listWidgetLabelFromRunAndBankNumber(pair.first,
+                                                              pair.second);
+                 });
+    m_view->updateFittingListWidget(listWidgetLabels);
+  } else {
+    m_view->userWarning("No run selected",
+                        "Tried to remove run but no run was selected.\n"
+                        "Please select a run and try again");
   }
 }
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -350,11 +350,12 @@ void EnggDiffFittingPresenter::processLogMsg() {
   }
 }
 
-void EnggDiffFittingPresenter::processRemoveRun(){
+void EnggDiffFittingPresenter::processRemoveRun() {
   const auto workspaceLabel = m_view->getFittingListWidgetCurrentValue();
 
   if (workspaceLabel) {
-    const auto runBankPair = runAndBankNumberFromListWidgetLabel(*workspaceLabel);
+    const auto runBankPair =
+        runAndBankNumberFromListWidgetLabel(*workspaceLabel);
     const auto bank = runBankPair.first;
     const auto runNumber = runBankPair.second;
     m_model->removeRun(bank, runNumber);
@@ -362,11 +363,11 @@ void EnggDiffFittingPresenter::processRemoveRun(){
     const auto runNoBankPairs = m_model->getRunNumbersAndBankIDs();
     std::vector<std::string> listWidgetLabels;
     std::transform(runNoBankPairs.begin(), runNoBankPairs.end(),
-                 std::back_inserter(listWidgetLabels),
-                 [](const std::pair<int, size_t> &pair) {
-                   return listWidgetLabelFromRunAndBankNumber(pair.first,
-                                                              pair.second);
-                 });
+                   std::back_inserter(listWidgetLabels),
+                   [](const std::pair<int, size_t> &pair) {
+                     return listWidgetLabelFromRunAndBankNumber(pair.first,
+                                                                pair.second);
+                   });
     m_view->updateFittingListWidget(listWidgetLabels);
   } else {
     m_view->userWarning("No run selected",

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.h
@@ -87,6 +87,7 @@ protected:
   void processFitAllPeaks();
   void processShutDown();
   void processLogMsg();
+  void processRemoveRun();
 
   /// clean shut down of model, view, etc.
   void cleanup();

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
@@ -124,6 +124,10 @@ void EnggDiffFittingViewQtWidget::doSetup() {
   // Tool-tip button
   connect(m_ui.pushButton_tooltip, SIGNAL(released()), SLOT(showToolTipHelp()));
 
+  // Remove run button
+  connect(m_ui.pushButton_remove_run, SIGNAL(released()), this,
+          SLOT(removeRunClicked()));
+
   m_ui.dataPlot->setCanvasBackground(Qt::white);
   m_ui.dataPlot->setAxisTitle(QwtPlot::xBottom, "d-Spacing (A)");
   m_ui.dataPlot->setAxisTitle(QwtPlot::yLeft, "Counts (us)^-1");
@@ -243,6 +247,10 @@ void EnggDiffFittingViewQtWidget::listWidget_fitting_run_num_clicked(
     QListWidgetItem *clickedItem) {
   const auto label = clickedItem->text();
   m_presenter->notify(IEnggDiffFittingPresenter::selectRun);
+}
+
+void EnggDiffFittingViewQtWidget::removeRunClicked() {
+  m_presenter->notify(IEnggDiffFittingPresenter::removeRun);
 }
 
 void EnggDiffFittingViewQtWidget::resetFittingMode() {
@@ -475,6 +483,14 @@ EnggDiffFittingViewQtWidget::getFittingListWidgetCurrentValue() const {
 
 bool EnggDiffFittingViewQtWidget::listWidgetHasSelectedRow() const {
   return m_ui.listWidget_fitting_run_num->selectedItems().size() != 0;
+}
+
+void EnggDiffFittingViewQtWidget::updateFittingListWidget(
+  const std::vector<std::string>& rows) {
+  clearFittingListWidget();
+  std::for_each(rows.begin(), rows.end(),
+                [&](const auto &rowLabel) { addRunNoItem(rowLabel); });
+
 }
 
 void EnggDiffFittingViewQtWidget::setFittingListWidgetCurrentRow(

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
@@ -488,9 +488,10 @@ bool EnggDiffFittingViewQtWidget::listWidgetHasSelectedRow() const {
 void EnggDiffFittingViewQtWidget::updateFittingListWidget(
     const std::vector<std::string> &rows) {
   clearFittingListWidget();
-  std::for_each(rows.begin(), rows.end(), [&](const std::string &rowLabel) {
+
+  for (const auto &rowLabel : rows) {
     this->addRunNoItem(rowLabel);
-  });
+  }
 }
 
 void EnggDiffFittingViewQtWidget::setFittingListWidgetCurrentRow(

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
@@ -488,8 +488,9 @@ bool EnggDiffFittingViewQtWidget::listWidgetHasSelectedRow() const {
 void EnggDiffFittingViewQtWidget::updateFittingListWidget(
     const std::vector<std::string> &rows) {
   clearFittingListWidget();
-  std::for_each(rows.begin(), rows.end(),
-                [&](const auto &rowLabel) { this->addRunNoItem(rowLabel); });
+  std::for_each(rows.begin(), rows.end(), [&](const std::string &rowLabel) {
+    this->addRunNoItem(rowLabel);
+  });
 }
 
 void EnggDiffFittingViewQtWidget::setFittingListWidgetCurrentRow(

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
@@ -489,7 +489,7 @@ void EnggDiffFittingViewQtWidget::updateFittingListWidget(
   const std::vector<std::string>& rows) {
   clearFittingListWidget();
   std::for_each(rows.begin(), rows.end(),
-                [&](const auto &rowLabel) { addRunNoItem(rowLabel); });
+                [&](const auto &rowLabel) { this->addRunNoItem(rowLabel); });
 
 }
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
@@ -486,11 +486,10 @@ bool EnggDiffFittingViewQtWidget::listWidgetHasSelectedRow() const {
 }
 
 void EnggDiffFittingViewQtWidget::updateFittingListWidget(
-  const std::vector<std::string>& rows) {
+    const std::vector<std::string> &rows) {
   clearFittingListWidget();
   std::for_each(rows.begin(), rows.end(),
                 [&](const auto &rowLabel) { this->addRunNoItem(rowLabel); });
-
 }
 
 void EnggDiffFittingViewQtWidget::setFittingListWidgetCurrentRow(

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
@@ -106,6 +106,8 @@ public:
 
   bool listWidgetHasSelectedRow() const override;
 
+  void updateFittingListWidget(const std::vector<std::string> &rows) override;
+
   void setFittingListWidgetCurrentRow(int idx) const override;
 
   std::string getExpectedPeaksInput() const override;
@@ -183,6 +185,7 @@ private slots:
   void plotSeparateWindow();
   void showToolTipHelp();
   void listWidget_fitting_run_num_clicked(QListWidgetItem *listWidget);
+  void removeRunClicked();
 
 private:
   /// Setup the interface (tab UI)

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionQtTabFitting.ui
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionQtTabFitting.ui
@@ -274,20 +274,7 @@
         </property>
        </spacer>
       </item>
-      <item row="3" column="2">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>28</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="1" column="2">
+      <item row="1" column="3">
        <widget class="QLabel" name="label_qlist_bank">
         <property name="layoutDirection">
          <enum>Qt::LeftToRight</enum>
@@ -300,7 +287,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="2">
+      <item row="2" column="3">
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <item>
          <widget class="QListWidget" name="listWidget_fitting_run_num">
@@ -315,7 +302,7 @@
           </property>
           <property name="maximumSize">
            <size>
-            <width>60</width>
+            <width>75</width>
             <height>16777215</height>
            </size>
           </property>
@@ -345,7 +332,7 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0" colspan="3">
+      <item row="4" column="0" colspan="4">
        <widget class="QGroupBox" name="groupBox_peak_tools">
         <property name="title">
          <string>Peak Tools</string>
@@ -431,6 +418,13 @@ background-color: rgb(179, 214, 255)</string>
           </layout>
          </item>
         </layout>
+       </widget>
+      </item>
+      <item row="3" column="3">
+       <widget class="QPushButton" name="pushButton_remove_run">
+        <property name="text">
+         <string>Remove Run</string>
+        </property>
        </widget>
       </item>
      </layout>

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffFittingModel.h
@@ -16,20 +16,20 @@ class IEnggDiffFittingModel {
 public:
   virtual ~IEnggDiffFittingModel() = default;
 
-  virtual const Mantid::API::MatrixWorkspace_sptr&
+  virtual Mantid::API::MatrixWorkspace_sptr
   getFocusedWorkspace(const int runNumber, const size_t bank) const = 0;
 
-  virtual const Mantid::API::MatrixWorkspace_sptr&
+  virtual Mantid::API::MatrixWorkspace_sptr
   getAlignedWorkspace(const int runNumber, const size_t bank) const = 0;
 
-  virtual const Mantid::API::MatrixWorkspace_sptr&
+  virtual Mantid::API::MatrixWorkspace_sptr
   getFittedPeaksWS(const int runNumber, const size_t bank) const = 0;
 
-  virtual const Mantid::API::ITableWorkspace_sptr&
+  virtual Mantid::API::ITableWorkspace_sptr
   getFitResults(const int runNumber, const size_t bank) const = 0;
 
-  virtual const std::string& getWorkspaceFilename(const int runNumber,
-                                                  const size_t bank) const = 0;
+  virtual std::string getWorkspaceFilename(const int runNumber,
+                                           const size_t bank) const = 0;
 
   virtual void removeRun(const int runNumber, const size_t bank) = 0;
 

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffFittingModel.h
@@ -28,7 +28,7 @@ public:
   virtual Mantid::API::ITableWorkspace_sptr
   getFitResults(const int runNumber, const size_t bank) const = 0;
 
-  virtual const std::string& getWorkspaceFilename(const int runNumber,
+  virtual const std::string &getWorkspaceFilename(const int runNumber,
                                                   const size_t bank) const = 0;
 
   virtual void removeRun(const int runNumber, const size_t bank) = 0;

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffFittingModel.h
@@ -16,20 +16,20 @@ class IEnggDiffFittingModel {
 public:
   virtual ~IEnggDiffFittingModel() = default;
 
-  virtual Mantid::API::MatrixWorkspace_sptr
+  virtual const Mantid::API::MatrixWorkspace_sptr&
   getFocusedWorkspace(const int runNumber, const size_t bank) const = 0;
 
-  virtual Mantid::API::MatrixWorkspace_sptr
+  virtual const Mantid::API::MatrixWorkspace_sptr&
   getAlignedWorkspace(const int runNumber, const size_t bank) const = 0;
 
-  virtual Mantid::API::MatrixWorkspace_sptr
+  virtual const Mantid::API::MatrixWorkspace_sptr&
   getFittedPeaksWS(const int runNumber, const size_t bank) const = 0;
 
-  virtual Mantid::API::ITableWorkspace_sptr
+  virtual const Mantid::API::ITableWorkspace_sptr&
   getFitResults(const int runNumber, const size_t bank) const = 0;
 
-  virtual std::string getWorkspaceFilename(const int runNumber,
-                                           const size_t bank) const = 0;
+  virtual const std::string& getWorkspaceFilename(const int runNumber,
+                                                  const size_t bank) const = 0;
 
   virtual void removeRun(const int runNumber, const size_t bank) = 0;
 

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffFittingModel.h
@@ -28,8 +28,8 @@ public:
   virtual Mantid::API::ITableWorkspace_sptr
   getFitResults(const int runNumber, const size_t bank) const = 0;
 
-  virtual std::string getWorkspaceFilename(const int runNumber,
-                                           const size_t bank) const = 0;
+  virtual const std::string& getWorkspaceFilename(const int runNumber,
+                                                  const size_t bank) const = 0;
 
   virtual void removeRun(const int runNumber, const size_t bank) = 0;
 

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffFittingModel.h
@@ -31,6 +31,8 @@ public:
   virtual std::string getWorkspaceFilename(const int runNumber,
                                            const size_t bank) const = 0;
 
+  virtual void removeRun(const int runNumber, const size_t bank) = 0;
+
   virtual void loadWorkspaces(const std::string &filenames) = 0;
 
   virtual std::vector<std::pair<int, size_t>>

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffFittingPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffFittingPresenter.h
@@ -52,6 +52,7 @@ public:
     ShutDown,    ///< closing the interface
     LogMsg,      ///< need to send a message to the Mantid log system
     selectRun,   ///< update plot with new run selected from list widget
+    removeRun,   ///< remove a run from the model and the list widget
   };
 
   /**

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffFittingView.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffFittingView.h
@@ -155,6 +155,11 @@ public:
   virtual int getFittingListWidgetCurrentRow() const = 0;
 
   /**
+  * Update the fitting list widget with a list of workspace run and bank numbers
+  */
+  virtual void updateFittingListWidget(const std::vector<std::string> &rows) = 0;
+
+  /**
   * @return The text on the current selected row of the list widget
   */
   virtual boost::optional<std::string>

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffFittingView.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffFittingView.h
@@ -157,7 +157,8 @@ public:
   /**
   * Update the fitting list widget with a list of workspace run and bank numbers
   */
-  virtual void updateFittingListWidget(const std::vector<std::string> &rows) = 0;
+  virtual void
+  updateFittingListWidget(const std::vector<std::string> &rows) = 0;
 
   /**
   * @return The text on the current selected row of the list widget

--- a/qt/scientific_interfaces/test/EnggDiffFittingModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffFittingModelMock.h
@@ -35,7 +35,8 @@ public:
                                                        const size_t bank));
 
   MOCK_CONST_METHOD2(getWorkspaceFilename,
-                     const std::string&(const int runNumber, const size_t bank));
+                     const std::string &(const int runNumber,
+                                         const size_t bank));
 
   MOCK_METHOD1(loadWorkspaces, void(const std::string &filenames));
 

--- a/qt/scientific_interfaces/test/EnggDiffFittingModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffFittingModelMock.h
@@ -35,7 +35,7 @@ public:
                                                        const size_t bank));
 
   MOCK_CONST_METHOD2(getWorkspaceFilename,
-                     std::string(const int runNumber, const size_t bank));
+                     const std::string&(const int runNumber, const size_t bank));
 
   MOCK_METHOD1(loadWorkspaces, void(const std::string &filenames));
 

--- a/qt/scientific_interfaces/test/EnggDiffFittingModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffFittingModelMock.h
@@ -64,6 +64,8 @@ public:
 
   MOCK_CONST_METHOD2(hasFittedPeaksForRun,
                      bool(const int runNumber, const size_t bank));
+
+  MOCK_METHOD2(removeRun, void(const int runNumber, const size_t bank));
 };
 
 GCC_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/EnggDiffFittingModelTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffFittingModelTest.h
@@ -266,7 +266,7 @@ public:
     }
   }
 
-  void test_removeRun(){
+  void test_removeRun() {
     auto model = EnggDiffFittingModelAddWSExposed();
 
     addSampleWorkspaceToModel(123, 1, model);

--- a/qt/scientific_interfaces/test/EnggDiffFittingModelTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffFittingModelTest.h
@@ -266,6 +266,22 @@ public:
     }
   }
 
+  void test_removeRun(){
+    auto model = EnggDiffFittingModelAddWSExposed();
+
+    addSampleWorkspaceToModel(123, 1, model);
+    addSampleWorkspaceToModel(456, 2, model);
+    addSampleWorkspaceToModel(789, 1, model);
+
+    model.removeRun(123, 1);
+
+    const auto runBankPairs = model.getRunNumbersAndBankIDs();
+    TS_ASSERT_EQUALS(runBankPairs.size(), 2);
+
+    TS_ASSERT_EQUALS(runBankPairs[0], RunBankPair(456, 2));
+    TS_ASSERT_EQUALS(runBankPairs[1], RunBankPair(789, 1));
+  }
+
 private:
   const static std::string FOCUSED_WS_FILENAME;
   const static int FOCUSED_WS_RUN_NUMBER;

--- a/qt/scientific_interfaces/test/EnggDiffFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffFittingPresenterTest.h
@@ -575,7 +575,7 @@ public:
         .WillOnce(Return(std::vector<std::pair<int, size_t>>(
             {std::make_pair(123, 2), std::make_pair(456, 1)})));
     EXPECT_CALL(mockView, updateFittingListWidget(
-                            std::vector<std::string>({"123_2", "456_1"})));
+                              std::vector<std::string>({"123_2", "456_1"})));
 
     pres.notify(IEnggDiffFittingPresenter::removeRun);
 

--- a/qt/scientific_interfaces/test/EnggDiffFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffFittingPresenterTest.h
@@ -14,6 +14,7 @@
 using namespace MantidQt::CustomInterfaces;
 using testing::TypedEq;
 using testing::Return;
+using testing::ReturnRef;
 
 // Use this mocked presenter for tests that will start the focusing
 // workers/threads. Otherwise you'll run into trouble with issues like
@@ -196,7 +197,7 @@ public:
             boost::optional<std::string>("123_1"))));
     EXPECT_CALL(*mockModel_ptr, getWorkspaceFilename(testing::_, testing::_))
         .Times(1)
-        .WillOnce(Return(""));
+        .WillOnce(ReturnRef(EMPTY));
 
     EXPECT_CALL(mockView, getExpectedPeaksInput())
         .Times(1)
@@ -239,6 +240,10 @@ public:
         .WillOnce(Return(
             std::vector<std::pair<int, size_t>>({std::make_pair(123, 1)})));
 
+    EXPECT_CALL(*mockModel_ptr, getWorkspaceFilename(123, 1))
+        .Times(1)
+        .WillOnce(ReturnRef(EMPTY));
+
     EXPECT_CALL(mockView, setPeakList(testing::_)).Times(1);
 
     EXPECT_CALL(mockView, enableFitAllButton(testing::_)).Times(0);
@@ -274,6 +279,10 @@ public:
         .Times(1)
         .WillOnce(Return(
             std::vector<std::pair<int, size_t>>({std::make_pair(123, 1)})));
+
+    EXPECT_CALL(*mockModel_ptr, getWorkspaceFilename(123, 1))
+        .Times(1)
+        .WillOnce(ReturnRef(EMPTY));
 
     // should not get to the point where the status is updated
     EXPECT_CALL(mockView, showStatus(testing::_)).Times(0);
@@ -595,6 +604,7 @@ private:
   const static std::string g_focusedRun;
   const static std::string g_focusedBankFile;
   const static std::string g_focusedFittingRunNo;
+  const static std::string EMPTY;
   EnggDiffCalibSettings m_basicCalibSettings;
 
   std::vector<std::string> m_ex_empty_run_num;
@@ -614,5 +624,7 @@ const std::string EnggDiffFittingPresenterTest::g_focusedBankFile =
 
 const std::string EnggDiffFittingPresenterTest::g_focusedFittingRunNo =
     "241391-241394";
+
+const std::string EnggDiffFittingPresenterTest::EMPTY = "";
 
 #endif // MANTID_CUSTOMINTERFACES_ENGGDIFFFITTINGPRESENTERTEST_H

--- a/qt/scientific_interfaces/test/EnggDiffFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffFittingPresenterTest.h
@@ -558,6 +558,33 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
+  void test_removeRun() {
+    testing::NiceMock<MockEnggDiffFittingView> mockView;
+    auto mockModel = Mantid::Kernel::make_unique<
+        testing::NiceMock<MockEnggDiffFittingModel>>();
+    auto *mockModel_ptr = mockModel.get();
+    MantidQt::CustomInterfaces::EnggDiffFittingPresenter pres(
+        &mockView, std::move(mockModel), nullptr, nullptr);
+
+    EXPECT_CALL(mockView, getFittingListWidgetCurrentValue())
+        .Times(1)
+        .WillOnce(Return(boost::optional<std::string>("123_1")));
+    EXPECT_CALL(*mockModel_ptr, removeRun(123, 1));
+    EXPECT_CALL(*mockModel_ptr, getRunNumbersAndBankIDs())
+        .Times(1)
+        .WillOnce(Return(std::vector<std::pair<int, size_t>>(
+            {std::make_pair(123, 2), std::make_pair(456, 1)})));
+    EXPECT_CALL(mockView, updateFittingListWidget(
+                            std::vector<std::string>({"123_2", "456_1"})));
+
+    pres.notify(IEnggDiffFittingPresenter::removeRun);
+
+    TSM_ASSERT(
+        "Mock not used as expected. Some EXPECT_CALL conditions were not "
+        "satisfied.",
+        testing::Mock::VerifyAndClearExpectations(&mockView))
+  }
+
 private:
   std::unique_ptr<testing::NiceMock<MockEnggDiffFittingView>> m_view;
   std::unique_ptr<MantidQt::CustomInterfaces::EnggDiffFittingPresenter>

--- a/qt/scientific_interfaces/test/EnggDiffFittingViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffFittingViewMock.h
@@ -160,7 +160,7 @@ public:
   // virtual void updateFittingListWidget(const std::vector<std::string> &rows)
   // = 0;
   MOCK_METHOD1(updateFittingListWidget,
-	       void(const std::vector<std::string> &rows));
+               void(const std::vector<std::string> &rows));
 };
 
 GCC_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/EnggDiffFittingViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffFittingViewMock.h
@@ -156,6 +156,11 @@ public:
 
   // virtual void setCurrentInstrument(const std::string &newInstrument) = 0;
   MOCK_METHOD1(setCurrentInstrument, void(const std::string &newInstrument));
+
+  // virtual void updateFittingListWidget(const std::vector<std::string> &rows)
+  // = 0;
+  MOCK_METHOD1(updateFittingListWidget,
+	       void(const std::vector<std::string> &rows));
 };
 
 GCC_DIAG_ON_SUGGEST_OVERRIDE


### PR DESCRIPTION
The ability to remove runs from the list widget (and the model) was added to the ED GUI. Users can now discard runs they're not interested in before doing **Fit All**.

**To test:**

Make sure `EnggDiffFittingModelTest` and `EnggDiffFittingPresenterTest` pass locally.

Some sample data is [here](https://github.com/mantidproject/mantid/files/1460806/ENGINX_focused_runs.zip).

Load up the ED GUI and go to the **Fitting** tab.

Load at least 2 of the runs from the attached zip file. Select one, and click **Remove run**. The run should disappear from the list widget, and the corresponding workspace should no longer appear in the workspaces area.

Fixes #21365 

**Release Notes** 
Doesn't need to be in the release notes, as is quite a minor (and obviously necessary) part of the larger work to enable multirun fitting

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
