### PR TITLE
Fix DirectILLApplySelfShielding when running in no-op mode

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLApplySelfShielding.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLApplySelfShielding.py
@@ -6,7 +6,7 @@ import DirectILL_common as common
 from mantid.api import (AlgorithmFactory, DataProcessorAlgorithm, InstrumentValidator, MatrixWorkspaceProperty,
                         Progress, PropertyMode,  WorkspaceProperty, WorkspaceUnitValidator)
 from mantid.kernel import (CompositeValidator, Direction, FloatBoundedValidator, StringListValidator)
-from mantid.simpleapi import (CreateSingleValuedWorkspace, Divide, Minus, Multiply)
+from mantid.simpleapi import (CloneWorkspace, CreateSingleValuedWorkspace, Divide, Minus, Multiply)
 
 
 def _subtractEC(ws, ecWS, ecScaling, wsNames, wsCleanup, algorithmLogging):
@@ -69,10 +69,13 @@ class DirectILLApplySelfShielding(DataProcessorAlgorithm):
         mainWS = self._inputWS(wsCleanup)
 
         progress.report('Applying self shielding corrections')
-        mainWS = self._applyCorrections(mainWS, wsNames, wsCleanup, subalgLogging)
+        mainWS, applied = self._applyCorrections(mainWS, wsNames, wsCleanup, subalgLogging)
 
         progress.report('Subtracting EC')
-        mainWS = self._subtractEC(mainWS, wsNames, wsCleanup, subalgLogging)
+        mainWS, subtracted = self._subtractEC(mainWS, wsNames, wsCleanup, subalgLogging)
+
+        if not applied and not subtracted:
+            mainWS = self._cloneOnly(mainWS, wsNames, wsCleanup, subalgLogging)
 
         self._finalize(mainWS, wsCleanup)
         progress.report('Done')
@@ -130,10 +133,16 @@ class DirectILLApplySelfShielding(DataProcessorAlgorithm):
             optional=PropertyMode.Optional),
             doc='A workspace containing self shielding correction factors.')
 
+    def _cloneOnly(self, mainWS, wsNames, wsCleanup, subalgLogging):
+        cloneWSName = wsNames.withSuffix('cloned_only')
+        cloneWS = CloneWorkspace(InputWorkspace=mainWS,
+                                 OutputWorkspace=cloneWSName)
+        return cloneWS
+
     def _applyCorrections(self, mainWS, wsNames, wsCleanup, subalgLogging):
         """Applies self shielding corrections to a workspace, if corrections exist."""
         if self.getProperty(common.PROP_SELF_SHIELDING_CORRECTION_WS).isDefault:
-            return mainWS
+            return mainWS, False
         correctionWS = self.getProperty(common.PROP_SELF_SHIELDING_CORRECTION_WS).value
         correctedWSName = wsNames.withSuffix('self_shielding_corrected')
         correctedWS = Divide(LHSWorkspace=mainWS,
@@ -141,7 +150,7 @@ class DirectILLApplySelfShielding(DataProcessorAlgorithm):
                              OutputWorkspace=correctedWSName,
                              EnableLogging=subalgLogging)
         wsCleanup.cleanup(mainWS)
-        return correctedWS
+        return correctedWS, True
 
     def _finalize(self, outWS, wsCleanup):
         """Do final cleanup and set the output property."""
@@ -158,12 +167,12 @@ class DirectILLApplySelfShielding(DataProcessorAlgorithm):
     def _subtractEC(self, mainWS, wsNames, wsCleanup, subalgLogging):
         """Subtract the empty container workspace without self-shielding corrections."""
         if self.getProperty(common.PROP_EC_WS).isDefault:
-            return mainWS
+            return mainWS, False
         ecWS = self.getProperty(common.PROP_EC_WS).value
         ecScaling = self.getProperty(common.PROP_EC_SCALING).value
         subtractedWS = _subtractEC(mainWS, ecWS, ecScaling, wsNames, wsCleanup, subalgLogging)
         wsCleanup.cleanup(mainWS)
-        return subtractedWS
+        return subtractedWS, True
 
 
 AlgorithmFactory.subscribe(DirectILLApplySelfShielding)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLCollectData.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLCollectData.py
@@ -9,7 +9,7 @@ from mantid.api import (AlgorithmFactory, DataProcessorAlgorithm, FileAction, In
 from mantid.kernel import (CompositeValidator, Direct, Direction, FloatBoundedValidator, IntBoundedValidator, IntArrayBoundedValidator,
                            IntMandatoryValidator, Property, StringListValidator, UnitConversion)
 from mantid.simpleapi import (AddSampleLog, CalculateFlatBackground, CloneWorkspace, CorrectTOFAxis, CreateEPP, CreateSingleValuedWorkspace,
-                              CreateWorkspace, CropWorkspace, Divide, ExtractMonitors, FindEPP, GetEiMonDet, Minus,
+                              CreateWorkspace, CropWorkspace, DeleteWorkspace, Divide, ExtractMonitors, FindEPP, GetEiMonDet, Minus,
                               NormaliseToMonitor, Scale, LoadAndMerge)
 import numpy
 
@@ -798,6 +798,8 @@ class DirectILLCollectData(DataProcessorAlgorithm):
                            ReferenceWorkspace=mainWS,
                            EnableLogging=subalgLogging)
             self.setProperty(common.PROP_OUTPUT_RAW_WS, rawWS)
+            DeleteWorkspace(Workspace=rawWS,
+                            EnableLogging=subalgLogging)
 
     def _separateMons(self, mainWS, wsNames, wsCleanup, subalgLogging):
         """Extract monitors to a separate workspace."""

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLDiagnostics.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLDiagnostics.py
@@ -336,6 +336,7 @@ class DirectILLDiagnostics(DataProcessorAlgorithm):
 
         maskWSName = wsNames.withSuffix('combined_mask')
         maskWS = _createMaskWS(mainWS, maskWSName, subalgLogging)
+        wsCleanup.cleanupLater(maskWS)
 
         reportWS = None
         if not self.getProperty(common.PROP_OUTPUT_DIAGNOSTICS_REPORT_WS).isDefault:

--- a/docs/source/release/v3.12.0/direct_inelastic.rst
+++ b/docs/source/release/v3.12.0/direct_inelastic.rst
@@ -22,7 +22,7 @@ Instrument definitions
 Algorithms
 ##########
 
-
+- Fixed a bug in :ref:`algm-DirectILLApplySelfShielding` which could cause confusion among workspaces when the algorithm was run without both self shielding correction and empty container workspaces.
 
 Crystal Field
 #############


### PR DESCRIPTION
This PR fixes [`DirectILLApplySelfShielding`](http://docs.mantidproject.org/nightly/algorithms/DirectILLApplySelfShielding-v1.html) by cloning the input workspace if no operation is applied. Before this fix, the input workspace would be set as OutputWorkspace which could cause two entries to the same workspace in the ADS messing up later operations which used the original input workspace.

Additionally, this PR fixes minor intermediate workspace cleanup problems found in `DirectILLCollectData` and `DirectILLDiagnostics`

**To test:**

The following script could be used for testing:
```python
# You need to have the unit test data directory in Mantid's data search directories.
DirectILLCollectData(
    Run='ILL/IN4/084446',
    OutputWorkspace='ws'
)
DirectILLApplySelfShielding(
    'ws',
    OutputWorkspace='outWS'
)
DirectILLApplySelfShielding(
    'ws',
    SelfShieldingCorrectionWorkspace='ws',
    OutputWorkspace='outWS'
)
DirectILLApplySelfShielding(
    'ws',
    SelfShieldingCorrectionWorkspace='ws',
    OutputWorkspace='outWS2'
)
# The workspaces should match when this PR is applied
CompareWorkspaces('outWS', 'outWS2')
```

Fixes #21533.

**Release Notes** 

The Direct Inelastic release notes were updated accordingly.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [x] Are the unit tests small and test the class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] Do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
