### PR TITLE
ISIS Powder allow offset files to live outside calibration directory

### DIFF
--- a/docs/source/release/v3.12.0/diffraction.rst
+++ b/docs/source/release/v3.12.0/diffraction.rst
@@ -32,6 +32,7 @@ Powder Diffraction
 - Using grouping files with only one bank was enabled in ISIS Powder, and related errors to do with mismatched number of parameters were made more readable
 - It is now possible to set beam parameters (height and width) using instrument_object.set_beam_parameters(height=123, width=456).
 - The ``mode`` parameter for POLARIS in ISIS Powder now behaves as described in the documentation - it persists through function calls and is case insensitive
+- For instruments in ISIS Powder, offset files may now be specified by an absolute path. The default behaviour of assuming they live in calibration/label has been retained
 
 Engineering Diffraction
 -----------------------

--- a/docs/source/techniques/ISISPowder-Tutorials.rst
+++ b/docs/source/techniques/ISISPowder-Tutorials.rst
@@ -612,8 +612,9 @@ you must update the calibration directory. Using the cycle mapping from Peal:
 
 The relevant fields from the cycle mapping are the ``label`` and 
 ``offset_file_name``. Within the calibration directory a folder
-with the ``label`` name must exist and contain a cal file with
-the ``offset_file_name``.
+with the ``label`` name must exist. ``offset_file_name`` must either
+be the name of a cal file within that folder, or the full path to a
+cal file elsewhere.
 
 In this example we need a folder within the calibration 
 directory called *1_2* which holds a

--- a/scripts/Diffraction/isis_powder/routines/run_details.py
+++ b/scripts/Diffraction/isis_powder/routines/run_details.py
@@ -33,9 +33,9 @@ def create_run_details_object(run_number_string, inst_settings, is_vanadium_run,
     if splined_name_list:
         # Force Python to make a copy so we don't modify original
         new_splined_list = list(splined_name_list)
-        new_splined_list.append(offset_file_name)
+        new_splined_list.append(os.path.basename(offset_file_name))
     else:
-        new_splined_list = [offset_file_name]
+        new_splined_list = [os.path.basename(offset_file_name)]
 
     # These can either be generic or custom so defer to another method
     results_dict = _get_customisable_attributes(
@@ -67,8 +67,14 @@ def create_run_details_object(run_number_string, inst_settings, is_vanadium_run,
 
     # Generate the paths
     grouping_file_path = os.path.join(calibration_dir, results_dict["grouping_file_name"])
-    # Offset  and splined vanadium is within the correct label folder
-    offset_file_path = os.path.join(calibration_dir, label, offset_file_name)
+
+    # By default, offset file sits in correct label folder, but it can also be given as an absolute path
+    if os.path.exists(offset_file_name):
+        offset_file_path = offset_file_name
+    else:
+        offset_file_path = os.path.join(calibration_dir, label, offset_file_name)
+
+    # splined vanadium is within the correct label folder
     splined_van_path = os.path.join(calibration_dir, label, results_dict["splined_van_name"])
     unsplined_van_path = os.path.join(calibration_dir, label, results_dict["unsplined_van_name"])
     van_absorb_path = os.path.join(calibration_dir, van_abs_file_name) if van_abs_file_name else None


### PR DESCRIPTION
In the cycle mapping file for `isis_powder` instruments, the parameter `offset_file` may be given as an absolute path to a cal file which exists outside of the default directory. The default behaviour of assuming the cal files lives in `calibration_dir/label` is still in place, but the new behaviour allows instrument scientists to better separate the old and new scripts when testing out `isis_powder` on their beamlines.

**To test:**

First, try creating a vanadium and focusing with the default behaviour:
```
from isis_powder import Pearl
pearl = Pearl(config_file=r"\\olympic\babylon5\Public\JoeRamsay\PEARL\pearl_shared_config.yaml")

pearl.create_vanadium(run_in_cycle=97545)
pearl.focus(run_number=97570)
```

You should see `VanSplined_97534-97544_tt70_pearl_offset_16_4.cal.nxs` created in `\\olypmpic\babylon5\Public\JoeRamsay\PEARL\calib\16_5`.

Now change line 10 in `\\olympic\Babylon5\Public\JoeRamsay\PEARL\pearl_run_mapping.yaml` from `  offset_file_name : 'pearl_offset_16_4.cal'` to `offset_file_name : '\\olympic\Babylon5\Public\JoeRamsay\PEARL\calib\17_2\pearl_offset_17_2.cal'`. Delete `VanSplined_97534-97544_tt70_pearl_offset_16_4.cal.nxs` and rerun the script - you should see  `VanSplined_97534-97544_tt70_pearl_offset_17_2.cal.nxs` after `create_vanadium` has completed, and focusing should run with no issues.

Fixes #21692 

**Release Notes** 
[Here](https://github.com/mantidproject/mantid/commit/3bfa1dc7700a193185369d494540a08df11803ef)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
