### PR TITLE
Update WorkspaceTreeWidget to not require shared ptr

### DIFF
--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -98,8 +98,6 @@
 #include "MantidQtWidgets/SpectrumViewer/SpectrumView.h"
 #include <typeinfo>
 
-#include "MantidQtWidgets/Common/MantidTreeModel.h"
-
 using namespace std;
 
 using namespace Mantid::API;

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -98,6 +98,8 @@
 #include "MantidQtWidgets/SpectrumViewer/SpectrumView.h"
 #include <typeinfo>
 
+#include "MantidQtWidgets/Common/MantidTreeModel.h"
+
 using namespace std;
 
 using namespace Mantid::API;
@@ -232,8 +234,7 @@ MantidUI::MantidUI(ApplicationWindow *aw)
     qRegisterMetaType<std::string>();
   }
 
-  m_exploreMantid = boost::make_shared<WorkspaceTreeWidget>(this);
-  m_exploreMantid->init();
+  m_exploreMantid = new WorkspaceTreeWidget(this);
   m_exploreMantid->enableDeletePrompt(
       appWindow()->isDeleteWorkspacePromptEnabled());
 
@@ -242,7 +243,7 @@ MantidUI::MantidUI(ApplicationWindow *aw)
   m_workspaceDockWidget->setObjectName("exploreMantid");
   m_workspaceDockWidget->setMinimumHeight(150);
   m_workspaceDockWidget->setMinimumWidth(200);
-  m_workspaceDockWidget->setWidget(m_exploreMantid.get());
+  m_workspaceDockWidget->setWidget(m_exploreMantid);
   aw->addDockWidget(Qt::RightDockWidgetArea, m_workspaceDockWidget);
 
   m_exploreAlgorithms = new AlgorithmDockWidget(this, aw);
@@ -2260,7 +2261,7 @@ void MantidUI::menuMantidMatrixAboutToShow() {
   menuMantidMatrix->addAction(action);
 
   action = new QAction("Plot spectrum...", this);
-  connect(action, SIGNAL(triggered()), m_exploreMantid.get(),
+  connect(action, SIGNAL(triggered()), m_exploreMantid,
           SLOT(plotSpectra()));
   menuMantidMatrix->addAction(action);
 
@@ -2292,7 +2293,7 @@ void MantidUI::menuMantidMatrixAboutToShow() {
   menuMantidMatrix->addSeparator();
 
   action = new QAction("Delete", this);
-  connect(action, SIGNAL(triggered()), m_exploreMantid.get(),
+  connect(action, SIGNAL(triggered()), m_exploreMantid,
           SLOT(deleteWorkspaces()));
   menuMantidMatrix->addAction(action);
 }

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -2259,8 +2259,7 @@ void MantidUI::menuMantidMatrixAboutToShow() {
   menuMantidMatrix->addAction(action);
 
   action = new QAction("Plot spectrum...", this);
-  connect(action, SIGNAL(triggered()), m_exploreMantid,
-          SLOT(plotSpectra()));
+  connect(action, SIGNAL(triggered()), m_exploreMantid, SLOT(plotSpectra()));
   menuMantidMatrix->addAction(action);
 
   action = new QAction("Plot as waterfall", this);

--- a/MantidPlot/src/Mantid/MantidUI.h
+++ b/MantidPlot/src/Mantid/MantidUI.h
@@ -648,8 +648,7 @@ private:
 
   ApplicationWindow *m_appWindow; // QtiPlot main ApplicationWindow
   QDockWidget *m_workspaceDockWidget;
-  boost::shared_ptr<MantidQt::MantidWidgets::WorkspaceTreeWidget>
-      m_exploreMantid; // Widget for manipulating workspaces
+  MantidQt::MantidWidgets::WorkspaceTreeWidget *m_exploreMantid; // Widget for manipulating workspaces
   AlgorithmDockWidget *m_exploreAlgorithms; // Dock window for using algorithms
   RemoteClusterDockWidget *
       m_exploreRemoteTasks; // Dock window for using remote tasks

--- a/MantidPlot/src/Mantid/MantidUI.h
+++ b/MantidPlot/src/Mantid/MantidUI.h
@@ -648,7 +648,8 @@ private:
 
   ApplicationWindow *m_appWindow; // QtiPlot main ApplicationWindow
   QDockWidget *m_workspaceDockWidget;
-  MantidQt::MantidWidgets::WorkspaceTreeWidget *m_exploreMantid; // Widget for manipulating workspaces
+  MantidQt::MantidWidgets::WorkspaceTreeWidget *
+      m_exploreMantid; // Widget for manipulating workspaces
   AlgorithmDockWidget *m_exploreAlgorithms; // Dock window for using algorithms
   RemoteClusterDockWidget *
       m_exploreRemoteTasks; // Dock window for using remote tasks

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/IWorkspaceDockView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/IWorkspaceDockView.h
@@ -51,7 +51,6 @@ public:
 
   virtual ~IWorkspaceDockView(){};
 
-  virtual void init() = 0;
   virtual WorkspacePresenterWN_wptr getPresenterWeakPtr() = 0;
 
   virtual bool askUserYesNo(const std::string &caption,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceDockMockObjects.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceDockMockObjects.h
@@ -23,12 +23,6 @@ public:
   MockWorkspaceDockView() {}
   ~MockWorkspaceDockView() override {}
 
-  void init() override {
-    auto presenter = boost::make_shared<WorkspacePresenter>(shared_from_this());
-    m_presenter = boost::dynamic_pointer_cast<ViewNotifiable>(presenter);
-    presenter->init();
-  }
-
   MOCK_CONST_METHOD2(askUserYesNo, bool(const std::string &caption,
                                         const std::string &message));
   MOCK_CONST_METHOD2(showCriticalUserMessage, void(const std::string &caption,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceDockMockObjects.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceDockMockObjects.h
@@ -17,10 +17,13 @@ GCC_DIAG_OFF_SUGGEST_OVERRIDE
 class MockMantidDisplayBase;
 
 class MockWorkspaceDockView
-    : public IWorkspaceDockView,
-      public boost::enable_shared_from_this<MockWorkspaceDockView> {
+    : public IWorkspaceDockView {
 public:
-  MockWorkspaceDockView() {}
+  MockWorkspaceDockView() {
+	auto presenter = boost::make_shared<WorkspacePresenter>(this);
+	m_presenter = boost::dynamic_pointer_cast<ViewNotifiable>(presenter);
+	presenter->init();
+  }
   ~MockWorkspaceDockView() override {}
 
   MOCK_CONST_METHOD2(askUserYesNo, bool(const std::string &caption,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceDockMockObjects.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceDockMockObjects.h
@@ -16,13 +16,12 @@ GCC_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockMantidDisplayBase;
 
-class MockWorkspaceDockView
-    : public IWorkspaceDockView {
+class MockWorkspaceDockView : public IWorkspaceDockView {
 public:
   MockWorkspaceDockView() {
-	auto presenter = boost::make_shared<WorkspacePresenter>(this);
-	m_presenter = boost::dynamic_pointer_cast<ViewNotifiable>(presenter);
-	presenter->init();
+    auto presenter = boost::make_shared<WorkspacePresenter>(this);
+    m_presenter = boost::dynamic_pointer_cast<ViewNotifiable>(presenter);
+    presenter->init();
   }
   ~MockWorkspaceDockView() override {}
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspacePresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspacePresenter.h
@@ -48,7 +48,7 @@ class EXPORT_OPT_MANTIDQT_COMMON WorkspacePresenter
       public ViewNotifiable {
 
 public:
-  explicit WorkspacePresenter(IWorkspaceDockView &view);
+  explicit WorkspacePresenter(IWorkspaceDockView* view);
   ~WorkspacePresenter() override;
 
   void init();
@@ -103,7 +103,7 @@ private:
   void updateView();
 
 private:
-  IWorkspaceDockView &m_view;
+  IWorkspaceDockView* m_view;
   ADSAdapter_uptr m_adapter;
 };
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspacePresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspacePresenter.h
@@ -14,8 +14,6 @@ namespace MantidWidgets {
 class IWorkspaceDockView;
 class WorkspaceProvider;
 
-using DockView_sptr = boost::shared_ptr<IWorkspaceDockView>;
-using DockView_wptr = boost::weak_ptr<IWorkspaceDockView>;
 using ADSAdapter_uptr = std::unique_ptr<WorkspaceProvider>;
 /**
 \class  WorkspacePresenter
@@ -48,8 +46,9 @@ File change history is stored at: <https://github.com/mantidproject/mantid>
 class EXPORT_OPT_MANTIDQT_COMMON WorkspacePresenter
     : public WorkspaceProviderNotifiable,
       public ViewNotifiable {
+
 public:
-  explicit WorkspacePresenter(DockView_wptr view);
+  explicit WorkspacePresenter(IWorkspaceDockView& view);
   ~WorkspacePresenter() override;
 
   void init();
@@ -101,11 +100,10 @@ private:
   void workspacesDeleted();
   void workspacesCleared();
 
-  DockView_sptr lockView();
   void updateView();
 
 private:
-  DockView_wptr m_view;
+  IWorkspaceDockView& m_view;
   ADSAdapter_uptr m_adapter;
 };
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspacePresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspacePresenter.h
@@ -48,7 +48,7 @@ class EXPORT_OPT_MANTIDQT_COMMON WorkspacePresenter
       public ViewNotifiable {
 
 public:
-  explicit WorkspacePresenter(IWorkspaceDockView* view);
+  explicit WorkspacePresenter(IWorkspaceDockView *view);
   ~WorkspacePresenter() override;
 
   void init();
@@ -103,7 +103,7 @@ private:
   void updateView();
 
 private:
-  IWorkspaceDockView* m_view;
+  IWorkspaceDockView *m_view;
   ADSAdapter_uptr m_adapter;
 };
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspacePresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspacePresenter.h
@@ -48,7 +48,7 @@ class EXPORT_OPT_MANTIDQT_COMMON WorkspacePresenter
       public ViewNotifiable {
 
 public:
-  explicit WorkspacePresenter(IWorkspaceDockView& view);
+  explicit WorkspacePresenter(IWorkspaceDockView &view);
   ~WorkspacePresenter() override;
 
   void init();
@@ -103,7 +103,7 @@ private:
   void updateView();
 
 private:
-  IWorkspaceDockView& m_view;
+  IWorkspaceDockView &m_view;
   ADSAdapter_uptr m_adapter;
 };
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidget.h
@@ -17,7 +17,6 @@
 #include <QMap>
 #include <QMetaType>
 #include <QHash>
-#include <boost/enable_shared_from_this.hpp>
 #include <boost/shared_ptr.hpp>
 #include <map>
 
@@ -46,10 +45,10 @@ class MantidTreeWidgetItem;
 class MantidTreeWidget;
 
 /**
-\class  QWorkspaceDockView
+\class  WorkspaceTreeWidget
 \author Lamar Moore
 \date   24-08-2016
-\version 1.0
+\version 1.1
 
 
 Copyright &copy; 2016 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
@@ -74,8 +73,7 @@ File change history is stored at: <https://github.com/mantidproject/mantid>
 */
 class EXPORT_OPT_MANTIDQT_COMMON WorkspaceTreeWidget
     : public QWidget,
-      public IWorkspaceDockView,
-      public boost::enable_shared_from_this<WorkspaceTreeWidget> {
+      public IWorkspaceDockView {
   Q_OBJECT
 public:
   explicit WorkspaceTreeWidget(MantidQt::MantidWidgets::MantidDisplayBase *mdb,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidget.h
@@ -82,7 +82,7 @@ public:
                                QWidget *parent = nullptr);
   ~WorkspaceTreeWidget();
   void dropEvent(QDropEvent *de) override;
-  void init() override;
+
   MantidQt::MantidWidgets::WorkspacePresenterWN_wptr
   getPresenterWeakPtr() override;
 

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspacePresenter.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspacePresenter.cpp
@@ -9,7 +9,7 @@ using namespace Mantid;
 namespace MantidQt {
 namespace MantidWidgets {
 
-WorkspacePresenter::WorkspacePresenter(IWorkspaceDockView* view)
+WorkspacePresenter::WorkspacePresenter(IWorkspaceDockView *view)
     : m_view(std::move(view)), m_adapter(Kernel::make_unique<ADSAdapter>()) {}
 
 WorkspacePresenter::~WorkspacePresenter() {}
@@ -170,14 +170,14 @@ void WorkspacePresenter::groupWorkspaces() {
   // get selected workspaces
   if (selected.size() < 2) {
     m_view->showCriticalUserMessage("Cannot Group Workspaces",
-                                   "Select at least two workspaces to group ");
+                                    "Select at least two workspaces to group ");
     return;
   }
 
   if (m_adapter->doesWorkspaceExist(groupName)) {
-    if (!m_view->askUserYesNo("",
-                             "Workspace " + groupName +
-                                 " already exists. Do you want to replace it?"))
+    if (!m_view->askUserYesNo(
+            "", "Workspace " + groupName +
+                    " already exists. Do you want to replace it?"))
       return;
   }
 
@@ -192,11 +192,11 @@ void WorkspacePresenter::groupWorkspaces() {
     bool bStatus = alg->execute();
     if (!bStatus) {
       m_view->showCriticalUserMessage("MantidPlot - Algorithm error",
-                                     " Error in GroupWorkspaces algorithm");
+                                      " Error in GroupWorkspaces algorithm");
     }
   } catch (...) {
     m_view->showCriticalUserMessage("MantidPlot - Algorithm error",
-                                   " Error in GroupWorkspaces algorithm");
+                                    " Error in GroupWorkspaces algorithm");
   }
 }
 
@@ -205,7 +205,7 @@ void WorkspacePresenter::ungroupWorkspaces() {
 
   if (selected.size() == 0) {
     m_view->showCriticalUserMessage("Error Ungrouping Workspaces",
-                                   "Select a group workspace to Ungroup.");
+                                    "Select a group workspace to Ungroup.");
     return;
   }
 
@@ -223,11 +223,11 @@ void WorkspacePresenter::ungroupWorkspaces() {
     bool bStatus = alg->execute();
     if (!bStatus) {
       m_view->showCriticalUserMessage("MantidPlot - Algorithm error",
-                                     " Error in UnGroupWorkspace algorithm");
+                                      " Error in UnGroupWorkspace algorithm");
     }
   } catch (...) {
     m_view->showCriticalUserMessage("MantidPlot - Algorithm error",
-                                   " Error in UnGroupWorkspace algorithm");
+                                    " Error in UnGroupWorkspace algorithm");
   }
 }
 
@@ -347,7 +347,7 @@ void WorkspacePresenter::workspaceLoaded() { updateView(); }
 
 void WorkspacePresenter::workspaceRenamed() {
   m_view->recordWorkspaceRename(m_adapter->getOldName(),
-                               m_adapter->getNewName());
+                                m_adapter->getNewName());
   m_view->updateTree(m_adapter->topLevelItems());
 }
 

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspacePresenter.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspacePresenter.cpp
@@ -9,14 +9,14 @@ using namespace Mantid;
 namespace MantidQt {
 namespace MantidWidgets {
 
-WorkspacePresenter::WorkspacePresenter(IWorkspaceDockView &view)
+WorkspacePresenter::WorkspacePresenter(IWorkspaceDockView* view)
     : m_view(std::move(view)), m_adapter(Kernel::make_unique<ADSAdapter>()) {}
 
 WorkspacePresenter::~WorkspacePresenter() {}
 
 /// Initialises the view weak pointer for the Workspace Provider.
 void WorkspacePresenter::init() {
-  m_adapter->registerPresenter(m_view.getPresenterWeakPtr());
+  m_adapter->registerPresenter(m_view->getPresenterWeakPtr());
 }
 
 /// Handle WorkspaceProvider (ADS) notifications
@@ -155,27 +155,27 @@ void WorkspacePresenter::notifyFromView(ViewNotifiable::Flag flag) {
   }
 }
 
-void WorkspacePresenter::loadWorkspace() { m_view.showLoadDialog(); }
+void WorkspacePresenter::loadWorkspace() { m_view->showLoadDialog(); }
 
-void WorkspacePresenter::loadLiveData() { m_view.showLiveDataDialog(); }
+void WorkspacePresenter::loadLiveData() { m_view->showLiveDataDialog(); }
 
 void WorkspacePresenter::renameWorkspace() {
-  m_view.showRenameDialog(m_view.getSelectedWorkspaceNames());
+  m_view->showRenameDialog(m_view->getSelectedWorkspaceNames());
 }
 
 void WorkspacePresenter::groupWorkspaces() {
-  auto selected = m_view.getSelectedWorkspaceNames();
+  auto selected = m_view->getSelectedWorkspaceNames();
 
   std::string groupName("NewGroup");
   // get selected workspaces
   if (selected.size() < 2) {
-    m_view.showCriticalUserMessage("Cannot Group Workspaces",
+    m_view->showCriticalUserMessage("Cannot Group Workspaces",
                                    "Select at least two workspaces to group ");
     return;
   }
 
   if (m_adapter->doesWorkspaceExist(groupName)) {
-    if (!m_view.askUserYesNo("",
+    if (!m_view->askUserYesNo("",
                              "Workspace " + groupName +
                                  " already exists. Do you want to replace it?"))
       return;
@@ -191,20 +191,20 @@ void WorkspacePresenter::groupWorkspaces() {
     // execute the algorithm
     bool bStatus = alg->execute();
     if (!bStatus) {
-      m_view.showCriticalUserMessage("MantidPlot - Algorithm error",
+      m_view->showCriticalUserMessage("MantidPlot - Algorithm error",
                                      " Error in GroupWorkspaces algorithm");
     }
   } catch (...) {
-    m_view.showCriticalUserMessage("MantidPlot - Algorithm error",
+    m_view->showCriticalUserMessage("MantidPlot - Algorithm error",
                                    " Error in GroupWorkspaces algorithm");
   }
 }
 
 void WorkspacePresenter::ungroupWorkspaces() {
-  auto selected = m_view.getSelectedWorkspaceNames();
+  auto selected = m_view->getSelectedWorkspaceNames();
 
   if (selected.size() == 0) {
-    m_view.showCriticalUserMessage("Error Ungrouping Workspaces",
+    m_view->showCriticalUserMessage("Error Ungrouping Workspaces",
                                    "Select a group workspace to Ungroup.");
     return;
   }
@@ -222,111 +222,111 @@ void WorkspacePresenter::ungroupWorkspaces() {
     // execute the algorithm
     bool bStatus = alg->execute();
     if (!bStatus) {
-      m_view.showCriticalUserMessage("MantidPlot - Algorithm error",
+      m_view->showCriticalUserMessage("MantidPlot - Algorithm error",
                                      " Error in UnGroupWorkspace algorithm");
     }
   } catch (...) {
-    m_view.showCriticalUserMessage("MantidPlot - Algorithm error",
+    m_view->showCriticalUserMessage("MantidPlot - Algorithm error",
                                    " Error in UnGroupWorkspace algorithm");
   }
 }
 
 void WorkspacePresenter::sortWorkspaces() {
-  m_view.sortWorkspaces(m_view.getSortCriteria(), m_view.getSortDirection());
+  m_view->sortWorkspaces(m_view->getSortCriteria(), m_view->getSortDirection());
 }
 
 void WorkspacePresenter::deleteWorkspaces() {
   bool deleteWs = true;
-  auto selected = m_view.getSelectedWorkspaceNames();
+  auto selected = m_view->getSelectedWorkspaceNames();
 
   // Ensure all workspaces exist in the ADS
   if (!std::all_of(selected.cbegin(), selected.cend(),
                    [=](const std::string &ws) {
                      return m_adapter->doesWorkspaceExist(ws);
                    })) {
-    m_view.showCriticalUserMessage(
+    m_view->showCriticalUserMessage(
         "Delete Workspaces",
         "Unabel to delete workspaces. Invalid workspace names provided.");
     return;
   }
 
-  if (m_view.isPromptDelete())
-    deleteWs = m_view.deleteConfirmation();
+  if (m_view->isPromptDelete())
+    deleteWs = m_view->deleteConfirmation();
 
   if (deleteWs)
-    m_view.deleteWorkspaces(selected);
+    m_view->deleteWorkspaces(selected);
 }
 
 void WorkspacePresenter::saveSingleWorkspace() {
-  m_view.saveWorkspace(m_view.getSaveFileType());
+  m_view->saveWorkspace(m_view->getSaveFileType());
 }
 
 void WorkspacePresenter::saveWorkspaceCollection() {
-  m_view.saveWorkspaces(m_view.getSelectedWorkspaceNames());
+  m_view->saveWorkspaces(m_view->getSelectedWorkspaceNames());
 }
 
 void WorkspacePresenter::filterWorkspaces() {
-  m_view.filterWorkspaces(m_view.getFilterText());
+  m_view->filterWorkspaces(m_view->getFilterText());
 }
 
 void WorkspacePresenter::populateAndShowWorkspaceContextMenu() {
-  m_view.popupContextMenu();
+  m_view->popupContextMenu();
 }
 
-void WorkspacePresenter::showWorkspaceData() { m_view.showWorkspaceData(); }
+void WorkspacePresenter::showWorkspaceData() { m_view->showWorkspaceData(); }
 
-void WorkspacePresenter::showInstrumentView() { m_view.showInstrumentView(); }
+void WorkspacePresenter::showInstrumentView() { m_view->showInstrumentView(); }
 
-void WorkspacePresenter::saveToProgram() { m_view.saveToProgram(); }
+void WorkspacePresenter::saveToProgram() { m_view->saveToProgram(); }
 
-void WorkspacePresenter::plotSpectrum() { m_view.plotSpectrum("Simple"); }
+void WorkspacePresenter::plotSpectrum() { m_view->plotSpectrum("Simple"); }
 
 void WorkspacePresenter::plotSpectrumWithErrors() {
-  m_view.plotSpectrum("Errors");
+  m_view->plotSpectrum("Errors");
 }
 
 void WorkspacePresenter::plotSpectrumAdvanced() {
-  m_view.plotSpectrum("Advanced");
+  m_view->plotSpectrum("Advanced");
 }
 
-void WorkspacePresenter::showColourFillPlot() { m_view.showColourFillPlot(); }
+void WorkspacePresenter::showColourFillPlot() { m_view->showColourFillPlot(); }
 
-void WorkspacePresenter::showDetectorsTable() { m_view.showDetectorsTable(); }
+void WorkspacePresenter::showDetectorsTable() { m_view->showDetectorsTable(); }
 
-void WorkspacePresenter::showBoxDataTable() { m_view.showBoxDataTable(); }
+void WorkspacePresenter::showBoxDataTable() { m_view->showBoxDataTable(); }
 
-void WorkspacePresenter::showVatesGUI() { m_view.showVatesGUI(); }
+void WorkspacePresenter::showVatesGUI() { m_view->showVatesGUI(); }
 
-void WorkspacePresenter::showMDPlot() { m_view.showMDPlot(); }
+void WorkspacePresenter::showMDPlot() { m_view->showMDPlot(); }
 
-void WorkspacePresenter::showListData() { m_view.showListData(); }
+void WorkspacePresenter::showListData() { m_view->showListData(); }
 
-void WorkspacePresenter::showSpectrumViewer() { m_view.showSpectrumViewer(); }
+void WorkspacePresenter::showSpectrumViewer() { m_view->showSpectrumViewer(); }
 
-void WorkspacePresenter::showSliceViewer() { m_view.showSliceViewer(); }
+void WorkspacePresenter::showSliceViewer() { m_view->showSliceViewer(); }
 
-void WorkspacePresenter::showLogs() { m_view.showLogs(); }
+void WorkspacePresenter::showLogs() { m_view->showLogs(); }
 
 void WorkspacePresenter::showSampleMaterialWindow() {
-  m_view.showSampleMaterialWindow();
+  m_view->showSampleMaterialWindow();
 }
 
 void WorkspacePresenter::showAlgorithmHistory() {
-  m_view.showAlgorithmHistory();
+  m_view->showAlgorithmHistory();
 }
 
-void WorkspacePresenter::showTransposed() { m_view.showTransposed(); }
+void WorkspacePresenter::showTransposed() { m_view->showTransposed(); }
 
 void WorkspacePresenter::convertToMatrixWorkspace() {
-  m_view.convertToMatrixWorkspace();
+  m_view->convertToMatrixWorkspace();
 }
 
 void WorkspacePresenter::convertMDHistoToMatrixWorkspace() {
-  m_view.convertMDHistoToMatrixWorkspace();
+  m_view->convertMDHistoToMatrixWorkspace();
 }
 
 void WorkspacePresenter::clearUBMatrix() {
-  auto wsNames = m_view.getSelectedWorkspaceNames();
+  auto wsNames = m_view->getSelectedWorkspaceNames();
 
   for (auto &ws : wsNames) {
     auto alg = Mantid::API::AlgorithmManager::Instance().create("ClearUB", -1);
@@ -335,7 +335,7 @@ void WorkspacePresenter::clearUBMatrix() {
       alg->setPropertyValue("Workspace", ws);
       // Run in this manner due to Qt dependencies within this method.
       // otherwise it would have been implemented here.
-      m_view.executeAlgorithmAsync(alg);
+      m_view->executeAlgorithmAsync(alg);
     } else
       break;
   }
@@ -346,9 +346,9 @@ void WorkspacePresenter::refreshWorkspaces() { updateView(); }
 void WorkspacePresenter::workspaceLoaded() { updateView(); }
 
 void WorkspacePresenter::workspaceRenamed() {
-  m_view.recordWorkspaceRename(m_adapter->getOldName(),
+  m_view->recordWorkspaceRename(m_adapter->getOldName(),
                                m_adapter->getNewName());
-  m_view.updateTree(m_adapter->topLevelItems());
+  m_view->updateTree(m_adapter->topLevelItems());
 }
 
 void WorkspacePresenter::workspacesGrouped() { updateView(); }
@@ -357,11 +357,11 @@ void WorkspacePresenter::workspaceGroupUpdated() { updateView(); }
 
 void WorkspacePresenter::workspacesDeleted() { updateView(); }
 
-void WorkspacePresenter::workspacesCleared() { m_view.clearView(); }
+void WorkspacePresenter::workspacesCleared() { m_view->clearView(); }
 
 /// Update the view by publishing the ADS contents.
 void WorkspacePresenter::updateView() {
-  m_view.updateTree(m_adapter->topLevelItems());
+  m_view->updateTree(m_adapter->topLevelItems());
 }
 
 } // namespace MantidQt

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspacePresenter.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspacePresenter.cpp
@@ -9,7 +9,7 @@ using namespace Mantid;
 namespace MantidQt {
 namespace MantidWidgets {
 
-WorkspacePresenter::WorkspacePresenter(IWorkspaceDockView& view)
+WorkspacePresenter::WorkspacePresenter(IWorkspaceDockView &view)
     : m_view(std::move(view)), m_adapter(Kernel::make_unique<ADSAdapter>()) {}
 
 WorkspacePresenter::~WorkspacePresenter() {}
@@ -155,13 +155,9 @@ void WorkspacePresenter::notifyFromView(ViewNotifiable::Flag flag) {
   }
 }
 
-void WorkspacePresenter::loadWorkspace() {
-  m_view.showLoadDialog();
-}
+void WorkspacePresenter::loadWorkspace() { m_view.showLoadDialog(); }
 
-void WorkspacePresenter::loadLiveData() {
-  m_view.showLiveDataDialog();
-}
+void WorkspacePresenter::loadLiveData() { m_view.showLiveDataDialog(); }
 
 void WorkspacePresenter::renameWorkspace() {
   m_view.showRenameDialog(m_view.getSelectedWorkspaceNames());
@@ -173,15 +169,15 @@ void WorkspacePresenter::groupWorkspaces() {
   std::string groupName("NewGroup");
   // get selected workspaces
   if (selected.size() < 2) {
-	m_view.showCriticalUserMessage("Cannot Group Workspaces",
-                                  "Select at least two workspaces to group ");
+    m_view.showCriticalUserMessage("Cannot Group Workspaces",
+                                   "Select at least two workspaces to group ");
     return;
   }
 
   if (m_adapter->doesWorkspaceExist(groupName)) {
     if (!m_view.askUserYesNo("",
-                            "Workspace " + groupName +
-                                " already exists. Do you want to replace it?"))
+                             "Workspace " + groupName +
+                                 " already exists. Do you want to replace it?"))
       return;
   }
 
@@ -195,12 +191,12 @@ void WorkspacePresenter::groupWorkspaces() {
     // execute the algorithm
     bool bStatus = alg->execute();
     if (!bStatus) {
-	  m_view.showCriticalUserMessage("MantidPlot - Algorithm error",
-                                    " Error in GroupWorkspaces algorithm");
+      m_view.showCriticalUserMessage("MantidPlot - Algorithm error",
+                                     " Error in GroupWorkspaces algorithm");
     }
   } catch (...) {
-	  m_view.showCriticalUserMessage("MantidPlot - Algorithm error",
-                                  " Error in GroupWorkspaces algorithm");
+    m_view.showCriticalUserMessage("MantidPlot - Algorithm error",
+                                   " Error in GroupWorkspaces algorithm");
   }
 }
 
@@ -208,8 +204,8 @@ void WorkspacePresenter::ungroupWorkspaces() {
   auto selected = m_view.getSelectedWorkspaceNames();
 
   if (selected.size() == 0) {
-	  m_view.showCriticalUserMessage("Error Ungrouping Workspaces",
-                                  "Select a group workspace to Ungroup.");
+    m_view.showCriticalUserMessage("Error Ungrouping Workspaces",
+                                   "Select a group workspace to Ungroup.");
     return;
   }
 
@@ -226,12 +222,12 @@ void WorkspacePresenter::ungroupWorkspaces() {
     // execute the algorithm
     bool bStatus = alg->execute();
     if (!bStatus) {
-	  m_view.showCriticalUserMessage("MantidPlot - Algorithm error",
-                                    " Error in UnGroupWorkspace algorithm");
+      m_view.showCriticalUserMessage("MantidPlot - Algorithm error",
+                                     " Error in UnGroupWorkspace algorithm");
     }
   } catch (...) {
-	  m_view.showCriticalUserMessage("MantidPlot - Algorithm error",
-                                  " Error in UnGroupWorkspace algorithm");
+    m_view.showCriticalUserMessage("MantidPlot - Algorithm error",
+                                   " Error in UnGroupWorkspace algorithm");
   }
 }
 
@@ -248,7 +244,7 @@ void WorkspacePresenter::deleteWorkspaces() {
                    [=](const std::string &ws) {
                      return m_adapter->doesWorkspaceExist(ws);
                    })) {
-	  m_view.showCriticalUserMessage(
+    m_view.showCriticalUserMessage(
         "Delete Workspaces",
         "Unabel to delete workspaces. Invalid workspace names provided.");
     return;
@@ -258,7 +254,7 @@ void WorkspacePresenter::deleteWorkspaces() {
     deleteWs = m_view.deleteConfirmation();
 
   if (deleteWs)
-	  m_view.deleteWorkspaces(selected);
+    m_view.deleteWorkspaces(selected);
 }
 
 void WorkspacePresenter::saveSingleWorkspace() {
@@ -277,21 +273,13 @@ void WorkspacePresenter::populateAndShowWorkspaceContextMenu() {
   m_view.popupContextMenu();
 }
 
-void WorkspacePresenter::showWorkspaceData() {
-  m_view.showWorkspaceData();
-}
+void WorkspacePresenter::showWorkspaceData() { m_view.showWorkspaceData(); }
 
-void WorkspacePresenter::showInstrumentView() {
-  m_view.showInstrumentView();
-}
+void WorkspacePresenter::showInstrumentView() { m_view.showInstrumentView(); }
 
-void WorkspacePresenter::saveToProgram() {
-  m_view.saveToProgram();
-}
+void WorkspacePresenter::saveToProgram() { m_view.saveToProgram(); }
 
-void WorkspacePresenter::plotSpectrum() {
-  m_view.plotSpectrum("Simple");
-}
+void WorkspacePresenter::plotSpectrum() { m_view.plotSpectrum("Simple"); }
 
 void WorkspacePresenter::plotSpectrumWithErrors() {
   m_view.plotSpectrum("Errors");
@@ -301,41 +289,23 @@ void WorkspacePresenter::plotSpectrumAdvanced() {
   m_view.plotSpectrum("Advanced");
 }
 
-void WorkspacePresenter::showColourFillPlot() {
-  m_view.showColourFillPlot();
-}
+void WorkspacePresenter::showColourFillPlot() { m_view.showColourFillPlot(); }
 
-void WorkspacePresenter::showDetectorsTable() {
-  m_view.showDetectorsTable();
-}
+void WorkspacePresenter::showDetectorsTable() { m_view.showDetectorsTable(); }
 
-void WorkspacePresenter::showBoxDataTable() {
-  m_view.showBoxDataTable();
-}
+void WorkspacePresenter::showBoxDataTable() { m_view.showBoxDataTable(); }
 
-void WorkspacePresenter::showVatesGUI() {
-  m_view.showVatesGUI();
-}
+void WorkspacePresenter::showVatesGUI() { m_view.showVatesGUI(); }
 
-void WorkspacePresenter::showMDPlot() {
-  m_view.showMDPlot();
-}
+void WorkspacePresenter::showMDPlot() { m_view.showMDPlot(); }
 
-void WorkspacePresenter::showListData() {
-  m_view.showListData();
-}
+void WorkspacePresenter::showListData() { m_view.showListData(); }
 
-void WorkspacePresenter::showSpectrumViewer() {
-	m_view.showSpectrumViewer();
-}
+void WorkspacePresenter::showSpectrumViewer() { m_view.showSpectrumViewer(); }
 
-void WorkspacePresenter::showSliceViewer() {
-  m_view.showSliceViewer();
-}
+void WorkspacePresenter::showSliceViewer() { m_view.showSliceViewer(); }
 
-void WorkspacePresenter::showLogs() {
-  m_view.showLogs();
-}
+void WorkspacePresenter::showLogs() { m_view.showLogs(); }
 
 void WorkspacePresenter::showSampleMaterialWindow() {
   m_view.showSampleMaterialWindow();
@@ -345,12 +315,10 @@ void WorkspacePresenter::showAlgorithmHistory() {
   m_view.showAlgorithmHistory();
 }
 
-void WorkspacePresenter::showTransposed() {
-  m_view.showTransposed();
-}
+void WorkspacePresenter::showTransposed() { m_view.showTransposed(); }
 
 void WorkspacePresenter::convertToMatrixWorkspace() {
-	m_view.convertToMatrixWorkspace();
+  m_view.convertToMatrixWorkspace();
 }
 
 void WorkspacePresenter::convertMDHistoToMatrixWorkspace() {
@@ -367,7 +335,7 @@ void WorkspacePresenter::clearUBMatrix() {
       alg->setPropertyValue("Workspace", ws);
       // Run in this manner due to Qt dependencies within this method.
       // otherwise it would have been implemented here.
-	  m_view.executeAlgorithmAsync(alg);
+      m_view.executeAlgorithmAsync(alg);
     } else
       break;
   }
@@ -378,7 +346,8 @@ void WorkspacePresenter::refreshWorkspaces() { updateView(); }
 void WorkspacePresenter::workspaceLoaded() { updateView(); }
 
 void WorkspacePresenter::workspaceRenamed() {
-  m_view.recordWorkspaceRename(m_adapter->getOldName(), m_adapter->getNewName());
+  m_view.recordWorkspaceRename(m_adapter->getOldName(),
+                               m_adapter->getNewName());
   m_view.updateTree(m_adapter->topLevelItems());
 }
 
@@ -388,10 +357,7 @@ void WorkspacePresenter::workspaceGroupUpdated() { updateView(); }
 
 void WorkspacePresenter::workspacesDeleted() { updateView(); }
 
-void WorkspacePresenter::workspacesCleared() {
-
-  m_view.clearView();
-}
+void WorkspacePresenter::workspacesCleared() { m_view.clearView(); }
 
 /// Update the view by publishing the ADS contents.
 void WorkspacePresenter::updateView() {

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspacePresenter.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspacePresenter.cpp
@@ -9,14 +9,14 @@ using namespace Mantid;
 namespace MantidQt {
 namespace MantidWidgets {
 
-WorkspacePresenter::WorkspacePresenter(DockView_wptr view)
+WorkspacePresenter::WorkspacePresenter(IWorkspaceDockView& view)
     : m_view(std::move(view)), m_adapter(Kernel::make_unique<ADSAdapter>()) {}
 
 WorkspacePresenter::~WorkspacePresenter() {}
 
 /// Initialises the view weak pointer for the Workspace Provider.
 void WorkspacePresenter::init() {
-  m_adapter->registerPresenter(m_view.lock()->getPresenterWeakPtr());
+  m_adapter->registerPresenter(m_view.getPresenterWeakPtr());
 }
 
 /// Handle WorkspaceProvider (ADS) notifications
@@ -156,34 +156,30 @@ void WorkspacePresenter::notifyFromView(ViewNotifiable::Flag flag) {
 }
 
 void WorkspacePresenter::loadWorkspace() {
-  auto view = lockView();
-  view->showLoadDialog();
+  m_view.showLoadDialog();
 }
 
 void WorkspacePresenter::loadLiveData() {
-  auto view = lockView();
-  view->showLiveDataDialog();
+  m_view.showLiveDataDialog();
 }
 
 void WorkspacePresenter::renameWorkspace() {
-  auto view = lockView();
-  view->showRenameDialog(view->getSelectedWorkspaceNames());
+  m_view.showRenameDialog(m_view.getSelectedWorkspaceNames());
 }
 
 void WorkspacePresenter::groupWorkspaces() {
-  auto view = lockView();
-  auto selected = view->getSelectedWorkspaceNames();
+  auto selected = m_view.getSelectedWorkspaceNames();
 
   std::string groupName("NewGroup");
   // get selected workspaces
   if (selected.size() < 2) {
-    view->showCriticalUserMessage("Cannot Group Workspaces",
+	m_view.showCriticalUserMessage("Cannot Group Workspaces",
                                   "Select at least two workspaces to group ");
     return;
   }
 
   if (m_adapter->doesWorkspaceExist(groupName)) {
-    if (!view->askUserYesNo("",
+    if (!m_view.askUserYesNo("",
                             "Workspace " + groupName +
                                 " already exists. Do you want to replace it?"))
       return;
@@ -199,21 +195,20 @@ void WorkspacePresenter::groupWorkspaces() {
     // execute the algorithm
     bool bStatus = alg->execute();
     if (!bStatus) {
-      view->showCriticalUserMessage("MantidPlot - Algorithm error",
+	  m_view.showCriticalUserMessage("MantidPlot - Algorithm error",
                                     " Error in GroupWorkspaces algorithm");
     }
   } catch (...) {
-    view->showCriticalUserMessage("MantidPlot - Algorithm error",
+	  m_view.showCriticalUserMessage("MantidPlot - Algorithm error",
                                   " Error in GroupWorkspaces algorithm");
   }
 }
 
 void WorkspacePresenter::ungroupWorkspaces() {
-  auto view = lockView();
-  auto selected = view->getSelectedWorkspaceNames();
+  auto selected = m_view.getSelectedWorkspaceNames();
 
   if (selected.size() == 0) {
-    view->showCriticalUserMessage("Error Ungrouping Workspaces",
+	  m_view.showCriticalUserMessage("Error Ungrouping Workspaces",
                                   "Select a group workspace to Ungroup.");
     return;
   }
@@ -231,167 +226,139 @@ void WorkspacePresenter::ungroupWorkspaces() {
     // execute the algorithm
     bool bStatus = alg->execute();
     if (!bStatus) {
-      view->showCriticalUserMessage("MantidPlot - Algorithm error",
+	  m_view.showCriticalUserMessage("MantidPlot - Algorithm error",
                                     " Error in UnGroupWorkspace algorithm");
     }
   } catch (...) {
-    view->showCriticalUserMessage("MantidPlot - Algorithm error",
+	  m_view.showCriticalUserMessage("MantidPlot - Algorithm error",
                                   " Error in UnGroupWorkspace algorithm");
   }
 }
 
 void WorkspacePresenter::sortWorkspaces() {
-  auto view = lockView();
-
-  view->sortWorkspaces(view->getSortCriteria(), view->getSortDirection());
+  m_view.sortWorkspaces(m_view.getSortCriteria(), m_view.getSortDirection());
 }
 
 void WorkspacePresenter::deleteWorkspaces() {
-  auto view = lockView();
   bool deleteWs = true;
-  auto selected = view->getSelectedWorkspaceNames();
+  auto selected = m_view.getSelectedWorkspaceNames();
 
   // Ensure all workspaces exist in the ADS
   if (!std::all_of(selected.cbegin(), selected.cend(),
                    [=](const std::string &ws) {
                      return m_adapter->doesWorkspaceExist(ws);
                    })) {
-    view->showCriticalUserMessage(
+	  m_view.showCriticalUserMessage(
         "Delete Workspaces",
         "Unabel to delete workspaces. Invalid workspace names provided.");
     return;
   }
 
-  if (view->isPromptDelete())
-    deleteWs = view->deleteConfirmation();
+  if (m_view.isPromptDelete())
+    deleteWs = m_view.deleteConfirmation();
 
   if (deleteWs)
-    view->deleteWorkspaces(selected);
+	  m_view.deleteWorkspaces(selected);
 }
 
 void WorkspacePresenter::saveSingleWorkspace() {
-  auto view = lockView();
-  view->saveWorkspace(view->getSaveFileType());
+  m_view.saveWorkspace(m_view.getSaveFileType());
 }
 
 void WorkspacePresenter::saveWorkspaceCollection() {
-  auto view = lockView();
-  view->saveWorkspaces(view->getSelectedWorkspaceNames());
+  m_view.saveWorkspaces(m_view.getSelectedWorkspaceNames());
 }
 
 void WorkspacePresenter::filterWorkspaces() {
-  auto view = lockView();
-  view->filterWorkspaces(view->getFilterText());
+  m_view.filterWorkspaces(m_view.getFilterText());
 }
 
 void WorkspacePresenter::populateAndShowWorkspaceContextMenu() {
-  auto view = lockView();
-  view->popupContextMenu();
+  m_view.popupContextMenu();
 }
 
 void WorkspacePresenter::showWorkspaceData() {
-  auto view = lockView();
-  view->showWorkspaceData();
+  m_view.showWorkspaceData();
 }
 
 void WorkspacePresenter::showInstrumentView() {
-  auto view = lockView();
-  view->showInstrumentView();
+  m_view.showInstrumentView();
 }
 
 void WorkspacePresenter::saveToProgram() {
-  auto view = lockView();
-  view->saveToProgram();
+  m_view.saveToProgram();
 }
 
 void WorkspacePresenter::plotSpectrum() {
-  auto view = lockView();
-  view->plotSpectrum("Simple");
+  m_view.plotSpectrum("Simple");
 }
 
 void WorkspacePresenter::plotSpectrumWithErrors() {
-  auto view = lockView();
-  view->plotSpectrum("Errors");
+  m_view.plotSpectrum("Errors");
 }
 
 void WorkspacePresenter::plotSpectrumAdvanced() {
-  auto view = lockView();
-  view->plotSpectrum("Advanced");
+  m_view.plotSpectrum("Advanced");
 }
 
 void WorkspacePresenter::showColourFillPlot() {
-  auto view = lockView();
-  view->showColourFillPlot();
+  m_view.showColourFillPlot();
 }
 
 void WorkspacePresenter::showDetectorsTable() {
-  auto view = lockView();
-  view->showDetectorsTable();
+  m_view.showDetectorsTable();
 }
 
 void WorkspacePresenter::showBoxDataTable() {
-  auto view = lockView();
-  view->showBoxDataTable();
+  m_view.showBoxDataTable();
 }
 
 void WorkspacePresenter::showVatesGUI() {
-  auto view = lockView();
-  view->showVatesGUI();
+  m_view.showVatesGUI();
 }
 
 void WorkspacePresenter::showMDPlot() {
-  auto view = lockView();
-  view->showMDPlot();
+  m_view.showMDPlot();
 }
 
 void WorkspacePresenter::showListData() {
-  auto view = lockView();
-  view->showListData();
+  m_view.showListData();
 }
 
 void WorkspacePresenter::showSpectrumViewer() {
-  auto view = lockView();
-  view->showSpectrumViewer();
+	m_view.showSpectrumViewer();
 }
 
 void WorkspacePresenter::showSliceViewer() {
-  auto view = lockView();
-  view->showSliceViewer();
+  m_view.showSliceViewer();
 }
 
 void WorkspacePresenter::showLogs() {
-  auto view = lockView();
-  view->showLogs();
+  m_view.showLogs();
 }
 
 void WorkspacePresenter::showSampleMaterialWindow() {
-  auto view = lockView();
-  view->showSampleMaterialWindow();
+  m_view.showSampleMaterialWindow();
 }
 
 void WorkspacePresenter::showAlgorithmHistory() {
-  auto view = lockView();
-  view->showAlgorithmHistory();
+  m_view.showAlgorithmHistory();
 }
 
 void WorkspacePresenter::showTransposed() {
-  auto view = lockView();
-  view->showTransposed();
+  m_view.showTransposed();
 }
 
 void WorkspacePresenter::convertToMatrixWorkspace() {
-  auto view = lockView();
-  view->convertToMatrixWorkspace();
+	m_view.convertToMatrixWorkspace();
 }
 
 void WorkspacePresenter::convertMDHistoToMatrixWorkspace() {
-  auto view = lockView();
-  view->convertMDHistoToMatrixWorkspace();
+  m_view.convertMDHistoToMatrixWorkspace();
 }
 
 void WorkspacePresenter::clearUBMatrix() {
-  auto view = lockView();
-  auto wsNames = view->getSelectedWorkspaceNames();
+  auto wsNames = m_view.getSelectedWorkspaceNames();
 
   for (auto &ws : wsNames) {
     auto alg = Mantid::API::AlgorithmManager::Instance().create("ClearUB", -1);
@@ -400,7 +367,7 @@ void WorkspacePresenter::clearUBMatrix() {
       alg->setPropertyValue("Workspace", ws);
       // Run in this manner due to Qt dependencies within this method.
       // otherwise it would have been implemented here.
-      view->executeAlgorithmAsync(alg);
+	  m_view.executeAlgorithmAsync(alg);
     } else
       break;
   }
@@ -411,9 +378,8 @@ void WorkspacePresenter::refreshWorkspaces() { updateView(); }
 void WorkspacePresenter::workspaceLoaded() { updateView(); }
 
 void WorkspacePresenter::workspaceRenamed() {
-  auto view = lockView();
-  view->recordWorkspaceRename(m_adapter->getOldName(), m_adapter->getNewName());
-  view->updateTree(m_adapter->topLevelItems());
+  m_view.recordWorkspaceRename(m_adapter->getOldName(), m_adapter->getNewName());
+  m_view.updateTree(m_adapter->topLevelItems());
 }
 
 void WorkspacePresenter::workspacesGrouped() { updateView(); }
@@ -423,24 +389,13 @@ void WorkspacePresenter::workspaceGroupUpdated() { updateView(); }
 void WorkspacePresenter::workspacesDeleted() { updateView(); }
 
 void WorkspacePresenter::workspacesCleared() {
-  auto view = lockView();
-  view->clearView();
-}
 
-/// Lock the view weak_ptr and return the shared_ptr generated.
-DockView_sptr WorkspacePresenter::lockView() {
-  auto view_sptr = m_view.lock();
-
-  if (view_sptr == nullptr)
-    throw std::runtime_error("Could not obtain pointer to DockView.");
-
-  return view_sptr;
+  m_view.clearView();
 }
 
 /// Update the view by publishing the ADS contents.
 void WorkspacePresenter::updateView() {
-  auto view = lockView();
-  view->updateTree(m_adapter->topLevelItems());
+  m_view.updateTree(m_adapter->topLevelItems());
 }
 
 } // namespace MantidQt

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
@@ -79,7 +79,11 @@ WorkspaceTreeWidget::WorkspaceTreeWidget(MantidDisplayBase *mdb,
   m_tree->setDragEnabled(true);
 }
 
-WorkspaceTreeWidget::~WorkspaceTreeWidget() {}
+WorkspaceTreeWidget::~WorkspaceTreeWidget() {
+	auto presenter = boost::make_shared<WorkspacePresenter>(*this);
+	m_presenter = boost::dynamic_pointer_cast<ViewNotifiable>(presenter);
+	presenter->init();
+}
 
 /**
 * Accept a drag drop event and process the data appropriately
@@ -172,11 +176,6 @@ void WorkspaceTreeWidget::setTreeUpdating(const bool state) {
 
 void WorkspaceTreeWidget::incrementUpdateCount() { m_updateCount.ref(); }
 
-void WorkspaceTreeWidget::init() {
-  auto presenter = boost::make_shared<WorkspacePresenter>(shared_from_this());
-  m_presenter = boost::dynamic_pointer_cast<ViewNotifiable>(presenter);
-  presenter->init();
-}
 
 WorkspacePresenterWN_wptr WorkspaceTreeWidget::getPresenterWeakPtr() {
   return boost::dynamic_pointer_cast<WorkspacePresenter>(m_presenter);

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
@@ -78,7 +78,7 @@ WorkspaceTreeWidget::WorkspaceTreeWidget(MantidDisplayBase *mdb,
 
   m_tree->setDragEnabled(true);
 
-  auto presenter = boost::make_shared<WorkspacePresenter>(*this);
+  auto presenter = boost::make_shared<WorkspacePresenter>(this);
   m_presenter = boost::dynamic_pointer_cast<ViewNotifiable>(presenter);
   presenter->init();
 }

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
@@ -77,13 +77,13 @@ WorkspaceTreeWidget::WorkspaceTreeWidget(MantidDisplayBase *mdb,
   setupConnections();
 
   m_tree->setDragEnabled(true);
-}
 
-WorkspaceTreeWidget::~WorkspaceTreeWidget() {
   auto presenter = boost::make_shared<WorkspacePresenter>(*this);
   m_presenter = boost::dynamic_pointer_cast<ViewNotifiable>(presenter);
   presenter->init();
 }
+
+WorkspaceTreeWidget::~WorkspaceTreeWidget() {}
 
 /**
 * Accept a drag drop event and process the data appropriately

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
@@ -80,9 +80,9 @@ WorkspaceTreeWidget::WorkspaceTreeWidget(MantidDisplayBase *mdb,
 }
 
 WorkspaceTreeWidget::~WorkspaceTreeWidget() {
-	auto presenter = boost::make_shared<WorkspacePresenter>(*this);
-	m_presenter = boost::dynamic_pointer_cast<ViewNotifiable>(presenter);
-	presenter->init();
+  auto presenter = boost::make_shared<WorkspacePresenter>(*this);
+  m_presenter = boost::dynamic_pointer_cast<ViewNotifiable>(presenter);
+  presenter->init();
 }
 
 /**
@@ -175,7 +175,6 @@ void WorkspaceTreeWidget::setTreeUpdating(const bool state) {
 }
 
 void WorkspaceTreeWidget::incrementUpdateCount() { m_updateCount.ref(); }
-
 
 WorkspacePresenterWN_wptr WorkspaceTreeWidget::getPresenterWeakPtr() {
   return boost::dynamic_pointer_cast<WorkspacePresenter>(m_presenter);

--- a/qt/widgets/common/test/WorkspacePresenter/WorkspacePresenterTest.h
+++ b/qt/widgets/common/test/WorkspacePresenter/WorkspacePresenterTest.h
@@ -31,7 +31,6 @@ public:
   void setUp() override {
     mockView.reset();
     mockView = boost::make_shared<NiceMock<MockWorkspaceDockView>>();
-
     presenter = mockView->getPresenterSharedPtr();
   }
 

--- a/qt/widgets/common/test/WorkspacePresenter/WorkspacePresenterTest.h
+++ b/qt/widgets/common/test/WorkspacePresenter/WorkspacePresenterTest.h
@@ -31,7 +31,6 @@ public:
   void setUp() override {
     mockView.reset();
     mockView = boost::make_shared<NiceMock<MockWorkspaceDockView>>();
-    mockView->init();
 
     presenter = mockView->getPresenterSharedPtr();
   }


### PR DESCRIPTION
The `WorkspaceTreeWidget` (previously `QWorkspaceDockWidget`) uses `shared_from_this()` when creating it's presenter. The problem with this is this relies upon there being a shared_ptr already created for this object which causes a problem with the workbench (because it's python - no shared_ptrs). 

This covers removing the shared pointer and refactoring code to use a pointer reference instead. As its a reference, not null checks can be removed. Additionally this PR covers removing the `init()` function from `WorkspaceTreeWidget` as this is no longer required as `shared_from_this` is not used. Finally this PR makes the changes in MantidUI to accommodate the new way of creating a `WorkspaceTreeWidget`.

Quick turn around on this issue would be appreciated as it blocks #21442 - hence high priority assigned

**To test:**

* Code review - specifically ensuring pointer safety / memory management is still okay!

* Run MantidPlot and try to break the Workspace Widget

Fixes - no issue number

**Release Notes** 
*Internal change not required in release notes*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
