### PR TITLE
Make 'reduce' call python 3 compliant

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/MagnetismReflectometryReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/MagnetismReflectometryReduction.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, print_function)
 import math
 import numpy as np
+import functools
 from mantid.api import *
 from mantid.simpleapi import *
 from mantid.kernel import *
@@ -195,7 +196,7 @@ class MagnetismReflectometryReduction(PythonAlgorithm):
                     # Allow for a file name or file path as input
                     data_file = FileFinder.findRuns(item)[0]
                 file_list.append(data_file)
-            runs = reduce((lambda x, y: '%s+%s' % (x, y)), file_list)
+            runs = functools.reduce((lambda x, y: '%s+%s' % (x, y)), file_list)
             entry_name = self.getProperty("EntryName").value
             ws_event_data = LoadEventNexus(Filename=runs, NXentryName=entry_name,
                                            OutputWorkspace="%s_%s" % (INSTRUMENT_NAME, dataRunNumbers[0]))


### PR DESCRIPTION
A call to reduce() is made in MagnetismReflectometryReduction. Although this works for python 2, we must get reduce() from functools in python 3.

**To test:**
- Inspect code
- Make sure the tests that failed now pass.

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
