### PR TITLE
Engineering Diffraction GUI skeleton presenter for multi-run fitting widget

### DIFF
--- a/qt/scientific_interfaces/CMakeLists.txt
+++ b/qt/scientific_interfaces/CMakeLists.txt
@@ -32,6 +32,7 @@ set ( TEST_FILES
   test/ALCPeakFittingPresenterTest.h
   test/EnggDiffGSASFittingModelTest.h
   test/EnggDiffGSASFittingPresenterTest.h
+  test/EnggDiffMultiRunFittingWidgetPresenterTest.h
   test/EnggDiffFittingModelTest.h
   test/EnggDiffFittingPresenterTest.h
   test/EnggDiffractionPresenterTest.h

--- a/qt/scientific_interfaces/EnggDiffraction/CMakeLists.txt
+++ b/qt/scientific_interfaces/EnggDiffraction/CMakeLists.txt
@@ -4,6 +4,7 @@ set ( SRC_FILES
 	EnggDiffFittingViewQtWidget.cpp
 	EnggDiffGSASFittingModel.cpp
 	EnggDiffGSASFittingPresenter.cpp
+	EnggDiffMultiRunFittingWidgetPresenter.cpp
 	EnggDiffractionPresenter.cpp
 	EnggDiffractionViewQtGUI.cpp
 )
@@ -19,6 +20,7 @@ set ( INC_FILES
 	EnggDiffGSASFittingModel.h
 	EnggDiffGSASFittingPresenter.h
 	EnggDiffGSASRefinementMethod.h
+	EnggDiffMultiRunFittingWidgetPresenter.h
 	EnggDiffractionPresWorker.h
 	EnggDiffractionPresenter.h
 	EnggDiffractionViewQtGUI.h
@@ -27,6 +29,9 @@ set ( INC_FILES
 	IEnggDiffGSASFittingModel.h
 	IEnggDiffGSASFittingPresenter.h
 	IEnggDiffGSASFittingView.h
+	IEnggDiffMultiRunFittingWidgetModel.h
+	IEnggDiffMultiRunFittingWidgetPresenter.h
+	IEnggDiffMultiRunFittingWidgetView.h
 	IEnggDiffractionPresenter.h
 	IEnggDiffractionView.h
 	RunMap.h

--- a/qt/scientific_interfaces/EnggDiffraction/CMakeLists.txt
+++ b/qt/scientific_interfaces/EnggDiffraction/CMakeLists.txt
@@ -7,6 +7,7 @@ set ( SRC_FILES
 	EnggDiffMultiRunFittingWidgetPresenter.cpp
 	EnggDiffractionPresenter.cpp
 	EnggDiffractionViewQtGUI.cpp
+	RunLabel.cpp
 )
 
 # Include files aren't required, but this makes them appear in Visual Studio
@@ -34,6 +35,7 @@ set ( INC_FILES
 	IEnggDiffMultiRunFittingWidgetView.h
 	IEnggDiffractionPresenter.h
 	IEnggDiffractionView.h
+	RunLabel.h
 	RunMap.h
 )
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.cpp
@@ -27,39 +27,35 @@ namespace MantidQt {
 namespace CustomInterfaces {
 
 void EnggDiffFittingModel::addFocusedWorkspace(
-    const int runNumber, const size_t bank, const API::MatrixWorkspace_sptr ws,
+    const RunLabel &runLabel, const API::MatrixWorkspace_sptr ws,
     const std::string &filename) {
-  m_focusedWorkspaceMap.add(runNumber, bank, ws);
-  m_wsFilenameMap.add(runNumber, bank, filename);
+  m_focusedWorkspaceMap.add(runLabel, ws);
+  m_wsFilenameMap.add(runLabel, filename);
 }
 
 void EnggDiffFittingModel::addFitResults(
-    const int runNumber, const size_t bank,
-    const Mantid::API::ITableWorkspace_sptr ws) {
-  m_fitParamsMap.add(runNumber, bank, ws);
+    const RunLabel &runLabel, const Mantid::API::ITableWorkspace_sptr ws) {
+  m_fitParamsMap.add(runLabel, ws);
 }
 
 const std::string &
-EnggDiffFittingModel::getWorkspaceFilename(const int runNumber,
-                                           const size_t bank) const {
-  return m_wsFilenameMap.get(runNumber, bank);
+EnggDiffFittingModel::getWorkspaceFilename(const RunLabel &runLabel) const {
+  return m_wsFilenameMap.get(runLabel);
 }
 
 Mantid::API::ITableWorkspace_sptr
-EnggDiffFittingModel::getFitResults(const int runNumber,
-                                    const size_t bank) const {
-  return m_fitParamsMap.get(runNumber, bank);
+EnggDiffFittingModel::getFitResults(const RunLabel &runLabel) const {
+  return m_fitParamsMap.get(runLabel);
 }
 
 namespace {
 
 template <size_t S, typename T>
-void removeFromRunMapAndADS(const int runNumber, const size_t bank,
-                            RunMap<S, T> &map,
+void removeFromRunMapAndADS(const RunLabel &runLabel, RunMap<S, T> &map,
                             Mantid::API::AnalysisDataServiceImpl &ADS) {
-  if (map.contains(runNumber, bank)) {
-    const auto &name = map.get(runNumber, bank)->getName();
-    map.remove(runNumber, bank);
+  if (map.contains(runLabel)) {
+    const auto &name = map.get(runLabel)->getName();
+    map.remove(runLabel);
     if (ADS.doesExist(name)) {
       ADS.remove(name);
     }
@@ -68,20 +64,20 @@ void removeFromRunMapAndADS(const int runNumber, const size_t bank,
 
 } // anonymous namespace
 
-void EnggDiffFittingModel::removeRun(const int runNumber, const size_t bank) {
-  m_wsFilenameMap.remove(runNumber, bank);
+void EnggDiffFittingModel::removeRun(const RunLabel &runLabel) {
+  m_wsFilenameMap.remove(runLabel);
 
   auto &ADS = Mantid::API::AnalysisDataService::Instance();
-  removeFromRunMapAndADS(runNumber, bank, m_focusedWorkspaceMap, ADS);
-  removeFromRunMapAndADS(runNumber, bank, m_fittedPeaksMap, ADS);
-  removeFromRunMapAndADS(runNumber, bank, m_alignedWorkspaceMap, ADS);
-  removeFromRunMapAndADS(runNumber, bank, m_fitParamsMap, ADS);
+  removeFromRunMapAndADS(runLabel, m_focusedWorkspaceMap, ADS);
+  removeFromRunMapAndADS(runLabel, m_fittedPeaksMap, ADS);
+  removeFromRunMapAndADS(runLabel, m_alignedWorkspaceMap, ADS);
+  removeFromRunMapAndADS(runLabel, m_fitParamsMap, ADS);
 }
 
 void EnggDiffFittingModel::setDifcTzero(
-    const int runNumber, const size_t bank,
+    const RunLabel &runLabel,
     const std::vector<GSASCalibrationParms> &calibParams) {
-  auto ws = getFocusedWorkspace(runNumber, bank);
+  auto ws = getFocusedWorkspace(runLabel);
   auto &run = ws->mutableRun();
   const std::string units = "none";
 
@@ -92,7 +88,7 @@ void EnggDiffFittingModel::setDifcTzero(
   } else {
     GSASCalibrationParms params(0, 0.0, 0.0, 0.0);
     for (const auto &paramSet : calibParams) {
-      if (paramSet.bankid == bank) {
+      if (paramSet.bankid == runLabel.bank) {
         params = paramSet;
         break;
       }
@@ -107,9 +103,9 @@ void EnggDiffFittingModel::setDifcTzero(
   }
 }
 
-void EnggDiffFittingModel::enggFitPeaks(const int runNumber, const size_t bank,
+void EnggDiffFittingModel::enggFitPeaks(const RunLabel &runLabel,
                                         const std::string &expectedPeaks) {
-  const auto ws = getFocusedWorkspace(runNumber, bank);
+  const auto ws = getFocusedWorkspace(runLabel);
   auto enggFitPeaksAlg =
       Mantid::API::AlgorithmManager::Instance().create("EnggFitPeaks");
 
@@ -124,27 +120,26 @@ void EnggDiffFittingModel::enggFitPeaks(const int runNumber, const size_t bank,
   API::AnalysisDataServiceImpl &ADS = API::AnalysisDataService::Instance();
   const auto fitResultsTable =
       ADS.retrieveWS<API::ITableWorkspace>(FIT_RESULTS_TABLE_NAME);
-  addFitResults(runNumber, bank, fitResultsTable);
+  addFitResults(runLabel, fitResultsTable);
 }
 
 void EnggDiffFittingModel::saveDiffFittingAscii(
-    const int runNumber, const size_t bank, const std::string &filename) const {
-  const auto ws = getFitResults(runNumber, bank);
+    const RunLabel &runLabel, const std::string &filename) const {
+  const auto ws = getFitResults(runLabel);
   auto saveAlg =
       Mantid::API::AlgorithmManager::Instance().create("SaveDiffFittingAscii");
   saveAlg->initialize();
   saveAlg->setProperty("InputWorkspace", ws);
-  saveAlg->setProperty("RunNumber", std::to_string(runNumber));
-  saveAlg->setProperty("Bank", std::to_string(bank));
+  saveAlg->setProperty("RunNumber", std::to_string(runLabel.runNumber));
+  saveAlg->setProperty("Bank", std::to_string(runLabel.bank));
   saveAlg->setProperty("OutMode", "AppendToExistingFile");
   saveAlg->setProperty("Filename", filename);
   saveAlg->execute();
 }
 
-void EnggDiffFittingModel::createFittedPeaksWS(const int runNumber,
-                                               const size_t bank) {
-  const auto fitFunctionParams = getFitResults(runNumber, bank);
-  const auto focusedWS = getFocusedWorkspace(runNumber, bank);
+void EnggDiffFittingModel::createFittedPeaksWS(const RunLabel &runLabel) {
+  const auto fitFunctionParams = getFitResults(runLabel);
+  const auto focusedWS = getFocusedWorkspace(runLabel);
 
   const size_t numberOfPeaks = fitFunctionParams->rowCount();
 
@@ -161,8 +156,7 @@ void EnggDiffFittingModel::createFittedPeaksWS(const int runNumber,
 
     cropWorkspace(singlePeakWSName, singlePeakWSName, 1, 1);
 
-    rebinToFocusedWorkspace(singlePeakWSName, runNumber, bank,
-                            singlePeakWSName);
+    rebinToFocusedWorkspace(singlePeakWSName, runLabel, singlePeakWSName);
 
     if (i == 0) {
       cloneWorkspace(focusedWS, FITTED_PEAKS_WS_NAME);
@@ -187,32 +181,30 @@ void EnggDiffFittingModel::createFittedPeaksWS(const int runNumber,
 
   const auto fittedPeaksWS =
       ADS.retrieveWS<Mantid::API::MatrixWorkspace>(FITTED_PEAKS_WS_NAME);
-  m_fittedPeaksMap.add(runNumber, bank, fittedPeaksWS);
+  m_fittedPeaksMap.add(runLabel, fittedPeaksWS);
 
   const auto alignedFocusedWS =
       ADS.retrieveWS<Mantid::API::MatrixWorkspace>(alignedWSName);
-  m_alignedWorkspaceMap.add(runNumber, bank, alignedFocusedWS);
+  m_alignedWorkspaceMap.add(runLabel, alignedFocusedWS);
 }
 
 size_t EnggDiffFittingModel::getNumFocusedWorkspaces() const {
   return m_focusedWorkspaceMap.size();
 }
 
-bool EnggDiffFittingModel::hasFittedPeaksForRun(const int runNumber,
-                                                const size_t bank) const {
-  return m_fittedPeaksMap.contains(runNumber, bank);
+bool EnggDiffFittingModel::hasFittedPeaksForRun(
+    const RunLabel &runLabel) const {
+  return m_fittedPeaksMap.contains(runLabel);
 }
 
 Mantid::API::MatrixWorkspace_sptr
-EnggDiffFittingModel::getAlignedWorkspace(const int runNumber,
-                                          const size_t bank) const {
-  return m_alignedWorkspaceMap.get(runNumber, bank);
+EnggDiffFittingModel::getAlignedWorkspace(const RunLabel &runLabel) const {
+  return m_alignedWorkspaceMap.get(runLabel);
 }
 
 Mantid::API::MatrixWorkspace_sptr
-EnggDiffFittingModel::getFittedPeaksWS(const int runNumber,
-                                       const size_t bank) const {
-  return m_fittedPeaksMap.get(runNumber, bank);
+EnggDiffFittingModel::getFittedPeaksWS(const RunLabel &runLabel) const {
+  return m_fittedPeaksMap.get(runLabel);
 }
 
 void EnggDiffFittingModel::evaluateFunction(
@@ -246,15 +238,15 @@ void EnggDiffFittingModel::cropWorkspace(const std::string &inputWSName,
 }
 
 void EnggDiffFittingModel::rebinToFocusedWorkspace(
-    const std::string &wsToRebinName, const int runNumberToMatch,
-    const size_t bankToMatch, const std::string &outputWSName) {
+    const std::string &wsToRebinName, const RunLabel &runLabelToMatch,
+    const std::string &outputWSName) {
   auto rebinToWSAlg =
       Mantid::API::AlgorithmManager::Instance().create("RebinToWorkspace");
 
   rebinToWSAlg->initialize();
   rebinToWSAlg->setProperty("WorkspaceToRebin", wsToRebinName);
 
-  const auto wsToMatch = getFocusedWorkspace(runNumberToMatch, bankToMatch);
+  const auto wsToMatch = getFocusedWorkspace(runLabelToMatch);
   rebinToWSAlg->setProperty("WorkspaceToMatch", wsToMatch);
   rebinToWSAlg->setProperty("OutputWorkspace", outputWSName);
   rebinToWSAlg->execute();
@@ -388,9 +380,8 @@ void EnggDiffFittingModel::groupWorkspaces(
 }
 
 API::MatrixWorkspace_sptr
-EnggDiffFittingModel::getFocusedWorkspace(const int runNumber,
-                                          const size_t bank) const {
-  return m_focusedWorkspaceMap.get(runNumber, bank);
+EnggDiffFittingModel::getFocusedWorkspace(const RunLabel &runLabel) const {
+  return m_focusedWorkspaceMap.get(runLabel);
 }
 
 void EnggDiffFittingModel::mergeTables(
@@ -412,15 +403,12 @@ void EnggDiffFittingModel::addAllFitResultsToADS() const {
   auto fitParamsTable = Mantid::API::WorkspaceFactory::Instance().createTable();
   renameWorkspace(fitParamsTable, FIT_RESULTS_TABLE_NAME);
 
-  const auto runNumberBankPairs = getRunNumbersAndBankIDs();
+  const auto runLabels = getRunLabels();
 
-  for (const auto &runNumberBankPair : runNumberBankPairs) {
-    const int runNumber = runNumberBankPair.first;
-    const size_t bank = runNumberBankPair.second;
+  for (const auto &runLabel : runLabels) {
+    const auto singleWSFitResults = getFitResults(runLabel);
 
-    const auto singleWSFitResults = getFitResults(runNumber, bank);
-
-    if (runNumberBankPair == *runNumberBankPairs.begin()) {
+    if (runLabel == *runLabels.begin()) {
       // First element - copy column headings over
       const auto columnHeaders = singleWSFitResults->getColumnNames();
       for (const auto &header : columnHeaders) {
@@ -432,21 +420,16 @@ void EnggDiffFittingModel::addAllFitResultsToADS() const {
 }
 
 void EnggDiffFittingModel::addAllFittedPeaksToADS() const {
-  const auto runNumberBankPairs = getRunNumbersAndBankIDs();
-  if (runNumberBankPairs.size() < 1) {
+  const auto runLabels = getRunLabels();
+  if (runLabels.size() < 1) {
     return;
   }
-  const auto firstWSLabel = runNumberBankPairs[0];
-  auto fittedPeaksWS =
-      getFittedPeaksWS(firstWSLabel.first, firstWSLabel.second);
+  const auto firstWSLabel = runLabels[0];
+  auto fittedPeaksWS = getFittedPeaksWS(firstWSLabel);
   cloneWorkspace(fittedPeaksWS, FITTED_PEAKS_WS_NAME);
 
-  for (size_t i = 1; i < runNumberBankPairs.size(); ++i) {
-    const auto wsLabel = runNumberBankPairs[i];
-    const int runNumber = wsLabel.first;
-    const size_t bank = wsLabel.second;
-
-    auto wsToAppend = getFittedPeaksWS(runNumber, bank);
+  for (size_t i = 1; i < runLabels.size(); ++i) {
+    auto wsToAppend = getFittedPeaksWS(runLabels[i]);
     appendSpectra(FITTED_PEAKS_WS_NAME, wsToAppend->getName());
   }
 }
@@ -467,7 +450,7 @@ void EnggDiffFittingModel::loadWorkspaces(const std::string &filenamesString) {
   std::vector<std::string> filenames;
   boost::split(filenames, filenamesString, boost::is_any_of(","));
 
-  std::vector<std::pair<int, size_t>> collectedRunBankPairs;
+  std::vector<RunLabel> collectedRunLabels;
 
   for (const auto &filename : filenames) {
     // Set ws name to filename first, in case we need to guess bank ID from it
@@ -479,30 +462,28 @@ void EnggDiffFittingModel::loadWorkspaces(const std::string &filenamesString) {
 
     const auto bank = guessBankID(ws);
     const int runNumber = ws->getRunNumber();
+    RunLabel runLabel(runNumber, bank);
 
-    addFocusedWorkspace(runNumber, bank, ws, filename);
-    collectedRunBankPairs.push_back(std::make_pair(runNumber, bank));
+    addFocusedWorkspace(runLabel, ws, filename);
+    collectedRunLabels.push_back(runLabel);
   }
 
-  if (collectedRunBankPairs.size() == 1) {
-    auto ws = getFocusedWorkspace(collectedRunBankPairs[0].first,
-                                  collectedRunBankPairs[0].second);
+  if (collectedRunLabels.size() == 1) {
+    auto ws = getFocusedWorkspace(collectedRunLabels[0]);
     renameWorkspace(ws, FOCUSED_WS_NAME);
   } else {
     std::vector<std::string> workspaceNames;
-    std::transform(collectedRunBankPairs.begin(), collectedRunBankPairs.end(),
+    std::transform(collectedRunLabels.begin(), collectedRunLabels.end(),
                    std::back_inserter(workspaceNames),
-                   [&](const std::pair<int, size_t> &runBankPair) {
-                     return getFocusedWorkspace(runBankPair.first,
-                                                runBankPair.second)->getName();
+                   [&](const RunLabel &runLabel) {
+                     return getFocusedWorkspace(runLabel)->getName();
                    });
     groupWorkspaces(workspaceNames, FOCUSED_WS_NAME);
   }
 }
 
-std::vector<std::pair<int, size_t>>
-EnggDiffFittingModel::getRunNumbersAndBankIDs() const {
-  return m_focusedWorkspaceMap.getRunNumbersAndBankIDs();
+std::vector<RunLabel> EnggDiffFittingModel::getRunLabels() const {
+  return m_focusedWorkspaceMap.getRunLabels();
 }
 
 size_t

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.h
@@ -17,37 +17,37 @@ class MANTIDQT_ENGGDIFFRACTION_DLL EnggDiffFittingModel
 
 public:
   Mantid::API::MatrixWorkspace_sptr
-  getFocusedWorkspace(const int runNumber, const size_t bank) const override;
+  getFocusedWorkspace(const RunLabel &runLabel) const override;
 
   Mantid::API::MatrixWorkspace_sptr
-  getAlignedWorkspace(const int runNumber, const size_t bank) const override;
+  getAlignedWorkspace(const RunLabel &runLabel) const override;
 
   Mantid::API::MatrixWorkspace_sptr
-  getFittedPeaksWS(const int runNumber, const size_t bank) const override;
+  getFittedPeaksWS(const RunLabel &runLabel) const override;
 
   Mantid::API::ITableWorkspace_sptr
-  getFitResults(const int runNumber, const size_t bank) const override;
+  getFitResults(const RunLabel &runLabel) const override;
 
-  const std::string &getWorkspaceFilename(const int runNumber,
-                                          const size_t bank) const override;
+  const std::string &
+  getWorkspaceFilename(const RunLabel &runLabel) const override;
 
-  void removeRun(const int runNumber, const size_t bank) override;
+  void removeRun(const RunLabel &runLabel) override;
 
   void loadWorkspaces(const std::string &filenames) override;
 
-  std::vector<std::pair<int, size_t>> getRunNumbersAndBankIDs() const override;
+  std::vector<RunLabel> getRunLabels() const override;
 
   void
-  setDifcTzero(const int runNumber, const size_t bank,
+  setDifcTzero(const RunLabel &runLabel,
                const std::vector<GSASCalibrationParms> &calibParams) override;
 
-  void enggFitPeaks(const int runNumber, const size_t bank,
+  void enggFitPeaks(const RunLabel &runLabel,
                     const std::string &expectedPeaks) override;
 
-  void saveDiffFittingAscii(const int runNumber, const size_t bank,
+  void saveDiffFittingAscii(const RunLabel &runLabel,
                             const std::string &filename) const override;
 
-  void createFittedPeaksWS(const int runNumber, const size_t bank) override;
+  void createFittedPeaksWS(const RunLabel &runLabel) override;
 
   size_t getNumFocusedWorkspaces() const override;
 
@@ -55,15 +55,14 @@ public:
 
   void addAllFittedPeaksToADS() const override;
 
-  bool hasFittedPeaksForRun(const int runNumber,
-                            const size_t bank) const override;
+  bool hasFittedPeaksForRun(const RunLabel &runLabel) const override;
 
 protected:
-  void addFocusedWorkspace(const int runNumber, const size_t bank,
+  void addFocusedWorkspace(const RunLabel &runLabel,
                            const Mantid::API::MatrixWorkspace_sptr ws,
                            const std::string &filename);
 
-  void addFitResults(const int runNumber, const size_t bank,
+  void addFitResults(const RunLabel &runLabel,
                      const Mantid::API::ITableWorkspace_sptr ws);
 
   void mergeTables(const Mantid::API::ITableWorkspace_sptr tableToCopy,
@@ -102,8 +101,7 @@ private:
                      const int endWSIndex);
 
   void rebinToFocusedWorkspace(const std::string &wsToRebinName,
-                               const int runNumberToMatch,
-                               const size_t bankToMatch,
+                               const RunLabel &runLabelToMatch,
                                const std::string &outputWSName);
 
   void cloneWorkspace(const Mantid::API::MatrixWorkspace_sptr inputWorkspace,

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresWorker.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresWorker.h
@@ -41,21 +41,17 @@ class EnggDiffFittingWorker : public QObject {
 
 public:
   // for fitting (single peak fits)
-  EnggDiffFittingWorker(
-      EnggDiffFittingPresenter *pres,
-      const std::vector<std::pair<int, size_t>> &runNumberBankPairs,
-      const std::string &expectedPeaks)
-      : m_pres(pres), m_runNumberBankPairs(runNumberBankPairs),
-        m_expectedPeaks(expectedPeaks) {}
+  EnggDiffFittingWorker(EnggDiffFittingPresenter *pres,
+                        const std::vector<RunLabel> &runLabels,
+                        const std::string &expectedPeaks)
+      : m_pres(pres), m_runLabels(runLabels), m_expectedPeaks(expectedPeaks) {}
 
 private slots:
 
   void fitting() {
     try {
-      for (const auto &runNumberBankPair : m_runNumberBankPairs) {
-        const int runNumber = runNumberBankPair.first;
-        const size_t bank = runNumberBankPair.second;
-        m_pres->doFitting(runNumber, bank, m_expectedPeaks);
+      for (const auto &runLabel : m_runLabels) {
+        m_pres->doFitting(runLabel, m_expectedPeaks);
       }
     } catch (std::exception &ex) {
       Mantid::Kernel::Logger log("EngineeringDiffractionFitting");
@@ -71,7 +67,7 @@ private:
   EnggDiffFittingPresenter *m_pres;
 
   /// sample run to process
-  const std::vector<std::pair<int, size_t>> m_runNumberBankPairs;
+  const std::vector<RunLabel> m_runLabels;
   // parameters for fitting, list of peaks
   const std::string m_expectedPeaks;
 };

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -25,19 +25,17 @@ namespace CustomInterfaces {
 namespace {
 Mantid::Kernel::Logger g_log("EngineeringDiffractionGUI");
 
-std::pair<int, size_t>
-runAndBankNumberFromListWidgetLabel(const std::string &listLabel) {
+RunLabel runLabelFromListWidgetLabel(const std::string &listLabel) {
   const size_t underscorePosition = listLabel.find_first_of("_");
   const auto runNumber = listLabel.substr(0, underscorePosition);
   const auto bank = listLabel.substr(underscorePosition + 1);
 
-  return std::pair<int, size_t>(std::atoi(runNumber.c_str()),
-                                std::atoi(bank.c_str()));
+  return RunLabel(std::atoi(runNumber.c_str()), std::atoi(bank.c_str()));
 }
 
-std::string listWidgetLabelFromRunAndBankNumber(const int runNumber,
-                                                const size_t bank) {
-  return std::to_string(runNumber) + "_" + std::to_string(bank);
+std::string listWidgetLabelFromRunLabel(const RunLabel &runLabel) {
+  return std::to_string(runLabel.runNumber) + "_" +
+         std::to_string(runLabel.bank);
 }
 
 // Remove commas at the start and end of the string,
@@ -199,13 +197,12 @@ EnggDiffFittingPresenter::outFilesUserDir(const std::string &addToDir) {
 }
 
 void EnggDiffFittingPresenter::startAsyncFittingWorker(
-    const std::vector<std::pair<int, size_t>> &runNumberBankPairs,
-    const std::string &expectedPeaks) {
+    const std::vector<RunLabel> &runLabels, const std::string &expectedPeaks) {
 
   delete m_workerThread;
   m_workerThread = new QThread(this);
   EnggDiffFittingWorker *worker =
-      new EnggDiffFittingWorker(this, runNumberBankPairs, expectedPeaks);
+      new EnggDiffFittingWorker(this, runLabels, expectedPeaks);
   worker->moveToThread(m_workerThread);
 
   connect(m_workerThread, SIGNAL(started()), worker, SLOT(fitting()));
@@ -313,13 +310,12 @@ void EnggDiffFittingPresenter::processLoad() {
     return;
   }
 
-  const auto runNoBankPairs = m_model->getRunNumbersAndBankIDs();
+  const auto runLabels = m_model->getRunLabels();
   std::vector<std::string> listWidgetLabels;
-  std::transform(runNoBankPairs.begin(), runNoBankPairs.end(),
+  std::transform(runLabels.begin(), runLabels.end(),
                  std::back_inserter(listWidgetLabels),
-                 [](const std::pair<int, size_t> &pair) {
-                   return listWidgetLabelFromRunAndBankNumber(pair.first,
-                                                              pair.second);
+                 [](const RunLabel &runLabel) {
+                   return listWidgetLabelFromRunLabel(runLabel);
                  });
   m_view->enableFittingListWidget(true);
   m_view->updateFittingListWidget(listWidgetLabels);
@@ -346,19 +342,15 @@ void EnggDiffFittingPresenter::processRemoveRun() {
   const auto workspaceLabel = m_view->getFittingListWidgetCurrentValue();
 
   if (workspaceLabel) {
-    const auto runBankPair =
-        runAndBankNumberFromListWidgetLabel(*workspaceLabel);
-    const auto bank = runBankPair.first;
-    const auto runNumber = runBankPair.second;
-    m_model->removeRun(bank, runNumber);
+    const auto runLabel = runLabelFromListWidgetLabel(*workspaceLabel);
+    m_model->removeRun(runLabel);
 
-    const auto runNoBankPairs = m_model->getRunNumbersAndBankIDs();
+    const auto runLabels = m_model->getRunLabels();
     std::vector<std::string> listWidgetLabels;
-    std::transform(runNoBankPairs.begin(), runNoBankPairs.end(),
+    std::transform(runLabels.begin(), runLabels.end(),
                    std::back_inserter(listWidgetLabels),
-                   [](const std::pair<int, size_t> &pair) {
-                     return listWidgetLabelFromRunAndBankNumber(pair.first,
-                                                                pair.second);
+                   [](const RunLabel &runLabel) {
+                     return listWidgetLabelFromRunLabel(runLabel);
                    });
     m_view->updateFittingListWidget(listWidgetLabels);
   } else {
@@ -375,21 +367,18 @@ void EnggDiffFittingPresenter::processFitAllPeaks() {
   const std::string normalisedPeakCentres = stripExtraCommas(fittingPeaks);
   m_view->setPeakList(normalisedPeakCentres);
 
-  const auto workspaceLabels = m_model->getRunNumbersAndBankIDs();
+  const auto runLabels = m_model->getRunLabels();
 
   g_log.debug() << "Focused files found are: " << normalisedPeakCentres << '\n';
-  for (const auto &workspaceLabel : workspaceLabels) {
-    g_log.debug() << listWidgetLabelFromRunAndBankNumber(
-                         workspaceLabel.first, workspaceLabel.second) << '\n';
+  for (const auto &runLabel : runLabels) {
+    g_log.debug() << listWidgetLabelFromRunLabel(runLabel) << '\n';
   }
 
-  if (!workspaceLabels.empty()) {
+  if (!runLabels.empty()) {
 
-    for (const auto &workspaceLabel : workspaceLabels) {
-      const int runNumber = workspaceLabel.first;
-      const size_t bank = workspaceLabel.second;
+    for (const auto &runLabel : runLabels) {
       try {
-        validateFittingInputs(m_model->getWorkspaceFilename(runNumber, bank),
+        validateFittingInputs(m_model->getWorkspaceFilename(runLabel),
                               normalisedPeakCentres);
       } catch (std::invalid_argument &ia) {
         m_view->userWarning("Error in the inputs required for fitting",
@@ -406,7 +395,7 @@ void EnggDiffFittingPresenter::processFitAllPeaks() {
     m_view->enableCalibrateFocusFitUserActions(false);
     m_view->enableFitAllButton(false);
 
-    startAsyncFittingWorker(workspaceLabels, normalisedPeakCentres);
+    startAsyncFittingWorker(runLabels, normalisedPeakCentres);
   } else {
     m_view->userWarning("Error in the inputs required for fitting",
                         "No runs were loaded for fitting");
@@ -422,9 +411,7 @@ void EnggDiffFittingPresenter::processFitPeaks() {
     return;
   }
 
-  int runNumber;
-  size_t bank;
-  std::tie(runNumber, bank) = runAndBankNumberFromListWidgetLabel(*listLabel);
+  const auto runLabel = runLabelFromListWidgetLabel(*listLabel);
   std::string fittingPeaks = m_view->getExpectedPeaksInput();
 
   const std::string normalisedPeakCentres = stripExtraCommas(fittingPeaks);
@@ -432,7 +419,7 @@ void EnggDiffFittingPresenter::processFitPeaks() {
 
   g_log.debug() << "the expected peaks are: " << normalisedPeakCentres << '\n';
 
-  const auto filename = m_model->getWorkspaceFilename(runNumber, bank);
+  const auto filename = m_model->getWorkspaceFilename(runLabel);
   try {
     validateFittingInputs(filename, normalisedPeakCentres);
   } catch (std::invalid_argument &ia) {
@@ -453,8 +440,7 @@ void EnggDiffFittingPresenter::processFitPeaks() {
   // disable GUI to avoid any double threads
   m_view->enableCalibrateFocusFitUserActions(false);
 
-  startAsyncFittingWorker({std::make_pair(runNumber, bank)},
-                          normalisedPeakCentres);
+  startAsyncFittingWorker({runLabel}, normalisedPeakCentres);
 }
 
 void EnggDiffFittingPresenter::validateFittingInputs(
@@ -485,10 +471,10 @@ void EnggDiffFittingPresenter::validateFittingInputs(
   }
 }
 
-void EnggDiffFittingPresenter::doFitting(const int runNumber, const size_t bank,
+void EnggDiffFittingPresenter::doFitting(const RunLabel &runLabel,
                                          const std::string &expectedPeaks) {
   g_log.notice() << "EnggDiffraction GUI: starting new fitting with run "
-                 << runNumber << " and bank " << bank
+                 << runLabel.runNumber << " and bank " << runLabel.bank
                  << ". This may take a few seconds... \n";
 
   m_fittingFinishedOK = false;
@@ -496,12 +482,12 @@ void EnggDiffFittingPresenter::doFitting(const int runNumber, const size_t bank,
   // load the focused workspace file to perform single peak fits
 
   // apply calibration to the focused workspace
-  m_model->setDifcTzero(runNumber, bank, currentCalibration());
+  m_model->setDifcTzero(runLabel, currentCalibration());
 
   // run the algorithm EnggFitPeaks with workspace loaded above
   // requires unit in Time of Flight
   try {
-    m_model->enggFitPeaks(runNumber, bank, expectedPeaks);
+    m_model->enggFitPeaks(runLabel, expectedPeaks);
   } catch (const std::runtime_error &exc) {
     g_log.error() << "Could not run the algorithm EnggFitPeaks successfully."
                   << exc.what();
@@ -511,13 +497,13 @@ void EnggDiffFittingPresenter::doFitting(const int runNumber, const size_t bank,
   }
 
   const auto outFilename = m_view->getCurrentInstrument() +
-                           std::to_string(runNumber) +
+                           std::to_string(runLabel.runNumber) +
                            "_Single_Peak_Fitting.csv";
   auto saveDirectory = outFilesUserDir("SinglePeakFitting");
   saveDirectory.append(outFilename);
-  m_model->saveDiffFittingAscii(runNumber, bank, saveDirectory.toString());
+  m_model->saveDiffFittingAscii(runLabel, saveDirectory.toString());
 
-  m_model->createFittedPeaksWS(runNumber, bank);
+  m_model->createFittedPeaksWS(runLabel);
   m_fittingFinishedOK = true;
 }
 
@@ -639,11 +625,9 @@ void EnggDiffFittingPresenter::fittingWriteFile(const std::string &fileDir) {
 void EnggDiffFittingPresenter::updatePlot() {
   const auto listLabel = m_view->getFittingListWidgetCurrentValue();
   if (listLabel) {
-    int runNumber;
-    size_t bank;
-    std::tie(runNumber, bank) = runAndBankNumberFromListWidgetLabel(*listLabel);
+    const auto runLabel = runLabelFromListWidgetLabel(*listLabel);
 
-    const bool fitResultsExist = m_model->hasFittedPeaksForRun(runNumber, bank);
+    const bool fitResultsExist = m_model->hasFittedPeaksForRun(runLabel);
     const bool plotFittedPeaksEnabled = m_view->plotFittedPeaksEnabled();
 
     if (fitResultsExist) {
@@ -655,7 +639,7 @@ void EnggDiffFittingPresenter::updatePlot() {
                             "generated by a fit. Plotting focused workspace "
                             "instead.");
       }
-      const auto ws = m_model->getFocusedWorkspace(runNumber, bank);
+      const auto ws = m_model->getFocusedWorkspace(runLabel);
       plotFocusedFile(false, ws);
     }
   }
@@ -721,17 +705,16 @@ void EnggDiffFittingPresenter::plotAlignedWorkspace(
                           "Tried to plot a focused file which does not exist");
       return;
     }
-    int runNumber;
-    size_t bank;
-    std::tie(runNumber, bank) = runAndBankNumberFromListWidgetLabel(*listLabel);
-    const auto ws = m_model->getAlignedWorkspace(runNumber, bank);
+
+    const auto runLabel = runLabelFromListWidgetLabel(*listLabel);
+    const auto ws = m_model->getAlignedWorkspace(runLabel);
 
     // plots focused workspace
     plotFocusedFile(m_fittingFinishedOK, ws);
 
     if (plotFittedPeaks) {
       g_log.debug() << "single peaks fitting being plotted now.\n";
-      auto singlePeaksWS = m_model->getFittedPeaksWS(runNumber, bank);
+      auto singlePeaksWS = m_model->getFittedPeaksWS(runLabel);
       auto singlePeaksData = QwtHelper::curveDataFromWs(singlePeaksWS);
       m_view->setDataVector(singlePeaksData, false, true,
                             generateXAxisLabel(ws->getAxis(0)->unit()));

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.h
@@ -72,8 +72,7 @@ public:
   //@}
 
   /// the fitting hard work that a worker / thread will run
-  void doFitting(const int runNumber, const size_t bank,
-                 const std::string &expectedPeaks);
+  void doFitting(const RunLabel &runLabel, const std::string &expectedPeaks);
 
   void plotFocusedFile(bool plotSinglePeaks,
                        Mantid::API::MatrixWorkspace_sptr focusedPeaksWS);
@@ -105,9 +104,8 @@ private:
   void warnFileNotFound(const std::exception &ex);
 
   // Methods related single peak fits
-  virtual void startAsyncFittingWorker(
-      const std::vector<std::pair<int, size_t>> &runNumberBankPairs,
-      const std::string &expectedPeaks);
+  virtual void startAsyncFittingWorker(const std::vector<RunLabel> &runLabels,
+                                       const std::string &expectedPeaks);
 
   std::string getBaseNameFromStr(const std::string &filePath) const;
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
@@ -12,7 +12,7 @@ class MANTIDQT_ENGGDIFFRACTION_DLL EnggDiffGSASFittingModel
     : public IEnggDiffGSASFittingModel {
 
 public:
-  bool doPawleyRefinement(const int runNumber, const size_t bank,
+  bool doPawleyRefinement(const RunLabel &runLabel,
                           const std::string &instParamFile,
                           const std::vector<std::string> &phaseFiles,
                           const std::string &pathToGSASII,
@@ -20,28 +20,26 @@ public:
                           const double dMin,
                           const double negativeWeight) override;
 
-  bool doRietveldRefinement(const int runNumber, const size_t bank,
+  bool doRietveldRefinement(const RunLabel &runLabel,
                             const std::string &instParamFile,
                             const std::vector<std::string> &phaseFiles,
                             const std::string &pathToGSASII,
                             const std::string &GSASIIProjectFile) override;
 
   boost::optional<Mantid::API::MatrixWorkspace_sptr>
-  getFittedPeaks(const int runNumber, const size_t bank) const override;
+  getFittedPeaks(const RunLabel &runLabel) const override;
 
   boost::optional<Mantid::API::MatrixWorkspace_sptr>
-  getFocusedWorkspace(const int runNumber, const size_t bank) const override;
+  getFocusedWorkspace(const RunLabel &runLabel) const override;
 
   boost::optional<Mantid::API::ITableWorkspace_sptr>
-  getLatticeParams(const int runNumber, const size_t bank) const override;
+  getLatticeParams(const RunLabel &runLabel) const override;
 
-  std::vector<std::pair<int, size_t>> getRunLabels() const override;
+  std::vector<RunLabel> getRunLabels() const override;
 
-  boost::optional<double> getRwp(const int runNumber,
-                                 const size_t bank) const override;
+  boost::optional<double> getRwp(const RunLabel &runLabel) const override;
 
-  bool hasFittedPeaksForRun(const int runNumber,
-                            const size_t bank) const override;
+  bool hasFittedPeaksForRun(const RunLabel &runLabel) const override;
 
   bool loadFocusedRun(const std::string &filename) override;
 
@@ -50,23 +48,23 @@ protected:
   /// by a helper class in the tests
 
   // Add a workspace to the fitted peaks map
-  void addFittedPeaks(const int runNumber, const size_t bank,
+  void addFittedPeaks(const RunLabel &runLabel,
                       Mantid::API::MatrixWorkspace_sptr ws);
 
   /// Add a workspace to the focused workspace map
-  void addFocusedRun(const int runNumber, const size_t bank,
+  void addFocusedRun(const RunLabel &runLabel,
                      Mantid::API::MatrixWorkspace_sptr ws);
 
   /// Add a lattice parameter table to the map
-  void addLatticeParams(const int runNumber, const size_t bank,
+  void addLatticeParams(const RunLabel &runLabel,
                         Mantid::API::ITableWorkspace_sptr table);
 
   /// Add an rwp value to the rwp map
-  void addRwp(const int runNumber, const size_t bank, const double rwp);
+  void addRwp(const RunLabel &runLabel, const double rwp);
 
   /// Get whether a focused run has been loaded with a given runNumber and bank
   /// ID.
-  bool hasFocusedRun(const int runNumber, const size_t bank) const;
+  bool hasFocusedRun(const RunLabel &runLabel) const;
 
 private:
   static constexpr double DEFAULT_PAWLEY_DMIN = 1;
@@ -80,17 +78,15 @@ private:
 
   /// Add Rwp, fitted peaks workspace and lattice params table to their
   /// respective RunMaps
-  void addFitResultsToMaps(const int runNumber, const size_t bank,
-                           const double rwp,
+  void addFitResultsToMaps(const RunLabel &runLabel, const double rwp,
                            const std::string &fittedPeaksWSName,
                            const std::string &latticeParamsTableName);
 
   template <typename T>
   boost::optional<T> getFromRunMapOptional(const RunMap<MAX_BANKS, T> &map,
-                                           const int runNumber,
-                                           const size_t bank) const {
-    if (map.contains(runNumber, bank)) {
-      return map.get(runNumber, bank);
+                                           const RunLabel &runLabel) const {
+    if (map.contains(runLabel)) {
+      return map.get(runLabel);
     }
     return boost::none;
   }

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.h
@@ -38,8 +38,7 @@ private:
 
   /**
    Perform a Pawley refinement on a run
-   @param runNumber The run number of the run
-   @param bank The bank ID of the run
+   @param runLabel Run number and bank ID of the workspace to refine
    @param instParamFile The instrument parameter file name (.prm) to use for
    refinement
    @param phaseFiles Vector of file paths to phases to use in refinement
@@ -48,7 +47,7 @@ private:
    @param GSASIIProjectFile Location to save the .gpx project to
    @return Whether the refinement was successful
    */
-  bool doPawleyRefinement(const int runNumber, const size_t bank,
+  bool doPawleyRefinement(const RunLabel &runLabel,
                           const std::string &instParamFile,
                           const std::vector<std::string> &phaseFiles,
                           const std::string &pathToGSASII,
@@ -56,8 +55,7 @@ private:
 
   /**
    Perform a Rietveld refinement on a run
-   @param runNumber The run number of the run
-   @param bank The bank ID of the run
+   @param runLabel Run number and bank ID of the workspace to refine
    @param instParamFile The instrument parameter file name (.prm) to use for
    refinement
    @param phaseFiles Vector of file paths to phases to use in refinement
@@ -66,7 +64,7 @@ private:
    @param GSASIIProjectFile Location to save the .gpx project to
    @return Whether the refinement was successful
    */
-  bool doRietveldRefinement(const int runNumber, const size_t bank,
+  bool doRietveldRefinement(const RunLabel &runLabel,
                             const std::string &instParamFile,
                             const std::vector<std::string> &phaseFiles,
                             const std::string &pathToGSASII,
@@ -75,18 +73,16 @@ private:
   /**
    Overplot fitted peaks for a run, and display lattice parameters and Rwp in
    the view
-   @param runNumber The run number of the run
-   @param bank The bank ID of the run
+   @param runLabel Run number and bank ID of the run to display
   */
-  void displayFitResults(const int runNumber, const size_t bank);
+  void displayFitResults(const RunLabel &runLabel);
 
   /**
    Update the view with the data from a run, and refinement results if they are
    available and the user has selected to show them
-   @param runNumber Run number of the run
-   @param bank Bank ID of the run
+   @param runLabel Run number and bank ID of the run
   */
-  void updatePlot(const int runNumber, const size_t bank);
+  void updatePlot(const RunLabel &runLabel);
 
   std::unique_ptr<IEnggDiffGSASFittingModel> m_model;
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
@@ -18,6 +18,10 @@ void EnggDiffMultiRunFittingWidgetPresenter::notify(
   }
   switch (notif) {
 
+  case IEnggDiffMultiRunFittingWidgetPresenter::AddFittedPeaks:
+    processAddFittedPeaks();
+    break;
+
   case IEnggDiffMultiRunFittingWidgetPresenter::AddFocusedRun:
     processAddFocusedRun();
     break;
@@ -30,6 +34,13 @@ void EnggDiffMultiRunFittingWidgetPresenter::notify(
     processStart();
     break;
   }
+}
+
+void EnggDiffMultiRunFittingWidgetPresenter::processAddFittedPeaks() {
+  const auto ws = m_view->getFittedPeaksWorkspaceToAdd();
+  const auto bankID = m_view->getFittedPeaksBankIDToAdd();
+  const auto runNumber = m_view->getFittedPeaksRunNumberToAdd();
+  m_model->addFittedPeaks(runNumber, bankID, ws);
 }
 
 void EnggDiffMultiRunFittingWidgetPresenter::processAddFocusedRun() {

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
@@ -30,6 +30,10 @@ void EnggDiffMultiRunFittingWidgetPresenter::notify(
     processGetFittedPeaks();
     break;
 
+  case IEnggDiffMultiRunFittingWidgetPresenter::GetFocusedRun:
+    processGetFocusedRun();
+    break;
+
   case IEnggDiffMultiRunFittingWidgetPresenter::ShutDown:
     processShutDown();
     break;
@@ -69,6 +73,23 @@ void EnggDiffMultiRunFittingWidgetPresenter::processGetFittedPeaks() {
     return;
   }
   m_view->setFittedPeaksWorkspaceToReturn(*ws);
+}
+
+void EnggDiffMultiRunFittingWidgetPresenter::processGetFocusedRun() {
+  const auto bankID = m_view->getFocusedRunBankIDToReturn();
+  const auto runNumber = m_view->getFocusedRunNumberToReturn();
+  const auto ws = m_model->getFocusedRun(runNumber, bankID);
+
+  if (!ws) {
+    m_view->userError(
+        "Invalid focused run identifier",
+        "Could not find a focused run with run number " +
+            std::to_string(runNumber) + " and bank ID " +
+            std::to_string(bankID) +
+            ". Please contact the development team with this message");
+    return;
+  }
+  m_view->setFocusedRunWorkspaceToReturn(*ws);
 }
 
 void EnggDiffMultiRunFittingWidgetPresenter::processShutDown() {

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
@@ -1,0 +1,38 @@
+#include "EnggDiffMultiRunFittingWidgetPresenter.h"
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+EnggDiffMultiRunFittingWidgetPresenter::EnggDiffMultiRunFittingWidgetPresenter(
+    std::unique_ptr<IEnggDiffMultiRunFittingWidgetModel> model,
+    IEnggDiffMultiRunFittingWidgetView *view)
+    : m_model(std::move(model)), m_view(view), m_viewHasClosed(false) {}
+
+EnggDiffMultiRunFittingWidgetPresenter::
+    ~EnggDiffMultiRunFittingWidgetPresenter() {}
+
+void EnggDiffMultiRunFittingWidgetPresenter::notify(
+    IEnggDiffMultiRunFittingWidgetPresenter::Notification notif) {
+  if (m_viewHasClosed) {
+    return;
+  }
+  switch (notif) {
+
+  case IEnggDiffMultiRunFittingWidgetPresenter::ShutDown:
+    processShutDown();
+    break;
+
+  case IEnggDiffMultiRunFittingWidgetPresenter::Start:
+    processStart();
+    break;
+  }
+}
+
+void EnggDiffMultiRunFittingWidgetPresenter::processShutDown() {
+  m_viewHasClosed = true;
+}
+
+void EnggDiffMultiRunFittingWidgetPresenter::processStart() {}
+
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
@@ -18,6 +18,10 @@ void EnggDiffMultiRunFittingWidgetPresenter::notify(
   }
   switch (notif) {
 
+  case IEnggDiffMultiRunFittingWidgetPresenter::AddFocusedRun:
+    processAddFocusedRun();
+    break;
+
   case IEnggDiffMultiRunFittingWidgetPresenter::ShutDown:
     processShutDown();
     break;
@@ -26,6 +30,13 @@ void EnggDiffMultiRunFittingWidgetPresenter::notify(
     processStart();
     break;
   }
+}
+
+void EnggDiffMultiRunFittingWidgetPresenter::processAddFocusedRun() {
+  const auto ws = m_view->getFocusedWorkspaceToAdd();
+  const auto bankID = m_view->getFocusedRunBankIDToAdd();
+  const auto runNumber = m_view->getFocusedRunNumberToAdd();
+  m_model->addFocusedRun(runNumber, bankID, ws);
 }
 
 void EnggDiffMultiRunFittingWidgetPresenter::processShutDown() {

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
@@ -6,8 +6,7 @@ namespace CustomInterfaces {
 EnggDiffMultiRunFittingWidgetPresenter::EnggDiffMultiRunFittingWidgetPresenter(
     std::unique_ptr<IEnggDiffMultiRunFittingWidgetModel> model,
     std::unique_ptr<IEnggDiffMultiRunFittingWidgetView> view)
-    : m_model(std::move(model)), m_view(std::move(view)),
-      m_viewHasClosed(false) {}
+    : m_model(std::move(model)), m_view(std::move(view)) {}
 
 void EnggDiffMultiRunFittingWidgetPresenter::addFittedPeaks(
     const int runNumber, const size_t bank,
@@ -32,29 +31,6 @@ EnggDiffMultiRunFittingWidgetPresenter::getFocusedRun(const int runNumber,
                                                       const size_t bank) const {
   return m_model->getFocusedRun(runNumber, bank);
 }
-
-void EnggDiffMultiRunFittingWidgetPresenter::notify(
-    IEnggDiffMultiRunFittingWidgetPresenter::Notification notif) {
-  if (m_viewHasClosed) {
-    return;
-  }
-  switch (notif) {
-
-  case IEnggDiffMultiRunFittingWidgetPresenter::ShutDown:
-    processShutDown();
-    break;
-
-  case IEnggDiffMultiRunFittingWidgetPresenter::Start:
-    processStart();
-    break;
-  }
-}
-
-void EnggDiffMultiRunFittingWidgetPresenter::processShutDown() {
-  m_viewHasClosed = true;
-}
-
-void EnggDiffMultiRunFittingWidgetPresenter::processStart() {}
 
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
@@ -26,6 +26,10 @@ void EnggDiffMultiRunFittingWidgetPresenter::notify(
     processAddFocusedRun();
     break;
 
+  case IEnggDiffMultiRunFittingWidgetPresenter::GetFittedPeaks:
+    processGetFittedPeaks();
+    break;
+
   case IEnggDiffMultiRunFittingWidgetPresenter::ShutDown:
     processShutDown();
     break;
@@ -48,6 +52,23 @@ void EnggDiffMultiRunFittingWidgetPresenter::processAddFocusedRun() {
   const auto bankID = m_view->getFocusedRunBankIDToAdd();
   const auto runNumber = m_view->getFocusedRunNumberToAdd();
   m_model->addFocusedRun(runNumber, bankID, ws);
+}
+
+void EnggDiffMultiRunFittingWidgetPresenter::processGetFittedPeaks() {
+  const auto bankID = m_view->getFittedPeaksBankIDToReturn();
+  const auto runNumber = m_view->getFittedPeaksRunNumberToReturn();
+  const auto ws = m_model->getFittedPeaks(runNumber, bankID);
+
+  if (!ws) {
+    m_view->userError(
+        "Invalid fitted peaks run identifier",
+        "Could not find a fitted peaks workspace with run number " +
+            std::to_string(runNumber) + " and bank ID " +
+            std::to_string(bankID) +
+            ". Please contact the development team with this message");
+    return;
+  }
+  m_view->setFittedPeaksWorkspaceToReturn(*ws);
 }
 
 void EnggDiffMultiRunFittingWidgetPresenter::processShutDown() {

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
@@ -5,11 +5,33 @@ namespace CustomInterfaces {
 
 EnggDiffMultiRunFittingWidgetPresenter::EnggDiffMultiRunFittingWidgetPresenter(
     std::unique_ptr<IEnggDiffMultiRunFittingWidgetModel> model,
-    IEnggDiffMultiRunFittingWidgetView *view)
-    : m_model(std::move(model)), m_view(view), m_viewHasClosed(false) {}
+    std::unique_ptr<IEnggDiffMultiRunFittingWidgetView> view)
+    : m_model(std::move(model)), m_view(std::move(view)),
+      m_viewHasClosed(false) {}
 
-EnggDiffMultiRunFittingWidgetPresenter::
-    ~EnggDiffMultiRunFittingWidgetPresenter() {}
+void EnggDiffMultiRunFittingWidgetPresenter::addFittedPeaks(
+    const int runNumber, const size_t bank,
+    const Mantid::API::MatrixWorkspace_sptr ws) {
+  m_model->addFittedPeaks(runNumber, bank, ws);
+}
+void EnggDiffMultiRunFittingWidgetPresenter::addFocusedRun(
+    const int runNumber, const size_t bank,
+    const Mantid::API::MatrixWorkspace_sptr ws) {
+  m_model->addFocusedRun(runNumber, bank, ws);
+  m_view->updateRunList(m_model->getAllWorkspaceLabels());
+}
+
+boost::optional<Mantid::API::MatrixWorkspace_sptr>
+EnggDiffMultiRunFittingWidgetPresenter::getFittedPeaks(
+    const int runNumber, const size_t bank) const {
+  return m_model->getFittedPeaks(runNumber, bank);
+}
+
+boost::optional<Mantid::API::MatrixWorkspace_sptr>
+EnggDiffMultiRunFittingWidgetPresenter::getFocusedRun(const int runNumber,
+                                                      const size_t bank) const {
+  return m_model->getFocusedRun(runNumber, bank);
+}
 
 void EnggDiffMultiRunFittingWidgetPresenter::notify(
     IEnggDiffMultiRunFittingWidgetPresenter::Notification notif) {
@@ -17,22 +39,6 @@ void EnggDiffMultiRunFittingWidgetPresenter::notify(
     return;
   }
   switch (notif) {
-
-  case IEnggDiffMultiRunFittingWidgetPresenter::AddFittedPeaks:
-    processAddFittedPeaks();
-    break;
-
-  case IEnggDiffMultiRunFittingWidgetPresenter::AddFocusedRun:
-    processAddFocusedRun();
-    break;
-
-  case IEnggDiffMultiRunFittingWidgetPresenter::GetFittedPeaks:
-    processGetFittedPeaks();
-    break;
-
-  case IEnggDiffMultiRunFittingWidgetPresenter::GetFocusedRun:
-    processGetFocusedRun();
-    break;
 
   case IEnggDiffMultiRunFittingWidgetPresenter::ShutDown:
     processShutDown();
@@ -42,54 +48,6 @@ void EnggDiffMultiRunFittingWidgetPresenter::notify(
     processStart();
     break;
   }
-}
-
-void EnggDiffMultiRunFittingWidgetPresenter::processAddFittedPeaks() {
-  const auto ws = m_view->getFittedPeaksWorkspaceToAdd();
-  const auto bankID = m_view->getFittedPeaksBankIDToAdd();
-  const auto runNumber = m_view->getFittedPeaksRunNumberToAdd();
-  m_model->addFittedPeaks(runNumber, bankID, ws);
-}
-
-void EnggDiffMultiRunFittingWidgetPresenter::processAddFocusedRun() {
-  const auto ws = m_view->getFocusedWorkspaceToAdd();
-  const auto bankID = m_view->getFocusedRunBankIDToAdd();
-  const auto runNumber = m_view->getFocusedRunNumberToAdd();
-  m_model->addFocusedRun(runNumber, bankID, ws);
-}
-
-void EnggDiffMultiRunFittingWidgetPresenter::processGetFittedPeaks() {
-  const auto bankID = m_view->getFittedPeaksBankIDToReturn();
-  const auto runNumber = m_view->getFittedPeaksRunNumberToReturn();
-  const auto ws = m_model->getFittedPeaks(runNumber, bankID);
-
-  if (!ws) {
-    m_view->userError(
-        "Invalid fitted peaks run identifier",
-        "Could not find a fitted peaks workspace with run number " +
-            std::to_string(runNumber) + " and bank ID " +
-            std::to_string(bankID) +
-            ". Please contact the development team with this message");
-    return;
-  }
-  m_view->setFittedPeaksWorkspaceToReturn(*ws);
-}
-
-void EnggDiffMultiRunFittingWidgetPresenter::processGetFocusedRun() {
-  const auto bankID = m_view->getFocusedRunBankIDToReturn();
-  const auto runNumber = m_view->getFocusedRunNumberToReturn();
-  const auto ws = m_model->getFocusedRun(runNumber, bankID);
-
-  if (!ws) {
-    m_view->userError(
-        "Invalid focused run identifier",
-        "Could not find a focused run with run number " +
-            std::to_string(runNumber) + " and bank ID " +
-            std::to_string(bankID) +
-            ". Please contact the development team with this message");
-    return;
-  }
-  m_view->setFocusedRunWorkspaceToReturn(*ws);
 }
 
 void EnggDiffMultiRunFittingWidgetPresenter::processShutDown() {

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
@@ -9,27 +9,25 @@ EnggDiffMultiRunFittingWidgetPresenter::EnggDiffMultiRunFittingWidgetPresenter(
     : m_model(std::move(model)), m_view(std::move(view)) {}
 
 void EnggDiffMultiRunFittingWidgetPresenter::addFittedPeaks(
-    const int runNumber, const size_t bank,
-    const Mantid::API::MatrixWorkspace_sptr ws) {
-  m_model->addFittedPeaks(runNumber, bank, ws);
+    const RunLabel &runLabel, const Mantid::API::MatrixWorkspace_sptr ws) {
+  m_model->addFittedPeaks(runLabel, ws);
 }
 void EnggDiffMultiRunFittingWidgetPresenter::addFocusedRun(
-    const int runNumber, const size_t bank,
-    const Mantid::API::MatrixWorkspace_sptr ws) {
-  m_model->addFocusedRun(runNumber, bank, ws);
+    const RunLabel &runLabel, const Mantid::API::MatrixWorkspace_sptr ws) {
+  m_model->addFocusedRun(runLabel, ws);
   m_view->updateRunList(m_model->getAllWorkspaceLabels());
 }
 
 boost::optional<Mantid::API::MatrixWorkspace_sptr>
 EnggDiffMultiRunFittingWidgetPresenter::getFittedPeaks(
-    const int runNumber, const size_t bank) const {
-  return m_model->getFittedPeaks(runNumber, bank);
+    const RunLabel &runLabel) const {
+  return m_model->getFittedPeaks(runLabel);
 }
 
 boost::optional<Mantid::API::MatrixWorkspace_sptr>
-EnggDiffMultiRunFittingWidgetPresenter::getFocusedRun(const int runNumber,
-                                                      const size_t bank) const {
-  return m_model->getFocusedRun(runNumber, bank);
+EnggDiffMultiRunFittingWidgetPresenter::getFocusedRun(
+    const RunLabel &runLabel) const {
+  return m_model->getFocusedRun(runLabel);
 }
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
@@ -31,7 +31,7 @@ private:
   void processStart();
 
   std::unique_ptr<IEnggDiffMultiRunFittingWidgetModel> m_model;
-  
+
   IEnggDiffMultiRunFittingWidgetView *m_view;
 
   bool m_viewHasClosed;

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
@@ -25,7 +25,7 @@ public:
   notify(IEnggDiffMultiRunFittingWidgetPresenter::Notification notif) override;
 
 private:
-
+  void processAddFocusedRun();
   void processShutDown();
   void processStart();
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
@@ -19,17 +19,17 @@ public:
       std::unique_ptr<IEnggDiffMultiRunFittingWidgetModel> model,
       std::unique_ptr<IEnggDiffMultiRunFittingWidgetView> view);
 
-  void addFittedPeaks(const int runNumber, const size_t bank,
+  void addFittedPeaks(const RunLabel &runLabel,
                       const Mantid::API::MatrixWorkspace_sptr ws) override;
 
-  void addFocusedRun(const int runNumber, const size_t bank,
+  void addFocusedRun(const RunLabel &runLabel,
                      const Mantid::API::MatrixWorkspace_sptr ws) override;
 
   boost::optional<Mantid::API::MatrixWorkspace_sptr>
-  getFittedPeaks(const int runNumber, const size_t bank) const override;
+  getFittedPeaks(const RunLabel &runLabel) const override;
 
   boost::optional<Mantid::API::MatrixWorkspace_sptr>
-  getFocusedRun(const int runNumber, const size_t bank) const override;
+  getFocusedRun(const RunLabel &runLabel) const override;
 
 private:
   std::unique_ptr<IEnggDiffMultiRunFittingWidgetModel> m_model;

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
@@ -27,6 +27,7 @@ public:
 private:
   void processAddFittedPeaks();
   void processAddFocusedRun();
+  void processGetFittedPeaks();
   void processShutDown();
   void processStart();
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
@@ -1,0 +1,42 @@
+#ifndef MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETPRESENTER_H_
+#define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETPRESENTER_H_
+
+#include "DllConfig.h"
+#include "IEnggDiffMultiRunFittingWidgetModel.h"
+#include "IEnggDiffMultiRunFittingWidgetPresenter.h"
+#include "IEnggDiffMultiRunFittingWidgetView.h"
+
+#include <memory>
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+class MANTIDQT_ENGGDIFFRACTION_DLL EnggDiffMultiRunFittingWidgetPresenter
+    : public IEnggDiffMultiRunFittingWidgetPresenter {
+
+public:
+  EnggDiffMultiRunFittingWidgetPresenter(
+      std::unique_ptr<IEnggDiffMultiRunFittingWidgetModel> model,
+      IEnggDiffMultiRunFittingWidgetView *view);
+
+  ~EnggDiffMultiRunFittingWidgetPresenter() override;
+
+  void
+  notify(IEnggDiffMultiRunFittingWidgetPresenter::Notification notif) override;
+
+private:
+
+  void processShutDown();
+  void processStart();
+
+  std::unique_ptr<IEnggDiffMultiRunFittingWidgetModel> m_model;
+  
+  IEnggDiffMultiRunFittingWidgetView *m_view;
+
+  bool m_viewHasClosed;
+};
+
+} // namespace CustomInterfaces
+} // namespace MantidQt
+
+#endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETPRESENTER_H_

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
@@ -31,13 +31,7 @@ public:
   boost::optional<Mantid::API::MatrixWorkspace_sptr>
   getFocusedRun(const int runNumber, const size_t bank) const override;
 
-  void
-  notify(IEnggDiffMultiRunFittingWidgetPresenter::Notification notif) override;
-
 private:
-  void processShutDown();
-  void processStart();
-
   std::unique_ptr<IEnggDiffMultiRunFittingWidgetModel> m_model;
 
   std::unique_ptr<IEnggDiffMultiRunFittingWidgetView> m_view;

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
@@ -17,24 +17,30 @@ class MANTIDQT_ENGGDIFFRACTION_DLL EnggDiffMultiRunFittingWidgetPresenter
 public:
   EnggDiffMultiRunFittingWidgetPresenter(
       std::unique_ptr<IEnggDiffMultiRunFittingWidgetModel> model,
-      IEnggDiffMultiRunFittingWidgetView *view);
+      std::unique_ptr<IEnggDiffMultiRunFittingWidgetView> view);
 
-  ~EnggDiffMultiRunFittingWidgetPresenter() override;
+  void addFittedPeaks(const int runNumber, const size_t bank,
+                      const Mantid::API::MatrixWorkspace_sptr ws) override;
+
+  void addFocusedRun(const int runNumber, const size_t bank,
+                     const Mantid::API::MatrixWorkspace_sptr ws) override;
+
+  boost::optional<Mantid::API::MatrixWorkspace_sptr>
+  getFittedPeaks(const int runNumber, const size_t bank) const override;
+
+  boost::optional<Mantid::API::MatrixWorkspace_sptr>
+  getFocusedRun(const int runNumber, const size_t bank) const override;
 
   void
   notify(IEnggDiffMultiRunFittingWidgetPresenter::Notification notif) override;
 
 private:
-  void processAddFittedPeaks();
-  void processAddFocusedRun();
-  void processGetFittedPeaks();
-  void processGetFocusedRun();
   void processShutDown();
   void processStart();
 
   std::unique_ptr<IEnggDiffMultiRunFittingWidgetModel> m_model;
 
-  IEnggDiffMultiRunFittingWidgetView *m_view;
+  std::unique_ptr<IEnggDiffMultiRunFittingWidgetView> m_view;
 
   bool m_viewHasClosed;
 };

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
@@ -28,6 +28,7 @@ private:
   void processAddFittedPeaks();
   void processAddFocusedRun();
   void processGetFittedPeaks();
+  void processGetFocusedRun();
   void processShutDown();
   void processStart();
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
@@ -35,8 +35,6 @@ private:
   std::unique_ptr<IEnggDiffMultiRunFittingWidgetModel> m_model;
 
   std::unique_ptr<IEnggDiffMultiRunFittingWidgetView> m_view;
-
-  bool m_viewHasClosed;
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
@@ -25,6 +25,7 @@ public:
   notify(IEnggDiffMultiRunFittingWidgetPresenter::Notification notif) override;
 
 private:
+  void processAddFittedPeaks();
   void processAddFocusedRun();
   void processShutDown();
   void processStart();

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffFittingModel.h
@@ -1,10 +1,12 @@
 #ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFFITTINGMODEL_H_
 #define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFFITTINGMODEL_H_
 
+#include "RunLabel.h"
+
 #include "DllConfig.h"
+#include "IEnggDiffractionCalibration.h"
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
-#include "IEnggDiffractionCalibration.h"
 
 #include <vector>
 
@@ -17,38 +19,37 @@ public:
   virtual ~IEnggDiffFittingModel() = default;
 
   virtual Mantid::API::MatrixWorkspace_sptr
-  getFocusedWorkspace(const int runNumber, const size_t bank) const = 0;
+  getFocusedWorkspace(const RunLabel &runLabel) const = 0;
 
   virtual Mantid::API::MatrixWorkspace_sptr
-  getAlignedWorkspace(const int runNumber, const size_t bank) const = 0;
+  getAlignedWorkspace(const RunLabel &runLabel) const = 0;
 
   virtual Mantid::API::MatrixWorkspace_sptr
-  getFittedPeaksWS(const int runNumber, const size_t bank) const = 0;
+  getFittedPeaksWS(const RunLabel &runLabel) const = 0;
 
   virtual Mantid::API::ITableWorkspace_sptr
-  getFitResults(const int runNumber, const size_t bank) const = 0;
+  getFitResults(const RunLabel &runLabel) const = 0;
 
-  virtual const std::string &getWorkspaceFilename(const int runNumber,
-                                                  const size_t bank) const = 0;
+  virtual const std::string &
+  getWorkspaceFilename(const RunLabel &runLabel) const = 0;
 
-  virtual void removeRun(const int runNumber, const size_t bank) = 0;
+  virtual void removeRun(const RunLabel &runLabel) = 0;
 
   virtual void loadWorkspaces(const std::string &filenames) = 0;
 
-  virtual std::vector<std::pair<int, size_t>>
-  getRunNumbersAndBankIDs() const = 0;
+  virtual std::vector<RunLabel> getRunLabels() const = 0;
 
   virtual void
-  setDifcTzero(const int runNumber, const size_t bank,
+  setDifcTzero(const RunLabel &runLabel,
                const std::vector<GSASCalibrationParms> &calibParams) = 0;
 
-  virtual void enggFitPeaks(const int runNumber, const size_t bank,
+  virtual void enggFitPeaks(const RunLabel &runLabel,
                             const std::string &expectedPeaks) = 0;
 
-  virtual void saveDiffFittingAscii(const int runNumber, const size_t bank,
+  virtual void saveDiffFittingAscii(const RunLabel &runLabel,
                                     const std::string &filename) const = 0;
 
-  virtual void createFittedPeaksWS(const int runNumber, const size_t bank) = 0;
+  virtual void createFittedPeaksWS(const RunLabel &runLabel) = 0;
 
   virtual size_t getNumFocusedWorkspaces() const = 0;
 
@@ -56,8 +57,7 @@ public:
 
   virtual void addAllFittedPeaksToADS() const = 0;
 
-  virtual bool hasFittedPeaksForRun(const int runNumber,
-                                    const size_t bank) const = 0;
+  virtual bool hasFittedPeaksForRun(const RunLabel &runLabel) const = 0;
 };
 
 } // namespace MantidQt

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
@@ -1,6 +1,8 @@
 #ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFGSASFITTINGMODEL_H_
 #define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFGSASFITTINGMODEL_H_
 
+#include "RunLabel.h"
+
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 
@@ -20,8 +22,7 @@ public:
 
   /**
    Perform a Pawley refinement on a run
-   @param runNumber The run number of the run
-   @param bank The bank ID of the run
+   @param runLabel Run number and bank ID of the workspace to refine
    @param instParamFile The instrument parameter file name (.prm) to use for
    refinement
    @param phaseFiles Vector of file paths to phases to use in refinement
@@ -32,7 +33,7 @@ public:
    @param negativeWeight The weight of the penalty function
    @return Whether the refinement was successful
    */
-  virtual bool doPawleyRefinement(const int runNumber, const size_t bank,
+  virtual bool doPawleyRefinement(const RunLabel &runLabel,
                                   const std::string &instParamFile,
                                   const std::vector<std::string> &phaseFiles,
                                   const std::string &pathToGSASII,
@@ -41,8 +42,7 @@ public:
                                   const double negativeWeight) = 0;
   /**
    Perform a Rietveld refinement on a run
-   @param runNumber The run number of the run
-   @param bank The bank ID of the run
+   @param runLabel Run number and bank ID of the workspace to refine
    @param instParamFile The instrument parameter file name (.prm) to use for
    refinement
    @param phaseFiles Vector of file paths to phases to use in refinement
@@ -51,7 +51,7 @@ public:
    @param GSASIIProjectFile Location to save the .gpx project to
    @return Whether the refinement was successful
    */
-  virtual bool doRietveldRefinement(const int runNumber, const size_t bank,
+  virtual bool doRietveldRefinement(const RunLabel &runLabel,
                                     const std::string &instParamFile,
                                     const std::vector<std::string> &phaseFiles,
                                     const std::string &pathToGSASII,
@@ -59,59 +59,52 @@ public:
 
   /**
    Get the fit results for a given run
-   @param runNumber The run number of the run
-   @param bank The bank ID of the run
+   @param runLabel Run number and bank ID of the run
    @return MatrixWorkspace containing the fitted peaks, or empty if the model
    does not contain fit results for this run
    */
   virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
-  getFittedPeaks(const int runNumber, const size_t bank) const = 0;
+  getFittedPeaks(const RunLabel &runLabel) const = 0;
 
   /**
    Get a focused run (as a MatrixWorkspace) by run label
-   @param runNumber The runNumber of the run
-   @param bank The bank ID of the run
+   @param runLabel Run number and bank ID of the run
    @return The corresponding workspace (empty if the model does not contain this
    run)
    */
   virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
-  getFocusedWorkspace(const int runNumber, const size_t bank) const = 0;
+  getFocusedWorkspace(const RunLabel &runLabel) const = 0;
 
   /**
    Get refined lattice parameters for a run
-   @param runNumber The run number of the run
-   @param bank The bank ID of the run
+   @param runLabel Run number and bank ID of the run
    @return TableWorkspace of the corresponding lattice parameters (empty
    optional if the model does not contain fit results for this run)
    */
   virtual boost::optional<Mantid::API::ITableWorkspace_sptr>
-  getLatticeParams(const int runNumber, const size_t bank) const = 0;
+  getLatticeParams(const RunLabel &runLabel) const = 0;
 
   /**
    Get run labels (ie run number and bank id) of all runs loaded into model
-   @return Vector of all run labels (as pairs)
+   @return Vector of all run labels
    */
-  virtual std::vector<std::pair<int, size_t>> getRunLabels() const = 0;
+  virtual std::vector<RunLabel> getRunLabels() const = 0;
 
   /**
    Get the weighted profile R-factor discrepancy index for goodness of fit on a
    run
-   @param runNumber The run number of the run
-   @param bank The bank ID of the run
+   @param runLabel Run number and bank ID of the run
    @return The corresponding Rwp value (empty optional if a refinement has not
    been performed on this run)
   */
-  virtual boost::optional<double> getRwp(const int runNumber,
-                                         const size_t bank) const = 0;
+  virtual boost::optional<double> getRwp(const RunLabel &runLabel) const = 0;
 
   /**
    Has a fit been performed on a given run?
-   @param runNumber The run number of the run
-   @param bank The bank ID of the run
+   @param runLabel Run number and bank ID of the run to check
    @return Whether the model contains the results of a fit for this run
    */
-  virtual bool hasFittedPeaksForRun(const int runNumber,
-                                    const size_t bank) const = 0;
+  virtual bool hasFittedPeaksForRun(const RunLabel &runLabel) const = 0;
 
   /**
    Load a focused run from a file to the model

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingView.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingView.h
@@ -77,11 +77,8 @@ public:
    */
   virtual GSASRefinementMethod getRefinementMethod() const = 0;
 
-  /**
-   Get the run label (run number and bank id) currently selected in the list
-   @return Run label as a pair
-   */
-  virtual std::pair<int, size_t> getSelectedRunLabel() const = 0;
+  /// Get the run label (run number and bank id) currently selected in the list
+  virtual RunLabel getSelectedRunLabel() const = 0;
 
   /**
    Plot a Qwt curve in the canvas
@@ -103,10 +100,9 @@ public:
 
   /**
    Update the run list with labels of all runs loaded into the model
-   @param runLabels Vector of run labels (as pairs)
+   @param runLabels Vector of run labels
    */
-  virtual void
-  updateRunList(const std::vector<std::pair<int, size_t>> &runLabels) = 0;
+  virtual void updateRunList(const std::vector<RunLabel> &runLabels) = 0;
 
   /**
    Display a warning to the user

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetModel.h
@@ -33,8 +33,8 @@ public:
                              const Mantid::API::MatrixWorkspace_sptr ws) = 0;
 
   /// Get run numbers and bank IDs of all runs loaded into the model
-  virtual std::vector<std::pair<int, size_t>> getAllWorkspaceLabels() const = 0; 
-  
+  virtual std::vector<std::pair<int, size_t>> getAllWorkspaceLabels() const = 0;
+
   /**
    Get fitted peaks workspace corresponding to a given run and bank, if a fit
    has been done on that run

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetModel.h
@@ -32,6 +32,9 @@ public:
   virtual void addFocusedRun(const int runNumber, const size_t bank,
                              const Mantid::API::MatrixWorkspace_sptr ws) = 0;
 
+  /// Get run numbers and bank IDs of all runs loaded into the model
+  virtual std::vector<std::pair<int, size_t>> getAllWorkspaceLabels() const = 0; 
+  
   /**
    Get fitted peaks workspace corresponding to a given run and bank, if a fit
    has been done on that run

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetModel.h
@@ -1,6 +1,8 @@
 #ifndef MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETMODEL_H_
 #define MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETMODEL_H_
 
+#include "RunLabel.h"
+
 #include "MantidAPI/MatrixWorkspace.h"
 
 #include <boost/optional.hpp>
@@ -15,45 +17,41 @@ public:
   /**
    Add a fitted peaks workspace to the widget, so it can be overplotted on its
    focused run
-   @param runNumber The run number of the workspace to add
-   @param bank The bank ID of the workspace to add
+   @param runLabel Run number and bank ID of the workspace to add
    @param ws The workspace to add
   */
-  virtual void addFittedPeaks(const int runNumber, const size_t bank,
+  virtual void addFittedPeaks(const RunLabel &runLabel,
                               const Mantid::API::MatrixWorkspace_sptr ws) = 0;
 
   /**
    Add a focused run to the widget. The run should be added to the list and
    plotting it should be possible
-   @param runNumber The run number of the workspace to add
-   @param bank The bank ID of the workspace to add
+   @param runLabel Run number and bank ID of the workspace to add
    @param ws The workspace to add
   */
-  virtual void addFocusedRun(const int runNumber, const size_t bank,
+  virtual void addFocusedRun(const RunLabel &runLabel,
                              const Mantid::API::MatrixWorkspace_sptr ws) = 0;
 
   /// Get run numbers and bank IDs of all runs loaded into the model
-  virtual std::vector<std::pair<int, size_t>> getAllWorkspaceLabels() const = 0;
+  virtual std::vector<RunLabel> getAllWorkspaceLabels() const = 0;
 
   /**
    Get fitted peaks workspace corresponding to a given run and bank, if a fit
    has been done on that run
-   @param runNumber The run number of the run
-   @param bank The bank ID of the run
+   @param runLabel Run number and bank ID of the run
    @return The workspace, or an empty optional if a fit has not been run
   */
   virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
-  getFittedPeaks(const int runNumber, const size_t bank) const = 0;
+  getFittedPeaks(const RunLabel &runLabel) const = 0;
 
   /**
    Get focused workspace corresponding to a given run and bank, if that run has
    been loaded into the widget
-   @param runNumber The run number of the run
-   @param bank The bank ID of the run
+   @param runLabel Run number and bank ID of the run
    @return The workspace, or empty optional if that run has not been loaded in
   */
   virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
-  getFocusedRun(const int runNumber, const size_t bank) const = 0;
+  getFocusedRun(const RunLabel &runLabel) const = 0;
 };
 
 } // namespace MantidQt

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetModel.h
@@ -1,0 +1,29 @@
+#ifndef MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETMODEL_H_
+#define MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETMODEL_H_
+
+#include "MantidAPI/MatrixWorkspace.h"
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+class IEnggDiffMultiRunFittingWidgetModel {
+public:
+  virtual ~IEnggDiffMultiRunFittingWidgetModel() = default;
+
+  virtual void addFittedPeaks(const int runNumber, const size_t bank,
+                              const Mantid::API::MatrixWorkspace_sptr ws) = 0;
+
+  virtual void addFocusedRun(const int runNumber, const size_t bank,
+                             const Mantid::API::MatrixWorkspace_sptr ws) = 0;
+
+  virtual void getFittedPeaks(const int runNumber, const size_t bank) const = 0;
+
+  virtual Mantid::API::MatrixWorkspace_sptr
+  getFocusedRun(const int runNumber, const size_t bank) const = 0;
+
+};
+
+} // namespace MantidQt
+} // namespace CustomInterfaces
+
+#endif // MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETMODEL_H_

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetModel.h
@@ -3,6 +3,8 @@
 
 #include "MantidAPI/MatrixWorkspace.h"
 
+#include <boost/optional.hpp>
+
 namespace MantidQt {
 namespace CustomInterfaces {
 
@@ -10,17 +12,45 @@ class IEnggDiffMultiRunFittingWidgetModel {
 public:
   virtual ~IEnggDiffMultiRunFittingWidgetModel() = default;
 
+  /**
+   Add a fitted peaks workspace to the widget, so it can be overplotted on its
+   focused run
+   @param runNumber The run number of the workspace to add
+   @param bank The bank ID of the workspace to add
+   @param ws The workspace to add
+  */
   virtual void addFittedPeaks(const int runNumber, const size_t bank,
                               const Mantid::API::MatrixWorkspace_sptr ws) = 0;
 
+  /**
+   Add a focused run to the widget. The run should be added to the list and
+   plotting it should be possible
+   @param runNumber The run number of the workspace to add
+   @param bank The bank ID of the workspace to add
+   @param ws The workspace to add
+  */
   virtual void addFocusedRun(const int runNumber, const size_t bank,
                              const Mantid::API::MatrixWorkspace_sptr ws) = 0;
 
-  virtual void getFittedPeaks(const int runNumber, const size_t bank) const = 0;
+  /**
+   Get fitted peaks workspace corresponding to a given run and bank, if a fit
+   has been done on that run
+   @param runNumber The run number of the run
+   @param bank The bank ID of the run
+   @return The workspace, or an empty optional if a fit has not been run
+  */
+  virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
+  getFittedPeaks(const int runNumber, const size_t bank) const = 0;
 
-  virtual Mantid::API::MatrixWorkspace_sptr
+  /**
+   Get focused workspace corresponding to a given run and bank, if that run has
+   been loaded into the widget
+   @param runNumber The run number of the run
+   @param bank The bank ID of the run
+   @return The workspace, or empty optional if that run has not been loaded in
+  */
+  virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
   getFocusedRun(const int runNumber, const size_t bank) const = 0;
-
 };
 
 } // namespace MantidQt

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
@@ -12,13 +12,6 @@ class IEnggDiffMultiRunFittingWidgetPresenter {
 public:
   virtual ~IEnggDiffMultiRunFittingWidgetPresenter() = default;
 
-  // User actions, triggered by the (passive) view,
-  // which need handling in implementation
-  enum Notification {
-    ShutDown, ///< Shut down the widget
-    Start,    ///< Start and set up the interface
-  };
-
   /**
    Add a fitted peaks workspace to the widget, so it can be overplotted on its
    focused run
@@ -58,16 +51,6 @@ public:
   */
   virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
   getFocusedRun(const int runNumber, const size_t bank) const = 0;
-
-  /**
-   * Notifications sent through the presenter when something changes
-   * in the view. This plays the role of signals emitted by the view
-   * to this presenter.
-   *
-   * @param notif Type of notification to process.
-   */
-  virtual void
-  notify(IEnggDiffMultiRunFittingWidgetPresenter::Notification notif) = 0;
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
@@ -15,8 +15,8 @@ public:
   // User actions, triggered by the (passive) view,
   // which need handling in implementation
   enum Notification {
-    ShutDown,       ///< Shut down the widget
-    Start,          ///< Start and set up the interface
+    ShutDown, ///< Shut down the widget
+    Start,    ///< Start and set up the interface
   };
 
   /**

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
@@ -13,6 +13,7 @@ public:
   enum Notification {
     AddFittedPeaks, /// The view has been passed a fitted peaks workspace to add
     AddFocusedRun,  ///< The view has been passed a focused run to add
+    GetFittedPeaks, ///< The view has been asked for a fitted peaks workspace
     ShutDown,       ///< Shut down the widget
     Start,          ///< Start and set up the interface
   };

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
@@ -14,6 +14,7 @@ public:
     AddFittedPeaks, /// The view has been passed a fitted peaks workspace to add
     AddFocusedRun,  ///< The view has been passed a focused run to add
     GetFittedPeaks, ///< The view has been asked for a fitted peaks workspace
+    GetFocusedRun,  ///< The view has been asked for a focused run
     ShutDown,       ///< Shut down the widget
     Start,          ///< Start and set up the interface
   };

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
@@ -11,8 +11,9 @@ public:
   // User actions, triggered by the (passive) view,
   // which need handling in implementation
   enum Notification {
-    ShutDown, ///< Shut down the widget
-    Start,    ///< Start and set up the interface
+    AddFocusedRun, ///< The view has been passed a focused run to add
+    ShutDown,      ///< Shut down the widget
+    Start,         ///< Start and set up the interface
   };
 
   /**

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
@@ -1,6 +1,8 @@
 #ifndef MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETPRESENTER_H_
 #define MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETPRESENTER_H_
 
+#include "RunLabel.h"
+
 #include "MantidAPI/MatrixWorkspace.h"
 
 #include <boost/optional.hpp>
@@ -15,42 +17,38 @@ public:
   /**
    Add a fitted peaks workspace to the widget, so it can be overplotted on its
    focused run
-   @param runNumber The run number of the workspace to add
-   @param bank The bank ID of the workspace to add
+   @param runLabel Identifier of the workspace to add
    @param ws The workspace to add
   */
-  virtual void addFittedPeaks(const int runNumber, const size_t bank,
+  virtual void addFittedPeaks(const RunLabel &runLabel,
                               const Mantid::API::MatrixWorkspace_sptr ws) = 0;
 
   /**
    Add a focused run to the widget. The run should be added to the list and
    plotting it should be possible
-   @param runNumber The run number of the workspace to add
-   @param bank The bank ID of the workspace to add
+   @param runLabel Identifier of the workspace to add
    @param ws The workspace to add
   */
-  virtual void addFocusedRun(const int runNumber, const size_t bank,
+  virtual void addFocusedRun(const RunLabel &runLabel,
                              const Mantid::API::MatrixWorkspace_sptr ws) = 0;
 
   /**
    Get fitted peaks workspace corresponding to a given run and bank, if a fit
    has been done on that run
-   @param runNumber The run number of the run
-   @param bank The bank ID of the run
+   @param runLabel Identifier of the workspace to get
    @return The workspace, or an empty optional if a fit has not been run
   */
   virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
-  getFittedPeaks(const int runNumber, const size_t bank) const = 0;
+  getFittedPeaks(const RunLabel &runLabel) const = 0;
 
   /**
    Get focused workspace corresponding to a given run and bank, if that run has
    been loaded into the widget
-   @param runNumber The run number of the run
-   @param bank The bank ID of the run
+   @param runLabel Identifier of the workspace to get
    @return The workspace, or empty optional if that run has not been loaded in
   */
   virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
-  getFocusedRun(const int runNumber, const size_t bank) const = 0;
+  getFocusedRun(const RunLabel &runLabel) const = 0;
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
@@ -1,0 +1,32 @@
+#ifndef MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETPRESENTER_H_
+#define MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETPRESENTER_H_
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+class IEnggDiffMultiRunFittingWidgetPresenter {
+public:
+  virtual ~IEnggDiffMultiRunFittingWidgetPresenter() = default;
+
+  // User actions, triggered by the (passive) view,
+  // which need handling in implementation
+  enum Notification {
+    ShutDown, ///< Shut down the widget
+    Start,    ///< Start and set up the interface
+  };
+
+  /**
+   * Notifications sent through the presenter when something changes
+   * in the view. This plays the role of signals emitted by the view
+   * to this presenter.
+   *
+   * @param notif Type of notification to process.
+   */
+  virtual void
+  notify(IEnggDiffMultiRunFittingWidgetPresenter::Notification notif) = 0;
+};
+
+} // namespace CustomInterfaces
+} // namespace MantidQt
+
+#endif // MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETPRESENTER_H_

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
@@ -11,9 +11,10 @@ public:
   // User actions, triggered by the (passive) view,
   // which need handling in implementation
   enum Notification {
-    AddFocusedRun, ///< The view has been passed a focused run to add
-    ShutDown,      ///< Shut down the widget
-    Start,         ///< Start and set up the interface
+    AddFittedPeaks, /// The view has been passed a fitted peaks workspace to add
+    AddFocusedRun,  ///< The view has been passed a focused run to add
+    ShutDown,       ///< Shut down the widget
+    Start,          ///< Start and set up the interface
   };
 
   /**

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
@@ -1,6 +1,10 @@
 #ifndef MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETPRESENTER_H_
 #define MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETPRESENTER_H_
 
+#include "MantidAPI/MatrixWorkspace.h"
+
+#include <boost/optional.hpp>
+
 namespace MantidQt {
 namespace CustomInterfaces {
 
@@ -11,13 +15,49 @@ public:
   // User actions, triggered by the (passive) view,
   // which need handling in implementation
   enum Notification {
-    AddFittedPeaks, /// The view has been passed a fitted peaks workspace to add
-    AddFocusedRun,  ///< The view has been passed a focused run to add
-    GetFittedPeaks, ///< The view has been asked for a fitted peaks workspace
-    GetFocusedRun,  ///< The view has been asked for a focused run
     ShutDown,       ///< Shut down the widget
     Start,          ///< Start and set up the interface
   };
+
+  /**
+   Add a fitted peaks workspace to the widget, so it can be overplotted on its
+   focused run
+   @param runNumber The run number of the workspace to add
+   @param bank The bank ID of the workspace to add
+   @param ws The workspace to add
+  */
+  virtual void addFittedPeaks(const int runNumber, const size_t bank,
+                              const Mantid::API::MatrixWorkspace_sptr ws) = 0;
+
+  /**
+   Add a focused run to the widget. The run should be added to the list and
+   plotting it should be possible
+   @param runNumber The run number of the workspace to add
+   @param bank The bank ID of the workspace to add
+   @param ws The workspace to add
+  */
+  virtual void addFocusedRun(const int runNumber, const size_t bank,
+                             const Mantid::API::MatrixWorkspace_sptr ws) = 0;
+
+  /**
+   Get fitted peaks workspace corresponding to a given run and bank, if a fit
+   has been done on that run
+   @param runNumber The run number of the run
+   @param bank The bank ID of the run
+   @return The workspace, or an empty optional if a fit has not been run
+  */
+  virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
+  getFittedPeaks(const int runNumber, const size_t bank) const = 0;
+
+  /**
+   Get focused workspace corresponding to a given run and bank, if that run has
+   been loaded into the widget
+   @param runNumber The run number of the run
+   @param bank The bank ID of the run
+   @return The workspace, or empty optional if that run has not been loaded in
+  */
+  virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
+  getFocusedRun(const int runNumber, const size_t bank) const = 0;
 
   /**
    * Notifications sent through the presenter when something changes

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
@@ -42,16 +42,6 @@ public:
   virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
   getFittedPeaks(const int runNumber, const size_t bank) const = 0;
 
-  /**
-   Get focused workspace corresponding to a given run and bank, if that run has
-   been loaded into the widget
-   @param runNumber The run number of the run
-   @param bank The bank ID of the run
-   @return The workspace, or empty optional if that run has not been loaded in
-  */
-  virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
-  getFocusedRun(const int runNumber, const size_t bank) const = 0;
-
   /// Get the fitted peaks workspace which has been passed to the view to be
   /// loaded into the widget, in order to pass it to the model
   virtual Mantid::API::MatrixWorkspace_sptr
@@ -61,9 +51,25 @@ public:
   /// view
   virtual size_t getFittedPeaksBankIDToAdd() const = 0;
 
+  /// Get the bank ID requested when getFittedPeaks is run
+  virtual size_t getFittedPeaksBankIDToReturn() const = 0;
+
+  /// Get the run number requested when getFittedPeaks is run
+  virtual int getFittedPeaksRunNumberToReturn() const = 0;
+
   /// Get the run number of the fitted peaks workspace which has been passed to
   /// the view
   virtual int getFittedPeaksRunNumberToAdd() const = 0;
+
+  /**
+   Get focused workspace corresponding to a given run and bank, if that run has
+   been loaded into the widget
+   @param runNumber The run number of the run
+   @param bank The bank ID of the run
+   @return The workspace, or empty optional if that run has not been loaded in
+  */
+  virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
+  getFocusedRun(const int runNumber, const size_t bank) const = 0;
 
   /// Get the focused run which has been passed to the view to be loaded into
   /// the widget, in order to pass it to the model
@@ -75,6 +81,19 @@ public:
 
   /// Get the run number of the focused run which has been passed to the view
   virtual int getFocusedRunNumberToAdd() const = 0;
+
+  /// Set the the fitted peaks workspace to be returned when getFittedPeaks is
+  /// run on the widget
+  virtual void setFittedPeaksWorkspaceToReturn(
+      const Mantid::API::MatrixWorkspace_sptr ws) = 0;
+
+  /**
+   Display an error message to the user
+   @param errorTitle Title of the error
+   @param errorDescription Longer description of the error
+  */
+  virtual void userError(const std::string &errorTitle,
+                         const std::string &errorDescription) = 0;
 };
 
 } // CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
@@ -4,6 +4,7 @@
 #include "MantidAPI/MatrixWorkspace.h"
 
 #include <boost/optional.hpp>
+#include <vector>
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -12,99 +13,9 @@ class IEnggDiffMultiRunFittingWidgetView {
 public:
   virtual ~IEnggDiffMultiRunFittingWidgetView() = default;
 
-  /**
-   Add a fitted peaks workspace to the widget, so it can be overplotted on its
-   focused run
-   @param runNumber The run number of the workspace to add
-   @param bank The bank ID of the workspace to add
-   @param ws The workspace to add
-  */
-  virtual void addFittedPeaks(const int runNumber, const size_t bank,
-                              const Mantid::API::MatrixWorkspace_sptr ws) = 0;
-
-  /**
-   Add a focused run to the widget. The run should be added to the list and
-   plotting it should be possible
-   @param runNumber The run number of the workspace to add
-   @param bank The bank ID of the workspace to add
-   @param ws The workspace to add
-  */
-  virtual void addFocusedRun(const int runNumber, const size_t bank,
-                             const Mantid::API::MatrixWorkspace_sptr ws) = 0;
-
-  /**
-   Get fitted peaks workspace corresponding to a given run and bank, if a fit
-   has been done on that run
-   @param runNumber The run number of the run
-   @param bank The bank ID of the run
-   @return The workspace, or an empty optional if a fit has not been run
-  */
-  virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
-  getFittedPeaks(const int runNumber, const size_t bank) const = 0;
-
-  /// Get the fitted peaks workspace which has been passed to the view to be
-  /// loaded into the widget, in order to pass it to the model
-  virtual Mantid::API::MatrixWorkspace_sptr
-  getFittedPeaksWorkspaceToAdd() const = 0;
-
-  /// Get the bank ID of the fitted peaks workspace which has been passed to the
-  /// view
-  virtual size_t getFittedPeaksBankIDToAdd() const = 0;
-
-  /// Get the bank ID requested when getFittedPeaks is run
-  virtual size_t getFittedPeaksBankIDToReturn() const = 0;
-
-  /// Get the run number requested when getFittedPeaks is run
-  virtual int getFittedPeaksRunNumberToReturn() const = 0;
-
-  /// Get the run number of the fitted peaks workspace which has been passed to
-  /// the view
-  virtual int getFittedPeaksRunNumberToAdd() const = 0;
-
-  /**
-   Get focused workspace corresponding to a given run and bank, if that run has
-   been loaded into the widget
-   @param runNumber The run number of the run
-   @param bank The bank ID of the run
-   @return The workspace, or empty optional if that run has not been loaded in
-  */
-  virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
-  getFocusedRun(const int runNumber, const size_t bank) const = 0;
-
-  /// Get the focused run which has been passed to the view to be loaded into
-  /// the widget, in order to pass it to the model
-  virtual Mantid::API::MatrixWorkspace_sptr
-  getFocusedWorkspaceToAdd() const = 0;
-
-  /// Get the bank ID of the focused run which has been passed to the view
-  virtual size_t getFocusedRunBankIDToAdd() const = 0;
-
-  /// Get the bank ID requested when getFocusedRun is run
-  virtual size_t getFocusedRunBankIDToReturn() const = 0;
-
-  /// Get the run number of the focused run which has been passed to the view
-  virtual int getFocusedRunNumberToAdd() const = 0;
-
-  // Get the run number requested when getFocusedRun is run
-  virtual int getFocusedRunNumberToReturn() const = 0;
-
-  /// Set the fitted peaks workspace to be returned when getFittedPeaks is
-  /// run on the widget
-  virtual void setFittedPeaksWorkspaceToReturn(
-      const Mantid::API::MatrixWorkspace_sptr ws) = 0;
-
-  /// Set the focused run workspace to be return when getFocusedRun is run on
-  /// the widget
-  virtual void setFocusedRunWorkspaceToReturn(
-      const Mantid::API::MatrixWorkspace_sptr ws) = 0;
-
-  /**
-   Display an error message to the user
-   @param errorTitle Title of the error
-   @param errorDescription Longer description of the error
-  */
-  virtual void userError(const std::string &errorTitle,
-                         const std::string &errorDescription) = 0;
+  /// Update the list of loaded run numbers and bank IDs
+  virtual void
+  updateRunList(const std::vector<std::pair<int, size_t>> &runLabels) = 0;
 };
 
 } // CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
@@ -52,6 +52,19 @@ public:
   virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
   getFocusedRun(const int runNumber, const size_t bank) const = 0;
 
+  /// Get the fitted peaks workspace which has been passed to the view to be
+  /// loaded into the widget, in order to pass it to the model
+  virtual Mantid::API::MatrixWorkspace_sptr
+  getFittedPeaksWorkspaceToAdd() const = 0;
+
+  /// Get the bank ID of the fitted peaks workspace which has been passed to the
+  /// view
+  virtual size_t getFittedPeaksBankIDToAdd() const = 0;
+
+  /// Get the run number of the fitted peaks workspace which has been passed to
+  /// the view
+  virtual int getFittedPeaksRunNumberToAdd() const = 0;
+
   /// Get the focused run which has been passed to the view to be loaded into
   /// the widget, in order to pass it to the model
   virtual Mantid::API::MatrixWorkspace_sptr

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
@@ -1,6 +1,8 @@
 #ifndef MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETVIEW_H_
 #define MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETVIEW_H_
 
+#include "RunLabel.h"
+
 #include "MantidAPI/MatrixWorkspace.h"
 
 #include <boost/optional.hpp>
@@ -14,8 +16,7 @@ public:
   virtual ~IEnggDiffMultiRunFittingWidgetView() = default;
 
   /// Update the list of loaded run numbers and bank IDs
-  virtual void
-  updateRunList(const std::vector<std::pair<int, size_t>> &runLabels) = 0;
+  virtual void updateRunList(const std::vector<RunLabel> &runLabels) = 0;
 };
 
 } // CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
@@ -79,12 +79,23 @@ public:
   /// Get the bank ID of the focused run which has been passed to the view
   virtual size_t getFocusedRunBankIDToAdd() const = 0;
 
+  /// Get the bank ID requested when getFocusedRun is run
+  virtual size_t getFocusedRunBankIDToReturn() const = 0;
+
   /// Get the run number of the focused run which has been passed to the view
   virtual int getFocusedRunNumberToAdd() const = 0;
 
-  /// Set the the fitted peaks workspace to be returned when getFittedPeaks is
+  // Get the run number requested when getFocusedRun is run
+  virtual int getFocusedRunNumberToReturn() const = 0;
+
+  /// Set the fitted peaks workspace to be returned when getFittedPeaks is
   /// run on the widget
   virtual void setFittedPeaksWorkspaceToReturn(
+      const Mantid::API::MatrixWorkspace_sptr ws) = 0;
+
+  /// Set the focused run workspace to be return when getFocusedRun is run on
+  /// the widget
+  virtual void setFocusedRunWorkspaceToReturn(
       const Mantid::API::MatrixWorkspace_sptr ws) = 0;
 
   /**

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
@@ -1,0 +1,28 @@
+#ifndef MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETVIEW_H_
+#define MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETVIEW_H_
+
+#include "MantidAPI/MatrixWorkspace.h"
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+class IEnggDiffMultiRunFittingWidgetView {
+public:
+  virtual ~IEnggDiffMultiRunFittingWidgetView() = default;
+
+  virtual void addFittedPeaks(const int runNumber, const size_t bank,
+                              const Mantid::API::MatrixWorkspace_sptr ws) = 0;
+
+  virtual void addFocusedRun(const int runNumber, const size_t bank,
+                             const Mantid::API::MatrixWorkspace_sptr ws) = 0;
+
+  virtual void getFittedPeaks(const int runNumber, const size_t bank) const = 0;
+
+  virtual Mantid::API::MatrixWorkspace_sptr
+  getFocusedRun(const int runNumber, const size_t bank) const = 0;
+};
+
+} // CustomInterfaces
+} // MantidQt
+
+#endif // MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETVIEW_H_

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
@@ -3,6 +3,8 @@
 
 #include "MantidAPI/MatrixWorkspace.h"
 
+#include <boost/optional.hpp>
+
 namespace MantidQt {
 namespace CustomInterfaces {
 
@@ -10,16 +12,56 @@ class IEnggDiffMultiRunFittingWidgetView {
 public:
   virtual ~IEnggDiffMultiRunFittingWidgetView() = default;
 
+  /**
+   Add a fitted peaks workspace to the widget, so it can be overplotted on its
+   focused run
+   @param runNumber The run number of the workspace to add
+   @param bank The bank ID of the workspace to add
+   @param ws The workspace to add
+  */
   virtual void addFittedPeaks(const int runNumber, const size_t bank,
                               const Mantid::API::MatrixWorkspace_sptr ws) = 0;
 
+  /**
+   Add a focused run to the widget. The run should be added to the list and
+   plotting it should be possible
+   @param runNumber The run number of the workspace to add
+   @param bank The bank ID of the workspace to add
+   @param ws The workspace to add
+  */
   virtual void addFocusedRun(const int runNumber, const size_t bank,
                              const Mantid::API::MatrixWorkspace_sptr ws) = 0;
 
-  virtual void getFittedPeaks(const int runNumber, const size_t bank) const = 0;
+  /**
+   Get fitted peaks workspace corresponding to a given run and bank, if a fit
+   has been done on that run
+   @param runNumber The run number of the run
+   @param bank The bank ID of the run
+   @return The workspace, or an empty optional if a fit has not been run
+  */
+  virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
+  getFittedPeaks(const int runNumber, const size_t bank) const = 0;
 
-  virtual Mantid::API::MatrixWorkspace_sptr
+  /**
+   Get focused workspace corresponding to a given run and bank, if that run has
+   been loaded into the widget
+   @param runNumber The run number of the run
+   @param bank The bank ID of the run
+   @return The workspace, or empty optional if that run has not been loaded in
+  */
+  virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
   getFocusedRun(const int runNumber, const size_t bank) const = 0;
+
+  /// Get the focused run which has been passed to the view to be loaded into
+  /// the widget, in order to pass it to the model
+  virtual Mantid::API::MatrixWorkspace_sptr
+  getFocusedWorkspaceToAdd() const = 0;
+
+  /// Get the bank ID of the focused run which has been passed to the view
+  virtual size_t getFocusedRunBankIDToAdd() const = 0;
+
+  /// Get the run number of the focused run which has been passed to the view
+  virtual int getFocusedRunNumberToAdd() const = 0;
 };
 
 } // CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/RunLabel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/RunLabel.cpp
@@ -1,0 +1,14 @@
+#include "RunLabel.h"
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+RunLabel::RunLabel(const int _runNumber, const size_t _bank)
+    : runNumber(_runNumber), bank(_bank) {}
+
+bool operator==(const RunLabel &lhs, const RunLabel &rhs) {
+  return lhs.bank == rhs.bank && lhs.runNumber == rhs.runNumber;
+}
+
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/EnggDiffraction/RunLabel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/RunLabel.cpp
@@ -10,5 +10,9 @@ bool operator==(const RunLabel &lhs, const RunLabel &rhs) {
   return lhs.bank == rhs.bank && lhs.runNumber == rhs.runNumber;
 }
 
+bool operator!=(const RunLabel &lhs, const RunLabel &rhs) {
+  return !(lhs == rhs);
+}
+
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/EnggDiffraction/RunLabel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/RunLabel.h
@@ -1,0 +1,27 @@
+#ifndef MANTIDQT_CUSTOMINTERFACES_ENGGDIFFRUNLABEL_H_
+#define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFRUNLABEL_H_
+
+#include "DllConfig.h"
+
+#include <cstddef>
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+/// POD class for containing run number and bank ID used to index runs loaded
+/// into the ED GUI
+class MANTIDQT_ENGGDIFFRACTION_DLL RunLabel {
+public:
+  RunLabel(const int runNumber, const size_t bank);
+
+  const int runNumber;
+  const std::size_t bank;
+};
+
+MANTIDQT_ENGGDIFFRACTION_DLL bool operator==(const RunLabel &lhs,
+                                             const RunLabel &rhs);
+
+} // namespace CustomInterfaces
+} // namespace MantidQt
+
+#endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFRUNLABEL_H_

--- a/qt/scientific_interfaces/EnggDiffraction/RunLabel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/RunLabel.h
@@ -21,6 +21,9 @@ public:
 MANTIDQT_ENGGDIFFRACTION_DLL bool operator==(const RunLabel &lhs,
                                              const RunLabel &rhs);
 
+MANTIDQT_ENGGDIFFRACTION_DLL bool operator!=(const RunLabel &lhs,
+                                             const RunLabel &rhs);
+
 } // namespace CustomInterfaces
 } // namespace MantidQt
 

--- a/qt/scientific_interfaces/EnggDiffraction/RunMap.h
+++ b/qt/scientific_interfaces/EnggDiffraction/RunMap.h
@@ -1,6 +1,8 @@
 #ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_RUNMAP_H_
 #define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_RUNMAP_H_
 
+#include "RunLabel.h"
+
 #include <array>
 #include <set>
 #include <unordered_map>
@@ -18,23 +20,22 @@ template <size_t NumBanks, typename T> class RunMap {
 public:
   /**
    Add an item to the map
-   @param runNumber The run number associated with the item
-   @param bank The bank ID associated with the item
+   @param runLabel Run number and bank ID of the item to add
    @param itemToAdd The item to add
    */
-  void add(const int runNumber, const size_t bank, const T &itemToAdd);
+  void add(const RunLabel &runLabel, const T &itemToAdd);
 
-  /// Check whether the map contains an entry for this run number and bank ID
-  bool contains(const int runNumber, const size_t bank) const;
+  /// Check whether the map contains an entry for a given run number and bank ID
+  bool contains(const RunLabel &runLabel) const;
 
   /// Get the value stored at a given run number and bank ID
-  const T &get(const int runNumber, const size_t bank) const;
+  const T &get(const RunLabel &runLabel) const;
 
   /// Remove an item from the map
-  void remove(const int runNumber, const size_t bank);
+  void remove(const RunLabel &runLabel);
 
   /// Get the associated run number and bank ID of every item stored in the map
-  std::vector<std::pair<int, size_t>> getRunNumbersAndBankIDs() const;
+  std::vector<RunLabel> getRunLabels() const;
 
   /// Get the number of items stored in the map
   size_t size() const;

--- a/qt/scientific_interfaces/EnggDiffraction/RunMap.tpp
+++ b/qt/scientific_interfaces/EnggDiffraction/RunMap.tpp
@@ -4,47 +4,44 @@ namespace MantidQt {
 namespace CustomInterfaces {
 
 template <size_t NumBanks, typename T>
-void RunMap<NumBanks, T>::add(const int runNumber, const size_t bank,
-                              const T &itemToAdd) {
-  validateBankID(bank);
-  m_map[bank - 1][runNumber] = itemToAdd;
+void RunMap<NumBanks, T>::add(const RunLabel &runLabel, const T &itemToAdd) {
+  validateBankID(runLabel.bank);
+  m_map[runLabel.bank - 1][runLabel.runNumber] = itemToAdd;
 }
 
 template <size_t NumBanks, typename T>
-bool RunMap<NumBanks, T>::contains(const int runNumber,
-                                   const size_t bank) const {
-  return bank > 0 && bank <= NumBanks &&
-         m_map[bank - 1].find(runNumber) != m_map[bank - 1].end();
+bool RunMap<NumBanks, T>::contains(const RunLabel &runLabel) const {
+  return runLabel.bank > 0 && runLabel.bank <= NumBanks &&
+         m_map[runLabel.bank - 1].find(runLabel.runNumber) !=
+             m_map[runLabel.bank - 1].end();
 }
 
 template <size_t NumBanks, typename T>
-const T &RunMap<NumBanks, T>::get(const int runNumber,
-                                  const size_t bank) const {
-  validateBankID(bank);
-  if (!contains(runNumber, bank)) {
+const T &RunMap<NumBanks, T>::get(const RunLabel &runLabel) const {
+  validateBankID(runLabel.bank);
+  if (!contains(runLabel)) {
     throw std::invalid_argument("Tried to access invalid run number " +
-                                std::to_string(runNumber) + " for bank " +
-                                std::to_string(bank));
+                                std::to_string(runLabel.runNumber) +
+                                " for bank " + std::to_string(runLabel.bank));
   }
-  return m_map[bank - 1].at(runNumber);
+  return m_map[runLabel.bank - 1].at(runLabel.runNumber);
 }
 
 template <size_t NumBanks, typename T>
-void RunMap<NumBanks, T>::remove(const int runNumber, const size_t bank) {
-  validateBankID(bank);
-  m_map[bank - 1].erase(runNumber);
+void RunMap<NumBanks, T>::remove(const RunLabel &runLabel) {
+  validateBankID(runLabel.bank);
+  m_map[runLabel.bank - 1].erase(runLabel.runNumber);
 }
 
 template <size_t NumBanks, typename T>
-std::vector<std::pair<int, size_t>>
-RunMap<NumBanks, T>::getRunNumbersAndBankIDs() const {
-  std::vector<std::pair<int, size_t>> pairs;
+std::vector<RunLabel> RunMap<NumBanks, T>::getRunLabels() const {
+  std::vector<RunLabel> pairs;
 
   const auto runNumbers = getAllRunNumbers();
   for (const auto runNumber : runNumbers) {
     for (size_t i = 0; i < NumBanks; ++i) {
       if (m_map[i].find(runNumber) != m_map[i].end()) {
-        pairs.push_back(std::pair<int, size_t>(runNumber, i + 1));
+        pairs.push_back(RunLabel(runNumber, i + 1));
       }
     }
   }
@@ -56,9 +53,8 @@ std::set<int> RunMap<NumBanks, T>::getAllRunNumbers() const {
   std::set<int> runNumbers;
 
   for (const auto &bank : m_map) {
-    for (const auto &runBankPair : bank) {
-      const auto runNumber = runBankPair.first;
-      runNumbers.insert(runNumber);
+    for (const auto &runLabel : bank) {
+      runNumbers.insert(runLabel.first);
     }
   }
 

--- a/qt/scientific_interfaces/test/EnggDiffFittingModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffFittingModelMock.h
@@ -18,44 +18,36 @@ GCC_DIAG_OFF_SUGGEST_OVERRIDE
 class MockEnggDiffFittingModel : public IEnggDiffFittingModel {
 
 public:
-  MOCK_CONST_METHOD2(getFocusedWorkspace,
-                     Mantid::API::MatrixWorkspace_sptr(const int runNumber,
-                                                       const size_t bank));
+  MOCK_CONST_METHOD1(getFocusedWorkspace, Mantid::API::MatrixWorkspace_sptr(
+                                              const RunLabel &runLabel));
 
-  MOCK_CONST_METHOD2(getAlignedWorkspace,
-                     Mantid::API::MatrixWorkspace_sptr(const int runNumber,
-                                                       const size_t bank));
+  MOCK_CONST_METHOD1(getAlignedWorkspace, Mantid::API::MatrixWorkspace_sptr(
+                                              const RunLabel &runLabel));
 
-  MOCK_CONST_METHOD2(getFittedPeaksWS,
-                     Mantid::API::MatrixWorkspace_sptr(const int runNumber,
-                                                       const size_t bank));
+  MOCK_CONST_METHOD1(getFittedPeaksWS, Mantid::API::MatrixWorkspace_sptr(
+                                           const RunLabel &runLabel));
 
-  MOCK_CONST_METHOD2(getFitResults,
-                     Mantid::API::ITableWorkspace_sptr(const int runNumber,
-                                                       const size_t bank));
+  MOCK_CONST_METHOD1(getFitResults, Mantid::API::ITableWorkspace_sptr(
+                                        const RunLabel &runLabel));
 
-  MOCK_CONST_METHOD2(getWorkspaceFilename,
-                     const std::string &(const int runNumber,
-                                         const size_t bank));
+  MOCK_CONST_METHOD1(getWorkspaceFilename,
+                     const std::string &(const RunLabel &runLabel));
 
   MOCK_METHOD1(loadWorkspaces, void(const std::string &filenames));
 
-  MOCK_CONST_METHOD0(getRunNumbersAndBankIDs,
-                     std::vector<std::pair<int, size_t>>());
+  MOCK_CONST_METHOD0(getRunLabels, std::vector<RunLabel>());
 
-  MOCK_METHOD3(setDifcTzero,
-               void(const int runNumber, const size_t bank,
+  MOCK_METHOD2(setDifcTzero,
+               void(const RunLabel &runLabel,
                     const std::vector<GSASCalibrationParms> &calibParams));
 
-  MOCK_METHOD3(enggFitPeaks, void(const int runNumber, const size_t bank,
+  MOCK_METHOD2(enggFitPeaks, void(const RunLabel &runLabel,
                                   const std::string &expectedPeaks));
 
-  MOCK_CONST_METHOD3(saveDiffFittingAscii,
-                     void(const int runNumber, const size_t bank,
-                          const std::string &filename));
+  MOCK_CONST_METHOD2(saveDiffFittingAscii, void(const RunLabel &runLabel,
+                                                const std::string &filename));
 
-  MOCK_METHOD2(createFittedPeaksWS,
-               void(const int runNumber, const size_t bank));
+  MOCK_METHOD1(createFittedPeaksWS, void(const RunLabel &runLabel));
 
   MOCK_CONST_METHOD0(getNumFocusedWorkspaces, size_t());
 
@@ -63,10 +55,9 @@ public:
 
   MOCK_CONST_METHOD0(addAllFittedPeaksToADS, void());
 
-  MOCK_CONST_METHOD2(hasFittedPeaksForRun,
-                     bool(const int runNumber, const size_t bank));
+  MOCK_CONST_METHOD1(hasFittedPeaksForRun, bool(const RunLabel &runLabel));
 
-  MOCK_METHOD2(removeRun, void(const int runNumber, const size_t bank));
+  MOCK_METHOD1(removeRun, void(const RunLabel &runLabel));
 };
 
 GCC_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/EnggDiffFittingModelTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffFittingModelTest.h
@@ -64,8 +64,7 @@ API::ITableWorkspace_sptr createFitParamsTable() {
   const std::array<std::string, numColumns> headings({{
       "dSpacing[Y]", "A0[Y]", "A0_Err[yEr]", "A1[Y]", "A1_Err[yEr]", "X0[Y]",
       "X0_Err[yEr]", "A[Y]", "A_Err[yEr]", "B[Y]", "B_Err[yEr]", "S[Y]",
-      "S_Err[yEr]", "I[Y]", "I_Err[yEr]", "Chi[Y]",
-  }});
+      "S_Err[yEr]", "I[Y]", "I_Err[yEr]", "Chi[Y]", }});
 
   for (const auto &columnHeading : headings) {
     table->addColumn("double", columnHeading);

--- a/qt/scientific_interfaces/test/EnggDiffFittingModelTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffFittingModelTest.h
@@ -13,9 +13,6 @@
 #include <cxxtest/TestSuite.h>
 #include <vector>
 
-// Lets us have pairs inside assertion macros
-typedef std::pair<int, size_t> RunBankPair;
-
 using namespace Mantid;
 using namespace MantidQt::CustomInterfaces;
 
@@ -25,26 +22,26 @@ namespace {
 // This means we can test the workspace maps without having to run Load
 class EnggDiffFittingModelAddWSExposed : public EnggDiffFittingModel {
 public:
-  void addWorkspace(const int runNumber, const size_t bank,
+  void addWorkspace(const RunLabel &runLabel,
                     Mantid::API::MatrixWorkspace_sptr ws);
 
-  void addFitParams(const int runNumber, const size_t bank,
+  void addFitParams(const RunLabel &runLabel,
                     Mantid::API::ITableWorkspace_sptr ws);
 
   void mergeTablesExposed(API::ITableWorkspace_sptr tableToCopy,
                           API::ITableWorkspace_sptr targetTable);
 };
 
-inline void EnggDiffFittingModelAddWSExposed::addWorkspace(
-    const int runNumber, const size_t bank, API::MatrixWorkspace_sptr ws) {
-  addFocusedWorkspace(runNumber, bank, ws,
-                      std::to_string(runNumber) + "_" + std::to_string(bank));
+inline void
+EnggDiffFittingModelAddWSExposed::addWorkspace(const RunLabel &runLabel,
+                                               API::MatrixWorkspace_sptr ws) {
+  addFocusedWorkspace(runLabel, ws, std::to_string(runLabel.runNumber) + "_" +
+                                        std::to_string(runLabel.bank));
 }
 
 inline void EnggDiffFittingModelAddWSExposed::addFitParams(
-    const int runNumber, const size_t bank,
-    Mantid::API::ITableWorkspace_sptr ws) {
-  addFitResults(runNumber, bank, ws);
+    const RunLabel &runLabel, Mantid::API::ITableWorkspace_sptr ws) {
+  addFitResults(runLabel, ws);
 }
 
 inline void EnggDiffFittingModelAddWSExposed::mergeTablesExposed(
@@ -53,11 +50,11 @@ inline void EnggDiffFittingModelAddWSExposed::mergeTablesExposed(
   mergeTables(tableToCopy, targetTable);
 }
 
-void addSampleWorkspaceToModel(const int runNumber, const int bank,
+void addSampleWorkspaceToModel(const RunLabel &runLabel,
                                EnggDiffFittingModelAddWSExposed &model) {
   API::MatrixWorkspace_sptr ws =
       API::WorkspaceFactory::Instance().create("Workspace2D", 1, 10, 10);
-  model.addWorkspace(runNumber, bank, ws);
+  model.addWorkspace(runLabel, ws);
 }
 
 API::ITableWorkspace_sptr createFitParamsTable() {
@@ -67,7 +64,8 @@ API::ITableWorkspace_sptr createFitParamsTable() {
   const std::array<std::string, numColumns> headings({{
       "dSpacing[Y]", "A0[Y]", "A0_Err[yEr]", "A1[Y]", "A1_Err[yEr]", "X0[Y]",
       "X0_Err[yEr]", "A[Y]", "A_Err[yEr]", "B[Y]", "B_Err[yEr]", "S[Y]",
-      "S_Err[yEr]", "I[Y]", "I_Err[yEr]", "Chi[Y]", }});
+      "S_Err[yEr]", "I[Y]", "I_Err[yEr]", "Chi[Y]",
+  }});
 
   for (const auto &columnHeading : headings) {
     table->addColumn("double", columnHeading);
@@ -143,10 +141,10 @@ public:
     auto model = EnggDiffFittingModelAddWSExposed();
     API::MatrixWorkspace_sptr ws =
         API::WorkspaceFactory::Instance().create("Workspace2D", 1, 10, 10);
-    const int runNumber = 100;
-    const int bank = 1;
-    TS_ASSERT_THROWS_NOTHING(model.addWorkspace(runNumber, bank, ws));
-    const auto retrievedWS = model.getFocusedWorkspace(runNumber, bank);
+
+    const RunLabel runLabel(100, 1);
+    TS_ASSERT_THROWS_NOTHING(model.addWorkspace(runLabel, ws));
+    const auto retrievedWS = model.getFocusedWorkspace(runLabel);
 
     TS_ASSERT(retrievedWS != nullptr);
     TS_ASSERT_EQUALS(ws, retrievedWS);
@@ -155,18 +153,18 @@ public:
   void test_getRunNumbersAndBankIDs() {
     auto model = EnggDiffFittingModelAddWSExposed();
 
-    addSampleWorkspaceToModel(123, 1, model);
-    addSampleWorkspaceToModel(456, 2, model);
-    addSampleWorkspaceToModel(789, 1, model);
-    addSampleWorkspaceToModel(123, 2, model);
+    addSampleWorkspaceToModel(RunLabel(123, 1), model);
+    addSampleWorkspaceToModel(RunLabel(456, 2), model);
+    addSampleWorkspaceToModel(RunLabel(789, 1), model);
+    addSampleWorkspaceToModel(RunLabel(123, 2), model);
 
-    const auto runNoBankPairs = model.getRunNumbersAndBankIDs();
+    const auto runLabels = model.getRunLabels();
 
-    TS_ASSERT_EQUALS(runNoBankPairs.size(), 4);
-    TS_ASSERT_EQUALS(runNoBankPairs[0], RunBankPair(123, 1));
-    TS_ASSERT_EQUALS(runNoBankPairs[1], RunBankPair(123, 2));
-    TS_ASSERT_EQUALS(runNoBankPairs[2], RunBankPair(456, 2));
-    TS_ASSERT_EQUALS(runNoBankPairs[3], RunBankPair(789, 1));
+    TS_ASSERT_EQUALS(runLabels.size(), 4);
+    TS_ASSERT_EQUALS(runLabels[0], RunLabel(123, 1));
+    TS_ASSERT_EQUALS(runLabels[1], RunLabel(123, 2));
+    TS_ASSERT_EQUALS(runLabels[2], RunLabel(456, 2));
+    TS_ASSERT_EQUALS(runLabels[3], RunLabel(789, 1));
   }
 
   void test_loadWorkspaces() {
@@ -174,19 +172,18 @@ public:
     TS_ASSERT_THROWS_NOTHING(model.loadWorkspaces(FOCUSED_WS_FILENAME));
     API::MatrixWorkspace_sptr ws;
     TS_ASSERT_THROWS_NOTHING(
-        ws = model.getFocusedWorkspace(FOCUSED_WS_RUN_NUMBER, FOCUSED_WS_BANK));
+        ws = model.getFocusedWorkspace(FOCUSED_WS_RUN_LABEL));
     TS_ASSERT_EQUALS(ws->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(ws->getRunNumber(), FOCUSED_WS_RUN_NUMBER);
+    TS_ASSERT_EQUALS(ws->getRunNumber(), FOCUSED_WS_RUN_LABEL.runNumber);
   }
 
   void test_setDifcTzero() {
     auto model = EnggDiffFittingModel();
     TS_ASSERT_THROWS_NOTHING(model.loadWorkspaces(FOCUSED_WS_FILENAME));
 
-    TS_ASSERT_THROWS_NOTHING(
-        model.setDifcTzero(FOCUSED_WS_RUN_NUMBER, FOCUSED_WS_BANK,
-                           std::vector<GSASCalibrationParms>()));
-    auto ws = model.getFocusedWorkspace(FOCUSED_WS_RUN_NUMBER, FOCUSED_WS_BANK);
+    TS_ASSERT_THROWS_NOTHING(model.setDifcTzero(
+        FOCUSED_WS_RUN_LABEL, std::vector<GSASCalibrationParms>()));
+    auto ws = model.getFocusedWorkspace(FOCUSED_WS_RUN_LABEL);
     auto run = ws->run();
     TS_ASSERT(run.hasProperty("difa"));
     TS_ASSERT(run.hasProperty("difc"));
@@ -198,27 +195,25 @@ public:
 
     const auto fitParams = createFitParamsTable();
     TS_ASSERT_THROWS_NOTHING(
-        model.addFitParams(FOCUSED_WS_RUN_NUMBER, FOCUSED_WS_BANK, fitParams));
+        model.addFitParams(FOCUSED_WS_RUN_LABEL, fitParams));
     TS_ASSERT_THROWS_NOTHING(model.loadWorkspaces(FOCUSED_WS_FILENAME));
 
-    TS_ASSERT_THROWS_NOTHING(
-        model.setDifcTzero(FOCUSED_WS_RUN_NUMBER, FOCUSED_WS_BANK,
-                           std::vector<GSASCalibrationParms>()));
-    TS_ASSERT_THROWS_NOTHING(
-        model.createFittedPeaksWS(FOCUSED_WS_RUN_NUMBER, FOCUSED_WS_BANK));
+    TS_ASSERT_THROWS_NOTHING(model.setDifcTzero(
+        FOCUSED_WS_RUN_LABEL, std::vector<GSASCalibrationParms>()));
+    TS_ASSERT_THROWS_NOTHING(model.createFittedPeaksWS(FOCUSED_WS_RUN_LABEL));
 
     API::MatrixWorkspace_sptr fittedPeaksWS;
-    TS_ASSERT_THROWS_NOTHING(fittedPeaksWS = model.getFittedPeaksWS(
-                                 FOCUSED_WS_RUN_NUMBER, FOCUSED_WS_BANK));
+    TS_ASSERT_THROWS_NOTHING(fittedPeaksWS =
+                                 model.getFittedPeaksWS(FOCUSED_WS_RUN_LABEL));
     TS_ASSERT_EQUALS(fittedPeaksWS->getNumberHistograms(), 4);
   }
 
   void test_getNumFocusedWorkspaces() {
     auto model = EnggDiffFittingModelAddWSExposed();
 
-    addSampleWorkspaceToModel(123, 1, model);
-    addSampleWorkspaceToModel(456, 2, model);
-    addSampleWorkspaceToModel(789, 1, model);
+    addSampleWorkspaceToModel(RunLabel(123, 1), model);
+    addSampleWorkspaceToModel(RunLabel(456, 2), model);
+    addSampleWorkspaceToModel(RunLabel(789, 1), model);
 
     TS_ASSERT_EQUALS(model.getNumFocusedWorkspaces(), 3);
   }
@@ -269,30 +264,31 @@ public:
   void test_removeRun() {
     auto model = EnggDiffFittingModelAddWSExposed();
 
-    addSampleWorkspaceToModel(123, 1, model);
-    addSampleWorkspaceToModel(456, 2, model);
-    addSampleWorkspaceToModel(789, 1, model);
+    const RunLabel label1(123, 1);
+    addSampleWorkspaceToModel(label1, model);
+    const RunLabel label2(456, 2);
+    addSampleWorkspaceToModel(label2, model);
+    const RunLabel label3(789, 1);
+    addSampleWorkspaceToModel(label3, model);
 
-    model.removeRun(123, 1);
+    model.removeRun(label1);
 
-    const auto runBankPairs = model.getRunNumbersAndBankIDs();
-    TS_ASSERT_EQUALS(runBankPairs.size(), 2);
+    const auto runLabels = model.getRunLabels();
+    TS_ASSERT_EQUALS(runLabels.size(), 2);
 
-    TS_ASSERT_EQUALS(runBankPairs[0], RunBankPair(456, 2));
-    TS_ASSERT_EQUALS(runBankPairs[1], RunBankPair(789, 1));
+    TS_ASSERT_EQUALS(runLabels[0], label2);
+    TS_ASSERT_EQUALS(runLabels[1], label3);
   }
 
 private:
   const static std::string FOCUSED_WS_FILENAME;
-  const static int FOCUSED_WS_RUN_NUMBER;
-  const static size_t FOCUSED_WS_BANK;
+  const static RunLabel FOCUSED_WS_RUN_LABEL;
 };
 
 const std::string EnggDiffFittingModelTest::FOCUSED_WS_FILENAME =
     "ENGINX_277208_focused_bank_2.nxs";
 
-const int EnggDiffFittingModelTest::FOCUSED_WS_RUN_NUMBER = 277208;
-
-const size_t EnggDiffFittingModelTest::FOCUSED_WS_BANK = 2;
+const RunLabel EnggDiffFittingModelTest::FOCUSED_WS_RUN_LABEL =
+    RunLabel(277208, 2);
 
 #endif

--- a/qt/scientific_interfaces/test/EnggDiffFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffFittingPresenterTest.h
@@ -34,13 +34,10 @@ public:
 
 private:
   // not async at all
-  void startAsyncFittingWorker(
-      const std::vector<std::pair<int, size_t>> &runNumberBankPairs,
-      const std::string &ExpectedPeaks) override {
-    assert(runNumberBankPairs.size() == 1);
-    const auto runNumber = runNumberBankPairs[0].first;
-    const auto bank = runNumberBankPairs[0].second;
-    doFitting(runNumber, bank, ExpectedPeaks);
+  void startAsyncFittingWorker(const std::vector<RunLabel> &runLabels,
+                               const std::string &ExpectedPeaks) override {
+    assert(runLabels.size() == 1);
+    doFitting(runLabels[0], ExpectedPeaks);
     fittingFinished();
   }
 };
@@ -195,7 +192,7 @@ public:
         .Times(1)
         .WillOnce(Return(boost::optional<std::string>(
             boost::optional<std::string>("123_1"))));
-    EXPECT_CALL(*mockModel_ptr, getWorkspaceFilename(testing::_, testing::_))
+    EXPECT_CALL(*mockModel_ptr, getWorkspaceFilename(testing::_))
         .Times(1)
         .WillOnce(ReturnRef(EMPTY));
 
@@ -235,12 +232,12 @@ public:
         .Times(1)
         .WillOnce(Return("2.3445,3.3433,4.5664"));
 
-    EXPECT_CALL(*mockModel_ptr, getRunNumbersAndBankIDs())
+    const RunLabel runLabel(123, 1);
+    EXPECT_CALL(*mockModel_ptr, getRunLabels())
         .Times(1)
-        .WillOnce(Return(
-            std::vector<std::pair<int, size_t>>({std::make_pair(123, 1)})));
+        .WillOnce(Return(std::vector<RunLabel>({runLabel})));
 
-    EXPECT_CALL(*mockModel_ptr, getWorkspaceFilename(123, 1))
+    EXPECT_CALL(*mockModel_ptr, getWorkspaceFilename(runLabel))
         .Times(1)
         .WillOnce(ReturnRef(EMPTY));
 
@@ -275,12 +272,12 @@ public:
         .WillOnce(Return(",3.5,7.78,r43d"));
     EXPECT_CALL(mockView, setPeakList(testing::_)).Times(1);
 
-    EXPECT_CALL(*mockModel_ptr, getRunNumbersAndBankIDs())
+    const RunLabel runLabel(123, 1);
+    EXPECT_CALL(*mockModel_ptr, getRunLabels())
         .Times(1)
-        .WillOnce(Return(
-            std::vector<std::pair<int, size_t>>({std::make_pair(123, 1)})));
+        .WillOnce(Return(std::vector<RunLabel>({runLabel})));
 
-    EXPECT_CALL(*mockModel_ptr, getWorkspaceFilename(123, 1))
+    EXPECT_CALL(*mockModel_ptr, getWorkspaceFilename(runLabel))
         .Times(1)
         .WillOnce(ReturnRef(EMPTY));
 
@@ -578,11 +575,11 @@ public:
     EXPECT_CALL(mockView, getFittingListWidgetCurrentValue())
         .Times(1)
         .WillOnce(Return(boost::optional<std::string>("123_1")));
-    EXPECT_CALL(*mockModel_ptr, removeRun(123, 1));
-    EXPECT_CALL(*mockModel_ptr, getRunNumbersAndBankIDs())
+    EXPECT_CALL(*mockModel_ptr, removeRun(RunLabel(123, 1)));
+    EXPECT_CALL(*mockModel_ptr, getRunLabels())
         .Times(1)
-        .WillOnce(Return(std::vector<std::pair<int, size_t>>(
-            {std::make_pair(123, 2), std::make_pair(456, 1)})));
+        .WillOnce(Return(
+            std::vector<RunLabel>({RunLabel(123, 2), RunLabel(456, 1)})));
     EXPECT_CALL(mockView, updateFittingListWidget(
                               std::vector<std::string>({"123_2", "456_1"})));
 
@@ -602,23 +599,25 @@ public:
 
     EnggDiffFittingPresenterNoThread pres(&mockView, std::move(mockModel));
 
+    const RunLabel runLabel(123, 1);
     EXPECT_CALL(mockView, getFittingListWidgetCurrentValue())
         .Times(2)
         .WillRepeatedly(Return(boost::optional<std::string>("123_1")));
-    EXPECT_CALL(*mockModel_ptr, hasFittedPeaksForRun(123, 1))
+    EXPECT_CALL(*mockModel_ptr, hasFittedPeaksForRun(runLabel))
         .Times(1)
         .WillOnce(Return(true));
-    EXPECT_CALL(*mockModel_ptr, getAlignedWorkspace(123, 1))
+    EXPECT_CALL(*mockModel_ptr, getAlignedWorkspace(runLabel))
         .Times(1)
         .WillOnce(Return(WorkspaceCreationHelper::create2DWorkspace(10, 10)));
     EXPECT_CALL(mockView, plotFittedPeaksEnabled())
         .Times(1)
         .WillOnce(Return(true));
-    EXPECT_CALL(*mockModel_ptr, getFittedPeaksWS(123, 1))
+    EXPECT_CALL(*mockModel_ptr, getFittedPeaksWS(runLabel))
         .Times(1)
         .WillOnce(Return(WorkspaceCreationHelper::create2DWorkspace(10, 10)));
-    EXPECT_CALL(mockView, setDataVector(testing::_, testing::_, testing::_,
-                                        testing::_)).Times(2);
+    EXPECT_CALL(mockView,
+                setDataVector(testing::_, testing::_, testing::_, testing::_))
+        .Times(2);
 
     pres.notify(IEnggDiffFittingPresenter::updatePlotFittedPeaks);
     TSM_ASSERT(
@@ -635,21 +634,23 @@ public:
 
     EnggDiffFittingPresenterNoThread pres(&mockView, std::move(mockModel));
 
+    const RunLabel runLabel(123, 1);
     EXPECT_CALL(mockView, getFittingListWidgetCurrentValue())
         .Times(1)
         .WillOnce(Return(boost::optional<std::string>("123_1")));
-    EXPECT_CALL(*mockModel_ptr, hasFittedPeaksForRun(123, 1))
+    EXPECT_CALL(*mockModel_ptr, hasFittedPeaksForRun(runLabel))
         .Times(1)
         .WillOnce(Return(false));
-    EXPECT_CALL(*mockModel_ptr, getFocusedWorkspace(123, 1))
+    EXPECT_CALL(*mockModel_ptr, getFocusedWorkspace(runLabel))
         .Times(1)
         .WillOnce(Return(WorkspaceCreationHelper::create2DWorkspace(10, 10)));
     EXPECT_CALL(mockView, plotFittedPeaksEnabled())
         .Times(1)
         .WillOnce(Return(true));
-    EXPECT_CALL(*mockModel_ptr, getFittedPeaksWS(123, 1)).Times(0);
-    EXPECT_CALL(mockView, setDataVector(testing::_, testing::_, testing::_,
-                                        testing::_)).Times(1);
+    EXPECT_CALL(*mockModel_ptr, getFittedPeaksWS(runLabel)).Times(0);
+    EXPECT_CALL(mockView,
+                setDataVector(testing::_, testing::_, testing::_, testing::_))
+        .Times(1);
     EXPECT_CALL(mockView, userWarning("Cannot plot fitted peaks", testing::_))
         .Times(1);
 
@@ -668,21 +669,23 @@ public:
 
     EnggDiffFittingPresenterNoThread pres(&mockView, std::move(mockModel));
 
+    const RunLabel runLabel(123, 1);
     EXPECT_CALL(mockView, getFittingListWidgetCurrentValue())
         .Times(2)
         .WillRepeatedly(Return(boost::optional<std::string>("123_1")));
-    EXPECT_CALL(*mockModel_ptr, hasFittedPeaksForRun(123, 1))
+    EXPECT_CALL(*mockModel_ptr, hasFittedPeaksForRun(runLabel))
         .Times(1)
         .WillOnce(Return(true));
-    EXPECT_CALL(*mockModel_ptr, getAlignedWorkspace(123, 1))
+    EXPECT_CALL(*mockModel_ptr, getAlignedWorkspace(runLabel))
         .Times(1)
         .WillOnce(Return(WorkspaceCreationHelper::create2DWorkspace(10, 10)));
     EXPECT_CALL(mockView, plotFittedPeaksEnabled())
         .Times(1)
         .WillOnce(Return(false));
-    EXPECT_CALL(*mockModel_ptr, getFittedPeaksWS(123, 1)).Times(0);
-    EXPECT_CALL(mockView, setDataVector(testing::_, testing::_, testing::_,
-                                        testing::_)).Times(1);
+    EXPECT_CALL(*mockModel_ptr, getFittedPeaksWS(runLabel)).Times(0);
+    EXPECT_CALL(mockView,
+                setDataVector(testing::_, testing::_, testing::_, testing::_))
+        .Times(1);
 
     pres.notify(IEnggDiffFittingPresenter::updatePlotFittedPeaks);
     TSM_ASSERT(

--- a/qt/scientific_interfaces/test/EnggDiffFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffFittingPresenterTest.h
@@ -615,9 +615,8 @@ public:
     EXPECT_CALL(*mockModel_ptr, getFittedPeaksWS(runLabel))
         .Times(1)
         .WillOnce(Return(WorkspaceCreationHelper::create2DWorkspace(10, 10)));
-    EXPECT_CALL(mockView,
-                setDataVector(testing::_, testing::_, testing::_, testing::_))
-        .Times(2);
+    EXPECT_CALL(mockView, setDataVector(testing::_, testing::_, testing::_,
+                                        testing::_)).Times(2);
 
     pres.notify(IEnggDiffFittingPresenter::updatePlotFittedPeaks);
     TSM_ASSERT(
@@ -648,9 +647,8 @@ public:
         .Times(1)
         .WillOnce(Return(true));
     EXPECT_CALL(*mockModel_ptr, getFittedPeaksWS(runLabel)).Times(0);
-    EXPECT_CALL(mockView,
-                setDataVector(testing::_, testing::_, testing::_, testing::_))
-        .Times(1);
+    EXPECT_CALL(mockView, setDataVector(testing::_, testing::_, testing::_,
+                                        testing::_)).Times(1);
     EXPECT_CALL(mockView, userWarning("Cannot plot fitted peaks", testing::_))
         .Times(1);
 
@@ -683,9 +681,8 @@ public:
         .Times(1)
         .WillOnce(Return(false));
     EXPECT_CALL(*mockModel_ptr, getFittedPeaksWS(runLabel)).Times(0);
-    EXPECT_CALL(mockView,
-                setDataVector(testing::_, testing::_, testing::_, testing::_))
-        .Times(1);
+    EXPECT_CALL(mockView, setDataVector(testing::_, testing::_, testing::_,
+                                        testing::_)).Times(1);
 
     pres.notify(IEnggDiffFittingPresenter::updatePlotFittedPeaks);
     TSM_ASSERT(

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
@@ -8,44 +8,41 @@
 
 GCC_DIAG_OFF_SUGGEST_OVERRIDE
 
-class MockEnggDiffGSASFittingModel
-    : public MantidQt::CustomInterfaces::IEnggDiffGSASFittingModel {
+using namespace MantidQt::CustomInterfaces;
+
+class MockEnggDiffGSASFittingModel : public IEnggDiffGSASFittingModel {
 
 public:
-  MOCK_METHOD8(doPawleyRefinement,
-               bool(const int runNumber, const size_t bank,
-                    const std::string &instParamFile,
+  MOCK_METHOD7(doPawleyRefinement,
+               bool(const RunLabel &runLabel, const std::string &instParamFile,
                     const std::vector<std::string> &phaseFiles,
                     const std::string &pathToGSASII,
                     const std::string &GSASIIProjectFile, const double dMin,
                     const double negativeWeight));
 
-  MOCK_METHOD6(doRietveldRefinement,
-               bool(const int runNumber, const size_t bank,
-                    const std::string &instParamFile,
+  MOCK_METHOD5(doRietveldRefinement,
+               bool(const RunLabel &runLabel, const std::string &instParamFile,
                     const std::vector<std::string> &phaseFiles,
                     const std::string &pathToGSASII,
                     const std::string &GSASIIProjectFile));
 
-  MOCK_CONST_METHOD2(getFittedPeaks,
+  MOCK_CONST_METHOD1(getFittedPeaks,
                      boost::optional<Mantid::API::MatrixWorkspace_sptr>(
-                         const int runNumber, const size_t bank));
+                         const RunLabel &runLabel));
 
-  MOCK_CONST_METHOD2(getFocusedWorkspace,
+  MOCK_CONST_METHOD1(getFocusedWorkspace,
                      boost::optional<Mantid::API::MatrixWorkspace_sptr>(
-                         const int runNumber, const size_t bank));
+                         const RunLabel &runLabel));
 
-  MOCK_CONST_METHOD2(getLatticeParams,
+  MOCK_CONST_METHOD1(getLatticeParams,
                      boost::optional<Mantid::API::ITableWorkspace_sptr>(
-                         const int runNumber, const size_t bank));
+                         const RunLabel &runLabel));
 
-  MOCK_CONST_METHOD0(getRunLabels, std::vector<std::pair<int, size_t>>());
+  MOCK_CONST_METHOD0(getRunLabels, std::vector<RunLabel>());
 
-  MOCK_CONST_METHOD2(getRwp, boost::optional<double>(const int runNumber,
-                                                     const size_t bank));
+  MOCK_CONST_METHOD1(getRwp, boost::optional<double>(const RunLabel &runLabel));
 
-  MOCK_CONST_METHOD2(hasFittedPeaksForRun,
-                     bool(const int runNumber, const size_t bank));
+  MOCK_CONST_METHOD1(hasFittedPeaksForRun, bool(const RunLabel &runLabel));
 
   MOCK_METHOD1(loadFocusedRun, bool(const std::string &filename));
 };

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
@@ -29,8 +29,7 @@ public:
         .Times(1)
         .WillOnce(Return(true));
 
-    const std::vector<std::pair<int, size_t>> runLabels(
-        {std::make_pair(123, 1)});
+    const std::vector<RunLabel> runLabels({RunLabel(123, 1)});
 
     EXPECT_CALL(*m_mockModelPtr, getRunLabels())
         .Times(1)
@@ -67,7 +66,7 @@ public:
 
   void test_selectValidRun() {
     auto presenter = setUpPresenter();
-    const std::pair<int, size_t> selectedRunLabel = std::make_pair(123, 1);
+    const RunLabel selectedRunLabel(123, 1);
     EXPECT_CALL(*m_mockViewPtr, getSelectedRunLabel())
         .Times(1)
         .WillOnce(Return(selectedRunLabel));
@@ -75,7 +74,7 @@ public:
     const boost::optional<Mantid::API::MatrixWorkspace_sptr> sampleWorkspace(
         WorkspaceCreationHelper::create2DWorkspaceBinned(1, 100));
 
-    EXPECT_CALL(*m_mockModelPtr, getFocusedWorkspace(123, 1))
+    EXPECT_CALL(*m_mockModelPtr, getFocusedWorkspace(selectedRunLabel))
         .Times(1)
         .WillOnce(Return(sampleWorkspace));
 
@@ -88,12 +87,12 @@ public:
 
   void test_selectInvalidRun() {
     auto presenter = setUpPresenter();
-    const std::pair<int, size_t> selectedRunLabel = std::make_pair(123, 1);
+    const RunLabel selectedRunLabel(123, 1);
     EXPECT_CALL(*m_mockViewPtr, getSelectedRunLabel())
         .Times(1)
         .WillOnce(Return(selectedRunLabel));
 
-    EXPECT_CALL(*m_mockModelPtr, getFocusedWorkspace(123, 1))
+    EXPECT_CALL(*m_mockModelPtr, getFocusedWorkspace(selectedRunLabel))
         .Times(1)
         .WillOnce(Return(boost::none));
 
@@ -110,36 +109,38 @@ public:
 
   void test_selectValidRunPlotFitResults() {
     auto presenter = setUpPresenter();
-    const std::pair<int, size_t> selectedRunLabel = std::make_pair(123, 1);
+    const RunLabel selectedRunLabel(123, 1);
     EXPECT_CALL(*m_mockViewPtr, getSelectedRunLabel())
         .Times(1)
         .WillOnce(Return(selectedRunLabel));
 
     const boost::optional<Mantid::API::MatrixWorkspace_sptr> sampleWorkspace(
         WorkspaceCreationHelper::create2DWorkspaceBinned(1, 100));
-    EXPECT_CALL(*m_mockModelPtr, getFocusedWorkspace(123, 1))
+    EXPECT_CALL(*m_mockModelPtr, getFocusedWorkspace(selectedRunLabel))
         .Times(1)
         .WillOnce(Return(sampleWorkspace));
     EXPECT_CALL(*m_mockViewPtr, showRefinementResultsSelected())
         .Times(1)
         .WillOnce(Return(true));
-    EXPECT_CALL(*m_mockModelPtr, hasFittedPeaksForRun(123, 1))
+    EXPECT_CALL(*m_mockModelPtr, hasFittedPeaksForRun(selectedRunLabel))
         .Times(1)
         .WillOnce(Return(true));
 
-    EXPECT_CALL(*m_mockModelPtr, getFittedPeaks(123, 1))
+    EXPECT_CALL(*m_mockModelPtr, getFittedPeaks(selectedRunLabel))
         .Times(1)
         .WillOnce(Return(sampleWorkspace));
 
     const boost::optional<Mantid::API::ITableWorkspace_sptr> emptyTableWS(
         Mantid::API::WorkspaceFactory::Instance().createTable());
 
-    EXPECT_CALL(*m_mockModelPtr, getLatticeParams(123, 1))
+    EXPECT_CALL(*m_mockModelPtr, getLatticeParams(selectedRunLabel))
         .Times(1)
         .WillOnce(Return(emptyTableWS));
 
     const boost::optional<double> rwp = 50.0;
-    EXPECT_CALL(*m_mockModelPtr, getRwp(123, 1)).Times(1).WillOnce(Return(rwp));
+    EXPECT_CALL(*m_mockModelPtr, getRwp(selectedRunLabel))
+        .Times(1)
+        .WillOnce(Return(rwp));
 
     EXPECT_CALL(*m_mockViewPtr, resetCanvas()).Times(1);
     EXPECT_CALL(*m_mockViewPtr, plotCurve(testing::_)).Times(2);
@@ -152,9 +153,7 @@ public:
   void test_doRietveldRefinement() {
     auto presenter = setUpPresenter();
 
-    const int runNumber = 123;
-    const size_t bank = 1;
-    const auto runLabel = std::make_pair(runNumber, bank);
+    const RunLabel runLabel(123, 1);
     const auto refinementMethod = GSASRefinementMethod::RIETVELD;
     const auto instParams = "Instrument file";
     const std::vector<std::string> phaseFiles({"phase1", "phase2"});
@@ -181,7 +180,7 @@ public:
         .WillOnce(Return(GSASIIProjectFile));
 
     EXPECT_CALL(*m_mockModelPtr,
-                doRietveldRefinement(runNumber, bank, instParams, phaseFiles,
+                doRietveldRefinement(runLabel, instParams, phaseFiles,
                                      pathToGSASII, GSASIIProjectFile))
         .Times(1)
         .WillOnce(Return(false));
@@ -195,9 +194,7 @@ public:
   void test_doPawleyRefinement() {
     auto presenter = setUpPresenter();
 
-    const int runNumber = 123;
-    const size_t bank = 1;
-    const auto runLabel = std::make_pair(runNumber, bank);
+    const RunLabel runLabel(123, 1);
     const auto refinementMethod = GSASRefinementMethod::PAWLEY;
     const auto instParams = "Instrument file";
     const std::vector<std::string> phaseFiles({"phase1", "phase2"});
@@ -232,7 +229,7 @@ public:
         .WillOnce(Return(negativeWeight));
 
     EXPECT_CALL(*m_mockModelPtr,
-                doPawleyRefinement(runNumber, bank, instParams, phaseFiles,
+                doPawleyRefinement(runLabel, instParams, phaseFiles,
                                    pathToGSASII, GSASIIProjectFile, dmin,
                                    negativeWeight))
         .Times(1)

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingViewMock.h
@@ -6,10 +6,11 @@
 
 #include <gmock/gmock.h>
 
+using namespace MantidQt::CustomInterfaces;
+
 GCC_DIAG_OFF_SUGGEST_OVERRIDE
 
-class MockEnggDiffGSASFittingView
-    : public MantidQt::CustomInterfaces::IEnggDiffGSASFittingView {
+class MockEnggDiffGSASFittingView : public IEnggDiffGSASFittingView {
 
 public:
   MOCK_CONST_METHOD1(displayLatticeParams,
@@ -27,13 +28,11 @@ public:
 
   MOCK_CONST_METHOD0(getPhaseFileNames, std::vector<std::string>());
 
-  MOCK_CONST_METHOD0(getSelectedRunLabel, std::pair<int, size_t>());
+  MOCK_CONST_METHOD0(getSelectedRunLabel, RunLabel());
 
-  MOCK_CONST_METHOD0(getSelectedRunMethod,
-                     MantidQt::CustomInterfaces::GSASRefinementMethod());
+  MOCK_CONST_METHOD0(getSelectedRunMethod, GSASRefinementMethod());
 
-  MOCK_CONST_METHOD0(getRefinementMethod,
-                     MantidQt::CustomInterfaces::GSASRefinementMethod());
+  MOCK_CONST_METHOD0(getRefinementMethod, GSASRefinementMethod());
 
   MOCK_CONST_METHOD0(getPawleyDMin, double());
 
@@ -46,8 +45,7 @@ public:
 
   MOCK_METHOD0(showRefinementResultsSelected, bool());
 
-  MOCK_METHOD1(updateRunList,
-               void(const std::vector<std::pair<int, size_t>> &runLabels));
+  MOCK_METHOD1(updateRunList, void(const std::vector<RunLabel> &runLabels));
 
   MOCK_CONST_METHOD1(userWarning, void(const std::string &warningDescription));
 };

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelMock.h
@@ -1,0 +1,36 @@
+#ifndef MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETMODELMOCK_H_
+#define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETMODELMOCK_H_
+
+#include "../EnggDiffraction/IEnggDiffMultiRunFittingWidgetModel.h"
+#include "MantidKernel/WarningSuppressions.h"
+
+#include <gmock/gmock.h>
+
+GCC_DIAG_OFF_SUGGEST_OVERRIDE
+
+class MockEnggDiffMultiRunFittingWidgetModel
+    : public MantidQt::CustomInterfaces::IEnggDiffMultiRunFittingWidgetModel {
+
+public:
+  MOCK_METHOD3(addFittedPeaks,
+               void(const int runNumber, const size_t bank,
+                    const Mantid::API::MatrixWorkspace_sptr ws));
+
+  MOCK_METHOD3(addFocusedRun, void(const int runNumber, const size_t bank,
+                                   const Mantid::API::MatrixWorkspace_sptr ws));
+
+  MOCK_CONST_METHOD2(getFittedPeaks,
+                     boost::optional<Mantid::API::MatrixWorkspace_sptr>(
+                         const int runNumber, const size_t bank));
+
+  MOCK_CONST_METHOD2(getFocusedRun,
+                     boost::optional<Mantid::API::MatrixWorkspace_sptr>(
+                         const int runNumber, const size_t bank));
+
+  MOCK_CONST_METHOD0(getFocusedWorkspaceToAdd,
+                     Mantid::API::MatrixWorkspace_sptr());
+};
+
+GCC_DIAG_ON_SUGGEST_OVERRIDE
+
+#endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETMODELMOCK_H_

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelMock.h
@@ -6,29 +6,30 @@
 
 #include <gmock/gmock.h>
 
+using namespace MantidQt::CustomInterfaces;
+
 GCC_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockEnggDiffMultiRunFittingWidgetModel
-    : public MantidQt::CustomInterfaces::IEnggDiffMultiRunFittingWidgetModel {
+    : public IEnggDiffMultiRunFittingWidgetModel {
 
 public:
-  MOCK_METHOD3(addFittedPeaks,
-               void(const int runNumber, const size_t bank,
+  MOCK_METHOD2(addFittedPeaks,
+               void(const RunLabel &runLabel,
                     const Mantid::API::MatrixWorkspace_sptr ws));
 
-  MOCK_METHOD3(addFocusedRun, void(const int runNumber, const size_t bank,
+  MOCK_METHOD2(addFocusedRun, void(const RunLabel &runLabel,
                                    const Mantid::API::MatrixWorkspace_sptr ws));
 
-  MOCK_CONST_METHOD0(getAllWorkspaceLabels,
-                     std::vector<std::pair<int, size_t>>());
+  MOCK_CONST_METHOD0(getAllWorkspaceLabels, std::vector<RunLabel>());
 
-  MOCK_CONST_METHOD2(getFittedPeaks,
+  MOCK_CONST_METHOD1(getFittedPeaks,
                      boost::optional<Mantid::API::MatrixWorkspace_sptr>(
-                         const int runNumber, const size_t bank));
+                         const RunLabel &runLabel));
 
-  MOCK_CONST_METHOD2(getFocusedRun,
+  MOCK_CONST_METHOD1(getFocusedRun,
                      boost::optional<Mantid::API::MatrixWorkspace_sptr>(
-                         const int runNumber, const size_t bank));
+                         const RunLabel &runLabel));
 };
 
 GCC_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelMock.h
@@ -19,6 +19,9 @@ public:
   MOCK_METHOD3(addFocusedRun, void(const int runNumber, const size_t bank,
                                    const Mantid::API::MatrixWorkspace_sptr ws));
 
+  MOCK_CONST_METHOD0(getAllWorkspaceLabels,
+                     std::vector<std::pair<int, size_t>>());
+
   MOCK_CONST_METHOD2(getFittedPeaks,
                      boost::optional<Mantid::API::MatrixWorkspace_sptr>(
                          const int runNumber, const size_t bank));

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelMock.h
@@ -26,9 +26,6 @@ public:
   MOCK_CONST_METHOD2(getFocusedRun,
                      boost::optional<Mantid::API::MatrixWorkspace_sptr>(
                          const int runNumber, const size_t bank));
-
-  MOCK_CONST_METHOD0(getFocusedWorkspaceToAdd,
-                     Mantid::API::MatrixWorkspace_sptr());
 };
 
 GCC_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
@@ -98,8 +98,7 @@ public:
                 userError("Invalid fitted peaks run identifier",
                           "Could not find a fitted peaks workspace with run "
                           "number 123 and bank ID 1. Please contact the "
-                          "development team with this message"))
-        .Times(1);
+                          "development team with this message")).Times(1);
     EXPECT_CALL(*m_mockViewPtr, setFittedPeaksWorkspaceToReturn(testing::_))
         .Times(0);
 
@@ -150,8 +149,7 @@ public:
                 userError("Invalid focused run identifier",
                           "Could not find a focused run with run "
                           "number 123 and bank ID 1. Please contact the "
-                          "development team with this message"))
-        .Times(1);
+                          "development team with this message")).Times(1);
     EXPECT_CALL(*m_mockViewPtr, setFocusedRunWorkspaceToReturn(testing::_))
         .Times(0);
 

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
@@ -1,0 +1,70 @@
+#ifndef MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETPRESENTERTEST_H_
+#define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETPRESENTERTEST_H_
+
+#include "../EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h"
+#include "EnggDiffMultiRunFittingWidgetModelMock.h"
+#include "EnggDiffMultiRunFittingWidgetViewMock.h"
+
+#include "MantidAPI/WorkspaceFactory.h"
+
+#include <cxxtest/TestSuite.h>
+
+using namespace Mantid;
+
+using namespace MantidQt::CustomInterfaces;
+using testing::Return;
+
+class EnggDiffMultiRunFittingWidgetPresenterTest : public CxxTest::TestSuite {
+public:
+  void test_addFocusedWorkspace() {
+    auto presenter = setUpPresenter();
+    const API::MatrixWorkspace_sptr ws =
+        API::WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
+
+    EXPECT_CALL(*m_mockViewPtr, getFocusedWorkspaceToAdd())
+        .Times(1)
+        .WillOnce(Return(ws));
+    EXPECT_CALL(*m_mockViewPtr, getFocusedRunBankIDToAdd())
+        .Times(1)
+        .WillOnce(Return(1));
+    EXPECT_CALL(*m_mockViewPtr, getFocusedRunNumberToAdd())
+        .Times(1)
+        .WillOnce(Return(123));
+    EXPECT_CALL(*m_mockModelPtr, addFocusedRun(123, 1, ws));
+
+    presenter->notify(IEnggDiffMultiRunFittingWidgetPresenter::AddFocusedRun);
+    assertMocksUsedCorrectly();
+  }
+
+private:
+  MockEnggDiffMultiRunFittingWidgetModel *m_mockModelPtr;
+  MockEnggDiffMultiRunFittingWidgetView *m_mockViewPtr;
+
+  std::unique_ptr<EnggDiffMultiRunFittingWidgetPresenter> setUpPresenter() {
+    auto mockModel = Mantid::Kernel::make_unique<
+        testing::NiceMock<MockEnggDiffMultiRunFittingWidgetModel>>();
+    m_mockModelPtr = mockModel.get();
+
+    m_mockViewPtr =
+        new testing::NiceMock<MockEnggDiffMultiRunFittingWidgetView>();
+
+    std::unique_ptr<EnggDiffMultiRunFittingWidgetPresenter> pres_uptr(
+        new EnggDiffMultiRunFittingWidgetPresenter(std::move(mockModel),
+                                                   m_mockViewPtr));
+    return pres_uptr;
+  }
+
+  void assertMocksUsedCorrectly() {
+    if (m_mockViewPtr) {
+      delete m_mockViewPtr;
+    }
+    TSM_ASSERT("View mock not used as expected: some EXPECT_CALL conditions "
+               "not satisfied",
+               testing::Mock::VerifyAndClearExpectations(m_mockModelPtr));
+    TSM_ASSERT("Model mock not used as expected: some EXPECT_CALL conditions "
+               "not satisfied",
+               testing::Mock::VerifyAndClearExpectations(m_mockViewPtr));
+  }
+};
+
+#endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETPRESENTERTEST_H_

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
@@ -56,6 +56,58 @@ public:
     assertMocksUsedCorrectly();
   }
 
+  void test_getFittedPeaksValid() {
+    auto presenter = setUpPresenter();
+
+    EXPECT_CALL(*m_mockViewPtr, getFittedPeaksBankIDToReturn())
+        .Times(1)
+        .WillOnce(Return(1));
+    EXPECT_CALL(*m_mockViewPtr, getFittedPeaksRunNumberToReturn())
+        .Times(1)
+        .WillOnce(Return(123));
+
+    const API::MatrixWorkspace_sptr ws =
+        API::WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
+
+    EXPECT_CALL(*m_mockModelPtr, getFittedPeaks(123, 1))
+        .Times(1)
+        .WillOnce(Return(boost::make_optional<API::MatrixWorkspace_sptr>(ws)));
+    EXPECT_CALL(*m_mockViewPtr, setFittedPeaksWorkspaceToReturn(ws));
+    EXPECT_CALL(*m_mockViewPtr, userError(testing::_, testing::_)).Times(0);
+
+    presenter->notify(IEnggDiffMultiRunFittingWidgetPresenter::GetFittedPeaks);
+
+    assertMocksUsedCorrectly();
+  }
+
+  void test_getFittedPeaksInvalid() {
+    auto presenter = setUpPresenter();
+
+    EXPECT_CALL(*m_mockViewPtr, getFittedPeaksBankIDToReturn())
+        .Times(1)
+        .WillOnce(Return(1));
+    EXPECT_CALL(*m_mockViewPtr, getFittedPeaksRunNumberToReturn())
+        .Times(1)
+        .WillOnce(Return(123));
+
+    EXPECT_CALL(*m_mockModelPtr, getFittedPeaks(123, 1))
+        .Times(1)
+        .WillOnce(Return(boost::none));
+
+    EXPECT_CALL(*m_mockViewPtr,
+                userError("Invalid fitted peaks run identifier",
+                          "Could not find a fitted peaks workspace with run "
+                          "number 123 and bank ID 1. Please contact the "
+                          "development team with this message"))
+        .Times(1);
+    EXPECT_CALL(*m_mockViewPtr, setFittedPeaksWorkspaceToReturn(testing::_))
+        .Times(0);
+
+    presenter->notify(IEnggDiffMultiRunFittingWidgetPresenter::GetFittedPeaks);
+
+    assertMocksUsedCorrectly();
+  }
+
 private:
   MockEnggDiffMultiRunFittingWidgetModel *m_mockModelPtr;
   MockEnggDiffMultiRunFittingWidgetView *m_mockViewPtr;

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
@@ -27,7 +27,7 @@ public:
     assertMocksUsedCorrectly();
   }
 
-  void test_addFocusedRun() {
+  void test_focusedRunIsAddedToModel() {
     auto presenter = setUpPresenter();
     const API::MatrixWorkspace_sptr ws =
         API::WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
@@ -39,6 +39,20 @@ public:
     EXPECT_CALL(*m_mockModelPtr, getAllWorkspaceLabels())
         .Times(1)
         .WillOnce(Return(workspaceLabels));
+
+    presenter->addFocusedRun(123, 1, ws);
+    assertMocksUsedCorrectly();
+  }
+
+  void test_loadRunUpdatesView() {
+    auto presenter = setUpPresenter();
+    const API::MatrixWorkspace_sptr ws =
+        API::WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
+
+    const std::vector<std::pair<int, size_t>> workspaceLabels(
+        {std::make_pair(123, 1)});
+    ON_CALL(*m_mockModelPtr, getAllWorkspaceLabels())
+        .WillByDefault(Return(workspaceLabels));
     EXPECT_CALL(*m_mockViewPtr, updateRunList(workspaceLabels));
 
     presenter->addFocusedRun(123, 1, ws);

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
@@ -94,7 +94,7 @@ private:
         testing::NiceMock<MockEnggDiffMultiRunFittingWidgetView>>();
     m_mockView = mockView_uptr.get();
 
-    return std::make_unique<EnggDiffMultiRunFittingWidgetPresenter>(
+    return Mantid::Kernel::make_unique<EnggDiffMultiRunFittingWidgetPresenter>(
         std::move(mockModel_uptr), std::move(mockView_uptr));
   }
 

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
@@ -36,6 +36,26 @@ public:
     assertMocksUsedCorrectly();
   }
 
+  void test_addFittedPeaks() {
+    auto presenter = setUpPresenter();
+    const API::MatrixWorkspace_sptr ws =
+        API::WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
+
+    EXPECT_CALL(*m_mockViewPtr, getFittedPeaksWorkspaceToAdd())
+        .Times(1)
+        .WillOnce(Return(ws));
+    EXPECT_CALL(*m_mockViewPtr, getFittedPeaksBankIDToAdd())
+        .Times(1)
+        .WillOnce(Return(1));
+    EXPECT_CALL(*m_mockViewPtr, getFittedPeaksRunNumberToAdd())
+        .Times(1)
+        .WillOnce(Return(123));
+    EXPECT_CALL(*m_mockModelPtr, addFittedPeaks(123, 1, ws));
+
+    presenter->notify(IEnggDiffMultiRunFittingWidgetPresenter::AddFittedPeaks);
+    assertMocksUsedCorrectly();
+  }
+
 private:
   MockEnggDiffMultiRunFittingWidgetModel *m_mockModelPtr;
   MockEnggDiffMultiRunFittingWidgetView *m_mockViewPtr;

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
@@ -108,6 +108,58 @@ public:
     assertMocksUsedCorrectly();
   }
 
+  void test_getFocusedRunValid() {
+    auto presenter = setUpPresenter();
+
+    EXPECT_CALL(*m_mockViewPtr, getFocusedRunBankIDToReturn())
+        .Times(1)
+        .WillOnce(Return(1));
+    EXPECT_CALL(*m_mockViewPtr, getFocusedRunNumberToReturn())
+        .Times(1)
+        .WillOnce(Return(123));
+
+    const API::MatrixWorkspace_sptr ws =
+        API::WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
+
+    EXPECT_CALL(*m_mockModelPtr, getFocusedRun(123, 1))
+        .Times(1)
+        .WillOnce(Return(boost::make_optional<API::MatrixWorkspace_sptr>(ws)));
+    EXPECT_CALL(*m_mockViewPtr, setFocusedRunWorkspaceToReturn(ws));
+    EXPECT_CALL(*m_mockViewPtr, userError(testing::_, testing::_)).Times(0);
+
+    presenter->notify(IEnggDiffMultiRunFittingWidgetPresenter::GetFocusedRun);
+
+    assertMocksUsedCorrectly();
+  }
+
+  void test_getFocusedRunInvalid() {
+    auto presenter = setUpPresenter();
+
+    EXPECT_CALL(*m_mockViewPtr, getFocusedRunBankIDToReturn())
+        .Times(1)
+        .WillOnce(Return(1));
+    EXPECT_CALL(*m_mockViewPtr, getFocusedRunNumberToReturn())
+        .Times(1)
+        .WillOnce(Return(123));
+
+    EXPECT_CALL(*m_mockModelPtr, getFocusedRun(123, 1))
+        .Times(1)
+        .WillOnce(Return(boost::none));
+
+    EXPECT_CALL(*m_mockViewPtr,
+                userError("Invalid focused run identifier",
+                          "Could not find a focused run with run "
+                          "number 123 and bank ID 1. Please contact the "
+                          "development team with this message"))
+        .Times(1);
+    EXPECT_CALL(*m_mockViewPtr, setFocusedRunWorkspaceToReturn(testing::_))
+        .Times(0);
+
+    presenter->notify(IEnggDiffMultiRunFittingWidgetPresenter::GetFocusedRun);
+
+    assertMocksUsedCorrectly();
+  }
+
 private:
   MockEnggDiffMultiRunFittingWidgetModel *m_mockModelPtr;
   MockEnggDiffMultiRunFittingWidgetView *m_mockViewPtr;

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
@@ -21,7 +21,7 @@ public:
     const API::MatrixWorkspace_sptr ws =
         API::WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
 
-    EXPECT_CALL(*m_mockModelPtr, addFittedPeaks(123, 1, ws)).Times(1);
+    EXPECT_CALL(*m_mockModel, addFittedPeaks(123, 1, ws)).Times(1);
 
     presenter->addFittedPeaks(123, 1, ws);
     assertMocksUsedCorrectly();
@@ -32,11 +32,11 @@ public:
     const API::MatrixWorkspace_sptr ws =
         API::WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
 
-    EXPECT_CALL(*m_mockModelPtr, addFocusedRun(123, 1, ws)).Times(1);
+    EXPECT_CALL(*m_mockModel, addFocusedRun(123, 1, ws)).Times(1);
 
     const std::vector<std::pair<int, size_t>> workspaceLabels(
         {std::make_pair(123, 1)});
-    EXPECT_CALL(*m_mockModelPtr, getAllWorkspaceLabels())
+    EXPECT_CALL(*m_mockModel, getAllWorkspaceLabels())
         .Times(1)
         .WillOnce(Return(workspaceLabels));
 
@@ -51,9 +51,9 @@ public:
 
     const std::vector<std::pair<int, size_t>> workspaceLabels(
         {std::make_pair(123, 1)});
-    ON_CALL(*m_mockModelPtr, getAllWorkspaceLabels())
+    ON_CALL(*m_mockModel, getAllWorkspaceLabels())
         .WillByDefault(Return(workspaceLabels));
-    EXPECT_CALL(*m_mockViewPtr, updateRunList(workspaceLabels));
+    EXPECT_CALL(*m_mockView, updateRunList(workspaceLabels));
 
     presenter->addFocusedRun(123, 1, ws);
     assertMocksUsedCorrectly();
@@ -62,7 +62,7 @@ public:
   void test_getFittedPeaks() {
     auto presenter = setUpPresenter();
 
-    EXPECT_CALL(*m_mockModelPtr, getFittedPeaks(123, 1))
+    EXPECT_CALL(*m_mockModel, getFittedPeaks(123, 1))
         .Times(1)
         .WillOnce(Return(boost::none));
 
@@ -73,7 +73,7 @@ public:
   void test_getFocusedRun() {
     auto presenter = setUpPresenter();
 
-    EXPECT_CALL(*m_mockModelPtr, getFocusedRun(123, 1))
+    EXPECT_CALL(*m_mockModel, getFocusedRun(123, 1))
         .Times(1)
         .WillOnce(Return(boost::none));
 
@@ -82,31 +82,29 @@ public:
   }
 
 private:
-  MockEnggDiffMultiRunFittingWidgetModel *m_mockModelPtr;
-  MockEnggDiffMultiRunFittingWidgetView *m_mockViewPtr;
+  MockEnggDiffMultiRunFittingWidgetModel *m_mockModel;
+  MockEnggDiffMultiRunFittingWidgetView *m_mockView;
 
   std::unique_ptr<EnggDiffMultiRunFittingWidgetPresenter> setUpPresenter() {
-    auto mockModel = Mantid::Kernel::make_unique<
+    auto mockModel_uptr = Mantid::Kernel::make_unique<
         testing::NiceMock<MockEnggDiffMultiRunFittingWidgetModel>>();
-    m_mockModelPtr = mockModel.get();
+    m_mockModel = mockModel_uptr.get();
 
-    auto mockView = Mantid::Kernel::make_unique<
+    auto mockView_uptr = Mantid::Kernel::make_unique<
         testing::NiceMock<MockEnggDiffMultiRunFittingWidgetView>>();
-    m_mockViewPtr = mockView.get();
+    m_mockView = mockView_uptr.get();
 
-    std::unique_ptr<EnggDiffMultiRunFittingWidgetPresenter> pres_uptr(
-        new EnggDiffMultiRunFittingWidgetPresenter(std::move(mockModel),
-                                                   std::move(mockView)));
-    return pres_uptr;
+    return std::make_unique<EnggDiffMultiRunFittingWidgetPresenter>(
+        std::move(mockModel_uptr), std::move(mockView_uptr));
   }
 
   void assertMocksUsedCorrectly() {
     TSM_ASSERT("View mock not used as expected: some EXPECT_CALL conditions "
                "not satisfied",
-               testing::Mock::VerifyAndClearExpectations(m_mockModelPtr));
+               testing::Mock::VerifyAndClearExpectations(m_mockModel));
     TSM_ASSERT("Model mock not used as expected: some EXPECT_CALL conditions "
                "not satisfied",
-               testing::Mock::VerifyAndClearExpectations(m_mockViewPtr));
+               testing::Mock::VerifyAndClearExpectations(m_mockView));
   }
 };
 

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
@@ -48,16 +48,20 @@ public:
   void test_getFittedPeaks() {
     auto presenter = setUpPresenter();
 
-    EXPECT_CALL(*m_mockModelPtr, getFittedPeaks(123, 1)).Times(1);
+    EXPECT_CALL(*m_mockModelPtr, getFittedPeaks(123, 1))
+        .Times(1)
+        .WillOnce(Return(boost::none));
 
     presenter->getFittedPeaks(123, 1);
     assertMocksUsedCorrectly();
   }
 
-  void test_getFocsedRun() {
+  void test_getFocusedRun() {
     auto presenter = setUpPresenter();
 
-    EXPECT_CALL(*m_mockModelPtr, getFocusedRun(123, 1)).Times(1);
+    EXPECT_CALL(*m_mockModelPtr, getFocusedRun(123, 1))
+        .Times(1)
+        .WillOnce(Return(boost::none));
 
     presenter->getFocusedRun(123, 1);
     assertMocksUsedCorrectly();

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
@@ -16,145 +16,50 @@ using testing::Return;
 
 class EnggDiffMultiRunFittingWidgetPresenterTest : public CxxTest::TestSuite {
 public:
-  void test_addFocusedWorkspace() {
-    auto presenter = setUpPresenter();
-    const API::MatrixWorkspace_sptr ws =
-        API::WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
-
-    EXPECT_CALL(*m_mockViewPtr, getFocusedWorkspaceToAdd())
-        .Times(1)
-        .WillOnce(Return(ws));
-    EXPECT_CALL(*m_mockViewPtr, getFocusedRunBankIDToAdd())
-        .Times(1)
-        .WillOnce(Return(1));
-    EXPECT_CALL(*m_mockViewPtr, getFocusedRunNumberToAdd())
-        .Times(1)
-        .WillOnce(Return(123));
-    EXPECT_CALL(*m_mockModelPtr, addFocusedRun(123, 1, ws));
-
-    presenter->notify(IEnggDiffMultiRunFittingWidgetPresenter::AddFocusedRun);
-    assertMocksUsedCorrectly();
-  }
-
   void test_addFittedPeaks() {
     auto presenter = setUpPresenter();
     const API::MatrixWorkspace_sptr ws =
         API::WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
 
-    EXPECT_CALL(*m_mockViewPtr, getFittedPeaksWorkspaceToAdd())
-        .Times(1)
-        .WillOnce(Return(ws));
-    EXPECT_CALL(*m_mockViewPtr, getFittedPeaksBankIDToAdd())
-        .Times(1)
-        .WillOnce(Return(1));
-    EXPECT_CALL(*m_mockViewPtr, getFittedPeaksRunNumberToAdd())
-        .Times(1)
-        .WillOnce(Return(123));
-    EXPECT_CALL(*m_mockModelPtr, addFittedPeaks(123, 1, ws));
+    EXPECT_CALL(*m_mockModelPtr, addFittedPeaks(123, 1, ws)).Times(1);
 
-    presenter->notify(IEnggDiffMultiRunFittingWidgetPresenter::AddFittedPeaks);
+    presenter->addFittedPeaks(123, 1, ws);
     assertMocksUsedCorrectly();
   }
 
-  void test_getFittedPeaksValid() {
+  void test_addFocusedRun() {
     auto presenter = setUpPresenter();
-
-    EXPECT_CALL(*m_mockViewPtr, getFittedPeaksBankIDToReturn())
-        .Times(1)
-        .WillOnce(Return(1));
-    EXPECT_CALL(*m_mockViewPtr, getFittedPeaksRunNumberToReturn())
-        .Times(1)
-        .WillOnce(Return(123));
-
     const API::MatrixWorkspace_sptr ws =
         API::WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
 
-    EXPECT_CALL(*m_mockModelPtr, getFittedPeaks(123, 1))
+    EXPECT_CALL(*m_mockModelPtr, addFocusedRun(123, 1, ws)).Times(1);
+
+    const std::vector<std::pair<int, size_t>> workspaceLabels(
+        {std::make_pair(123, 1)});
+    EXPECT_CALL(*m_mockModelPtr, getAllWorkspaceLabels())
         .Times(1)
-        .WillOnce(Return(boost::make_optional<API::MatrixWorkspace_sptr>(ws)));
-    EXPECT_CALL(*m_mockViewPtr, setFittedPeaksWorkspaceToReturn(ws));
-    EXPECT_CALL(*m_mockViewPtr, userError(testing::_, testing::_)).Times(0);
+        .WillOnce(Return(workspaceLabels));
+    EXPECT_CALL(*m_mockViewPtr, updateRunList(workspaceLabels));
 
-    presenter->notify(IEnggDiffMultiRunFittingWidgetPresenter::GetFittedPeaks);
-
+    presenter->addFocusedRun(123, 1, ws);
     assertMocksUsedCorrectly();
   }
 
-  void test_getFittedPeaksInvalid() {
+  void test_getFittedPeaks() {
     auto presenter = setUpPresenter();
 
-    EXPECT_CALL(*m_mockViewPtr, getFittedPeaksBankIDToReturn())
-        .Times(1)
-        .WillOnce(Return(1));
-    EXPECT_CALL(*m_mockViewPtr, getFittedPeaksRunNumberToReturn())
-        .Times(1)
-        .WillOnce(Return(123));
+    EXPECT_CALL(*m_mockModelPtr, getFittedPeaks(123, 1)).Times(1);
 
-    EXPECT_CALL(*m_mockModelPtr, getFittedPeaks(123, 1))
-        .Times(1)
-        .WillOnce(Return(boost::none));
-
-    EXPECT_CALL(*m_mockViewPtr,
-                userError("Invalid fitted peaks run identifier",
-                          "Could not find a fitted peaks workspace with run "
-                          "number 123 and bank ID 1. Please contact the "
-                          "development team with this message")).Times(1);
-    EXPECT_CALL(*m_mockViewPtr, setFittedPeaksWorkspaceToReturn(testing::_))
-        .Times(0);
-
-    presenter->notify(IEnggDiffMultiRunFittingWidgetPresenter::GetFittedPeaks);
-
+    presenter->getFittedPeaks(123, 1);
     assertMocksUsedCorrectly();
   }
 
-  void test_getFocusedRunValid() {
+  void test_getFocsedRun() {
     auto presenter = setUpPresenter();
 
-    EXPECT_CALL(*m_mockViewPtr, getFocusedRunBankIDToReturn())
-        .Times(1)
-        .WillOnce(Return(1));
-    EXPECT_CALL(*m_mockViewPtr, getFocusedRunNumberToReturn())
-        .Times(1)
-        .WillOnce(Return(123));
+    EXPECT_CALL(*m_mockModelPtr, getFocusedRun(123, 1)).Times(1);
 
-    const API::MatrixWorkspace_sptr ws =
-        API::WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
-
-    EXPECT_CALL(*m_mockModelPtr, getFocusedRun(123, 1))
-        .Times(1)
-        .WillOnce(Return(boost::make_optional<API::MatrixWorkspace_sptr>(ws)));
-    EXPECT_CALL(*m_mockViewPtr, setFocusedRunWorkspaceToReturn(ws));
-    EXPECT_CALL(*m_mockViewPtr, userError(testing::_, testing::_)).Times(0);
-
-    presenter->notify(IEnggDiffMultiRunFittingWidgetPresenter::GetFocusedRun);
-
-    assertMocksUsedCorrectly();
-  }
-
-  void test_getFocusedRunInvalid() {
-    auto presenter = setUpPresenter();
-
-    EXPECT_CALL(*m_mockViewPtr, getFocusedRunBankIDToReturn())
-        .Times(1)
-        .WillOnce(Return(1));
-    EXPECT_CALL(*m_mockViewPtr, getFocusedRunNumberToReturn())
-        .Times(1)
-        .WillOnce(Return(123));
-
-    EXPECT_CALL(*m_mockModelPtr, getFocusedRun(123, 1))
-        .Times(1)
-        .WillOnce(Return(boost::none));
-
-    EXPECT_CALL(*m_mockViewPtr,
-                userError("Invalid focused run identifier",
-                          "Could not find a focused run with run "
-                          "number 123 and bank ID 1. Please contact the "
-                          "development team with this message")).Times(1);
-    EXPECT_CALL(*m_mockViewPtr, setFocusedRunWorkspaceToReturn(testing::_))
-        .Times(0);
-
-    presenter->notify(IEnggDiffMultiRunFittingWidgetPresenter::GetFocusedRun);
-
+    presenter->getFocusedRun(123, 1);
     assertMocksUsedCorrectly();
   }
 
@@ -167,19 +72,17 @@ private:
         testing::NiceMock<MockEnggDiffMultiRunFittingWidgetModel>>();
     m_mockModelPtr = mockModel.get();
 
-    m_mockViewPtr =
-        new testing::NiceMock<MockEnggDiffMultiRunFittingWidgetView>();
+    auto mockView = Mantid::Kernel::make_unique<
+        testing::NiceMock<MockEnggDiffMultiRunFittingWidgetView>>();
+    m_mockViewPtr = mockView.get();
 
     std::unique_ptr<EnggDiffMultiRunFittingWidgetPresenter> pres_uptr(
         new EnggDiffMultiRunFittingWidgetPresenter(std::move(mockModel),
-                                                   m_mockViewPtr));
+                                                   std::move(mockView)));
     return pres_uptr;
   }
 
   void assertMocksUsedCorrectly() {
-    if (m_mockViewPtr) {
-      delete m_mockViewPtr;
-    }
     TSM_ASSERT("View mock not used as expected: some EXPECT_CALL conditions "
                "not satisfied",
                testing::Mock::VerifyAndClearExpectations(m_mockModelPtr));

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
@@ -21,9 +21,10 @@ public:
     const API::MatrixWorkspace_sptr ws =
         API::WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
 
-    EXPECT_CALL(*m_mockModel, addFittedPeaks(123, 1, ws)).Times(1);
+    const RunLabel runLabel(123, 1);
+    EXPECT_CALL(*m_mockModel, addFittedPeaks(runLabel, ws)).Times(1);
 
-    presenter->addFittedPeaks(123, 1, ws);
+    presenter->addFittedPeaks(runLabel, ws);
     assertMocksUsedCorrectly();
   }
 
@@ -32,15 +33,16 @@ public:
     const API::MatrixWorkspace_sptr ws =
         API::WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
 
-    EXPECT_CALL(*m_mockModel, addFocusedRun(123, 1, ws)).Times(1);
+    const RunLabel runLabel(123, 1);
 
-    const std::vector<std::pair<int, size_t>> workspaceLabels(
-        {std::make_pair(123, 1)});
+    EXPECT_CALL(*m_mockModel, addFocusedRun(runLabel, ws)).Times(1);
+
+    const std::vector<RunLabel> workspaceLabels({runLabel});
     EXPECT_CALL(*m_mockModel, getAllWorkspaceLabels())
         .Times(1)
         .WillOnce(Return(workspaceLabels));
 
-    presenter->addFocusedRun(123, 1, ws);
+    presenter->addFocusedRun(runLabel, ws);
     assertMocksUsedCorrectly();
   }
 
@@ -49,35 +51,37 @@ public:
     const API::MatrixWorkspace_sptr ws =
         API::WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
 
-    const std::vector<std::pair<int, size_t>> workspaceLabels(
-        {std::make_pair(123, 1)});
+    const RunLabel runLabel(123, 1);
+    const std::vector<RunLabel> workspaceLabels({runLabel});
     ON_CALL(*m_mockModel, getAllWorkspaceLabels())
         .WillByDefault(Return(workspaceLabels));
     EXPECT_CALL(*m_mockView, updateRunList(workspaceLabels));
 
-    presenter->addFocusedRun(123, 1, ws);
+    presenter->addFocusedRun(runLabel, ws);
     assertMocksUsedCorrectly();
   }
 
   void test_getFittedPeaks() {
     auto presenter = setUpPresenter();
 
-    EXPECT_CALL(*m_mockModel, getFittedPeaks(123, 1))
+    const RunLabel runLabel(123, 1);
+    EXPECT_CALL(*m_mockModel, getFittedPeaks(runLabel))
         .Times(1)
         .WillOnce(Return(boost::none));
 
-    presenter->getFittedPeaks(123, 1);
+    presenter->getFittedPeaks(runLabel);
     assertMocksUsedCorrectly();
   }
 
   void test_getFocusedRun() {
     auto presenter = setUpPresenter();
 
-    EXPECT_CALL(*m_mockModel, getFocusedRun(123, 1))
+    const RunLabel runLabel(123, 1);
+    EXPECT_CALL(*m_mockModel, getFocusedRun(runLabel))
         .Times(1)
         .WillOnce(Return(boost::none));
 
-    presenter->getFocusedRun(123, 1);
+    presenter->getFocusedRun(runLabel);
     assertMocksUsedCorrectly();
   }
 

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
@@ -1,0 +1,40 @@
+#ifndef MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETVIEWMOCK_H_
+#define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETVIEWMOCK_H_
+
+#include "../EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h"
+#include "MantidKernel/WarningSuppressions.h"
+
+#include <gmock/gmock.h>
+
+GCC_DIAG_OFF_SUGGEST_OVERRIDE
+
+class MockEnggDiffMultiRunFittingWidgetView
+    : public MantidQt::CustomInterfaces::IEnggDiffMultiRunFittingWidgetView {
+
+public:
+  MOCK_METHOD3(addFittedPeaks,
+               void(const int runNumber, const size_t bank,
+                    const Mantid::API::MatrixWorkspace_sptr ws));
+
+  MOCK_METHOD3(addFocusedRun, void(const int runNumber, const size_t bank,
+                                   const Mantid::API::MatrixWorkspace_sptr ws));
+
+  MOCK_CONST_METHOD2(getFittedPeaks,
+                     boost::optional<Mantid::API::MatrixWorkspace_sptr>(
+                         const int runNumber, const size_t bank));
+
+  MOCK_CONST_METHOD2(getFocusedRun,
+                     boost::optional<Mantid::API::MatrixWorkspace_sptr>(
+                         const int runNumber, const size_t bank));
+
+  MOCK_CONST_METHOD0(getFocusedWorkspaceToAdd,
+                     Mantid::API::MatrixWorkspace_sptr());
+
+  MOCK_CONST_METHOD0(getFocusedRunBankIDToAdd, size_t());
+
+  MOCK_CONST_METHOD0(getFocusedRunNumberToAdd, int());
+};
+
+GCC_DIAG_ON_SUGGEST_OVERRIDE
+
+#endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETVIEWMOCK_H_

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
@@ -23,6 +23,13 @@ public:
                      boost::optional<Mantid::API::MatrixWorkspace_sptr>(
                          const int runNumber, const size_t bank));
 
+  MOCK_CONST_METHOD0(getFittedPeaksWorkspaceToAdd,
+                     Mantid::API::MatrixWorkspace_sptr());
+
+  MOCK_CONST_METHOD0(getFittedPeaksBankIDToAdd, size_t());
+
+  MOCK_CONST_METHOD0(getFittedPeaksRunNumberToAdd, int());
+
   MOCK_CONST_METHOD2(getFocusedRun,
                      boost::optional<Mantid::API::MatrixWorkspace_sptr>(
                          const int runNumber, const size_t bank));

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
@@ -12,51 +12,8 @@ class MockEnggDiffMultiRunFittingWidgetView
     : public MantidQt::CustomInterfaces::IEnggDiffMultiRunFittingWidgetView {
 
 public:
-  MOCK_METHOD3(addFittedPeaks,
-               void(const int runNumber, const size_t bank,
-                    const Mantid::API::MatrixWorkspace_sptr ws));
-
-  MOCK_METHOD3(addFocusedRun, void(const int runNumber, const size_t bank,
-                                   const Mantid::API::MatrixWorkspace_sptr ws));
-
-  MOCK_CONST_METHOD2(getFittedPeaks,
-                     boost::optional<Mantid::API::MatrixWorkspace_sptr>(
-                         const int runNumber, const size_t bank));
-
-  MOCK_CONST_METHOD0(getFittedPeaksWorkspaceToAdd,
-                     Mantid::API::MatrixWorkspace_sptr());
-
-  MOCK_CONST_METHOD0(getFittedPeaksBankIDToAdd, size_t());
-
-  MOCK_CONST_METHOD0(getFittedPeaksBankIDToReturn, size_t());
-
-  MOCK_CONST_METHOD0(getFittedPeaksRunNumberToAdd, int());
-
-  MOCK_CONST_METHOD0(getFittedPeaksRunNumberToReturn, int());
-
-  MOCK_CONST_METHOD2(getFocusedRun,
-                     boost::optional<Mantid::API::MatrixWorkspace_sptr>(
-                         const int runNumber, const size_t bank));
-
-  MOCK_CONST_METHOD0(getFocusedWorkspaceToAdd,
-                     Mantid::API::MatrixWorkspace_sptr());
-
-  MOCK_CONST_METHOD0(getFocusedRunBankIDToAdd, size_t());
-
-  MOCK_CONST_METHOD0(getFocusedRunBankIDToReturn, size_t());
-
-  MOCK_CONST_METHOD0(getFocusedRunNumberToAdd, int());
-
-  MOCK_CONST_METHOD0(getFocusedRunNumberToReturn, int());
-
-  MOCK_METHOD1(setFittedPeaksWorkspaceToReturn,
-               void(const Mantid::API::MatrixWorkspace_sptr ws));
-
-  MOCK_METHOD1(setFocusedRunWorkspaceToReturn,
-               void(const Mantid::API::MatrixWorkspace_sptr ws));
-
-  MOCK_METHOD2(userError, void(const std::string &errorTitle,
-                               const std::string &errorDescription));
+  MOCK_METHOD1(updateRunList,
+               void(const std::vector<std::pair<int, size_t>> &runLabels));
 };
 
 GCC_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
@@ -28,7 +28,11 @@ public:
 
   MOCK_CONST_METHOD0(getFittedPeaksBankIDToAdd, size_t());
 
+  MOCK_CONST_METHOD0(getFittedPeaksBankIDToReturn, size_t());
+
   MOCK_CONST_METHOD0(getFittedPeaksRunNumberToAdd, int());
+
+  MOCK_CONST_METHOD0(getFittedPeaksRunNumberToReturn, int());
 
   MOCK_CONST_METHOD2(getFocusedRun,
                      boost::optional<Mantid::API::MatrixWorkspace_sptr>(
@@ -40,6 +44,12 @@ public:
   MOCK_CONST_METHOD0(getFocusedRunBankIDToAdd, size_t());
 
   MOCK_CONST_METHOD0(getFocusedRunNumberToAdd, int());
+
+  MOCK_METHOD1(setFittedPeaksWorkspaceToReturn,
+               void(const Mantid::API::MatrixWorkspace_sptr ws));
+
+  MOCK_METHOD2(userError, void(const std::string &errorTitle,
+                               const std::string &errorDescription));
 };
 
 GCC_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
@@ -6,14 +6,15 @@
 
 #include <gmock/gmock.h>
 
+using namespace MantidQt::CustomInterfaces;
+
 GCC_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockEnggDiffMultiRunFittingWidgetView
-    : public MantidQt::CustomInterfaces::IEnggDiffMultiRunFittingWidgetView {
+    : public IEnggDiffMultiRunFittingWidgetView {
 
 public:
-  MOCK_METHOD1(updateRunList,
-               void(const std::vector<std::pair<int, size_t>> &runLabels));
+  MOCK_METHOD1(updateRunList, void(const std::vector<RunLabel> &runLabels));
 };
 
 GCC_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
@@ -43,9 +43,16 @@ public:
 
   MOCK_CONST_METHOD0(getFocusedRunBankIDToAdd, size_t());
 
+  MOCK_CONST_METHOD0(getFocusedRunBankIDToReturn, size_t());
+
   MOCK_CONST_METHOD0(getFocusedRunNumberToAdd, int());
 
+  MOCK_CONST_METHOD0(getFocusedRunNumberToReturn, int());
+
   MOCK_METHOD1(setFittedPeaksWorkspaceToReturn,
+               void(const Mantid::API::MatrixWorkspace_sptr ws));
+
+  MOCK_METHOD1(setFocusedRunWorkspaceToReturn,
                void(const Mantid::API::MatrixWorkspace_sptr ws));
 
   MOCK_METHOD2(userError, void(const std::string &errorTitle,

--- a/qt/scientific_interfaces/test/RunMapTest.h
+++ b/qt/scientific_interfaces/test/RunMapTest.h
@@ -50,7 +50,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(runMap.remove(polly));
     TS_ASSERT(!runMap.contains(polly));
 
-    const RunLabel invalid(456, 2);
+    const RunLabel invalid(123, 4);
     TS_ASSERT_THROWS(runMap.remove(invalid), std::invalid_argument);
   }
 

--- a/qt/scientific_interfaces/test/RunMapTest.h
+++ b/qt/scientific_interfaces/test/RunMapTest.h
@@ -12,51 +12,71 @@ class RunMapTest : public CxxTest::TestSuite {
 public:
   void test_addedItemsExistInMap() {
     RunMap<3, std::string> runMap;
-    TS_ASSERT_THROWS_NOTHING(runMap.add(123, 1, "Polly"));
-    TS_ASSERT_THROWS_NOTHING(runMap.add(456, 2, "Morphism"));
-    TS_ASSERT_THROWS(runMap.add(789, 4, "Al"), std::invalid_argument);
 
-    TS_ASSERT(runMap.contains(123, 1));
-    TS_ASSERT(runMap.contains(456, 2));
-    TS_ASSERT(!runMap.contains(789, 4));
+    const RunLabel polly(123, 1);
+    TS_ASSERT_THROWS_NOTHING(runMap.add(polly, "Polly"));
+
+    const RunLabel morphism(456, 2);
+    TS_ASSERT_THROWS_NOTHING(runMap.add(morphism, "Morphism"));
+
+    const RunLabel al(789, 4);
+    TS_ASSERT_THROWS(runMap.add(al, "Al"), std::invalid_argument);
+
+    TS_ASSERT(runMap.contains(polly));
+    TS_ASSERT(runMap.contains(morphism));
+    TS_ASSERT(!runMap.contains(al));
   }
 
   void test_addedItemsAreCorrect() {
     RunMap<3, std::string> runMap;
-    runMap.add(123, 1, "Polly");
-    runMap.add(456, 2, "Morphism");
 
-    TS_ASSERT_EQUALS(runMap.get(123, 1), "Polly");
-    TS_ASSERT_EQUALS(runMap.get(456, 2), "Morphism");
+    const RunLabel polly(123, 1);
+    runMap.add(polly, "Polly");
+
+    const RunLabel morphism(456, 2);
+    runMap.add(morphism, "Morphism");
+
+    TS_ASSERT_EQUALS(runMap.get(polly), "Polly");
+    TS_ASSERT_EQUALS(runMap.get(morphism), "Morphism");
   }
 
   void test_remove() {
     RunMap<3, std::string> runMap;
 
-    runMap.add(123, 1, "Polly");
-    TS_ASSERT(runMap.contains(123, 1));
+    const RunLabel polly(123, 1);
+    runMap.add(polly, "Polly");
+    TS_ASSERT(runMap.contains(polly));
 
-    TS_ASSERT_THROWS_NOTHING(runMap.remove(123, 1));
-    TS_ASSERT(!runMap.contains(123, 1));
+    TS_ASSERT_THROWS_NOTHING(runMap.remove(polly));
+    TS_ASSERT(!runMap.contains(polly));
 
-    TS_ASSERT_THROWS(runMap.remove(123, 4), std::invalid_argument);
+    const RunLabel invalid(456, 2);
+    TS_ASSERT_THROWS(runMap.remove(invalid), std::invalid_argument);
   }
 
-  void test_getRunNumbersAndBankIDs() {
+  void test_getRunLabels() {
     RunMap<3, std::string> runMap;
 
-    runMap.add(111, 1, "Polly");
-    runMap.add(222, 2, "Morphism");
-    runMap.add(333, 3, "Al");
-    runMap.add(444, 1, "Gorithm");
+    const RunLabel polly(111, 1);
+    runMap.add(polly, "Polly");
 
-    std::vector<std::pair<int, size_t>> runBankPairs;
-    TS_ASSERT_THROWS_NOTHING(runBankPairs = runMap.getRunNumbersAndBankIDs());
+    const RunLabel morphism(222, 2);
+    runMap.add(morphism, "Morphism");
 
-    TS_ASSERT_EQUALS(runBankPairs.size(), 4);
+    const RunLabel al(333, 3);
+    runMap.add(al, "Al");
+
+    const RunLabel gorithm(444, 1);
+    runMap.add(gorithm, "Gorithm");
+
+    const std::vector<RunLabel> runLabels({polly, morphism, al, gorithm});
+
+    std::vector<RunLabel> retrievedRunLabels;
+    TS_ASSERT_THROWS_NOTHING(retrievedRunLabels = runMap.getRunLabels());
+
+    TS_ASSERT_EQUALS(retrievedRunLabels.size(), 4);
     for (int i = 0; i < 4; ++i) {
-      TS_ASSERT_EQUALS(runBankPairs[i],
-                       std::make_pair((i + 1) * 111, size_t(i % 3 + 1)));
+      TS_ASSERT_EQUALS(runLabels[i], retrievedRunLabels[i]);
     }
   }
 
@@ -64,12 +84,12 @@ public:
     RunMap<3, std::string> runMap;
     TS_ASSERT_EQUALS(runMap.size(), 0);
 
-    runMap.add(111, 1, "Polly");
-    runMap.add(222, 2, "Morphism");
+    runMap.add(RunLabel(111, 1), "Polly");
+    runMap.add(RunLabel(222, 2), "Morphism");
     TS_ASSERT_EQUALS(runMap.size(), 2);
 
-    runMap.add(333, 3, "Al");
-    runMap.add(444, 1, "Gorithm");
+    runMap.add(RunLabel(333, 3), "Al");
+    runMap.add(RunLabel(444, 1), "Gorithm");
     TS_ASSERT_EQUALS(runMap.size(), 4);
   }
 };


### PR DESCRIPTION
Basic functionality was implemented for a new widget to be used in the ED GUI. This will extract the shared behaviour of selecting runs from a list widget, plotting them, and overplotting their fit results. 

The ability to add workspaces to the widget and get them out again was implemented in the presenter, but nowhere else.

This PR doesn't make any attempt to replace any existing behaviour - it's just putting in place the beginnings of the code to do so.

In addition, all instances of `std::pair<int, size_t>` were replaced with a new class `RunLabel`, which makes for much cleaner code

**To test:**

Code review, make sure `EnggDiffMultiRunFittingWidgetPresenterTest` (what a mouthful) passes locally

Partially address #21640 

**Release Notes** 
Internal change, doesn't need to be in the release notes

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
