### PR TITLE
Add IPython console to mantidqt.widgets

### DIFF
--- a/qt/python/CMakeLists.txt
+++ b/qt/python/CMakeLists.txt
@@ -41,6 +41,7 @@ if ( ENABLE_WORKBENCH )
     mantidqt/test/test_import.py
     mantidqt/utils/test/test_qt_utils.py
     mantidqt/widgets/test/test_algorithmselector.py
+    mantidqt/widgets/test/test_ipythonconsole.py
     mantidqt/widgets/test/test_messagedisplay.py
   )
 

--- a/qt/python/mantidqt/utils/async.py
+++ b/qt/python/mantidqt/utils/async.py
@@ -1,0 +1,81 @@
+#  This file is part of the mantid workbench.
+#
+#  Copyright (C) 2017 mantidproject
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import
+
+# system imports
+import sys
+import threading
+
+
+class AsyncTask(threading.Thread):
+
+    def __init__(self, target, args=(), kwargs=None,
+                 success_cb=None, error_cb=None,
+                 finished_cb=None):
+        """
+
+        :param target: A Python callable object
+        :param args: Arguments to pass to the callable
+        :param kwargs: Keyword arguments to pass to the callable
+        :param success_cb: Optional callback called when operation was successful
+        :param error_cb: Optional callback called when operation was not successful
+        :param finished_cb: Optional callback called when operation has finished
+        """
+        super(AsyncTask, self).__init__()
+        if not callable(target):
+            raise TypeError("Target object is required to be callable")
+
+        self.target = target
+        self.args = args
+        self.kwargs = kwargs if kwargs is not None else {}
+        self.success_cb = success_cb if success_cb is not None else lambda x: None
+        self.error_cb = error_cb if error_cb is not None else lambda x: None
+        self.finished_cb = finished_cb if finished_cb is not None else lambda: None
+
+    def run(self):
+        try:
+            out = self.target(*self.args, **self.kwargs)
+        except:  # noqa
+            self.error_cb(AsyncTaskFailure(sys.exc_info()[1]))
+        else:
+            self.success_cb(AsyncTaskSuccess(out))
+
+        self.finished_cb()
+
+
+class AsyncTaskSuccess(object):
+    """Object describing the successful execution of an asynchronous task
+    """
+
+    def __init__(self, output):
+        self.output = output
+
+    @property
+    def success(self):
+        return True
+
+
+class AsyncTaskFailure(object):
+    """Object describing the failed execution of an asynchronous task
+    """
+
+    def __init__(self, exception):
+        self.exception = exception
+
+    @property
+    def success(self):
+        return False

--- a/qt/python/mantidqt/utils/test/test_async.py
+++ b/qt/python/mantidqt/utils/test/test_async.py
@@ -1,0 +1,137 @@
+#  This file is part of the mantid workbench.
+#
+#  Copyright (C) 2017 mantidproject
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import
+
+# system imports
+import unittest
+
+# 3rdparty imports
+
+# local imports
+from mantidqt.utils.async import AsyncTask
+
+
+class AsyncTaskTest(unittest.TestCase):
+
+    class Receiver(object):
+        success_cb_called = False
+        error_cb_called = False
+        finished_cb_called = False
+        task_output = None
+        task_exc = None
+
+        def on_success(self, task_result):
+            self.success_cb_called = True
+            self.task_output = task_result.output
+
+        def on_error(self, task_result):
+            self.error_cb_called = True
+            self.task_exc = task_result.exception
+
+        def on_finished(self):
+            self.finished_cb_called = True
+
+    # ---------------------------------------------------------------
+    # Success cases
+    # ---------------------------------------------------------------
+    def test_successful_no_arg_operation_calls_success_and_finished_callback(self):
+        def foo():
+            return 42
+
+        recv = AsyncTaskTest.Receiver()
+        t = AsyncTask(foo, success_cb=recv.on_success, error_cb=recv.on_error,
+                      finished_cb=recv.on_finished)
+        t.start()
+        t.join()
+        self.assertTrue(recv.finished_cb_called)
+        self.assertTrue(recv.success_cb_called)
+        self.assertFalse(recv.error_cb_called)
+        self.assertEqual(42, recv.task_output)
+
+    def test_successful_positional_args_operation_calls_success_and_finished_callback(self):
+        def foo(shift):
+            return 42 + shift
+
+        recv = AsyncTaskTest.Receiver()
+        shift = 2
+        t = AsyncTask(foo, args = (shift,),
+                      success_cb=recv.on_success, error_cb=recv.on_error,
+                      finished_cb=recv.on_finished)
+        t.start()
+        t.join()
+        self.assertTrue(recv.finished_cb_called)
+        self.assertTrue(recv.success_cb_called)
+        self.assertFalse(recv.error_cb_called)
+        self.assertEqual(42 + shift, recv.task_output)
+
+    def test_successful_args_and_kwargs_operation_calls_success_and_finished_callback(self):
+        def foo(scale, shift):
+            return scale*42 + shift
+
+        recv = AsyncTaskTest.Receiver()
+        scale, shift = 2, 4
+        t = AsyncTask(foo, args = (scale,), kwargs={'shift': shift},
+                      success_cb=recv.on_success, error_cb=recv.on_error,
+                      finished_cb=recv.on_finished)
+        t.start()
+        t.join()
+        self.assertTrue(recv.finished_cb_called)
+        self.assertTrue(recv.success_cb_called)
+        self.assertFalse(recv.error_cb_called)
+        self.assertEqual(scale*42 + shift, recv.task_output)
+
+    def test_unsuccessful_no_arg_operation_calls_error_and_finished_callback(self):
+        def foo():
+            raise RuntimeError("Bad operation")
+
+        recv = AsyncTaskTest.Receiver()
+        t = AsyncTask(foo, success_cb=recv.on_success,
+                      error_cb=recv.on_error,
+                      finished_cb=recv.on_finished)
+        t.start()
+        t.join()
+        self.assertTrue(recv.finished_cb_called)
+        self.assertFalse(recv.success_cb_called)
+        self.assertTrue(recv.error_cb_called)
+        self.assertTrue(isinstance(recv.task_exc, RuntimeError))
+
+    def test_unsuccessful_args_and_kwargs_operation_calls_error_and_finished_callback(self):
+        def foo(scale, shift):
+            raise RuntimeError("Bad operation")
+
+        recv = AsyncTaskTest.Receiver()
+        scale, shift = 2, 4
+        t = AsyncTask(foo, args = (scale,), kwargs={'shift': shift},
+                      success_cb=recv.on_success, error_cb=recv.on_error,
+                      finished_cb=recv.on_finished)
+        t.start()
+        t.join()
+        self.assertTrue(recv.finished_cb_called)
+        self.assertFalse(recv.success_cb_called)
+        self.assertTrue(recv.error_cb_called)
+        self.assertTrue(isinstance(recv.task_exc, RuntimeError))
+
+    # ---------------------------------------------------------------
+    # Failure cases
+    # ---------------------------------------------------------------
+    def test_non_callable_object_raises_exception(self):
+        self.assertRaises(TypeError, AsyncTask, None)
+        self.assertRaises(TypeError, AsyncTask, object())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/mantidqt/utils/test/test_async.py
+++ b/qt/python/mantidqt/utils/test/test_async.py
@@ -22,7 +22,7 @@ import unittest
 # 3rdparty imports
 
 # local imports
-from mantidqt.utils.async import AsyncTask
+from mantidqt.utils.async import AsyncTask, blocking_async_task
 
 
 class AsyncTaskTest(unittest.TestCase):
@@ -131,6 +131,40 @@ class AsyncTaskTest(unittest.TestCase):
     def test_non_callable_object_raises_exception(self):
         self.assertRaises(TypeError, AsyncTask, None)
         self.assertRaises(TypeError, AsyncTask, object())
+
+
+class BlockingAsyncTaskTest(unittest.TestCase):
+
+    # ---------------------------------------------------------------
+    # Success cases
+    # ---------------------------------------------------------------
+    def test_successful_no_arg_operation_without_callback(self):
+        def foo():
+            return 42
+
+        self.assertEqual(42, blocking_async_task(foo))
+
+    def test_successful_positional_args_operation(self):
+        def foo(shift):
+            return 42 + shift
+
+        shift = 2
+        self.assertEqual(42 + shift, blocking_async_task(foo, args=(shift,)))
+
+    def test_successful_args_and_kwargs_operation(self):
+        def foo(scale, shift):
+            return scale*42 + shift
+
+        scale, shift = 2, 4
+        self.assertEqual(scale*42 + shift, blocking_async_task(foo, args=(scale,), kwargs={'shift': shift}))
+
+    def test_unsuccessful_args_and_kwargs_operation_raises_exception(self):
+        def foo(scale, shift):
+            raise RuntimeError("Bad operation")
+
+        scale, shift = 2, 4
+        self.assertRaises(RuntimeError,
+                          blocking_async_task, foo, args=(scale,), kwargs={'shift': shift})
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqt/widgets/ipythonconsole/__init__.py
+++ b/qt/python/mantidqt/widgets/ipythonconsole/__init__.py
@@ -1,0 +1,19 @@
+#  This file is part of the mantidqt package
+#
+#  Copyright (C) 2017 mantidproject
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import
+
+from .widget import InProcessIPythonConsole

--- a/qt/python/mantidqt/widgets/ipythonconsole/__init__.py
+++ b/qt/python/mantidqt/widgets/ipythonconsole/__init__.py
@@ -16,4 +16,4 @@
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import absolute_import
 
-from .widget import InProcessIPythonConsole
+from .widget import InProcessIPythonConsole  # noqa

--- a/qt/python/mantidqt/widgets/ipythonconsole/widget.py
+++ b/qt/python/mantidqt/widgets/ipythonconsole/widget.py
@@ -1,0 +1,48 @@
+#  This file is part of the mantidqt package
+#
+#  Copyright (C) 2017 mantidproject
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import
+
+# 3rd party imports
+# IPython tries to force PyQt4 first whereas qtpy prefers Qt5. Import qtpy to
+# make the selection first
+import qtpy  # noqa
+try:
+    # Later versions of Qtconsole are part of Jupyter
+    from qtconsole.rich_jupyter_widget import RichJupyterWidget as RichIPythonWidget
+    from qtconsole.inprocess import QtInProcessKernelManager
+except ImportError:
+    from IPython.qt.console.rich_ipython_widget import RichIPythonWidget
+    from IPython.qt.inprocess import QtInProcessKernelManager
+
+
+class InProcessIPythonConsole(RichIPythonWidget):
+
+    def __init__(self, *args, **kwargs):
+        super(InProcessIPythonConsole, self).__init__(*args, **kwargs)
+
+        # create an in-process kernel
+        kernel_manager = QtInProcessKernelManager()
+        kernel_manager.start_kernel()
+        kernel = kernel_manager.kernel
+        kernel.gui = 'qt'
+
+        # attach channels
+        kernel_client = kernel_manager.client()
+        kernel_client.start_channels()
+
+        self.kernel_manager = kernel_manager
+        self.kernel_client = kernel_client

--- a/qt/python/mantidqt/widgets/test/test_ipythonconsole.py
+++ b/qt/python/mantidqt/widgets/test/test_ipythonconsole.py
@@ -1,0 +1,39 @@
+#    This file is part of the mantid workbench.
+#
+#    Copyright (C) 2017 mantidproject
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import (absolute_import)
+
+# system imports
+import unittest
+
+# third-party library imports
+
+# local package imports
+from mantidqt.widgets.ipythonconsole import InProcessIPythonConsole
+from mantidqt.utils.qt.testing import requires_qapp
+
+
+@requires_qapp
+class InProcessIPythonConsoleTest(unittest.TestCase):
+
+    def test_construction_raises_no_errors(self):
+        widget = InProcessIPythonConsole()
+        self.assertTrue(hasattr(widget, "kernel_manager"))
+        self.assertTrue(hasattr(widget, "kernel_client"))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Description of work.

Adds a basic in-process IPython console to the available `mantidqt` widgets.

**To test:**

* Review the code
* Build the branch, and from the build directory run

```
bin/mantidpython --classic [PATH_TO_REPOSITORY]/qt/python/mantidqt/utils/qt/testing/run_test_app.py mantidqt.widgets.ipythonconsole.InProcessIPythonConsole
```

and the console should start. Try typing some commands.

Refs #21251 

**Release Notes** 

*Does not need to be in the release notes. It is part of the ongoing workbench effort.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
