### PR TITLE
Tolerance for select cell algorithms in SCD interface

### DIFF
--- a/docs/source/release/v3.12.0/diffraction.rst
+++ b/docs/source/release/v3.12.0/diffraction.rst
@@ -52,6 +52,8 @@ Single Crystal Diffraction
 
 - :ref:`FindUBUsingLatticeParameters <algm-FindUBUsingLatticeParameters>` now has option to specify number of iterations to refine UB. 
 
+- SCD Event Data Reduction interface now uses the Indexing Tolerance for Index Peaks to index the peaks for the Select Cell options in Choose Cell tab.  Previously it used a constant, 0.12, for the tolerance.
+
 
 Total Scattering
 ----------------

--- a/qt/scientific_interfaces/General/MantidEV.cpp
+++ b/qt/scientific_interfaces/General/MantidEV.cpp
@@ -962,17 +962,23 @@ void MantidEV::chooseCell_slot() {
     std::string cell_type = m_uiForm.CellType_cmbx->currentText().toStdString();
     std::string centering =
         m_uiForm.CellCentering_cmbx->currentText().toStdString();
+    double index_tolerance = 0.12;
+    if (!getPositiveDouble(m_uiForm.IndexingTolerance_ledt, index_tolerance))
+      return;
     if (!worker->selectCellOfType(peaks_ws_name, cell_type, centering,
-                                  allow_perm)) {
+                                  allow_perm, index_tolerance)) {
       errorMessage("Failed to Select Specified Conventional Cell");
     }
   } else if (select_cell_form) {
     std::string form =
         m_uiForm.CellFormNumber_cmbx->currentText().toStdString();
     double form_num = 0;
+    double index_tolerance = 0.12;
+    if (!getPositiveDouble(m_uiForm.IndexingTolerance_ledt, index_tolerance))
+      return;
     getDouble(form, form_num);
     if (!worker->selectCellWithForm(peaks_ws_name, (size_t)form_num,
-                                    allow_perm)) {
+                                    allow_perm, index_tolerance)) {
       errorMessage("Failed to Select the Requested Form Number");
     }
   }

--- a/qt/scientific_interfaces/General/MantidEV.cpp
+++ b/qt/scientific_interfaces/General/MantidEV.cpp
@@ -977,8 +977,8 @@ void MantidEV::chooseCell_slot() {
     if (!getPositiveDouble(m_uiForm.IndexingTolerance_ledt, index_tolerance))
       return;
     getDouble(form, form_num);
-    if (!worker->selectCellWithForm(peaks_ws_name, (size_t)form_num,
-                                    allow_perm, index_tolerance)) {
+    if (!worker->selectCellWithForm(peaks_ws_name, (size_t)form_num, allow_perm,
+                                    index_tolerance)) {
       errorMessage("Failed to Select the Requested Form Number");
     }
   }

--- a/qt/scientific_interfaces/General/MantidEVWorker.cpp
+++ b/qt/scientific_interfaces/General/MantidEVWorker.cpp
@@ -700,7 +700,7 @@ bool MantidEVWorker::selectCellOfType(const std::string &peaks_ws_name,
  *  @return true if the SelectCellWithForm algorithm completes successfully.
  */
 bool MantidEVWorker::selectCellWithForm(const std::string &peaks_ws_name,
-                                        size_t form_num, bool allow_perm, 
+                                        size_t form_num, bool allow_perm,
                                         double tolerance) {
   if (!isPeaksWorkspace(peaks_ws_name))
     return false;

--- a/qt/scientific_interfaces/General/MantidEVWorker.cpp
+++ b/qt/scientific_interfaces/General/MantidEVWorker.cpp
@@ -662,13 +662,14 @@ bool MantidEVWorker::showCells(const std::string &peaks_ws_name,
  *  @param allow_perm        If true, permutations are used to find the
  *                           best fitting cell of any
  *                           particular type.
+ *  @param tolerance       The tolerance on hkl values to use when
  *
  *  @return true if the SelectCellOfType algorithm completes successfully.
  */
 bool MantidEVWorker::selectCellOfType(const std::string &peaks_ws_name,
                                       const std::string &cell_type,
                                       const std::string &centering,
-                                      bool allow_perm) {
+                                      bool allow_perm, double tolerance) {
   if (!isPeaksWorkspace(peaks_ws_name))
     return false;
 
@@ -677,7 +678,7 @@ bool MantidEVWorker::selectCellOfType(const std::string &peaks_ws_name,
   alg->setProperty("CellType", cell_type);
   alg->setProperty("Centering", centering);
   alg->setProperty("Apply", true);
-  alg->setProperty("tolerance", 0.12);
+  alg->setProperty("tolerance", tolerance);
   alg->setProperty("AllowPermutations", allow_perm);
 
   return alg->execute();
@@ -694,11 +695,13 @@ bool MantidEVWorker::selectCellOfType(const std::string &peaks_ws_name,
  *  @param allow_perm        If true, permutations are used to find the
  *                           best fitting cell of any
  *                           particular type.
+ *  @param tolerance       The tolerance on hkl values to use when
  *
  *  @return true if the SelectCellWithForm algorithm completes successfully.
  */
 bool MantidEVWorker::selectCellWithForm(const std::string &peaks_ws_name,
-                                        size_t form_num, bool allow_perm) {
+                                        size_t form_num, bool allow_perm, 
+                                        double tolerance) {
   if (!isPeaksWorkspace(peaks_ws_name))
     return false;
 
@@ -707,7 +710,7 @@ bool MantidEVWorker::selectCellWithForm(const std::string &peaks_ws_name,
   alg->setProperty("PeaksWorkspace", peaks_ws_name);
   alg->setProperty("FormNumber", (int)form_num);
   alg->setProperty("Apply", true);
-  alg->setProperty("tolerance", 0.12);
+  alg->setProperty("tolerance", tolerance);
   alg->setProperty("AllowPermutations", allow_perm);
 
   return alg->execute();

--- a/qt/scientific_interfaces/General/MantidEVWorker.h
+++ b/qt/scientific_interfaces/General/MantidEVWorker.h
@@ -124,11 +124,12 @@ public:
   /// Select conventional cell using the cell type and centering
   bool selectCellOfType(const std::string &peaks_ws_name,
                         const std::string &cell_type,
-                        const std::string &centering, bool allow_perm);
+                        const std::string &centering, bool allow_perm,
+                        const double tolerance);
 
   /// Select conventional cell using the form number from the Mighell paper
   bool selectCellWithForm(const std::string &peaks_ws_name, size_t form_num,
-                          bool allow_perm);
+                          bool allow_perm, const double tolerance);
 
   /// Apply a mapping to the h,k,l indices and the UB matrix
   bool changeHKL(const std::string &peaks_ws_name, const std::string &row_1_str,


### PR DESCRIPTION
Description of work.
SCD Event Data Reduction interface now uses the Indexing Tolerance for Index Peaks to index the peaks for the Select Cell options in Choose Cell tab.  Previously it used a constant, 0.12, for the tolerance.

Use SCD Event Data Reduction interface with filename "TOPAZ_3132_event.nxs" from system tests. Click apply on first 2 tabs.  On 3rd tab enter Indexing Tolerance=0.01 and then apply.  On 4th tab use Select Cell With Form=32 and check that the same number of peaks were indexed.

<!-- Instructions for testing. -->

Fixes #21410 

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
