### PR TITLE
Fix leak of H5 attribute in parallel event loader

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -67,7 +67,6 @@ class DLLExport LoadEventNexus
 
 public:
   LoadEventNexus();
-  ~LoadEventNexus() override;
 
   const std::string name() const override { return "LoadEventNexus"; };
 
@@ -166,7 +165,7 @@ public:
 
   /// name of top level NXentry to use
   std::string m_top_entry_name;
-  ::NeXus::File *m_file;
+  std::unique_ptr<::NeXus::File> m_file;
 
 protected:
   Parallel::ExecutionMode getParallelExecutionMode(

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -78,15 +78,8 @@ void copyLogs(const Mantid::DataHandling::EventWorkspaceCollection_sptr &from,
 LoadEventNexus::LoadEventNexus()
     : filter_tof_min(0), filter_tof_max(0), m_specMin(0), m_specMax(0),
       longest_tof(0), shortest_tof(0), bad_tofs(0), discarded_events(0),
-      compressTolerance(0), m_file(nullptr),
-      m_instrument_loaded_correctly(false), loadlogs(false),
-      m_logs_loaded_correctly(false), event_id_is_spec(false) {}
-
-//----------------------------------------------------------------------------------------------
-/** Destructor */
-LoadEventNexus::~LoadEventNexus() {
-  if (m_file)
-    delete m_file;
+      compressTolerance(0), m_instrument_loaded_correctly(false),
+      loadlogs(false), m_logs_loaded_correctly(false), event_id_is_spec(false) {
 }
 
 //----------------------------------------------------------------------------------------------
@@ -1655,7 +1648,7 @@ void LoadEventNexus::loadSampleDataISIScompatibility(
  */
 void LoadEventNexus::safeOpenFile(const std::string fname) {
   try {
-    m_file = new ::NeXus::File(m_filename, NXACC_READ);
+    m_file = Kernel::make_unique<::NeXus::File>(m_filename, NXACC_READ);
   } catch (std::runtime_error &e) {
     throw std::runtime_error("Severe failure when trying to open NeXus file: " +
                              std::string(e.what()));

--- a/Framework/Parallel/inc/MantidParallel/IO/NXEventDataLoader.h
+++ b/Framework/Parallel/inc/MantidParallel/IO/NXEventDataLoader.h
@@ -131,6 +131,7 @@ makeEventDataPartitioner(const H5::Group &group, const int numWorkers) {
     attr.read(attr.getDataType(), offset);
     time_zero_offset = Types::Core::DateAndTime(offset).totalNanoseconds();
   }
+  H5Aclose(attr_id);
   return Kernel::make_unique<
       EventDataPartitioner<IndexType, TimeZeroType, TimeOffsetType>>(
       numWorkers, PulseTimeGenerator<IndexType, TimeZeroType>{


### PR DESCRIPTION
The leak caused crashes when using the NeXus API after the even loading via HDF5 in the parallel event loader was complete. The parallel loader is only enabled in MPI builds so this does not affect any normal Mantid build.

Also cleans `LoadEventNexus`, to remove raw owning pointer.

**To test:**

Code review.
No isse and no release notes. The crash was only happing in MPI builds, which are not public.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
