### PR TITLE
Engineering Diffraction GUI implement skeleton model and view for multi-run widget

### DIFF
--- a/qt/scientific_interfaces/CMakeLists.txt
+++ b/qt/scientific_interfaces/CMakeLists.txt
@@ -32,6 +32,7 @@ set ( TEST_FILES
   test/ALCPeakFittingPresenterTest.h
   test/EnggDiffGSASFittingModelTest.h
   test/EnggDiffGSASFittingPresenterTest.h
+  test/EnggDiffMultiRunFittingWidgetPresenterTest.h
   test/EnggDiffFittingModelTest.h
   test/EnggDiffFittingPresenterTest.h
   test/EnggDiffractionPresenterTest.h

--- a/qt/scientific_interfaces/CMakeLists.txt
+++ b/qt/scientific_interfaces/CMakeLists.txt
@@ -32,6 +32,7 @@ set ( TEST_FILES
   test/ALCPeakFittingPresenterTest.h
   test/EnggDiffGSASFittingModelTest.h
   test/EnggDiffGSASFittingPresenterTest.h
+  test/EnggDiffMultiRunFittingWidgetModelTest.h
   test/EnggDiffMultiRunFittingWidgetPresenterTest.h
   test/EnggDiffFittingModelTest.h
   test/EnggDiffFittingPresenterTest.h

--- a/qt/scientific_interfaces/EnggDiffraction/CMakeLists.txt
+++ b/qt/scientific_interfaces/EnggDiffraction/CMakeLists.txt
@@ -45,6 +45,7 @@ set ( MOC_FILES
     EnggDiffFittingPresenter.h
     EnggDiffFittingPresWorker.h
     EnggDiffFittingViewQtWidget.h
+    EnggDiffMultiRunFittingViewQtWidget.h
     EnggDiffractionPresenter.h
     EnggDiffractionPresWorker.h
     EnggDiffractionViewQtGUI.h

--- a/qt/scientific_interfaces/EnggDiffraction/CMakeLists.txt
+++ b/qt/scientific_interfaces/EnggDiffraction/CMakeLists.txt
@@ -4,6 +4,7 @@ set ( SRC_FILES
 	EnggDiffFittingViewQtWidget.cpp
 	EnggDiffGSASFittingModel.cpp
 	EnggDiffGSASFittingPresenter.cpp
+	EnggDiffMultiRunFittingWidgetPresenter.cpp
 	EnggDiffractionPresenter.cpp
 	EnggDiffractionViewQtGUI.cpp
 )
@@ -19,6 +20,7 @@ set ( INC_FILES
 	EnggDiffGSASFittingModel.h
 	EnggDiffGSASFittingPresenter.h
 	EnggDiffGSASRefinementMethod.h
+	EnggDiffMultiRunFittingWidgetPresenter.h
 	EnggDiffractionPresWorker.h
 	EnggDiffractionPresenter.h
 	EnggDiffractionViewQtGUI.h
@@ -27,6 +29,9 @@ set ( INC_FILES
 	IEnggDiffGSASFittingModel.h
 	IEnggDiffGSASFittingPresenter.h
 	IEnggDiffGSASFittingView.h
+	IEnggDiffMultiRunFittingWidgetModel.h
+	IEnggDiffMultiRunFittingWidgetPresenter.h
+	IEnggDiffMultiRunFittingWidgetView.h
 	IEnggDiffractionPresenter.h
 	IEnggDiffractionView.h
 	RunMap.h

--- a/qt/scientific_interfaces/EnggDiffraction/CMakeLists.txt
+++ b/qt/scientific_interfaces/EnggDiffraction/CMakeLists.txt
@@ -49,6 +49,7 @@ set ( MOC_FILES
 )
 
 set ( UI_FILES
+   EnggDiffMultiRunFittingQtWidget.ui
    EnggDiffractionQtGUI.ui
    EnggDiffractionQtTabCalib.ui
    EnggDiffractionQtTabFocus.ui

--- a/qt/scientific_interfaces/EnggDiffraction/CMakeLists.txt
+++ b/qt/scientific_interfaces/EnggDiffraction/CMakeLists.txt
@@ -5,6 +5,7 @@ set ( SRC_FILES
 	EnggDiffGSASFittingModel.cpp
 	EnggDiffGSASFittingPresenter.cpp
 	EnggDiffMultiRunFittingWidgetModel.cpp
+	EnggDiffMultiRunFittingViewQtWidget.cpp
 	EnggDiffMultiRunFittingWidgetPresenter.cpp
 	EnggDiffractionPresenter.cpp
 	EnggDiffractionViewQtGUI.cpp
@@ -22,6 +23,7 @@ set ( INC_FILES
 	EnggDiffGSASFittingPresenter.h
 	EnggDiffGSASRefinementMethod.h
 	EnggDiffMultiRunFittingWidgetModel.h
+	EnggDiffMultiRunFittingViewQtWidget.h
 	EnggDiffMultiRunFittingWidgetPresenter.h
 	EnggDiffractionPresWorker.h
 	EnggDiffractionPresenter.h

--- a/qt/scientific_interfaces/EnggDiffraction/CMakeLists.txt
+++ b/qt/scientific_interfaces/EnggDiffraction/CMakeLists.txt
@@ -4,6 +4,7 @@ set ( SRC_FILES
 	EnggDiffFittingViewQtWidget.cpp
 	EnggDiffGSASFittingModel.cpp
 	EnggDiffGSASFittingPresenter.cpp
+	EnggDiffMultiRunFittingWidgetModel.cpp
 	EnggDiffMultiRunFittingWidgetPresenter.cpp
 	EnggDiffractionPresenter.cpp
 	EnggDiffractionViewQtGUI.cpp
@@ -20,6 +21,7 @@ set ( INC_FILES
 	EnggDiffGSASFittingModel.h
 	EnggDiffGSASFittingPresenter.h
 	EnggDiffGSASRefinementMethod.h
+	EnggDiffMultiRunFittingWidgetModel.h
 	EnggDiffMultiRunFittingWidgetPresenter.h
 	EnggDiffractionPresWorker.h
 	EnggDiffractionPresenter.h

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingQtWidget.ui
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingQtWidget.ui
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>EnggDiffMultiRunFittingWidget</class>
+ <widget class="QWidget" name="EnggDiffMultiRunFittingWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>499</width>
+    <height>453</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="1">
+    <widget class="QLabel" name="label_runLabels">
+     <property name="text">
+      <string>Run Number</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QwtPlot" name="plotArea">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>4</horstretch>
+       <verstretch>2</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="sizeIncrement">
+      <size>
+       <width>2</width>
+       <height>2</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QListWidget" name="listWidget_runLabels">
+     <property name="minimumSize">
+      <size>
+       <width>75</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>75</width>
+       <height>16777215</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QPushButton" name="pushButton_removeRun">
+     <property name="text">
+      <string>Remove Run</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_plotControls">
+     <item>
+      <widget class="QPushButton" name="pushButton_plotToSeparateWindow">
+       <property name="text">
+        <string>Plot To Separate Window</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="checkBox_plotFittedPeaks">
+       <property name="text">
+        <string>Plot Fitted Peaks</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QwtPlot</class>
+   <extends>QFrame</extends>
+   <header>qwt_plot.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingViewQtWidget.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingViewQtWidget.cpp
@@ -1,0 +1,113 @@
+#include "EnggDiffMultiRunFittingViewQtWidget.h"
+#include "EnggDiffMultiRunFittingWidgetModel.h"
+#include "EnggDiffMultiRunFittingWidgetPresenter.h"
+
+#include "MantidKernel/make_unique.h"
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+EnggDiffMultiRunFittingViewQtWidget::EnggDiffMultiRunFittingViewQtWidget() {
+  m_ui.setupUi(this);
+
+  auto model =
+      Mantid::Kernel::make_unique<EnggDiffMultiRunFittingWidgetModel>();
+  m_presenter =
+      Mantid::Kernel::make_unique<EnggDiffMultiRunFittingWidgetPresenter>(
+          std::move(model), this);
+  m_presenter->notify(IEnggDiffMultiRunFittingWidgetPresenter::Start);
+}
+
+void EnggDiffMultiRunFittingViewQtWidget::addFittedPeaks(
+    const int runNumber, const size_t bank,
+    const Mantid::API::MatrixWorkspace_sptr ws) {
+  m_fittedPeaksRunNumberToAdd = runNumber;
+  m_fittedPeaksBankIDToAdd = bank;
+  m_fittedPeaksWorkspaceToAdd = ws;
+  m_presenter->notify(IEnggDiffMultiRunFittingWidgetPresenter::AddFittedPeaks);
+}
+
+void EnggDiffMultiRunFittingViewQtWidget::addFocusedRun(
+    const int runNumber, const size_t bank,
+    const Mantid::API::MatrixWorkspace_sptr ws) {
+  m_focusedRunBankIDToAdd = bank;
+  m_focusedRunNumberToAdd = runNumber;
+  m_focusedWorkspaceToAdd = ws;
+  m_presenter->notify(IEnggDiffMultiRunFittingWidgetPresenter::AddFocusedRun);
+}
+
+boost::optional<Mantid::API::MatrixWorkspace_sptr>
+EnggDiffMultiRunFittingViewQtWidget::getFittedPeaks(const int runNumber,
+                                                    const size_t bank) const {
+  m_fittedPeaksBankIDToReturn = bank;
+  m_fittedPeaksRunNumberToReturn = runNumber;
+  m_presenter->notify(IEnggDiffMultiRunFittingWidgetPresenter::GetFittedPeaks);
+  return m_fittedPeaksWorkspaceToReturn;
+}
+
+Mantid::API::MatrixWorkspace_sptr
+EnggDiffMultiRunFittingViewQtWidget::getFittedPeaksWorkspaceToAdd() const {
+  return m_fittedPeaksWorkspaceToAdd;
+}
+
+size_t EnggDiffMultiRunFittingViewQtWidget::getFittedPeaksBankIDToAdd() const {
+  return m_fittedPeaksBankIDToAdd;
+}
+
+int EnggDiffMultiRunFittingViewQtWidget::getFittedPeaksRunNumberToAdd() const {
+  return m_fittedPeaksRunNumberToAdd;
+}
+
+size_t
+EnggDiffMultiRunFittingViewQtWidget::getFittedPeaksBankIDToReturn() const {
+  return m_fittedPeaksBankIDToReturn;
+}
+
+int EnggDiffMultiRunFittingViewQtWidget::getFittedPeaksRunNumberToReturn()
+    const {
+  return m_fittedPeaksRunNumberToReturn;
+}
+
+boost::optional<Mantid::API::MatrixWorkspace_sptr>
+EnggDiffMultiRunFittingViewQtWidget::getFocusedRun(const int runNumber,
+                                                   const size_t bank) const {
+  m_focusedRunNumberToReturn = runNumber;
+  m_focusedRunBankIDToReturn = bank;
+  m_presenter->notify(IEnggDiffMultiRunFittingWidgetPresenter::GetFocusedRun);
+  return m_focusedWorkspaceToReturn;
+}
+
+Mantid::API::MatrixWorkspace_sptr
+EnggDiffMultiRunFittingViewQtWidget::getFocusedWorkspaceToAdd() const {
+  return m_focusedWorkspaceToAdd;
+}
+
+size_t EnggDiffMultiRunFittingViewQtWidget::getFocusedRunBankIDToAdd() const {
+  return m_focusedRunBankIDToAdd;
+}
+
+size_t
+EnggDiffMultiRunFittingViewQtWidget::getFocusedRunBankIDToReturn() const {
+  return m_focusedRunBankIDToReturn;
+}
+
+int EnggDiffMultiRunFittingViewQtWidget::getFocusedRunNumberToAdd() const {
+  return m_focusedRunNumberToAdd;
+}
+
+int EnggDiffMultiRunFittingViewQtWidget::getFocusedRunNumberToReturn() const {
+  return m_focusedRunNumberToReturn;
+}
+
+void EnggDiffMultiRunFittingViewQtWidget::setFittedPeaksWorkspaceToReturn(
+    const Mantid::API::MatrixWorkspace_sptr ws) {
+  m_fittedPeaksWorkspaceToReturn = ws;
+}
+
+void EnggDiffMultiRunFittingViewQtWidget::setFocusedRunWorkspaceToReturn(
+    const Mantid::API::MatrixWorkspace_sptr ws) {
+  m_focusedWorkspaceToReturn = ws;
+}
+
+} // CustomInterfaces
+} // MantidQt

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingViewQtWidget.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingViewQtWidget.cpp
@@ -111,6 +111,16 @@ void EnggDiffMultiRunFittingViewQtWidget::setFocusedRunWorkspaceToReturn(
   m_focusedWorkspaceToReturn = ws;
 }
 
+void EnggDiffMultiRunFittingViewQtWidget::updateRunList(
+    const std::vector<std::pair<int, size_t>> &runLabels) {
+  m_ui.listWidget_runLabels->clear();
+  for (const auto &runLabel : runLabels) {
+    const auto labelStr = QString::number(runLabel.first) + tr("_") +
+                          QString::number(runLabel.second);
+    m_ui.listWidget_runLabels->addItem(labelStr);
+  }
+}
+
 void EnggDiffMultiRunFittingViewQtWidget::userError(
     const std::string &errorTitle, const std::string &errorDescription) {
   m_userMessageProvider->userError(errorTitle, errorDescription);

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingViewQtWidget.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingViewQtWidget.cpp
@@ -7,7 +7,9 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 
-EnggDiffMultiRunFittingViewQtWidget::EnggDiffMultiRunFittingViewQtWidget() {
+EnggDiffMultiRunFittingViewQtWidget::EnggDiffMultiRunFittingViewQtWidget(
+    boost::shared_ptr<IEnggDiffractionUserMsg> userMessageProvider)
+    : m_userMessageProvider(userMessageProvider) {
   m_ui.setupUi(this);
 
   auto model =
@@ -107,6 +109,11 @@ void EnggDiffMultiRunFittingViewQtWidget::setFittedPeaksWorkspaceToReturn(
 void EnggDiffMultiRunFittingViewQtWidget::setFocusedRunWorkspaceToReturn(
     const Mantid::API::MatrixWorkspace_sptr ws) {
   m_focusedWorkspaceToReturn = ws;
+}
+
+void EnggDiffMultiRunFittingViewQtWidget::userError(
+    const std::string &errorTitle, const std::string &errorDescription) {
+  m_userMessageProvider->userError(errorTitle, errorDescription);
 }
 
 } // CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingViewQtWidget.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingViewQtWidget.h
@@ -4,6 +4,7 @@
 #include "DllConfig.h"
 #include "IEnggDiffMultiRunFittingWidgetPresenter.h"
 #include "IEnggDiffMultiRunFittingWidgetView.h"
+#include "IEnggDiffractionUserMsg.h"
 #include "ui_EnggDiffMultiRunFittingQtWidget.h"
 
 namespace MantidQt {
@@ -15,7 +16,8 @@ class MANTIDQT_ENGGDIFFRACTION_DLL EnggDiffMultiRunFittingViewQtWidget
   Q_OBJECT
 
 public:
-  EnggDiffMultiRunFittingViewQtWidget();
+  EnggDiffMultiRunFittingViewQtWidget(
+      boost::shared_ptr<IEnggDiffractionUserMsg> userMessageProvider);
 
   void addFittedPeaks(const int runNumber, const size_t bank,
                       const Mantid::API::MatrixWorkspace_sptr ws) override;
@@ -80,15 +82,16 @@ private:
   int m_focusedRunNumberToAdd;
 
   mutable int m_focusedRunNumberToReturn;
-  
+
   Mantid::API::MatrixWorkspace_sptr m_focusedWorkspaceToAdd;
 
-  boost::optional<Mantid::API::MatrixWorkspace_sptr>
-      m_focusedWorkspaceToReturn;
+  boost::optional<Mantid::API::MatrixWorkspace_sptr> m_focusedWorkspaceToReturn;
 
   std::unique_ptr<IEnggDiffMultiRunFittingWidgetPresenter> m_presenter;
 
   Ui::EnggDiffMultiRunFittingWidget m_ui;
+
+  boost::shared_ptr<IEnggDiffractionUserMsg> m_userMessageProvider;
 };
 
 } // CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingViewQtWidget.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingViewQtWidget.h
@@ -58,6 +58,9 @@ public:
   void setFocusedRunWorkspaceToReturn(
       const Mantid::API::MatrixWorkspace_sptr ws) override;
 
+  void
+  updateRunList(const std::vector<std::pair<int, size_t>> &runLabels) override;
+
   void userError(const std::string &errorTitle,
                  const std::string &errorDescription) override;
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingViewQtWidget.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingViewQtWidget.h
@@ -1,0 +1,97 @@
+#ifndef MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETVIEW_H_
+#define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETVIEW_H_
+
+#include "DllConfig.h"
+#include "IEnggDiffMultiRunFittingWidgetPresenter.h"
+#include "IEnggDiffMultiRunFittingWidgetView.h"
+#include "ui_EnggDiffMultiRunFittingQtWidget.h"
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+class MANTIDQT_ENGGDIFFRACTION_DLL EnggDiffMultiRunFittingViewQtWidget
+    : public QWidget,
+      public IEnggDiffMultiRunFittingWidgetView {
+  Q_OBJECT
+
+public:
+  EnggDiffMultiRunFittingViewQtWidget();
+
+  void addFittedPeaks(const int runNumber, const size_t bank,
+                      const Mantid::API::MatrixWorkspace_sptr ws) override;
+
+  void addFocusedRun(const int runNumber, const size_t bank,
+                     const Mantid::API::MatrixWorkspace_sptr ws) override;
+
+  boost::optional<Mantid::API::MatrixWorkspace_sptr>
+  getFittedPeaks(const int runNumber, const size_t bank) const override;
+
+  Mantid::API::MatrixWorkspace_sptr
+  getFittedPeaksWorkspaceToAdd() const override;
+
+  size_t getFittedPeaksBankIDToAdd() const override;
+
+  size_t getFittedPeaksBankIDToReturn() const override;
+
+  int getFittedPeaksRunNumberToReturn() const override;
+
+  int getFittedPeaksRunNumberToAdd() const override;
+
+  boost::optional<Mantid::API::MatrixWorkspace_sptr>
+  getFocusedRun(const int runNumber, const size_t bank) const override;
+
+  Mantid::API::MatrixWorkspace_sptr getFocusedWorkspaceToAdd() const override;
+
+  size_t getFocusedRunBankIDToAdd() const override;
+
+  size_t getFocusedRunBankIDToReturn() const override;
+
+  int getFocusedRunNumberToAdd() const override;
+
+  int getFocusedRunNumberToReturn() const override;
+
+  void setFittedPeaksWorkspaceToReturn(
+      const Mantid::API::MatrixWorkspace_sptr ws) override;
+
+  void setFocusedRunWorkspaceToReturn(
+      const Mantid::API::MatrixWorkspace_sptr ws) override;
+
+  void userError(const std::string &errorTitle,
+                 const std::string &errorDescription) override;
+
+private:
+  size_t m_fittedPeaksBankIDToAdd;
+
+  mutable size_t m_fittedPeaksBankIDToReturn;
+
+  int m_fittedPeaksRunNumberToAdd;
+
+  mutable int m_fittedPeaksRunNumberToReturn;
+
+  Mantid::API::MatrixWorkspace_sptr m_fittedPeaksWorkspaceToAdd;
+
+  boost::optional<Mantid::API::MatrixWorkspace_sptr>
+      m_fittedPeaksWorkspaceToReturn;
+
+  size_t m_focusedRunBankIDToAdd;
+
+  mutable size_t m_focusedRunBankIDToReturn;
+
+  int m_focusedRunNumberToAdd;
+
+  mutable int m_focusedRunNumberToReturn;
+  
+  Mantid::API::MatrixWorkspace_sptr m_focusedWorkspaceToAdd;
+
+  boost::optional<Mantid::API::MatrixWorkspace_sptr>
+      m_focusedWorkspaceToReturn;
+
+  std::unique_ptr<IEnggDiffMultiRunFittingWidgetPresenter> m_presenter;
+
+  Ui::EnggDiffMultiRunFittingWidget m_ui;
+};
+
+} // CustomInterfaces
+} // MantidQt
+
+#endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETVIEW_H_

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetModel.cpp
@@ -33,5 +33,10 @@ EnggDiffMultiRunFittingWidgetModel::getFocusedRun(const int runNumber,
   return boost::none;
 }
 
+std::vector<std::pair<int, size_t>>
+EnggDiffMultiRunFittingWidgetModel::getAllWorkspaceLabels() const {
+  return m_focusedWorkspaceMap.getRunNumbersAndBankIDs();
+}
+
 } // namespace MantidQt
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetModel.cpp
@@ -1,0 +1,37 @@
+#include "EnggDiffMultiRunFittingWidgetModel.h"
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+void EnggDiffMultiRunFittingWidgetModel::addFittedPeaks(
+    const int runNumber, const size_t bank,
+    const Mantid::API::MatrixWorkspace_sptr ws) {
+  m_fittedPeaksMap.add(runNumber, bank, ws);
+}
+
+void EnggDiffMultiRunFittingWidgetModel::addFocusedRun(
+    const int runNumber, const size_t bank,
+    const Mantid::API::MatrixWorkspace_sptr ws) {
+  m_focusedWorkspaceMap.add(runNumber, bank, ws);
+}
+
+boost::optional<Mantid::API::MatrixWorkspace_sptr>
+EnggDiffMultiRunFittingWidgetModel::getFittedPeaks(const int runNumber,
+                                                   const size_t bank) const {
+  if (m_fittedPeaksMap.contains(runNumber, bank)) {
+    return m_fittedPeaksMap.get(runNumber, bank);
+  }
+  return boost::none;
+}
+
+boost::optional<Mantid::API::MatrixWorkspace_sptr>
+EnggDiffMultiRunFittingWidgetModel::getFocusedRun(const int runNumber,
+                                                  const size_t bank) const {
+  if (m_focusedWorkspaceMap.contains(runNumber, bank)) {
+    return m_focusedWorkspaceMap.get(runNumber, bank);
+  }
+  return boost::none;
+}
+
+} // namespace MantidQt
+} // namespace CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetModel.h
@@ -1,13 +1,14 @@
 #ifndef MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETMODEL_H_
 #define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETMODEL_H_
 
+#include "DllConfig.h"
 #include "IEnggDiffMultiRunFittingWidgetModel.h"
 #include "RunMap.h"
 
 namespace MantidQt {
 namespace CustomInterfaces {
 
-class EnggDiffMultiRunFittingWidgetModel
+class MANTIDQT_ENGGDIFFRACTION_DLL EnggDiffMultiRunFittingWidgetModel
     : public IEnggDiffMultiRunFittingWidgetModel {
 public:
   void addFittedPeaks(const int runNumber, const size_t bank,
@@ -23,7 +24,7 @@ public:
   getFocusedRun(const int runNumber, const size_t bank) const override;
 
 private:
-  static const size_t MAX_BANKS = 2;
+  static constexpr size_t MAX_BANKS = 2;
 
   RunMap<MAX_BANKS, Mantid::API::MatrixWorkspace_sptr> m_fittedPeaksMap;
   RunMap<MAX_BANKS, Mantid::API::MatrixWorkspace_sptr> m_focusedWorkspaceMap;

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetModel.h
@@ -23,6 +23,8 @@ public:
   boost::optional<Mantid::API::MatrixWorkspace_sptr>
   getFocusedRun(const int runNumber, const size_t bank) const override;
 
+  std::vector<std::pair<int, size_t>> getAllWorkspaceLabels() const override;
+
 private:
   static constexpr size_t MAX_BANKS = 2;
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetModel.h
@@ -1,0 +1,35 @@
+#ifndef MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETMODEL_H_
+#define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETMODEL_H_
+
+#include "IEnggDiffMultiRunFittingWidgetModel.h"
+#include "RunMap.h"
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+class EnggDiffMultiRunFittingWidgetModel
+    : public IEnggDiffMultiRunFittingWidgetModel {
+public:
+  void addFittedPeaks(const int runNumber, const size_t bank,
+                      const Mantid::API::MatrixWorkspace_sptr ws) override;
+
+  void addFocusedRun(const int runNumber, const size_t bank,
+                     const Mantid::API::MatrixWorkspace_sptr ws) override;
+
+  boost::optional<Mantid::API::MatrixWorkspace_sptr>
+  getFittedPeaks(const int runNumber, const size_t bank) const override;
+
+  boost::optional<Mantid::API::MatrixWorkspace_sptr>
+  getFocusedRun(const int runNumber, const size_t bank) const override;
+
+private:
+  static const size_t MAX_BANKS = 2;
+
+  RunMap<MAX_BANKS, Mantid::API::MatrixWorkspace_sptr> m_fittedPeaksMap;
+  RunMap<MAX_BANKS, Mantid::API::MatrixWorkspace_sptr> m_focusedWorkspaceMap;
+};
+
+} // namespace MantidQt
+} // namespace CustomInterfaces
+
+#endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETMODEL_H_

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
@@ -18,6 +18,10 @@ void EnggDiffMultiRunFittingWidgetPresenter::notify(
   }
   switch (notif) {
 
+  case IEnggDiffMultiRunFittingWidgetPresenter::AddFittedPeaks:
+    processAddFittedPeaks();
+    break;
+
   case IEnggDiffMultiRunFittingWidgetPresenter::AddFocusedRun:
     processAddFocusedRun();
     break;
@@ -30,6 +34,13 @@ void EnggDiffMultiRunFittingWidgetPresenter::notify(
     processStart();
     break;
   }
+}
+
+void EnggDiffMultiRunFittingWidgetPresenter::processAddFittedPeaks() {
+  const auto ws = m_view->getFittedPeaksWorkspaceToAdd();
+  const auto bankID = m_view->getFittedPeaksBankIDToAdd();
+  const auto runNumber = m_view->getFittedPeaksRunNumberToAdd();
+  m_model->addFittedPeaks(runNumber, bankID, ws);
 }
 
 void EnggDiffMultiRunFittingWidgetPresenter::processAddFocusedRun() {

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
@@ -30,6 +30,10 @@ void EnggDiffMultiRunFittingWidgetPresenter::notify(
     processGetFittedPeaks();
     break;
 
+  case IEnggDiffMultiRunFittingWidgetPresenter::GetFocusedRun:
+    processGetFocusedRun();
+    break;
+
   case IEnggDiffMultiRunFittingWidgetPresenter::ShutDown:
     processShutDown();
     break;
@@ -69,6 +73,23 @@ void EnggDiffMultiRunFittingWidgetPresenter::processGetFittedPeaks() {
     return;
   }
   m_view->setFittedPeaksWorkspaceToReturn(*ws);
+}
+
+void EnggDiffMultiRunFittingWidgetPresenter::processGetFocusedRun() {
+  const auto bankID = m_view->getFocusedRunBankIDToReturn();
+  const auto runNumber = m_view->getFocusedRunNumberToReturn();
+  const auto ws = m_model->getFocusedRun(runNumber, bankID);
+
+  if (!ws) {
+    m_view->userError(
+        "Invalid focused run identifier",
+        "Could not find a focused run with run number " +
+            std::to_string(runNumber) + " and bank ID " +
+            std::to_string(bankID) +
+            ". Please contact the development team with this message");
+    return;
+  }
+  m_view->setFocusedRunWorkspaceToReturn(*ws);
 }
 
 void EnggDiffMultiRunFittingWidgetPresenter::processShutDown() {

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
@@ -1,0 +1,38 @@
+#include "EnggDiffMultiRunFittingWidgetPresenter.h"
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+EnggDiffMultiRunFittingWidgetPresenter::EnggDiffMultiRunFittingWidgetPresenter(
+    std::unique_ptr<IEnggDiffMultiRunFittingWidgetModel> model,
+    IEnggDiffMultiRunFittingWidgetView *view)
+    : m_model(std::move(model)), m_view(view), m_viewHasClosed(false) {}
+
+EnggDiffMultiRunFittingWidgetPresenter::
+    ~EnggDiffMultiRunFittingWidgetPresenter() {}
+
+void EnggDiffMultiRunFittingWidgetPresenter::notify(
+    IEnggDiffMultiRunFittingWidgetPresenter::Notification notif) {
+  if (m_viewHasClosed) {
+    return;
+  }
+  switch (notif) {
+
+  case IEnggDiffMultiRunFittingWidgetPresenter::ShutDown:
+    processShutDown();
+    break;
+
+  case IEnggDiffMultiRunFittingWidgetPresenter::Start:
+    processStart();
+    break;
+  }
+}
+
+void EnggDiffMultiRunFittingWidgetPresenter::processShutDown() {
+  m_viewHasClosed = true;
+}
+
+void EnggDiffMultiRunFittingWidgetPresenter::processStart() {}
+
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
@@ -18,6 +18,10 @@ void EnggDiffMultiRunFittingWidgetPresenter::notify(
   }
   switch (notif) {
 
+  case IEnggDiffMultiRunFittingWidgetPresenter::AddFocusedRun:
+    processAddFocusedRun();
+    break;
+
   case IEnggDiffMultiRunFittingWidgetPresenter::ShutDown:
     processShutDown();
     break;
@@ -26,6 +30,13 @@ void EnggDiffMultiRunFittingWidgetPresenter::notify(
     processStart();
     break;
   }
+}
+
+void EnggDiffMultiRunFittingWidgetPresenter::processAddFocusedRun() {
+  const auto ws = m_view->getFocusedWorkspaceToAdd();
+  const auto bankID = m_view->getFocusedRunBankIDToAdd();
+  const auto runNumber = m_view->getFocusedRunNumberToAdd();
+  m_model->addFocusedRun(runNumber, bankID, ws);
 }
 
 void EnggDiffMultiRunFittingWidgetPresenter::processShutDown() {

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
@@ -56,6 +56,7 @@ void EnggDiffMultiRunFittingWidgetPresenter::processAddFocusedRun() {
   const auto bankID = m_view->getFocusedRunBankIDToAdd();
   const auto runNumber = m_view->getFocusedRunNumberToAdd();
   m_model->addFocusedRun(runNumber, bankID, ws);
+  m_view->updateRunList(m_model->getAllWorkspaceLabels());
 }
 
 void EnggDiffMultiRunFittingWidgetPresenter::processGetFittedPeaks() {

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
@@ -26,6 +26,10 @@ void EnggDiffMultiRunFittingWidgetPresenter::notify(
     processAddFocusedRun();
     break;
 
+  case IEnggDiffMultiRunFittingWidgetPresenter::GetFittedPeaks:
+    processGetFittedPeaks();
+    break;
+
   case IEnggDiffMultiRunFittingWidgetPresenter::ShutDown:
     processShutDown();
     break;
@@ -48,6 +52,23 @@ void EnggDiffMultiRunFittingWidgetPresenter::processAddFocusedRun() {
   const auto bankID = m_view->getFocusedRunBankIDToAdd();
   const auto runNumber = m_view->getFocusedRunNumberToAdd();
   m_model->addFocusedRun(runNumber, bankID, ws);
+}
+
+void EnggDiffMultiRunFittingWidgetPresenter::processGetFittedPeaks() {
+  const auto bankID = m_view->getFittedPeaksBankIDToReturn();
+  const auto runNumber = m_view->getFittedPeaksRunNumberToReturn();
+  const auto ws = m_model->getFittedPeaks(runNumber, bankID);
+
+  if (!ws) {
+    m_view->userError(
+        "Invalid fitted peaks run identifier",
+        "Could not find a fitted peaks workspace with run number " +
+            std::to_string(runNumber) + " and bank ID " +
+            std::to_string(bankID) +
+            ". Please contact the development team with this message");
+    return;
+  }
+  m_view->setFittedPeaksWorkspaceToReturn(*ws);
 }
 
 void EnggDiffMultiRunFittingWidgetPresenter::processShutDown() {

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
@@ -31,7 +31,7 @@ private:
   void processStart();
 
   std::unique_ptr<IEnggDiffMultiRunFittingWidgetModel> m_model;
-  
+
   IEnggDiffMultiRunFittingWidgetView *m_view;
 
   bool m_viewHasClosed;

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
@@ -25,7 +25,7 @@ public:
   notify(IEnggDiffMultiRunFittingWidgetPresenter::Notification notif) override;
 
 private:
-
+  void processAddFocusedRun();
   void processShutDown();
   void processStart();
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
@@ -27,6 +27,7 @@ public:
 private:
   void processAddFittedPeaks();
   void processAddFocusedRun();
+  void processGetFittedPeaks();
   void processShutDown();
   void processStart();
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
@@ -1,0 +1,42 @@
+#ifndef MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETPRESENTER_H_
+#define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETPRESENTER_H_
+
+#include "DllConfig.h"
+#include "IEnggDiffMultiRunFittingWidgetModel.h"
+#include "IEnggDiffMultiRunFittingWidgetPresenter.h"
+#include "IEnggDiffMultiRunFittingWidgetView.h"
+
+#include <memory>
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+class MANTIDQT_ENGGDIFFRACTION_DLL EnggDiffMultiRunFittingWidgetPresenter
+    : public IEnggDiffMultiRunFittingWidgetPresenter {
+
+public:
+  EnggDiffMultiRunFittingWidgetPresenter(
+      std::unique_ptr<IEnggDiffMultiRunFittingWidgetModel> model,
+      IEnggDiffMultiRunFittingWidgetView *view);
+
+  ~EnggDiffMultiRunFittingWidgetPresenter() override;
+
+  void
+  notify(IEnggDiffMultiRunFittingWidgetPresenter::Notification notif) override;
+
+private:
+
+  void processShutDown();
+  void processStart();
+
+  std::unique_ptr<IEnggDiffMultiRunFittingWidgetModel> m_model;
+  
+  IEnggDiffMultiRunFittingWidgetView *m_view;
+
+  bool m_viewHasClosed;
+};
+
+} // namespace CustomInterfaces
+} // namespace MantidQt
+
+#endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETPRESENTER_H_

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
@@ -28,6 +28,7 @@ private:
   void processAddFittedPeaks();
   void processAddFocusedRun();
   void processGetFittedPeaks();
+  void processGetFocusedRun();
   void processShutDown();
   void processStart();
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
@@ -25,6 +25,7 @@ public:
   notify(IEnggDiffMultiRunFittingWidgetPresenter::Notification notif) override;
 
 private:
+  void processAddFittedPeaks();
   void processAddFocusedRun();
   void processShutDown();
   void processStart();

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetModel.h
@@ -1,0 +1,29 @@
+#ifndef MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETMODEL_H_
+#define MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETMODEL_H_
+
+#include "MantidAPI/MatrixWorkspace.h"
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+class IEnggDiffMultiRunFittingWidgetModel {
+public:
+  virtual ~IEnggDiffMultiRunFittingWidgetModel() = default;
+
+  virtual void addFittedPeaks(const int runNumber, const size_t bank,
+                              const Mantid::API::MatrixWorkspace_sptr ws) = 0;
+
+  virtual void addFocusedRun(const int runNumber, const size_t bank,
+                             const Mantid::API::MatrixWorkspace_sptr ws) = 0;
+
+  virtual void getFittedPeaks(const int runNumber, const size_t bank) const = 0;
+
+  virtual Mantid::API::MatrixWorkspace_sptr
+  getFocusedRun(const int runNumber, const size_t bank) const = 0;
+
+};
+
+} // namespace MantidQt
+} // namespace CustomInterfaces
+
+#endif // MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETMODEL_H_

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetModel.h
@@ -5,6 +5,8 @@
 
 #include <boost/optional.hpp>
 
+#include <vector>
+
 namespace MantidQt {
 namespace CustomInterfaces {
 
@@ -51,6 +53,9 @@ public:
   */
   virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
   getFocusedRun(const int runNumber, const size_t bank) const = 0;
+
+  /// Get run numbers and bank IDs of all focused runs loaded into the model
+  virtual std::vector<std::pair<int, size_t>> getAllWorkspaceLabels() const = 0;
 };
 
 } // namespace MantidQt

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetModel.h
@@ -3,6 +3,8 @@
 
 #include "MantidAPI/MatrixWorkspace.h"
 
+#include <boost/optional.hpp>
+
 namespace MantidQt {
 namespace CustomInterfaces {
 
@@ -10,17 +12,45 @@ class IEnggDiffMultiRunFittingWidgetModel {
 public:
   virtual ~IEnggDiffMultiRunFittingWidgetModel() = default;
 
+  /**
+   Add a fitted peaks workspace to the widget, so it can be overplotted on its
+   focused run
+   @param runNumber The run number of the workspace to add
+   @param bank The bank ID of the workspace to add
+   @param ws The workspace to add
+  */
   virtual void addFittedPeaks(const int runNumber, const size_t bank,
                               const Mantid::API::MatrixWorkspace_sptr ws) = 0;
 
+  /**
+   Add a focused run to the widget. The run should be added to the list and
+   plotting it should be possible
+   @param runNumber The run number of the workspace to add
+   @param bank The bank ID of the workspace to add
+   @param ws The workspace to add
+  */
   virtual void addFocusedRun(const int runNumber, const size_t bank,
                              const Mantid::API::MatrixWorkspace_sptr ws) = 0;
 
-  virtual void getFittedPeaks(const int runNumber, const size_t bank) const = 0;
+  /**
+   Get fitted peaks workspace corresponding to a given run and bank, if a fit
+   has been done on that run
+   @param runNumber The run number of the run
+   @param bank The bank ID of the run
+   @return The workspace, or an empty optional if a fit has not been run
+  */
+  virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
+  getFittedPeaks(const int runNumber, const size_t bank) const = 0;
 
-  virtual Mantid::API::MatrixWorkspace_sptr
+  /**
+   Get focused workspace corresponding to a given run and bank, if that run has
+   been loaded into the widget
+   @param runNumber The run number of the run
+   @param bank The bank ID of the run
+   @return The workspace, or empty optional if that run has not been loaded in
+  */
+  virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
   getFocusedRun(const int runNumber, const size_t bank) const = 0;
-
 };
 
 } // namespace MantidQt

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
@@ -13,6 +13,7 @@ public:
   enum Notification {
     AddFittedPeaks, /// The view has been passed a fitted peaks workspace to add
     AddFocusedRun,  ///< The view has been passed a focused run to add
+    GetFittedPeaks, ///< The view has been asked for a fitted peaks workspace
     ShutDown,       ///< Shut down the widget
     Start,          ///< Start and set up the interface
   };

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
@@ -14,6 +14,7 @@ public:
     AddFittedPeaks, /// The view has been passed a fitted peaks workspace to add
     AddFocusedRun,  ///< The view has been passed a focused run to add
     GetFittedPeaks, ///< The view has been asked for a fitted peaks workspace
+    GetFocusedRun,  ///< The view has been asked for a focused run
     ShutDown,       ///< Shut down the widget
     Start,          ///< Start and set up the interface
   };

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
@@ -11,8 +11,9 @@ public:
   // User actions, triggered by the (passive) view,
   // which need handling in implementation
   enum Notification {
-    ShutDown, ///< Shut down the widget
-    Start,    ///< Start and set up the interface
+    AddFocusedRun, ///< The view has been passed a focused run to add
+    ShutDown,      ///< Shut down the widget
+    Start,         ///< Start and set up the interface
   };
 
   /**

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
@@ -1,0 +1,32 @@
+#ifndef MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETPRESENTER_H_
+#define MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETPRESENTER_H_
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+class IEnggDiffMultiRunFittingWidgetPresenter {
+public:
+  virtual ~IEnggDiffMultiRunFittingWidgetPresenter() = default;
+
+  // User actions, triggered by the (passive) view,
+  // which need handling in implementation
+  enum Notification {
+    ShutDown, ///< Shut down the widget
+    Start,    ///< Start and set up the interface
+  };
+
+  /**
+   * Notifications sent through the presenter when something changes
+   * in the view. This plays the role of signals emitted by the view
+   * to this presenter.
+   *
+   * @param notif Type of notification to process.
+   */
+  virtual void
+  notify(IEnggDiffMultiRunFittingWidgetPresenter::Notification notif) = 0;
+};
+
+} // namespace CustomInterfaces
+} // namespace MantidQt
+
+#endif // MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETPRESENTER_H_

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
@@ -11,9 +11,10 @@ public:
   // User actions, triggered by the (passive) view,
   // which need handling in implementation
   enum Notification {
-    AddFocusedRun, ///< The view has been passed a focused run to add
-    ShutDown,      ///< Shut down the widget
-    Start,         ///< Start and set up the interface
+    AddFittedPeaks, /// The view has been passed a fitted peaks workspace to add
+    AddFocusedRun,  ///< The view has been passed a focused run to add
+    ShutDown,       ///< Shut down the widget
+    Start,          ///< Start and set up the interface
   };
 
   /**

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
@@ -42,16 +42,6 @@ public:
   virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
   getFittedPeaks(const int runNumber, const size_t bank) const = 0;
 
-  /**
-   Get focused workspace corresponding to a given run and bank, if that run has
-   been loaded into the widget
-   @param runNumber The run number of the run
-   @param bank The bank ID of the run
-   @return The workspace, or empty optional if that run has not been loaded in
-  */
-  virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
-  getFocusedRun(const int runNumber, const size_t bank) const = 0;
-
   /// Get the fitted peaks workspace which has been passed to the view to be
   /// loaded into the widget, in order to pass it to the model
   virtual Mantid::API::MatrixWorkspace_sptr
@@ -61,9 +51,25 @@ public:
   /// view
   virtual size_t getFittedPeaksBankIDToAdd() const = 0;
 
+  /// Get the bank ID requested when getFittedPeaks is run
+  virtual size_t getFittedPeaksBankIDToReturn() const = 0;
+
+  /// Get the run number requested when getFittedPeaks is run
+  virtual int getFittedPeaksRunNumberToReturn() const = 0;
+
   /// Get the run number of the fitted peaks workspace which has been passed to
   /// the view
   virtual int getFittedPeaksRunNumberToAdd() const = 0;
+
+  /**
+   Get focused workspace corresponding to a given run and bank, if that run has
+   been loaded into the widget
+   @param runNumber The run number of the run
+   @param bank The bank ID of the run
+   @return The workspace, or empty optional if that run has not been loaded in
+  */
+  virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
+  getFocusedRun(const int runNumber, const size_t bank) const = 0;
 
   /// Get the focused run which has been passed to the view to be loaded into
   /// the widget, in order to pass it to the model
@@ -75,6 +81,19 @@ public:
 
   /// Get the run number of the focused run which has been passed to the view
   virtual int getFocusedRunNumberToAdd() const = 0;
+
+  /// Set the the fitted peaks workspace to be returned when getFittedPeaks is
+  /// run on the widget
+  virtual void setFittedPeaksWorkspaceToReturn(
+      const Mantid::API::MatrixWorkspace_sptr ws) = 0;
+
+  /**
+   Display an error message to the user
+   @param errorTitle Title of the error
+   @param errorDescription Longer description of the error
+  */
+  virtual void userError(const std::string &errorTitle,
+                         const std::string &errorDescription) = 0;
 };
 
 } // CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
@@ -52,6 +52,19 @@ public:
   virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
   getFocusedRun(const int runNumber, const size_t bank) const = 0;
 
+  /// Get the fitted peaks workspace which has been passed to the view to be
+  /// loaded into the widget, in order to pass it to the model
+  virtual Mantid::API::MatrixWorkspace_sptr
+  getFittedPeaksWorkspaceToAdd() const = 0;
+
+  /// Get the bank ID of the fitted peaks workspace which has been passed to the
+  /// view
+  virtual size_t getFittedPeaksBankIDToAdd() const = 0;
+
+  /// Get the run number of the fitted peaks workspace which has been passed to
+  /// the view
+  virtual int getFittedPeaksRunNumberToAdd() const = 0;
+
   /// Get the focused run which has been passed to the view to be loaded into
   /// the widget, in order to pass it to the model
   virtual Mantid::API::MatrixWorkspace_sptr

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
@@ -98,6 +98,11 @@ public:
   virtual void setFocusedRunWorkspaceToReturn(
       const Mantid::API::MatrixWorkspace_sptr ws) = 0;
 
+  /// Update the focused run list with run numbers and bank IDs of all runs
+  /// loaded into the widget
+  virtual void
+  updateRunList(const std::vector<std::pair<int, size_t>> &runLabels) = 0;
+
   /**
    Display an error message to the user
    @param errorTitle Title of the error

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
@@ -79,12 +79,23 @@ public:
   /// Get the bank ID of the focused run which has been passed to the view
   virtual size_t getFocusedRunBankIDToAdd() const = 0;
 
+  /// Get the bank ID requested when getFocusedRun is run
+  virtual size_t getFocusedRunBankIDToReturn() const = 0;
+
   /// Get the run number of the focused run which has been passed to the view
   virtual int getFocusedRunNumberToAdd() const = 0;
 
-  /// Set the the fitted peaks workspace to be returned when getFittedPeaks is
+  // Get the run number requested when getFocusedRun is run
+  virtual int getFocusedRunNumberToReturn() const = 0;
+
+  /// Set the fitted peaks workspace to be returned when getFittedPeaks is
   /// run on the widget
   virtual void setFittedPeaksWorkspaceToReturn(
+      const Mantid::API::MatrixWorkspace_sptr ws) = 0;
+
+  /// Set the focused run workspace to be return when getFocusedRun is run on
+  /// the widget
+  virtual void setFocusedRunWorkspaceToReturn(
       const Mantid::API::MatrixWorkspace_sptr ws) = 0;
 
   /**

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
@@ -1,0 +1,28 @@
+#ifndef MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETVIEW_H_
+#define MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETVIEW_H_
+
+#include "MantidAPI/MatrixWorkspace.h"
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+class IEnggDiffMultiRunFittingWidgetView {
+public:
+  virtual ~IEnggDiffMultiRunFittingWidgetView() = default;
+
+  virtual void addFittedPeaks(const int runNumber, const size_t bank,
+                              const Mantid::API::MatrixWorkspace_sptr ws) = 0;
+
+  virtual void addFocusedRun(const int runNumber, const size_t bank,
+                             const Mantid::API::MatrixWorkspace_sptr ws) = 0;
+
+  virtual void getFittedPeaks(const int runNumber, const size_t bank) const = 0;
+
+  virtual Mantid::API::MatrixWorkspace_sptr
+  getFocusedRun(const int runNumber, const size_t bank) const = 0;
+};
+
+} // CustomInterfaces
+} // MantidQt
+
+#endif // MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETVIEW_H_

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
@@ -85,7 +85,7 @@ public:
   /// Get the run number of the focused run which has been passed to the view
   virtual int getFocusedRunNumberToAdd() const = 0;
 
-  // Get the run number requested when getFocusedRun is run
+  /// Get the run number requested when getFocusedRun is run
   virtual int getFocusedRunNumberToReturn() const = 0;
 
   /// Set the fitted peaks workspace to be returned when getFittedPeaks is

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
@@ -3,6 +3,8 @@
 
 #include "MantidAPI/MatrixWorkspace.h"
 
+#include <boost/optional.hpp>
+
 namespace MantidQt {
 namespace CustomInterfaces {
 
@@ -10,16 +12,56 @@ class IEnggDiffMultiRunFittingWidgetView {
 public:
   virtual ~IEnggDiffMultiRunFittingWidgetView() = default;
 
+  /**
+   Add a fitted peaks workspace to the widget, so it can be overplotted on its
+   focused run
+   @param runNumber The run number of the workspace to add
+   @param bank The bank ID of the workspace to add
+   @param ws The workspace to add
+  */
   virtual void addFittedPeaks(const int runNumber, const size_t bank,
                               const Mantid::API::MatrixWorkspace_sptr ws) = 0;
 
+  /**
+   Add a focused run to the widget. The run should be added to the list and
+   plotting it should be possible
+   @param runNumber The run number of the workspace to add
+   @param bank The bank ID of the workspace to add
+   @param ws The workspace to add
+  */
   virtual void addFocusedRun(const int runNumber, const size_t bank,
                              const Mantid::API::MatrixWorkspace_sptr ws) = 0;
 
-  virtual void getFittedPeaks(const int runNumber, const size_t bank) const = 0;
+  /**
+   Get fitted peaks workspace corresponding to a given run and bank, if a fit
+   has been done on that run
+   @param runNumber The run number of the run
+   @param bank The bank ID of the run
+   @return The workspace, or an empty optional if a fit has not been run
+  */
+  virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
+  getFittedPeaks(const int runNumber, const size_t bank) const = 0;
 
-  virtual Mantid::API::MatrixWorkspace_sptr
+  /**
+   Get focused workspace corresponding to a given run and bank, if that run has
+   been loaded into the widget
+   @param runNumber The run number of the run
+   @param bank The bank ID of the run
+   @return The workspace, or empty optional if that run has not been loaded in
+  */
+  virtual boost::optional<Mantid::API::MatrixWorkspace_sptr>
   getFocusedRun(const int runNumber, const size_t bank) const = 0;
+
+  /// Get the focused run which has been passed to the view to be loaded into
+  /// the widget, in order to pass it to the model
+  virtual Mantid::API::MatrixWorkspace_sptr
+  getFocusedWorkspaceToAdd() const = 0;
+
+  /// Get the bank ID of the focused run which has been passed to the view
+  virtual size_t getFocusedRunBankIDToAdd() const = 0;
+
+  /// Get the run number of the focused run which has been passed to the view
+  virtual int getFocusedRunNumberToAdd() const = 0;
 };
 
 } // CustomInterfaces

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelMock.h
@@ -26,6 +26,9 @@ public:
   MOCK_CONST_METHOD2(getFocusedRun,
                      boost::optional<Mantid::API::MatrixWorkspace_sptr>(
                          const int runNumber, const size_t bank));
+
+  MOCK_CONST_METHOD0(getAllWorkspaceLabels,
+                     std::vector<std::pair<int, size_t>>());
 };
 
 GCC_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelMock.h
@@ -1,0 +1,36 @@
+#ifndef MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETMODELMOCK_H_
+#define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETMODELMOCK_H_
+
+#include "../EnggDiffraction/IEnggDiffMultiRunFittingWidgetModel.h"
+#include "MantidKernel/WarningSuppressions.h"
+
+#include <gmock/gmock.h>
+
+GCC_DIAG_OFF_SUGGEST_OVERRIDE
+
+class MockEnggDiffMultiRunFittingWidgetModel
+    : public MantidQt::CustomInterfaces::IEnggDiffMultiRunFittingWidgetModel {
+
+public:
+  MOCK_METHOD3(addFittedPeaks,
+               void(const int runNumber, const size_t bank,
+                    const Mantid::API::MatrixWorkspace_sptr ws));
+
+  MOCK_METHOD3(addFocusedRun, void(const int runNumber, const size_t bank,
+                                   const Mantid::API::MatrixWorkspace_sptr ws));
+
+  MOCK_CONST_METHOD2(getFittedPeaks,
+                     boost::optional<Mantid::API::MatrixWorkspace_sptr>(
+                         const int runNumber, const size_t bank));
+
+  MOCK_CONST_METHOD2(getFocusedRun,
+                     boost::optional<Mantid::API::MatrixWorkspace_sptr>(
+                         const int runNumber, const size_t bank));
+
+  MOCK_CONST_METHOD0(getFocusedWorkspaceToAdd,
+                     Mantid::API::MatrixWorkspace_sptr());
+};
+
+GCC_DIAG_ON_SUGGEST_OVERRIDE
+
+#endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETMODELMOCK_H_

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelMock.h
@@ -26,9 +26,6 @@ public:
   MOCK_CONST_METHOD2(getFocusedRun,
                      boost::optional<Mantid::API::MatrixWorkspace_sptr>(
                          const int runNumber, const size_t bank));
-
-  MOCK_CONST_METHOD0(getFocusedWorkspaceToAdd,
-                     Mantid::API::MatrixWorkspace_sptr());
 };
 
 GCC_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelTest.h
@@ -1,0 +1,31 @@
+#ifndef MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETMODELTEST_H_
+#define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETMODELTEST_H_
+
+#include "../EnggDiffraction/EnggDiffMultiRunFittingWidgetModel.h"
+
+#include "MantidTestHelpers/WorkspaceCreationHelper.h"
+
+#include <cxxtest/TestSuite.h>
+
+using namespace MantidQt::CustomInterfaces;
+
+class EnggDiffMultiRunFittingWidgetModelTest : public CxxTest::TestSuite {
+public:
+  void test_addAndGetFittedPeaks() {
+    EnggDiffMultiRunFittingWidgetModel model;
+
+    Mantid::API::MatrixWorkspace_sptr ws =
+        WorkspaceCreationHelper::create2DWorkspaceBinned(4, 4, 0.5);
+    TS_ASSERT_THROWS_NOTHING(model.addFittedPeaks(123, 1, ws));
+
+    boost::optional<Mantid::API::MatrixWorkspace_sptr> retrievedWS(boost::none);
+    TS_ASSERT_THROWS_NOTHING(retrievedWS = model.getFittedPeaks(123, 1));
+    TS_ASSERT(retrievedWS);
+    TS_ASSERT_EQUALS(ws, *retrievedWS);
+
+    TS_ASSERT_THROWS_NOTHING(retrievedWS = model.getFittedPeaks(456, 2));
+    TS_ASSERT(!retrievedWS);
+  }
+};
+
+#endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETMODELTEST_H_

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelTest.h
@@ -26,6 +26,22 @@ public:
     TS_ASSERT_THROWS_NOTHING(retrievedWS = model.getFittedPeaks(456, 2));
     TS_ASSERT(!retrievedWS);
   }
+
+  void test_addAndGetFocusedRun() {
+    EnggDiffMultiRunFittingWidgetModel model;
+
+    Mantid::API::MatrixWorkspace_sptr ws =
+        WorkspaceCreationHelper::create2DWorkspaceBinned(4, 4, 0.5);
+
+    TS_ASSERT_THROWS_NOTHING(model.addFocusedRun(123, 1, ws));
+    boost::optional<Mantid::API::MatrixWorkspace_sptr> retrievedWS(boost::none);
+    TS_ASSERT_THROWS_NOTHING(retrievedWS = model.getFocusedRun(123, 1));
+    TS_ASSERT(retrievedWS);
+    TS_ASSERT_EQUALS(ws, *retrievedWS);
+
+    TS_ASSERT_THROWS_NOTHING(retrievedWS = model.getFocusedRun(456, 2));
+    TS_ASSERT(!retrievedWS);
+  }
 };
 
 #endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETMODELTEST_H_

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelTest.h
@@ -42,6 +42,29 @@ public:
     TS_ASSERT_THROWS_NOTHING(retrievedWS = model.getFocusedRun(456, 2));
     TS_ASSERT(!retrievedWS);
   }
+
+  void test_getWorkspaceLabels() {
+    EnggDiffMultiRunFittingWidgetModel model;
+
+    Mantid::API::MatrixWorkspace_sptr ws =
+        WorkspaceCreationHelper::create2DWorkspaceBinned(4, 4, 0.5);
+
+    model.addFocusedRun(123, 1, ws);
+    model.addFocusedRun(456, 2, ws);
+    model.addFocusedRun(123, 2, ws);
+
+    std::vector<std::pair<int, size_t>> workspaceLabels;
+
+    TS_ASSERT_THROWS_NOTHING(workspaceLabels = model.getAllWorkspaceLabels());
+
+    TS_ASSERT_EQUALS(workspaceLabels.size(), 3);
+    TS_ASSERT_EQUALS(workspaceLabels[0].first, 123);
+    TS_ASSERT_EQUALS(workspaceLabels[0].second, 1);
+    TS_ASSERT_EQUALS(workspaceLabels[1].first, 123);
+    TS_ASSERT_EQUALS(workspaceLabels[1].second, 2);
+    TS_ASSERT_EQUALS(workspaceLabels[2].first, 456);
+    TS_ASSERT_EQUALS(workspaceLabels[2].second, 2);
+  }
 };
 
 #endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETMODELTEST_H_

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
@@ -98,8 +98,7 @@ public:
                 userError("Invalid fitted peaks run identifier",
                           "Could not find a fitted peaks workspace with run "
                           "number 123 and bank ID 1. Please contact the "
-                          "development team with this message"))
-        .Times(1);
+                          "development team with this message")).Times(1);
     EXPECT_CALL(*m_mockViewPtr, setFittedPeaksWorkspaceToReturn(testing::_))
         .Times(0);
 
@@ -150,8 +149,7 @@ public:
                 userError("Invalid focused run identifier",
                           "Could not find a focused run with run "
                           "number 123 and bank ID 1. Please contact the "
-                          "development team with this message"))
-        .Times(1);
+                          "development team with this message")).Times(1);
     EXPECT_CALL(*m_mockViewPtr, setFocusedRunWorkspaceToReturn(testing::_))
         .Times(0);
 

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
@@ -1,0 +1,70 @@
+#ifndef MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETPRESENTERTEST_H_
+#define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETPRESENTERTEST_H_
+
+#include "../EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h"
+#include "EnggDiffMultiRunFittingWidgetModelMock.h"
+#include "EnggDiffMultiRunFittingWidgetViewMock.h"
+
+#include "MantidAPI/WorkspaceFactory.h"
+
+#include <cxxtest/TestSuite.h>
+
+using namespace Mantid;
+
+using namespace MantidQt::CustomInterfaces;
+using testing::Return;
+
+class EnggDiffMultiRunFittingWidgetPresenterTest : public CxxTest::TestSuite {
+public:
+  void test_addFocusedWorkspace() {
+    auto presenter = setUpPresenter();
+    const API::MatrixWorkspace_sptr ws =
+        API::WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
+
+    EXPECT_CALL(*m_mockViewPtr, getFocusedWorkspaceToAdd())
+        .Times(1)
+        .WillOnce(Return(ws));
+    EXPECT_CALL(*m_mockViewPtr, getFocusedRunBankIDToAdd())
+        .Times(1)
+        .WillOnce(Return(1));
+    EXPECT_CALL(*m_mockViewPtr, getFocusedRunNumberToAdd())
+        .Times(1)
+        .WillOnce(Return(123));
+    EXPECT_CALL(*m_mockModelPtr, addFocusedRun(123, 1, ws));
+
+    presenter->notify(IEnggDiffMultiRunFittingWidgetPresenter::AddFocusedRun);
+    assertMocksUsedCorrectly();
+  }
+
+private:
+  MockEnggDiffMultiRunFittingWidgetModel *m_mockModelPtr;
+  MockEnggDiffMultiRunFittingWidgetView *m_mockViewPtr;
+
+  std::unique_ptr<EnggDiffMultiRunFittingWidgetPresenter> setUpPresenter() {
+    auto mockModel = Mantid::Kernel::make_unique<
+        testing::NiceMock<MockEnggDiffMultiRunFittingWidgetModel>>();
+    m_mockModelPtr = mockModel.get();
+
+    m_mockViewPtr =
+        new testing::NiceMock<MockEnggDiffMultiRunFittingWidgetView>();
+
+    std::unique_ptr<EnggDiffMultiRunFittingWidgetPresenter> pres_uptr(
+        new EnggDiffMultiRunFittingWidgetPresenter(std::move(mockModel),
+                                                   m_mockViewPtr));
+    return pres_uptr;
+  }
+
+  void assertMocksUsedCorrectly() {
+    if (m_mockViewPtr) {
+      delete m_mockViewPtr;
+    }
+    TSM_ASSERT("View mock not used as expected: some EXPECT_CALL conditions "
+               "not satisfied",
+               testing::Mock::VerifyAndClearExpectations(m_mockModelPtr));
+    TSM_ASSERT("Model mock not used as expected: some EXPECT_CALL conditions "
+               "not satisfied",
+               testing::Mock::VerifyAndClearExpectations(m_mockViewPtr));
+  }
+};
+
+#endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETPRESENTERTEST_H_

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
@@ -32,6 +32,13 @@ public:
         .WillOnce(Return(123));
     EXPECT_CALL(*m_mockModelPtr, addFocusedRun(123, 1, ws));
 
+    const std::vector<std::pair<int, size_t>> workspaceLabels(
+        {std::make_pair(123, 1)});
+    EXPECT_CALL(*m_mockModelPtr, getAllWorkspaceLabels())
+        .Times(1)
+        .WillOnce(Return(workspaceLabels));
+    EXPECT_CALL(*m_mockViewPtr, updateRunList(workspaceLabels)).Times(1);
+
     presenter->notify(IEnggDiffMultiRunFittingWidgetPresenter::AddFocusedRun);
     assertMocksUsedCorrectly();
   }
@@ -98,7 +105,8 @@ public:
                 userError("Invalid fitted peaks run identifier",
                           "Could not find a fitted peaks workspace with run "
                           "number 123 and bank ID 1. Please contact the "
-                          "development team with this message")).Times(1);
+                          "development team with this message"))
+        .Times(1);
     EXPECT_CALL(*m_mockViewPtr, setFittedPeaksWorkspaceToReturn(testing::_))
         .Times(0);
 
@@ -149,7 +157,8 @@ public:
                 userError("Invalid focused run identifier",
                           "Could not find a focused run with run "
                           "number 123 and bank ID 1. Please contact the "
-                          "development team with this message")).Times(1);
+                          "development team with this message"))
+        .Times(1);
     EXPECT_CALL(*m_mockViewPtr, setFocusedRunWorkspaceToReturn(testing::_))
         .Times(0);
 

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
@@ -56,6 +56,58 @@ public:
     assertMocksUsedCorrectly();
   }
 
+  void test_getFittedPeaksValid() {
+    auto presenter = setUpPresenter();
+
+    EXPECT_CALL(*m_mockViewPtr, getFittedPeaksBankIDToReturn())
+        .Times(1)
+        .WillOnce(Return(1));
+    EXPECT_CALL(*m_mockViewPtr, getFittedPeaksRunNumberToReturn())
+        .Times(1)
+        .WillOnce(Return(123));
+
+    const API::MatrixWorkspace_sptr ws =
+        API::WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
+
+    EXPECT_CALL(*m_mockModelPtr, getFittedPeaks(123, 1))
+        .Times(1)
+        .WillOnce(Return(boost::make_optional<API::MatrixWorkspace_sptr>(ws)));
+    EXPECT_CALL(*m_mockViewPtr, setFittedPeaksWorkspaceToReturn(ws));
+    EXPECT_CALL(*m_mockViewPtr, userError(testing::_, testing::_)).Times(0);
+
+    presenter->notify(IEnggDiffMultiRunFittingWidgetPresenter::GetFittedPeaks);
+
+    assertMocksUsedCorrectly();
+  }
+
+  void test_getFittedPeaksInvalid() {
+    auto presenter = setUpPresenter();
+
+    EXPECT_CALL(*m_mockViewPtr, getFittedPeaksBankIDToReturn())
+        .Times(1)
+        .WillOnce(Return(1));
+    EXPECT_CALL(*m_mockViewPtr, getFittedPeaksRunNumberToReturn())
+        .Times(1)
+        .WillOnce(Return(123));
+
+    EXPECT_CALL(*m_mockModelPtr, getFittedPeaks(123, 1))
+        .Times(1)
+        .WillOnce(Return(boost::none));
+
+    EXPECT_CALL(*m_mockViewPtr,
+                userError("Invalid fitted peaks run identifier",
+                          "Could not find a fitted peaks workspace with run "
+                          "number 123 and bank ID 1. Please contact the "
+                          "development team with this message"))
+        .Times(1);
+    EXPECT_CALL(*m_mockViewPtr, setFittedPeaksWorkspaceToReturn(testing::_))
+        .Times(0);
+
+    presenter->notify(IEnggDiffMultiRunFittingWidgetPresenter::GetFittedPeaks);
+
+    assertMocksUsedCorrectly();
+  }
+
 private:
   MockEnggDiffMultiRunFittingWidgetModel *m_mockModelPtr;
   MockEnggDiffMultiRunFittingWidgetView *m_mockViewPtr;

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
@@ -36,6 +36,26 @@ public:
     assertMocksUsedCorrectly();
   }
 
+  void test_addFittedPeaks() {
+    auto presenter = setUpPresenter();
+    const API::MatrixWorkspace_sptr ws =
+        API::WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
+
+    EXPECT_CALL(*m_mockViewPtr, getFittedPeaksWorkspaceToAdd())
+        .Times(1)
+        .WillOnce(Return(ws));
+    EXPECT_CALL(*m_mockViewPtr, getFittedPeaksBankIDToAdd())
+        .Times(1)
+        .WillOnce(Return(1));
+    EXPECT_CALL(*m_mockViewPtr, getFittedPeaksRunNumberToAdd())
+        .Times(1)
+        .WillOnce(Return(123));
+    EXPECT_CALL(*m_mockModelPtr, addFittedPeaks(123, 1, ws));
+
+    presenter->notify(IEnggDiffMultiRunFittingWidgetPresenter::AddFittedPeaks);
+    assertMocksUsedCorrectly();
+  }
+
 private:
   MockEnggDiffMultiRunFittingWidgetModel *m_mockModelPtr;
   MockEnggDiffMultiRunFittingWidgetView *m_mockViewPtr;

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
@@ -108,6 +108,58 @@ public:
     assertMocksUsedCorrectly();
   }
 
+  void test_getFocusedRunValid() {
+    auto presenter = setUpPresenter();
+
+    EXPECT_CALL(*m_mockViewPtr, getFocusedRunBankIDToReturn())
+        .Times(1)
+        .WillOnce(Return(1));
+    EXPECT_CALL(*m_mockViewPtr, getFocusedRunNumberToReturn())
+        .Times(1)
+        .WillOnce(Return(123));
+
+    const API::MatrixWorkspace_sptr ws =
+        API::WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
+
+    EXPECT_CALL(*m_mockModelPtr, getFocusedRun(123, 1))
+        .Times(1)
+        .WillOnce(Return(boost::make_optional<API::MatrixWorkspace_sptr>(ws)));
+    EXPECT_CALL(*m_mockViewPtr, setFocusedRunWorkspaceToReturn(ws));
+    EXPECT_CALL(*m_mockViewPtr, userError(testing::_, testing::_)).Times(0);
+
+    presenter->notify(IEnggDiffMultiRunFittingWidgetPresenter::GetFocusedRun);
+
+    assertMocksUsedCorrectly();
+  }
+
+  void test_getFocusedRunInvalid() {
+    auto presenter = setUpPresenter();
+
+    EXPECT_CALL(*m_mockViewPtr, getFocusedRunBankIDToReturn())
+        .Times(1)
+        .WillOnce(Return(1));
+    EXPECT_CALL(*m_mockViewPtr, getFocusedRunNumberToReturn())
+        .Times(1)
+        .WillOnce(Return(123));
+
+    EXPECT_CALL(*m_mockModelPtr, getFocusedRun(123, 1))
+        .Times(1)
+        .WillOnce(Return(boost::none));
+
+    EXPECT_CALL(*m_mockViewPtr,
+                userError("Invalid focused run identifier",
+                          "Could not find a focused run with run "
+                          "number 123 and bank ID 1. Please contact the "
+                          "development team with this message"))
+        .Times(1);
+    EXPECT_CALL(*m_mockViewPtr, setFocusedRunWorkspaceToReturn(testing::_))
+        .Times(0);
+
+    presenter->notify(IEnggDiffMultiRunFittingWidgetPresenter::GetFocusedRun);
+
+    assertMocksUsedCorrectly();
+  }
+
 private:
   MockEnggDiffMultiRunFittingWidgetModel *m_mockModelPtr;
   MockEnggDiffMultiRunFittingWidgetView *m_mockViewPtr;

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
@@ -105,8 +105,7 @@ public:
                 userError("Invalid fitted peaks run identifier",
                           "Could not find a fitted peaks workspace with run "
                           "number 123 and bank ID 1. Please contact the "
-                          "development team with this message"))
-        .Times(1);
+                          "development team with this message")).Times(1);
     EXPECT_CALL(*m_mockViewPtr, setFittedPeaksWorkspaceToReturn(testing::_))
         .Times(0);
 
@@ -157,8 +156,7 @@ public:
                 userError("Invalid focused run identifier",
                           "Could not find a focused run with run "
                           "number 123 and bank ID 1. Please contact the "
-                          "development team with this message"))
-        .Times(1);
+                          "development team with this message")).Times(1);
     EXPECT_CALL(*m_mockViewPtr, setFocusedRunWorkspaceToReturn(testing::_))
         .Times(0);
 

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
@@ -1,0 +1,40 @@
+#ifndef MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETVIEWMOCK_H_
+#define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETVIEWMOCK_H_
+
+#include "../EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h"
+#include "MantidKernel/WarningSuppressions.h"
+
+#include <gmock/gmock.h>
+
+GCC_DIAG_OFF_SUGGEST_OVERRIDE
+
+class MockEnggDiffMultiRunFittingWidgetView
+    : public MantidQt::CustomInterfaces::IEnggDiffMultiRunFittingWidgetView {
+
+public:
+  MOCK_METHOD3(addFittedPeaks,
+               void(const int runNumber, const size_t bank,
+                    const Mantid::API::MatrixWorkspace_sptr ws));
+
+  MOCK_METHOD3(addFocusedRun, void(const int runNumber, const size_t bank,
+                                   const Mantid::API::MatrixWorkspace_sptr ws));
+
+  MOCK_CONST_METHOD2(getFittedPeaks,
+                     boost::optional<Mantid::API::MatrixWorkspace_sptr>(
+                         const int runNumber, const size_t bank));
+
+  MOCK_CONST_METHOD2(getFocusedRun,
+                     boost::optional<Mantid::API::MatrixWorkspace_sptr>(
+                         const int runNumber, const size_t bank));
+
+  MOCK_CONST_METHOD0(getFocusedWorkspaceToAdd,
+                     Mantid::API::MatrixWorkspace_sptr());
+
+  MOCK_CONST_METHOD0(getFocusedRunBankIDToAdd, size_t());
+
+  MOCK_CONST_METHOD0(getFocusedRunNumberToAdd, int());
+};
+
+GCC_DIAG_ON_SUGGEST_OVERRIDE
+
+#endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETVIEWMOCK_H_

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
@@ -23,6 +23,13 @@ public:
                      boost::optional<Mantid::API::MatrixWorkspace_sptr>(
                          const int runNumber, const size_t bank));
 
+  MOCK_CONST_METHOD0(getFittedPeaksWorkspaceToAdd,
+                     Mantid::API::MatrixWorkspace_sptr());
+
+  MOCK_CONST_METHOD0(getFittedPeaksBankIDToAdd, size_t());
+
+  MOCK_CONST_METHOD0(getFittedPeaksRunNumberToAdd, int());
+
   MOCK_CONST_METHOD2(getFocusedRun,
                      boost::optional<Mantid::API::MatrixWorkspace_sptr>(
                          const int runNumber, const size_t bank));

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
@@ -28,7 +28,11 @@ public:
 
   MOCK_CONST_METHOD0(getFittedPeaksBankIDToAdd, size_t());
 
+  MOCK_CONST_METHOD0(getFittedPeaksBankIDToReturn, size_t());
+
   MOCK_CONST_METHOD0(getFittedPeaksRunNumberToAdd, int());
+
+  MOCK_CONST_METHOD0(getFittedPeaksRunNumberToReturn, int());
 
   MOCK_CONST_METHOD2(getFocusedRun,
                      boost::optional<Mantid::API::MatrixWorkspace_sptr>(
@@ -40,6 +44,12 @@ public:
   MOCK_CONST_METHOD0(getFocusedRunBankIDToAdd, size_t());
 
   MOCK_CONST_METHOD0(getFocusedRunNumberToAdd, int());
+
+  MOCK_METHOD1(setFittedPeaksWorkspaceToReturn,
+               void(const Mantid::API::MatrixWorkspace_sptr ws));
+
+  MOCK_METHOD2(userError, void(const std::string &errorTitle,
+                               const std::string &errorDescription));
 };
 
 GCC_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
@@ -43,9 +43,16 @@ public:
 
   MOCK_CONST_METHOD0(getFocusedRunBankIDToAdd, size_t());
 
+  MOCK_CONST_METHOD0(getFocusedRunBankIDToReturn, size_t());
+
   MOCK_CONST_METHOD0(getFocusedRunNumberToAdd, int());
 
+  MOCK_CONST_METHOD0(getFocusedRunNumberToReturn, int());
+
   MOCK_METHOD1(setFittedPeaksWorkspaceToReturn,
+               void(const Mantid::API::MatrixWorkspace_sptr ws));
+
+  MOCK_METHOD1(setFocusedRunWorkspaceToReturn,
                void(const Mantid::API::MatrixWorkspace_sptr ws));
 
   MOCK_METHOD2(userError, void(const std::string &errorTitle,

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
@@ -55,6 +55,10 @@ public:
   MOCK_METHOD1(setFocusedRunWorkspaceToReturn,
                void(const Mantid::API::MatrixWorkspace_sptr ws));
 
+  MOCK_METHOD1(
+      updateRunList,
+      void(const std::vector<std::pair<int, size_t>> &workspaceLabels));
+
   MOCK_METHOD2(userError, void(const std::string &errorTitle,
                                const std::string &errorDescription));
 };


### PR DESCRIPTION
**Note: do NOT merge before #21658**

Basic functionality for the view and model for the new multi-run plotting widget in the ED GUI has been implemented. The widget can now be passed focused run and fitted peaks workspaces, which are stored in the model (via the presenter), and these can then also be retrieved.

**To test:**

As yet the widget isn't used anywhere, as it doesn't have enough functionality to be able to replace its equivalent in either the GSAS tab or the fitting tab. Therefore a code review, and making sure the unit tests pass, will have to be adequate

Partially addresses #21640 

**Release Notes** 
Internal change, so it doesn't need to be in the release notes

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
