### PR TITLE
Add buildscript to create UsageData.zip

### DIFF
--- a/buildconfig/Jenkins/usagedata.sh
+++ b/buildconfig/Jenkins/usagedata.sh
@@ -28,6 +28,6 @@ if [ -f UsageData.zip ]; then
 fi
 
 # create the zip archive
-zip -r UsageData UsageData -x \*hash-stamp -x README\*
+zip -r UsageData UsageData -x \*hash-stamp README\*
 cd -
 mv ExternalData/Testing/Data/UsageData.zip .

--- a/buildconfig/Jenkins/usagedata.sh
+++ b/buildconfig/Jenkins/usagedata.sh
@@ -28,6 +28,6 @@ if [ -f UsageData.zip ]; then
 fi
 
 # create the zip archive
-zip -r UsageData UsageData -x \*hash-stamp README\*
+zip -r UsageData UsageData -x \*hash-stamp \*md5-stamp README\*
 cd -
 mv ExternalData/Testing/Data/UsageData.zip .

--- a/buildconfig/Jenkins/usagedata.sh
+++ b/buildconfig/Jenkins/usagedata.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# make testing easier - BUILD_DIR should be root of build tree
+if [ -z "$BUILD_DIR" ]; then
+    BUILD_DIR=`pwd`
+    echo "setting BUILD_DIR to $BUILD_DIR"
+fi
+
+# remove old copy
+cd $BUILD_DIR
+if [ -f UsageData.zip ]; then
+    echo "removing old version of UsageData.zip"
+    rm UsageData.zip
+fi
+
+# create the symbolic link so the zip decompresses into the familiar name
+cd ExternalData/Testing/Data
+if [ -d UsageData ]; then
+    echo "symbolic link already exists"
+else
+    echo "creating symbolic link"
+    ln -s DocTest UsageData
+fi
+
+# remove the file if it exists - which shouldn't ever happen
+if [ -f UsageData.zip ]; then
+    echo "removing old version of UsageData.zip"
+    rm UsageData.zip
+fi
+
+# create the zip archive
+zip -r UsageData UsageData -x \*hash-stamp -x README\*
+cd -
+mv ExternalData/Testing/Data/UsageData.zip .


### PR DESCRIPTION
It has been noticed that the usage data is not updated on sourceforge often enough. This buildscript will be used to fix that issue.

**To test:**

Go into the root of your build tree and run this twice and look at the contents of the archive are reasonable (only works on linux). This is to insure that running it multiple times on a build server works as expected.

*There is no associated issue*

*Does not need to be in the release notes* because it is a buildscript.

**Update the [rhel7 clean build](http://builds.mantidproject.org/view/Master%20Pipeline/job/master_clean-rhel7/) once this is merged.**

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
