### PR TITLE
Faster SCDCalibratePanels in SCDCalibratePanelsTest

### DIFF
--- a/Framework/Beamline/src/ComponentInfo.cpp
+++ b/Framework/Beamline/src/ComponentInfo.cpp
@@ -246,9 +246,10 @@ void ComponentInfo::doSetPosition(const std::pair<size_t, size_t> &index,
         m_detectorInfo->position({subIndex, timeIndex}) + offset);
   }
 
+  auto &accessPos = m_positions.access();
   for (const auto &subIndex : componentRangeInSubtree(componentIndex)) {
     size_t offsetIndex = compOffsetIndex(subIndex);
-    m_positions.access()[offsetIndex] += offset;
+    accessPos[offsetIndex] += offset;
   }
 }
 
@@ -272,15 +273,16 @@ void ComponentInfo::doSetRotation(const std::pair<size_t, size_t> &index,
     m_detectorInfo->setRotation({subDetIndex, timeIndex}, newRot);
   }
 
+  auto &accessPos = m_positions.access();
+  auto &accessRot = m_rotations.access();
   for (const auto &subCompIndex : componentRangeInSubtree(componentIndex)) {
     auto oldPos = position({subCompIndex, timeIndex});
     auto newPos = transform * (oldPos - compPos) + compPos;
     auto newRot = rotDelta * rotation({subCompIndex, timeIndex});
     const size_t childCompIndexOffset = compOffsetIndex(subCompIndex);
-    m_positions.access()[linearIndex({childCompIndexOffset, timeIndex})] =
-        newPos;
-    m_rotations.access()[linearIndex({childCompIndexOffset, timeIndex})] =
-        newRot.normalized();
+    auto childIndex = linearIndex({childCompIndexOffset, timeIndex});
+    accessPos[childIndex] = newPos;
+    accessRot[childIndex] = newRot.normalized();
   }
 }
 


### PR DESCRIPTION
Description of work.

This refactors `Beamline::ComponentInfo` to substantially speed up the SCDCalibratePanels algorithm in SCDCalibratePanelsTest. I think we can justify the change by its effect on this unit test, but real-world numbers would be of more interest to users.

On my machine (Fedora 26, 2 x Intel Xeon E5-2630 v4 @ 2.2 GHz)
master: 47.6 +/- 1.6 seconds
FasterSCDCalibratePanels: 3.73 +/- 0.13 seconds

**To test:**

<!-- Instructions for testing. -->

1. Code review
2. Check builds

Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 

May we use numbers from "real calibration data" instead of the unit test?


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
