### PR TITLE
Set also TBB thread count based on MultiThreaded.MaxCores.

### DIFF
--- a/Framework/API/src/FrameworkManager.cpp
+++ b/Framework/API/src/FrameworkManager.cpp
@@ -16,6 +16,7 @@
 #include <nexus/NeXusFile.hpp>
 
 #include <Poco/ActiveResult.h>
+#include <tbb/task_scheduler_init.h>
 
 #include <clocale>
 #include <cstdarg>
@@ -175,6 +176,7 @@ void FrameworkManagerImpl::setNumOMPThreadsToConfigValue() {
 void FrameworkManagerImpl::setNumOMPThreads(const int nthreads) {
   g_log.debug() << "Setting maximum number of threads to " << nthreads << "\n";
   PARALLEL_SET_NUM_THREADS(nthreads);
+  static tbb::task_scheduler_init m_init{nthreads};
 }
 
 /**

--- a/Framework/DataObjects/test/EventListTest.h
+++ b/Framework/DataObjects/test/EventListTest.h
@@ -5,6 +5,7 @@
 #include "MantidDataObjects/EventList.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidDataObjects/Histogram1D.h"
+#include "MantidAPI/FrameworkManager.h"
 #include "MantidKernel/Timer.h"
 #include "MantidKernel/CPUTimer.h"
 #include "MantidKernel/Unit.h"
@@ -2764,6 +2765,12 @@ public:
     // Coarse vector, 1000 bins.
     for (double i = 0; i < 100000; i += 100)
       coarseX.push_back(i);
+
+    // Create FrameworkManager such that the effect of config option
+    // `MultiThreaded.MaxCores` is visible: The FrameworkManager sets the TBB
+    // thread count according to this value if applicable. TBB threading is used
+    // when sorting events.
+    Mantid::API::FrameworkManager::Instance();
   }
 
   EventList el_random, el_random_source, el_sorted, el_sorted_original,


### PR DESCRIPTION
`MultiThreaded.MaxCores` is used to configure the number of OpenMP threads and the number of threads in the Poco thread pool. However, the TBB thread count was previously not set. This is use for example for parallel sorting in `EventList`.

**To test:**

Code review. The effect of this PR can be check by running `EventListTestPerformance::test_sort_tof` with `MultiThreaded.MaxCores = 1` and without. Before this PR the option had no effect on the timings, afterwards it should.

No issue, no release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
