### PR TITLE
Engineering Diffraction GUI GSAS tab improve warnings

### DIFF
--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.cpp
@@ -203,7 +203,7 @@ bool EnggDiffGSASFittingModel::hasFocusedRun(const int runNumber,
   return m_focusedWorkspaceMap.contains(runNumber, bank);
 }
 
-boost::optional<std::string>
+std::string
 EnggDiffGSASFittingModel::loadFocusedRun(const std::string &filename) {
   const auto wsName = stripWSNameFromFilename(filename);
 
@@ -213,7 +213,7 @@ EnggDiffGSASFittingModel::loadFocusedRun(const std::string &filename) {
     loadAlg->setProperty("OutputWorkspace", wsName);
     loadAlg->execute();
   } catch (const std::exception &e) {
-    return boost::make_optional<std::string>(e.what());
+    return e.what();
   }
 
   API::AnalysisDataServiceImpl &ADS = API::AnalysisDataService::Instance();
@@ -225,11 +225,11 @@ EnggDiffGSASFittingModel::loadFocusedRun(const std::string &filename) {
   try {
     bank = getBankID(ws);
   } catch (const std::runtime_error &e) {
-    return boost::make_optional<std::string>(e.what());
+    return e.what();
   }
 
   m_focusedWorkspaceMap.add(runNumber, bank, ws);
-  return boost::none;
+  return "";
 }
 
 } // CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.cpp
@@ -18,14 +18,14 @@ std::string stripWSNameFromFilename(const std::string &fullyQualifiedFilename) {
   return filenameSegments[0];
 }
 
-size_t getBankID(API::MatrixWorkspace_const_sptr ws) {
+boost::optional<size_t> getBankID(API::MatrixWorkspace_const_sptr ws) {
   const static std::string bankIDPropertyName = "bankid";
   if (ws->run().hasProperty(bankIDPropertyName)) {
     const auto log = dynamic_cast<Kernel::PropertyWithValue<int> *>(
         ws->run().getLogData(bankIDPropertyName));
     return boost::lexical_cast<size_t>(log->value());
   }
-  throw std::runtime_error("Bank ID was not set in the sample logs.");
+  return boost::none;
 }
 
 } // anonymous namespace
@@ -222,15 +222,15 @@ EnggDiffGSASFittingModel::loadFocusedRun(const std::string &filename) {
   const auto ws = ADS.retrieveWS<API::MatrixWorkspace>(wsName);
 
   const auto runNumber = ws->getRunNumber();
-  size_t bank = 0;
+  const auto bankID = getBankID(ws);
 
-  try {
-    bank = getBankID(ws);
-  } catch (const std::runtime_error &e) {
-    return e.what();
+  if (!bankID) {
+    return "Bank ID was not set in the sample logs for run " +
+           std::to_string(runNumber) +
+           ". Make sure it has been focused correctly";
   }
 
-  m_focusedWorkspaceMap.add(runNumber, bank, ws);
+  m_focusedWorkspaceMap.add(runNumber, *bankID, ws);
   return "";
 }
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
@@ -43,8 +43,7 @@ public:
   bool hasFittedPeaksForRun(const int runNumber,
                             const size_t bank) const override;
 
-  boost::optional<std::string>
-  loadFocusedRun(const std::string &filename) override;
+  std::string loadFocusedRun(const std::string &filename) override;
 
 protected:
   /// The following methods are marked as protected so that they can be exposed

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
@@ -43,7 +43,8 @@ public:
   bool hasFittedPeaksForRun(const int runNumber,
                             const size_t bank) const override;
 
-  bool loadFocusedRun(const std::string &filename) override;
+  boost::optional<std::string>
+  loadFocusedRun(const std::string &filename) override;
 
 protected:
   /// The following methods are marked as protected so that they can be exposed

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
@@ -12,19 +12,20 @@ class MANTIDQT_ENGGDIFFRACTION_DLL EnggDiffGSASFittingModel
     : public IEnggDiffGSASFittingModel {
 
 public:
-  bool doPawleyRefinement(const int runNumber, const size_t bank,
-                          const std::string &instParamFile,
-                          const std::vector<std::string> &phaseFiles,
-                          const std::string &pathToGSASII,
-                          const std::string &GSASIIProjectFile,
-                          const double dMin,
-                          const double negativeWeight) override;
+  std::string doPawleyRefinement(const int runNumber, const size_t bank,
+                                 const std::string &instParamFile,
+                                 const std::vector<std::string> &phaseFiles,
+                                 const std::string &pathToGSASII,
+                                 const std::string &GSASIIProjectFile,
+                                 const double dMin,
+                                 const double negativeWeight) override;
 
-  bool doRietveldRefinement(const int runNumber, const size_t bank,
-                            const std::string &instParamFile,
-                            const std::vector<std::string> &phaseFiles,
-                            const std::string &pathToGSASII,
-                            const std::string &GSASIIProjectFile) override;
+  std::string
+  doRietveldRefinement(const int runNumber, const size_t bank,
+                       const std::string &instParamFile,
+                       const std::vector<std::string> &phaseFiles,
+                       const std::string &pathToGSASII,
+                       const std::string &GSASIIProjectFile) override;
 
   boost::optional<Mantid::API::MatrixWorkspace_sptr>
   getFittedPeaks(const int runNumber, const size_t bank) const override;
@@ -98,8 +99,8 @@ private:
   /// Run GSASIIRefineFitPeaks
   /// Note this must be virtual so that it can be mocked out by the helper class
   /// in EnggDiffGSASFittingModelTest
-  /// Returns Rwp of the fit (empty optional if fit was unsuccessful)
-  virtual boost::optional<double> doGSASRefinementAlgorithm(
+  /// Returns Rwp of the fit
+  virtual double doGSASRefinementAlgorithm(
       Mantid::API::MatrixWorkspace_sptr inputWorkspace,
       const std::string &outputWorkspaceName,
       const std::string &latticeParamsName, const std::string &refinementMethod,

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
@@ -138,18 +138,16 @@ void EnggDiffGSASFittingPresenter::processDoRefinement() {
 
 void EnggDiffGSASFittingPresenter::processLoadRun() {
   const auto focusedFileNames = m_view->getFocusedFileNames();
-  bool loadSuccessful = true;
 
   for (const auto fileName : focusedFileNames) {
-    loadSuccessful &= m_model->loadFocusedRun(fileName);
-  }
+    const auto loadFailure = m_model->loadFocusedRun(fileName);
 
-  if (loadSuccessful) {
-    const auto runLabels = m_model->getRunLabels();
-    m_view->updateRunList(runLabels);
-  } else {
-    m_view->userWarning("Load failed",
-                        "Load failed, see the log for more details");
+    if (loadFailure) {
+      m_view->userWarning("Load failed", *loadFailure);
+    } else {
+      const auto runLabels = m_model->getRunLabels();
+      m_view->updateRunList(runLabels);
+    }
   }
 }
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
@@ -78,7 +78,7 @@ void EnggDiffGSASFittingPresenter::displayFitResults(const int runNumber,
   m_view->displayRwp(*rwp);
 }
 
-bool EnggDiffGSASFittingPresenter::doPawleyRefinement(
+std::string EnggDiffGSASFittingPresenter::doPawleyRefinement(
     const int runNumber, const size_t bank, const std::string &instParamFile,
     const std::vector<std::string> &phaseFiles, const std::string &pathToGSASII,
     const std::string &GSASIIProjectFile) {
@@ -90,7 +90,7 @@ bool EnggDiffGSASFittingPresenter::doPawleyRefinement(
                                      negativeWeight);
 }
 
-bool EnggDiffGSASFittingPresenter::doRietveldRefinement(
+std::string EnggDiffGSASFittingPresenter::doRietveldRefinement(
     const int runNumber, const size_t bank, const std::string &instParamFile,
     const std::vector<std::string> &phaseFiles, const std::string &pathToGSASII,
     const std::string &GSASIIProjectFile) {
@@ -111,28 +111,28 @@ void EnggDiffGSASFittingPresenter::processDoRefinement() {
   const auto pathToGSASII = m_view->getPathToGSASII();
   const auto GSASIIProjectFile = m_view->getGSASIIProjectPath();
 
-  bool refinementSuccessful = false;
+  std::string refinementFailure(
+      "Contact developers if you see this message");
 
   switch (refinementMethod) {
 
   case GSASRefinementMethod::PAWLEY:
-    refinementSuccessful =
+    refinementFailure =
         doPawleyRefinement(runNumber, bank, instParamFile, phaseFiles,
                            pathToGSASII, GSASIIProjectFile);
     break;
 
   case GSASRefinementMethod::RIETVELD:
-    refinementSuccessful =
+    refinementFailure =
         doRietveldRefinement(runNumber, bank, instParamFile, phaseFiles,
                              pathToGSASII, GSASIIProjectFile);
     break;
   }
 
-  if (refinementSuccessful) {
+  if (refinementFailure.empty()) {
     updatePlot(runNumber, bank);
   } else {
-    m_view->userWarning("Refinement failed",
-                        "Refinement failed, see the log for more details");
+    m_view->userWarning("Refinement failed", refinementFailure);
   }
 }
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
@@ -62,11 +62,12 @@ void EnggDiffGSASFittingPresenter::displayFitResults(const int runNumber,
   const auto rwp = m_model->getRwp(runNumber, bank);
 
   if (!fittedPeaks || !latticeParams || !rwp) {
-    m_view->userWarning("Unexpectedly tried to plot fit results for invalid "
-                        "run, run number = " +
-                        std::to_string(runNumber) + ", bank ID = " +
-                        std::to_string(bank) +
-                        ". Please contact the development team");
+    m_view->userError("Invalid run identifier",
+                      "Unexpectedly tried to plot fit results for invalid "
+                      "run, run number = " +
+                          std::to_string(runNumber) + ", bank ID = " +
+                          std::to_string(bank) +
+                          ". Please contact the development team");
     return;
   }
 
@@ -130,7 +131,8 @@ void EnggDiffGSASFittingPresenter::processDoRefinement() {
   if (refinementSuccessful) {
     updatePlot(runNumber, bank);
   } else {
-    m_view->userWarning("Refinement failed, see the log for more details");
+    m_view->userWarning("Refinement failed",
+                        "Refinement failed, see the log for more details");
   }
 }
 
@@ -146,7 +148,8 @@ void EnggDiffGSASFittingPresenter::processLoadRun() {
     const auto runLabels = m_model->getRunLabels();
     m_view->updateRunList(runLabels);
   } else {
-    m_view->userWarning("Load failed, see the log for more details");
+    m_view->userWarning("Load failed",
+                        "Load failed, see the log for more details");
   }
 }
 
@@ -166,9 +169,11 @@ void EnggDiffGSASFittingPresenter::updatePlot(const int runNumber,
                                               const size_t bank) {
   const auto focusedWSOptional = m_model->getFocusedWorkspace(runNumber, bank);
   if (!focusedWSOptional) {
-    m_view->userWarning("Tried to access invalid run, runNumber " +
-                        std::to_string(runNumber) + " and bank ID " +
-                        std::to_string(bank));
+    m_view->userError("Invalid run identifier",
+                      "Tried to access invalid run, runNumber " +
+                          std::to_string(runNumber) + " and bank ID " +
+                          std::to_string(bank) +
+                          ". Please contact the development team");
     return;
   }
   const auto focusedWS = *focusedWSOptional;

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
@@ -142,11 +142,11 @@ void EnggDiffGSASFittingPresenter::processLoadRun() {
   for (const auto fileName : focusedFileNames) {
     const auto loadFailure = m_model->loadFocusedRun(fileName);
 
-    if (loadFailure) {
-      m_view->userWarning("Load failed", *loadFailure);
-    } else {
+    if (loadFailure.empty()) {
       const auto runLabels = m_model->getRunLabels();
       m_view->updateRunList(runLabels);
+    } else {
+      m_view->userWarning("Load failed", loadFailure);
     }
   }
 }

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.h
@@ -46,13 +46,13 @@ private:
    @param pathToGSASII Location of the directory containing GSASIIscriptable.py
    (and GSAS-II executables)
    @param GSASIIProjectFile Location to save the .gpx project to
-   @return Whether the refinement was successful
+   @return Empty string if refinement was successful, error description if not
    */
-  bool doPawleyRefinement(const int runNumber, const size_t bank,
-                          const std::string &instParamFile,
-                          const std::vector<std::string> &phaseFiles,
-                          const std::string &pathToGSASII,
-                          const std::string &GSASIIProjectFile);
+  std::string doPawleyRefinement(const int runNumber, const size_t bank,
+                                 const std::string &instParamFile,
+                                 const std::vector<std::string> &phaseFiles,
+                                 const std::string &pathToGSASII,
+                                 const std::string &GSASIIProjectFile);
 
   /**
    Perform a Rietveld refinement on a run
@@ -64,13 +64,13 @@ private:
    @param pathToGSASII Location of the directory containing GSASIIscriptable.py
    (and GSAS-II executables)
    @param GSASIIProjectFile Location to save the .gpx project to
-   @return Whether the refinement was successful
+   @return Empty string if refinement was successful, error description if not
    */
-  bool doRietveldRefinement(const int runNumber, const size_t bank,
-                            const std::string &instParamFile,
-                            const std::vector<std::string> &phaseFiles,
-                            const std::string &pathToGSASII,
-                            const std::string &GSASIIProjectFile);
+  std::string doRietveldRefinement(const int runNumber, const size_t bank,
+                                   const std::string &instParamFile,
+                                   const std::vector<std::string> &phaseFiles,
+                                   const std::string &pathToGSASII,
+                                   const std::string &GSASIIProjectFile);
 
   /**
    Overplot fitted peaks for a run, and display lattice parameters and Rwp in

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
@@ -7,7 +7,9 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 
-EnggDiffGSASFittingViewQtWidget::EnggDiffGSASFittingViewQtWidget() {
+EnggDiffGSASFittingViewQtWidget::EnggDiffGSASFittingViewQtWidget(
+    boost::shared_ptr<IEnggDiffractionUserMsg> userMessageProvider)
+    : m_userMessageProvider(userMessageProvider) {
   setupUI();
 
   auto model = Mantid::Kernel::make_unique<EnggDiffGSASFittingModel>();
@@ -180,10 +182,15 @@ void EnggDiffGSASFittingViewQtWidget::updateRunList(
   }
 }
 
+void EnggDiffGSASFittingViewQtWidget::userError(
+    const std::string &errorTitle, const std::string &errorDescription) const {
+  m_userMessageProvider->userError(errorTitle, errorDescription);
+}
+
 void EnggDiffGSASFittingViewQtWidget::userWarning(
+    const std::string &warningTitle,
     const std::string &warningDescription) const {
-  (void)warningDescription;
-  throw std::runtime_error("userWarning not yet implemented");
+  m_userMessageProvider->userWarning(warningTitle, warningDescription);
 }
 
 } // CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.h
@@ -4,6 +4,7 @@
 #include "DllConfig.h"
 #include "IEnggDiffGSASFittingPresenter.h"
 #include "IEnggDiffGSASFittingView.h"
+#include "IEnggDiffractionUserMsg.h"
 
 #include <qwt_plot_curve.h>
 
@@ -18,7 +19,8 @@ class MANTIDQT_ENGGDIFFRACTION_DLL EnggDiffGSASFittingViewQtWidget
   Q_OBJECT
 
 public:
-  EnggDiffGSASFittingViewQtWidget();
+  EnggDiffGSASFittingViewQtWidget(
+      boost::shared_ptr<IEnggDiffractionUserMsg> userMessageProvider);
 
   ~EnggDiffGSASFittingViewQtWidget() override;
 
@@ -56,7 +58,11 @@ public:
   void
   updateRunList(const std::vector<std::pair<int, size_t>> &runLabels) override;
 
-  void userWarning(const std::string &warningDescription) const override;
+  void userError(const std::string &errorTitle,
+                 const std::string &errorDescription) const override;
+
+  void userWarning(const std::string &warningTitle,
+                   const std::string &warningDescription) const override;
 
 private slots:
   void browseFocusedRun();
@@ -65,6 +71,8 @@ private slots:
 
 private:
   std::vector<QwtPlotCurve *> m_focusedRunCurves;
+
+  boost::shared_ptr<IEnggDiffractionUserMsg> m_userMessageProvider;
 
   std::unique_ptr<IEnggDiffGSASFittingPresenter> m_presenter;
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -92,7 +92,7 @@ void EnggDiffractionViewQtGUI::initLayout() {
       m_ui.tabMain, sharedView, sharedView, fullPres, fullPres, sharedView);
   m_ui.tabMain->addTab(m_fittingWidget, QString("Fitting"));
 
-  m_gsasWidget = new EnggDiffGSASFittingViewQtWidget();
+  m_gsasWidget = new EnggDiffGSASFittingViewQtWidget(sharedView);
   m_ui.tabMain->addTab(m_gsasWidget, QString("GSAS-II Refinement"));
 
   QWidget *wSettings = new QWidget(m_ui.tabMain);

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
@@ -30,15 +30,13 @@ public:
    @param GSASIIProjectFile Location to save the .gpx project to
    @param dMin The minimum d-spacing to use for refinement
    @param negativeWeight The weight of the penalty function
-   @return Whether the refinement was successful
+   @return Empty string if refinement was successful, error description if not
    */
-  virtual bool doPawleyRefinement(const int runNumber, const size_t bank,
-                                  const std::string &instParamFile,
-                                  const std::vector<std::string> &phaseFiles,
-                                  const std::string &pathToGSASII,
-                                  const std::string &GSASIIProjectFile,
-                                  const double dMin,
-                                  const double negativeWeight) = 0;
+  virtual std::string doPawleyRefinement(
+      const int runNumber, const size_t bank, const std::string &instParamFile,
+      const std::vector<std::string> &phaseFiles,
+      const std::string &pathToGSASII, const std::string &GSASIIProjectFile,
+      const double dMin, const double negativeWeight) = 0;
   /**
    Perform a Rietveld refinement on a run
    @param runNumber The run number of the run
@@ -49,13 +47,14 @@ public:
    @param pathToGSASII Location of the directory containing GSASIIscriptable.py
    (and GSAS-II executables)
    @param GSASIIProjectFile Location to save the .gpx project to
-   @return Whether the refinement was successful
+   @return Empty string if refinement was successful, error description if not
    */
-  virtual bool doRietveldRefinement(const int runNumber, const size_t bank,
-                                    const std::string &instParamFile,
-                                    const std::vector<std::string> &phaseFiles,
-                                    const std::string &pathToGSASII,
-                                    const std::string &GSASIIProjectFile) = 0;
+  virtual std::string
+  doRietveldRefinement(const int runNumber, const size_t bank,
+                       const std::string &instParamFile,
+                       const std::vector<std::string> &phaseFiles,
+                       const std::string &pathToGSASII,
+                       const std::string &GSASIIProjectFile) = 0;
 
   /**
    Get the fit results for a given run

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
@@ -116,11 +116,9 @@ public:
   /**
    Load a focused run from a file to the model
    @param filename The name of the file to load
-   @return Empty optional if load was a success, string describing the error if
-   not
+   @return Empty string if load was a success, description of error if not
    */
-  virtual boost::optional<std::string>
-  loadFocusedRun(const std::string &filename) = 0;
+  virtual std::string loadFocusedRun(const std::string &filename) = 0;
 };
 
 } // namespace MantidQt

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
@@ -116,9 +116,11 @@ public:
   /**
    Load a focused run from a file to the model
    @param filename The name of the file to load
-   @return Whether the load was a success
+   @return Empty optional if load was a success, string describing the error if
+   not
    */
-  virtual bool loadFocusedRun(const std::string &filename) = 0;
+  virtual boost::optional<std::string>
+  loadFocusedRun(const std::string &filename) = 0;
 };
 
 } // namespace MantidQt

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingView.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingView.h
@@ -109,10 +109,20 @@ public:
   updateRunList(const std::vector<std::pair<int, size_t>> &runLabels) = 0;
 
   /**
+   Display an error to the user
+   @param errorTitle Title of the error
+   @param errorDescription Longer description of the error
+  */
+  virtual void userError(const std::string &errorTitle,
+                         const std::string &errorDescription) const = 0;
+
+  /**
    Display a warning to the user
-   @param warningDescription The warning to show
+   @param warningTitle Title of the warning
+   @param warningDescription Longer description of the warning
    */
-  virtual void userWarning(const std::string &warningDescription) const = 0;
+  virtual void userWarning(const std::string &warningTitle,
+                           const std::string &warningDescription) const = 0;
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
@@ -47,7 +47,8 @@ public:
   MOCK_CONST_METHOD2(hasFittedPeaksForRun,
                      bool(const int runNumber, const size_t bank));
 
-  MOCK_METHOD1(loadFocusedRun, bool(const std::string &filename));
+  MOCK_METHOD1(loadFocusedRun,
+               boost::optional<std::string>(const std::string &filename));
 };
 
 GCC_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
@@ -47,8 +47,7 @@ public:
   MOCK_CONST_METHOD2(hasFittedPeaksForRun,
                      bool(const int runNumber, const size_t bank));
 
-  MOCK_METHOD1(loadFocusedRun,
-               boost::optional<std::string>(const std::string &filename));
+  MOCK_METHOD1(loadFocusedRun, std::string(const std::string &filename));
 };
 
 GCC_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
@@ -13,19 +13,19 @@ class MockEnggDiffGSASFittingModel
 
 public:
   MOCK_METHOD8(doPawleyRefinement,
-               bool(const int runNumber, const size_t bank,
-                    const std::string &instParamFile,
-                    const std::vector<std::string> &phaseFiles,
-                    const std::string &pathToGSASII,
-                    const std::string &GSASIIProjectFile, const double dMin,
-                    const double negativeWeight));
+               std::string(const int runNumber, const size_t bank,
+                           const std::string &instParamFile,
+                           const std::vector<std::string> &phaseFiles,
+                           const std::string &pathToGSASII,
+                           const std::string &GSASIIProjectFile,
+                           const double dMin, const double negativeWeight));
 
   MOCK_METHOD6(doRietveldRefinement,
-               bool(const int runNumber, const size_t bank,
-                    const std::string &instParamFile,
-                    const std::vector<std::string> &phaseFiles,
-                    const std::string &pathToGSASII,
-                    const std::string &GSASIIProjectFile));
+               std::string(const int runNumber, const size_t bank,
+                           const std::string &instParamFile,
+                           const std::vector<std::string> &phaseFiles,
+                           const std::string &pathToGSASII,
+                           const std::string &GSASIIProjectFile));
 
   MOCK_CONST_METHOD2(getFittedPeaks,
                      boost::optional<Mantid::API::MatrixWorkspace_sptr>(

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelTest.h
@@ -142,9 +142,9 @@ public:
     const static std::string inputFilename = "ENGINX_277208_focused_bank_2.nxs";
     TestEnggDiffGSASFittingModel model;
 
-    bool success = false;
-    TS_ASSERT_THROWS_NOTHING(success = model.loadFocusedRun(inputFilename));
-    TS_ASSERT(success);
+    auto failure = boost::make_optional<std::string>("Failure");
+    TS_ASSERT_THROWS_NOTHING(failure = model.loadFocusedRun(inputFilename));
+    TS_ASSERT(!failure);
 
     TS_ASSERT(model.containsFocusedRun(277208, 2));
   }
@@ -153,9 +153,9 @@ public:
     const static std::string inputFilename = "ENGINX_277209_focused_bank_2.nxs";
     TestEnggDiffGSASFittingModel model;
 
-    bool success = false;
-    TS_ASSERT_THROWS_NOTHING(success = model.loadFocusedRun(inputFilename));
-    TS_ASSERT(!success);
+    boost::optional<std::string> failure = boost::make_optional(false, std::string());
+    TS_ASSERT_THROWS_NOTHING(failure = model.loadFocusedRun(inputFilename));
+    TS_ASSERT(failure);
   }
 
   void test_getFocusedRun() {

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelTest.h
@@ -50,7 +50,7 @@ public:
   void addRwpValue(const int runNumber, const size_t bank, const double rwp);
 
 private:
-  inline boost::optional<double> doGSASRefinementAlgorithm(
+  inline double doGSASRefinementAlgorithm(
       API::MatrixWorkspace_sptr inputWorkspace,
       const std::string &outputWorkspaceName,
       const std::string &latticeParamsName, const std::string &refinementMethod,
@@ -87,8 +87,7 @@ TestEnggDiffGSASFittingModel::containsFocusedRun(const int runNumber,
   return hasFocusedRun(runNumber, bank);
 }
 
-inline boost::optional<double>
-TestEnggDiffGSASFittingModel::doGSASRefinementAlgorithm(
+inline double TestEnggDiffGSASFittingModel::doGSASRefinementAlgorithm(
     API::MatrixWorkspace_sptr inputWorkspace,
     const std::string &outputWorkspaceName,
     const std::string &latticeParamsName, const std::string &refinementMethod,
@@ -279,11 +278,11 @@ public:
         API::WorkspaceFactory::Instance().create("Workspace2D", 1, 10, 10);
     model.addFocusedWorkspace(123, 1, ws);
 
-    bool success = false;
+    std::string failure = "Failure";
     TS_ASSERT_THROWS_NOTHING(
-        success = model.doPawleyRefinement(
+        failure = model.doPawleyRefinement(
             123, 1, "", std::vector<std::string>({}), "", "", 0, 0));
-    TS_ASSERT(success);
+    TS_ASSERT(failure.empty());
 
     const auto rwp = model.getRwp(123, 1);
     TS_ASSERT(rwp);
@@ -307,11 +306,11 @@ public:
         API::WorkspaceFactory::Instance().create("Workspace2D", 1, 10, 10);
     model.addFocusedWorkspace(123, 1, ws);
 
-    bool success = false;
+    std::string failure = "Failure";
     TS_ASSERT_THROWS_NOTHING(
-        success = model.doRietveldRefinement(
+        failure = model.doRietveldRefinement(
             123, 1, "", std::vector<std::string>({}), "", ""));
-    TS_ASSERT(success);
+    TS_ASSERT(failure.empty());
 
     const auto rwp = model.getRwp(123, 1);
     TS_ASSERT(rwp);

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelTest.h
@@ -142,9 +142,9 @@ public:
     const static std::string inputFilename = "ENGINX_277208_focused_bank_2.nxs";
     TestEnggDiffGSASFittingModel model;
 
-    auto failure = boost::make_optional<std::string>("Failure");
+    std::string failure = "Failure";
     TS_ASSERT_THROWS_NOTHING(failure = model.loadFocusedRun(inputFilename));
-    TS_ASSERT(!failure);
+    TS_ASSERT(failure.empty());
 
     TS_ASSERT(model.containsFocusedRun(277208, 2));
   }
@@ -153,9 +153,9 @@ public:
     const static std::string inputFilename = "ENGINX_277209_focused_bank_2.nxs";
     TestEnggDiffGSASFittingModel model;
 
-    boost::optional<std::string> failure = boost::make_optional(false, std::string());
+    std::string failure = "";
     TS_ASSERT_THROWS_NOTHING(failure = model.loadFocusedRun(inputFilename));
-    TS_ASSERT(failure);
+    TS_ASSERT(!failure.empty());
   }
 
   void test_getFocusedRun() {

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
@@ -57,9 +57,7 @@ public:
 
     EXPECT_CALL(*m_mockModelPtr, getRunLabels()).Times(0);
 
-    EXPECT_CALL(
-        *m_mockViewPtr,
-        userWarning("Load failed", "Failure message"))
+    EXPECT_CALL(*m_mockViewPtr, userWarning("Load failed", "Failure message"))
         .Times(1);
 
     presenter->notify(IEnggDiffGSASFittingPresenter::LoadRun);
@@ -185,10 +183,9 @@ public:
                 doRietveldRefinement(runNumber, bank, instParams, phaseFiles,
                                      pathToGSASII, GSASIIProjectFile))
         .Times(1)
-        .WillOnce(Return(false));
-    EXPECT_CALL(*m_mockViewPtr,
-                userWarning("Refinement failed",
-                            "Refinement failed, see the log for more details"));
+        .WillOnce(Return("Refinement failure description"));
+    EXPECT_CALL(*m_mockViewPtr, userWarning("Refinement failed",
+                                            "Refinement failure description"));
 
     presenter->notify(IEnggDiffGSASFittingPresenter::DoRefinement);
     assertMocksUsedCorrectly();
@@ -238,10 +235,9 @@ public:
                                    pathToGSASII, GSASIIProjectFile, dmin,
                                    negativeWeight))
         .Times(1)
-        .WillOnce(Return(false));
-    EXPECT_CALL(*m_mockViewPtr,
-                userWarning("Refinement failed",
-                            "Refinement failed, see the log for more details"));
+        .WillOnce(Return("Refinement failure description"));
+    EXPECT_CALL(*m_mockViewPtr, userWarning("Refinement failed",
+                                            "Refinement failure description"));
 
     presenter->notify(IEnggDiffGSASFittingPresenter::DoRefinement);
     assertMocksUsedCorrectly();

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
@@ -37,7 +37,7 @@ public:
         .WillOnce(Return(runLabels));
     EXPECT_CALL(*m_mockViewPtr, updateRunList(runLabels)).Times(1);
 
-    EXPECT_CALL(*m_mockViewPtr, userWarning(testing::_)).Times(0);
+    EXPECT_CALL(*m_mockViewPtr, userWarning(testing::_, testing::_)).Times(0);
 
     presenter->notify(IEnggDiffGSASFittingPresenter::LoadRun);
     assertMocksUsedCorrectly();
@@ -57,8 +57,9 @@ public:
 
     EXPECT_CALL(*m_mockModelPtr, getRunLabels()).Times(0);
 
-    EXPECT_CALL(*m_mockViewPtr,
-                userWarning("Load failed, see the log for more details"))
+    EXPECT_CALL(
+        *m_mockViewPtr,
+        userWarning("Load failed", "Load failed, see the log for more details"))
         .Times(1);
 
     presenter->notify(IEnggDiffGSASFittingPresenter::LoadRun);
@@ -80,7 +81,7 @@ public:
         .WillOnce(Return(sampleWorkspace));
 
     EXPECT_CALL(*m_mockViewPtr, resetCanvas()).Times(1);
-    EXPECT_CALL(*m_mockViewPtr, userWarning(testing::_)).Times(0);
+    EXPECT_CALL(*m_mockViewPtr, userWarning(testing::_, testing::_)).Times(0);
 
     presenter->notify(IEnggDiffGSASFittingPresenter::SelectRun);
     assertMocksUsedCorrectly();
@@ -97,10 +98,10 @@ public:
         .Times(1)
         .WillOnce(Return(boost::none));
 
-    EXPECT_CALL(
-        *m_mockViewPtr,
-        userWarning(
-            "Tried to access invalid run, runNumber 123 and bank ID 1"));
+    EXPECT_CALL(*m_mockViewPtr,
+                userError("Invalid run identifier",
+                          "Tried to access invalid run, runNumber 123 and "
+                          "bank ID 1. Please contact the development team"));
 
     EXPECT_CALL(*m_mockViewPtr, resetCanvas()).Times(0);
 
@@ -143,7 +144,7 @@ public:
 
     EXPECT_CALL(*m_mockViewPtr, resetCanvas()).Times(1);
     EXPECT_CALL(*m_mockViewPtr, plotCurve(testing::_)).Times(2);
-    EXPECT_CALL(*m_mockViewPtr, userWarning(testing::_)).Times(0);
+    EXPECT_CALL(*m_mockViewPtr, userWarning(testing::_, testing::_)).Times(0);
 
     presenter->notify(IEnggDiffGSASFittingPresenter::SelectRun);
     assertMocksUsedCorrectly();
@@ -186,7 +187,8 @@ public:
         .Times(1)
         .WillOnce(Return(false));
     EXPECT_CALL(*m_mockViewPtr,
-                userWarning("Refinement failed, see the log for more details"));
+                userWarning("Refinement failed",
+                            "Refinement failed, see the log for more details"));
 
     presenter->notify(IEnggDiffGSASFittingPresenter::DoRefinement);
     assertMocksUsedCorrectly();
@@ -238,7 +240,8 @@ public:
         .Times(1)
         .WillOnce(Return(false));
     EXPECT_CALL(*m_mockViewPtr,
-                userWarning("Refinement failed, see the log for more details"));
+                userWarning("Refinement failed",
+                            "Refinement failed, see the log for more details"));
 
     presenter->notify(IEnggDiffGSASFittingPresenter::DoRefinement);
     assertMocksUsedCorrectly();
@@ -261,15 +264,15 @@ private:
   }
 
   void assertMocksUsedCorrectly() {
-    if (m_mockViewPtr) {
-      delete m_mockViewPtr;
-    }
     TSM_ASSERT("View mock not used as expected: some EXPECT_CALL conditions "
                "not satisfied",
                testing::Mock::VerifyAndClearExpectations(m_mockModelPtr));
     TSM_ASSERT("Model mock not used as expected: some EXPECT_CALL conditions "
                "not satisfied",
                testing::Mock::VerifyAndClearExpectations(m_mockViewPtr));
+    if (m_mockViewPtr) {
+      delete m_mockViewPtr;
+    }
   }
 };
 

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
@@ -27,7 +27,7 @@ public:
         .WillOnce(Return(std::vector<std::string>({filename})));
     EXPECT_CALL(*m_mockModelPtr, loadFocusedRun(filename))
         .Times(1)
-      .WillOnce(Return(boost::none));
+        .WillOnce(Return(""));
 
     const std::vector<std::pair<int, size_t>> runLabels(
         {std::make_pair(123, 1)});
@@ -53,7 +53,7 @@ public:
 
     EXPECT_CALL(*m_mockModelPtr, loadFocusedRun(filename))
         .Times(1)
-        .WillOnce(Return(boost::make_optional<std::string>("Failure message")));
+        .WillOnce(Return("Failure message"));
 
     EXPECT_CALL(*m_mockModelPtr, getRunLabels()).Times(0);
 

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
@@ -27,7 +27,7 @@ public:
         .WillOnce(Return(std::vector<std::string>({filename})));
     EXPECT_CALL(*m_mockModelPtr, loadFocusedRun(filename))
         .Times(1)
-        .WillOnce(Return(true));
+      .WillOnce(Return(boost::none));
 
     const std::vector<std::pair<int, size_t>> runLabels(
         {std::make_pair(123, 1)});
@@ -53,13 +53,13 @@ public:
 
     EXPECT_CALL(*m_mockModelPtr, loadFocusedRun(filename))
         .Times(1)
-        .WillOnce(Return(false));
+        .WillOnce(Return(boost::make_optional<std::string>("Failure message")));
 
     EXPECT_CALL(*m_mockModelPtr, getRunLabels()).Times(0);
 
     EXPECT_CALL(
         *m_mockViewPtr,
-        userWarning("Load failed", "Load failed, see the log for more details"))
+        userWarning("Load failed", "Failure message"))
         .Times(1);
 
     presenter->notify(IEnggDiffGSASFittingPresenter::LoadRun);

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingViewMock.h
@@ -49,7 +49,11 @@ public:
   MOCK_METHOD1(updateRunList,
                void(const std::vector<std::pair<int, size_t>> &runLabels));
 
-  MOCK_CONST_METHOD1(userWarning, void(const std::string &warningDescription));
+  MOCK_CONST_METHOD2(userError, void(const std::string &errorTitle,
+                                     const std::string &errorDescription));
+
+  MOCK_CONST_METHOD2(userWarning, void(const std::string &warningTitle,
+                                       const std::string &warningDescription));
 };
 
 GCC_DIAG_ON_SUGGEST_OVERRIDE


### PR DESCRIPTION
**Note: do NOT merge before #21617**

There was previously no proper error handling in the GSAS tab of the ED GUI. Errors in loading and refinement (though refinement is not yet properly hooked up) are now dealt with via a message box in the same way as the fitting tab.

**To test:**

Some sample data is[here](https://github.com/mantidproject/mantid/files/1656872/engggui_pr_data.zip).

Open up the ED GUI (`Interfaces -> Diffraction -> Engineering Diffraction`). Go to the GSAS tab and put some nonsense into the **Focused Run** line-edit. Clicking **Load** should give you a message box saying something along the lines of "File doesn't exist".

Click the first **Browse** button and select all the files from the attached zip, then click **Load**. The two runs from 277208 should load fine, and there should be a warning for 277209 that the bank ID was not set.

Partially address #15552 

**Release Notes** 
Will be added to the release notes once refinement can be done from the GUI

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
