### PR TITLE
Add dependency on PythonInterface

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -144,9 +144,7 @@ add_subdirectory (ScriptRepository)
 ###########################################################################
 
 set ( FRAMEWORK_LIBS Kernel HistogramData Indexing Beamline Geometry API DataObjects
-                     PythonKernelModule PythonGeometryModule PythonAPIModule
-                     PythonDataObjectsModule PythonCurveFittingModule
-                     DataHandling Nexus Algorithms CurveFitting ICat
+                     PythonInterface DataHandling Nexus Algorithms CurveFitting ICat
                      Crystal MDAlgorithms WorkflowAlgorithms
                      LiveData RemoteAlgorithms RemoteJobManagers
                      SINQ


### PR DESCRIPTION
**To test:**

```shell
cmake -G Ninja ~/code/mantid -DENABLE_MANTIDPLOT=False -DENABLE_WORKBENCH=False
ninja
bin/mantidpython
```
followed by
```python
import mantid
```

This fixes #21360

*Does not need to be in the release notes* because it is a fix for framework builds with mantidplot enabled.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
