### PR TITLE
Force reset of googletest before applying patches

### DIFF
--- a/buildconfig/CMake/GoogleTest.cmake
+++ b/buildconfig/CMake/GoogleTest.cmake
@@ -20,7 +20,7 @@ else()
 
   # Download and unpack googletest at configure time
   configure_file(${CMAKE_SOURCE_DIR}/buildconfig/CMake/GoogleTest.in
-                 ${CMAKE_BINARY_DIR}/googletest-download/CMakeLists.txt)
+                 ${CMAKE_BINARY_DIR}/googletest-download/CMakeLists.txt @ONLY)
   execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
                   RESULT_VARIABLE result
                   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download )

--- a/buildconfig/CMake/GoogleTest.in
+++ b/buildconfig/CMake/GoogleTest.in
@@ -5,13 +5,16 @@ project(googletest-download NONE)
 find_package(Git)
 
 include(ExternalProject)
+
+set ( _tag release-@gtest_version@ )
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           "release-${gtest_version}"
-  SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
-  BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
-  PATCH_COMMAND     "${GIT_EXECUTABLE}" apply --whitespace fix "${CMAKE_SOURCE_DIR}/buildconfig/CMake/googletest_override.patch"
-            COMMAND "${GIT_EXECUTABLE}" apply --whitespace fix "${CMAKE_SOURCE_DIR}/buildconfig/CMake/googletest_static.patch"
+  GIT_TAG           "${_tag}"
+  SOURCE_DIR        "@CMAKE_BINARY_DIR@/googletest-src"
+  BINARY_DIR        "@CMAKE_BINARY_DIR@/googletest-build"
+  PATCH_COMMAND     "@GIT_EXECUTABLE@" reset --hard ${_tag}
+            COMMAND "@GIT_EXECUTABLE@" apply --whitespace fix "@CMAKE_SOURCE_DIR@/buildconfig/CMake/googletest_override.patch"
+            COMMAND "@GIT_EXECUTABLE@" apply --whitespace fix "@CMAKE_SOURCE_DIR@/buildconfig/CMake/googletest_static.patch"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
   INSTALL_COMMAND   ""


### PR DESCRIPTION
Description of work.

**To test:**

Before apply the changes:
* `ninja clean`
* `cmake .`
* 💥 when applying patches

After applying changes the above steps should work.

*No issue*

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
