### PR TITLE
Speed up MergeRuns for detector scan workspaces

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/MergeRuns.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/MergeRuns.h
@@ -5,6 +5,7 @@
 #include "MantidAPI/MultiPeriodGroupAlgorithm.h"
 #include "MantidAPI/WorkspaceHistory.h"
 #include "MantidDataObjects/EventWorkspace.h"
+#include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidKernel/System.h"
 
 namespace Mantid {
@@ -153,6 +154,12 @@ private:
   std::vector<AdditionTable> m_tables;
   /// Total number of histograms in the output workspace
   size_t m_outputSize = 0;
+
+  std::vector<SpectrumDefinition>
+  buildScanIntervals(const std::vector<SpectrumDefinition> &addeeSpecDefs,
+                     const Geometry::DetectorInfo &addeeDetInfo,
+                     const Geometry::DetectorInfo &outDetInfo,
+                     const Geometry::DetectorInfo &newOutDetInfo);
 };
 
 } // namespace Algorithm

--- a/Framework/Algorithms/test/MergeRunsTest.h
+++ b/Framework/Algorithms/test/MergeRunsTest.h
@@ -1741,7 +1741,7 @@ public:
 
   MergeRunsTestPerformance() {}
 
-  void setUp() {
+  void setUp() override {
     for (size_t i = 0; i < 10; ++i) {
       // Create a D2B type workspace
       const auto &ws = WorkspaceCreationHelper::
@@ -1759,7 +1759,7 @@ public:
 
   void test_merge_detector_scan_workspaces() { m_mergeRuns.execute(); }
 
-  void tearDown() {
+  void tearDown() override {
     for (size_t i = 0; i < 10; ++i) {
       std::string wsName = "a" + std::to_string(i);
       AnalysisDataService::Instance().remove(wsName);

--- a/Framework/Algorithms/test/MergeRunsTest.h
+++ b/Framework/Algorithms/test/MergeRunsTest.h
@@ -1745,7 +1745,7 @@ public:
     for (size_t i = 0; i < 10; ++i) {
       // Create a D2B type workspace
       const auto &ws = WorkspaceCreationHelper::
-          create2DDetectorScanWorkspaceWithFullInstrument(10000, 1, 25,
+          create2DDetectorScanWorkspaceWithFullInstrument(5000, 1, 25,
                                                           i * 1000);
       std::string wsName = "a" + std::to_string(i);
       AnalysisDataService::Instance().addOrReplace(wsName, ws);

--- a/Framework/Algorithms/test/MergeRunsTest.h
+++ b/Framework/Algorithms/test/MergeRunsTest.h
@@ -1741,7 +1741,7 @@ public:
 
   MergeRunsTestPerformance() {}
 
-  void test_merge_detector_scan_workspaces() {
+  void setUp() {
     for (size_t i = 0; i < 10; ++i) {
       // Create a D2B type workspace
       const auto &ws = WorkspaceCreationHelper::
@@ -1751,18 +1751,24 @@ public:
       AnalysisDataService::Instance().addOrReplace(wsName, ws);
     }
 
-    Mantid::Algorithms::MergeRuns mergeRuns;
-    mergeRuns.initialize();
-    mergeRuns.setPropertyValue("InputWorkspaces",
-                               "a0, a1, a2, a3, a4, a5, a6, a7, a8, a9");
-    mergeRuns.setPropertyValue("OutputWorkspace", "outputWS");
-    mergeRuns.execute();
+    m_mergeRuns.initialize();
+    m_mergeRuns.setPropertyValue("InputWorkspaces",
+                                 "a0, a1, a2, a3, a4, a5, a6, a7, a8, a9");
+    m_mergeRuns.setPropertyValue("OutputWorkspace", "outputWS");
+  }
+
+  void test_merge_detector_scan_workspaces() { m_mergeRuns.execute(); }
+
+  void tearDown() {
     for (size_t i = 0; i < 10; ++i) {
       std::string wsName = "a" + std::to_string(i);
       AnalysisDataService::Instance().remove(wsName);
     }
     AnalysisDataService::Instance().remove("outputWS");
   }
+
+private:
+  Mantid::Algorithms::MergeRuns m_mergeRuns;
 };
 
 #endif /*MERGERUNSTEST_H_*/

--- a/Framework/Algorithms/test/MergeRunsTest.h
+++ b/Framework/Algorithms/test/MergeRunsTest.h
@@ -1732,4 +1732,37 @@ public:
   }
 };
 
+class MergeRunsTestPerformance : public CxxTest::TestSuite {
+public:
+  static MergeRunsTestPerformance *createSuite() {
+    return new MergeRunsTestPerformance();
+  }
+  static void destroySuite(MergeRunsTestPerformance *suite) { delete suite; }
+
+  MergeRunsTestPerformance() {}
+
+  void test_merge_detector_scan_workspaces() {
+    for (size_t i = 0; i < 10; ++i) {
+      // Create a D2B type workspace
+      const auto &ws = WorkspaceCreationHelper::
+          create2DDetectorScanWorkspaceWithFullInstrument(10000, 1, 25,
+                                                          i * 1000);
+      std::string wsName = "a" + std::to_string(i);
+      AnalysisDataService::Instance().addOrReplace(wsName, ws);
+    }
+
+    Mantid::Algorithms::MergeRuns mergeRuns;
+    mergeRuns.initialize();
+    mergeRuns.setPropertyValue("InputWorkspaces",
+                               "a0, a1, a2, a3, a4, a5, a6, a7, a8, a9");
+    mergeRuns.setPropertyValue("OutputWorkspace", "outputWS");
+    mergeRuns.execute();
+    for (size_t i = 0; i < 10; ++i) {
+      std::string wsName = "a" + std::to_string(i);
+      AnalysisDataService::Instance().remove(wsName);
+    }
+    AnalysisDataService::Instance().remove("outputWS");
+  }
+};
+
 #endif /*MERGERUNSTEST_H_*/


### PR DESCRIPTION
Speeds up `MergeRuns` for detector scan workspaces by parallelising a slow loop.

**To test:**

Run performance test `ctest -R MergeRunsPerformance`. Then delete line 684 in `MergeRuns.cpp` and run again. With the parallelisation there should be a ~20% speed up.

Fixes #21452.

**Release Notes** 
*Does not need to be in the release notes.* - non functional change.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
