### PR TITLE
Fix parsing serialization string in StepScan interface with LiveData

### DIFF
--- a/qt/scientific_interfaces/General/StepScan.cpp
+++ b/qt/scientific_interfaces/General/StepScan.cpp
@@ -554,7 +554,7 @@ bool StepScan::runStepScanAlgLive(std::string stepScanProperties) {
     throw std::runtime_error("Parsing parameters failed for StepScan.");
   }
   Json::Value &prop = root["properties"];
-  if (prop.type() == Json::nullValue) {
+  if (prop.isNull()) {
     throw std::runtime_error("Parsing parameters failed for StepScan.");
   }
   std::string ssp = prop.toStyledString();

--- a/qt/scientific_interfaces/General/StepScan.cpp
+++ b/qt/scientific_interfaces/General/StepScan.cpp
@@ -548,11 +548,16 @@ bool StepScan::runStepScanAlgLive(std::string stepScanProperties) {
 
   Json::Value root;
   Json::Reader reader;
-  bool parsingSuccessful = reader.parse(stepScanProperties.c_str(), root);
+
+  bool parsingSuccessful = reader.parse(stepScanProperties, root);
   if (!parsingSuccessful) {
     throw std::runtime_error("Parsing parameters failed for StepScan.");
   }
-  std::string ssp = root.get("properties", "").toStyledString();
+  Json::Value &prop = root["properties"];
+  if (prop.type() == Json::nullValue) {
+    throw std::runtime_error("Parsing parameters failed for StepScan.");
+  }
+  std::string ssp = prop.toStyledString();
 
   IAlgorithm_sptr startLiveData =
       AlgorithmManager::Instance().create("StartLiveData");

--- a/qt/scientific_interfaces/General/StepScan.cpp
+++ b/qt/scientific_interfaces/General/StepScan.cpp
@@ -16,7 +16,7 @@
 #include <Poco/ActiveResult.h>
 #include <Poco/Thread.h>
 
-#include <jsoncpp/json/reader.h>
+#include <json/reader.h>
 
 namespace MantidQt {
 using API::MantidDesktopServices;

--- a/qt/scientific_interfaces/General/StepScan.cpp
+++ b/qt/scientific_interfaces/General/StepScan.cpp
@@ -548,11 +548,11 @@ bool StepScan::runStepScanAlgLive(std::string stepScanProperties) {
 
   Json::Value root;
   Json::Reader reader;
-  bool parsingSuccessful = reader.parse( stepScanProperties.c_str(), root );
-  if (!parsingSuccessful){
-      throw std::runtime_error("Parsing parameters failed for StepScan.");
+  bool parsingSuccessful = reader.parse(stepScanProperties.c_str(), root);
+  if (!parsingSuccessful) {
+    throw std::runtime_error("Parsing parameters failed for StepScan.");
   }
-  std::string ssp=root.get("properties","").toStyledString();
+  std::string ssp = root.get("properties", "").toStyledString();
 
   IAlgorithm_sptr startLiveData =
       AlgorithmManager::Instance().create("StartLiveData");


### PR DESCRIPTION
StepScan interface used to parse a string to get the parameters to pass to `StartLiveData`. Unfortunately, the format of the string changed in PR #14156 to a json. Live data was not working with the step scan interface since this changed in Mantid 3.6.

**To test:**
Code review. If you are at SNS, set your instrument to SEQUOIA, start the `StepScanAnalysis` interface, click on live data, then start. Even if there is no scan running, the interface should not crash.

Fixes #18184  

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
