### PR TITLE
Fixing intermittent failing tests for matplotlib

### DIFF
--- a/Framework/PythonInterface/test/python/mantid/plots/functionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/functionsTest.py
@@ -2,10 +2,12 @@ from __future__ import (absolute_import, division, print_function)
 
 import unittest
 from mantid.simpleapi import CreateWorkspace,DeleteWorkspace,CreateMDHistoWorkspace, ConjoinWorkspaces
-import mantid.plots.functions as funcs
 import mantid.api
 import numpy as np
 from mantid.kernel import config
+import matplotlib
+matplotlib.use('AGG')
+import mantid.plots.functions as funcs
 import matplotlib.pyplot as plt
 
 

--- a/Framework/PythonInterface/test/python/mantid/plots/plots__init__Test.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/plots__init__Test.py
@@ -2,6 +2,8 @@ from __future__ import (absolute_import, division, print_function)
 
 import unittest
 from mantid.simpleapi import CreateWorkspace,DeleteWorkspace
+import matplotlib
+matplotlib.use('AGG')
 import mantid.plots
 import matplotlib.pyplot as plt
 import numpy as np


### PR DESCRIPTION
Trying to fix 
```
15:47:46 FrameworkManager-[Notice] Welcome to Mantid 3.11.20180115.1521
15:47:46 FrameworkManager-[Notice] Please cite: http://dx.doi.org/10.1016/j.nima.2014.07.029 and this release: http://dx.doi.org/10.5286/Software/Mantid
15:47:46 Traceback (most recent call last):
15:47:46   File "/usr/lib/python3.5/tkinter/__init__.py", line 36, in <module>
15:47:46     import _tkinter
15:47:46 ImportError: No module named '_tkinter'
15:47:46 
15:47:46 During handling of the above exception, another exception occurred:
15:47:46 
15:47:46 Traceback (most recent call last):
15:47:46   File "/home/builder/jenkins-linode/workspace/pull_requests-ubuntu-python3/Framework/PythonInterface/test/testhelpers/testrunner.py", line 135, in <module>
15:47:46     main(sys.argv)
15:47:46   File "/home/builder/jenkins-linode/workspace/pull_requests-ubuntu-python3/Framework/PythonInterface/test/testhelpers/testrunner.py", line 87, in main
15:47:46     test_module = imp.load_source(module_name(pathname), pathname)
15:47:46   File "/usr/lib/python3.5/imp.py", line 172, in load_source
15:47:46     module = _load(spec)
15:47:46   File "<frozen importlib._bootstrap>", line 693, in _load
15:47:46   File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
15:47:46   File "<frozen importlib._bootstrap_external>", line 665, in exec_module
15:47:46   File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
15:47:46   File "/home/builder/jenkins-linode/workspace/pull_requests-ubuntu-python3/Framework/PythonInterface/test/python/mantid/plots/plots__init__Test.py", line 6, in <module>
15:47:46     import matplotlib.pyplot as plt
15:47:46   File "/usr/lib/python3/dist-packages/matplotlib/pyplot.py", line 114, in <module>
15:47:46     _backend_mod, new_figure_manager, draw_if_interactive, _show = pylab_setup()
15:47:46   File "/usr/lib/python3/dist-packages/matplotlib/backends/__init__.py", line 32, in pylab_setup
15:47:46     globals(),locals(),[backend_name],0)
15:47:46   File "/usr/lib/python3/dist-packages/matplotlib/backends/backend_tkagg.py", line 6, in <module>
15:47:46     from matplotlib.externals.six.moves import tkinter as Tk
15:47:46   File "/usr/lib/python3/dist-packages/matplotlib/externals/six.py", line 90, in __get__
15:47:46     result = self._resolve()
15:47:46   File "/usr/lib/python3/dist-packages/matplotlib/externals/six.py", line 113, in _resolve
15:47:46     return _import_module(self.mod)
15:47:46   File "/usr/lib/python3/dist-packages/matplotlib/externals/six.py", line 80, in _import_module
15:47:46     __import__(name)
15:47:46   File "/usr/lib/python3.5/tkinter/__init__.py", line 38, in <module>
15:47:46     raise ImportError(str(msg) + ', please install the python3-tk package')
15:47:46 ImportError: No module named '_tkinter', please install the python3-tk package
```
<!-- Instructions for testing. -->

I am forcing the use of `agg` backend.
No associated issue or release notes. Build tests should pass and simple code review

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
