### PR TITLE
Fix possible crash when plotting from an asynchronous script in workbench

### DIFF
--- a/MantidPlot/pymantidplot/mpl/backend_mtdqt4agg.py
+++ b/MantidPlot/pymantidplot/mpl/backend_mtdqt4agg.py
@@ -96,12 +96,15 @@ class ThreadAwareFigureManagerQT(FigureManagerQT):
         FigureManagerQT.__init__(self, canvas, num)
         self._destroy_orig = self.destroy
         self.destroy = QAppThreadCall(self._destroy_orig)
+        self._show_orig = self.show
+        self.show = QAppThreadCall(self._show_orig)
 
 
 # ----------------------------------------------------------------------------------------------------------------------
-# Wrap the required functions
+# Patch known functions
+# ----------------------------------------------------------------------------------------------------------------------
 show = QAppThreadCall(show)
-# Use our figure manager
+
 FigureManager = ThreadAwareFigureManagerQT
 
 if MPL_HAVE_GIVEN_FIG_METHOD:

--- a/qt/applications/workbench/workbench/plotting/backend_workbench.py
+++ b/qt/applications/workbench/workbench/plotting/backend_workbench.py
@@ -25,25 +25,20 @@ from __future__ import (absolute_import, division, print_function,
 
 # std imports
 import importlib
-import sys
+
 
 # 3rd party imports
 # Put these first so that the correct Qt version is selected by qtpy
 from qtpy import QT_VERSION
-from qtpy.QtCore import Qt, QMetaObject, QObject, QThread, Slot
-from qtpy.QtWidgets import QApplication
-from six import reraise
 
 # local imports
 from workbench.plotting.figuremanager import (backend_version,  # noqa
     draw_if_interactive as draw_if_interactive_impl,
     new_figure_manager as new_figure_manager_impl,
     new_figure_manager_given_figure as new_figure_manager_given_figure_impl,
-    show as show_impl
+    show as show_impl,
+    QAppThreadCall
 )
-
-if not QApplication.instance():
-    raise ImportError("The 'qt_async_backend' requires an QApplication object to have been created")
 
 # Import the *real* matplotlib backend for the canvas
 mpl_qtagg_backend = importlib.import_module('matplotlib.backends.backend_qt{}agg'.format(QT_VERSION[0]))
@@ -51,64 +46,6 @@ try:
     FigureCanvas = getattr(mpl_qtagg_backend, 'FigureCanvasQTAgg')
 except KeyError:
     raise ImportError("Unknown form of matplotlib Qt backend.")
-
-QAPP = QApplication.instance()
-
-
-# -----------------------------------------------------------------------------
-# Threading helpers
-# -----------------------------------------------------------------------------
-class QAppThreadCall(QObject):
-    """
-    Wraps a callable object and forces any calls made to it to be executed
-    on the same thread as the qApp object.
-    """
-
-    def __init__(self, callee):
-        QObject.__init__(self)
-        self.moveToThread(QAPP.thread())
-        self.callee = callee
-        # Help should then give the correct doc
-        self.__call__.__func__.__doc__ = callee.__doc__
-        self._args = None
-        self._kwargs = None
-        self._result = None
-        self._exc_info = None
-
-    def __call__(self, *args, **kwargs):
-        """
-        If the current thread is the qApp thread then this
-        performs a straight call to the wrapped callable_obj. Otherwise
-        it invokes the do_call method as a slot via a
-        BlockingQueuedConnection.
-        """
-        if QThread.currentThread() == QAPP.thread():
-            return self.callee(*args, **kwargs)
-        else:
-            self._store_function_args(*args, **kwargs)
-            QMetaObject.invokeMethod(self, "on_call",
-                                     Qt.BlockingQueuedConnection)
-            if self._exc_info is not None:
-                reraise(*self._exc_info)
-            return self._result
-
-    @Slot()
-    def on_call(self):
-        """Perform a call to a GUI function across a
-        thread and return the result
-        """
-        try:
-            self._result = \
-                self.callee(*self._args, **self._kwargs)
-        except Exception: # pylint: disable=broad-except
-            self._exc_info = sys.exc_info()
-
-    def _store_function_args(self, *args, **kwargs):
-        self._args = args
-        self._kwargs = kwargs
-        # Reset return value and exception
-        self._result = None
-        self._exc_info = None
 
 
 # -----------------------------------------------------------------------------

--- a/qt/applications/workbench/workbench/plotting/backend_workbench.py
+++ b/qt/applications/workbench/workbench/plotting/backend_workbench.py
@@ -25,14 +25,22 @@ from __future__ import (absolute_import, division, print_function,
 
 # std imports
 import importlib
+import sys
 
 # 3rd party imports
 # Put these first so that the correct Qt version is selected by qtpy
 from qtpy import QT_VERSION
+from qtpy.QtCore import Qt, QMetaObject, QObject, QThread, Slot
 from qtpy.QtWidgets import QApplication
+from six import reraise
 
 # local imports
-from workbench.plotting.figuremanager import new_figure_manager, new_figure_manager_given_figure, show  # noqa
+from workbench.plotting.figuremanager import (backend_version,  # noqa
+    draw_if_interactive as draw_if_interactive_impl,
+    new_figure_manager as new_figure_manager_impl,
+    new_figure_manager_given_figure as new_figure_manager_given_figure_impl,
+    show as show_impl
+)
 
 if not QApplication.instance():
     raise ImportError("The 'qt_async_backend' requires an QApplication object to have been created")
@@ -44,89 +52,69 @@ try:
 except KeyError:
     raise ImportError("Unknown form of matplotlib Qt backend.")
 
+QAPP = QApplication.instance()
+
 
 # -----------------------------------------------------------------------------
 # Threading helpers
 # -----------------------------------------------------------------------------
-# class QAppThreadCall(QObject):
-#     """
-#     Wraps a callable object and forces any calls made to it to be executed
-#     on the same thread as the qApp object.
-#     """
-#
-#     def __init__(self, callee):
-#         QObject.__init__(self)
-#         self.moveToThread(qApp.thread())
-#         self.callee = callee
-#         # Help should then give the correct doc
-#         self.__call__.__func__.__doc__ = callee.__doc__
-#         self._args = None
-#         self._kwargs = None
-#         self._result = None
-#         self._exc_info = None
-#
-#     def __call__(self, *args, **kwargs):
-#         """
-#         If the current thread is the qApp thread then this
-#         performs a straight call to the wrapped callable_obj. Otherwise
-#         it invokes the do_call method as a slot via a
-#         BlockingQueuedConnection.
-#         """
-#         if QThread.currentThread() == qApp.thread():
-#             return self.callee(*args, **kwargs)
-#         else:
-#             self._store_function_args(*args, **kwargs)
-#             QMetaObject.invokeMethod(self, "on_call",
-#                                      Qt.BlockingQueuedConnection)
-#             if self._exc_info is not None:
-#                 reraise(*self._exc_info)
-#             return self._result
-#
-#     @Slot()
-#     def on_call(self):
-#         """Perform a call to a GUI function across a
-#         thread and return the result
-#         """
-#         try:
-#             self._result = \
-#                 self.callee(*self._args, **self._kwargs)
-#         except Exception: #pylint: disable=broad-except
-#             self._exc_info = sys.exc_info()
-#
-#     def _store_function_args(self, *args, **kwargs):
-#         self._args = args
-#         self._kwargs = kwargs
-#         # Reset return value and exception
-#         self._result = None
-#         self._exc_info = None
+class QAppThreadCall(QObject):
+    """
+    Wraps a callable object and forces any calls made to it to be executed
+    on the same thread as the qApp object.
+    """
+
+    def __init__(self, callee):
+        QObject.__init__(self)
+        self.moveToThread(QAPP.thread())
+        self.callee = callee
+        # Help should then give the correct doc
+        self.__call__.__func__.__doc__ = callee.__doc__
+        self._args = None
+        self._kwargs = None
+        self._result = None
+        self._exc_info = None
+
+    def __call__(self, *args, **kwargs):
+        """
+        If the current thread is the qApp thread then this
+        performs a straight call to the wrapped callable_obj. Otherwise
+        it invokes the do_call method as a slot via a
+        BlockingQueuedConnection.
+        """
+        if QThread.currentThread() == QAPP.thread():
+            return self.callee(*args, **kwargs)
+        else:
+            self._store_function_args(*args, **kwargs)
+            QMetaObject.invokeMethod(self, "on_call",
+                                     Qt.BlockingQueuedConnection)
+            if self._exc_info is not None:
+                reraise(*self._exc_info)
+            return self._result
+
+    @Slot()
+    def on_call(self):
+        """Perform a call to a GUI function across a
+        thread and return the result
+        """
+        try:
+            self._result = \
+                self.callee(*self._args, **self._kwargs)
+        except Exception: # pylint: disable=broad-except
+            self._exc_info = sys.exc_info()
+
+    def _store_function_args(self, *args, **kwargs):
+        self._args = args
+        self._kwargs = kwargs
+        # Reset return value and exception
+        self._result = None
+        self._exc_info = None
 
 
 # -----------------------------------------------------------------------------
 # Backend implementation
 # -----------------------------------------------------------------------------
-
-
-# # Wrap other required calls
-# show = QAppThreadCall(mpl_qtagg_backend.show)
-#
-#
-# def _new_figure_manager_impl(num, *args, **kwargs):
-#     """
-#     Create a new figure manager instance
-#     """
-#
-#     figure_class = kwargs.pop('FigureClass', Figure)
-#     this_fig = figure_class(*args, **kwargs)
-#     return new_figure_manager_given_figure(num, this_fig)
-#
-#
-# def _new_figure_manager_given_figure_impl(num, figure):
-#     """
-#     Create a new figure manager instance for the given figure.
-#     """
-#     canvas = FigureCanvas(figure)
-#     manager = FigureManager(canvas, num)
-#     return manager
-#
-# new_figure_manager = QAppThreadCall(_new_figure_manager_impl)
-# new_figure_manager_given_figure = QAppThreadCall(_new_figure_manager_given_figure_impl)
+show = QAppThreadCall(show_impl)
+new_figure_manager = QAppThreadCall(new_figure_manager_impl)
+new_figure_manager_given_figure = QAppThreadCall(new_figure_manager_given_figure_impl)
+draw_if_interactive = QAppThreadCall(draw_if_interactive_impl)

--- a/qt/applications/workbench/workbench/plotting/currentfigure.py
+++ b/qt/applications/workbench/workbench/plotting/currentfigure.py
@@ -119,6 +119,8 @@ class CurrentFigure(object):
         """
         Return the manager of the active figure, or *None*.
         """
+        if cls._active is not None:
+            cls._active.canvas.figure.clf()
         return cls._active
 
     @classmethod

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -18,16 +18,15 @@
 
 # std imports
 import functools
-import sys
 
 # 3rdparty imports
 import matplotlib
 from matplotlib.backend_bases import FigureManagerBase
-from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
+from matplotlib.backends.backend_qt5agg import (FigureCanvasQTAgg, backend_version, draw_if_interactive, show)  # noqa
 from matplotlib._pylab_helpers import Gcf
-from qtpy.QtCore import Qt, QMetaObject, QThread, Signal
-from qtpy.QtWidgets import qApp, QApplication, QLabel, QMainWindow
-from six import reraise, text_type
+from qtpy.QtCore import Qt, QObject, Signal
+from qtpy.QtWidgets import QApplication, QLabel, QMainWindow
+from six import text_type
 
 # local imports
 from workbench.plotting.propertiesdialog import LabelEditor, XAxisEditor, YAxisEditor
@@ -42,7 +41,7 @@ class MainWindow(QMainWindow):
         QMainWindow.closeEvent(self, event)
 
 
-class FigureManagerWorkbench(FigureManagerBase):
+class FigureManagerWorkbench(FigureManagerBase, QObject):
     """
     Attributes
     ----------
@@ -56,10 +55,12 @@ class FigureManagerWorkbench(FigureManagerBase):
         The qt.QMainWindow
 
     """
+    sig_show_requested = Signal()
+    sig_destroy_requested = Signal()
 
     def __init__(self, canvas, num):
+        QObject.__init__(self)
         FigureManagerBase.__init__(self, canvas, num)
-        self._destroy_exc = None
         self.canvas = canvas
         self.window = MainWindow()
         self.window.closing.connect(canvas.close_event)
@@ -121,6 +122,10 @@ class FigureManagerWorkbench(FigureManagerBase):
 
         self.window.raise_()
 
+        # Connect show/destroy signals
+        self.sig_show_requested.connect(self._show_impl, type=Qt.BlockingQueuedConnection)
+        self.sig_destroy_requested.connect(self._destroy_impl, type=Qt.BlockingQueuedConnection)
+
     def full_screen_toggle(self):
         if self.window.isFullScreen():
             self.window.showNormal()
@@ -147,7 +152,12 @@ class FigureManagerWorkbench(FigureManagerBase):
         'set the canvas size in pixels'
         self.window.resize(width, height + self._status_and_tool_height)
 
-    def show(self):
+    def show(self):  # noqa
+        """Queue a request in the event loop just in case
+        the call comes from a non-GUI thread"""
+        self.sig_show_requested.emit()
+
+    def _show_impl(self):
         self.window.show()
         self.window.activateWindow()
         self.window.raise_()
@@ -158,17 +168,14 @@ class FigureManagerWorkbench(FigureManagerBase):
             return
         if self.window._destroying:
             return
-        if QThread.currentThread() == qApp.thread():
-            # direct call
-            self._destroy_impl()
-        else:
-            # dispatch through event loop to we end up on the main thread
-            QMetaObject.invokeMethod(self, "_destroy_impl",
-                                     Qt.BlockingQueuedConnection)
-            if self._destroy_exc is not None:
-                exc_info = self._destroy_exc
-                self._destroy_exc = None
-                reraise(*exc_info)
+        self.sig_destroy_requested.emit()
+
+    def _destroy_impl(self):
+        self.window._destroying = True
+        self.window.destroyed.connect(self._widgetclosed)
+        if self.toolbar:
+            self.toolbar.destroy()
+        self.window.close()
 
     def grid_toggle(self):
         """
@@ -185,16 +192,6 @@ class FigureManagerWorkbench(FigureManagerBase):
         Mark this figure as held
         """
         self.toolbar.hold()
-
-    def _destroy_impl(self):
-        self.window._destroying = True
-        self.window.destroyed.connect(self._widgetclosed)
-        try:
-            if self.toolbar:
-                self.toolbar.destroy()
-            self.window.close()
-        except BaseException:  # noqa
-            self._destroy_exc = sys.exc_info()
 
     def get_window_title(self):
         return text_type(self.window.windowTitle())
@@ -230,49 +227,6 @@ class FigureManagerWorkbench(FigureManagerBase):
                 move_and_show(YAxisEditor(canvas, ax))
 
 
-class Show(object):
-
-    def __call__(self, block=None):
-        """
-        Show all figures.
-
-        block is ignored as calling mainloop does nothing anyway
-        since the event loop is already running
-        """
-        managers = Gcf.get_all_fig_managers()
-        if not managers:
-            return
-
-        for manager in managers:
-            manager.show()
-
-        # I'm not sure if we need to do this...
-
-        # # Hack: determine at runtime whether we are
-        # # inside ipython in pylab mode.
-        # from matplotlib import pyplot
-        # try:
-        #     ipython_pylab = not pyplot.show._needmain
-        #     # IPython versions >= 0.10 tack the _needmain
-        #     # attribute onto pyplot.show, and always set
-        #     # it to False, when in %pylab mode.
-        #     ipython_pylab = ipython_pylab and get_backend() != 'WebAgg'
-        #     # TODO: The above is a hack to get the WebAgg backend
-        #     # working with ipython's `%pylab` mode until proper
-        #     # integration is implemented.
-        # except AttributeError:
-        #     ipython_pylab = False
-        #
-        # # Leave the following as a separate step in case we
-        # # want to control this behavior with an rcParam.
-        # if ipython_pylab:
-        #     return
-
-    def mainloop(self):
-        # we have already started the event loop
-        pass
-
-
 # -----------------------------------------------------------------------------
 # Figure control
 # -----------------------------------------------------------------------------
@@ -294,9 +248,6 @@ def new_figure_manager_given_figure(num, figure):
     canvas = FigureCanvasQTAgg(figure)
     manager = FigureManagerWorkbench(canvas, num)
     return manager
-
-
-show = Show()
 
 
 if __name__ == '__main__':

--- a/qt/applications/workbench/workbench/plotting/functions.py
+++ b/qt/applications/workbench/workbench/plotting/functions.py
@@ -88,6 +88,7 @@ def plot(workspaces, spectrum_nums=None, wksp_indices=None, errors=False):
         kw, nums = 'wkspIndex', wksp_indices
     # create figure
     fig = plt.figure()
+    fig.clf()
     ax = fig.add_subplot(111, projection=PROJECTION)
     plot_fn = ax.errorbar if errors else ax.plot
     for ws in workspaces:


### PR DESCRIPTION
Description of work.

Wraps key calls in the `matplotlib` backend so that they occur on the main GUI thread.

**To test:**

The following script either crashed the workbench immediately or on exit before these changes. 

```python
from __future__ import (absolute_import, print_function)

import matplotlib.pyplot as plt
import numpy as np

x = np.linspace(0, 10, 1000)
y = np.sin(x)

# plot
fig, ax = plt.subplots()
ax.plot(x, y)
fig.show()
```

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
