### PR TITLE
SpectrumView exposed to Python

### DIFF
--- a/MantidPlot/pymantidplot/__init__.py
+++ b/MantidPlot/pymantidplot/__init__.py
@@ -726,6 +726,7 @@ InstrumentWidgetRenderTab = mantidqtpython.MantidQt.MantidWidgets.InstrumentWidg
 InstrumentWidgetPickTab = mantidqtpython.MantidQt.MantidWidgets.InstrumentWidgetPickTab
 InstrumentWidgetMaskTab = mantidqtpython.MantidQt.MantidWidgets.InstrumentWidgetMaskTab
 InstrumentWidgetTreeTab = mantidqtpython.MantidQt.MantidWidgets.InstrumentWidgetTreeTab
+SpectrumView = mantidqtpython.MantidQt.SpectrumView.SpectrumView
 
 
 def getInstrumentView(name, tab=InstrumentWidget.RENDER):

--- a/docs/source/release/v3.12.0/ui.rst
+++ b/docs/source/release/v3.12.0/ui.rst
@@ -41,6 +41,7 @@ SpectrumView
 ------------
 
 - The SpectrumView is now available as a standalone widget in mantidpython. Below is a simple example of how the widget can be used in python.
+
 .. code-block:: python
    :emphasize-lines: 11,12
 

--- a/docs/source/release/v3.12.0/ui.rst
+++ b/docs/source/release/v3.12.0/ui.rst
@@ -37,4 +37,26 @@ MultiDataset Fitting Interface
 - After a simultaneous fit the parameters are saved in a TableWorkspace made to simplify plotting their values against the datasets.
   The parameters are organised into columns and each row corresponds to a dataset.
 
+SpectrumView
+------------
+
+- The SpectrumView is now available as a standalone widget in mantidpython. Below is a simple example of how the widget can be used in python.
+.. code-block:: python
+   :emphasize-lines: 11,12
+
+   import PyQt4
+   import mantid.simpleapi as simpleapi
+   import mantidqtpython as mpy
+   import sys
+
+   SpectrumView = mpy.MantidQt.SpectrumView.SpectrumView
+   app = PyQt4.QtGui.QApplication(sys.argv)
+
+   wsOut = simpleapi.Load("/Path/to/multispectrum/dataset")
+
+   sv = SpectrumView()
+   sv.renderWorkspace("wsOut")
+   sv.show()
+   app.exec_()
+
 :ref:`Release 3.12.0 <v3.12.0>`

--- a/qt/python/mantidqtpython/mantidqtpython_def.sip
+++ b/qt/python/mantidqtpython/mantidqtpython_def.sip
@@ -2484,6 +2484,14 @@ public:
         wsName The name of the workspace to be rendered.
 %End
 
+    void selectData(int spectrumNumber, double dataVal) const;
+%Docstring
+    Programmatically set horizontal and vertical graph data.
+
+    Args:
+        spectrumNumber SpectrumNumber in the workspace to be displayed.
+        dataVal Data value to be displayed (based on workspace units).
+%End
 private:
     SpectrumView(const MantidQt::SpectrumView::SpectrumView &);
 };

--- a/qt/python/mantidqtpython/mantidqtpython_def.sip
+++ b/qt/python/mantidqtpython/mantidqtpython_def.sip
@@ -2459,4 +2459,33 @@ private:
 };
 
 };//end namespace MantidWidgets
+
+
+namespace SpectrumView 
+{
+class SpectrumView : QMainWindow
+{
+%TypeHeaderCode
+#include "MantidQtWidgets/SpectrumViewer/SpectrumView.h"
+%End
+
+%Docstring
+    This is the QMainWindow for the SpectrumView data viewer.  Data is
+    displayed in an SpectrumView, by constructing the SpectrumView object and
+    specifying a particular data source.
+%End
+public:
+    SpectrumView(QWidget *parent=nullptr);
+    void renderWorkspace(const QString &wsName);
+%Docstring
+    Renders a workspace in the SpectrumViewer
+
+    Args:
+        wsName The name of the workspace to be rendered.
+%End
+
+private:
+    SpectrumView(const MantidQt::SpectrumView::SpectrumView &);
+};
+};//end namespace SpectrumView
 };//end namespace MantidQt

--- a/qt/python/mantidqtpython/mantidqtpython_def.sip
+++ b/qt/python/mantidqtpython/mantidqtpython_def.sip
@@ -2484,7 +2484,7 @@ public:
         wsName The name of the workspace to be rendered.
 %End
 
-    void selectData(int spectrumNumber, double dataVal) const;
+    void selectData(int spectrumNumber, double dataVal);
 %Docstring
     Programmatically set horizontal and vertical graph data.
 

--- a/qt/widgets/spectrumviewer/inc/MantidQtWidgets/SpectrumViewer/SpectrumView.h
+++ b/qt/widgets/spectrumviewer/inc/MantidQtWidgets/SpectrumViewer/SpectrumView.h
@@ -76,7 +76,7 @@ public:
     return m_spectrumDisplay;
   }
 
-  void selectData(int spectrumNumber, double dataVal) const;
+  void selectData(int spectrumNumber, double dataVal);
   bool isTrackingOn() const;
   /// Load the state of the spectrum viewer from a Mantid project file
   static API::IProjectSerialisable *loadFromProject(const std::string &lines,

--- a/qt/widgets/spectrumviewer/inc/MantidQtWidgets/SpectrumViewer/SpectrumView.h
+++ b/qt/widgets/spectrumviewer/inc/MantidQtWidgets/SpectrumViewer/SpectrumView.h
@@ -71,6 +71,7 @@ public:
 
   ~SpectrumView() override;
   void renderWorkspace(Mantid::API::MatrixWorkspace_const_sptr wksp);
+  void renderWorkspace(const QString &wsName);
   QList<boost::shared_ptr<SpectrumDisplay>> getSpectrumDisplays() const {
     return m_spectrumDisplay;
   }

--- a/qt/widgets/spectrumviewer/inc/MantidQtWidgets/SpectrumViewer/SpectrumView.h
+++ b/qt/widgets/spectrumviewer/inc/MantidQtWidgets/SpectrumViewer/SpectrumView.h
@@ -75,6 +75,8 @@ public:
   QList<boost::shared_ptr<SpectrumDisplay>> getSpectrumDisplays() const {
     return m_spectrumDisplay;
   }
+
+  void selectData(int spectrumNumber, double dataVal) const;
   bool isTrackingOn() const;
   /// Load the state of the spectrum viewer from a Mantid project file
   static API::IProjectSerialisable *loadFromProject(const std::string &lines,

--- a/qt/widgets/spectrumviewer/src/SpectrumView.cpp
+++ b/qt/widgets/spectrumviewer/src/SpectrumView.cpp
@@ -264,7 +264,7 @@ void SpectrumView::respondToTabCloseReqest(int tab) {
 
 void SpectrumView::selectData(int spectrumNumber, double dataVal) const {
   auto index = m_ui->imageTabs->currentIndex();
-  auto y = static_cast<double>(spectrumNumber-1);
+  auto y = static_cast<double>(spectrumNumber - 1);
   auto x = dataVal;
   m_spectrumDisplay.at(index)->setHGraph(y);
   m_spectrumDisplay.at(index)->setVGraph(x);

--- a/qt/widgets/spectrumviewer/src/SpectrumView.cpp
+++ b/qt/widgets/spectrumviewer/src/SpectrumView.cpp
@@ -158,7 +158,7 @@ void SpectrumView::renderWorkspace(
 /**
  * Renders a new workspace on the spectrum viewer.
  *
- * @param wkName The name of the matrix workspace to render
+ * @param wsName The name of the matrix workspace to render
  */
 void SpectrumView::renderWorkspace(const QString &wsName) {
   Mantid::API::MatrixWorkspace_const_sptr wksp =

--- a/qt/widgets/spectrumviewer/src/SpectrumView.cpp
+++ b/qt/widgets/spectrumviewer/src/SpectrumView.cpp
@@ -262,6 +262,15 @@ void SpectrumView::respondToTabCloseReqest(int tab) {
   }
 }
 
+void SpectrumView::selectData(int spectrumNumber, double dataVal) const {
+  auto index = m_ui->imageTabs->currentIndex();
+  auto y = static_cast<double>(spectrumNumber-1);
+  auto x = dataVal;
+  m_spectrumDisplay.at(index)->setHGraph(y);
+  m_spectrumDisplay.at(index)->setVGraph(x);
+  m_spectrumDisplay.at(index)->showInfoList(x, y);
+}
+
 /**
  * Check if mouse tracking should be "always on".
  */

--- a/qt/widgets/spectrumviewer/src/SpectrumView.cpp
+++ b/qt/widgets/spectrumviewer/src/SpectrumView.cpp
@@ -262,7 +262,7 @@ void SpectrumView::respondToTabCloseReqest(int tab) {
   }
 }
 
-void SpectrumView::selectData(int spectrumNumber, double dataVal) const {
+void SpectrumView::selectData(int spectrumNumber, double dataVal) {
   auto index = m_ui->imageTabs->currentIndex();
   auto y = static_cast<double>(spectrumNumber - 1);
   auto x = dataVal;

--- a/qt/widgets/spectrumviewer/src/SpectrumView.cpp
+++ b/qt/widgets/spectrumviewer/src/SpectrumView.cpp
@@ -2,6 +2,7 @@
 
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidKernel/UsageService.h"
+#include "MantidAPI/AnalysisDataService.h"
 #include "MantidQtWidgets/Common/TSVSerialiser.h"
 #include "MantidQtWidgets/SpectrumViewer/ColorMaps.h"
 #include "MantidQtWidgets/SpectrumViewer/SVConnections.h"
@@ -152,6 +153,19 @@ void SpectrumView::renderWorkspace(
 
   m_spectrumDisplay.append(spectrumDisplay);
   m_ui->imageTabs->setCurrentIndex(tab);
+}
+
+/**
+ * Renders a new workspace on the spectrum viewer.
+ *
+ * @param wkName The name of the matrix workspace to render
+ */
+void SpectrumView::renderWorkspace(const QString &wsName) {
+  Mantid::API::MatrixWorkspace_const_sptr wksp =
+      Mantid::API::AnalysisDataService::Instance()
+          .retrieveWS<const Mantid::API::MatrixWorkspace>(wsName.toStdString());
+
+  renderWorkspace(wksp);
 }
 
 /**


### PR DESCRIPTION
The SpectrumView has been exposed to python as a standalone widget using sip.

**To test:**
Run the below script using `mantidpython`
```python
from threading import Thread
import time
import sys
import PyQt4
import mantid.simpleapi as simpleapi
import mantidqtpython as mpy
import os

SpectrumView = mpy.MantidQt.SpectrumView.SpectrumView
app = PyQt4.QtGui.QApplication(sys.argv)

wsOut = simpleapi.Load("Path/to/multispectrum/dataset")

sv = SpectrumView()
sv.renderWorkspace("wsOut")
sv.show()
app.exec_()
```
<!-- Instructions for testing. -->

Fixes #21402. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
