### PR TITLE
New polarization correction algorithm for reflectometers

### DIFF
--- a/Framework/Algorithms/CMakeLists.txt
+++ b/Framework/Algorithms/CMakeLists.txt
@@ -220,6 +220,7 @@ set ( SRC_FILES
 	src/PointByPointVCorrection.cpp
 	src/PoissonErrors.cpp
 	src/PolarizationCorrection.cpp
+	src/PolarizationEfficiencyCor.cpp
 	src/PolynomialCorrection.cpp
 	src/Power.cpp
 	src/PowerLawCorrection.cpp
@@ -556,6 +557,7 @@ set ( INC_FILES
 	inc/MantidAlgorithms/PointByPointVCorrection.h
 	inc/MantidAlgorithms/PoissonErrors.h
 	inc/MantidAlgorithms/PolarizationCorrection.h
+	inc/MantidAlgorithms/PolarizationEfficiencyCor.h
 	inc/MantidAlgorithms/PolynomialCorrection.h
 	inc/MantidAlgorithms/Power.h
 	inc/MantidAlgorithms/PowerLawCorrection.h
@@ -894,6 +896,7 @@ set ( TEST_FILES
 	PointByPointVCorrectionTest.h
 	PoissonErrorsTest.h
 	PolarizationCorrectionTest.h
+	PolarizationEfficiencyCorTest.h
 	PolynomialCorrectionTest.h
 	PowerLawCorrectionTest.h
 	PowerTest.h

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationEfficiencyCor.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationEfficiencyCor.h
@@ -64,13 +64,19 @@ private:
   void exec() override;
   std::map<std::string, std::string> validateInputs() override;
   void checkConsistentNumberHistograms(const WorkspaceMap &inputs);
-  void checkConsistentX(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
+  void checkConsistentX(const WorkspaceMap &inputs,
+                        const EfficiencyMap &efficiencies);
   EfficiencyMap efficiencyFactors();
-  WorkspaceMap directBeamCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
-  WorkspaceMap analyzerlessCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
-  WorkspaceMap twoInputCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
-  WorkspaceMap threeInputCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
-  WorkspaceMap fullCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
+  WorkspaceMap directBeamCorrections(const WorkspaceMap &inputs,
+                                     const EfficiencyMap &efficiencies);
+  WorkspaceMap analyzerlessCorrections(const WorkspaceMap &inputs,
+                                       const EfficiencyMap &efficiencies);
+  WorkspaceMap twoInputCorrections(const WorkspaceMap &inputs,
+                                   const EfficiencyMap &efficiencies);
+  WorkspaceMap threeInputCorrections(const WorkspaceMap &inputs,
+                                     const EfficiencyMap &efficiencies);
+  WorkspaceMap fullCorrections(const WorkspaceMap &inputs,
+                               const EfficiencyMap &efficiencies);
   API::WorkspaceGroup_sptr groupOutput(const WorkspaceMap &outputs);
   WorkspaceMap mapInputsToDirections(const std::vector<std::string> &flippers);
   void solve01(WorkspaceMap &inputs, const EfficiencyMap &efficiencies);

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationEfficiencyCor.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationEfficiencyCor.h
@@ -61,9 +61,12 @@ private:
   void init() override;
   void exec() override;
   EfficiencyMap efficiencyFactors();
-  WorkspaceMap fullCorrections(const WorkspaceMap &inputs);
-  API::WorkspaceGroup_sptr groupOutput(WorkspaceMap &outputs);
+  WorkspaceMap threeInputCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
+  WorkspaceMap fullCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
+  API::WorkspaceGroup_sptr groupOutput(const WorkspaceMap &outputs);
   WorkspaceMap mapInputsToDirections();
+  void solve01(WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
+  void solve10(WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationEfficiencyCor.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationEfficiencyCor.h
@@ -43,6 +43,7 @@ public:
   const std::string summary() const override;
 
 private:
+  /// A convenience set of workspaces corresponding flipper configurations.
   struct WorkspaceMap {
     API::MatrixWorkspace_sptr mmWS{nullptr};
     API::MatrixWorkspace_sptr mpWS{nullptr};
@@ -51,6 +52,7 @@ private:
     size_t size() const noexcept;
   };
 
+  /// A convenience set of efficiency factors.
   struct EfficiencyMap {
     const API::ISpectrum *P1{nullptr};
     const API::ISpectrum *P2{nullptr};

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationEfficiencyCor.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationEfficiencyCor.h
@@ -61,6 +61,7 @@ private:
   void init() override;
   void exec() override;
   EfficiencyMap efficiencyFactors();
+  WorkspaceMap analyzerlessCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
   WorkspaceMap threeInputCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
   WorkspaceMap fullCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
   API::WorkspaceGroup_sptr groupOutput(const WorkspaceMap &outputs);

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationEfficiencyCor.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationEfficiencyCor.h
@@ -63,6 +63,7 @@ private:
   EfficiencyMap efficiencyFactors();
   WorkspaceMap directBeamCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
   WorkspaceMap analyzerlessCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
+  WorkspaceMap twoInputCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
   WorkspaceMap threeInputCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
   WorkspaceMap fullCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
   API::WorkspaceGroup_sptr groupOutput(const WorkspaceMap &outputs);

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationEfficiencyCor.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationEfficiencyCor.h
@@ -1,0 +1,72 @@
+#ifndef MANTID_ALGORITHMS_POLARIZATIONEFFICIENCYCOR_H_
+#define MANTID_ALGORITHMS_POLARIZATIONEFFICIENCYCOR_H_
+
+#include "MantidAlgorithms/DllConfig.h"
+#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/WorkspaceGroup_fwd.h"
+
+namespace Mantid {
+namespace HistogramData {
+class HistogramY;
+}
+
+namespace Algorithms {
+
+/** PolarizationEfficiencyCor : TODO: DESCRIPTION
+
+  Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class MANTID_ALGORITHMS_DLL PolarizationEfficiencyCor : public API::Algorithm {
+public:
+  const std::string name() const override;
+  int version() const override;
+  const std::string category() const override;
+  const std::string summary() const override;
+
+private:
+  struct WorkspaceMap {
+    API::MatrixWorkspace_sptr mmWS{nullptr};
+    API::MatrixWorkspace_sptr mpWS{nullptr};
+    API::MatrixWorkspace_sptr pmWS{nullptr};
+    API::MatrixWorkspace_sptr ppWS{nullptr};
+    size_t size() const noexcept;
+  };
+
+  struct EfficiencyMap {
+    const HistogramData::HistogramY *P1{nullptr};
+    const HistogramData::HistogramY *P2{nullptr};
+    const HistogramData::HistogramY *F1{nullptr};
+    const HistogramData::HistogramY *F2{nullptr};
+  };
+
+  void init() override;
+  void exec() override;
+  EfficiencyMap efficiencyFactors();
+  WorkspaceMap fullCorrections(const WorkspaceMap &inputs);
+  API::WorkspaceGroup_sptr groupOutput(WorkspaceMap &outputs);
+  WorkspaceMap mapInputsToDirections();
+};
+
+} // namespace Algorithms
+} // namespace Mantid
+
+#endif /* MANTID_ALGORITHMS_POLARIZATIONEFFICIENCYCOR_H_ */

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationEfficiencyCor.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationEfficiencyCor.h
@@ -82,9 +82,13 @@ private:
                                const EfficiencyMap &efficiencies);
   API::WorkspaceGroup_sptr groupOutput(const WorkspaceMap &outputs);
   WorkspaceMap mapInputsToDirections(const std::vector<std::string> &flippers);
-  void threeInputsSolve01(WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
-  void threeInputsSolve10(WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
-  void twoInputsSolve01And10(WorkspaceMap &fullInputs, const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
+  void threeInputsSolve01(WorkspaceMap &inputs,
+                          const EfficiencyMap &efficiencies);
+  void threeInputsSolve10(WorkspaceMap &inputs,
+                          const EfficiencyMap &efficiencies);
+  void twoInputsSolve01And10(WorkspaceMap &fullInputs,
+                             const WorkspaceMap &inputs,
+                             const EfficiencyMap &efficiencies);
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationEfficiencyCor.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationEfficiencyCor.h
@@ -6,8 +6,8 @@
 #include "MantidAPI/WorkspaceGroup_fwd.h"
 
 namespace Mantid {
-namespace HistogramData {
-class HistogramY;
+namespace API {
+class ISpectrum;
 }
 
 namespace Algorithms {
@@ -52,10 +52,10 @@ private:
   };
 
   struct EfficiencyMap {
-    const HistogramData::HistogramY *P1{nullptr};
-    const HistogramData::HistogramY *P2{nullptr};
-    const HistogramData::HistogramY *F1{nullptr};
-    const HistogramData::HistogramY *F2{nullptr};
+    const API::ISpectrum *P1{nullptr};
+    const API::ISpectrum *P2{nullptr};
+    const API::ISpectrum *F1{nullptr};
+    const API::ISpectrum *F2{nullptr};
   };
 
   void init() override;

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationEfficiencyCor.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationEfficiencyCor.h
@@ -60,6 +60,9 @@ private:
 
   void init() override;
   void exec() override;
+  std::map<std::string, std::string> validateInputs() override;
+  void checkConsistentNumberHistograms(const WorkspaceMap &inputs);
+  void checkConsistentX(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
   EfficiencyMap efficiencyFactors();
   WorkspaceMap directBeamCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
   WorkspaceMap analyzerlessCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationEfficiencyCor.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationEfficiencyCor.h
@@ -70,7 +70,7 @@ private:
   WorkspaceMap threeInputCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
   WorkspaceMap fullCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
   API::WorkspaceGroup_sptr groupOutput(const WorkspaceMap &outputs);
-  WorkspaceMap mapInputsToDirections();
+  WorkspaceMap mapInputsToDirections(const std::vector<std::string> &flippers);
   void solve01(WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
   void solve10(WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
 };

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationEfficiencyCor.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationEfficiencyCor.h
@@ -12,9 +12,12 @@ class ISpectrum;
 
 namespace Algorithms {
 
-/** PolarizationEfficiencyCor : TODO: DESCRIPTION
+/** PolarizationEfficiencyCor : This algorithm corrects for non-ideal
+  component efficiencies in polarized neutron analysis. It is based on
+  [A. R. Wildes (2006) Neutron News, 17:2, 17-25,
+  DOI: 10.1080/10448630600668738]
 
-  Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
   National Laboratory & European Spallation Source
 
   This file is part of Mantid.

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationEfficiencyCor.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationEfficiencyCor.h
@@ -61,6 +61,7 @@ private:
   void init() override;
   void exec() override;
   EfficiencyMap efficiencyFactors();
+  WorkspaceMap directBeamCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
   WorkspaceMap analyzerlessCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
   WorkspaceMap threeInputCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
   WorkspaceMap fullCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationEfficiencyCor.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationEfficiencyCor.h
@@ -82,8 +82,9 @@ private:
                                const EfficiencyMap &efficiencies);
   API::WorkspaceGroup_sptr groupOutput(const WorkspaceMap &outputs);
   WorkspaceMap mapInputsToDirections(const std::vector<std::string> &flippers);
-  void solve01(WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
-  void solve10(WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
+  void threeInputsSolve01(WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
+  void threeInputsSolve10(WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
+  void twoInputsSolve01And10(WorkspaceMap &fullInputs, const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
@@ -191,7 +191,7 @@ PolarizationEfficiencyCor::WorkspaceMap PolarizationEfficiencyCor::analyzerlessC
     const auto &mmY = inputs.mmWS->y(wsIndex);
     const auto &mmE = inputs.mmWS->e(wsIndex);
     const auto &ppY = inputs.ppWS->y(wsIndex);
-    const auto &ppE = inputs.ppWS->y(wsIndex);
+    const auto &ppE = inputs.ppWS->e(wsIndex);
     auto &mmYOut = outputs.mmWS->mutableY(wsIndex);
     auto &mmEOut = outputs.mmWS->mutableE(wsIndex);
     auto &ppYOut = outputs.ppWS->mutableY(wsIndex);

--- a/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
@@ -351,8 +351,8 @@ PolarizationEfficiencyCor::WorkspaceMap PolarizationEfficiencyCor::analyzerlessC
       P1Em <<  elemE2, -elemE2,
               -elemE2,  elemE2;
       const Eigen::Vector2d errors(ppE[binIndex], mmE[binIndex]);
-      const auto e1 = (F1Em * P1m * intensities).array();
-      const auto e2 = (F1m * P1Em * intensities).array();
+      const auto e1 = (P1Em * F1m * intensities).array();
+      const auto e2 = (P1m * F1Em * intensities).array();
       const auto sqPFProduct = (PFProduct.array() * PFProduct.array()).matrix();
       const auto sqErrors = (errors.array() * errors.array()).matrix();
       const auto e3 = (sqPFProduct * sqErrors).array();

--- a/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
@@ -352,9 +352,9 @@ PolarizationEfficiencyCor::WorkspaceMap PolarizationEfficiencyCor::twoInputCorre
 PolarizationEfficiencyCor::WorkspaceMap PolarizationEfficiencyCor::threeInputCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies) {
   WorkspaceMap fullInputs = inputs;
   if (!inputs.mpWS) {
-    solve01(fullInputs, efficiencies);
-  } else {
     solve10(fullInputs, efficiencies);
+  } else {
+    solve01(fullInputs, efficiencies);
   }
   return fullCorrections(fullInputs, efficiencies);
 }

--- a/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
@@ -52,7 +52,7 @@ const std::string PolarizationEfficiencyCor::summary() const {
 }
 
 size_t PolarizationEfficiencyCor::WorkspaceMap::size() const noexcept {
-  return mmWS ? 1 : 0 + mpWS ? 1 : 0 + pmWS ? 1 : 0 + ppWS ? 1 : 0;
+  return (mmWS ? 1 : 0) + (mpWS ? 1 : 0) + (pmWS ? 1 : 0) + (ppWS ? 1 : 0);
 }
 
 //----------------------------------------------------------------------------------------------
@@ -65,7 +65,7 @@ void PolarizationEfficiencyCor::init() {
       "A group of workspaces to be corrected.");
   const std::vector<std::string> defaultFlippers{{Flippers::OffOff, Flippers::OffOn, Flippers::OnOff, Flippers::OnOn}};
   declareProperty(
-      Kernel::make_unique<Kernel::ArrayProperty<std::string>>(Prop::FLIPPERS, defaultFlippers, boost::make_shared<Kernel::ArrayLengthValidator<double>>(2, 4)),
+      Kernel::make_unique<Kernel::ArrayProperty<std::string>>(Prop::FLIPPERS, defaultFlippers, boost::make_shared<Kernel::ArrayLengthValidator<std::string>>(2, 4)),
         "A list of flipper configurations (accepted values: 00, 01, 10 and 11) corresponding to each input workspace.");
   declareProperty(
       Kernel::make_unique<API::WorkspaceProperty<API::WorkspaceGroup>>(Prop::OUTPUT_WS, "",

--- a/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
@@ -971,6 +971,7 @@ void PolarizationEfficiencyCor::threeInputsSolve10(
 /**
  * Solve in-place the 01 and 10 flipper configurations from the assumption that
  * for the corrected intensities R01 = R10 = 0.
+ * @param fullInputs a set of output workspaces
  * @param inputs a set of input workspaces
  * @param efficiencies a set of efficiency factors
  */

--- a/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
@@ -173,7 +173,7 @@ PolarizationEfficiencyCor::WorkspaceMap PolarizationEfficiencyCor::directBeamCor
       const auto P2E = efficiencies.P2->e()[binIndex];
       const auto e1 = pow<2>(P1E * (2. * P1 - 1.) / pow<2>(f) * ppY[binIndex]);
       const auto e2 = pow<2>(P2E * (2. * P2 - 1.) / pow<2>(f) * ppY[binIndex]);
-      const auto e3 = ppE[binIndex] / pow<2>(f);
+      const auto e3 = pow<2>(ppE[binIndex] / f);
       const auto errorSum = std::sqrt(e1 + e2 + e3);
       ppEOut[binIndex] = errorSum;
     }

--- a/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
@@ -224,9 +224,8 @@ double twoInputsErrorEstimate01(const double i00, const double e00,
                    ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)))) +
       (f2 * i11 * p1 * (1. - 2. * p2) +
        f2 * i11 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) -
-       2. * f1 * i00 *
-           (-f2 * pow<2>(1. - 2. * p2) + pow<2>(f2) * pow<2>(1. - 2. * p2) +
-            (-1. + p2) * p2)) /
+       2. * f1 * i00 * (-f2 * pow<2>(1. - 2. * p2) +
+                        pow<2>(f2) * pow<2>(1. - 2. * p2) + (-1. + p2) * p2)) /
           (f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
            f1 * (-1. + 2. * p1) *
                ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)));
@@ -236,9 +235,8 @@ double twoInputsErrorEstimate01(const double i00, const double e00,
               (-f2 * pow<2>(1. - 2. * p2) + pow<2>(f2) * pow<2>(1. - 2. * p2) +
                (-1. + p2) * p2)) *
          (f2 * (2. - 2. * p1) * p1 +
-          f1 * (-1. + 2. * p1) *
-              (1. - 2. * p2 + 2. * f2 * (-1. + p1 + p2) +
-               f2 * (-1. + 2. * p2)))) /
+          f1 * (-1. + 2. * p1) * (1. - 2. * p2 + 2. * f2 * (-1. + p1 + p2) +
+                                  f2 * (-1. + 2. * p2)))) /
         pow<2>(f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
                f1 * (-1. + 2. * p1) *
                    ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)))) +
@@ -539,19 +537,19 @@ void PolarizationEfficiencyCor::checkConsistentX(
   // Compare everything to F1 efficiency.
   const auto &F1x = efficiencies.F1->x();
   // A local helper function to check a HistogramX against F1.
-  auto checkX = [&F1x](const HistogramData::HistogramX &x,
-                       const std::string &tag) {
-    if (x.size() != F1x.size()) {
-      throw std::runtime_error("Mismatch of histogram lengths between F1 and " +
-                               tag + '.');
-    }
-    for (size_t i = 0; i != x.size(); ++i) {
-      if (x[i] != F1x[i]) {
-        throw std::runtime_error("Mismatch of X data between F1 and " + tag +
-                                 '.');
-      }
-    }
-  };
+  auto checkX =
+      [&F1x](const HistogramData::HistogramX &x, const std::string &tag) {
+        if (x.size() != F1x.size()) {
+          throw std::runtime_error(
+              "Mismatch of histogram lengths between F1 and " + tag + '.');
+        }
+        for (size_t i = 0; i != x.size(); ++i) {
+          if (x[i] != F1x[i]) {
+            throw std::runtime_error("Mismatch of X data between F1 and " +
+                                     tag + '.');
+          }
+        }
+      };
   const auto &F2x = efficiencies.F2->x();
   checkX(F2x, "F2");
   const auto &P1x = efficiencies.P1->x();

--- a/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
@@ -446,11 +446,17 @@ PolarizationEfficiencyCor::WorkspaceMap PolarizationEfficiencyCor::twoInputCorre
       // Derivatives of the above with respect to i00, i11, f1, etc.
       const auto mpdi00 = (-pow<2>(f1) * f2 * pow<2>(b) * c + f1 * f2 * pow<2>(b) * c + f2 * p1 * a) / (f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c));
       const auto mpdi11 = -((f1 * b * d * p2) / (f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c)));
-      const auto mpdf1 = (f2 * i11 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) -
-         f1 * i00 * (-1. + 2. * p1) * (-f2 * pow<2>(1. - 2. * p2) +
-            pow<2>(f2) * pow<2>(1. - 2. * p2) + (-1. + p2) * p2)) / (f2 * p1 * (-1. + p1 + 2. * p2 -
-            2. * p1 * p2) +
-         f1 * (-1. + 2. * p1) * (-(-1 + p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)));
+      const auto mpdf1 = -(((-1. + 2. * p1) * ((1. - p2) * p2 +
+                                         f2 * (-1. + p1 + p2) * (-1. + 2. * p2)) * (-pow<2>(f1) * f2 * i00 * pow<2>(1. - 2. * p1) * (-1. + 2. * p2) +
+                                         f2 * i00 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
+                                         f1 * (-1. + 2. * p1) * (-i11 * (-1. + p2) * p2 +
+                                            f2 * i00 * (-1. + 2. * p1) * (-1. + 2. * p2)))) / pow<2>(f2 * p1 * (-1. + p1 + 2. * p2 -
+                                          2. * p1 * p2) +
+                                       f1 * (-1. + 2. * p1) * ((1. - p2) * p2 +
+                                          f2 * (-1. + p1 + p2) * (-1. + 2. * p2)))) + (-2. * f1 * f2 * i00 * pow<2>(1. - 2. * p1) * (-1. + 2. * p2) + (-1. + 2. * p1) * (-i11 * (-1. + p2) * p2 +
+                                        f2 * i00 * (-1. + 2. * p1) * (-1. + 2. * p2))) / (f2 * p1 * (-1. + p1 + 2. * p2 -
+                                        2. * p1 * p2) +
+                                     f1 * (-1. + 2. * p1) * ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)));
       const auto mpdf2 = -(((f1 * b * (p1 + d) * c + p1 * a) * (-pow<2>(f1) * f2 * i00 * pow<2>(b) * c + f2 * i00 * p1 * a + f1 * b * (-i11 * d * p2 + f2 * i00 * b * c))) /
                          pow<2>(f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c))) +
           (-pow<2>(f1) * i00 * pow<2>(b) * c + f1 * i00 * pow<2>(b) * c + i00 * p1 * a) /

--- a/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
@@ -94,7 +94,7 @@ void PolarizationEfficiencyCor::init() {
   declareProperty(
       Kernel::make_unique<Kernel::ArrayProperty<std::string>>(Prop::INPUT_WS, "", boost::make_shared<API::ADSValidator>(),
                                                              Kernel::Direction::Input),
-      "A list of workspaces corresponding to the flipper configurations to be corrected.");
+      "A list of workspaces to be corrected corresponding to the flipper configurations.");
   declareProperty(
       Kernel::make_unique<API::WorkspaceProperty<API::WorkspaceGroup>>(Prop::OUTPUT_WS, "",
                                                              Kernel::Direction::Output),

--- a/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
@@ -10,8 +10,8 @@
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/StringTokenizer.h"
 
-#include <boost/math/special_functions/pow.hpp>
 #include <Eigen/Dense>
+#include <boost/math/special_functions/pow.hpp>
 
 namespace {
 /// Property names.
@@ -20,7 +20,7 @@ static const std::string FLIPPERS{"Flippers"};
 static const std::string EFFICIENCIES{"Efficiencies"};
 static const std::string INPUT_WS{"InputWorkspaces"};
 static const std::string OUTPUT_WS{"OutputWorkspace"};
-}
+} // namespace Prop
 
 /// Flipper configurations.
 namespace Flippers {
@@ -30,7 +30,7 @@ static const std::string OffOn{"01"};
 static const std::string On{"1"};
 static const std::string OnOff{"10"};
 static const std::string OnOn{"11"};
-}
+} // namespace Flippers
 
 /**
  * Parse a flipper configuration string.
@@ -77,7 +77,12 @@ void checkInputExists(const Mantid::API::MatrixWorkspace_sptr &ws,
  * @param p2 analyzer flipper efficiency
  * @param p2E error of p2
  */
-void fourInputsCorrectedAndErrors(Eigen::Vector4d &corrected, Eigen::Vector4d &errors, const double ppy, const double ppyE, const double pmy, const double pmyE, const double mpy, const double mpyE, const double mmy, const double mmyE, const double f1, const double f1E, const double f2, const double f2E, const double p1, const double p1E, const double p2, const double p2E) {
+void fourInputsCorrectedAndErrors(
+    Eigen::Vector4d &corrected, Eigen::Vector4d &errors, const double ppy,
+    const double ppyE, const double pmy, const double pmyE, const double mpy,
+    const double mpyE, const double mmy, const double mmyE, const double f1,
+    const double f1E, const double f2, const double f2E, const double p1,
+    const double p1E, const double p2, const double p2E) {
   using namespace boost::math;
   // Note that f1 and f2 correspond to 1-F1 and 1-F2 in [Wildes, 1999].
   // These are inverted forms of the efficiency matrices.
@@ -94,13 +99,13 @@ void fourInputsCorrectedAndErrors(Eigen::Vector4d &corrected, Eigen::Vector4d &e
   const auto diag3 = (p1 - 1.) / (2. * p1 - 1.);
   const auto off3 = p1 / (2. * p1 - 1);
   Eigen::Matrix4d P1m;
-  P1m << diag3, 0, off3, 0, 0, diag3, 0, off3, off3, 0, diag3, 0, 0, off3,
-      0, diag3;
+  P1m << diag3, 0, off3, 0, 0, diag3, 0, off3, off3, 0, diag3, 0, 0, off3, 0,
+      diag3;
   const auto diag4 = (p2 - 1.) / (2. * p2 - 1.);
   const auto off4 = p2 / (2. * p2 - 1.);
   Eigen::Matrix4d P2m;
-  P2m << diag4, off4, 0., 0., off4, diag4, 0., 0., 0., 0., diag4, off4, 0.,
-      0., off4, diag4;
+  P2m << diag4, off4, 0., 0., off4, diag4, 0., 0., 0., 0., diag4, off4, 0., 0.,
+      off4, diag4;
   const Eigen::Vector4d intensities(ppy, pmy, mpy, mmy);
   const auto FProduct = F2m * F1m;
   const auto PProduct = P2m * P1m;
@@ -110,16 +115,16 @@ void fourInputsCorrectedAndErrors(Eigen::Vector4d &corrected, Eigen::Vector4d &e
   // the matrices above, multiplied by the error.
   const auto elemE1 = -1. / pow<2>(f1) * f1E;
   Eigen::Matrix4d F1Em;
-  F1Em << 0., 0., 0., 0., 0., 0., 0., 0., -elemE1, 0., elemE1, 0., 0.,
-      -elemE1, 0., elemE1;
+  F1Em << 0., 0., 0., 0., 0., 0., 0., 0., -elemE1, 0., elemE1, 0., 0., -elemE1,
+      0., elemE1;
   const auto elemE2 = -1. / pow<2>(f2) * f2E;
   Eigen::Matrix4d F2Em;
   F2Em << 0., 0., 0., 0., -elemE2, elemE2, 0., 0., 0., 0., 0., 0., 0., 0.,
       -elemE2, elemE2;
   const auto elemE3 = 1. / pow<2>(2. * p1 - 1.) * p1E;
   Eigen::Matrix4d P1Em;
-  P1Em << elemE3, 0., -elemE3, 0., 0., elemE3, 0., -elemE3, -elemE3, 0.,
-      elemE3, 0., 0., -elemE3, 0., elemE3;
+  P1Em << elemE3, 0., -elemE3, 0., 0., elemE3, 0., -elemE3, -elemE3, 0., elemE3,
+      0., 0., -elemE3, 0., elemE3;
   const auto elemE4 = 1. / pow<2>(2. * p2 - 1.) * p2E;
   Eigen::Matrix4d P2Em;
   P2Em << elemE4, -elemE4, 0., 0., -elemE4, elemE4, 0., 0., 0., 0., elemE4,
@@ -151,7 +156,12 @@ void fourInputsCorrectedAndErrors(Eigen::Vector4d &corrected, Eigen::Vector4d &e
  * @param f2E error of f2
  * @return the error estimate
  */
-double twoInputsErrorEstimate01(const double i00, const double e00, const double i11, const double e11, const double p1, const double p1E, const double p2, const double p2E, const double f1, const double f1E, const double f2, const double f2E) {
+double twoInputsErrorEstimate01(const double i00, const double e00,
+                                const double i11, const double e11,
+                                const double p1, const double p1E,
+                                const double p2, const double p2E,
+                                const double f1, const double f1E,
+                                const double f2, const double f2E) {
   using namespace boost::math;
   // Derivatives of the equation which solves the I01 intensities
   // with respect to i00, i11, f1, etc.
@@ -172,12 +182,11 @@ double twoInputsErrorEstimate01(const double i00, const double e00, const double
          ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)) *
          (f2 * i11 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) -
           f1 * i00 * (-1. + 2. * p1) *
-              (-f2 * pow<2>(1. - 2. * p2) +
-               pow<2>(f2) * pow<2>(1. - 2. * p2) + (-1. + p2) * p2))) /
+              (-f2 * pow<2>(1. - 2. * p2) + pow<2>(f2) * pow<2>(1. - 2. * p2) +
+               (-1. + p2) * p2))) /
         pow<2>(f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
                f1 * (-1. + 2. * p1) *
-                   ((1. - p2) * p2 +
-                    f2 * (-1. + p1 + p2) * (-1. + 2. * p2)))) -
+                   ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)))) -
       (i00 * (-1. + 2. * p1) *
        (-f2 * pow<2>(1. - 2. * p2) + pow<2>(f2) * pow<2>(1. - 2. * p2) +
         (-1. + p2) * p2)) /
@@ -189,12 +198,11 @@ double twoInputsErrorEstimate01(const double i00, const double e00, const double
           p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2)) *
          (f2 * i11 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) -
           f1 * i00 * (-1. + 2. * p1) *
-              (-f2 * pow<2>(1. - 2. * p2) +
-               pow<2>(f2) * pow<2>(1. - 2. * p2) + (-1. + p2) * p2))) /
+              (-f2 * pow<2>(1. - 2. * p2) + pow<2>(f2) * pow<2>(1. - 2. * p2) +
+               (-1. + p2) * p2))) /
         pow<2>(f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
                f1 * (-1. + 2. * p1) *
-                   ((1. - p2) * p2 +
-                    f2 * (-1. + p1 + p2) * (-1. + 2. * p2)))) +
+                   ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)))) +
       (-f1 * i00 * (-1. + 2. * p1) *
            (-pow<2>(1. - 2. * p2) + 2 * f2 * pow<2>(1. - 2. * p2)) +
        i11 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2)) /
@@ -204,8 +212,8 @@ double twoInputsErrorEstimate01(const double i00, const double e00, const double
   const auto pmdp1 =
       -(((f2 * i11 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) -
           f1 * i00 * (-1. + 2. * p1) *
-              (-f2 * pow<2>(1. - 2. * p2) +
-               pow<2>(f2) * pow<2>(1. - 2. * p2) + (-1. + p2) * p2)) *
+              (-f2 * pow<2>(1. - 2. * p2) + pow<2>(f2) * pow<2>(1. - 2. * p2) +
+               (-1. + p2) * p2)) *
          (f2 * p1 * (1. - 2. * p2) +
           f1 * f2 * (-1. + 2. * p1) * (-1. + 2. * p2) +
           f2 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
@@ -213,8 +221,7 @@ double twoInputsErrorEstimate01(const double i00, const double e00, const double
               ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)))) /
         pow<2>(f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
                f1 * (-1. + 2. * p1) *
-                   ((1. - p2) * p2 +
-                    f2 * (-1. + p1 + p2) * (-1. + 2. * p2)))) +
+                   ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)))) +
       (f2 * i11 * p1 * (1. - 2. * p2) +
        f2 * i11 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) -
        2. * f1 * i00 *
@@ -226,19 +233,19 @@ double twoInputsErrorEstimate01(const double i00, const double e00, const double
   const auto pmdp2 =
       -(((f2 * i11 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) -
           f1 * i00 * (-1. + 2. * p1) *
-              (-f2 * pow<2>(1. - 2. * p2) +
-               pow<2>(f2) * pow<2>(1. - 2. * p2) + (-1. + p2) * p2)) *
+              (-f2 * pow<2>(1. - 2. * p2) + pow<2>(f2) * pow<2>(1. - 2. * p2) +
+               (-1. + p2) * p2)) *
          (f2 * (2. - 2. * p1) * p1 +
-          f1 * (-1. + 2. * p1) * (1. - 2. * p2 + 2. * f2 * (-1. + p1 + p2) +
-                                  f2 * (-1. + 2. * p2)))) /
+          f1 * (-1. + 2. * p1) *
+              (1. - 2. * p2 + 2. * f2 * (-1. + p1 + p2) +
+               f2 * (-1. + 2. * p2)))) /
         pow<2>(f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
                f1 * (-1. + 2. * p1) *
-                   ((1. - p2) * p2 +
-                    f2 * (-1. + p1 + p2) * (-1. + 2. * p2)))) +
+                   ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)))) +
       (f2 * i11 * (2. - 2. * p1) * p1 -
        f1 * i00 * (-1. + 2. * p1) *
-           (-1. + 4. * f2 * (1. - 2. * p2) -
-            4. * pow<2>(f2) * (1. - 2. * p2) + 2. * p2)) /
+           (-1. + 4. * f2 * (1. - 2. * p2) - 4. * pow<2>(f2) * (1. - 2. * p2) +
+            2. * p2)) /
           (f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
            f1 * (-1. + 2. * p1) *
                ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)));
@@ -269,7 +276,12 @@ double twoInputsErrorEstimate01(const double i00, const double e00, const double
  * @param f2E error of f2
  * @return the error estimate
  */
-double twoInputsErrorEstimate10(const double i00, const double e00, const double i11, const double e11, const double p1, const double p1E, const double p2, const double p2E, const double f1, const double f1E, const double f2, const double f2E) {
+double twoInputsErrorEstimate10(const double i00, const double e00,
+                                const double i11, const double e11,
+                                const double p1, const double p1E,
+                                const double p2, const double p2E,
+                                const double f1, const double f1E,
+                                const double f2, const double f2E) {
   using namespace boost::math;
   // Derivatives of the equation which solves the I10 intensities
   // with respect to i00, i11, f1, etc.
@@ -277,13 +289,11 @@ double twoInputsErrorEstimate10(const double i00, const double e00, const double
   const auto b = -1. + 2. * p1;
   const auto c = -1. + 2. * p2;
   const auto d = -1. + p2;
-  const auto mpdi00 =
-      (-pow<2>(f1) * f2 * pow<2>(b) * c + f1 * f2 * pow<2>(b) * c +
-       f2 * p1 * a) /
-      (f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c));
-  const auto mpdi11 =
-      -((f1 * b * d * p2) /
-        (f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c)));
+  const auto mpdi00 = (-pow<2>(f1) * f2 * pow<2>(b) * c +
+                       f1 * f2 * pow<2>(b) * c + f2 * p1 * a) /
+                      (f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c));
+  const auto mpdi11 = -((f1 * b * d * p2) /
+                        (f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c)));
   const auto mpdf1 =
       -(((-1. + 2. * p1) *
          ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)) *
@@ -294,8 +304,7 @@ double twoInputsErrorEstimate10(const double i00, const double e00, const double
                f2 * i00 * (-1. + 2. * p1) * (-1. + 2. * p2)))) /
         pow<2>(f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
                f1 * (-1. + 2. * p1) *
-                   ((1. - p2) * p2 +
-                    f2 * (-1. + p1 + p2) * (-1. + 2. * p2)))) +
+                   ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)))) +
       (-2. * f1 * f2 * i00 * pow<2>(1. - 2. * p1) * (-1. + 2. * p2) +
        (-1. + 2. * p1) * (-i11 * (-1. + p2) * p2 +
                           f2 * i00 * (-1. + 2. * p1) * (-1. + 2. * p2))) /
@@ -340,7 +349,7 @@ double twoInputsErrorEstimate10(const double i00, const double e00, const double
   const auto e10_P2 = pow<2>(mpdp2 * p2E);
   return std::sqrt(e10_I00 + e10_I11 + e10_F1 + e10_F2 + e10_P1 + e10_P2);
 }
-}
+} // namespace
 
 namespace Mantid {
 namespace Algorithms {
@@ -530,19 +539,19 @@ void PolarizationEfficiencyCor::checkConsistentX(
   // Compare everything to F1 efficiency.
   const auto &F1x = efficiencies.F1->x();
   // A local helper function to check a HistogramX against F1.
-  auto checkX =
-      [&F1x](const HistogramData::HistogramX &x, const std::string &tag) {
-        if (x.size() != F1x.size()) {
-          throw std::runtime_error(
-              "Mismatch of histogram lengths between F1 and " + tag + '.');
-        }
-        for (size_t i = 0; i != x.size(); ++i) {
-          if (x[i] != F1x[i]) {
-            throw std::runtime_error("Mismatch of X data between F1 and " +
-                                     tag + '.');
-          }
-        }
-      };
+  auto checkX = [&F1x](const HistogramData::HistogramX &x,
+                       const std::string &tag) {
+    if (x.size() != F1x.size()) {
+      throw std::runtime_error("Mismatch of histogram lengths between F1 and " +
+                               tag + '.');
+    }
+    for (size_t i = 0; i != x.size(); ++i) {
+      if (x[i] != F1x[i]) {
+        throw std::runtime_error("Mismatch of X data between F1 and " + tag +
+                                 '.');
+      }
+    }
+  };
   const auto &F2x = efficiencies.F2->x();
   checkX(F2x, "F2");
   const auto &P1x = efficiencies.P1->x();
@@ -834,7 +843,12 @@ PolarizationEfficiencyCor::fullCorrections(const WorkspaceMap &inputs,
     for (size_t binIndex = 0; binIndex < mmY.size(); ++binIndex) {
       Eigen::Vector4d corrected;
       Eigen::Vector4d errors;
-      fourInputsCorrectedAndErrors(corrected, errors, ppY[binIndex], ppE[binIndex], pmY[binIndex], pmE[binIndex], mpY[binIndex], mpE[binIndex], mmY[binIndex], mmE[binIndex], F1[binIndex], F1E[binIndex], F2[binIndex], F2E[binIndex], P1[binIndex], P1E[binIndex], P2[binIndex], P2E[binIndex]);
+      fourInputsCorrectedAndErrors(corrected, errors, ppY[binIndex],
+                                   ppE[binIndex], pmY[binIndex], pmE[binIndex],
+                                   mpY[binIndex], mpE[binIndex], mmY[binIndex],
+                                   mmE[binIndex], F1[binIndex], F1E[binIndex],
+                                   F2[binIndex], F2E[binIndex], P1[binIndex],
+                                   P1E[binIndex], P2[binIndex], P2E[binIndex]);
       ppYOut[binIndex] = corrected[0];
       pmYOut[binIndex] = corrected[1];
       mpYOut[binIndex] = corrected[2];
@@ -889,8 +903,8 @@ PolarizationEfficiencyCor::mapInputsToDirections(
  * @param inputs a set of input workspaces
  * @param efficiencies a set of efficiency factors
  */
-void PolarizationEfficiencyCor::threeInputsSolve01(WorkspaceMap &inputs,
-                                        const EfficiencyMap &efficiencies) {
+void PolarizationEfficiencyCor::threeInputsSolve01(
+    WorkspaceMap &inputs, const EfficiencyMap &efficiencies) {
   using namespace Mantid::DataObjects;
   inputs.pmWS = create<Workspace2D>(*inputs.mpWS);
   const auto &F1 = efficiencies.F1->y();
@@ -926,8 +940,8 @@ void PolarizationEfficiencyCor::threeInputsSolve01(WorkspaceMap &inputs,
  * @param inputs a set of input workspaces
  * @param efficiencies a set of efficiency factors
  */
-void PolarizationEfficiencyCor::threeInputsSolve10(WorkspaceMap &inputs,
-                                        const EfficiencyMap &efficiencies) {
+void PolarizationEfficiencyCor::threeInputsSolve10(
+    WorkspaceMap &inputs, const EfficiencyMap &efficiencies) {
   inputs.mpWS = DataObjects::create<DataObjects::Workspace2D>(*inputs.pmWS);
   const auto &F1 = efficiencies.F1->y();
   const auto &F2 = efficiencies.F2->y();
@@ -962,7 +976,9 @@ void PolarizationEfficiencyCor::threeInputsSolve10(WorkspaceMap &inputs,
  * @param inputs a set of input workspaces
  * @param efficiencies a set of efficiency factors
  */
-void PolarizationEfficiencyCor::twoInputsSolve01And10(WorkspaceMap &fullInputs, const WorkspaceMap &inputs, const EfficiencyMap &efficiencies) {
+void PolarizationEfficiencyCor::twoInputsSolve01And10(
+    WorkspaceMap &fullInputs, const WorkspaceMap &inputs,
+    const EfficiencyMap &efficiencies) {
   using namespace boost::math;
   const auto &F1 = efficiencies.F1->y();
   const auto &F1E = efficiencies.F1->e();
@@ -999,13 +1015,17 @@ void PolarizationEfficiencyCor::twoInputsSolve01And10(WorkspaceMap &fullInputs, 
           (f2 * i11 * p1 * a -
            f1 * i00 * b * (-f2 * pow<2>(c) + pow<2>(f2 * c) + d * p2)) /
           divisor;
-      E01[binIndex] = twoInputsErrorEstimate01(i00, E00[binIndex], i11, E11[binIndex], p1, P1E[binIndex], p2, P2E[binIndex], f1, F1E[binIndex], f2, F2E[binIndex]);
+      E01[binIndex] = twoInputsErrorEstimate01(
+          i00, E00[binIndex], i11, E11[binIndex], p1, P1E[binIndex], p2,
+          P2E[binIndex], f1, F1E[binIndex], f2, F2E[binIndex]);
       // Case: 10
       I10[binIndex] =
           (-pow<2>(f1) * f2 * i00 * pow<2>(b) * c + f2 * i00 * p1 * a +
            f1 * b * (-i11 * d * p2 + f2 * i00 * b * c)) /
           divisor;
-      E10[binIndex] = twoInputsErrorEstimate10(i00, E00[binIndex], i11, E11[binIndex], p1, P1E[binIndex], p2, P2E[binIndex], f1, F1E[binIndex], f2, F2E[binIndex]);
+      E10[binIndex] = twoInputsErrorEstimate10(
+          i00, E00[binIndex], i11, E11[binIndex], p1, P1E[binIndex], p2,
+          P2E[binIndex], f1, F1E[binIndex], f2, F2E[binIndex]);
     }
   }
 }

--- a/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
@@ -56,6 +56,27 @@ void checkInputExists(const Mantid::API::MatrixWorkspace_sptr &ws,
   }
 }
 
+/**
+ * Calculate the corrected intensities and error estimates.
+ * @param corrected an output vector for R00, R01, R10 and R11
+ * @param errors an output vector for the error estimates
+ * @param ppy intensity I00
+ * @param ppyE error of ppy
+ * @param pmy intensity I01
+ * @param pmyE error of pmy
+ * @param mpy intensity I10
+ * @param mpyE error of mpy
+ * @param mmy intensity I11
+ * @param mmyE error of mmy
+ * @param f1 polarizer efficiency
+ * @param f1E error of f1
+ * @param f2 analyzer efficiency
+ * @param f2E error of f2
+ * @param p1 polarizer flipper efficiency
+ * @param p1E error of p1
+ * @param p2 analyzer flipper efficiency
+ * @param p2E error of p2
+ */
 void fourInputsCorrectedAndErrors(Eigen::Vector4d &corrected, Eigen::Vector4d &errors, const double ppy, const double ppyE, const double pmy, const double pmyE, const double mpy, const double mpyE, const double mmy, const double mmyE, const double f1, const double f1E, const double f2, const double f2E, const double p1, const double p1E, const double p2, const double p2E) {
   using namespace boost::math;
   // Note that f1 and f2 correspond to 1-F1 and 1-F2 in [Wildes, 1999].

--- a/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
@@ -91,9 +91,9 @@ void PolarizationEfficiencyCor::exec() {
     break;
   case 2:
     if (analyzer) {
-      twoInputCorrections(inputs, efficiencies);
+      outputs = twoInputCorrections(inputs, efficiencies);
     } else {
-      analyzerlessCorrections(inputs, efficiencies);
+      outputs = analyzerlessCorrections(inputs, efficiencies);
     }
     break;
   case 3:
@@ -250,16 +250,16 @@ PolarizationEfficiencyCor::WorkspaceMap PolarizationEfficiencyCor::twoInputCorre
   const auto &P1E = efficiencies.P1->e();
   const auto &P2 = efficiencies.P2->y();
   const auto &P2E = efficiencies.P2->e();
-  const auto nHisto = inputs.mpWS->getNumberHistograms();
+  const auto nHisto = inputs.mmWS->getNumberHistograms();
   for (size_t wsIndex = 0; wsIndex != nHisto; ++wsIndex) {
     const auto &I00 = inputs.ppWS->y(wsIndex);
     const auto &E00 = inputs.ppWS->e(wsIndex);
     const auto &I11 = inputs.mmWS->y(wsIndex);
     const auto &E11 = inputs.mmWS->e(wsIndex);
-    auto &I01 = inputs.pmWS->mutableY(wsIndex);
-    auto &E01 = inputs.pmWS->mutableE(wsIndex);
-    auto &I10 = inputs.mpWS->mutableY(wsIndex);
-    auto &E10 = inputs.mpWS->mutableE(wsIndex);
+    auto &I01 = fullInputs.pmWS->mutableY(wsIndex);
+    auto &E01 = fullInputs.pmWS->mutableE(wsIndex);
+    auto &I10 = fullInputs.mpWS->mutableY(wsIndex);
+    auto &E10 = fullInputs.mpWS->mutableE(wsIndex);
     for (size_t binIndex = 0; binIndex != I00.size(); ++binIndex) {
       const auto i00 = I00[binIndex];
       const auto i11 = I11[binIndex];

--- a/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
@@ -109,7 +109,7 @@ API::WorkspaceGroup_sptr PolarizationEfficiencyCor::groupOutput(const WorkspaceM
   const std::string outWSName = getProperty(Prop::OUTPUT_WS);
   std::vector<std::string> names;
   if (outputs.mmWS) {
-    names.emplace_back(outWSName + "_++");
+    names.emplace_back(outWSName + "_--");
     API::AnalysisDataService::Instance().addOrReplace(names.back(), outputs.mmWS);
   }
   if (outputs.mpWS) {

--- a/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
@@ -65,7 +65,7 @@ void PolarizationEfficiencyCor::init() {
       "A group of workspaces to be corrected.");
   const std::vector<std::string> defaultFlippers{{Flippers::OffOff, Flippers::OffOn, Flippers::OnOff, Flippers::OnOn}};
   declareProperty(
-      Kernel::make_unique<Kernel::ArrayProperty<std::string>>(Prop::FLIPPERS, defaultFlippers, boost::make_shared<Kernel::ArrayLengthValidator<std::string>>(2, 4)),
+      Kernel::make_unique<Kernel::ArrayProperty<std::string>>(Prop::FLIPPERS, defaultFlippers, boost::make_shared<Kernel::ArrayLengthValidator<std::string>>(1, 4)),
         "A list of flipper configurations (accepted values: 00, 01, 10 and 11) corresponding to each input workspace.");
   declareProperty(
       Kernel::make_unique<API::WorkspaceProperty<API::WorkspaceGroup>>(Prop::OUTPUT_WS, "",

--- a/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
@@ -16,10 +16,10 @@
 namespace {
 /// Property names.
 namespace Prop {
-constexpr char *FLIPPERS{"Flippers"};
-constexpr char *EFFICIENCIES{"Efficiencies"};
-constexpr char *INPUT_WS{"InputWorkspaces"};
-constexpr char *OUTPUT_WS{"OutputWorkspace"};
+static const std::string FLIPPERS{"Flippers"};
+static const std::string EFFICIENCIES{"Efficiencies"};
+static const std::string INPUT_WS{"InputWorkspaces"};
+static const std::string OUTPUT_WS{"OutputWorkspace"};
 }
 
 /// Flipper configurations.

--- a/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
@@ -1,0 +1,233 @@
+#include "MantidAlgorithms/PolarizationEfficiencyCor.h"
+
+#include "MantidAPI/Axis.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidKernel/ArrayLengthValidator.h"
+#include "MantidKernel/ArrayProperty.h"
+
+#include <Eigen/Dense>
+
+namespace {
+namespace Prop {
+constexpr char *DIRECTIONS{"PolarizationDirections"};
+constexpr char *EFFICIENCIES{"Efficiencies"};
+constexpr char *INPUT_WS{"InputWorkspace"};
+constexpr char *OUTPUT_WS{"OutputWorkspace"};
+}
+namespace PolDir {
+constexpr char *MM{"--"};
+constexpr char *MP{"-+"};
+constexpr char *PM{"+-"};
+constexpr char *PP{"++"};
+}
+}
+
+namespace Mantid {
+namespace Algorithms {
+
+// Register the algorithm into the AlgorithmFactory
+DECLARE_ALGORITHM(PolarizationEfficiencyCor)
+
+//----------------------------------------------------------------------------------------------
+
+/// Algorithms name for identification. @see Algorithm::name
+const std::string PolarizationEfficiencyCor::name() const { return "PolarizationEfficiencyCor"; }
+
+/// Algorithm's version for identification. @see Algorithm::version
+int PolarizationEfficiencyCor::version() const { return 1; }
+
+/// Algorithm's category for identification. @see Algorithm::category
+const std::string PolarizationEfficiencyCor::category() const {
+  return "Reflectometry";
+}
+
+/// Algorithm's summary for use in the GUI and help. @see Algorithm::summary
+const std::string PolarizationEfficiencyCor::summary() const {
+  return "Corrects a group of polarization analysis workspaces for polarizer and analyzer efficiencies.";
+}
+
+size_t PolarizationEfficiencyCor::WorkspaceMap::size() const noexcept {
+  return mmWS ? 1 : 0 + mpWS ? 1 : 0 + pmWS ? 1 : 0 + ppWS ? 1 : 0;
+}
+
+//----------------------------------------------------------------------------------------------
+/** Initialize the algorithm's properties.
+ */
+void PolarizationEfficiencyCor::init() {
+  declareProperty(
+      Kernel::make_unique<API::WorkspaceProperty<API::WorkspaceGroup>>(Prop::INPUT_WS, "",
+                                                             Kernel::Direction::Input),
+      "A group of workspaces to be corrected.");
+  const std::vector<std::string> defaultDirections{{PolDir::PP, PolDir::PM, PolDir::MP, PolDir::MM}};
+  declareProperty(
+      Kernel::make_unique<Kernel::ArrayProperty<std::string>>(Prop::DIRECTIONS, defaultDirections, boost::make_shared<Kernel::ArrayLengthValidator<double>>(2, 4)),
+        "A list of polarization directions (++, +-, -+, --) corresponding to each input workspace.");
+  declareProperty(
+      Kernel::make_unique<API::WorkspaceProperty<API::WorkspaceGroup>>(Prop::OUTPUT_WS, "",
+                                                             Kernel::Direction::Output),
+      "A group of polarization efficiency corrected workspaces.");
+  declareProperty(
+        Kernel::make_unique<API::WorkspaceProperty<API::MatrixWorkspace>>(Prop::EFFICIENCIES, "", Kernel::Direction::Input),
+        "A workspace containing the efficiency factors P1, P2, F1 and F2 as histograms");
+}
+
+//----------------------------------------------------------------------------------------------
+/** Execute the algorithm.
+ */
+void PolarizationEfficiencyCor::exec() {
+  const auto inputs = mapInputsToDirections();
+  WorkspaceMap outputs;
+  switch (inputs.size()) {
+  case 2:
+    break;
+  case 3:
+    break;
+  case 4:
+    outputs = fullCorrections(inputs);
+  }
+  setProperty(Prop::OUTPUT_WS, groupOutput(outputs));
+}
+
+API::WorkspaceGroup_sptr PolarizationEfficiencyCor::groupOutput(WorkspaceMap &outputs) {
+  const std::string outWSName = getProperty(Prop::OUTPUT_WS);
+  std::vector<std::string> names;
+  if (outputs.mmWS) {
+    names.emplace_back(outWSName + "_" + PolDir::MM);
+    API::AnalysisDataService::Instance().addOrReplace(names.back(), outputs.mmWS);
+  }
+  if (outputs.mpWS) {
+    names.emplace_back(outWSName + "_" + PolDir::MP);
+    API::AnalysisDataService::Instance().addOrReplace(names.back(), outputs.mpWS);
+  }
+  if (outputs.pmWS) {
+    names.emplace_back(outWSName + "_" + PolDir::PM);
+    API::AnalysisDataService::Instance().addOrReplace(names.back(), outputs.pmWS);
+  }
+  if (outputs.ppWS) {
+    names.emplace_back(outWSName + "_" + PolDir::PP);
+    API::AnalysisDataService::Instance().addOrReplace(names.back(), outputs.ppWS);
+  }
+  auto group = createChildAlgorithm("GroupWorkspaces");
+  group->initialize();
+  group->setProperty("InputWorkspaces", names);
+  group->setProperty("OutputWorkspace", outWSName);
+  group->execute();
+  API::WorkspaceGroup_sptr outWS = group->getProperty("OutputWorkspace");
+  return outWS;
+}
+
+PolarizationEfficiencyCor::EfficiencyMap PolarizationEfficiencyCor::efficiencyFactors() {
+  // TODO validate efficiencies.
+  EfficiencyMap e;
+  API::MatrixWorkspace_const_sptr factorWS = getProperty(Prop::EFFICIENCIES);
+  const auto &vertAxis = factorWS->getAxis(1);
+  for (size_t i = 0; i != vertAxis->length(); ++i) {
+    const auto label = vertAxis->label(i);
+    if (label == "P1") {
+      e.P1 = &factorWS->y(i);
+    } else if (label == "P2") {
+      e.P2 = &factorWS->y(i);
+    } else if (label == "F1") {
+      e.F1 = &factorWS->y(i);
+    } else if (label == "F2") {
+      e.F2 = &factorWS->y(i);
+    }
+    // Ignore other histograms such as 'Phi' in ILL's efficiency ws.
+  }
+  return e;
+}
+
+PolarizationEfficiencyCor::WorkspaceMap PolarizationEfficiencyCor::fullCorrections(const PolarizationEfficiencyCor::WorkspaceMap &inputs) {
+  EfficiencyMap efficiencies = efficiencyFactors();
+  WorkspaceMap outputs;
+  outputs.mmWS = DataObjects::create<DataObjects::Workspace2D>(*inputs.mmWS);
+  outputs.mpWS = DataObjects::create<DataObjects::Workspace2D>(*inputs.mpWS);
+  outputs.pmWS = DataObjects::create<DataObjects::Workspace2D>(*inputs.pmWS);
+  outputs.ppWS = DataObjects::create<DataObjects::Workspace2D>(*inputs.ppWS);
+  const size_t nHisto = inputs.mmWS->getNumberHistograms();
+  for (size_t wsIndex = 0; wsIndex != nHisto; ++wsIndex) {
+    const auto &mmY = inputs.mmWS->y(wsIndex);
+    const auto &mpY = inputs.mpWS->y(wsIndex);
+    const auto &pmY = inputs.pmWS->y(wsIndex);
+    const auto &ppY = inputs.ppWS->y(wsIndex);
+    auto &mmYOut = outputs.mmWS->mutableY(wsIndex);
+    auto &mpYOut = outputs.mpWS->mutableY(wsIndex);
+    auto &pmYOut = outputs.pmWS->mutableY(wsIndex);
+    auto &ppYOut = outputs.ppWS->mutableY(wsIndex);
+    for (size_t binIndex = 0; binIndex < mmY.size(); ++binIndex) {
+      // Note that F1 and F2 correspond to 1-F1 and 1-F2 in [Wildes, 1999].
+      const auto F1 = (*efficiencies.F1)[binIndex];
+      const auto F2 = (*efficiencies.F2)[binIndex];
+      const auto P1 = (*efficiencies.P1)[binIndex];
+      const auto P2 = (*efficiencies.P2)[binIndex];
+      // These are inverted forms of the efficiency matrices.
+      const auto diag1 = 1. / F1;
+      const auto off1 = (F1 - 1.) * diag1;
+      Eigen::Matrix4d F1m;
+      F1m <<   1.,   0.,    0.,    0.,
+               0.,   1.,    0.,    0.,
+             off1,   0., diag1,    0.,
+               0., off1,    0., diag1;
+      const auto diag2 = 1. / F2;
+      const auto off2 = (F2 - 1.) * diag2;
+      Eigen::Matrix4d F2m;
+      F2m <<   1.,    0.,   0.,    0.,
+             off2, diag2,   0.,    0.,
+               0.,    0.,   1.,    0.,
+               0.,    0., off2, diag2;
+      const auto diag3 = (P1 - 1.) / (2. * P1 - 1.);
+      const auto off3 = P1 / (2. * P1 - 1);
+      Eigen::Matrix4d P1m;
+      P1m << diag3,     0,  off3,     0,
+                 0, diag3,     0,  off3,
+              off3,     0, diag3,     0,
+                 0,  off3,     0, diag3;
+      const auto diag4 = (P2 - 1.) / (2. * P2 - 1.);
+      const auto off4 = P2 / (2. * P2 - 1.);
+      Eigen::Matrix4d P2m;
+      P2m << diag4,  off4,    0.,    0.,
+              off4, diag4,    0.,    0.,
+                0.,    0., diag4,  off4,
+                0.,    0.,  off4, diag4;
+      const Eigen::Vector4d intensities(ppY[binIndex], pmY[binIndex], mpY[binIndex], mmY[binIndex]);
+      const auto corrected = P2m * P1m * F2m * F1m * intensities;
+      ppYOut[binIndex] = corrected[0];
+      pmYOut[binIndex] = corrected[1];
+      mpYOut[binIndex] = corrected[2];
+      mmYOut[binIndex] = corrected[3];
+    }
+  }
+  return outputs;
+}
+
+PolarizationEfficiencyCor::WorkspaceMap PolarizationEfficiencyCor::mapInputsToDirections() {
+  API::WorkspaceGroup_const_sptr inGroup = getProperty(Prop::INPUT_WS);
+  // TODO: Validate dirs in validateInputs().
+  const std::vector<std::string> dirs = getProperty(Prop::DIRECTIONS);
+  WorkspaceMap inputs;
+  for (size_t i = 0; i < dirs.size(); ++i) {
+    auto ws = boost::dynamic_pointer_cast<API::MatrixWorkspace>(inGroup->getItem(i));
+    if (!ws) {
+      throw std::runtime_error("One of the input workspaces doesn't seem to be a MatrixWorkspace.");
+    }
+    const auto &dir = dirs[i];
+    if (dir == PolDir::MM) {
+      inputs.mmWS = ws;
+    } else if (dir == PolDir::MP) {
+      inputs.mpWS = ws;
+    } else if (dir == PolDir::PM) {
+      inputs.pmWS = ws;
+    } else if (dir == PolDir::PP) {
+      inputs.ppWS = ws;
+    } else {
+      throw std::runtime_error(std::string{"Unknown entry in "} + Prop::DIRECTIONS);
+    }
+  }
+  return inputs;
+}
+
+} // namespace Algorithms
+} // namespace Mantid

--- a/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
@@ -158,7 +158,7 @@ PolarizationEfficiencyCor::WorkspaceMap PolarizationEfficiencyCor::directBeamCor
   using namespace boost::math;
   WorkspaceMap outputs;
   outputs.ppWS = DataObjects::create<DataObjects::Workspace2D>(*inputs.ppWS);
-  const size_t nHisto = inputs.mmWS->getNumberHistograms();
+  const size_t nHisto = inputs.ppWS->getNumberHistograms();
   for (size_t wsIndex = 0; wsIndex != nHisto; ++wsIndex) {
     const auto &ppY = inputs.ppWS->y(wsIndex);
     const auto &ppE = inputs.ppWS->e(wsIndex);

--- a/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
@@ -55,6 +55,212 @@ void checkInputExists(const Mantid::API::MatrixWorkspace_sptr &ws,
                              " is missing in inputs.");
   }
 }
+
+/**
+ * Estimate errors for I01 in the two inputs case.
+ * @param i00 intensity of 00 flipper configuration
+ * @param e00 error of i00
+ * @param i11 intensity of 11 flipper configuration
+ * @param e11 error of i11
+ * @param p1 polarizer efficiency
+ * @param p1E error of p1
+ * @param p2 analyzer efficiency
+ * @param p2E error of p2
+ * @param f1 polarizer flipper efficiency
+ * @param f1E error of f1
+ * @param f2 analyzer flipper efficiency
+ * @param f2E error of f2
+ * @return the error estimate
+ */
+double twoInputsErrorEstimate01(const double i00, const double e00, const double i11, const double e11, const double p1, const double p1E, const double p2, const double p2E, const double f1, const double f1E, const double f2, const double f2E) {
+  using namespace boost::math;
+  // Derivatives of the equation which solves the I01 intensities
+  // with respect to i00, i11, f1, etc.
+  const auto pmdi00 =
+      -((f1 * (-1. + 2. * p1) *
+         (-f2 * pow<2>(1. - 2. * p2) + pow<2>(f2) * pow<2>(1. - 2. * p2) +
+          (-1. + p2) * p2)) /
+        (f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
+         f1 * (-1. + 2. * p1) *
+             ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2))));
+  const auto pmdi11 =
+      (f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2)) /
+      (f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
+       f1 * (-1. + 2. * p1) *
+           ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)));
+  const auto pmdf1 =
+      -(((-1. + 2. * p1) *
+         ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)) *
+         (f2 * i11 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) -
+          f1 * i00 * (-1. + 2. * p1) *
+              (-f2 * pow<2>(1. - 2. * p2) +
+               pow<2>(f2) * pow<2>(1. - 2. * p2) + (-1. + p2) * p2))) /
+        pow<2>(f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
+               f1 * (-1. + 2. * p1) *
+                   ((1. - p2) * p2 +
+                    f2 * (-1. + p1 + p2) * (-1. + 2. * p2)))) -
+      (i00 * (-1. + 2. * p1) *
+       (-f2 * pow<2>(1. - 2. * p2) + pow<2>(f2) * pow<2>(1. - 2. * p2) +
+        (-1. + p2) * p2)) /
+          (f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
+           f1 * (-1. + 2. * p1) *
+               ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)));
+  const auto pmdf2 =
+      -(((f1 * (-1. + 2. * p1) * (-1. + p1 + p2) * (-1 + 2 * p2) +
+          p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2)) *
+         (f2 * i11 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) -
+          f1 * i00 * (-1. + 2. * p1) *
+              (-f2 * pow<2>(1. - 2. * p2) +
+               pow<2>(f2) * pow<2>(1. - 2. * p2) + (-1. + p2) * p2))) /
+        pow<2>(f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
+               f1 * (-1. + 2. * p1) *
+                   ((1. - p2) * p2 +
+                    f2 * (-1. + p1 + p2) * (-1. + 2. * p2)))) +
+      (-f1 * i00 * (-1. + 2. * p1) *
+           (-pow<2>(1. - 2. * p2) + 2 * f2 * pow<2>(1. - 2. * p2)) +
+       i11 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2)) /
+          (f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
+           f1 * (-1. + 2. * p1) *
+               ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)));
+  const auto pmdp1 =
+      -(((f2 * i11 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) -
+          f1 * i00 * (-1. + 2. * p1) *
+              (-f2 * pow<2>(1. - 2. * p2) +
+               pow<2>(f2) * pow<2>(1. - 2. * p2) + (-1. + p2) * p2)) *
+         (f2 * p1 * (1. - 2. * p2) +
+          f1 * f2 * (-1. + 2. * p1) * (-1. + 2. * p2) +
+          f2 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
+          2. * f1 *
+              ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)))) /
+        pow<2>(f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
+               f1 * (-1. + 2. * p1) *
+                   ((1. - p2) * p2 +
+                    f2 * (-1. + p1 + p2) * (-1. + 2. * p2)))) +
+      (f2 * i11 * p1 * (1. - 2. * p2) +
+       f2 * i11 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) -
+       2. * f1 * i00 *
+           (-f2 * pow<2>(1. - 2. * p2) + pow<2>(f2) * pow<2>(1. - 2. * p2) +
+            (-1. + p2) * p2)) /
+          (f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
+           f1 * (-1. + 2. * p1) *
+               ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)));
+  const auto pmdp2 =
+      -(((f2 * i11 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) -
+          f1 * i00 * (-1. + 2. * p1) *
+              (-f2 * pow<2>(1. - 2. * p2) +
+               pow<2>(f2) * pow<2>(1. - 2. * p2) + (-1. + p2) * p2)) *
+         (f2 * (2. - 2. * p1) * p1 +
+          f1 * (-1. + 2. * p1) * (1. - 2. * p2 + 2. * f2 * (-1. + p1 + p2) +
+                                  f2 * (-1. + 2. * p2)))) /
+        pow<2>(f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
+               f1 * (-1. + 2. * p1) *
+                   ((1. - p2) * p2 +
+                    f2 * (-1. + p1 + p2) * (-1. + 2. * p2)))) +
+      (f2 * i11 * (2. - 2. * p1) * p1 -
+       f1 * i00 * (-1. + 2. * p1) *
+           (-1. + 4. * f2 * (1. - 2. * p2) -
+            4. * pow<2>(f2) * (1. - 2. * p2) + 2. * p2)) /
+          (f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
+           f1 * (-1. + 2. * p1) *
+               ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)));
+  // Estimate the error components using linearized extrapolation,
+  // sum in squares.
+  const auto e01_I00 = pow<2>(pmdi00 * e00);
+  const auto e01_I11 = pow<2>(pmdi11 * e11);
+  const auto e01_F1 = pow<2>(pmdf1 * f1E);
+  const auto e01_F2 = pow<2>(pmdf2 * f2E);
+  const auto e01_P1 = pow<2>(pmdp1 * p1E);
+  const auto e01_P2 = pow<2>(pmdp2 * p2E);
+  return std::sqrt(e01_I00 + e01_I11 + e01_F1 + e01_F2 + e01_P1 + e01_P2);
+}
+
+/**
+ * Estimate errors for I10 in the two inputs case.
+ * @param i00 intensity of 00 flipper configuration
+ * @param e00 error of i00
+ * @param i11 intensity of 11 flipper configuration
+ * @param e11 error of i11
+ * @param p1 polarizer efficiency
+ * @param p1E error of p1
+ * @param p2 analyzer efficiency
+ * @param p2E error of p2
+ * @param f1 polarizer flipper efficiency
+ * @param f1E error of f1
+ * @param f2 analyzer flipper efficiency
+ * @param f2E error of f2
+ * @return the error estimate
+ */
+double twoInputsErrorEstimate10(const double i00, const double e00, const double i11, const double e11, const double p1, const double p1E, const double p2, const double p2E, const double f1, const double f1E, const double f2, const double f2E) {
+  using namespace boost::math;
+  // Derivatives of the equation which solves the I10 intensities
+  // with respect to i00, i11, f1, etc.
+  const auto a = -1. + p1 + 2. * p2 - 2. * p1 * p2;
+  const auto b = -1. + 2. * p1;
+  const auto c = -1. + 2. * p2;
+  const auto d = -1. + p2;
+  const auto mpdi00 =
+      (-pow<2>(f1) * f2 * pow<2>(b) * c + f1 * f2 * pow<2>(b) * c +
+       f2 * p1 * a) /
+      (f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c));
+  const auto mpdi11 =
+      -((f1 * b * d * p2) /
+        (f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c)));
+  const auto mpdf1 =
+      -(((-1. + 2. * p1) *
+         ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)) *
+         (-pow<2>(f1) * f2 * i00 * pow<2>(1. - 2. * p1) * (-1. + 2. * p2) +
+          f2 * i00 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
+          f1 * (-1. + 2. * p1) *
+              (-i11 * (-1. + p2) * p2 +
+               f2 * i00 * (-1. + 2. * p1) * (-1. + 2. * p2)))) /
+        pow<2>(f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
+               f1 * (-1. + 2. * p1) *
+                   ((1. - p2) * p2 +
+                    f2 * (-1. + p1 + p2) * (-1. + 2. * p2)))) +
+      (-2. * f1 * f2 * i00 * pow<2>(1. - 2. * p1) * (-1. + 2. * p2) +
+       (-1. + 2. * p1) * (-i11 * (-1. + p2) * p2 +
+                          f2 * i00 * (-1. + 2. * p1) * (-1. + 2. * p2))) /
+          (f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
+           f1 * (-1. + 2. * p1) *
+               ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)));
+  const auto mpdf2 =
+      -(((f1 * b * (p1 + d) * c + p1 * a) *
+         (-pow<2>(f1) * f2 * i00 * pow<2>(b) * c + f2 * i00 * p1 * a +
+          f1 * b * (-i11 * d * p2 + f2 * i00 * b * c))) /
+        pow<2>(f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c))) +
+      (-pow<2>(f1) * i00 * pow<2>(b) * c + f1 * i00 * pow<2>(b) * c +
+       i00 * p1 * a) /
+          (f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c));
+  const auto mpdp1 =
+      -(((-pow<2>(f1) * f2 * i00 * pow<2>(b) * c + f2 * i00 * p1 * a +
+          f1 * b * (-i11 * d * p2 + f2 * i00 * b * c)) *
+         (f2 * p1 * -c + f1 * f2 * b * c + f2 * a +
+          2. * f1 * (-d * p2 + f2 * (p1 + d) * c))) /
+        pow<2>(f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c))) +
+      (f2 * i00 * p1 * -c + 4. * pow<2>(f1) * f2 * i00 * -b * c +
+       2. * f1 * f2 * i00 * b * c + f2 * i00 * a +
+       2. * f1 * (-i11 * d * p2 + f2 * i00 * b * c)) /
+          (f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c));
+  const auto mpdp2 =
+      -(((f2 * (2. - 2. * p1) * p1 +
+          f1 * b * (1. - 2. * p2 + 2. * f2 * (p1 + d) + f2 * c)) *
+         (-pow<2>(f1) * f2 * i00 * pow<2>(b) * c + f2 * i00 * p1 * a +
+          f1 * b * (-i11 * d * p2 + f2 * i00 * b * c))) /
+        pow<2>(f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c))) +
+      (-2. * pow<2>(f1) * f2 * i00 * pow<2>(b) +
+       f2 * i00 * (2. - 2. * p1) * p1 +
+       f1 * b * (2. * f2 * i00 * b - i11 * d - i11 * p2)) /
+          (f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c));
+  // Estimate the error components using linearized extrapolation,
+  // sum in squares.
+  const auto e10_I00 = pow<2>(mpdi00 * e00);
+  const auto e10_I11 = pow<2>(mpdi11 * e11);
+  const auto e10_F1 = pow<2>(mpdf1 * f1E);
+  const auto e10_F2 = pow<2>(mpdf2 * f2E);
+  const auto e10_P1 = pow<2>(mpdp1 * p1E);
+  const auto e10_P2 = pow<2>(mpdp2 * p2E);
+  return std::sqrt(e10_I00 + e10_I11 + e10_F1 + e10_F2 + e10_P1 + e10_P2);
+}
 }
 
 namespace Mantid {
@@ -470,207 +676,7 @@ PolarizationEfficiencyCor::twoInputCorrections(
   WorkspaceMap fullInputs = inputs;
   fullInputs.mpWS = DataObjects::create<DataObjects::Workspace2D>(*inputs.mmWS);
   fullInputs.pmWS = DataObjects::create<DataObjects::Workspace2D>(*inputs.ppWS);
-  const auto &F1 = efficiencies.F1->y();
-  const auto &F1E = efficiencies.F1->e();
-  const auto &F2 = efficiencies.F2->y();
-  const auto &F2E = efficiencies.F2->e();
-  const auto &P1 = efficiencies.P1->y();
-  const auto &P1E = efficiencies.P1->e();
-  const auto &P2 = efficiencies.P2->y();
-  const auto &P2E = efficiencies.P2->e();
-  const auto nHisto = inputs.mmWS->getNumberHistograms();
-  for (size_t wsIndex = 0; wsIndex != nHisto; ++wsIndex) {
-    const auto &I00 = inputs.ppWS->y(wsIndex);
-    const auto &E00 = inputs.ppWS->e(wsIndex);
-    const auto &I11 = inputs.mmWS->y(wsIndex);
-    const auto &E11 = inputs.mmWS->e(wsIndex);
-    auto &I01 = fullInputs.pmWS->mutableY(wsIndex);
-    auto &E01 = fullInputs.pmWS->mutableE(wsIndex);
-    auto &I10 = fullInputs.mpWS->mutableY(wsIndex);
-    auto &E10 = fullInputs.mpWS->mutableE(wsIndex);
-    for (size_t binIndex = 0; binIndex != I00.size(); ++binIndex) {
-      const auto i00 = I00[binIndex];
-      const auto i11 = I11[binIndex];
-      const auto f1 = F1[binIndex];
-      const auto f2 = F2[binIndex];
-      const auto p1 = P1[binIndex];
-      const auto p2 = P2[binIndex];
-      const auto a = -1. + p1 + 2. * p2 - 2. * p1 * p2;
-      const auto b = -1. + 2. * p1;
-      const auto c = -1. + 2. * p2;
-      const auto d = -1. + p2;
-      // Case: 01
-      const auto divisor = f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c);
-      I01[binIndex] =
-          (f2 * i11 * p1 * a -
-           f1 * i00 * b * (-f2 * pow<2>(c) + pow<2>(f2 * c) + d * p2)) /
-          divisor;
-      // Error estimates.
-      // Derivatives of the above with respect to i00, i11, f1, etc.
-      const auto pmdi00 =
-          -((f1 * (-1. + 2. * p1) *
-             (-f2 * pow<2>(1. - 2. * p2) + pow<2>(f2) * pow<2>(1. - 2. * p2) +
-              (-1. + p2) * p2)) /
-            (f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
-             f1 * (-1. + 2. * p1) *
-                 ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2))));
-      const auto pmdi11 =
-          (f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2)) /
-          (f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
-           f1 * (-1. + 2. * p1) *
-               ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)));
-      const auto pmdf1 =
-          -(((-1. + 2. * p1) *
-             ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)) *
-             (f2 * i11 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) -
-              f1 * i00 * (-1. + 2. * p1) *
-                  (-f2 * pow<2>(1. - 2. * p2) +
-                   pow<2>(f2) * pow<2>(1. - 2. * p2) + (-1. + p2) * p2))) /
-            pow<2>(f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
-                   f1 * (-1. + 2. * p1) *
-                       ((1. - p2) * p2 +
-                        f2 * (-1. + p1 + p2) * (-1. + 2. * p2)))) -
-          (i00 * (-1. + 2. * p1) *
-           (-f2 * pow<2>(1. - 2. * p2) + pow<2>(f2) * pow<2>(1. - 2. * p2) +
-            (-1. + p2) * p2)) /
-              (f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
-               f1 * (-1. + 2. * p1) *
-                   ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)));
-      const auto pmdf2 =
-          -(((f1 * (-1. + 2. * p1) * (-1. + p1 + p2) * (-1 + 2 * p2) +
-              p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2)) *
-             (f2 * i11 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) -
-              f1 * i00 * (-1. + 2. * p1) *
-                  (-f2 * pow<2>(1. - 2. * p2) +
-                   pow<2>(f2) * pow<2>(1. - 2. * p2) + (-1. + p2) * p2))) /
-            pow<2>(f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
-                   f1 * (-1. + 2. * p1) *
-                       ((1. - p2) * p2 +
-                        f2 * (-1. + p1 + p2) * (-1. + 2. * p2)))) +
-          (-f1 * i00 * (-1. + 2. * p1) *
-               (-pow<2>(1. - 2. * p2) + 2 * f2 * pow<2>(1. - 2. * p2)) +
-           i11 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2)) /
-              (f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
-               f1 * (-1. + 2. * p1) *
-                   ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)));
-      const auto pmdp1 =
-          -(((f2 * i11 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) -
-              f1 * i00 * (-1. + 2. * p1) *
-                  (-f2 * pow<2>(1. - 2. * p2) +
-                   pow<2>(f2) * pow<2>(1. - 2. * p2) + (-1. + p2) * p2)) *
-             (f2 * p1 * (1. - 2. * p2) +
-              f1 * f2 * (-1. + 2. * p1) * (-1. + 2. * p2) +
-              f2 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
-              2. * f1 *
-                  ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)))) /
-            pow<2>(f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
-                   f1 * (-1. + 2. * p1) *
-                       ((1. - p2) * p2 +
-                        f2 * (-1. + p1 + p2) * (-1. + 2. * p2)))) +
-          (f2 * i11 * p1 * (1. - 2. * p2) +
-           f2 * i11 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) -
-           2. * f1 * i00 *
-               (-f2 * pow<2>(1. - 2. * p2) + pow<2>(f2) * pow<2>(1. - 2. * p2) +
-                (-1. + p2) * p2)) /
-              (f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
-               f1 * (-1. + 2. * p1) *
-                   ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)));
-      const auto pmdp2 =
-          -(((f2 * i11 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) -
-              f1 * i00 * (-1. + 2. * p1) *
-                  (-f2 * pow<2>(1. - 2. * p2) +
-                   pow<2>(f2) * pow<2>(1. - 2. * p2) + (-1. + p2) * p2)) *
-             (f2 * (2. - 2. * p1) * p1 +
-              f1 * (-1. + 2. * p1) * (1. - 2. * p2 + 2. * f2 * (-1. + p1 + p2) +
-                                      f2 * (-1. + 2. * p2)))) /
-            pow<2>(f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
-                   f1 * (-1. + 2. * p1) *
-                       ((1. - p2) * p2 +
-                        f2 * (-1. + p1 + p2) * (-1. + 2. * p2)))) +
-          (f2 * i11 * (2. - 2. * p1) * p1 -
-           f1 * i00 * (-1. + 2. * p1) *
-               (-1. + 4. * f2 * (1. - 2. * p2) -
-                4. * pow<2>(f2) * (1. - 2. * p2) + 2. * p2)) /
-              (f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
-               f1 * (-1. + 2. * p1) *
-                   ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)));
-      const auto e01_I00 = pow<2>(pmdi00 * E00[binIndex]);
-      const auto e01_I11 = pow<2>(pmdi11 * E11[binIndex]);
-      const auto e01_F1 = pow<2>(pmdf1 * F1E[binIndex]);
-      const auto e01_F2 = pow<2>(pmdf2 * F2E[binIndex]);
-      const auto e01_P1 = pow<2>(pmdp1 * P1E[binIndex]);
-      const auto e01_P2 = pow<2>(pmdp2 * P2E[binIndex]);
-      E01[binIndex] =
-          std::sqrt(e01_I00 + e01_I11 + e01_F1 + e01_F2 + e01_P1 + e01_P2);
-      // Case: 10
-      I10[binIndex] =
-          (-pow<2>(f1) * f2 * i00 * pow<2>(b) * c + f2 * i00 * p1 * a +
-           f1 * b * (-i11 * d * p2 + f2 * i00 * b * c)) /
-          divisor;
-      // Derivatives of the above with respect to i00, i11, f1, etc.
-      const auto mpdi00 =
-          (-pow<2>(f1) * f2 * pow<2>(b) * c + f1 * f2 * pow<2>(b) * c +
-           f2 * p1 * a) /
-          (f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c));
-      const auto mpdi11 =
-          -((f1 * b * d * p2) /
-            (f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c)));
-      const auto mpdf1 =
-          -(((-1. + 2. * p1) *
-             ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)) *
-             (-pow<2>(f1) * f2 * i00 * pow<2>(1. - 2. * p1) * (-1. + 2. * p2) +
-              f2 * i00 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
-              f1 * (-1. + 2. * p1) *
-                  (-i11 * (-1. + p2) * p2 +
-                   f2 * i00 * (-1. + 2. * p1) * (-1. + 2. * p2)))) /
-            pow<2>(f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
-                   f1 * (-1. + 2. * p1) *
-                       ((1. - p2) * p2 +
-                        f2 * (-1. + p1 + p2) * (-1. + 2. * p2)))) +
-          (-2. * f1 * f2 * i00 * pow<2>(1. - 2. * p1) * (-1. + 2. * p2) +
-           (-1. + 2. * p1) * (-i11 * (-1. + p2) * p2 +
-                              f2 * i00 * (-1. + 2. * p1) * (-1. + 2. * p2))) /
-              (f2 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) +
-               f1 * (-1. + 2. * p1) *
-                   ((1. - p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)));
-      const auto mpdf2 =
-          -(((f1 * b * (p1 + d) * c + p1 * a) *
-             (-pow<2>(f1) * f2 * i00 * pow<2>(b) * c + f2 * i00 * p1 * a +
-              f1 * b * (-i11 * d * p2 + f2 * i00 * b * c))) /
-            pow<2>(f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c))) +
-          (-pow<2>(f1) * i00 * pow<2>(b) * c + f1 * i00 * pow<2>(b) * c +
-           i00 * p1 * a) /
-              (f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c));
-      const auto mpdp1 =
-          -(((-pow<2>(f1) * f2 * i00 * pow<2>(b) * c + f2 * i00 * p1 * a +
-              f1 * b * (-i11 * d * p2 + f2 * i00 * b * c)) *
-             (f2 * p1 * -c + f1 * f2 * b * c + f2 * a +
-              2. * f1 * (-d * p2 + f2 * (p1 + d) * c))) /
-            pow<2>(f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c))) +
-          (f2 * i00 * p1 * -c + 4. * pow<2>(f1) * f2 * i00 * -b * c +
-           2. * f1 * f2 * i00 * b * c + f2 * i00 * a +
-           2. * f1 * (-i11 * d * p2 + f2 * i00 * b * c)) /
-              (f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c));
-      const auto mpdp2 =
-          -(((f2 * (2. - 2. * p1) * p1 +
-              f1 * b * (1. - 2. * p2 + 2. * f2 * (p1 + d) + f2 * c)) *
-             (-pow<2>(f1) * f2 * i00 * pow<2>(b) * c + f2 * i00 * p1 * a +
-              f1 * b * (-i11 * d * p2 + f2 * i00 * b * c))) /
-            pow<2>(f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c))) +
-          (-2. * pow<2>(f1) * f2 * i00 * pow<2>(b) +
-           f2 * i00 * (2. - 2. * p1) * p1 +
-           f1 * b * (2. * f2 * i00 * b - i11 * d - i11 * p2)) /
-              (f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c));
-      const auto e10_I00 = pow<2>(mpdi00 * E00[binIndex]);
-      const auto e10_I11 = pow<2>(mpdi11 * E11[binIndex]);
-      const auto e10_F1 = pow<2>(mpdf1 * F1E[binIndex]);
-      const auto e10_F2 = pow<2>(mpdf2 * F2E[binIndex]);
-      const auto e10_P1 = pow<2>(mpdp1 * P1E[binIndex]);
-      const auto e10_P2 = pow<2>(mpdp2 * P2E[binIndex]);
-      E10[binIndex] =
-          std::sqrt(e10_I00 + e10_I11 + e10_F1 + e10_F2 + e10_P1 + e10_P2);
-    }
-  }
+  twoInputsSolve01And10(fullInputs, inputs, efficiencies);
   return fullCorrections(fullInputs, efficiencies);
 }
 
@@ -691,10 +697,10 @@ PolarizationEfficiencyCor::threeInputCorrections(
   checkInputExists(inputs.ppWS, Flippers::OffOff);
   if (!inputs.mpWS) {
     checkInputExists(inputs.pmWS, Flippers::OffOn);
-    solve10(fullInputs, efficiencies);
+    threeInputsSolve10(fullInputs, efficiencies);
   } else {
     checkInputExists(inputs.mpWS, Flippers::OnOff);
-    solve01(fullInputs, efficiencies);
+    threeInputsSolve01(fullInputs, efficiencies);
   }
   return fullCorrections(fullInputs, efficiencies);
 }
@@ -716,7 +722,6 @@ PolarizationEfficiencyCor::fullCorrections(const WorkspaceMap &inputs,
   checkInputExists(inputs.pmWS, Flippers::OffOn);
   checkInputExists(inputs.ppWS, Flippers::OffOff);
   WorkspaceMap outputs;
-  // TODO check if history is retained with create().
   outputs.mmWS = DataObjects::create<DataObjects::Workspace2D>(*inputs.mmWS);
   outputs.mpWS = DataObjects::create<DataObjects::Workspace2D>(*inputs.mpWS);
   outputs.pmWS = DataObjects::create<DataObjects::Workspace2D>(*inputs.pmWS);
@@ -858,7 +863,7 @@ PolarizationEfficiencyCor::mapInputsToDirections(
  * @param inputs a set of input workspaces
  * @param efficiencies a set of efficiency factors
  */
-void PolarizationEfficiencyCor::solve01(WorkspaceMap &inputs,
+void PolarizationEfficiencyCor::threeInputsSolve01(WorkspaceMap &inputs,
                                         const EfficiencyMap &efficiencies) {
   using namespace Mantid::DataObjects;
   inputs.pmWS = create<Workspace2D>(*inputs.mpWS);
@@ -895,7 +900,7 @@ void PolarizationEfficiencyCor::solve01(WorkspaceMap &inputs,
  * @param inputs a set of input workspaces
  * @param efficiencies a set of efficiency factors
  */
-void PolarizationEfficiencyCor::solve10(WorkspaceMap &inputs,
+void PolarizationEfficiencyCor::threeInputsSolve10(WorkspaceMap &inputs,
                                         const EfficiencyMap &efficiencies) {
   inputs.mpWS = DataObjects::create<DataObjects::Workspace2D>(*inputs.pmWS);
   const auto &F1 = efficiencies.F1->y();
@@ -921,6 +926,60 @@ void PolarizationEfficiencyCor::solve10(WorkspaceMap &inputs,
            f2 * i00 * (-1. + 2. * p2)) /
           (p1 - p2 + f2 * (-1. + 2. * p2));
       // The errors are left to zero.
+    }
+  }
+}
+
+/**
+ * Solve in-place the 01 and 10 flipper configurations from the assumption that
+ * for the corrected intensities R01 = R10 = 0.
+ * @param inputs a set of input workspaces
+ * @param efficiencies a set of efficiency factors
+ */
+void PolarizationEfficiencyCor::twoInputsSolve01And10(WorkspaceMap &fullInputs, const WorkspaceMap &inputs, const EfficiencyMap &efficiencies) {
+  using namespace boost::math;
+  const auto &F1 = efficiencies.F1->y();
+  const auto &F1E = efficiencies.F1->e();
+  const auto &F2 = efficiencies.F2->y();
+  const auto &F2E = efficiencies.F2->e();
+  const auto &P1 = efficiencies.P1->y();
+  const auto &P1E = efficiencies.P1->e();
+  const auto &P2 = efficiencies.P2->y();
+  const auto &P2E = efficiencies.P2->e();
+  const auto nHisto = inputs.mmWS->getNumberHistograms();
+  for (size_t wsIndex = 0; wsIndex != nHisto; ++wsIndex) {
+    const auto &I00 = inputs.ppWS->y(wsIndex);
+    const auto &E00 = inputs.ppWS->e(wsIndex);
+    const auto &I11 = inputs.mmWS->y(wsIndex);
+    const auto &E11 = inputs.mmWS->e(wsIndex);
+    auto &I01 = fullInputs.pmWS->mutableY(wsIndex);
+    auto &E01 = fullInputs.pmWS->mutableE(wsIndex);
+    auto &I10 = fullInputs.mpWS->mutableY(wsIndex);
+    auto &E10 = fullInputs.mpWS->mutableE(wsIndex);
+    for (size_t binIndex = 0; binIndex != I00.size(); ++binIndex) {
+      const auto i00 = I00[binIndex];
+      const auto i11 = I11[binIndex];
+      const auto f1 = F1[binIndex];
+      const auto f2 = F2[binIndex];
+      const auto p1 = P1[binIndex];
+      const auto p2 = P2[binIndex];
+      const auto a = -1. + p1 + 2. * p2 - 2. * p1 * p2;
+      const auto b = -1. + 2. * p1;
+      const auto c = -1. + 2. * p2;
+      const auto d = -1. + p2;
+      // Case: 01
+      const auto divisor = f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c);
+      I01[binIndex] =
+          (f2 * i11 * p1 * a -
+           f1 * i00 * b * (-f2 * pow<2>(c) + pow<2>(f2 * c) + d * p2)) /
+          divisor;
+      E01[binIndex] = twoInputsErrorEstimate01(i00, E00[binIndex], i11, E11[binIndex], p1, P1E[binIndex], p2, P2E[binIndex], f1, F1E[binIndex], f2, F2E[binIndex]);
+      // Case: 10
+      I10[binIndex] =
+          (-pow<2>(f1) * f2 * i00 * pow<2>(b) * c + f2 * i00 * p1 * a +
+           f1 * b * (-i11 * d * p2 + f2 * i00 * b * c)) /
+          divisor;
+      E10[binIndex] = twoInputsErrorEstimate10(i00, E00[binIndex], i11, E11[binIndex], p1, P1E[binIndex], p2, P2E[binIndex], f1, F1E[binIndex], f2, F2E[binIndex]);
     }
   }
 }

--- a/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
@@ -392,8 +392,8 @@ PolarizationEfficiencyCor::WorkspaceMap PolarizationEfficiencyCor::analyzerlessC
       const Eigen::Vector2d intensities(ppY[binIndex], mmY[binIndex]);
       const auto PFProduct = P1m * F1m;
       const auto corrected = PFProduct * intensities;
-      ppYOut = corrected[0];
-      mmYOut = corrected[1];
+      ppYOut[binIndex] = corrected[0];
+      mmYOut[binIndex] = corrected[1];
       const auto F1E = efficiencies.F1->e()[binIndex];
       const auto P1E = efficiencies.P1->e()[binIndex];
       const auto elemE1 = -1. / pow<2>(F1) * F1E;

--- a/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
@@ -322,10 +322,11 @@ PolarizationEfficiencyCor::WorkspaceMap PolarizationEfficiencyCor::twoInputCorre
       // Derivatives of the above with respect to i00, i11, f1, etc.
       const auto mpdi00 = (-pow<2>(f1) * f2 * pow<2>(b) * c + f1 * f2 * pow<2>(b) * c + f2 * p1 * a) / (f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c));
       const auto mpdi11 = -((f1 * b * d * p2) / (f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c)));
-      const auto mpdf1 = -((b * ((1. - p2) * p2 + f2 * (p1 + d) * c) * (-pow<2>(f1) * f2 * i00 * pow<2>(b) * c + f2 * i00 * p1 * a + f1 * b * (-i11 * d * p2 + f2 * i00 * b * c))) /
-                         pow<2>(f2 * p1 * a * + f1 * b * (-d * p2 + f2 * (p1 + d) * c))) +
-          (-2. * f1 * f2 * i00 * pow<2>(b) * c + b * (-i11 * d * p2 + f2 * i00 * b * c)) /
-          (f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c));
+      const auto mpdf1 = (f2 * i11 * p1 * (-1. + p1 + 2. * p2 - 2. * p1 * p2) -
+         f1 * i00 * (-1. + 2. * p1) * (-f2 * pow<2>(1. - 2. * p2) +
+            pow<2>(f2) * pow<2>(1. - 2. * p2) + (-1. + p2) * p2)) / (f2 * p1 * (-1. + p1 + 2. * p2 -
+            2. * p1 * p2) +
+         f1 * (-1. + 2. * p1) * (-(-1 + p2) * p2 + f2 * (-1. + p1 + p2) * (-1. + 2. * p2)));
       const auto mpdf2 = -(((f1 * b * (p1 + d) * c + p1 * a) * (-pow<2>(f1) * f2 * i00 * pow<2>(b) * c + f2 * i00 * p1 * a + f1 * b * (-i11 * d * p2 + f2 * i00 * b * c))) /
                          pow<2>(f2 * p1 * a + f1 * b * (-d * p2 + f2 * (p1 + d) * c))) +
           (-pow<2>(f1) * i00 * pow<2>(b) * c + f1 * i00 * pow<2>(b) * c + i00 * p1 * a) /

--- a/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
@@ -1068,8 +1068,9 @@ private:
     const auto f2Error = (P2 * P1 * dF2 * F1 * y).array();
     const auto f1Error = (P2 * P1 * F2 * dF1 * y).array();
     const auto inverted = (P2 * P1 * F2 * F1).array();
-    const auto yError = ((inverted * inverted).matrix() *
-                         (e.array() * e.array()).matrix()).array();
+    const auto yError =
+        ((inverted * inverted).matrix() * (e.array() * e.array()).matrix())
+            .array();
     return (p2Error * p2Error + p1Error * p1Error + f2Error * f2Error +
             f1Error * f1Error + yError)
         .sqrt()
@@ -1107,8 +1108,9 @@ private:
     const auto p1Error = (dP1 * F1 * y).array();
     const auto f1Error = (P1 * dF1 * y).array();
     const auto inverted = (P1 * F1).array();
-    const auto yError = ((inverted * inverted).matrix() *
-                         (e.array() * e.array()).matrix()).array();
+    const auto yError =
+        ((inverted * inverted).matrix() * (e.array() * e.array()).matrix())
+            .array();
     return (p1Error * p1Error + f1Error * f1Error + yError).sqrt().matrix();
   }
 

--- a/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
@@ -62,14 +62,13 @@ public:
       }
     }
     auto effWS = idealEfficiencies(edges);
-    constexpr char *OUTWS_NAME{"output"};
     PolarizationEfficiencyCor alg;
     alg.setChild(true);
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", OUTWS_NAME))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.execute())
     TS_ASSERT(alg.isExecuted())
@@ -78,7 +77,7 @@ public:
     TS_ASSERT_EQUALS(outputWS->getNumberOfEntries(), 4)
     const std::array<std::string, 4> POL_DIRS{{"++", "+-", "-+", "--"}};
     for (size_t i = 0; i != 4; ++i) {
-      const std::string wsName = OUTWS_NAME + std::string("_") + POL_DIRS[i];
+      const std::string wsName = m_outputWSName + std::string("_") + POL_DIRS[i];
       MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(wsName));
       TS_ASSERT(ws)
       TS_ASSERT_EQUALS(ws->getNumberHistograms(), nHist)
@@ -97,11 +96,11 @@ public:
   }
 
   void test_IdealCaseThreeInputs10Missing() {
-    threeInputsTest("10");
+    idealThreeInputsTest("10");
   }
 
   void test_IdealCaseThreeInputs01Missing() {
-    threeInputsTest("01");
+    idealThreeInputsTest("01");
   }
 
   void test_IdealCaseTwoInputsWithAnalyzer() {
@@ -125,14 +124,13 @@ public:
     }
 
     auto effWS = idealEfficiencies(edges);
-    constexpr char *OUTWS_NAME{"output"};
     PolarizationEfficiencyCor alg;
     alg.setChild(true);
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", OUTWS_NAME))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", "00, 11"))
     TS_ASSERT_THROWS_NOTHING(alg.execute())
@@ -143,7 +141,7 @@ public:
     const std::array<std::string, 4> POL_DIRS{{"++", "+-", "-+", "--"}};
     for (size_t i = 0; i != 4; ++i) {
       const auto &dir = POL_DIRS[i];
-      const std::string wsName = OUTWS_NAME + std::string("_") + dir;
+      const std::string wsName = m_outputWSName + std::string("_") + dir;
       MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(wsName));
       TS_ASSERT(ws)
       const double expected = [yVal, &dir]() {
@@ -199,14 +197,13 @@ public:
       ws11->mutableE(i) *= 2.;
     }
     auto effWS = idealEfficiencies(edges);
-    constexpr char *OUTWS_NAME{"output"};
     PolarizationEfficiencyCor alg;
     alg.setChild(true);
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", OUTWS_NAME))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", "00, 11"))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Analyzer", false))
@@ -218,7 +215,7 @@ public:
     const std::array<std::string, 2> POL_DIRS{{"++", "--"}};
     for (size_t i = 0; i != 2; ++i) {
       const auto &dir = POL_DIRS[i];
-      const std::string wsName = OUTWS_NAME + std::string("_") + dir;
+      const std::string wsName = m_outputWSName + std::string("_") + dir;
       MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(wsName));
       TS_ASSERT(ws)
       TS_ASSERT_EQUALS(ws->getNumberHistograms(), nHist)
@@ -250,14 +247,13 @@ public:
     WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
     inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
     auto effWS = idealEfficiencies(edges);
-    constexpr char *OUTWS_NAME{"output"};
     PolarizationEfficiencyCor alg;
     alg.setChild(true);
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", OUTWS_NAME))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", "00"))
     TS_ASSERT_THROWS_NOTHING(alg.execute())
@@ -265,7 +261,7 @@ public:
     WorkspaceGroup_sptr outputWS = alg.getProperty("OutputWorkspace");
     TS_ASSERT(outputWS)
     TS_ASSERT_EQUALS(outputWS->getNumberOfEntries(), 1)
-    MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(OUTWS_NAME + std::string("_++")));
+    MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(m_outputWSName + std::string("_++")));
     TS_ASSERT(ws)
     TS_ASSERT_EQUALS(ws->getNumberHistograms(), nHist)
     for (size_t i = 0; i != nHist; ++i) {
@@ -286,7 +282,6 @@ public:
     using namespace Mantid::DataObjects;
     using namespace Mantid::HistogramData;
     using namespace Mantid::Kernel;
-    constexpr size_t nBins{3};
     constexpr size_t nHist{2};
     BinEdges edges{0.3, 0.6, 0.9, 1.2};
     const double yVal = 2.3;
@@ -308,20 +303,71 @@ public:
       }
     }
     auto effWS = efficiencies(edges);
-    constexpr char *OUTWS_NAME{"output"};
     PolarizationEfficiencyCor alg;
     alg.setChild(true);
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", OUTWS_NAME))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.execute())
     TS_ASSERT(alg.isExecuted())
     WorkspaceGroup_sptr outputWS = alg.getProperty("OutputWorkspace");
     TS_ASSERT(outputWS)
     TS_ASSERT_EQUALS(outputWS->getNumberOfEntries(), 4)
+    fullFourInputsResultsCheck(outputWS, ws00, ws01, ws10, ws11, effWS);
+  }
+
+  void test_ThreeInputsWithMissing01FlipperConfiguration() {
+    threeInputsTest("01");
+  }
+
+  void test_ThreeInputsWithMissing10FlipperConfiguration() {
+    threeInputsTest("10");
+  }
+
+  void test_TwoInputsWithAnalyzer() {
+    using namespace Mantid::API;
+    using namespace Mantid::DataObjects;
+    using namespace Mantid::HistogramData;
+    using namespace Mantid::Kernel;
+    constexpr size_t nHist{2};
+    constexpr size_t nBins{3};
+    BinEdges edges{0.3, 0.6, 0.9, 1.2};
+    const double yVal = 2.3;
+    Counts counts{yVal, yVal, yVal};
+    MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
+    MatrixWorkspace_sptr ws01 = nullptr;
+    MatrixWorkspace_sptr ws10 = nullptr;
+    MatrixWorkspace_sptr ws11 = ws00->clone();
+    WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
+    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
+    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws11));
+    for (size_t i = 0; i != 2; ++i) {
+      MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(inputWS->getItem(i));
+      for (size_t j = 0; j != nHist; ++j) {
+        ws->mutableY(j) *= static_cast<double>(i + 1);
+        ws->mutableE(j) *= static_cast<double>(i + 1);
+      }
+    }
+    auto effWS = efficiencies(edges);
+    PolarizationEfficiencyCor alg;
+    alg.setChild(true);
+    alg.setRethrows(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Flippers", "00, 11"))
+    TS_ASSERT_THROWS_NOTHING(alg.execute())
+    TS_ASSERT(alg.isExecuted())
+    WorkspaceGroup_sptr outputWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outputWS)
+    TS_ASSERT_EQUALS(outputWS->getNumberOfEntries(), 4)
+    solveMissingIntensities(ws00, ws01, ws10, ws11, effWS);
+    using namespace Mantid::API;
     const double F1 = effWS->y(0).front();
     const double F1e = effWS->e(0).front();
     const double F2 = effWS->y(1).front();
@@ -334,10 +380,10 @@ public:
     const auto expected = correction(y, F1, F2, P1, P2);
     const Eigen::Vector4d e{ws00->e(0).front(), ws01->e(0).front(), ws10->e(0).front(), ws11->e(0).front()};
     const auto expectedError = error(y, e, F1, F1e, F2, F2e, P1, P1e, P2, P2e);
-    MatrixWorkspace_sptr ppWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(OUTWS_NAME + std::string("_++")));
-    MatrixWorkspace_sptr pmWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(OUTWS_NAME + std::string("_+-")));
-    MatrixWorkspace_sptr mpWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(OUTWS_NAME + std::string("_-+")));
-    MatrixWorkspace_sptr mmWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(OUTWS_NAME + std::string("_--")));
+    MatrixWorkspace_sptr ppWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(m_outputWSName + std::string("_++")));
+    MatrixWorkspace_sptr pmWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(m_outputWSName + std::string("_+-")));
+    MatrixWorkspace_sptr mpWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(m_outputWSName + std::string("_-+")));
+    MatrixWorkspace_sptr mmWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(m_outputWSName + std::string("_--")));
     TS_ASSERT(ppWS)
     TS_ASSERT(pmWS)
     TS_ASSERT(mpWS)
@@ -372,10 +418,19 @@ public:
         TS_ASSERT_DELTA(pmY[k], expected[1], 1e-12)
         TS_ASSERT_DELTA(mpY[k], expected[2], 1e-12)
         TS_ASSERT_DELTA(mmY[k], expected[3], 1e-12)
-        TS_ASSERT_DELTA(ppE[k], expectedError[0], 1e-12)
-        TS_ASSERT_DELTA(pmE[k], expectedError[1], 1e-12)
-        TS_ASSERT_DELTA(mpE[k], expectedError[2], 1e-12)
-        TS_ASSERT_DELTA(mmE[k], expectedError[3], 1e-12)
+        // This test constructs the expected missing I01 and I10 intensities
+        // slightly different from what the algorithm does: I10 is solved
+        // first and then I01 is solved using all I00, I10 and I11. This
+        // results in slightly larger errors estimates for I01 and thus for
+        // the final corrected expected intensities.
+        TS_ASSERT_DELTA(ppE[k], expectedError[0], 1e-6)
+        TS_ASSERT_LESS_THAN(ppE[k], expectedError[0])
+        TS_ASSERT_DELTA(pmE[k], expectedError[1], 1e-2)
+        TS_ASSERT_LESS_THAN(pmE[k], expectedError[1])
+        TS_ASSERT_DELTA(mpE[k], expectedError[2], 1e-7)
+        TS_ASSERT_LESS_THAN(mpE[k], expectedError[2])
+        TS_ASSERT_DELTA(mmE[k], expectedError[3], 1e-5)
+        TS_ASSERT_LESS_THAN(mmE[k], expectedError[3])
       }
     }
   }
@@ -398,14 +453,13 @@ public:
     axis->setLabel(2, "P1");
     axis->setLabel(3, "P2");
     effWS->replaceAxis(1, axis.release());
-    constexpr char *OUTWS_NAME{"output"};
     PolarizationEfficiencyCor alg;
     alg.setChild(true);
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", OUTWS_NAME))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", "00"))
     TS_ASSERT_THROWS(alg.execute(), std::runtime_error)
@@ -426,14 +480,13 @@ public:
     // Change a bin edge of one of the histograms.
     auto &xs = effWS->mutableX(0);
     xs[xs.size() / 2] *= 1.01;
-    constexpr char *OUTWS_NAME{"output"};
     PolarizationEfficiencyCor alg;
     alg.setChild(true);
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", OUTWS_NAME))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", "00"))
     TS_ASSERT_THROWS(alg.execute(), std::runtime_error)
@@ -458,14 +511,13 @@ public:
     inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws10));
     inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws11));
     auto effWS = idealEfficiencies(edges);
-    constexpr char *OUTWS_NAME{"output"};
     PolarizationEfficiencyCor alg;
     alg.setChild(true);
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", OUTWS_NAME))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS(alg.execute(), std::runtime_error)
     TS_ASSERT(!alg.isExecuted())
@@ -487,20 +539,21 @@ public:
     inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws01));
     inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws11));
     auto effWS = idealEfficiencies(edges);
-    constexpr char *OUTWS_NAME{"output"};
     PolarizationEfficiencyCor alg;
     alg.setChild(true);
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", OUTWS_NAME))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS(alg.execute(), std::runtime_error)
     TS_ASSERT(!alg.isExecuted())
   }
 
 private:
+  std::string m_outputWSName{"output"};
+
   Mantid::API::MatrixWorkspace_sptr efficiencies(const Mantid::HistogramData::BinEdges &edges) {
     using namespace Mantid::API;
     using namespace Mantid::DataObjects;
@@ -547,7 +600,7 @@ private:
     return ws;
   }
 
-  void threeInputsTest(const std::string &missingFlipperConf) {
+  void idealThreeInputsTest(const std::string &missingFlipperConf) {
     using namespace Mantid::API;
     using namespace Mantid::DataObjects;
     using namespace Mantid::HistogramData;
@@ -633,6 +686,117 @@ private:
     }
   }
 
+  void threeInputsTest(const std::string &missingFlipperConf) {
+    using namespace Mantid::API;
+    using namespace Mantid::DataObjects;
+    using namespace Mantid::HistogramData;
+    using namespace Mantid::Kernel;
+    constexpr size_t nHist{2};
+    BinEdges edges{0.3, 0.6, 0.9, 1.2};
+    const double yVal = 2.3;
+    Counts counts{yVal, yVal, yVal};
+    MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
+    MatrixWorkspace_sptr ws01 = missingFlipperConf == "01" ? nullptr : ws00->clone();
+    MatrixWorkspace_sptr ws10 = missingFlipperConf == "10" ? nullptr : ws00->clone();
+    MatrixWorkspace_sptr ws11 = ws00->clone();
+    WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
+    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
+    if (ws01) {
+      inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws01));
+    } else {
+      inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws10));
+    }
+    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws11));
+    for (size_t i = 0; i != 3; ++i) {
+      MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(inputWS->getItem(i));
+      for (size_t j = 0; j != nHist; ++j) {
+        ws->mutableY(j) *= static_cast<double>(i + 1);
+        ws->mutableE(j) *= static_cast<double>(i + 1);
+      }
+    }
+    auto effWS = efficiencies(edges);
+    PolarizationEfficiencyCor alg;
+    alg.setChild(true);
+    alg.setRethrows(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
+    const std::string presentFlipperConf = missingFlipperConf == "01" ? "10" : "01";
+    const std::string flipperConf = "00, " + presentFlipperConf + ", 11";
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Flippers", flipperConf))
+    TS_ASSERT_THROWS_NOTHING(alg.execute())
+    TS_ASSERT(alg.isExecuted())
+    WorkspaceGroup_sptr outputWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outputWS)
+    TS_ASSERT_EQUALS(outputWS->getNumberOfEntries(), 4)
+    solveMissingIntensity(ws00, ws01, ws10, ws11, effWS);
+    fullFourInputsResultsCheck(outputWS, ws00, ws01, ws10, ws11, effWS);
+  }
+
+  void fullFourInputsResultsCheck(Mantid::API::WorkspaceGroup_sptr &outputWS, Mantid::API::MatrixWorkspace_sptr &ws00, Mantid::API::MatrixWorkspace_sptr &ws01, Mantid::API::MatrixWorkspace_sptr &ws10, Mantid::API::MatrixWorkspace_sptr &ws11, Mantid::API::MatrixWorkspace_sptr &effWS) {
+    using namespace Mantid::API;
+    const auto nHist = ws00->getNumberHistograms();
+    const auto nBins = ws00->y(0).size();
+    const auto edges = ws00->binEdges(0);
+    const double F1 = effWS->y(0).front();
+    const double F1e = effWS->e(0).front();
+    const double F2 = effWS->y(1).front();
+    const double F2e = effWS->e(1).front();
+    const double P1 = effWS->y(2).front();
+    const double P1e = effWS->e(2).front();
+    const double P2 = effWS->y(3).front();
+    const double P2e = effWS->e(3).front();
+    const Eigen::Vector4d y{ws00->y(0).front(), ws01->y(0).front(), ws10->y(0).front(), ws11->y(0).front()};
+    const auto expected = correction(y, F1, F2, P1, P2);
+    const Eigen::Vector4d e{ws00->e(0).front(), ws01->e(0).front(), ws10->e(0).front(), ws11->e(0).front()};
+    const auto expectedError = error(y, e, F1, F1e, F2, F2e, P1, P1e, P2, P2e);
+    MatrixWorkspace_sptr ppWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(m_outputWSName + std::string("_++")));
+    MatrixWorkspace_sptr pmWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(m_outputWSName + std::string("_+-")));
+    MatrixWorkspace_sptr mpWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(m_outputWSName + std::string("_-+")));
+    MatrixWorkspace_sptr mmWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(m_outputWSName + std::string("_--")));
+    TS_ASSERT(ppWS)
+    TS_ASSERT(pmWS)
+    TS_ASSERT(mpWS)
+    TS_ASSERT(mmWS)
+    TS_ASSERT_EQUALS(ppWS->getNumberHistograms(), nHist)
+    TS_ASSERT_EQUALS(pmWS->getNumberHistograms(), nHist)
+    TS_ASSERT_EQUALS(mpWS->getNumberHistograms(), nHist)
+    TS_ASSERT_EQUALS(mmWS->getNumberHistograms(), nHist)
+    for (size_t j = 0; j != nHist; ++j) {
+      const auto &ppX = ppWS->x(j);
+      const auto &ppY = ppWS->y(j);
+      const auto &ppE = ppWS->e(j);
+      const auto &pmX = pmWS->x(j);
+      const auto &pmY = pmWS->y(j);
+      const auto &pmE = pmWS->e(j);
+      const auto &mpX = mpWS->x(j);
+      const auto &mpY = mpWS->y(j);
+      const auto &mpE = mpWS->e(j);
+      const auto &mmX = mmWS->x(j);
+      const auto &mmY = mmWS->y(j);
+      const auto &mmE = mmWS->e(j);
+      TS_ASSERT_EQUALS(ppY.size(), nBins)
+      TS_ASSERT_EQUALS(pmY.size(), nBins)
+      TS_ASSERT_EQUALS(mpY.size(), nBins)
+      TS_ASSERT_EQUALS(mmY.size(), nBins)
+      for (size_t k = 0; k != nBins; ++k) {
+        TS_ASSERT_EQUALS(ppX[k], edges[k])
+        TS_ASSERT_EQUALS(pmX[k], edges[k])
+        TS_ASSERT_EQUALS(mpX[k], edges[k])
+        TS_ASSERT_EQUALS(mmX[k], edges[k])
+        TS_ASSERT_DELTA(ppY[k], expected[0], 1e-12)
+        TS_ASSERT_DELTA(pmY[k], expected[1], 1e-12)
+        TS_ASSERT_DELTA(mpY[k], expected[2], 1e-12)
+        TS_ASSERT_DELTA(mmY[k], expected[3], 1e-12)
+        TS_ASSERT_DELTA(ppE[k], expectedError[0], 1e-12)
+        TS_ASSERT_DELTA(pmE[k], expectedError[1], 1e-12)
+        TS_ASSERT_DELTA(mpE[k], expectedError[2], 1e-12)
+        TS_ASSERT_DELTA(mmE[k], expectedError[3], 1e-12)
+      }
+    }
+  }
   void invertedF1(Eigen::Matrix4d &m, const double f1) {
     m << f1, 0., 0., 0.,
          0., f1, 0., 0.,
@@ -738,6 +902,117 @@ private:
     const auto inverted = (P2 * P1 * F2 * F1).array();
     const auto yError = ((inverted * inverted).matrix() * (e.array() * e.array()).matrix()).array();
     return (p2Error * p2Error + p1Error * p1Error + f2Error * f2Error + f1Error * f1Error + yError).sqrt().matrix();
+  }
+
+  void solveMissingIntensity(const Mantid::API::MatrixWorkspace_sptr &ppWS, Mantid::API::MatrixWorkspace_sptr &pmWS, Mantid::API::MatrixWorkspace_sptr &mpWS, const Mantid::API::MatrixWorkspace_sptr &mmWS, const Mantid::API::MatrixWorkspace_sptr &effWS) {
+    const auto &F1 = effWS->y(0);
+    const auto &F2 = effWS->y(1);
+    const auto &P1 = effWS->y(2);
+    const auto &P2 = effWS->y(3);
+    if (!pmWS) {
+      pmWS = mpWS->clone();
+      for (size_t wsIndex = 0; wsIndex != pmWS->getNumberHistograms(); ++wsIndex) {
+        const auto &ppY = ppWS->y(wsIndex);
+        auto &pmY = pmWS->mutableY(wsIndex);
+        auto &pmE = pmWS->mutableE(wsIndex);
+        const auto &mpY = mpWS->y(wsIndex);
+        const auto &mmY = mmWS->y(wsIndex);
+        for (size_t binIndex = 0; binIndex != mpY.size(); ++binIndex) {
+          // mI01[j] = -(2*MI00[j]*f2L[j]*P2L[j]-P2L[j]*MI11[j]-2*MI10[j]*f2L[j]*P2L[j]+MI10[j]*P2L[j]-MI00[j]*P2L[j]+P1L[j]*MI11[j]-2*MI00[j]*f1L[j]*P1L[j]+MI00[j]*P1L[j]-P1L[j]*MI10[j]+MI00[j]*f1L[j]+MI10[j]*f2L[j]-MI00[j]*f2L[j])/(P2L[j]-P1L[j]+2*f1L[j]*P1L[j]-f1L[j])
+          pmY[binIndex] = -(2*ppY[binIndex]*F2[binIndex]*P2[binIndex]-P2[binIndex]*mmY[binIndex]-2*mpY[binIndex]*F2[binIndex]*P2[binIndex]+mpY[binIndex]*P2[binIndex]-ppY[binIndex]*P2[binIndex]+P1[binIndex]*mmY[binIndex]-2*ppY[binIndex]*F1[binIndex]*P1[binIndex]+ppY[binIndex]*P1[binIndex]-P1[binIndex]*mpY[binIndex]+ppY[binIndex]*F1[binIndex]+mpY[binIndex]*F2[binIndex]-ppY[binIndex]*F2[binIndex])/(P2[binIndex]-P1[binIndex]+2*F1[binIndex]*P1[binIndex]-F1[binIndex]);
+          // Error propagation is not implemented in the algorithm.
+          pmE[binIndex] = 0.;
+        }
+      }
+    } else {
+      mpWS = pmWS->clone();
+      for (size_t wsIndex = 0; wsIndex != mpWS->getNumberHistograms(); ++wsIndex) {
+        const auto &ppY = ppWS->y(wsIndex);
+        const auto &pmY = pmWS->y(wsIndex);
+        auto &mpY = mpWS->mutableY(wsIndex);
+        auto &mpE = mpWS->mutableE(wsIndex);
+        const auto &mmY = mmWS->y(wsIndex);
+        for (size_t binIndex = 0; binIndex != mpY.size(); ++binIndex) {
+          // mI10[j] = (-MI00[j]*P2L[j]+P2L[j]*MI01[j]-P2L[j]*MI11[j]+2*MI00[j]*f2L[j]*P2L[j]-MI01[j]*P1L[j]+P1L[j]*MI11[j]+MI00[j]*P1L[j]-2*MI00[j]*f1L[j]*P1L[j]+2*MI01[j]*f1L[j]*P1L[j]+MI00[j]*f1L[j]-MI00[j]*f2L[j]-MI01[j]*f1L[j])/(-P2L[j]+2*f2L[j]*P2L[j]+P1L[j]-f2L[j])
+          mpY[binIndex] = (-ppY[binIndex]*P2[binIndex]+P2[binIndex]*pmY[binIndex]-P2[binIndex]*mmY[binIndex]+2*ppY[binIndex]*F2[binIndex]*P2[binIndex]-pmY[binIndex]*P1[binIndex]+P1[binIndex]*mmY[binIndex]+ppY[binIndex]*P1[binIndex]-2*ppY[binIndex]*F1[binIndex]*P1[binIndex]+2*pmY[binIndex]*F1[binIndex]*P1[binIndex]+ppY[binIndex]*F1[binIndex]-ppY[binIndex]*F2[binIndex]-pmY[binIndex]*F1[binIndex])/(-P2[binIndex]+2*F2[binIndex]*P2[binIndex]+P1[binIndex]-F2[binIndex]);
+          // Error propagation is not implemented in the algorithm.
+          mpE[binIndex] = 0.;
+        }
+      }
+    }
+  }
+
+  void solveMissingIntensities(const Mantid::API::MatrixWorkspace_sptr &ppWS, Mantid::API::MatrixWorkspace_sptr &pmWS, Mantid::API::MatrixWorkspace_sptr &mpWS, const Mantid::API::MatrixWorkspace_sptr &mmWS, const Mantid::API::MatrixWorkspace_sptr &effWS) {
+    const auto &F1 = effWS->y(0);
+    const auto &F1E = effWS->e(0);
+    const auto &F2 = effWS->y(1);
+    const auto &F2E = effWS->e(1);
+    const auto &P1 = effWS->y(2);
+    const auto &P1E = effWS->e(2);
+    const auto &P2 = effWS->y(3);
+    const auto &P2E = effWS->e(3);
+    pmWS = ppWS->clone();
+    mpWS = ppWS->clone();
+    for (size_t wsIndex = 0; wsIndex != ppWS->getNumberHistograms(); ++wsIndex) {
+      const auto &ppY = ppWS->y(wsIndex);
+      const auto &ppE = ppWS->e(wsIndex);
+      auto &pmY = pmWS->mutableY(wsIndex);
+      auto &pmE = pmWS->mutableE(wsIndex);
+      auto &mpY = mpWS->mutableY(wsIndex);
+      auto &mpE = mpWS->mutableE(wsIndex);
+      const auto &mmY = mmWS->y(wsIndex);
+      const auto &mmE = mmWS->e(wsIndex);
+      for (size_t binIndex = 0; binIndex != mpY.size(); ++binIndex) {
+        const double P12 = P1[binIndex] * P1[binIndex];
+        const double P13 = P1[binIndex] * P12;
+        const double P14 = P1[binIndex] * P13;
+        const double P22 = P2[binIndex] * P2[binIndex];
+        const double P23 = P2[binIndex] * P22;
+        const double F12 = F1[binIndex] * F1[binIndex];
+        {
+          mpY[binIndex] = -(-mmY[binIndex]*P22*F1[binIndex]+2*F1[binIndex]*P1[binIndex]*mmY[binIndex]*P22-2*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P2[binIndex]-8*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P12*P2[binIndex]+2*ppY[binIndex]*F2[binIndex]*P12*P2[binIndex]+8*ppY[binIndex]*F12*F2[binIndex]*P12*P2[binIndex]+2*ppY[binIndex]*F12*F2[binIndex]*P2[binIndex]-8*ppY[binIndex]*F12*F2[binIndex]*P2[binIndex]*P1[binIndex]-2*F1[binIndex]*P1[binIndex]*mmY[binIndex]*P2[binIndex]-2*ppY[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+8*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+mmY[binIndex]*P2[binIndex]*F1[binIndex]+ppY[binIndex]*F1[binIndex]*F2[binIndex]-ppY[binIndex]*F2[binIndex]*P12+4*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P12+4*ppY[binIndex]*F12*F2[binIndex]*P1[binIndex]-4*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]+ppY[binIndex]*F2[binIndex]*P1[binIndex]-4*ppY[binIndex]*F12*F2[binIndex]*P12-ppY[binIndex]*F12*F2[binIndex])/(-F1[binIndex]*F2[binIndex]+2*F2[binIndex]*P1[binIndex]*P2[binIndex]+3*F1[binIndex]*F2[binIndex]*P1[binIndex]-2*F1[binIndex]*F2[binIndex]*P22-2*P22*F1[binIndex]*P1[binIndex]+2*P2[binIndex]*F1[binIndex]*P1[binIndex]+3*F1[binIndex]*F2[binIndex]*P2[binIndex]-P2[binIndex]*F1[binIndex]+P22*F1[binIndex]+F2[binIndex]*P12-2*F2[binIndex]*P12*P2[binIndex]-2*F1[binIndex]*F2[binIndex]*P12-F2[binIndex]*P1[binIndex]-8*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+4*F1[binIndex]*F2[binIndex]*P1[binIndex]*P22+4*F1[binIndex]*F2[binIndex]*P12*P2[binIndex]);
+          const double dI00 = -F2[binIndex]*(-2*P2[binIndex]*F1[binIndex]+2*P12*P2[binIndex]+8*P2[binIndex]*F1[binIndex]*P1[binIndex]-2*P1[binIndex]*P2[binIndex]+2*P2[binIndex]*F12-8*P2[binIndex]*F12*P1[binIndex]-8*P2[binIndex]*F1[binIndex]*P12+8*P2[binIndex]*F12*P12-4*F1[binIndex]*P1[binIndex]-F12+4*F12*P1[binIndex]+P1[binIndex]+F1[binIndex]-P12+4*F1[binIndex]*P12-4*F12*P12)/(-P2[binIndex]*F1[binIndex]+3*F1[binIndex]*F2[binIndex]*P2[binIndex]-2*P22*F1[binIndex]*P1[binIndex]-2*F1[binIndex]*F2[binIndex]*P22-2*F2[binIndex]*P12*P2[binIndex]-2*F1[binIndex]*F2[binIndex]*P12+2*P2[binIndex]*F1[binIndex]*P1[binIndex]+P22*F1[binIndex]+F2[binIndex]*P12+3*F1[binIndex]*F2[binIndex]*P1[binIndex]+2*F2[binIndex]*P1[binIndex]*P2[binIndex]-F1[binIndex]*F2[binIndex]-F2[binIndex]*P1[binIndex]-8*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+4*F1[binIndex]*F2[binIndex]*P1[binIndex]*P22+4*F1[binIndex]*F2[binIndex]*P12*P2[binIndex]);
+          const double dI11 = -P2[binIndex]*F1[binIndex]*(1-2*P1[binIndex]-P2[binIndex]+2*P1[binIndex]*P2[binIndex])/(-P2[binIndex]*F1[binIndex]+3*F1[binIndex]*F2[binIndex]*P2[binIndex]-2*P22*F1[binIndex]*P1[binIndex]-2*F1[binIndex]*F2[binIndex]*P22-2*F2[binIndex]*P12*P2[binIndex]-2*F1[binIndex]*F2[binIndex]*P12+2*P2[binIndex]*F1[binIndex]*P1[binIndex]+P22*F1[binIndex]+F2[binIndex]*P12+3*F1[binIndex]*F2[binIndex]*P1[binIndex]+2*F2[binIndex]*P1[binIndex]*P2[binIndex]-F1[binIndex]*F2[binIndex]-F2[binIndex]*P1[binIndex]-8*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+4*F1[binIndex]*F2[binIndex]*P1[binIndex]*P22+4*F1[binIndex]*F2[binIndex]*P12*P2[binIndex]);
+          const double divisor1 = (-P2[binIndex]*F1[binIndex]+3*F1[binIndex]*F2[binIndex]*P2[binIndex]-2*P22*F1[binIndex]*P1[binIndex]-2*F1[binIndex]*F2[binIndex]*P22-2*F2[binIndex]*P12*P2[binIndex]-2*F1[binIndex]*F2[binIndex]*P12+2*P2[binIndex]*F1[binIndex]*P1[binIndex]+P22*F1[binIndex]+F2[binIndex]*P12+3*F1[binIndex]*F2[binIndex]*P1[binIndex]+2*F2[binIndex]*P1[binIndex]*P2[binIndex]-F1[binIndex]*F2[binIndex]-F2[binIndex]*P1[binIndex]-8*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+4*F1[binIndex]*F2[binIndex]*P1[binIndex]*P22+4*F1[binIndex]*F2[binIndex]*P12*P2[binIndex]);
+          const double dF1 = -F2[binIndex]*(-P1[binIndex]*mmY[binIndex]*P2[binIndex]+4*ppY[binIndex]*F2[binIndex]*P1[binIndex]*P22-ppY[binIndex]*F2[binIndex]*P12*P2[binIndex]-10*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P12-8*ppY[binIndex]*F2[binIndex]*P12*P22+2*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]-ppY[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]-32*ppY[binIndex]*F12*F2[binIndex]*P14*P2[binIndex]+32*ppY[binIndex]*F2[binIndex]*P14*P2[binIndex]*F1[binIndex]-32*ppY[binIndex]*F2[binIndex]*P14*P22*F1[binIndex]+32*ppY[binIndex]*F12*F2[binIndex]*P14*P22+32*ppY[binIndex]*F12*F2[binIndex]*P13*P23+2*ppY[binIndex]*F2[binIndex]*P14+4*ppY[binIndex]*P13*P23-4*P13*mmY[binIndex]*P23-8*ppY[binIndex]*F2[binIndex]*P13*P23-16*ppY[binIndex]*P23*F12*P13+8*ppY[binIndex]*F12*F2[binIndex]*P14-8*ppY[binIndex]*F2[binIndex]*P14*P2[binIndex]+8*ppY[binIndex]*F2[binIndex]*P14*P22-8*ppY[binIndex]*F2[binIndex]*P14*F1[binIndex]+10*ppY[binIndex]*F2[binIndex]*P13*P2[binIndex]-4*ppY[binIndex]*F2[binIndex]*P13*P22+16*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P13-4*ppY[binIndex]*F2[binIndex]*P1[binIndex]*P23+12*ppY[binIndex]*F2[binIndex]*P12*P23+18*ppY[binIndex]*P22*F12*P1[binIndex]-20*ppY[binIndex]*F12*F2[binIndex]*P13-36*ppY[binIndex]*P22*F12*P12+24*ppY[binIndex]*P22*F12*P13-6*ppY[binIndex]*P2[binIndex]*F12*P1[binIndex]-5*ppY[binIndex]*F12*F2[binIndex]*P2[binIndex]+8*ppY[binIndex]*F12*F2[binIndex]*P22-8*ppY[binIndex]*P2[binIndex]*F12*P13+12*ppY[binIndex]*P2[binIndex]*F12*P12+18*ppY[binIndex]*F12*F2[binIndex]*P12-7*ppY[binIndex]*F12*F2[binIndex]*P1[binIndex]-12*ppY[binIndex]*P23*F12*P1[binIndex]+24*ppY[binIndex]*P23*F12*P12-4*ppY[binIndex]*F12*F2[binIndex]*P23-3*ppY[binIndex]*P1[binIndex]*P22+ppY[binIndex]*F2[binIndex]*P12-3*ppY[binIndex]*P12*P2[binIndex]+3*P12*mmY[binIndex]*P2[binIndex]-9*P12*mmY[binIndex]*P22+9*ppY[binIndex]*P12*P22+ppY[binIndex]*P1[binIndex]*P2[binIndex]+3*P1[binIndex]*mmY[binIndex]*P22-8*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+8*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]*P22+40*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P12*P2[binIndex]-40*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P12*P22-64*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P13*P2[binIndex]+64*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P13*P22+34*ppY[binIndex]*F12*F2[binIndex]*P2[binIndex]*P1[binIndex]-52*ppY[binIndex]*F12*F2[binIndex]*P22*P1[binIndex]-84*ppY[binIndex]*F12*F2[binIndex]*P12*P2[binIndex]+120*ppY[binIndex]*F12*F2[binIndex]*P12*P22+88*ppY[binIndex]*F12*F2[binIndex]*P13*P2[binIndex]-112*ppY[binIndex]*F12*F2[binIndex]*P13*P22+24*ppY[binIndex]*F12*F2[binIndex]*P23*P1[binIndex]-48*ppY[binIndex]*F12*F2[binIndex]*P12*P23+2*ppY[binIndex]*P13*P2[binIndex]-6*ppY[binIndex]*P13*P22-3*ppY[binIndex]*F2[binIndex]*P13+2*ppY[binIndex]*P1[binIndex]*P23-6*ppY[binIndex]*P12*P23+ppY[binIndex]*P2[binIndex]*F12-3*ppY[binIndex]*P22*F12+ppY[binIndex]*F12*F2[binIndex]+2*ppY[binIndex]*P23*F12-2*P13*mmY[binIndex]*P2[binIndex]+6*P13*mmY[binIndex]*P22+6*P12*mmY[binIndex]*P23-2*P1[binIndex]*mmY[binIndex]*P23)/(divisor1 * divisor1);
+          const double divisor2 = (-P2[binIndex]*F1[binIndex]+3*F1[binIndex]*F2[binIndex]*P2[binIndex]-2*P22*F1[binIndex]*P1[binIndex]-2*F1[binIndex]*F2[binIndex]*P22-2*F2[binIndex]*P12*P2[binIndex]-2*F1[binIndex]*F2[binIndex]*P12+2*P2[binIndex]*F1[binIndex]*P1[binIndex]+P22*F1[binIndex]+F2[binIndex]*P12+3*F1[binIndex]*F2[binIndex]*P1[binIndex]+2*F2[binIndex]*P1[binIndex]*P2[binIndex]-F1[binIndex]*F2[binIndex]-F2[binIndex]*P1[binIndex]-8*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+4*F1[binIndex]*F2[binIndex]*P1[binIndex]*P22+4*F1[binIndex]*F2[binIndex]*P12*P2[binIndex]);
+          const double dF2 = P2[binIndex]*F1[binIndex]*(3*P1[binIndex]*mmY[binIndex]*P2[binIndex]-12*ppY[binIndex]*P22*F1[binIndex]*P1[binIndex]-36*ppY[binIndex]*P2[binIndex]*F1[binIndex]*P12+24*ppY[binIndex]*P22*F1[binIndex]*P12+18*ppY[binIndex]*P2[binIndex]*F1[binIndex]*P1[binIndex]+12*ppY[binIndex]*F1[binIndex]*P12+24*ppY[binIndex]*P2[binIndex]*F1[binIndex]*P13-16*ppY[binIndex]*P22*F1[binIndex]*P13+12*ppY[binIndex]*P22*F12*P1[binIndex]-24*ppY[binIndex]*P22*F12*P12+16*ppY[binIndex]*P22*F12*P13-18*ppY[binIndex]*P2[binIndex]*F12*P1[binIndex]-24*ppY[binIndex]*P2[binIndex]*F12*P13+36*ppY[binIndex]*P2[binIndex]*F12*P12-19*F1[binIndex]*P1[binIndex]*mmY[binIndex]*P2[binIndex]+28*F1[binIndex]*P12*mmY[binIndex]*P2[binIndex]-12*F1[binIndex]*P13*mmY[binIndex]*P2[binIndex]+22*F1[binIndex]*P1[binIndex]*mmY[binIndex]*P22-28*F1[binIndex]*P12*mmY[binIndex]*P22+8*F1[binIndex]*P13*mmY[binIndex]*P22-8*F1[binIndex]*P1[binIndex]*mmY[binIndex]*P23+8*F1[binIndex]*P12*mmY[binIndex]*P23-ppY[binIndex]*F12+2*ppY[binIndex]*P13-2*P13*mmY[binIndex]-mmY[binIndex]*F1[binIndex]+2*ppY[binIndex]*P1[binIndex]*P22+9*ppY[binIndex]*P12*P2[binIndex]-9*P12*mmY[binIndex]*P2[binIndex]+6*P12*mmY[binIndex]*P22-6*ppY[binIndex]*P12*P22-3*ppY[binIndex]*P1[binIndex]*P2[binIndex]-2*P1[binIndex]*mmY[binIndex]*P22-6*ppY[binIndex]*F1[binIndex]*P1[binIndex]+2*ppY[binIndex]*P22*F1[binIndex]-3*ppY[binIndex]*P2[binIndex]*F1[binIndex]-P1[binIndex]*mmY[binIndex]+ppY[binIndex]*P1[binIndex]-3*ppY[binIndex]*P12+ppY[binIndex]*F1[binIndex]+3*P12*mmY[binIndex]-6*ppY[binIndex]*P13*P2[binIndex]+4*ppY[binIndex]*P13*P22+3*ppY[binIndex]*P2[binIndex]*F12-2*ppY[binIndex]*P22*F12+5*F1[binIndex]*P1[binIndex]*mmY[binIndex]+6*ppY[binIndex]*F12*P1[binIndex]-8*F1[binIndex]*P12*mmY[binIndex]-12*F12*P12*ppY[binIndex]-8*ppY[binIndex]*F1[binIndex]*P13+6*P13*mmY[binIndex]*P2[binIndex]+4*F1[binIndex]*P13*mmY[binIndex]+8*F12*P13*ppY[binIndex]-4*P13*mmY[binIndex]*P22-5*mmY[binIndex]*P22*F1[binIndex]+2*mmY[binIndex]*P23*F1[binIndex]+4*mmY[binIndex]*P2[binIndex]*F1[binIndex])/(divisor2 * divisor2);
+          const double divisor3 = (-P2[binIndex]*F1[binIndex]+3*F1[binIndex]*F2[binIndex]*P2[binIndex]-2*P22*F1[binIndex]*P1[binIndex]-2*F1[binIndex]*F2[binIndex]*P22-2*F2[binIndex]*P12*P2[binIndex]-2*F1[binIndex]*F2[binIndex]*P12+2*P2[binIndex]*F1[binIndex]*P1[binIndex]+P22*F1[binIndex]+F2[binIndex]*P12+3*F1[binIndex]*F2[binIndex]*P1[binIndex]+2*F2[binIndex]*P1[binIndex]*P2[binIndex]-F1[binIndex]*F2[binIndex]-F2[binIndex]*P1[binIndex]-8*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+4*F1[binIndex]*F2[binIndex]*P1[binIndex]*P22+4*F1[binIndex]*F2[binIndex]*P12*P2[binIndex]);
+          const double dP1 = -F1[binIndex]*F2[binIndex]*(-2*P1[binIndex]*mmY[binIndex]*P2[binIndex]-2*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P2[binIndex]+8*ppY[binIndex]*F2[binIndex]*P1[binIndex]*P22+24*ppY[binIndex]*P22*F1[binIndex]*P1[binIndex]+8*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P22+8*ppY[binIndex]*P2[binIndex]*F1[binIndex]*P12+6*ppY[binIndex]*F2[binIndex]*P12*P2[binIndex]+4*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P12-24*ppY[binIndex]*P22*F1[binIndex]*P12-12*ppY[binIndex]*F2[binIndex]*P12*P22-8*ppY[binIndex]*P2[binIndex]*F1[binIndex]*P1[binIndex]-2*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]-2*ppY[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+ppY[binIndex]*F2[binIndex]*P2[binIndex]-4*ppY[binIndex]*F2[binIndex]*P22-8*ppY[binIndex]*F2[binIndex]*P1[binIndex]*P23-16*ppY[binIndex]*P23*F1[binIndex]*P1[binIndex]-8*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P23+16*ppY[binIndex]*P23*F1[binIndex]*P12+8*ppY[binIndex]*F2[binIndex]*P12*P23-24*ppY[binIndex]*P22*F12*P1[binIndex]+24*ppY[binIndex]*P22*F12*P12+8*ppY[binIndex]*P2[binIndex]*F12*P1[binIndex]+6*ppY[binIndex]*F12*F2[binIndex]*P2[binIndex]-12*ppY[binIndex]*F12*F2[binIndex]*P22-8*ppY[binIndex]*P2[binIndex]*F12*P12-4*ppY[binIndex]*F12*F2[binIndex]*P12+4*ppY[binIndex]*F12*F2[binIndex]*P1[binIndex]+16*ppY[binIndex]*P23*F12*P1[binIndex]-16*ppY[binIndex]*P23*F12*P12+8*ppY[binIndex]*F12*F2[binIndex]*P23+4*F1[binIndex]*P1[binIndex]*mmY[binIndex]*P2[binIndex]-4*F1[binIndex]*P12*mmY[binIndex]*P2[binIndex]-12*F1[binIndex]*P1[binIndex]*mmY[binIndex]*P22+12*F1[binIndex]*P12*mmY[binIndex]*P22+8*F1[binIndex]*P1[binIndex]*mmY[binIndex]*P23-8*F1[binIndex]*P12*mmY[binIndex]*P23+2*mmY[binIndex]*P23-2*ppY[binIndex]*P23+4*ppY[binIndex]*F2[binIndex]*P23-6*ppY[binIndex]*P1[binIndex]*P22-ppY[binIndex]*F2[binIndex]*P12-2*ppY[binIndex]*P12*P2[binIndex]+2*P12*mmY[binIndex]*P2[binIndex]-6*P12*mmY[binIndex]*P22+6*ppY[binIndex]*P12*P22+2*ppY[binIndex]*P1[binIndex]*P2[binIndex]-ppY[binIndex]*P2[binIndex]+6*P1[binIndex]*mmY[binIndex]*P22-6*ppY[binIndex]*P22*F1[binIndex]+2*ppY[binIndex]*P2[binIndex]*F1[binIndex]+3*ppY[binIndex]*P22+16*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]-40*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]*P22-24*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P12*P2[binIndex]+48*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P12*P22+mmY[binIndex]*P2[binIndex]-3*mmY[binIndex]*P22+32*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]*P23-32*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P12*P23-24*ppY[binIndex]*F12*F2[binIndex]*P2[binIndex]*P1[binIndex]+48*ppY[binIndex]*F12*F2[binIndex]*P22*P1[binIndex]+24*ppY[binIndex]*F12*F2[binIndex]*P12*P2[binIndex]-48*ppY[binIndex]*F12*F2[binIndex]*P12*P22-32*ppY[binIndex]*F12*F2[binIndex]*P23*P1[binIndex]+32*ppY[binIndex]*F12*F2[binIndex]*P12*P23+4*ppY[binIndex]*P1[binIndex]*P23+4*ppY[binIndex]*P23*F1[binIndex]-4*ppY[binIndex]*P12*P23-2*ppY[binIndex]*P2[binIndex]*F12+6*ppY[binIndex]*P22*F12-ppY[binIndex]*F12*F2[binIndex]-4*ppY[binIndex]*P23*F12+4*P12*mmY[binIndex]*P23-4*P1[binIndex]*mmY[binIndex]*P23+3*mmY[binIndex]*P22*F1[binIndex]-2*mmY[binIndex]*P23*F1[binIndex]-mmY[binIndex]*P2[binIndex]*F1[binIndex])/(divisor3 * divisor3);
+          const double divisor4 = (-P2[binIndex]*F1[binIndex]+3*F1[binIndex]*F2[binIndex]*P2[binIndex]-2*P22*F1[binIndex]*P1[binIndex]-2*F1[binIndex]*F2[binIndex]*P22-2*F2[binIndex]*P12*P2[binIndex]-2*F1[binIndex]*F2[binIndex]*P12+2*P2[binIndex]*F1[binIndex]*P1[binIndex]+P22*F1[binIndex]+F2[binIndex]*P12+3*F1[binIndex]*F2[binIndex]*P1[binIndex]+2*F2[binIndex]*P1[binIndex]*P2[binIndex]-F1[binIndex]*F2[binIndex]-F2[binIndex]*P1[binIndex]-8*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+4*F1[binIndex]*F2[binIndex]*P1[binIndex]*P22+4*F1[binIndex]*F2[binIndex]*P12*P2[binIndex]);
+          const double dP2 = F1[binIndex]*F2[binIndex]*(-2*P1[binIndex]*mmY[binIndex]*P2[binIndex]-4*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P2[binIndex]+4*ppY[binIndex]*F2[binIndex]*P1[binIndex]*P22+12*ppY[binIndex]*P22*F1[binIndex]*P1[binIndex]+4*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P22+24*ppY[binIndex]*P2[binIndex]*F1[binIndex]*P12+12*ppY[binIndex]*F2[binIndex]*P12*P2[binIndex]+12*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P12-24*ppY[binIndex]*P22*F1[binIndex]*P12-12*ppY[binIndex]*F2[binIndex]*P12*P22-12*ppY[binIndex]*P2[binIndex]*F1[binIndex]*P1[binIndex]-6*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]-4*ppY[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]-12*ppY[binIndex]*F1[binIndex]*P12-16*ppY[binIndex]*P2[binIndex]*F1[binIndex]*P13+16*ppY[binIndex]*P22*F1[binIndex]*P13-8*ppY[binIndex]*F2[binIndex]*P13*P2[binIndex]+8*ppY[binIndex]*F2[binIndex]*P13*P22-8*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P13-12*ppY[binIndex]*P22*F12*P1[binIndex]+8*ppY[binIndex]*F12*F2[binIndex]*P13+24*ppY[binIndex]*P22*F12*P12-16*ppY[binIndex]*P22*F12*P13+12*ppY[binIndex]*P2[binIndex]*F12*P1[binIndex]+4*ppY[binIndex]*F12*F2[binIndex]*P2[binIndex]-4*ppY[binIndex]*F12*F2[binIndex]*P22+16*ppY[binIndex]*P2[binIndex]*F12*P13-24*ppY[binIndex]*P2[binIndex]*F12*P12-12*ppY[binIndex]*F12*F2[binIndex]*P12+6*ppY[binIndex]*F12*F2[binIndex]*P1[binIndex]+10*F1[binIndex]*P1[binIndex]*mmY[binIndex]*P2[binIndex]-16*F1[binIndex]*P12*mmY[binIndex]*P2[binIndex]+8*F1[binIndex]*P13*mmY[binIndex]*P2[binIndex]-6*F1[binIndex]*P1[binIndex]*mmY[binIndex]*P22+12*F1[binIndex]*P12*mmY[binIndex]*P22-8*F1[binIndex]*P13*mmY[binIndex]*P22+ppY[binIndex]*F12-2*ppY[binIndex]*P13+2*P13*mmY[binIndex]+mmY[binIndex]*F1[binIndex]-2*ppY[binIndex]*P1[binIndex]*P22+ppY[binIndex]*F2[binIndex]*P1[binIndex]-3*ppY[binIndex]*F2[binIndex]*P12-6*ppY[binIndex]*P12*P2[binIndex]+6*P12*mmY[binIndex]*P2[binIndex]-6*P12*mmY[binIndex]*P22+6*ppY[binIndex]*P12*P22+2*ppY[binIndex]*P1[binIndex]*P2[binIndex]+ppY[binIndex]*F1[binIndex]*F2[binIndex]+2*P1[binIndex]*mmY[binIndex]*P22+6*ppY[binIndex]*F1[binIndex]*P1[binIndex]-2*ppY[binIndex]*P22*F1[binIndex]+2*ppY[binIndex]*P2[binIndex]*F1[binIndex]+24*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]-24*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]*P22-48*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P12*P2[binIndex]+48*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P12*P22+P1[binIndex]*mmY[binIndex]-ppY[binIndex]*P1[binIndex]+3*ppY[binIndex]*P12-ppY[binIndex]*F1[binIndex]-3*P12*mmY[binIndex]+32*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P13*P2[binIndex]-32*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P13*P22-24*ppY[binIndex]*F12*F2[binIndex]*P2[binIndex]*P1[binIndex]+24*ppY[binIndex]*F12*F2[binIndex]*P22*P1[binIndex]+48*ppY[binIndex]*F12*F2[binIndex]*P12*P2[binIndex]-48*ppY[binIndex]*F12*F2[binIndex]*P12*P22-32*ppY[binIndex]*F12*F2[binIndex]*P13*P2[binIndex]+32*ppY[binIndex]*F12*F2[binIndex]*P13*P22+4*ppY[binIndex]*P13*P2[binIndex]-4*ppY[binIndex]*P13*P22+2*ppY[binIndex]*F2[binIndex]*P13-2*ppY[binIndex]*P2[binIndex]*F12+2*ppY[binIndex]*P22*F12-ppY[binIndex]*F12*F2[binIndex]-5*F1[binIndex]*P1[binIndex]*mmY[binIndex]-6*ppY[binIndex]*F12*P1[binIndex]+8*F1[binIndex]*P12*mmY[binIndex]+12*F12*P12*ppY[binIndex]+8*ppY[binIndex]*F1[binIndex]*P13-4*P13*mmY[binIndex]*P2[binIndex]-4*F1[binIndex]*P13*mmY[binIndex]-8*F12*P13*ppY[binIndex]+4*P13*mmY[binIndex]*P22+mmY[binIndex]*P22*F1[binIndex]-2*mmY[binIndex]*P2[binIndex]*F1[binIndex])/(divisor4 * divisor4);
+          const double e1 = dI00 * ppE[binIndex];
+          const double e2 = dI11 * mmE[binIndex];
+          const double e3 = dF1 * F1E[binIndex];
+          const double e4 = dF2 * F2E[binIndex];
+          const double e5 = dP1 * P1E[binIndex];
+          const double e6 = dP2 * P2E[binIndex];
+          mpE[binIndex] = std::sqrt(e1 * e1 + e2 * e2 + e3 * e3 + e4 * e4 + e5 * e5 + e6 * e6);
+        }
+        {
+          pmY[binIndex] = -(ppY[binIndex]*P2[binIndex]*F1[binIndex]-2*ppY[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]-2*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P2[binIndex]-2*ppY[binIndex]*P2[binIndex]*F1[binIndex]*P1[binIndex]+2*P1[binIndex]*mpY[binIndex]*F2[binIndex]*P2[binIndex]+ppY[binIndex]*P1[binIndex]*P2[binIndex]-P1[binIndex]*mpY[binIndex]*P2[binIndex]+4*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+P1[binIndex]*mmY[binIndex]*P2[binIndex]-ppY[binIndex]*F1[binIndex]+2*ppY[binIndex]*F1[binIndex]*P1[binIndex]-P1[binIndex]*mmY[binIndex]-P1[binIndex]*mpY[binIndex]*F2[binIndex]+ppY[binIndex]*F2[binIndex]*P1[binIndex]+ppY[binIndex]*F1[binIndex]*F2[binIndex]-2*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]+P1[binIndex]*mpY[binIndex]-ppY[binIndex]*P1[binIndex])/((-P1[binIndex]+2*F1[binIndex]*P1[binIndex]-F1[binIndex])*(-1+P2[binIndex]));
+          const double dI00 = -(-P1[binIndex]+P1[binIndex]*P2[binIndex]+F2[binIndex]*P1[binIndex]-2*F2[binIndex]*P1[binIndex]*P2[binIndex]+2*F1[binIndex]*P1[binIndex]-2*P2[binIndex]*F1[binIndex]*P1[binIndex]-2*F1[binIndex]*F2[binIndex]*P1[binIndex]+4*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+F1[binIndex]*F2[binIndex]-F1[binIndex]+P2[binIndex]*F1[binIndex]-2*F1[binIndex]*F2[binIndex]*P2[binIndex])/((-P1[binIndex]+2*F1[binIndex]*P1[binIndex]-F1[binIndex])*(-1+P2[binIndex]));
+          const double dI11 = -(P1[binIndex]*P2[binIndex]-P1[binIndex])/((-P1[binIndex]+2*F1[binIndex]*P1[binIndex]-F1[binIndex])*(-1+P2[binIndex]));
+          const double dI10 = -(P1[binIndex]-P1[binIndex]*P2[binIndex]-F2[binIndex]*P1[binIndex]+2*F2[binIndex]*P1[binIndex]*P2[binIndex])/((-P1[binIndex]+2*F1[binIndex]*P1[binIndex]-F1[binIndex])*(-1+P2[binIndex]));
+          const double factor1 = (-P1[binIndex]+2*F1[binIndex]*P1[binIndex]-F1[binIndex]);
+          const double dF1 = -(ppY[binIndex]*P2[binIndex]-2*ppY[binIndex]*F2[binIndex]*P2[binIndex]-2*ppY[binIndex]*P1[binIndex]*P2[binIndex]+4*ppY[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]-ppY[binIndex]+2*ppY[binIndex]*P1[binIndex]+ppY[binIndex]*F2[binIndex]-2*ppY[binIndex]*F2[binIndex]*P1[binIndex])/((-P1[binIndex]+2*F1[binIndex]*P1[binIndex]-F1[binIndex])*(-1+P2[binIndex]))+(ppY[binIndex]*P2[binIndex]*F1[binIndex]-2*ppY[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]-2*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P2[binIndex]-2*ppY[binIndex]*P2[binIndex]*F1[binIndex]*P1[binIndex]+2*P1[binIndex]*mpY[binIndex]*F2[binIndex]*P2[binIndex]+ppY[binIndex]*P1[binIndex]*P2[binIndex]-P1[binIndex]*mpY[binIndex]*P2[binIndex]+4*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+P1[binIndex]*mmY[binIndex]*P2[binIndex]-ppY[binIndex]*F1[binIndex]+2*ppY[binIndex]*F1[binIndex]*P1[binIndex]-P1[binIndex]*mmY[binIndex]-P1[binIndex]*mpY[binIndex]*F2[binIndex]+ppY[binIndex]*F2[binIndex]*P1[binIndex]+ppY[binIndex]*F1[binIndex]*F2[binIndex]-2*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]+P1[binIndex]*mpY[binIndex]-ppY[binIndex]*P1[binIndex])*(-1+2*P1[binIndex])/((factor1 * factor1)*(-1+P2[binIndex]));
+          const double dF2 = -(-2*ppY[binIndex]*P1[binIndex]*P2[binIndex]-2*ppY[binIndex]*P2[binIndex]*F1[binIndex]+2*P1[binIndex]*mpY[binIndex]*P2[binIndex]+4*ppY[binIndex]*P2[binIndex]*F1[binIndex]*P1[binIndex]-P1[binIndex]*mpY[binIndex]+ppY[binIndex]*P1[binIndex]+ppY[binIndex]*F1[binIndex]-2*ppY[binIndex]*F1[binIndex]*P1[binIndex])/((-P1[binIndex]+2*F1[binIndex]*P1[binIndex]-F1[binIndex])*(-1+P2[binIndex]));
+          const double factor2 = (-P1[binIndex]+2*F1[binIndex]*P1[binIndex]-F1[binIndex]);
+          const double dP1 = -(-2*ppY[binIndex]*F2[binIndex]*P2[binIndex]-2*ppY[binIndex]*P2[binIndex]*F1[binIndex]+2*mpY[binIndex]*F2[binIndex]*P2[binIndex]+ppY[binIndex]*P2[binIndex]-mpY[binIndex]*P2[binIndex]+4*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P2[binIndex]+mmY[binIndex]*P2[binIndex]+2*ppY[binIndex]*F1[binIndex]-mmY[binIndex]-mpY[binIndex]*F2[binIndex]+ppY[binIndex]*F2[binIndex]-2*ppY[binIndex]*F1[binIndex]*F2[binIndex]+mpY[binIndex]-ppY[binIndex])/((-P1[binIndex]+2*F1[binIndex]*P1[binIndex]-F1[binIndex])*(-1+P2[binIndex]))+(ppY[binIndex]*P2[binIndex]*F1[binIndex]-2*ppY[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]-2*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P2[binIndex]-2*ppY[binIndex]*P2[binIndex]*F1[binIndex]*P1[binIndex]+2*P1[binIndex]*mpY[binIndex]*F2[binIndex]*P2[binIndex]+ppY[binIndex]*P1[binIndex]*P2[binIndex]-P1[binIndex]*mpY[binIndex]*P2[binIndex]+4*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+P1[binIndex]*mmY[binIndex]*P2[binIndex]-ppY[binIndex]*F1[binIndex]+2*ppY[binIndex]*F1[binIndex]*P1[binIndex]-P1[binIndex]*mmY[binIndex]-P1[binIndex]*mpY[binIndex]*F2[binIndex]+ppY[binIndex]*F2[binIndex]*P1[binIndex]+ppY[binIndex]*F1[binIndex]*F2[binIndex]-2*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]+P1[binIndex]*mpY[binIndex]-ppY[binIndex]*P1[binIndex])*(-1+2*F1[binIndex])/((factor2*factor2)*(-1+P2[binIndex]));
+          const double factor3 = (-1+P2[binIndex]);
+          const double dP2 = -(ppY[binIndex]*F1[binIndex]-2*ppY[binIndex]*F2[binIndex]*P1[binIndex]-2*ppY[binIndex]*F1[binIndex]*F2[binIndex]-2*ppY[binIndex]*F1[binIndex]*P1[binIndex]+2*P1[binIndex]*mpY[binIndex]*F2[binIndex]+ppY[binIndex]*P1[binIndex]-P1[binIndex]*mpY[binIndex]+4*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]+P1[binIndex]*mmY[binIndex])/((-P1[binIndex]+2*F1[binIndex]*P1[binIndex]-F1[binIndex])*(-1+P2[binIndex]))+(ppY[binIndex]*P2[binIndex]*F1[binIndex]-2*ppY[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]-2*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P2[binIndex]-2*ppY[binIndex]*P2[binIndex]*F1[binIndex]*P1[binIndex]+2*P1[binIndex]*mpY[binIndex]*F2[binIndex]*P2[binIndex]+ppY[binIndex]*P1[binIndex]*P2[binIndex]-P1[binIndex]*mpY[binIndex]*P2[binIndex]+4*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+P1[binIndex]*mmY[binIndex]*P2[binIndex]-ppY[binIndex]*F1[binIndex]+2*ppY[binIndex]*F1[binIndex]*P1[binIndex]-P1[binIndex]*mmY[binIndex]-P1[binIndex]*mpY[binIndex]*F2[binIndex]+ppY[binIndex]*F2[binIndex]*P1[binIndex]+ppY[binIndex]*F1[binIndex]*F2[binIndex]-2*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]+P1[binIndex]*mpY[binIndex]-ppY[binIndex]*P1[binIndex])/((-P1[binIndex]+2*F1[binIndex]*P1[binIndex]-F1[binIndex])*(factor3 * factor3));
+          const double e1 = dI00 * ppE[binIndex];
+          const double e2 = dI11 * mmE[binIndex];
+          const double e3 = dI10 * mpE[binIndex];
+          const double e4 = dF1 * F1E[binIndex];
+          const double e5 = dF2 * F2E[binIndex];
+          const double e6 = dP1 * P1E[binIndex];
+          const double e7 = dP2 * P2E[binIndex];
+          pmE[binIndex] = std::sqrt(e1 * e1 + e2 * e2 + e3 * e3 + e4 * e4 + e5 * e5 + e6 * e6 + e7 * e7);
+
+        }
+      }
+    }
   }
 };
 

--- a/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
@@ -793,7 +793,6 @@ private:
       AnalysisDataService::Instance().addOrReplace(wsNames[i], wsList[i]);
     }
     auto effWS = idealEfficiencies(edges);
-    constexpr char *OUTWS_NAME{"output"};
     PolarizationEfficiencyCor alg;
     alg.setChild(true);
     alg.setRethrows(true);
@@ -801,7 +800,7 @@ private:
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", wsNames))
     TS_ASSERT_THROWS_NOTHING(
-        alg.setPropertyValue("OutputWorkspace", OUTWS_NAME))
+        alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     const std::string presentFlipperConf =
         missingFlipperConf == "01" ? "10" : "01";
@@ -815,7 +814,7 @@ private:
     const std::array<std::string, 4> POL_DIRS{{"++", "+-", "-+", "--"}};
     for (size_t i = 0; i != 4; ++i) {
       const auto &dir = POL_DIRS[i];
-      const std::string wsName = OUTWS_NAME + std::string("_") + dir;
+      const std::string wsName = m_outputWSName + std::string("_") + dir;
       MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(
           outputWS->getItem(wsName));
       TS_ASSERT(ws)

--- a/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
@@ -980,61 +980,73 @@ private:
       }
     }
   }
-  void invertedF1(Eigen::Matrix4d &m, const double f1) {
+  Eigen::Matrix4d invertedF1(const double f1) {
+    Eigen::Matrix4d m;
     m << f1, 0., 0., 0., 0., f1, 0., 0., f1 - 1., 0., 1., 0., 0., f1 - 1., 0.,
         1.;
     m *= 1. / f1;
+    return m;
   }
 
-  void invertedF1Derivative(Eigen::Matrix4d &m, const double f1) {
+  Eigen::Matrix4d invertedF1Derivative(const double f1) {
+    Eigen::Matrix4d m;
     m << 0., 0., 0., 0., 0., 0., 0., 0., 1., 0., -1., 0., 0., 1., 0., -1.;
     m *= 1. / (f1 * f1);
+    return m;
   }
 
-  void invertedF2(Eigen::Matrix4d &m, const double f2) {
+  Eigen::Matrix4d invertedF2(const double f2) {
+    Eigen::Matrix4d m;
     m << f2, 0., 0., 0., f2 - 1., 1., 0., 0., 0., 0., f2, 0., 0., 0., f2 - 1.,
         1.;
     m *= 1. / f2;
+    return m;
   }
 
-  void invertedF2Derivative(Eigen::Matrix4d &m, const double f2) {
+  Eigen::Matrix4d invertedF2Derivative(const double f2) {
+    Eigen::Matrix4d m;
     m << 0., 0., 0., 0., 1., -1., 0., 0., 0., 0., 0., 0., 0., 0., 1., -1.;
     m *= 1. / (f2 * f2);
+    return m;
   }
 
-  void invertedP1(Eigen::Matrix4d &m, const double p1) {
+  Eigen::Matrix4d invertedP1(const double p1) {
+    Eigen::Matrix4d m;
     m << p1 - 1., 0., p1, 0., 0., p1 - 1., 0., p1, p1, 0., p1 - 1., 0., 0., p1,
         0., p1 - 1.;
     m *= 1. / (2. * p1 - 1.);
+    return m;
   }
 
-  void invertedP1Derivative(Eigen::Matrix4d &m, const double p1) {
+  Eigen::Matrix4d invertedP1Derivative(const double p1) {
+    Eigen::Matrix4d m;
     m << 1., 0., -1., 0., 0., 1., 0., -1., -1., 0., 1., 0., 0., -1., 0., 1.;
     m *= 1. / (2. * p1 - 1.) / (2. * p1 - 1.);
+    return m;
   }
 
-  void invertedP2(Eigen::Matrix4d &m, const double p2) {
+  Eigen::Matrix4d invertedP2(const double p2) {
+    Eigen::Matrix4d m;
     m << p2 - 1., p2, 0., 0., p2, p2 - 1., 0., 0., 0., 0., p2 - 1., p2, 0., 0.,
         p2, p2 - 1.;
     m *= 1. / (2. * p2 - 1.);
+    return m;
   }
 
-  void invertedP2Derivative(Eigen::Matrix4d &m, const double p2) {
+  Eigen::Matrix4d invertedP2Derivative(const double p2) {
+    Eigen::Matrix4d m;
     m << 1., -1., 0., 0., -1., 1., 0., 0., 0., 0., 1., -1., 0., 0., -1., 1.;
     m *= 1. / (2. * p2 - 1.) / (2. * p2 - 1.);
+    return m;
   }
 
   Eigen::Vector4d correction(const Eigen::Vector4d &y, const double f1,
                              const double f2, const double p1,
                              const double p2) {
-    Eigen::Matrix4d F1;
-    invertedF1(F1, f1);
-    Eigen::Matrix4d F2;
-    invertedF2(F2, f2);
-    Eigen::Matrix4d P1;
-    invertedP1(P1, p1);
-    Eigen::Matrix4d P2;
-    invertedP2(P2, p2);
+    const Eigen::Matrix4d F1 = invertedF1(f1);
+    const Eigen::Matrix4d F2 = invertedF2(f2);
+    const Eigen::Matrix4d P1 = invertedP1(p1);
+    const Eigen::Matrix4d P2 = invertedP2(p2);
     const Eigen::Matrix4d inverted = (P2 * P1 * F2 * F1).matrix();
     return (inverted * y).matrix();
   }
@@ -1043,26 +1055,14 @@ private:
                         const double f1, const double f1e, const double f2,
                         const double f2e, const double p1, const double p1e,
                         const double p2, const double p2e) {
-    Eigen::Matrix4d F1;
-    invertedF1(F1, f1);
-    Eigen::Matrix4d dF1;
-    invertedF1Derivative(dF1, f1);
-    dF1 *= f1e;
-    Eigen::Matrix4d F2;
-    invertedF2(F2, f2);
-    Eigen::Matrix4d dF2;
-    invertedF2Derivative(dF2, f2);
-    dF2 *= f2e;
-    Eigen::Matrix4d P1;
-    invertedP1(P1, p1);
-    Eigen::Matrix4d dP1;
-    invertedP1Derivative(dP1, p1);
-    dP1 *= p1e;
-    Eigen::Matrix4d P2;
-    invertedP2(P2, p2);
-    Eigen::Matrix4d dP2;
-    invertedP2Derivative(dP2, p2);
-    dP2 *= p2e;
+    const Eigen::Matrix4d F1 = invertedF1(f1);
+    const Eigen::Matrix4d dF1 = f1e * invertedF1Derivative(f1);
+    const Eigen::Matrix4d F2 = invertedF2(f2);
+    const Eigen::Matrix4d dF2 = f2e * invertedF2Derivative(f2);
+    const Eigen::Matrix4d P1 = invertedP1(p1);
+    const Eigen::Matrix4d dP1 = p1e * invertedP1Derivative(p1);
+    const Eigen::Matrix4d P2 = invertedP2(p2);
+    const Eigen::Matrix4d dP2 = p2e * invertedP2Derivative(p2);
     const auto p2Error = (dP2 * P1 * F2 * F1 * y).array();
     const auto p1Error = (P2 * dP1 * F2 * F1 * y).array();
     const auto f2Error = (P2 * P1 * dF2 * F1 * y).array();
@@ -1084,7 +1084,7 @@ private:
     Eigen::Matrix2d P1;
     P1 << p1 - 1., p1, p1, p1 - 1.;
     P1 *= 1. / (2. * p1 - 1.);
-    const auto inverted = P1 * F1;
+    const Eigen::Matrix2d inverted = (P1 * F1).matrix();
     return static_cast<Eigen::Vector2d>(inverted * y);
   }
 

--- a/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
@@ -1068,9 +1068,8 @@ private:
     const auto f2Error = (P2 * P1 * dF2 * F1 * y).array();
     const auto f1Error = (P2 * P1 * F2 * dF1 * y).array();
     const auto inverted = (P2 * P1 * F2 * F1).array();
-    const auto yError =
-        ((inverted * inverted).matrix() * (e.array() * e.array()).matrix())
-            .array();
+    const auto yError = ((inverted * inverted).matrix() *
+                         (e.array() * e.array()).matrix()).array();
     return (p2Error * p2Error + p1Error * p1Error + f2Error * f2Error +
             f1Error * f1Error + yError)
         .sqrt()
@@ -1108,9 +1107,8 @@ private:
     const auto p1Error = (dP1 * F1 * y).array();
     const auto f1Error = (P1 * dF1 * y).array();
     const auto inverted = (P1 * F1).array();
-    const auto yError =
-        ((inverted * inverted).matrix() * (e.array() * e.array()).matrix())
-            .array();
+    const auto yError = ((inverted * inverted).matrix() *
+                         (e.array() * e.array()).matrix()).array();
     return (p1Error * p1Error + f1Error * f1Error + yError).sqrt().matrix();
   }
 

--- a/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
@@ -177,6 +177,63 @@ public:
     }
   }
 
+  void test_IdealCaseTwoInputsNoAnalyzer() {
+    using namespace Mantid::API;
+    using namespace Mantid::DataObjects;
+    using namespace Mantid::HistogramData;
+    using namespace Mantid::Kernel;
+    constexpr size_t nBins{3};
+    constexpr size_t nHist{2};
+    BinEdges edges{0.3, 0.6, 0.9, 1.2};
+    const double yVal = 2.3;
+    Counts counts{yVal, yVal, yVal};
+    MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
+    MatrixWorkspace_sptr ws11 = ws00->clone();
+    WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
+    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
+    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws11));
+    for (size_t i = 0; i != nHist; ++i) {
+      ws11->mutableY(i) *= 2.;
+      ws11->mutableE(i) *= 2.;
+    }
+    auto effWS = efficiencies(edges);
+    constexpr char *OUTWS_NAME{"output"};
+    PolarizationEfficiencyCor alg;
+    alg.setChild(true);
+    alg.setRethrows(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", OUTWS_NAME))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", "00, 11"))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Analyzer", false))
+    TS_ASSERT_THROWS_NOTHING(alg.execute())
+    TS_ASSERT(alg.isExecuted())
+    WorkspaceGroup_sptr outputWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outputWS)
+    TS_ASSERT_EQUALS(outputWS->getNumberOfEntries(), 2)
+    const std::array<std::string, 2> POL_DIRS{{"++", "--"}};
+    for (size_t i = 0; i != 2; ++i) {
+      const auto &dir = POL_DIRS[i];
+      const std::string wsName = OUTWS_NAME + std::string("_") + dir;
+      MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(wsName));
+      TS_ASSERT(ws)
+      TS_ASSERT_EQUALS(ws->getNumberHistograms(), nHist)
+      for (size_t j = 0; j != nHist; ++j) {
+        const auto &xs = ws->x(j);
+        const auto &ys = ws->y(j);
+        const auto &es = ws->e(j);
+        TS_ASSERT_EQUALS(ys.size(), nBins)
+        for (size_t k = 0; k != nBins; ++k) {
+          TS_ASSERT_EQUALS(xs[k], edges[k])
+          TS_ASSERT_EQUALS(ys[k], yVal * static_cast<double>(i + 1))
+          TS_ASSERT_EQUALS(es[k], std::sqrt(yVal) * static_cast<double>(i + 1))
+        }
+      }
+    }
+  }
+
 private:
   Mantid::API::MatrixWorkspace_sptr efficiencies(const Mantid::HistogramData::BinEdges &edges) {
     using namespace Mantid::API;

--- a/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
@@ -22,8 +22,12 @@ class PolarizationEfficiencyCorTest : public CxxTest::TestSuite {
 public:
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests
-  static PolarizationEfficiencyCorTest *createSuite() { return new PolarizationEfficiencyCorTest(); }
-  static void destroySuite( PolarizationEfficiencyCorTest *suite ) { delete suite; }
+  static PolarizationEfficiencyCorTest *createSuite() {
+    return new PolarizationEfficiencyCorTest();
+  }
+  static void destroySuite(PolarizationEfficiencyCorTest *suite) {
+    delete suite;
+  }
 
   void tearDown() override {
     using namespace Mantid::API;
@@ -32,8 +36,8 @@ public:
 
   void test_Init() {
     PolarizationEfficiencyCor alg;
-    TS_ASSERT_THROWS_NOTHING( alg.initialize() )
-    TS_ASSERT( alg.isInitialized() )
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
   }
 
   void test_IdealCaseFullCorrections() {
@@ -46,7 +50,8 @@ public:
     BinEdges edges{0.3, 0.6, 0.9, 1.2};
     const double yVal = 2.3;
     Counts counts{yVal, 4.2 * yVal, yVal};
-    MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
+    MatrixWorkspace_sptr ws00 =
+        create<Workspace2D>(nHist, Histogram(edges, counts));
     MatrixWorkspace_sptr ws01 = ws00->clone();
     MatrixWorkspace_sptr ws10 = ws00->clone();
     MatrixWorkspace_sptr ws11 = ws00->clone();
@@ -66,7 +71,8 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", wsNames))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.execute())
     TS_ASSERT(alg.isExecuted())
@@ -75,8 +81,10 @@ public:
     TS_ASSERT_EQUALS(outputWS->getNumberOfEntries(), 4)
     const std::array<std::string, 4> POL_DIRS{{"++", "+-", "-+", "--"}};
     for (size_t i = 0; i != 4; ++i) {
-      const std::string wsName = m_outputWSName + std::string("_") + POL_DIRS[i];
-      MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(wsName));
+      const std::string wsName =
+          m_outputWSName + std::string("_") + POL_DIRS[i];
+      MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(
+          outputWS->getItem(wsName));
       TS_ASSERT(ws)
       TS_ASSERT_EQUALS(ws->getNumberHistograms(), nHist)
       for (size_t j = 0; j != nHist; ++j) {
@@ -94,13 +102,9 @@ public:
     }
   }
 
-  void test_IdealCaseThreeInputs10Missing() {
-    idealThreeInputsTest("10");
-  }
+  void test_IdealCaseThreeInputs10Missing() { idealThreeInputsTest("10"); }
 
-  void test_IdealCaseThreeInputs01Missing() {
-    idealThreeInputsTest("01");
-  }
+  void test_IdealCaseThreeInputs01Missing() { idealThreeInputsTest("01"); }
 
   void test_IdealCaseTwoInputsWithAnalyzer() {
     using namespace Mantid::API;
@@ -112,15 +116,18 @@ public:
     BinEdges edges{0.3, 0.6, 0.9, 1.2};
     const double yVal = 2.3;
     Counts counts{yVal, 4.2 * yVal, yVal};
-    MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
+    MatrixWorkspace_sptr ws00 =
+        create<Workspace2D>(nHist, Histogram(edges, counts));
     MatrixWorkspace_sptr ws11 = ws00->clone();
-    const std::vector<std::string> wsNames{std::initializer_list<std::string>{"ws00", "ws11"}};
+    const std::vector<std::string> wsNames{
+        std::initializer_list<std::string>{"ws00", "ws11"}};
     const std::array<MatrixWorkspace_sptr, 2> wsList{{ws00, ws11}};
     for (size_t i = 0; i != nHist; ++i) {
       ws11->mutableY(i) *= 2.;
       ws11->mutableE(i) *= 2.;
     }
-    AnalysisDataService::Instance().addOrReplace(wsNames.front(), wsList.front());
+    AnalysisDataService::Instance().addOrReplace(wsNames.front(),
+                                                 wsList.front());
     AnalysisDataService::Instance().addOrReplace(wsNames.back(), wsList.back());
     auto effWS = idealEfficiencies(edges);
     PolarizationEfficiencyCor alg;
@@ -129,7 +136,8 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", wsNames))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", "00, 11"))
     TS_ASSERT_THROWS_NOTHING(alg.execute())
@@ -141,7 +149,8 @@ public:
     for (size_t i = 0; i != 4; ++i) {
       const auto &dir = POL_DIRS[i];
       const std::string wsName = m_outputWSName + std::string("_") + dir;
-      MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(wsName));
+      MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(
+          outputWS->getItem(wsName));
       TS_ASSERT(ws)
       TS_ASSERT_EQUALS(ws->getNumberHistograms(), nHist)
       for (size_t j = 0; j != nHist; ++j) {
@@ -166,7 +175,7 @@ public:
             } else if (dir == "--") {
               return 2. * std::sqrt(y);
             } else {
-                return 0.;
+              return 0.;
             }
           }();
           TS_ASSERT_EQUALS(xs[k], edges[k])
@@ -187,15 +196,18 @@ public:
     BinEdges edges{0.3, 0.6, 0.9, 1.2};
     const double yVal = 2.3;
     Counts counts{yVal, 4.2 * yVal, yVal};
-    MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
+    MatrixWorkspace_sptr ws00 =
+        create<Workspace2D>(nHist, Histogram(edges, counts));
     MatrixWorkspace_sptr ws11 = ws00->clone();
-    const std::vector<std::string> wsNames{std::initializer_list<std::string>{"ws00", "ws11"}};
+    const std::vector<std::string> wsNames{
+        std::initializer_list<std::string>{"ws00", "ws11"}};
     const std::array<MatrixWorkspace_sptr, 2> wsList{{ws00, ws11}};
     for (size_t i = 0; i != nHist; ++i) {
       ws11->mutableY(i) *= 2.;
       ws11->mutableE(i) *= 2.;
     }
-    AnalysisDataService::Instance().addOrReplace(wsNames.front(), wsList.front());
+    AnalysisDataService::Instance().addOrReplace(wsNames.front(),
+                                                 wsList.front());
     AnalysisDataService::Instance().addOrReplace(wsNames.back(), wsList.back());
     auto effWS = idealEfficiencies(edges);
     PolarizationEfficiencyCor alg;
@@ -204,7 +216,8 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", wsNames))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", "0, 1"))
     TS_ASSERT_THROWS_NOTHING(alg.execute())
@@ -216,7 +229,8 @@ public:
     for (size_t i = 0; i != 2; ++i) {
       const auto &dir = POL_DIRS[i];
       const std::string wsName = m_outputWSName + std::string("_") + dir;
-      MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(wsName));
+      MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(
+          outputWS->getItem(wsName));
       TS_ASSERT(ws)
       TS_ASSERT_EQUALS(ws->getNumberHistograms(), nHist)
       for (size_t j = 0; j != nHist; ++j) {
@@ -244,7 +258,8 @@ public:
     BinEdges edges{0.3, 0.6, 0.9, 1.2};
     const double yVal = 2.3;
     Counts counts{yVal, 4.2 * yVal, yVal};
-    MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
+    MatrixWorkspace_sptr ws00 =
+        create<Workspace2D>(nHist, Histogram(edges, counts));
     const std::vector<std::string> wsNames{{"ws00"}};
     AnalysisDataService::Instance().addOrReplace(wsNames.front(), ws00);
     auto effWS = idealEfficiencies(edges);
@@ -254,7 +269,8 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", wsNames))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", "0"))
     TS_ASSERT_THROWS_NOTHING(alg.execute())
@@ -262,7 +278,8 @@ public:
     WorkspaceGroup_sptr outputWS = alg.getProperty("OutputWorkspace");
     TS_ASSERT(outputWS)
     TS_ASSERT_EQUALS(outputWS->getNumberOfEntries(), 1)
-    MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(m_outputWSName + std::string("_++")));
+    MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(
+        outputWS->getItem(m_outputWSName + std::string("_++")));
     TS_ASSERT(ws)
     TS_ASSERT_EQUALS(ws->getNumberHistograms(), nHist)
     for (size_t i = 0; i != nHist; ++i) {
@@ -288,7 +305,8 @@ public:
     BinEdges edges{0.3, 0.6, 0.9, 1.2};
     const double yVal = 2.3;
     Counts counts{yVal, yVal, yVal};
-    MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
+    MatrixWorkspace_sptr ws00 =
+        create<Workspace2D>(nHist, Histogram(edges, counts));
     MatrixWorkspace_sptr ws01 = ws00->clone();
     MatrixWorkspace_sptr ws10 = ws00->clone();
     MatrixWorkspace_sptr ws11 = ws00->clone();
@@ -308,7 +326,8 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", wsNames))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.execute())
     TS_ASSERT(alg.isExecuted())
@@ -336,11 +355,13 @@ public:
     BinEdges edges{0.3, 0.6, 0.9, 1.2};
     const double yVal = 2.3;
     Counts counts{yVal, yVal, yVal};
-    MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
+    MatrixWorkspace_sptr ws00 =
+        create<Workspace2D>(nHist, Histogram(edges, counts));
     MatrixWorkspace_sptr ws01 = nullptr;
     MatrixWorkspace_sptr ws10 = nullptr;
     MatrixWorkspace_sptr ws11 = ws00->clone();
-    const std::vector<std::string> wsNames{std::initializer_list<std::string>{"ws00", "ws11"}};
+    const std::vector<std::string> wsNames{
+        std::initializer_list<std::string>{"ws00", "ws11"}};
     const std::array<MatrixWorkspace_sptr, 2> wsList{{ws00, ws11}};
     for (size_t i = 0; i != 2; ++i) {
       for (size_t j = 0; j != nHist; ++j) {
@@ -356,7 +377,8 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", wsNames))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Flippers", "00, 11"))
     TS_ASSERT_THROWS_NOTHING(alg.execute())
@@ -374,14 +396,20 @@ public:
     const double P1e = effWS->e(2).front();
     const double P2 = effWS->y(3).front();
     const double P2e = effWS->e(3).front();
-    const Eigen::Vector4d y{ws00->y(0).front(), ws01->y(0).front(), ws10->y(0).front(), ws11->y(0).front()};
+    const Eigen::Vector4d y{ws00->y(0).front(), ws01->y(0).front(),
+                            ws10->y(0).front(), ws11->y(0).front()};
     const auto expected = correction(y, F1, F2, P1, P2);
-    const Eigen::Vector4d e{ws00->e(0).front(), ws01->e(0).front(), ws10->e(0).front(), ws11->e(0).front()};
+    const Eigen::Vector4d e{ws00->e(0).front(), ws01->e(0).front(),
+                            ws10->e(0).front(), ws11->e(0).front()};
     const auto expectedError = error(y, e, F1, F1e, F2, F2e, P1, P1e, P2, P2e);
-    MatrixWorkspace_sptr ppWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(m_outputWSName + std::string("_++")));
-    MatrixWorkspace_sptr pmWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(m_outputWSName + std::string("_+-")));
-    MatrixWorkspace_sptr mpWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(m_outputWSName + std::string("_-+")));
-    MatrixWorkspace_sptr mmWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(m_outputWSName + std::string("_--")));
+    MatrixWorkspace_sptr ppWS = boost::dynamic_pointer_cast<MatrixWorkspace>(
+        outputWS->getItem(m_outputWSName + std::string("_++")));
+    MatrixWorkspace_sptr pmWS = boost::dynamic_pointer_cast<MatrixWorkspace>(
+        outputWS->getItem(m_outputWSName + std::string("_+-")));
+    MatrixWorkspace_sptr mpWS = boost::dynamic_pointer_cast<MatrixWorkspace>(
+        outputWS->getItem(m_outputWSName + std::string("_-+")));
+    MatrixWorkspace_sptr mmWS = boost::dynamic_pointer_cast<MatrixWorkspace>(
+        outputWS->getItem(m_outputWSName + std::string("_--")));
     TS_ASSERT(ppWS)
     TS_ASSERT(pmWS)
     TS_ASSERT(mpWS)
@@ -443,9 +471,11 @@ public:
     BinEdges edges{0.3, 0.6, 0.9, 1.2};
     const double yVal = 2.3;
     Counts counts{yVal, yVal, yVal};
-    MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
+    MatrixWorkspace_sptr ws00 =
+        create<Workspace2D>(nHist, Histogram(edges, counts));
     MatrixWorkspace_sptr ws11 = ws00->clone();
-    const std::vector<std::string> wsNames{std::initializer_list<std::string>{"ws00", "ws11"}};
+    const std::vector<std::string> wsNames{
+        std::initializer_list<std::string>{"ws00", "ws11"}};
     const std::array<MatrixWorkspace_sptr, 2> wsList{{ws00, ws11}};
     for (size_t i = 0; i != 2; ++i) {
       for (size_t j = 0; j != nHist; ++j) {
@@ -461,7 +491,8 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", wsNames))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Flippers", "0, 1"))
     TS_ASSERT_THROWS_NOTHING(alg.execute())
@@ -477,8 +508,10 @@ public:
     const auto expected = correctionWithoutAnalyzer(y, F1, P1);
     const Eigen::Vector2d e{ws00->e(0).front(), ws11->e(0).front()};
     const auto expectedError = errorWithoutAnalyzer(y, e, F1, F1e, P1, P1e);
-    MatrixWorkspace_sptr ppWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(m_outputWSName + std::string("_++")));
-    MatrixWorkspace_sptr mmWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(m_outputWSName + std::string("_--")));
+    MatrixWorkspace_sptr ppWS = boost::dynamic_pointer_cast<MatrixWorkspace>(
+        outputWS->getItem(m_outputWSName + std::string("_++")));
+    MatrixWorkspace_sptr mmWS = boost::dynamic_pointer_cast<MatrixWorkspace>(
+        outputWS->getItem(m_outputWSName + std::string("_--")));
     TS_ASSERT(ppWS)
     TS_ASSERT(mmWS)
     TS_ASSERT_EQUALS(ppWS->getNumberHistograms(), nHist)
@@ -513,7 +546,8 @@ public:
     BinEdges edges{0.3, 0.6, 0.9, 1.2};
     const double yVal = 2.3;
     Counts counts{yVal, yVal, yVal};
-    MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
+    MatrixWorkspace_sptr ws00 =
+        create<Workspace2D>(nHist, Histogram(edges, counts));
     const std::string wsName{"ws00"};
     AnalysisDataService::Instance().addOrReplace(wsName, ws00);
     auto effWS = efficiencies(edges);
@@ -523,7 +557,8 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("InputWorkspaces", wsName))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Flippers", "0"))
     TS_ASSERT_THROWS_NOTHING(alg.execute())
@@ -542,8 +577,10 @@ public:
     const auto errorP1 = P1e * y * (2. * P1 - 1.) * inverted * inverted;
     const auto errorP2 = P2e * y * (2. * P2 - 1.) * inverted * inverted;
     const auto errorY = e * e * inverted * inverted;
-    const auto expectedError = std::sqrt(errorP1 * errorP1 + errorP2 * errorP2 + errorY);
-    MatrixWorkspace_sptr ppWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(m_outputWSName + std::string("_++")));
+    const auto expectedError =
+        std::sqrt(errorP1 * errorP1 + errorP2 * errorP2 + errorY);
+    MatrixWorkspace_sptr ppWS = boost::dynamic_pointer_cast<MatrixWorkspace>(
+        outputWS->getItem(m_outputWSName + std::string("_++")));
     TS_ASSERT(ppWS)
     TS_ASSERT_EQUALS(ppWS->getNumberHistograms(), nHist)
     for (size_t j = 0; j != nHist; ++j) {
@@ -566,7 +603,8 @@ public:
     using namespace Mantid::Kernel;
     BinEdges edges{0.3, 0.6, 0.9, 1.2};
     Counts counts{0., 0., 0.};
-    MatrixWorkspace_sptr ws00 = create<Workspace2D>(1, Histogram(edges, counts));
+    MatrixWorkspace_sptr ws00 =
+        create<Workspace2D>(1, Histogram(edges, counts));
     const std::string wsName{"ws00"};
     AnalysisDataService::Instance().addOrReplace(wsName, ws00);
     auto effWS = idealEfficiencies(edges);
@@ -583,7 +621,8 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("InputWorkspaces", wsName))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", "0"))
     TS_ASSERT_THROWS(alg.execute(), std::runtime_error)
@@ -597,7 +636,8 @@ public:
     using namespace Mantid::Kernel;
     BinEdges edges{0.3, 0.6, 0.9, 1.2};
     Counts counts{0., 0., 0.};
-    MatrixWorkspace_sptr ws00 = create<Workspace2D>(1, Histogram(edges, counts));
+    MatrixWorkspace_sptr ws00 =
+        create<Workspace2D>(1, Histogram(edges, counts));
     const std::string wsName{"ws00"};
     AnalysisDataService::Instance().addOrReplace(wsName, ws00);
     auto effWS = idealEfficiencies(edges);
@@ -610,7 +650,8 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("InputWorkspaces", wsName))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", "0"))
     TS_ASSERT_THROWS(alg.execute(), std::runtime_error)
@@ -625,14 +666,16 @@ public:
     constexpr size_t nHist{2};
     BinEdges edges{0.3, 0.6, 0.9, 1.2};
     Counts counts{0., 0., 0.};
-    MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
+    MatrixWorkspace_sptr ws00 =
+        create<Workspace2D>(nHist, Histogram(edges, counts));
     MatrixWorkspace_sptr ws01 = ws00->clone();
-    MatrixWorkspace_sptr ws10 = create<Workspace2D>(nHist + 1, Histogram(edges, counts));
+    MatrixWorkspace_sptr ws10 =
+        create<Workspace2D>(nHist + 1, Histogram(edges, counts));
     MatrixWorkspace_sptr ws11 = ws00->clone();
     const std::vector<std::string> wsNames{{"ws00", "ws01", "ws10", "ws11"}};
     const std::array<MatrixWorkspace_sptr, 4> wsList{{ws00, ws01, ws10, ws11}};
     for (size_t i = 0; i != 4; ++i) {
-        AnalysisDataService::Instance().addOrReplace(wsNames[i], wsList[i]);
+      AnalysisDataService::Instance().addOrReplace(wsNames[i], wsList[i]);
     }
     auto effWS = idealEfficiencies(edges);
     PolarizationEfficiencyCor alg;
@@ -641,7 +684,8 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", wsNames))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS(alg.execute(), std::runtime_error)
     TS_ASSERT(!alg.isExecuted())
@@ -655,7 +699,8 @@ public:
     constexpr size_t nHist{2};
     BinEdges edges{0.3, 0.6, 0.9, 1.2};
     Counts counts{0., 0., 0.};
-    MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
+    MatrixWorkspace_sptr ws00 =
+        create<Workspace2D>(nHist, Histogram(edges, counts));
     MatrixWorkspace_sptr ws01 = ws00->clone();
     MatrixWorkspace_sptr ws11 = ws00->clone();
     AnalysisDataService::Instance().addOrReplace("ws00", ws00);
@@ -666,13 +711,16 @@ public:
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS(alg.setPropertyValue("InputWorkspaces", "ws00, ws01, ws10, ws11"), std::invalid_argument)
+    TS_ASSERT_THROWS(
+        alg.setPropertyValue("InputWorkspaces", "ws00, ws01, ws10, ws11"),
+        std::invalid_argument)
   }
 
 private:
   const std::string m_outputWSName{"output"};
 
-  Mantid::API::MatrixWorkspace_sptr efficiencies(const Mantid::HistogramData::BinEdges &edges) {
+  Mantid::API::MatrixWorkspace_sptr
+  efficiencies(const Mantid::HistogramData::BinEdges &edges) {
     using namespace Mantid::API;
     using namespace Mantid::DataObjects;
     using namespace Mantid::HistogramData;
@@ -680,7 +728,8 @@ private:
     const auto nBins = edges.size() - 1;
     constexpr size_t nHist{4};
     Counts counts(nBins, 0.0);
-    MatrixWorkspace_sptr ws = create<Workspace2D>(nHist, Histogram(edges, counts));
+    MatrixWorkspace_sptr ws =
+        create<Workspace2D>(nHist, Histogram(edges, counts));
     ws->mutableY(0) = 0.95;
     ws->mutableE(0) = 0.01;
     ws->mutableY(1) = 0.92;
@@ -698,7 +747,8 @@ private:
     return ws;
   }
 
-  Mantid::API::MatrixWorkspace_sptr idealEfficiencies(const Mantid::HistogramData::BinEdges &edges) {
+  Mantid::API::MatrixWorkspace_sptr
+  idealEfficiencies(const Mantid::HistogramData::BinEdges &edges) {
     using namespace Mantid::API;
     using namespace Mantid::DataObjects;
     using namespace Mantid::HistogramData;
@@ -706,7 +756,8 @@ private:
     const auto nBins = edges.size() - 1;
     constexpr size_t nHist{4};
     Counts counts(nBins, 0.0);
-    MatrixWorkspace_sptr ws = create<Workspace2D>(nHist, Histogram(edges, counts));
+    MatrixWorkspace_sptr ws =
+        create<Workspace2D>(nHist, Histogram(edges, counts));
     ws->mutableY(0) = 1.;
     ws->mutableY(1) = 1.;
     auto axis = make_unique<TextAxis>(4);
@@ -728,7 +779,8 @@ private:
     BinEdges edges{0.3, 0.6, 0.9, 1.2};
     const double yVal = 2.3;
     Counts counts{yVal, 4.2 * yVal, yVal};
-    MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
+    MatrixWorkspace_sptr ws00 =
+        create<Workspace2D>(nHist, Histogram(edges, counts));
     MatrixWorkspace_sptr wsXX = ws00->clone();
     MatrixWorkspace_sptr ws11 = ws00->clone();
     const std::vector<std::string> wsNames{{"ws00", "wsXX", "ws11"}};
@@ -748,9 +800,11 @@ private:
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", wsNames))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", OUTWS_NAME))
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", OUTWS_NAME))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
-    const std::string presentFlipperConf = missingFlipperConf == "01" ? "10" : "01";
+    const std::string presentFlipperConf =
+        missingFlipperConf == "01" ? "10" : "01";
     const std::string flipperConf = "00, " + presentFlipperConf + ", 11";
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", flipperConf))
     TS_ASSERT_THROWS_NOTHING(alg.execute())
@@ -762,7 +816,8 @@ private:
     for (size_t i = 0; i != 4; ++i) {
       const auto &dir = POL_DIRS[i];
       const std::string wsName = OUTWS_NAME + std::string("_") + dir;
-      MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(wsName));
+      MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(
+          outputWS->getItem(wsName));
       TS_ASSERT(ws)
       TS_ASSERT_EQUALS(ws->getNumberHistograms(), nHist)
       for (size_t j = 0; j != nHist; ++j) {
@@ -787,7 +842,8 @@ private:
             } else if (dir == "--") {
               return 3. * std::sqrt(y);
             } else {
-              std::string conf = std::string(dir.front() == '+' ? "0" : "1") + std::string(dir.back() == '+' ? "0" : "1");
+              std::string conf = std::string(dir.front() == '+' ? "0" : "1") +
+                                 std::string(dir.back() == '+' ? "0" : "1");
               if (conf != missingFlipperConf) {
                 return 2. * std::sqrt(y);
               } else {
@@ -812,12 +868,16 @@ private:
     BinEdges edges{0.3, 0.6, 0.9, 1.2};
     const double yVal = 2.3;
     Counts counts{yVal, yVal, yVal};
-    MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
-    MatrixWorkspace_sptr ws01 = missingFlipperConf == "01" ? nullptr : ws00->clone();
-    MatrixWorkspace_sptr ws10 = missingFlipperConf == "10" ? nullptr : ws00->clone();
+    MatrixWorkspace_sptr ws00 =
+        create<Workspace2D>(nHist, Histogram(edges, counts));
+    MatrixWorkspace_sptr ws01 =
+        missingFlipperConf == "01" ? nullptr : ws00->clone();
+    MatrixWorkspace_sptr ws10 =
+        missingFlipperConf == "10" ? nullptr : ws00->clone();
     MatrixWorkspace_sptr ws11 = ws00->clone();
     const std::vector<std::string> wsNames{{"ws00", "wsXX", "ws11"}};
-    const std::array<MatrixWorkspace_sptr, 3> wsList{{ws00, ws01 != nullptr ? ws01 : ws10, ws11}};
+    const std::array<MatrixWorkspace_sptr, 3> wsList{
+        {ws00, ws01 != nullptr ? ws01 : ws10, ws11}};
     for (size_t i = 0; i != 3; ++i) {
       for (size_t j = 0; j != nHist; ++j) {
         wsList[i]->mutableY(j) *= static_cast<double>(i + 1);
@@ -832,9 +892,11 @@ private:
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", wsNames))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
-    const std::string presentFlipperConf = missingFlipperConf == "01" ? "10" : "01";
+    const std::string presentFlipperConf =
+        missingFlipperConf == "01" ? "10" : "01";
     const std::string flipperConf = "00, " + presentFlipperConf + ", 11";
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Flippers", flipperConf))
     TS_ASSERT_THROWS_NOTHING(alg.execute())
@@ -846,7 +908,12 @@ private:
     fullFourInputsResultsCheck(outputWS, ws00, ws01, ws10, ws11, effWS);
   }
 
-  void fullFourInputsResultsCheck(Mantid::API::WorkspaceGroup_sptr &outputWS, Mantid::API::MatrixWorkspace_sptr &ws00, Mantid::API::MatrixWorkspace_sptr &ws01, Mantid::API::MatrixWorkspace_sptr &ws10, Mantid::API::MatrixWorkspace_sptr &ws11, Mantid::API::MatrixWorkspace_sptr &effWS) {
+  void fullFourInputsResultsCheck(Mantid::API::WorkspaceGroup_sptr &outputWS,
+                                  Mantid::API::MatrixWorkspace_sptr &ws00,
+                                  Mantid::API::MatrixWorkspace_sptr &ws01,
+                                  Mantid::API::MatrixWorkspace_sptr &ws10,
+                                  Mantid::API::MatrixWorkspace_sptr &ws11,
+                                  Mantid::API::MatrixWorkspace_sptr &effWS) {
     using namespace Mantid::API;
     const auto nHist = ws00->getNumberHistograms();
     const auto nBins = ws00->y(0).size();
@@ -859,14 +926,20 @@ private:
     const double P1e = effWS->e(2).front();
     const double P2 = effWS->y(3).front();
     const double P2e = effWS->e(3).front();
-    const Eigen::Vector4d y{ws00->y(0).front(), ws01->y(0).front(), ws10->y(0).front(), ws11->y(0).front()};
+    const Eigen::Vector4d y{ws00->y(0).front(), ws01->y(0).front(),
+                            ws10->y(0).front(), ws11->y(0).front()};
     const auto expected = correction(y, F1, F2, P1, P2);
-    const Eigen::Vector4d e{ws00->e(0).front(), ws01->e(0).front(), ws10->e(0).front(), ws11->e(0).front()};
+    const Eigen::Vector4d e{ws00->e(0).front(), ws01->e(0).front(),
+                            ws10->e(0).front(), ws11->e(0).front()};
     const auto expectedError = error(y, e, F1, F1e, F2, F2e, P1, P1e, P2, P2e);
-    MatrixWorkspace_sptr ppWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(m_outputWSName + std::string("_++")));
-    MatrixWorkspace_sptr pmWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(m_outputWSName + std::string("_+-")));
-    MatrixWorkspace_sptr mpWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(m_outputWSName + std::string("_-+")));
-    MatrixWorkspace_sptr mmWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(m_outputWSName + std::string("_--")));
+    MatrixWorkspace_sptr ppWS = boost::dynamic_pointer_cast<MatrixWorkspace>(
+        outputWS->getItem(m_outputWSName + std::string("_++")));
+    MatrixWorkspace_sptr pmWS = boost::dynamic_pointer_cast<MatrixWorkspace>(
+        outputWS->getItem(m_outputWSName + std::string("_+-")));
+    MatrixWorkspace_sptr mpWS = boost::dynamic_pointer_cast<MatrixWorkspace>(
+        outputWS->getItem(m_outputWSName + std::string("_-+")));
+    MatrixWorkspace_sptr mmWS = boost::dynamic_pointer_cast<MatrixWorkspace>(
+        outputWS->getItem(m_outputWSName + std::string("_--")));
     TS_ASSERT(ppWS)
     TS_ASSERT(pmWS)
     TS_ASSERT(mpWS)
@@ -909,70 +982,52 @@ private:
     }
   }
   void invertedF1(Eigen::Matrix4d &m, const double f1) {
-    m << f1, 0., 0., 0.,
-         0., f1, 0., 0.,
-         f1 - 1., 0., 1., 0.,
-         0., f1 - 1., 0., 1.;
+    m << f1, 0., 0., 0., 0., f1, 0., 0., f1 - 1., 0., 1., 0., 0., f1 - 1., 0.,
+        1.;
     m *= 1. / f1;
   }
 
   void invertedF1Derivative(Eigen::Matrix4d &m, const double f1) {
-    m << 0., 0., 0., 0.,
-         0., 0., 0., 0.,
-         1., 0., -1., 0.,
-         0., 1., 0., -1.;
+    m << 0., 0., 0., 0., 0., 0., 0., 0., 1., 0., -1., 0., 0., 1., 0., -1.;
     m *= 1. / (f1 * f1);
   }
 
   void invertedF2(Eigen::Matrix4d &m, const double f2) {
-    m << f2, 0., 0., 0.,
-         f2 - 1., 1., 0., 0.,
-         0., 0., f2, 0.,
-         0., 0., f2 - 1., 1.;
+    m << f2, 0., 0., 0., f2 - 1., 1., 0., 0., 0., 0., f2, 0., 0., 0., f2 - 1.,
+        1.;
     m *= 1. / f2;
   }
 
   void invertedF2Derivative(Eigen::Matrix4d &m, const double f2) {
-    m << 0., 0., 0., 0.,
-         1., -1., 0., 0.,
-         0., 0., 0., 0.,
-         0., 0., 1., -1.;
+    m << 0., 0., 0., 0., 1., -1., 0., 0., 0., 0., 0., 0., 0., 0., 1., -1.;
     m *= 1. / (f2 * f2);
   }
 
   void invertedP1(Eigen::Matrix4d &m, const double p1) {
-    m << p1 - 1., 0., p1, 0.,
-         0., p1 - 1., 0., p1,
-         p1, 0., p1 - 1., 0.,
-         0., p1, 0., p1 - 1.;
+    m << p1 - 1., 0., p1, 0., 0., p1 - 1., 0., p1, p1, 0., p1 - 1., 0., 0., p1,
+        0., p1 - 1.;
     m *= 1. / (2. * p1 - 1.);
   }
 
   void invertedP1Derivative(Eigen::Matrix4d &m, const double p1) {
-    m << 1., 0., -1., 0.,
-         0., 1., 0., -1.,
-         -1., 0., 1., 0.,
-         0., -1., 0., 1.;
+    m << 1., 0., -1., 0., 0., 1., 0., -1., -1., 0., 1., 0., 0., -1., 0., 1.;
     m *= 1. / (2. * p1 - 1.) / (2. * p1 - 1.);
   }
 
   void invertedP2(Eigen::Matrix4d &m, const double p2) {
-    m << p2 - 1., p2, 0., 0.,
-         p2, p2 - 1., 0., 0.,
-         0., 0., p2 - 1., p2,
-         0., 0., p2, p2 - 1.;
+    m << p2 - 1., p2, 0., 0., p2, p2 - 1., 0., 0., 0., 0., p2 - 1., p2, 0., 0.,
+        p2, p2 - 1.;
     m *= 1. / (2. * p2 - 1.);
   }
 
   void invertedP2Derivative(Eigen::Matrix4d &m, const double p2) {
-    m << 1., -1., 0., 0.,
-         -1., 1., 0., 0.,
-         0., 0., 1., -1.,
-         0., 0., -1., 1.;
+    m << 1., -1., 0., 0., -1., 1., 0., 0., 0., 0., 1., -1., 0., 0., -1., 1.;
     m *= 1. / (2. * p2 - 1.) / (2. * p2 - 1.);
   }
 
-  Eigen::Vector4d correction(const Eigen::Vector4d &y, const double f1, const double f2, const double p1, const double p2) {
+  Eigen::Vector4d correction(const Eigen::Vector4d &y, const double f1,
+                             const double f2, const double p1,
+                             const double p2) {
     Eigen::Matrix4d F1;
     invertedF1(F1, f1);
     Eigen::Matrix4d F2;
@@ -985,7 +1040,10 @@ private:
     return static_cast<Eigen::Vector4d>(inverted * y);
   }
 
-  Eigen::Vector4d error(const Eigen::Vector4d &y, const Eigen::Vector4d &e, const double f1, const double f1e, const double f2, const double f2e, const double p1, const double p1e, const double p2, const double p2e) {
+  Eigen::Vector4d error(const Eigen::Vector4d &y, const Eigen::Vector4d &e,
+                        const double f1, const double f1e, const double f2,
+                        const double f2e, const double p1, const double p1e,
+                        const double p2, const double p2e) {
     Eigen::Matrix4d F1;
     invertedF1(F1, f1);
     Eigen::Matrix4d dF1;
@@ -1011,78 +1069,107 @@ private:
     const auto f2Error = (P2 * P1 * dF2 * F1 * y).array();
     const auto f1Error = (P2 * P1 * F2 * dF1 * y).array();
     const auto inverted = (P2 * P1 * F2 * F1).array();
-    const auto yError = ((inverted * inverted).matrix() * (e.array() * e.array()).matrix()).array();
-    return (p2Error * p2Error + p1Error * p1Error + f2Error * f2Error + f1Error * f1Error + yError).sqrt().matrix();
+    const auto yError = ((inverted * inverted).matrix() *
+                         (e.array() * e.array()).matrix()).array();
+    return (p2Error * p2Error + p1Error * p1Error + f2Error * f2Error +
+            f1Error * f1Error + yError)
+        .sqrt()
+        .matrix();
   }
 
-  Eigen::Vector2d correctionWithoutAnalyzer(const Eigen::Vector2d &y, const double f1, const double p1) {
+  Eigen::Vector2d correctionWithoutAnalyzer(const Eigen::Vector2d &y,
+                                            const double f1, const double p1) {
     Eigen::Matrix2d F1;
-    F1 << f1, 0.,
-          f1 - 1., 1.;
+    F1 << f1, 0., f1 - 1., 1.;
     F1 *= 1. / f1;
     Eigen::Matrix2d P1;
-    P1 << p1 - 1., p1,
-          p1, p1 - 1.;
+    P1 << p1 - 1., p1, p1, p1 - 1.;
     P1 *= 1. / (2. * p1 - 1.);
     const auto inverted = P1 * F1;
     return static_cast<Eigen::Vector2d>(inverted * y);
   }
 
-  Eigen::Vector2d errorWithoutAnalyzer(const Eigen::Vector2d &y, const Eigen::Vector2d &e, const double f1, const double f1e, const double p1, const double p1e) {
+  Eigen::Vector2d errorWithoutAnalyzer(const Eigen::Vector2d &y,
+                                       const Eigen::Vector2d &e,
+                                       const double f1, const double f1e,
+                                       const double p1, const double p1e) {
     Eigen::Matrix2d F1;
-    F1 << f1, 0,
-          f1 - 1., 1.;
+    F1 << f1, 0, f1 - 1., 1.;
     F1 *= 1. / f1;
     Eigen::Matrix2d dF1;
-    dF1 << 0., 0.,
-           1., -1.;
+    dF1 << 0., 0., 1., -1.;
     dF1 *= f1e / (f1 * f1);
     Eigen::Matrix2d P1;
-    P1 << p1 - 1., p1,
-          p1, p1 - 1.;
+    P1 << p1 - 1., p1, p1, p1 - 1.;
     P1 *= 1. / (2. * p1 - 1.);
     Eigen::Matrix2d dP1;
-    dP1 << 1., -1.,
-           -1., 1.;
+    dP1 << 1., -1., -1., 1.;
     dP1 *= p1e / ((2. * p1 - 1.) * (2. * p1 - 1.));
     const auto p1Error = (dP1 * F1 * y).array();
     const auto f1Error = (P1 * dF1 * y).array();
     const auto inverted = (P1 * F1).array();
-    const auto yError = ((inverted * inverted).matrix() * (e.array() * e.array()).matrix()).array();
+    const auto yError = ((inverted * inverted).matrix() *
+                         (e.array() * e.array()).matrix()).array();
     return (p1Error * p1Error + f1Error * f1Error + yError).sqrt().matrix();
   }
 
-  void solveMissingIntensity(const Mantid::API::MatrixWorkspace_sptr &ppWS, Mantid::API::MatrixWorkspace_sptr &pmWS, Mantid::API::MatrixWorkspace_sptr &mpWS, const Mantid::API::MatrixWorkspace_sptr &mmWS, const Mantid::API::MatrixWorkspace_sptr &effWS) {
+  void solveMissingIntensity(const Mantid::API::MatrixWorkspace_sptr &ppWS,
+                             Mantid::API::MatrixWorkspace_sptr &pmWS,
+                             Mantid::API::MatrixWorkspace_sptr &mpWS,
+                             const Mantid::API::MatrixWorkspace_sptr &mmWS,
+                             const Mantid::API::MatrixWorkspace_sptr &effWS) {
     const auto &F1 = effWS->y(0);
     const auto &F2 = effWS->y(1);
     const auto &P1 = effWS->y(2);
     const auto &P2 = effWS->y(3);
     if (!pmWS) {
       pmWS = mpWS->clone();
-      for (size_t wsIndex = 0; wsIndex != pmWS->getNumberHistograms(); ++wsIndex) {
+      for (size_t wsIndex = 0; wsIndex != pmWS->getNumberHistograms();
+           ++wsIndex) {
         const auto &ppY = ppWS->y(wsIndex);
         auto &pmY = pmWS->mutableY(wsIndex);
         auto &pmE = pmWS->mutableE(wsIndex);
         const auto &mpY = mpWS->y(wsIndex);
         const auto &mmY = mmWS->y(wsIndex);
         for (size_t binIndex = 0; binIndex != mpY.size(); ++binIndex) {
-          // mI01[j] = -(2*MI00[j]*f2L[j]*P2L[j]-P2L[j]*MI11[j]-2*MI10[j]*f2L[j]*P2L[j]+MI10[j]*P2L[j]-MI00[j]*P2L[j]+P1L[j]*MI11[j]-2*MI00[j]*f1L[j]*P1L[j]+MI00[j]*P1L[j]-P1L[j]*MI10[j]+MI00[j]*f1L[j]+MI10[j]*f2L[j]-MI00[j]*f2L[j])/(P2L[j]-P1L[j]+2*f1L[j]*P1L[j]-f1L[j])
-          pmY[binIndex] = -(2*ppY[binIndex]*F2[binIndex]*P2[binIndex]-P2[binIndex]*mmY[binIndex]-2*mpY[binIndex]*F2[binIndex]*P2[binIndex]+mpY[binIndex]*P2[binIndex]-ppY[binIndex]*P2[binIndex]+P1[binIndex]*mmY[binIndex]-2*ppY[binIndex]*F1[binIndex]*P1[binIndex]+ppY[binIndex]*P1[binIndex]-P1[binIndex]*mpY[binIndex]+ppY[binIndex]*F1[binIndex]+mpY[binIndex]*F2[binIndex]-ppY[binIndex]*F2[binIndex])/(P2[binIndex]-P1[binIndex]+2*F1[binIndex]*P1[binIndex]-F1[binIndex]);
+          pmY[binIndex] =
+              -(2 * ppY[binIndex] * F2[binIndex] * P2[binIndex] -
+                P2[binIndex] * mmY[binIndex] -
+                2 * mpY[binIndex] * F2[binIndex] * P2[binIndex] +
+                mpY[binIndex] * P2[binIndex] - ppY[binIndex] * P2[binIndex] +
+                P1[binIndex] * mmY[binIndex] -
+                2 * ppY[binIndex] * F1[binIndex] * P1[binIndex] +
+                ppY[binIndex] * P1[binIndex] - P1[binIndex] * mpY[binIndex] +
+                ppY[binIndex] * F1[binIndex] + mpY[binIndex] * F2[binIndex] -
+                ppY[binIndex] * F2[binIndex]) /
+              (P2[binIndex] - P1[binIndex] + 2 * F1[binIndex] * P1[binIndex] -
+               F1[binIndex]);
           // Error propagation is not implemented in the algorithm.
           pmE[binIndex] = 0.;
         }
       }
     } else {
       mpWS = pmWS->clone();
-      for (size_t wsIndex = 0; wsIndex != mpWS->getNumberHistograms(); ++wsIndex) {
+      for (size_t wsIndex = 0; wsIndex != mpWS->getNumberHistograms();
+           ++wsIndex) {
         const auto &ppY = ppWS->y(wsIndex);
         const auto &pmY = pmWS->y(wsIndex);
         auto &mpY = mpWS->mutableY(wsIndex);
         auto &mpE = mpWS->mutableE(wsIndex);
         const auto &mmY = mmWS->y(wsIndex);
         for (size_t binIndex = 0; binIndex != mpY.size(); ++binIndex) {
-          // mI10[j] = (-MI00[j]*P2L[j]+P2L[j]*MI01[j]-P2L[j]*MI11[j]+2*MI00[j]*f2L[j]*P2L[j]-MI01[j]*P1L[j]+P1L[j]*MI11[j]+MI00[j]*P1L[j]-2*MI00[j]*f1L[j]*P1L[j]+2*MI01[j]*f1L[j]*P1L[j]+MI00[j]*f1L[j]-MI00[j]*f2L[j]-MI01[j]*f1L[j])/(-P2L[j]+2*f2L[j]*P2L[j]+P1L[j]-f2L[j])
-          mpY[binIndex] = (-ppY[binIndex]*P2[binIndex]+P2[binIndex]*pmY[binIndex]-P2[binIndex]*mmY[binIndex]+2*ppY[binIndex]*F2[binIndex]*P2[binIndex]-pmY[binIndex]*P1[binIndex]+P1[binIndex]*mmY[binIndex]+ppY[binIndex]*P1[binIndex]-2*ppY[binIndex]*F1[binIndex]*P1[binIndex]+2*pmY[binIndex]*F1[binIndex]*P1[binIndex]+ppY[binIndex]*F1[binIndex]-ppY[binIndex]*F2[binIndex]-pmY[binIndex]*F1[binIndex])/(-P2[binIndex]+2*F2[binIndex]*P2[binIndex]+P1[binIndex]-F2[binIndex]);
+          mpY[binIndex] =
+              (-ppY[binIndex] * P2[binIndex] + P2[binIndex] * pmY[binIndex] -
+               P2[binIndex] * mmY[binIndex] +
+               2 * ppY[binIndex] * F2[binIndex] * P2[binIndex] -
+               pmY[binIndex] * P1[binIndex] + P1[binIndex] * mmY[binIndex] +
+               ppY[binIndex] * P1[binIndex] -
+               2 * ppY[binIndex] * F1[binIndex] * P1[binIndex] +
+               2 * pmY[binIndex] * F1[binIndex] * P1[binIndex] +
+               ppY[binIndex] * F1[binIndex] - ppY[binIndex] * F2[binIndex] -
+               pmY[binIndex] * F1[binIndex]) /
+              (-P2[binIndex] + 2 * F2[binIndex] * P2[binIndex] + P1[binIndex] -
+               F2[binIndex]);
           // Error propagation is not implemented in the algorithm.
           mpE[binIndex] = 0.;
         }
@@ -1090,7 +1177,11 @@ private:
     }
   }
 
-  void solveMissingIntensities(const Mantid::API::MatrixWorkspace_sptr &ppWS, Mantid::API::MatrixWorkspace_sptr &pmWS, Mantid::API::MatrixWorkspace_sptr &mpWS, const Mantid::API::MatrixWorkspace_sptr &mmWS, const Mantid::API::MatrixWorkspace_sptr &effWS) {
+  void solveMissingIntensities(const Mantid::API::MatrixWorkspace_sptr &ppWS,
+                               Mantid::API::MatrixWorkspace_sptr &pmWS,
+                               Mantid::API::MatrixWorkspace_sptr &mpWS,
+                               const Mantid::API::MatrixWorkspace_sptr &mmWS,
+                               const Mantid::API::MatrixWorkspace_sptr &effWS) {
     const auto &F1 = effWS->y(0);
     const auto &F1E = effWS->e(0);
     const auto &F2 = effWS->y(1);
@@ -1101,7 +1192,8 @@ private:
     const auto &P2E = effWS->e(3);
     pmWS = ppWS->clone();
     mpWS = ppWS->clone();
-    for (size_t wsIndex = 0; wsIndex != ppWS->getNumberHistograms(); ++wsIndex) {
+    for (size_t wsIndex = 0; wsIndex != ppWS->getNumberHistograms();
+         ++wsIndex) {
       const auto &ppY = ppWS->y(wsIndex);
       const auto &ppE = ppWS->e(wsIndex);
       auto &pmY = pmWS->mutableY(wsIndex);
@@ -1118,37 +1210,624 @@ private:
         const double P23 = P2[binIndex] * P22;
         const double F12 = F1[binIndex] * F1[binIndex];
         {
-          mpY[binIndex] = -(-mmY[binIndex]*P22*F1[binIndex]+2*F1[binIndex]*P1[binIndex]*mmY[binIndex]*P22-2*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P2[binIndex]-8*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P12*P2[binIndex]+2*ppY[binIndex]*F2[binIndex]*P12*P2[binIndex]+8*ppY[binIndex]*F12*F2[binIndex]*P12*P2[binIndex]+2*ppY[binIndex]*F12*F2[binIndex]*P2[binIndex]-8*ppY[binIndex]*F12*F2[binIndex]*P2[binIndex]*P1[binIndex]-2*F1[binIndex]*P1[binIndex]*mmY[binIndex]*P2[binIndex]-2*ppY[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+8*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+mmY[binIndex]*P2[binIndex]*F1[binIndex]+ppY[binIndex]*F1[binIndex]*F2[binIndex]-ppY[binIndex]*F2[binIndex]*P12+4*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P12+4*ppY[binIndex]*F12*F2[binIndex]*P1[binIndex]-4*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]+ppY[binIndex]*F2[binIndex]*P1[binIndex]-4*ppY[binIndex]*F12*F2[binIndex]*P12-ppY[binIndex]*F12*F2[binIndex])/(-F1[binIndex]*F2[binIndex]+2*F2[binIndex]*P1[binIndex]*P2[binIndex]+3*F1[binIndex]*F2[binIndex]*P1[binIndex]-2*F1[binIndex]*F2[binIndex]*P22-2*P22*F1[binIndex]*P1[binIndex]+2*P2[binIndex]*F1[binIndex]*P1[binIndex]+3*F1[binIndex]*F2[binIndex]*P2[binIndex]-P2[binIndex]*F1[binIndex]+P22*F1[binIndex]+F2[binIndex]*P12-2*F2[binIndex]*P12*P2[binIndex]-2*F1[binIndex]*F2[binIndex]*P12-F2[binIndex]*P1[binIndex]-8*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+4*F1[binIndex]*F2[binIndex]*P1[binIndex]*P22+4*F1[binIndex]*F2[binIndex]*P12*P2[binIndex]);
-          const double dI00 = -F2[binIndex]*(-2*P2[binIndex]*F1[binIndex]+2*P12*P2[binIndex]+8*P2[binIndex]*F1[binIndex]*P1[binIndex]-2*P1[binIndex]*P2[binIndex]+2*P2[binIndex]*F12-8*P2[binIndex]*F12*P1[binIndex]-8*P2[binIndex]*F1[binIndex]*P12+8*P2[binIndex]*F12*P12-4*F1[binIndex]*P1[binIndex]-F12+4*F12*P1[binIndex]+P1[binIndex]+F1[binIndex]-P12+4*F1[binIndex]*P12-4*F12*P12)/(-P2[binIndex]*F1[binIndex]+3*F1[binIndex]*F2[binIndex]*P2[binIndex]-2*P22*F1[binIndex]*P1[binIndex]-2*F1[binIndex]*F2[binIndex]*P22-2*F2[binIndex]*P12*P2[binIndex]-2*F1[binIndex]*F2[binIndex]*P12+2*P2[binIndex]*F1[binIndex]*P1[binIndex]+P22*F1[binIndex]+F2[binIndex]*P12+3*F1[binIndex]*F2[binIndex]*P1[binIndex]+2*F2[binIndex]*P1[binIndex]*P2[binIndex]-F1[binIndex]*F2[binIndex]-F2[binIndex]*P1[binIndex]-8*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+4*F1[binIndex]*F2[binIndex]*P1[binIndex]*P22+4*F1[binIndex]*F2[binIndex]*P12*P2[binIndex]);
-          const double dI11 = -P2[binIndex]*F1[binIndex]*(1-2*P1[binIndex]-P2[binIndex]+2*P1[binIndex]*P2[binIndex])/(-P2[binIndex]*F1[binIndex]+3*F1[binIndex]*F2[binIndex]*P2[binIndex]-2*P22*F1[binIndex]*P1[binIndex]-2*F1[binIndex]*F2[binIndex]*P22-2*F2[binIndex]*P12*P2[binIndex]-2*F1[binIndex]*F2[binIndex]*P12+2*P2[binIndex]*F1[binIndex]*P1[binIndex]+P22*F1[binIndex]+F2[binIndex]*P12+3*F1[binIndex]*F2[binIndex]*P1[binIndex]+2*F2[binIndex]*P1[binIndex]*P2[binIndex]-F1[binIndex]*F2[binIndex]-F2[binIndex]*P1[binIndex]-8*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+4*F1[binIndex]*F2[binIndex]*P1[binIndex]*P22+4*F1[binIndex]*F2[binIndex]*P12*P2[binIndex]);
-          const double divisor1 = (-P2[binIndex]*F1[binIndex]+3*F1[binIndex]*F2[binIndex]*P2[binIndex]-2*P22*F1[binIndex]*P1[binIndex]-2*F1[binIndex]*F2[binIndex]*P22-2*F2[binIndex]*P12*P2[binIndex]-2*F1[binIndex]*F2[binIndex]*P12+2*P2[binIndex]*F1[binIndex]*P1[binIndex]+P22*F1[binIndex]+F2[binIndex]*P12+3*F1[binIndex]*F2[binIndex]*P1[binIndex]+2*F2[binIndex]*P1[binIndex]*P2[binIndex]-F1[binIndex]*F2[binIndex]-F2[binIndex]*P1[binIndex]-8*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+4*F1[binIndex]*F2[binIndex]*P1[binIndex]*P22+4*F1[binIndex]*F2[binIndex]*P12*P2[binIndex]);
-          const double dF1 = -F2[binIndex]*(-P1[binIndex]*mmY[binIndex]*P2[binIndex]+4*ppY[binIndex]*F2[binIndex]*P1[binIndex]*P22-ppY[binIndex]*F2[binIndex]*P12*P2[binIndex]-10*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P12-8*ppY[binIndex]*F2[binIndex]*P12*P22+2*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]-ppY[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]-32*ppY[binIndex]*F12*F2[binIndex]*P14*P2[binIndex]+32*ppY[binIndex]*F2[binIndex]*P14*P2[binIndex]*F1[binIndex]-32*ppY[binIndex]*F2[binIndex]*P14*P22*F1[binIndex]+32*ppY[binIndex]*F12*F2[binIndex]*P14*P22+32*ppY[binIndex]*F12*F2[binIndex]*P13*P23+2*ppY[binIndex]*F2[binIndex]*P14+4*ppY[binIndex]*P13*P23-4*P13*mmY[binIndex]*P23-8*ppY[binIndex]*F2[binIndex]*P13*P23-16*ppY[binIndex]*P23*F12*P13+8*ppY[binIndex]*F12*F2[binIndex]*P14-8*ppY[binIndex]*F2[binIndex]*P14*P2[binIndex]+8*ppY[binIndex]*F2[binIndex]*P14*P22-8*ppY[binIndex]*F2[binIndex]*P14*F1[binIndex]+10*ppY[binIndex]*F2[binIndex]*P13*P2[binIndex]-4*ppY[binIndex]*F2[binIndex]*P13*P22+16*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P13-4*ppY[binIndex]*F2[binIndex]*P1[binIndex]*P23+12*ppY[binIndex]*F2[binIndex]*P12*P23+18*ppY[binIndex]*P22*F12*P1[binIndex]-20*ppY[binIndex]*F12*F2[binIndex]*P13-36*ppY[binIndex]*P22*F12*P12+24*ppY[binIndex]*P22*F12*P13-6*ppY[binIndex]*P2[binIndex]*F12*P1[binIndex]-5*ppY[binIndex]*F12*F2[binIndex]*P2[binIndex]+8*ppY[binIndex]*F12*F2[binIndex]*P22-8*ppY[binIndex]*P2[binIndex]*F12*P13+12*ppY[binIndex]*P2[binIndex]*F12*P12+18*ppY[binIndex]*F12*F2[binIndex]*P12-7*ppY[binIndex]*F12*F2[binIndex]*P1[binIndex]-12*ppY[binIndex]*P23*F12*P1[binIndex]+24*ppY[binIndex]*P23*F12*P12-4*ppY[binIndex]*F12*F2[binIndex]*P23-3*ppY[binIndex]*P1[binIndex]*P22+ppY[binIndex]*F2[binIndex]*P12-3*ppY[binIndex]*P12*P2[binIndex]+3*P12*mmY[binIndex]*P2[binIndex]-9*P12*mmY[binIndex]*P22+9*ppY[binIndex]*P12*P22+ppY[binIndex]*P1[binIndex]*P2[binIndex]+3*P1[binIndex]*mmY[binIndex]*P22-8*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+8*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]*P22+40*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P12*P2[binIndex]-40*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P12*P22-64*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P13*P2[binIndex]+64*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P13*P22+34*ppY[binIndex]*F12*F2[binIndex]*P2[binIndex]*P1[binIndex]-52*ppY[binIndex]*F12*F2[binIndex]*P22*P1[binIndex]-84*ppY[binIndex]*F12*F2[binIndex]*P12*P2[binIndex]+120*ppY[binIndex]*F12*F2[binIndex]*P12*P22+88*ppY[binIndex]*F12*F2[binIndex]*P13*P2[binIndex]-112*ppY[binIndex]*F12*F2[binIndex]*P13*P22+24*ppY[binIndex]*F12*F2[binIndex]*P23*P1[binIndex]-48*ppY[binIndex]*F12*F2[binIndex]*P12*P23+2*ppY[binIndex]*P13*P2[binIndex]-6*ppY[binIndex]*P13*P22-3*ppY[binIndex]*F2[binIndex]*P13+2*ppY[binIndex]*P1[binIndex]*P23-6*ppY[binIndex]*P12*P23+ppY[binIndex]*P2[binIndex]*F12-3*ppY[binIndex]*P22*F12+ppY[binIndex]*F12*F2[binIndex]+2*ppY[binIndex]*P23*F12-2*P13*mmY[binIndex]*P2[binIndex]+6*P13*mmY[binIndex]*P22+6*P12*mmY[binIndex]*P23-2*P1[binIndex]*mmY[binIndex]*P23)/(divisor1 * divisor1);
-          const double divisor2 = (-P2[binIndex]*F1[binIndex]+3*F1[binIndex]*F2[binIndex]*P2[binIndex]-2*P22*F1[binIndex]*P1[binIndex]-2*F1[binIndex]*F2[binIndex]*P22-2*F2[binIndex]*P12*P2[binIndex]-2*F1[binIndex]*F2[binIndex]*P12+2*P2[binIndex]*F1[binIndex]*P1[binIndex]+P22*F1[binIndex]+F2[binIndex]*P12+3*F1[binIndex]*F2[binIndex]*P1[binIndex]+2*F2[binIndex]*P1[binIndex]*P2[binIndex]-F1[binIndex]*F2[binIndex]-F2[binIndex]*P1[binIndex]-8*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+4*F1[binIndex]*F2[binIndex]*P1[binIndex]*P22+4*F1[binIndex]*F2[binIndex]*P12*P2[binIndex]);
-          const double dF2 = P2[binIndex]*F1[binIndex]*(3*P1[binIndex]*mmY[binIndex]*P2[binIndex]-12*ppY[binIndex]*P22*F1[binIndex]*P1[binIndex]-36*ppY[binIndex]*P2[binIndex]*F1[binIndex]*P12+24*ppY[binIndex]*P22*F1[binIndex]*P12+18*ppY[binIndex]*P2[binIndex]*F1[binIndex]*P1[binIndex]+12*ppY[binIndex]*F1[binIndex]*P12+24*ppY[binIndex]*P2[binIndex]*F1[binIndex]*P13-16*ppY[binIndex]*P22*F1[binIndex]*P13+12*ppY[binIndex]*P22*F12*P1[binIndex]-24*ppY[binIndex]*P22*F12*P12+16*ppY[binIndex]*P22*F12*P13-18*ppY[binIndex]*P2[binIndex]*F12*P1[binIndex]-24*ppY[binIndex]*P2[binIndex]*F12*P13+36*ppY[binIndex]*P2[binIndex]*F12*P12-19*F1[binIndex]*P1[binIndex]*mmY[binIndex]*P2[binIndex]+28*F1[binIndex]*P12*mmY[binIndex]*P2[binIndex]-12*F1[binIndex]*P13*mmY[binIndex]*P2[binIndex]+22*F1[binIndex]*P1[binIndex]*mmY[binIndex]*P22-28*F1[binIndex]*P12*mmY[binIndex]*P22+8*F1[binIndex]*P13*mmY[binIndex]*P22-8*F1[binIndex]*P1[binIndex]*mmY[binIndex]*P23+8*F1[binIndex]*P12*mmY[binIndex]*P23-ppY[binIndex]*F12+2*ppY[binIndex]*P13-2*P13*mmY[binIndex]-mmY[binIndex]*F1[binIndex]+2*ppY[binIndex]*P1[binIndex]*P22+9*ppY[binIndex]*P12*P2[binIndex]-9*P12*mmY[binIndex]*P2[binIndex]+6*P12*mmY[binIndex]*P22-6*ppY[binIndex]*P12*P22-3*ppY[binIndex]*P1[binIndex]*P2[binIndex]-2*P1[binIndex]*mmY[binIndex]*P22-6*ppY[binIndex]*F1[binIndex]*P1[binIndex]+2*ppY[binIndex]*P22*F1[binIndex]-3*ppY[binIndex]*P2[binIndex]*F1[binIndex]-P1[binIndex]*mmY[binIndex]+ppY[binIndex]*P1[binIndex]-3*ppY[binIndex]*P12+ppY[binIndex]*F1[binIndex]+3*P12*mmY[binIndex]-6*ppY[binIndex]*P13*P2[binIndex]+4*ppY[binIndex]*P13*P22+3*ppY[binIndex]*P2[binIndex]*F12-2*ppY[binIndex]*P22*F12+5*F1[binIndex]*P1[binIndex]*mmY[binIndex]+6*ppY[binIndex]*F12*P1[binIndex]-8*F1[binIndex]*P12*mmY[binIndex]-12*F12*P12*ppY[binIndex]-8*ppY[binIndex]*F1[binIndex]*P13+6*P13*mmY[binIndex]*P2[binIndex]+4*F1[binIndex]*P13*mmY[binIndex]+8*F12*P13*ppY[binIndex]-4*P13*mmY[binIndex]*P22-5*mmY[binIndex]*P22*F1[binIndex]+2*mmY[binIndex]*P23*F1[binIndex]+4*mmY[binIndex]*P2[binIndex]*F1[binIndex])/(divisor2 * divisor2);
-          const double divisor3 = (-P2[binIndex]*F1[binIndex]+3*F1[binIndex]*F2[binIndex]*P2[binIndex]-2*P22*F1[binIndex]*P1[binIndex]-2*F1[binIndex]*F2[binIndex]*P22-2*F2[binIndex]*P12*P2[binIndex]-2*F1[binIndex]*F2[binIndex]*P12+2*P2[binIndex]*F1[binIndex]*P1[binIndex]+P22*F1[binIndex]+F2[binIndex]*P12+3*F1[binIndex]*F2[binIndex]*P1[binIndex]+2*F2[binIndex]*P1[binIndex]*P2[binIndex]-F1[binIndex]*F2[binIndex]-F2[binIndex]*P1[binIndex]-8*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+4*F1[binIndex]*F2[binIndex]*P1[binIndex]*P22+4*F1[binIndex]*F2[binIndex]*P12*P2[binIndex]);
-          const double dP1 = -F1[binIndex]*F2[binIndex]*(-2*P1[binIndex]*mmY[binIndex]*P2[binIndex]-2*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P2[binIndex]+8*ppY[binIndex]*F2[binIndex]*P1[binIndex]*P22+24*ppY[binIndex]*P22*F1[binIndex]*P1[binIndex]+8*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P22+8*ppY[binIndex]*P2[binIndex]*F1[binIndex]*P12+6*ppY[binIndex]*F2[binIndex]*P12*P2[binIndex]+4*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P12-24*ppY[binIndex]*P22*F1[binIndex]*P12-12*ppY[binIndex]*F2[binIndex]*P12*P22-8*ppY[binIndex]*P2[binIndex]*F1[binIndex]*P1[binIndex]-2*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]-2*ppY[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+ppY[binIndex]*F2[binIndex]*P2[binIndex]-4*ppY[binIndex]*F2[binIndex]*P22-8*ppY[binIndex]*F2[binIndex]*P1[binIndex]*P23-16*ppY[binIndex]*P23*F1[binIndex]*P1[binIndex]-8*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P23+16*ppY[binIndex]*P23*F1[binIndex]*P12+8*ppY[binIndex]*F2[binIndex]*P12*P23-24*ppY[binIndex]*P22*F12*P1[binIndex]+24*ppY[binIndex]*P22*F12*P12+8*ppY[binIndex]*P2[binIndex]*F12*P1[binIndex]+6*ppY[binIndex]*F12*F2[binIndex]*P2[binIndex]-12*ppY[binIndex]*F12*F2[binIndex]*P22-8*ppY[binIndex]*P2[binIndex]*F12*P12-4*ppY[binIndex]*F12*F2[binIndex]*P12+4*ppY[binIndex]*F12*F2[binIndex]*P1[binIndex]+16*ppY[binIndex]*P23*F12*P1[binIndex]-16*ppY[binIndex]*P23*F12*P12+8*ppY[binIndex]*F12*F2[binIndex]*P23+4*F1[binIndex]*P1[binIndex]*mmY[binIndex]*P2[binIndex]-4*F1[binIndex]*P12*mmY[binIndex]*P2[binIndex]-12*F1[binIndex]*P1[binIndex]*mmY[binIndex]*P22+12*F1[binIndex]*P12*mmY[binIndex]*P22+8*F1[binIndex]*P1[binIndex]*mmY[binIndex]*P23-8*F1[binIndex]*P12*mmY[binIndex]*P23+2*mmY[binIndex]*P23-2*ppY[binIndex]*P23+4*ppY[binIndex]*F2[binIndex]*P23-6*ppY[binIndex]*P1[binIndex]*P22-ppY[binIndex]*F2[binIndex]*P12-2*ppY[binIndex]*P12*P2[binIndex]+2*P12*mmY[binIndex]*P2[binIndex]-6*P12*mmY[binIndex]*P22+6*ppY[binIndex]*P12*P22+2*ppY[binIndex]*P1[binIndex]*P2[binIndex]-ppY[binIndex]*P2[binIndex]+6*P1[binIndex]*mmY[binIndex]*P22-6*ppY[binIndex]*P22*F1[binIndex]+2*ppY[binIndex]*P2[binIndex]*F1[binIndex]+3*ppY[binIndex]*P22+16*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]-40*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]*P22-24*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P12*P2[binIndex]+48*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P12*P22+mmY[binIndex]*P2[binIndex]-3*mmY[binIndex]*P22+32*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]*P23-32*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P12*P23-24*ppY[binIndex]*F12*F2[binIndex]*P2[binIndex]*P1[binIndex]+48*ppY[binIndex]*F12*F2[binIndex]*P22*P1[binIndex]+24*ppY[binIndex]*F12*F2[binIndex]*P12*P2[binIndex]-48*ppY[binIndex]*F12*F2[binIndex]*P12*P22-32*ppY[binIndex]*F12*F2[binIndex]*P23*P1[binIndex]+32*ppY[binIndex]*F12*F2[binIndex]*P12*P23+4*ppY[binIndex]*P1[binIndex]*P23+4*ppY[binIndex]*P23*F1[binIndex]-4*ppY[binIndex]*P12*P23-2*ppY[binIndex]*P2[binIndex]*F12+6*ppY[binIndex]*P22*F12-ppY[binIndex]*F12*F2[binIndex]-4*ppY[binIndex]*P23*F12+4*P12*mmY[binIndex]*P23-4*P1[binIndex]*mmY[binIndex]*P23+3*mmY[binIndex]*P22*F1[binIndex]-2*mmY[binIndex]*P23*F1[binIndex]-mmY[binIndex]*P2[binIndex]*F1[binIndex])/(divisor3 * divisor3);
-          const double divisor4 = (-P2[binIndex]*F1[binIndex]+3*F1[binIndex]*F2[binIndex]*P2[binIndex]-2*P22*F1[binIndex]*P1[binIndex]-2*F1[binIndex]*F2[binIndex]*P22-2*F2[binIndex]*P12*P2[binIndex]-2*F1[binIndex]*F2[binIndex]*P12+2*P2[binIndex]*F1[binIndex]*P1[binIndex]+P22*F1[binIndex]+F2[binIndex]*P12+3*F1[binIndex]*F2[binIndex]*P1[binIndex]+2*F2[binIndex]*P1[binIndex]*P2[binIndex]-F1[binIndex]*F2[binIndex]-F2[binIndex]*P1[binIndex]-8*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+4*F1[binIndex]*F2[binIndex]*P1[binIndex]*P22+4*F1[binIndex]*F2[binIndex]*P12*P2[binIndex]);
-          const double dP2 = F1[binIndex]*F2[binIndex]*(-2*P1[binIndex]*mmY[binIndex]*P2[binIndex]-4*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P2[binIndex]+4*ppY[binIndex]*F2[binIndex]*P1[binIndex]*P22+12*ppY[binIndex]*P22*F1[binIndex]*P1[binIndex]+4*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P22+24*ppY[binIndex]*P2[binIndex]*F1[binIndex]*P12+12*ppY[binIndex]*F2[binIndex]*P12*P2[binIndex]+12*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P12-24*ppY[binIndex]*P22*F1[binIndex]*P12-12*ppY[binIndex]*F2[binIndex]*P12*P22-12*ppY[binIndex]*P2[binIndex]*F1[binIndex]*P1[binIndex]-6*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]-4*ppY[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]-12*ppY[binIndex]*F1[binIndex]*P12-16*ppY[binIndex]*P2[binIndex]*F1[binIndex]*P13+16*ppY[binIndex]*P22*F1[binIndex]*P13-8*ppY[binIndex]*F2[binIndex]*P13*P2[binIndex]+8*ppY[binIndex]*F2[binIndex]*P13*P22-8*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P13-12*ppY[binIndex]*P22*F12*P1[binIndex]+8*ppY[binIndex]*F12*F2[binIndex]*P13+24*ppY[binIndex]*P22*F12*P12-16*ppY[binIndex]*P22*F12*P13+12*ppY[binIndex]*P2[binIndex]*F12*P1[binIndex]+4*ppY[binIndex]*F12*F2[binIndex]*P2[binIndex]-4*ppY[binIndex]*F12*F2[binIndex]*P22+16*ppY[binIndex]*P2[binIndex]*F12*P13-24*ppY[binIndex]*P2[binIndex]*F12*P12-12*ppY[binIndex]*F12*F2[binIndex]*P12+6*ppY[binIndex]*F12*F2[binIndex]*P1[binIndex]+10*F1[binIndex]*P1[binIndex]*mmY[binIndex]*P2[binIndex]-16*F1[binIndex]*P12*mmY[binIndex]*P2[binIndex]+8*F1[binIndex]*P13*mmY[binIndex]*P2[binIndex]-6*F1[binIndex]*P1[binIndex]*mmY[binIndex]*P22+12*F1[binIndex]*P12*mmY[binIndex]*P22-8*F1[binIndex]*P13*mmY[binIndex]*P22+ppY[binIndex]*F12-2*ppY[binIndex]*P13+2*P13*mmY[binIndex]+mmY[binIndex]*F1[binIndex]-2*ppY[binIndex]*P1[binIndex]*P22+ppY[binIndex]*F2[binIndex]*P1[binIndex]-3*ppY[binIndex]*F2[binIndex]*P12-6*ppY[binIndex]*P12*P2[binIndex]+6*P12*mmY[binIndex]*P2[binIndex]-6*P12*mmY[binIndex]*P22+6*ppY[binIndex]*P12*P22+2*ppY[binIndex]*P1[binIndex]*P2[binIndex]+ppY[binIndex]*F1[binIndex]*F2[binIndex]+2*P1[binIndex]*mmY[binIndex]*P22+6*ppY[binIndex]*F1[binIndex]*P1[binIndex]-2*ppY[binIndex]*P22*F1[binIndex]+2*ppY[binIndex]*P2[binIndex]*F1[binIndex]+24*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]-24*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]*P22-48*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P12*P2[binIndex]+48*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P12*P22+P1[binIndex]*mmY[binIndex]-ppY[binIndex]*P1[binIndex]+3*ppY[binIndex]*P12-ppY[binIndex]*F1[binIndex]-3*P12*mmY[binIndex]+32*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P13*P2[binIndex]-32*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P13*P22-24*ppY[binIndex]*F12*F2[binIndex]*P2[binIndex]*P1[binIndex]+24*ppY[binIndex]*F12*F2[binIndex]*P22*P1[binIndex]+48*ppY[binIndex]*F12*F2[binIndex]*P12*P2[binIndex]-48*ppY[binIndex]*F12*F2[binIndex]*P12*P22-32*ppY[binIndex]*F12*F2[binIndex]*P13*P2[binIndex]+32*ppY[binIndex]*F12*F2[binIndex]*P13*P22+4*ppY[binIndex]*P13*P2[binIndex]-4*ppY[binIndex]*P13*P22+2*ppY[binIndex]*F2[binIndex]*P13-2*ppY[binIndex]*P2[binIndex]*F12+2*ppY[binIndex]*P22*F12-ppY[binIndex]*F12*F2[binIndex]-5*F1[binIndex]*P1[binIndex]*mmY[binIndex]-6*ppY[binIndex]*F12*P1[binIndex]+8*F1[binIndex]*P12*mmY[binIndex]+12*F12*P12*ppY[binIndex]+8*ppY[binIndex]*F1[binIndex]*P13-4*P13*mmY[binIndex]*P2[binIndex]-4*F1[binIndex]*P13*mmY[binIndex]-8*F12*P13*ppY[binIndex]+4*P13*mmY[binIndex]*P22+mmY[binIndex]*P22*F1[binIndex]-2*mmY[binIndex]*P2[binIndex]*F1[binIndex])/(divisor4 * divisor4);
+          mpY[binIndex] =
+              -(-mmY[binIndex] * P22 * F1[binIndex] +
+                2 * F1[binIndex] * P1[binIndex] * mmY[binIndex] * P22 -
+                2 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P2[binIndex] -
+                8 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P12 *
+                    P2[binIndex] +
+                2 * ppY[binIndex] * F2[binIndex] * P12 * P2[binIndex] +
+                8 * ppY[binIndex] * F12 * F2[binIndex] * P12 * P2[binIndex] +
+                2 * ppY[binIndex] * F12 * F2[binIndex] * P2[binIndex] -
+                8 * ppY[binIndex] * F12 * F2[binIndex] * P2[binIndex] *
+                    P1[binIndex] -
+                2 * F1[binIndex] * P1[binIndex] * mmY[binIndex] * P2[binIndex] -
+                2 * ppY[binIndex] * F2[binIndex] * P1[binIndex] * P2[binIndex] +
+                8 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P1[binIndex] *
+                    P2[binIndex] +
+                mmY[binIndex] * P2[binIndex] * F1[binIndex] +
+                ppY[binIndex] * F1[binIndex] * F2[binIndex] -
+                ppY[binIndex] * F2[binIndex] * P12 +
+                4 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P12 +
+                4 * ppY[binIndex] * F12 * F2[binIndex] * P1[binIndex] -
+                4 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P1[binIndex] +
+                ppY[binIndex] * F2[binIndex] * P1[binIndex] -
+                4 * ppY[binIndex] * F12 * F2[binIndex] * P12 -
+                ppY[binIndex] * F12 * F2[binIndex]) /
+              (-F1[binIndex] * F2[binIndex] +
+               2 * F2[binIndex] * P1[binIndex] * P2[binIndex] +
+               3 * F1[binIndex] * F2[binIndex] * P1[binIndex] -
+               2 * F1[binIndex] * F2[binIndex] * P22 -
+               2 * P22 * F1[binIndex] * P1[binIndex] +
+               2 * P2[binIndex] * F1[binIndex] * P1[binIndex] +
+               3 * F1[binIndex] * F2[binIndex] * P2[binIndex] -
+               P2[binIndex] * F1[binIndex] + P22 * F1[binIndex] +
+               F2[binIndex] * P12 - 2 * F2[binIndex] * P12 * P2[binIndex] -
+               2 * F1[binIndex] * F2[binIndex] * P12 -
+               F2[binIndex] * P1[binIndex] -
+               8 * F1[binIndex] * F2[binIndex] * P1[binIndex] * P2[binIndex] +
+               4 * F1[binIndex] * F2[binIndex] * P1[binIndex] * P22 +
+               4 * F1[binIndex] * F2[binIndex] * P12 * P2[binIndex]);
+          const double dI00 =
+              -F2[binIndex] *
+              (-2 * P2[binIndex] * F1[binIndex] + 2 * P12 * P2[binIndex] +
+               8 * P2[binIndex] * F1[binIndex] * P1[binIndex] -
+               2 * P1[binIndex] * P2[binIndex] + 2 * P2[binIndex] * F12 -
+               8 * P2[binIndex] * F12 * P1[binIndex] -
+               8 * P2[binIndex] * F1[binIndex] * P12 +
+               8 * P2[binIndex] * F12 * P12 - 4 * F1[binIndex] * P1[binIndex] -
+               F12 + 4 * F12 * P1[binIndex] + P1[binIndex] + F1[binIndex] -
+               P12 + 4 * F1[binIndex] * P12 - 4 * F12 * P12) /
+              (-P2[binIndex] * F1[binIndex] +
+               3 * F1[binIndex] * F2[binIndex] * P2[binIndex] -
+               2 * P22 * F1[binIndex] * P1[binIndex] -
+               2 * F1[binIndex] * F2[binIndex] * P22 -
+               2 * F2[binIndex] * P12 * P2[binIndex] -
+               2 * F1[binIndex] * F2[binIndex] * P12 +
+               2 * P2[binIndex] * F1[binIndex] * P1[binIndex] +
+               P22 * F1[binIndex] + F2[binIndex] * P12 +
+               3 * F1[binIndex] * F2[binIndex] * P1[binIndex] +
+               2 * F2[binIndex] * P1[binIndex] * P2[binIndex] -
+               F1[binIndex] * F2[binIndex] - F2[binIndex] * P1[binIndex] -
+               8 * F1[binIndex] * F2[binIndex] * P1[binIndex] * P2[binIndex] +
+               4 * F1[binIndex] * F2[binIndex] * P1[binIndex] * P22 +
+               4 * F1[binIndex] * F2[binIndex] * P12 * P2[binIndex]);
+          const double dI11 =
+              -P2[binIndex] * F1[binIndex] *
+              (1 - 2 * P1[binIndex] - P2[binIndex] +
+               2 * P1[binIndex] * P2[binIndex]) /
+              (-P2[binIndex] * F1[binIndex] +
+               3 * F1[binIndex] * F2[binIndex] * P2[binIndex] -
+               2 * P22 * F1[binIndex] * P1[binIndex] -
+               2 * F1[binIndex] * F2[binIndex] * P22 -
+               2 * F2[binIndex] * P12 * P2[binIndex] -
+               2 * F1[binIndex] * F2[binIndex] * P12 +
+               2 * P2[binIndex] * F1[binIndex] * P1[binIndex] +
+               P22 * F1[binIndex] + F2[binIndex] * P12 +
+               3 * F1[binIndex] * F2[binIndex] * P1[binIndex] +
+               2 * F2[binIndex] * P1[binIndex] * P2[binIndex] -
+               F1[binIndex] * F2[binIndex] - F2[binIndex] * P1[binIndex] -
+               8 * F1[binIndex] * F2[binIndex] * P1[binIndex] * P2[binIndex] +
+               4 * F1[binIndex] * F2[binIndex] * P1[binIndex] * P22 +
+               4 * F1[binIndex] * F2[binIndex] * P12 * P2[binIndex]);
+          const double divisor1 =
+              (-P2[binIndex] * F1[binIndex] +
+               3 * F1[binIndex] * F2[binIndex] * P2[binIndex] -
+               2 * P22 * F1[binIndex] * P1[binIndex] -
+               2 * F1[binIndex] * F2[binIndex] * P22 -
+               2 * F2[binIndex] * P12 * P2[binIndex] -
+               2 * F1[binIndex] * F2[binIndex] * P12 +
+               2 * P2[binIndex] * F1[binIndex] * P1[binIndex] +
+               P22 * F1[binIndex] + F2[binIndex] * P12 +
+               3 * F1[binIndex] * F2[binIndex] * P1[binIndex] +
+               2 * F2[binIndex] * P1[binIndex] * P2[binIndex] -
+               F1[binIndex] * F2[binIndex] - F2[binIndex] * P1[binIndex] -
+               8 * F1[binIndex] * F2[binIndex] * P1[binIndex] * P2[binIndex] +
+               4 * F1[binIndex] * F2[binIndex] * P1[binIndex] * P22 +
+               4 * F1[binIndex] * F2[binIndex] * P12 * P2[binIndex]);
+          const double dF1 =
+              -F2[binIndex] *
+              (-P1[binIndex] * mmY[binIndex] * P2[binIndex] +
+               4 * ppY[binIndex] * F2[binIndex] * P1[binIndex] * P22 -
+               ppY[binIndex] * F2[binIndex] * P12 * P2[binIndex] -
+               10 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P12 -
+               8 * ppY[binIndex] * F2[binIndex] * P12 * P22 +
+               2 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P1[binIndex] -
+               ppY[binIndex] * F2[binIndex] * P1[binIndex] * P2[binIndex] -
+               32 * ppY[binIndex] * F12 * F2[binIndex] * P14 * P2[binIndex] +
+               32 * ppY[binIndex] * F2[binIndex] * P14 * P2[binIndex] *
+                   F1[binIndex] -
+               32 * ppY[binIndex] * F2[binIndex] * P14 * P22 * F1[binIndex] +
+               32 * ppY[binIndex] * F12 * F2[binIndex] * P14 * P22 +
+               32 * ppY[binIndex] * F12 * F2[binIndex] * P13 * P23 +
+               2 * ppY[binIndex] * F2[binIndex] * P14 +
+               4 * ppY[binIndex] * P13 * P23 - 4 * P13 * mmY[binIndex] * P23 -
+               8 * ppY[binIndex] * F2[binIndex] * P13 * P23 -
+               16 * ppY[binIndex] * P23 * F12 * P13 +
+               8 * ppY[binIndex] * F12 * F2[binIndex] * P14 -
+               8 * ppY[binIndex] * F2[binIndex] * P14 * P2[binIndex] +
+               8 * ppY[binIndex] * F2[binIndex] * P14 * P22 -
+               8 * ppY[binIndex] * F2[binIndex] * P14 * F1[binIndex] +
+               10 * ppY[binIndex] * F2[binIndex] * P13 * P2[binIndex] -
+               4 * ppY[binIndex] * F2[binIndex] * P13 * P22 +
+               16 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P13 -
+               4 * ppY[binIndex] * F2[binIndex] * P1[binIndex] * P23 +
+               12 * ppY[binIndex] * F2[binIndex] * P12 * P23 +
+               18 * ppY[binIndex] * P22 * F12 * P1[binIndex] -
+               20 * ppY[binIndex] * F12 * F2[binIndex] * P13 -
+               36 * ppY[binIndex] * P22 * F12 * P12 +
+               24 * ppY[binIndex] * P22 * F12 * P13 -
+               6 * ppY[binIndex] * P2[binIndex] * F12 * P1[binIndex] -
+               5 * ppY[binIndex] * F12 * F2[binIndex] * P2[binIndex] +
+               8 * ppY[binIndex] * F12 * F2[binIndex] * P22 -
+               8 * ppY[binIndex] * P2[binIndex] * F12 * P13 +
+               12 * ppY[binIndex] * P2[binIndex] * F12 * P12 +
+               18 * ppY[binIndex] * F12 * F2[binIndex] * P12 -
+               7 * ppY[binIndex] * F12 * F2[binIndex] * P1[binIndex] -
+               12 * ppY[binIndex] * P23 * F12 * P1[binIndex] +
+               24 * ppY[binIndex] * P23 * F12 * P12 -
+               4 * ppY[binIndex] * F12 * F2[binIndex] * P23 -
+               3 * ppY[binIndex] * P1[binIndex] * P22 +
+               ppY[binIndex] * F2[binIndex] * P12 -
+               3 * ppY[binIndex] * P12 * P2[binIndex] +
+               3 * P12 * mmY[binIndex] * P2[binIndex] -
+               9 * P12 * mmY[binIndex] * P22 + 9 * ppY[binIndex] * P12 * P22 +
+               ppY[binIndex] * P1[binIndex] * P2[binIndex] +
+               3 * P1[binIndex] * mmY[binIndex] * P22 -
+               8 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P1[binIndex] *
+                   P2[binIndex] +
+               8 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P1[binIndex] *
+                   P22 +
+               40 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P12 *
+                   P2[binIndex] -
+               40 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P12 * P22 -
+               64 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P13 *
+                   P2[binIndex] +
+               64 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P13 * P22 +
+               34 * ppY[binIndex] * F12 * F2[binIndex] * P2[binIndex] *
+                   P1[binIndex] -
+               52 * ppY[binIndex] * F12 * F2[binIndex] * P22 * P1[binIndex] -
+               84 * ppY[binIndex] * F12 * F2[binIndex] * P12 * P2[binIndex] +
+               120 * ppY[binIndex] * F12 * F2[binIndex] * P12 * P22 +
+               88 * ppY[binIndex] * F12 * F2[binIndex] * P13 * P2[binIndex] -
+               112 * ppY[binIndex] * F12 * F2[binIndex] * P13 * P22 +
+               24 * ppY[binIndex] * F12 * F2[binIndex] * P23 * P1[binIndex] -
+               48 * ppY[binIndex] * F12 * F2[binIndex] * P12 * P23 +
+               2 * ppY[binIndex] * P13 * P2[binIndex] -
+               6 * ppY[binIndex] * P13 * P22 -
+               3 * ppY[binIndex] * F2[binIndex] * P13 +
+               2 * ppY[binIndex] * P1[binIndex] * P23 -
+               6 * ppY[binIndex] * P12 * P23 +
+               ppY[binIndex] * P2[binIndex] * F12 -
+               3 * ppY[binIndex] * P22 * F12 +
+               ppY[binIndex] * F12 * F2[binIndex] +
+               2 * ppY[binIndex] * P23 * F12 -
+               2 * P13 * mmY[binIndex] * P2[binIndex] +
+               6 * P13 * mmY[binIndex] * P22 + 6 * P12 * mmY[binIndex] * P23 -
+               2 * P1[binIndex] * mmY[binIndex] * P23) /
+              (divisor1 * divisor1);
+          const double divisor2 =
+              (-P2[binIndex] * F1[binIndex] +
+               3 * F1[binIndex] * F2[binIndex] * P2[binIndex] -
+               2 * P22 * F1[binIndex] * P1[binIndex] -
+               2 * F1[binIndex] * F2[binIndex] * P22 -
+               2 * F2[binIndex] * P12 * P2[binIndex] -
+               2 * F1[binIndex] * F2[binIndex] * P12 +
+               2 * P2[binIndex] * F1[binIndex] * P1[binIndex] +
+               P22 * F1[binIndex] + F2[binIndex] * P12 +
+               3 * F1[binIndex] * F2[binIndex] * P1[binIndex] +
+               2 * F2[binIndex] * P1[binIndex] * P2[binIndex] -
+               F1[binIndex] * F2[binIndex] - F2[binIndex] * P1[binIndex] -
+               8 * F1[binIndex] * F2[binIndex] * P1[binIndex] * P2[binIndex] +
+               4 * F1[binIndex] * F2[binIndex] * P1[binIndex] * P22 +
+               4 * F1[binIndex] * F2[binIndex] * P12 * P2[binIndex]);
+          const double dF2 =
+              P2[binIndex] * F1[binIndex] *
+              (3 * P1[binIndex] * mmY[binIndex] * P2[binIndex] -
+               12 * ppY[binIndex] * P22 * F1[binIndex] * P1[binIndex] -
+               36 * ppY[binIndex] * P2[binIndex] * F1[binIndex] * P12 +
+               24 * ppY[binIndex] * P22 * F1[binIndex] * P12 +
+               18 * ppY[binIndex] * P2[binIndex] * F1[binIndex] * P1[binIndex] +
+               12 * ppY[binIndex] * F1[binIndex] * P12 +
+               24 * ppY[binIndex] * P2[binIndex] * F1[binIndex] * P13 -
+               16 * ppY[binIndex] * P22 * F1[binIndex] * P13 +
+               12 * ppY[binIndex] * P22 * F12 * P1[binIndex] -
+               24 * ppY[binIndex] * P22 * F12 * P12 +
+               16 * ppY[binIndex] * P22 * F12 * P13 -
+               18 * ppY[binIndex] * P2[binIndex] * F12 * P1[binIndex] -
+               24 * ppY[binIndex] * P2[binIndex] * F12 * P13 +
+               36 * ppY[binIndex] * P2[binIndex] * F12 * P12 -
+               19 * F1[binIndex] * P1[binIndex] * mmY[binIndex] * P2[binIndex] +
+               28 * F1[binIndex] * P12 * mmY[binIndex] * P2[binIndex] -
+               12 * F1[binIndex] * P13 * mmY[binIndex] * P2[binIndex] +
+               22 * F1[binIndex] * P1[binIndex] * mmY[binIndex] * P22 -
+               28 * F1[binIndex] * P12 * mmY[binIndex] * P22 +
+               8 * F1[binIndex] * P13 * mmY[binIndex] * P22 -
+               8 * F1[binIndex] * P1[binIndex] * mmY[binIndex] * P23 +
+               8 * F1[binIndex] * P12 * mmY[binIndex] * P23 -
+               ppY[binIndex] * F12 + 2 * ppY[binIndex] * P13 -
+               2 * P13 * mmY[binIndex] - mmY[binIndex] * F1[binIndex] +
+               2 * ppY[binIndex] * P1[binIndex] * P22 +
+               9 * ppY[binIndex] * P12 * P2[binIndex] -
+               9 * P12 * mmY[binIndex] * P2[binIndex] +
+               6 * P12 * mmY[binIndex] * P22 - 6 * ppY[binIndex] * P12 * P22 -
+               3 * ppY[binIndex] * P1[binIndex] * P2[binIndex] -
+               2 * P1[binIndex] * mmY[binIndex] * P22 -
+               6 * ppY[binIndex] * F1[binIndex] * P1[binIndex] +
+               2 * ppY[binIndex] * P22 * F1[binIndex] -
+               3 * ppY[binIndex] * P2[binIndex] * F1[binIndex] -
+               P1[binIndex] * mmY[binIndex] + ppY[binIndex] * P1[binIndex] -
+               3 * ppY[binIndex] * P12 + ppY[binIndex] * F1[binIndex] +
+               3 * P12 * mmY[binIndex] -
+               6 * ppY[binIndex] * P13 * P2[binIndex] +
+               4 * ppY[binIndex] * P13 * P22 +
+               3 * ppY[binIndex] * P2[binIndex] * F12 -
+               2 * ppY[binIndex] * P22 * F12 +
+               5 * F1[binIndex] * P1[binIndex] * mmY[binIndex] +
+               6 * ppY[binIndex] * F12 * P1[binIndex] -
+               8 * F1[binIndex] * P12 * mmY[binIndex] -
+               12 * F12 * P12 * ppY[binIndex] -
+               8 * ppY[binIndex] * F1[binIndex] * P13 +
+               6 * P13 * mmY[binIndex] * P2[binIndex] +
+               4 * F1[binIndex] * P13 * mmY[binIndex] +
+               8 * F12 * P13 * ppY[binIndex] - 4 * P13 * mmY[binIndex] * P22 -
+               5 * mmY[binIndex] * P22 * F1[binIndex] +
+               2 * mmY[binIndex] * P23 * F1[binIndex] +
+               4 * mmY[binIndex] * P2[binIndex] * F1[binIndex]) /
+              (divisor2 * divisor2);
+          const double divisor3 =
+              (-P2[binIndex] * F1[binIndex] +
+               3 * F1[binIndex] * F2[binIndex] * P2[binIndex] -
+               2 * P22 * F1[binIndex] * P1[binIndex] -
+               2 * F1[binIndex] * F2[binIndex] * P22 -
+               2 * F2[binIndex] * P12 * P2[binIndex] -
+               2 * F1[binIndex] * F2[binIndex] * P12 +
+               2 * P2[binIndex] * F1[binIndex] * P1[binIndex] +
+               P22 * F1[binIndex] + F2[binIndex] * P12 +
+               3 * F1[binIndex] * F2[binIndex] * P1[binIndex] +
+               2 * F2[binIndex] * P1[binIndex] * P2[binIndex] -
+               F1[binIndex] * F2[binIndex] - F2[binIndex] * P1[binIndex] -
+               8 * F1[binIndex] * F2[binIndex] * P1[binIndex] * P2[binIndex] +
+               4 * F1[binIndex] * F2[binIndex] * P1[binIndex] * P22 +
+               4 * F1[binIndex] * F2[binIndex] * P12 * P2[binIndex]);
+          const double dP1 =
+              -F1[binIndex] * F2[binIndex] *
+              (-2 * P1[binIndex] * mmY[binIndex] * P2[binIndex] -
+               2 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P2[binIndex] +
+               8 * ppY[binIndex] * F2[binIndex] * P1[binIndex] * P22 +
+               24 * ppY[binIndex] * P22 * F1[binIndex] * P1[binIndex] +
+               8 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P22 +
+               8 * ppY[binIndex] * P2[binIndex] * F1[binIndex] * P12 +
+               6 * ppY[binIndex] * F2[binIndex] * P12 * P2[binIndex] +
+               4 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P12 -
+               24 * ppY[binIndex] * P22 * F1[binIndex] * P12 -
+               12 * ppY[binIndex] * F2[binIndex] * P12 * P22 -
+               8 * ppY[binIndex] * P2[binIndex] * F1[binIndex] * P1[binIndex] -
+               2 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P1[binIndex] -
+               2 * ppY[binIndex] * F2[binIndex] * P1[binIndex] * P2[binIndex] +
+               ppY[binIndex] * F2[binIndex] * P2[binIndex] -
+               4 * ppY[binIndex] * F2[binIndex] * P22 -
+               8 * ppY[binIndex] * F2[binIndex] * P1[binIndex] * P23 -
+               16 * ppY[binIndex] * P23 * F1[binIndex] * P1[binIndex] -
+               8 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P23 +
+               16 * ppY[binIndex] * P23 * F1[binIndex] * P12 +
+               8 * ppY[binIndex] * F2[binIndex] * P12 * P23 -
+               24 * ppY[binIndex] * P22 * F12 * P1[binIndex] +
+               24 * ppY[binIndex] * P22 * F12 * P12 +
+               8 * ppY[binIndex] * P2[binIndex] * F12 * P1[binIndex] +
+               6 * ppY[binIndex] * F12 * F2[binIndex] * P2[binIndex] -
+               12 * ppY[binIndex] * F12 * F2[binIndex] * P22 -
+               8 * ppY[binIndex] * P2[binIndex] * F12 * P12 -
+               4 * ppY[binIndex] * F12 * F2[binIndex] * P12 +
+               4 * ppY[binIndex] * F12 * F2[binIndex] * P1[binIndex] +
+               16 * ppY[binIndex] * P23 * F12 * P1[binIndex] -
+               16 * ppY[binIndex] * P23 * F12 * P12 +
+               8 * ppY[binIndex] * F12 * F2[binIndex] * P23 +
+               4 * F1[binIndex] * P1[binIndex] * mmY[binIndex] * P2[binIndex] -
+               4 * F1[binIndex] * P12 * mmY[binIndex] * P2[binIndex] -
+               12 * F1[binIndex] * P1[binIndex] * mmY[binIndex] * P22 +
+               12 * F1[binIndex] * P12 * mmY[binIndex] * P22 +
+               8 * F1[binIndex] * P1[binIndex] * mmY[binIndex] * P23 -
+               8 * F1[binIndex] * P12 * mmY[binIndex] * P23 +
+               2 * mmY[binIndex] * P23 - 2 * ppY[binIndex] * P23 +
+               4 * ppY[binIndex] * F2[binIndex] * P23 -
+               6 * ppY[binIndex] * P1[binIndex] * P22 -
+               ppY[binIndex] * F2[binIndex] * P12 -
+               2 * ppY[binIndex] * P12 * P2[binIndex] +
+               2 * P12 * mmY[binIndex] * P2[binIndex] -
+               6 * P12 * mmY[binIndex] * P22 + 6 * ppY[binIndex] * P12 * P22 +
+               2 * ppY[binIndex] * P1[binIndex] * P2[binIndex] -
+               ppY[binIndex] * P2[binIndex] +
+               6 * P1[binIndex] * mmY[binIndex] * P22 -
+               6 * ppY[binIndex] * P22 * F1[binIndex] +
+               2 * ppY[binIndex] * P2[binIndex] * F1[binIndex] +
+               3 * ppY[binIndex] * P22 +
+               16 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P1[binIndex] *
+                   P2[binIndex] -
+               40 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P1[binIndex] *
+                   P22 -
+               24 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P12 *
+                   P2[binIndex] +
+               48 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P12 * P22 +
+               mmY[binIndex] * P2[binIndex] - 3 * mmY[binIndex] * P22 +
+               32 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P1[binIndex] *
+                   P23 -
+               32 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P12 * P23 -
+               24 * ppY[binIndex] * F12 * F2[binIndex] * P2[binIndex] *
+                   P1[binIndex] +
+               48 * ppY[binIndex] * F12 * F2[binIndex] * P22 * P1[binIndex] +
+               24 * ppY[binIndex] * F12 * F2[binIndex] * P12 * P2[binIndex] -
+               48 * ppY[binIndex] * F12 * F2[binIndex] * P12 * P22 -
+               32 * ppY[binIndex] * F12 * F2[binIndex] * P23 * P1[binIndex] +
+               32 * ppY[binIndex] * F12 * F2[binIndex] * P12 * P23 +
+               4 * ppY[binIndex] * P1[binIndex] * P23 +
+               4 * ppY[binIndex] * P23 * F1[binIndex] -
+               4 * ppY[binIndex] * P12 * P23 -
+               2 * ppY[binIndex] * P2[binIndex] * F12 +
+               6 * ppY[binIndex] * P22 * F12 -
+               ppY[binIndex] * F12 * F2[binIndex] -
+               4 * ppY[binIndex] * P23 * F12 + 4 * P12 * mmY[binIndex] * P23 -
+               4 * P1[binIndex] * mmY[binIndex] * P23 +
+               3 * mmY[binIndex] * P22 * F1[binIndex] -
+               2 * mmY[binIndex] * P23 * F1[binIndex] -
+               mmY[binIndex] * P2[binIndex] * F1[binIndex]) /
+              (divisor3 * divisor3);
+          const double divisor4 =
+              (-P2[binIndex] * F1[binIndex] +
+               3 * F1[binIndex] * F2[binIndex] * P2[binIndex] -
+               2 * P22 * F1[binIndex] * P1[binIndex] -
+               2 * F1[binIndex] * F2[binIndex] * P22 -
+               2 * F2[binIndex] * P12 * P2[binIndex] -
+               2 * F1[binIndex] * F2[binIndex] * P12 +
+               2 * P2[binIndex] * F1[binIndex] * P1[binIndex] +
+               P22 * F1[binIndex] + F2[binIndex] * P12 +
+               3 * F1[binIndex] * F2[binIndex] * P1[binIndex] +
+               2 * F2[binIndex] * P1[binIndex] * P2[binIndex] -
+               F1[binIndex] * F2[binIndex] - F2[binIndex] * P1[binIndex] -
+               8 * F1[binIndex] * F2[binIndex] * P1[binIndex] * P2[binIndex] +
+               4 * F1[binIndex] * F2[binIndex] * P1[binIndex] * P22 +
+               4 * F1[binIndex] * F2[binIndex] * P12 * P2[binIndex]);
+          const double dP2 =
+              F1[binIndex] * F2[binIndex] *
+              (-2 * P1[binIndex] * mmY[binIndex] * P2[binIndex] -
+               4 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P2[binIndex] +
+               4 * ppY[binIndex] * F2[binIndex] * P1[binIndex] * P22 +
+               12 * ppY[binIndex] * P22 * F1[binIndex] * P1[binIndex] +
+               4 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P22 +
+               24 * ppY[binIndex] * P2[binIndex] * F1[binIndex] * P12 +
+               12 * ppY[binIndex] * F2[binIndex] * P12 * P2[binIndex] +
+               12 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P12 -
+               24 * ppY[binIndex] * P22 * F1[binIndex] * P12 -
+               12 * ppY[binIndex] * F2[binIndex] * P12 * P22 -
+               12 * ppY[binIndex] * P2[binIndex] * F1[binIndex] * P1[binIndex] -
+               6 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P1[binIndex] -
+               4 * ppY[binIndex] * F2[binIndex] * P1[binIndex] * P2[binIndex] -
+               12 * ppY[binIndex] * F1[binIndex] * P12 -
+               16 * ppY[binIndex] * P2[binIndex] * F1[binIndex] * P13 +
+               16 * ppY[binIndex] * P22 * F1[binIndex] * P13 -
+               8 * ppY[binIndex] * F2[binIndex] * P13 * P2[binIndex] +
+               8 * ppY[binIndex] * F2[binIndex] * P13 * P22 -
+               8 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P13 -
+               12 * ppY[binIndex] * P22 * F12 * P1[binIndex] +
+               8 * ppY[binIndex] * F12 * F2[binIndex] * P13 +
+               24 * ppY[binIndex] * P22 * F12 * P12 -
+               16 * ppY[binIndex] * P22 * F12 * P13 +
+               12 * ppY[binIndex] * P2[binIndex] * F12 * P1[binIndex] +
+               4 * ppY[binIndex] * F12 * F2[binIndex] * P2[binIndex] -
+               4 * ppY[binIndex] * F12 * F2[binIndex] * P22 +
+               16 * ppY[binIndex] * P2[binIndex] * F12 * P13 -
+               24 * ppY[binIndex] * P2[binIndex] * F12 * P12 -
+               12 * ppY[binIndex] * F12 * F2[binIndex] * P12 +
+               6 * ppY[binIndex] * F12 * F2[binIndex] * P1[binIndex] +
+               10 * F1[binIndex] * P1[binIndex] * mmY[binIndex] * P2[binIndex] -
+               16 * F1[binIndex] * P12 * mmY[binIndex] * P2[binIndex] +
+               8 * F1[binIndex] * P13 * mmY[binIndex] * P2[binIndex] -
+               6 * F1[binIndex] * P1[binIndex] * mmY[binIndex] * P22 +
+               12 * F1[binIndex] * P12 * mmY[binIndex] * P22 -
+               8 * F1[binIndex] * P13 * mmY[binIndex] * P22 +
+               ppY[binIndex] * F12 - 2 * ppY[binIndex] * P13 +
+               2 * P13 * mmY[binIndex] + mmY[binIndex] * F1[binIndex] -
+               2 * ppY[binIndex] * P1[binIndex] * P22 +
+               ppY[binIndex] * F2[binIndex] * P1[binIndex] -
+               3 * ppY[binIndex] * F2[binIndex] * P12 -
+               6 * ppY[binIndex] * P12 * P2[binIndex] +
+               6 * P12 * mmY[binIndex] * P2[binIndex] -
+               6 * P12 * mmY[binIndex] * P22 + 6 * ppY[binIndex] * P12 * P22 +
+               2 * ppY[binIndex] * P1[binIndex] * P2[binIndex] +
+               ppY[binIndex] * F1[binIndex] * F2[binIndex] +
+               2 * P1[binIndex] * mmY[binIndex] * P22 +
+               6 * ppY[binIndex] * F1[binIndex] * P1[binIndex] -
+               2 * ppY[binIndex] * P22 * F1[binIndex] +
+               2 * ppY[binIndex] * P2[binIndex] * F1[binIndex] +
+               24 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P1[binIndex] *
+                   P2[binIndex] -
+               24 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P1[binIndex] *
+                   P22 -
+               48 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P12 *
+                   P2[binIndex] +
+               48 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P12 * P22 +
+               P1[binIndex] * mmY[binIndex] - ppY[binIndex] * P1[binIndex] +
+               3 * ppY[binIndex] * P12 - ppY[binIndex] * F1[binIndex] -
+               3 * P12 * mmY[binIndex] +
+               32 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P13 *
+                   P2[binIndex] -
+               32 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P13 * P22 -
+               24 * ppY[binIndex] * F12 * F2[binIndex] * P2[binIndex] *
+                   P1[binIndex] +
+               24 * ppY[binIndex] * F12 * F2[binIndex] * P22 * P1[binIndex] +
+               48 * ppY[binIndex] * F12 * F2[binIndex] * P12 * P2[binIndex] -
+               48 * ppY[binIndex] * F12 * F2[binIndex] * P12 * P22 -
+               32 * ppY[binIndex] * F12 * F2[binIndex] * P13 * P2[binIndex] +
+               32 * ppY[binIndex] * F12 * F2[binIndex] * P13 * P22 +
+               4 * ppY[binIndex] * P13 * P2[binIndex] -
+               4 * ppY[binIndex] * P13 * P22 +
+               2 * ppY[binIndex] * F2[binIndex] * P13 -
+               2 * ppY[binIndex] * P2[binIndex] * F12 +
+               2 * ppY[binIndex] * P22 * F12 -
+               ppY[binIndex] * F12 * F2[binIndex] -
+               5 * F1[binIndex] * P1[binIndex] * mmY[binIndex] -
+               6 * ppY[binIndex] * F12 * P1[binIndex] +
+               8 * F1[binIndex] * P12 * mmY[binIndex] +
+               12 * F12 * P12 * ppY[binIndex] +
+               8 * ppY[binIndex] * F1[binIndex] * P13 -
+               4 * P13 * mmY[binIndex] * P2[binIndex] -
+               4 * F1[binIndex] * P13 * mmY[binIndex] -
+               8 * F12 * P13 * ppY[binIndex] + 4 * P13 * mmY[binIndex] * P22 +
+               mmY[binIndex] * P22 * F1[binIndex] -
+               2 * mmY[binIndex] * P2[binIndex] * F1[binIndex]) /
+              (divisor4 * divisor4);
           const double e1 = dI00 * ppE[binIndex];
           const double e2 = dI11 * mmE[binIndex];
           const double e3 = dF1 * F1E[binIndex];
           const double e4 = dF2 * F2E[binIndex];
           const double e5 = dP1 * P1E[binIndex];
           const double e6 = dP2 * P2E[binIndex];
-          mpE[binIndex] = std::sqrt(e1 * e1 + e2 * e2 + e3 * e3 + e4 * e4 + e5 * e5 + e6 * e6);
+          mpE[binIndex] = std::sqrt(e1 * e1 + e2 * e2 + e3 * e3 + e4 * e4 +
+                                    e5 * e5 + e6 * e6);
         }
         {
-          pmY[binIndex] = -(ppY[binIndex]*P2[binIndex]*F1[binIndex]-2*ppY[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]-2*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P2[binIndex]-2*ppY[binIndex]*P2[binIndex]*F1[binIndex]*P1[binIndex]+2*P1[binIndex]*mpY[binIndex]*F2[binIndex]*P2[binIndex]+ppY[binIndex]*P1[binIndex]*P2[binIndex]-P1[binIndex]*mpY[binIndex]*P2[binIndex]+4*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+P1[binIndex]*mmY[binIndex]*P2[binIndex]-ppY[binIndex]*F1[binIndex]+2*ppY[binIndex]*F1[binIndex]*P1[binIndex]-P1[binIndex]*mmY[binIndex]-P1[binIndex]*mpY[binIndex]*F2[binIndex]+ppY[binIndex]*F2[binIndex]*P1[binIndex]+ppY[binIndex]*F1[binIndex]*F2[binIndex]-2*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]+P1[binIndex]*mpY[binIndex]-ppY[binIndex]*P1[binIndex])/((-P1[binIndex]+2*F1[binIndex]*P1[binIndex]-F1[binIndex])*(-1+P2[binIndex]));
-          const double dI00 = -(-P1[binIndex]+P1[binIndex]*P2[binIndex]+F2[binIndex]*P1[binIndex]-2*F2[binIndex]*P1[binIndex]*P2[binIndex]+2*F1[binIndex]*P1[binIndex]-2*P2[binIndex]*F1[binIndex]*P1[binIndex]-2*F1[binIndex]*F2[binIndex]*P1[binIndex]+4*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+F1[binIndex]*F2[binIndex]-F1[binIndex]+P2[binIndex]*F1[binIndex]-2*F1[binIndex]*F2[binIndex]*P2[binIndex])/((-P1[binIndex]+2*F1[binIndex]*P1[binIndex]-F1[binIndex])*(-1+P2[binIndex]));
-          const double dI11 = -(P1[binIndex]*P2[binIndex]-P1[binIndex])/((-P1[binIndex]+2*F1[binIndex]*P1[binIndex]-F1[binIndex])*(-1+P2[binIndex]));
-          const double dI10 = -(P1[binIndex]-P1[binIndex]*P2[binIndex]-F2[binIndex]*P1[binIndex]+2*F2[binIndex]*P1[binIndex]*P2[binIndex])/((-P1[binIndex]+2*F1[binIndex]*P1[binIndex]-F1[binIndex])*(-1+P2[binIndex]));
-          const double factor1 = (-P1[binIndex]+2*F1[binIndex]*P1[binIndex]-F1[binIndex]);
-          const double dF1 = -(ppY[binIndex]*P2[binIndex]-2*ppY[binIndex]*F2[binIndex]*P2[binIndex]-2*ppY[binIndex]*P1[binIndex]*P2[binIndex]+4*ppY[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]-ppY[binIndex]+2*ppY[binIndex]*P1[binIndex]+ppY[binIndex]*F2[binIndex]-2*ppY[binIndex]*F2[binIndex]*P1[binIndex])/((-P1[binIndex]+2*F1[binIndex]*P1[binIndex]-F1[binIndex])*(-1+P2[binIndex]))+(ppY[binIndex]*P2[binIndex]*F1[binIndex]-2*ppY[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]-2*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P2[binIndex]-2*ppY[binIndex]*P2[binIndex]*F1[binIndex]*P1[binIndex]+2*P1[binIndex]*mpY[binIndex]*F2[binIndex]*P2[binIndex]+ppY[binIndex]*P1[binIndex]*P2[binIndex]-P1[binIndex]*mpY[binIndex]*P2[binIndex]+4*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+P1[binIndex]*mmY[binIndex]*P2[binIndex]-ppY[binIndex]*F1[binIndex]+2*ppY[binIndex]*F1[binIndex]*P1[binIndex]-P1[binIndex]*mmY[binIndex]-P1[binIndex]*mpY[binIndex]*F2[binIndex]+ppY[binIndex]*F2[binIndex]*P1[binIndex]+ppY[binIndex]*F1[binIndex]*F2[binIndex]-2*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]+P1[binIndex]*mpY[binIndex]-ppY[binIndex]*P1[binIndex])*(-1+2*P1[binIndex])/((factor1 * factor1)*(-1+P2[binIndex]));
-          const double dF2 = -(-2*ppY[binIndex]*P1[binIndex]*P2[binIndex]-2*ppY[binIndex]*P2[binIndex]*F1[binIndex]+2*P1[binIndex]*mpY[binIndex]*P2[binIndex]+4*ppY[binIndex]*P2[binIndex]*F1[binIndex]*P1[binIndex]-P1[binIndex]*mpY[binIndex]+ppY[binIndex]*P1[binIndex]+ppY[binIndex]*F1[binIndex]-2*ppY[binIndex]*F1[binIndex]*P1[binIndex])/((-P1[binIndex]+2*F1[binIndex]*P1[binIndex]-F1[binIndex])*(-1+P2[binIndex]));
-          const double factor2 = (-P1[binIndex]+2*F1[binIndex]*P1[binIndex]-F1[binIndex]);
-          const double dP1 = -(-2*ppY[binIndex]*F2[binIndex]*P2[binIndex]-2*ppY[binIndex]*P2[binIndex]*F1[binIndex]+2*mpY[binIndex]*F2[binIndex]*P2[binIndex]+ppY[binIndex]*P2[binIndex]-mpY[binIndex]*P2[binIndex]+4*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P2[binIndex]+mmY[binIndex]*P2[binIndex]+2*ppY[binIndex]*F1[binIndex]-mmY[binIndex]-mpY[binIndex]*F2[binIndex]+ppY[binIndex]*F2[binIndex]-2*ppY[binIndex]*F1[binIndex]*F2[binIndex]+mpY[binIndex]-ppY[binIndex])/((-P1[binIndex]+2*F1[binIndex]*P1[binIndex]-F1[binIndex])*(-1+P2[binIndex]))+(ppY[binIndex]*P2[binIndex]*F1[binIndex]-2*ppY[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]-2*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P2[binIndex]-2*ppY[binIndex]*P2[binIndex]*F1[binIndex]*P1[binIndex]+2*P1[binIndex]*mpY[binIndex]*F2[binIndex]*P2[binIndex]+ppY[binIndex]*P1[binIndex]*P2[binIndex]-P1[binIndex]*mpY[binIndex]*P2[binIndex]+4*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+P1[binIndex]*mmY[binIndex]*P2[binIndex]-ppY[binIndex]*F1[binIndex]+2*ppY[binIndex]*F1[binIndex]*P1[binIndex]-P1[binIndex]*mmY[binIndex]-P1[binIndex]*mpY[binIndex]*F2[binIndex]+ppY[binIndex]*F2[binIndex]*P1[binIndex]+ppY[binIndex]*F1[binIndex]*F2[binIndex]-2*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]+P1[binIndex]*mpY[binIndex]-ppY[binIndex]*P1[binIndex])*(-1+2*F1[binIndex])/((factor2*factor2)*(-1+P2[binIndex]));
-          const double factor3 = (-1+P2[binIndex]);
-          const double dP2 = -(ppY[binIndex]*F1[binIndex]-2*ppY[binIndex]*F2[binIndex]*P1[binIndex]-2*ppY[binIndex]*F1[binIndex]*F2[binIndex]-2*ppY[binIndex]*F1[binIndex]*P1[binIndex]+2*P1[binIndex]*mpY[binIndex]*F2[binIndex]+ppY[binIndex]*P1[binIndex]-P1[binIndex]*mpY[binIndex]+4*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]+P1[binIndex]*mmY[binIndex])/((-P1[binIndex]+2*F1[binIndex]*P1[binIndex]-F1[binIndex])*(-1+P2[binIndex]))+(ppY[binIndex]*P2[binIndex]*F1[binIndex]-2*ppY[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]-2*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P2[binIndex]-2*ppY[binIndex]*P2[binIndex]*F1[binIndex]*P1[binIndex]+2*P1[binIndex]*mpY[binIndex]*F2[binIndex]*P2[binIndex]+ppY[binIndex]*P1[binIndex]*P2[binIndex]-P1[binIndex]*mpY[binIndex]*P2[binIndex]+4*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]*P2[binIndex]+P1[binIndex]*mmY[binIndex]*P2[binIndex]-ppY[binIndex]*F1[binIndex]+2*ppY[binIndex]*F1[binIndex]*P1[binIndex]-P1[binIndex]*mmY[binIndex]-P1[binIndex]*mpY[binIndex]*F2[binIndex]+ppY[binIndex]*F2[binIndex]*P1[binIndex]+ppY[binIndex]*F1[binIndex]*F2[binIndex]-2*ppY[binIndex]*F1[binIndex]*F2[binIndex]*P1[binIndex]+P1[binIndex]*mpY[binIndex]-ppY[binIndex]*P1[binIndex])/((-P1[binIndex]+2*F1[binIndex]*P1[binIndex]-F1[binIndex])*(factor3 * factor3));
+          pmY[binIndex] =
+              -(ppY[binIndex] * P2[binIndex] * F1[binIndex] -
+                2 * ppY[binIndex] * F2[binIndex] * P1[binIndex] * P2[binIndex] -
+                2 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P2[binIndex] -
+                2 * ppY[binIndex] * P2[binIndex] * F1[binIndex] * P1[binIndex] +
+                2 * P1[binIndex] * mpY[binIndex] * F2[binIndex] * P2[binIndex] +
+                ppY[binIndex] * P1[binIndex] * P2[binIndex] -
+                P1[binIndex] * mpY[binIndex] * P2[binIndex] +
+                4 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P1[binIndex] *
+                    P2[binIndex] +
+                P1[binIndex] * mmY[binIndex] * P2[binIndex] -
+                ppY[binIndex] * F1[binIndex] +
+                2 * ppY[binIndex] * F1[binIndex] * P1[binIndex] -
+                P1[binIndex] * mmY[binIndex] -
+                P1[binIndex] * mpY[binIndex] * F2[binIndex] +
+                ppY[binIndex] * F2[binIndex] * P1[binIndex] +
+                ppY[binIndex] * F1[binIndex] * F2[binIndex] -
+                2 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P1[binIndex] +
+                P1[binIndex] * mpY[binIndex] - ppY[binIndex] * P1[binIndex]) /
+              ((-P1[binIndex] + 2 * F1[binIndex] * P1[binIndex] -
+                F1[binIndex]) *
+               (-1 + P2[binIndex]));
+          const double dI00 =
+              -(-P1[binIndex] + P1[binIndex] * P2[binIndex] +
+                F2[binIndex] * P1[binIndex] -
+                2 * F2[binIndex] * P1[binIndex] * P2[binIndex] +
+                2 * F1[binIndex] * P1[binIndex] -
+                2 * P2[binIndex] * F1[binIndex] * P1[binIndex] -
+                2 * F1[binIndex] * F2[binIndex] * P1[binIndex] +
+                4 * F1[binIndex] * F2[binIndex] * P1[binIndex] * P2[binIndex] +
+                F1[binIndex] * F2[binIndex] - F1[binIndex] +
+                P2[binIndex] * F1[binIndex] -
+                2 * F1[binIndex] * F2[binIndex] * P2[binIndex]) /
+              ((-P1[binIndex] + 2 * F1[binIndex] * P1[binIndex] -
+                F1[binIndex]) *
+               (-1 + P2[binIndex]));
+          const double dI11 =
+              -(P1[binIndex] * P2[binIndex] - P1[binIndex]) /
+              ((-P1[binIndex] + 2 * F1[binIndex] * P1[binIndex] -
+                F1[binIndex]) *
+               (-1 + P2[binIndex]));
+          const double dI10 =
+              -(P1[binIndex] - P1[binIndex] * P2[binIndex] -
+                F2[binIndex] * P1[binIndex] +
+                2 * F2[binIndex] * P1[binIndex] * P2[binIndex]) /
+              ((-P1[binIndex] + 2 * F1[binIndex] * P1[binIndex] -
+                F1[binIndex]) *
+               (-1 + P2[binIndex]));
+          const double factor1 =
+              (-P1[binIndex] + 2 * F1[binIndex] * P1[binIndex] - F1[binIndex]);
+          const double dF1 =
+              -(ppY[binIndex] * P2[binIndex] -
+                2 * ppY[binIndex] * F2[binIndex] * P2[binIndex] -
+                2 * ppY[binIndex] * P1[binIndex] * P2[binIndex] +
+                4 * ppY[binIndex] * F2[binIndex] * P1[binIndex] * P2[binIndex] -
+                ppY[binIndex] + 2 * ppY[binIndex] * P1[binIndex] +
+                ppY[binIndex] * F2[binIndex] -
+                2 * ppY[binIndex] * F2[binIndex] * P1[binIndex]) /
+                  ((-P1[binIndex] + 2 * F1[binIndex] * P1[binIndex] -
+                    F1[binIndex]) *
+                   (-1 + P2[binIndex])) +
+              (ppY[binIndex] * P2[binIndex] * F1[binIndex] -
+               2 * ppY[binIndex] * F2[binIndex] * P1[binIndex] * P2[binIndex] -
+               2 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P2[binIndex] -
+               2 * ppY[binIndex] * P2[binIndex] * F1[binIndex] * P1[binIndex] +
+               2 * P1[binIndex] * mpY[binIndex] * F2[binIndex] * P2[binIndex] +
+               ppY[binIndex] * P1[binIndex] * P2[binIndex] -
+               P1[binIndex] * mpY[binIndex] * P2[binIndex] +
+               4 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P1[binIndex] *
+                   P2[binIndex] +
+               P1[binIndex] * mmY[binIndex] * P2[binIndex] -
+               ppY[binIndex] * F1[binIndex] +
+               2 * ppY[binIndex] * F1[binIndex] * P1[binIndex] -
+               P1[binIndex] * mmY[binIndex] -
+               P1[binIndex] * mpY[binIndex] * F2[binIndex] +
+               ppY[binIndex] * F2[binIndex] * P1[binIndex] +
+               ppY[binIndex] * F1[binIndex] * F2[binIndex] -
+               2 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P1[binIndex] +
+               P1[binIndex] * mpY[binIndex] - ppY[binIndex] * P1[binIndex]) *
+                  (-1 + 2 * P1[binIndex]) /
+                  ((factor1 * factor1) * (-1 + P2[binIndex]));
+          const double dF2 =
+              -(-2 * ppY[binIndex] * P1[binIndex] * P2[binIndex] -
+                2 * ppY[binIndex] * P2[binIndex] * F1[binIndex] +
+                2 * P1[binIndex] * mpY[binIndex] * P2[binIndex] +
+                4 * ppY[binIndex] * P2[binIndex] * F1[binIndex] * P1[binIndex] -
+                P1[binIndex] * mpY[binIndex] + ppY[binIndex] * P1[binIndex] +
+                ppY[binIndex] * F1[binIndex] -
+                2 * ppY[binIndex] * F1[binIndex] * P1[binIndex]) /
+              ((-P1[binIndex] + 2 * F1[binIndex] * P1[binIndex] -
+                F1[binIndex]) *
+               (-1 + P2[binIndex]));
+          const double factor2 =
+              (-P1[binIndex] + 2 * F1[binIndex] * P1[binIndex] - F1[binIndex]);
+          const double dP1 =
+              -(-2 * ppY[binIndex] * F2[binIndex] * P2[binIndex] -
+                2 * ppY[binIndex] * P2[binIndex] * F1[binIndex] +
+                2 * mpY[binIndex] * F2[binIndex] * P2[binIndex] +
+                ppY[binIndex] * P2[binIndex] - mpY[binIndex] * P2[binIndex] +
+                4 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P2[binIndex] +
+                mmY[binIndex] * P2[binIndex] +
+                2 * ppY[binIndex] * F1[binIndex] - mmY[binIndex] -
+                mpY[binIndex] * F2[binIndex] + ppY[binIndex] * F2[binIndex] -
+                2 * ppY[binIndex] * F1[binIndex] * F2[binIndex] +
+                mpY[binIndex] - ppY[binIndex]) /
+                  ((-P1[binIndex] + 2 * F1[binIndex] * P1[binIndex] -
+                    F1[binIndex]) *
+                   (-1 + P2[binIndex])) +
+              (ppY[binIndex] * P2[binIndex] * F1[binIndex] -
+               2 * ppY[binIndex] * F2[binIndex] * P1[binIndex] * P2[binIndex] -
+               2 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P2[binIndex] -
+               2 * ppY[binIndex] * P2[binIndex] * F1[binIndex] * P1[binIndex] +
+               2 * P1[binIndex] * mpY[binIndex] * F2[binIndex] * P2[binIndex] +
+               ppY[binIndex] * P1[binIndex] * P2[binIndex] -
+               P1[binIndex] * mpY[binIndex] * P2[binIndex] +
+               4 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P1[binIndex] *
+                   P2[binIndex] +
+               P1[binIndex] * mmY[binIndex] * P2[binIndex] -
+               ppY[binIndex] * F1[binIndex] +
+               2 * ppY[binIndex] * F1[binIndex] * P1[binIndex] -
+               P1[binIndex] * mmY[binIndex] -
+               P1[binIndex] * mpY[binIndex] * F2[binIndex] +
+               ppY[binIndex] * F2[binIndex] * P1[binIndex] +
+               ppY[binIndex] * F1[binIndex] * F2[binIndex] -
+               2 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P1[binIndex] +
+               P1[binIndex] * mpY[binIndex] - ppY[binIndex] * P1[binIndex]) *
+                  (-1 + 2 * F1[binIndex]) /
+                  ((factor2 * factor2) * (-1 + P2[binIndex]));
+          const double factor3 = (-1 + P2[binIndex]);
+          const double dP2 =
+              -(ppY[binIndex] * F1[binIndex] -
+                2 * ppY[binIndex] * F2[binIndex] * P1[binIndex] -
+                2 * ppY[binIndex] * F1[binIndex] * F2[binIndex] -
+                2 * ppY[binIndex] * F1[binIndex] * P1[binIndex] +
+                2 * P1[binIndex] * mpY[binIndex] * F2[binIndex] +
+                ppY[binIndex] * P1[binIndex] - P1[binIndex] * mpY[binIndex] +
+                4 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P1[binIndex] +
+                P1[binIndex] * mmY[binIndex]) /
+                  ((-P1[binIndex] + 2 * F1[binIndex] * P1[binIndex] -
+                    F1[binIndex]) *
+                   (-1 + P2[binIndex])) +
+              (ppY[binIndex] * P2[binIndex] * F1[binIndex] -
+               2 * ppY[binIndex] * F2[binIndex] * P1[binIndex] * P2[binIndex] -
+               2 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P2[binIndex] -
+               2 * ppY[binIndex] * P2[binIndex] * F1[binIndex] * P1[binIndex] +
+               2 * P1[binIndex] * mpY[binIndex] * F2[binIndex] * P2[binIndex] +
+               ppY[binIndex] * P1[binIndex] * P2[binIndex] -
+               P1[binIndex] * mpY[binIndex] * P2[binIndex] +
+               4 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P1[binIndex] *
+                   P2[binIndex] +
+               P1[binIndex] * mmY[binIndex] * P2[binIndex] -
+               ppY[binIndex] * F1[binIndex] +
+               2 * ppY[binIndex] * F1[binIndex] * P1[binIndex] -
+               P1[binIndex] * mmY[binIndex] -
+               P1[binIndex] * mpY[binIndex] * F2[binIndex] +
+               ppY[binIndex] * F2[binIndex] * P1[binIndex] +
+               ppY[binIndex] * F1[binIndex] * F2[binIndex] -
+               2 * ppY[binIndex] * F1[binIndex] * F2[binIndex] * P1[binIndex] +
+               P1[binIndex] * mpY[binIndex] - ppY[binIndex] * P1[binIndex]) /
+                  ((-P1[binIndex] + 2 * F1[binIndex] * P1[binIndex] -
+                    F1[binIndex]) *
+                   (factor3 * factor3));
           const double e1 = dI00 * ppE[binIndex];
           const double e2 = dI11 * mmE[binIndex];
           const double e3 = dI10 * mpE[binIndex];
@@ -1156,8 +1835,8 @@ private:
           const double e5 = dF2 * F2E[binIndex];
           const double e6 = dP1 * P1E[binIndex];
           const double e7 = dP2 * P2E[binIndex];
-          pmE[binIndex] = std::sqrt(e1 * e1 + e2 * e2 + e3 * e3 + e4 * e4 + e5 * e5 + e6 * e6 + e7 * e7);
-
+          pmE[binIndex] = std::sqrt(e1 * e1 + e2 * e2 + e3 * e3 + e4 * e4 +
+                                    e5 * e5 + e6 * e6 + e7 * e7);
         }
       }
     }
@@ -1168,7 +1847,8 @@ class PolarizationEfficiencyCorTestPerformance : public CxxTest::TestSuite {
 public:
   void setUp() override {
     using namespace Mantid::API;
-    auto loadWS = AlgorithmManager::Instance().createUnmanaged("LoadILLReflectometry");
+    auto loadWS =
+        AlgorithmManager::Instance().createUnmanaged("LoadILLReflectometry");
     loadWS->setChild(true);
     loadWS->initialize();
     loadWS->setProperty("Filename", "ILL/D17/317370.nxs");
@@ -1176,7 +1856,8 @@ public:
     loadWS->setProperty("XUnit", "TimeOfFlight");
     loadWS->execute();
     m_ws00 = loadWS->getProperty("OutputWorkspace");
-    auto groupDetectors = AlgorithmManager::Instance().createUnmanaged("GroupDetectors");
+    auto groupDetectors =
+        AlgorithmManager::Instance().createUnmanaged("GroupDetectors");
     groupDetectors->setChild(true);
     groupDetectors->initialize();
     groupDetectors->setProperty("InputWorkspace", m_ws00);
@@ -1184,7 +1865,8 @@ public:
     groupDetectors->setPropertyValue("WorkspaceIndexList", "201, 202, 203");
     groupDetectors->execute();
     m_ws00 = groupDetectors->getProperty("OutputWorkspace");
-    auto convertUnits = AlgorithmManager::Instance().createUnmanaged("ConvertUnits");
+    auto convertUnits =
+        AlgorithmManager::Instance().createUnmanaged("ConvertUnits");
     convertUnits->setChild(true);
     convertUnits->initialize();
     convertUnits->setProperty("InputWorkspace", m_ws00);
@@ -1206,7 +1888,8 @@ public:
     m_group->addWorkspace(boost::dynamic_pointer_cast<Workspace>(m_ws00));
     m_group->addWorkspace(boost::dynamic_pointer_cast<Workspace>(m_ws01));
     m_group->addWorkspace(boost::dynamic_pointer_cast<Workspace>(m_ws11));
-    auto loadEff = AlgorithmManager::Instance().createUnmanaged("LoadILLPolarizationFactors");
+    auto loadEff = AlgorithmManager::Instance().createUnmanaged(
+        "LoadILLPolarizationFactors");
     loadEff->setChild(true);
     loadEff->initialize();
     loadEff->setProperty("Filename", "ILL/D17/PolarizationFactors.txt");

--- a/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
@@ -13,6 +13,8 @@
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidDataObjects/WorkspaceCreation.h"
 
+#include <Eigen/Dense>
+
 using Mantid::Algorithms::PolarizationEfficiencyCor;
 
 class PolarizationEfficiencyCorTest : public CxxTest::TestSuite {
@@ -59,7 +61,7 @@ public:
         ws->mutableE(j) *= static_cast<double>(i + 1);
       }
     }
-    auto effWS = efficiencies(edges);
+    auto effWS = idealEfficiencies(edges);
     constexpr char *OUTWS_NAME{"output"};
     PolarizationEfficiencyCor alg;
     alg.setChild(true);
@@ -122,7 +124,7 @@ public:
       ws11->mutableE(i) *= 2.;
     }
 
-    auto effWS = efficiencies(edges);
+    auto effWS = idealEfficiencies(edges);
     constexpr char *OUTWS_NAME{"output"};
     PolarizationEfficiencyCor alg;
     alg.setChild(true);
@@ -196,7 +198,7 @@ public:
       ws11->mutableY(i) *= 2.;
       ws11->mutableE(i) *= 2.;
     }
-    auto effWS = efficiencies(edges);
+    auto effWS = idealEfficiencies(edges);
     constexpr char *OUTWS_NAME{"output"};
     PolarizationEfficiencyCor alg;
     alg.setChild(true);
@@ -247,7 +249,7 @@ public:
     MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
     WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
     inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
-    auto effWS = efficiencies(edges);
+    auto effWS = idealEfficiencies(edges);
     constexpr char *OUTWS_NAME{"output"};
     PolarizationEfficiencyCor alg;
     alg.setChild(true);
@@ -279,6 +281,105 @@ public:
     }
   }
 
+  void test_FullCorrections() {
+    using namespace Mantid::API;
+    using namespace Mantid::DataObjects;
+    using namespace Mantid::HistogramData;
+    using namespace Mantid::Kernel;
+    constexpr size_t nBins{3};
+    constexpr size_t nHist{2};
+    BinEdges edges{0.3, 0.6, 0.9, 1.2};
+    const double yVal = 2.3;
+    Counts counts{yVal, yVal, yVal};
+    MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
+    MatrixWorkspace_sptr ws01 = ws00->clone();
+    MatrixWorkspace_sptr ws10 = ws00->clone();
+    MatrixWorkspace_sptr ws11 = ws00->clone();
+    WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
+    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
+    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws01));
+    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws10));
+    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws11));
+    for (size_t i = 0; i != 4; ++i) {
+      MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(inputWS->getItem(i));
+      for (size_t j = 0; j != nHist; ++j) {
+        ws->mutableY(j) *= static_cast<double>(i + 1);
+        ws->mutableE(j) *= static_cast<double>(i + 1);
+      }
+    }
+    auto effWS = efficiencies(edges);
+    constexpr char *OUTWS_NAME{"output"};
+    PolarizationEfficiencyCor alg;
+    alg.setChild(true);
+    alg.setRethrows(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", OUTWS_NAME))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
+    TS_ASSERT_THROWS_NOTHING(alg.execute())
+    TS_ASSERT(alg.isExecuted())
+    WorkspaceGroup_sptr outputWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outputWS)
+    TS_ASSERT_EQUALS(outputWS->getNumberOfEntries(), 4)
+    const double F1 = effWS->y(0).front();
+    const double F1e = effWS->e(0).front();
+    const double F2 = effWS->y(1).front();
+    const double F2e = effWS->e(1).front();
+    const double P1 = effWS->y(2).front();
+    const double P1e = effWS->e(2).front();
+    const double P2 = effWS->y(3).front();
+    const double P2e = effWS->e(3).front();
+    const Eigen::Vector4d y{ws00->y(0).front(), ws01->y(0).front(), ws10->y(0).front(), ws11->y(0).front()};
+    const auto expected = correction(y, F1, F2, P1, P2);
+    const Eigen::Vector4d e{ws00->e(0).front(), ws01->e(0).front(), ws10->e(0).front(), ws11->e(0).front()};
+    const auto expectedError = error(y, e, F1, F1e, F2, F2e, P1, P1e, P2, P2e);
+    MatrixWorkspace_sptr ppWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(OUTWS_NAME + std::string("_++")));
+    MatrixWorkspace_sptr pmWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(OUTWS_NAME + std::string("_+-")));
+    MatrixWorkspace_sptr mpWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(OUTWS_NAME + std::string("_-+")));
+    MatrixWorkspace_sptr mmWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(OUTWS_NAME + std::string("_--")));
+    TS_ASSERT(ppWS)
+    TS_ASSERT(pmWS)
+    TS_ASSERT(mpWS)
+    TS_ASSERT(mmWS)
+    TS_ASSERT_EQUALS(ppWS->getNumberHistograms(), nHist)
+    TS_ASSERT_EQUALS(pmWS->getNumberHistograms(), nHist)
+    TS_ASSERT_EQUALS(mpWS->getNumberHistograms(), nHist)
+    TS_ASSERT_EQUALS(mmWS->getNumberHistograms(), nHist)
+    for (size_t j = 0; j != nHist; ++j) {
+      const auto &ppX = ppWS->x(j);
+      const auto &ppY = ppWS->y(j);
+      const auto &ppE = ppWS->e(j);
+      const auto &pmX = pmWS->x(j);
+      const auto &pmY = pmWS->y(j);
+      const auto &pmE = pmWS->e(j);
+      const auto &mpX = mpWS->x(j);
+      const auto &mpY = mpWS->y(j);
+      const auto &mpE = mpWS->e(j);
+      const auto &mmX = mmWS->x(j);
+      const auto &mmY = mmWS->y(j);
+      const auto &mmE = mmWS->e(j);
+      TS_ASSERT_EQUALS(ppY.size(), nBins)
+      TS_ASSERT_EQUALS(pmY.size(), nBins)
+      TS_ASSERT_EQUALS(mpY.size(), nBins)
+      TS_ASSERT_EQUALS(mmY.size(), nBins)
+      for (size_t k = 0; k != nBins; ++k) {
+        TS_ASSERT_EQUALS(ppX[k], edges[k])
+        TS_ASSERT_EQUALS(pmX[k], edges[k])
+        TS_ASSERT_EQUALS(mpX[k], edges[k])
+        TS_ASSERT_EQUALS(mmX[k], edges[k])
+        TS_ASSERT_DELTA(ppY[k], expected[0], 1e-12)
+        TS_ASSERT_DELTA(pmY[k], expected[1], 1e-12)
+        TS_ASSERT_DELTA(mpY[k], expected[2], 1e-12)
+        TS_ASSERT_DELTA(mmY[k], expected[3], 1e-12)
+        TS_ASSERT_DELTA(ppE[k], expectedError[0], 1e-12)
+        TS_ASSERT_DELTA(pmE[k], expectedError[1], 1e-12)
+        TS_ASSERT_DELTA(mpE[k], expectedError[2], 1e-12)
+        TS_ASSERT_DELTA(mmE[k], expectedError[3], 1e-12)
+      }
+    }
+  }
+
   void test_FailureWhenEfficiencyHistogramIsMissing() {
     using namespace Mantid::API;
     using namespace Mantid::DataObjects;
@@ -289,7 +390,7 @@ public:
     MatrixWorkspace_sptr ws00 = create<Workspace2D>(1, Histogram(edges, counts));
     WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
     inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
-    auto effWS = efficiencies(edges);
+    auto effWS = idealEfficiencies(edges);
     // Rename F1 to something else.
     auto axis = make_unique<TextAxis>(4);
     axis->setLabel(0, "__wrong_histogram_label");
@@ -321,7 +422,7 @@ public:
     MatrixWorkspace_sptr ws00 = create<Workspace2D>(1, Histogram(edges, counts));
     WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
     inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
-    auto effWS = efficiencies(edges);
+    auto effWS = idealEfficiencies(edges);
     // Change a bin edge of one of the histograms.
     auto &xs = effWS->mutableX(0);
     xs[xs.size() / 2] *= 1.01;
@@ -356,7 +457,7 @@ public:
     inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws01));
     inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws10));
     inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws11));
-    auto effWS = efficiencies(edges);
+    auto effWS = idealEfficiencies(edges);
     constexpr char *OUTWS_NAME{"output"};
     PolarizationEfficiencyCor alg;
     alg.setChild(true);
@@ -385,7 +486,7 @@ public:
     inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
     inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws01));
     inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws11));
-    auto effWS = efficiencies(edges);
+    auto effWS = idealEfficiencies(edges);
     constexpr char *OUTWS_NAME{"output"};
     PolarizationEfficiencyCor alg;
     alg.setChild(true);
@@ -401,6 +502,32 @@ public:
 
 private:
   Mantid::API::MatrixWorkspace_sptr efficiencies(const Mantid::HistogramData::BinEdges &edges) {
+    using namespace Mantid::API;
+    using namespace Mantid::DataObjects;
+    using namespace Mantid::HistogramData;
+    using namespace Mantid::Kernel;
+    const auto nBins = edges.size() - 1;
+    constexpr size_t nHist{4};
+    Counts counts(nBins, 0.0);
+    MatrixWorkspace_sptr ws = create<Workspace2D>(nHist, Histogram(edges, counts));
+    ws->mutableY(0) = 0.95;
+    ws->mutableE(0) = 0.01;
+    ws->mutableY(1) = 0.92;
+    ws->mutableE(1) = 0.02;
+    ws->mutableY(2) = 0.05;
+    ws->mutableE(2) = 0.015;
+    ws->mutableY(3) = 0.04;
+    ws->mutableE(3) = 0.03;
+    auto axis = make_unique<TextAxis>(4);
+    axis->setLabel(0, "F1");
+    axis->setLabel(1, "F2");
+    axis->setLabel(2, "P1");
+    axis->setLabel(3, "P2");
+    ws->replaceAxis(1, axis.release());
+    return ws;
+  }
+
+  Mantid::API::MatrixWorkspace_sptr idealEfficiencies(const Mantid::HistogramData::BinEdges &edges) {
     using namespace Mantid::API;
     using namespace Mantid::DataObjects;
     using namespace Mantid::HistogramData;
@@ -444,7 +571,7 @@ private:
         ws->mutableE(j) *= static_cast<double>(i + 1);
       }
     }
-    auto effWS = efficiencies(edges);
+    auto effWS = idealEfficiencies(edges);
     constexpr char *OUTWS_NAME{"output"};
     PolarizationEfficiencyCor alg;
     alg.setChild(true);
@@ -504,6 +631,113 @@ private:
         }
       }
     }
+  }
+
+  void invertedF1(Eigen::Matrix4d &m, const double f1) {
+    m << f1, 0., 0., 0.,
+         0., f1, 0., 0.,
+         f1 - 1., 0., 1., 0.,
+         0., f1 - 1., 0., 1.;
+    m *= 1. / f1;
+  }
+
+  void invertedF1Derivative(Eigen::Matrix4d &m, const double f1) {
+    m << 0., 0., 0., 0.,
+         0., 0., 0., 0.,
+         1., 0., -1., 0.,
+         0., 1., 0., -1.;
+    m *= 1. / (f1 * f1);
+  }
+
+  void invertedF2(Eigen::Matrix4d &m, const double f2) {
+    m << f2, 0., 0., 0.,
+         f2 - 1., 1., 0., 0.,
+         0., 0., f2, 0.,
+         0., 0., f2 - 1., 1.;
+    m *= 1. / f2;
+  }
+
+  void invertedF2Derivative(Eigen::Matrix4d &m, const double f2) {
+    m << 0., 0., 0., 0.,
+         1., -1., 0., 0.,
+         0., 0., 0., 0.,
+         0., 0., 1., -1.;
+    m *= 1. / (f2 * f2);
+  }
+
+  void invertedP1(Eigen::Matrix4d &m, const double p1) {
+    m << p1 - 1., 0., p1, 0.,
+         0., p1 - 1., 0., p1,
+         p1, 0., p1 - 1., 0.,
+         0., p1, 0., p1 - 1.;
+    m *= 1. / (2. * p1 - 1.);
+  }
+
+  void invertedP1Derivative(Eigen::Matrix4d &m, const double p1) {
+    m << 1., 0., -1., 0.,
+         0., 1., 0., -1.,
+         -1., 0., 1., 0.,
+         0., -1., 0., 1.;
+    m *= 1. / (2. * p1 - 1.) / (2. * p1 - 1.);
+  }
+
+  void invertedP2(Eigen::Matrix4d &m, const double p2) {
+    m << p2 - 1., p2, 0., 0.,
+         p2, p2 - 1., 0., 0.,
+         0., 0., p2 - 1., p2,
+         0., 0., p2, p2 - 1.;
+    m *= 1. / (2. * p2 - 1.);
+  }
+
+  void invertedP2Derivative(Eigen::Matrix4d &m, const double p2) {
+    m << 1., -1., 0., 0.,
+         -1., 1., 0., 0.,
+         0., 0., 1., -1.,
+         0., 0., -1., 1.;
+    m *= 1. / (2. * p2 - 1.) / (2. * p2 - 1.);
+  }
+
+  Eigen::Vector4d correction(const Eigen::Vector4d &y, const double f1, const double f2, const double p1, const double p2) {
+    Eigen::Matrix4d F1;
+    invertedF1(F1, f1);
+    Eigen::Matrix4d F2;
+    invertedF2(F2, f2);
+    Eigen::Matrix4d P1;
+    invertedP1(P1, p1);
+    Eigen::Matrix4d P2;
+    invertedP2(P2, p2);
+    const auto inverted = P2 * P1 * F2 * F1;
+    return static_cast<Eigen::Vector4d>(inverted * y);
+  }
+
+  Eigen::Vector4d error(const Eigen::Vector4d &y, const Eigen::Vector4d &e, const double f1, const double f1e, const double f2, const double f2e, const double p1, const double p1e, const double p2, const double p2e) {
+    Eigen::Matrix4d F1;
+    invertedF1(F1, f1);
+    Eigen::Matrix4d dF1;
+    invertedF1Derivative(dF1, f1);
+    dF1 *= f1e;
+    Eigen::Matrix4d F2;
+    invertedF2(F2, f2);
+    Eigen::Matrix4d dF2;
+    invertedF2Derivative(dF2, f2);
+    dF2 *= f2e;
+    Eigen::Matrix4d P1;
+    invertedP1(P1, p1);
+    Eigen::Matrix4d dP1;
+    invertedP1Derivative(dP1, p1);
+    dP1 *= p1e;
+    Eigen::Matrix4d P2;
+    invertedP2(P2, p2);
+    Eigen::Matrix4d dP2;
+    invertedP2Derivative(dP2, p2);
+    dP2 *= p2e;
+    const auto p2Error = (dP2 * P1 * F2 * F1 * y).array();
+    const auto p1Error = (P2 * dP1 * F2 * F1 * y).array();
+    const auto f2Error = (P2 * P1 * dF2 * F1 * y).array();
+    const auto f1Error = (P2 * P1 * F2 * dF1 * y).array();
+    const auto inverted = (P2 * P1 * F2 * F1).array();
+    const auto yError = ((inverted * inverted).matrix() * (e.array() * e.array()).matrix()).array();
+    return (p2Error * p2Error + p1Error * p1Error + f2Error * f2Error + f1Error * f1Error + yError).sqrt().matrix();
   }
 };
 

--- a/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
@@ -5,6 +5,14 @@
 
 #include "MantidAlgorithms/PolarizationEfficiencyCor.h"
 
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/TextAxis.h"
+#include "MantidAPI/WorkspaceFactory.h"
+#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+
 using Mantid::Algorithms::PolarizationEfficiencyCor;
 
 class PolarizationEfficiencyCorTest : public CxxTest::TestSuite {
@@ -14,43 +22,86 @@ public:
   static PolarizationEfficiencyCorTest *createSuite() { return new PolarizationEfficiencyCorTest(); }
   static void destroySuite( PolarizationEfficiencyCorTest *suite ) { delete suite; }
 
+  void tearDown() override {
+    using namespace Mantid::API;
+    AnalysisDataService::Instance().clear();
+  }
 
-  void test_Init()
-  {
+  void test_Init() {
     PolarizationEfficiencyCor alg;
     TS_ASSERT_THROWS_NOTHING( alg.initialize() )
     TS_ASSERT( alg.isInitialized() )
   }
 
-  void test_exec()
-  {
-    // Create test input if necessary
-    MatrixWorkspace_sptr inputWS = //-- Fill in appropriate code. Consider using TestHelpers/WorkspaceCreationHelpers.h --
-
+  void test_exec() {
+    using namespace Mantid::API;
+    using namespace Mantid::DataObjects;
+    using namespace Mantid::HistogramData;
+    using namespace Mantid::Kernel;
+    constexpr size_t nBins{3};
+    constexpr size_t nHist{2};
+    BinEdges edges{0.3, 0.6, 0.9, 1.2};
+    const double yVal = 2.3;
+    Counts counts{yVal, yVal, yVal};
+    MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
+    MatrixWorkspace_sptr ws01 = WorkspaceFactory::Instance().create(ws00);
+    MatrixWorkspace_sptr ws10 = WorkspaceFactory::Instance().create(ws00);
+    MatrixWorkspace_sptr ws11 = WorkspaceFactory::Instance().create(ws00);
+    WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
+    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
+    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws01));
+    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws10));
+    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws11));
+    auto effWS = efficiencies(edges);
     PolarizationEfficiencyCor alg;
-    // Don't put output in ADS by default
     alg.setChild(true);
-    TS_ASSERT_THROWS_NOTHING( alg.initialize() )
-    TS_ASSERT( alg.isInitialized() )
-    TS_ASSERT_THROWS_NOTHING( alg.setProperty("InputWorkspace", inputWS) );
-    TS_ASSERT_THROWS_NOTHING( alg.setPropertyValue("OutputWorkspace", "_unused_for_child") );
-    TS_ASSERT_THROWS_NOTHING( alg.execute(); );
-    TS_ASSERT( alg.isExecuted() );
-
-    // Retrieve the workspace from the algorithm. The type here will probably need to change. It should
-    // be the type using in declareProperty for the "OutputWorkspace" type.
-    // We can't use auto as it's an implicit conversion.
-    Workspace_sptr outputWS = alg.getProperty("OutputWorkspace");
+    alg.setRethrows(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_unused_for_child"))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
+    TS_ASSERT_THROWS_NOTHING(alg.execute())
+    TS_ASSERT(alg.isExecuted())
+    WorkspaceGroup_sptr outputWS = alg.getProperty("OutputWorkspace");
     TS_ASSERT(outputWS);
-    TS_FAIL("TODO: Check the results and remove this line");
-  }
-  
-  void test_Something()
-  {
-    TS_FAIL( "You forgot to write a test!");
+    TS_ASSERT_EQUALS(outputWS->getNumberOfEntries(), 4);
+    MatrixWorkspace_sptr out00 = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(0));
+    TS_ASSERT(out00)
+    TS_ASSERT_EQUALS(out00->getNumberHistograms(), nHist)
+    for (size_t i = 0; i != nHist; ++i) {
+      const auto &xs = out00->x(i);
+      const auto &ys = out00->y(i);
+      const auto &es = out00->e(i);
+      TS_ASSERT_EQUALS(ys.size(), nBins)
+      for (size_t j = 0; j != nBins; ++j) {
+        TS_ASSERT_EQUALS(xs[j], edges[j])
+        TS_ASSERT_EQUALS(ys[j], yVal)
+        TS_ASSERT_EQUALS(es[j], std::sqrt(yVal))
+      }
+    }
   }
 
-
+private:
+  Mantid::API::MatrixWorkspace_sptr efficiencies(const Mantid::HistogramData::BinEdges &edges) {
+    using namespace Mantid::API;
+    using namespace Mantid::DataObjects;
+    using namespace Mantid::HistogramData;
+    using namespace Mantid::Kernel;
+    const auto nBins = edges.size() - 1;
+    constexpr size_t nHist{4};
+    Counts counts(nBins, 0.0);
+    MatrixWorkspace_sptr ws = create<Workspace2D>(nHist, Histogram(edges, counts));
+    ws->mutableY(0) = 1.;
+    ws->mutableY(1) = 1.;
+    auto axis = make_unique<TextAxis>(4);
+    axis->setLabel(0, "F1");
+    axis->setLabel(1, "F2");
+    axis->setLabel(2, "P1");
+    axis->setLabel(3, "P2");
+    ws->replaceAxis(1, axis.release());
+    return ws;
+  }
 };
 
 

--- a/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
@@ -1036,8 +1036,8 @@ private:
     invertedP1(P1, p1);
     Eigen::Matrix4d P2;
     invertedP2(P2, p2);
-    const auto inverted = P2 * P1 * F2 * F1;
-    return static_cast<Eigen::Vector4d>(inverted * y);
+    const Eigen::Matrix4d inverted = (P2 * P1 * F2 * F1).matrix();
+    return (inverted * y).matrix();
   }
 
   Eigen::Vector4d error(const Eigen::Vector4d &y, const Eigen::Vector4d &e,

--- a/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
@@ -187,7 +187,7 @@ public:
     constexpr size_t nHist{2};
     BinEdges edges{0.3, 0.6, 0.9, 1.2};
     const double yVal = 2.3;
-    Counts counts{yVal, yVal, yVal};
+    Counts counts{yVal, 4.2 * yVal, yVal};
     MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
     MatrixWorkspace_sptr ws11 = ws00->clone();
     WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
@@ -225,9 +225,10 @@ public:
         const auto &es = ws->e(j);
         TS_ASSERT_EQUALS(ys.size(), nBins)
         for (size_t k = 0; k != nBins; ++k) {
+          const double y = counts[k];
           TS_ASSERT_EQUALS(xs[k], edges[k])
-          TS_ASSERT_EQUALS(ys[k], yVal * static_cast<double>(i + 1))
-          TS_ASSERT_EQUALS(es[k], std::sqrt(yVal) * static_cast<double>(i + 1))
+          TS_ASSERT_EQUALS(ys[k], y * static_cast<double>(i + 1))
+          TS_ASSERT_EQUALS(es[k], std::sqrt(y) * static_cast<double>(i + 1))
         }
       }
     }

--- a/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
@@ -205,8 +205,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", "00, 11"))
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Analyzer", false))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", "0, 1"))
     TS_ASSERT_THROWS_NOTHING(alg.execute())
     TS_ASSERT(alg.isExecuted())
     WorkspaceGroup_sptr outputWS = alg.getProperty("OutputWorkspace");
@@ -255,7 +254,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", "00"))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", "0"))
     TS_ASSERT_THROWS_NOTHING(alg.execute())
     TS_ASSERT(alg.isExecuted())
     WorkspaceGroup_sptr outputWS = alg.getProperty("OutputWorkspace");
@@ -435,6 +434,45 @@ public:
     }
   }
 
+  void test_TwoInputsWithoutAnalyzer() {
+    using namespace Mantid::API;
+    using namespace Mantid::DataObjects;
+    using namespace Mantid::HistogramData;
+    using namespace Mantid::Kernel;
+    constexpr size_t nHist{2};
+    constexpr size_t nBins{3};
+    BinEdges edges{0.3, 0.6, 0.9, 1.2};
+    const double yVal = 2.3;
+    Counts counts{yVal, yVal, yVal};
+    MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
+    MatrixWorkspace_sptr ws11 = ws00->clone();
+    WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
+    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
+    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws11));
+    for (size_t i = 0; i != 2; ++i) {
+      MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(inputWS->getItem(i));
+      for (size_t j = 0; j != nHist; ++j) {
+        ws->mutableY(j) *= static_cast<double>(i + 1);
+        ws->mutableE(j) *= static_cast<double>(i + 1);
+      }
+    }
+    auto effWS = efficiencies(edges);
+    PolarizationEfficiencyCor alg;
+    alg.setChild(true);
+    alg.setRethrows(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Flippers", "0, 1"))
+    TS_ASSERT_THROWS_NOTHING(alg.execute())
+    TS_ASSERT(alg.isExecuted())
+    WorkspaceGroup_sptr outputWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outputWS)
+    TS_ASSERT_EQUALS(outputWS->getNumberOfEntries(), 2)
+  }
+
   void test_FailureWhenEfficiencyHistogramIsMissing() {
     using namespace Mantid::API;
     using namespace Mantid::DataObjects;
@@ -461,7 +499,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", "00"))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", "0"))
     TS_ASSERT_THROWS(alg.execute(), std::runtime_error)
     TS_ASSERT(!alg.isExecuted())
   }
@@ -488,7 +526,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", "00"))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", "0"))
     TS_ASSERT_THROWS(alg.execute(), std::runtime_error)
     TS_ASSERT(!alg.isExecuted())
   }

--- a/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
@@ -50,17 +50,14 @@ public:
     MatrixWorkspace_sptr ws01 = ws00->clone();
     MatrixWorkspace_sptr ws10 = ws00->clone();
     MatrixWorkspace_sptr ws11 = ws00->clone();
-    WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws01));
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws10));
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws11));
+    const std::vector<std::string> wsNames{{"ws00", "ws01", "ws10", "ws11"}};
+    const std::array<MatrixWorkspace_sptr, 4> wsList{{ws00, ws01, ws10, ws11}};
     for (size_t i = 0; i != 4; ++i) {
-      MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(inputWS->getItem(i));
       for (size_t j = 0; j != nHist; ++j) {
-        ws->mutableY(j) *= static_cast<double>(i + 1);
-        ws->mutableE(j) *= static_cast<double>(i + 1);
+        wsList[i]->mutableY(j) *= static_cast<double>(i + 1);
+        wsList[i]->mutableE(j) *= static_cast<double>(i + 1);
       }
+      AnalysisDataService::Instance().addOrReplace(wsNames[i], wsList[i]);
     }
     auto effWS = idealEfficiencies(edges);
     PolarizationEfficiencyCor alg;
@@ -68,7 +65,7 @@ public:
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", wsNames))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.execute())
@@ -117,21 +114,21 @@ public:
     Counts counts{yVal, 4.2 * yVal, yVal};
     MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
     MatrixWorkspace_sptr ws11 = ws00->clone();
-    WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws11));
+    const std::vector<std::string> wsNames{std::initializer_list<std::string>{"ws00", "ws11"}};
+    const std::array<MatrixWorkspace_sptr, 2> wsList{{ws00, ws11}};
     for (size_t i = 0; i != nHist; ++i) {
       ws11->mutableY(i) *= 2.;
       ws11->mutableE(i) *= 2.;
     }
-
+    AnalysisDataService::Instance().addOrReplace(wsNames.front(), wsList.front());
+    AnalysisDataService::Instance().addOrReplace(wsNames.back(), wsList.back());
     auto effWS = idealEfficiencies(edges);
     PolarizationEfficiencyCor alg;
     alg.setChild(true);
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", wsNames))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", "00, 11"))
@@ -192,20 +189,21 @@ public:
     Counts counts{yVal, 4.2 * yVal, yVal};
     MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
     MatrixWorkspace_sptr ws11 = ws00->clone();
-    WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws11));
+    const std::vector<std::string> wsNames{std::initializer_list<std::string>{"ws00", "ws11"}};
+    const std::array<MatrixWorkspace_sptr, 2> wsList{{ws00, ws11}};
     for (size_t i = 0; i != nHist; ++i) {
       ws11->mutableY(i) *= 2.;
       ws11->mutableE(i) *= 2.;
     }
+    AnalysisDataService::Instance().addOrReplace(wsNames.front(), wsList.front());
+    AnalysisDataService::Instance().addOrReplace(wsNames.back(), wsList.back());
     auto effWS = idealEfficiencies(edges);
     PolarizationEfficiencyCor alg;
     alg.setChild(true);
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", wsNames))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", "0, 1"))
@@ -247,15 +245,15 @@ public:
     const double yVal = 2.3;
     Counts counts{yVal, 4.2 * yVal, yVal};
     MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
-    WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
+    const std::vector<std::string> wsNames{{"ws00"}};
+    AnalysisDataService::Instance().addOrReplace(wsNames.front(), ws00);
     auto effWS = idealEfficiencies(edges);
     PolarizationEfficiencyCor alg;
     alg.setChild(true);
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", wsNames))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", "0"))
@@ -294,17 +292,14 @@ public:
     MatrixWorkspace_sptr ws01 = ws00->clone();
     MatrixWorkspace_sptr ws10 = ws00->clone();
     MatrixWorkspace_sptr ws11 = ws00->clone();
-    WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws01));
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws10));
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws11));
+    const std::vector<std::string> wsNames{{"ws00", "ws01", "ws10", "ws11"}};
+    const std::array<MatrixWorkspace_sptr, 4> wsList{{ws00, ws01, ws10, ws11}};
     for (size_t i = 0; i != 4; ++i) {
-      MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(inputWS->getItem(i));
       for (size_t j = 0; j != nHist; ++j) {
-        ws->mutableY(j) *= static_cast<double>(i + 1);
-        ws->mutableE(j) *= static_cast<double>(i + 1);
+        wsList[i]->mutableY(j) *= static_cast<double>(i + 1);
+        wsList[i]->mutableE(j) *= static_cast<double>(i + 1);
       }
+      AnalysisDataService::Instance().addOrReplace(wsNames[i], wsList[i]);
     }
     auto effWS = efficiencies(edges);
     PolarizationEfficiencyCor alg;
@@ -312,7 +307,7 @@ public:
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", wsNames))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.execute())
@@ -345,15 +340,14 @@ public:
     MatrixWorkspace_sptr ws01 = nullptr;
     MatrixWorkspace_sptr ws10 = nullptr;
     MatrixWorkspace_sptr ws11 = ws00->clone();
-    WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws11));
+    const std::vector<std::string> wsNames{std::initializer_list<std::string>{"ws00", "ws11"}};
+    const std::array<MatrixWorkspace_sptr, 2> wsList{{ws00, ws11}};
     for (size_t i = 0; i != 2; ++i) {
-      MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(inputWS->getItem(i));
       for (size_t j = 0; j != nHist; ++j) {
-        ws->mutableY(j) *= static_cast<double>(i + 1);
-        ws->mutableE(j) *= static_cast<double>(i + 1);
+        wsList[i]->mutableY(j) *= static_cast<double>(i + 1);
+        wsList[i]->mutableE(j) *= static_cast<double>(i + 1);
       }
+      AnalysisDataService::Instance().addOrReplace(wsNames[i], wsList[i]);
     }
     auto effWS = efficiencies(edges);
     PolarizationEfficiencyCor alg;
@@ -361,7 +355,7 @@ public:
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", wsNames))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Flippers", "00, 11"))
@@ -451,15 +445,14 @@ public:
     Counts counts{yVal, yVal, yVal};
     MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
     MatrixWorkspace_sptr ws11 = ws00->clone();
-    WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws11));
+    const std::vector<std::string> wsNames{std::initializer_list<std::string>{"ws00", "ws11"}};
+    const std::array<MatrixWorkspace_sptr, 2> wsList{{ws00, ws11}};
     for (size_t i = 0; i != 2; ++i) {
-      MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(inputWS->getItem(i));
       for (size_t j = 0; j != nHist; ++j) {
-        ws->mutableY(j) *= static_cast<double>(i + 1);
-        ws->mutableE(j) *= static_cast<double>(i + 1);
+        wsList[i]->mutableY(j) *= static_cast<double>(i + 1);
+        wsList[i]->mutableE(j) *= static_cast<double>(i + 1);
       }
+      AnalysisDataService::Instance().addOrReplace(wsNames[i], wsList[i]);
     }
     auto effWS = efficiencies(edges);
     PolarizationEfficiencyCor alg;
@@ -467,7 +460,7 @@ public:
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", wsNames))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Flippers", "0, 1"))
@@ -521,15 +514,15 @@ public:
     const double yVal = 2.3;
     Counts counts{yVal, yVal, yVal};
     MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
-    WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
+    const std::string wsName{"ws00"};
+    AnalysisDataService::Instance().addOrReplace(wsName, ws00);
     auto effWS = efficiencies(edges);
     PolarizationEfficiencyCor alg;
     alg.setChild(true);
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("InputWorkspaces", wsName))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Flippers", "0"))
@@ -574,8 +567,8 @@ public:
     BinEdges edges{0.3, 0.6, 0.9, 1.2};
     Counts counts{0., 0., 0.};
     MatrixWorkspace_sptr ws00 = create<Workspace2D>(1, Histogram(edges, counts));
-    WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
+    const std::string wsName{"ws00"};
+    AnalysisDataService::Instance().addOrReplace(wsName, ws00);
     auto effWS = idealEfficiencies(edges);
     // Rename F1 to something else.
     auto axis = make_unique<TextAxis>(4);
@@ -589,7 +582,7 @@ public:
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("InputWorkspaces", wsName))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", "0"))
@@ -605,8 +598,8 @@ public:
     BinEdges edges{0.3, 0.6, 0.9, 1.2};
     Counts counts{0., 0., 0.};
     MatrixWorkspace_sptr ws00 = create<Workspace2D>(1, Histogram(edges, counts));
-    WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
+    const std::string wsName{"ws00"};
+    AnalysisDataService::Instance().addOrReplace(wsName, ws00);
     auto effWS = idealEfficiencies(edges);
     // Change a bin edge of one of the histograms.
     auto &xs = effWS->mutableX(0);
@@ -616,7 +609,7 @@ public:
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("InputWorkspaces", wsName))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", "0"))
@@ -636,18 +629,18 @@ public:
     MatrixWorkspace_sptr ws01 = ws00->clone();
     MatrixWorkspace_sptr ws10 = create<Workspace2D>(nHist + 1, Histogram(edges, counts));
     MatrixWorkspace_sptr ws11 = ws00->clone();
-    WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws01));
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws10));
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws11));
+    const std::vector<std::string> wsNames{{"ws00", "ws01", "ws10", "ws11"}};
+    const std::array<MatrixWorkspace_sptr, 4> wsList{{ws00, ws01, ws10, ws11}};
+    for (size_t i = 0; i != 4; ++i) {
+        AnalysisDataService::Instance().addOrReplace(wsNames[i], wsList[i]);
+    }
     auto effWS = idealEfficiencies(edges);
     PolarizationEfficiencyCor alg;
     alg.setChild(true);
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", wsNames))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS(alg.execute(), std::runtime_error)
@@ -665,25 +658,19 @@ public:
     MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
     MatrixWorkspace_sptr ws01 = ws00->clone();
     MatrixWorkspace_sptr ws11 = ws00->clone();
-    WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws01));
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws11));
-    auto effWS = idealEfficiencies(edges);
+    AnalysisDataService::Instance().addOrReplace("ws00", ws00);
+    AnalysisDataService::Instance().addOrReplace("ws01", ws01);
+    AnalysisDataService::Instance().addOrReplace("ws11", ws11);
     PolarizationEfficiencyCor alg;
     alg.setChild(true);
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
-    TS_ASSERT_THROWS(alg.execute(), std::runtime_error)
-    TS_ASSERT(!alg.isExecuted())
+    TS_ASSERT_THROWS(alg.setPropertyValue("InputWorkspaces", "ws00, ws01, ws10, ws11"), std::invalid_argument)
   }
 
 private:
-  std::string m_outputWSName{"output"};
+  const std::string m_outputWSName{"output"};
 
   Mantid::API::MatrixWorkspace_sptr efficiencies(const Mantid::HistogramData::BinEdges &edges) {
     using namespace Mantid::API;
@@ -744,16 +731,14 @@ private:
     MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
     MatrixWorkspace_sptr wsXX = ws00->clone();
     MatrixWorkspace_sptr ws11 = ws00->clone();
-    WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(wsXX));
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws11));
+    const std::vector<std::string> wsNames{{"ws00", "wsXX", "ws11"}};
+    const std::array<MatrixWorkspace_sptr, 3> wsList{{ws00, wsXX, ws11}};
     for (size_t i = 0; i != 3; ++i) {
-      MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(inputWS->getItem(i));
       for (size_t j = 0; j != nHist; ++j) {
-        ws->mutableY(j) *= static_cast<double>(i + 1);
-        ws->mutableE(j) *= static_cast<double>(i + 1);
+        wsList[i]->mutableY(j) *= static_cast<double>(i + 1);
+        wsList[i]->mutableE(j) *= static_cast<double>(i + 1);
       }
+      AnalysisDataService::Instance().addOrReplace(wsNames[i], wsList[i]);
     }
     auto effWS = idealEfficiencies(edges);
     constexpr char *OUTWS_NAME{"output"};
@@ -762,7 +747,7 @@ private:
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", wsNames))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", OUTWS_NAME))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     const std::string presentFlipperConf = missingFlipperConf == "01" ? "10" : "01";
@@ -831,20 +816,14 @@ private:
     MatrixWorkspace_sptr ws01 = missingFlipperConf == "01" ? nullptr : ws00->clone();
     MatrixWorkspace_sptr ws10 = missingFlipperConf == "10" ? nullptr : ws00->clone();
     MatrixWorkspace_sptr ws11 = ws00->clone();
-    WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
-    if (ws01) {
-      inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws01));
-    } else {
-      inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws10));
-    }
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws11));
+    const std::vector<std::string> wsNames{{"ws00", "wsXX", "ws11"}};
+    const std::array<MatrixWorkspace_sptr, 3> wsList{{ws00, ws01 != nullptr ? ws01 : ws10, ws11}};
     for (size_t i = 0; i != 3; ++i) {
-      MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(inputWS->getItem(i));
       for (size_t j = 0; j != nHist; ++j) {
-        ws->mutableY(j) *= static_cast<double>(i + 1);
-        ws->mutableE(j) *= static_cast<double>(i + 1);
+        wsList[i]->mutableY(j) *= static_cast<double>(i + 1);
+        wsList[i]->mutableE(j) *= static_cast<double>(i + 1);
       }
+      AnalysisDataService::Instance().addOrReplace(wsNames[i], wsList[i]);
     }
     auto effWS = efficiencies(edges);
     PolarizationEfficiencyCor alg;
@@ -852,7 +831,7 @@ private:
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", wsNames))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     const std::string presentFlipperConf = missingFlipperConf == "01" ? "10" : "01";

--- a/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
@@ -95,87 +95,14 @@ public:
   }
 
   void test_IdealCaseThreeInputs10Missing() {
-    using namespace Mantid::API;
-    using namespace Mantid::DataObjects;
-    using namespace Mantid::HistogramData;
-    using namespace Mantid::Kernel;
-    constexpr size_t nBins{3};
-    constexpr size_t nHist{2};
-    BinEdges edges{0.3, 0.6, 0.9, 1.2};
-    const double yVal = 2.3;
-    Counts counts{yVal, yVal, yVal};
-    MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
-    MatrixWorkspace_sptr ws01 = ws00->clone();
-    MatrixWorkspace_sptr ws11 = ws00->clone();
-    WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws01));
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws11));
-    for (size_t i = 0; i != 3; ++i) {
-      MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(inputWS->getItem(i));
-      for (size_t j = 0; j != nHist; ++j) {
-        ws->mutableY(j) *= static_cast<double>(i + 1);
-        ws->mutableE(j) *= static_cast<double>(i + 1);
-      }
-    }
-    auto effWS = efficiencies(edges);
-    constexpr char *OUTWS_NAME{"output"};
-    PolarizationEfficiencyCor alg;
-    alg.setChild(true);
-    alg.setRethrows(true);
-    TS_ASSERT_THROWS_NOTHING(alg.initialize())
-    TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", OUTWS_NAME))
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", "00, 01, 11"))
-    TS_ASSERT_THROWS_NOTHING(alg.execute())
-    TS_ASSERT(alg.isExecuted())
-    WorkspaceGroup_sptr outputWS = alg.getProperty("OutputWorkspace");
-    TS_ASSERT(outputWS)
-    TS_ASSERT_EQUALS(outputWS->getNumberOfEntries(), 4)
-    const std::array<std::string, 4> POL_DIRS{{"++", "+-", "-+", "--"}};
-    for (size_t i = 0; i != 4; ++i) {
-      const auto &dir = POL_DIRS[i];
-      const std::string wsName = OUTWS_NAME + std::string("_") + dir;
-      MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(wsName));
-      TS_ASSERT(ws)
-      const double expected = [yVal, &dir]() {
-        if (dir == "++") {
-          return yVal;
-        } else if (dir == "--") {
-          return 3. * yVal;
-        } else {
-          return 2. * yVal;
-        }
-      }();
-      const double expectedError = [yVal, &dir]() {
-        if (dir == "++") {
-          return std::sqrt(yVal);
-        } else if (dir == "--") {
-          return 3. * std::sqrt(yVal);
-        } else if (dir == "+-"){
-          return 2. * std::sqrt(yVal);
-        } else {
-          return 0.;
-        }
-      }();
-      TS_ASSERT_EQUALS(ws->getNumberHistograms(), nHist)
-      for (size_t j = 0; j != nHist; ++j) {
-        const auto &xs = ws->x(j);
-        const auto &ys = ws->y(j);
-        const auto &es = ws->e(j);
-        TS_ASSERT_EQUALS(ys.size(), nBins)
-        for (size_t k = 0; k != nBins; ++k) {
-          TS_ASSERT_EQUALS(xs[k], edges[k])
-          TS_ASSERT_EQUALS(ys[k], expected)
-          TS_ASSERT_EQUALS(es[k], expectedError)
-        }
-      }
-    }
+    threeInputsTest("10");
   }
 
   void test_IdealCaseThreeInputs01Missing() {
+    threeInputsTest("01");
+  }
+
+  void test_IdealCaseTwoInputsWithAnalyzer() {
     using namespace Mantid::API;
     using namespace Mantid::DataObjects;
     using namespace Mantid::HistogramData;
@@ -186,19 +113,15 @@ public:
     const double yVal = 2.3;
     Counts counts{yVal, yVal, yVal};
     MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
-    MatrixWorkspace_sptr ws10 = ws00->clone();
     MatrixWorkspace_sptr ws11 = ws00->clone();
     WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
     inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
-    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws10));
     inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws11));
-    for (size_t i = 0; i != 3; ++i) {
-      MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(inputWS->getItem(i));
-      for (size_t j = 0; j != nHist; ++j) {
-        ws->mutableY(j) *= static_cast<double>(i + 1);
-        ws->mutableE(j) *= static_cast<double>(i + 1);
-      }
+    for (size_t i = 0; i != nHist; ++i) {
+      ws11->mutableY(i) *= 2.;
+      ws11->mutableE(i) *= 2.;
     }
+
     auto effWS = efficiencies(edges);
     constexpr char *OUTWS_NAME{"output"};
     PolarizationEfficiencyCor alg;
@@ -209,7 +132,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", OUTWS_NAME))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", "00, 10, 11"))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", "00, 11"))
     TS_ASSERT_THROWS_NOTHING(alg.execute())
     TS_ASSERT(alg.isExecuted())
     WorkspaceGroup_sptr outputWS = alg.getProperty("OutputWorkspace");
@@ -225,20 +148,18 @@ public:
         if (dir == "++") {
           return yVal;
         } else if (dir == "--") {
-          return 3. * yVal;
-        } else {
           return 2. * yVal;
+        } else {
+          return 0.;
         }
       }();
       const double expectedError = [yVal, &dir]() {
         if (dir == "++") {
           return std::sqrt(yVal);
         } else if (dir == "--") {
-          return 3. * std::sqrt(yVal);
-        } else if (dir == "-+"){
           return 2. * std::sqrt(yVal);
         } else {
-          return 0.;
+            return 0.;
         }
       }();
       TS_ASSERT_EQUALS(ws->getNumberHistograms(), nHist)
@@ -275,6 +196,92 @@ private:
     axis->setLabel(3, "P2");
     ws->replaceAxis(1, axis.release());
     return ws;
+  }
+
+  void threeInputsTest(const std::string &missingFlipperConf) {
+    using namespace Mantid::API;
+    using namespace Mantid::DataObjects;
+    using namespace Mantid::HistogramData;
+    using namespace Mantid::Kernel;
+    constexpr size_t nBins{3};
+    constexpr size_t nHist{2};
+    BinEdges edges{0.3, 0.6, 0.9, 1.2};
+    const double yVal = 2.3;
+    Counts counts{yVal, yVal, yVal};
+    MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
+    MatrixWorkspace_sptr wsXX = ws00->clone();
+    MatrixWorkspace_sptr ws11 = ws00->clone();
+    WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
+    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
+    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(wsXX));
+    inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws11));
+    for (size_t i = 0; i != 3; ++i) {
+      MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(inputWS->getItem(i));
+      for (size_t j = 0; j != nHist; ++j) {
+        ws->mutableY(j) *= static_cast<double>(i + 1);
+        ws->mutableE(j) *= static_cast<double>(i + 1);
+      }
+    }
+    auto effWS = efficiencies(edges);
+    constexpr char *OUTWS_NAME{"output"};
+    PolarizationEfficiencyCor alg;
+    alg.setChild(true);
+    alg.setRethrows(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", OUTWS_NAME))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
+    const std::string presentFlipperConf = missingFlipperConf == "01" ? "10" : "01";
+    const std::string flipperConf = "00, " + presentFlipperConf + ", 11";
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", flipperConf))
+    TS_ASSERT_THROWS_NOTHING(alg.execute())
+    TS_ASSERT(alg.isExecuted())
+    WorkspaceGroup_sptr outputWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outputWS)
+    TS_ASSERT_EQUALS(outputWS->getNumberOfEntries(), 4)
+    const std::array<std::string, 4> POL_DIRS{{"++", "+-", "-+", "--"}};
+    for (size_t i = 0; i != 4; ++i) {
+      const auto &dir = POL_DIRS[i];
+      const std::string wsName = OUTWS_NAME + std::string("_") + dir;
+      MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(wsName));
+      TS_ASSERT(ws)
+      const double expected = [yVal, &dir]() {
+        if (dir == "++") {
+          return yVal;
+        } else if (dir == "--") {
+          return 3. * yVal;
+        } else {
+          return 2. * yVal;
+        }
+      }();
+      const double expectedError = [yVal, &dir, &missingFlipperConf]() {
+        if (dir == "++") {
+          return std::sqrt(yVal);
+        } else if (dir == "--") {
+          return 3. * std::sqrt(yVal);
+        } else {
+          std::string conf = std::string(dir.front() == '+' ? "0" : "1") + std::string(dir.back() == '+' ? "0" : "1");
+          if (conf != missingFlipperConf) {
+            return 2. * std::sqrt(yVal);
+          } else {
+            return 0.;
+          }
+        }
+      }();
+      TS_ASSERT_EQUALS(ws->getNumberHistograms(), nHist)
+      for (size_t j = 0; j != nHist; ++j) {
+        const auto &xs = ws->x(j);
+        const auto &ys = ws->y(j);
+        const auto &es = ws->e(j);
+        TS_ASSERT_EQUALS(ys.size(), nBins)
+        for (size_t k = 0; k != nBins; ++k) {
+          TS_ASSERT_EQUALS(xs[k], edges[k])
+          TS_ASSERT_EQUALS(ys[k], expected)
+          TS_ASSERT_EQUALS(es[k], expectedError)
+        }
+      }
+    }
   }
 };
 

--- a/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
@@ -1,0 +1,57 @@
+#ifndef MANTID_ALGORITHMS_POLARIZATIONEFFICIENCYCORTEST_H_
+#define MANTID_ALGORITHMS_POLARIZATIONEFFICIENCYCORTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAlgorithms/PolarizationEfficiencyCor.h"
+
+using Mantid::Algorithms::PolarizationEfficiencyCor;
+
+class PolarizationEfficiencyCorTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static PolarizationEfficiencyCorTest *createSuite() { return new PolarizationEfficiencyCorTest(); }
+  static void destroySuite( PolarizationEfficiencyCorTest *suite ) { delete suite; }
+
+
+  void test_Init()
+  {
+    PolarizationEfficiencyCor alg;
+    TS_ASSERT_THROWS_NOTHING( alg.initialize() )
+    TS_ASSERT( alg.isInitialized() )
+  }
+
+  void test_exec()
+  {
+    // Create test input if necessary
+    MatrixWorkspace_sptr inputWS = //-- Fill in appropriate code. Consider using TestHelpers/WorkspaceCreationHelpers.h --
+
+    PolarizationEfficiencyCor alg;
+    // Don't put output in ADS by default
+    alg.setChild(true);
+    TS_ASSERT_THROWS_NOTHING( alg.initialize() )
+    TS_ASSERT( alg.isInitialized() )
+    TS_ASSERT_THROWS_NOTHING( alg.setProperty("InputWorkspace", inputWS) );
+    TS_ASSERT_THROWS_NOTHING( alg.setPropertyValue("OutputWorkspace", "_unused_for_child") );
+    TS_ASSERT_THROWS_NOTHING( alg.execute(); );
+    TS_ASSERT( alg.isExecuted() );
+
+    // Retrieve the workspace from the algorithm. The type here will probably need to change. It should
+    // be the type using in declareProperty for the "OutputWorkspace" type.
+    // We can't use auto as it's an implicit conversion.
+    Workspace_sptr outputWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outputWS);
+    TS_FAIL("TODO: Check the results and remove this line");
+  }
+  
+  void test_Something()
+  {
+    TS_FAIL( "You forgot to write a test!");
+  }
+
+
+};
+
+
+#endif /* MANTID_ALGORITHMS_POLARIZATIONEFFICIENCYCORTEST_H_ */

--- a/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
@@ -1881,12 +1881,11 @@ public:
     crop->setProperty("XMin", 0.);
     crop->execute();
     m_ws00 = crop->getProperty("OutputWorkspace");
+    AnalysisDataService::Instance().addOrReplace("00", m_ws00);
     m_ws01 = m_ws00->clone();
+    AnalysisDataService::Instance().addOrReplace("01", m_ws01);
     m_ws11 = m_ws00->clone();
-    m_group = boost::make_shared<WorkspaceGroup>();
-    m_group->addWorkspace(boost::dynamic_pointer_cast<Workspace>(m_ws00));
-    m_group->addWorkspace(boost::dynamic_pointer_cast<Workspace>(m_ws01));
-    m_group->addWorkspace(boost::dynamic_pointer_cast<Workspace>(m_ws11));
+    AnalysisDataService::Instance().addOrReplace("11", m_ws11);
     auto loadEff = AlgorithmManager::Instance().createUnmanaged(
         "LoadILLPolarizationFactors");
     loadEff->setChild(true);
@@ -1910,7 +1909,7 @@ public:
       correction.setChild(true);
       correction.setRethrows(true);
       correction.initialize();
-      correction.setProperty("InputWorkspace", m_group);
+      correction.setProperty("InputWorkspaces", "00, 01, 11");
       correction.setProperty("OutputWorkspace", "output");
       correction.setProperty("Flippers", "00, 01, 11");
       correction.setProperty("Efficiencies", m_effWS);
@@ -1920,7 +1919,6 @@ public:
 
 private:
   Mantid::API::MatrixWorkspace_sptr m_effWS;
-  Mantid::API::WorkspaceGroup_sptr m_group;
   Mantid::API::MatrixWorkspace_sptr m_ws00;
   Mantid::API::MatrixWorkspace_sptr m_ws01;
   Mantid::API::MatrixWorkspace_sptr m_ws11;

--- a/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
@@ -45,7 +45,7 @@ public:
     constexpr size_t nHist{2};
     BinEdges edges{0.3, 0.6, 0.9, 1.2};
     const double yVal = 2.3;
-    Counts counts{yVal, yVal, yVal};
+    Counts counts{yVal, 4.2 * yVal, yVal};
     MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
     MatrixWorkspace_sptr ws01 = ws00->clone();
     MatrixWorkspace_sptr ws10 = ws00->clone();
@@ -88,9 +88,10 @@ public:
         const auto &es = ws->e(j);
         TS_ASSERT_EQUALS(ys.size(), nBins)
         for (size_t k = 0; k != nBins; ++k) {
+          const double y = counts[k];
           TS_ASSERT_EQUALS(xs[k], edges[k])
-          TS_ASSERT_EQUALS(ys[k], yVal * static_cast<double>(i + 1))
-          TS_ASSERT_EQUALS(es[k], std::sqrt(yVal) * static_cast<double>(i + 1))
+          TS_ASSERT_EQUALS(ys[k], y * static_cast<double>(i + 1))
+          TS_ASSERT_EQUALS(es[k], std::sqrt(y) * static_cast<double>(i + 1))
         }
       }
     }
@@ -113,7 +114,7 @@ public:
     constexpr size_t nHist{2};
     BinEdges edges{0.3, 0.6, 0.9, 1.2};
     const double yVal = 2.3;
-    Counts counts{yVal, yVal, yVal};
+    Counts counts{yVal, 4.2 * yVal, yVal};
     MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
     MatrixWorkspace_sptr ws11 = ws00->clone();
     WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
@@ -145,24 +146,6 @@ public:
       const std::string wsName = m_outputWSName + std::string("_") + dir;
       MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(wsName));
       TS_ASSERT(ws)
-      const double expected = [yVal, &dir]() {
-        if (dir == "++") {
-          return yVal;
-        } else if (dir == "--") {
-          return 2. * yVal;
-        } else {
-          return 0.;
-        }
-      }();
-      const double expectedError = [yVal, &dir]() {
-        if (dir == "++") {
-          return std::sqrt(yVal);
-        } else if (dir == "--") {
-          return 2. * std::sqrt(yVal);
-        } else {
-            return 0.;
-        }
-      }();
       TS_ASSERT_EQUALS(ws->getNumberHistograms(), nHist)
       for (size_t j = 0; j != nHist; ++j) {
         const auto &xs = ws->x(j);
@@ -170,6 +153,25 @@ public:
         const auto &es = ws->e(j);
         TS_ASSERT_EQUALS(ys.size(), nBins)
         for (size_t k = 0; k != nBins; ++k) {
+          const double y = counts[k];
+          const double expected = [y, &dir]() {
+            if (dir == "++") {
+              return y;
+            } else if (dir == "--") {
+              return 2. * y;
+            } else {
+              return 0.;
+            }
+          }();
+          const double expectedError = [y, &dir]() {
+            if (dir == "++") {
+              return std::sqrt(y);
+            } else if (dir == "--") {
+              return 2. * std::sqrt(y);
+            } else {
+                return 0.;
+            }
+          }();
           TS_ASSERT_EQUALS(xs[k], edges[k])
           TS_ASSERT_EQUALS(ys[k], expected)
           TS_ASSERT_EQUALS(es[k], expectedError)
@@ -243,7 +245,7 @@ public:
     constexpr size_t nHist{2};
     BinEdges edges{0.3, 0.6, 0.9, 1.2};
     const double yVal = 2.3;
-    Counts counts{yVal, yVal, yVal};
+    Counts counts{yVal, 4.2 * yVal, yVal};
     MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
     WorkspaceGroup_sptr inputWS = boost::make_shared<WorkspaceGroup>();
     inputWS->addWorkspace(boost::dynamic_pointer_cast<Workspace>(ws00));
@@ -271,9 +273,10 @@ public:
       const auto &es = ws->e(i);
       TS_ASSERT_EQUALS(ys.size(), nBins)
       for (size_t j = 0; j != nBins; ++j) {
+        const double y = counts[j];
         TS_ASSERT_EQUALS(xs[j], edges[j])
-        TS_ASSERT_EQUALS(ys[j], yVal)
-        TS_ASSERT_EQUALS(es[j], std::sqrt(yVal))
+        TS_ASSERT_EQUALS(ys[j], y)
+        TS_ASSERT_EQUALS(es[j], std::sqrt(y))
       }
     }
   }
@@ -737,7 +740,7 @@ private:
     constexpr size_t nHist{2};
     BinEdges edges{0.3, 0.6, 0.9, 1.2};
     const double yVal = 2.3;
-    Counts counts{yVal, yVal, yVal};
+    Counts counts{yVal, 4.2 * yVal, yVal};
     MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
     MatrixWorkspace_sptr wsXX = ws00->clone();
     MatrixWorkspace_sptr ws11 = ws00->clone();
@@ -776,29 +779,6 @@ private:
       const std::string wsName = OUTWS_NAME + std::string("_") + dir;
       MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(wsName));
       TS_ASSERT(ws)
-      const double expected = [yVal, &dir]() {
-        if (dir == "++") {
-          return yVal;
-        } else if (dir == "--") {
-          return 3. * yVal;
-        } else {
-          return 2. * yVal;
-        }
-      }();
-      const double expectedError = [yVal, &dir, &missingFlipperConf]() {
-        if (dir == "++") {
-          return std::sqrt(yVal);
-        } else if (dir == "--") {
-          return 3. * std::sqrt(yVal);
-        } else {
-          std::string conf = std::string(dir.front() == '+' ? "0" : "1") + std::string(dir.back() == '+' ? "0" : "1");
-          if (conf != missingFlipperConf) {
-            return 2. * std::sqrt(yVal);
-          } else {
-            return 0.;
-          }
-        }
-      }();
       TS_ASSERT_EQUALS(ws->getNumberHistograms(), nHist)
       for (size_t j = 0; j != nHist; ++j) {
         const auto &xs = ws->x(j);
@@ -806,6 +786,30 @@ private:
         const auto &es = ws->e(j);
         TS_ASSERT_EQUALS(ys.size(), nBins)
         for (size_t k = 0; k != nBins; ++k) {
+          const double y = counts[k];
+          const double expected = [y, &dir]() {
+            if (dir == "++") {
+              return y;
+            } else if (dir == "--") {
+              return 3. * y;
+            } else {
+              return 2. * y;
+            }
+          }();
+          const double expectedError = [y, &dir, &missingFlipperConf]() {
+            if (dir == "++") {
+              return std::sqrt(y);
+            } else if (dir == "--") {
+              return 3. * std::sqrt(y);
+            } else {
+              std::string conf = std::string(dir.front() == '+' ? "0" : "1") + std::string(dir.back() == '+' ? "0" : "1");
+              if (conf != missingFlipperConf) {
+                return 2. * std::sqrt(y);
+              } else {
+                return 0.;
+              }
+            }
+          }();
           TS_ASSERT_EQUALS(xs[k], edges[k])
           TS_ASSERT_EQUALS(ys[k], expected)
           TS_ASSERT_EQUALS(es[k], expectedError)

--- a/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
@@ -1884,6 +1884,8 @@ public:
     AnalysisDataService::Instance().addOrReplace("00", m_ws00);
     m_ws01 = m_ws00->clone();
     AnalysisDataService::Instance().addOrReplace("01", m_ws01);
+    m_ws10 = m_ws00->clone();
+    AnalysisDataService::Instance().addOrReplace("10", m_ws10);
     m_ws11 = m_ws00->clone();
     AnalysisDataService::Instance().addOrReplace("11", m_ws11);
     auto loadEff = AlgorithmManager::Instance().createUnmanaged(
@@ -1902,9 +1904,39 @@ public:
     AnalysisDataService::Instance().clear();
   }
 
-  void test_Performance() {
+  void test_DirectBeamPerformance() {
     using namespace Mantid::API;
-    for (int i = 0; i < 10000; ++i) {
+    for (int i = 0; i < 3000; ++i) {
+      PolarizationEfficiencyCor correction;
+      correction.setChild(true);
+      correction.setRethrows(true);
+      correction.initialize();
+      correction.setProperty("InputWorkspaces", "00");
+      correction.setProperty("OutputWorkspace", "output");
+      correction.setProperty("Flippers", "0");
+      correction.setProperty("Efficiencies", m_effWS);
+      TS_ASSERT_THROWS_NOTHING(correction.execute())
+    }
+  }
+
+  void test_ThreeInputsPerformanceMissing01() {
+    using namespace Mantid::API;
+    for (int i = 0; i < 3000; ++i) {
+      PolarizationEfficiencyCor correction;
+      correction.setChild(true);
+      correction.setRethrows(true);
+      correction.initialize();
+      correction.setProperty("InputWorkspaces", "00, 10, 11");
+      correction.setProperty("OutputWorkspace", "output");
+      correction.setProperty("Flippers", "00, 10, 11");
+      correction.setProperty("Efficiencies", m_effWS);
+      TS_ASSERT_THROWS_NOTHING(correction.execute())
+    }
+  }
+
+  void test_ThreeInputsPerformanceMissing10() {
+    using namespace Mantid::API;
+    for (int i = 0; i < 3000; ++i) {
       PolarizationEfficiencyCor correction;
       correction.setChild(true);
       correction.setRethrows(true);
@@ -1913,7 +1945,37 @@ public:
       correction.setProperty("OutputWorkspace", "output");
       correction.setProperty("Flippers", "00, 01, 11");
       correction.setProperty("Efficiencies", m_effWS);
-      correction.execute();
+      TS_ASSERT_THROWS_NOTHING(correction.execute())
+    }
+  }
+
+  void test_TwoInputsNoAnalyzerPerformance() {
+    using namespace Mantid::API;
+    for (int i = 0; i < 3000; ++i) {
+      PolarizationEfficiencyCor correction;
+      correction.setChild(true);
+      correction.setRethrows(true);
+      correction.initialize();
+      correction.setProperty("InputWorkspaces", "00, 11");
+      correction.setProperty("OutputWorkspace", "output");
+      correction.setProperty("Flippers", "0, 1");
+      correction.setProperty("Efficiencies", m_effWS);
+      TS_ASSERT_THROWS_NOTHING(correction.execute())
+    }
+  }
+
+  void test_TwoInputsPerformance() {
+    using namespace Mantid::API;
+    for (int i = 0; i < 3000; ++i) {
+      PolarizationEfficiencyCor correction;
+      correction.setChild(true);
+      correction.setRethrows(true);
+      correction.initialize();
+      correction.setProperty("InputWorkspaces", "00, 11");
+      correction.setProperty("OutputWorkspace", "output");
+      correction.setProperty("Flippers", "00, 11");
+      correction.setProperty("Efficiencies", m_effWS);
+      TS_ASSERT_THROWS_NOTHING(correction.execute())
     }
   }
 
@@ -1921,6 +1983,7 @@ private:
   Mantid::API::MatrixWorkspace_sptr m_effWS;
   Mantid::API::MatrixWorkspace_sptr m_ws00;
   Mantid::API::MatrixWorkspace_sptr m_ws01;
+  Mantid::API::MatrixWorkspace_sptr m_ws10;
   Mantid::API::MatrixWorkspace_sptr m_ws11;
 };
 

--- a/docs/source/algorithms/PolarizationEfficiencyCor-v1.rst
+++ b/docs/source/algorithms/PolarizationEfficiencyCor-v1.rst
@@ -89,7 +89,7 @@ Usage
    LoadILLReflectometry(
        Filename='ILL/D17/317370.nxs',
        OutputWorkspace='reflected_beam',
-       BeamPosition='direct_beam_position',
+       DirectBeamPosition='direct_beam_position',
        XUnit='TimeOfFlight')
    # Sum pixels containing the reflected intensity
    GroupDetectors(

--- a/docs/source/algorithms/PolarizationEfficiencyCor-v1.rst
+++ b/docs/source/algorithms/PolarizationEfficiencyCor-v1.rst
@@ -1,0 +1,160 @@
+
+.. algorithm::
+
+.. summary::
+
+.. alias::
+
+.. properties::
+
+Description
+-----------
+
+This algorithm corrects for non-ideal instrument component efficiencies in a polarization analysis experiment by following the procedure and conventions introduced by Wildes [#WILDES]_. In the full polarization analysis case it solves the corrected count rates :math:`\Sigma^{++}`, :math:`\Sigma^{+-}`, :math:`\Sigma^{-+}` and :math:`\Sigma^{--}` from the equation
+
+.. math::
+   \begin{bmatrix}
+   \Sigma^{++} \\
+   \Sigma^{+-} \\
+   \Sigma^{-+} \\
+   \Sigma^{--}
+   \end{bmatrix}
+   = \bm{M}
+   \begin{bmatrix}
+   I^{00} \\
+   I^{01} \\
+   I^{10} \\
+   I^{11}
+   \end{bmatrix},
+
+where :math:`I^{jk}` are the experimental count rates for flipper configuration :math:`jk` and :math:`\bm{M}` is the four-by-four correction matrix as defined by equations (4) in [#WILDES]_.
+
+Flipper configurations
+######################
+
+*InputWorkspaces* is a list containing one to four workspace names (X unit: wavelength) corresponding to the instrument configurations given as *Flippers*. Supported configurations are:
+
+:literal:`'00, 01, 10, 11'`
+   Full polarization corrections. Four input workspaces are required. They should be in the input group in the following order: both flippers off, polarizer flipper on, analyzer flipper on, both flippers on.
+
+:literal:`'00, 01, 11'` and :literal:`'00, 10, 11'`
+   Polarization corrections with the assumption that the corrected count rates :math:`\Sigma^{+-} = \Sigma^{-+}`. In this case the intensity of the missing flipper configuration (01 or 10) can be solved from the other intensities. Workspaces in the input group should be in the following order: both flippers off, one flipper on, both flippers on.
+
+:literal:`'00, 11'`
+   Polarization corrections with the assumption that the corrected count rates :math:`\Sigma^{+-} = \Sigma^{-+} = 0`. In this case the intensities of the missing flipper configurations (01 and 11) can be solved from the other intensities. Workspaces in the input group should be in the following order: both flippers off, both flippers on.
+
+:literal:`'0, 1'`
+   Polarization corrections when no analyzer has been used. Workspaces in the input group should be in the following order: polarizer flipper off, polarizer flipper on.
+
+:literal:`'0'`
+   Polarization corrections for a direct beam measurement in a reflectometry experiment.
+
+Output
+######
+
+The algorithm's output is a group workspace containing the corrected workspaces. The names of each corrected workspace is prefixed by :literal:`_++`, :literal:`_+-`, :literal:`_-+` or :literal:`_--` depending on which :math:`\Sigma^{mn}` they correspond to.
+
+Efficiency factors
+##################
+
+The *Efficiencies* input property expects to get a workspace with the following properties:
+
+* Contains four histograms, each labeled by their vertical axis as :literal:`P1`, :literal:`P2`, :literal:`F1`, :literal:`F2`. Other histograms (if present) are ignored.
+* The Y values of each histogram should be the corresponding efficiencies as functions of wavelength as defined in [#WILDES]_.
+* The wavelength values (X values) should be the same is in the input workspaces.
+
+.. note::
+   Users at ILL can load a conforming efficiency workspace from disk by :ref:`algm-LoadILLPolarizationFactors`.
+
+Error propagation
+#################
+
+.. note::
+   Errors are calculated as per Wildes [#WILDES]_, except for the numerically solved intensity in :literal:`'00, 01, 11'` and :literal:`'00, 10, 11'` flipper configurations in which case the uncertainties of :math:`\Sigma^{+-}` or :math:`\Sigma^{-+}` are set to zero.
+
+Usage
+-----
+
+.. include:: ../usagedata-note.txt
+
+**Example - PolarizationEfficiencyCor**
+
+.. testcode:: PolarizationEfficiencyCorExample
+
+   LoadILLReflectometry(
+       Filename='ILL/D17/317370.nxs',
+       OutputWorkspace='direct_beam',
+       OutputBeamPosition='direct_beam_position',
+       XUnit='TimeOfFlight')
+   LoadILLReflectometry(
+       Filename='ILL/D17/317370.nxs',
+       OutputWorkspace='reflected_beam',
+       BeamPosition='direct_beam_position',
+       XUnit='TimeOfFlight')
+   # Sum pixels containing the reflected intensity
+   GroupDetectors(
+       InputWorkspace='reflected_beam',
+       OutputWorkspace='reflected_beam',
+       WorkspaceIndexList=[199, 200, 201, 202, 203, 204, 205])
+   ConvertUnits(
+       InputWorkspace='reflected_beam',
+       OutputWorkspace='reflected_beam',
+       Target='Wavelength',
+       EMode='Elastic')
+   # There are some unphysical wavelengths
+   CropWorkspace(
+       InputWorkspace='reflected_beam',
+       OutputWorkspace='reflected_beam',
+       XMin=0.)
+   # Fake two flipper configurations 
+   RenameWorkspace(
+       InputWorkspace='reflected_beam',
+       OutputWorkspace='up'
+   )
+   CloneWorkspace(
+       InputWorkspace='up',
+       OutputWorkspace='down'
+   )
+   Scale(
+       InputWorkspace='down',
+       OutputWorkspace='down',
+       Factor=0.1
+   )
+   LoadILLPolarizationFactors(
+       Filename='ILL/D17/PolarizationFactors.txt',
+       OutputWorkspace='efficiencies',
+       WavelengthReference='up')
+   PolarizationEfficiencyCor(
+       InputWorkspaces='up, down',
+       OutputWorkspace='corrected',
+       Efficiencies='efficiencies',
+       Flippers='00, 11')
+   
+   orig = mtd['up']
+   corr = mtd['corrected_++']
+   index = orig.binIndexOf(15.)
+   ratio_up = corr.readY(0)[index] / orig.readY(0)[index]
+   print("Ratio of corrected and original 'up' intensity at 15A: {:.4}".format(ratio_up))
+   orig = mtd['down']
+   corr = mtd['corrected_--']
+   index = orig.binIndexOf(15.)
+   ratio_down = corr.readY(0)[index] / orig.readY(0)[index]
+   print("Ratio of corrected and original 'down' intensity at 15A: {:.4}".format(ratio_down))
+
+Output:
+
+.. testoutput:: PolarizationEfficiencyCorExample
+
+   Ratio of corrected and original 'up' intensity at 15A: 1.038
+   Ratio of corrected and original 'down' intensity at 15A: 1.062
+
+References
+----------
+
+.. [#WILDES] A. R. Wildes, *Neutron News*, **17** 17 (2006)
+             `doi: 10.1080/10448630600668738 <https://doi.org/10.1080/10448630600668738>`_
+
+.. categories::
+
+.. sourcelink::
+

--- a/docs/source/release/v3.12.0/reflectometry.rst
+++ b/docs/source/release/v3.12.0/reflectometry.rst
@@ -61,6 +61,7 @@ Algorithms
 New features
 ############
 
+- The new algorithm :ref:`algm-PolarizationEfficiencyCor` corrects for efficiencies in polarization analysis.
 - The new algorithm :ref:`algm-LoadILLPolarizationFactors` can load the polarization efficiency files used on D17 at ILL.
 - The new algorithm :ref:`algm-MRInspectData` takes in raw event data and determines reduction parameters.
 


### PR DESCRIPTION
This PR introduces new `PolarizationEfficiencyCor` algorithm for reflectometrer polarization analysis. The polarization corrections are based on [A. R. Wildes (2006), Neutron News, 17:2, 17-25].

**To test:**

Scientific validation will be done by scientists at ILL. For the purpose of this PR, try to break the algorithm. The following script could serve as a basis for testing:
```python
# The unit test data dir has to be in Mantid's data search directories.
ws00 = CreateSampleWorkspace(
    Function='Quasielastic',
    NumBanks=1,
    BankPixelWidth=1,
    XUnit='Wavelength',
    XMin=0.1,
    XMax=10.,
    BinWidth=0.1
)
ws01 = CloneWorkspace(ws00)
ws10 = CloneWorkspace(ws00)
ws11 = CloneWorkspace(ws00)

factors = LoadILLPolarizationFactors(
    Filename='ILL/D17/PolarizationFactors.txt',
    WavelengthReference=ws00
)

PolarizationEfficiencyCor(
    Inputworkspaces='ws00, ws01, ws10, ws11',
    OutputWorkspace='corr',
    Efficiencies=factors,
    Flippers='00, 01, 10, 11'
)
```

Fixes #20962.

**Release Notes** 

A note was added to the reflectometry release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
