### PR TITLE
Coerce data correctly from Python Matrixworkspace::setXYE methods

### DIFF
--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayToVector.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayToVector.h
@@ -23,28 +23,33 @@
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
 #include "MantidKernel/System.h"
-#include <boost/python/object.hpp>
+#include "MantidPythonInterface/kernel/NdArray.h"
 #include <vector>
 
 namespace Mantid {
 namespace PythonInterface {
 namespace Converters {
 /**
- * Converts a Python sequence type to a C++ std::vector, where the vector
- * element
- * type is defined by the template type
+ * Converter taking an input numpy array and converting it to a std::vector.
+ * Multi-dimensional arrays are flattened and copied.
  */
 template <typename DestElementType> struct DLLExport NDArrayToVector {
+  // Alias definitions
+  using TypedVector = std::vector<DestElementType>;
+  using TypedVectorIterator = typename std::vector<DestElementType>::iterator;
+
   /// Constructor
-  NDArrayToVector(const boost::python::object &value);
-  /// Do the conversion
-  const std::vector<DestElementType> operator()();
+  NDArrayToVector(const NumPy::NdArray &value);
+  /// Create a new vector from the contents of the array
+  const TypedVector operator()();
+  /// Fill the container with data from the array
+  void copyTo(TypedVector &dest) const;
 
 private:
-  /// Check the array is of the correct type and coerce it if not
-  void typeCheck();
-  /// Pointer to ndarray object
-  boost::python::object m_arr;
+  void throwIfSizeMismatched(const TypedVector &dest) const;
+
+  // reference to the held array
+  NumPy::NdArray m_arr;
 };
 }
 }

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h
@@ -40,6 +40,7 @@ namespace Converters {
  */
 template <typename T> struct PYTHON_KERNEL_DLL NDArrayTypeIndex {
   static int typenum;
+  static char typecode;
 };
 }
 }

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/PySequenceToVector.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/PySequenceToVector.h
@@ -50,7 +50,7 @@ template <typename CType> struct ExtractCType {
  */
 template <> struct ExtractCType<std::string> {
   /**
-   * Uses boost lexical cast to convert the type to a string
+   * Forces a Python string conversion before calling extract
    * @param value A pointer to the Python object
    * @return The value as a C type
    */
@@ -85,7 +85,7 @@ template <typename DestElementType> struct DLLExport PySequenceToVector {
 
   /**
    * Fill a provided vector with values from the sequence
-   * @param A vector<DestElementType> to fill
+   * @param dest A vector<DestElementType> to fill
    */
   inline void fill(std::vector<DestElementType> &dest) {
     auto length = static_cast<size_t>(PySequence_Size(m_obj));

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/PySequenceToVector.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/PySequenceToVector.h
@@ -67,48 +67,45 @@ namespace Converters {
  * type is defined by the template type
  */
 template <typename DestElementType> struct DLLExport PySequenceToVector {
-  PySequenceToVector(const boost::python::object &value) : m_obj(value.ptr()) {
-    check(value);
-  }
+  // Alias definitions
+  using TypedVector = std::vector<DestElementType>;
+
+  PySequenceToVector(const boost::python::object &value) : m_obj(value.ptr()) {}
 
   /**
    * Converts the Python object to a C++ vector
    * @return A std::vector<ElementType> containing the values
    * from the Python sequence
    */
-  inline const std::vector<DestElementType> operator()() {
-    Py_ssize_t length = PySequence_Size(m_obj);
-    std::vector<DestElementType> cvector(length);
-    fill(cvector);
+  inline const TypedVector operator()() {
+    TypedVector cvector(PySequence_Size(m_obj));
+    copyTo(cvector);
     return cvector;
   }
 
   /**
-   * Fill a provided vector with values from the sequence
-   * @param dest A vector<DestElementType> to fill
+   * Fill the container with data from the array
+   * @param dest A vector<DestElementType> that receives the data
    */
-  inline void fill(std::vector<DestElementType> &dest) {
-    auto length = static_cast<size_t>(PySequence_Size(m_obj));
-    if (length != dest.size()) {
-      throw std::invalid_argument(
-          "Length mismatch between python list & C array. python=" +
-          std::to_string(length) + ", C=" + std::to_string(dest.size()));
-    }
+  inline void copyTo(TypedVector &dest) {
+    throwIfSizeMismatched(dest);
     ExtractCType<DestElementType> elementConverter;
+    auto length = static_cast<size_t>(PySequence_Size(m_obj));
     for (size_t i = 0; i < length; ++i) {
       dest[i] = elementConverter(PySequence_GetItem(m_obj, i));
     }
   }
 
 private:
-  inline void check(const boost::python::object &obj) {
-    if (!PySequence_Check(obj.ptr())) {
+  inline void throwIfSizeMismatched(const TypedVector &dest) const {
+    auto length = static_cast<size_t>(PySequence_Size(m_obj));
+    if (length != dest.size()) {
       throw std::invalid_argument(
-          std::string(
-              "PySequenceToVector expects Python sequence type, found ") +
-          obj.ptr()->ob_type->tp_name);
+          "Length mismatch between python list & C array. python=" +
+          std::to_string(length) + ", C=" + std::to_string(dest.size()));
     }
   }
+
   /// Python object to convert
   PyObject *m_obj;
 };

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/PySequenceToVector.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/PySequenceToVector.h
@@ -79,14 +79,25 @@ template <typename DestElementType> struct DLLExport PySequenceToVector {
   inline const std::vector<DestElementType> operator()() {
     Py_ssize_t length = PySequence_Size(m_obj);
     std::vector<DestElementType> cvector(length);
-    if (length == 0)
-      return cvector;
-    ExtractCType<DestElementType> elementConverter;
-    for (Py_ssize_t i = 0; i < length; ++i) {
-      DestElementType element = elementConverter(PySequence_GetItem(m_obj, i));
-      cvector[i] = element;
-    }
+    fill(cvector);
     return cvector;
+  }
+
+  /**
+   * Fill a provided vector with values from the sequence
+   * @param A vector<DestElementType> to fill
+   */
+  inline void fill(std::vector<DestElementType> &dest) {
+    auto length = static_cast<size_t>(PySequence_Size(m_obj));
+    if (length != dest.size()) {
+      throw std::invalid_argument(
+          "Length mismatch between python list & C array. python=" +
+          std::to_string(length) + ", C=" + std::to_string(dest.size()));
+    }
+    ExtractCType<DestElementType> elementConverter;
+    for (size_t i = 0; i < length; ++i) {
+      dest[i] = elementConverter(PySequence_GetItem(m_obj, i));
+    }
   }
 
 private:

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/NdArray.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/NdArray.h
@@ -17,11 +17,14 @@ namespace NumPy {
  */
 class PYTHON_KERNEL_DLL NdArray : public boost::python::object {
 public:
+  NdArray(const boost::python::object &obj);
   BOOST_PYTHON_FORWARD_OBJECT_CONSTRUCTORS(NdArray, boost::python::object);
 
   Py_intptr_t const *get_shape() const;
   int get_nd() const;
   void *get_data() const;
+
+  NdArray astype(char dtype, bool copy = true) const;
 };
 
 } // end namespace NumPy

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/NdArray.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/NdArray.h
@@ -17,6 +17,8 @@ namespace NumPy {
  */
 class PYTHON_KERNEL_DLL NdArray : public boost::python::object {
 public:
+  static bool check(const boost::python::object &obj);
+
   NdArray(const boost::python::object &obj);
   BOOST_PYTHON_FORWARD_OBJECT_CONSTRUCTORS(NdArray, boost::python::object);
 

--- a/Framework/PythonInterface/mantid/CMakeLists.txt
+++ b/Framework/PythonInterface/mantid/CMakeLists.txt
@@ -46,7 +46,9 @@ add_subdirectory ( _plugins )
 add_subdirectory ( plots )
 
 # Create an overall target
-add_custom_target ( PythonInterface DEPENDS PythonInterface )
+add_custom_target ( PythonInterface DEPENDS PythonKernelModule
+  PythonGeometryModule PythonAPIModule PythonDataObjectsModule
+  PythonCurveFittingModule PythonPlotsModule )
 set_property ( TARGET PythonInterface PROPERTY FOLDER "MantidFramework/Python" )
 
 ###########################################################################

--- a/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
@@ -6,6 +6,7 @@
 #include "MantidPythonInterface/kernel/Converters/NDArrayToVector.h"
 #include "MantidPythonInterface/kernel/Converters/PySequenceToVector.h"
 #include "MantidPythonInterface/kernel/Converters/CloneToNumpy.h"
+#include "MantidPythonInterface/kernel/NdArray.h"
 #include "MantidPythonInterface/kernel/Registry/RegisterWorkspacePtrToPython.h"
 #include "MantidPythonInterface/kernel/Policies/VectorToNumpy.h"
 
@@ -33,6 +34,7 @@ GET_POINTER_SPECIALIZATION(ITableWorkspace)
 namespace {
 namespace bpl = boost::python;
 namespace Converters = Mantid::PythonInterface::Converters;
+namespace NumPy = Mantid::PythonInterface::NumPy;
 
 // Numpy PyArray_IsIntegerScalar is broken for Python 3 for numpy < 1.11
 #if PY_MAJOR_VERSION >= 3
@@ -139,7 +141,7 @@ void setValue(const Column_sptr column, const int row,
   }
 #define SET_VECTOR_CELL(R, _, T)                                               \
   else if (typeID.hash_code() == typeid(T).hash_code()) {                      \
-    if (!PyArray_Check(value.ptr())) {                                         \
+    if (!NumPy::NdArray::check(value)) {                                       \
       column->cell<T>(row) =                                                   \
           Converters::PySequenceToVector<T::value_type>(value)();              \
     } else {                                                                   \

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -78,7 +78,7 @@ void setSpectrumFromPyObject(MatrixWorkspace &self, data_modifier accessor,
                              const size_t wsIndex,
                              const boost::python::object &values) {
   if (PyArray_Check(values.ptr())) {
-    NDArrayToVector<double> converter(values));
+    NDArrayToVector<double> converter(values);
     converter.copyTo((self.*accessor)(wsIndex));
   } else {
     PySequenceToVector<double> converter(values);
@@ -124,7 +124,7 @@ void clearMonitorWorkspace(MatrixWorkspace &self) {
  * @param values :: A numpy array. The length must match the size of the
  */
 void setXFromPyObject(MatrixWorkspace &self, const size_t wsIndex,
-                      const NumPy::NdArray &values) {
+                      const boost::python::object &values) {
   setSpectrumFromPyObject(self, &MatrixWorkspace::dataX, wsIndex, values);
 }
 
@@ -135,7 +135,7 @@ void setXFromPyObject(MatrixWorkspace &self, const size_t wsIndex,
  * @param values :: A numpy array. The length must match the size of the
  */
 void setYFromPyObject(MatrixWorkspace &self, const size_t wsIndex,
-                      const NumPy::NdArray &values) {
+                      const boost::python::object &values) {
   setSpectrumFromPyObject(self, &MatrixWorkspace::dataY, wsIndex, values);
 }
 
@@ -157,7 +157,7 @@ void setEFromPyObject(MatrixWorkspace &self, const size_t wsIndex,
  * @param values :: A numpy array. The length must match the size of the
  */
 void setDxFromPyObject(MatrixWorkspace &self, const size_t wsIndex,
-                       const NumPy::NdArray &values) {
+                       const boost::python::object &values) {
   setSpectrumFromPyObject(self, &MatrixWorkspace::dataDx, wsIndex, values);
 }
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -77,7 +77,7 @@ GCC_DIAG_ON(conversion)
 void setSpectrumFromPyObject(MatrixWorkspace &self, data_modifier accessor,
                              const size_t wsIndex,
                              const boost::python::object &values) {
-  if (PyArray_Check(values.ptr())) {
+  if (NumPy::NdArray::check(values)) {
     NDArrayToVector<double> converter(values);
     converter.copyTo((self.*accessor)(wsIndex));
   } else {

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -82,7 +82,7 @@ void setSpectrumFromPyObject(MatrixWorkspace &self, data_modifier accessor,
     converter.copyTo((self.*accessor)(wsIndex));
   } else {
     PySequenceToVector<double> converter(values);
-    converter.fill((self.*accessor)(wsIndex));
+    converter.copyTo((self.*accessor)(wsIndex));
   }
 }
 

--- a/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp
@@ -121,7 +121,8 @@ const typename NDArrayToVector<DestElementType>::TypedVector
 }
 
 /**
- * @dest A pre-sized container that will receive the values from the array.
+ * @param dest A pre-sized container that will receive the values from the
+ * array.
  * It's size is checked against the array size.
  */
 template <typename DestElementType>

--- a/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp
@@ -3,8 +3,11 @@
 //-----------------------------------------------------------------------------
 #include "MantidPythonInterface/kernel/Converters/NDArrayToVector.h"
 #include "MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h"
-#include <boost/python/extract.hpp>
 #include "MantidPythonInterface/kernel/Converters/NumpyFunctions.h"
+
+#include <boost/python/extract.hpp>
+#include <boost/python/stl_iterator.hpp>
+#include <boost/python/str.hpp>
 
 namespace Mantid {
 namespace PythonInterface {
@@ -22,15 +25,20 @@ extern template int NDArrayTypeIndex<double>::typenum;
 }
 
 namespace {
+
 //-------------------------------------------------------------------------
 // Template helpers
 //-------------------------------------------------------------------------
 /**
- * Templated structure to fill a std::vector
- * with values from a numpy array
+ * Templated structure to fill a container
+ * with values from a numpy array. It is assumed range pointed
+ * to by the starting iterator has been preallocated to at least the
+ * number of elements in the array and that the array is not emtpy
  */
-template <typename DestElementType> struct fill_vector {
-  void operator()(PyArrayObject *arr, std::vector<DestElementType> &cvector) {
+template <typename DestElementType> struct CopyToImpl {
+  void operator()(typename Converters::NDArrayToVector<
+                      DestElementType>::TypedVectorIterator first,
+                  PyArrayObject *arr) {
     // Use the iterator API to iterate through the array
     // and assign each value to the corresponding vector
     typedef union {
@@ -39,11 +47,9 @@ template <typename DestElementType> struct fill_vector {
     } npy_union;
     npy_union data;
     PyObject *iter = Converters::Impl::func_PyArray_IterNew(arr);
-    npy_intp index(0);
     do {
       data.input = PyArray_ITER_DATA(iter);
-      cvector[index] = *data.output;
-      ++index;
+      *first++ = *data.output;
       PyArray_ITER_NEXT(iter);
     } while (PyArray_ITER_NOTDONE(iter));
   }
@@ -53,17 +59,14 @@ template <typename DestElementType> struct fill_vector {
  * Specialization for a std::string to convert the values directly
  * to the string representation
  */
-template <> struct fill_vector<std::string> {
-  void operator()(PyArrayObject *arr, std::vector<std::string> &cvector) {
+template <> struct CopyToImpl<std::string> {
+  void operator()(typename std::vector<std::string>::iterator first,
+                  PyArrayObject *arr) {
     using namespace boost::python;
-    PyObject *flattened = PyArray_Ravel(arr, NPY_CORDER);
-    object nparray = object(handle<>(flattened));
-    const Py_ssize_t nelements =
-        PyArray_Size(reinterpret_cast<PyObject *>(arr));
+    object flattened(handle<>(PyArray_Ravel(arr, NPY_CORDER)));
+    const Py_ssize_t nelements = PyArray_Size(flattened.ptr());
     for (Py_ssize_t i = 0; i < nelements; ++i) {
-      boost::python::object item = nparray[i];
-      PyObject *s = PyObject_Str(item.ptr());
-      cvector[i] = boost::python::extract<std::string>(s)();
+      *first++ = extract<std::string>(str(flattened[i]))();
     }
   }
 };
@@ -73,16 +76,10 @@ template <> struct fill_vector<std::string> {
  * and convert the array if necessary. It is assumed that
  * the object points to numpy array, no checking is performed
  */
-template <typename DestElementType> struct coerce_type {
-  boost::python::object operator()(const boost::python::object &arr) {
-    int sourceType = PyArray_TYPE(reinterpret_cast<PyArrayObject *>(arr.ptr()));
-    int destType = Converters::NDArrayTypeIndex<DestElementType>::typenum;
-    boost::python::object result = arr;
-    if (sourceType != destType) {
-      PyObject *sameType = PyArray_Cast((PyArrayObject *)arr.ptr(), destType);
-      result = boost::python::object(boost::python::handle<>(sameType));
-    }
-    return result;
+template <typename DestElementType> struct CoerceType {
+  NumPy::NdArray operator()(const NumPy::NdArray &x) {
+    return x.astype(Converters::NDArrayTypeIndex<DestElementType>::typecode,
+                    false);
   }
 };
 
@@ -90,10 +87,8 @@ template <typename DestElementType> struct coerce_type {
  * Specialized version for std::string as we don't need
  * to convert the underlying representation
  */
-template <> struct coerce_type<std::string> {
-  boost::python::object operator()(const boost::python::object &arr) {
-    return arr;
-  }
+template <> struct CoerceType<std::string> {
+  boost::python::object operator()(const NumPy::NdArray &x) { return x; }
 };
 }
 
@@ -107,11 +102,8 @@ namespace Converters {
  * @param value :: A boost python object wrapping a numpy.ndarray
  */
 template <typename DestElementType>
-NDArrayToVector<DestElementType>::NDArrayToVector(
-    const boost::python::object &value)
-    : m_arr(value) {
-  typeCheck();
-}
+NDArrayToVector<DestElementType>::NDArrayToVector(const NumPy::NdArray &value)
+    : m_arr(CoerceType<DestElementType>()(value)) {}
 
 /**
  * Creates a vector of the DestElementType from the numpy array of
@@ -119,33 +111,47 @@ NDArrayToVector<DestElementType>::NDArrayToVector(
  * @return A vector of the DestElementType created from the numpy array
  */
 template <typename DestElementType>
-const std::vector<DestElementType> NDArrayToVector<DestElementType>::
-operator()() {
-  npy_intp length = PyArray_SIZE(
-      (PyArrayObject *)
-          m_arr.ptr()); // Returns the total number of elements in the array
-  std::vector<DestElementType> cvector(length);
-  if (length > 0) {
-    fill_vector<DestElementType>()((PyArrayObject *)m_arr.ptr(), cvector);
-  }
+const typename NDArrayToVector<DestElementType>::TypedVector
+    NDArrayToVector<DestElementType>::
+    operator()() {
+  std::vector<DestElementType> cvector(
+      PyArray_SIZE((PyArrayObject *)m_arr.ptr()));
+  copyTo(cvector);
   return cvector;
 }
 
 /**
- * Checks if the python object points to a numpy.ndarray and also checks if the
- * type
- * is compatible with the DestElementType. If the types do not match the
- * array is cast to the DestElementType
- * @throws std::invalid_argument if the object is not of type numpy.ndarray
+ * @dest A pre-sized container that will receive the values from the array.
+ * It's size is checked against the array size.
  */
 template <typename DestElementType>
-void NDArrayToVector<DestElementType>::typeCheck() {
-  if (!PyArray_Check(m_arr.ptr())) {
-    throw std::invalid_argument(
-        std::string("NDArrayConverter expects ndarray type, found ") +
-        m_arr.ptr()->ob_type->tp_name);
+void NDArrayToVector<DestElementType>::copyTo(TypedVector &dest) const {
+  if (PyArray_SIZE((PyArrayObject *)m_arr.ptr()) > 0) {
+    throwIfSizeMismatched(dest);
+    CopyToImpl<DestElementType>()(std::begin(dest),
+                                  (PyArrayObject *)m_arr.ptr());
   }
-  m_arr = coerce_type<DestElementType>()(m_arr);
+}
+
+/**
+ * @param dest A reference to a vector whose capacity is checked that it can
+ * contain the values from the numpy array
+ * @throws std::invalid_argument if the vector is the wrong size or the numpy
+ * array is not 1D
+ */
+template <typename DestElementType>
+void NDArrayToVector<DestElementType>::throwIfSizeMismatched(
+    const TypedVector &dest) const {
+  namespace bp = boost::python;
+  if (PyArray_Size(m_arr.ptr()) == static_cast<ssize_t>(dest.size())) {
+    return;
+  } else {
+    throw std::invalid_argument(
+        "Invalid number of elements while copying from ndarray. "
+        "ndarray=" +
+        std::to_string(PyArray_Size(m_arr.ptr())) + " destination=(" +
+        std::to_string(dest.size()) + ",)");
+  }
 }
 
 //------------------------------------------------------------------------

--- a/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp
@@ -144,14 +144,15 @@ template <typename DestElementType>
 void NDArrayToVector<DestElementType>::throwIfSizeMismatched(
     const TypedVector &dest) const {
   namespace bp = boost::python;
-  if (PyArray_Size(m_arr.ptr()) == static_cast<ssize_t>(dest.size())) {
+  if (PyArray_SIZE((PyArrayObject *)m_arr.ptr()) ==
+      static_cast<ssize_t>(dest.size())) {
     return;
   } else {
     throw std::invalid_argument(
         "Invalid number of elements while copying from ndarray. "
         "ndarray=" +
-        std::to_string(PyArray_Size(m_arr.ptr())) + " destination=(" +
-        std::to_string(dest.size()) + ",)");
+        std::to_string(PyArray_SIZE((PyArrayObject *)m_arr.ptr())) +
+        " destination=(" + std::to_string(dest.size()) + ",)");
   }
 }
 

--- a/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayTypeIndex.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayTypeIndex.cpp
@@ -15,19 +15,20 @@ namespace Mantid {
 namespace PythonInterface {
 namespace Converters {
 /// Macro to define mappings between the CType and Numpy enum
-#define DEFINE_TYPE_MAPPING(CType, NDTypeNum)                                  \
+#define DEFINE_TYPE_MAPPING(CType, NDTypeNum, NDTypeCode)                      \
   template <> int NDArrayTypeIndex<CType>::typenum = NDTypeNum;                \
+  template <> char NDArrayTypeIndex<CType>::typecode = NDTypeCode;             \
   template struct NDArrayTypeIndex<CType>;
 
-DEFINE_TYPE_MAPPING(int, NPY_INT)
-DEFINE_TYPE_MAPPING(long, NPY_LONG)
-DEFINE_TYPE_MAPPING(long long, NPY_LONGLONG)
-DEFINE_TYPE_MAPPING(unsigned int, NPY_UINT)
-DEFINE_TYPE_MAPPING(unsigned long, NPY_ULONG)
-DEFINE_TYPE_MAPPING(unsigned long long, NPY_ULONGLONG)
-DEFINE_TYPE_MAPPING(bool, NPY_BOOL)
-DEFINE_TYPE_MAPPING(double, NPY_DOUBLE)
-DEFINE_TYPE_MAPPING(float, NPY_FLOAT)
+DEFINE_TYPE_MAPPING(int, NPY_INT, NPY_INTLTR)
+DEFINE_TYPE_MAPPING(long, NPY_LONG, NPY_LONGLTR)
+DEFINE_TYPE_MAPPING(long long, NPY_LONGLONG, NPY_LONGLONGLTR)
+DEFINE_TYPE_MAPPING(unsigned int, NPY_UINT, NPY_UINTLTR)
+DEFINE_TYPE_MAPPING(unsigned long, NPY_ULONG, NPY_ULONGLTR)
+DEFINE_TYPE_MAPPING(unsigned long long, NPY_ULONGLONG, NPY_ULONGLONGLTR)
+DEFINE_TYPE_MAPPING(bool, NPY_BOOL, NPY_BOOLLTR)
+DEFINE_TYPE_MAPPING(double, NPY_DOUBLE, NPY_DOUBLELTR)
+DEFINE_TYPE_MAPPING(float, NPY_FLOAT, NPY_CFLOATLTR)
 }
 }
 }

--- a/Framework/PythonInterface/mantid/kernel/src/Converters/PyObjectToMatrix.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Converters/PyObjectToMatrix.cpp
@@ -35,7 +35,7 @@ PyObjectToMatrix::PyObjectToMatrix(const boost::python::object &p)
     return;
   }
   // Is it a 2D numpy array
-  if (!PyArray_Check(p.ptr())) {
+  if (!NumPy::NdArray::check(p)) {
     std::ostringstream msg;
     msg << "Cannot convert object to Matrix. Expected numpy array, found "
         << p.ptr()->ob_type->tp_name;

--- a/Framework/PythonInterface/mantid/kernel/src/NdArray.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/NdArray.cpp
@@ -23,6 +23,16 @@ inline PyArrayObject *rawArray(const NdArray &obj) {
 // -----------------------------------------------------------------------------
 // NdArray - public methods
 // -----------------------------------------------------------------------------
+
+/**
+ * Check if a python object points to an array type object
+ * @param obj A pointer to an arbitrary python object
+ * @returns True if the underlying object is an ndarray, false otherwise
+ */
+bool NdArray::check(const boost::python::api::object &obj) {
+  return PyArray_Check(obj.ptr());
+}
+
 /**
  * Construction from a plain object. Assumes the array is actually a
  * a numpy array

--- a/Framework/PythonInterface/mantid/kernel/src/NdArray.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/NdArray.cpp
@@ -2,11 +2,13 @@
 #include "MantidPythonInterface/kernel/Converters/PyArrayType.h"
 
 #include <boost/python/detail/prefix.hpp> // Safe include of Python.h
+#include <boost/python/tuple.hpp>
 #define PY_ARRAY_UNIQUE_SYMBOL KERNEL_ARRAY_API
 #define NO_IMPORT_ARRAY
 #include <numpy/arrayobject.h>
 
 using Mantid::PythonInterface::Converters::getNDArrayType;
+using namespace boost::python;
 
 namespace Mantid {
 namespace PythonInterface {
@@ -21,9 +23,16 @@ inline PyArrayObject *rawArray(const NdArray &obj) {
 // -----------------------------------------------------------------------------
 // NdArray - public methods
 // -----------------------------------------------------------------------------
+/**
+ * Construction from a plain object. Assumes the array is actually a
+ * a numpy array
+ * @param obj A wrapper around a Python object pointing to a numpy array
+ */
+NdArray::NdArray(const boost::python::api::object &obj)
+    : object(boost::python::detail::borrowed_reference(obj.ptr())) {}
 
 /**
- * @return The shape of the array as a C-array
+ * @return Return the shape of the array
  */
 Py_intptr_t const *NdArray::get_shape() const {
   return PyArray_DIMS(rawArray(*this));
@@ -40,6 +49,24 @@ int NdArray::get_nd() const { return PyArray_NDIM(rawArray(*this)); }
  * @return The array's raw data pointer
  */
 void *NdArray::get_data() const { return PyArray_DATA(rawArray(*this)); }
+
+/**
+ * Casts (and copies if necessary) the array to the given data type
+ * @param dtype Character code for the numpy data types
+ * (https://docs.scipy.org/doc/numpy/reference/arrays.dtypes.html)
+ * @param copy If true then the return array is always a copy otherwise
+ * the returned array will only be copied if necessary
+ * @return A numpy array with values of the requested type
+ */
+NdArray NdArray::astype(char dtype, bool copy) const {
+  auto callable = object(handle<>(
+      PyObject_GetAttrString(this->ptr(), const_cast<char *>("astype"))));
+  auto args = tuple();
+  auto kwargs = object(handle<>(Py_BuildValue(
+      const_cast<char *>("{s:c,s:i}"), "dtype", dtype, "copy", copy ? 1 : 0)));
+  return NdArray(boost::python::detail::new_reference(
+      PyObject_Call(callable.ptr(), args.ptr(), kwargs.ptr())));
+}
 }
 }
 }

--- a/Framework/PythonInterface/mantid/kernel/src/NdArray.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/NdArray.cpp
@@ -29,17 +29,15 @@ inline PyArrayObject *rawArray(const NdArray &obj) {
  * @param obj A pointer to an arbitrary python object
  * @returns True if the underlying object is an ndarray, false otherwise
  */
-bool NdArray::check(const boost::python::api::object &obj) {
-  return PyArray_Check(obj.ptr());
-}
+bool NdArray::check(const object &obj) { return PyArray_Check(obj.ptr()); }
 
 /**
  * Construction from a plain object. Assumes the array is actually a
  * a numpy array
  * @param obj A wrapper around a Python object pointing to a numpy array
  */
-NdArray::NdArray(const boost::python::api::object &obj)
-    : object(boost::python::detail::borrowed_reference(obj.ptr())) {}
+NdArray::NdArray(const object &obj)
+    : object(detail::borrowed_reference(obj.ptr())) {}
 
 /**
  * @return Return the shape of the array

--- a/Framework/PythonInterface/mantid/kernel/src/Registry/SequenceTypeHandler.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Registry/SequenceTypeHandler.cpp
@@ -43,7 +43,7 @@ template <typename ContainerType>
 void SequenceTypeHandler<ContainerType>::set(
     Kernel::IPropertyManager *alg, const std::string &name,
     const boost::python::object &value) const {
-  using boost::python::len;
+  using namespace boost::python;
   typedef typename ContainerType::value_type DestElementType;
 
   // Current workaround for things that still pass back wrapped vectors...
@@ -53,8 +53,8 @@ void SequenceTypeHandler<ContainerType>::set(
   // numpy arrays requires special handling to extract their types. Hand-off to
   // a more appropriate handler
   else if (PyArray_Check(value.ptr())) {
-    alg->setProperty(name,
-                     Converters::NDArrayToVector<DestElementType>(value)());
+    alg->setProperty(name, Converters::NDArrayToVector<DestElementType>(
+                               NumPy::NdArray(value))());
   } else if (PySequence_Check(value.ptr())) {
     alg->setProperty(name,
                      Converters::PySequenceToVector<DestElementType>(value)());

--- a/Framework/PythonInterface/mantid/kernel/src/Registry/SequenceTypeHandler.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Registry/SequenceTypeHandler.cpp
@@ -52,7 +52,7 @@ void SequenceTypeHandler<ContainerType>::set(
   }
   // numpy arrays requires special handling to extract their types. Hand-off to
   // a more appropriate handler
-  else if (PyArray_Check(value.ptr())) {
+  else if (NumPy::NdArray::check(value)) {
     alg->setProperty(name, Converters::NDArrayToVector<DestElementType>(
                                NumPy::NdArray(value))());
   } else if (PySequence_Check(value.ptr())) {

--- a/Framework/PythonInterface/test/cpp/PySequenceToVectorTest.h
+++ b/Framework/PythonInterface/test/cpp/PySequenceToVectorTest.h
@@ -19,12 +19,6 @@ public:
     TS_ASSERT_THROWS_NOTHING(PySequenceToVectorDouble converter(testList));
   }
 
-  void test_construction_throws_when_not_given_a_PySequence() {
-    boost::python::dict testDict;
-    TS_ASSERT_THROWS(PySequenceToVectorDouble converter(testDict),
-                     std::invalid_argument);
-  }
-
   void test_that_a_python_list_of_all_matching_types_is_converted_correctly() {
     boost::python::list testlist = createHomogeneousPythonList();
     const size_t ntestvals = boost::python::len(testlist);

--- a/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
@@ -140,18 +140,6 @@ class MatrixWorkspaceTest(unittest.TestCase):
         self.assertRaises(ValueError, test_ws.setY, 0, values)
         self.assertRaises(ValueError, test_ws.setE, 0, values)
 
-    def test_setting_spectra_from_array_of_incorrect_shape_raises_error(self):
-        nvectors = 2
-        xlength = 11
-        ylength = 10
-        test_ws = WorkspaceFactory.create("Workspace2D", nvectors, xlength, ylength)
-
-        values = np.linspace(0,1,num=xlength-1)
-        values = values.reshape(5,2)
-        self.assertRaises(ValueError, test_ws.setX, 0, values)
-        self.assertRaises(ValueError, test_ws.setY, 0, values)
-        self.assertRaises(ValueError, test_ws.setE, 0, values)
-
     def test_setting_spectra_from_array_using_incorrect_index_raises_error(self):
         nvectors = 2
         xlength = 11
@@ -183,6 +171,39 @@ class MatrixWorkspaceTest(unittest.TestCase):
         test_ws.setE(ws_index, values)
         ws_values = test_ws.readE(ws_index)
         self.assertTrue(np.array_equal(values, ws_values))
+
+    def test_setxy_data_coerced_correctly_to_float64(self):
+        nbins = 10
+        nspec = 2
+        xdata = np.arange(nbins+1)
+        ydata = np.arange(nbins)
+        ws = WorkspaceFactory.create("Workspace2D", NVectors=nspec, XLength=nbins+1, YLength=nbins)
+        for i in xrange(nspec):
+            ws.setX(i, xdata)
+            ws.setY(i, ydata)
+
+        # Verify
+        x_expected, y_expected = np.vstack((xdata, xdata)), np.vstack((ydata, ydata))
+        x_extracted, y_extracted = ws.extractX(), ws.extractY()
+        self.assertTrue(np.array_equal(x_expected, x_extracted))
+        self.assertTrue(np.array_equal(y_expected, y_extracted))
+
+    def xtest_setxy_accepts_python_list(self):
+        nbins = 10
+        nspec = 2
+        xdata = list(range(nbins+1))
+        ydata = list(range(nbins))
+        ws = WorkspaceFactory.create("Workspace2D", NVectors=nspec, XLength=nbins+1, YLength=nbins)
+        for i in xrange(nspec):
+            ws.setX(i, xdata)
+            ws.setY(i, ydata)
+
+        # Verify
+        xdata, ydata = np.array(xdata), np.array(ydata)
+        x_expected, y_expected = np.vstack((xdata, xdata)), np.vstack((ydata, ydata))
+        x_extracted, y_extracted = ws.extractX(), ws.extractY()
+        self.assertTrue(np.array_equal(x_expected, x_extracted))
+        self.assertTrue(np.array_equal(y_expected, y_extracted))
 
     def test_data_can_be_extracted_to_numpy_successfully(self):
         x = self._test_ws.extractX()

--- a/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
@@ -4,12 +4,13 @@ import unittest
 import sys
 import math
 from testhelpers import create_algorithm, run_algorithm, can_be_instantiated, WorkspaceCreationHelper
+
 from mantid.api import (MatrixWorkspace, MatrixWorkspaceProperty, WorkspaceProperty, Workspace,
                         ExperimentInfo, AnalysisDataService, WorkspaceFactory)
 from mantid.geometry import Detector
 from mantid.kernel import Direction, V3D
-
 import numpy as np
+from six.moves import range
 
 class MatrixWorkspaceTest(unittest.TestCase):
 
@@ -178,7 +179,7 @@ class MatrixWorkspaceTest(unittest.TestCase):
         xdata = np.arange(nbins+1)
         ydata = np.arange(nbins)
         ws = WorkspaceFactory.create("Workspace2D", NVectors=nspec, XLength=nbins+1, YLength=nbins)
-        for i in xrange(nspec):
+        for i in range(nspec):
             ws.setX(i, xdata)
             ws.setY(i, ydata)
 
@@ -194,7 +195,7 @@ class MatrixWorkspaceTest(unittest.TestCase):
         xdata = list(range(nbins+1))
         ydata = list(range(nbins))
         ws = WorkspaceFactory.create("Workspace2D", NVectors=nspec, XLength=nbins+1, YLength=nbins)
-        for i in xrange(nspec):
+        for i in range(nspec):
             ws.setX(i, xdata)
             ws.setY(i, ydata)
 

--- a/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
@@ -188,7 +188,7 @@ class MatrixWorkspaceTest(unittest.TestCase):
         self.assertTrue(np.array_equal(x_expected, x_extracted))
         self.assertTrue(np.array_equal(y_expected, y_extracted))
 
-    def xtest_setxy_accepts_python_list(self):
+    def test_setxy_accepts_python_list(self):
         nbins = 10
         nspec = 2
         xdata = list(range(nbins+1))

--- a/docs/source/release/v3.12.0/framework.rst
+++ b/docs/source/release/v3.12.0/framework.rst
@@ -64,4 +64,6 @@ Support for unicode property names has been added to python. This means that one
    props = json.loads('{"DryRun":true}')
    Segfault(**props)
 
+- Fixed an issue with coercing data from python lists or numpy arrays where the datatype!=float64 into a workspace 
+
 :ref:`Release 3.12.0 <v3.12.0>`


### PR DESCRIPTION
**Description of work**

Fixed a bug in the data coercion logic when entering data through the python MatrixWorkspace::setX/setY/setE methods.

Also now allows lists as sources of the data.

**To test:**

See instructions in the issue for testing. The errors should now be gone and the data should be correct.

Fixes #20444

**Release Notes** 

Add note to [framework section](/mantidproject/mantid/commit/ddfd1969b569c6c39f7a96921b5a2537d4b69c09)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
