### PR TITLE
Expand check for numpy version

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/ExportSampleLogsToCSVFile.py
+++ b/Framework/PythonInterface/plugins/algorithms/ExportSampleLogsToCSVFile.py
@@ -2,6 +2,7 @@
 from __future__ import (absolute_import, division, print_function)
 from mantid.api import *
 from mantid.kernel import *
+from distutils.version import LooseVersion
 import numpy as np
 import os
 from six.moves import range # pylint: disable=redefined-builtin
@@ -179,7 +180,8 @@ class ExportSampleLogsToCSVFile(PythonAlgorithm):
             localtimediff = np.timedelta64(0, 's')
 
         epoch = '1990-01-01T00:00'
-        if np.__version__.startswith('1.7.'):
+        # older numpy assumes local timezone
+        if LooseVersion(np.__version__) < LooseVersion('1.9'):
             epoch = epoch+'Z'
         return np.datetime64(epoch) + localtimediff
 

--- a/Framework/PythonInterface/test/python/mantid/kernel/DateAndTimeTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/DateAndTimeTest.py
@@ -4,6 +4,7 @@ import unittest
 from mantid.kernel import DateAndTime
 import numpy
 from numpy import timedelta64, datetime64
+from distutils.version import LooseVersion
 
 
 class DateAndTimeTest(unittest.TestCase):
@@ -31,7 +32,7 @@ class DateAndTimeTest(unittest.TestCase):
         self.assertEquals(dt, dt_np)
 
     def test_convert_from_np(self):
-        if numpy.__version__.startswith('1.7.'):
+        if LooseVersion(numpy.__version__) < LooseVersion('1.9'):
             dt_np = datetime64('2000-01-01T00:00Z')
         else: # newer numpy only uses UTC and warns on specifying timezones
             dt_np = datetime64('2000-01-01T00:00')

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ExportSampleLogsToCSVFileTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ExportSampleLogsToCSVFileTest.py
@@ -6,6 +6,7 @@ import mantid.kernel as kernel
 from testhelpers import run_algorithm
 from mantid.api import AnalysisDataService
 import os
+from distutils.version import LooseVersion
 from six.moves import range
 
 
@@ -300,7 +301,8 @@ class ExportVulcanSampleLogTest(unittest.TestCase):
         dtimesec = 0.0010
         timefluc = 0.0001
         runstart = '2014-02-15T13:34:03'
-        if numpy.__version__.startswith('1.7.'): # older numpy assumes local timezone
+        # older numpy assumes local timezone
+        if LooseVersion(numpy.__version__) < LooseVersion('1.9'):
             runstart = runstart + 'Z'
         runstart = datetime64(runstart, 'us') # microsecond needed for deltas
 


### PR DESCRIPTION
rhel7 is using numpy 1.7 and ubuntu14.04 is using numpy 1.8. Expand the check to encompass both.

**To test:**

A code review and passing builds should be enough.

*There is no associated issue.*

*Does not need to be in the release notes* because it is covered by the entry mentioning the new `datetime64` functionality.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
