### PR TITLE
Add more prominent instrument selection and process button

### DIFF
--- a/qt/python/mantidqtpython/mantidqtpython_def.sip
+++ b/qt/python/mantidqtpython/mantidqtpython_def.sip
@@ -1597,6 +1597,8 @@ DataProcessorMainPresenter();
 virtual QVariantMap getPreprocessingOptions() const;
 virtual QVariantMap getProcessingOptions() const;
 virtual QString getPostprocessingOptionsAsString() const;
+virtual void confirmReductionPaused() const;
+virtual void confirmReductionResumed() const;
 
 virtual void notifyADSChanged(const QSet<QString> &);
 };

--- a/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -287,7 +287,7 @@ bool GenericDataProcessorPresenter::areOptionsUpdated() {
 Process selected data
 */
 void GenericDataProcessorPresenter::process() {
-  // Emit a signal hat the process is starting
+  // Emit a signal that the process is starting
   m_view->emitProcessClicked();
   if (GenericDataProcessorPresenter::m_skipProcessing) {
     m_skipProcessing = false;
@@ -296,9 +296,10 @@ void GenericDataProcessorPresenter::process() {
   m_selectedData = m_manager->selectedData(m_promptUser);
 
   // Don't continue if there are no items selected
-  if (m_selectedData.size() == 0)
+  if (m_selectedData.size() == 0){
+    m_mainPresenter->confirmReductionPaused();
     return;
-
+  }
   // Set the global settings. If any have been changed, set all groups and rows
   // as unprocessed
   auto settingsHaveChanged = areOptionsUpdated();

--- a/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -296,7 +296,7 @@ void GenericDataProcessorPresenter::process() {
   m_selectedData = m_manager->selectedData(m_promptUser);
 
   // Don't continue if there are no items selected
-  if (m_selectedData.size() == 0){
+  if (m_selectedData.size() == 0) {
     m_mainPresenter->confirmReductionPaused();
     return;
   }

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -282,8 +282,6 @@ class SANSDataProcessorGui(QtGui.QMainWindow, ui_sans_data_processor_window.Ui_S
         """
         Clean up
         """
-        import pydevd
-        pydevd.settrace('localhost', port=5434, stdoutToServer=True, stderrToServer=True)
         self._call_settings_listeners(lambda listener: listener.on_processing_finished())
 
     def _data_changed(self):

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -24,7 +24,7 @@ from . import ui_sans_data_processor_window as ui_sans_data_processor_window
 from sans.common.enums import (ReductionDimensionality, OutputMode, SaveType, SANSInstrument,
                                RangeStepType, SampleShape, ReductionMode, FitType)
 from sans.gui_logic.gui_common import (get_reduction_mode_from_gui_selection, get_reduction_mode_strings_for_gui,
-                                       get_string_for_gui_from_reduction_mode, GENERIC_SETTINGS, load_file)
+                                       get_string_for_gui_from_reduction_mode, GENERIC_SETTINGS, load_file, get_instrument_from_gui_selection, get_instrument_strings_for_gui, get_string_for_gui_from_instrument)
 
 
 # ----------------------------------------------------------------------------------------------------------------------
@@ -110,7 +110,8 @@ class SANSDataProcessorGui(QtGui.QMainWindow, ui_sans_data_processor_window.Ui_S
                                          SANSInstrument.to_string(SANSInstrument.NoInstrument),
                                          type=str)
         settings.endGroup()
-        self._instrument = SANSInstrument.from_string(instrument_name)
+
+        self.instrument = SANSInstrument.from_string(instrument_name)
 
         # Attach validators
         self._attach_validators()
@@ -168,6 +169,10 @@ class SANSDataProcessorGui(QtGui.QMainWindow, ui_sans_data_processor_window.Ui_S
         self._setup_main_tab()
 
         self.multi_period_check_box.stateChanged.connect(self._on_multi_period_selection)
+
+        self.instrument_combo_box.currentIndexChanged.connect(self._on_instrument_selection_has_changed)
+
+        self.process_button.clicked.connect(self._on_python_process)
 
         # --------------------------------------------------------------------------------------------------------------
         # Settings tabs
@@ -246,7 +251,7 @@ class SANSDataProcessorGui(QtGui.QMainWindow, ui_sans_data_processor_window.Ui_S
         self.data_processor_table.accept(self._main_presenter)
 
         # Set the list of available instruments in the widget and the default instrument
-        instrument_name = SANSInstrument.to_string(self._instrument)
+        instrument_name = SANSInstrument.to_string(self.instrument)
         self.data_processor_table.setInstrumentList(SANSDataProcessorGui.INSTRUMENTS, instrument_name)
 
         if instrument_name:
@@ -277,6 +282,8 @@ class SANSDataProcessorGui(QtGui.QMainWindow, ui_sans_data_processor_window.Ui_S
         """
         Clean up
         """
+        import pydevd
+        pydevd.settrace('localhost', port=5434, stdoutToServer=True, stderrToServer=True)
         self._call_settings_listeners(lambda listener: listener.on_processing_finished())
 
     def _data_changed(self):
@@ -316,15 +323,39 @@ class SANSDataProcessorGui(QtGui.QMainWindow, ui_sans_data_processor_window.Ui_S
         config.setString("default.instrument", instrument_string)
 
     def _handle_instrument_change(self):
-        # Set instrument as the default instrument
         instrument_string = str(self.data_processor_table.getCurrentInstrument())
-        self._set_mantid_instrument(instrument_string)
+
+        if instrument_string:
+            instrument = get_instrument_from_gui_selection(instrument_string)
+            self.instrument = instrument
+
+    def _on_instrument_selection_has_changed(self):
+        # Set instrument as the default instrument
+        self._set_mantid_instrument(SANSInstrument.to_string(self.instrument))
 
         # Set the reduction mode
-        if instrument_string:
-            self._instrument = SANSInstrument.from_string(instrument_string)
-            reduction_mode_list = get_reduction_mode_strings_for_gui(self._instrument)
+        if self.instrument:
+            reduction_mode_list = get_reduction_mode_strings_for_gui(self.instrument)
             self.set_reduction_modes(reduction_mode_list)
+            if SANSInstrument.to_string(self.instrument) != str(self.data_processor_table.getCurrentInstrument()):
+                self.data_processor_table.on_comboProcessInstrument_currentIndexChanged(self.instrument_combo_box.currentIndex())
+
+    def _on_python_process(self):
+        self.data_processor_table.processClicked()
+
+    def disable_buttons(self):
+        self.process_button.setEnabled(False)
+        self.instrument_combo_box.setEnabled(False)
+        self.batch_button.setEnabled(False)
+        self.user_file_button.setEnabled(False)
+        self.manage_directories_button.setEnabled(False)
+
+    def enable_buttons(self):
+        self.process_button.setEnabled(True)
+        self.instrument_combo_box.setEnabled(True)
+        self.batch_button.setEnabled(True)
+        self.user_file_button.setEnabled(True)
+        self.manage_directories_button.setEnabled(True)
 
     def get_user_file_path(self):
         return str(self.user_file_line_edit.text())
@@ -518,7 +549,7 @@ class SANSDataProcessorGui(QtGui.QMainWindow, ui_sans_data_processor_window.Ui_S
     # ------------------------------------------------------------------------------------------------------------------
     def set_instrument_settings(self, instrument):
         if instrument:
-            self._instrument = instrument
+            self.instrument = instrument
             instrument_string = SANSInstrument.to_string(instrument)
             self.data_processor_table.setInstrumentList(SANSDataProcessorGui.INSTRUMENTS, instrument_string)
             self._set_mantid_instrument(instrument_string)
@@ -679,6 +710,27 @@ class SANSDataProcessorGui(QtGui.QMainWindow, ui_sans_data_processor_window.Ui_S
     def show_transmission(self, value):
         self.show_transmission_view.setChecked(value)
 
+    @property
+    def instrument(self):
+        instrument_as_string = self.instrument_combo_box.currentText()
+        return get_instrument_from_gui_selection(instrument_as_string)
+
+    @instrument.setter
+    def instrument(self, value):
+        instrument_as_string = get_string_for_gui_from_instrument(value)
+        if instrument_as_string:
+            index = self.instrument_combo_box.findText(instrument_as_string)
+            if index != -1:
+                self.instrument_combo_box.setCurrentIndex(index)
+
+    def set_instruments(self, instrument_list):
+        current_index = self.instrument_combo_box.currentIndex()
+        self.instrument_combo_box.clear()
+        for element in instrument_list:
+            self.instrument_combo_box.addItem(element)
+        if current_index != -1:
+            self.instrument_combo_box.setCurrentIndex(current_index)
+
     # ==================================================================================================================
     # ==================================================================================================================
     # General TAB
@@ -711,10 +763,10 @@ class SANSDataProcessorGui(QtGui.QMainWindow, ui_sans_data_processor_window.Ui_S
         # Convert the value to the correct GUI string
 
         # Set the correct selection of reduction modes which are available
-        reduction_mode_list = get_reduction_mode_strings_for_gui(self._instrument)
+        reduction_mode_list = get_reduction_mode_strings_for_gui(self.instrument)
         self.set_reduction_modes(reduction_mode_list)
 
-        reduction_mode_as_string = get_string_for_gui_from_reduction_mode(value, self._instrument)
+        reduction_mode_as_string = get_string_for_gui_from_reduction_mode(value, self.instrument)
         if reduction_mode_as_string:
             index = self.reduction_mode_combo_box.findText(reduction_mode_as_string)
             if index != -1:

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -24,7 +24,8 @@ from . import ui_sans_data_processor_window as ui_sans_data_processor_window
 from sans.common.enums import (ReductionDimensionality, OutputMode, SaveType, SANSInstrument,
                                RangeStepType, SampleShape, ReductionMode, FitType)
 from sans.gui_logic.gui_common import (get_reduction_mode_from_gui_selection, get_reduction_mode_strings_for_gui,
-                                       get_string_for_gui_from_reduction_mode, GENERIC_SETTINGS, load_file, get_instrument_from_gui_selection, get_instrument_strings_for_gui, get_string_for_gui_from_instrument)
+                                       get_string_for_gui_from_reduction_mode, GENERIC_SETTINGS, load_file,
+                                       get_instrument_from_gui_selection, get_string_for_gui_from_instrument)
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
@@ -64,7 +64,7 @@ QGroupBox::title {
       <item>
        <widget class="QStackedWidget" name="main_stacked_widget">
         <property name="currentIndex">
-         <number>1</number>
+         <number>0</number>
         </property>
         <widget class="QWidget" name="run_page">
          <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -88,30 +88,13 @@ QGroupBox::title {
                 </property>
                </widget>
               </item>
-              <item row="2" column="3">
-               <widget class="QPushButton" name="batch_button">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify a batch file to load. For the batch file format see &lt;a href=&quot;https://www.mantidproject.org/SANS_batch_file_format&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;here&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="text">
-                 <string>Load Batch File</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="3">
+              <item row="1" column="5">
                <widget class="QPushButton" name="user_file_button">
                 <property name="toolTip">
                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify the user file (aka mask file) which is used to provide the bulk of the reduction settings. For a list of user file commands see &lt;a href=&quot;https://www.mantidproject.org/SANS_User_File_Commands&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;here&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                 <property name="text">
                  <string>Load User File</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="2">
-               <widget class="QLineEdit" name="batch_line_edit">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify a batch file to load. For the batch file format see &lt;a href=&quot;https://www.mantidproject.org/SANS_batch_file_format&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;here&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                </widget>
               </item>
@@ -125,17 +108,81 @@ QGroupBox::title {
                 </property>
                </widget>
               </item>
-              <item row="1" column="2">
+              <item row="2" column="4">
+               <widget class="QLineEdit" name="batch_line_edit">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify a batch file to load. For the batch file format see &lt;a href=&quot;https://www.mantidproject.org/SANS_batch_file_format&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;here&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="4">
                <widget class="QLineEdit" name="user_file_line_edit">
                 <property name="toolTip">
                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify the user file (aka mask file) which is used to provide the bulk of the reduction settings. For a list of user file commands see &lt;a href=&quot;https://www.mantidproject.org/SANS_User_File_Commands&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;here&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                </widget>
               </item>
-              <item row="3" column="3">
+              <item row="2" column="5">
+               <widget class="QPushButton" name="batch_button">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify a batch file to load. For the batch file format see &lt;a href=&quot;https://www.mantidproject.org/SANS_batch_file_format&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;here&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string>Load Batch File</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QLabel" name="instrument_label">
+                <property name="text">
+                 <string>Instrument:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="5">
                <widget class="QPushButton" name="manage_directories_button">
                 <property name="text">
                  <string>Manage Directories</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="4">
+               <layout class="QHBoxLayout" name="horizontalLayout_2">
+                <item>
+                 <widget class="QComboBox" name="instrument_combo_box">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>834</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </item>
+              <item row="3" column="5">
+               <widget class="QPushButton" name="process_button">
+                <property name="text">
+                 <string>Process</string>
                 </property>
                </widget>
               </item>
@@ -360,7 +407,7 @@ QGroupBox::title {
           <item>
            <widget class="QTabWidget" name="settings_tab_widget">
             <property name="currentIndex">
-             <number>1</number>
+             <number>0</number>
             </property>
             <widget class="QWidget" name="general_tab">
              <attribute name="title">
@@ -1942,7 +1989,7 @@ QGroupBox::title {
      <x>0</x>
      <y>0</y>
      <width>1211</width>
-     <height>28</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuEdit">

--- a/scripts/SANS/sans/gui_logic/gui_common.py
+++ b/scripts/SANS/sans/gui_logic/gui_common.py
@@ -26,6 +26,7 @@ def generate_table_index(multi_period):
     table_index.update({'HIDDEN_OPTIONS_INDEX': 15 if multi_period else 9})
     return table_index
 
+
 OPTIONS_SEPARATOR = ","
 OPTIONS_EQUAL = "="
 
@@ -64,6 +65,7 @@ def get_reduction_mode_strings_for_gui(instrument=None):
     else:
         return [DEFAULT_LAB, DEFAULT_HAB, MERGED, ALL]
 
+
 def get_instrument_strings_for_gui():
         return ['SANS2D', 'LOQ', 'LARMOR', 'ZOOM']
 
@@ -94,8 +96,10 @@ def get_string_for_gui_from_reduction_mode(reduction_mode, instrument):
     else:
         return None
 
+
 def get_string_for_gui_from_instrument(instrument):
-    instrument_selection = {SANSInstrument.SANS2D: 'SANS2D', SANSInstrument.LOQ: 'LOQ', SANSInstrument.LARMOR: 'LARMOR',  SANSInstrument.ZOOM: 'ZOOM'}
+    instrument_selection = {SANSInstrument.SANS2D: 'SANS2D', SANSInstrument.LOQ: 'LOQ', SANSInstrument.LARMOR: 'LARMOR'
+                            , SANSInstrument.ZOOM: 'ZOOM'}
     if instrument in list(instrument_selection.keys()):
         return instrument_selection[instrument]
     else:
@@ -113,6 +117,7 @@ def get_reduction_mode_from_gui_selection(gui_selection):
         return ISISReductionMode.HAB
     else:
         raise RuntimeError("Reduction mode selection is not valid.")
+
 
 def get_instrument_from_gui_selection(gui_selection):
     if gui_selection == 'LOQ':

--- a/scripts/SANS/sans/gui_logic/gui_common.py
+++ b/scripts/SANS/sans/gui_logic/gui_common.py
@@ -64,6 +64,9 @@ def get_reduction_mode_strings_for_gui(instrument=None):
     else:
         return [DEFAULT_LAB, DEFAULT_HAB, MERGED, ALL]
 
+def get_instrument_strings_for_gui():
+        return ['SANS2D', 'LOQ', 'LARMOR', 'ZOOM']
+
 
 def get_reduction_selection(instrument):
     selection = {ISISReductionMode.Merged: MERGED,
@@ -91,6 +94,13 @@ def get_string_for_gui_from_reduction_mode(reduction_mode, instrument):
     else:
         return None
 
+def get_string_for_gui_from_instrument(instrument):
+    instrument_selection = {SANSInstrument.SANS2D: 'SANS2D', SANSInstrument.LOQ: 'LOQ', SANSInstrument.LARMOR: 'LARMOR',  SANSInstrument.ZOOM: 'ZOOM'}
+    if instrument in list(instrument_selection.keys()):
+        return instrument_selection[instrument]
+    else:
+        return None
+
 
 def get_reduction_mode_from_gui_selection(gui_selection):
     if gui_selection == MERGED:
@@ -103,6 +113,18 @@ def get_reduction_mode_from_gui_selection(gui_selection):
         return ISISReductionMode.HAB
     else:
         raise RuntimeError("Reduction mode selection is not valid.")
+
+def get_instrument_from_gui_selection(gui_selection):
+    if gui_selection == 'LOQ':
+        return SANSInstrument.LOQ
+    elif gui_selection == 'LARMOR':
+        return SANSInstrument.LARMOR
+    elif gui_selection == 'SANS2D':
+        return SANSInstrument.SANS2D
+    elif gui_selection == 'ZOOM':
+        return SANSInstrument.ZOOM
+    else:
+        raise RuntimeError("Instrument selection is not valid.")
 
 
 def load_file(line_edit_field, filter_for_dialog, q_settings_group_key, q_settings_key, func):

--- a/scripts/SANS/sans/gui_logic/presenter/main_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/main_presenter.py
@@ -72,6 +72,8 @@ class MainPresenter(MantidQt.MantidWidgets.DataProcessor.DataProcessorMainPresen
             self._black_list = get_black_list()
         return self._black_list
 
+    def confirmReductionPaused(self):
+        self._presenters[PresenterEnum.RunTabPresenter].on_processing_finished()
     # ------------------------------------------------------------------------------------------------------------------
     # Inherited methods
     # ------------------------------------------------------------------------------------------------------------------

--- a/scripts/SANS/sans/gui_logic/presenter/main_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/main_presenter.py
@@ -74,6 +74,7 @@ class MainPresenter(MantidQt.MantidWidgets.DataProcessor.DataProcessorMainPresen
 
     def confirmReductionPaused(self):
         self._presenters[PresenterEnum.RunTabPresenter].on_processing_finished()
+
     # ------------------------------------------------------------------------------------------------------------------
     # Inherited methods
     # ------------------------------------------------------------------------------------------------------------------

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -23,7 +23,7 @@ from sans.gui_logic.presenter.beam_centre_presenter import BeamCentrePresenter
 from sans.gui_logic.sans_data_processor_gui_algorithm import SANS_DUMMY_INPUT_ALGORITHM_PROPERTY_NAME
 from sans.gui_logic.presenter.property_manager_service import PropertyManagerService
 from sans.gui_logic.gui_common import (get_reduction_mode_strings_for_gui, generate_table_index, OPTIONS_SEPARATOR,
-                                       OPTIONS_EQUAL)
+                                       OPTIONS_EQUAL, get_instrument_strings_for_gui)
 from sans.common.enums import (BatchReductionEntry, OutputMode, SANSInstrument, RangeStepType, SampleShape, FitType)
 from sans.common.file_information import (SANSFileInformationFactory)
 from sans.user_file.user_file_reader import UserFileReader
@@ -116,6 +116,10 @@ class RunTabPresenter(object):
         # Set the possible reduction modes
         reduction_mode_list = get_reduction_mode_strings_for_gui()
         self._view.set_reduction_modes(reduction_mode_list)
+
+        # Set the possible instruments
+        instrument_list = get_instrument_strings_for_gui()
+        self._view.set_instruments(instrument_list)
 
         # Set the step type options for wavelength
         range_step_types = [RangeStepType.to_string(RangeStepType.Lin),
@@ -264,6 +268,7 @@ class RunTabPresenter(object):
         """
 
         try:
+            self._view.disable_buttons()
             self.sans_logger.information("Starting processing of batch table.")
             # 0. Validate rows
             self._create_dummy_input_workspace()
@@ -295,6 +300,7 @@ class RunTabPresenter(object):
 
     def on_processing_finished(self):
         self._remove_dummy_workspaces_and_row_index()
+        self._view.enable_buttons()
 
     def on_multi_period_selection(self):
         multi_period = self._view.is_multi_period_view()


### PR DESCRIPTION
It was requested that the instrument selection and the process button on the SANS GUI were placed in more prominent positions, where they would be less easy to miss. 

**To test:**

- Code Review

- Check new GUI design.

- Check that when you change the instrument from the drop down menu at the top it changes at the bottom an vice versa.

- Check that when you click the process button at the top a reduction starts.

<!-- Instructions for testing. -->

Fixes #21531 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
