### PR TITLE
Add matplotlib and numpy to workbench user startup code

### DIFF
--- a/qt/applications/workbench/workbench/plugins/editor.py
+++ b/qt/applications/workbench/workbench/plugins/editor.py
@@ -35,7 +35,9 @@ from __future__ import (absolute_import, division, print_function, unicode_liter
 
 # import mantid algorithms, numpy and matplotlib
 from mantid.simpleapi import *
+
 import matplotlib.pyplot as plt
+
 import numpy as np
 """
 

--- a/qt/applications/workbench/workbench/plugins/editor.py
+++ b/qt/applications/workbench/workbench/plugins/editor.py
@@ -33,8 +33,10 @@ DEFAULT_CONTENT = """# The following line helps with future compatibility with P
 # print must now be used as a function, e.g print('Hello','World')
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
-# Import all mantid algorithms
+# import mantid algorithms, numpy and matplotlib
 from mantid.simpleapi import *
+import matplotlib.pyplot as plt
+import numpy as np
 """
 
 

--- a/qt/applications/workbench/workbench/plugins/jupyterconsole.py
+++ b/qt/applications/workbench/workbench/plugins/jupyterconsole.py
@@ -17,18 +17,36 @@
 from __future__ import (absolute_import, unicode_literals)
 
 # system imports
+import sys
 
 # third-party library imports
 from mantidqt.widgets.jupyterconsole import InProcessJupyterConsole
+from IPython.core.usage import quick_guide, release as ipy_release
+from matplotlib import __version__ as mpl_version
+from numpy.version import version as np_version
 from qtpy.QtWidgets import QVBoxLayout
 
 # local package imports
 from workbench.plugins.base import PluginWidget
 
+DEFAULT_BANNER_PARTS = [
+    'Python {}, numpy {}, matplotlib {}\n'.format(sys.version.split('\n')[0].strip(), np_version, mpl_version),
+    'Type "copyright", "credits" or "license" for more information.\n\n',
+    'IPython {version} -- An enhanced Interactive Python.\n'.format(
+        version=ipy_release.version,
+        ),
+    quick_guide
+]
+
+BANNER = ''.join(DEFAULT_BANNER_PARTS)
+
 # should we share this with plugins.editor?
 STARTUP_CODE = """from __future__ import (absolute_import, division, print_function, unicode_literals)
+
 from mantid.simpleapi import *
+
 import matplotlib.pyplot as plt
+
 import numpy as np
 """
 
@@ -40,7 +58,8 @@ class JupyterConsole(PluginWidget):
         super(JupyterConsole, self).__init__(parent)
 
         # layout
-        self.console = InProcessJupyterConsole(self, startup_code=STARTUP_CODE)
+        self.console = InProcessJupyterConsole(self, banner=BANNER,
+                                               startup_code=STARTUP_CODE)
         layout = QVBoxLayout()
         layout.addWidget(self.console)
         self.setLayout(layout)

--- a/qt/applications/workbench/workbench/plugins/jupyterconsole.py
+++ b/qt/applications/workbench/workbench/plugins/jupyterconsole.py
@@ -25,6 +25,13 @@ from qtpy.QtWidgets import QVBoxLayout
 # local package imports
 from workbench.plugins.base import PluginWidget
 
+# should we share this with plugins.editor?
+STARTUP_CODE = """from __future__ import (absolute_import, division, print_function, unicode_literals)
+from mantid.simpleapi import *
+import matplotlib.pyplot as plt
+import numpy as np
+"""
+
 
 class JupyterConsole(PluginWidget):
     """Provides an in-process Jupyter Qt-based console"""
@@ -33,7 +40,7 @@ class JupyterConsole(PluginWidget):
         super(JupyterConsole, self).__init__(parent)
 
         # layout
-        self.console = InProcessJupyterConsole(self)
+        self.console = InProcessJupyterConsole(self, startup_code=STARTUP_CODE)
         layout = QVBoxLayout()
         layout.addWidget(self.console)
         self.setLayout(layout)

--- a/qt/applications/workbench/workbench/plugins/jupyterconsole.py
+++ b/qt/applications/workbench/workbench/plugins/jupyterconsole.py
@@ -30,23 +30,20 @@ from qtpy.QtWidgets import QVBoxLayout
 from workbench.plugins.base import PluginWidget
 
 DEFAULT_BANNER_PARTS = [
-    'Python {}, numpy {}, matplotlib {}\n'.format(sys.version.split('\n')[0].strip(), np_version, mpl_version),
-    'Type "copyright", "credits" or "license" for more information.\n\n',
     'IPython {version} -- An enhanced Interactive Python.\n'.format(
         version=ipy_release.version,
         ),
-    quick_guide
+    quick_guide,
+    '\nPython {}, numpy {}, matplotlib {}\n'.format(sys.version.split('\n')[0].strip(), np_version, mpl_version),
+    'Type "copyright", "credits" or "license" for more information.\n',
 ]
 
 BANNER = ''.join(DEFAULT_BANNER_PARTS)
 
 # should we share this with plugins.editor?
 STARTUP_CODE = """from __future__ import (absolute_import, division, print_function, unicode_literals)
-
 from mantid.simpleapi import *
-
 import matplotlib.pyplot as plt
-
 import numpy as np
 """
 

--- a/qt/python/mantidqt/widgets/codeeditor/execution.py
+++ b/qt/python/mantidqt/widgets/codeeditor/execution.py
@@ -107,7 +107,7 @@ class PythonCodeExecution(QObject):
     sig_exec_error = Signal(object)
     sig_exec_progress = Signal(int)
 
-    def __init__(self):
+    def __init__(self, startup_code=None):
         """Initialize the object"""
         super(PythonCodeExecution, self).__init__()
 
@@ -115,6 +115,9 @@ class PythonCodeExecution(QObject):
         self._task = None
 
         self.reset_context()
+
+        if startup_code:
+            self.execute(startup_code)
 
     @property
     def globals_ns(self):

--- a/qt/python/mantidqt/widgets/codeeditor/interpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/interpreter.py
@@ -115,7 +115,7 @@ class PythonFileInterpreter(QWidget):
         self._setup_editor(content, filename)
 
         self._presenter = PythonFileInterpreterPresenter(self,
-                                                         PythonCodeExecution())
+                                                         PythonCodeExecution(content))
 
         self.editor.modificationChanged.connect(self.sig_editor_modified)
         self.editor.fileNameChanged.connect(self.sig_filename_modified)
@@ -190,6 +190,9 @@ class PythonFileInterpreterPresenter(QObject):
         self._code_start_offset = 0
         self._is_executing = False
         self._error_formatter = ErrorFormatter()
+
+        # If startup code was executed then populate autocomplete
+        self.view.editor.updateCompletionAPI(self.model.generate_calltips())
 
         # connect signals
         self.model.sig_exec_success.connect(self._on_exec_success)

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_execution.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_execution.py
@@ -65,6 +65,10 @@ class PythonCodeExecutionTest(unittest.TestCase):
         executor.reset_context()
         self.assertEqual(0, len(executor.globals_ns))
 
+    def test_startup_code_executed_by_default(self):
+        executor = PythonCodeExecution(startup_code="x=100")
+        self.assertEqual(100, executor.globals_ns['x'])
+
     # ---------------------------------------------------------------------------
     # Successful execution tests
     # ---------------------------------------------------------------------------

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_interpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_interpreter.py
@@ -47,8 +47,8 @@ class PythonFileInterpreterTest(unittest.TestCase):
         self.assertTrue("Status: Idle", w.status.currentMessage())
 
     def test_constructor_populates_editor_with_content(self):
-        w = PythonFileInterpreter(content='my funky code')
-        self.assertEqual('my funky code', w.editor.text())
+        w = PythonFileInterpreter(content='# my funky code')
+        self.assertEqual('# my funky code', w.editor.text())
 
     def test_constructor_respects_filename(self):
         w = PythonFileInterpreter(filename='test.py')

--- a/qt/python/mantidqt/widgets/jupyterconsole.py
+++ b/qt/python/mantidqt/widgets/jupyterconsole.py
@@ -44,18 +44,29 @@ class InProcessJupyterConsole(RichJupyterWidget):
         :param args: Positional arguments passed directly to RichJupyterWidget
         :param kwargs: Keyword arguments. The following keywords are understood by this widget:
 
+          - banner: Replace the default banner with this text
           - startup_code: A code snippet to run on startup. It is also added to the banner to inform the user.
 
         the rest are passed to RichJupyterWidget
         """
+        banner = kwargs.pop("banner", "")
         startup_code = kwargs.pop("startup_code", "")
         super(InProcessJupyterConsole, self).__init__(*args, **kwargs)
 
         # adjust startup banner accordingly
+        # newer ipython has banner1 & banner2 and not just banner
+        two_ptr_banner = hasattr(self, 'banner1')
+        if not banner:
+            banner = self.banner1 if two_ptr_banner else self.banner
         if startup_code:
-            self.banner += "\n" + \
-                "The following code has been executed at startup:\n" + \
+            banner += "\n" + \
+                "The following code has been executed at startup:\n\n" + \
                 startup_code
+        if two_ptr_banner:
+            self.banner1 = banner
+            self.banner2 = ''
+        else:
+            self.banner = banner
 
         # create an in-process kernel
         kernel_manager = QtInProcessKernelManager()

--- a/qt/python/mantidqt/widgets/test/test_jupyterconsole.py
+++ b/qt/python/mantidqt/widgets/test/test_jupyterconsole.py
@@ -35,6 +35,11 @@ class InProcessJupyterConsoleTest(unittest.TestCase):
         self.assertTrue(hasattr(widget, "kernel_client"))
         self.assertTrue(len(widget.banner) > 0)
 
+    def test_construction_with_startup_code_adds_to_banner_and_executes(self):
+        widget = InProcessJupyterConsole(startup_code="x = 1")
+        self.assertTrue("x = 1" in widget.banner)
+        self.assertEquals(1, widget.kernel_manager.kernel.shell.user_ns['x'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/qt/python/mantidqt/widgets/test/test_jupyterconsole.py
+++ b/qt/python/mantidqt/widgets/test/test_jupyterconsole.py
@@ -35,6 +35,10 @@ class InProcessJupyterConsoleTest(unittest.TestCase):
         self.assertTrue(hasattr(widget, "kernel_client"))
         self.assertTrue(len(widget.banner) > 0)
 
+    def test_construction_with_banner_replaces_default(self):
+        widget = InProcessJupyterConsole(banner="Hello!")
+        self.assertEquals("Hello!", widget.banner)
+
     def test_construction_with_startup_code_adds_to_banner_and_executes(self):
         widget = InProcessJupyterConsole(startup_code="x = 1")
         self.assertTrue("x = 1" in widget.banner)


### PR DESCRIPTION
Description of work.

Adds import of `matplotlib` and `numpy` to workbench editor and IPython by default. 

**To test:**

* start workbench
* see that `matplotlib` and `numpy` are in the editor
* without executing type `Lo` and see that autocompletion now pops up
* Check the IPython console for the same import code.

*No issue*

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
