### PR TITLE
Engineering Diffraction GUI GSAS tab improve warnings

### DIFF
--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.cpp
@@ -200,7 +200,7 @@ bool EnggDiffGSASFittingModel::hasFocusedRun(const RunLabel &runLabel) const {
   return m_focusedWorkspaceMap.contains(runLabel);
 }
 
-std::string
+boost::optional<std::string>
 EnggDiffGSASFittingModel::loadFocusedRun(const std::string &filename) {
   const auto wsName = stripWSNameFromFilename(filename);
 
@@ -210,7 +210,7 @@ EnggDiffGSASFittingModel::loadFocusedRun(const std::string &filename) {
     loadAlg->setProperty("OutputWorkspace", wsName);
     loadAlg->execute();
   } catch (const std::exception &e) {
-    return e.what();
+    return boost::make_optional<std::string>(e.what());
   }
 
   API::AnalysisDataServiceImpl &ADS = API::AnalysisDataService::Instance();
@@ -226,7 +226,7 @@ EnggDiffGSASFittingModel::loadFocusedRun(const std::string &filename) {
   }
 
   m_focusedWorkspaceMap.add(RunLabel(runNumber, *bankID), ws);
-  return "";
+  return boost::none;
 }
 
 } // CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.cpp
@@ -81,7 +81,7 @@ std::string generateLatticeParamsName(const RunLabel &runLabel) {
 }
 }
 
-std::string EnggDiffGSASFittingModel::doPawleyRefinement(
+boost::optional<std::string> EnggDiffGSASFittingModel::doPawleyRefinement(
     const RunLabel &runLabel, const std::string &instParamFile,
     const std::vector<std::string> &phaseFiles, const std::string &pathToGSASII,
     const std::string &GSASIIProjectFile, const double dMin,
@@ -103,12 +103,12 @@ std::string EnggDiffGSASFittingModel::doPawleyRefinement(
                                     phaseFiles, pathToGSASII, GSASIIProjectFile,
                                     dMin, negativeWeight);
   } catch (const std::exception &e) {
-    return e.what();
+    return boost::make_optional<std::string>(e.what());
   }
 
   addFitResultsToMaps(runLabel, rwp, outputWSName, latticeParamsName);
 
-  return "";
+  return boost::none;
 }
 
 double EnggDiffGSASFittingModel::doGSASRefinementAlgorithm(
@@ -137,7 +137,7 @@ double EnggDiffGSASFittingModel::doGSASRefinementAlgorithm(
   return rwp;
 }
 
-std::string EnggDiffGSASFittingModel::doRietveldRefinement(
+boost::optional<std::string> EnggDiffGSASFittingModel::doRietveldRefinement(
     const RunLabel &runLabel, const std::string &instParamFile,
     const std::vector<std::string> &phaseFiles, const std::string &pathToGSASII,
     const std::string &GSASIIProjectFile) {
@@ -160,11 +160,11 @@ std::string EnggDiffGSASFittingModel::doRietveldRefinement(
   }
 
   catch (const std::exception &e) {
-    return e.what();
+    return boost::make_optional<std::string>(e.what());
   }
   addFitResultsToMaps(runLabel, rwp, outputWSName, latticeParamsName);
 
-  return "";
+  return boost::none;
 }
 
 boost::optional<API::MatrixWorkspace_sptr>

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.cpp
@@ -196,7 +196,7 @@ bool EnggDiffGSASFittingModel::hasFocusedRun(const RunLabel &runLabel) const {
   return m_focusedWorkspaceMap.contains(runLabel);
 }
 
-boost::optional<std::string>
+std::string
 EnggDiffGSASFittingModel::loadFocusedRun(const std::string &filename) {
   const auto wsName = stripWSNameFromFilename(filename);
 
@@ -206,7 +206,7 @@ EnggDiffGSASFittingModel::loadFocusedRun(const std::string &filename) {
     loadAlg->setProperty("OutputWorkspace", wsName);
     loadAlg->execute();
   } catch (const std::exception &e) {
-    return boost::make_optional<std::string>(e.what());
+    return e.what();
   }
 
   API::AnalysisDataServiceImpl &ADS = API::AnalysisDataService::Instance();
@@ -218,11 +218,11 @@ EnggDiffGSASFittingModel::loadFocusedRun(const std::string &filename) {
   try {
     bank = getBankID(ws);
   } catch (const std::runtime_error &e) {
-    return boost::make_optional<std::string>(e.what());
+    return e.what();
   }
 
   m_focusedWorkspaceMap.add(RunLabel(runNumber, bank), ws);
-  return boost::none;
+  return "";
 }
 
 } // CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.cpp
@@ -196,7 +196,8 @@ bool EnggDiffGSASFittingModel::hasFocusedRun(const RunLabel &runLabel) const {
   return m_focusedWorkspaceMap.contains(runLabel);
 }
 
-bool EnggDiffGSASFittingModel::loadFocusedRun(const std::string &filename) {
+boost::optional<std::string>
+EnggDiffGSASFittingModel::loadFocusedRun(const std::string &filename) {
   const auto wsName = stripWSNameFromFilename(filename);
 
   try {
@@ -204,17 +205,24 @@ bool EnggDiffGSASFittingModel::loadFocusedRun(const std::string &filename) {
     loadAlg->setProperty("Filename", filename);
     loadAlg->setProperty("OutputWorkspace", wsName);
     loadAlg->execute();
-  } catch (const std::exception) {
-    return false;
+  } catch (const std::exception &e) {
+    return boost::make_optional<std::string>(e.what());
   }
 
   API::AnalysisDataServiceImpl &ADS = API::AnalysisDataService::Instance();
   const auto ws = ADS.retrieveWS<API::MatrixWorkspace>(wsName);
 
   const auto runNumber = ws->getRunNumber();
-  const auto bank = getBankID(ws);
+  size_t bank = 0;
+
+  try {
+    bank = getBankID(ws);
+  } catch (const std::runtime_error &e) {
+    return boost::make_optional<std::string>(e.what());
+  }
+
   m_focusedWorkspaceMap.add(RunLabel(runNumber, bank), ws);
-  return true;
+  return boost::none;
 }
 
 } // CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.cpp
@@ -81,33 +81,37 @@ std::string generateLatticeParamsName(const RunLabel &runLabel) {
 }
 }
 
-bool EnggDiffGSASFittingModel::doPawleyRefinement(
+std::string EnggDiffGSASFittingModel::doPawleyRefinement(
     const RunLabel &runLabel, const std::string &instParamFile,
     const std::vector<std::string> &phaseFiles, const std::string &pathToGSASII,
     const std::string &GSASIIProjectFile, const double dMin,
     const double negativeWeight) {
   const auto inputWS = getFocusedWorkspace(runLabel);
   if (!inputWS) {
-    return false;
+    return "Could not find focused run for run number " +
+           std::to_string(runLabel.runNumber) + " and bank ID " +
+           std::to_string(runLabel.bank);
   }
   const auto outputWSName = generateFittedPeaksWSName(runLabel);
   const auto latticeParamsName = generateLatticeParamsName(runLabel);
 
-  const auto rwp = doGSASRefinementAlgorithm(
-      *inputWS, outputWSName, latticeParamsName, "Pawley refinement",
-      instParamFile, phaseFiles, pathToGSASII, GSASIIProjectFile, dMin,
-      negativeWeight);
+  double rwp = 0;
 
-  if (!rwp) {
-    return false;
+  try {
+    rwp = doGSASRefinementAlgorithm(*inputWS, outputWSName, latticeParamsName,
+                                    "Pawley refinement", instParamFile,
+                                    phaseFiles, pathToGSASII, GSASIIProjectFile,
+                                    dMin, negativeWeight);
+  } catch (const std::exception &e) {
+    return e.what();
   }
 
-  addFitResultsToMaps(runLabel, *rwp, outputWSName, latticeParamsName);
+  addFitResultsToMaps(runLabel, rwp, outputWSName, latticeParamsName);
 
-  return true;
+  return "";
 }
 
-boost::optional<double> EnggDiffGSASFittingModel::doGSASRefinementAlgorithm(
+double EnggDiffGSASFittingModel::doGSASRefinementAlgorithm(
     API::MatrixWorkspace_sptr inputWorkspace,
     const std::string &outputWorkspaceName,
     const std::string &latticeParamsName, const std::string &refinementMethod,
@@ -115,52 +119,52 @@ boost::optional<double> EnggDiffGSASFittingModel::doGSASRefinementAlgorithm(
     const std::vector<std::string> &phaseFiles, const std::string &pathToGSASII,
     const std::string &GSASIIProjectFile, const double dMin,
     const double negativeWeight) {
-  double rwp = -1;
-  try {
-    auto gsasAlg =
-        API::AlgorithmManager::Instance().create("GSASIIRefineFitPeaks");
-    gsasAlg->setProperty("RefinementMethod", refinementMethod);
-    gsasAlg->setProperty("InputWorkspace", inputWorkspace);
-    gsasAlg->setProperty("OutputWorkspace", outputWorkspaceName);
-    gsasAlg->setProperty("LatticeParameters", latticeParamsName);
-    gsasAlg->setProperty("InstrumentFile", instParamFile);
-    gsasAlg->setProperty("PhaseInfoFiles", phaseFiles);
-    gsasAlg->setProperty("PathToGSASII", pathToGSASII);
-    gsasAlg->setProperty("SaveGSASIIProjectFile", GSASIIProjectFile);
-    gsasAlg->setProperty("PawleyDMin", dMin);
-    gsasAlg->setProperty("PawleyNegativeWeight", negativeWeight);
-    gsasAlg->execute();
+  auto gsasAlg =
+      API::AlgorithmManager::Instance().create("GSASIIRefineFitPeaks");
+  gsasAlg->setProperty("RefinementMethod", refinementMethod);
+  gsasAlg->setProperty("InputWorkspace", inputWorkspace);
+  gsasAlg->setProperty("OutputWorkspace", outputWorkspaceName);
+  gsasAlg->setProperty("LatticeParameters", latticeParamsName);
+  gsasAlg->setProperty("InstrumentFile", instParamFile);
+  gsasAlg->setProperty("PhaseInfoFiles", phaseFiles);
+  gsasAlg->setProperty("PathToGSASII", pathToGSASII);
+  gsasAlg->setProperty("SaveGSASIIProjectFile", GSASIIProjectFile);
+  gsasAlg->setProperty("PawleyDMin", dMin);
+  gsasAlg->setProperty("PawleyNegativeWeight", negativeWeight);
+  gsasAlg->execute();
 
-    rwp = gsasAlg->getProperty("Rwp");
-  } catch (const std::exception) {
-    return boost::none;
-  }
+  const double rwp = gsasAlg->getProperty("Rwp");
   return rwp;
 }
 
-bool EnggDiffGSASFittingModel::doRietveldRefinement(
+std::string EnggDiffGSASFittingModel::doRietveldRefinement(
     const RunLabel &runLabel, const std::string &instParamFile,
     const std::vector<std::string> &phaseFiles, const std::string &pathToGSASII,
     const std::string &GSASIIProjectFile) {
   const auto inputWS = getFocusedWorkspace(runLabel);
   if (!inputWS) {
-    return false;
+    return "Could not find focused run for run number " +
+           std::to_string(runLabel.runNumber) + " and bank ID " +
+           std::to_string(runLabel.bank);
   }
+
   const auto outputWSName = generateFittedPeaksWSName(runLabel);
   const auto latticeParamsName = generateLatticeParamsName(runLabel);
 
-  const auto rwp = doGSASRefinementAlgorithm(
-      *inputWS, outputWSName, latticeParamsName, "Rietveld refinement",
-      instParamFile, phaseFiles, pathToGSASII, GSASIIProjectFile,
-      DEFAULT_PAWLEY_DMIN, DEFAULT_PAWLEY_NEGATIVE_WEIGHT);
-
-  if (!rwp) {
-    return false;
+  double rwp = 0;
+  try {
+    rwp = doGSASRefinementAlgorithm(
+        *inputWS, outputWSName, latticeParamsName, "Rietveld refinement",
+        instParamFile, phaseFiles, pathToGSASII, GSASIIProjectFile,
+        DEFAULT_PAWLEY_DMIN, DEFAULT_PAWLEY_NEGATIVE_WEIGHT);
   }
 
-  addFitResultsToMaps(runLabel, *rwp, outputWSName, latticeParamsName);
+  catch (const std::exception &e) {
+    return e.what();
+  }
+  addFitResultsToMaps(runLabel, rwp, outputWSName, latticeParamsName);
 
-  return true;
+  return "";
 }
 
 boost::optional<API::MatrixWorkspace_sptr>

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
@@ -41,8 +41,7 @@ public:
 
   bool hasFittedPeaksForRun(const RunLabel &runLabel) const override;
 
-  boost::optional<std::string>
-  loadFocusedRun(const std::string &filename) override;
+  std::string loadFocusedRun(const std::string &filename) override;
 
 protected:
   /// The following methods are marked as protected so that they can be exposed

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
@@ -12,19 +12,20 @@ class MANTIDQT_ENGGDIFFRACTION_DLL EnggDiffGSASFittingModel
     : public IEnggDiffGSASFittingModel {
 
 public:
-  bool doPawleyRefinement(const RunLabel &runLabel,
-                          const std::string &instParamFile,
-                          const std::vector<std::string> &phaseFiles,
-                          const std::string &pathToGSASII,
-                          const std::string &GSASIIProjectFile,
-                          const double dMin,
-                          const double negativeWeight) override;
+  std::string doPawleyRefinement(const RunLabel &runLabel,
+                                 const std::string &instParamFile,
+                                 const std::vector<std::string> &phaseFiles,
+                                 const std::string &pathToGSASII,
+                                 const std::string &GSASIIProjectFile,
+                                 const double dMin,
+                                 const double negativeWeight) override;
 
-  bool doRietveldRefinement(const RunLabel &runLabel,
-                            const std::string &instParamFile,
-                            const std::vector<std::string> &phaseFiles,
-                            const std::string &pathToGSASII,
-                            const std::string &GSASIIProjectFile) override;
+  std::string
+  doRietveldRefinement(const RunLabel &runLabel,
+                       const std::string &instParamFile,
+                       const std::vector<std::string> &phaseFiles,
+                       const std::string &pathToGSASII,
+                       const std::string &GSASIIProjectFile) override;
 
   boost::optional<Mantid::API::MatrixWorkspace_sptr>
   getFittedPeaks(const RunLabel &runLabel) const override;
@@ -94,8 +95,8 @@ private:
   /// Run GSASIIRefineFitPeaks
   /// Note this must be virtual so that it can be mocked out by the helper class
   /// in EnggDiffGSASFittingModelTest
-  /// Returns Rwp of the fit (empty optional if fit was unsuccessful)
-  virtual boost::optional<double> doGSASRefinementAlgorithm(
+  /// Returns Rwp of the fit
+  virtual double doGSASRefinementAlgorithm(
       Mantid::API::MatrixWorkspace_sptr inputWorkspace,
       const std::string &outputWorkspaceName,
       const std::string &latticeParamsName, const std::string &refinementMethod,

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
@@ -41,7 +41,8 @@ public:
 
   bool hasFittedPeaksForRun(const RunLabel &runLabel) const override;
 
-  std::string loadFocusedRun(const std::string &filename) override;
+  boost::optional<std::string>
+  loadFocusedRun(const std::string &filename) override;
 
 protected:
   /// The following methods are marked as protected so that they can be exposed

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
@@ -41,7 +41,8 @@ public:
 
   bool hasFittedPeaksForRun(const RunLabel &runLabel) const override;
 
-  bool loadFocusedRun(const std::string &filename) override;
+  boost::optional<std::string>
+  loadFocusedRun(const std::string &filename) override;
 
 protected:
   /// The following methods are marked as protected so that they can be exposed

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
@@ -12,15 +12,14 @@ class MANTIDQT_ENGGDIFFRACTION_DLL EnggDiffGSASFittingModel
     : public IEnggDiffGSASFittingModel {
 
 public:
-  std::string doPawleyRefinement(const RunLabel &runLabel,
-                                 const std::string &instParamFile,
-                                 const std::vector<std::string> &phaseFiles,
-                                 const std::string &pathToGSASII,
-                                 const std::string &GSASIIProjectFile,
-                                 const double dMin,
-                                 const double negativeWeight) override;
+  boost::optional<std::string>
+  doPawleyRefinement(const RunLabel &runLabel, const std::string &instParamFile,
+                     const std::vector<std::string> &phaseFiles,
+                     const std::string &pathToGSASII,
+                     const std::string &GSASIIProjectFile, const double dMin,
+                     const double negativeWeight) override;
 
-  std::string
+  boost::optional<std::string>
   doRietveldRefinement(const RunLabel &runLabel,
                        const std::string &instParamFile,
                        const std::vector<std::string> &phaseFiles,

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
@@ -132,18 +132,16 @@ void EnggDiffGSASFittingPresenter::processDoRefinement() {
 
 void EnggDiffGSASFittingPresenter::processLoadRun() {
   const auto focusedFileNames = m_view->getFocusedFileNames();
-  bool loadSuccessful = true;
 
-  for (const auto &fileName : focusedFileNames) {
-    loadSuccessful &= m_model->loadFocusedRun(fileName);
-  }
+  for (const auto fileName : focusedFileNames) {
+    const auto loadFailure = m_model->loadFocusedRun(fileName);
 
-  if (loadSuccessful) {
-    const auto runLabels = m_model->getRunLabels();
-    m_view->updateRunList(runLabels);
-  } else {
-    m_view->userWarning("Load failed",
-                        "Load failed, see the log for more details");
+    if (loadFailure) {
+      m_view->userWarning("Load failed", *loadFailure);
+    } else {
+      const auto runLabels = m_model->getRunLabels();
+      m_view->updateRunList(runLabels);
+    }
   }
 }
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
@@ -135,11 +135,11 @@ void EnggDiffGSASFittingPresenter::processLoadRun() {
   for (const auto fileName : focusedFileNames) {
     const auto loadFailure = m_model->loadFocusedRun(fileName);
 
-    if (loadFailure.empty()) {
+    if (loadFailure) {
+      m_view->userWarning("Load failed", *loadFailure);
+    } else {
       const auto runLabels = m_model->getRunLabels();
       m_view->updateRunList(runLabels);
-    } else {
-      m_view->userWarning("Load failed", loadFailure);
     }
   }
 }

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
@@ -61,11 +61,12 @@ void EnggDiffGSASFittingPresenter::displayFitResults(const RunLabel &runLabel) {
   const auto rwp = m_model->getRwp(runLabel);
 
   if (!fittedPeaks || !latticeParams || !rwp) {
-    m_view->userWarning("Unexpectedly tried to plot fit results for invalid "
-                        "run, run number = " +
-                        std::to_string(runLabel.runNumber) + ", bank ID = " +
-                        std::to_string(runLabel.bank) +
-                        ". Please contact the development team");
+    m_view->userError("Invalid run identifier",
+                      "Unexpectedly tried to plot fit results for invalid "
+                      "run, run number = " +
+                          std::to_string(runLabel.runNumber) + ", bank ID = " +
+                          std::to_string(runLabel.bank) +
+                          ". Please contact the development team");
     return;
   }
 
@@ -124,7 +125,8 @@ void EnggDiffGSASFittingPresenter::processDoRefinement() {
   if (refinementSuccessful) {
     updatePlot(runLabel);
   } else {
-    m_view->userWarning("Refinement failed, see the log for more details");
+    m_view->userWarning("Refinement failed",
+                        "Refinement failed, see the log for more details");
   }
 }
 
@@ -140,7 +142,8 @@ void EnggDiffGSASFittingPresenter::processLoadRun() {
     const auto runLabels = m_model->getRunLabels();
     m_view->updateRunList(runLabels);
   } else {
-    m_view->userWarning("Load failed, see the log for more details");
+    m_view->userWarning("Load failed",
+                        "Load failed, see the log for more details");
   }
 }
 
@@ -156,9 +159,11 @@ void EnggDiffGSASFittingPresenter::processShutDown() { m_viewHasClosed = true; }
 void EnggDiffGSASFittingPresenter::updatePlot(const RunLabel &runLabel) {
   const auto focusedWSOptional = m_model->getFocusedWorkspace(runLabel);
   if (!focusedWSOptional) {
-    m_view->userWarning("Tried to access invalid run, runNumber " +
-                        std::to_string(runLabel.runNumber) + " and bank ID " +
-                        std::to_string(runLabel.bank));
+    m_view->userError("Invalid run identifier",
+                      "Tried to access invalid run, runNumber " +
+                          std::to_string(runLabel.runNumber) + " and bank ID " +
+                          std::to_string(runLabel.bank) +
+                          ". Please contact the development team");
     return;
   }
   const auto focusedWS = *focusedWSOptional;

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
@@ -77,7 +77,7 @@ void EnggDiffGSASFittingPresenter::displayFitResults(const RunLabel &runLabel) {
   m_view->displayRwp(*rwp);
 }
 
-std::string EnggDiffGSASFittingPresenter::doPawleyRefinement(
+boost::optional<std::string> EnggDiffGSASFittingPresenter::doPawleyRefinement(
     const RunLabel &runLabel, const std::string &instParamFile,
     const std::vector<std::string> &phaseFiles, const std::string &pathToGSASII,
     const std::string &GSASIIProjectFile) {
@@ -89,7 +89,7 @@ std::string EnggDiffGSASFittingPresenter::doPawleyRefinement(
                                      negativeWeight);
 }
 
-std::string EnggDiffGSASFittingPresenter::doRietveldRefinement(
+boost::optional<std::string> EnggDiffGSASFittingPresenter::doRietveldRefinement(
     const RunLabel &runLabel, const std::string &instParamFile,
     const std::vector<std::string> &phaseFiles, const std::string &pathToGSASII,
     const std::string &GSASIIProjectFile) {
@@ -107,7 +107,7 @@ void EnggDiffGSASFittingPresenter::processDoRefinement() {
   const auto pathToGSASII = m_view->getPathToGSASII();
   const auto GSASIIProjectFile = m_view->getGSASIIProjectPath();
 
-  std::string refinementFailure("Contact developers if you see this message");
+  boost::optional<std::string> refinementFailure(boost::none);
 
   switch (refinementMethod) {
 
@@ -122,10 +122,10 @@ void EnggDiffGSASFittingPresenter::processDoRefinement() {
     break;
   }
 
-  if (refinementFailure.empty()) {
-    updatePlot(runLabel);
+  if (refinementFailure) {
+    m_view->userWarning("Refinement failed", *refinementFailure);
   } else {
-    m_view->userWarning("Refinement failed", refinementFailure);
+    updatePlot(runLabel);
   }
 }
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
@@ -77,7 +77,7 @@ void EnggDiffGSASFittingPresenter::displayFitResults(const RunLabel &runLabel) {
   m_view->displayRwp(*rwp);
 }
 
-bool EnggDiffGSASFittingPresenter::doPawleyRefinement(
+std::string EnggDiffGSASFittingPresenter::doPawleyRefinement(
     const RunLabel &runLabel, const std::string &instParamFile,
     const std::vector<std::string> &phaseFiles, const std::string &pathToGSASII,
     const std::string &GSASIIProjectFile) {
@@ -89,7 +89,7 @@ bool EnggDiffGSASFittingPresenter::doPawleyRefinement(
                                      negativeWeight);
 }
 
-bool EnggDiffGSASFittingPresenter::doRietveldRefinement(
+std::string EnggDiffGSASFittingPresenter::doRietveldRefinement(
     const RunLabel &runLabel, const std::string &instParamFile,
     const std::vector<std::string> &phaseFiles, const std::string &pathToGSASII,
     const std::string &GSASIIProjectFile) {
@@ -107,26 +107,25 @@ void EnggDiffGSASFittingPresenter::processDoRefinement() {
   const auto pathToGSASII = m_view->getPathToGSASII();
   const auto GSASIIProjectFile = m_view->getGSASIIProjectPath();
 
-  bool refinementSuccessful = false;
+  std::string refinementFailure("Contact developers if you see this message");
 
   switch (refinementMethod) {
 
   case GSASRefinementMethod::PAWLEY:
-    refinementSuccessful = doPawleyRefinement(
-        runLabel, instParamFile, phaseFiles, pathToGSASII, GSASIIProjectFile);
+    refinementFailure = doPawleyRefinement(runLabel, instParamFile, phaseFiles,
+                                           pathToGSASII, GSASIIProjectFile);
     break;
 
   case GSASRefinementMethod::RIETVELD:
-    refinementSuccessful = doRietveldRefinement(
+    refinementFailure = doRietveldRefinement(
         runLabel, instParamFile, phaseFiles, pathToGSASII, GSASIIProjectFile);
     break;
   }
 
-  if (refinementSuccessful) {
+  if (refinementFailure.empty()) {
     updatePlot(runLabel);
   } else {
-    m_view->userWarning("Refinement failed",
-                        "Refinement failed, see the log for more details");
+    m_view->userWarning("Refinement failed", refinementFailure);
   }
 }
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
@@ -136,11 +136,11 @@ void EnggDiffGSASFittingPresenter::processLoadRun() {
   for (const auto fileName : focusedFileNames) {
     const auto loadFailure = m_model->loadFocusedRun(fileName);
 
-    if (loadFailure) {
-      m_view->userWarning("Load failed", *loadFailure);
-    } else {
+    if (loadFailure.empty()) {
       const auto runLabels = m_model->getRunLabels();
       m_view->updateRunList(runLabels);
+    } else {
+      m_view->userWarning("Load failed", loadFailure);
     }
   }
 }

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.h
@@ -45,13 +45,14 @@ private:
    @param pathToGSASII Location of the directory containing GSASIIscriptable.py
    (and GSAS-II executables)
    @param GSASIIProjectFile Location to save the .gpx project to
-   @return Empty string if refinement was successful, error description if not
+   @return String describing any failures, empty optional if refinement was
+   successful
    */
-  std::string doPawleyRefinement(const RunLabel &runLabel,
-                                 const std::string &instParamFile,
-                                 const std::vector<std::string> &phaseFiles,
-                                 const std::string &pathToGSASII,
-                                 const std::string &GSASIIProjectFile);
+  boost::optional<std::string>
+  doPawleyRefinement(const RunLabel &runLabel, const std::string &instParamFile,
+                     const std::vector<std::string> &phaseFiles,
+                     const std::string &pathToGSASII,
+                     const std::string &GSASIIProjectFile);
 
   /**
    Perform a Rietveld refinement on a run
@@ -62,13 +63,13 @@ private:
    @param pathToGSASII Location of the directory containing GSASIIscriptable.py
    (and GSAS-II executables)
    @param GSASIIProjectFile Location to save the .gpx project to
-   @return Empty string if refinement was successful, error description if not
+   @return String describing any failures, empty optional if refinement was
+   successful
    */
-  std::string doRietveldRefinement(const RunLabel &runLabel,
-                                   const std::string &instParamFile,
-                                   const std::vector<std::string> &phaseFiles,
-                                   const std::string &pathToGSASII,
-                                   const std::string &GSASIIProjectFile);
+  boost::optional<std::string> doRietveldRefinement(
+      const RunLabel &runLabel, const std::string &instParamFile,
+      const std::vector<std::string> &phaseFiles,
+      const std::string &pathToGSASII, const std::string &GSASIIProjectFile);
 
   /**
    Overplot fitted peaks for a run, and display lattice parameters and Rwp in

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.h
@@ -45,13 +45,13 @@ private:
    @param pathToGSASII Location of the directory containing GSASIIscriptable.py
    (and GSAS-II executables)
    @param GSASIIProjectFile Location to save the .gpx project to
-   @return Whether the refinement was successful
+   @return Empty string if refinement was successful, error description if not
    */
-  bool doPawleyRefinement(const RunLabel &runLabel,
-                          const std::string &instParamFile,
-                          const std::vector<std::string> &phaseFiles,
-                          const std::string &pathToGSASII,
-                          const std::string &GSASIIProjectFile);
+  std::string doPawleyRefinement(const RunLabel &runLabel,
+                                 const std::string &instParamFile,
+                                 const std::vector<std::string> &phaseFiles,
+                                 const std::string &pathToGSASII,
+                                 const std::string &GSASIIProjectFile);
 
   /**
    Perform a Rietveld refinement on a run
@@ -62,13 +62,13 @@ private:
    @param pathToGSASII Location of the directory containing GSASIIscriptable.py
    (and GSAS-II executables)
    @param GSASIIProjectFile Location to save the .gpx project to
-   @return Whether the refinement was successful
+   @return Empty string if refinement was successful, error description if not
    */
-  bool doRietveldRefinement(const RunLabel &runLabel,
-                            const std::string &instParamFile,
-                            const std::vector<std::string> &phaseFiles,
-                            const std::string &pathToGSASII,
-                            const std::string &GSASIIProjectFile);
+  std::string doRietveldRefinement(const RunLabel &runLabel,
+                                   const std::string &instParamFile,
+                                   const std::vector<std::string> &phaseFiles,
+                                   const std::string &pathToGSASII,
+                                   const std::string &GSASIIProjectFile);
 
   /**
    Overplot fitted peaks for a run, and display lattice parameters and Rwp in

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
@@ -7,7 +7,9 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 
-EnggDiffGSASFittingViewQtWidget::EnggDiffGSASFittingViewQtWidget() {
+EnggDiffGSASFittingViewQtWidget::EnggDiffGSASFittingViewQtWidget(
+    boost::shared_ptr<IEnggDiffractionUserMsg> userMessageProvider)
+    : m_userMessageProvider(userMessageProvider) {
   setupUI();
 
   m_zoomTool = Mantid::Kernel::make_unique<QwtPlotZoomer>(
@@ -200,10 +202,15 @@ void EnggDiffGSASFittingViewQtWidget::updateRunList(
   }
 }
 
+void EnggDiffGSASFittingViewQtWidget::userError(
+    const std::string &errorTitle, const std::string &errorDescription) const {
+  m_userMessageProvider->userError(errorTitle, errorDescription);
+}
+
 void EnggDiffGSASFittingViewQtWidget::userWarning(
+    const std::string &warningTitle,
     const std::string &warningDescription) const {
-  UNUSED_ARG(warningDescription);
-  throw std::runtime_error("userWarning not yet implemented");
+  m_userMessageProvider->userWarning(warningTitle, warningDescription);
 }
 
 } // CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.h
@@ -4,6 +4,7 @@
 #include "DllConfig.h"
 #include "IEnggDiffGSASFittingPresenter.h"
 #include "IEnggDiffGSASFittingView.h"
+#include "IEnggDiffractionUserMsg.h"
 
 #include <qwt_plot_curve.h>
 #include <qwt_plot_zoomer.h>
@@ -19,7 +20,8 @@ class MANTIDQT_ENGGDIFFRACTION_DLL EnggDiffGSASFittingViewQtWidget
   Q_OBJECT
 
 public:
-  EnggDiffGSASFittingViewQtWidget();
+  EnggDiffGSASFittingViewQtWidget(
+      boost::shared_ptr<IEnggDiffractionUserMsg> userMessageProvider);
 
   ~EnggDiffGSASFittingViewQtWidget() override;
 
@@ -60,7 +62,11 @@ public:
 
   void updateRunList(const std::vector<RunLabel> &runLabels) override;
 
-  void userWarning(const std::string &warningDescription) const override;
+  void userError(const std::string &errorTitle,
+                 const std::string &errorDescription) const override;
+
+  void userWarning(const std::string &warningTitle,
+                   const std::string &warningDescription) const override;
 
 private slots:
   void browseFocusedRun();
@@ -69,6 +75,8 @@ private slots:
 
 private:
   std::vector<std::unique_ptr<QwtPlotCurve>> m_focusedRunCurves;
+
+  boost::shared_ptr<IEnggDiffractionUserMsg> m_userMessageProvider;
 
   std::unique_ptr<IEnggDiffGSASFittingPresenter> m_presenter;
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -92,7 +92,7 @@ void EnggDiffractionViewQtGUI::initLayout() {
       m_ui.tabMain, sharedView, sharedView, fullPres, fullPres, sharedView);
   m_ui.tabMain->addTab(m_fittingWidget, QString("Fitting"));
 
-  m_gsasWidget = new EnggDiffGSASFittingViewQtWidget();
+  m_gsasWidget = new EnggDiffGSASFittingViewQtWidget(sharedView);
   m_ui.tabMain->addTab(m_gsasWidget, QString("GSAS-II Refinement"));
 
   QWidget *wSettings = new QWidget(m_ui.tabMain);

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
@@ -31,9 +31,10 @@ public:
    @param GSASIIProjectFile Location to save the .gpx project to
    @param dMin The minimum d-spacing to use for refinement
    @param negativeWeight The weight of the penalty function
-   @return Empty string if refinement was successful, error description if not
+   @return String decription any failures that occurred (empty optional if
+   success)
    */
-  virtual std::string
+  virtual boost::optional<std::string>
   doPawleyRefinement(const RunLabel &runLabel, const std::string &instParamFile,
                      const std::vector<std::string> &phaseFiles,
                      const std::string &pathToGSASII,
@@ -49,9 +50,10 @@ public:
    @param pathToGSASII Location of the directory containing GSASIIscriptable.py
    (and GSAS-II executables)
    @param GSASIIProjectFile Location to save the .gpx project to
-   @return Empty string if refinement was successful, error description if not
+   @return String decription any failures that occurred (empty optional if
+   success)
    */
-  virtual std::string
+  virtual boost::optional<std::string>
   doRietveldRefinement(const RunLabel &runLabel,
                        const std::string &instParamFile,
                        const std::vector<std::string> &phaseFiles,

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
@@ -112,9 +112,11 @@ public:
   /**
    Load a focused run from a file to the model
    @param filename The name of the file to load
-   @return Empty string if load was a success, description of error if not
+   @return Empty optional if load was a success, string describing failure if
+   not
    */
-  virtual std::string loadFocusedRun(const std::string &filename) = 0;
+  virtual boost::optional<std::string>
+  loadFocusedRun(const std::string &filename) = 0;
 };
 
 } // namespace MantidQt

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
@@ -31,15 +31,15 @@ public:
    @param GSASIIProjectFile Location to save the .gpx project to
    @param dMin The minimum d-spacing to use for refinement
    @param negativeWeight The weight of the penalty function
-   @return Whether the refinement was successful
+   @return Empty string if refinement was successful, error description if not
    */
-  virtual bool doPawleyRefinement(const RunLabel &runLabel,
-                                  const std::string &instParamFile,
-                                  const std::vector<std::string> &phaseFiles,
-                                  const std::string &pathToGSASII,
-                                  const std::string &GSASIIProjectFile,
-                                  const double dMin,
-                                  const double negativeWeight) = 0;
+  virtual std::string
+  doPawleyRefinement(const RunLabel &runLabel, const std::string &instParamFile,
+                     const std::vector<std::string> &phaseFiles,
+                     const std::string &pathToGSASII,
+                     const std::string &GSASIIProjectFile, const double dMin,
+                     const double negativeWeight) = 0;
+
   /**
    Perform a Rietveld refinement on a run
    @param runLabel Run number and bank ID of the workspace to refine
@@ -49,13 +49,14 @@ public:
    @param pathToGSASII Location of the directory containing GSASIIscriptable.py
    (and GSAS-II executables)
    @param GSASIIProjectFile Location to save the .gpx project to
-   @return Whether the refinement was successful
+   @return Empty string if refinement was successful, error description if not
    */
-  virtual bool doRietveldRefinement(const RunLabel &runLabel,
-                                    const std::string &instParamFile,
-                                    const std::vector<std::string> &phaseFiles,
-                                    const std::string &pathToGSASII,
-                                    const std::string &GSASIIProjectFile) = 0;
+  virtual std::string
+  doRietveldRefinement(const RunLabel &runLabel,
+                       const std::string &instParamFile,
+                       const std::vector<std::string> &phaseFiles,
+                       const std::string &pathToGSASII,
+                       const std::string &GSASIIProjectFile) = 0;
 
   /**
    Get the fit results for a given run

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
@@ -109,11 +109,9 @@ public:
   /**
    Load a focused run from a file to the model
    @param filename The name of the file to load
-   @return Empty optional if load was a success, string describing the error if
-   not
+   @return Empty string if load was a success, description of error if not
    */
-  virtual boost::optional<std::string>
-  loadFocusedRun(const std::string &filename) = 0;
+  virtual std::string loadFocusedRun(const std::string &filename) = 0;
 };
 
 } // namespace MantidQt

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
@@ -109,9 +109,11 @@ public:
   /**
    Load a focused run from a file to the model
    @param filename The name of the file to load
-   @return Whether the load was a success
+   @return Empty optional if load was a success, string describing the error if
+   not
    */
-  virtual bool loadFocusedRun(const std::string &filename) = 0;
+  virtual boost::optional<std::string>
+  loadFocusedRun(const std::string &filename) = 0;
 };
 
 } // namespace MantidQt

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingView.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingView.h
@@ -107,10 +107,20 @@ public:
   virtual void updateRunList(const std::vector<RunLabel> &runLabels) = 0;
 
   /**
+   Display an error to the user
+   @param errorTitle Title of the error
+   @param errorDescription Longer description of the error
+  */
+  virtual void userError(const std::string &errorTitle,
+                         const std::string &errorDescription) const = 0;
+
+  /**
    Display a warning to the user
-   @param warningDescription The warning to show
+   @param warningTitle Title of the warning
+   @param warningDescription Longer description of the warning
    */
-  virtual void userWarning(const std::string &warningDescription) const = 0;
+  virtual void userWarning(const std::string &warningTitle,
+                           const std::string &warningDescription) const = 0;
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
@@ -46,7 +46,8 @@ public:
 
   MOCK_CONST_METHOD1(hasFittedPeaksForRun, bool(const RunLabel &runLabel));
 
-  MOCK_METHOD1(loadFocusedRun, std::string(const std::string &filename));
+  MOCK_METHOD1(loadFocusedRun,
+               boost::optional<std::string>(const std::string &filename));
 };
 
 GCC_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
@@ -14,19 +14,19 @@ class MockEnggDiffGSASFittingModel : public IEnggDiffGSASFittingModel {
 
 public:
   MOCK_METHOD7(doPawleyRefinement,
-               std::string(const RunLabel &runLabel,
-                           const std::string &instParamFile,
-                           const std::vector<std::string> &phaseFiles,
-                           const std::string &pathToGSASII,
-                           const std::string &GSASIIProjectFile,
-                           const double dMin, const double negativeWeight));
+               boost::optional<std::string>(
+                   const RunLabel &runLabel, const std::string &instParamFile,
+                   const std::vector<std::string> &phaseFiles,
+                   const std::string &pathToGSASII,
+                   const std::string &GSASIIProjectFile, const double dMin,
+                   const double negativeWeight));
 
   MOCK_METHOD5(doRietveldRefinement,
-               std::string(const RunLabel &runLabel,
-                           const std::string &instParamFile,
-                           const std::vector<std::string> &phaseFiles,
-                           const std::string &pathToGSASII,
-                           const std::string &GSASIIProjectFile));
+               boost::optional<std::string>(
+                   const RunLabel &runLabel, const std::string &instParamFile,
+                   const std::vector<std::string> &phaseFiles,
+                   const std::string &pathToGSASII,
+                   const std::string &GSASIIProjectFile));
 
   MOCK_CONST_METHOD1(getFittedPeaks,
                      boost::optional<Mantid::API::MatrixWorkspace_sptr>(

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
@@ -44,8 +44,7 @@ public:
 
   MOCK_CONST_METHOD1(hasFittedPeaksForRun, bool(const RunLabel &runLabel));
 
-  MOCK_METHOD1(loadFocusedRun,
-               boost::optional<std::string>(const std::string &filename));
+  MOCK_METHOD1(loadFocusedRun, std::string(const std::string &filename));
 };
 
 GCC_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
@@ -44,7 +44,8 @@ public:
 
   MOCK_CONST_METHOD1(hasFittedPeaksForRun, bool(const RunLabel &runLabel));
 
-  MOCK_METHOD1(loadFocusedRun, bool(const std::string &filename));
+  MOCK_METHOD1(loadFocusedRun,
+               boost::optional<std::string>(const std::string &filename));
 };
 
 GCC_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
@@ -14,17 +14,19 @@ class MockEnggDiffGSASFittingModel : public IEnggDiffGSASFittingModel {
 
 public:
   MOCK_METHOD7(doPawleyRefinement,
-               bool(const RunLabel &runLabel, const std::string &instParamFile,
-                    const std::vector<std::string> &phaseFiles,
-                    const std::string &pathToGSASII,
-                    const std::string &GSASIIProjectFile, const double dMin,
-                    const double negativeWeight));
+               std::string(const RunLabel &runLabel,
+                           const std::string &instParamFile,
+                           const std::vector<std::string> &phaseFiles,
+                           const std::string &pathToGSASII,
+                           const std::string &GSASIIProjectFile,
+                           const double dMin, const double negativeWeight));
 
   MOCK_METHOD5(doRietveldRefinement,
-               bool(const RunLabel &runLabel, const std::string &instParamFile,
-                    const std::vector<std::string> &phaseFiles,
-                    const std::string &pathToGSASII,
-                    const std::string &GSASIIProjectFile));
+               std::string(const RunLabel &runLabel,
+                           const std::string &instParamFile,
+                           const std::vector<std::string> &phaseFiles,
+                           const std::string &pathToGSASII,
+                           const std::string &GSASIIProjectFile));
 
   MOCK_CONST_METHOD1(getFittedPeaks,
                      boost::optional<Mantid::API::MatrixWorkspace_sptr>(

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelTest.h
@@ -287,11 +287,11 @@ public:
         API::WorkspaceFactory::Instance().create("Workspace2D", 1, 10, 10);
     model.addFocusedWorkspace(runLabel, ws);
 
-    std::string failure = "Failure";
+    boost::optional<std::string> failure(boost::none);
     TS_ASSERT_THROWS_NOTHING(
         failure = model.doPawleyRefinement(
             runLabel, "", std::vector<std::string>({}), "", "", 0, 0));
-    TS_ASSERT(failure.empty());
+    TS_ASSERT(!failure);
 
     const auto rwp = model.getRwp(runLabel);
     TS_ASSERT(rwp);
@@ -316,11 +316,11 @@ public:
         API::WorkspaceFactory::Instance().create("Workspace2D", 1, 10, 10);
     model.addFocusedWorkspace(runLabel, ws);
 
-    std::string failure = "Failure";
+    boost::optional<std::string> failure(boost::none);
     TS_ASSERT_THROWS_NOTHING(
         failure = model.doRietveldRefinement(
             runLabel, "", std::vector<std::string>({}), "", ""));
-    TS_ASSERT(failure.empty());
+    TS_ASSERT(!failure);
 
     const auto rwp = model.getRwp(runLabel);
     TS_ASSERT(rwp);

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelTest.h
@@ -140,9 +140,9 @@ public:
     const static std::string inputFilename = "ENGINX_277208_focused_bank_2.nxs";
     TestEnggDiffGSASFittingModel model;
 
-    auto failure = boost::make_optional<std::string>("Failure");
+    std::string failure = "Failure";
     TS_ASSERT_THROWS_NOTHING(failure = model.loadFocusedRun(inputFilename));
-    TS_ASSERT(!failure);
+    TS_ASSERT(failure.empty());
 
     TS_ASSERT(model.containsFocusedRun(RunLabel(277208, 2)));
   }
@@ -151,9 +151,9 @@ public:
     const static std::string inputFilename = "ENGINX_277209_focused_bank_2.nxs";
     TestEnggDiffGSASFittingModel model;
 
-    boost::optional<std::string> failure = boost::make_optional(false, std::string());
+    std::string failure = "";
     TS_ASSERT_THROWS_NOTHING(failure = model.loadFocusedRun(inputFilename));
-    TS_ASSERT(failure);
+    TS_ASSERT(!failure.empty());
   }
 
   void test_getFocusedRun() {

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelTest.h
@@ -49,7 +49,7 @@ public:
   void addRwpValue(const RunLabel &runLabel, const double rwp);
 
 private:
-  inline boost::optional<double> doGSASRefinementAlgorithm(
+  inline double doGSASRefinementAlgorithm(
       API::MatrixWorkspace_sptr inputWorkspace,
       const std::string &outputWorkspaceName,
       const std::string &latticeParamsName, const std::string &refinementMethod,
@@ -85,8 +85,7 @@ inline bool TestEnggDiffGSASFittingModel::containsFocusedRun(
   return hasFocusedRun(runLabel);
 }
 
-inline boost::optional<double>
-TestEnggDiffGSASFittingModel::doGSASRefinementAlgorithm(
+inline double TestEnggDiffGSASFittingModel::doGSASRefinementAlgorithm(
     API::MatrixWorkspace_sptr inputWorkspace,
     const std::string &outputWorkspaceName,
     const std::string &latticeParamsName, const std::string &refinementMethod,
@@ -288,11 +287,11 @@ public:
         API::WorkspaceFactory::Instance().create("Workspace2D", 1, 10, 10);
     model.addFocusedWorkspace(runLabel, ws);
 
-    bool success = false;
+    std::string failure = "Failure";
     TS_ASSERT_THROWS_NOTHING(
-        success = model.doPawleyRefinement(
+        failure = model.doPawleyRefinement(
             runLabel, "", std::vector<std::string>({}), "", "", 0, 0));
-    TS_ASSERT(success);
+    TS_ASSERT(failure.empty());
 
     const auto rwp = model.getRwp(runLabel);
     TS_ASSERT(rwp);
@@ -317,11 +316,11 @@ public:
         API::WorkspaceFactory::Instance().create("Workspace2D", 1, 10, 10);
     model.addFocusedWorkspace(runLabel, ws);
 
-    bool success = false;
+    std::string failure = "Failure";
     TS_ASSERT_THROWS_NOTHING(
-        success = model.doRietveldRefinement(
+        failure = model.doRietveldRefinement(
             runLabel, "", std::vector<std::string>({}), "", ""));
-    TS_ASSERT(success);
+    TS_ASSERT(failure.empty());
 
     const auto rwp = model.getRwp(runLabel);
     TS_ASSERT(rwp);

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelTest.h
@@ -140,9 +140,9 @@ public:
     const static std::string inputFilename = "ENGINX_277208_focused_bank_2.nxs";
     TestEnggDiffGSASFittingModel model;
 
-    bool success = false;
-    TS_ASSERT_THROWS_NOTHING(success = model.loadFocusedRun(inputFilename));
-    TS_ASSERT(success);
+    auto failure = boost::make_optional<std::string>("Failure");
+    TS_ASSERT_THROWS_NOTHING(failure = model.loadFocusedRun(inputFilename));
+    TS_ASSERT(!failure);
 
     TS_ASSERT(model.containsFocusedRun(RunLabel(277208, 2)));
   }
@@ -151,9 +151,9 @@ public:
     const static std::string inputFilename = "ENGINX_277209_focused_bank_2.nxs";
     TestEnggDiffGSASFittingModel model;
 
-    bool success = false;
-    TS_ASSERT_THROWS_NOTHING(success = model.loadFocusedRun(inputFilename));
-    TS_ASSERT(!success);
+    boost::optional<std::string> failure = boost::make_optional(false, std::string());
+    TS_ASSERT_THROWS_NOTHING(failure = model.loadFocusedRun(inputFilename));
+    TS_ASSERT(failure);
   }
 
   void test_getFocusedRun() {

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelTest.h
@@ -139,9 +139,9 @@ public:
     const static std::string inputFilename = "ENGINX_277208_focused_bank_2.nxs";
     TestEnggDiffGSASFittingModel model;
 
-    std::string failure = "Failure";
+    boost::optional<std::string> failure(boost::none);
     TS_ASSERT_THROWS_NOTHING(failure = model.loadFocusedRun(inputFilename));
-    TS_ASSERT(failure.empty());
+    TS_ASSERT(!failure);
 
     TS_ASSERT(model.containsFocusedRun(RunLabel(277208, 2)));
   }
@@ -150,9 +150,9 @@ public:
     const static std::string inputFilename = "ENGINX_277209_focused_bank_2.nxs";
     TestEnggDiffGSASFittingModel model;
 
-    std::string failure = "";
+    boost::optional<std::string> failure(boost::none);
     TS_ASSERT_THROWS_NOTHING(failure = model.loadFocusedRun(inputFilename));
-    TS_ASSERT(!failure.empty());
+    TS_ASSERT(failure);
   }
 
   void test_getFocusedRun() {

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
@@ -27,7 +27,7 @@ public:
         .WillOnce(Return(std::vector<std::string>({filename})));
     EXPECT_CALL(*m_mockModelPtr, loadFocusedRun(filename))
         .Times(1)
-      .WillOnce(Return(boost::none));
+        .WillOnce(Return(""));
 
     const std::vector<RunLabel> runLabels({RunLabel(123, 1)});
 
@@ -52,7 +52,7 @@ public:
 
     EXPECT_CALL(*m_mockModelPtr, loadFocusedRun(filename))
         .Times(1)
-        .WillOnce(Return(boost::make_optional<std::string>("Failure message")));
+        .WillOnce(Return("Failure message"));
 
     EXPECT_CALL(*m_mockModelPtr, getRunLabels()).Times(0);
 

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
@@ -56,9 +56,7 @@ public:
 
     EXPECT_CALL(*m_mockModelPtr, getRunLabels()).Times(0);
 
-    EXPECT_CALL(
-        *m_mockViewPtr,
-        userWarning("Load failed", "Failure message"))
+    EXPECT_CALL(*m_mockViewPtr, userWarning("Load failed", "Failure message"))
         .Times(1);
 
     presenter->notify(IEnggDiffGSASFittingPresenter::LoadRun);
@@ -184,10 +182,9 @@ public:
                 doRietveldRefinement(runLabel, instParams, phaseFiles,
                                      pathToGSASII, GSASIIProjectFile))
         .Times(1)
-        .WillOnce(Return(false));
-    EXPECT_CALL(*m_mockViewPtr,
-                userWarning("Refinement failed",
-                            "Refinement failed, see the log for more details"));
+        .WillOnce(Return("Refinement failure description"));
+    EXPECT_CALL(*m_mockViewPtr, userWarning("Refinement failed",
+                                            "Refinement failure description"));
 
     presenter->notify(IEnggDiffGSASFittingPresenter::DoRefinement);
     assertMocksUsedCorrectly();
@@ -235,10 +232,9 @@ public:
                                    pathToGSASII, GSASIIProjectFile, dmin,
                                    negativeWeight))
         .Times(1)
-        .WillOnce(Return(false));
-    EXPECT_CALL(*m_mockViewPtr,
-                userWarning("Refinement failed",
-                            "Refinement failed, see the log for more details"));
+        .WillOnce(Return("Refinement failure description"));
+    EXPECT_CALL(*m_mockViewPtr, userWarning("Refinement failed",
+                                            "Refinement failure description"));
 
     presenter->notify(IEnggDiffGSASFittingPresenter::DoRefinement);
     assertMocksUsedCorrectly();

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
@@ -182,7 +182,8 @@ public:
                 doRietveldRefinement(runLabel, instParams, phaseFiles,
                                      pathToGSASII, GSASIIProjectFile))
         .Times(1)
-        .WillOnce(Return("Refinement failure description"));
+        .WillOnce(Return(boost::make_optional<std::string>(
+            "Refinement failure description")));
     EXPECT_CALL(*m_mockViewPtr, userWarning("Refinement failed",
                                             "Refinement failure description"));
 
@@ -232,7 +233,8 @@ public:
                                    pathToGSASII, GSASIIProjectFile, dmin,
                                    negativeWeight))
         .Times(1)
-        .WillOnce(Return("Refinement failure description"));
+        .WillOnce(Return(boost::make_optional<std::string>(
+            "Refinement failure description")));
     EXPECT_CALL(*m_mockViewPtr, userWarning("Refinement failed",
                                             "Refinement failure description"));
 

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
@@ -36,7 +36,7 @@ public:
         .WillOnce(Return(runLabels));
     EXPECT_CALL(*m_mockViewPtr, updateRunList(runLabels)).Times(1);
 
-    EXPECT_CALL(*m_mockViewPtr, userWarning(testing::_)).Times(0);
+    EXPECT_CALL(*m_mockViewPtr, userWarning(testing::_, testing::_)).Times(0);
 
     presenter->notify(IEnggDiffGSASFittingPresenter::LoadRun);
     assertMocksUsedCorrectly();
@@ -56,8 +56,9 @@ public:
 
     EXPECT_CALL(*m_mockModelPtr, getRunLabels()).Times(0);
 
-    EXPECT_CALL(*m_mockViewPtr,
-                userWarning("Load failed, see the log for more details"))
+    EXPECT_CALL(
+        *m_mockViewPtr,
+        userWarning("Load failed", "Load failed, see the log for more details"))
         .Times(1);
 
     presenter->notify(IEnggDiffGSASFittingPresenter::LoadRun);
@@ -79,7 +80,7 @@ public:
         .WillOnce(Return(sampleWorkspace));
 
     EXPECT_CALL(*m_mockViewPtr, resetCanvas()).Times(1);
-    EXPECT_CALL(*m_mockViewPtr, userWarning(testing::_)).Times(0);
+    EXPECT_CALL(*m_mockViewPtr, userWarning(testing::_, testing::_)).Times(0);
 
     presenter->notify(IEnggDiffGSASFittingPresenter::SelectRun);
     assertMocksUsedCorrectly();
@@ -96,10 +97,10 @@ public:
         .Times(1)
         .WillOnce(Return(boost::none));
 
-    EXPECT_CALL(
-        *m_mockViewPtr,
-        userWarning(
-            "Tried to access invalid run, runNumber 123 and bank ID 1"));
+    EXPECT_CALL(*m_mockViewPtr,
+                userError("Invalid run identifier",
+                          "Tried to access invalid run, runNumber 123 and "
+                          "bank ID 1. Please contact the development team"));
 
     EXPECT_CALL(*m_mockViewPtr, resetCanvas()).Times(0);
 
@@ -144,7 +145,7 @@ public:
 
     EXPECT_CALL(*m_mockViewPtr, resetCanvas()).Times(1);
     EXPECT_CALL(*m_mockViewPtr, plotCurve(testing::_)).Times(2);
-    EXPECT_CALL(*m_mockViewPtr, userWarning(testing::_)).Times(0);
+    EXPECT_CALL(*m_mockViewPtr, userWarning(testing::_, testing::_)).Times(0);
 
     presenter->notify(IEnggDiffGSASFittingPresenter::SelectRun);
     assertMocksUsedCorrectly();
@@ -185,7 +186,8 @@ public:
         .Times(1)
         .WillOnce(Return(false));
     EXPECT_CALL(*m_mockViewPtr,
-                userWarning("Refinement failed, see the log for more details"));
+                userWarning("Refinement failed",
+                            "Refinement failed, see the log for more details"));
 
     presenter->notify(IEnggDiffGSASFittingPresenter::DoRefinement);
     assertMocksUsedCorrectly();
@@ -235,7 +237,8 @@ public:
         .Times(1)
         .WillOnce(Return(false));
     EXPECT_CALL(*m_mockViewPtr,
-                userWarning("Refinement failed, see the log for more details"));
+                userWarning("Refinement failed",
+                            "Refinement failed, see the log for more details"));
 
     presenter->notify(IEnggDiffGSASFittingPresenter::DoRefinement);
     assertMocksUsedCorrectly();
@@ -258,15 +261,15 @@ private:
   }
 
   void assertMocksUsedCorrectly() {
-    if (m_mockViewPtr) {
-      delete m_mockViewPtr;
-    }
     TSM_ASSERT("View mock not used as expected: some EXPECT_CALL conditions "
                "not satisfied",
                testing::Mock::VerifyAndClearExpectations(m_mockModelPtr));
     TSM_ASSERT("Model mock not used as expected: some EXPECT_CALL conditions "
                "not satisfied",
                testing::Mock::VerifyAndClearExpectations(m_mockViewPtr));
+    if (m_mockViewPtr) {
+      delete m_mockViewPtr;
+    }
   }
 };
 

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
@@ -27,7 +27,7 @@ public:
         .WillOnce(Return(std::vector<std::string>({filename})));
     EXPECT_CALL(*m_mockModelPtr, loadFocusedRun(filename))
         .Times(1)
-        .WillOnce(Return(""));
+        .WillOnce(Return(boost::none));
 
     const std::vector<RunLabel> runLabels({RunLabel(123, 1)});
 
@@ -52,7 +52,7 @@ public:
 
     EXPECT_CALL(*m_mockModelPtr, loadFocusedRun(filename))
         .Times(1)
-        .WillOnce(Return("Failure message"));
+        .WillOnce(Return(boost::make_optional<std::string>("Failure message")));
 
     EXPECT_CALL(*m_mockModelPtr, getRunLabels()).Times(0);
 

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
@@ -27,7 +27,7 @@ public:
         .WillOnce(Return(std::vector<std::string>({filename})));
     EXPECT_CALL(*m_mockModelPtr, loadFocusedRun(filename))
         .Times(1)
-        .WillOnce(Return(true));
+      .WillOnce(Return(boost::none));
 
     const std::vector<RunLabel> runLabels({RunLabel(123, 1)});
 
@@ -52,13 +52,13 @@ public:
 
     EXPECT_CALL(*m_mockModelPtr, loadFocusedRun(filename))
         .Times(1)
-        .WillOnce(Return(false));
+        .WillOnce(Return(boost::make_optional<std::string>("Failure message")));
 
     EXPECT_CALL(*m_mockModelPtr, getRunLabels()).Times(0);
 
     EXPECT_CALL(
         *m_mockViewPtr,
-        userWarning("Load failed", "Load failed, see the log for more details"))
+        userWarning("Load failed", "Failure message"))
         .Times(1);
 
     presenter->notify(IEnggDiffGSASFittingPresenter::LoadRun);

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingViewMock.h
@@ -47,7 +47,11 @@ public:
 
   MOCK_METHOD1(updateRunList, void(const std::vector<RunLabel> &runLabels));
 
-  MOCK_CONST_METHOD1(userWarning, void(const std::string &warningDescription));
+  MOCK_CONST_METHOD2(userError, void(const std::string &errorTitle,
+                                     const std::string &errorDescription));
+
+  MOCK_CONST_METHOD2(userWarning, void(const std::string &warningTitle,
+                                       const std::string &warningDescription));
 };
 
 GCC_DIAG_ON_SUGGEST_OVERRIDE


### PR DESCRIPTION
There was previously no proper error handling in the GSAS tab of the ED GUI. Errors in loading and refinement (though refinement is not yet properly hooked up) are now dealt with via a message box in the same way as the fitting tab.

**To test:**

Some sample data is [here](https://github.com/mantidproject/mantid/files/1656872/engggui_pr_data.zip).

Open up the ED GUI (`Interfaces -> Diffraction -> Engineering Diffraction`). Go to the GSAS tab and put some nonsense into the **Focused Run** line-edit. Clicking **Load** should give you a message box saying something along the lines of "File doesn't exist".

Click the first **Browse** button and select all the files from the attached zip, then click **Load**. The two runs from 277208 should load fine, and there should be a warning for 277209 that the bank ID was not set.

Partially address #15552 

**Release Notes** 
Will be added to the release notes once refinement can be done from the GUI

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
