### PR TITLE
Add negation operators to V2D and V3D

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/V2D.h
+++ b/Framework/Kernel/inc/MantidKernel/V2D.h
@@ -76,6 +76,8 @@ public:
   V2D operator*(const double factor) const;
   /// Scale this
   V2D &operator*=(const double factor);
+  /// Negate
+  V2D operator-() const noexcept;
 
   ///@}
 

--- a/Framework/Kernel/inc/MantidKernel/V3D.h
+++ b/Framework/Kernel/inc/MantidKernel/V3D.h
@@ -46,10 +46,6 @@ public:
   V3D();
   V3D(const double, const double, const double);
 
-  // Arithemetic operators overloaded
-  V3D operator+(const V3D &v) const;
-  V3D &operator+=(const V3D &v);
-
   /// Convenience method for sorting list of V3D objects based on magnitude
   static bool CompareMagnitude(const Kernel::V3D &v1, const Kernel::V3D &v2);
 
@@ -62,6 +58,9 @@ public:
     return tmp;
   }
 
+  // Arithemetic operators overloaded
+  V3D operator+(const V3D &v) const;
+  V3D &operator+=(const V3D &v);
   V3D operator-(const V3D &v) const;
   V3D &operator-=(const V3D &v);
   // Inner product
@@ -75,6 +74,8 @@ public:
   V3D &operator*=(const double D);
   V3D operator/(const double D) const;
   V3D &operator/=(const double D);
+  // Negation
+  V3D operator-() const noexcept;
   // Simple Comparison
   bool operator==(const V3D &) const;
   bool operator!=(const V3D &) const;

--- a/Framework/Kernel/src/V2D.cpp
+++ b/Framework/Kernel/src/V2D.cpp
@@ -80,6 +80,14 @@ V2D &V2D::operator*=(const double factor) {
 }
 
 /**
+* Negate and return
+* @returns A new negated V2D object
+*/
+V2D V2D::operator-() const noexcept {
+  return V2D{-m_x, -m_y};
+}
+
+/**
  * Equality operator including a tolerance
  * @param rhs :: The rhs object
  * @returns True if they are considered equal false otherwise

--- a/Framework/Kernel/src/V2D.cpp
+++ b/Framework/Kernel/src/V2D.cpp
@@ -83,9 +83,7 @@ V2D &V2D::operator*=(const double factor) {
 * Negate and return
 * @returns A new negated V2D object
 */
-V2D V2D::operator-() const noexcept {
-  return V2D{-m_x, -m_y};
-}
+V2D V2D::operator-() const noexcept { return V2D{-m_x, -m_y}; }
 
 /**
  * Equality operator including a tolerance

--- a/Framework/Kernel/src/V3D.cpp
+++ b/Framework/Kernel/src/V3D.cpp
@@ -243,9 +243,7 @@ V3D &V3D::operator/=(const double D) {
   Negation
  * @return a vector with same magnitude but in opposite direction
  */
-V3D V3D::operator-() const noexcept {
-  return V3D(-x, -y, -z);
-}
+V3D V3D::operator-() const noexcept { return V3D(-x, -y, -z); }
 
 /**
   Equals operator with tolerance factor

--- a/Framework/Kernel/src/V3D.cpp
+++ b/Framework/Kernel/src/V3D.cpp
@@ -240,6 +240,14 @@ V3D &V3D::operator/=(const double D) {
 }
 
 /**
+  Negation
+ * @return a vector with same magnitude but in opposite direction
+ */
+V3D V3D::operator-() const noexcept {
+  return V3D(-x, -y, -z);
+}
+
+/**
   Equals operator with tolerance factor
   @param v :: V3D for comparison
   @return true if the items are equal

--- a/Framework/Kernel/test/V2DTest.h
+++ b/Framework/Kernel/test/V2DTest.h
@@ -114,7 +114,7 @@ public:
   }
 
   void test_Negate_Works_With_Special_Values() {
-    const V2D p1(1. / 0., 0. / 0.);
+    const V2D p1(INFINITY, std::nan(""));
     const V2D p2 = -p1;
     TS_ASSERT_EQUALS(p2.X(), -INFINITY);
     TS_ASSERT(std::isnan(p2.Y()));

--- a/Framework/Kernel/test/V2DTest.h
+++ b/Framework/Kernel/test/V2DTest.h
@@ -107,6 +107,12 @@ public:
     TS_ASSERT_EQUALS(p1, V2D(9.0, 27.0));
   }
 
+  void test_Negate_Gives_Same_Length_But_Opposite_Direction() {
+    const V2D p1(-3, 9);
+    const V2D p2 = -p1;
+    TS_ASSERT_EQUALS(p2, V2D(3, -9))
+  }
+
   void test_Equality_Gives_True_When_Diff_Less_Than_Tolerance() {
     const double tolerance = std::numeric_limits<double>::epsilon();
     V2D first(5, 10);

--- a/Framework/Kernel/test/V2DTest.h
+++ b/Framework/Kernel/test/V2DTest.h
@@ -113,6 +113,13 @@ public:
     TS_ASSERT_EQUALS(p2, V2D(3, -9))
   }
 
+  void test_Negate_Works_With_Special_Values() {
+    const V2D p1(1. / 0., 0. / 0.);
+    const V2D p2 = -p1;
+    TS_ASSERT_EQUALS(p2.X(), -INFINITY);
+    TS_ASSERT(std::isnan(p2.Y()));
+  }
+
   void test_Equality_Gives_True_When_Diff_Less_Than_Tolerance() {
     const double tolerance = std::numeric_limits<double>::epsilon();
     V2D first(5, 10);

--- a/Framework/Kernel/test/V3DTest.h
+++ b/Framework/Kernel/test/V3DTest.h
@@ -153,7 +153,7 @@ public:
     TS_ASSERT_EQUALS(b.Z(), 3.0)
   }
   void testNegationSpecialValues() {
-    a(0. / 0., -1. / 0., 1. / 0.);
+    a(std::nan(""), -INFINITY, INFINITY);
     b = -a;
     TS_ASSERT(std::isnan(b.X()));
     TS_ASSERT_EQUALS(b.Y(), INFINITY)

--- a/Framework/Kernel/test/V3DTest.h
+++ b/Framework/Kernel/test/V3DTest.h
@@ -145,6 +145,13 @@ public:
     TS_ASSERT_EQUALS(a.Y(), 1.0);
     TS_ASSERT_EQUALS(a.Z(), 1.5);
   }
+  void testNegation() {
+    a(-1.0, 2.0, -3.0);
+    b = -a;
+    TS_ASSERT_EQUALS(b.X(), 1.0)
+    TS_ASSERT_EQUALS(b.Y(), -2.0)
+    TS_ASSERT_EQUALS(b.Z(), 3.0)
+  }
   void testEqualEqualOperator() {
     a(1.0, 1.0, 1.0);
     b = a;

--- a/Framework/Kernel/test/V3DTest.h
+++ b/Framework/Kernel/test/V3DTest.h
@@ -152,6 +152,13 @@ public:
     TS_ASSERT_EQUALS(b.Y(), -2.0)
     TS_ASSERT_EQUALS(b.Z(), 3.0)
   }
+  void testNegationSpecialValues() {
+    a(0. / 0., -1. / 0., 1. / 0.);
+    b = -a;
+    TS_ASSERT(std::isnan(b.X()));
+    TS_ASSERT_EQUALS(b.Y(), INFINITY)
+    TS_ASSERT_EQUALS(b.Z(), -INFINITY)
+  }
   void testEqualEqualOperator() {
     a(1.0, 1.0, 1.0);
     b = a;

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/V3D.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/V3D.cpp
@@ -108,10 +108,13 @@ void export_V3D() {
       .def("__add__", &V3D::operator+, (arg("left"), arg("right")))
       .def("__iadd__", &V3D::operator+=, return_self<>(),
            (arg("self"), arg("other")))
-      .def("__sub__", static_cast<V3D (V3D::*) (const V3D &) const>(&V3D::operator-), (arg("left"), arg("right")))
+      .def("__sub__",
+           static_cast<V3D (V3D::*)(const V3D &) const>(&V3D::operator-),
+           (arg("left"), arg("right")))
       .def("__isub__", &V3D::operator-=, return_self<>(),
            (arg("self"), arg("other")))
-      .def("__neg__",  static_cast<V3D (V3D::*) () const>(&V3D::operator-), (arg("self")))
+      .def("__neg__", static_cast<V3D (V3D::*)() const>(&V3D::operator-),
+           (arg("self")))
       .def("__len__", &getV3DLength, (arg("self")),
            "Returns the length of the vector for list-like interface. Always "
            "returns 3.")

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/V3D.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/V3D.cpp
@@ -108,9 +108,10 @@ void export_V3D() {
       .def("__add__", &V3D::operator+, (arg("left"), arg("right")))
       .def("__iadd__", &V3D::operator+=, return_self<>(),
            (arg("self"), arg("other")))
-      .def("__sub__", &V3D::operator-, (arg("left"), arg("right")))
+      .def("__sub__", static_cast<V3D (V3D::*) (const V3D &) const>(&V3D::operator-), (arg("left"), arg("right")))
       .def("__isub__", &V3D::operator-=, return_self<>(),
            (arg("self"), arg("other")))
+      .def("__neg__",  static_cast<V3D (V3D::*) () const>(&V3D::operator-), (arg("self")))
       .def("__len__", &getV3DLength, (arg("self")),
            "Returns the length of the vector for list-like interface. Always "
            "returns 3.")

--- a/docs/source/release/v3.12.0/framework.rst
+++ b/docs/source/release/v3.12.0/framework.rst
@@ -54,6 +54,7 @@ In `mantid.simpleapi`, a keyword has been implemented for function-like algorith
 
 - The standard Python operators, e.g. ``+``, ``+=``, etc., now work also with workspaces not in the ADS.
 - The ``isDefault`` attribute for workspace properties now works correctly with workspaces not in the ADS.
+- ``mantid.kernel.V3D`` vectors now support negation through the usual ``-`` operator.
 
 Support for unicode property names has been added to python. This means that one can run the following in python2 or python3.
 


### PR DESCRIPTION
This PR adds the unary `operator-()` functions to `V2D` and `V3D`. The negation operator of `V3D` is also exposed to Python (`V2D` itself in not available in Python).

**To test:**

Check that negation of `V3D` objects produce vectors of the same length but in opposite direction. Testing `V2D` might be a bit tricky as it is not available in Python, but since it's not used too much, maybe it's enough to do a throughout code review.

Fixes #19958.

**Release Notes** 

Framework release notes were updated accordingly.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
