### PR TITLE
Add V20 IDFs

### DIFF
--- a/instrument/Facilities.xml
+++ b/instrument/Facilities.xml
@@ -797,6 +797,12 @@
     <technique>TOF Direct Geometry Spectroscopy</technique>
     <technique>Single Crystal Diffraction</technique>
   </instrument>
+  <instrument name="V20_DIFFRACTION">
+    <technique>Neutron Diffraction</technique>
+  </instrument>
+  <instrument name="V20_IMAGING">
+    <technique>Neutron Imaging</technique>
+  </instrument>
 </facility>
 
 <!--  Test Facility to allow example usage of Live listeners against "Fake" instrument sources -->

--- a/instrument/V20_DIFFRACTION_Definition.xml
+++ b/instrument/V20_DIFFRACTION_Definition.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- For help on the notation used to specify an Instrument Definition File
+see http://www.mantidproject.org/IDF -->
+<instrument xmlns="http://www.mantidproject.org/IDF/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 Schema/IDFSchema.xsd"
+name="IMAT" valid-from ="1900-01-31 23:59:59"
+valid-to ="2099-12-31 23:59:59"
+last-modified="2018-02-09 09:00:00">
+  <defaults>
+    <length unit="meter"/>
+    <angle unit="degree"/>
+    <reference-frame>
+      <!-- The z-axis is set parallel to and in the direction of the beam. the
+           y-axis points up and the coordinate system is right handed. -->
+      <along-beam axis="z"/>
+      <pointing-up axis="y"/>
+      <handedness val="right"/>
+    </reference-frame>
+    <default-view axis-view="z"/>
+  </defaults>
+
+  <component type="source-chopper">
+    <location x="0.0" y="0.0" z="-50.6"/>
+  </component>
+  <type name="source-chopper"/>
+
+  <component type="wfm-chopper">
+    <location x="0.0" y="0.0" z="-22.05"/>
+  </component>
+  <type name="wfm-chopper" is="Source" />
+
+  <component type="some-sample-holder">
+    <location x="0.0" y="0.0" z="0"/>
+  </component>
+  <type name="some-sample-holder" is="SamplePos" />
+
+  <component type="90 degree bank" idlist="90 degree bank">
+    <location x="1.0" y="0.0" z="0" rot="90.0" axis-x="0.0" axis-y="1.0" axis-z="0.0"/>
+  </component>  
+  
+  <type name="90 degree bank"> 
+    <component type="tall He3 element">  
+      <location x="-0.06" />
+      <location x="-0.02" />
+      <location x="0.02" />
+      <location x="0.06" />
+    </component>
+  </type>
+  
+  <type name="tall He3 element" is="detector">     
+    <cylinder id="shape">
+      <centre-of-bottom-base x="0.0" y="-0.15" z="0.0" />
+      <axis x="0.0" y="1.0" z="0" /> 
+      <radius val="0.0125" />
+      <height val="0.3" />
+    </cylinder> 
+  </type>  
+
+  <idlist idname="90 degree bank">
+    <id start="5" end="8" />
+  </idlist>
+
+</instrument>

--- a/instrument/V20_IMAGING_Definition.xml
+++ b/instrument/V20_IMAGING_Definition.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- For help on the notation used to specify an Instrument Definition File
+see http://www.mantidproject.org/IDF -->
+<instrument xmlns="http://www.mantidproject.org/IDF/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 Schema/IDFSchema.xsd"
+name="IMAT" valid-from ="1900-01-31 23:59:59"
+valid-to ="2015-07-31 23:59:59"
+last-modified="2018-02-08 09:00:00">
+  <defaults>
+    <length unit="meter"/>
+    <angle unit="degree"/>
+    <reference-frame>
+      <!-- The z-axis is set parallel to and in the direction of the beam. the
+           y-axis points up and the coordinate system is right handed. -->
+      <along-beam axis="z"/>
+      <pointing-up axis="y"/>
+      <handedness val="right"/>
+    </reference-frame>
+    <default-view axis-view="z"/>
+  </defaults>
+  <!-- BRIEF DESCRIPTION OF V20 @HZB INSTRUMENT:
+    
+  -->
+
+  <!-- LIST OF PHYSICAL COMPONENTS (which the instrument consists of) -->
+
+  <!-- source and sample-position components -->
+
+  <component type="source-chopper">
+    <location x="0.0" y="0.0" z="0.0"/>
+  </component>
+  <type name="source-chopper"/>
+
+  <component type="wfm-chopper">
+    <location x="0.0" y="0.0" z="28.55"/>
+  </component>
+  <type name="wfm-chopper" is="Source" />
+
+  <component type="some-sample-holder">
+    <location x="0.0" y="0.0" z="51.39"/>
+  </component>
+  <type name="some-sample-holder" is="SamplePos" />
+
+  <!-- detector components (including monitors) -->
+  
+  <component type="detector-bank" idstart="0" idfillbyfirst="y" idstep="1000" idstepbyrow="1">
+    <location z="51.4" name="detector"/>
+  </component>
+  <type name="detector-bank" is="rectangular_detector" type="pixel"
+  xpixels="512" xstart="-0.261" xstep="+0.001"
+  ypixels="512" ystart="-0.261" ystep="+0.001" >
+  </type>
+  <type name="pixel" is="detector">
+    <cuboid id="shape">
+      <left-front-bottom-point x="0.0005104167" y="-0.0005104167" z="0.0" />
+      <left-front-top-point x="0.0005104167" y="-0.0005104167" z="0.000005" />
+      <left-back-bottom-point x="-0.0005104167" y="-0.0005104167" z="0.0" />
+      <right-front-bottom-point x="0.0005104167" y="0.0005104167" z="0.0" />
+    </cuboid>
+    <algebra val="shape" />
+  </type>
+
+  <!-- DEFINITION OF TYPES -->
+
+  
+
+  <!-- shape for monitors, borrowed from GEM -->
+  
+
+  <!-- DETECTOR and MONITOR ID LISTS -->
+  
+</instrument>


### PR DESCRIPTION
Fixes #21728 

I'm proposing that these are added as two separate instruments
**V20_DIFFRACTION** and 
**V20_IMAGING**

This would allow us to make a small modification [here](https://git.esss.dk/wedel/wfm_stitching/blob/master/wfm_stitching/wfm_processing.py#L79)

which would allow users to simplify something existing like [this](https://git.esss.dk/wedel/wfm_stitching/blob/master/diffraction_example.py#L18)

```python
instrument_filename = 'sample-data/HZB_V20_Definition_4-tubes-90-degree.xml'
...
sample_processed = p.process(
    sample_workspace, instrument_filename, '0,64,70000', scale=1e3,
    delete_temporary_workspaces=True)

```

to this
```
sample_processed = p.process(
    sample_workspace, 'V20_DIFFRACTION', '0,64,70000', scale=1e3,
    delete_temporary_workspaces=True)
```
**Discussion**
There are pros and cons to the multi-name approach to the same instrument. We should consider these before merging.
**Notes**
According to [this](http://docs.mantidproject.org/nightly/algorithms/DownloadInstrument-v1.html) once changes are pushed to master these instruments should be available immediately.
**Testing**
* Run `LoadEmptyInstrument` setting the instrument name to be either of the above.
* Check the facilities xml file. HZB should now have three instruments.



