### PR TITLE
Check for `ENABLE_WORKBENCH` before finding pyrcc5

### DIFF
--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -34,8 +34,8 @@ function ( add_python_package pkg_name )
   )
 endfunction ()
 
-# Resource compiler
-if ( NOT PYRCC5_CMD )
+# Resource compiler for PyQt5
+if ( ENABLE_WORKBENCH AND NOT PYRCC5_CMD )
   # Newer versions of PyQt5 have a pyrcc_main python module, whereas older
   # versions have a pyrcc5 executable. We prefer calling the python module.
   execute_process ( COMMAND  ${PYTHON_EXECUTABLE} -c "import PyQt5.pyrcc_main" RESULT_VARIABLE _status)


### PR DESCRIPTION
Description of work.

Add a check that `ENABLE_WORKBENCH` is defined before looking for pyrcc5.

**To test:**

Run cmake with `ENABLE_WORKBENCH=OFF` on a machine without the pyqt5-dev-tools installed. It should complete.

*No issue*

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
