### PR TITLE
Fix ErrorFormatter to workaround bug in Python 3.4

### DIFF
--- a/qt/python/mantidqt/widgets/codeeditor/errorformatter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/errorformatter.py
@@ -34,7 +34,7 @@ class ErrorFormatter(object):
         all return by traceback.extract_tb
         :return: A formatted string.
         """
-        lines = traceback.format_exception(exc_type, exc_value, None)
+        lines = traceback.format_exception_only(exc_type, exc_value)
         if stack is not None:
             lines.extend(traceback.format_list(stack))
         return ''.join(lines)


### PR DESCRIPTION
Description of work.

Python 3.4 contained a bug the handling of the `tb` argument of `traceback.format_exception`. The documentation claimed that if `tb=None` then the traceback would not be printed yet it is. This was fixed in Python 3.5.

**To test:**

* Run the `test_errorformatter` test on Python 3.4 and see that it passes. 

*No issue*

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
