### PR TITLE
Update WAND² IDF

### DIFF
--- a/instrument/WAND_Definition.xml
+++ b/instrument/WAND_Definition.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='ASCII'?>
-<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2018-01-12 10:00:22.746679" name="WAND" valid-from="2017-12-01 00:00:00" valid-to="2100-01-31 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
+<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2018-02-06 14:40:00.479056" name="WAND" valid-from="2017-12-01 00:00:00" valid-to="2100-01-31 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
   <!--Created by Ross Whitfield-->
   <defaults>
     <length unit="metre"/>
@@ -23,7 +23,7 @@
   <component idlist="bank1" type="bank1">
     <location>
       <parameter name="y">
-        <logfile eq="value/100" extract-single-value-as="mean" id="HB2C:Mot:detz.RBV"/>
+        <logfile eq="rint(value*1000)/100000" extract-single-value-as="mean" id="HB2C:Mot:detz.RBV"/>
       </parameter>
     </location>
   </component>
@@ -34,7 +34,7 @@
           <value val="0.728"/>
         </parameter>
         <parameter name="t-position">
-          <logfile eq="7.5+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
+          <logfile eq="7.5+rint(value*1000)/1000" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
         </parameter>
         <parameter name="roty">
           <logfile eq="7.5+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
@@ -45,7 +45,7 @@
   <component idlist="bank2" type="bank2">
     <location>
       <parameter name="y">
-        <logfile eq="value/100" extract-single-value-as="mean" id="HB2C:Mot:detz.RBV"/>
+        <logfile eq="rint(value*1000)/100000" extract-single-value-as="mean" id="HB2C:Mot:detz.RBV"/>
       </parameter>
     </location>
   </component>
@@ -56,7 +56,7 @@
           <value val="0.728"/>
         </parameter>
         <parameter name="t-position">
-          <logfile eq="22.5+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
+          <logfile eq="22.5+rint(value*1000)/1000" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
         </parameter>
         <parameter name="roty">
           <logfile eq="22.5+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
@@ -67,7 +67,7 @@
   <component idlist="bank3" type="bank3">
     <location>
       <parameter name="y">
-        <logfile eq="value/100" extract-single-value-as="mean" id="HB2C:Mot:detz.RBV"/>
+        <logfile eq="rint(value*1000)/100000" extract-single-value-as="mean" id="HB2C:Mot:detz.RBV"/>
       </parameter>
     </location>
   </component>
@@ -78,7 +78,7 @@
           <value val="0.728"/>
         </parameter>
         <parameter name="t-position">
-          <logfile eq="37.5+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
+          <logfile eq="37.5+rint(value*1000)/1000" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
         </parameter>
         <parameter name="roty">
           <logfile eq="37.5+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
@@ -89,7 +89,7 @@
   <component idlist="bank4" type="bank4">
     <location>
       <parameter name="y">
-        <logfile eq="value/100" extract-single-value-as="mean" id="HB2C:Mot:detz.RBV"/>
+        <logfile eq="rint(value*1000)/100000" extract-single-value-as="mean" id="HB2C:Mot:detz.RBV"/>
       </parameter>
     </location>
   </component>
@@ -100,7 +100,7 @@
           <value val="0.728"/>
         </parameter>
         <parameter name="t-position">
-          <logfile eq="52.5+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
+          <logfile eq="52.5+rint(value*1000)/1000" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
         </parameter>
         <parameter name="roty">
           <logfile eq="52.5+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
@@ -111,7 +111,7 @@
   <component idlist="bank5" type="bank5">
     <location>
       <parameter name="y">
-        <logfile eq="value/100" extract-single-value-as="mean" id="HB2C:Mot:detz.RBV"/>
+        <logfile eq="rint(value*1000)/100000" extract-single-value-as="mean" id="HB2C:Mot:detz.RBV"/>
       </parameter>
     </location>
   </component>
@@ -122,7 +122,7 @@
           <value val="0.728"/>
         </parameter>
         <parameter name="t-position">
-          <logfile eq="67.5+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
+          <logfile eq="67.5+rint(value*1000)/1000" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
         </parameter>
         <parameter name="roty">
           <logfile eq="67.5+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
@@ -133,7 +133,7 @@
   <component idlist="bank6" type="bank6">
     <location>
       <parameter name="y">
-        <logfile eq="value/100" extract-single-value-as="mean" id="HB2C:Mot:detz.RBV"/>
+        <logfile eq="rint(value*1000)/100000" extract-single-value-as="mean" id="HB2C:Mot:detz.RBV"/>
       </parameter>
     </location>
   </component>
@@ -144,7 +144,7 @@
           <value val="0.728"/>
         </parameter>
         <parameter name="t-position">
-          <logfile eq="82.5+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
+          <logfile eq="82.5+rint(value*1000)/1000" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
         </parameter>
         <parameter name="roty">
           <logfile eq="82.5+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
@@ -155,7 +155,7 @@
   <component idlist="bank7" type="bank7">
     <location>
       <parameter name="y">
-        <logfile eq="value/100" extract-single-value-as="mean" id="HB2C:Mot:detz.RBV"/>
+        <logfile eq="rint(value*1000)/100000" extract-single-value-as="mean" id="HB2C:Mot:detz.RBV"/>
       </parameter>
     </location>
   </component>
@@ -166,7 +166,7 @@
           <value val="0.728"/>
         </parameter>
         <parameter name="t-position">
-          <logfile eq="97.5+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
+          <logfile eq="97.5+rint(value*1000)/1000" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
         </parameter>
         <parameter name="roty">
           <logfile eq="97.5+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
@@ -177,7 +177,7 @@
   <component idlist="bank8" type="bank8">
     <location>
       <parameter name="y">
-        <logfile eq="value/100" extract-single-value-as="mean" id="HB2C:Mot:detz.RBV"/>
+        <logfile eq="rint(value*1000)/100000" extract-single-value-as="mean" id="HB2C:Mot:detz.RBV"/>
       </parameter>
     </location>
   </component>
@@ -188,7 +188,7 @@
           <value val="0.728"/>
         </parameter>
         <parameter name="t-position">
-          <logfile eq="112.5+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
+          <logfile eq="112.5+rint(value*1000)/1000" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
         </parameter>
         <parameter name="roty">
           <logfile eq="112.5+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
@@ -686,518 +686,518 @@
   <type name="wire" outline="yes">
     <properties/>
     <component type="pixel">
-      <location name="pixel1" y="0.0998046875"/>
-      <location name="pixel2" y="0.0994140625"/>
-      <location name="pixel3" y="0.0990234375"/>
-      <location name="pixel4" y="0.0986328125"/>
-      <location name="pixel5" y="0.0982421875"/>
-      <location name="pixel6" y="0.0978515625"/>
-      <location name="pixel7" y="0.0974609375"/>
-      <location name="pixel8" y="0.0970703125"/>
-      <location name="pixel9" y="0.0966796875"/>
-      <location name="pixel10" y="0.0962890625"/>
-      <location name="pixel11" y="0.0958984375"/>
-      <location name="pixel12" y="0.0955078125"/>
-      <location name="pixel13" y="0.0951171875"/>
-      <location name="pixel14" y="0.0947265625"/>
-      <location name="pixel15" y="0.0943359375"/>
-      <location name="pixel16" y="0.0939453125"/>
-      <location name="pixel17" y="0.0935546875"/>
-      <location name="pixel18" y="0.0931640625"/>
-      <location name="pixel19" y="0.0927734375"/>
-      <location name="pixel20" y="0.0923828125"/>
-      <location name="pixel21" y="0.0919921875"/>
-      <location name="pixel22" y="0.0916015625"/>
-      <location name="pixel23" y="0.0912109375"/>
-      <location name="pixel24" y="0.0908203125"/>
-      <location name="pixel25" y="0.0904296875"/>
-      <location name="pixel26" y="0.0900390625"/>
-      <location name="pixel27" y="0.0896484375"/>
-      <location name="pixel28" y="0.0892578125"/>
-      <location name="pixel29" y="0.0888671875"/>
-      <location name="pixel30" y="0.0884765625"/>
-      <location name="pixel31" y="0.0880859375"/>
-      <location name="pixel32" y="0.0876953125"/>
-      <location name="pixel33" y="0.0873046875"/>
-      <location name="pixel34" y="0.0869140625"/>
-      <location name="pixel35" y="0.0865234375"/>
-      <location name="pixel36" y="0.0861328125"/>
-      <location name="pixel37" y="0.0857421875"/>
-      <location name="pixel38" y="0.0853515625"/>
-      <location name="pixel39" y="0.0849609375"/>
-      <location name="pixel40" y="0.0845703125"/>
-      <location name="pixel41" y="0.0841796875"/>
-      <location name="pixel42" y="0.0837890625"/>
-      <location name="pixel43" y="0.0833984375"/>
-      <location name="pixel44" y="0.0830078125"/>
-      <location name="pixel45" y="0.0826171875"/>
-      <location name="pixel46" y="0.0822265625"/>
-      <location name="pixel47" y="0.0818359375"/>
-      <location name="pixel48" y="0.0814453125"/>
-      <location name="pixel49" y="0.0810546875"/>
-      <location name="pixel50" y="0.0806640625"/>
-      <location name="pixel51" y="0.0802734375"/>
-      <location name="pixel52" y="0.0798828125"/>
-      <location name="pixel53" y="0.0794921875"/>
-      <location name="pixel54" y="0.0791015625"/>
-      <location name="pixel55" y="0.0787109375"/>
-      <location name="pixel56" y="0.0783203125"/>
-      <location name="pixel57" y="0.0779296875"/>
-      <location name="pixel58" y="0.0775390625"/>
-      <location name="pixel59" y="0.0771484375"/>
-      <location name="pixel60" y="0.0767578125"/>
-      <location name="pixel61" y="0.0763671875"/>
-      <location name="pixel62" y="0.0759765625"/>
-      <location name="pixel63" y="0.0755859375"/>
-      <location name="pixel64" y="0.0751953125"/>
-      <location name="pixel65" y="0.0748046875"/>
-      <location name="pixel66" y="0.0744140625"/>
-      <location name="pixel67" y="0.0740234375"/>
-      <location name="pixel68" y="0.0736328125"/>
-      <location name="pixel69" y="0.0732421875"/>
-      <location name="pixel70" y="0.0728515625"/>
-      <location name="pixel71" y="0.0724609375"/>
-      <location name="pixel72" y="0.0720703125"/>
-      <location name="pixel73" y="0.0716796875"/>
-      <location name="pixel74" y="0.0712890625"/>
-      <location name="pixel75" y="0.0708984375"/>
-      <location name="pixel76" y="0.0705078125"/>
-      <location name="pixel77" y="0.0701171875"/>
-      <location name="pixel78" y="0.0697265625"/>
-      <location name="pixel79" y="0.0693359375"/>
-      <location name="pixel80" y="0.0689453125"/>
-      <location name="pixel81" y="0.0685546875"/>
-      <location name="pixel82" y="0.0681640625"/>
-      <location name="pixel83" y="0.0677734375"/>
-      <location name="pixel84" y="0.0673828125"/>
-      <location name="pixel85" y="0.0669921875"/>
-      <location name="pixel86" y="0.0666015625"/>
-      <location name="pixel87" y="0.0662109375"/>
-      <location name="pixel88" y="0.0658203125"/>
-      <location name="pixel89" y="0.0654296875"/>
-      <location name="pixel90" y="0.0650390625"/>
-      <location name="pixel91" y="0.0646484375"/>
-      <location name="pixel92" y="0.0642578125"/>
-      <location name="pixel93" y="0.0638671875"/>
-      <location name="pixel94" y="0.0634765625"/>
-      <location name="pixel95" y="0.0630859375"/>
-      <location name="pixel96" y="0.0626953125"/>
-      <location name="pixel97" y="0.0623046875"/>
-      <location name="pixel98" y="0.0619140625"/>
-      <location name="pixel99" y="0.0615234375"/>
-      <location name="pixel100" y="0.0611328125"/>
-      <location name="pixel101" y="0.0607421875"/>
-      <location name="pixel102" y="0.0603515625"/>
-      <location name="pixel103" y="0.0599609375"/>
-      <location name="pixel104" y="0.0595703125"/>
-      <location name="pixel105" y="0.0591796875"/>
-      <location name="pixel106" y="0.0587890625"/>
-      <location name="pixel107" y="0.0583984375"/>
-      <location name="pixel108" y="0.0580078125"/>
-      <location name="pixel109" y="0.0576171875"/>
-      <location name="pixel110" y="0.0572265625"/>
-      <location name="pixel111" y="0.0568359375"/>
-      <location name="pixel112" y="0.0564453125"/>
-      <location name="pixel113" y="0.0560546875"/>
-      <location name="pixel114" y="0.0556640625"/>
-      <location name="pixel115" y="0.0552734375"/>
-      <location name="pixel116" y="0.0548828125"/>
-      <location name="pixel117" y="0.0544921875"/>
-      <location name="pixel118" y="0.0541015625"/>
-      <location name="pixel119" y="0.0537109375"/>
-      <location name="pixel120" y="0.0533203125"/>
-      <location name="pixel121" y="0.0529296875"/>
-      <location name="pixel122" y="0.0525390625"/>
-      <location name="pixel123" y="0.0521484375"/>
-      <location name="pixel124" y="0.0517578125"/>
-      <location name="pixel125" y="0.0513671875"/>
-      <location name="pixel126" y="0.0509765625"/>
-      <location name="pixel127" y="0.0505859375"/>
-      <location name="pixel128" y="0.0501953125"/>
-      <location name="pixel129" y="0.0498046875"/>
-      <location name="pixel130" y="0.0494140625"/>
-      <location name="pixel131" y="0.0490234375"/>
-      <location name="pixel132" y="0.0486328125"/>
-      <location name="pixel133" y="0.0482421875"/>
-      <location name="pixel134" y="0.0478515625"/>
-      <location name="pixel135" y="0.0474609375"/>
-      <location name="pixel136" y="0.0470703125"/>
-      <location name="pixel137" y="0.0466796875"/>
-      <location name="pixel138" y="0.0462890625"/>
-      <location name="pixel139" y="0.0458984375"/>
-      <location name="pixel140" y="0.0455078125"/>
-      <location name="pixel141" y="0.0451171875"/>
-      <location name="pixel142" y="0.0447265625"/>
-      <location name="pixel143" y="0.0443359375"/>
-      <location name="pixel144" y="0.0439453125"/>
-      <location name="pixel145" y="0.0435546875"/>
-      <location name="pixel146" y="0.0431640625"/>
-      <location name="pixel147" y="0.0427734375"/>
-      <location name="pixel148" y="0.0423828125"/>
-      <location name="pixel149" y="0.0419921875"/>
-      <location name="pixel150" y="0.0416015625"/>
-      <location name="pixel151" y="0.0412109375"/>
-      <location name="pixel152" y="0.0408203125"/>
-      <location name="pixel153" y="0.0404296875"/>
-      <location name="pixel154" y="0.0400390625"/>
-      <location name="pixel155" y="0.0396484375"/>
-      <location name="pixel156" y="0.0392578125"/>
-      <location name="pixel157" y="0.0388671875"/>
-      <location name="pixel158" y="0.0384765625"/>
-      <location name="pixel159" y="0.0380859375"/>
-      <location name="pixel160" y="0.0376953125"/>
-      <location name="pixel161" y="0.0373046875"/>
-      <location name="pixel162" y="0.0369140625"/>
-      <location name="pixel163" y="0.0365234375"/>
-      <location name="pixel164" y="0.0361328125"/>
-      <location name="pixel165" y="0.0357421875"/>
-      <location name="pixel166" y="0.0353515625"/>
-      <location name="pixel167" y="0.0349609375"/>
-      <location name="pixel168" y="0.0345703125"/>
-      <location name="pixel169" y="0.0341796875"/>
-      <location name="pixel170" y="0.0337890625"/>
-      <location name="pixel171" y="0.0333984375"/>
-      <location name="pixel172" y="0.0330078125"/>
-      <location name="pixel173" y="0.0326171875"/>
-      <location name="pixel174" y="0.0322265625"/>
-      <location name="pixel175" y="0.0318359375"/>
-      <location name="pixel176" y="0.0314453125"/>
-      <location name="pixel177" y="0.0310546875"/>
-      <location name="pixel178" y="0.0306640625"/>
-      <location name="pixel179" y="0.0302734375"/>
-      <location name="pixel180" y="0.0298828125"/>
-      <location name="pixel181" y="0.0294921875"/>
-      <location name="pixel182" y="0.0291015625"/>
-      <location name="pixel183" y="0.0287109375"/>
-      <location name="pixel184" y="0.0283203125"/>
-      <location name="pixel185" y="0.0279296875"/>
-      <location name="pixel186" y="0.0275390625"/>
-      <location name="pixel187" y="0.0271484375"/>
-      <location name="pixel188" y="0.0267578125"/>
-      <location name="pixel189" y="0.0263671875"/>
-      <location name="pixel190" y="0.0259765625"/>
-      <location name="pixel191" y="0.0255859375"/>
-      <location name="pixel192" y="0.0251953125"/>
-      <location name="pixel193" y="0.0248046875"/>
-      <location name="pixel194" y="0.0244140625"/>
-      <location name="pixel195" y="0.0240234375"/>
-      <location name="pixel196" y="0.0236328125"/>
-      <location name="pixel197" y="0.0232421875"/>
-      <location name="pixel198" y="0.0228515625"/>
-      <location name="pixel199" y="0.0224609375"/>
-      <location name="pixel200" y="0.0220703125"/>
-      <location name="pixel201" y="0.0216796875"/>
-      <location name="pixel202" y="0.0212890625"/>
-      <location name="pixel203" y="0.0208984375"/>
-      <location name="pixel204" y="0.0205078125"/>
-      <location name="pixel205" y="0.0201171875"/>
-      <location name="pixel206" y="0.0197265625"/>
-      <location name="pixel207" y="0.0193359375"/>
-      <location name="pixel208" y="0.0189453125"/>
-      <location name="pixel209" y="0.0185546875"/>
-      <location name="pixel210" y="0.0181640625"/>
-      <location name="pixel211" y="0.0177734375"/>
-      <location name="pixel212" y="0.0173828125"/>
-      <location name="pixel213" y="0.0169921875"/>
-      <location name="pixel214" y="0.0166015625"/>
-      <location name="pixel215" y="0.0162109375"/>
-      <location name="pixel216" y="0.0158203125"/>
-      <location name="pixel217" y="0.0154296875"/>
-      <location name="pixel218" y="0.0150390625"/>
-      <location name="pixel219" y="0.0146484375"/>
-      <location name="pixel220" y="0.0142578125"/>
-      <location name="pixel221" y="0.0138671875"/>
-      <location name="pixel222" y="0.0134765625"/>
-      <location name="pixel223" y="0.0130859375"/>
-      <location name="pixel224" y="0.0126953125"/>
-      <location name="pixel225" y="0.0123046875"/>
-      <location name="pixel226" y="0.0119140625"/>
-      <location name="pixel227" y="0.0115234375"/>
-      <location name="pixel228" y="0.0111328125"/>
-      <location name="pixel229" y="0.0107421875"/>
-      <location name="pixel230" y="0.0103515625"/>
-      <location name="pixel231" y="0.0099609375"/>
-      <location name="pixel232" y="0.0095703125"/>
-      <location name="pixel233" y="0.0091796875"/>
-      <location name="pixel234" y="0.0087890625"/>
-      <location name="pixel235" y="0.0083984375"/>
-      <location name="pixel236" y="0.0080078125"/>
-      <location name="pixel237" y="0.0076171875"/>
-      <location name="pixel238" y="0.0072265625"/>
-      <location name="pixel239" y="0.0068359375"/>
-      <location name="pixel240" y="0.0064453125"/>
-      <location name="pixel241" y="0.0060546875"/>
-      <location name="pixel242" y="0.0056640625"/>
-      <location name="pixel243" y="0.0052734375"/>
-      <location name="pixel244" y="0.0048828125"/>
-      <location name="pixel245" y="0.0044921875"/>
-      <location name="pixel246" y="0.0041015625"/>
-      <location name="pixel247" y="0.0037109375"/>
-      <location name="pixel248" y="0.0033203125"/>
-      <location name="pixel249" y="0.0029296875"/>
-      <location name="pixel250" y="0.0025390625"/>
-      <location name="pixel251" y="0.0021484375"/>
-      <location name="pixel252" y="0.0017578125"/>
-      <location name="pixel253" y="0.0013671875"/>
-      <location name="pixel254" y="0.0009765625"/>
-      <location name="pixel255" y="0.0005859375"/>
-      <location name="pixel256" y="0.0001953125"/>
-      <location name="pixel257" y="-0.0001953125"/>
-      <location name="pixel258" y="-0.0005859375"/>
-      <location name="pixel259" y="-0.0009765625"/>
-      <location name="pixel260" y="-0.0013671875"/>
-      <location name="pixel261" y="-0.0017578125"/>
-      <location name="pixel262" y="-0.0021484375"/>
-      <location name="pixel263" y="-0.0025390625"/>
-      <location name="pixel264" y="-0.0029296875"/>
-      <location name="pixel265" y="-0.0033203125"/>
-      <location name="pixel266" y="-0.0037109375"/>
-      <location name="pixel267" y="-0.0041015625"/>
-      <location name="pixel268" y="-0.0044921875"/>
-      <location name="pixel269" y="-0.0048828125"/>
-      <location name="pixel270" y="-0.0052734375"/>
-      <location name="pixel271" y="-0.0056640625"/>
-      <location name="pixel272" y="-0.0060546875"/>
-      <location name="pixel273" y="-0.0064453125"/>
-      <location name="pixel274" y="-0.0068359375"/>
-      <location name="pixel275" y="-0.0072265625"/>
-      <location name="pixel276" y="-0.0076171875"/>
-      <location name="pixel277" y="-0.0080078125"/>
-      <location name="pixel278" y="-0.0083984375"/>
-      <location name="pixel279" y="-0.0087890625"/>
-      <location name="pixel280" y="-0.0091796875"/>
-      <location name="pixel281" y="-0.0095703125"/>
-      <location name="pixel282" y="-0.0099609375"/>
-      <location name="pixel283" y="-0.0103515625"/>
-      <location name="pixel284" y="-0.0107421875"/>
-      <location name="pixel285" y="-0.0111328125"/>
-      <location name="pixel286" y="-0.0115234375"/>
-      <location name="pixel287" y="-0.0119140625"/>
-      <location name="pixel288" y="-0.0123046875"/>
-      <location name="pixel289" y="-0.0126953125"/>
-      <location name="pixel290" y="-0.0130859375"/>
-      <location name="pixel291" y="-0.0134765625"/>
-      <location name="pixel292" y="-0.0138671875"/>
-      <location name="pixel293" y="-0.0142578125"/>
-      <location name="pixel294" y="-0.0146484375"/>
-      <location name="pixel295" y="-0.0150390625"/>
-      <location name="pixel296" y="-0.0154296875"/>
-      <location name="pixel297" y="-0.0158203125"/>
-      <location name="pixel298" y="-0.0162109375"/>
-      <location name="pixel299" y="-0.0166015625"/>
-      <location name="pixel300" y="-0.0169921875"/>
-      <location name="pixel301" y="-0.0173828125"/>
-      <location name="pixel302" y="-0.0177734375"/>
-      <location name="pixel303" y="-0.0181640625"/>
-      <location name="pixel304" y="-0.0185546875"/>
-      <location name="pixel305" y="-0.0189453125"/>
-      <location name="pixel306" y="-0.0193359375"/>
-      <location name="pixel307" y="-0.0197265625"/>
-      <location name="pixel308" y="-0.0201171875"/>
-      <location name="pixel309" y="-0.0205078125"/>
-      <location name="pixel310" y="-0.0208984375"/>
-      <location name="pixel311" y="-0.0212890625"/>
-      <location name="pixel312" y="-0.0216796875"/>
-      <location name="pixel313" y="-0.0220703125"/>
-      <location name="pixel314" y="-0.0224609375"/>
-      <location name="pixel315" y="-0.0228515625"/>
-      <location name="pixel316" y="-0.0232421875"/>
-      <location name="pixel317" y="-0.0236328125"/>
-      <location name="pixel318" y="-0.0240234375"/>
-      <location name="pixel319" y="-0.0244140625"/>
-      <location name="pixel320" y="-0.0248046875"/>
-      <location name="pixel321" y="-0.0251953125"/>
-      <location name="pixel322" y="-0.0255859375"/>
-      <location name="pixel323" y="-0.0259765625"/>
-      <location name="pixel324" y="-0.0263671875"/>
-      <location name="pixel325" y="-0.0267578125"/>
-      <location name="pixel326" y="-0.0271484375"/>
-      <location name="pixel327" y="-0.0275390625"/>
-      <location name="pixel328" y="-0.0279296875"/>
-      <location name="pixel329" y="-0.0283203125"/>
-      <location name="pixel330" y="-0.0287109375"/>
-      <location name="pixel331" y="-0.0291015625"/>
-      <location name="pixel332" y="-0.0294921875"/>
-      <location name="pixel333" y="-0.0298828125"/>
-      <location name="pixel334" y="-0.0302734375"/>
-      <location name="pixel335" y="-0.0306640625"/>
-      <location name="pixel336" y="-0.0310546875"/>
-      <location name="pixel337" y="-0.0314453125"/>
-      <location name="pixel338" y="-0.0318359375"/>
-      <location name="pixel339" y="-0.0322265625"/>
-      <location name="pixel340" y="-0.0326171875"/>
-      <location name="pixel341" y="-0.0330078125"/>
-      <location name="pixel342" y="-0.0333984375"/>
-      <location name="pixel343" y="-0.0337890625"/>
-      <location name="pixel344" y="-0.0341796875"/>
-      <location name="pixel345" y="-0.0345703125"/>
-      <location name="pixel346" y="-0.0349609375"/>
-      <location name="pixel347" y="-0.0353515625"/>
-      <location name="pixel348" y="-0.0357421875"/>
-      <location name="pixel349" y="-0.0361328125"/>
-      <location name="pixel350" y="-0.0365234375"/>
-      <location name="pixel351" y="-0.0369140625"/>
-      <location name="pixel352" y="-0.0373046875"/>
-      <location name="pixel353" y="-0.0376953125"/>
-      <location name="pixel354" y="-0.0380859375"/>
-      <location name="pixel355" y="-0.0384765625"/>
-      <location name="pixel356" y="-0.0388671875"/>
-      <location name="pixel357" y="-0.0392578125"/>
-      <location name="pixel358" y="-0.0396484375"/>
-      <location name="pixel359" y="-0.0400390625"/>
-      <location name="pixel360" y="-0.0404296875"/>
-      <location name="pixel361" y="-0.0408203125"/>
-      <location name="pixel362" y="-0.0412109375"/>
-      <location name="pixel363" y="-0.0416015625"/>
-      <location name="pixel364" y="-0.0419921875"/>
-      <location name="pixel365" y="-0.0423828125"/>
-      <location name="pixel366" y="-0.0427734375"/>
-      <location name="pixel367" y="-0.0431640625"/>
-      <location name="pixel368" y="-0.0435546875"/>
-      <location name="pixel369" y="-0.0439453125"/>
-      <location name="pixel370" y="-0.0443359375"/>
-      <location name="pixel371" y="-0.0447265625"/>
-      <location name="pixel372" y="-0.0451171875"/>
-      <location name="pixel373" y="-0.0455078125"/>
-      <location name="pixel374" y="-0.0458984375"/>
-      <location name="pixel375" y="-0.0462890625"/>
-      <location name="pixel376" y="-0.0466796875"/>
-      <location name="pixel377" y="-0.0470703125"/>
-      <location name="pixel378" y="-0.0474609375"/>
-      <location name="pixel379" y="-0.0478515625"/>
-      <location name="pixel380" y="-0.0482421875"/>
-      <location name="pixel381" y="-0.0486328125"/>
-      <location name="pixel382" y="-0.0490234375"/>
-      <location name="pixel383" y="-0.0494140625"/>
-      <location name="pixel384" y="-0.0498046875"/>
-      <location name="pixel385" y="-0.0501953125"/>
-      <location name="pixel386" y="-0.0505859375"/>
-      <location name="pixel387" y="-0.0509765625"/>
-      <location name="pixel388" y="-0.0513671875"/>
-      <location name="pixel389" y="-0.0517578125"/>
-      <location name="pixel390" y="-0.0521484375"/>
-      <location name="pixel391" y="-0.0525390625"/>
-      <location name="pixel392" y="-0.0529296875"/>
-      <location name="pixel393" y="-0.0533203125"/>
-      <location name="pixel394" y="-0.0537109375"/>
-      <location name="pixel395" y="-0.0541015625"/>
-      <location name="pixel396" y="-0.0544921875"/>
-      <location name="pixel397" y="-0.0548828125"/>
-      <location name="pixel398" y="-0.0552734375"/>
-      <location name="pixel399" y="-0.0556640625"/>
-      <location name="pixel400" y="-0.0560546875"/>
-      <location name="pixel401" y="-0.0564453125"/>
-      <location name="pixel402" y="-0.0568359375"/>
-      <location name="pixel403" y="-0.0572265625"/>
-      <location name="pixel404" y="-0.0576171875"/>
-      <location name="pixel405" y="-0.0580078125"/>
-      <location name="pixel406" y="-0.0583984375"/>
-      <location name="pixel407" y="-0.0587890625"/>
-      <location name="pixel408" y="-0.0591796875"/>
-      <location name="pixel409" y="-0.0595703125"/>
-      <location name="pixel410" y="-0.0599609375"/>
-      <location name="pixel411" y="-0.0603515625"/>
-      <location name="pixel412" y="-0.0607421875"/>
-      <location name="pixel413" y="-0.0611328125"/>
-      <location name="pixel414" y="-0.0615234375"/>
-      <location name="pixel415" y="-0.0619140625"/>
-      <location name="pixel416" y="-0.0623046875"/>
-      <location name="pixel417" y="-0.0626953125"/>
-      <location name="pixel418" y="-0.0630859375"/>
-      <location name="pixel419" y="-0.0634765625"/>
-      <location name="pixel420" y="-0.0638671875"/>
-      <location name="pixel421" y="-0.0642578125"/>
-      <location name="pixel422" y="-0.0646484375"/>
-      <location name="pixel423" y="-0.0650390625"/>
-      <location name="pixel424" y="-0.0654296875"/>
-      <location name="pixel425" y="-0.0658203125"/>
-      <location name="pixel426" y="-0.0662109375"/>
-      <location name="pixel427" y="-0.0666015625"/>
-      <location name="pixel428" y="-0.0669921875"/>
-      <location name="pixel429" y="-0.0673828125"/>
-      <location name="pixel430" y="-0.0677734375"/>
-      <location name="pixel431" y="-0.0681640625"/>
-      <location name="pixel432" y="-0.0685546875"/>
-      <location name="pixel433" y="-0.0689453125"/>
-      <location name="pixel434" y="-0.0693359375"/>
-      <location name="pixel435" y="-0.0697265625"/>
-      <location name="pixel436" y="-0.0701171875"/>
-      <location name="pixel437" y="-0.0705078125"/>
-      <location name="pixel438" y="-0.0708984375"/>
-      <location name="pixel439" y="-0.0712890625"/>
-      <location name="pixel440" y="-0.0716796875"/>
-      <location name="pixel441" y="-0.0720703125"/>
-      <location name="pixel442" y="-0.0724609375"/>
-      <location name="pixel443" y="-0.0728515625"/>
-      <location name="pixel444" y="-0.0732421875"/>
-      <location name="pixel445" y="-0.0736328125"/>
-      <location name="pixel446" y="-0.0740234375"/>
-      <location name="pixel447" y="-0.0744140625"/>
-      <location name="pixel448" y="-0.0748046875"/>
-      <location name="pixel449" y="-0.0751953125"/>
-      <location name="pixel450" y="-0.0755859375"/>
-      <location name="pixel451" y="-0.0759765625"/>
-      <location name="pixel452" y="-0.0763671875"/>
-      <location name="pixel453" y="-0.0767578125"/>
-      <location name="pixel454" y="-0.0771484375"/>
-      <location name="pixel455" y="-0.0775390625"/>
-      <location name="pixel456" y="-0.0779296875"/>
-      <location name="pixel457" y="-0.0783203125"/>
-      <location name="pixel458" y="-0.0787109375"/>
-      <location name="pixel459" y="-0.0791015625"/>
-      <location name="pixel460" y="-0.0794921875"/>
-      <location name="pixel461" y="-0.0798828125"/>
-      <location name="pixel462" y="-0.0802734375"/>
-      <location name="pixel463" y="-0.0806640625"/>
-      <location name="pixel464" y="-0.0810546875"/>
-      <location name="pixel465" y="-0.0814453125"/>
-      <location name="pixel466" y="-0.0818359375"/>
-      <location name="pixel467" y="-0.0822265625"/>
-      <location name="pixel468" y="-0.0826171875"/>
-      <location name="pixel469" y="-0.0830078125"/>
-      <location name="pixel470" y="-0.0833984375"/>
-      <location name="pixel471" y="-0.0837890625"/>
-      <location name="pixel472" y="-0.0841796875"/>
-      <location name="pixel473" y="-0.0845703125"/>
-      <location name="pixel474" y="-0.0849609375"/>
-      <location name="pixel475" y="-0.0853515625"/>
-      <location name="pixel476" y="-0.0857421875"/>
-      <location name="pixel477" y="-0.0861328125"/>
-      <location name="pixel478" y="-0.0865234375"/>
-      <location name="pixel479" y="-0.0869140625"/>
-      <location name="pixel480" y="-0.0873046875"/>
-      <location name="pixel481" y="-0.0876953125"/>
-      <location name="pixel482" y="-0.0880859375"/>
-      <location name="pixel483" y="-0.0884765625"/>
-      <location name="pixel484" y="-0.0888671875"/>
-      <location name="pixel485" y="-0.0892578125"/>
-      <location name="pixel486" y="-0.0896484375"/>
-      <location name="pixel487" y="-0.0900390625"/>
-      <location name="pixel488" y="-0.0904296875"/>
-      <location name="pixel489" y="-0.0908203125"/>
-      <location name="pixel490" y="-0.0912109375"/>
-      <location name="pixel491" y="-0.0916015625"/>
-      <location name="pixel492" y="-0.0919921875"/>
-      <location name="pixel493" y="-0.0923828125"/>
-      <location name="pixel494" y="-0.0927734375"/>
-      <location name="pixel495" y="-0.0931640625"/>
-      <location name="pixel496" y="-0.0935546875"/>
-      <location name="pixel497" y="-0.0939453125"/>
-      <location name="pixel498" y="-0.0943359375"/>
-      <location name="pixel499" y="-0.0947265625"/>
-      <location name="pixel500" y="-0.0951171875"/>
-      <location name="pixel501" y="-0.0955078125"/>
-      <location name="pixel502" y="-0.0958984375"/>
-      <location name="pixel503" y="-0.0962890625"/>
-      <location name="pixel504" y="-0.0966796875"/>
-      <location name="pixel505" y="-0.0970703125"/>
-      <location name="pixel506" y="-0.0974609375"/>
-      <location name="pixel507" y="-0.0978515625"/>
-      <location name="pixel508" y="-0.0982421875"/>
-      <location name="pixel509" y="-0.0986328125"/>
-      <location name="pixel510" y="-0.0990234375"/>
-      <location name="pixel511" y="-0.0994140625"/>
-      <location name="pixel512" y="-0.0998046875"/>
+      <location name="pixel1" y="-0.0998046875"/>
+      <location name="pixel2" y="-0.0994140625"/>
+      <location name="pixel3" y="-0.0990234375"/>
+      <location name="pixel4" y="-0.0986328125"/>
+      <location name="pixel5" y="-0.0982421875"/>
+      <location name="pixel6" y="-0.0978515625"/>
+      <location name="pixel7" y="-0.0974609375"/>
+      <location name="pixel8" y="-0.0970703125"/>
+      <location name="pixel9" y="-0.0966796875"/>
+      <location name="pixel10" y="-0.0962890625"/>
+      <location name="pixel11" y="-0.0958984375"/>
+      <location name="pixel12" y="-0.0955078125"/>
+      <location name="pixel13" y="-0.0951171875"/>
+      <location name="pixel14" y="-0.0947265625"/>
+      <location name="pixel15" y="-0.0943359375"/>
+      <location name="pixel16" y="-0.0939453125"/>
+      <location name="pixel17" y="-0.0935546875"/>
+      <location name="pixel18" y="-0.0931640625"/>
+      <location name="pixel19" y="-0.0927734375"/>
+      <location name="pixel20" y="-0.0923828125"/>
+      <location name="pixel21" y="-0.0919921875"/>
+      <location name="pixel22" y="-0.0916015625"/>
+      <location name="pixel23" y="-0.0912109375"/>
+      <location name="pixel24" y="-0.0908203125"/>
+      <location name="pixel25" y="-0.0904296875"/>
+      <location name="pixel26" y="-0.0900390625"/>
+      <location name="pixel27" y="-0.0896484375"/>
+      <location name="pixel28" y="-0.0892578125"/>
+      <location name="pixel29" y="-0.0888671875"/>
+      <location name="pixel30" y="-0.0884765625"/>
+      <location name="pixel31" y="-0.0880859375"/>
+      <location name="pixel32" y="-0.0876953125"/>
+      <location name="pixel33" y="-0.0873046875"/>
+      <location name="pixel34" y="-0.0869140625"/>
+      <location name="pixel35" y="-0.0865234375"/>
+      <location name="pixel36" y="-0.0861328125"/>
+      <location name="pixel37" y="-0.0857421875"/>
+      <location name="pixel38" y="-0.0853515625"/>
+      <location name="pixel39" y="-0.0849609375"/>
+      <location name="pixel40" y="-0.0845703125"/>
+      <location name="pixel41" y="-0.0841796875"/>
+      <location name="pixel42" y="-0.0837890625"/>
+      <location name="pixel43" y="-0.0833984375"/>
+      <location name="pixel44" y="-0.0830078125"/>
+      <location name="pixel45" y="-0.0826171875"/>
+      <location name="pixel46" y="-0.0822265625"/>
+      <location name="pixel47" y="-0.0818359375"/>
+      <location name="pixel48" y="-0.0814453125"/>
+      <location name="pixel49" y="-0.0810546875"/>
+      <location name="pixel50" y="-0.0806640625"/>
+      <location name="pixel51" y="-0.0802734375"/>
+      <location name="pixel52" y="-0.0798828125"/>
+      <location name="pixel53" y="-0.0794921875"/>
+      <location name="pixel54" y="-0.0791015625"/>
+      <location name="pixel55" y="-0.0787109375"/>
+      <location name="pixel56" y="-0.0783203125"/>
+      <location name="pixel57" y="-0.0779296875"/>
+      <location name="pixel58" y="-0.0775390625"/>
+      <location name="pixel59" y="-0.0771484375"/>
+      <location name="pixel60" y="-0.0767578125"/>
+      <location name="pixel61" y="-0.0763671875"/>
+      <location name="pixel62" y="-0.0759765625"/>
+      <location name="pixel63" y="-0.0755859375"/>
+      <location name="pixel64" y="-0.0751953125"/>
+      <location name="pixel65" y="-0.0748046875"/>
+      <location name="pixel66" y="-0.0744140625"/>
+      <location name="pixel67" y="-0.0740234375"/>
+      <location name="pixel68" y="-0.0736328125"/>
+      <location name="pixel69" y="-0.0732421875"/>
+      <location name="pixel70" y="-0.0728515625"/>
+      <location name="pixel71" y="-0.0724609375"/>
+      <location name="pixel72" y="-0.0720703125"/>
+      <location name="pixel73" y="-0.0716796875"/>
+      <location name="pixel74" y="-0.0712890625"/>
+      <location name="pixel75" y="-0.0708984375"/>
+      <location name="pixel76" y="-0.0705078125"/>
+      <location name="pixel77" y="-0.0701171875"/>
+      <location name="pixel78" y="-0.0697265625"/>
+      <location name="pixel79" y="-0.0693359375"/>
+      <location name="pixel80" y="-0.0689453125"/>
+      <location name="pixel81" y="-0.0685546875"/>
+      <location name="pixel82" y="-0.0681640625"/>
+      <location name="pixel83" y="-0.0677734375"/>
+      <location name="pixel84" y="-0.0673828125"/>
+      <location name="pixel85" y="-0.0669921875"/>
+      <location name="pixel86" y="-0.0666015625"/>
+      <location name="pixel87" y="-0.0662109375"/>
+      <location name="pixel88" y="-0.0658203125"/>
+      <location name="pixel89" y="-0.0654296875"/>
+      <location name="pixel90" y="-0.0650390625"/>
+      <location name="pixel91" y="-0.0646484375"/>
+      <location name="pixel92" y="-0.0642578125"/>
+      <location name="pixel93" y="-0.0638671875"/>
+      <location name="pixel94" y="-0.0634765625"/>
+      <location name="pixel95" y="-0.0630859375"/>
+      <location name="pixel96" y="-0.0626953125"/>
+      <location name="pixel97" y="-0.0623046875"/>
+      <location name="pixel98" y="-0.0619140625"/>
+      <location name="pixel99" y="-0.0615234375"/>
+      <location name="pixel100" y="-0.0611328125"/>
+      <location name="pixel101" y="-0.0607421875"/>
+      <location name="pixel102" y="-0.0603515625"/>
+      <location name="pixel103" y="-0.0599609375"/>
+      <location name="pixel104" y="-0.0595703125"/>
+      <location name="pixel105" y="-0.0591796875"/>
+      <location name="pixel106" y="-0.0587890625"/>
+      <location name="pixel107" y="-0.0583984375"/>
+      <location name="pixel108" y="-0.0580078125"/>
+      <location name="pixel109" y="-0.0576171875"/>
+      <location name="pixel110" y="-0.0572265625"/>
+      <location name="pixel111" y="-0.0568359375"/>
+      <location name="pixel112" y="-0.0564453125"/>
+      <location name="pixel113" y="-0.0560546875"/>
+      <location name="pixel114" y="-0.0556640625"/>
+      <location name="pixel115" y="-0.0552734375"/>
+      <location name="pixel116" y="-0.0548828125"/>
+      <location name="pixel117" y="-0.0544921875"/>
+      <location name="pixel118" y="-0.0541015625"/>
+      <location name="pixel119" y="-0.0537109375"/>
+      <location name="pixel120" y="-0.0533203125"/>
+      <location name="pixel121" y="-0.0529296875"/>
+      <location name="pixel122" y="-0.0525390625"/>
+      <location name="pixel123" y="-0.0521484375"/>
+      <location name="pixel124" y="-0.0517578125"/>
+      <location name="pixel125" y="-0.0513671875"/>
+      <location name="pixel126" y="-0.0509765625"/>
+      <location name="pixel127" y="-0.0505859375"/>
+      <location name="pixel128" y="-0.0501953125"/>
+      <location name="pixel129" y="-0.0498046875"/>
+      <location name="pixel130" y="-0.0494140625"/>
+      <location name="pixel131" y="-0.0490234375"/>
+      <location name="pixel132" y="-0.0486328125"/>
+      <location name="pixel133" y="-0.0482421875"/>
+      <location name="pixel134" y="-0.0478515625"/>
+      <location name="pixel135" y="-0.0474609375"/>
+      <location name="pixel136" y="-0.0470703125"/>
+      <location name="pixel137" y="-0.0466796875"/>
+      <location name="pixel138" y="-0.0462890625"/>
+      <location name="pixel139" y="-0.0458984375"/>
+      <location name="pixel140" y="-0.0455078125"/>
+      <location name="pixel141" y="-0.0451171875"/>
+      <location name="pixel142" y="-0.0447265625"/>
+      <location name="pixel143" y="-0.0443359375"/>
+      <location name="pixel144" y="-0.0439453125"/>
+      <location name="pixel145" y="-0.0435546875"/>
+      <location name="pixel146" y="-0.0431640625"/>
+      <location name="pixel147" y="-0.0427734375"/>
+      <location name="pixel148" y="-0.0423828125"/>
+      <location name="pixel149" y="-0.0419921875"/>
+      <location name="pixel150" y="-0.0416015625"/>
+      <location name="pixel151" y="-0.0412109375"/>
+      <location name="pixel152" y="-0.0408203125"/>
+      <location name="pixel153" y="-0.0404296875"/>
+      <location name="pixel154" y="-0.0400390625"/>
+      <location name="pixel155" y="-0.0396484375"/>
+      <location name="pixel156" y="-0.0392578125"/>
+      <location name="pixel157" y="-0.0388671875"/>
+      <location name="pixel158" y="-0.0384765625"/>
+      <location name="pixel159" y="-0.0380859375"/>
+      <location name="pixel160" y="-0.0376953125"/>
+      <location name="pixel161" y="-0.0373046875"/>
+      <location name="pixel162" y="-0.0369140625"/>
+      <location name="pixel163" y="-0.0365234375"/>
+      <location name="pixel164" y="-0.0361328125"/>
+      <location name="pixel165" y="-0.0357421875"/>
+      <location name="pixel166" y="-0.0353515625"/>
+      <location name="pixel167" y="-0.0349609375"/>
+      <location name="pixel168" y="-0.0345703125"/>
+      <location name="pixel169" y="-0.0341796875"/>
+      <location name="pixel170" y="-0.0337890625"/>
+      <location name="pixel171" y="-0.0333984375"/>
+      <location name="pixel172" y="-0.0330078125"/>
+      <location name="pixel173" y="-0.0326171875"/>
+      <location name="pixel174" y="-0.0322265625"/>
+      <location name="pixel175" y="-0.0318359375"/>
+      <location name="pixel176" y="-0.0314453125"/>
+      <location name="pixel177" y="-0.0310546875"/>
+      <location name="pixel178" y="-0.0306640625"/>
+      <location name="pixel179" y="-0.0302734375"/>
+      <location name="pixel180" y="-0.0298828125"/>
+      <location name="pixel181" y="-0.0294921875"/>
+      <location name="pixel182" y="-0.0291015625"/>
+      <location name="pixel183" y="-0.0287109375"/>
+      <location name="pixel184" y="-0.0283203125"/>
+      <location name="pixel185" y="-0.0279296875"/>
+      <location name="pixel186" y="-0.0275390625"/>
+      <location name="pixel187" y="-0.0271484375"/>
+      <location name="pixel188" y="-0.0267578125"/>
+      <location name="pixel189" y="-0.0263671875"/>
+      <location name="pixel190" y="-0.0259765625"/>
+      <location name="pixel191" y="-0.0255859375"/>
+      <location name="pixel192" y="-0.0251953125"/>
+      <location name="pixel193" y="-0.0248046875"/>
+      <location name="pixel194" y="-0.0244140625"/>
+      <location name="pixel195" y="-0.0240234375"/>
+      <location name="pixel196" y="-0.0236328125"/>
+      <location name="pixel197" y="-0.0232421875"/>
+      <location name="pixel198" y="-0.0228515625"/>
+      <location name="pixel199" y="-0.0224609375"/>
+      <location name="pixel200" y="-0.0220703125"/>
+      <location name="pixel201" y="-0.0216796875"/>
+      <location name="pixel202" y="-0.0212890625"/>
+      <location name="pixel203" y="-0.0208984375"/>
+      <location name="pixel204" y="-0.0205078125"/>
+      <location name="pixel205" y="-0.0201171875"/>
+      <location name="pixel206" y="-0.0197265625"/>
+      <location name="pixel207" y="-0.0193359375"/>
+      <location name="pixel208" y="-0.0189453125"/>
+      <location name="pixel209" y="-0.0185546875"/>
+      <location name="pixel210" y="-0.0181640625"/>
+      <location name="pixel211" y="-0.0177734375"/>
+      <location name="pixel212" y="-0.0173828125"/>
+      <location name="pixel213" y="-0.0169921875"/>
+      <location name="pixel214" y="-0.0166015625"/>
+      <location name="pixel215" y="-0.0162109375"/>
+      <location name="pixel216" y="-0.0158203125"/>
+      <location name="pixel217" y="-0.0154296875"/>
+      <location name="pixel218" y="-0.0150390625"/>
+      <location name="pixel219" y="-0.0146484375"/>
+      <location name="pixel220" y="-0.0142578125"/>
+      <location name="pixel221" y="-0.0138671875"/>
+      <location name="pixel222" y="-0.0134765625"/>
+      <location name="pixel223" y="-0.0130859375"/>
+      <location name="pixel224" y="-0.0126953125"/>
+      <location name="pixel225" y="-0.0123046875"/>
+      <location name="pixel226" y="-0.0119140625"/>
+      <location name="pixel227" y="-0.0115234375"/>
+      <location name="pixel228" y="-0.0111328125"/>
+      <location name="pixel229" y="-0.0107421875"/>
+      <location name="pixel230" y="-0.0103515625"/>
+      <location name="pixel231" y="-0.0099609375"/>
+      <location name="pixel232" y="-0.0095703125"/>
+      <location name="pixel233" y="-0.0091796875"/>
+      <location name="pixel234" y="-0.0087890625"/>
+      <location name="pixel235" y="-0.0083984375"/>
+      <location name="pixel236" y="-0.0080078125"/>
+      <location name="pixel237" y="-0.0076171875"/>
+      <location name="pixel238" y="-0.0072265625"/>
+      <location name="pixel239" y="-0.0068359375"/>
+      <location name="pixel240" y="-0.0064453125"/>
+      <location name="pixel241" y="-0.0060546875"/>
+      <location name="pixel242" y="-0.0056640625"/>
+      <location name="pixel243" y="-0.0052734375"/>
+      <location name="pixel244" y="-0.0048828125"/>
+      <location name="pixel245" y="-0.0044921875"/>
+      <location name="pixel246" y="-0.0041015625"/>
+      <location name="pixel247" y="-0.0037109375"/>
+      <location name="pixel248" y="-0.0033203125"/>
+      <location name="pixel249" y="-0.0029296875"/>
+      <location name="pixel250" y="-0.0025390625"/>
+      <location name="pixel251" y="-0.0021484375"/>
+      <location name="pixel252" y="-0.0017578125"/>
+      <location name="pixel253" y="-0.0013671875"/>
+      <location name="pixel254" y="-0.0009765625"/>
+      <location name="pixel255" y="-0.0005859375"/>
+      <location name="pixel256" y="-0.0001953125"/>
+      <location name="pixel257" y="0.0001953125"/>
+      <location name="pixel258" y="0.0005859375"/>
+      <location name="pixel259" y="0.0009765625"/>
+      <location name="pixel260" y="0.0013671875"/>
+      <location name="pixel261" y="0.0017578125"/>
+      <location name="pixel262" y="0.0021484375"/>
+      <location name="pixel263" y="0.0025390625"/>
+      <location name="pixel264" y="0.0029296875"/>
+      <location name="pixel265" y="0.0033203125"/>
+      <location name="pixel266" y="0.0037109375"/>
+      <location name="pixel267" y="0.0041015625"/>
+      <location name="pixel268" y="0.0044921875"/>
+      <location name="pixel269" y="0.0048828125"/>
+      <location name="pixel270" y="0.0052734375"/>
+      <location name="pixel271" y="0.0056640625"/>
+      <location name="pixel272" y="0.0060546875"/>
+      <location name="pixel273" y="0.0064453125"/>
+      <location name="pixel274" y="0.0068359375"/>
+      <location name="pixel275" y="0.0072265625"/>
+      <location name="pixel276" y="0.0076171875"/>
+      <location name="pixel277" y="0.0080078125"/>
+      <location name="pixel278" y="0.0083984375"/>
+      <location name="pixel279" y="0.0087890625"/>
+      <location name="pixel280" y="0.0091796875"/>
+      <location name="pixel281" y="0.0095703125"/>
+      <location name="pixel282" y="0.0099609375"/>
+      <location name="pixel283" y="0.0103515625"/>
+      <location name="pixel284" y="0.0107421875"/>
+      <location name="pixel285" y="0.0111328125"/>
+      <location name="pixel286" y="0.0115234375"/>
+      <location name="pixel287" y="0.0119140625"/>
+      <location name="pixel288" y="0.0123046875"/>
+      <location name="pixel289" y="0.0126953125"/>
+      <location name="pixel290" y="0.0130859375"/>
+      <location name="pixel291" y="0.0134765625"/>
+      <location name="pixel292" y="0.0138671875"/>
+      <location name="pixel293" y="0.0142578125"/>
+      <location name="pixel294" y="0.0146484375"/>
+      <location name="pixel295" y="0.0150390625"/>
+      <location name="pixel296" y="0.0154296875"/>
+      <location name="pixel297" y="0.0158203125"/>
+      <location name="pixel298" y="0.0162109375"/>
+      <location name="pixel299" y="0.0166015625"/>
+      <location name="pixel300" y="0.0169921875"/>
+      <location name="pixel301" y="0.0173828125"/>
+      <location name="pixel302" y="0.0177734375"/>
+      <location name="pixel303" y="0.0181640625"/>
+      <location name="pixel304" y="0.0185546875"/>
+      <location name="pixel305" y="0.0189453125"/>
+      <location name="pixel306" y="0.0193359375"/>
+      <location name="pixel307" y="0.0197265625"/>
+      <location name="pixel308" y="0.0201171875"/>
+      <location name="pixel309" y="0.0205078125"/>
+      <location name="pixel310" y="0.0208984375"/>
+      <location name="pixel311" y="0.0212890625"/>
+      <location name="pixel312" y="0.0216796875"/>
+      <location name="pixel313" y="0.0220703125"/>
+      <location name="pixel314" y="0.0224609375"/>
+      <location name="pixel315" y="0.0228515625"/>
+      <location name="pixel316" y="0.0232421875"/>
+      <location name="pixel317" y="0.0236328125"/>
+      <location name="pixel318" y="0.0240234375"/>
+      <location name="pixel319" y="0.0244140625"/>
+      <location name="pixel320" y="0.0248046875"/>
+      <location name="pixel321" y="0.0251953125"/>
+      <location name="pixel322" y="0.0255859375"/>
+      <location name="pixel323" y="0.0259765625"/>
+      <location name="pixel324" y="0.0263671875"/>
+      <location name="pixel325" y="0.0267578125"/>
+      <location name="pixel326" y="0.0271484375"/>
+      <location name="pixel327" y="0.0275390625"/>
+      <location name="pixel328" y="0.0279296875"/>
+      <location name="pixel329" y="0.0283203125"/>
+      <location name="pixel330" y="0.0287109375"/>
+      <location name="pixel331" y="0.0291015625"/>
+      <location name="pixel332" y="0.0294921875"/>
+      <location name="pixel333" y="0.0298828125"/>
+      <location name="pixel334" y="0.0302734375"/>
+      <location name="pixel335" y="0.0306640625"/>
+      <location name="pixel336" y="0.0310546875"/>
+      <location name="pixel337" y="0.0314453125"/>
+      <location name="pixel338" y="0.0318359375"/>
+      <location name="pixel339" y="0.0322265625"/>
+      <location name="pixel340" y="0.0326171875"/>
+      <location name="pixel341" y="0.0330078125"/>
+      <location name="pixel342" y="0.0333984375"/>
+      <location name="pixel343" y="0.0337890625"/>
+      <location name="pixel344" y="0.0341796875"/>
+      <location name="pixel345" y="0.0345703125"/>
+      <location name="pixel346" y="0.0349609375"/>
+      <location name="pixel347" y="0.0353515625"/>
+      <location name="pixel348" y="0.0357421875"/>
+      <location name="pixel349" y="0.0361328125"/>
+      <location name="pixel350" y="0.0365234375"/>
+      <location name="pixel351" y="0.0369140625"/>
+      <location name="pixel352" y="0.0373046875"/>
+      <location name="pixel353" y="0.0376953125"/>
+      <location name="pixel354" y="0.0380859375"/>
+      <location name="pixel355" y="0.0384765625"/>
+      <location name="pixel356" y="0.0388671875"/>
+      <location name="pixel357" y="0.0392578125"/>
+      <location name="pixel358" y="0.0396484375"/>
+      <location name="pixel359" y="0.0400390625"/>
+      <location name="pixel360" y="0.0404296875"/>
+      <location name="pixel361" y="0.0408203125"/>
+      <location name="pixel362" y="0.0412109375"/>
+      <location name="pixel363" y="0.0416015625"/>
+      <location name="pixel364" y="0.0419921875"/>
+      <location name="pixel365" y="0.0423828125"/>
+      <location name="pixel366" y="0.0427734375"/>
+      <location name="pixel367" y="0.0431640625"/>
+      <location name="pixel368" y="0.0435546875"/>
+      <location name="pixel369" y="0.0439453125"/>
+      <location name="pixel370" y="0.0443359375"/>
+      <location name="pixel371" y="0.0447265625"/>
+      <location name="pixel372" y="0.0451171875"/>
+      <location name="pixel373" y="0.0455078125"/>
+      <location name="pixel374" y="0.0458984375"/>
+      <location name="pixel375" y="0.0462890625"/>
+      <location name="pixel376" y="0.0466796875"/>
+      <location name="pixel377" y="0.0470703125"/>
+      <location name="pixel378" y="0.0474609375"/>
+      <location name="pixel379" y="0.0478515625"/>
+      <location name="pixel380" y="0.0482421875"/>
+      <location name="pixel381" y="0.0486328125"/>
+      <location name="pixel382" y="0.0490234375"/>
+      <location name="pixel383" y="0.0494140625"/>
+      <location name="pixel384" y="0.0498046875"/>
+      <location name="pixel385" y="0.0501953125"/>
+      <location name="pixel386" y="0.0505859375"/>
+      <location name="pixel387" y="0.0509765625"/>
+      <location name="pixel388" y="0.0513671875"/>
+      <location name="pixel389" y="0.0517578125"/>
+      <location name="pixel390" y="0.0521484375"/>
+      <location name="pixel391" y="0.0525390625"/>
+      <location name="pixel392" y="0.0529296875"/>
+      <location name="pixel393" y="0.0533203125"/>
+      <location name="pixel394" y="0.0537109375"/>
+      <location name="pixel395" y="0.0541015625"/>
+      <location name="pixel396" y="0.0544921875"/>
+      <location name="pixel397" y="0.0548828125"/>
+      <location name="pixel398" y="0.0552734375"/>
+      <location name="pixel399" y="0.0556640625"/>
+      <location name="pixel400" y="0.0560546875"/>
+      <location name="pixel401" y="0.0564453125"/>
+      <location name="pixel402" y="0.0568359375"/>
+      <location name="pixel403" y="0.0572265625"/>
+      <location name="pixel404" y="0.0576171875"/>
+      <location name="pixel405" y="0.0580078125"/>
+      <location name="pixel406" y="0.0583984375"/>
+      <location name="pixel407" y="0.0587890625"/>
+      <location name="pixel408" y="0.0591796875"/>
+      <location name="pixel409" y="0.0595703125"/>
+      <location name="pixel410" y="0.0599609375"/>
+      <location name="pixel411" y="0.0603515625"/>
+      <location name="pixel412" y="0.0607421875"/>
+      <location name="pixel413" y="0.0611328125"/>
+      <location name="pixel414" y="0.0615234375"/>
+      <location name="pixel415" y="0.0619140625"/>
+      <location name="pixel416" y="0.0623046875"/>
+      <location name="pixel417" y="0.0626953125"/>
+      <location name="pixel418" y="0.0630859375"/>
+      <location name="pixel419" y="0.0634765625"/>
+      <location name="pixel420" y="0.0638671875"/>
+      <location name="pixel421" y="0.0642578125"/>
+      <location name="pixel422" y="0.0646484375"/>
+      <location name="pixel423" y="0.0650390625"/>
+      <location name="pixel424" y="0.0654296875"/>
+      <location name="pixel425" y="0.0658203125"/>
+      <location name="pixel426" y="0.0662109375"/>
+      <location name="pixel427" y="0.0666015625"/>
+      <location name="pixel428" y="0.0669921875"/>
+      <location name="pixel429" y="0.0673828125"/>
+      <location name="pixel430" y="0.0677734375"/>
+      <location name="pixel431" y="0.0681640625"/>
+      <location name="pixel432" y="0.0685546875"/>
+      <location name="pixel433" y="0.0689453125"/>
+      <location name="pixel434" y="0.0693359375"/>
+      <location name="pixel435" y="0.0697265625"/>
+      <location name="pixel436" y="0.0701171875"/>
+      <location name="pixel437" y="0.0705078125"/>
+      <location name="pixel438" y="0.0708984375"/>
+      <location name="pixel439" y="0.0712890625"/>
+      <location name="pixel440" y="0.0716796875"/>
+      <location name="pixel441" y="0.0720703125"/>
+      <location name="pixel442" y="0.0724609375"/>
+      <location name="pixel443" y="0.0728515625"/>
+      <location name="pixel444" y="0.0732421875"/>
+      <location name="pixel445" y="0.0736328125"/>
+      <location name="pixel446" y="0.0740234375"/>
+      <location name="pixel447" y="0.0744140625"/>
+      <location name="pixel448" y="0.0748046875"/>
+      <location name="pixel449" y="0.0751953125"/>
+      <location name="pixel450" y="0.0755859375"/>
+      <location name="pixel451" y="0.0759765625"/>
+      <location name="pixel452" y="0.0763671875"/>
+      <location name="pixel453" y="0.0767578125"/>
+      <location name="pixel454" y="0.0771484375"/>
+      <location name="pixel455" y="0.0775390625"/>
+      <location name="pixel456" y="0.0779296875"/>
+      <location name="pixel457" y="0.0783203125"/>
+      <location name="pixel458" y="0.0787109375"/>
+      <location name="pixel459" y="0.0791015625"/>
+      <location name="pixel460" y="0.0794921875"/>
+      <location name="pixel461" y="0.0798828125"/>
+      <location name="pixel462" y="0.0802734375"/>
+      <location name="pixel463" y="0.0806640625"/>
+      <location name="pixel464" y="0.0810546875"/>
+      <location name="pixel465" y="0.0814453125"/>
+      <location name="pixel466" y="0.0818359375"/>
+      <location name="pixel467" y="0.0822265625"/>
+      <location name="pixel468" y="0.0826171875"/>
+      <location name="pixel469" y="0.0830078125"/>
+      <location name="pixel470" y="0.0833984375"/>
+      <location name="pixel471" y="0.0837890625"/>
+      <location name="pixel472" y="0.0841796875"/>
+      <location name="pixel473" y="0.0845703125"/>
+      <location name="pixel474" y="0.0849609375"/>
+      <location name="pixel475" y="0.0853515625"/>
+      <location name="pixel476" y="0.0857421875"/>
+      <location name="pixel477" y="0.0861328125"/>
+      <location name="pixel478" y="0.0865234375"/>
+      <location name="pixel479" y="0.0869140625"/>
+      <location name="pixel480" y="0.0873046875"/>
+      <location name="pixel481" y="0.0876953125"/>
+      <location name="pixel482" y="0.0880859375"/>
+      <location name="pixel483" y="0.0884765625"/>
+      <location name="pixel484" y="0.0888671875"/>
+      <location name="pixel485" y="0.0892578125"/>
+      <location name="pixel486" y="0.0896484375"/>
+      <location name="pixel487" y="0.0900390625"/>
+      <location name="pixel488" y="0.0904296875"/>
+      <location name="pixel489" y="0.0908203125"/>
+      <location name="pixel490" y="0.0912109375"/>
+      <location name="pixel491" y="0.0916015625"/>
+      <location name="pixel492" y="0.0919921875"/>
+      <location name="pixel493" y="0.0923828125"/>
+      <location name="pixel494" y="0.0927734375"/>
+      <location name="pixel495" y="0.0931640625"/>
+      <location name="pixel496" y="0.0935546875"/>
+      <location name="pixel497" y="0.0939453125"/>
+      <location name="pixel498" y="0.0943359375"/>
+      <location name="pixel499" y="0.0947265625"/>
+      <location name="pixel500" y="0.0951171875"/>
+      <location name="pixel501" y="0.0955078125"/>
+      <location name="pixel502" y="0.0958984375"/>
+      <location name="pixel503" y="0.0962890625"/>
+      <location name="pixel504" y="0.0966796875"/>
+      <location name="pixel505" y="0.0970703125"/>
+      <location name="pixel506" y="0.0974609375"/>
+      <location name="pixel507" y="0.0978515625"/>
+      <location name="pixel508" y="0.0982421875"/>
+      <location name="pixel509" y="0.0986328125"/>
+      <location name="pixel510" y="0.0990234375"/>
+      <location name="pixel511" y="0.0994140625"/>
+      <location name="pixel512" y="0.0998046875"/>
     </component>
   </type>
   <!--PIXEL FOR WIRE-->


### PR DESCRIPTION
Update WAND² IDF to round s2 and detz; also invert pixel indexing along wire so hopefully it's now correct.

The pixel mapping will probably change again before we start up again but hopefully it is correct for now.

**To test:**
Look at the diff of the IDF.

Try loading some data *e.g.* `ws = LoadEventNexus('/HFIR/HB2C/IPTS-7776/nexus/HB2C_6500.nxs.h5')` and see that it looks correct.

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
