### PR TITLE
Remove Python.h include

### DIFF
--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/DateAndTime.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/DateAndTime.h
@@ -23,7 +23,6 @@
     Code Documentation is available at: <http://doxygen.mantidproject.org>
  */
 #include "MantidKernel/DateAndTime.h"
-#include <Python.h>
 #include <boost/python/object.hpp>
 #include <numpy/ndarraytypes.h>
 


### PR DESCRIPTION
Including this on its own forces MSVC to use the special debug build of Python in Debug mode which is not the behaviour that we want.

Description of work.

**To test:**

* Build in debug mode on Windows and everything should complete
* Start MantidPlot

*No issue*

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
