### PR TITLE
Generate pycharm.bat script on windows

### DIFF
--- a/buildconfig/CMake/MSVCSetup.cmake
+++ b/buildconfig/CMake/MSVCSetup.cmake
@@ -89,6 +89,7 @@ set ( WINDOWS_BUILDCONFIG ${PROJECT_SOURCE_DIR}/buildconfig/windows )
 configure_file ( ${WINDOWS_BUILDCONFIG}/buildenv.bat.in ${PROJECT_BINARY_DIR}/buildenv.bat @ONLY )
 configure_file ( ${WINDOWS_BUILDCONFIG}/command-prompt.bat ${PROJECT_BINARY_DIR}/command-prompt.bat @ONLY )
 configure_file ( ${WINDOWS_BUILDCONFIG}/visual-studio.bat ${PROJECT_BINARY_DIR}/visual-studio.bat @ONLY )
+configure_file ( ${WINDOWS_BUILDCONFIG}/pycharm.bat ${PROJECT_BINARY_DIR}/pycharm.bat @ONLY )
 
 ###########################################################################
 # Configure Mantid startup scripts

--- a/buildconfig/windows/pycharm.bat
+++ b/buildconfig/windows/pycharm.bat
@@ -1,0 +1,19 @@
+@echo OFF
+
+call %~dp0buildenv.bat
+
+setlocal ENABLEEXTENSIONS
+set KEY_NAME="HKCR\Applications\pycharm.exe\shell\open\command"
+
+FOR /F "usebackq tokens=2*" %%A IN (`REG QUERY %KEY_NAME% `) DO (
+    set ValueType=%%A
+    set ValueValue=%%B
+)
+
+if defined ValueValue (
+    @echo Value Type = %ValueType%
+    @echo Command = %ValueValue%
+    start "" %ValueValue: "%1"=%
+) else (
+    @echo %KEY_NAME% not found.
+)

--- a/buildconfig/windows/pycharm.bat
+++ b/buildconfig/windows/pycharm.bat
@@ -3,6 +3,8 @@
 call %~dp0buildenv.bat
 
 setlocal ENABLEEXTENSIONS
+setlocal enabledelayedexpansion
+
 set KEY_NAME="HKCR\Applications\pycharm.exe\shell\open\command"
 
 FOR /F "usebackq tokens=2*" %%A IN (`REG QUERY %KEY_NAME% `) DO (
@@ -11,9 +13,10 @@ FOR /F "usebackq tokens=2*" %%A IN (`REG QUERY %KEY_NAME% `) DO (
 )
 
 if defined ValueValue (
-    @echo Value Type = %ValueType%
-    @echo Command = %ValueValue%
-    start "" %ValueValue: "%1"=%
+    :: Strip "" and %1
+    set ValueValue=!ValueValue:"=!
+    set ValueValue=!ValueValue: %%1=!
+    start "" "!ValueValue!"
 ) else (
     @echo %KEY_NAME% not found.
 )


### PR DESCRIPTION
This script is required when launching pycharm for mantid workbench to ensure the paths are correct.

**To test:**

**This can only be tested on windows**

* Run Cmake on windows.
* Ensure that the `pycharm.bat` file is create in your build directory.
* Download and install [PyCharm community edition](https://www.jetbrains.com/pycharm/download/#section=windows) (if you don't already have it)
* Run the batch file and ensure Pycharm launches.


Additionally, you can try to build and run the Mantid Workbench using the instructions below:
[Build instruction for the workbench with Pycharm](https://www.mantidproject.org/Building_the_workbench_with_pycharm)


Fixes #21690 

**Release Notes** 
*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
