### PR TITLE
Use np.datetime_to_string for consistent output in doctests

### DIFF
--- a/docs/source/algorithms/AddNote-v1.rst
+++ b/docs/source/algorithms/AddNote-v1.rst
@@ -33,7 +33,8 @@ Usage
 	log = ws.getRun().getLogData("my_log")
 	print("my_log has {} entries".format(log.size()))
 	for time, value in zip(log.times, log.value):
-		print("\t{}\t{}".format(time.astype(np.dtype('M8[s]')), value))
+		ts = np.datetime_as_string(time.astype(np.dtype('M8[s]')), timezone='UTC')
+		print("\t{}\t{}".format(ts, value))
 
 	AddNote(ws, Name="my_log", Time="2014-01-01T00:00:00", Value="New Initial", DeleteExisting=True)
 	AddNote(ws, Name="my_log", Time="2014-01-01T00:30:00", Value="New Final")
@@ -41,7 +42,8 @@ Usage
 	log = ws.getRun().getLogData("my_log")
 	print("my_log now has {} entries".format(log.size()))
 	for time, value in zip(log.times, log.value):
-		print("\t{}\t{}".format(time.astype(np.dtype('M8[s]')), value))
+		ts = np.datetime_as_string(time.astype(np.dtype('M8[s]')), timezone='UTC')
+		print("\t{}\t{}".format(ts, value))
 
 Output:
 
@@ -49,11 +51,11 @@ Output:
     :options: +NORMALIZE_WHITESPACE
 
 	my_log has 3 entries
-            2014-01-01T00:00:00     Initial
-            2014-01-01T00:30:30     Second
-            2014-01-01T00:50:00     Final
+            2014-01-01T00:00:00Z     Initial
+            2014-01-01T00:30:30Z     Second
+            2014-01-01T00:50:00Z     Final
     my_log now has 2 entries
-            2014-01-01T00:00:00     New Initial
-            2014-01-01T00:30:00     New Final
+            2014-01-01T00:00:00Z     New Initial
+            2014-01-01T00:30:00Z     New Final
 
 .. categories::

--- a/docs/source/algorithms/AddTimeSeriesLog-v1.rst
+++ b/docs/source/algorithms/AddTimeSeriesLog-v1.rst
@@ -36,7 +36,8 @@ Usage
     log = ws.getRun().getLogData("my_log")
     print("my_log has {} entries".format(log.size()))
     for time, value in zip(log.times, log.value):
-      print("\t{}\t{:.6f}".format(time.astype(np.dtype('M8[s]')), value))
+      ts = np.datetime_as_string(time.astype(np.dtype('M8[s]')), timezone='UTC')
+      print("\t{}\t{:.6f}".format(ts, value))
 
     AddTimeSeriesLog(ws, Name="my_log", Time="2010-01-01T00:00:00", Value=12, Type="int", DeleteExisting=True)
     AddTimeSeriesLog(ws, Name="my_log", Time="2010-01-01T00:50:00", Value=34, Type="int")
@@ -44,7 +45,9 @@ Usage
     log = ws.getRun().getLogData("my_log")
     print("my_log now has {} entries".format(log.size()))
     for time, value in zip(log.times, log.value):
-      print("\t{}\t{}".format(time.astype(np.dtype('M8[s]')), value))
+      ts = np.datetime_as_string(time.astype(np.dtype('M8[s]')), timezone='UTC')
+      print("\t{}\t{:.6f}".format(ts, value))
+
 
 Output:
 
@@ -52,12 +55,12 @@ Output:
     :options: +NORMALIZE_WHITESPACE
 
     my_log has 3 entries
-            2010-01-01T00:00:00     100.000000
-            2010-01-01T00:30:00     15.000000
-            2010-01-01T00:50:00     100.200000
+        2010-01-01T00:00:00Z     100.000000
+        2010-01-01T00:30:00Z     15.000000
+        2010-01-01T00:50:00Z     100.200000
     my_log now has 2 entries
-            2010-01-01T00:00:00     12
-            2010-01-01T00:50:00     34
+        2010-01-01T00:00:00Z     12.000000
+        2010-01-01T00:50:00Z     34.000000
 
 .. categories::
 

--- a/docs/source/algorithms/ChangeLogTime-v1.rst
+++ b/docs/source/algorithms/ChangeLogTime-v1.rst
@@ -30,8 +30,8 @@ Usage
     #get the log times for a particular variable, after change
     modified=w.getRun()['Speed5'].times
     #print times
-    print("OriginalTimes:  {}".format(original))
-    print("ModifiedTimes:  {}".format(modified))
+    print("OriginalTimes:  {}".format(np.datetime_as_string(original, timezone='UTC')))
+    print("ModifiedTimes:  {}".format(np.datetime_as_string(modified, timezone='UTC')))
 
 
 .. testcleanup:: ChangeLogTime
@@ -43,10 +43,10 @@ Output:
 
 .. testoutput:: ChangeLogTime
 
-    OriginalTimes:  ['2010-03-25T16:09:27.780000000' '2010-03-25T16:10:01.560998229'
-     '2010-03-25T16:10:31.514001159' '2010-03-25T16:11:25.498002319']
-    ModifiedTimes:  ['2010-03-25T16:09:37.780000000' '2010-03-25T16:10:11.560998229'
-     '2010-03-25T16:10:41.514001159' '2010-03-25T16:11:35.498002319']
+    OriginalTimes:  ['2010-03-25T16:09:27.780000000Z' '2010-03-25T16:10:01.560998229Z'
+     '2010-03-25T16:10:31.514001159Z' '2010-03-25T16:11:25.498002319Z']
+    ModifiedTimes:  ['2010-03-25T16:09:37.780000000Z' '2010-03-25T16:10:11.560998229Z'
+     '2010-03-25T16:10:41.514001159Z' '2010-03-25T16:11:35.498002319Z']
 
 .. categories::
 

--- a/docs/source/algorithms/CorrectLogTimes-v1.rst
+++ b/docs/source/algorithms/CorrectLogTimes-v1.rst
@@ -25,12 +25,16 @@ Usage
 .. testcode:: CorrectLogTimes
 
     w=Load('CNCS_7860')
-    print("Original start time for 'proton_charge': {}".format(w.getRun()['proton_charge'].times[0]).strip())
-    print("Original start time for 'Speed5': {}".format(w.getRun()['Speed5'].times[0]).strip())
+    run=w.getRun()
+    ts = np.datetime_as_string(run['proton_charge'].times[0].astype(np.dtype('M8[s]')), timezone='UTC')
+    print("Original start time for 'proton_charge': {}".format(ts).strip())
+    ts = np.datetime_as_string(run['Speed5'].times[0].astype(np.dtype('M8[s]')), timezone='UTC')
+    print("Original start time for 'Speed5': {}".format(ts).strip())
     #Change the log times
     CorrectLogTimes(w)
     #there should be almost 10 seconds different than before
-    print("Corrected start time for 'Speed5': {}".format(w.getRun()['Speed5'].times[0]).strip())
+    ts = np.datetime_as_string(run['Speed5'].times[0].astype(np.dtype('M8[s]')), timezone='UTC')
+    print("Corrected start time for 'Speed5': {}".format(ts).strip())
 
 
 .. testcleanup:: CorrectLogTimes
@@ -42,9 +46,9 @@ Output:
 
 .. testoutput:: CorrectLogTimes
 
-    Original start time for 'proton_charge': 2010-03-25T16:08:37.000000000
-    Original start time for 'Speed5': 2010-03-25T16:09:27.780000000
-    Corrected start time for 'Speed5': 2010-03-25T16:08:37.000000000
+    Original start time for 'proton_charge': 2010-03-25T16:08:37Z
+    Original start time for 'Speed5': 2010-03-25T16:09:27Z
+    Corrected start time for 'Speed5': 2010-03-25T16:08:37Z
 
 .. categories::
 

--- a/docs/source/algorithms/FilterEvents-v1.rst
+++ b/docs/source/algorithms/FilterEvents-v1.rst
@@ -210,7 +210,9 @@ Output:
         tmpws = mtd[name]
         print("workspace %s has %d events" % (name, tmpws.getNumberEvents()))
         split_log = tmpws.run().getProperty('splitter')
-        print('event splitter log: entry 0 and entry 1 are {0} and {1}.'.format(split_log.times[0].astype(np.dtype('M8[s]')), split_log.times[1].astype(np.dtype('M8[s]'))))
+        entry_0 = np.datetime_as_string(split_log.times[0].astype(np.dtype('M8[s]')), timezone='UTC')
+        entry_1 = np.datetime_as_string(split_log.times[1].astype(np.dtype('M8[s]')), timezone='UTC')
+        print('event splitter log: entry 0 and entry 1 are {0} and {1}.'.format(entry_0, entry_1))
 
 
 Output:
@@ -218,13 +220,13 @@ Output:
 .. testoutput:: FilterEventNoCorrection
 
     workspace tempsplitws3_a has 77580 events
-    event splitter log: entry 0 and entry 1 are 2010-03-25T16:08:37 and 2010-03-25T16:10:17.
+    event splitter log: entry 0 and entry 1 are 2010-03-25T16:08:37Z and 2010-03-25T16:10:17Z.
     workspace tempsplitws3_b has 0 events
-    event splitter log: entry 0 and entry 1 are 2010-03-25T16:08:37 and 2010-03-25T16:11:57.
+    event splitter log: entry 0 and entry 1 are 2010-03-25T16:08:37Z and 2010-03-25T16:11:57Z.
     workspace tempsplitws3_c has 0 events
-    event splitter log: entry 0 and entry 1 are 2010-03-25T16:08:37 and 2010-03-25T16:15:17.
+    event splitter log: entry 0 and entry 1 are 2010-03-25T16:08:37Z and 2010-03-25T16:15:17Z.
     workspace tempsplitws3_unfiltered has 34686 events
-    event splitter log: entry 0 and entry 1 are 2010-03-25T16:08:37 and 2010-03-25T16:10:17.
+    event splitter log: entry 0 and entry 1 are 2010-03-25T16:08:37Z and 2010-03-25T16:10:17Z.
 
 
 **Example - Filtering event by pulse time**

--- a/docs/source/algorithms/ShiftLogTime-v1.rst
+++ b/docs/source/algorithms/ShiftLogTime-v1.rst
@@ -20,6 +20,7 @@ Usage
 
 .. testcode:: ShiftLogTime
 
+    import numpy as np
     #Load a workspace
     w = Load('CNCS_7860')
     #get the log times for a particular variable
@@ -29,8 +30,8 @@ Usage
     #get the log times for a particular variable, after change
     modified = w.getRun()['Speed5'].times
     #print times
-    print("OriginalTimes:  {}".format(original))
-    print("ModifiedTimes:  {}".format(modified))
+    print("OriginalTimes:  {}".format(np.datetime_as_string(original, timezone='UTC')))
+    print("ModifiedTimes:  {}".format(np.datetime_as_string(modified, timezone='UTC')))
 
 
 .. testcleanup:: ShiftLogTime
@@ -42,9 +43,9 @@ Output:
 
 .. testoutput:: ShiftLogTime
 
-    OriginalTimes:  ['2010-03-25T16:09:27.780000000' '2010-03-25T16:10:01.560998229'
-     '2010-03-25T16:10:31.514001159' '2010-03-25T16:11:25.498002319']
-    ModifiedTimes:  ['2010-03-25T16:10:31.514001159' '2010-03-25T16:11:25.498002319']
+    OriginalTimes:  ['2010-03-25T16:09:27.780000000Z' '2010-03-25T16:10:01.560998229Z'
+     '2010-03-25T16:10:31.514001159Z' '2010-03-25T16:11:25.498002319Z']
+    ModifiedTimes:  ['2010-03-25T16:10:31.514001159Z' '2010-03-25T16:11:25.498002319Z']
 
 .. categories::
 


### PR DESCRIPTION
Description of work.

This *should* fix the problem of inconsistent output in the doctests on RHEL 7 seen in http://builds.mantidproject.org/job/master_doctests/lastCompletedBuild/label=rhel7-build/testReport/docs. 

**To test:**

* Checks the tests pass locally
* Run them on a RHEL7 machine if possible!

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
