### PR TITLE
Fix python package build command for Makefiles

### DIFF
--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -20,7 +20,7 @@ function ( add_python_package pkg_name )
         set ( _startup_exe ${_egg_link_dir}/${pkg_name} )
       endif ()
   endif ()
-  set ( _outputs "${_egg_link} ${_startup_script} ${_startup_exe}" )
+  set ( _outputs ${_egg_link} ${_startup_script} ${_startup_exe} )
   add_custom_command ( OUTPUT ${_outputs}
     COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${_egg_link_dir}
       ${PYTHON_EXECUTABLE} ${_setup_py} develop


### PR DESCRIPTION
Description of work.

Fixes `mantidqt build target for Makefile generators.

**To test:**

Before merging the changes configure with the Makefiles generator and run `make mantidqt`. It spits out an error:
```
make[3]: *** No rule to make target `bin/mantidqt.egg-link \', needed by `qt/python/CMakeFiles/mantidqt'.  Stop.
make[2]: *** [qt/python/CMakeFiles/mantidqt.dir/all] Error 2
make[1]: *** [qt/python/CMakeFiles/mantidqt.dir/rule] Error 2
make: *** [mantidqt] Error 
``` 

After merging the fix run `make mantidqt` again and it should complete successfully.

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
