### PR TITLE
Copy ExperimentInfo to output in SliceMD

### DIFF
--- a/Framework/MDAlgorithms/src/SliceMD.cpp
+++ b/Framework/MDAlgorithms/src/SliceMD.cpp
@@ -270,12 +270,11 @@ void SliceMD::slice(typename MDEventWorkspace<MDE, nd>::sptr ws) {
 
   try {
     outWS->copyExperimentInfos(*ws);
-  }
-  catch (std::runtime_error &) {
+  } catch (std::runtime_error &) {
     g_log.warning()
-      << this->name()
-      << " was not able to copy experiment info to output workspace "
-      << outWS->getName() << '\n';
+        << this->name()
+        << " was not able to copy experiment info to output workspace "
+        << outWS->getName() << '\n';
   }
 
   // Pass on the display normalization from the input event workspace to the

--- a/Framework/MDAlgorithms/src/SliceMD.cpp
+++ b/Framework/MDAlgorithms/src/SliceMD.cpp
@@ -268,6 +268,16 @@ void SliceMD::slice(typename MDEventWorkspace<MDE, nd>::sptr ws) {
     alg->executeAsChildAlg();
   }
 
+  try {
+    outWS->copyExperimentInfos(*ws);
+  }
+  catch (std::runtime_error &) {
+    g_log.warning()
+      << this->name()
+      << " was not able to copy experiment info to output workspace "
+      << outWS->getName() << '\n';
+  }
+
   // Pass on the display normalization from the input event workspace to the
   // output event workspace
   IMDEventWorkspace_sptr outEvent =


### PR DESCRIPTION
Previously, SliceMD did not copy `ExperimentInfo` to the output workspace, so this information was lost. Now, it's copied across as intended.

**To test:**
- Run SliceMD on a workspace
- Check output has `ExperimentInfo` (Easiest way is to check the sample logs are non-empty).

Fixes #21586 

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
