### PR TITLE
Fix relying on undocumented bug in older jinja2.

### DIFF
--- a/docs/source/_templates/category.html
+++ b/docs/source/_templates/category.html
@@ -7,20 +7,23 @@
 {# Uses bootstrap col-md-4 for each column along with slice(3) to divide input list #}
 {# It currently assumes the items in the list are mantiddoc.directives.categories.PageRef classes #}
     <div class="row">
-    {%- for column in item_list|slice(3) %}
+    {% for column in item_list|slice(3) %}
       <div class="col-md-4">
-      {%- set first = True %}
-      {%- for item in column %}
-        {%- if (item.name[0] != section or first) %}
-          {%- set section = item.name[0] %}
-          {%- if first != true %}
+      {% set first = [True] %}
+      {% set section = [0] %}
+      {% for item in column %}
+        {% if (item.name[0] != section[0] or first[0]) %}
+          {% set _ = section.pop() %}
+          {% set _ = section.append(item.name[0]) %}
+          {% if first[0] != True %}
             </ul>
-          {%- endif %}
-          <h3 style="font-weight:bold">{{ section }}</h3>
+          {% endif %}
+          <h3 style="font-weight:bold">{{ section[0] }}</h3>
           <ul>
-        {%- endif %}
+        {% endif %}
         <li><a href="{{ item.link(outpath) }}">{{ item.name }}</a></li>
-        {%- set first = False -%}
+        {% set _ = first.pop() %}
+        {% set _ = first.append(False) %}
       {%- endfor -%}
       </ul>
       </div>


### PR DESCRIPTION
On new linux operating systems building documentation yields ugly pages 
![bad](https://user-images.githubusercontent.com/1128952/35879598-a3334adc-0b49-11e8-96c3-670bdc91d842.png)
This is what I expect
![good](https://user-images.githubusercontent.com/1128952/35879586-95acb682-0b49-11e8-9fa5-44c83765b164.png)

The reason is that the template file used relies on an undocumented bug of jinja2. In the documentation, setting a variable inside a scope has no effect on that variable outside of it. In some older versions this was not enforced. In the new versions, setting a variable inside the `for` loop does not affect the value in the next iteration.
I've used this [solution](https://stackoverflow.com/a/42888347/6259479)


**Release Notes** 

*Does not need to be in the release notes.*
---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
