### PR TITLE
Simpler MasterOnly MPI mechanism

### DIFF
--- a/Framework/API/inc/MantidAPI/Algorithm.h
+++ b/Framework/API/inc/MantidAPI/Algorithm.h
@@ -325,7 +325,6 @@ protected:
   void exec(Parallel::ExecutionMode executionMode);
   virtual void execDistributed();
   virtual void execMasterOnly();
-  virtual void execNonMaster();
 
   virtual Parallel::ExecutionMode getParallelExecutionMode(
       const std::map<std::string, Parallel::StorageMode> &storageModes) const;

--- a/Framework/API/inc/MantidAPI/WorkspaceProperty.tcc
+++ b/Framework/API/inc/MantidAPI/WorkspaceProperty.tcc
@@ -142,7 +142,7 @@ template <typename TYPE> std::string WorkspaceProperty<TYPE>::value() const {
 /** Returns true if the workspace is in the ADS or there is none.
  * @return true if the string returned by value() is valid
  */
-template<typename TYPE>
+template <typename TYPE>
 bool WorkspaceProperty<TYPE>::isValueSerializable() const {
   return !m_workspaceName.empty() || !this->m_value;
 }
@@ -441,7 +441,7 @@ std::string WorkspaceProperty<TYPE>::isOptionalWs() const {
   std::string error;
 
   if (m_workspaceName.empty()) {
-    if (isOptional()) {
+    if (isOptional() || !m_isMasterRank) {
       error = "";
     } else {
       error = "Enter a name for the Input/InOut workspace";

--- a/Framework/API/inc/MantidAPI/WorkspaceProperty.tcc
+++ b/Framework/API/inc/MantidAPI/WorkspaceProperty.tcc
@@ -216,15 +216,28 @@ template <typename TYPE> std::string WorkspaceProperty<TYPE>::isValid() const {
     if (!Kernel::PropertyWithValue<boost::shared_ptr<TYPE>>::m_value) {
       Mantid::API::Workspace_sptr wksp;
       // if the workspace name is empty then there is no point asking the ADS
-      if (m_workspaceName.empty())
-        return isOptionalWs();
+      if (m_workspaceName.empty()) {
+        // If workspace is null on a non-master rank this usually indicates that
+        // this is a MasterOnly workspace and algorithm execution. In cases
+        // where the workspace is null for other reasons we can rely on the
+        // master rank failing.
+        if (!m_isMasterRank)
+          return {};
+        else
+          return isOptionalWs();
+      }
 
       try {
         wksp = AnalysisDataService::Instance().retrieve(m_workspaceName);
       } catch (Kernel::Exception::NotFoundError &) {
         // Check to see if the workspace is not logged with the ADS because it
         // is optional.
-        return isOptionalWs();
+        // Similar to above, if the workspace is not in the ADS this indicates
+        // MasterOnly workspace and execution.
+        if (!m_isMasterRank)
+          return {};
+        else
+          return isOptionalWs();
       }
 
       // At this point we have a valid pointer to a Workspace so we need to
@@ -236,12 +249,6 @@ template <typename TYPE> std::string WorkspaceProperty<TYPE>::isValid() const {
         error = "Workspace " + this->value() + " is not of the correct type";
       }
       return error;
-    } else {
-      // Skip validation on non-master ranks if storage mode is MasterOnly.
-      if (!m_isMasterRank &&
-          Kernel::PropertyWithValue<boost::shared_ptr<TYPE>>::m_value
-                  ->storageMode() == Parallel::StorageMode::MasterOnly)
-        return {};
     }
   }
   // Call superclass method to access any attached validators (which do their
@@ -334,12 +341,14 @@ template <typename TYPE> bool WorkspaceProperty<TYPE>::store() {
   if (this->direction()) // Output or InOut
   {
     // Check that workspace exists
-    if (!this->operator()())
+    if (this->operator()()) {
+      // Note use of addOrReplace rather than add
+      API::AnalysisDataService::Instance().addOrReplace(m_workspaceName,
+                                                        this->operator()());
+    } else if (m_isMasterRank) {
       throw std::runtime_error(
           "WorkspaceProperty doesn't point to a workspace");
-    // Note use of addOrReplace rather than add
-    API::AnalysisDataService::Instance().addOrReplace(m_workspaceName,
-                                                      this->operator()());
+    }
     result = true;
   }
   // always clear the internal pointer after storing
@@ -441,7 +450,7 @@ std::string WorkspaceProperty<TYPE>::isOptionalWs() const {
   std::string error;
 
   if (m_workspaceName.empty()) {
-    if (isOptional() || !m_isMasterRank) {
+    if (isOptional()) {
       error = "";
     } else {
       error = "Enter a name for the Input/InOut workspace";

--- a/Framework/API/test/AlgorithmMPITest.h
+++ b/Framework/API/test/AlgorithmMPITest.h
@@ -390,8 +390,6 @@ void run1To1StorageModeTransition(const Parallel::Communicator &comm) {
   auto alg = create<FakeAlg1To1StorageModeTransition<modeOut>>(comm);
   if (modeIn != Parallel::StorageMode::MasterOnly || comm.rank() == 0) {
     alg->setProperty("InputWorkspace", in);
-  } else {
-    alg->setProperty("InputWorkspace", in->cloneEmpty());
   }
   TS_ASSERT_THROWS_NOTHING(alg->execute());
   TS_ASSERT(alg->isExecuted());

--- a/Framework/API/test/AlgorithmMPITest.h
+++ b/Framework/API/test/AlgorithmMPITest.h
@@ -172,11 +172,9 @@ protected:
   }
 };
 
-class FakeAlgNTo1StorageModeFailure : public Algorithm {
+class FakeAlgNTo1 : public Algorithm {
 public:
-  const std::string name() const override {
-    return "FakeAlgNTo1StorageModeFailure";
-  }
+  const std::string name() const override { return "FakeAlgNTo1"; }
   int version() const override { return 1; }
   const std::string category() const override { return ""; }
   const std::string summary() const override { return ""; }
@@ -204,19 +202,6 @@ protected:
   }
 };
 
-class FakeAlgNTo1 : public FakeAlgNTo1StorageModeFailure {
-public:
-  const std::string name() const override { return "FakeAlgNTo1"; }
-
-protected:
-  void execNonMaster() override {
-    // Default implementation only works for 1:1 input->output, so we have to
-    // provide an alternative implementation here.
-    boost::shared_ptr<MatrixWorkspace> ws1 = getProperty("InputWorkspace1");
-    setProperty("OutputWorkspace", ws1->cloneEmpty());
-  }
-};
-
 template <Parallel::StorageMode storageMode>
 class FakeAlg0To1 : public Algorithm {
 public:
@@ -237,12 +222,6 @@ public:
   }
 
 protected:
-  void execNonMaster() override {
-    // This method should never create anything that is not
-    // StorageMode::MasterOnly.
-    setProperty("OutputWorkspace", Kernel::make_unique<FakeWorkspaceA>(
-                                       Parallel::StorageMode::MasterOnly));
-  }
   Parallel::ExecutionMode getParallelExecutionMode(
       const std::map<std::string, Parallel::StorageMode> &storageModes)
       const override {
@@ -274,12 +253,6 @@ public:
   }
 
 protected:
-  void execNonMaster() override {
-    // This method should never create anything that is not
-    // StorageMode::MasterOnly.
-    setProperty("OutputWorkspace", Kernel::make_unique<FakeWorkspaceA>(
-                                       Parallel::StorageMode::MasterOnly));
-  }
   Parallel::ExecutionMode getParallelExecutionMode(
       const std::map<std::string, Parallel::StorageMode> &storageModes)
       const override {
@@ -340,13 +313,15 @@ void run1To1(const Parallel::Communicator &comm) {
     auto alg = create<FakeAlg1To1>(comm);
     if (storageMode != Parallel::StorageMode::MasterOnly || comm.rank() == 0) {
       alg->setProperty("InputWorkspace", in);
-    } else {
-      alg->setProperty("InputWorkspace", in->cloneEmpty());
     }
     TS_ASSERT_THROWS_NOTHING(alg->execute());
     Workspace_const_sptr out = alg->getProperty("OutputWorkspace");
-    TS_ASSERT_EQUALS(out->storageMode(), storageMode);
-    TS_ASSERT_EQUALS(out->id(), "FakeWorkspaceA");
+    if (storageMode != Parallel::StorageMode::MasterOnly || comm.rank() == 0) {
+      TS_ASSERT_EQUALS(out->storageMode(), storageMode);
+      TS_ASSERT_EQUALS(out->id(), "FakeWorkspaceA");
+    } else {
+      TS_ASSERT_EQUALS(out, nullptr);
+    }
   }
 }
 
@@ -362,44 +337,8 @@ void runNTo0(const Parallel::Communicator &comm) {
     if (storageMode != Parallel::StorageMode::MasterOnly || comm.rank() == 0) {
       alg->setProperty("InputWorkspace1", in1);
       alg->setProperty("InputWorkspace2", in2);
-    } else {
-      alg->setProperty("InputWorkspace1", in1->cloneEmpty());
-      alg->setProperty("InputWorkspace2", in2->cloneEmpty());
     }
     TS_ASSERT_THROWS_NOTHING(alg->execute());
-  }
-}
-
-void runNTo1StorageModeFailure(const Parallel::Communicator &comm) {
-  for (auto storageMode :
-       {Parallel::StorageMode::Cloned, Parallel::StorageMode::Distributed,
-        Parallel::StorageMode::MasterOnly}) {
-    auto in1 = boost::make_shared<FakeWorkspaceA>(storageMode);
-    auto in2 = boost::make_shared<FakeWorkspaceB>(storageMode);
-    in1->initialize(1, 2, 1);
-    in2->initialize(1, 2, 1);
-    auto alg = create<FakeAlgNTo1StorageModeFailure>(comm);
-    if (storageMode != Parallel::StorageMode::MasterOnly || comm.rank() == 0) {
-      alg->setProperty("InputWorkspace1", in1);
-      alg->setProperty("InputWorkspace2", in2);
-    } else {
-      alg->setProperty("InputWorkspace1", in1->cloneEmpty());
-      alg->setProperty("InputWorkspace2", in2->cloneEmpty());
-    }
-    if (storageMode != Parallel::StorageMode::MasterOnly || comm.rank() == 0) {
-      TS_ASSERT_THROWS_NOTHING(alg->execute());
-      TS_ASSERT(alg->isExecuted());
-      Workspace_const_sptr out = alg->getProperty("OutputWorkspace");
-      // Preserving storage mode is actually not guaranteed, but this
-      // implementation does of FakeAlgNTo1StorageModeFailure does.
-      TS_ASSERT_EQUALS(out->storageMode(), storageMode);
-      TS_ASSERT_EQUALS(out->id(), "FakeWorkspaceA");
-    } else {
-      TS_ASSERT_THROWS_EQUALS(
-          alg->execute(), const std::runtime_error &e, std::string(e.what()),
-          "Attempt to run algorithm with Parallel::ExecutionMode::MasterOnly: "
-          "Execution in this mode not implemented.");
-    }
   }
 }
 
@@ -415,15 +354,18 @@ void runNTo1(const Parallel::Communicator &comm) {
     if (storageMode != Parallel::StorageMode::MasterOnly || comm.rank() == 0) {
       alg->setProperty("InputWorkspace1", in1);
       alg->setProperty("InputWorkspace2", in2);
-    } else {
-      alg->setProperty("InputWorkspace1", in1->cloneEmpty());
-      alg->setProperty("InputWorkspace2", in2->cloneEmpty());
     }
     TS_ASSERT_THROWS_NOTHING(alg->execute());
     TS_ASSERT(alg->isExecuted());
     Workspace_const_sptr out = alg->getProperty("OutputWorkspace");
-    TS_ASSERT_EQUALS(out->storageMode(), storageMode);
-    TS_ASSERT_EQUALS(out->id(), "FakeWorkspaceA");
+    if (storageMode != Parallel::StorageMode::MasterOnly || comm.rank() == 0) {
+      // Preserving storage mode is actually not guaranteed, but this
+      // implementation does of FakeAlgNTo1 does.
+      TS_ASSERT_EQUALS(out->storageMode(), storageMode);
+      TS_ASSERT_EQUALS(out->id(), "FakeWorkspaceA");
+    } else {
+      TS_ASSERT_EQUALS(out, nullptr);
+    }
   }
 }
 
@@ -433,8 +375,12 @@ void run0To1(const Parallel::Communicator &comm) {
   TS_ASSERT_THROWS_NOTHING(alg->execute());
   TS_ASSERT(alg->isExecuted());
   Workspace_const_sptr out = alg->getProperty("OutputWorkspace");
-  TS_ASSERT_EQUALS(out->storageMode(), storageMode);
-  TS_ASSERT_EQUALS(out->id(), "FakeWorkspaceA");
+  if (storageMode != Parallel::StorageMode::MasterOnly || comm.rank() == 0) {
+    TS_ASSERT_EQUALS(out->storageMode(), storageMode);
+    TS_ASSERT_EQUALS(out->id(), "FakeWorkspaceA");
+  } else {
+    TS_ASSERT_EQUALS(out, nullptr);
+  }
 }
 
 template <Parallel::StorageMode modeIn, Parallel::StorageMode modeOut>
@@ -450,8 +396,12 @@ void run1To1StorageModeTransition(const Parallel::Communicator &comm) {
   TS_ASSERT_THROWS_NOTHING(alg->execute());
   TS_ASSERT(alg->isExecuted());
   Workspace_const_sptr out = alg->getProperty("OutputWorkspace");
-  TS_ASSERT_EQUALS(out->storageMode(), modeOut);
-  TS_ASSERT_EQUALS(out->id(), "FakeWorkspaceA");
+  if (modeOut != Parallel::StorageMode::MasterOnly || comm.rank() == 0) {
+    TS_ASSERT_EQUALS(out->storageMode(), modeOut);
+    TS_ASSERT_EQUALS(out->id(), "FakeWorkspaceA");
+  } else {
+    TS_ASSERT_EQUALS(out, nullptr);
+  }
 }
 
 void runChained(const Parallel::Communicator &comm) {
@@ -460,7 +410,11 @@ void runChained(const Parallel::Communicator &comm) {
   TS_ASSERT_THROWS_NOTHING(alg1->execute());
   TS_ASSERT(alg1->isExecuted());
   Workspace_sptr ws1 = alg1->getProperty("OutputWorkspace");
-  TS_ASSERT_EQUALS(ws1->storageMode(), StorageMode::MasterOnly);
+  if (comm.rank() == 0) {
+    TS_ASSERT_EQUALS(ws1->storageMode(), StorageMode::MasterOnly);
+  } else {
+    TS_ASSERT_EQUALS(ws1, nullptr);
+  }
 
   auto alg2 =
       create<FakeAlg1To1StorageModeTransition<StorageMode::Distributed>>(comm);
@@ -492,8 +446,6 @@ public:
   void test1To1() { runParallel(run1To1); }
 
   void testNTo0() { runParallel(runNTo0); }
-
-  void testNTo1StorageModeFailure() { runParallel(runNTo1StorageModeFailure); }
 
   void testNTo1() { runParallel(runNTo1); }
 

--- a/Framework/Algorithms/inc/MantidAlgorithms/BinaryOperation.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/BinaryOperation.h
@@ -74,7 +74,6 @@ protected:
   Parallel::ExecutionMode getParallelExecutionMode(
       const std::map<std::string, Parallel::StorageMode> &storageModes)
       const override;
-  void execNonMaster() override;
 
   // Overridden Algorithm methods
   void exec() override;

--- a/Framework/Algorithms/inc/MantidAlgorithms/CreateWorkspace.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CreateWorkspace.h
@@ -71,7 +71,6 @@ protected:
   Parallel::ExecutionMode getParallelExecutionMode(
       const std::map<std::string, Parallel::StorageMode> &storageModes)
       const override;
-  void execNonMaster() override;
 
 private:
   /// Initialise the Algorithm (declare properties)

--- a/Framework/Algorithms/src/BinaryOperation.cpp
+++ b/Framework/Algorithms/src/BinaryOperation.cpp
@@ -1053,10 +1053,5 @@ Parallel::ExecutionMode BinaryOperation::getParallelExecutionMode(
   return Parallel::ExecutionMode::Invalid;
 }
 
-void BinaryOperation::execNonMaster() {
-  API::MatrixWorkspace_const_sptr ws = getProperty(inputPropName1());
-  setProperty(outputPropName(), ws->cloneEmpty());
-}
-
 } // namespace Algorithms
 } // namespace Mantid

--- a/Framework/Algorithms/src/CreateWorkspace.cpp
+++ b/Framework/Algorithms/src/CreateWorkspace.cpp
@@ -286,13 +286,5 @@ Parallel::ExecutionMode CreateWorkspace::getParallelExecutionMode(
   return Parallel::getCorrespondingExecutionMode(storageMode);
 }
 
-void CreateWorkspace::execNonMaster() {
-  MatrixWorkspace_const_sptr parentWS = getProperty("ParentWorkspace");
-  if (parentWS)
-    return Algorithm::execNonMaster();
-  setProperty("OutputWorkspace", Kernel::make_unique<Workspace2D>(
-                                     Parallel::StorageMode::MasterOnly));
-}
-
 } // Algorithms
 } // Mantid

--- a/Framework/Algorithms/test/RebinTest.h
+++ b/Framework/Algorithms/test/RebinTest.h
@@ -52,26 +52,36 @@ std::unique_ptr<Rebin> prepare_rebin(const Parallel::Communicator &comm,
 
 void run_rebin(const Parallel::Communicator &comm,
                const std::string &storageMode) {
+  using namespace Parallel;
   auto rebin = prepare_rebin(comm, storageMode);
   rebin->setProperty("Params", "1,1,3");
   TS_ASSERT_THROWS_NOTHING(rebin->execute());
   MatrixWorkspace_const_sptr ws = rebin->getProperty("OutputWorkspace");
-  TS_ASSERT_EQUALS(ws->storageMode(), Parallel::fromString(storageMode));
+  if (comm.rank() == 0 || fromString(storageMode) != StorageMode::MasterOnly) {
+    TS_ASSERT_EQUALS(ws->storageMode(), fromString(storageMode));
+  } else {
+    TS_ASSERT_EQUALS(ws, nullptr);
+  }
 }
 
 void run_rebin_params_only_bin_width(const Parallel::Communicator &comm,
                                      const std::string &storageMode) {
+  using namespace Parallel;
   auto rebin = prepare_rebin(comm, storageMode);
   rebin->setProperty("Params", "0.5");
-  if (Parallel::fromString(storageMode) == Parallel::StorageMode::Distributed &&
-      comm.size() > 1) {
+  if (fromString(storageMode) == StorageMode::Distributed && comm.size() > 1) {
     TS_ASSERT_THROWS_EQUALS(
         rebin->execute(), const std::runtime_error &e, std::string(e.what()),
         "MatrixWorkspace: Parallel support for XMin and XMax not implemented.");
   } else {
     TS_ASSERT_THROWS_NOTHING(rebin->execute());
     MatrixWorkspace_const_sptr ws = rebin->getProperty("OutputWorkspace");
-    TS_ASSERT_EQUALS(ws->storageMode(), Parallel::fromString(storageMode));
+    if (comm.rank() == 0 ||
+        fromString(storageMode) != StorageMode::MasterOnly) {
+      TS_ASSERT_EQUALS(ws->storageMode(), fromString(storageMode));
+    } else {
+      TS_ASSERT_EQUALS(ws, nullptr);
+    }
   }
 }
 }


### PR DESCRIPTION
Replaces dummy workspaces by NULL/None workspaces. This seems to make handling `MasterOnly` execution and implementation of such algorithms easier.

There is a minor drawback to this approach: Previously Python scripts could rely on obtained a default-constructed (but uninitialized) workspace on non-master ranks. This allow for, e.g.,

```python
ws = MyAlg()
for i in range ws.getNumberHistograms():
  pass
```
`getNumberHistograms()` returns 0 if the worksapce is not initialized so this piece of code worked. Now `ws` is `None`, so we have to write:

```python
ws = MyAlg()
if ws is not None:
  for i in range ws.getNumberHistograms():
    pass
```
This is slightly more verbose and might necessitate slightly more changes in some reduction scripts. On the other hand it may also catch some actual issues -- code that is actually broken for a parallel workflow -- so this change could maybe also be seen as having a positive effect.

**To test:**

Code review.
No issue, no release notes, since MPI is still internal.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
