### PR TITLE
Beamline for Physical Instrument

### DIFF
--- a/Framework/API/inc/MantidAPI/ExperimentInfo.h
+++ b/Framework/API/inc/MantidAPI/ExperimentInfo.h
@@ -163,12 +163,14 @@ public:
                                            const std::string &date = "");
 
   const Geometry::DetectorInfo &detectorInfo() const;
+  const Geometry::DetectorInfo &detectorInfoPhysical() const;
   Geometry::DetectorInfo &mutableDetectorInfo();
 
   const SpectrumInfo &spectrumInfo() const;
   SpectrumInfo &mutableSpectrumInfo();
 
   const Geometry::ComponentInfo &componentInfo() const;
+  const Geometry::ComponentInfo &componentInfoPhysical() const;
   Geometry::ComponentInfo &mutableComponentInfo();
 
   void invalidateSpectrumDefinition(const size_t index);

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -1042,6 +1042,14 @@ const Geometry::DetectorInfo &ExperimentInfo::detectorInfo() const {
   return m_parmap->detectorInfo();
 }
 
+const DetectorInfo &ExperimentInfo::detectorInfoPhysical() const {
+  populateIfNotLoaded();
+  if (m_parmap->hasPhysicalBeamline())
+    return m_parmap->detectorInfoPhysical();
+  // Neturonic is the same as physical
+  return m_parmap->detectorInfo();
+}
+
 /** Return a non-const reference to the DetectorInfo object. */
 Geometry::DetectorInfo &ExperimentInfo::mutableDetectorInfo() {
   populateIfNotLoaded();
@@ -1107,6 +1115,13 @@ SpectrumInfo &ExperimentInfo::mutableSpectrumInfo() {
 }
 
 const Geometry::ComponentInfo &ExperimentInfo::componentInfo() const {
+  return m_parmap->componentInfo();
+}
+
+const ComponentInfo &ExperimentInfo::componentInfoPhysical() const {
+  if (m_parmap->hasPhysicalBeamline())
+    return m_parmap->componentInfoPhysical();
+  // Neutronic and physical are the same
   return m_parmap->componentInfo();
 }
 

--- a/Framework/API/test/ExperimentInfoTest.h
+++ b/Framework/API/test/ExperimentInfoTest.h
@@ -940,6 +940,43 @@ public:
                      compInfo.parent(compInfo.indexOf(bankId)));
   }
 
+  void test_physical_neutronic_beamline_same_when_no_physical_instrument_set() {
+
+    auto inst = ComponentCreationHelper::createMinimalInstrument(
+        V3D{-2, 0, 0} /*source*/, V3D{10, 0, 0} /*sample*/,
+        V3D{12, 0, 0} /*detector*/);
+
+    // instrument has no physical instrument associated. Neturonic and physical
+    // instrument are the same.
+
+    ExperimentInfo expInfo;
+    expInfo.setInstrument(inst);
+
+    // Beamline parts are actually same objects
+    TS_ASSERT_EQUALS(&expInfo.componentInfo(),
+                     &expInfo.componentInfoPhysical());
+    TS_ASSERT_EQUALS(&expInfo.detectorInfo(), &expInfo.detectorInfoPhysical());
+  }
+
+  void test_physical_neutronic_beamline_differ_when_physical_instrument_set() {
+
+    auto neutInst = ComponentCreationHelper::createMinimalInstrument(
+        V3D{-2, 0, 0} /*source*/, V3D{10, 0, 0} /*sample*/,
+        V3D{12, 0, 0} /*detector*/);
+
+    // Attach a physical instrument to the neutronic one
+    neutInst->setPhysicalInstrument(
+        std::unique_ptr<Mantid::Geometry::Instrument>(neutInst->clone()));
+
+    ExperimentInfo expInfo;
+    expInfo.setInstrument(neutInst);
+
+    // Beamline parts are actually same objects
+    TS_ASSERT_DIFFERS(&expInfo.componentInfo(),
+                      &expInfo.componentInfoPhysical());
+    TS_ASSERT_DIFFERS(&expInfo.detectorInfo(), &expInfo.detectorInfoPhysical());
+  }
+
 private:
   void addInstrumentWithParameter(ExperimentInfo &expt, const std::string &name,
                                   const std::string &value) {

--- a/Framework/DataHandling/test/LoadInstrumentTest.h
+++ b/Framework/DataHandling/test/LoadInstrumentTest.h
@@ -391,36 +391,54 @@ public:
     TS_ASSERT_EQUALS(neutronicInst.get(),
                      ws->getInstrument()->baseInstrument().get());
     // Check the neutronic positions
-    const auto &detectorInfo = ws->detectorInfo();
-    TS_ASSERT_EQUALS(detectorInfo.position(detectorInfo.indexOf(1000)),
-                     V3D(2, 2, 0));
-    TS_ASSERT_EQUALS(detectorInfo.position(detectorInfo.indexOf(1001)),
-                     V3D(2, 3, 0));
-    TS_ASSERT_EQUALS(detectorInfo.position(detectorInfo.indexOf(1002)),
-                     V3D(3, 2, 0));
-    TS_ASSERT_EQUALS(detectorInfo.position(detectorInfo.indexOf(1003)),
-                     V3D(3, 3, 0));
+    const auto &neutronicDetectorInfo = ws->detectorInfo();
+    const auto &physicalDetectorInfo = ws->detectorInfoPhysical();
+    TS_ASSERT_EQUALS(
+        neutronicDetectorInfo.position(neutronicDetectorInfo.indexOf(1000)),
+        V3D(2, 2, 0));
+    TS_ASSERT_EQUALS(
+        neutronicDetectorInfo.position(neutronicDetectorInfo.indexOf(1001)),
+        V3D(2, 3, 0));
+    TS_ASSERT_EQUALS(
+        neutronicDetectorInfo.position(neutronicDetectorInfo.indexOf(1002)),
+        V3D(3, 2, 0));
+    TS_ASSERT_EQUALS(
+        neutronicDetectorInfo.position(neutronicDetectorInfo.indexOf(1003)),
+        V3D(3, 3, 0));
     // Note that one of the physical pixels doesn't exist in the neutronic
     // space
-    TS_ASSERT_THROWS(detectorInfo.indexOf(1004), std::out_of_range);
-    TS_ASSERT_EQUALS(detectorInfo.position(detectorInfo.indexOf(1005)),
-                     V3D(4, 3, 0));
+    TS_ASSERT_THROWS(neutronicDetectorInfo.indexOf(1004), std::out_of_range);
+    // But it is in the physical space.
+    TS_ASSERT_THROWS_NOTHING(physicalDetectorInfo.indexOf(1004));
+    TS_ASSERT_EQUALS(
+        neutronicDetectorInfo.position(neutronicDetectorInfo.indexOf(1005)),
+        V3D(4, 3, 0));
 
     // Check that the first 2 detectors share the same shape in the physical
     // instrument...
-    TS_ASSERT_EQUALS(physicalInst->getDetector(1000)->shape(),
-                     physicalInst->getDetector(1001)->shape())
+    TS_ASSERT_EQUALS(
+        physicalDetectorInfo.detector(physicalDetectorInfo.indexOf(1000))
+            .shape(),
+        physicalDetectorInfo.detector(physicalDetectorInfo.indexOf(1001))
+            .shape())
     // ...but not in the neutronic instrument
-    TS_ASSERT_DIFFERS(detectorInfo.detector(detectorInfo.indexOf(1000)).shape(),
-                      neutronicInst->getDetector(1001)->shape())
+    TS_ASSERT_DIFFERS(
+        neutronicDetectorInfo.detector(neutronicDetectorInfo.indexOf(1000))
+            .shape(),
+        neutronicDetectorInfo.detector(neutronicDetectorInfo.indexOf(1001))
+            .shape())
     // Also, the same shape is shared between the corresponding '1000'
     // detectors
-    TS_ASSERT_EQUALS(physicalInst->getDetector(1000)->shape(),
-                     detectorInfo.detector(detectorInfo.indexOf(1000)).shape())
+    TS_ASSERT_EQUALS(
+        physicalDetectorInfo.detector(physicalDetectorInfo.indexOf(1000))
+            .shape(),
+        neutronicDetectorInfo.detector(neutronicDetectorInfo.indexOf(1000))
+            .shape())
 
     // Check the monitor is in the same place in each instrument
-    TS_ASSERT_EQUALS(physicalInst->getDetector(1)->getPos(),
-                     detectorInfo.position(detectorInfo.indexOf(1)));
+    TS_ASSERT_EQUALS(
+        physicalDetectorInfo.position(physicalDetectorInfo.indexOf(1)),
+        neutronicDetectorInfo.position(neutronicDetectorInfo.indexOf(1)));
     // ...but is not the same object
     TS_ASSERT_DIFFERS(physicalInst->getDetector(1).get(),
                       neutronicInst->getDetector(1).get());
@@ -429,8 +447,9 @@ public:
     // positions from DetectorInfo.
     auto physInstFromWS = ws->getInstrument()->getPhysicalInstrument();
     TS_ASSERT(physInstFromWS->isParametrized());
-    TS_ASSERT_DIFFERS(physInstFromWS->getDetector(1003)->getPos(),
-                      detectorInfo.position(detectorInfo.indexOf(1003)));
+    TS_ASSERT_DIFFERS(
+        physInstFromWS->getDetector(1003)->getPos(),
+        neutronicDetectorInfo.position(neutronicDetectorInfo.indexOf(1003)));
     TS_ASSERT_EQUALS(physInstFromWS->getDetector(1000)->getPos(), V3D(0, 0, 0));
     TS_ASSERT_EQUALS(physInstFromWS->getDetector(1001)->getPos(), V3D(0, 1, 0));
     TS_ASSERT_EQUALS(physInstFromWS->getDetector(1002)->getPos(), V3D(1, 0, 0));

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -212,6 +212,7 @@ public:
   // Methods for use with indirect geometry instruments,
   // where the physical instrument differs from the 'neutronic' one
   boost::shared_ptr<const Instrument> getPhysicalInstrument() const;
+  bool hasPhysicalInstrument() const;
   void setPhysicalInstrument(std::unique_ptr<Instrument>);
 
   void getInstrumentParameters(double &l1, Kernel::V3D &beamline,

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
@@ -339,9 +339,12 @@ public:
 
   bool hasDetectorInfo(const Instrument *instrument) const;
   bool hasComponentInfo(const Instrument *instrument) const;
+  bool hasPhysicalBeamline() const;
   const Geometry::DetectorInfo &detectorInfo() const;
+  const Geometry::DetectorInfo &detectorInfoPhysical() const;
   Geometry::DetectorInfo &mutableDetectorInfo();
   const Geometry::ComponentInfo &componentInfo() const;
+  const Geometry::ComponentInfo &componentInfoPhysical() const;
   Geometry::ComponentInfo &mutableComponentInfo();
   size_t detectorIndex(const detid_t detID) const;
   size_t componentIndex(const Geometry::ComponentID componentId) const;
@@ -379,6 +382,14 @@ private:
   /// Pointer to the ComponentInfo wrapper. NULL unless the instrument is
   /// associated with an ExperimentInfo object.
   std::unique_ptr<Geometry::ComponentInfo> m_componentInfo;
+
+  /// Pointer to the DetectorInfo wrapper. NULL unless the instrument is
+  /// associated with the instrument and that has a physical instrument.
+  std::unique_ptr<Geometry::DetectorInfo> m_detectorInfoPhysical;
+
+  /// Pointer to the ComponentInfo wrapper. NULL unless the instrument is
+  /// associated with the instrument and that has a physical instrument.
+  std::unique_ptr<Geometry::ComponentInfo> m_componentInfoPhysical;
 
   /// Pointer to the owning instrument for translating detector IDs into
   /// detector indices when accessing the DetectorInfo object. If the workspace

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -188,6 +188,10 @@ Instrument_const_sptr Instrument::getPhysicalInstrument() const {
   }
 }
 
+bool Instrument::hasPhysicalInstrument() const {
+  return bool(m_physicalInstrument);
+}
+
 /** INDIRECT GEOMETRY INSTRUMENTS ONLY: Sets the physical instrument.
  *  The holding instrument is then the 'neutronic' one, and is used in all
  * algorithms.

--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -1156,11 +1156,23 @@ bool ParameterMap::hasComponentInfo(const Instrument *instrument) const {
   return static_cast<bool>(m_componentInfo);
 }
 
+bool ParameterMap::hasPhysicalBeamline() const {
+  return static_cast<bool>(m_componentInfoPhysical);
+}
+
 /// Only for use by ExperimentInfo. Returns a reference to the DetectorInfo.
 const Geometry::DetectorInfo &ParameterMap::detectorInfo() const {
   if (!hasDetectorInfo(m_instrument))
     throw std::runtime_error("Cannot return reference to NULL DetectorInfo");
   return *m_detectorInfo;
+}
+
+const DetectorInfo &ParameterMap::detectorInfoPhysical() const {
+  if (!static_cast<bool>(m_detectorInfoPhysical)) {
+    throw std::runtime_error(
+        "Cannot return reference to NULL physical DetectorInfo");
+  }
+  return *m_detectorInfoPhysical;
 }
 
 /// Only for use by ExperimentInfo. Returns a reference to the DetectorInfo.
@@ -1176,6 +1188,14 @@ const Geometry::ComponentInfo &ParameterMap::componentInfo() const {
     throw std::runtime_error("Cannot return reference to NULL ComponentInfo");
   }
   return *m_componentInfo;
+}
+
+const ComponentInfo &ParameterMap::componentInfoPhysical() const {
+  if (!static_cast<bool>(m_componentInfoPhysical)) {
+    throw std::runtime_error(
+        "Cannot return reference to NULL physical ComponentInfo");
+  }
+  return *m_componentInfoPhysical;
 }
 
 /// Only for use by ExperimentInfo. Returns a reference to the ComponentInfo.
@@ -1212,6 +1232,10 @@ void ParameterMap::setInstrument(const Instrument *instrument) {
                            "base instrument, not a parametrized instrument");
   m_instrument = instrument;
   std::tie(m_componentInfo, m_detectorInfo) = m_instrument->makeBeamline(*this);
+  if (m_instrument->hasPhysicalInstrument()) {
+    std::tie(m_componentInfoPhysical, m_detectorInfoPhysical) =
+        m_instrument->getPhysicalInstrument()->makeBeamline(*this);
+  }
 }
 
 } // Namespace Geometry


### PR DESCRIPTION
Fixes #21587 by adding const ref `DetectorInfo` and `ComponentInfo` access to new objects created around a physical instrument if present.

**WIP - Do not merge** I'm just making this available for early review.
