### PR TITLE
Change to try/except instead of checking version for numpy >= 1.14 doctests

### DIFF
--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -103,8 +103,10 @@ except NameError:
 # TODO: remove this workaround once minimal required numpy is set to 1.14.0
 import numpy as np
 
-if np.version.full_version >= '1.14.0':
+try:
     np.set_printoptions(legacy='1.13')
+except TypeError:
+    pass
 """.format(mantid_config_reset)
 
 # Run this after each test group has executed


### PR DESCRIPTION
The doctests fail on RHEL7 with #21576 because`'1.7.0' >= '1.14.0'` is `True` so use `try/except` instead.

http://builds.mantidproject.org/job/master_doctests/726/

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
