### PR TITLE
Build HTML docs target in addition to tests target

### DIFF
--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -305,6 +305,8 @@ if [[ ${ON_UBUNTU} == true ]] && [[ ${PRBUILD} == true ]]; then
   if [ -d $BUILD_DIR/docs/doctrees ]; then
     rm -rf $BUILD_DIR/docs/doctrees/*
   fi
+  # Build HTML to verify that no referencing errors have crept in.
+  $SCL_ON_RHEL6 "${CMAKE_EXE} --build . --target docs-html"
   $SCL_ON_RHEL6 "${CMAKE_EXE} --build . --target docs-test"
 fi
 


### PR DESCRIPTION
Description of work.

When building the documentation the script now runs the `docs-html` target before running the `docs-test` target. This allows any cross-referencing errors to be picked up on the pull requests. 

**To test:**

Code review and ensure builds pass

*No issue*

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
