### PR TITLE
Change doctests to use legacy numpy printing for numpy >=1.14

### DIFF
--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -98,6 +98,13 @@ try:
     del unicode_literals
 except NameError:
     pass
+
+# Use legacy numpy printing. This fix is made to keep doctests functional.
+# TODO: remove this workaround once minimal required numpy is set to 1.14.0
+import numpy as np
+
+if np.version.full_version >= '1.14.0':
+    np.set_printoptions(legacy='1.13')
 """.format(mantid_config_reset)
 
 # Run this after each test group has executed


### PR DESCRIPTION
numpy `1.14.0` had [**"Major improvements to printing of NumPy arrays and scalars."**](https://numpy.org/doc/stable/release/1.14.0-notes.html#many-changes-to-array-printing-disableable-with-the-new-legacy-printing-mode) which causes many of our [doctests to fail](http://builds.mantidproject.org/job/master_clean-archlinux/1073/testReport/).


**To test:**
Code review?

Does not need to be in the release notes. Internal change only.


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
