### PR TITLE
Fixes failing unit test for numpy >=1.14

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/sans/SANSConvertToWavelengthTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/sans/SANSConvertToWavelengthTest.py
@@ -117,7 +117,7 @@ class SANSSConvertToWavelengthImplementationTest(unittest.TestCase):
         data_x0 = output_workspace.dataX(0)
         self.assertTrue(data_x0[0] == 1.0)
         expected_upper_bound = 5.27471197274
-        self.assertTrue(data_x0[-1] == expected_upper_bound)
+        self.assertEqual(round(data_x0[-1],11), expected_upper_bound)
 
         # Check the units part
         axis0 = output_workspace.getAxis(0)


### PR DESCRIPTION
With numpy `1.14` the `SANSConvertToWavelengthTest` unit test fails with:
```
714: Traceback (most recent call last):
714:   File "/home/rwp/mantid/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/sans/SANSConvertToWavelengthTest.py", line 120, in test_that_not_setting_upper_bound_takes_it_from_original_value
714:     self.assertTrue(data_x0[-1] == expected_upper_bound)
714: AssertionError: False is not true
```
numpy 1.14 had [**"Major improvements to printing of NumPy arrays and scalars."**](https://docs.scipy.org/doc/numpy/release.html#highlights) so the precision of printing scalars changed. This rounds the number to the same as < 1.14 and fixes the test.

**To test:**
Code review should be enough
If I didn't break any other OS's unittests

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
