### PR TITLE
Fix OSX qmake issue

### DIFF
--- a/buildconfig/CMake/DarwinSetup.cmake
+++ b/buildconfig/CMake/DarwinSetup.cmake
@@ -36,8 +36,8 @@ message (STATUS "Operating System: Mac OS X ${OSX_VERSION} (${OSX_CODENAME})")
 # Enable the use of the -isystem flag to mark headers in Third_Party as system headers
 set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-isystem ")
 
-# Add default location of Qt5 from homebrew to prefix path so that find_package works
-list ( APPEND CMAKE_PREFIX_PATH "/usr/local/opt/qt" )
+# Set Qt5 dir according to homebrew location
+set ( Qt5_DIR /usr/local/opt/qt/lib/cmake/Qt5 )
 
 ###########################################################################
 # Use python libraries associated with PYTHON_EXECUTABLE


### PR DESCRIPTION
Fixes #21492. See issue for instructions on how to replicate. 

**To test:**

**You must be on OSX to test the fix**. Run cmake, (delete an existing cmake cache file in directory). 

1. cmake should complete. 
1. The QT_QMAKE_EXECUTABLE found/set should be the 4.x.x version.

