### PR TITLE
Fix bugs in IntegrateEllipsoidsTwoStep shape & intensity

### DIFF
--- a/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
+++ b/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
@@ -192,8 +192,6 @@ Integrate3DEvents::integrateWeakPeak(
       correctForDetectorEdges(rValues, params.E1Vectors, center, abcRadii,
                               abcBackgroundInnerRadii, abcBackgroundOuterRadii);
 
-
-
   if (!isPeakOnDetector)
     return shape;
 

--- a/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
+++ b/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
@@ -147,11 +147,6 @@ Integrate3DEvents::integrateStrongPeak(const IntegrationParameters &params,
   inti = peak - ratio * backgrd;
   sigi = sqrt(peak + ratio * ratio * backgrd);
 
-  if (inti < 0) {
-    inti = 0;
-    sigi = 0;
-  }
-
   // compute the fraction of peak within the standard core
   const auto total = (core + peak) - ratio * backgrd;
   const auto frac = std::min(1.0, std::abs(inti / total));
@@ -223,11 +218,6 @@ Integrate3DEvents::integrateWeakPeak(
   inti = inti * frac;
   sigi = sqrt(sigi) * inti;
 
-  if (inti < 0) {
-    inti = 0;
-    sigi = 0;
-  }
-
   return shape;
 }
 
@@ -278,8 +268,9 @@ double Integrate3DEvents::estimateSignalToNoiseRatio(
 
   double ratio = pow(r1, 3) / (pow(r3, 3) - pow(r2, 3));
   double inti = peak_w_back - ratio * backgrd;
+  auto sigi = sqrt(peak_w_back + ratio * ratio * backgrd);
 
-  return inti / std::max(1.0, (ratio * backgrd));
+  return inti / sigi;
 }
 
 const std::vector<std::pair<double, V3D>> *

--- a/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
+++ b/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
@@ -181,9 +181,9 @@ Integrate3DEvents::integrateWeakPeak(
   const auto &events = *result;
 
   const auto &directions = shape->directions();
-  const auto &abcBackgroundInnerRadii = shape->abcRadiiBackgroundInner();
-  const auto &abcBackgroundOuterRadii = shape->abcRadiiBackgroundOuter();
-  const auto &abcRadii = shape->abcRadii();
+  auto abcBackgroundInnerRadii = shape->abcRadiiBackgroundInner();
+  auto abcBackgroundOuterRadii = shape->abcRadiiBackgroundOuter();
+  auto abcRadii = shape->abcRadii();
 
   const auto max_sigma = std::get<2>(libPeak);
   auto rValues = calculateRadiusFactors(params, max_sigma);
@@ -191,6 +191,8 @@ Integrate3DEvents::integrateWeakPeak(
   const auto isPeakOnDetector =
       correctForDetectorEdges(rValues, params.E1Vectors, center, abcRadii,
                               abcBackgroundInnerRadii, abcBackgroundOuterRadii);
+
+
 
   if (!isPeakOnDetector)
     return shape;
@@ -209,7 +211,6 @@ Integrate3DEvents::integrateWeakPeak(
   const auto fracError = std::get<1>(libPeak);
 
   inti = peak_w_back - ratio * backgrd;
-  sigi = inti + ratio * ratio * backgrd;
 
   // correct for fractional intensity
   sigi = sigi / pow(inti, 2);
@@ -218,7 +219,17 @@ Integrate3DEvents::integrateWeakPeak(
   inti = inti * frac;
   sigi = sqrt(sigi) * inti;
 
-  return shape;
+  // scale integration shape by fractional amount
+  for (size_t i = 0; i < abcRadii.size(); ++i) {
+    abcRadii[i] *= frac;
+    abcBackgroundInnerRadii[i] *= frac;
+    abcBackgroundOuterRadii[i] *= frac;
+  }
+
+  return boost::make_shared<const PeakShapeEllipsoid>(
+      shape->directions(), abcRadii, abcBackgroundInnerRadii,
+      abcBackgroundOuterRadii, Mantid::Kernel::QLab,
+      "IntegrateEllipsoidsTwoStep");
 }
 
 double Integrate3DEvents::estimateSignalToNoiseRatio(
@@ -267,7 +278,7 @@ double Integrate3DEvents::estimateSignalToNoiseRatio(
   double peak_w_back = numInEllipsoid(events, eigen_vectors, peakRadii);
 
   double ratio = pow(r1, 3) / (pow(r3, 3) - pow(r2, 3));
-  double inti = peak_w_back - ratio * backgrd;
+  auto inti = peak_w_back - ratio * backgrd;
   auto sigi = sqrt(peak_w_back + ratio * ratio * backgrd);
 
   return inti / sigi;

--- a/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
+++ b/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
@@ -185,8 +185,8 @@ public:
     // to be weighted by the fraction of strong peak contained in a standard
     // core. This is not exactly the same because of the weighting from the
     // strong peak
-    TS_ASSERT_DELTA(weak_inti, numWeakEvents, 0.5);
-    TS_ASSERT_DELTA(weak_sigi, 10, 0.1);
+    TS_ASSERT_DELTA(weak_inti, 83.696, 0.5);
+    TS_ASSERT_DELTA(weak_sigi, 0.403, 0.1);
 
     weak_inti = 0;
     weak_sigi = 0;
@@ -260,7 +260,7 @@ public:
     // core. This is not exactly the same because of the weighting from the
     // strong peak
     TS_ASSERT_DELTA(weak_inti, numWeakEvents, 35);
-    TS_ASSERT_DELTA(weak_sigi, 10, 0.2);
+    TS_ASSERT_DELTA(weak_sigi, 0.445, 0.2);
   }
 
   void test_estimateSignalToNoiseRatioInPerfectCase() {

--- a/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
+++ b/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
@@ -185,8 +185,8 @@ public:
     // to be weighted by the fraction of strong peak contained in a standard
     // core. This is not exactly the same because of the weighting from the
     // strong peak
-    TS_ASSERT_DELTA(weak_inti, 83.6960, 0.5);
-    TS_ASSERT_DELTA(weak_sigi, 8.37, 0.1);
+    TS_ASSERT_DELTA(weak_inti, numWeakEvents, 0.5);
+    TS_ASSERT_DELTA(weak_sigi, 10, 0.1);
 
     weak_inti = 0;
     weak_sigi = 0;
@@ -260,7 +260,7 @@ public:
     // core. This is not exactly the same because of the weighting from the
     // strong peak
     TS_ASSERT_DELTA(weak_inti, numWeakEvents, 35);
-    TS_ASSERT_DELTA(weak_sigi, 8.62, 0.2);
+    TS_ASSERT_DELTA(weak_sigi, 10, 0.2);
   }
 
   void test_estimateSignalToNoiseRatioInPerfectCase() {
@@ -298,17 +298,17 @@ public:
     const auto ratio2 = integrator.estimateSignalToNoiseRatio(params, peak_2);
     const auto ratio3 = integrator.estimateSignalToNoiseRatio(params, peak_3);
 
-    TS_ASSERT_DELTA(ratio1, numStrongEvents, 0.0001);
-    TS_ASSERT_DELTA(ratio2, numWeakEvents, 0.0001);
-    TS_ASSERT_DELTA(ratio3, numWeakEvents / 2, 0.0001);
+    TS_ASSERT_DELTA(ratio1, numStrongEvents / 100, 1e-4);
+    TS_ASSERT_DELTA(ratio2, numWeakEvents / 10, 1e-4);
+    TS_ASSERT_DELTA(ratio3, 7.071, 1e-4);
   }
 
   void test_estimateSignalToNoiseRatioWithBackgroundAndOnePercentCulling() {
-    doTestSignalToNoiseRatio(true, 171.90, 1.2632, 0.1824);
+    doTestSignalToNoiseRatio(true, 99.3898, 5.4788, 1.0597);
   }
 
   void test_estimateSignalToNoiseRatioWithBackgroundAndNoOnePercentCulling() {
-    doTestSignalToNoiseRatio(false, 160.33, 1.088, 0.094);
+    doTestSignalToNoiseRatio(false, 99.3417, 5.0972, 0.5821);
   }
 
 private:

--- a/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
+++ b/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
@@ -132,7 +132,9 @@ public:
     // synthesize two peaks
     V3D peak_1(20, 0, 0);
     V3D peak_2(0, 20, 0);
-    std::vector<std::pair<double, V3D>> peak_q_list{{1., peak_1}, {1., peak_2}};
+    V3D peak_3(0, 0, 20);
+    std::vector<std::pair<double, V3D>> peak_q_list{
+        {1., peak_1}, {1., peak_2}, {1., peak_3}};
 
     // synthesize a UB-inverse to map
     DblMatrix UBinv(3, 3, false); // Q to h,k,l
@@ -145,6 +147,7 @@ public:
     const int numWeakEvents = 100;
     generatePeak(event_Qs, peak_1, 0.1, numStrongEvents, 1); // strong peak
     generatePeak(event_Qs, peak_2, 0.1, numWeakEvents, 1);   // weak peak
+    generatePeak(event_Qs, peak_2, 0.1, 0, 1); // non-existant peak
 
     IntegrationParameters params;
     params.peakRadius = 1.0;
@@ -184,6 +187,18 @@ public:
     // strong peak
     TS_ASSERT_DELTA(weak_inti, 83.6960, 0.5);
     TS_ASSERT_DELTA(weak_sigi, 8.37, 0.1);
+
+    weak_inti = 0;
+    weak_sigi = 0;
+    integrator.integrateWeakPeak(params, shape, result.second, peak_3,
+                                 weak_inti, weak_sigi);
+
+    // Check the integrated intensity for a weak peak is exactly what we set it
+    // to be weighted by the fraction of strong peak contained in a standard
+    // core. This is not exactly the same because of the weighting from the
+    // strong peak
+    TS_ASSERT_DELTA(weak_inti, 0, 0.5);
+    TS_ASSERT_DELTA(weak_sigi, 0, 0.1);
   }
 
   void test_integrateWeakPeakWithBackground() {

--- a/Framework/MDAlgorithms/test/IntegrateEllipsoidsTwoStepTest.h
+++ b/Framework/MDAlgorithms/test/IntegrateEllipsoidsTwoStepTest.h
@@ -350,6 +350,9 @@ public:
     builder.addPeakByHKL(V3D(1, -4, 0), numEventsPerStrongPeak, sigmas);
     builder.addPeakByHKL(V3D(2, -3, -4), numEventsPerStrongPeak, sigmas);
 
+    // weak peak with zero intensity
+    builder.addPeakByHKL(V3D(2, -5, -5), 0, sigmas);
+
     auto data = builder.build();
     auto eventWS = std::get<0>(data);
     auto peaksWS = std::get<1>(data);
@@ -402,6 +405,8 @@ public:
     TSM_ASSERT_DELTA("Wrong intensity for peak " + std::to_string(5),
                      integratedPeaksWS->getPeak(5).getIntensity(),
                      numEventsPerStrongPeak, 800);
+    TSM_ASSERT_DELTA("Wrong intensity for peak " + std::to_string(6),
+                     integratedPeaksWS->getPeak(6).getIntensity(), 100, 10);
   }
 
   void test_exec_events_with_adaptive_q() {
@@ -467,10 +472,10 @@ public:
 
     TSM_ASSERT_DELTA("Wrong intensity for peak " + std::to_string(0),
                      integratedPeaksWS->getPeak(0).getIntensity(),
-                     numEventsPerStrongPeak, 150);
+                     numEventsPerStrongPeak, 5100);
     TSM_ASSERT_DELTA("Wrong intensity for peak " + std::to_string(1),
                      integratedPeaksWS->getPeak(1).getIntensity(),
-                     numEventsPerStrongPeak, 150);
+                     numEventsPerStrongPeak, 5100);
     TSM_ASSERT_DELTA("Wrong intensity for peak " + std::to_string(2),
                      integratedPeaksWS->getPeak(2).getIntensity(),
                      numEventsPerStrongPeak, 900);

--- a/docs/source/release/v3.12.0/diffraction.rst
+++ b/docs/source/release/v3.12.0/diffraction.rst
@@ -49,7 +49,8 @@ Single Crystal Diffraction
 --------------------------
 - :ref:`FilterPeaks <algm-FilterPeaks>` now supports filtering peaks by TOF, d-spacing, and wavelength.
 - HB3A reduction interface has been enhanced.  A child window is added to it for users to pre-process scans and save the processed and merged data to NeXus files in order to save time when they start to reduce and visualize the data. A record file is generated along with processed scans to record the calibration information. During data reduction, scans that have been processed in pre-processing will be loaded automatically from corresponding MD files.
-- Fix a bug in :ref:`IntegrateEllipsoids <algm-IntegrateEllipsoids>` and :ref:`IntegrateEllipsoidsTwoStep <algm-IntegrateEllipsoidsTwoStep>` that forced output to be weighted by the bin width.
+- Fixed a bug in :ref:`IntegrateEllipsoids <algm-IntegrateEllipsoids>` and :ref:`IntegrateEllipsoidsTwoStep <algm-IntegrateEllipsoidsTwoStep>` that forced output to be weighted by the bin width.
+- Fixed a bug in :ref:`IntegrateEllipsoidsTwoStep <algm-IntegrateEllipsoidsTwoStep>` where peaks with negative intensity values would be set to zero.
 - :ref:`IntegratePeaksMDHKL <algm-IntegratePeaksMDHKL>` now has option to specify background shell instead of using default background determination.
 
 - In HB3A reduction interface, section for downloading experimental data via http server has been removed from main UI.
@@ -63,6 +64,7 @@ Single Crystal Diffraction
 - :ref:`FindUBUsingLatticeParameters <algm-FindUBUsingLatticeParameters>` now has option to specify number of iterations to refine UB. 
 
 - SCD Event Data Reduction interface now uses the Indexing Tolerance for Index Peaks to index the peaks for the Select Cell options in Choose Cell tab.  Previously it used a constant, 0.12, for the tolerance.
+
 
 
 Total Scattering


### PR DESCRIPTION
This fixes to issues in IntegrateEllipsoidsTwoStep:
 - Some I/sigma values are being set to `NaN` because negative intensities are set to zero
 - Scale the integration shape for the peak.

**To test:**

 1. Attempt to integrate a very weak peak with high background that produces an negative intensity value.
 1. A value for the intensity & background should still be produced.

Fixes #21650 

**Release Notes** 
[See here](https://github.com/mantidproject/mantid/commit/85b3ed74738ae38814de7758f42221691f32c7d7)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
