### PR TITLE
Fix compilation with Boost 1.66

### DIFF
--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
@@ -109,7 +109,7 @@ public:
 
 private:
   /// Get a list of events for a given Q
-  boost::optional<const std::vector<std::pair<double, Mantid::Kernel::V3D>> &>
+  const std::vector<std::pair<double, Mantid::Kernel::V3D>> *
   getEvents(const Mantid::Kernel::V3D &peak_q);
 
   bool correctForDetectorEdges(std::tuple<double, double, double> &radii,

--- a/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
+++ b/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
@@ -87,7 +87,7 @@ Integrate3DEvents::integrateStrongPeak(const IntegrationParameters &params,
     return std::make_pair(boost::make_shared<NoShape>(),
                           make_tuple(0., 0., 0.));
 
-  const auto &events = result.get();
+  const auto &events = *result;
   if (events.empty())
     return std::make_pair(boost::make_shared<NoShape>(),
                           make_tuple(0., 0., 0.));
@@ -183,7 +183,7 @@ Integrate3DEvents::integrateWeakPeak(
   if (!result)
     return boost::make_shared<NoShape>();
 
-  const auto &events = result.get();
+  const auto &events = *result;
 
   const auto &directions = shape->directions();
   const auto &abcBackgroundInnerRadii = shape->abcRadiiBackgroundInner();
@@ -238,7 +238,7 @@ double Integrate3DEvents::estimateSignalToNoiseRatio(
   if (!result)
     return .0;
 
-  const auto &events = result.get();
+  const auto &events = *result;
   if (events.empty())
     return .0;
 
@@ -282,23 +282,22 @@ double Integrate3DEvents::estimateSignalToNoiseRatio(
   return inti / std::max(1.0, (ratio * backgrd));
 }
 
-boost::optional<const std::vector<std::pair<double, V3D>> &>
+const std::vector<std::pair<double, V3D>> *
 Integrate3DEvents::getEvents(const V3D &peak_q) {
   const auto hkl_key = getHklKey(peak_q);
 
   if (hkl_key == 0)
-    return boost::optional<const std::vector<std::pair<double, V3D>> &>();
+    return nullptr;
 
   const auto pos = m_event_lists.find(hkl_key);
-  using EventListType = const decltype(pos->second) &;
 
   if (m_event_lists.end() == pos)
-    return boost::optional<EventListType>();
+    return nullptr;
 
   if (pos->second.size() < 3) // if there are not enough events
-    return boost::optional<EventListType>();
+    return nullptr;
 
-  return boost::make_optional<EventListType>(pos->second);
+  return &(pos->second);
 }
 
 bool Integrate3DEvents::correctForDetectorEdges(


### PR DESCRIPTION
Description of work.

Mantid fails to compile with Boost 1.66 (error message below). It looks like `boost::make_optional` decays the reference to a value and then returns an incompatible value type. 

@rosswhitfield found that calling `boost::optional` directly gets this to compile and run, but I'm not sure that is the best option.  Specifically, for `std::optional` reference types are ill-defined (see http://en.cppreference.com/w/cpp/utility/optional). There is a proposal for [optional references](https://isocpp.org/files/papers/N3672.html#optional_ref), but until it is in the standard, I think it's better to just use a pointer.

```
[1665/3970] Building CXX object Framework/MDAlgorithms/CMakeFiles/MDAlgorithms.dir/src/Integrate3DEvents.cpp.o
FAILED: Framework/MDAlgorithms/CMakeFiles/MDAlgorithms.dir/src/Integrate3DEvents.cpp.o 
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -DBOOST_ALL_DYN_LINK -DBOOST_ALL_NO_LIB -DBOOST_DATE_TIME_POSIX_TIME_STD_CONFIG -DENABLE_OPENCASCADE -DHAVE_STDINT_H -DIN_MANTID_MDALGORITHMS -DMAKE_VATES -DMDAlgorithms_EXPORTS -I/Users/svh/Documents/MantidProject/mantid/Framework/Types/inc -I/Users/svh/Documents/MantidProject/mantid/Framework/Kernel/inc -I/Users/svh/Documents/MantidProject/mantid/Framework/Parallel/inc -I/Users/svh/Documents/MantidProject/mantid/Framework/HistogramData/inc -I/Users/svh/Documents/MantidProject/mantid/Framework/Indexing/inc -I/Users/svh/Documents/MantidProject/mantid/Framework/Beamline/inc -I/Users/svh/Documents/MantidProject/mantid/Framework/Geometry/inc -I/usr/local/include -I/Users/svh/Documents/MantidProject/mantid/Framework/API/inc -I/Users/svh/Documents/MantidProject/mantid/Framework/DataObjects/inc -I/Users/svh/Documents/MantidProject/mantid/Framework/MDAlgorithms/inc -IFramework/Types -isystem eigen-src -O3 -DNDEBUG -fPIC   -Wall -Wextra -Wconversion -Winit-self -Wpointer-arith -Wcast-qual -Wcast-align -fno-common -Wno-deprecated -Wno-write-strings -Wno-unused-result -Woverloaded-virtual -fno-operator-names -Wno-sign-conversion -std=gnu++14 -MD -MT Framework/MDAlgorithms/CMakeFiles/MDAlgorithms.dir/src/Integrate3DEvents.cpp.o -MF Framework/MDAlgorithms/CMakeFiles/MDAlgorithms.dir/src/Integrate3DEvents.cpp.o.d -o Framework/MDAlgorithms/CMakeFiles/MDAlgorithms.dir/src/Integrate3DEvents.cpp.o -c /Users/svh/Documents/MantidProject/mantid/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
/Users/svh/Documents/MantidProject/mantid/Framework/MDAlgorithms/src/Integrate3DEvents.cpp:301:10: error: no viable conversion from returned value of type 'optional<typename boost::decay<const vector<pair<double, V3D>, allocator<pair<double, V3D> > > &>::type>' to function return type 'optional<const std::vector<std::pair<double, V3D> > &>'
  return boost::make_optional<EventListType>(pos->second);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/local/include/boost/optional/detail/optional_reference_spec.hpp:127:5: note: candidate constructor not viable: no known conversion from 'optional<typename boost::decay<const vector<pair<double, V3D>, allocator<pair<double, V3D> > > &>::type>' (aka 'optional<std::__1::vector<std::__1::pair<double, Mantid::Kernel::V3D>, std::__1::allocator<std::__1::pair<double, Mantid::Kernel::V3D> > > >') to 'boost::none_t' for 1st argument
    optional(none_t) BOOST_NOEXCEPT : ptr_() {}  
    ^
/usr/local/include/boost/optional/detail/optional_reference_spec.hpp:131:5: note: candidate constructor not viable: no known conversion from 'optional<typename boost::decay<const vector<pair<double, V3D>, allocator<pair<double, V3D> > > &>::type>' (aka 'optional<std::__1::vector<std::__1::pair<double, Mantid::Kernel::V3D>, std::__1::allocator<std::__1::pair<double, Mantid::Kernel::V3D> > > >') to 'const boost::optional<const std::__1::vector<std::__1::pair<double, Mantid::Kernel::V3D>, std::__1::allocator<std::__1::pair<double, Mantid::Kernel::V3D> > > &> &' for 1st argument
    optional(const optional& rhs) BOOST_NOEXCEPT : ptr_(rhs.get_ptr()) {}
    ^
/usr/local/include/boost/optional/detail/optional_reference_spec.hpp:165:5: note: candidate constructor not viable: no known conversion from 'optional<typename boost::decay<const vector<pair<double, V3D>, allocator<pair<double, V3D> > > &>::type>' (aka 'optional<std::__1::vector<std::__1::pair<double, Mantid::Kernel::V3D>, std::__1::allocator<std::__1::pair<double, Mantid::Kernel::V3D> > > >') to 'const std::__1::vector<std::__1::pair<double, Mantid::Kernel::V3D>, std::__1::allocator<std::__1::pair<double, Mantid::Kernel::V3D> > > &&' for 1st argument
    optional(T&& /* rhs */) BOOST_NOEXCEPT { detail::prevent_binding_rvalue<T&&>(); }
    ^
/usr/local/include/boost/optional/detail/optional_reference_spec.hpp:139:7: note: candidate template ignored: substitution failure [with U = boost::optional<std::__1::vector<std::__1::pair<double, Mantid::Kernel::V3D>, std::__1::allocator<std::__1::pair<double, Mantid::Kernel::V3D> > > >]: no type named 'type' in 'boost::enable_if_c<false, void>'
      optional(U& rhs, BOOST_DEDUCED_TYPENAME boost::enable_if_c<detail::is_same_decayed<T, U>::value && !detail::is_const_integral_bad_for_conversion<U>::value>::type* = 0) BOOST_NOEXCEPT
      ^                                                                                                                                                            ~~~~
/usr/local/include/boost/optional/detail/optional_reference_spec.hpp:168:65: note: candidate template ignored: disabled by 'enable_if' [with R = boost::optional<std::__1::vector<std::__1::pair<double, Mantid::Kernel::V3D>, std::__1::allocator<std::__1::pair<double, Mantid::Kernel::V3D> > > >]
        optional(R&& r, BOOST_DEDUCED_TYPENAME boost::enable_if<detail::no_unboxing_cond<T, R> >::type* = 0) BOOST_NOEXCEPT
                                                                ^
1 error generated.
[1690/3970] Building CXX object Framework/ICat/CMakeFiles/ICat.dir/src/ICat3/ICat3GSoapGenerated.cpp.o
```

**To test:**

<!-- Instructions for testing. -->

Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
