### PR TITLE
Fix BASISDiffraction system test on windows

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/BASISDiffraction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISDiffraction.py
@@ -487,10 +487,12 @@ class BASISDiffraction(DataProcessorAlgorithm):
         Create a temporary file and flag for removal upon algorithm completion.
         :return: (str) absolute path to the temporary file.
         """
-        file_object, file_name = \
-            tempfile.mkstemp(prefix='BASISDiffraction_',
-                             suffix='.nxs',
-                             dir=mantid_config['defaultsave.directory'])
+        f = tempfile.NamedTemporaryFile(prefix='BASISDiffraction_',
+                                        suffix='.nxs',
+                                        dir=mantid_config['defaultsave.directory'],
+                                        delete=False)
+        file_name = f.name
+        f.close()
         self._temps.files.append(file_name)  # flag for removal
         return file_name
 


### PR DESCRIPTION
Description of work: windows apparently doesn't like when the created temporary file stays open. Close it right after creation without deleting and keep the name for later use and delete.

**To test:**

Run the system test on windows:

```
systemtest.bat -C Release -R BASISTest.CrystalDiffractionTest
```


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
