### PR TITLE
Engineering Diffraction GUI - make RunMap its own class

### DIFF
--- a/qt/scientific_interfaces/CMakeLists.txt
+++ b/qt/scientific_interfaces/CMakeLists.txt
@@ -52,6 +52,7 @@ set ( TEST_FILES
   test/ReflSaveTabPresenterTest.h
   test/ReflSettingsPresenterTest.h
   test/ReflSettingsTabPresenterTest.h
+  test/RunMapTest.h
   test/UserInputValidatorTest.h
 )
 

--- a/qt/scientific_interfaces/EnggDiffraction/CMakeLists.txt
+++ b/qt/scientific_interfaces/EnggDiffraction/CMakeLists.txt
@@ -21,6 +21,7 @@ set ( INC_FILES
 	IEnggDiffFittingPresenter.h
 	IEnggDiffractionPresenter.h
 	IEnggDiffractionView.h
+	RunMap.h
 )
 
 set ( MOC_FILES

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.cpp
@@ -499,8 +499,7 @@ void EnggDiffFittingModel::loadWorkspaces(const std::string &filenamesString) {
                    std::back_inserter(workspaceNames),
                    [&](const std::pair<int, size_t> &runBankPair) {
                      return getFocusedWorkspace(runBankPair.first,
-                                                runBankPair.second)
-                         ->getName();
+                                                runBankPair.second)->getName();
                    });
     groupWorkspaces(workspaceNames, FOCUSED_WS_NAME);
   }

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.h
@@ -4,12 +4,10 @@
 #include "DllConfig.h"
 #include "IEnggDiffFittingModel.h"
 #include "IEnggDiffractionCalibration.h"
+#include "RunMap.h"
 
 #include <array>
 #include <unordered_map>
-
-template <size_t S, typename T>
-using RunMap = std::array<std::unordered_map<int, T>, S>;
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -85,8 +83,6 @@ private:
   RunMap<MAX_BANKS, Mantid::API::ITableWorkspace_sptr> m_fitParamsMap;
   RunMap<MAX_BANKS, Mantid::API::MatrixWorkspace_sptr> m_fittedPeaksMap;
   RunMap<MAX_BANKS, Mantid::API::MatrixWorkspace_sptr> m_alignedWorkspaceMap;
-
-  std::vector<int> getAllRunNumbers() const;
 
   std::string createFunctionString(
       const Mantid::API::ITableWorkspace_sptr fitFunctionParams,

--- a/qt/scientific_interfaces/EnggDiffraction/RunMap.h
+++ b/qt/scientific_interfaces/EnggDiffraction/RunMap.h
@@ -10,6 +10,14 @@ namespace CustomInterfaces {
 template <size_t NumBanks, typename T> class RunMap {
 
 public:
+  void add(const int runNumber, const size_t bank, const T itemToAdd) {
+    if (bank < 1 || bank > NumBanks) {
+      throw std::invalid_argument("Tried to access invalid bank: " +
+                                  std::to_string(bank));
+    }
+    m_map[bank - 1][runNumber] = itemToAdd;
+  }
+
   bool contains(const int runNumber, const size_t bank) const {
     return bank > 0 && bank <= NumBanks &&
            m_map[bank - 1].find(runNumber) != m_map[bank - 1].end();
@@ -26,14 +34,6 @@ public:
                                   std::to_string(bank));
     }
     return m_map[bank - 1].at(runNumber);
-  }
-
-  void add(const int runNumber, const size_t bank, const T itemToAdd) {
-    if (bank < 1 || bank > NumBanks) {
-      throw std::invalid_argument("Tried to access invalid bank: " +
-                                  std::to_string(bank));
-    }
-    m_map[bank - 1][runNumber] = itemToAdd;
   }
 
 private:

--- a/qt/scientific_interfaces/EnggDiffraction/RunMap.h
+++ b/qt/scientific_interfaces/EnggDiffraction/RunMap.h
@@ -21,6 +21,8 @@ public:
 
   std::vector<std::pair<int, size_t>> getRunNumbersAndBankIDs() const;
 
+  size_t size() const;
+
 private:
   std::vector<int> getAllRunNumbers() const;
 

--- a/qt/scientific_interfaces/EnggDiffraction/RunMap.h
+++ b/qt/scientific_interfaces/EnggDiffraction/RunMap.h
@@ -8,19 +8,34 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 
+/**
+Templated container class holding information relating to runs, indexed by
+run number and bank ID.
+*/
 template <size_t NumBanks, typename T> class RunMap {
 
 public:
+  /**
+   Add an item to the map
+   @param runNumber The run number associated with the item
+   @param bank The bank ID associated with the item
+   @param itemToAdd The item to add
+   */
   void add(const int runNumber, const size_t bank, const T itemToAdd);
 
+  /// Check whether the map contains an entry for this run number and bank ID
   bool contains(const int runNumber, const size_t bank) const;
 
+  /// Get the value stored at a given run number and bank ID
   const T &get(const int runNumber, const size_t bank) const;
 
+  /// Remove an item from the map
   void remove(const int runNumber, const size_t bank);
 
+  /// Get the associated run number and bank ID of every item stored in the map
   std::vector<std::pair<int, size_t>> getRunNumbersAndBankIDs() const;
 
+  /// Get the number of items stored in the map
   size_t size() const;
 
 private:

--- a/qt/scientific_interfaces/EnggDiffraction/RunMap.h
+++ b/qt/scientific_interfaces/EnggDiffraction/RunMap.h
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <unordered_map>
+#include <vector>
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -34,6 +35,14 @@ public:
                                   std::to_string(bank));
     }
     return m_map[bank - 1].at(runNumber);
+  }
+
+  void remove(const int runNumber, const size_t bank){
+    m_map[bank - 1].erase(runNumber);
+  }
+
+  std::vector<std::pair<int, size_t>> getRunNumbersAndBankIDs(){
+    throw std::runtime_error("Not yet implemented");
   }
 
 private:

--- a/qt/scientific_interfaces/EnggDiffraction/RunMap.h
+++ b/qt/scientific_interfaces/EnggDiffraction/RunMap.h
@@ -2,6 +2,7 @@
 #define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_RUNMAP_H_
 
 #include <array>
+#include <set>
 #include <unordered_map>
 #include <vector>
 
@@ -39,7 +40,7 @@ public:
   size_t size() const;
 
 private:
-  std::vector<int> getAllRunNumbers() const;
+  std::set<int> getAllRunNumbers() const;
 
   void validateBankID(const size_t bank) const;
 

--- a/qt/scientific_interfaces/EnggDiffraction/RunMap.h
+++ b/qt/scientific_interfaces/EnggDiffraction/RunMap.h
@@ -11,45 +11,25 @@ namespace CustomInterfaces {
 template <size_t NumBanks, typename T> class RunMap {
 
 public:
-  void add(const int runNumber, const size_t bank, const T itemToAdd) {
-    if (bank < 1 || bank > NumBanks) {
-      throw std::invalid_argument("Tried to access invalid bank: " +
-                                  std::to_string(bank));
-    }
-    m_map[bank - 1][runNumber] = itemToAdd;
-  }
+  void add(const int runNumber, const size_t bank, const T itemToAdd);
 
-  bool contains(const int runNumber, const size_t bank) const {
-    return bank > 0 && bank <= NumBanks &&
-           m_map[bank - 1].find(runNumber) != m_map[bank - 1].end();
-  }
+  bool contains(const int runNumber, const size_t bank) const;
 
-  const T &get(const int runNumber, const size_t bank) const {
-    if (bank < 1 || bank > NumBanks) {
-      throw std::invalid_argument("Tried to access invalid bank: " +
-                                  std::to_string(bank));
-    }
-    if (!contains(runNumber, bank)) {
-      throw std::invalid_argument("Tried to access invalid run number " +
-                                  std::to_string(runNumber) + " for bank " +
-                                  std::to_string(bank));
-    }
-    return m_map[bank - 1].at(runNumber);
-  }
+  const T &get(const int runNumber, const size_t bank) const;
 
-  void remove(const int runNumber, const size_t bank){
-    m_map[bank - 1].erase(runNumber);
-  }
+  void remove(const int runNumber, const size_t bank);
 
-  std::vector<std::pair<int, size_t>> getRunNumbersAndBankIDs(){
-    throw std::runtime_error("Not yet implemented");
-  }
+  std::vector<std::pair<int, size_t>> getRunNumbersAndBankIDs() const;
 
 private:
+  std::vector<int> getAllRunNumbers() const;
+
   std::array<std::unordered_map<int, T>, NumBanks> m_map;
 };
 
 } // CustomInterfaces
 } // MantidQt
+
+#include "RunMap.tpp"
 
 #endif

--- a/qt/scientific_interfaces/EnggDiffraction/RunMap.h
+++ b/qt/scientific_interfaces/EnggDiffraction/RunMap.h
@@ -41,6 +41,8 @@ public:
 private:
   std::vector<int> getAllRunNumbers() const;
 
+  void validateBankID(const size_t bank) const;
+
   std::array<std::unordered_map<int, T>, NumBanks> m_map;
 };
 

--- a/qt/scientific_interfaces/EnggDiffraction/RunMap.h
+++ b/qt/scientific_interfaces/EnggDiffraction/RunMap.h
@@ -1,0 +1,46 @@
+#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_RUNMAP_H_
+#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_RUNMAP_H_
+
+#include <array>
+#include <unordered_map>
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+template <size_t NumBanks, typename T> class RunMap {
+
+public:
+  bool contains(const int runNumber, const size_t bank) const {
+    return bank > 0 && bank <= NumBanks &&
+           m_map[bank - 1].find(runNumber) != m_map[bank - 1].end();
+  }
+
+  const T &get(const int runNumber, const size_t bank) const {
+    if (bank < 1 || bank > NumBanks) {
+      throw std::invalid_argument("Tried to access invalid bank: " +
+                                  std::to_string(bank));
+    }
+    if (!contains(runNumber, bank)) {
+      throw std::invalid_argument("Tried to access invalid run number " +
+                                  std::to_string(runNumber) + " for bank " +
+                                  std::to_string(bank));
+    }
+    return m_map[bank - 1].at(runNumber);
+  }
+
+  void add(const int runNumber, const size_t bank, const T itemToAdd) {
+    if (bank < 1 || bank > NumBanks) {
+      throw std::invalid_argument("Tried to access invalid bank: " +
+                                  std::to_string(bank));
+    }
+    m_map[bank - 1][runNumber] = itemToAdd;
+  }
+
+private:
+  std::array<std::unordered_map<int, T>, NumBanks> m_map;
+};
+
+} // CustomInterfaces
+} // MantidQt
+
+#endif

--- a/qt/scientific_interfaces/EnggDiffraction/RunMap.h
+++ b/qt/scientific_interfaces/EnggDiffraction/RunMap.h
@@ -22,7 +22,7 @@ public:
    @param bank The bank ID associated with the item
    @param itemToAdd The item to add
    */
-  void add(const int runNumber, const size_t bank, const T itemToAdd);
+  void add(const int runNumber, const size_t bank, const T &itemToAdd);
 
   /// Check whether the map contains an entry for this run number and bank ID
   bool contains(const int runNumber, const size_t bank) const;

--- a/qt/scientific_interfaces/EnggDiffraction/RunMap.tpp
+++ b/qt/scientific_interfaces/EnggDiffraction/RunMap.tpp
@@ -67,7 +67,7 @@ template <size_t NumBanks, typename T>
 std::vector<int> RunMap<NumBanks, T>::getAllRunNumbers() const {
   std::vector<int> runNumbers;
 
-  for (const auto &bank: m_map) {
+  for (const auto &bank : m_map) {
     for (const auto &runBankPair : bank) {
       const auto runNumber = runBankPair.first;
       if (std::find(runNumbers.begin(), runNumbers.end(), runNumber) ==
@@ -78,6 +78,16 @@ std::vector<int> RunMap<NumBanks, T>::getAllRunNumbers() const {
   }
 
   return runNumbers;
+}
+
+template <size_t NumBanks, typename T>
+size_t RunMap<NumBanks, T>::size() const {
+  size_t numElements = 0;
+
+  for (const auto &bank : m_map) {
+    numElements += bank.size();
+  }
+  return numElements;
 }
 
 } // CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/RunMap.tpp
+++ b/qt/scientific_interfaces/EnggDiffraction/RunMap.tpp
@@ -1,12 +1,5 @@
 #include <algorithm>
 
-namespace {
-
-template <typename T> void insertInOrder(const T &item, std::vector<T> &vec) {
-  vec.insert(std::upper_bound(vec.begin(), vec.end(), item), item);
-}
-}
-
 namespace MantidQt {
 namespace CustomInterfaces {
 
@@ -59,16 +52,13 @@ RunMap<NumBanks, T>::getRunNumbersAndBankIDs() const {
 }
 
 template <size_t NumBanks, typename T>
-std::vector<int> RunMap<NumBanks, T>::getAllRunNumbers() const {
-  std::vector<int> runNumbers;
+std::set<int> RunMap<NumBanks, T>::getAllRunNumbers() const {
+  std::set<int> runNumbers;
 
   for (const auto &bank : m_map) {
     for (const auto &runBankPair : bank) {
       const auto runNumber = runBankPair.first;
-      if (std::find(runNumbers.begin(), runNumbers.end(), runNumber) ==
-          runNumbers.end()) {
-        insertInOrder(runNumber, runNumbers);
-      }
+      runNumbers.insert(runNumber);
     }
   }
 

--- a/qt/scientific_interfaces/EnggDiffraction/RunMap.tpp
+++ b/qt/scientific_interfaces/EnggDiffraction/RunMap.tpp
@@ -13,10 +13,7 @@ namespace CustomInterfaces {
 template <size_t NumBanks, typename T>
 void RunMap<NumBanks, T>::add(const int runNumber, const size_t bank,
                               const T itemToAdd) {
-  if (bank < 1 || bank > NumBanks) {
-    throw std::invalid_argument("Tried to access invalid bank: " +
-                                std::to_string(bank));
-  }
+  validateBankID(bank);
   m_map[bank - 1][runNumber] = itemToAdd;
 }
 
@@ -30,10 +27,7 @@ bool RunMap<NumBanks, T>::contains(const int runNumber,
 template <size_t NumBanks, typename T>
 const T &RunMap<NumBanks, T>::get(const int runNumber,
                                   const size_t bank) const {
-  if (bank < 1 || bank > NumBanks) {
-    throw std::invalid_argument("Tried to access invalid bank: " +
-                                std::to_string(bank));
-  }
+  validateBankID(bank);
   if (!contains(runNumber, bank)) {
     throw std::invalid_argument("Tried to access invalid run number " +
                                 std::to_string(runNumber) + " for bank " +
@@ -44,6 +38,7 @@ const T &RunMap<NumBanks, T>::get(const int runNumber,
 
 template <size_t NumBanks, typename T>
 void RunMap<NumBanks, T>::remove(const int runNumber, const size_t bank) {
+  validateBankID(bank);
   m_map[bank - 1].erase(runNumber);
 }
 
@@ -88,6 +83,14 @@ size_t RunMap<NumBanks, T>::size() const {
     numElements += bank.size();
   }
   return numElements;
+}
+
+template <size_t NumBanks, typename T>
+void RunMap<NumBanks, T>::validateBankID(const size_t bank) const {
+  if (bank < 1 || bank > NumBanks) {
+    throw std::invalid_argument("Tried to access invalid bank: " +
+                                std::to_string(bank));
+  }
 }
 
 } // CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/RunMap.tpp
+++ b/qt/scientific_interfaces/EnggDiffraction/RunMap.tpp
@@ -1,0 +1,84 @@
+#include <algorithm>
+
+namespace {
+
+template <typename T> void insertInOrder(const T &item, std::vector<T> &vec) {
+  vec.insert(std::upper_bound(vec.begin(), vec.end(), item), item);
+}
+}
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+template <size_t NumBanks, typename T>
+void RunMap<NumBanks, T>::add(const int runNumber, const size_t bank,
+                              const T itemToAdd) {
+  if (bank < 1 || bank > NumBanks) {
+    throw std::invalid_argument("Tried to access invalid bank: " +
+                                std::to_string(bank));
+  }
+  m_map[bank - 1][runNumber] = itemToAdd;
+}
+
+template <size_t NumBanks, typename T>
+bool RunMap<NumBanks, T>::contains(const int runNumber,
+                                   const size_t bank) const {
+  return bank > 0 && bank <= NumBanks &&
+         m_map[bank - 1].find(runNumber) != m_map[bank - 1].end();
+}
+
+template <size_t NumBanks, typename T>
+const T &RunMap<NumBanks, T>::get(const int runNumber,
+                                  const size_t bank) const {
+  if (bank < 1 || bank > NumBanks) {
+    throw std::invalid_argument("Tried to access invalid bank: " +
+                                std::to_string(bank));
+  }
+  if (!contains(runNumber, bank)) {
+    throw std::invalid_argument("Tried to access invalid run number " +
+                                std::to_string(runNumber) + " for bank " +
+                                std::to_string(bank));
+  }
+  return m_map[bank - 1].at(runNumber);
+}
+
+template <size_t NumBanks, typename T>
+void RunMap<NumBanks, T>::remove(const int runNumber, const size_t bank) {
+  m_map[bank - 1].erase(runNumber);
+}
+
+template <size_t NumBanks, typename T>
+std::vector<std::pair<int, size_t>>
+RunMap<NumBanks, T>::getRunNumbersAndBankIDs() const {
+  std::vector<std::pair<int, size_t>> pairs;
+
+  const auto runNumbers = getAllRunNumbers();
+  for (const auto runNumber : runNumbers) {
+    for (size_t i = 0; i < NumBanks; ++i) {
+      if (m_map[i].find(runNumber) != m_map[i].end()) {
+        pairs.push_back(std::pair<int, size_t>(runNumber, i + 1));
+      }
+    }
+  }
+  return pairs;
+}
+
+template <size_t NumBanks, typename T>
+std::vector<int> RunMap<NumBanks, T>::getAllRunNumbers() const {
+  std::vector<int> runNumbers;
+
+  for (const auto &bank: m_map) {
+    for (const auto &runBankPair : bank) {
+      const auto runNumber = runBankPair.first;
+      if (std::find(runNumbers.begin(), runNumbers.end(), runNumber) ==
+          runNumbers.end()) {
+        insertInOrder(runNumber, runNumbers);
+      }
+    }
+  }
+
+  return runNumbers;
+}
+
+} // CustomInterfaces
+} // MantidQt

--- a/qt/scientific_interfaces/EnggDiffraction/RunMap.tpp
+++ b/qt/scientific_interfaces/EnggDiffraction/RunMap.tpp
@@ -5,7 +5,7 @@ namespace CustomInterfaces {
 
 template <size_t NumBanks, typename T>
 void RunMap<NumBanks, T>::add(const int runNumber, const size_t bank,
-                              const T itemToAdd) {
+                              const T &itemToAdd) {
   validateBankID(bank);
   m_map[bank - 1][runNumber] = itemToAdd;
 }

--- a/qt/scientific_interfaces/test/RunMapTest.h
+++ b/qt/scientific_interfaces/test/RunMapTest.h
@@ -54,7 +54,7 @@ public:
     TS_ASSERT_EQUALS(runBankPairs.size(), 4);
     for (int i = 0; i < 4; ++i) {
       TS_ASSERT_EQUALS(runBankPairs[i],
-                       std::make_pair((i + 1) * 111, size_t((i + 1) % 3)));
+                       std::make_pair((i + 1) * 111, size_t(i % 3 + 1)));
     }
   }
 };

--- a/qt/scientific_interfaces/test/RunMapTest.h
+++ b/qt/scientific_interfaces/test/RunMapTest.h
@@ -38,6 +38,8 @@ public:
 
     TS_ASSERT_THROWS_NOTHING(runMap.remove(123, 1));
     TS_ASSERT(!runMap.contains(123, 1));
+
+    TS_ASSERT_THROWS(runMap.remove(123, 4), std::invalid_argument);
   }
 
   void test_getRunNumbersAndBankIDs() {

--- a/qt/scientific_interfaces/test/RunMapTest.h
+++ b/qt/scientific_interfaces/test/RunMapTest.h
@@ -41,17 +41,20 @@ public:
   }
 
   void test_getRunNumbersAndBankIDs() {
+    RunMap<3, std::string> runMap;
+
     runMap.add(111, 1, "Polly");
     runMap.add(222, 2, "Morphism");
     runMap.add(333, 3, "Al");
     runMap.add(444, 1, "Gorithm");
 
-    const auto runBankPairs = runMap.getRunNumbersAndBankIDs();
+    std::vector<std::pair<int, size_t>> runBankPairs;
+    TS_ASSERT_THROWS_NOTHING(runBankPairs = runMap.getRunNumbersAndBankIDs());
 
     TS_ASSERT_EQUALS(runBankPairs.size(), 4);
     for (int i = 0; i < 4; ++i) {
       TS_ASSERT_EQUALS(runBankPairs[i],
-                       std::make_pair((i + 1) * 111, (i + 1) % 3));
+                       std::make_pair((i + 1) * 111, size_t((i + 1) % 3)));
     }
   }
 };

--- a/qt/scientific_interfaces/test/RunMapTest.h
+++ b/qt/scientific_interfaces/test/RunMapTest.h
@@ -57,6 +57,19 @@ public:
                        std::make_pair((i + 1) * 111, size_t(i % 3 + 1)));
     }
   }
+
+  void test_size() {
+    RunMap<3, std::string> runMap;
+    TS_ASSERT_EQUALS(runMap.size(), 0);
+
+    runMap.add(111, 1, "Polly");
+    runMap.add(222, 2, "Morphism");
+    TS_ASSERT_EQUALS(runMap.size(), 2);
+
+    runMap.add(333, 3, "Al");
+    runMap.add(444, 1, "Gorithm");
+    TS_ASSERT_EQUALS(runMap.size(), 4);
+  }
 };
 
 #endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_RUNMAPTEST_H_

--- a/qt/scientific_interfaces/test/RunMapTest.h
+++ b/qt/scientific_interfaces/test/RunMapTest.h
@@ -1,0 +1,36 @@
+#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_RUNMAPTEST_H_
+#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_RUNMAPTEST_H_
+
+#include "../EnggDiffraction/RunMap.h"
+
+#include <cxxtest/TestSuite.h>
+
+using namespace MantidQt::CustomInterfaces;
+
+class RunMapTest: public CxxTest::TestSuite{
+
+public :
+  void test_addedItemsExistInMap(){
+    RunMap<3, std::string> runMap;
+    TS_ASSERT_THROWS_NOTHING(runMap.add(123, 1, "Polly"));
+    TS_ASSERT_THROWS_NOTHING(runMap.add(456, 2, "Morphism"));
+    TS_ASSERT_THROWS(runMap.add(789, 4, "Al"), std::invalid_argument);
+
+    TS_ASSERT(runMap.contains(123, 1));
+    TS_ASSERT(runMap.contains(456, 2));
+    TS_ASSERT(!runMap.contains(789, 4));
+  }
+  
+  void test_addedItemsAreCorrect(){
+    RunMap<3, std::string> runMap;
+    TS_ASSERT_THROWS_NOTHING(runMap.add(123, 1, "Polly"));
+    TS_ASSERT_THROWS_NOTHING(runMap.add(456, 2, "Morphism"));
+
+    TS_ASSERT_EQUALS(runMap.get(123, 1), "Polly");
+    TS_ASSERT_EQUALS(runMap.get(456, 2), "Morphism");
+    
+  }
+  
+};
+
+#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_RUNMAPTEST_H_

--- a/qt/scientific_interfaces/test/RunMapTest.h
+++ b/qt/scientific_interfaces/test/RunMapTest.h
@@ -7,10 +7,10 @@
 
 using namespace MantidQt::CustomInterfaces;
 
-class RunMapTest: public CxxTest::TestSuite{
+class RunMapTest : public CxxTest::TestSuite {
 
-public :
-  void test_addedItemsExistInMap(){
+public:
+  void test_addedItemsExistInMap() {
     RunMap<3, std::string> runMap;
     TS_ASSERT_THROWS_NOTHING(runMap.add(123, 1, "Polly"));
     TS_ASSERT_THROWS_NOTHING(runMap.add(456, 2, "Morphism"));
@@ -20,17 +20,40 @@ public :
     TS_ASSERT(runMap.contains(456, 2));
     TS_ASSERT(!runMap.contains(789, 4));
   }
-  
-  void test_addedItemsAreCorrect(){
+
+  void test_addedItemsAreCorrect() {
     RunMap<3, std::string> runMap;
-    TS_ASSERT_THROWS_NOTHING(runMap.add(123, 1, "Polly"));
-    TS_ASSERT_THROWS_NOTHING(runMap.add(456, 2, "Morphism"));
+    runMap.add(123, 1, "Polly");
+    runMap.add(456, 2, "Morphism");
 
     TS_ASSERT_EQUALS(runMap.get(123, 1), "Polly");
     TS_ASSERT_EQUALS(runMap.get(456, 2), "Morphism");
-    
   }
-  
+
+  void test_remove() {
+    RunMap<3, std::string> runMap;
+
+    runMap.add(123, 1, "Polly");
+    TS_ASSERT(runMap.contains(123, 1));
+
+    TS_ASSERT_THROWS_NOTHING(runMap.remove(123, 1));
+    TS_ASSERT(!runMap.contains(123, 1));
+  }
+
+  void test_getRunNumbersAndBankIDs() {
+    runMap.add(111, 1, "Polly");
+    runMap.add(222, 2, "Morphism");
+    runMap.add(333, 3, "Al");
+    runMap.add(444, 1, "Gorithm");
+
+    const auto runBankPairs = runMap.getRunNumbersAndBankIDs();
+
+    TS_ASSERT_EQUALS(runBankPairs.size(), 4);
+    for (int i = 0; i < 4; ++i) {
+      TS_ASSERT_EQUALS(runBankPairs[i],
+                       std::make_pair((i + 1) * 111, (i + 1) % 3));
+    }
+  }
 };
 
 #endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_RUNMAPTEST_H_


### PR DESCRIPTION
The typedef `RunMap`, basically just a container used to index run data by run number and bank ID, was previously only used in `EnggDiffFittingModel`. However it will also be useful for the GSAS fitting tab as well, so it was extracted out into its own class.

**To test:**

Code review, make sure unit tests for `RunMap` and `EnggDiffFittingModel` still pass locally and remotely.

Fixes #21565 

**Release Notes** 
The change is internal, so doesn't need to be in the release notes

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
