### PR TITLE
Improve finding of sip_dir on MacOS

### DIFF
--- a/Framework/Algorithms/src/MaxEnt.cpp
+++ b/Framework/Algorithms/src/MaxEnt.cpp
@@ -82,8 +82,8 @@ MatrixWorkspace_sptr removeZeros(const MatrixWorkspace_sptr &ws,
   for (size_t spec = 0; spec < nspec; spec++) {
     outWS->setPoints(spec, Points(maxIt, LinearGenerator(0.0, 1.0)));
     auto Data = ws->readY(spec);
-    outWS->setCounts(spec, std::move(std::vector<double>(
-                               Data.begin(), Data.begin() + maxIt)));
+    outWS->setCounts(spec,
+                     std::vector<double>(Data.begin(), Data.begin() + maxIt));
   }
   return outWS;
 }

--- a/Framework/DataHandling/test/MaskSpectraTest.h
+++ b/Framework/DataHandling/test/MaskSpectraTest.h
@@ -24,7 +24,7 @@ std::unique_ptr<Workspace2D> makeWorkspace() {
   ws->setHistogram(1, Points{1.1}, Counts{2.1});
   ws->setHistogram(2, Points{1.2}, Counts{2.2});
   ws->setHistogram(3, Points{1.3}, Counts{2.3});
-  return std::move(ws);
+  return ws;
 }
 
 void checkWorkspace(const MatrixWorkspace &ws) {

--- a/buildconfig/CMake/FindPyQt.py
+++ b/buildconfig/CMake/FindPyQt.py
@@ -35,12 +35,12 @@ class PyQtConfig(object):
           self.sip_dir = os.path.join(sys.prefix, 'sip', name)
       elif sys.platform == 'darwin':
           # hardcoded to homebrew Cellar
-          cellar_prefix = '/usr/local/Cellar'
+          cellar_prefix = '/usr/local/opt'
           qt_maj_version = self.version_str[0]
           if qt_maj_version == '4':
-              self.sip_dir = os.path.join(cellar_prefix, 'pyqt@4', self.version_str, 'share', 'sip')
+              self.sip_dir = os.path.join(cellar_prefix, 'pyqt@4', 'share', 'sip')
           elif qt_maj_version == '5':
-              self.sip_dir = os.path.join(cellar_prefix, 'pyqt', self.version_str, 'share', 'sip', 'Qt5')
+              self.sip_dir = os.path.join(cellar_prefix, 'pyqt', 'share', 'sip', 'Qt5')
           else:
               raise RuntimeError("Unknown Qt version ({}) found. Unable to determine location of PyQt sip files."
                                  "Please update FindPyQt accordingly.".format(self.version_str[0]))


### PR DESCRIPTION
Description of work.

This improves finding `sip_dir` by using the `opt` directory which doesn't change between minor versions. The earlier code failed for revisions like `5.9.2_1`.

**To test:**

<!-- Instructions for testing. -->

* Code Review
* Verify the MacOS build still passes.

There is no GitHub issue associated with this pull request.

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
