### PR TITLE
Fix registration of QMetaType for type Message

### DIFF
--- a/qt/python/mantidqt/widgets/src/_widgetscore.sip
+++ b/qt/python/mantidqt/widgets/src/_widgetscore.sip
@@ -5,7 +5,7 @@ using namespace MantidQt::MantidWidgets;
 %End
 
 %InitialisationCode
-qRegisterMetaType<MantidQt::MantidWidgets::Message>();
+qRegisterMetaType<Message>("Message");
 %End
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
**Description of work**

Fix `qRegisterMetatype` call for `Message` type.

**To test:**

Check what happens before the fix:

* start the workbench
* run an algorithm and notice that the usual logging messages don't appear in the "Messages" window.
* checkout the branch
* run the same tests and the log messages should appear in the Messages log window.

*No issue*

**Release Notes** 
*Part of the worbench. Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
