### PR TITLE
Add getGoniometerMatrix method to IPeak

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -126,7 +126,7 @@ public:
 
   double getInitialEnergy() const override;
   double getFinalEnergy() const override;
-  double getEnergy() const override;
+  double getEnergyTransfer() const override;
   void setInitialEnergy(double m_initialEnergy) override;
   void setFinalEnergy(double m_finalEnergy) override;
 

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -714,7 +714,9 @@ double Peak::getFinalEnergy() const { return m_finalEnergy; }
 double Peak::getInitialEnergy() const { return m_initialEnergy; }
 
 /** Get the difference between the initial and final neutron energy */
-double Peak::getEnergyTransfer() const { return getInitialEnergy() - getFinalEnergy(); }
+double Peak::getEnergyTransfer() const {
+  return getInitialEnergy() - getFinalEnergy();
+}
 
 //----------------------------------------------------------------------------------------------
 /** Get the H index of the peak */

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -846,7 +846,7 @@ void Peak::setGoniometerMatrix(
   m_InverseGoniometerMatrix = m_GoniometerMatrix;
   if (fabs(m_InverseGoniometerMatrix.Invert()) < 1e-8)
     throw std::invalid_argument(
-        "Peak::setGoniometerMatrix(): Goniometer matrix must non-singular.");
+        "Peak::setGoniometerMatrix(): Goniometer matrix must be non-singular.");
 }
 
 // -------------------------------------------------------------------------------------

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -714,7 +714,7 @@ double Peak::getFinalEnergy() const { return m_finalEnergy; }
 double Peak::getInitialEnergy() const { return m_initialEnergy; }
 
 /** Get the difference between the initial and final neutron energy */
-double Peak::getEnergy() const { return getInitialEnergy() - getFinalEnergy(); }
+double Peak::getEnergyTransfer() const { return getInitialEnergy() - getFinalEnergy(); }
 
 //----------------------------------------------------------------------------------------------
 /** Get the H index of the peak */

--- a/Framework/DataObjects/test/PeakTest.h
+++ b/Framework/DataObjects/test/PeakTest.h
@@ -594,7 +594,7 @@ public:
     p.setInitialEnergy(initialEnergy);
     p.setFinalEnergy(finalEnergy);
 
-    TS_ASSERT_EQUALS(p.getEnergy(), initialEnergy - finalEnergy);
+    TS_ASSERT_EQUALS(p.getEnergyTransfer(), initialEnergy - finalEnergy);
   }
 
 private:

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/IPeak.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/IPeak.h
@@ -63,7 +63,7 @@ public:
 
   virtual double getInitialEnergy() const = 0;
   virtual double getFinalEnergy() const = 0;
-  virtual double getEnergy() const = 0;
+  virtual double getEnergyTransfer() const = 0;
   virtual void setInitialEnergy(double m_InitialEnergy) = 0;
   virtual void setFinalEnergy(double m_FinalEnergy) = 0;
 

--- a/Framework/Geometry/test/MockObjects.h
+++ b/Framework/Geometry/test/MockObjects.h
@@ -91,7 +91,7 @@ public:
   MOCK_CONST_METHOD0(getTOF, double());
   MOCK_CONST_METHOD0(getInitialEnergy, double());
   MOCK_CONST_METHOD0(getFinalEnergy, double());
-  MOCK_CONST_METHOD0(getEnergy, double());
+  MOCK_CONST_METHOD0(getEnergyTransfer, double());
   MOCK_METHOD1(setInitialEnergy, void(double m_InitialEnergy));
   MOCK_METHOD1(setFinalEnergy, void(double m_FinalEnergy));
   MOCK_CONST_METHOD0(getIntensity, double());

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Policies/MatrixToNumpy.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Policies/MatrixToNumpy.h
@@ -23,7 +23,8 @@
     Code Documentation is available at: <http://doxygen.mantidproject.org>
  */
 #include "MantidKernel/System.h"
-#include "MantidPythonInterface/kernel/Converters/VectorToNDArray.h"
+#include "MantidPythonInterface/kernel/Converters/CloneToNumpy.h"
+#include "MantidPythonInterface/kernel/Converters/MatrixToNDArray.h"
 #include "MantidPythonInterface/kernel/Converters/PyArrayType.h"
 #include "MantidKernel/Matrix.h"
 
@@ -37,13 +38,27 @@ namespace PythonInterface {
 namespace Policies {
 
 namespace // anonymous
-    {
+{
+//-----------------------------------------------------------------------
+// MPL helper structs
+//-----------------------------------------------------------------------
+/// MPL struct to figure out if a type is a std::vector
+/// The general one inherits from boost::false_type
+template <typename T> struct is_matrix : boost::false_type {};
+
+/// Specialization for std::vector types to inherit from
+/// boost::true_type
+template <typename T> struct is_matrix<Kernel::Matrix<T>> : boost::true_type {};
+
+//-----------------------------------------------------------------------
+// MatrixRefToNumpyImpl - Policy for reference returns
+//-----------------------------------------------------------------------
 /**
  * Helper struct that implements the conversion
  * policy.
  */
 template <typename MatrixType, typename ConversionPolicy>
-struct ConvertMatrixToNDArray {
+struct MatrixRefToNumpyImpl {
   inline PyObject *operator()(const MatrixType &cmatrix) const {
     return Converters::MatrixToNDArray<typename MatrixType::value_type,
                                        ConversionPolicy>()(cmatrix);
@@ -53,23 +68,11 @@ struct ConvertMatrixToNDArray {
     return Converters::getNDArrayType();
   }
 };
-}
-
-//-----------------------------------------------------------------------
-// return_value_policy
-//-----------------------------------------------------------------------
-namespace {
-/// MPL struct to figure out if a type is a std::vector
-/// The general one inherits from boost::false_type
-template <typename T> struct is_matrix : boost::false_type {};
-
-/// Specialization for std::vector types to inherit from
-/// boost::true_type
-template <typename T> struct is_matrix<Kernel::Matrix<T>> : boost::true_type {};
 
 template <typename T>
-struct MatrixToNumpy_Requires_Reference_To_Matrix_Return_Type {};
+struct MatrixRefToNumpy_Requires_Reference_To_Matrix_Return_Type {};
 }
+
 /**
  * Implements a return value policy that
  * returns a numpy array from a Matrix
@@ -80,7 +83,7 @@ struct MatrixToNumpy_Requires_Reference_To_Matrix_Return_Type {};
  * (2) WrapReadWrite - Creates a read-write array around the original data (no
  *copy is performed)
  */
-template <typename ConversionPolicy> struct MatrixToNumpy {
+template <typename ConversionPolicy> struct MatrixRefToNumpy {
   // The boost::python framework calls return_value_policy::apply<T>::type
   template <class T> struct apply {
     // Typedef that removes and const or reference qualifiers from the return
@@ -91,8 +94,50 @@ template <typename ConversionPolicy> struct MatrixToNumpy {
     typedef typename boost::mpl::if_c<
         boost::mpl::and_<std::is_reference<T>,
                          is_matrix<non_const_type>>::value,
-        ConvertMatrixToNDArray<non_const_type, ConversionPolicy>,
-        MatrixToNumpy_Requires_Reference_To_Matrix_Return_Type<T>>::type type;
+        MatrixRefToNumpyImpl<non_const_type, ConversionPolicy>,
+        MatrixRefToNumpy_Requires_Reference_To_Matrix_Return_Type<T>>::type type;
+  };
+};
+
+//-----------------------------------------------------------------------
+// MatrixToNumpy return_value_policy
+//-----------------------------------------------------------------------
+namespace {
+/**
+ * Helper struct that implements the conversion policy. This can only clone
+ * as wrapping would wrap a temporary
+ */
+template <typename MatrixType> struct MatrixToNumpyImpl {
+  inline PyObject *operator()(const MatrixType &cvector) const {
+    return Converters::MatrixToNDArray<typename MatrixType::value_type,
+                                       Converters::Clone>()(cvector);
+  }
+
+  inline PyTypeObject const *get_pytype() const {
+    return Converters::getNDArrayType();
+  }
+};
+
+template <typename T>
+struct MatrixToNumpy_Requires_Matrix_Return_By_Value {};
+}
+
+/**
+ * Implements a return value policy that
+ * returns a numpy array from a function returning a std::vector by value
+ *
+ * It is only possible to clone these types since a wrapper would wrap temporary
+ */
+struct MatrixToNumpy {
+  // The boost::python framework calls return_value_policy::apply<T>::type
+  template <class T> struct apply {
+    // Typedef that removes any const from the type
+    typedef typename std::remove_const<T>::type non_const_type;
+    // MPL compile-time check that T is a std::vector
+    typedef typename boost::mpl::if_c<
+        is_matrix<non_const_type>::value,
+        MatrixRefToNumpyImpl<non_const_type, Converters::Clone>,
+        MatrixToNumpy_Requires_Matrix_Return_By_Value<T>>::type type;
   };
 };
 }

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Policies/MatrixToNumpy.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Policies/MatrixToNumpy.h
@@ -22,11 +22,11 @@
     File change history is stored at: <https://github.com/mantidproject/mantid>
     Code Documentation is available at: <http://doxygen.mantidproject.org>
  */
+#include "MantidKernel/Matrix.h"
 #include "MantidKernel/System.h"
 #include "MantidPythonInterface/kernel/Converters/CloneToNumpy.h"
 #include "MantidPythonInterface/kernel/Converters/MatrixToNDArray.h"
 #include "MantidPythonInterface/kernel/Converters/PyArrayType.h"
-#include "MantidKernel/Matrix.h"
 
 #include <type_traits>
 
@@ -95,7 +95,8 @@ template <typename ConversionPolicy> struct MatrixRefToNumpy {
         boost::mpl::and_<std::is_reference<T>,
                          is_matrix<non_const_type>>::value,
         MatrixRefToNumpyImpl<non_const_type, ConversionPolicy>,
-        MatrixRefToNumpy_Requires_Reference_To_Matrix_Return_Type<T>>::type type;
+        MatrixRefToNumpy_Requires_Reference_To_Matrix_Return_Type<T>>::type
+        type;
   };
 };
 
@@ -118,9 +119,8 @@ template <typename MatrixType> struct MatrixToNumpyImpl {
   }
 };
 
-template <typename T>
-struct MatrixToNumpy_Requires_Matrix_Return_By_Value {};
-}
+template <typename T> struct MatrixToNumpy_Requires_Matrix_Return_By_Value {};
+} // namespace
 
 /**
  * Implements a return value policy that

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Policies/MatrixToNumpy.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Policies/MatrixToNumpy.h
@@ -38,7 +38,7 @@ namespace PythonInterface {
 namespace Policies {
 
 namespace // anonymous
-{
+    {
 //-----------------------------------------------------------------------
 // MPL helper structs
 //-----------------------------------------------------------------------

--- a/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
@@ -1,9 +1,9 @@
-#include "MantidPythonInterface/kernel/GetPointer.h"
 #include "MantidGeometry/Crystal/IPeak.h"
+#include "MantidPythonInterface/kernel/Converters/PyObjectToMatrix.h"
+#include "MantidPythonInterface/kernel/GetPointer.h"
+#include <boost/optional.hpp>
 #include <boost/python/class.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
-#include "MantidPythonInterface/kernel/Converters/PyObjectToMatrix.h"
-#include <boost/optional.hpp>
 
 using Mantid::Geometry::IPeak;
 using namespace boost::python;
@@ -40,7 +40,7 @@ void setQSampleFrame2(IPeak &peak, Mantid::Kernel::V3D qSampleFrame,
 void setGoniometerMatrix(IPeak &self, const object &data) {
   self.setGoniometerMatrix(Converters::PyObjectToMatrix(data)());
 }
-}
+} // namespace
 
 void export_IPeak() {
   register_ptr_to_python<IPeak *>();
@@ -102,9 +102,10 @@ void export_IPeak() {
            "supplied.") // two argument
                         // overload
       .def("setQSampleFrame", setQSampleFrame1,
-           (arg("self"), arg("qsample_frame")), "Set the peak using the peak's "
-                                                "position in reciprocal space, "
-                                                "in the sample frame.")
+           (arg("self"), arg("qsample_frame")),
+           "Set the peak using the peak's "
+           "position in reciprocal space, "
+           "in the sample frame.")
       .def("setQSampleFrame", setQSampleFrame2,
            (arg("self"), arg("qsample_frame"), arg("distance")),
            "Set the peak using the peak's position in reciprocal space, in the "
@@ -128,6 +129,8 @@ void export_IPeak() {
            "Get the initial (incident) neutron energy")
       .def("getFinalEnergy", &IPeak::getFinalEnergy, arg("self"),
            "Get the final neutron energy")
+      .def("getEnergy", &IPeak::getEnergy, arg("self"),
+           "Get the initial neutron energy minus the final neutron energy")
       .def("setInitialEnergy", &IPeak::setInitialEnergy,
            (arg("self"), arg("initial_energy")),
            "Set the initial (incident) neutron energy")
@@ -137,6 +140,9 @@ void export_IPeak() {
            "Return the integrated peak intensity")
       .def("getSigmaIntensity", &IPeak::getSigmaIntensity, arg("self"),
            "Return the error on the integrated peak intensity")
+      .def("getIntensityOverSigma", &IPeak::getIntensityOverSigma, arg("self"),
+           "Return the error on the integrated peak intensity divided by the "
+           "error in intensity")
       .def("setIntensity", &IPeak::setIntensity,
            (arg("self"), arg("intensity")), "Set the integrated peak intensity")
       .def("setSigmaIntensity", &IPeak::setSigmaIntensity,

--- a/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
@@ -102,10 +102,9 @@ void export_IPeak() {
            "supplied.") // two argument
                         // overload
       .def("setQSampleFrame", setQSampleFrame1,
-           (arg("self"), arg("qsample_frame")),
-           "Set the peak using the peak's "
-           "position in reciprocal space, "
-           "in the sample frame.")
+           (arg("self"), arg("qsample_frame")), "Set the peak using the peak's "
+                                                "position in reciprocal space, "
+                                                "in the sample frame.")
       .def("setQSampleFrame", setQSampleFrame2,
            (arg("self"), arg("qsample_frame"), arg("distance")),
            "Set the peak using the peak's position in reciprocal space, in the "

--- a/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
@@ -1,11 +1,14 @@
 #include "MantidGeometry/Crystal/IPeak.h"
 #include "MantidPythonInterface/kernel/Converters/PyObjectToMatrix.h"
+#include "MantidPythonInterface/kernel/Converters/CloneToNumpy.h"
+#include "MantidPythonInterface/kernel/Policies/MatrixToNumpy.h"
 #include "MantidPythonInterface/kernel/GetPointer.h"
 #include <boost/optional.hpp>
 #include <boost/python/class.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
 
 using Mantid::Geometry::IPeak;
+using namespace Mantid::PythonInterface;
 using namespace boost::python;
 
 GET_POINTER_SPECIALIZATION(IPeak)
@@ -40,9 +43,14 @@ void setQSampleFrame2(IPeak &peak, Mantid::Kernel::V3D qSampleFrame,
 void setGoniometerMatrix(IPeak &self, const object &data) {
   self.setGoniometerMatrix(Converters::PyObjectToMatrix(data)());
 }
+
 } // namespace
 
 void export_IPeak() {
+  // return_value_policy for read-only numpy array
+  typedef return_value_policy<Policies::MatrixToNumpy>
+      return_copy_to_numpy;
+  
   register_ptr_to_python<IPeak *>();
 
   class_<IPeak, boost::noncopyable>("IPeak", no_init)
@@ -152,9 +160,13 @@ void export_IPeak() {
            "Return the # of counts in the bin at its peak")
       .def("setBinCount", &IPeak::setBinCount, (arg("self"), arg("bin_count")),
            "Set the # of counts in the bin at its peak")
+      .def("getGoniometerMatrix", &IPeak::getGoniometerMatrix,
+           arg("self"), return_copy_to_numpy(),
+           "Get the :class:`~mantid.geometry.Goniometer` rotation matrix of this peak."
+           "\n\n.. versionadded:: 3.12.0")
       .def("setGoniometerMatrix", &setGoniometerMatrix,
            (arg("self"), arg("goniometerMatrix")),
-           "Set the :class:`~mantid.geometry.Goniometer` of the peak")
+           "Set the :class:`~mantid.geometry.Goniometer` rotation matrix of this peak.")
       .def("getRow", &IPeak::getRow, arg("self"),
            "For :class:`~mantid.geometry.RectangularDetector` s only, returns "
            "the row (y) of the pixel of the "

--- a/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
@@ -1,8 +1,8 @@
 #include "MantidGeometry/Crystal/IPeak.h"
-#include "MantidPythonInterface/kernel/Converters/PyObjectToMatrix.h"
 #include "MantidPythonInterface/kernel/Converters/CloneToNumpy.h"
-#include "MantidPythonInterface/kernel/Policies/MatrixToNumpy.h"
+#include "MantidPythonInterface/kernel/Converters/PyObjectToMatrix.h"
 #include "MantidPythonInterface/kernel/GetPointer.h"
+#include "MantidPythonInterface/kernel/Policies/MatrixToNumpy.h"
 #include <boost/optional.hpp>
 #include <boost/python/class.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
@@ -48,9 +48,8 @@ void setGoniometerMatrix(IPeak &self, const object &data) {
 
 void export_IPeak() {
   // return_value_policy for read-only numpy array
-  typedef return_value_policy<Policies::MatrixToNumpy>
-      return_copy_to_numpy;
-  
+  typedef return_value_policy<Policies::MatrixToNumpy> return_copy_to_numpy;
+
   register_ptr_to_python<IPeak *>();
 
   class_<IPeak, boost::noncopyable>("IPeak", no_init)
@@ -110,9 +109,10 @@ void export_IPeak() {
            "supplied.") // two argument
                         // overload
       .def("setQSampleFrame", setQSampleFrame1,
-           (arg("self"), arg("qsample_frame")), "Set the peak using the peak's "
-                                                "position in reciprocal space, "
-                                                "in the sample frame.")
+           (arg("self"), arg("qsample_frame")),
+           "Set the peak using the peak's "
+           "position in reciprocal space, "
+           "in the sample frame.")
       .def("setQSampleFrame", setQSampleFrame2,
            (arg("self"), arg("qsample_frame"), arg("distance")),
            "Set the peak using the peak's position in reciprocal space, in the "
@@ -160,13 +160,15 @@ void export_IPeak() {
            "Return the # of counts in the bin at its peak")
       .def("setBinCount", &IPeak::setBinCount, (arg("self"), arg("bin_count")),
            "Set the # of counts in the bin at its peak")
-      .def("getGoniometerMatrix", &IPeak::getGoniometerMatrix,
-           arg("self"), return_copy_to_numpy(),
-           "Get the :class:`~mantid.geometry.Goniometer` rotation matrix of this peak."
+      .def("getGoniometerMatrix", &IPeak::getGoniometerMatrix, arg("self"),
+           return_copy_to_numpy(),
+           "Get the :class:`~mantid.geometry.Goniometer` rotation matrix of "
+           "this peak."
            "\n\n.. versionadded:: 3.12.0")
       .def("setGoniometerMatrix", &setGoniometerMatrix,
            (arg("self"), arg("goniometerMatrix")),
-           "Set the :class:`~mantid.geometry.Goniometer` rotation matrix of this peak.")
+           "Set the :class:`~mantid.geometry.Goniometer` rotation matrix of "
+           "this peak.")
       .def("getRow", &IPeak::getRow, arg("self"),
            "For :class:`~mantid.geometry.RectangularDetector` s only, returns "
            "the row (y) of the pixel of the "

--- a/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
@@ -109,10 +109,9 @@ void export_IPeak() {
            "supplied.") // two argument
                         // overload
       .def("setQSampleFrame", setQSampleFrame1,
-           (arg("self"), arg("qsample_frame")),
-           "Set the peak using the peak's "
-           "position in reciprocal space, "
-           "in the sample frame.")
+           (arg("self"), arg("qsample_frame")), "Set the peak using the peak's "
+                                                "position in reciprocal space, "
+                                                "in the sample frame.")
       .def("setQSampleFrame", setQSampleFrame2,
            (arg("self"), arg("qsample_frame"), arg("distance")),
            "Set the peak using the peak's position in reciprocal space, in the "

--- a/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
@@ -102,9 +102,10 @@ void export_IPeak() {
            "supplied.") // two argument
                         // overload
       .def("setQSampleFrame", setQSampleFrame1,
-           (arg("self"), arg("qsample_frame")), "Set the peak using the peak's "
-                                                "position in reciprocal space, "
-                                                "in the sample frame.")
+           (arg("self"), arg("qsample_frame")),
+           "Set the peak using the peak's "
+           "position in reciprocal space, "
+           "in the sample frame.")
       .def("setQSampleFrame", setQSampleFrame2,
            (arg("self"), arg("qsample_frame"), arg("distance")),
            "Set the peak using the peak's position in reciprocal space, in the "

--- a/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
@@ -128,8 +128,9 @@ void export_IPeak() {
            "Get the initial (incident) neutron energy")
       .def("getFinalEnergy", &IPeak::getFinalEnergy, arg("self"),
            "Get the final neutron energy")
-      .def("getEnergy", &IPeak::getEnergy, arg("self"),
-           "Get the initial neutron energy minus the final neutron energy")
+      .def("getEnergyTransfer", &IPeak::getEnergyTransfer, arg("self"),
+           "Get the initial neutron energy minus the final neutron energy."
+           "\n\n.. versionadded:: 3.12.0")
       .def("setInitialEnergy", &IPeak::setInitialEnergy,
            (arg("self"), arg("initial_energy")),
            "Set the initial (incident) neutron energy")
@@ -141,7 +142,7 @@ void export_IPeak() {
            "Return the error on the integrated peak intensity")
       .def("getIntensityOverSigma", &IPeak::getIntensityOverSigma, arg("self"),
            "Return the error on the integrated peak intensity divided by the "
-           "error in intensity")
+           "error in intensity.\n\n.. versionadded:: 3.12.0")
       .def("setIntensity", &IPeak::setIntensity,
            (arg("self"), arg("intensity")), "Set the integrated peak intensity")
       .def("setSigmaIntensity", &IPeak::setSigmaIntensity,

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
@@ -42,7 +42,8 @@ void setR(Goniometer &self, const object &data) {
 void export_Goniometer() {
 
   // return_value_policy for read-only numpy array
-  typedef return_value_policy<Policies::MatrixRefToNumpy<Converters::WrapReadOnly>>
+  typedef return_value_policy<
+      Policies::MatrixRefToNumpy<Converters::WrapReadOnly>>
       return_readonly_numpy;
 
   class_<Goniometer>("Goniometer", init<>(arg("self")))

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
@@ -42,7 +42,7 @@ void setR(Goniometer &self, const object &data) {
 void export_Goniometer() {
 
   // return_value_policy for read-only numpy array
-  typedef return_value_policy<Policies::MatrixToNumpy<Converters::WrapReadOnly>>
+  typedef return_value_policy<Policies::MatrixRefToNumpy<Converters::WrapReadOnly>>
       return_readonly_numpy;
 
   class_<Goniometer>("Goniometer", init<>(arg("self")))

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
@@ -42,9 +42,8 @@ void setR(Goniometer &self, const object &data) {
 void export_Goniometer() {
 
   // return_value_policy for read-only numpy array
-  typedef return_value_policy<
-      Policies::MatrixRefToNumpy<Converters::WrapReadOnly>>
-      return_readonly_numpy;
+  typedef return_value_policy<Policies::MatrixRefToNumpy<
+      Converters::WrapReadOnly>> return_readonly_numpy;
 
   class_<Goniometer>("Goniometer", init<>(arg("self")))
       .def(init<Goniometer const &>((arg("self"), arg("other"))))

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/OrientedLattice.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/OrientedLattice.cpp
@@ -45,7 +45,8 @@ Mantid::Kernel::V3D hklFromQ(OrientedLattice &self, const object &vec) {
 
 void export_OrientedLattice() {
   /// return_value_policy for read-only numpy array
-  typedef return_value_policy<Policies::MatrixRefToNumpy<Converters::WrapReadOnly>>
+  typedef return_value_policy<
+      Policies::MatrixRefToNumpy<Converters::WrapReadOnly>>
       return_readonly_numpy;
 
   class_<OrientedLattice, bases<UnitCell>>(

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/OrientedLattice.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/OrientedLattice.cpp
@@ -45,7 +45,7 @@ Mantid::Kernel::V3D hklFromQ(OrientedLattice &self, const object &vec) {
 
 void export_OrientedLattice() {
   /// return_value_policy for read-only numpy array
-  typedef return_value_policy<Policies::MatrixToNumpy<Converters::WrapReadOnly>>
+  typedef return_value_policy<Policies::MatrixRefToNumpy<Converters::WrapReadOnly>>
       return_readonly_numpy;
 
   class_<OrientedLattice, bases<UnitCell>>(

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/OrientedLattice.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/OrientedLattice.cpp
@@ -45,9 +45,8 @@ Mantid::Kernel::V3D hklFromQ(OrientedLattice &self, const object &vec) {
 
 void export_OrientedLattice() {
   /// return_value_policy for read-only numpy array
-  typedef return_value_policy<
-      Policies::MatrixRefToNumpy<Converters::WrapReadOnly>>
-      return_readonly_numpy;
+  typedef return_value_policy<Policies::MatrixRefToNumpy<
+      Converters::WrapReadOnly>> return_readonly_numpy;
 
   class_<OrientedLattice, bases<UnitCell>>(
       "OrientedLattice",

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/UnitCell.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/UnitCell.cpp
@@ -67,7 +67,8 @@ void export_UnitCell() {
       .export_values();
 
   /// return_value_policy for read-only numpy array
-  typedef return_value_policy<Policies::MatrixRefToNumpy<Converters::WrapReadOnly>>
+  typedef return_value_policy<
+      Policies::MatrixRefToNumpy<Converters::WrapReadOnly>>
       return_readonly_numpy;
 
   class_<UnitCell>(

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/UnitCell.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/UnitCell.cpp
@@ -67,7 +67,7 @@ void export_UnitCell() {
       .export_values();
 
   /// return_value_policy for read-only numpy array
-  typedef return_value_policy<Policies::MatrixToNumpy<Converters::WrapReadOnly>>
+  typedef return_value_policy<Policies::MatrixRefToNumpy<Converters::WrapReadOnly>>
       return_readonly_numpy;
 
   class_<UnitCell>(

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/UnitCell.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/UnitCell.cpp
@@ -67,9 +67,8 @@ void export_UnitCell() {
       .export_values();
 
   /// return_value_policy for read-only numpy array
-  typedef return_value_policy<
-      Policies::MatrixRefToNumpy<Converters::WrapReadOnly>>
-      return_readonly_numpy;
+  typedef return_value_policy<Policies::MatrixRefToNumpy<
+      Converters::WrapReadOnly>> return_readonly_numpy;
 
   class_<UnitCell>(
       "UnitCell",

--- a/Framework/PythonInterface/test/python/mantid/geometry/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/mantid/geometry/CMakeLists.txt
@@ -6,6 +6,7 @@ set ( TEST_PY_FILES
   CSGObjectTest.py
   GoniometerTest.py
   IComponentTest.py
+  IPeakTest.py
   InstrumentTest.py
   OrientedLatticeTest.py
   RectangularDetectorTest.py

--- a/Framework/PythonInterface/test/python/mantid/geometry/IPeakTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/IPeakTest.py
@@ -98,7 +98,7 @@ class IPeakTest(unittest.TestCase):
         det_id = 101
         expected_scattering_angle = 2.878973314094696
         self._peak.setDetectorID(det_id)
-        self.assertEqual(self._peak.getScattering(), expected_scattering_angle)
+        self.assertAlmostEqual(self._peak.getScattering(), expected_scattering_angle)
 
     def test_get_tof(self):
         det_id = 101
@@ -131,7 +131,7 @@ class IPeakTest(unittest.TestCase):
         final_energy = 10.0
         self._peak.setFinalEnergy(final_energy)
         self._peak.setInitialEnergy(initial_energy)
-        self.assertAlmostEqual(self._peak.getEnergy(), initial_energy - final_energy)
+        self.assertAlmostEqual(self._peak.getEnergyTransfer(), initial_energy - final_energy)
 
     def test_set_intensity(self):
         intensity = 10.0
@@ -166,7 +166,7 @@ class IPeakTest(unittest.TestCase):
         det_id = 101
         expected_det_pos = np.array([0.061999,  0.0135, -0.236032])
         self._peak.setDetectorID(det_id)
-        npt.assert_almost_equal(self._peak.getDetPos(), expected_det_pos, self._tolerance)
+        npt.assert_allclose(self._peak.getDetPos(), expected_det_pos, atol=self._tolerance)
 
     def test_get_l1(self):
         det_id = 101

--- a/Framework/PythonInterface/test/python/mantid/geometry/IPeakTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/IPeakTest.py
@@ -1,0 +1,185 @@
+import unittest
+from mantid.kernel import V3D
+from mantid.simpleapi import CreateSimulationWorkspace, CreatePeaksWorkspace
+import numpy as np
+import numpy.testing as npt
+
+
+class IPeakTest(unittest.TestCase):
+
+    def setUp(self):
+        # IPeak cannot currently be instatiated so this is a quick way
+        # getting a handle to a peak object
+        ws = CreateSimulationWorkspace("SXD", BinParams="1,1,10")
+        peaks = CreatePeaksWorkspace(ws, 1)
+        self._peak = peaks.getPeak(0)
+
+        # tolerance for differences in q vectors that a recomputed
+        # on every call.
+        self._tolerance = 1e-2
+
+    def test_set_detector_id_with_valid_id(self):
+        det_id = 101
+        self._peak.setDetectorID(det_id)
+        self.assertEqual(self._peak.getDetectorID(), det_id)
+
+    def test_set_detector_id_with_invalid_id(self):
+        det_id = -1
+        self.assertRaises(RuntimeError, self._peak.setDetectorID, det_id)
+
+    def test_set_run_number(self):
+        run_number = 101
+        self._peak.setRunNumber(run_number)
+        self.assertEqual(self._peak.getRunNumber(), run_number)
+
+    def test_set_monitor_count(self):
+        mon_count = 3
+        self._peak.setMonitorCount(mon_count)
+        self.assertEqual(self._peak.getMonitorCount(), mon_count)
+
+    def test_set_hkl_all_at_once(self):
+        H, K, L = 1, 2, 3
+        self._peak.setHKL(H, K, L)
+
+        self.assertEqual(self._peak.getH(), H)
+        self.assertEqual(self._peak.getK(), K)
+        self.assertEqual(self._peak.getL(), L)
+
+    def test_set_hkl_individually(self):
+        H, K, L = 1, 2, 3
+        self._peak.setH(H)
+        self._peak.setK(K)
+        self._peak.setL(L)
+
+        self.assertEqual(self._peak.getH(), H)
+        self.assertEqual(self._peak.getK(), K)
+        self.assertEqual(self._peak.getL(), L)
+
+    def test_set_q_lab_frame(self):
+        q_lab = V3D(0, 1, 1)
+        self._peak.setQLabFrame(q_lab)
+
+        npt.assert_allclose(self._peak.getQLabFrame(), q_lab, atol=self._tolerance)
+        npt.assert_allclose(self._peak.getQSampleFrame(), q_lab, atol=self._tolerance)
+
+    def test_set_q_sample_frame(self):
+        q_sample = V3D(0, 1, 1)
+        self._peak.setQSampleFrame(q_sample)
+
+        npt.assert_allclose(self._peak.getQSampleFrame(), q_sample, atol=self._tolerance)
+        npt.assert_allclose(self._peak.getQLabFrame(), q_sample, atol=self._tolerance)
+
+    def test_set_goniometer_matrix_with_valid_matrix(self):
+        angle = np.pi/4
+        rotation = np.array([
+            [np.cos(angle), -np.sin(angle), 0],
+            [np.sin(angle), np.cos(angle), 0],
+            [0, 0, 1]
+        ])
+        q_sample = V3D(1, 1, 1)
+
+        self._peak.setGoniometerMatrix(rotation)
+        self._peak.setQSampleFrame(q_sample)
+
+        q_lab = np.dot(self._peak.getQLabFrame(), rotation)
+        npt.assert_allclose(self._peak.getQSampleFrame(), q_sample, atol=self._tolerance)
+        npt.assert_allclose(q_lab, q_sample, atol=self._tolerance)
+
+    def test_set_goniometer_matrix_with_singular_matrix(self):
+        rotation = np.zeros((3,3))
+        self.assertRaises(ValueError, self._peak.setGoniometerMatrix, rotation)
+
+    def test_set_wavelength(self):
+        wavelength = 1.3
+        self._peak.setWavelength(wavelength)
+        self.assertAlmostEqual(self._peak.getWavelength(), wavelength)
+
+    def test_get_scattering(self):
+        det_id = 101
+        expected_scattering_angle = 2.878973314094696
+        self._peak.setDetectorID(det_id)
+        self.assertEqual(self._peak.getScattering(), expected_scattering_angle)
+
+    def test_get_tof(self):
+        det_id = 101
+        wavelength = 1.9
+        expected_tof = 4103.70182610731
+        self._peak.setDetectorID(det_id)
+        self._peak.setWavelength(wavelength)
+        self.assertEqual(self._peak.getTOF(), expected_tof)
+
+    def test_get_d_spacing(self):
+        det_id = 101
+        wavelength = 1.9
+        expected_d = 0.958249313959493
+        self._peak.setDetectorID(det_id)
+        self._peak.setWavelength(wavelength)
+        self.assertEqual(self._peak.getDSpacing(), expected_d)
+
+    def test_set_initial_energy(self):
+        initial_energy = 10.0
+        self._peak.setInitialEnergy(initial_energy)
+        self.assertAlmostEqual(self._peak.getInitialEnergy(), initial_energy)
+
+    def test_set_final_energy(self):
+        final_energy = 10.0
+        self._peak.setFinalEnergy(final_energy)
+        self.assertAlmostEqual(self._peak.getFinalEnergy(), final_energy)
+
+    def test_get_energy(self):
+        initial_energy = 10.0
+        final_energy = 10.0
+        self._peak.setFinalEnergy(final_energy)
+        self._peak.setInitialEnergy(initial_energy)
+        self.assertAlmostEqual(self._peak.getEnergy(), initial_energy - final_energy)
+
+    def test_set_intensity(self):
+        intensity = 10.0
+        self._peak.setIntensity(intensity)
+        self.assertAlmostEqual(self._peak.getIntensity(), intensity)
+
+    def test_set_sigma_intensity(self):
+        sigma = 10.0
+        self._peak.setSigmaIntensity(sigma)
+        self.assertAlmostEqual(self._peak.getSigmaIntensity(), sigma)
+
+    def test_get_intensity_over_sigma(self):
+        intensity = 100.0
+        sigma = 10.0
+        self._peak.setIntensity(intensity)
+        self._peak.setSigmaIntensity(sigma)
+        self.assertAlmostEqual(self._peak.getIntensityOverSigma(), intensity / sigma)
+
+    def test_set_bin_count(self):
+        bin_count = 10.0
+        self._peak.setBinCount(bin_count)
+        self.assertAlmostEqual(self._peak.getBinCount(), bin_count)
+
+    def test_get_row_and_column(self):
+        det_id = 101
+        row, col = 36, 1
+        self._peak.setDetectorID(det_id)
+        self.assertEqual(self._peak.getRow(), row)
+        self.assertEqual(self._peak.getCol(), col)
+
+    def test_get_det_pos(self):
+        det_id = 101
+        expected_det_pos = np.array([0.061999,  0.0135, -0.236032])
+        self._peak.setDetectorID(det_id)
+        npt.assert_almost_equal(self._peak.getDetPos(), expected_det_pos, self._tolerance)
+
+    def test_get_l1(self):
+        det_id = 101
+        expected_l1 = 8.3
+        self._peak.setDetectorID(det_id)
+        self.assertEqual(self._peak.getL1(), expected_l1)
+
+    def test_get_l2(self):
+        det_id = 101
+        expected_l2 = 0.2444125610784556
+        self._peak.setDetectorID(det_id)
+        self.assertEqual(self._peak.getL2(), expected_l2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Framework/PythonInterface/test/python/mantid/geometry/IPeakTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/IPeakTest.py
@@ -82,6 +82,7 @@ class IPeakTest(unittest.TestCase):
         self._peak.setQSampleFrame(q_sample)
 
         q_lab = np.dot(self._peak.getQLabFrame(), rotation)
+        npt.assert_allclose(self._peak.getGoniometerMatrix(), rotation)
         npt.assert_allclose(self._peak.getQSampleFrame(), q_sample, atol=self._tolerance)
         npt.assert_allclose(q_lab, q_sample, atol=self._tolerance)
 

--- a/docs/source/release/v3.12.0/framework.rst
+++ b/docs/source/release/v3.12.0/framework.rst
@@ -75,7 +75,7 @@ In `mantid.simpleapi`, a keyword has been implemented for function-like algorith
 - The ``isDefault`` attribute for workspace properties now works correctly with workspaces not in the ADS.
 - The previously mentioned ``ConfigObserver`` and ``ConfigPropertyObserver`` classes are also exposed to python.
 - ``mantid.kernel.V3D`` vectors now support negation through the usual ``-`` operator.
-- ``mantid.api.IPeak`` has two new functions ``getEnergy`` which returns the difference between the initial and final energy and ``getIntensityOverSigma`` which gets the peak intensity divided by the error in intensity.
+- ``mantid.api.IPeak`` has two new functions ``getEnergyTransfer`` which returns the difference between the initial and final energy and ``getIntensityOverSigma`` which gets the peak intensity divided by the error in intensity.
 
 Support for unicode property names has been added to python. This means that one can run the following in python2 or python3.
 

--- a/docs/source/release/v3.12.0/framework.rst
+++ b/docs/source/release/v3.12.0/framework.rst
@@ -75,7 +75,10 @@ In `mantid.simpleapi`, a keyword has been implemented for function-like algorith
 - The ``isDefault`` attribute for workspace properties now works correctly with workspaces not in the ADS.
 - The previously mentioned ``ConfigObserver`` and ``ConfigPropertyObserver`` classes are also exposed to python.
 - ``mantid.kernel.V3D`` vectors now support negation through the usual ``-`` operator.
-- ``mantid.api.IPeak`` has two new functions ``getEnergyTransfer`` which returns the difference between the initial and final energy and ``getIntensityOverSigma`` which gets the peak intensity divided by the error in intensity.
+- ``mantid.api.IPeak`` has three new functions:
+    - ``getEnergyTransfer`` which returns the difference between the initial and final energy.
+    - ``getIntensityOverSigma`` which returns the peak intensity divided by the error in intensity.
+    - ``getGoniometerMatrix`` which returns the goniometer rotation matrix associated with the peak.
 
 Support for unicode property names has been added to python. This means that one can run the following in python2 or python3.
 

--- a/docs/source/release/v3.12.0/framework.rst
+++ b/docs/source/release/v3.12.0/framework.rst
@@ -75,6 +75,7 @@ In `mantid.simpleapi`, a keyword has been implemented for function-like algorith
 - The ``isDefault`` attribute for workspace properties now works correctly with workspaces not in the ADS.
 - The previously mentioned ``ConfigObserver`` and ``ConfigPropertyObserver`` classes are also exposed to python.
 - ``mantid.kernel.V3D`` vectors now support negation through the usual ``-`` operator.
+- ``mantid.api.IPeak`` has two new functions ``getEnergy`` which returns the difference between the initial and final energy and ``getIntensityOverSigma`` which gets the peak intensity divided by the error in intensity.
 
 Support for unicode property names has been added to python. This means that one can run the following in python2 or python3.
 

--- a/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/QPeaksTableModel.h
+++ b/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/QPeaksTableModel.h
@@ -89,7 +89,7 @@ public:
   /// Label for wavelength column
   static const QString WAVELENGTH;
   /// Label for change in energy column
-  static const QString ENERGY;
+  static const QString ENERGY_TRANSFER;
   /// Label for initial energy column
   static const QString INITIAL_ENERGY;
   /// Label for final energy column
@@ -134,7 +134,7 @@ private:
   /// Index for wavelength column
   static const int COL_WAVELENGTH;
   /// Index for change in energy column
-  static const int COL_ENERGY;
+  static const int COL_ENERGY_TRANSFER;
   /// Index for initial energy column
   static const int COL_INITIAL_ENERGY;
   /// Index for final energy column

--- a/qt/widgets/sliceviewer/src/PeaksTableColumnsDialog.cpp
+++ b/qt/widgets/sliceviewer/src/PeaksTableColumnsDialog.cpp
@@ -34,8 +34,8 @@ void PeaksTableColumnsDialog::setVisibleColumns(const std::set<QString> &cols) {
                    m_origVisible.end());
   ui->cb_wavelength->setChecked(isChecked);
 
-  isChecked =
-      bool(m_origVisible.find(QPeaksTableModel::ENERGY_TRANSFER) != m_origVisible.end());
+  isChecked = bool(m_origVisible.find(QPeaksTableModel::ENERGY_TRANSFER) !=
+                   m_origVisible.end());
   ui->cb_deltaE->setChecked(isChecked);
 
   isChecked = bool(m_origVisible.find(QPeaksTableModel::INITIAL_ENERGY) !=
@@ -110,7 +110,8 @@ std::set<QString> PeaksTableColumnsDialog::getVisibleColumns() {
   updateChecked(result, QPeaksTableModel::DETID, ui->cb_detID->isChecked());
   updateChecked(result, QPeaksTableModel::WAVELENGTH,
                 ui->cb_wavelength->isChecked());
-  updateChecked(result, QPeaksTableModel::ENERGY_TRANSFER, ui->cb_deltaE->isChecked());
+  updateChecked(result, QPeaksTableModel::ENERGY_TRANSFER,
+                ui->cb_deltaE->isChecked());
   updateChecked(result, QPeaksTableModel::INITIAL_ENERGY,
                 ui->cb_ei->isChecked());
   updateChecked(result, QPeaksTableModel::FINAL_ENERGY, ui->cb_ef->isChecked());

--- a/qt/widgets/sliceviewer/src/PeaksTableColumnsDialog.cpp
+++ b/qt/widgets/sliceviewer/src/PeaksTableColumnsDialog.cpp
@@ -35,7 +35,7 @@ void PeaksTableColumnsDialog::setVisibleColumns(const std::set<QString> &cols) {
   ui->cb_wavelength->setChecked(isChecked);
 
   isChecked =
-      bool(m_origVisible.find(QPeaksTableModel::ENERGY) != m_origVisible.end());
+      bool(m_origVisible.find(QPeaksTableModel::ENERGY_TRANSFER) != m_origVisible.end());
   ui->cb_deltaE->setChecked(isChecked);
 
   isChecked = bool(m_origVisible.find(QPeaksTableModel::INITIAL_ENERGY) !=
@@ -110,7 +110,7 @@ std::set<QString> PeaksTableColumnsDialog::getVisibleColumns() {
   updateChecked(result, QPeaksTableModel::DETID, ui->cb_detID->isChecked());
   updateChecked(result, QPeaksTableModel::WAVELENGTH,
                 ui->cb_wavelength->isChecked());
-  updateChecked(result, QPeaksTableModel::ENERGY, ui->cb_deltaE->isChecked());
+  updateChecked(result, QPeaksTableModel::ENERGY_TRANSFER, ui->cb_deltaE->isChecked());
   updateChecked(result, QPeaksTableModel::INITIAL_ENERGY,
                 ui->cb_ei->isChecked());
   updateChecked(result, QPeaksTableModel::FINAL_ENERGY, ui->cb_ef->isChecked());

--- a/qt/widgets/sliceviewer/src/QPeaksTableModel.cpp
+++ b/qt/widgets/sliceviewer/src/QPeaksTableModel.cpp
@@ -48,7 +48,7 @@ const QString QPeaksTableModel::H = "h";
 const QString QPeaksTableModel::K = "k";
 const QString QPeaksTableModel::L = "l";
 const QString QPeaksTableModel::WAVELENGTH("Wavelength");
-const QString QPeaksTableModel::ENERGY("delta E");
+const QString QPeaksTableModel::ENERGY_TRANSFER("delta E");
 const QString QPeaksTableModel::INITIAL_ENERGY("E_i");
 const QString QPeaksTableModel::FINAL_ENERGY("E_f");
 const QString QPeaksTableModel::TOF("TOF");
@@ -71,7 +71,7 @@ const int QPeaksTableModel::COL_L(4);
 const int QPeaksTableModel::COL_WAVELENGTH(5);
 const int QPeaksTableModel::COL_INITIAL_ENERGY(6);
 const int QPeaksTableModel::COL_FINAL_ENERGY(7);
-const int QPeaksTableModel::COL_ENERGY(8);
+const int QPeaksTableModel::COL_ENERGY_TRANSFER(8);
 const int QPeaksTableModel::COL_TOF(9);
 const int QPeaksTableModel::COL_DSPACING(10);
 const int QPeaksTableModel::COL_INT(11);
@@ -104,7 +104,7 @@ int QPeaksTableModel::numCharacters(const int column) const {
     return 3 + m_hklPrec;
   else if (column == COL_WAVELENGTH)
     return 6;
-  else if (column == COL_ENERGY)
+  else if (column == COL_ENERGY_TRANSFER)
     return 6;
   else if (column == COL_INITIAL_ENERGY)
     return 6;
@@ -151,7 +151,7 @@ QPeaksTableModel::QPeaksTableModel(
                      {5, WAVELENGTH},
                      {6, INITIAL_ENERGY},
                      {7, FINAL_ENERGY},
-                     {8, ENERGY},
+                     {8, ENERGY_TRANSFER},
                      {9, TOF},
                      {10, DSPACING},
                      {11, INT},
@@ -179,7 +179,7 @@ QPeaksTableModel::QPeaksTableModel(
       [](const IPeak &peak) { return QVariant(peak.getWavelength()); },
       [](const IPeak &peak) { return QVariant(peak.getInitialEnergy()); },
       [](const IPeak &peak) { return QVariant(peak.getFinalEnergy()); },
-      [](const IPeak &peak) { return QVariant(peak.getEnergy()); },
+      [](const IPeak &peak) { return QVariant(peak.getEnergyTransfer()); },
       [](const IPeak &peak) { return QVariant(peak.getTOF()); },
       [](const IPeak &peak) { return QVariant(peak.getDSpacing()); },
       [](const IPeak &peak) { return QVariant(peak.getIntensity()); },
@@ -219,7 +219,7 @@ QPeaksTableModel::QPeaksTableModel(
         return QString::number(peak.getFinalEnergy(), 'f', 4);
       },
       [](const IPeak &peak) {
-        return QString::number(peak.getEnergy(), 'f', 4);
+        return QString::number(peak.getEnergyTransfer(), 'f', 4);
       },
       [](const IPeak &peak) { return QString::number(peak.getTOF(), 'f', 1); },
       [](const IPeak &peak) {
@@ -371,7 +371,7 @@ std::vector<int> QPeaksTableModel::defaultHideCols() {
       else
         showEnergy = true;
       if (!showEnergy)
-        result.push_back(COL_ENERGY);
+        result.push_back(COL_ENERGY_TRANSFER);
     }
   } catch (Mantid::Kernel::Exception::NotFoundError &) {
     // Unable to fetch instrument info, so continue without it.


### PR DESCRIPTION
~~**Cannot be merged before #21556**~~

During the work in #21556 I spotted that one can set a rotation matrix on a peak by not get it. Adding that method required additional work to add the ability to expose a matrix both by ref and by value to python, so I split that work into a new PR.

**To test:**
There's a test in `IPeakTest.py` that checks that the new method works.
 - Code review
 - Check `Goniometer.getR()`, `UnitCell.getB/G`, and `OrientedLattice.getUB` work correctly still in python.

*No issue associated with this PR*

**Release Notes** 
[See here](https://github.com/mantidproject/mantid/compare/master...add-get-goniometer-method#diff-9b244920fec43d1038705d089e2cee8b)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [x] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
