### PR TITLE
Refs #21447 fix peak picker for crystallography convention

### DIFF
--- a/Framework/Algorithms/src/AddPeak.cpp
+++ b/Framework/Algorithms/src/AddPeak.cpp
@@ -55,7 +55,8 @@ void AddPeak::exec() {
   double phi = det.getPhi();
 
   // In the inelastic convention, Q = ki - kf.
-  // qSign later in algorithm will change to kf - ki for Crystallography Convention
+  // qSign later in algorithm will change to kf - ki for Crystallography
+  // Convention
   double Qx = -sin(theta2) * cos(phi);
   double Qy = -sin(theta2) * sin(phi);
   double Qz = 1.0 - cos(theta2);
@@ -97,7 +98,8 @@ void AddPeak::exec() {
     tof = xdata[0];
   }
 
-  std::string m_qConvention = Kernel::ConfigService::Instance().getString("Q.convention");
+  std::string m_qConvention =
+      Kernel::ConfigService::Instance().getString("Q.convention");
   double qSign = 1.0;
   if (m_qConvention == "Crystallography") {
     qSign = -1.0;

--- a/Framework/Algorithms/src/AddPeak.cpp
+++ b/Framework/Algorithms/src/AddPeak.cpp
@@ -55,6 +55,7 @@ void AddPeak::exec() {
   double phi = det.getPhi();
 
   // In the inelastic convention, Q = ki - kf.
+  // qSign later in algorithm will change to kf - ki for Crystallography Convention
   double Qx = -sin(theta2) * cos(phi);
   double Qy = -sin(theta2) * sin(phi);
   double Qz = 1.0 - cos(theta2);
@@ -96,7 +97,12 @@ void AddPeak::exec() {
     tof = xdata[0];
   }
 
-  double knorm = NeutronMass * (l1 + l2) / (h_bar * tof * 1e-6) / 1e10;
+  std::string m_qConvention = Kernel::ConfigService::Instance().getString("Q.convention");
+  double qSign = 1.0;
+  if (m_qConvention == "Crystallography") {
+    qSign = -1.0;
+  }
+  double knorm = qSign * NeutronMass * (l1 + l2) / (h_bar * tof * 1e-6) / 1e10;
   Qx *= knorm;
   Qy *= knorm;
   Qz *= knorm;


### PR DESCRIPTION
Description of work.
Changed sign of q for peak picker when in Crystallography Convention 

**To test:**


```python
Load(Filename='TOPAZ_3132_event.nxs', OutputWorkspace='TOPAZ_3132_event')
Rebin(InputWorkspace='TOPAZ_3132_event', OutputWorkspace='TOPAZ_3132_event', Params='1000,-0.004,16666')
```
Show Instrument and then Add a Single Crystal Peak from Pick tab.  Click on peak in TOF plot to add to SingleCrystalPeakTable.
Set Q.convention=Crystallography in Mantid.user.properties or Mantid preferences and repeat

Fixes #21447 

**Release Notes** 

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
