### PR TITLE
Remove Qwt dependence from VatesAPI library

### DIFF
--- a/qt/paraview_ext/VatesAPI/CMakeLists.txt
+++ b/qt/paraview_ext/VatesAPI/CMakeLists.txt
@@ -190,7 +190,7 @@ set_target_properties( VatesAPI PROPERTIES OUTPUT_NAME MantidVatesAPI )
 set_property( TARGET VatesAPI PROPERTY FOLDER "MantidVates" )
 
 
-target_link_libraries( VatesAPI LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME}
+target_link_libraries( VatesAPI PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME}
 ${MANTID_SUBPROJECT_LIBS}
 vtkCommonCore
 vtkCommonDataModel
@@ -201,7 +201,6 @@ ${vtkjsoncpp_LIBRARIES}
 vtkPVVTKExtensionsDefault
 ${POCO_LIBRARIES}
 ${Boost_LIBRARIES}
-Qwt5
 )
 
 if ( MSVC )
@@ -252,7 +251,6 @@ target_link_libraries( VatesAPITest LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME}
   ${Boost_LIBRARIES}
   ${GMOCK_LIBRARIES}
   ${GTEST_LIBRARIES}
-  Qwt5
   )
 add_dependencies( AllTests VatesAPITest )
 # Add to the 'UnitTests' group in VS

--- a/qt/paraview_ext/VatesAPI/src/MDEWInMemoryLoadingPresenter.cpp
+++ b/qt/paraview_ext/VatesAPI/src/MDEWInMemoryLoadingPresenter.cpp
@@ -5,7 +5,6 @@
 #include "MantidVatesAPI/vtkDataSetFactory.h"
 #include "MantidVatesAPI/WorkspaceProvider.h"
 #include "MantidGeometry/MDGeometry/MDGeometryXMLBuilder.h"
-#include <qwt_double_interval.h>
 #include <vtkUnstructuredGrid.h>
 
 namespace Mantid {

--- a/qt/paraview_ext/VatesAPI/src/MDHWInMemoryLoadingPresenter.cpp
+++ b/qt/paraview_ext/VatesAPI/src/MDHWInMemoryLoadingPresenter.cpp
@@ -8,7 +8,6 @@
 #include "MantidVatesAPI/ProgressAction.h"
 #include "MantidVatesAPI/WorkspaceProvider.h"
 #include "MantidVatesAPI/vtkDataSetFactory.h"
-#include <qwt_double_interval.h>
 
 #include "tbb/tbb.h"
 #include "vtkStructuredGrid.h"

--- a/qt/paraview_ext/VatesAPI/src/MetaDataExtractorUtils.cpp
+++ b/qt/paraview_ext/VatesAPI/src/MetaDataExtractorUtils.cpp
@@ -1,5 +1,4 @@
 #include "MantidVatesAPI/MetaDataExtractorUtils.h"
-#include <qwt_double_interval.h>
 #include "MantidAPI/IMDIterator.h"
 #include "MantidAPI/IMDEventWorkspace.h"
 #include "MantidAPI/IMDHistoWorkspace.h"

--- a/qt/paraview_ext/VatesAPI/src/vtkSplatterPlotFactory.cpp
+++ b/qt/paraview_ext/VatesAPI/src/vtkSplatterPlotFactory.cpp
@@ -34,7 +34,6 @@
 
 #include <algorithm>
 #include <iterator>
-#include <qwt_double_interval.h>
 
 using namespace Mantid::API;
 using namespace Mantid::DataObjects;

--- a/qt/paraview_ext/VatesAPI/test/MetaDataExtractorUtilsTest.h
+++ b/qt/paraview_ext/VatesAPI/test/MetaDataExtractorUtilsTest.h
@@ -14,7 +14,6 @@
 #include <gtest/gtest.h>
 #include "MockObjects.h"
 
-#include <qwt_double_interval.h>
 #include "MantidTestHelpers/MDEventsTestHelper.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/FileFinder.h"


### PR DESCRIPTION
Description of work.

Qwt headers were included but nothing else from Qwt was used in VatesAPI. This removes the dependency.

**To test:**

Code review and the builds passing should be sufficient.

*No issue*

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
