### PR TITLE
Fix crash when saving peaks workspace.

### DIFF
--- a/Framework/DataObjects/src/PeakShapeSpherical.cpp
+++ b/Framework/DataObjects/src/PeakShapeSpherical.cpp
@@ -53,13 +53,10 @@ std::string PeakShapeSpherical::toJSON() const {
   Json::Value root;
   PeakShapeBase::buildCommon(root);
   root["radius"] = Json::Value(m_radius);
-  // Check that there is an inner radius before writing
-  if (m_backgroundInnerRadius.is_initialized()) {
+
+  if (m_backgroundInnerRadius && m_backgroundOuterRadius) {
     root["background_outer_radius"] =
         Json::Value(m_backgroundOuterRadius.get());
-  }
-  // Check that there is an outer radius before writing
-  if (m_backgroundOuterRadius.is_initialized()) {
     root["background_inner_radius"] =
         Json::Value(m_backgroundInnerRadius.get());
   }

--- a/docs/source/release/v3.12.0/framework.rst
+++ b/docs/source/release/v3.12.0/framework.rst
@@ -41,6 +41,7 @@ Algorithms
 - :ref:`LoadMask <algm-LoadMask>` has had a bug fixed that could, under certain conditions, cause detectors from previously loaded masking to be added to the currently loaded masking.
 - In :ref:`MaxEnt <algm-MaxEnt>` the ``EvolChi`` and  ``EvolAngle`` workspaces only contain data up until the result has converged.
 - :ref:`LoadLamp <algm-LoadLamp>` is a new algorithm to load processed HDF5 files produced by LAMP program at ILL.
+- :ref:`SaveNexus <algm-SaveNeuxs>` will no longer crash when passed a ``PeaksWorkspace`` with integrated peaks that have missing radius information. 
 
 Fitting
 -------

--- a/docs/source/release/v3.12.0/framework.rst
+++ b/docs/source/release/v3.12.0/framework.rst
@@ -41,7 +41,7 @@ Algorithms
 - :ref:`LoadMask <algm-LoadMask>` has had a bug fixed that could, under certain conditions, cause detectors from previously loaded masking to be added to the currently loaded masking.
 - In :ref:`MaxEnt <algm-MaxEnt>` the ``EvolChi`` and  ``EvolAngle`` workspaces only contain data up until the result has converged.
 - :ref:`LoadLamp <algm-LoadLamp>` is a new algorithm to load processed HDF5 files produced by LAMP program at ILL.
-- :ref:`SaveNexus <algm-SaveNeuxs>` will no longer crash when passed a ``PeaksWorkspace`` with integrated peaks that have missing radius information. 
+- :ref:`SaveNexus <algm-SaveNexus>` will no longer crash when passed a ``PeaksWorkspace`` with integrated peaks that have missing radius information. 
 
 Fitting
 -------


### PR DESCRIPTION
If for some reason one of the radii is not defined SaveNexus crashes
because we access the value without checking it first. We should just
check that both radii are present, then write them out.

(cherry picked from commit 5e7dc01597680694128a3897d2244238f17e145a)

**To test:**
Here's a script that should reproduce the issue. Data files are in a zip folder called `test_files.zip` in `Scratch/Sam`:

```python
md_workspace = Load(Filename='WISH_md_small.nxs', OutputWorkspace='WISH_md_small')
satellite_peaks = Load(Filename='WISH_peak_hkl_frac_small.nxs', OutputWorkspace='WISH_peak_hkl_frac_small')
main_peaks = Load(Filename='WISH_peak_hkl_small.nxs', OutputWorkspace='WISH_peak_hkl_small')

fixed_params = {
    "PeakRadius": 0.3,
    "BackgroundInnerRadius": 0.3,
    "BackgroundOuterRadius": 0.4,
    "OutputWorkspace": "refine_peaks_test"
}

k = 2

CloneWorkspace(InputWorkspace='WISH_peak_hkl_small', OutputWorkspace='predicted_satellites')
PredictFractionalPeaks(Peaks='WISH_peak_hkl_small', FracPeaks='predicted_q', HOffset='0', LOffset='0.88')
CombinePeaksWorkspaces(LHSWorkspace='predicted_satellites', RHSWorkspace='predicted_q', OutputWorkspace='predicted_satellites')
PredictFractionalPeaks(Peaks='WISH_peak_hkl_small', FracPeaks='predicted_q', HOffset='0', LOffset='-0.93')
CombinePeaksWorkspaces(LHSWorkspace='predicted_satellites', RHSWorkspace='predicted_q', OutputWorkspace='predicted_satellites')
DeleteWorkspace(Workspace='predicted_q')
CentroidPeaksMD(InputWorkspace='WISH_md_small', PeakRadius=0.29999999999999999, PeaksWorkspace='predicted_satellites', OutputWorkspace='centroid_satellites')
IntegratePeaksMD(InputWorkspace='WISH_md_small', PeakRadius=0.29999999999999999, BackgroundInnerRadius=0.29999999999999999, BackgroundOuterRadius=0.40000000000000002, PeaksWorkspace='centroid_satellites', OutputWorkspace='satellites_int_spherical')
FilterPeaks(InputWorkspace='satellites_int_spherical', OutputWorkspace='satellites_int_spherical', FilterVariable='Intensity', FilterValue=0, Operator='>')
FilterPeaks(InputWorkspace='satellites_int_spherical', OutputWorkspace='satellites_int_spherical', FilterVariable='Signal/Noise', FilterValue=2, Operator='>')
DeleteWorkspace(Workspace='predicted_satellites')
DeleteWorkspace(Workspace='centroid_satellites')
RenameWorkspace(InputWorkspace='satellites_int_spherical', OutputWorkspace='refine_peaks_test')

SaveNexus('refine_peaks_test', Filename="/Users/samueljackson/Desktop/refine_peaks_test_fixed_num_q.nxs")
```



*No issue associated with this PR*

**Release Notes** 
[See here](6d7a970)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
