### PR TITLE
Masked invalid numbers (nans and infs) from plots

### DIFF
--- a/Framework/PythonInterface/mantid/plots/functions.py
+++ b/Framework/PythonInterface/mantid/plots/functions.py
@@ -140,7 +140,9 @@ def _getSpectrum(workspace, wkspIndex, distribution, withDy=False, withDx=False)
             if dy is not None:
                 dy = dy / (x[1:] - x[0:-1])
         x = points_from_boundaries(x)
-
+    y=numpy.ma.masked_invalid(y)
+    if dy is not None:
+        dy=numpy.ma.masked_invalid(dy)
     return (x,y,dy,dx)
 
 
@@ -195,6 +197,7 @@ def _getMatrix2DData(workspace, distribution,histogram2D=False):
             if len(y)==z.shape[0]+1:
                 y=points_from_boundaries(y)
     y = numpy.tile(y,x.shape[1]).reshape(x.shape[1],x.shape[0]).transpose()
+    z=numpy.ma.masked_invalid(z)
     return (x,y,z)
 
 
@@ -242,6 +245,7 @@ def _getUnevenData(workspace, distribution):
                 zvals = zvals / (xvals[1:] - xvals[0:-1])
         else:
             xvals=boundaries_from_points(xvals)
+        zvals=numpy.ma.masked_invalid(zvals)
         z.append(zvals)
         x.append(xvals)
         y.append([yvals[index],yvals[index+1]])
@@ -309,8 +313,10 @@ def _getMDData(workspace,normalization,withError=False):
             err2/=(nev*nev)
         err=numpy.sqrt(err2)
     data=data.squeeze().T
+    data=numpy.ma.masked_invalid(data)
     if err is not None:
         err=err.squeeze().T
+        err=numpy.ma.masked_invalid(err)       
     return (dimarrays,data,err)
 
 


### PR DESCRIPTION
When plotting NaNs and infs, we want to mask those values. I run into problems with colorbar for a pcolormesh containing NaNs, when I used LogNorm. 


**To test:**
```
import matplotlib.pyplot as plt
from mantid.simpleapi import *
import numpy as np
import mantid.plots
from matplotlib.colors import LogNorm
LoadEventNexus(Filename='CNCS_7860_event.nxs', OutputWorkspace='CNCS_7860_event')
ConvertUnits(InputWorkspace='CNCS_7860_event', OutputWorkspace='CNCS_7860_event', Target='DeltaE', EMode='Direct', EFixed=3)
Rebin(InputWorkspace='CNCS_7860_event', OutputWorkspace='CNCS_7860_event', Params='-3,0.05,3',PreserveEvents=False)
mde=ConvertToMD('CNCS_7860_event',QDimensions='|Q|',dEAnalysisMode='Direct')
mdh=BinMD(mde,AxisAligned=True,AlignedDim0='|Q|,0,3,60',AlignedDim1='DeltaE,-3,3,100')

fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
c=ax.pcolormesh(mdh,norm=LogNorm())
fig.colorbar(c)
fig.show()
```

No associated issue or release notes

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
