### PR TITLE
MPI support for many algorithms as preparation for MPI support in SANS2D reduction

### DIFF
--- a/Framework/API/CMakeLists.txt
+++ b/Framework/API/CMakeLists.txt
@@ -110,6 +110,7 @@ set ( SRC_FILES
 	src/NullCoordTransform.cpp
 	src/NumericAxis.cpp
 	src/NumericAxisValidator.cpp
+	src/ParallelAlgorithm.cpp
 	src/ParamFunction.cpp
 	src/ParameterReference.cpp
 	src/ParameterTie.cpp
@@ -307,6 +308,7 @@ set ( INC_FILES
 	inc/MantidAPI/NullCoordTransform.h
 	inc/MantidAPI/NumericAxis.h
 	inc/MantidAPI/NumericAxisValidator.h
+	inc/MantidAPI/ParallelAlgorithm.h
 	inc/MantidAPI/ParamFunction.h
 	inc/MantidAPI/ParameterReference.h
 	inc/MantidAPI/ParameterTie.h

--- a/Framework/API/CMakeLists.txt
+++ b/Framework/API/CMakeLists.txt
@@ -28,6 +28,7 @@ set ( SRC_FILES
 	src/DataProcessorAlgorithm.cpp
 	src/DeprecatedAlgorithm.cpp
 	src/DetectorSearcher.cpp
+	src/DistributedAlgorithm.cpp
 	src/DomainCreatorFactory.cpp
 	src/EnabledWhenWorkspaceIsType.cpp
 	src/EqualBinSizesValidator.cpp
@@ -112,7 +113,6 @@ set ( SRC_FILES
 	src/ParamFunction.cpp
 	src/ParameterReference.cpp
 	src/ParameterTie.cpp
-	src/ParallelAlgorithm.cpp
 	src/PeakFunctionIntegrator.cpp
 	src/Progress.cpp
 	src/Projection.cpp
@@ -192,6 +192,7 @@ set ( INC_FILES
 	inc/MantidAPI/DeclareUserAlg.h
 	inc/MantidAPI/DeprecatedAlgorithm.h
 	inc/MantidAPI/DetectorSearcher.h
+	inc/MantidAPI/DistributedAlgorithm.h
 	inc/MantidAPI/DllConfig.h
 	inc/MantidAPI/DomainCreatorFactory.h
 	inc/MantidAPI/EnabledWhenWorkspaceIsType.h
@@ -308,7 +309,6 @@ set ( INC_FILES
 	inc/MantidAPI/ParamFunction.h
 	inc/MantidAPI/ParameterReference.h
 	inc/MantidAPI/ParameterTie.h
-	inc/MantidAPI/ParallelAlgorithm.h
 	inc/MantidAPI/PeakFunctionIntegrator.h
 	inc/MantidAPI/Progress.h
 	inc/MantidAPI/Projection.h

--- a/Framework/API/CMakeLists.txt
+++ b/Framework/API/CMakeLists.txt
@@ -129,6 +129,7 @@ set ( SRC_FILES
 	src/ScriptBuilder.cpp
 	src/ScriptRepository.cpp
 	src/ScriptRepositoryFactory.cpp
+	src/SerialAlgorithm.cpp
 	src/SingleCountValidator.cpp
 	src/SpectraAxis.cpp
 	src/SpectraAxisValidator.cpp
@@ -324,6 +325,7 @@ set ( INC_FILES
 	inc/MantidAPI/ScriptBuilder.h
 	inc/MantidAPI/ScriptRepository.h
 	inc/MantidAPI/ScriptRepositoryFactory.h
+	inc/MantidAPI/SerialAlgorithm.h
 	inc/MantidAPI/SingleCountValidator.h
 	inc/MantidAPI/SingleValueParameter.h
 	inc/MantidAPI/SingleValueParameterParser.h

--- a/Framework/API/inc/MantidAPI/DistributedAlgorithm.h
+++ b/Framework/API/inc/MantidAPI/DistributedAlgorithm.h
@@ -1,5 +1,5 @@
-#ifndef MANTID_API_PARALLELALGORITHM_H_
-#define MANTID_API_PARALLELALGORITHM_H_
+#ifndef MANTID_API_DISTRIBUTEDALGORITHM_H_
+#define MANTID_API_DISTRIBUTEDALGORITHM_H_
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/DllConfig.h"
@@ -13,7 +13,7 @@ namespace API {
   propagated from input to output. When a specific algorithm is determined to be
   trivially parallel (this is a manual process), the only required change to add
   MPI support is to inherit from this class instead of Algorithm. Inheriting
-  from ParallelAlgorithm instead of from Algorithm provides the necessary
+  from DistributedAlgorithm instead of from Algorithm provides the necessary
   overriden method(s) to allow running an algorithm with MPI. This works under
   the following conditions:
   1. The algorithm must have a single input and a single output workspace.
@@ -22,7 +22,7 @@ namespace API {
   class to support MPI. For example, modifications of the instrument are handled
   in a identical manner on all MPI ranks, without requiring changes to the
   algorithm, other than setting the correct execution mode via the overloads
-  provided by ParallelAlgorithm.
+  provided by DistributedAlgorithm.
 
   @author Simon Heybrock
   @date 2017
@@ -48,7 +48,7 @@ namespace API {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class MANTID_API_DLL ParallelAlgorithm : public Algorithm {
+class MANTID_API_DLL DistributedAlgorithm : public Algorithm {
 protected:
   Parallel::ExecutionMode getParallelExecutionMode(
       const std::map<std::string, Parallel::StorageMode> &storageModes)
@@ -58,4 +58,4 @@ protected:
 } // namespace API
 } // namespace Mantid
 
-#endif /* MANTID_API_PARALLELALGORITHM_H_ */
+#endif /* MANTID_API_DISTRIBUTEDALGORITHM_H_ */

--- a/Framework/API/inc/MantidAPI/IFileLoader.h
+++ b/Framework/API/inc/MantidAPI/IFileLoader.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_API_IFILELOADER_H_
 #define MANTID_API_IFILELOADER_H_
 
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/ParallelAlgorithm.h"
 #include "MantidKernel/FileDescriptor.h"
 #include "MantidKernel/NexusDescriptor.h"
 
@@ -35,7 +35,7 @@ File change history is stored at: <https://github.com/mantidproject/mantid>
 Code Documentation is available at: <http://doxygen.mantidproject.org>
  */
 template <typename DescriptorType>
-class MANTID_API_DLL IFileLoader : public Algorithm {
+class MANTID_API_DLL IFileLoader : public ParallelAlgorithm {
 public:
   /// Returns a confidence value that this algorithm can load a file
   virtual int confidence(DescriptorType &descriptor) const = 0;

--- a/Framework/API/inc/MantidAPI/ParallelAlgorithm.h
+++ b/Framework/API/inc/MantidAPI/ParallelAlgorithm.h
@@ -1,0 +1,59 @@
+#ifndef MANTID_API_PARALLELALGORITHM_H_
+#define MANTID_API_PARALLELALGORITHM_H_
+
+#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/DllConfig.h"
+
+namespace Mantid {
+namespace API {
+
+/** Base class for algorithms that can run in parallel on all MPI ranks but not
+  in a distributed fashion. A prime example are most `Load` algorithms, which,
+  since they read input data from a file have no automatic way of doing so in a
+  distributed manner. Creating an actual distributed workspace
+  (Parallel::StorageMode::Distributed) would require a manual implementation
+  taking care of setting up a workspace and partitioning it correctly.
+
+  When a specific algorithm is determined to be parallel (this is a manual
+  process), the only required change to add MPI support is to inherit from this
+  class instead of Algorithm. The algorithm will then support
+  Parallel::ExecutionMode::MasterOnly and Parallel::ExecutionMode::Identical,
+  provided that the mode can uniquely be determined from its input workspaces.
+  If there are no inputs it defaults to Parallel::ExecutionMode::Identical.
+
+  @author Simon Heybrock
+  @date 2017
+
+
+  Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class MANTID_API_DLL ParallelAlgorithm : public API::Algorithm {
+protected:
+  Parallel::ExecutionMode getParallelExecutionMode(
+      const std::map<std::string, Parallel::StorageMode> &storageModes)
+      const override;
+};
+
+} // namespace API
+} // namespace Mantid
+
+#endif /* MANTID_API_PARALLELALGORITHM_H_ */

--- a/Framework/API/inc/MantidAPI/SerialAlgorithm.h
+++ b/Framework/API/inc/MantidAPI/SerialAlgorithm.h
@@ -1,0 +1,60 @@
+#ifndef MANTID_API_SERIALALGORITHM_H_
+#define MANTID_API_SERIALALGORITHM_H_
+
+#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/DllConfig.h"
+
+namespace Mantid {
+namespace API {
+
+/** Base class for algorithms that can only run serially
+  (Parallel::ExecutionMode::MasterOnly) in an MPI run. A prime example are most
+  `Save` algorithms, which, since they write to a file, cannot run in parallel
+  (Parallel::ExecutionMode::Identical). By default such an algorithm also cannot
+  run in a distributed manner (Parallel::ExecutionMode::Distributed) since that
+  would require either gathering all data on the master rank or distributed
+  writes to the same file.
+
+  When a specific algorithm is determined to be serial (this is a manual
+  process), the only required change to add "MPI support" is to inherit from
+  this class instead of Algorithm. Inheriting from SerialAlgorithm instead of
+  from Algorithm provides the necessary overriden method(s) to allow running an
+  algorithm with MPI. This works out of the box if the algorithm has no output
+  workspace. If there are output workspaces their storage mode must be set
+  correctly in the algorithm.
+
+  @author Simon Heybrock
+  @date 2017
+
+  Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class MANTID_API_DLL SerialAlgorithm : public API::Algorithm {
+protected:
+  Parallel::ExecutionMode getParallelExecutionMode(
+      const std::map<std::string, Parallel::StorageMode> &storageModes)
+      const override;
+};
+
+} // namespace API
+} // namespace Mantid
+
+#endif /* MANTID_API_SERIALALGORITHM_H_ */

--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -1738,35 +1738,28 @@ void Algorithm::execNonMaster() {
   // If there is no output we can simply do nothing.
   if (m_pureOutputWorkspaceProps.empty())
     return;
-  if (m_pureOutputWorkspaceProps.size() == 1) {
-    // To create an output workspace we need at least one input workspace that
-    // provides the workspace type. Furthermore, all input workspaces must have
-    // the same storage mode since otherwise we have no strategy for propagating
-    // storage mode and workspace types.
-    if (m_inputWorkspaceProps.size() > 0 &&
-        std::all_of(m_inputWorkspaceProps.begin(), m_inputWorkspaceProps.end(),
-                    [](const IWorkspaceProperty *const prop) {
-                      const auto &ws = prop->getWorkspace();
-                      return ws &&
-                             ws->storageMode() ==
-                                 Parallel::StorageMode::MasterOnly;
-                    })) {
-      const auto &ws = m_inputWorkspaceProps.front()->getWorkspace();
-      const auto &wsProp = m_pureOutputWorkspaceProps.front();
-      // This is the reverse cast of what is done in
-      // cacheWorkspaceProperties(), so it should never fail.
-      const Property &prop = dynamic_cast<Property &>(*wsProp);
-      auto clone = ws->cloneEmpty();
-      // Currently we have not implemented a proper cloneEmpty() for all
-      // workspace types, in particular the abundance of Workspace2D subtypes,
-      // so we do a safety check here.
-      if (ws->storageMode() != clone->storageMode())
-        throw std::runtime_error(clone->id() +
-                                 "::cloneEmpty() did not return a workspace "
-                                 "with the correct storage mode. Make sure "
-                                 "cloneEmpty() sets the storage mode.");
-      setProperty(prop.name(), std::move(clone));
-      return;
+  // Does Algorithm have exactly one input and one output workspace property?
+  if (m_inputWorkspaceProps.size() == 1 &&
+      m_pureOutputWorkspaceProps.size() == 1) {
+    // Does the input workspace property point to an actual workspace?
+    if (const auto &ws = m_inputWorkspaceProps.front()->getWorkspace()) {
+      if (ws->storageMode() == Parallel::StorageMode::MasterOnly) {
+        const auto &wsProp = m_pureOutputWorkspaceProps.front();
+        // This is the reverse cast of what is done in
+        // cacheWorkspaceProperties(), so it should never fail.
+        const Property &prop = dynamic_cast<Property &>(*wsProp);
+        auto clone = ws->cloneEmpty();
+        // Currently we have not implemented a proper cloneEmpty() for all
+        // workspace types, in particular the abundance of Workspace2D subtypes,
+        // so we do a safety check here.
+        if (ws->storageMode() != clone->storageMode())
+          throw std::runtime_error(clone->id() +
+                                   "::cloneEmpty() did not return a workspace "
+                                   "with the correct storage mode. Make sure "
+                                   "cloneEmpty() sets the storage mode.");
+        setProperty(prop.name(), std::move(clone));
+        return;
+      }
     }
   }
   throw std::runtime_error(

--- a/Framework/API/src/DistributedAlgorithm.cpp
+++ b/Framework/API/src/DistributedAlgorithm.cpp
@@ -1,9 +1,9 @@
-#include "MantidAPI/ParallelAlgorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 
 namespace Mantid {
 namespace API {
 
-Parallel::ExecutionMode ParallelAlgorithm::getParallelExecutionMode(
+Parallel::ExecutionMode DistributedAlgorithm::getParallelExecutionMode(
     const std::map<std::string, Parallel::StorageMode> &storageModes) const {
   return Parallel::getCorrespondingExecutionMode(storageModes.begin()->second);
 }

--- a/Framework/API/src/ParallelAlgorithm.cpp
+++ b/Framework/API/src/ParallelAlgorithm.cpp
@@ -1,0 +1,29 @@
+#include "MantidAPI/ParallelAlgorithm.h"
+
+#include <algorithm>
+
+namespace Mantid {
+namespace API {
+
+Parallel::ExecutionMode ParallelAlgorithm::getParallelExecutionMode(
+    const std::map<std::string, Parallel::StorageMode> &storageModes) const {
+  using namespace Parallel;
+  // Match all cloned or empty.
+  if (std::all_of(
+          storageModes.begin(), storageModes.end(),
+          [](const std::pair<std::string, Parallel::StorageMode> &item) {
+            return item.second == StorageMode::Cloned;
+          }))
+    return getCorrespondingExecutionMode(StorageMode::Cloned);
+  // Match all master-only (empty handled earlier).
+  if (std::all_of(
+          storageModes.begin(), storageModes.end(),
+          [](const std::pair<std::string, Parallel::StorageMode> &item) {
+            return item.second == StorageMode::MasterOnly;
+          }))
+    return getCorrespondingExecutionMode(StorageMode::MasterOnly);
+  return ExecutionMode::Invalid;
+}
+
+} // namespace API
+} // namespace Mantid

--- a/Framework/API/src/SerialAlgorithm.cpp
+++ b/Framework/API/src/SerialAlgorithm.cpp
@@ -1,0 +1,17 @@
+#include "MantidAPI/SerialAlgorithm.h"
+
+namespace Mantid {
+namespace API {
+
+Parallel::ExecutionMode SerialAlgorithm::getParallelExecutionMode(
+    const std::map<std::string, Parallel::StorageMode> &storageModes) const {
+  using namespace Parallel;
+  for (const auto &item : storageModes)
+    if (item.second != StorageMode::MasterOnly)
+      throw std::runtime_error(item.first + " must have " +
+                               Parallel::toString(StorageMode::MasterOnly));
+  return getCorrespondingExecutionMode(StorageMode::MasterOnly);
+}
+
+} // namespace API
+} // namespace Mantid

--- a/Framework/API/test/AlgorithmMPITest.h
+++ b/Framework/API/test/AlgorithmMPITest.h
@@ -370,7 +370,7 @@ void runNTo0(const Parallel::Communicator &comm) {
   }
 }
 
-void runNTo1StorageModeFailure(const Parallel::Communicator &comm) {
+void runNTo1StorageMode(const Parallel::Communicator &comm) {
   for (auto storageMode :
        {Parallel::StorageMode::Cloned, Parallel::StorageMode::Distributed,
         Parallel::StorageMode::MasterOnly}) {
@@ -386,6 +386,34 @@ void runNTo1StorageModeFailure(const Parallel::Communicator &comm) {
       alg->setProperty("InputWorkspace1", in1->cloneEmpty());
       alg->setProperty("InputWorkspace2", in2->cloneEmpty());
     }
+    TS_ASSERT_THROWS_NOTHING(alg->execute());
+    TS_ASSERT(alg->isExecuted());
+    Workspace_const_sptr out = alg->getProperty("OutputWorkspace");
+    // Preserving storage mode is actually not guaranteed, but this
+    // implementation does of FakeAlgNTo1StorageModeFailure does.
+    // For the dummy workspace on non-master ranks it is guarenteed by the
+    // current implementation of Algorithm::execNonMaster.
+    TS_ASSERT_EQUALS(out->storageMode(), storageMode);
+    TS_ASSERT_EQUALS(out->id(), "FakeWorkspaceA");
+  }
+}
+
+void runNTo1StorageModeFailure(const Parallel::Communicator &comm) {
+  for (auto storageMode :
+       {Parallel::StorageMode::Cloned, Parallel::StorageMode::Distributed,
+        Parallel::StorageMode::MasterOnly}) {
+    auto in1 = boost::make_shared<FakeWorkspaceA>(storageMode);
+    auto in2 =
+        boost::make_shared<FakeWorkspaceB>(Parallel::StorageMode::Cloned);
+    in1->initialize(1, 2, 1);
+    in2->initialize(1, 2, 1);
+    auto alg = create<FakeAlgNTo1StorageModeFailure>(comm);
+    if (storageMode != Parallel::StorageMode::MasterOnly || comm.rank() == 0) {
+      alg->setProperty("InputWorkspace1", in1);
+    } else {
+      alg->setProperty("InputWorkspace1", in1->cloneEmpty());
+    }
+    alg->setProperty("InputWorkspace2", in2);
     if (storageMode != Parallel::StorageMode::MasterOnly || comm.rank() == 0) {
       TS_ASSERT_THROWS_NOTHING(alg->execute());
       TS_ASSERT(alg->isExecuted());
@@ -395,6 +423,8 @@ void runNTo1StorageModeFailure(const Parallel::Communicator &comm) {
       TS_ASSERT_EQUALS(out->storageMode(), storageMode);
       TS_ASSERT_EQUALS(out->id(), "FakeWorkspaceA");
     } else {
+      // Storage mode of inputs is mixed so an automatic setup of the ouput
+      // storage mode is not possible in MasterOnly execution.
       TS_ASSERT_THROWS_EQUALS(
           alg->execute(), const std::runtime_error &e, std::string(e.what()),
           "Attempt to run algorithm with Parallel::ExecutionMode::MasterOnly: "
@@ -492,6 +522,8 @@ public:
   void test1To1() { runParallel(run1To1); }
 
   void testNTo0() { runParallel(runNTo0); }
+
+  void testNTo1StorageMode() { runParallel(runNTo1StorageMode); }
 
   void testNTo1StorageModeFailure() { runParallel(runNTo1StorageModeFailure); }
 

--- a/Framework/Algorithms/inc/MantidAlgorithms/BinaryOperation.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/BinaryOperation.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_ALGORITHMS_BINARYOPERATION_H_
 #define MANTID_ALGORITHMS_BINARYOPERATION_H_
 
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/ParallelAlgorithm.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/WorkspaceGroup_fwd.h"
@@ -53,13 +53,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 File change history is stored at: <https://github.com/mantidproject/mantid>
 */
-class DLLExport BinaryOperation : public API::Algorithm {
+class DLLExport BinaryOperation : public API::ParallelAlgorithm {
 public:
-  /// Default constructor
-  BinaryOperation();
-  /// Destructor
-  ~BinaryOperation() override;
-
   /// Algorithm's category for identification overriding a virtual method
   const std::string category() const override { return "Arithmetic"; }
 
@@ -241,36 +236,36 @@ protected:
   DataObjects::EventWorkspace_sptr m_eout;
 
   /// The property value
-  bool m_AllowDifferentNumberSpectra;
+  bool m_AllowDifferentNumberSpectra{false};
   /// Flag to clear RHS workspace in binary operation
-  bool m_ClearRHSWorkspace;
+  bool m_ClearRHSWorkspace{false};
 
   //------ Requirements -----------
 
   /// matchXSize set to true if the X sizes of histograms must match.
-  bool m_matchXSize;
+  bool m_matchXSize{false};
 
   /// flipSides set to true if the rhs and lhs operands should be flipped - for
   /// commutative binary operations, normally.
-  bool m_flipSides;
+  bool m_flipSides{false};
 
   /// Variable set to true if the operation allows the output to stay as an
   /// EventWorkspace. If this returns false, any EventWorkspace will be
   /// converted to Workspace2D. This is ignored if the lhs operand is not an
   /// EventWorkspace.
-  bool m_keepEventWorkspace;
+  bool m_keepEventWorkspace{false};
 
   /** Are we going to use the histogram representation of the RHS event list
    * when performing the operation?
    * e.g. divide and multiply? Plus and Minus will set this to false (default).
    */
-  bool m_useHistogramForRhsEventWorkspace;
+  bool m_useHistogramForRhsEventWorkspace{false};
 
   /** Special case for plus/minus: if there is only one bin on the RHS, use the
    * 2D method (appending event lists)
    * so that the single bin is not treated as a scalar
    */
-  bool m_do2D_even_for_SingleColumn_on_rhs;
+  bool m_do2D_even_for_SingleColumn_on_rhs{false};
 
 private:
   void doSingleValue();

--- a/Framework/Algorithms/inc/MantidAlgorithms/BinaryOperation.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/BinaryOperation.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_ALGORITHMS_BINARYOPERATION_H_
 #define MANTID_ALGORITHMS_BINARYOPERATION_H_
 
-#include "MantidAPI/ParallelAlgorithm.h"
+#include "MantidAPI/Algorithm.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/WorkspaceGroup_fwd.h"
@@ -53,7 +53,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 File change history is stored at: <https://github.com/mantidproject/mantid>
 */
-class DLLExport BinaryOperation : public API::ParallelAlgorithm {
+class DLLExport BinaryOperation : public API::Algorithm {
 public:
   /// Algorithm's category for identification overriding a virtual method
   const std::string category() const override { return "Arithmetic"; }
@@ -71,6 +71,10 @@ public:
                             const API::MatrixWorkspace_const_sptr &rhs);
 
 protected:
+  Parallel::ExecutionMode getParallelExecutionMode(
+      const std::map<std::string, Parallel::StorageMode> &storageModes)
+      const override;
+
   // Overridden Algorithm methods
   void exec() override;
   void init() override;

--- a/Framework/Algorithms/inc/MantidAlgorithms/BinaryOperation.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/BinaryOperation.h
@@ -74,6 +74,7 @@ protected:
   Parallel::ExecutionMode getParallelExecutionMode(
       const std::map<std::string, Parallel::StorageMode> &storageModes)
       const override;
+  void execNonMaster() override;
 
   // Overridden Algorithm methods
   void exec() override;

--- a/Framework/Algorithms/inc/MantidAlgorithms/CalculateFlatBackground.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CalculateFlatBackground.h
@@ -1,10 +1,7 @@
 #ifndef MANTID_ALGORITHMS_CALCULATEFLATBACKGROUND_H_
 #define MANTID_ALGORITHMS_CALCULATEFLATBACKGROUND_H_
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/ParallelAlgorithm.h"
 
 namespace Mantid {
 namespace HistogramData {
@@ -53,13 +50,8 @@ namespace Algorithms {
     File change history is stored at: <https://github.com/mantidproject/mantid>
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport CalculateFlatBackground : public API::Algorithm {
+class DLLExport CalculateFlatBackground : public API::ParallelAlgorithm {
 public:
-  /// (Empty) Constructor
-  CalculateFlatBackground() : API::Algorithm() {}
-  /// Virtual destructor
-  ~CalculateFlatBackground() = default;
-
   /// Algorithm's name
   const std::string name() const override { return "CalculateFlatBackground"; }
   /// Summary of algorithms purpose

--- a/Framework/Algorithms/inc/MantidAlgorithms/CalculateTransmission.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CalculateTransmission.h
@@ -1,10 +1,7 @@
 #ifndef MANTID_ALGORITHMS_CALCULATETRANSMISSION_H_
 #define MANTID_ALGORITHMS_CALCULATETRANSMISSION_H_
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/ParallelAlgorithm.h"
 #include "MantidKernel/System.h"
 
 namespace Mantid {
@@ -66,7 +63,7 @@ namespace Algorithms {
     File change history is stored at: <https://github.com/mantidproject/mantid>
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport CalculateTransmission : public API::Algorithm {
+class DLLExport CalculateTransmission : public API::ParallelAlgorithm {
 public:
   /// Algorithm's name
   const std::string name() const override { return "CalculateTransmission"; }

--- a/Framework/Algorithms/inc/MantidAlgorithms/CloneWorkspace.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CloneWorkspace.h
@@ -1,10 +1,7 @@
 #ifndef MANTID_ALGORITHMS_CLONEWORKSPACE_H_
 #define MANTID_ALGORITHMS_CLONEWORKSPACE_H_
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/ParallelAlgorithm.h"
 
 namespace Mantid {
 namespace Algorithms {
@@ -43,7 +40,7 @@ namespace Algorithms {
     File change history is stored at: <https://github.com/mantidproject/mantid>
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport CloneWorkspace : public API::Algorithm {
+class DLLExport CloneWorkspace : public API::ParallelAlgorithm {
 public:
   /// Algorithm's name
   const std::string name() const override { return "CloneWorkspace"; }

--- a/Framework/Algorithms/inc/MantidAlgorithms/CloneWorkspace.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CloneWorkspace.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_ALGORITHMS_CLONEWORKSPACE_H_
 #define MANTID_ALGORITHMS_CLONEWORKSPACE_H_
 
-#include "MantidAPI/ParallelAlgorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 
 namespace Mantid {
 namespace Algorithms {
@@ -40,7 +40,7 @@ namespace Algorithms {
     File change history is stored at: <https://github.com/mantidproject/mantid>
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport CloneWorkspace : public API::ParallelAlgorithm {
+class DLLExport CloneWorkspace : public API::DistributedAlgorithm {
 public:
   /// Algorithm's name
   const std::string name() const override { return "CloneWorkspace"; }

--- a/Framework/Algorithms/inc/MantidAlgorithms/CompareWorkspaces.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CompareWorkspaces.h
@@ -71,10 +71,6 @@ namespace Algorithms {
  */
 class DLLExport CompareWorkspaces : public API::Algorithm {
 public:
-  CompareWorkspaces()
-      : API::Algorithm(), m_result(false), m_parallelComparison(true) {}
-  ~CompareWorkspaces() override {}
-
   /// Algorithm's name
   const std::string name() const override { return "CompareWorkspaces"; }
 
@@ -90,6 +86,11 @@ public:
            "intended for use by the Mantid development team as part of the "
            "testing process.";
   }
+
+protected:
+  Parallel::ExecutionMode getParallelExecutionMode(
+      const std::map<std::string, Parallel::StorageMode> &storageModes)
+      const override;
 
 private:
   /// Initialise algorithm
@@ -143,7 +144,7 @@ private:
   bool relErr(double x1, double x2, double errorVal) const;
 
   /// Result of comparison (true if equal, false otherwise)
-  bool m_result;
+  bool m_result{false};
 
   /// Mismatch messages that resulted from comparison
   API::ITableWorkspace_sptr m_messages;
@@ -156,7 +157,7 @@ private:
   /// comparison make things complicated as
   /// logs from different threads are mixed together.  In this case, it is
   /// better not to do parallell comparison.
-  bool m_parallelComparison;
+  bool m_parallelComparison{false};
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/ConvertUnits.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ConvertUnits.h
@@ -138,7 +138,7 @@ protected:
   std::size_t m_numberOfSpectra{
       0};                     ///< The number of spectra in the input workspace
   bool m_distribution{false}; ///< Whether input is a distribution. Only applies
-                              ///to histogram workspaces.
+  /// to histogram workspaces.
   bool m_inputEvents{
       false}; ///< Flag indicating whether input workspace is an EventWorkspace
   Kernel::Unit_const_sptr m_inputUnit; ///< The unit of the input workspace

--- a/Framework/Algorithms/inc/MantidAlgorithms/ConvertUnits.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ConvertUnits.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_ALGORITHMS_CONVERTUNITS_H_
 #define MANTID_ALGORITHMS_CONVERTUNITS_H_
 
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidKernel/Unit.h"
 
@@ -64,10 +64,8 @@ namespace Algorithms {
     File change history is stored at: <https://github.com/mantidproject/mantid>
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport ConvertUnits : public API::Algorithm {
+class DLLExport ConvertUnits : public API::DistributedAlgorithm {
 public:
-  /// Default constructor
-  ConvertUnits();
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "ConvertUnits"; }
   /// Summary of algorithms purpose
@@ -137,12 +135,12 @@ protected:
 
   void putBackBinWidth(const API::MatrixWorkspace_sptr outputWS);
 
-  std::size_t
-      m_numberOfSpectra; ///< The number of spectra in the input workspace
-  bool m_distribution;   ///< Whether input is a distribution. Only applies to
-  /// histogram workspaces.
-  bool m_inputEvents; ///< Flag indicating whether input workspace is an
-  /// EventWorkspace
+  std::size_t m_numberOfSpectra{
+      0};                     ///< The number of spectra in the input workspace
+  bool m_distribution{false}; ///< Whether input is a distribution. Only applies
+                              ///to histogram workspaces.
+  bool m_inputEvents{
+      false}; ///< Flag indicating whether input workspace is an EventWorkspace
   Kernel::Unit_const_sptr m_inputUnit; ///< The unit of the input workspace
   Kernel::Unit_sptr m_outputUnit;      ///< The unit we're going to
 };

--- a/Framework/Algorithms/inc/MantidAlgorithms/CreateSingleValuedWorkspace.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CreateSingleValuedWorkspace.h
@@ -1,13 +1,9 @@
 #ifndef ALGORITHMSCREATESINGLEVALUEDWORKSPACE_H_
 #define ALGORITHMSCREATESINGLEVALUEDWORKSPACE_H_
 
-//------------------------------
-// Includes
-//------------------------------
 #include "MantidAPI/Algorithm.h"
 
 namespace Mantid {
-
 namespace Algorithms {
 /**
    Required properties:
@@ -59,6 +55,11 @@ public:
   int version() const override { return (1); }
   /// Algorithm's category for identification
   const std::string category() const override { return "Utility\\Workspaces"; }
+
+protected:
+  Parallel::ExecutionMode getParallelExecutionMode(
+      const std::map<std::string, Parallel::StorageMode> &storageModes)
+      const override;
 
 private:
   /// Initialisation code

--- a/Framework/Algorithms/inc/MantidAlgorithms/CropToComponent.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CropToComponent.h
@@ -1,8 +1,9 @@
 #ifndef MANTID_ALGORITHMS_CROPTOCOMPONENT_H_
 #define MANTID_ALGORITHMS_CROPTOCOMPONENT_H_
 
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/ParallelAlgorithm.h"
 #include "MantidAlgorithms/DllConfig.h"
+
 namespace Mantid {
 namespace Algorithms {
 
@@ -29,7 +30,8 @@ namespace Algorithms {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class MANTID_ALGORITHMS_DLL CropToComponent final : public API::Algorithm {
+class MANTID_ALGORITHMS_DLL CropToComponent final
+    : public API::ParallelAlgorithm {
 public:
   const std::string name() const override final;
   int version() const override final;

--- a/Framework/Algorithms/inc/MantidAlgorithms/CropToComponent.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CropToComponent.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_ALGORITHMS_CROPTOCOMPONENT_H_
 #define MANTID_ALGORITHMS_CROPTOCOMPONENT_H_
 
-#include "MantidAPI/ParallelAlgorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 #include "MantidAlgorithms/DllConfig.h"
 
 namespace Mantid {
@@ -31,7 +31,7 @@ namespace Algorithms {
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
 class MANTID_ALGORITHMS_DLL CropToComponent final
-    : public API::ParallelAlgorithm {
+    : public API::DistributedAlgorithm {
 public:
   const std::string name() const override final;
   int version() const override final;

--- a/Framework/Algorithms/inc/MantidAlgorithms/CropWorkspace.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CropWorkspace.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_ALGORITHMS_CROPWORKSPACE_H_
 #define MANTID_ALGORITHMS_CROPWORKSPACE_H_
 
-#include "MantidAPI/ParallelAlgorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 
 namespace Mantid {
 namespace Algorithms {
@@ -63,7 +63,7 @@ namespace Algorithms {
     File change history is stored at: <https://github.com/mantidproject/mantid>
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport CropWorkspace : public API::ParallelAlgorithm {
+class DLLExport CropWorkspace : public API::DistributedAlgorithm {
 public:
   /// Algorithm's name
   const std::string name() const override { return "CropWorkspace"; }

--- a/Framework/Algorithms/inc/MantidAlgorithms/ExtractMask.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ExtractMask.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_ALGORITHMS_EXTRACTMASK_H_
 #define MANTID_ALGORITHMS_EXTRACTMASK_H_
 
-#include "MantidAPI/ParallelAlgorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 
 namespace Mantid {
 namespace Algorithms {
@@ -44,7 +44,7 @@ namespace Algorithms {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport ExtractMask : public Mantid::API::ParallelAlgorithm {
+class DLLExport ExtractMask : public Mantid::API::DistributedAlgorithm {
 public:
   /// Algorithm's name
   const std::string name() const override { return "ExtractMask"; }

--- a/Framework/Algorithms/inc/MantidAlgorithms/ExtractMask.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ExtractMask.h
@@ -1,10 +1,7 @@
 #ifndef MANTID_ALGORITHMS_EXTRACTMASK_H_
 #define MANTID_ALGORITHMS_EXTRACTMASK_H_
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/ParallelAlgorithm.h"
 
 namespace Mantid {
 namespace Algorithms {
@@ -47,7 +44,7 @@ namespace Algorithms {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport ExtractMask : public Mantid::API::Algorithm {
+class DLLExport ExtractMask : public Mantid::API::ParallelAlgorithm {
 public:
   /// Algorithm's name
   const std::string name() const override { return "ExtractMask"; }

--- a/Framework/Algorithms/inc/MantidAlgorithms/ExtractSingleSpectrum.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ExtractSingleSpectrum.h
@@ -1,10 +1,7 @@
 #ifndef MANTID_ALGORITHMS_EXTRACTSINGLESPECTRUM_H_
 #define MANTID_ALGORITHMS_EXTRACTSINGLESPECTRUM_H_
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/ParallelAlgorithm.h"
 
 namespace Mantid {
 namespace Algorithms {
@@ -43,7 +40,7 @@ namespace Algorithms {
     File change history is stored at: <https://github.com/mantidproject/mantid>
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport ExtractSingleSpectrum : public API::Algorithm {
+class DLLExport ExtractSingleSpectrum : public API::ParallelAlgorithm {
 public:
   /// Algorithm's name
   const std::string name() const override { return "ExtractSingleSpectrum"; }

--- a/Framework/Algorithms/inc/MantidAlgorithms/ExtractSingleSpectrum.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ExtractSingleSpectrum.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_ALGORITHMS_EXTRACTSINGLESPECTRUM_H_
 #define MANTID_ALGORITHMS_EXTRACTSINGLESPECTRUM_H_
 
-#include "MantidAPI/ParallelAlgorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 
 namespace Mantid {
 namespace Algorithms {
@@ -40,7 +40,7 @@ namespace Algorithms {
     File change history is stored at: <https://github.com/mantidproject/mantid>
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport ExtractSingleSpectrum : public API::ParallelAlgorithm {
+class DLLExport ExtractSingleSpectrum : public API::DistributedAlgorithm {
 public:
   /// Algorithm's name
   const std::string name() const override { return "ExtractSingleSpectrum"; }

--- a/Framework/Algorithms/inc/MantidAlgorithms/ExtractSpectra.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ExtractSpectra.h
@@ -2,7 +2,7 @@
 #define MANTID_ALGORITHMS_EXTRACTSPECTRA_H_
 
 #include "MantidKernel/System.h"
-#include "MantidAPI/ParallelAlgorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 #include "MantidDataObjects/EventWorkspace.h"
 
 namespace Mantid {
@@ -33,7 +33,7 @@ namespace Algorithms {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport ExtractSpectra : public API::ParallelAlgorithm {
+class DLLExport ExtractSpectra : public API::DistributedAlgorithm {
 public:
   const std::string name() const override;
   int version() const override;

--- a/Framework/Algorithms/inc/MantidAlgorithms/ExtractSpectra2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ExtractSpectra2.h
@@ -2,7 +2,7 @@
 #define MANTID_ALGORITHMS_EXTRACTSPECTRA2_H_
 
 #include "MantidAlgorithms/DllConfig.h"
-#include "MantidAPI/ParallelAlgorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 
 namespace Mantid {
 namespace Algorithms {
@@ -35,7 +35,7 @@ namespace Algorithms {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class MANTID_ALGORITHMS_DLL ExtractSpectra2 : public API::ParallelAlgorithm {
+class MANTID_ALGORITHMS_DLL ExtractSpectra2 : public API::DistributedAlgorithm {
 public:
   const std::string name() const override;
   int version() const override;

--- a/Framework/Algorithms/inc/MantidAlgorithms/FilterBadPulses.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FilterBadPulses.h
@@ -2,7 +2,7 @@
 #define MANTID_ALGORITHMS_FILTERBADPULSES_H_
 
 #include "MantidKernel/System.h"
-#include "MantidAPI/ParallelAlgorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 #include "MantidDataObjects/EventWorkspace.h"
 
 namespace Mantid {
@@ -46,7 +46,7 @@ namespace Algorithms {
     File change history is stored at: <https://github.com/mantidproject/mantid>.
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport FilterBadPulses : public API::ParallelAlgorithm {
+class DLLExport FilterBadPulses : public API::DistributedAlgorithm {
 public:
   const std::string name() const override;
   /// Summary of algorithms purpose

--- a/Framework/Algorithms/inc/MantidAlgorithms/FilterByLogValue.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FilterByLogValue.h
@@ -2,7 +2,7 @@
 #define MANTID_ALGORITHMS_FILTERBYLOGVALUE_H_
 
 #include "MantidKernel/System.h"
-#include "MantidAPI/ParallelAlgorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 #include "MantidDataObjects/EventWorkspace.h"
 
 namespace Mantid {
@@ -30,7 +30,7 @@ namespace Algorithms {
     File change history is stored at: <https://github.com/mantidproject/mantid>.
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport FilterByLogValue : public API::ParallelAlgorithm {
+class DLLExport FilterByLogValue : public API::DistributedAlgorithm {
 public:
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "FilterByLogValue"; };

--- a/Framework/Algorithms/inc/MantidAlgorithms/FilterByTime.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FilterByTime.h
@@ -2,7 +2,7 @@
 #define MANTID_ALGORITHMS_FILTERBYTIME_H_
 
 #include "MantidKernel/System.h"
-#include "MantidAPI/ParallelAlgorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 #include "MantidDataObjects/EventWorkspace.h"
 
 namespace Mantid {
@@ -37,7 +37,7 @@ namespace Algorithms {
     File change history is stored at: <https://github.com/mantidproject/mantid>.
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport FilterByTime : public API::ParallelAlgorithm {
+class DLLExport FilterByTime : public API::DistributedAlgorithm {
 public:
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "FilterByTime"; };

--- a/Framework/Algorithms/inc/MantidAlgorithms/FilterByTime.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FilterByTime.h
@@ -1,11 +1,8 @@
 #ifndef MANTID_ALGORITHMS_FILTERBYTIME_H_
 #define MANTID_ALGORITHMS_FILTERBYTIME_H_
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
 #include "MantidKernel/System.h"
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/ParallelAlgorithm.h"
 #include "MantidDataObjects/EventWorkspace.h"
 
 namespace Mantid {
@@ -40,7 +37,7 @@ namespace Algorithms {
     File change history is stored at: <https://github.com/mantidproject/mantid>.
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport FilterByTime : public API::Algorithm {
+class DLLExport FilterByTime : public API::ParallelAlgorithm {
 public:
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "FilterByTime"; };

--- a/Framework/Algorithms/inc/MantidAlgorithms/GroupWorkspaces.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/GroupWorkspaces.h
@@ -1,10 +1,7 @@
 #ifndef MANTID_ALGORITHM_GROUP_H_
 #define MANTID_ALGORITHM_GROUP_H_
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidAPI/WorkspaceProperty.h"
 #include "MantidAPI/WorkspaceGroup_fwd.h"
@@ -41,10 +38,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 File change history is stored at: <https://github.com/mantidproject/mantid>
 Code Documentation is available at: <http://doxygen.mantidproject.org>
  */
-class DLLExport GroupWorkspaces : public API::Algorithm {
+class DLLExport GroupWorkspaces : public API::DistributedAlgorithm {
 public:
-  /// Default constructor
-  GroupWorkspaces();
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "GroupWorkspaces"; }
   /// Summary of algorithms purpose

--- a/Framework/Algorithms/inc/MantidAlgorithms/MaskBins.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/MaskBins.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_ALGORITHMS_MASKBINS_H_
 #define MANTID_ALGORITHMS_MASKBINS_H_
 
-#include "MantidAPI/ParallelAlgorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 #include "MantidDataObjects/EventList.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidIndexing/SpectrumIndexSet.h"
@@ -53,7 +53,7 @@ namespace Algorithms {
     File change history is stored at: <https://github.com/mantidproject/mantid>
     Code Documentation is available at: <http://doxygen.mantidproject.org>
  */
-class DLLExport MaskBins : public API::ParallelAlgorithm {
+class DLLExport MaskBins : public API::DistributedAlgorithm {
 public:
   /// Algorithm's name
   const std::string name() const override { return "MaskBins"; }

--- a/Framework/Algorithms/inc/MantidAlgorithms/Rebin.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/Rebin.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_ALGORITHMS_REBIN_H_
 #define MANTID_ALGORITHMS_REBIN_H_
 
-#include "MantidAPI/ParallelAlgorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 
 namespace Mantid {
 namespace Algorithms {
@@ -50,7 +50,7 @@ namespace Algorithms {
     File change history is stored at: <https://github.com/mantidproject/mantid>
     Code Documentation is available at: <http://doxygen.mantidproject.org>
  */
-class DLLExport Rebin : public API::ParallelAlgorithm {
+class DLLExport Rebin : public API::DistributedAlgorithm {
 public:
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "Rebin"; }

--- a/Framework/Algorithms/inc/MantidAlgorithms/RebinToWorkspace.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/RebinToWorkspace.h
@@ -60,6 +60,11 @@ public:
   /// Algorithm's category for identification
   const std::string category() const override { return "Transforms\\Rebin"; }
 
+protected:
+  Parallel::ExecutionMode getParallelExecutionMode(
+      const std::map<std::string, Parallel::StorageMode> &storageModes)
+      const override;
+
 private:
   /// Initialisation code
   void init() override;

--- a/Framework/Algorithms/inc/MantidAlgorithms/RemovePromptPulse.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/RemovePromptPulse.h
@@ -2,7 +2,7 @@
 #define MANTID_ALGORITHMS_REMOVEPROMPTPULSE_H_
 
 #include "MantidKernel/System.h"
-#include "MantidAPI/ParallelAlgorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 #include "MantidAPI/Run.h"
 
 namespace Mantid {
@@ -34,7 +34,7 @@ namespace Algorithms {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport RemovePromptPulse : public API::ParallelAlgorithm {
+class DLLExport RemovePromptPulse : public API::DistributedAlgorithm {
 public:
   /// Algorithm's name for identification
   const std::string name() const override;

--- a/Framework/Algorithms/inc/MantidAlgorithms/SortEvents.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SortEvents.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_ALGORITHMS_SORTEVENTS_H_
 #define MANTID_ALGORITHMS_SORTEVENTS_H_
 
-#include "MantidAPI/ParallelAlgorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 
 namespace Mantid {
 namespace Algorithms {
@@ -39,7 +39,7 @@ namespace Algorithms {
     File change history is stored at: <https://github.com/mantidproject/mantid>
     Code Documentation is available at: <http://doxygen.mantidproject.org>
  */
-class DLLExport SortEvents : public API::ParallelAlgorithm {
+class DLLExport SortEvents : public API::DistributedAlgorithm {
 public:
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "SortEvents"; }

--- a/Framework/Algorithms/inc/MantidAlgorithms/SumSpectra.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SumSpectra.h
@@ -1,10 +1,7 @@
 #ifndef MANTID_ALGORITHMS_SUMSPECTRA_H_
 #define MANTID_ALGORITHMS_SUMSPECTRA_H_
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/ParallelAlgorithm.h"
 #include "MantidGeometry/IDTypes.h"
 #include <set>
 
@@ -54,10 +51,8 @@ namespace Algorithms {
     File change history is stored at: <https://github.com/mantidproject/mantid>
     Code Documentation is available at: <http://doxygen.mantidproject.org>
  */
-class DLLExport SumSpectra : public API::Algorithm {
+class DLLExport SumSpectra : public API::ParallelAlgorithm {
 public:
-  /// Default constructor
-  SumSpectra();
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "SumSpectra"; }
   /// Summary of algorithms purpose
@@ -96,21 +91,21 @@ private:
   void determineIndices(const size_t numberOfSpectra);
 
   /// The output spectrum number
-  specnum_t m_outSpecNum;
+  specnum_t m_outSpecNum{0};
   /// Set true to keep monitors
-  bool m_keepMonitors;
+  bool m_keepMonitors{false};
   /// Set true to remove special values before processing
-  bool m_replaceSpecialValues;
+  bool m_replaceSpecialValues{false};
   /// numberOfSpectra in the input
-  size_t m_numberOfSpectra;
+  size_t m_numberOfSpectra{0};
   /// Blocksize of the input workspace
-  size_t m_yLength;
+  size_t m_yLength{0};
   /// Set of indices to sum
   std::set<size_t> m_indices;
 
   // if calculating additional workspace with specially weighted averages is
   // necessary
-  bool m_calculateWeightedSum;
+  bool m_calculateWeightedSum{false};
 };
 
 } // namespace Algorithm

--- a/Framework/Algorithms/inc/MantidAlgorithms/UnaryOperation.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/UnaryOperation.h
@@ -1,10 +1,7 @@
 #ifndef MANTID_ALGORITHMS_UNARYOPERATION_H_
 #define MANTID_ALGORITHMS_UNARYOPERATION_H_
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 
 namespace Mantid {
 namespace Algorithms {
@@ -47,10 +44,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 File change history is stored at: <https://github.com/mantidproject/mantid>
 */
-class DLLExport UnaryOperation : public API::Algorithm {
+class DLLExport UnaryOperation : public API::DistributedAlgorithm {
 public:
-  /// Default constructor
-  UnaryOperation();
   /// Algorithm's category for identification
   const std::string category() const override { return "Arithmetic"; }
   /// Summary of algorithms purpose
@@ -93,7 +88,7 @@ protected:
 
   /// flag to use histogram representation instead of events for certain
   /// algorithms
-  bool useHistogram;
+  bool useHistogram{false};
 };
 
 } // namespace Algorithm

--- a/Framework/Algorithms/inc/MantidAlgorithms/XDataConverter.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/XDataConverter.h
@@ -1,10 +1,7 @@
 #ifndef MANTID_ALGORITHMS_XDATACONVERTER_H_
 #define MANTID_ALGORITHMS_XDATACONVERTER_H_
 
-//------------------------------------------------------------------------------
-// Includes
-//------------------------------------------------------------------------------
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 #include "MantidKernel/cow_ptr.h"
 
 namespace Mantid {
@@ -43,7 +40,7 @@ namespace Algorithms {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport XDataConverter : public API::Algorithm {
+class DLLExport XDataConverter : public API::DistributedAlgorithm {
 public:
   /// Default constructor
   XDataConverter();

--- a/Framework/Algorithms/src/BinaryOperation.cpp
+++ b/Framework/Algorithms/src/BinaryOperation.cpp
@@ -22,15 +22,6 @@ using std::size_t;
 
 namespace Mantid {
 namespace Algorithms {
-BinaryOperation::BinaryOperation()
-    : API::Algorithm(), m_lhs(), m_elhs(), m_rhs(), m_erhs(), m_out(), m_eout(),
-      m_AllowDifferentNumberSpectra(false), m_ClearRHSWorkspace(false),
-      m_matchXSize(false), m_flipSides(false), m_keepEventWorkspace(false),
-      m_useHistogramForRhsEventWorkspace(false),
-      m_do2D_even_for_SingleColumn_on_rhs(false) {}
-
-BinaryOperation::~BinaryOperation() {}
-
 /** Initialisation method.
  *  Defines input and output workspaces
  *

--- a/Framework/Algorithms/src/BinaryOperation.cpp
+++ b/Framework/Algorithms/src/BinaryOperation.cpp
@@ -1038,19 +1038,24 @@ Parallel::ExecutionMode BinaryOperation::getParallelExecutionMode(
     const std::map<std::string, Parallel::StorageMode> &storageModes) const {
   if (static_cast<bool>(getProperty("AllowDifferentNumberSpectra")))
     return Parallel::ExecutionMode::Invalid;
-  auto lhs = storageModes.find("LHSWorkspace")->second;
-  auto rhs = storageModes.find("RHSWorkspace")->second;
+  auto lhs = storageModes.find(inputPropName1())->second;
+  auto rhs = storageModes.find(inputPropName2())->second;
   // Two identical modes is ok
   if (lhs == rhs)
     return getCorrespondingExecutionMode(storageModes.begin()->second);
   // Mode <X> times Cloned is ok if the cloned workspace is WorkspaceSingleValue
   if (rhs == Parallel::StorageMode::Cloned) {
-    API::MatrixWorkspace_const_sptr ws = getProperty("RHSWorkspace");
+    API::MatrixWorkspace_const_sptr ws = getProperty(inputPropName2());
     if (boost::dynamic_pointer_cast<const WorkspaceSingleValue>(ws))
       return getCorrespondingExecutionMode(lhs);
   }
   // Other options are not ok (e.g., MasterOnly times Distributed)
   return Parallel::ExecutionMode::Invalid;
+}
+
+void BinaryOperation::execNonMaster() {
+  API::MatrixWorkspace_const_sptr ws = getProperty(inputPropName1());
+  setProperty(outputPropName(), ws->cloneEmpty());
 }
 
 } // namespace Algorithms

--- a/Framework/Algorithms/src/CalculateTransmission.cpp
+++ b/Framework/Algorithms/src/CalculateTransmission.cpp
@@ -1,7 +1,3 @@
-
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
 #include "MantidAlgorithms/CalculateTransmission.h"
 #include "MantidAPI/CommonBinsValidator.h"
 #include "MantidAPI/FunctionFactory.h"

--- a/Framework/Algorithms/src/CompareWorkspaces.cpp
+++ b/Framework/Algorithms/src/CompareWorkspaces.cpp
@@ -1180,5 +1180,21 @@ bool CompareWorkspaces::relErr(double x1, double x2, double errorVal) const {
   return (num / den > errorVal);
 }
 
+Parallel::ExecutionMode CompareWorkspaces::getParallelExecutionMode(
+    const std::map<std::string, Parallel::StorageMode> &storageModes) const {
+  using namespace Parallel;
+  if (storageModes.at("Workspace1") == StorageMode::Cloned) {
+    if (storageModes.at("Workspace2") == StorageMode::Cloned)
+      return getCorrespondingExecutionMode(StorageMode::Cloned);
+    if (storageModes.at("Workspace2") == StorageMode::MasterOnly)
+      return getCorrespondingExecutionMode(StorageMode::MasterOnly);
+  }
+  if (storageModes.at("Workspace1") == StorageMode::MasterOnly) {
+    if (storageModes.at("Workspace2") != StorageMode::Distributed)
+      return getCorrespondingExecutionMode(StorageMode::MasterOnly);
+  }
+  return ExecutionMode::Invalid;
+}
+
 } // namespace Algorithms
 } // namespace Mantid

--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -13,6 +13,7 @@
 #include "MantidKernel/CompositeValidator.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/UnitFactory.h"
+#include "MantidParallel/Communicator.h"
 
 #include <numeric>
 
@@ -26,11 +27,6 @@ using namespace Kernel;
 using namespace API;
 using namespace DataObjects;
 using namespace HistogramData;
-
-/// Default constructor
-ConvertUnits::ConvertUnits()
-    : Algorithm(), m_numberOfSpectra(0), m_distribution(false),
-      m_inputEvents(false), m_inputUnit(), m_outputUnit() {}
 
 /// Initialisation method
 void ConvertUnits::init() {
@@ -605,6 +601,9 @@ ConvertUnits::convertViaTOF(Kernel::Unit_const_sptr fromUnit,
 /// Calls Rebin as a Child Algorithm to align the bins
 API::MatrixWorkspace_sptr
 ConvertUnits::alignBins(API::MatrixWorkspace_sptr workspace) {
+  if (communicator().size() != 1)
+    throw std::runtime_error(
+        "ConvertUnits: Parallel support for aligning bins not implemented.");
   // Create a Rebin child algorithm
   IAlgorithm_sptr childAlg = createChildAlgorithm("Rebin");
   childAlg->setProperty<MatrixWorkspace_sptr>("InputWorkspace", workspace);

--- a/Framework/Algorithms/src/ExtractSingleSpectrum.cpp
+++ b/Framework/Algorithms/src/ExtractSingleSpectrum.cpp
@@ -1,6 +1,3 @@
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
 #include "MantidAlgorithms/ExtractSingleSpectrum.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/TextAxis.h"

--- a/Framework/Algorithms/src/GroupWorkspaces.cpp
+++ b/Framework/Algorithms/src/GroupWorkspaces.cpp
@@ -12,9 +12,6 @@ DECLARE_ALGORITHM(GroupWorkspaces)
 using namespace API;
 using namespace Kernel;
 
-/// Default constructor
-GroupWorkspaces::GroupWorkspaces() : API::Algorithm(), m_group() {}
-
 /// Initialisation method
 void GroupWorkspaces::init() {
 

--- a/Framework/Algorithms/src/RebinToWorkspace.cpp
+++ b/Framework/Algorithms/src/RebinToWorkspace.cpp
@@ -1,12 +1,11 @@
-//--------------------------------
-// Includes
-//------------------------------
 #include "MantidAlgorithms/RebinToWorkspace.h"
 #include "MantidAPI/HistogramValidator.h"
 #include "MantidAPI/MatrixWorkspace.h"
 
-using namespace Mantid::API;
-using namespace Mantid::Algorithms;
+namespace Mantid {
+namespace Algorithms {
+
+using namespace API;
 
 // Register the algorithm into the AlgorithmFactory
 DECLARE_ALGORITHM(RebinToWorkspace)
@@ -94,3 +93,18 @@ std::vector<double> RebinToWorkspace::createRebinParameters(
   }
   return rb_params;
 }
+
+Parallel::ExecutionMode RebinToWorkspace::getParallelExecutionMode(
+    const std::map<std::string, Parallel::StorageMode> &storageModes) const {
+  // Probably we can relax these restrictions based on particular combination
+  // with storage mode of WorkspaceToRebin, but this is simple and sufficient
+  // for now.
+  if (storageModes.at("WorkspaceToMatch") != Parallel::StorageMode::Cloned)
+    throw std::runtime_error("WorkspaceToMatch must have " +
+                             Parallel::toString(Parallel::StorageMode::Cloned));
+  return Parallel::getCorrespondingExecutionMode(
+      storageModes.at("WorkspaceToRebin"));
+}
+
+} // namespace Algorithms
+} // namespace Mantid

--- a/Framework/Algorithms/src/SumSpectra.cpp
+++ b/Framework/Algorithms/src/SumSpectra.cpp
@@ -20,11 +20,6 @@ using namespace Kernel;
 using namespace API;
 using namespace DataObjects;
 
-SumSpectra::SumSpectra()
-    : API::Algorithm(), m_outSpecNum(0), m_keepMonitors(false),
-      m_replaceSpecialValues(false), m_numberOfSpectra(0), m_yLength(0),
-      m_indices(), m_calculateWeightedSum(false) {}
-
 /** Initialisation method.
  *
  */

--- a/Framework/Algorithms/src/UnaryOperation.cpp
+++ b/Framework/Algorithms/src/UnaryOperation.cpp
@@ -1,6 +1,3 @@
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
 #include "MantidAlgorithms/UnaryOperation.h"
 #include "MantidAPI/WorkspaceProperty.h"
 #include "MantidAPI/WorkspaceFactory.h"
@@ -13,10 +10,6 @@ using namespace Mantid::DataObjects;
 
 namespace Mantid {
 namespace Algorithms {
-UnaryOperation::UnaryOperation() : API::Algorithm() {
-  this->useHistogram = false;
-}
-
 /** Initialisation method.
  *  Defines input and output workspace properties
  */

--- a/Framework/Algorithms/test/BinaryOperationTest.h
+++ b/Framework/Algorithms/test/BinaryOperationTest.h
@@ -4,6 +4,8 @@
 #include <cxxtest/TestSuite.h>
 #include <cmath>
 
+#include "MantidTestHelpers/ParallelAlgorithmCreation.h"
+#include "MantidTestHelpers/ParallelRunner.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidAlgorithms/BinaryOperation.h"
 #include "MantidAPI/AnalysisDataService.h"
@@ -11,21 +13,18 @@
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidKernel/Timer.h"
+#include "MantidIndexing/IndexInfo.h"
 
+using namespace Mantid;
 using namespace Mantid::API;
 using namespace Mantid::Algorithms;
 using namespace Mantid::DataObjects;
-using Mantid::DataObjects::Workspace2D_sptr;
 using Mantid::Geometry::IDetector_const_sptr;
 
 class BinaryOpHelper : public Mantid::Algorithms::BinaryOperation {
 public:
-  /// Default constructor
-  BinaryOpHelper() : BinaryOperation(){};
-  /// Destructor
-  ~BinaryOpHelper() override{};
-
   /// function to return a name of the algorithm, must be overridden in all
   /// algorithms
   const std::string name() const override { return "BinaryOpHelper"; }
@@ -63,6 +62,117 @@ private:
                               const double, Mantid::MantidVec &,
                               Mantid::MantidVec &) override {}
 };
+
+namespace {
+void run_parallel(const Parallel::Communicator &comm,
+                  const Parallel::StorageMode storageMode) {
+  using namespace Parallel;
+  auto alg = ParallelTestHelpers::create<BinaryOpHelper>(comm);
+  if (comm.rank() == 0 || storageMode != StorageMode::MasterOnly) {
+    Indexing::IndexInfo indexInfo(100, storageMode, comm);
+    alg->setProperty("LHSWorkspace",
+                     create<Workspace2D>(indexInfo, HistogramData::Points(1)));
+    alg->setProperty("RHSWorkspace",
+                     create<Workspace2D>(indexInfo, HistogramData::Points(1)));
+  } else {
+    alg->setProperty("LHSWorkspace",
+                     Kernel::make_unique<Workspace2D>(StorageMode::MasterOnly));
+    alg->setProperty("RHSWorkspace",
+                     Kernel::make_unique<Workspace2D>(StorageMode::MasterOnly));
+  }
+  TS_ASSERT_THROWS_NOTHING(alg->execute());
+  MatrixWorkspace_const_sptr out = alg->getProperty("OutputWorkspace");
+  TS_ASSERT_EQUALS(out->storageMode(), storageMode);
+}
+
+void run_parallel_mismatch_fail(const Parallel::Communicator &comm,
+                                const Parallel::StorageMode storageModeA,
+                                const Parallel::StorageMode storageModeB) {
+  using namespace Parallel;
+  auto alg = ParallelTestHelpers::create<BinaryOpHelper>(comm);
+  if (comm.rank() == 0 || storageModeA != StorageMode::MasterOnly) {
+    Indexing::IndexInfo indexInfo(100, storageModeA, comm);
+    alg->setProperty("LHSWorkspace",
+                     create<Workspace2D>(indexInfo, HistogramData::Points(1)));
+  } else {
+    alg->setProperty("LHSWorkspace",
+                     Kernel::make_unique<Workspace2D>(StorageMode::MasterOnly));
+  }
+  if (comm.rank() == 0 || storageModeB != StorageMode::MasterOnly) {
+    Indexing::IndexInfo indexInfo(100, storageModeB, comm);
+    alg->setProperty("RHSWorkspace",
+                     create<Workspace2D>(indexInfo, HistogramData::Points(1)));
+  } else {
+    alg->setProperty("RHSWorkspace",
+                     Kernel::make_unique<Workspace2D>(StorageMode::MasterOnly));
+  }
+  if (comm.size() > 1) {
+    TS_ASSERT_THROWS_EQUALS(
+        alg->execute(), const std::runtime_error &e, std::string(e.what()),
+        "Algorithm does not support execution with input workspaces of the "
+        "following storage types: \nLHSWorkspace " +
+            toString(storageModeA) + "\nRHSWorkspace " +
+            toString(storageModeB) + "\n.");
+  } else {
+    TS_ASSERT_THROWS_NOTHING(alg->execute());
+    MatrixWorkspace_const_sptr out = alg->getProperty("OutputWorkspace");
+    TS_ASSERT_EQUALS(out->storageMode(), storageModeA);
+  }
+}
+
+void run_parallel_single_value(const Parallel::Communicator &comm,
+                               const Parallel::StorageMode storageModeA,
+                               const Parallel::StorageMode storageModeB) {
+  using namespace Parallel;
+  auto alg = ParallelTestHelpers::create<BinaryOpHelper>(comm);
+  if (comm.rank() == 0 || storageModeA != StorageMode::MasterOnly) {
+    Indexing::IndexInfo indexInfo(100, storageModeA, comm);
+    alg->setProperty("LHSWorkspace",
+                     create<Workspace2D>(indexInfo, HistogramData::Points(1)));
+  } else {
+    alg->setProperty("LHSWorkspace",
+                     Kernel::make_unique<Workspace2D>(StorageMode::MasterOnly));
+  }
+  if (comm.rank() == 0 || storageModeB != StorageMode::MasterOnly) {
+    Indexing::IndexInfo indexInfo(1, storageModeB, comm);
+    alg->setProperty("RHSWorkspace", create<WorkspaceSingleValue>(
+                                         indexInfo, HistogramData::Points(1)));
+  } else {
+    alg->setProperty("RHSWorkspace", Kernel::make_unique<WorkspaceSingleValue>(
+                                         0.0, 0.0, StorageMode::MasterOnly));
+  }
+  TS_ASSERT_THROWS_NOTHING(alg->execute());
+  MatrixWorkspace_const_sptr out = alg->getProperty("OutputWorkspace");
+  TS_ASSERT_EQUALS(out->storageMode(), storageModeA);
+}
+
+void run_parallel_AllowDifferentNumberSpectra_fail(
+    const Parallel::Communicator &comm,
+    const Parallel::StorageMode storageMode) {
+  using namespace Parallel;
+  auto alg = ParallelTestHelpers::create<BinaryOpHelper>(comm);
+  if (comm.rank() == 0 || storageMode != StorageMode::MasterOnly) {
+    Indexing::IndexInfo indexInfo(100, storageMode, comm);
+    alg->setProperty("LHSWorkspace",
+                     create<Workspace2D>(indexInfo, HistogramData::Points(1)));
+    alg->setProperty("RHSWorkspace",
+                     create<Workspace2D>(indexInfo, HistogramData::Points(1)));
+  } else {
+    alg->setProperty("LHSWorkspace",
+                     Kernel::make_unique<Workspace2D>(StorageMode::MasterOnly));
+    alg->setProperty("RHSWorkspace",
+                     Kernel::make_unique<Workspace2D>(StorageMode::MasterOnly));
+  }
+  alg->setProperty("AllowDifferentNumberSpectra", true);
+  if (comm.size() > 1) {
+    TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &);
+  } else {
+    TS_ASSERT_THROWS_NOTHING(alg->execute());
+    MatrixWorkspace_const_sptr out = alg->getProperty("OutputWorkspace");
+    TS_ASSERT_EQUALS(out->storageMode(), storageMode);
+  }
+}
+}
 
 class BinaryOperationTest : public CxxTest::TestSuite {
 public:
@@ -290,6 +400,62 @@ public:
     for (int i = 0; i < 2000; i++) {
       TS_ASSERT_EQUALS((*table)[i], i / 100);
     }
+  }
+
+  void test_parallel_Distributed() {
+    ParallelTestHelpers::runParallel(run_parallel,
+                                     Parallel::StorageMode::Distributed);
+  }
+
+  void test_parallel_Cloned() {
+    ParallelTestHelpers::runParallel(run_parallel,
+                                     Parallel::StorageMode::Cloned);
+  }
+
+  void test_parallel_MasterOnly() {
+    ParallelTestHelpers::runParallel(run_parallel,
+                                     Parallel::StorageMode::MasterOnly);
+  }
+
+  void test_parallel_mistmatch_fail() {
+    using ParallelTestHelpers::runParallel;
+    auto cloned = Parallel::StorageMode::Cloned;
+    auto distri = Parallel::StorageMode::Distributed;
+    auto master = Parallel::StorageMode::MasterOnly;
+    runParallel(run_parallel_mismatch_fail, cloned, distri);
+    runParallel(run_parallel_mismatch_fail, cloned, master);
+    runParallel(run_parallel_mismatch_fail, distri, cloned);
+    runParallel(run_parallel_mismatch_fail, distri, master);
+    runParallel(run_parallel_mismatch_fail, master, cloned);
+    runParallel(run_parallel_mismatch_fail, master, distri);
+  }
+
+  void test_parallel_Cloned_ClonedSingle() {
+    ParallelTestHelpers::runParallel(run_parallel_single_value,
+                                     Parallel::StorageMode::Cloned,
+                                     Parallel::StorageMode::Cloned);
+  }
+
+  void test_parallel_Distributed_ClonedSingle() {
+    ParallelTestHelpers::runParallel(run_parallel_single_value,
+                                     Parallel::StorageMode::Distributed,
+                                     Parallel::StorageMode::Cloned);
+  }
+
+  void test_parallel_MasterOnly_ClonedSingle() {
+    ParallelTestHelpers::runParallel(run_parallel_single_value,
+                                     Parallel::StorageMode::MasterOnly,
+                                     Parallel::StorageMode::Cloned);
+  }
+
+  void test_parallel_AllowDifferentNumberSpectra_fail() {
+    using ParallelTestHelpers::runParallel;
+    runParallel(run_parallel_AllowDifferentNumberSpectra_fail,
+                Parallel::StorageMode::Cloned);
+    runParallel(run_parallel_AllowDifferentNumberSpectra_fail,
+                Parallel::StorageMode::Distributed);
+    runParallel(run_parallel_AllowDifferentNumberSpectra_fail,
+                Parallel::StorageMode::MasterOnly);
   }
 };
 

--- a/Framework/Algorithms/test/ExtractMaskTest.h
+++ b/Framework/Algorithms/test/ExtractMaskTest.h
@@ -30,7 +30,7 @@ public:
   // Commenting out test because I am not sure that this is indeed the correct
   // behaviour.
   void
-  xtest_That_Input_Masked_Spectra_Are_Assigned_Zero_And_Remain_Masked_On_Output() {
+  test_That_Input_Masked_Spectra_Are_Assigned_Zero_And_Remain_Masked_On_Output() {
     // Create a simple test workspace
     const int nvectors(50), nbins(10);
     Workspace2D_sptr inputWS =
@@ -91,29 +91,27 @@ private:
     const auto &oSpecInfo = outputWS->spectrumInfo();
     for (size_t i = 0; i < nOutputHists; ++i) {
       // Sizes
-      TS_ASSERT_EQUALS(outputWS->readX(i).size(), 1);
-      TS_ASSERT_EQUALS(outputWS->readY(i).size(), 1);
-      TS_ASSERT_EQUALS(outputWS->readE(i).size(), 1);
+      TS_ASSERT_EQUALS(outputWS->x(i).size(), 1);
+      TS_ASSERT_EQUALS(outputWS->y(i).size(), 1);
+      TS_ASSERT_EQUALS(outputWS->e(i).size(), 1);
       // Data
       double expectedValue(-1.0);
-      bool outputMasked(false);
       if (!iSpecInfo.hasDetectors(i) || !oSpecInfo.hasDetectors(i)) {
         expectedValue = 1.0;
       }
 
       if (iSpecInfo.hasDetectors(i) && iSpecInfo.isMasked(i)) {
         expectedValue = 1.0;
-        outputMasked = true;
       } else {
         expectedValue = 0.0;
-        outputMasked = false;
       }
 
-      TS_ASSERT_EQUALS(outputWS->dataY(i)[0], expectedValue);
-      TS_ASSERT_EQUALS(outputWS->dataE(i)[0], expectedValue);
-      TS_ASSERT_EQUALS(outputWS->dataX(i)[0], 0.0);
-      if (iSpecInfo.hasDetectors(i)) {
-        TS_ASSERT_EQUALS(oSpecInfo.isMasked(i), outputMasked);
+      TS_ASSERT_EQUALS(outputWS->y(i)[0], expectedValue);
+      TS_ASSERT_EQUALS(outputWS->e(i)[0], 0.0);
+      TS_ASSERT_EQUALS(outputWS->x(i)[0], 1.0);
+      // Detectors never masked since masking information is carried by Y.
+      if (oSpecInfo.hasDetectors(i)) {
+        TS_ASSERT_EQUALS(oSpecInfo.isMasked(i), false);
       }
     }
   }

--- a/Framework/CurveFitting/inc/MantidCurveFitting/IFittingAlgorithm.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/IFittingAlgorithm.h
@@ -2,7 +2,7 @@
 #define MANTID_CURVEFITTING_IFITTINGALGORITHM_H_
 
 #include "MantidKernel/System.h"
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/ParallelAlgorithm.h"
 #include "MantidAPI/IDomainCreator.h"
 
 namespace Mantid {
@@ -51,7 +51,7 @@ class CostFuncFitting;
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport IFittingAlgorithm : public API::Algorithm {
+class DLLExport IFittingAlgorithm : public API::ParallelAlgorithm {
 public:
   const std::string category() const override;
 

--- a/Framework/DataHandling/CMakeLists.txt
+++ b/Framework/DataHandling/CMakeLists.txt
@@ -113,6 +113,7 @@ set ( SRC_FILES
 	src/LoadVulcanCalFile.cpp
 	src/MaskDetectors.cpp
 	src/MaskDetectorsInShape.cpp
+	src/MaskSpectra.cpp
 	src/MergeLogs.cpp
 	src/ModifyDetectorDotDatFile.cpp
 	src/MoveInstrumentComponent.cpp
@@ -287,6 +288,7 @@ set ( INC_FILES
 	inc/MantidDataHandling/LoadVulcanCalFile.h
 	inc/MantidDataHandling/MaskDetectors.h
 	inc/MantidDataHandling/MaskDetectorsInShape.h
+	inc/MantidDataHandling/MaskSpectra.h
 	inc/MantidDataHandling/MergeLogs.h
 	inc/MantidDataHandling/ModifyDetectorDotDatFile.h
 	inc/MantidDataHandling/MoveInstrumentComponent.h
@@ -459,6 +461,7 @@ set ( TEST_FILES
 	LoadVulcanCalFileTest.h
 	MaskDetectorsInShapeTest.h
 	MaskDetectorsTest.h
+	MaskSpectraTest.h
 	MergeLogsTest.h
 	ModifyDetectorDotDatFileTest.h
 	MoveInstrumentComponentTest.h

--- a/Framework/DataHandling/inc/MantidDataHandling/CompressEvents.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/CompressEvents.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_DATAHANDLING_COMPRESSEVENTS_H_
 #define MANTID_DATAHANDLING_COMPRESSEVENTS_H_
 
-#include "MantidAPI/ParallelAlgorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 
 namespace Mantid {
 namespace DataHandling {
@@ -40,7 +40,7 @@ namespace DataHandling {
     File change history is stored at: <https://github.com/mantidproject/mantid>.
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport CompressEvents : public API::ParallelAlgorithm {
+class DLLExport CompressEvents : public API::DistributedAlgorithm {
 public:
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "CompressEvents"; };

--- a/Framework/DataHandling/inc/MantidDataHandling/FindDetectorsInShape.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/FindDetectorsInShape.h
@@ -1,10 +1,7 @@
 #ifndef MANTID_DATAHANDLING_FINDDETECTORSINSHAPE_H_
 #define MANTID_DATAHANDLING_FINDDETECTORSINSHAPE_H_
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 
 namespace Mantid {
 namespace DataHandling {
@@ -55,7 +52,7 @@ namespace DataHandling {
     File change history is stored at: <https://github.com/mantidproject/mantid>.
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport FindDetectorsInShape : public API::Algorithm {
+class DLLExport FindDetectorsInShape : public API::DistributedAlgorithm {
 public:
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "FindDetectorsInShape"; };

--- a/Framework/DataHandling/inc/MantidDataHandling/Load.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/Load.h
@@ -37,8 +37,6 @@ Code Documentation is available at: <http://doxygen.mantidproject.org>
  */
 class DLLExport Load : public API::Algorithm {
 public:
-  /// Default constructor
-  Load();
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "Load"; }
   /// Summary of algorithms purpose
@@ -56,6 +54,11 @@ public:
   /// Override setPropertyValue
   void setPropertyValue(const std::string &name,
                         const std::string &value) override;
+
+protected:
+  Parallel::ExecutionMode getParallelExecutionMode(
+      const std::map<std::string, Parallel::StorageMode> &storageModes)
+      const override;
 
 private:
   /// This method returns shared pointer to a load algorithm which got

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadInstrument.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadInstrument.h
@@ -2,7 +2,7 @@
 #define MANTID_DATAHANDLING_LOADINSTRUMENT_H_
 
 #include "MantidAPI/ExperimentInfo.h"
-#include "MantidAPI/ParallelAlgorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 
 #include <mutex>
 
@@ -69,7 +69,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 File change history is stored at: <https://github.com/mantidproject/mantid>
 */
-class DLLExport LoadInstrument : public API::ParallelAlgorithm {
+class DLLExport LoadInstrument : public API::DistributedAlgorithm {
 public:
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "LoadInstrument"; };

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNexusLogs.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNexusLogs.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_DATAHANDLING_LOADNEXUSLOGS_H_
 #define MANTID_DATAHANDLING_LOADNEXUSLOGS_H_
 
-#include "MantidAPI/ParallelAlgorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 #include <nexus/NeXusFile.hpp>
 
 namespace Mantid {
@@ -48,7 +48,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 File change history is stored at: <https://github.com/mantidproject/mantid>.
 Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport LoadNexusLogs : public API::ParallelAlgorithm {
+class DLLExport LoadNexusLogs : public API::DistributedAlgorithm {
 public:
   /// Default constructor
   LoadNexusLogs();

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNexusMonitors2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNexusMonitors2.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_DATAHANDLING_LOADNEXUSMONITORS2_H_
 #define MANTID_DATAHANDLING_LOADNEXUSMONITORS2_H_
 
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/ParallelAlgorithm.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidGeometry/IDTypes.h"
 #include <boost/scoped_array.hpp>
@@ -49,7 +49,7 @@ namespace DataHandling {
 *
 * File change history is stored at: <https://github.com/mantidproject/mantid>
 */
-class DLLExport LoadNexusMonitors2 : public API::Algorithm {
+class DLLExport LoadNexusMonitors2 : public API::ParallelAlgorithm {
 public:
   /// Algorithm's name for identification
   const std::string name() const override { return "LoadNexusMonitors"; }

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadParameterFile.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadParameterFile.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_DATAHANDLING_LOADPARAMETERFILE_H_
 #define MANTID_DATAHANDLING_LOADPARAMETERFILE_H_
 
-#include "MantidAPI/ParallelAlgorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 
 /// @cond Exclude from doxygen documentation
 namespace Poco {
@@ -62,7 +62,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 File change history is stored at: <https://github.com/mantidproject/mantid>
 */
-class DLLExport LoadParameterFile : public API::ParallelAlgorithm {
+class DLLExport LoadParameterFile : public API::DistributedAlgorithm {
 public:
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "LoadParameterFile"; };

--- a/Framework/DataHandling/inc/MantidDataHandling/MaskDetectorsInShape.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/MaskDetectorsInShape.h
@@ -1,10 +1,7 @@
 #ifndef MANTID_DATAHANDLING_MASKDETECTORSINSHAPE_H_
 #define MANTID_DATAHANDLING_MASKDETECTORSINSHAPE_H_
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 
 namespace Mantid {
 namespace DataHandling {
@@ -55,7 +52,7 @@ namespace DataHandling {
     File change history is stored at: <https://github.com/mantidproject/mantid>.
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport MaskDetectorsInShape : public API::Algorithm {
+class DLLExport MaskDetectorsInShape : public API::DistributedAlgorithm {
 public:
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "MaskDetectorsInShape"; };
@@ -79,7 +76,7 @@ private:
                                            const bool includeMonitors);
   /// Calls MaskDetectors as a Child Algorithm
   void runMaskDetectors(API::MatrixWorkspace_sptr workspace,
-                        const std::vector<int> detectorIds);
+                        const std::vector<int> &detectorIds);
 };
 
 } // namespace DataHandling

--- a/Framework/DataHandling/inc/MantidDataHandling/MaskSpectra.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/MaskSpectra.h
@@ -2,7 +2,7 @@
 #define MANTID_DATAHANDLING_MASKSPECTRA_H_
 
 #include "MantidDataHandling/DllConfig.h"
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 
 namespace Mantid {
 namespace DataHandling {
@@ -35,7 +35,7 @@ namespace DataHandling {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class MANTID_DATAHANDLING_DLL MaskSpectra : public API::Algorithm {
+class MANTID_DATAHANDLING_DLL MaskSpectra : public API::DistributedAlgorithm {
 public:
   const std::string name() const override;
   int version() const override;

--- a/Framework/DataHandling/inc/MantidDataHandling/MaskSpectra.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/MaskSpectra.h
@@ -1,0 +1,53 @@
+#ifndef MANTID_DATAHANDLING_MASKSPECTRA_H_
+#define MANTID_DATAHANDLING_MASKSPECTRA_H_
+
+#include "MantidDataHandling/DllConfig.h"
+#include "MantidAPI/Algorithm.h"
+
+namespace Mantid {
+namespace DataHandling {
+
+/** Mask specified spectra and the underlying detectors in a workspace. This is
+  equivalent to MaskDetectors but does not support PeaksWorkspace, which does
+  not have spectra.
+
+  @author Simon Heybrock
+  @date 2017
+
+  Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class MANTID_DATAHANDLING_DLL MaskSpectra : public API::Algorithm {
+public:
+  const std::string name() const override;
+  int version() const override;
+  const std::string category() const override;
+  const std::string summary() const override;
+
+private:
+  void init() override;
+  void exec() override;
+};
+
+} // namespace DataHandling
+} // namespace Mantid
+
+#endif /* MANTID_DATAHANDLING_MASKSPECTRA_H_ */

--- a/Framework/DataHandling/inc/MantidDataHandling/MoveInstrumentComponent.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/MoveInstrumentComponent.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_DATAHANDLING_MOVEINSTRUMENTCOMPONENT_H_
 #define MANTID_DATAHANDLING_MOVEINSTRUMENTCOMPONENT_H_
 
-#include "MantidAPI/ParallelAlgorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 #include "MantidGeometry/Instrument/Component.h"
 
 namespace Mantid {
@@ -58,7 +58,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 File change history is stored at: <https://github.com/mantidproject/mantid>.
 Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport MoveInstrumentComponent : public API::ParallelAlgorithm {
+class DLLExport MoveInstrumentComponent : public API::DistributedAlgorithm {
 public:
   /// Default constructor
   MoveInstrumentComponent();

--- a/Framework/DataHandling/inc/MantidDataHandling/MoveInstrumentComponent.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/MoveInstrumentComponent.h
@@ -1,10 +1,7 @@
 #ifndef MANTID_DATAHANDLING_MOVEINSTRUMENTCOMPONENT_H_
 #define MANTID_DATAHANDLING_MOVEINSTRUMENTCOMPONENT_H_
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/ParallelAlgorithm.h"
 #include "MantidGeometry/Instrument/Component.h"
 
 namespace Mantid {
@@ -61,7 +58,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 File change history is stored at: <https://github.com/mantidproject/mantid>.
 Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport MoveInstrumentComponent : public API::Algorithm {
+class DLLExport MoveInstrumentComponent : public API::ParallelAlgorithm {
 public:
   /// Default constructor
   MoveInstrumentComponent();

--- a/Framework/DataHandling/inc/MantidDataHandling/RotateInstrumentComponent.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/RotateInstrumentComponent.h
@@ -1,10 +1,7 @@
 #ifndef MANTID_DATAHANDLING_ROTATEINSTRUMENTCOMPONENT_H_
 #define MANTID_DATAHANDLING_ROTATEINSTRUMENTCOMPONENT_H_
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/ParallelAlgorithm.h"
 #include "MantidGeometry/Instrument/Component.h"
 
 namespace Mantid {
@@ -58,7 +55,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 File change history is stored at: <https://github.com/mantidproject/mantid>.
 Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport RotateInstrumentComponent : public API::Algorithm {
+class DLLExport RotateInstrumentComponent : public API::ParallelAlgorithm {
 public:
   /// Default constructor
   RotateInstrumentComponent();

--- a/Framework/DataHandling/inc/MantidDataHandling/RotateInstrumentComponent.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/RotateInstrumentComponent.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_DATAHANDLING_ROTATEINSTRUMENTCOMPONENT_H_
 #define MANTID_DATAHANDLING_ROTATEINSTRUMENTCOMPONENT_H_
 
-#include "MantidAPI/ParallelAlgorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
 #include "MantidGeometry/Instrument/Component.h"
 
 namespace Mantid {
@@ -55,7 +55,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 File change history is stored at: <https://github.com/mantidproject/mantid>.
 Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport RotateInstrumentComponent : public API::ParallelAlgorithm {
+class DLLExport RotateInstrumentComponent : public API::DistributedAlgorithm {
 public:
   /// Default constructor
   RotateInstrumentComponent();

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveNexus.h
@@ -1,10 +1,7 @@
 #ifndef MANTID_DATAHANDLING_SAVENEXUS_H_
 #define MANTID_DATAHANDLING_SAVENEXUS_H_
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/SerialAlgorithm.h"
 #include <climits>
 
 namespace Mantid {
@@ -46,10 +43,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 File change history is stored at: <https://github.com/mantidproject/mantid>.
 Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport SaveNexus : public API::Algorithm {
+class DLLExport SaveNexus : public API::SerialAlgorithm {
 public:
-  /// Default constructor
-  SaveNexus();
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "SaveNexus"; };
   /// Summary of algorithms purpose

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveNexusProcessed.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveNexusProcessed.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_DATAHANDLING_SAVENEXUSPROCESSED_H_
 #define MANTID_DATAHANDLING_SAVENEXUSPROCESSED_H_
 
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/SerialAlgorithm.h"
 #include "MantidAPI/Progress.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include <nexus/NeXusFile.hpp>
@@ -49,10 +49,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 File change history is stored at: <https://github.com/mantidproject/mantid>.
 Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport SaveNexusProcessed : public API::Algorithm {
+class DLLExport SaveNexusProcessed : public API::SerialAlgorithm {
 public:
-  /// Default constructor
-  SaveNexusProcessed();
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "SaveNexusProcessed"; };
   /// Summary of algorithms purpose
@@ -113,7 +111,7 @@ private:
   /// Pointer to the local workspace, cast to EventWorkspace
   DataObjects::EventWorkspace_const_sptr m_eventWorkspace;
   /// Proportion of progress time expected to write initial part
-  double m_timeProgInit;
+  double m_timeProgInit{0.0};
   /// Progress bar
   std::unique_ptr<API::Progress> m_progress;
 };

--- a/Framework/DataHandling/src/Load.cpp
+++ b/Framework/DataHandling/src/Load.cpp
@@ -95,9 +95,6 @@ using namespace API;
 // Public methods
 //--------------------------------------------------------------------------
 
-/// Default constructor
-Load::Load() : Algorithm(), m_baseProps(), m_loader(), m_filenamePropName() {}
-
 /** Override setPropertyValue to catch if filename is being set, as this may
  * mean
  *  a change of concrete loader. If it's any other property, just forward the
@@ -749,6 +746,15 @@ Load::groupWsList(const std::vector<API::Workspace_sptr> &wsList) {
   }
 
   return group;
+}
+
+Parallel::ExecutionMode Load::getParallelExecutionMode(
+    const std::map<std::string, Parallel::StorageMode> &storageModes) const {
+  static_cast<void>(storageModes);
+  // The actually relevant execution mode is that of the underlying loader. Here
+  // we simply default to ExecutionMode::Distributed to guarantee that the
+  // normal exec() is being run on all ranks.
+  return Parallel::ExecutionMode::Distributed;
 }
 
 } // namespace DataHandling

--- a/Framework/DataHandling/src/MaskSpectra.cpp
+++ b/Framework/DataHandling/src/MaskSpectra.cpp
@@ -1,0 +1,62 @@
+#include "MantidDataHandling/MaskSpectra.h"
+#include "MantidAPI/Algorithm.tcc"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/SpectrumInfo.h"
+
+namespace Mantid {
+namespace DataHandling {
+
+using namespace API;
+using namespace Kernel;
+
+// Register the algorithm into the AlgorithmFactory
+DECLARE_ALGORITHM(MaskSpectra)
+
+/// Algorithms name for identification. @see Algorithm::name
+const std::string MaskSpectra::name() const { return "MaskSpectra"; }
+
+/// Algorithm's version for identification. @see Algorithm::version
+int MaskSpectra::version() const { return 1; }
+
+/// Algorithm's category for identification. @see Algorithm::category
+const std::string MaskSpectra::category() const {
+  return "Transforms\\Masking";
+}
+
+/// Algorithm's summary for use in the GUI and help. @see Algorithm::summary
+const std::string MaskSpectra::summary() const {
+  return "Mask (zero) spectra and the underlying detectors in a workspace.";
+}
+
+void MaskSpectra::init() {
+  declareWorkspaceInputProperties<
+      MatrixWorkspace, IndexType::SpectrumNum | IndexType::WorkspaceIndex>(
+      "InputWorkspace", "The input workspace");
+  declareProperty(Kernel::make_unique<WorkspaceProperty<>>(
+                      "OutputWorkspace", "", Direction::Output),
+                  "Name of the output workspace");
+}
+
+void MaskSpectra::exec() {
+  boost::shared_ptr<MatrixWorkspace> inputWS;
+  Indexing::SpectrumIndexSet indexSet;
+  std::tie(inputWS, indexSet) =
+      getWorkspaceAndIndices<MatrixWorkspace>("InputWorkspace");
+  MatrixWorkspace_sptr outputWS = getProperty("OutputWorkspace");
+  if (outputWS != inputWS) {
+    outputWS = inputWS->clone();
+    setProperty("OutputWorkspace", outputWS);
+  }
+
+  auto &spectrumInfo = outputWS->mutableSpectrumInfo();
+  Progress prog(this, 0.0, 1.0, indexSet.size());
+  for (const auto i : indexSet) {
+    outputWS->getSpectrum(i).clearData();
+    if (spectrumInfo.hasDetectors(i))
+      spectrumInfo.setMasked(i, true);
+    prog.report();
+  }
+}
+
+} // namespace DataHandling
+} // namespace Mantid

--- a/Framework/DataHandling/src/SaveNexus.cpp
+++ b/Framework/DataHandling/src/SaveNexus.cpp
@@ -22,9 +22,6 @@ using namespace Kernel;
 using namespace API;
 using namespace DataObjects;
 
-/// Empty default constructor
-SaveNexus::SaveNexus() : Algorithm() {}
-
 /** Initialisation method.
  *
  */

--- a/Framework/DataHandling/src/SaveNexusProcessed.cpp
+++ b/Framework/DataHandling/src/SaveNexusProcessed.cpp
@@ -33,11 +33,6 @@ typedef NeXus::NexusFileIO::optional_size_t optional_size_t;
 // Register the algorithm into the algorithm factory
 DECLARE_ALGORITHM(SaveNexusProcessed)
 
-/// Empty default constructor
-SaveNexusProcessed::SaveNexusProcessed()
-    : Algorithm(), m_timeProgInit(0.0), m_progress() {}
-
-//-----------------------------------------------------------------------------------------------
 /** Initialisation method.
  *
  */

--- a/Framework/DataHandling/test/MaskSpectraTest.h
+++ b/Framework/DataHandling/test/MaskSpectraTest.h
@@ -1,0 +1,104 @@
+#ifndef MANTID_DATAHANDLING_MASKSPECTRATEST_H_
+#define MANTID_DATAHANDLING_MASKSPECTRATEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidDataHandling/MaskSpectra.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidAPI/Algorithm.tcc"
+#include "MantidAPI/SpectrumInfo.h"
+
+#include "MantidTestHelpers/InstrumentCreationHelper.h"
+
+using namespace Mantid;
+using namespace API;
+using namespace DataObjects;
+using namespace HistogramData;
+using Mantid::DataHandling::MaskSpectra;
+
+namespace {
+std::unique_ptr<Workspace2D> makeWorkspace() {
+  auto ws = create<Workspace2D>(4, Points(1));
+  ws->setHistogram(0, Points{1.0}, Counts{2.0});
+  ws->setHistogram(1, Points{1.1}, Counts{2.1});
+  ws->setHistogram(2, Points{1.2}, Counts{2.2});
+  ws->setHistogram(3, Points{1.3}, Counts{2.3});
+  return std::move(ws);
+}
+
+void checkWorkspace(const MatrixWorkspace &ws) {
+  TS_ASSERT_EQUALS(ws.x(0)[0], 1.0);
+  TS_ASSERT_EQUALS(ws.x(1)[0], 1.1);
+  TS_ASSERT_EQUALS(ws.x(2)[0], 1.2);
+  TS_ASSERT_EQUALS(ws.x(3)[0], 1.3);
+  TS_ASSERT_EQUALS(ws.y(0)[0], 2.0);
+  TS_ASSERT_EQUALS(ws.y(1)[0], 0.0);
+  TS_ASSERT_EQUALS(ws.y(2)[0], 2.2);
+  TS_ASSERT_EQUALS(ws.y(3)[0], 0.0);
+  TS_ASSERT_EQUALS(ws.e(0)[0], sqrt(2.0));
+  TS_ASSERT_EQUALS(ws.e(1)[0], 0.0);
+  TS_ASSERT_EQUALS(ws.e(2)[0], sqrt(2.2));
+  TS_ASSERT_EQUALS(ws.e(3)[0], 0.0);
+}
+
+MatrixWorkspace_sptr runMaskSpectra(MatrixWorkspace_sptr inputWS) {
+  MaskSpectra alg;
+  alg.setChild(true);
+  alg.initialize();
+  alg.setWorkspaceInputProperties("InputWorkspace", inputWS,
+                                  IndexType::WorkspaceIndex,
+                                  std::vector<int64_t>{1, 3});
+
+  TS_ASSERT_THROWS_NOTHING(
+      alg.setPropertyValue("OutputWorkspace", "_unused_for_child"));
+  TS_ASSERT_THROWS_NOTHING(alg.execute(););
+  TS_ASSERT(alg.isExecuted());
+
+  MatrixWorkspace_sptr outputWS = alg.getProperty("OutputWorkspace");
+  return outputWS;
+}
+}
+
+class MaskSpectraTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static MaskSpectraTest *createSuite() { return new MaskSpectraTest(); }
+  static void destroySuite(MaskSpectraTest *suite) { delete suite; }
+
+  void test_init() {
+    MaskSpectra alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+  }
+
+  void test_exec() {
+    MatrixWorkspace_sptr inputWS = makeWorkspace();
+    auto outputWS = runMaskSpectra(inputWS);
+
+    TS_ASSERT(outputWS);
+    TS_ASSERT_EQUALS(outputWS->getNumberHistograms(),
+                     inputWS->getNumberHistograms());
+    checkWorkspace(*outputWS);
+  }
+
+  void test_exec_with_instrument() {
+    MatrixWorkspace_sptr inputWS = makeWorkspace();
+    InstrumentCreationHelper::addFullInstrumentToWorkspace(*inputWS, false,
+                                                           false, "");
+    auto outputWS = runMaskSpectra(inputWS);
+
+    TS_ASSERT(outputWS);
+    TS_ASSERT_EQUALS(outputWS->getNumberHistograms(),
+                     inputWS->getNumberHistograms());
+    checkWorkspace(*outputWS);
+    const auto &spectrumInfo = outputWS->spectrumInfo();
+    TS_ASSERT_EQUALS(spectrumInfo.isMasked(0), false);
+    TS_ASSERT_EQUALS(spectrumInfo.isMasked(1), true);
+    TS_ASSERT_EQUALS(spectrumInfo.isMasked(2), false);
+    TS_ASSERT_EQUALS(spectrumInfo.isMasked(3), true);
+  }
+};
+
+#endif /* MANTID_DATAHANDLING_MASKSPECTRATEST_H_ */

--- a/Framework/DataHandling/test/MaskSpectraTest.h
+++ b/Framework/DataHandling/test/MaskSpectraTest.h
@@ -83,6 +83,27 @@ public:
     checkWorkspace(*outputWS);
   }
 
+  void test_exec_in_place() {
+    MatrixWorkspace_sptr inputWS = makeWorkspace();
+    MaskSpectra alg;
+    alg.setChild(true);
+    alg.initialize();
+    alg.setWorkspaceInputProperties("InputWorkspace", inputWS,
+                                    IndexType::WorkspaceIndex,
+                                    std::vector<int64_t>{1, 3});
+
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", "_unused_for_child"));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("OutputWorkspace", inputWS));
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+
+    MatrixWorkspace_sptr outputWS = alg.getProperty("OutputWorkspace");
+
+    TS_ASSERT_EQUALS(outputWS, inputWS);
+    checkWorkspace(*outputWS);
+  }
+
   void test_exec_with_instrument() {
     MatrixWorkspace_sptr inputWS = makeWorkspace();
     InstrumentCreationHelper::addFullInstrumentToWorkspace(*inputWS, false,

--- a/Framework/DataObjects/inc/MantidDataObjects/WorkspaceSingleValue.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/WorkspaceSingleValue.h
@@ -41,7 +41,9 @@ public:
    * @return Standard string name  */
   const std::string id() const override { return "WorkspaceSingleValue"; }
 
-  WorkspaceSingleValue(double value = 0.0, double error = 0.0);
+  WorkspaceSingleValue(
+      double value = 0.0, double error = 0.0,
+      const Parallel::StorageMode storageMode = Parallel::StorageMode::Cloned);
 
   /// Returns a clone of the workspace
   std::unique_ptr<WorkspaceSingleValue> clone() const {

--- a/Framework/DataObjects/src/WorkspaceSingleValue.cpp
+++ b/Framework/DataObjects/src/WorkspaceSingleValue.cpp
@@ -10,8 +10,9 @@ using std::size_t;
 DECLARE_WORKSPACE(WorkspaceSingleValue)
 
 /// Constructor
-WorkspaceSingleValue::WorkspaceSingleValue(double value, double error)
-    : API::HistoWorkspace() {
+WorkspaceSingleValue::WorkspaceSingleValue(
+    double value, double error, const Parallel::StorageMode storageMode)
+    : API::HistoWorkspace(storageMode) {
   initialize(1, 1, 1);
   // Set the "histogram" to the single value
   data.dataX().resize(1, 0.0);

--- a/Framework/Indexing/inc/MantidIndexing/IndexInfo.h
+++ b/Framework/Indexing/inc/MantidIndexing/IndexInfo.h
@@ -17,6 +17,7 @@ class Communicator;
 }
 namespace Indexing {
 class GlobalSpectrumIndex;
+class RoundRobinPartitioner;
 class SpectrumIndexSet;
 class SpectrumNumberTranslator;
 
@@ -135,6 +136,7 @@ private:
       nullptr};
   mutable Kernel::cow_ptr<SpectrumNumberTranslator> m_spectrumNumberTranslator{
       nullptr};
+  mutable std::unique_ptr<RoundRobinPartitioner> m_partitioner;
 };
 
 } // namespace Indexing

--- a/Framework/Indexing/inc/MantidIndexing/IndexInfo.h
+++ b/Framework/Indexing/inc/MantidIndexing/IndexInfo.h
@@ -17,7 +17,6 @@ class Communicator;
 }
 namespace Indexing {
 class GlobalSpectrumIndex;
-class RoundRobinPartitioner;
 class SpectrumIndexSet;
 class SpectrumNumberTranslator;
 
@@ -136,7 +135,6 @@ private:
       nullptr};
   mutable Kernel::cow_ptr<SpectrumNumberTranslator> m_spectrumNumberTranslator{
       nullptr};
-  mutable std::unique_ptr<RoundRobinPartitioner> m_partitioner;
 };
 
 } // namespace Indexing

--- a/Framework/Indexing/inc/MantidIndexing/SpectrumNumberTranslator.h
+++ b/Framework/Indexing/inc/MantidIndexing/SpectrumNumberTranslator.h
@@ -48,7 +48,7 @@ namespace Indexing {
 class MANTID_INDEXING_DLL SpectrumNumberTranslator {
 public:
   SpectrumNumberTranslator(const std::vector<SpectrumNumber> &spectrumNumbers,
-                           std::unique_ptr<Partitioner> partitioner,
+                           const Partitioner &partitioner,
                            const PartitionIndex &partition);
   SpectrumNumberTranslator(const std::vector<SpectrumNumber> &spectrumNumbers,
                            const SpectrumNumberTranslator &parent);

--- a/Framework/Indexing/inc/MantidIndexing/SpectrumNumberTranslator.h
+++ b/Framework/Indexing/inc/MantidIndexing/SpectrumNumberTranslator.h
@@ -70,6 +70,8 @@ public:
   SpectrumIndexSet
   makeIndexSet(const std::vector<GlobalSpectrumIndex> &globalIndices) const;
 
+  PartitionIndex partitionOf(const GlobalSpectrumIndex globalIndex) const;
+
 private:
   bool isPartitioned() const;
   void checkUniqueSpectrumNumbers() const;

--- a/Framework/Indexing/src/IndexInfo.cpp
+++ b/Framework/Indexing/src/IndexInfo.cpp
@@ -80,7 +80,9 @@ IndexInfo::IndexInfo(const IndexInfo &other)
       m_communicator(
           Kernel::make_unique<Parallel::Communicator>(*other.m_communicator)),
       m_spectrumDefinitions(other.m_spectrumDefinitions),
-      m_spectrumNumberTranslator(other.m_spectrumNumberTranslator) {}
+      m_spectrumNumberTranslator(other.m_spectrumNumberTranslator),
+      m_partitioner(
+          Kernel::make_unique<RoundRobinPartitioner>(*other.m_partitioner)) {}
 
 IndexInfo::IndexInfo(IndexInfo &&) = default;
 
@@ -307,11 +309,11 @@ void IndexInfo::makeSpectrumNumberTranslator(
     throw std::runtime_error("IndexInfo: unknown storage mode " +
                              Parallel::toString(m_storageMode));
   }
-  auto partitioner = Kernel::make_unique<RoundRobinPartitioner>(
+  m_partitioner = Kernel::make_unique<RoundRobinPartitioner>(
       numberOfPartitions, partition,
       Partitioner::MonitorStrategy::TreatAsNormalSpectrum);
   m_spectrumNumberTranslator = Kernel::make_cow<SpectrumNumberTranslator>(
-      std::move(spectrumNumbers), *partitioner, partition);
+      std::move(spectrumNumbers), *m_partitioner, partition);
 }
 
 template MANTID_INDEXING_DLL IndexInfo::IndexInfo(std::vector<SpectrumNumber>,

--- a/Framework/Indexing/src/IndexInfo.cpp
+++ b/Framework/Indexing/src/IndexInfo.cpp
@@ -226,6 +226,10 @@ SpectrumIndexSet IndexInfo::makeIndexSet(
 std::vector<GlobalSpectrumIndex>
 IndexInfo::globalSpectrumIndicesFromDetectorIndices(
     const std::vector<size_t> &detectorIndices) const {
+  if (m_communicator->size() != 1)
+    throw std::runtime_error("IndexInfo::"
+                             "globalSpectrumIndicesFromDetectorIndices does "
+                             "not support MPI runs");
   if (!m_spectrumDefinitions)
     throw std::runtime_error("IndexInfo::"
                              "globalSpectrumIndicesFromDetectorIndices -- no "

--- a/Framework/Indexing/src/IndexInfo.cpp
+++ b/Framework/Indexing/src/IndexInfo.cpp
@@ -80,9 +80,7 @@ IndexInfo::IndexInfo(const IndexInfo &other)
       m_communicator(
           Kernel::make_unique<Parallel::Communicator>(*other.m_communicator)),
       m_spectrumDefinitions(other.m_spectrumDefinitions),
-      m_spectrumNumberTranslator(other.m_spectrumNumberTranslator),
-      m_partitioner(
-          Kernel::make_unique<RoundRobinPartitioner>(*other.m_partitioner)) {}
+      m_spectrumNumberTranslator(other.m_spectrumNumberTranslator) {}
 
 IndexInfo::IndexInfo(IndexInfo &&) = default;
 
@@ -309,11 +307,11 @@ void IndexInfo::makeSpectrumNumberTranslator(
     throw std::runtime_error("IndexInfo: unknown storage mode " +
                              Parallel::toString(m_storageMode));
   }
-  m_partitioner = Kernel::make_unique<RoundRobinPartitioner>(
+  auto partitioner = Kernel::make_unique<RoundRobinPartitioner>(
       numberOfPartitions, partition,
       Partitioner::MonitorStrategy::TreatAsNormalSpectrum);
   m_spectrumNumberTranslator = Kernel::make_cow<SpectrumNumberTranslator>(
-      std::move(spectrumNumbers), *m_partitioner, partition);
+      std::move(spectrumNumbers), *partitioner, partition);
 }
 
 template MANTID_INDEXING_DLL IndexInfo::IndexInfo(std::vector<SpectrumNumber>,

--- a/Framework/Indexing/src/IndexInfo.cpp
+++ b/Framework/Indexing/src/IndexInfo.cpp
@@ -311,7 +311,7 @@ void IndexInfo::makeSpectrumNumberTranslator(
       numberOfPartitions, partition,
       Partitioner::MonitorStrategy::TreatAsNormalSpectrum);
   m_spectrumNumberTranslator = Kernel::make_cow<SpectrumNumberTranslator>(
-      std::move(spectrumNumbers), std::move(partitioner), partition);
+      std::move(spectrumNumbers), *partitioner, partition);
 }
 
 template MANTID_INDEXING_DLL IndexInfo::IndexInfo(std::vector<SpectrumNumber>,

--- a/Framework/Indexing/src/IndexInfo.cpp
+++ b/Framework/Indexing/src/IndexInfo.cpp
@@ -264,10 +264,10 @@ IndexInfo::globalSpectrumIndicesFromDetectorIndices(
   std::vector<size_t> allSizes;
   Parallel::gather(communicator(), size(), allSizes, 0);
   std::vector<GlobalSpectrumIndex> spectrumIndices;
+  int tag = 0;
   if (communicator().rank() == 0) {
     for (int rank = 1; rank < communicator().size(); ++rank) {
       spectrumDefinitions[rank].resize(allSizes[rank]);
-      int tag = 0;
       auto buffer = reinterpret_cast<char *>(spectrumDefinitions[rank].data());
       auto bytes = static_cast<int>(sizeof(int64_t) * allSizes[rank]);
       communicator().recv(rank, tag, buffer, bytes);
@@ -297,13 +297,11 @@ IndexInfo::globalSpectrumIndicesFromDetectorIndices(
             "possible");
     }
     for (int rank = 1; rank < communicator().size(); ++rank) {
-      int tag = 0;
       auto buffer = reinterpret_cast<char *>(spectrumIndices.data());
       auto bytes = static_cast<int>(sizeof(int64_t) * spectrumIndices.size());
       communicator().send(rank, tag, buffer, bytes);
     }
   } else {
-    int tag = 0;
     auto buffer = reinterpret_cast<char *>(thisRankSpectrumDefinitions.data());
     auto bytes = static_cast<int>(sizeof(int64_t) * size());
     communicator().send(0, tag, buffer, bytes);

--- a/Framework/Indexing/src/SpectrumNumberTranslator.cpp
+++ b/Framework/Indexing/src/SpectrumNumberTranslator.cpp
@@ -33,19 +33,19 @@ auto find(T &map, const Key key) -> decltype(map.begin()) {
 
 SpectrumNumberTranslator::SpectrumNumberTranslator(
     const std::vector<SpectrumNumber> &spectrumNumbers,
-    std::unique_ptr<Partitioner> partitioner, const PartitionIndex &partition)
+    const Partitioner &partitioner, const PartitionIndex &partition)
     : m_partition(partition), m_globalSpectrumNumbers(spectrumNumbers) {
-  partitioner->checkValid(m_partition);
+  partitioner.checkValid(m_partition);
 
   size_t currentIndex = 0;
   for (size_t i = 0; i < m_globalSpectrumNumbers.size(); ++i) {
-    auto partition = partitioner->indexOf(GlobalSpectrumIndex(i));
+    auto partition = partitioner.indexOf(GlobalSpectrumIndex(i));
     auto number = m_globalSpectrumNumbers[i];
     m_spectrumNumberToPartition.emplace(number, partition);
     if (partition == m_partition) {
       m_spectrumNumberToIndex.emplace_back(number, currentIndex);
       m_globalToLocal.emplace_back(GlobalSpectrumIndex(i), currentIndex);
-      if (partitioner->numberOfPartitions() > 1)
+      if (partitioner.numberOfPartitions() > 1)
         m_spectrumNumbers.emplace_back(number);
       ++currentIndex;
     }

--- a/Framework/Indexing/src/SpectrumNumberTranslator.cpp
+++ b/Framework/Indexing/src/SpectrumNumberTranslator.cpp
@@ -153,6 +153,14 @@ SpectrumIndexSet SpectrumNumberTranslator::makeIndexSet(
   return SpectrumIndexSet(indices, m_globalToLocal.size());
 }
 
+PartitionIndex SpectrumNumberTranslator::partitionOf(
+    const GlobalSpectrumIndex globalIndex) const {
+  checkUniqueSpectrumNumbers();
+  const auto spectrumNumber =
+      m_globalSpectrumNumbers[static_cast<size_t>(globalIndex)];
+  return m_spectrumNumberToPartition.at(spectrumNumber);
+}
+
 void SpectrumNumberTranslator::checkUniqueSpectrumNumbers() const {
   // To support legacy code that creates workspaces with duplicate spectrum
   // numbers we check for bad spectrum numbers only when needed, i.e., when

--- a/Framework/Indexing/test/IndexInfoTest.h
+++ b/Framework/Indexing/test/IndexInfoTest.h
@@ -94,6 +94,17 @@ void run_construct_from_parent_StorageMode_Distributed(
   }
   TS_ASSERT_EQUALS(i.size(), expectedSize);
 }
+
+void run_globalSpectrumIndicesFromDetectorIndices_Distributed(
+    const Parallel::Communicator &comm) {
+  IndexInfo i(47, Parallel::StorageMode::Distributed, comm);
+  if (comm.size() != 1)
+    TS_ASSERT_THROWS_EQUALS(
+        i.globalSpectrumIndicesFromDetectorIndices({}),
+        const std::runtime_error &e, std::string(e.what()),
+        "IndexInfo::globalSpectrumIndicesFromDetectorIndices "
+        "does not support MPI runs");
+}
 }
 
 class IndexInfoTest : public CxxTest::TestSuite {
@@ -363,6 +374,10 @@ public:
 
   void test_construct_from_parent_StorageMode_Distributed() {
     runParallel(run_construct_from_parent_StorageMode_Distributed);
+  }
+
+  void test_globalSpectrumIndicesFromDetectorIndices_Distributed() {
+    runParallel(run_globalSpectrumIndicesFromDetectorIndices_Distributed);
   }
 
 private:

--- a/Framework/Indexing/test/SpectrumNumberTranslatorTest.h
+++ b/Framework/Indexing/test/SpectrumNumberTranslatorTest.h
@@ -31,7 +31,7 @@ public:
     auto numbers = {2, 1, 4, 5};
     std::vector<SpectrumNumber> spectrumNumbers(numbers.begin(), numbers.end());
     return Kernel::make_unique<SpectrumNumberTranslator>(
-        spectrumNumbers, Kernel::make_unique<RoundRobinPartitioner>(
+        spectrumNumbers, RoundRobinPartitioner(
                              ranks, PartitionIndex(0),
                              Partitioner::MonitorStrategy::CloneOnEachPartition,
                              std::vector<GlobalSpectrumIndex>{}),
@@ -57,7 +57,7 @@ public:
     auto numbers = {1, 2, 3, 4};
     std::vector<SpectrumNumber> spectrumNumbers(numbers.begin(), numbers.end());
     TS_ASSERT_THROWS_NOTHING(SpectrumNumberTranslator(
-        spectrumNumbers, Kernel::make_unique<RoundRobinPartitioner>(
+        spectrumNumbers, RoundRobinPartitioner(
                              1, PartitionIndex(0),
                              Partitioner::MonitorStrategy::CloneOnEachPartition,
                              std::vector<GlobalSpectrumIndex>{}),
@@ -67,7 +67,7 @@ public:
   void test_construct_empty() {
     std::vector<SpectrumNumber> spectrumNumbers;
     TS_ASSERT_THROWS_NOTHING(SpectrumNumberTranslator(
-        spectrumNumbers, Kernel::make_unique<RoundRobinPartitioner>(
+        spectrumNumbers, RoundRobinPartitioner(
                              1, PartitionIndex(0),
                              Partitioner::MonitorStrategy::CloneOnEachPartition,
                              std::vector<GlobalSpectrumIndex>{}),
@@ -79,7 +79,7 @@ public:
     std::vector<SpectrumNumber> spectrumNumbers(numbers.begin(), numbers.end());
     // This works, but functionality is limited, see tests below.
     TS_ASSERT_THROWS_NOTHING(SpectrumNumberTranslator(
-        spectrumNumbers, Kernel::make_unique<RoundRobinPartitioner>(
+        spectrumNumbers, RoundRobinPartitioner(
                              1, PartitionIndex(0),
                              Partitioner::MonitorStrategy::CloneOnEachPartition,
                              std::vector<GlobalSpectrumIndex>{}),
@@ -90,7 +90,7 @@ public:
     auto numbers = {1, 2, 3, 4};
     std::vector<SpectrumNumber> spectrumNumbers(numbers.begin(), numbers.end());
     SpectrumNumberTranslator parent(
-        spectrumNumbers, Kernel::make_unique<RoundRobinPartitioner>(
+        spectrumNumbers, RoundRobinPartitioner(
                              1, PartitionIndex(0),
                              Partitioner::MonitorStrategy::CloneOnEachPartition,
                              std::vector<GlobalSpectrumIndex>{}),
@@ -111,7 +111,7 @@ public:
     auto numbers = {1, 2, 3, 4};
     std::vector<SpectrumNumber> spectrumNumbers(numbers.begin(), numbers.end());
     SpectrumNumberTranslator parent(
-        spectrumNumbers, Kernel::make_unique<RoundRobinPartitioner>(
+        spectrumNumbers, RoundRobinPartitioner(
                              1, PartitionIndex(0),
                              Partitioner::MonitorStrategy::CloneOnEachPartition,
                              std::vector<GlobalSpectrumIndex>{}),
@@ -127,7 +127,7 @@ public:
     auto numbers = {1, 2, 3, 4};
     std::vector<SpectrumNumber> spectrumNumbers(numbers.begin(), numbers.end());
     SpectrumNumberTranslator parent(
-        spectrumNumbers, Kernel::make_unique<RoundRobinPartitioner>(
+        spectrumNumbers, RoundRobinPartitioner(
                              1, PartitionIndex(0),
                              Partitioner::MonitorStrategy::CloneOnEachPartition,
                              std::vector<GlobalSpectrumIndex>{}),
@@ -142,7 +142,7 @@ public:
     auto numbers = {1, 2, 3, 3};
     std::vector<SpectrumNumber> spectrumNumbers(numbers.begin(), numbers.end());
     SpectrumNumberTranslator translator(
-        spectrumNumbers, Kernel::make_unique<RoundRobinPartitioner>(
+        spectrumNumbers, RoundRobinPartitioner(
                              1, PartitionIndex(0),
                              Partitioner::MonitorStrategy::CloneOnEachPartition,
                              std::vector<GlobalSpectrumIndex>{}),
@@ -169,7 +169,7 @@ public:
     auto numbers = {1, 0, 4, -1};
     std::vector<SpectrumNumber> spectrumNumbers(numbers.begin(), numbers.end());
     SpectrumNumberTranslator translator(
-        spectrumNumbers, Kernel::make_unique<RoundRobinPartitioner>(
+        spectrumNumbers, RoundRobinPartitioner(
                              1, PartitionIndex(0),
                              Partitioner::MonitorStrategy::CloneOnEachPartition,
                              std::vector<GlobalSpectrumIndex>{}),
@@ -195,7 +195,7 @@ public:
     auto numbers = {1, 0, 4, -1};
     std::vector<SpectrumNumber> spectrumNumbers(numbers.begin(), numbers.end());
     SpectrumNumberTranslator translator(
-        spectrumNumbers, Kernel::make_unique<RoundRobinPartitioner>(
+        spectrumNumbers, RoundRobinPartitioner(
                              1, PartitionIndex(0),
                              Partitioner::MonitorStrategy::CloneOnEachPartition,
                              std::vector<GlobalSpectrumIndex>{}),

--- a/Framework/Parallel/CMakeLists.txt
+++ b/Framework/Parallel/CMakeLists.txt
@@ -23,6 +23,7 @@ set ( INC_FILES
 	inc/MantidParallel/IO/PulseTimeGenerator.h
 	inc/MantidParallel/Nonblocking.h
 	inc/MantidParallel/Request.h
+	inc/MantidParallel/Status.h
 	inc/MantidParallel/StorageMode.h
 	inc/MantidParallel/ThreadingBackend.h
 )

--- a/Framework/Parallel/inc/MantidParallel/Collectives.h
+++ b/Framework/Parallel/inc/MantidParallel/Collectives.h
@@ -70,6 +70,12 @@ void gather(const Communicator &comm, const T &in_value, int root) {
   }
 }
 
+template <typename... T>
+void all_gather(const Communicator &comm, T &&... args) {
+  for (int root = 0; root < comm.size(); ++root)
+    gather(comm, std::forward<T>(args)..., root);
+}
+
 template <typename T>
 void all_to_all(const Communicator &comm, const std::vector<T> &in_values,
                 std::vector<T> &out_values) {
@@ -90,6 +96,15 @@ template <typename... T> void gather(const Communicator &comm, T &&... args) {
     return boost::mpi::gather(comm, std::forward<T>(args)...);
 #endif
   detail::gather(comm, std::forward<T>(args)...);
+}
+
+template <typename... T>
+void all_gather(const Communicator &comm, T &&... args) {
+#ifdef MPI_EXPERIMENTAL
+  if (!comm.hasBackend())
+    return boost::mpi::all_gather(comm, std::forward<T>(args)...);
+#endif
+  detail::all_gather(comm, std::forward<T>(args)...);
 }
 
 template <typename... T>

--- a/Framework/Parallel/inc/MantidParallel/Communicator.h
+++ b/Framework/Parallel/inc/MantidParallel/Communicator.h
@@ -3,6 +3,7 @@
 
 #include "MantidParallel/DllConfig.h"
 #include "MantidParallel/Request.h"
+#include "MantidParallel/Status.h"
 #include "MantidParallel/ThreadingBackend.h"
 
 #ifdef MPI_EXPERIMENTAL
@@ -62,7 +63,7 @@ public:
   int rank() const;
   int size() const;
   template <typename... T> void send(T &&... args) const;
-  template <typename... T> void recv(T &&... args) const;
+  template <typename... T> Status recv(T &&... args) const;
   template <typename... T> Request isend(T &&... args) const;
   template <typename... T> Request irecv(T &&... args) const;
 
@@ -95,14 +96,14 @@ template <typename... T> void Communicator::send(T &&... args) const {
   backend().send(m_rank, std::forward<T>(args)...);
 }
 
-template <typename... T> void Communicator::recv(T &&... args) const {
+template <typename... T> Status Communicator::recv(T &&... args) const {
 // Not returning a status since it would usually not get initialized. See
 // http://mpi-forum.org/docs/mpi-1.1/mpi-11-html/node35.html#Node35.
 #ifdef MPI_EXPERIMENTAL
   if (!hasBackend())
     return static_cast<void>(m_communicator.recv(std::forward<T>(args)...));
 #endif
-  backend().recv(m_rank, std::forward<T>(args)...);
+  return backend().recv(m_rank, std::forward<T>(args)...);
 }
 
 template <typename... T> Request Communicator::isend(T &&... args) const {

--- a/Framework/Parallel/inc/MantidParallel/Communicator.h
+++ b/Framework/Parallel/inc/MantidParallel/Communicator.h
@@ -101,7 +101,7 @@ template <typename... T> Status Communicator::recv(T &&... args) const {
 // http://mpi-forum.org/docs/mpi-1.1/mpi-11-html/node35.html#Node35.
 #ifdef MPI_EXPERIMENTAL
   if (!hasBackend())
-    return static_cast<void>(m_communicator.recv(std::forward<T>(args)...));
+    return Status(m_communicator.recv(std::forward<T>(args)...));
 #endif
   return backend().recv(m_rank, std::forward<T>(args)...);
 }

--- a/Framework/Parallel/inc/MantidParallel/Communicator.h
+++ b/Framework/Parallel/inc/MantidParallel/Communicator.h
@@ -97,8 +97,6 @@ template <typename... T> void Communicator::send(T &&... args) const {
 }
 
 template <typename... T> Status Communicator::recv(T &&... args) const {
-// Not returning a status since it would usually not get initialized. See
-// http://mpi-forum.org/docs/mpi-1.1/mpi-11-html/node35.html#Node35.
 #ifdef MPI_EXPERIMENTAL
   if (!hasBackend())
     return Status(m_communicator.recv(std::forward<T>(args)...));

--- a/Framework/Parallel/inc/MantidParallel/Status.h
+++ b/Framework/Parallel/inc/MantidParallel/Status.h
@@ -44,7 +44,7 @@ class ThreadingBackend;
 class MANTID_PARALLEL_DLL Status {
 public:
 #ifdef MPI_EXPERIMENTAL
-  Status(const boost::mpi::status &status);
+  Status(const boost::mpi::status &status) : m_status(status) {}
 #endif
 
   template <typename T> boost::optional<int> count() const {

--- a/Framework/Parallel/inc/MantidParallel/Status.h
+++ b/Framework/Parallel/inc/MantidParallel/Status.h
@@ -1,0 +1,72 @@
+#ifndef MANTID_PARALLEL_STATUS_H_
+#define MANTID_PARALLEL_STATUS_H_
+
+#include "MantidParallel/DllConfig.h"
+
+#include <boost/optional/optional.hpp>
+#ifdef MPI_EXPERIMENTAL
+#include <boost/mpi/status.hpp>
+#endif
+
+namespace Mantid {
+namespace Parallel {
+namespace detail {
+class ThreadingBackend;
+}
+
+/** Wrapper for boost::mpi::status. For non-MPI builds an equivalent
+  implementation is provided.
+
+  @author Simon Heybrock
+  @date 2017
+
+  Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class MANTID_PARALLEL_DLL Status {
+public:
+#ifdef MPI_EXPERIMENTAL
+  Status(const boost::mpi::status &status);
+#endif
+
+  template <typename T> boost::optional<int> count() const {
+#ifdef MPI_EXPERIMENTAL
+    if (!m_threadingBackend)
+      return m_status.count<T>();
+#endif
+    return static_cast<int>(m_size / sizeof(T));
+  }
+
+private:
+  Status(const size_t size) : m_size(size), m_threadingBackend(true) {}
+#ifdef MPI_EXPERIMENTAL
+  boost::mpi::status m_status;
+#endif
+  const size_t m_size{0};
+  const bool m_threadingBackend{false};
+  // For accessing constructor based on size.
+  friend class detail::ThreadingBackend;
+};
+
+} // namespace Parallel
+} // namespace Mantid
+
+#endif /* MANTID_PARALLEL_STATUS_H_ */

--- a/Framework/Parallel/inc/MantidParallel/ThreadingBackend.h
+++ b/Framework/Parallel/inc/MantidParallel/ThreadingBackend.h
@@ -3,6 +3,7 @@
 
 #include "MantidParallel/DllConfig.h"
 #include "MantidParallel/Request.h"
+#include "MantidParallel/Status.h"
 #include "MantidKernel/make_unique.h"
 
 #include <boost/archive/binary_oarchive.hpp>
@@ -63,7 +64,7 @@ public:
   void send(int source, int dest, int tag, T &&... args);
 
   template <typename... T>
-  void recv(int dest, int source, int tag, T &&... args);
+  Status recv(int dest, int source, int tag, T &&... args);
 
   template <typename... T>
   Request isend(int source, int dest, int tag, T &&... args);
@@ -92,22 +93,32 @@ void saveToStream(boost::archive::binary_oarchive &oa,
 template <class T>
 void saveToStream(boost::archive::binary_oarchive &oa, const T *data,
                   const size_t count) {
+  oa.operator<<(count);
   for (size_t i = 0; i < count; ++i)
     oa.operator<<(data[i]);
 }
 template <class T>
-void loadFromStream(boost::archive::binary_iarchive &ia, T &data) {
+size_t loadFromStream(boost::archive::binary_iarchive &ia, T &data) {
   ia.operator>>(data);
+  return sizeof(T);
 }
 template <class T>
-void loadFromStream(boost::archive::binary_iarchive &ia, std::vector<T> &data) {
+size_t loadFromStream(boost::archive::binary_iarchive &ia,
+                      std::vector<T> &data) {
   ia.operator>>(data);
+  return data.size() * sizeof(T);
 }
 template <class T>
-void loadFromStream(boost::archive::binary_iarchive &ia, T *data,
-                    const size_t count) {
-  for (size_t i = 0; i < count; ++i)
+size_t loadFromStream(boost::archive::binary_iarchive &ia, T *data,
+                      const size_t count) {
+  size_t received;
+  ia.operator>>(received);
+  for (size_t i = 0; i < count; ++i) {
+    if (i >= received)
+      return i * sizeof(T);
     ia.operator>>(data[i]);
+  }
+  return count * sizeof(T);
 }
 }
 
@@ -131,7 +142,7 @@ void ThreadingBackend::send(int source, int dest, int tag, T &&... args) {
 }
 
 template <typename... T>
-void ThreadingBackend::recv(int dest, int source, int tag, T &&... args) {
+Status ThreadingBackend::recv(int dest, int source, int tag, T &&... args) {
   const auto key = std::make_tuple(source, dest, tag);
   std::unique_ptr<std::stringbuf> buf;
   while (true) {
@@ -151,7 +162,7 @@ void ThreadingBackend::recv(int dest, int source, int tag, T &&... args) {
   }
   std::istream is(buf.get());
   boost::archive::binary_iarchive ia(is);
-  detail::loadFromStream(ia, std::forward<T>(args)...);
+  return Status(detail::loadFromStream(ia, std::forward<T>(args)...));
 }
 
 template <typename... T>

--- a/Framework/Parallel/test/CollectivesTest.h
+++ b/Framework/Parallel/test/CollectivesTest.h
@@ -40,6 +40,16 @@ void run_gather_short_version(const Communicator &comm) {
   }
 }
 
+void run_all_gather(const Communicator &comm) {
+  int value = 123 * comm.rank();
+  std::vector<int> result;
+  TS_ASSERT_THROWS_NOTHING(Parallel::all_gather(comm, value, result));
+  TS_ASSERT_EQUALS(result.size(), comm.size());
+  for (int i = 0; i < comm.size(); ++i) {
+    TS_ASSERT_EQUALS(result[i], 123 * i);
+  }
+}
+
 void run_all_to_all(const Communicator &comm) {
   std::vector<int> data;
   for (int rank = 0; rank < comm.size(); ++rank)
@@ -65,6 +75,8 @@ public:
   void test_gather_short_version() {
     ParallelTestHelpers::runParallel(run_gather_short_version);
   }
+
+  void test_all_gather() { ParallelTestHelpers::runParallel(run_all_gather); }
 
   void test_all_to_all() { ParallelTestHelpers::runParallel(run_all_to_all); }
 };

--- a/Framework/Parallel/test/CommunicatorTest.h
+++ b/Framework/Parallel/test/CommunicatorTest.h
@@ -25,6 +25,27 @@ void send_recv(const Communicator &comm) {
   }
 }
 
+void send_recv_status(const Communicator &comm) {
+  if (comm.size() < 2)
+    return;
+
+  std::vector<double> data{1.1, 2.2};
+
+  if (comm.rank() == 0)
+    (comm.send(1, 123, data.data(), 2));
+  (comm.send(1, 123, data.data(), 1));
+  if (comm.rank() == 1) {
+    std::vector<double> result1(2);
+    const auto status1 = comm.recv(0, 123, result1.data(), 2);
+    TS_ASSERT_EQUALS(*status1.count<double>(), 2);
+    TS_ASSERT_EQUALS(result1, data);
+    std::vector<double> result2(2);
+    const auto status2 = comm.recv(0, 123, result2.data(), 2);
+    TS_ASSERT_EQUALS(*status2.count<double>(), 1);
+    TS_ASSERT_EQUALS(result2, (std::vector<double>{1.1, 0.0}));
+  }
+}
+
 void isend_recv(const Communicator &comm) {
   int64_t data = 123456789 + comm.rank();
   int dest = (comm.rank() + 1) % comm.size();
@@ -89,6 +110,8 @@ public:
   }
 
   void test_send_recv() { runParallel(send_recv); }
+
+  void test_send_recv_status() { runParallel(send_recv_status); }
 
   void test_isend_recv() { runParallel(isend_recv); }
 

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -988,13 +988,20 @@ def set_properties(alg_object, *args, **kwargs):
         mandatory_props = alg_object.mandatoryProperties()
     else:
         mandatory_props = []
-    if len(kwargs) > 0:
-        for (key, value) in iteritems(kwargs):
-            do_set_property(key, value)
-            try:
-                mandatory_props.remove(key)
-            except ValueError:
-                pass
+    postponed = []
+    for (key, value) in iteritems(kwargs):
+        try:
+            mandatory_props.remove(key)
+        except ValueError:
+            pass
+        if "IndexSet" in key:
+            # The `IndexSet` sub-property of the "workspace property with index"
+            # must be set after the workspace since it is validated based on in.
+            postponed.append((key, value))
+            continue
+        do_set_property(key, value)
+    for (key, value) in postponed:
+        do_set_property(key, value)
     if len(args) > 0:
         for (key, value) in zip(mandatory_props[:len(args)], args):
             do_set_property(key, value)

--- a/Framework/TestHelpers/inc/MantidTestHelpers/ParallelAlgorithmCreation.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/ParallelAlgorithmCreation.h
@@ -2,6 +2,7 @@
 #define PARALLELALGORITHMCREATION_H_
 
 #include "MantidAPI/IWorkspaceProperty.h"
+#include "MantidKernel/Property.h"
 #include "MantidKernel/make_unique.h"
 
 namespace Mantid {

--- a/docs/source/algorithms/MaskSpectra-v1.rst
+++ b/docs/source/algorithms/MaskSpectra-v1.rst
@@ -1,0 +1,38 @@
+
+.. algorithm::
+
+.. summary::
+
+.. alias::
+
+.. properties::
+
+Description
+-----------
+
+Mask (zero) spectra and the underlying detectors in a workspace.
+If a spectrum corresponds to more than one detector, all detectors are masked.
+
+Usage
+-----
+
+**Example - MaskSpectra**
+
+.. testcode:: MaskSpectraExample
+
+  ws = CreateWorkspace(OutputWorkspace='ws', DataX='1,1', DataY='2,2', NSpec=2)
+  masked = MaskSpectra(InputWorkspace=ws, InputWorkspaceIndexType='WorkspaceIndex', InputWorkspaceIndexSet='1')
+  print(ws.readY(0), masked.readY(0))
+  print(ws.readY(1), masked.readY(1))
+
+Output:
+
+.. testoutput:: MaskSpectraExample
+
+  (array([ 2.]), array([ 2.]))
+  (array([ 2.]), array([ 0.]))
+
+.. categories::
+
+.. sourcelink::
+

--- a/docs/source/algorithms/MaskSpectra-v1.rst
+++ b/docs/source/algorithms/MaskSpectra-v1.rst
@@ -22,15 +22,15 @@ Usage
 
   ws = CreateWorkspace(OutputWorkspace='ws', DataX='1,1', DataY='2,2', NSpec=2)
   masked = MaskSpectra(InputWorkspace=ws, InputWorkspaceIndexType='WorkspaceIndex', InputWorkspaceIndexSet='1')
-  print(ws.readY(0), masked.readY(0))
-  print(ws.readY(1), masked.readY(1))
+  print(ws.readY(0)[0], masked.readY(0)[0])
+  print(ws.readY(1)[0], masked.readY(1)[0])
 
 Output:
 
 .. testoutput:: MaskSpectraExample
 
-  (array([ 2.]), array([ 2.]))
-  (array([ 2.]), array([ 0.]))
+  (2.0, 2.0)
+  (2.0, 0.0)
 
 .. categories::
 

--- a/docs/source/algorithms/MaskSpectra-v1.rst
+++ b/docs/source/algorithms/MaskSpectra-v1.rst
@@ -22,15 +22,15 @@ Usage
 
   ws = CreateWorkspace(OutputWorkspace='ws', DataX='1,1', DataY='2,2', NSpec=2)
   masked = MaskSpectra(InputWorkspace=ws, InputWorkspaceIndexType='WorkspaceIndex', InputWorkspaceIndexSet='1')
-  print(ws.readY(0)[0], masked.readY(0)[0])
-  print(ws.readY(1)[0], masked.readY(1)[0])
+  print('Spectrum 0 before {} after {}'.format(ws.readY(0)[0], masked.readY(0)[0]))
+  print('Spectrum 1 before {} after {}'.format(ws.readY(1)[0], masked.readY(1)[0]))
 
 Output:
 
 .. testoutput:: MaskSpectraExample
 
-  (2.0, 2.0)
-  (2.0, 0.0)
+  Spectrum 0 before 2.0 after 2.0
+  Spectrum 1 before 2.0 after 0.0
 
 .. categories::
 

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -482,6 +482,8 @@ Rebin                             all             min and max bin boundaries mus
 RebinToWorkspace                  all             ``WorkspaceToMatch`` must have ``StorageMode::Cloned``
 RemovePromptPulse                 all
 RotateInstrumentComponent         all
+SaveNexus                         MasterOnly
+SaveNexusProcessed                MasterOnly
 SortEvents                        all
 WeightedMean                      all             see ``BinaryOperation``
 ================================= =============== ========

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -459,6 +459,7 @@ CalculateChiSquared               MasterOnly, Identical   see ``IFittingAlgorith
 CalculateCostFunction             MasterOnly, Identical   see ``IFittingAlgorithm``
 CloneWorkspace                    all
 CompressEvents                    all
+CompareWorkspace                  MasterOnly, Identical   if one input has ``StorageMode::Cloned`` and the other has ``StorageMode::MasterOnly`` then ``ExecutionMode::MasterOnly`` is used
 CreateSingleValuedWorkspace       Identical               ``OutputWorkspace`` has ``StorageMode::Cloned``, support of ``MasterOnly`` would require adding property for selecting the mode
 CreateWorkspace                   all
 CropToComponent                   all

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -371,7 +371,7 @@ The consequences are as follows:
   It should not be logged, written as output, or used for branching execution paths since it is meaningless.
   If the total number of spectra in a workspace is required it can be accessed via ``MatrixWorkspace::indexInfo()::globalSize()``.
 - User input providing indices or spectrum numbers in one way or another must be translated into local indices by ``IndexInfo``.
-  The most common cases are a workspace property that also accepts indices, see `IndexProperty`_.
+  The most common cases are a workspace property that also accepts indices, see `IndexProperty <../concepts/IndexProperty.html>`__.
 - The distinction between local and global indices must not be exposed to the user.
   In particular, the 'global' prefix should be omitted, i.e., for the user interface we keep referring to 'workspace index', even though it is internally not what used to be the workspace index but rather a global index.
   Indices provided by a user may never be interpreted as local indices, since a local index has no fixed meaning.

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -454,15 +454,17 @@ Supported Algorithms
 ================================= =============== ========
 Algorithm                         Supported modes Comments
 ================================= =============== ========
+BinaryOperation                   all             not supported if ``AllowDifferentNumberSpectra`` is enabled
 CloneWorkspace                    all
 CompressEvents                    all
-CreateWorkspace                   all
 CreateSingleValuedWorkspace       Identical       ``OutputWorkspace`` has ``StorageMode::Cloned``, support of ``MasterOnly`` would require adding property for selecting the mode
+CreateWorkspace                   all
 CropToComponent                   all
-CropWorkspace                     all             see ExtractSpectra regarding X cropping
+CropWorkspace                     all             see ``ExtractSpectra`` regarding X cropping
+Divide                            all             see ``BinaryOperation``
+ExtractSingleSpectrum             all             in practice ``ExecutionMode::Distributed`` not supported due to current nonzero-spectrum-count limitation
 ExtractSpectra2                   all             currently not available via algorithm factory or Python
 ExtractSpectra                    all             not supported with ``DetectorList``, cropping in X may exhibit inconsistent behavior in case spectra have common boundaries within some ranks but not within all ranks or across ranks
-ExtractSingleSpectrum             all             in practice ``ExecutionMode::Distributed`` not supported due to current nonzero-spectrum-count limitation
 FilterBadPulses                   all
 FilterByLogValue                  all
 FilterByTime                      all
@@ -471,12 +473,17 @@ LoadInstrument                    all
 LoadNexusLogs                     all
 LoadParameterFile                 all             segfaults when used in unit tests with MPI threading backend due to `#9365 <https://github.com/mantidproject/mantid/issues/9365>`_, normal use should be ok
 MaskBins                          all
+Minus                             all             see ``BinaryOperation``
 MoveInstrumentComponent           all
+Multiply                          all             see ``BinaryOperation``
+Plus                              all             see ``BinaryOperation``
+PoissonErrors                     all             see ``BinaryOperation``
 Rebin                             all             min and max bin boundaries must be given explicitly
 RebinToWorkspace                  all             ``WorkspaceToMatch`` must have ``StorageMode::Cloned``
 RemovePromptPulse                 all
 RotateInstrumentComponent         all
 SortEvents                        all
+WeightedMean                      all             see ``BinaryOperation``
 ================================= =============== ========
 
 Currently none of the above algorithms works with ``StorageMode::Distributed`` in case there are zero spectra on any rank.

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -22,7 +22,7 @@ MPI support for these multi-dimensional workspaces is beyond the scope of this d
 Spectrum and Detector
 ---------------------
 
-In Mantid the terms spectrum and detector are used interchangeably at times, leading to unnecessary confusion.
+In Mantid the terms spectrum and detector are used interchangeably at times, leading to confusion.
 In particular, it is sometimes assumed that there is a 1:1 correspondence between spectra and detectors.
 It is important to clearly distinguish between a spectrum and a detector, especially in the context of MPI support.
 We may define the terms as follows:
@@ -370,10 +370,11 @@ The consequences are as follows:
 - The number of histograms in a workspace obtained from ``MatrixWorkspace::getNumberHistograms()`` may only be used for processing all spectra, i.e., when each MPI rank is processing all its local spectra.
   It should not be logged, written as output, or used for branching execution paths since it is meaningless.
   If the total number of spectra in a workspace is required it can be accessed via ``MatrixWorkspace::indexInfo()::globalSize()``.
-- User input providing indices or spectrum numbers in way or another must be translated into local indices by ``IndexInfo``.
-  The most common cases will be covered by a workspace property that also accepts indices (under development).
+- User input providing indices or spectrum numbers in one way or another must be translated into local indices by ``IndexInfo``.
+  The most common cases are a workspace property that also accepts indices, see `IndexProperty`_.
 - The distinction between local and global indices must not be exposed to the user.
   In particular, the 'global' prefix should be omitted, i.e., for the user interface we keep referring to 'workspace index', even though it is internally not what used to be the workspace index but rather a global index.
+  Indices provided by a user may never be interpreted as local indices, since a local index has no fixed meaning.
 
 
 Instrument and detectors

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -462,6 +462,8 @@ CalculateTransmission             MasterOnly, Identical
 CloneWorkspace                    all
 CompressEvents                    all
 CompareWorkspace                  MasterOnly, Identical   if one input has ``StorageMode::Cloned`` and the other has ``StorageMode::MasterOnly`` then ``ExecutionMode::MasterOnly`` is used
+ConvertToHistogram                all
+ConvertToPointData                all
 CreateSingleValuedWorkspace       Identical               ``OutputWorkspace`` has ``StorageMode::Cloned``, support of ``MasterOnly`` would require adding property for selecting the mode
 CreateWorkspace                   all
 CropToComponent                   all

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -266,8 +266,8 @@ In that case the execution mode can simply be determined from the input workspac
 Here the helper ``Parallel::getCorrespondingExecutionMode`` is used to obtain the 'natural' execution mode from a storage mode, i.e., ``ExecutionMode::Identical`` for ``StorageMode::Cloned``, ``ExecutionMode::Distributed`` for ``StorageMode::Distributed``, and ``ExecutionMode::MasterOnly`` for ``StorageMode::MasterOnly``.
 More complex algorithms may require more complex decision mechanism, e.g., when there is more than one input workspace.
 
-For many algorithms the base class ``API::ParallelAlgorithm`` provides a sufficient default implementation of ``Algorithm::getParallelExecutionMode()``.
-MPI support can simply be enabled by inheriting from ``ParallelAlgorithm`` instead of from ``Algorithm``.
+For many algorithms the base class ``API::DistributedAlgorithm`` provides a sufficient default implementation of ``Algorithm::getParallelExecutionMode()``.
+MPI support can simply be enabled by inheriting from ``DistributedAlgorithm`` instead of from ``Algorithm``.
 Generally this works only for algorithms with a single input and a single output that either process only non-spectrum data or process all spectra independently.
 
 If none of the other virtual methods listed above is implemented, ``Algorithm`` will run the normal ``exec()`` method on all MPI ranks.

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -455,6 +455,8 @@ Supported Algorithms
 Algorithm                         Supported modes         Comments
 ================================= ======================= ========
 BinaryOperation                   all                     not supported if ``AllowDifferentNumberSpectra`` is enabled
+CalculateChiSquared               MasterOnly, Identical   see ``IFittingAlgorithm``
+CalculateCostFunction             MasterOnly, Identical   see ``IFittingAlgorithm``
 CloneWorkspace                    all
 CompressEvents                    all
 CreateSingleValuedWorkspace       Identical               ``OutputWorkspace`` has ``StorageMode::Cloned``, support of ``MasterOnly`` would require adding property for selecting the mode
@@ -462,6 +464,8 @@ CreateWorkspace                   all
 CropToComponent                   all
 CropWorkspace                     all                     see ``ExtractSpectra`` regarding X cropping
 Divide                            all                     see ``BinaryOperation``
+EstimateFitParameters             MasterOnly, Identical   see ``IFittingAlgorithm``
+EvaluateFunction                  MasterOnly, Identical   see ``IFittingAlgorithm``
 ExtractSingleSpectrum             all                     in practice ``ExecutionMode::Distributed`` not supported due to current nonzero-spectrum-count limitation
 ExtractSpectra2                   all                     currently not available via algorithm factory or Python
 ExtractSpectra                    all                     not supported with ``DetectorList``, cropping in X may exhibit inconsistent behavior in case spectra have common boundaries within some ranks but not within all ranks or across ranks
@@ -469,7 +473,9 @@ FilterBadPulses                   all
 FilterByLogValue                  all
 FilterByTime                      all
 FilterEventsByLogValuePreNexus    Identical               see ``IFileLoader``
-IFileLoader                       Identical               implicitly adds support for many load inheriting from this
+Fit                               MasterOnly, Identical   see ``IFittingAlgorithm``
+IFileLoader                       Identical               implicitly adds support for many load-algorithms inheriting from this
+IFittingAlgorithm                 MasterOnly, Identical   implicitly adds support for several fit-algorithms inheriting from this
 LoadAscii2                        Identical               see ``IFileLoader``
 LoadAscii                         Identical               see ``IFileLoader``
 LoadBBY                           Identical               see ``IFileLoader``

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -454,13 +454,17 @@ Supported Algorithms
 ================================= =============== ========
 Algorithm                         Supported modes Comments
 ================================= =============== ========
+CloneWorkspace                    all
 CompressEvents                    all
 CreateWorkspace                   all
+CreateSingleValuedWorkspace       Identical       ``OutputWorkspace`` has ``StorageMode::Cloned``, support of ``MasterOnly`` would require adding property for selecting the mode
+CropToComponent                   all
 CropWorkspace                     all             see ExtractSpectra regarding X cropping
 ExtractSpectra2                   all             currently not available via algorithm factory or Python
 ExtractSpectra                    all             not supported with ``DetectorList``, cropping in X may exhibit inconsistent behavior in case spectra have common boundaries within some ranks but not within all ranks or across ranks
 FilterBadPulses                   all
 FilterByLogValue                  all
+FilterByTime                      all
 LoadEventNexus                    Distributed     storage mode of output cannot be changed via a parameter currently, min and max bin boundary are not globally the same
 LoadInstrument                    all
 LoadNexusLogs                     all
@@ -468,6 +472,7 @@ LoadParameterFile                 all             segfaults when used in unit te
 MaskBins                          all
 MoveInstrumentComponent           all
 Rebin                             all             min and max bin boundaries must be given explicitly
+RebinToWorkspace                  all             ``WorkspaceToMatch`` must have ``StorageMode::Cloned``
 RemovePromptPulse                 all
 RotateInstrumentComponent         all
 SortEvents                        all

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -517,6 +517,7 @@ LoadSwans                         Identical               see ``IFileLoader``
 LoadTBL                           Identical               see ``IFileLoader``
 LoadTOFRawNexus                   Identical               see ``IFileLoader``
 MaskBins                          all
+MaskSpectra                       all
 Minus                             all                     see ``BinaryOperation``
 MoveInstrumentComponent           all
 Multiply                          all                     see ``BinaryOperation``

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -457,6 +457,7 @@ Algorithm                         Supported modes         Comments
 BinaryOperation                   all                     not supported if ``AllowDifferentNumberSpectra`` is enabled
 CalculateChiSquared               MasterOnly, Identical   see ``IFittingAlgorithm``
 CalculateCostFunction             MasterOnly, Identical   see ``IFittingAlgorithm``
+CalculateFlatBackground           MasterOnly, Identical
 CalculateTransmission             MasterOnly, Identical
 CloneWorkspace                    all
 CompressEvents                    all

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -495,6 +495,7 @@ LoadMD                            Identical       see ``IFileLoader``
 LoadMLZ                           Identical       see ``IFileLoader``
 LoadMuonNexus                     Identical       see ``IFileLoader``
 LoadNexusLogs                     all
+LoadNexusMonitors2                Identical
 LoadNexusProcessed                Identical       see ``IFileLoader``
 LoadNXcanSAS                      Identical       see ``IFileLoader``
 LoadNXSPE                         Identical       see ``IFileLoader``

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -476,6 +476,7 @@ FilterBadPulses                   all
 FilterByLogValue                  all
 FilterByTime                      all
 FilterEventsByLogValuePreNexus    Identical               see ``IFileLoader``
+FindDetectorsInShape              all
 Fit                               MasterOnly, Identical   see ``IFittingAlgorithm``
 IFileLoader                       Identical               implicitly adds support for many load-algorithms inheriting from this
 IFittingAlgorithm                 MasterOnly, Identical   implicitly adds support for several fit-algorithms inheriting from this
@@ -526,6 +527,7 @@ LoadSwans                         Identical               see ``IFileLoader``
 LoadTBL                           Identical               see ``IFileLoader``
 LoadTOFRawNexus                   Identical               see ``IFileLoader``
 MaskBins                          all
+MaskDetectorsInShape              all
 MaskSpectra                       all
 Minus                             all                     see ``BinaryOperation``
 MoveInstrumentComponent           all

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -462,6 +462,7 @@ CropToComponent                   all
 CropWorkspace                     all             see ExtractSpectra regarding X cropping
 ExtractSpectra2                   all             currently not available via algorithm factory or Python
 ExtractSpectra                    all             not supported with ``DetectorList``, cropping in X may exhibit inconsistent behavior in case spectra have common boundaries within some ranks but not within all ranks or across ranks
+ExtractSingleSpectrum             all             in practice ``ExecutionMode::Distributed`` not supported due to current nonzero-spectrum-count limitation
 FilterBadPulses                   all
 FilterByLogValue                  all
 FilterByTime                      all

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -471,6 +471,7 @@ CompareWorkspace                  MasterOnly, Identical   if one input has ``Sto
 CompressEvents                    all
 ConvertToHistogram                all
 ConvertToPointData                all
+ConvertUnits                      all                     ``AlignBins`` not supported; for indirect energy mode the number of resulting bins is in general inconsistent across MPI ranks
 CreateSingleValuedWorkspace       Identical               ``OutputWorkspace`` has ``StorageMode::Cloned``, support of ``MasterOnly`` would require adding property for selecting the mode
 CreateWorkspace                   all
 CropToComponent                   all

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -468,10 +468,53 @@ ExtractSpectra                    all             not supported with ``DetectorL
 FilterBadPulses                   all
 FilterByLogValue                  all
 FilterByTime                      all
+FilterEventsByLogValuePreNexus    Identical       see ``IFileLoader``
+IFileLoader                       Identical       implicitly adds support for many load inheriting from this
+LoadAscii2                        Identical       see ``IFileLoader``
+LoadAscii                         Identical       see ``IFileLoader``
+LoadBBY                           Identical       see ``IFileLoader``
+LoadCanSAS1D                      Identical       see ``IFileLoader``
+LoadDaveGrp                       Identical       see ``IFileLoader``
+LoadEmptyInstrument               Identical       see ``IFileLoader``
 LoadEventNexus                    Distributed     storage mode of output cannot be changed via a parameter currently, min and max bin boundary are not globally the same
+LoadEventPreNexus2                Identical       see ``IFileLoader``
+LoadFITS                          Identical       see ``IFileLoader``
+LoadGSS                           Identical       see ``IFileLoader``
+LoadILLDiffraction                Identical       see ``IFileLoader``
+LoadILLIndirect2                  Identical       see ``IFileLoader``
+LoadILLReflectometry              Identical       see ``IFileLoader``
+LoadILLSANS                       Identical       see ``IFileLoader``
+LoadILLTOF2                       Identical       see ``IFileLoader``
 LoadInstrument                    all
+LoadIsawPeaks                     Identical       see ``IFileLoader``
+LoadISISNexus2                    Identical       see ``IFileLoader``
+LoadLLB                           Identical       see ``IFileLoader``
+LoadMcStas                        Identical       see ``IFileLoader``
+LoadMcStasNexus                   Identical       see ``IFileLoader``
+LoadMD                            Identical       see ``IFileLoader``
+LoadMLZ                           Identical       see ``IFileLoader``
+LoadMuonNexus                     Identical       see ``IFileLoader``
 LoadNexusLogs                     all
+LoadNexusProcessed                Identical       see ``IFileLoader``
+LoadNXcanSAS                      Identical       see ``IFileLoader``
+LoadNXSPE                         Identical       see ``IFileLoader``
 LoadParameterFile                 all             segfaults when used in unit tests with MPI threading backend due to `#9365 <https://github.com/mantidproject/mantid/issues/9365>`_, normal use should be ok
+LoadPDFgetNFile                   Identical       see ``IFileLoader``
+LoadPreNexus                      Identical       see ``IFileLoader``
+LoadQKK                           Identical       see ``IFileLoader``
+LoadRawHelper                     Identical       see ``IFileLoader``
+LoadRKH                           Identical       see ``IFileLoader``
+LoadSassena                       Identical       see ``IFileLoader``
+LoadSESANS                        Identical       see ``IFileLoader``
+LoadSINQFocus                     Identical       see ``IFileLoader``
+LoadSNSspec                       Identical       see ``IFileLoader``
+LoadSPE                           Identical       see ``IFileLoader``
+LoadSpice2D                       Identical       see ``IFileLoader``
+LoadSQW2                          Identical       see ``IFileLoader``
+LoadSQW                           Identical       see ``IFileLoader``
+LoadSwans                         Identical       see ``IFileLoader``
+LoadTBL                           Identical       see ``IFileLoader``
+LoadTOFRawNexus                   Identical       see ``IFileLoader``
 MaskBins                          all
 Minus                             all             see ``BinaryOperation``
 MoveInstrumentComponent           all

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -481,6 +481,7 @@ FilterByTime                      all
 FilterEventsByLogValuePreNexus    Identical               see ``IFileLoader``
 FindDetectorsInShape              all
 Fit                               MasterOnly, Identical   see ``IFittingAlgorithm``
+GroupWorkspaces                   all
 IFileLoader                       Identical               implicitly adds support for many load-algorithms inheriting from this
 IFittingAlgorithm                 MasterOnly, Identical   implicitly adds support for several fit-algorithms inheriting from this
 Load                              all                     actual supported mode is dictated by underlying load algorithm, which depends on file type

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -526,6 +526,7 @@ LoadSQW                           Identical               see ``IFileLoader``
 LoadSwans                         Identical               see ``IFileLoader``
 LoadTBL                           Identical               see ``IFileLoader``
 LoadTOFRawNexus                   Identical               see ``IFileLoader``
+Load                              all                     actual supported mode is dictated by underlying load algorithm, which depends on file type
 MaskBins                          all
 MaskDetectorsInShape              all
 MaskSpectra                       all

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -266,9 +266,16 @@ In that case the execution mode can simply be determined from the input workspac
 Here the helper ``Parallel::getCorrespondingExecutionMode`` is used to obtain the 'natural' execution mode from a storage mode, i.e., ``ExecutionMode::Identical`` for ``StorageMode::Cloned``, ``ExecutionMode::Distributed`` for ``StorageMode::Distributed``, and ``ExecutionMode::MasterOnly`` for ``StorageMode::MasterOnly``.
 More complex algorithms may require more complex decision mechanism, e.g., when there is more than one input workspace.
 
-For many algorithms the base class ``API::DistributedAlgorithm`` provides a sufficient default implementation of ``Algorithm::getParallelExecutionMode()``.
-MPI support can simply be enabled by inheriting from ``DistributedAlgorithm`` instead of from ``Algorithm``.
-Generally this works only for algorithms with a single input and a single output that either process only non-spectrum data or process all spectra independently.
+For many algorithms a sufficient default implementation of ``Algorithm::getParallelExecutionMode()`` is provided by one of the base classes ``API::SerialAlgorithm``, ``API::ParallelAlgorithm``, or ``API::DistributedAlgorithm``.
+MPI support can simply be enabled by inheriting from one of these instead of from ``Algorithm``.
+The level of thereby enabled MPI support is as follows:
+
+- ``API::SerialAlgorithm`` supports only ``ExecutionMode::MasterOnly``.
+- ``API::ParallelAlgorithm`` supports parallel execution, but not distributed execution, i.e., ``ExecutionMode::MasterOnly`` and  ``ExecutionMode::IdenticalOnly``.
+- ``API::DistributedAlgorithm`` supports distributed execution, i.e., ``ExecutionMode::MasterOnly``, ``ExecutionMode::IdenticalOnly``, and  ``ExecutionMode::Distributed``.
+
+In the latter two cases more than one execution mode is supported.
+Thus this usually works only for algorithms with a single input (and a single output) such that the execution mode can be uniquely derived from the storage mode of the input workpace.
 
 If none of the other virtual methods listed above is implemented, ``Algorithm`` will run the normal ``exec()`` method on all MPI ranks.
 The exception are non-master ranks if the execution mode is ``ExecutionMode::MasterOnly`` -- in that case creating a dummy workspace is attempted.

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -457,6 +457,7 @@ Algorithm                         Supported modes         Comments
 BinaryOperation                   all                     not supported if ``AllowDifferentNumberSpectra`` is enabled
 CalculateChiSquared               MasterOnly, Identical   see ``IFittingAlgorithm``
 CalculateCostFunction             MasterOnly, Identical   see ``IFittingAlgorithm``
+CalculateTransmission             MasterOnly, Identical
 CloneWorkspace                    all
 CompressEvents                    all
 CompareWorkspace                  MasterOnly, Identical   if one input has ``StorageMode::Cloned`` and the other has ``StorageMode::MasterOnly`` then ``ExecutionMode::MasterOnly`` is used

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -451,86 +451,87 @@ Potential limitations must be described in the comments.
 Supported Algorithms
 ####################
 
-================================= =============== ========
-Algorithm                         Supported modes Comments
-================================= =============== ========
-BinaryOperation                   all             not supported if ``AllowDifferentNumberSpectra`` is enabled
+================================= ======================= ========
+Algorithm                         Supported modes         Comments
+================================= ======================= ========
+BinaryOperation                   all                     not supported if ``AllowDifferentNumberSpectra`` is enabled
 CloneWorkspace                    all
 CompressEvents                    all
-CreateSingleValuedWorkspace       Identical       ``OutputWorkspace`` has ``StorageMode::Cloned``, support of ``MasterOnly`` would require adding property for selecting the mode
+CreateSingleValuedWorkspace       Identical               ``OutputWorkspace`` has ``StorageMode::Cloned``, support of ``MasterOnly`` would require adding property for selecting the mode
 CreateWorkspace                   all
 CropToComponent                   all
-CropWorkspace                     all             see ``ExtractSpectra`` regarding X cropping
-Divide                            all             see ``BinaryOperation``
-ExtractSingleSpectrum             all             in practice ``ExecutionMode::Distributed`` not supported due to current nonzero-spectrum-count limitation
-ExtractSpectra2                   all             currently not available via algorithm factory or Python
-ExtractSpectra                    all             not supported with ``DetectorList``, cropping in X may exhibit inconsistent behavior in case spectra have common boundaries within some ranks but not within all ranks or across ranks
+CropWorkspace                     all                     see ``ExtractSpectra`` regarding X cropping
+Divide                            all                     see ``BinaryOperation``
+ExtractSingleSpectrum             all                     in practice ``ExecutionMode::Distributed`` not supported due to current nonzero-spectrum-count limitation
+ExtractSpectra2                   all                     currently not available via algorithm factory or Python
+ExtractSpectra                    all                     not supported with ``DetectorList``, cropping in X may exhibit inconsistent behavior in case spectra have common boundaries within some ranks but not within all ranks or across ranks
 FilterBadPulses                   all
 FilterByLogValue                  all
 FilterByTime                      all
-FilterEventsByLogValuePreNexus    Identical       see ``IFileLoader``
-IFileLoader                       Identical       implicitly adds support for many load inheriting from this
-LoadAscii2                        Identical       see ``IFileLoader``
-LoadAscii                         Identical       see ``IFileLoader``
-LoadBBY                           Identical       see ``IFileLoader``
-LoadCanSAS1D                      Identical       see ``IFileLoader``
-LoadDaveGrp                       Identical       see ``IFileLoader``
-LoadEmptyInstrument               Identical       see ``IFileLoader``
-LoadEventNexus                    Distributed     storage mode of output cannot be changed via a parameter currently, min and max bin boundary are not globally the same
-LoadEventPreNexus2                Identical       see ``IFileLoader``
-LoadFITS                          Identical       see ``IFileLoader``
-LoadGSS                           Identical       see ``IFileLoader``
-LoadILLDiffraction                Identical       see ``IFileLoader``
-LoadILLIndirect2                  Identical       see ``IFileLoader``
-LoadILLReflectometry              Identical       see ``IFileLoader``
-LoadILLSANS                       Identical       see ``IFileLoader``
-LoadILLTOF2                       Identical       see ``IFileLoader``
+FilterEventsByLogValuePreNexus    Identical               see ``IFileLoader``
+IFileLoader                       Identical               implicitly adds support for many load inheriting from this
+LoadAscii2                        Identical               see ``IFileLoader``
+LoadAscii                         Identical               see ``IFileLoader``
+LoadBBY                           Identical               see ``IFileLoader``
+LoadCanSAS1D                      Identical               see ``IFileLoader``
+LoadDaveGrp                       Identical               see ``IFileLoader``
+LoadEmptyInstrument               Identical               see ``IFileLoader``
+LoadEventNexus                    Distributed             storage mode of output cannot be changed via a parameter currently, min and max bin boundary are not globally the same
+LoadEventPreNexus2                Identical               see ``IFileLoader``
+LoadFITS                          Identical               see ``IFileLoader``
+LoadGSS                           Identical               see ``IFileLoader``
+LoadILLDiffraction                Identical               see ``IFileLoader``
+LoadILLIndirect2                  Identical               see ``IFileLoader``
+LoadILLReflectometry              Identical               see ``IFileLoader``
+LoadILLSANS                       Identical               see ``IFileLoader``
+LoadILLTOF2                       Identical               see ``IFileLoader``
 LoadInstrument                    all
-LoadIsawPeaks                     Identical       see ``IFileLoader``
-LoadISISNexus2                    Identical       see ``IFileLoader``
-LoadLLB                           Identical       see ``IFileLoader``
-LoadMcStas                        Identical       see ``IFileLoader``
-LoadMcStasNexus                   Identical       see ``IFileLoader``
-LoadMD                            Identical       see ``IFileLoader``
-LoadMLZ                           Identical       see ``IFileLoader``
-LoadMuonNexus                     Identical       see ``IFileLoader``
+LoadIsawPeaks                     Identical               see ``IFileLoader``
+LoadISISNexus2                    Identical               see ``IFileLoader``
+LoadLLB                           Identical               see ``IFileLoader``
+LoadMcStas                        Identical               see ``IFileLoader``
+LoadMcStasNexus                   Identical               see ``IFileLoader``
+LoadMD                            Identical               see ``IFileLoader``
+LoadMLZ                           Identical               see ``IFileLoader``
+LoadMuonNexus                     Identical               see ``IFileLoader``
 LoadNexusLogs                     all
 LoadNexusMonitors2                Identical
-LoadNexusProcessed                Identical       see ``IFileLoader``
-LoadNXcanSAS                      Identical       see ``IFileLoader``
-LoadNXSPE                         Identical       see ``IFileLoader``
-LoadParameterFile                 all             segfaults when used in unit tests with MPI threading backend due to `#9365 <https://github.com/mantidproject/mantid/issues/9365>`_, normal use should be ok
-LoadPDFgetNFile                   Identical       see ``IFileLoader``
-LoadPreNexus                      Identical       see ``IFileLoader``
-LoadQKK                           Identical       see ``IFileLoader``
-LoadRawHelper                     Identical       see ``IFileLoader``
-LoadRKH                           Identical       see ``IFileLoader``
-LoadSassena                       Identical       see ``IFileLoader``
-LoadSESANS                        Identical       see ``IFileLoader``
-LoadSINQFocus                     Identical       see ``IFileLoader``
-LoadSNSspec                       Identical       see ``IFileLoader``
-LoadSPE                           Identical       see ``IFileLoader``
-LoadSpice2D                       Identical       see ``IFileLoader``
-LoadSQW2                          Identical       see ``IFileLoader``
-LoadSQW                           Identical       see ``IFileLoader``
-LoadSwans                         Identical       see ``IFileLoader``
-LoadTBL                           Identical       see ``IFileLoader``
-LoadTOFRawNexus                   Identical       see ``IFileLoader``
+LoadNexusProcessed                Identical               see ``IFileLoader``
+LoadNXcanSAS                      Identical               see ``IFileLoader``
+LoadNXSPE                         Identical               see ``IFileLoader``
+LoadParameterFile                 all                     segfaults when used in unit tests with MPI threading backend due to `#9365 <https://github.com/mantidproject/mantid/issues/9365>`_, normal use should be ok
+LoadPDFgetNFile                   Identical               see ``IFileLoader``
+LoadPreNexus                      Identical               see ``IFileLoader``
+LoadQKK                           Identical               see ``IFileLoader``
+LoadRawHelper                     Identical               see ``IFileLoader``
+LoadRKH                           Identical               see ``IFileLoader``
+LoadSassena                       Identical               see ``IFileLoader``
+LoadSESANS                        Identical               see ``IFileLoader``
+LoadSINQFocus                     Identical               see ``IFileLoader``
+LoadSNSspec                       Identical               see ``IFileLoader``
+LoadSPE                           Identical               see ``IFileLoader``
+LoadSpice2D                       Identical               see ``IFileLoader``
+LoadSQW2                          Identical               see ``IFileLoader``
+LoadSQW                           Identical               see ``IFileLoader``
+LoadSwans                         Identical               see ``IFileLoader``
+LoadTBL                           Identical               see ``IFileLoader``
+LoadTOFRawNexus                   Identical               see ``IFileLoader``
 MaskBins                          all
-Minus                             all             see ``BinaryOperation``
+Minus                             all                     see ``BinaryOperation``
 MoveInstrumentComponent           all
-Multiply                          all             see ``BinaryOperation``
-Plus                              all             see ``BinaryOperation``
-PoissonErrors                     all             see ``BinaryOperation``
-Rebin                             all             min and max bin boundaries must be given explicitly
-RebinToWorkspace                  all             ``WorkspaceToMatch`` must have ``StorageMode::Cloned``
+Multiply                          all                     see ``BinaryOperation``
+Plus                              all                     see ``BinaryOperation``
+PoissonErrors                     all                     see ``BinaryOperation``
+Rebin                             all                     min and max bin boundaries must be given explicitly
+RebinToWorkspace                  all                     ``WorkspaceToMatch`` must have ``StorageMode::Cloned``
 RemovePromptPulse                 all
 RotateInstrumentComponent         all
 SaveNexus                         MasterOnly
 SaveNexusProcessed                MasterOnly
 SortEvents                        all
-WeightedMean                      all             see ``BinaryOperation``
-================================= =============== ========
+SumSpectra                        MasterOnly, Identical
+WeightedMean                      all                     see ``BinaryOperation``
+================================= ======================= ========
 
 Currently none of the above algorithms works with ``StorageMode::Distributed`` in case there are zero spectra on any rank.
 

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -460,8 +460,8 @@ CalculateCostFunction             MasterOnly, Identical   see ``IFittingAlgorith
 CalculateFlatBackground           MasterOnly, Identical
 CalculateTransmission             MasterOnly, Identical
 CloneWorkspace                    all
-CompressEvents                    all
 CompareWorkspace                  MasterOnly, Identical   if one input has ``StorageMode::Cloned`` and the other has ``StorageMode::MasterOnly`` then ``ExecutionMode::MasterOnly`` is used
+CompressEvents                    all
 ConvertToHistogram                all
 ConvertToPointData                all
 CreateSingleValuedWorkspace       Identical               ``OutputWorkspace`` has ``StorageMode::Cloned``, support of ``MasterOnly`` would require adding property for selecting the mode
@@ -471,6 +471,7 @@ CropWorkspace                     all                     see ``ExtractSpectra``
 Divide                            all                     see ``BinaryOperation``
 EstimateFitParameters             MasterOnly, Identical   see ``IFittingAlgorithm``
 EvaluateFunction                  MasterOnly, Identical   see ``IFittingAlgorithm``
+ExponentialCorrection             all                     see ``UnaryOperation``
 ExtractSingleSpectrum             all                     in practice ``ExecutionMode::Distributed`` not supported due to current nonzero-spectrum-count limitation
 ExtractSpectra2                   all                     currently not available via algorithm factory or Python
 ExtractSpectra                    all                     not supported with ``DetectorList``, cropping in X may exhibit inconsistent behavior in case spectra have common boundaries within some ranks but not within all ranks or across ranks
@@ -482,6 +483,7 @@ FindDetectorsInShape              all
 Fit                               MasterOnly, Identical   see ``IFittingAlgorithm``
 IFileLoader                       Identical               implicitly adds support for many load-algorithms inheriting from this
 IFittingAlgorithm                 MasterOnly, Identical   implicitly adds support for several fit-algorithms inheriting from this
+Load                              all                     actual supported mode is dictated by underlying load algorithm, which depends on file type
 LoadAscii2                        Identical               see ``IFileLoader``
 LoadAscii                         Identical               see ``IFileLoader``
 LoadBBY                           Identical               see ``IFileLoader``
@@ -528,23 +530,30 @@ LoadSQW                           Identical               see ``IFileLoader``
 LoadSwans                         Identical               see ``IFileLoader``
 LoadTBL                           Identical               see ``IFileLoader``
 LoadTOFRawNexus                   Identical               see ``IFileLoader``
-Load                              all                     actual supported mode is dictated by underlying load algorithm, which depends on file type
+Logarithm                         all                     see ``UnaryOperation``
 MaskBins                          all
 MaskDetectorsInShape              all
 MaskSpectra                       all
 Minus                             all                     see ``BinaryOperation``
 MoveInstrumentComponent           all
 Multiply                          all                     see ``BinaryOperation``
+OneMinusExponentialCor            all                     see ``UnaryOperation``
 Plus                              all                     see ``BinaryOperation``
 PoissonErrors                     all                     see ``BinaryOperation``
+PolynomialCorrection              all                     see ``UnaryOperation``
+Power                             all                     see ``UnaryOperation``
+PowerLawCorrection                all                     see ``UnaryOperation``
 Rebin                             all                     min and max bin boundaries must be given explicitly
 RebinToWorkspace                  all                     ``WorkspaceToMatch`` must have ``StorageMode::Cloned``
 RemovePromptPulse                 all
+ReplaceSpecialValues              all                     see ``UnaryOperation``
 RotateInstrumentComponent         all
 SaveNexus                         MasterOnly
 SaveNexusProcessed                MasterOnly
+SignalOverError                   all                     see ``UnaryOperation``
 SortEvents                        all
 SumSpectra                        MasterOnly, Identical
+UnaryOperation                    all
 WeightedMean                      all                     see ``BinaryOperation``
 ================================= ======================= ========
 

--- a/docs/source/development/AlgorithmMPISupport.rst
+++ b/docs/source/development/AlgorithmMPISupport.rst
@@ -451,25 +451,27 @@ Potential limitations must be described in the comments.
 Supported Algorithms
 ####################
 
-================= =============== ========
-Algorithm         Supported modes Comments
-================= =============== ========
-CompressEvents    all
-CreateWorkspace   all
-CropWorkspace     all             see ExtractSpectra regarding X cropping
-ExtractSpectra2   all             currently not available via algorithm factory or Python
-ExtractSpectra    all             not supported with ``DetectorList``, cropping in X may exhibit inconsistent behavior in case spectra have common boundaries within some ranks but not within all ranks or across ranks
-FilterBadPulses   all
-FilterByLogValue  all
-LoadEventNexus    Distributed     storage mode of output cannot be changed via a parameter currently, min and max bin boundary are not globally the same
-LoadInstrument    all
-LoadNexusLogs     all
-LoadParameterFile all             segfaults when used in unit tests with MPI threading backend due to `#9365 <https://github.com/mantidproject/mantid/issues/9365>`_, normal use should be ok
-MaskBins          all
-Rebin             all             min and max bin boundaries must be given explicitly
-RemovePromptPulse all
-SortEvents        all
-================= =============== ========
+================================= =============== ========
+Algorithm                         Supported modes Comments
+================================= =============== ========
+CompressEvents                    all
+CreateWorkspace                   all
+CropWorkspace                     all             see ExtractSpectra regarding X cropping
+ExtractSpectra2                   all             currently not available via algorithm factory or Python
+ExtractSpectra                    all             not supported with ``DetectorList``, cropping in X may exhibit inconsistent behavior in case spectra have common boundaries within some ranks but not within all ranks or across ranks
+FilterBadPulses                   all
+FilterByLogValue                  all
+LoadEventNexus                    Distributed     storage mode of output cannot be changed via a parameter currently, min and max bin boundary are not globally the same
+LoadInstrument                    all
+LoadNexusLogs                     all
+LoadParameterFile                 all             segfaults when used in unit tests with MPI threading backend due to `#9365 <https://github.com/mantidproject/mantid/issues/9365>`_, normal use should be ok
+MaskBins                          all
+MoveInstrumentComponent           all
+Rebin                             all             min and max bin boundaries must be given explicitly
+RemovePromptPulse                 all
+RotateInstrumentComponent         all
+SortEvents                        all
+================================= =============== ========
 
 Currently none of the above algorithms works with ``StorageMode::Distributed`` in case there are zero spectra on any rank.
 


### PR DESCRIPTION
Add MPI support for many algorithms as preparation for MPI support in SANS2D reduction.

Key changes/additions:
- `SerialAlgorithm`, `ParallelAlgorithms`, and `DistributedAlgorithm` bases classes to support MPI semi-automatically in simple cases.
- Enabled MPI support in `IFileLoader` (not distributed), `IFittingAlgorithm` (not distributed), `BinaryOperation`, and `UnaryOperation`, giving MPI support (in one way or another) for a quite long list of algorithms.
- Add new algorithm `MaskSpectra`. This is meant to replace `MaskDetectors` if MPI support is required, and also provides a much cleaner interface. `MaskDetectors` (which is actually masking spectra, thus the changed name of the replacement) is written in a very convoluted name with a lot of input properties with interdependencies and double meaning and will (should) not get MPI support.
- Some enhancements in the `Parallel` module, including a wrapper for an MPI status object.
- For a fair number of algorithms MPI support was enabled.

Fixes #21181

**To test:**

Code review.
No completed issue yet.

**Release Notes** 

None, since we do not officially support MPI yet.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
