### PR TITLE
`ConjoinXRuns` to support varying bins

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/ConjoinXRuns.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ConjoinXRuns.h
@@ -61,6 +61,8 @@ private:
   std::list<API::MatrixWorkspace_sptr> m_inputWS;
   /// Output workspace
   API::MatrixWorkspace_sptr m_outWS;
+  /// X-axis cache if sample log is given
+  std::map<std::string, std::vector<double>> m_axisCache;
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/src/ConjoinXRuns.cpp
+++ b/Framework/Algorithms/src/ConjoinXRuns.cpp
@@ -120,6 +120,13 @@ std::map<std::string, std::string> ConjoinXRuns::validateInputs() {
       issues[INPUT_WORKSPACE_PROPERTY] +=
           "Workspace " + ws->getName() + " is not a point-data\n";
     } else {
+      try {
+        ws->blocksize();
+      } catch (std::length_error) {
+        issues[INPUT_WORKSPACE_PROPERTY] +=
+            "Workspace " + ws->getName() +
+            " has different number of points per histogram\n";
+      }
       m_inputWS.push_back(ws);
     }
   }
@@ -214,33 +221,28 @@ std::vector<double> ConjoinXRuns::getXAxis(MatrixWorkspace_sptr ws) const {
 
   std::vector<double> axis;
   axis.reserve(ws->blocksize());
-
-  if (m_logEntry.empty()) {
-    // return the actual x-axis of the first spectrum
-    axis = ws->x(0).rawData();
+  auto &run = ws->run();
+  // try time series first
+  TimeSeriesProperty<double> *timeSeriesDouble(nullptr);
+  timeSeriesDouble =
+      dynamic_cast<TimeSeriesProperty<double> *>(run.getLogData(m_logEntry));
+  if (timeSeriesDouble) {
+    // try double series
+    axis = timeSeriesDouble->filteredValuesAsVector();
   } else {
-    auto &run = ws->run();
-    // try time series first
-    TimeSeriesProperty<double> *timeSeriesDouble(nullptr);
-    timeSeriesDouble =
-        dynamic_cast<TimeSeriesProperty<double> *>(run.getLogData(m_logEntry));
-    if (timeSeriesDouble) {
-      // try double series
-      axis = timeSeriesDouble->filteredValuesAsVector();
+    // try int series next
+    TimeSeriesProperty<int> *timeSeriesInt(nullptr);
+    timeSeriesInt =
+        dynamic_cast<TimeSeriesProperty<int> *>(run.getLogData(m_logEntry));
+    if (timeSeriesInt) {
+      std::vector<int> intAxis = timeSeriesInt->filteredValuesAsVector();
+      axis = std::vector<double>(intAxis.begin(), intAxis.end());
     } else {
-      // try int series next
-      TimeSeriesProperty<int> *timeSeriesInt(nullptr);
-      timeSeriesInt =
-          dynamic_cast<TimeSeriesProperty<int> *>(run.getLogData(m_logEntry));
-      if (timeSeriesInt) {
-        std::vector<int> intAxis = timeSeriesInt->filteredValuesAsVector();
-        axis = std::vector<double>(intAxis.begin(), intAxis.end());
-      } else {
-        // then scalar
-        axis.push_back(run.getPropertyAsSingleValue(m_logEntry));
-      }
+      // then scalar
+      axis.push_back(run.getPropertyAsSingleValue(m_logEntry));
     }
   }
+
   return axis;
 }
 
@@ -271,19 +273,29 @@ void ConjoinXRuns::fillHistory() {
 void ConjoinXRuns::joinSpectrum(int64_t wsIndex) {
   std::vector<double> spectrum;
   std::vector<double> errors;
+  std::vector<double> axis;
   spectrum.reserve(m_outWS->blocksize());
   errors.reserve(m_outWS->blocksize());
+  axis.reserve(m_outWS->blocksize());
   size_t index = static_cast<size_t>(wsIndex);
 
   for (const auto &input : m_inputWS) {
     auto y = input->y(index).rawData();
     auto e = input->e(index).rawData();
+    std::vector<double> x;
+    if (m_logEntry.empty()) {
+      x = input->x(index).rawData();
+    } else {
+      x = m_axisCache[input->getName()];
+    }
     spectrum.insert(spectrum.end(), y.begin(), y.end());
     errors.insert(errors.end(), e.begin(), e.end());
+    axis.insert(axis.end(), x.begin(), x.end());
   }
 
   m_outWS->mutableY(index) = spectrum;
   m_outWS->mutableE(index) = errors;
+  m_outWS->mutableX(index) = axis;
 }
 
 //----------------------------------------------------------------------------------------------
@@ -319,10 +331,6 @@ void ConjoinXRuns::exec() {
   }
 
   auto first = m_inputWS.front();
-  std::vector<double> axisFirst = getXAxis(first);
-  std::vector<double> xAxis;
-  xAxis.insert(xAxis.end(), axisFirst.begin(), axisFirst.end());
-
   SampleLogsBehaviour sampleLogsBehaviour = SampleLogsBehaviour(
       *first, g_log, sampleLogsSum, sampleLogsTimeSeries, sampleLogsList,
       sampleLogsWarn, sampleLogsWarnTolerances, sampleLogsFail,
@@ -337,14 +345,14 @@ void ConjoinXRuns::exec() {
   // to be skipped, to compute the size of the output respectively.
   MatrixWorkspace_uptr temp = first->clone();
 
-  // First sequentially merge the sample logs and build the x-axis
+  size_t outBlockSize = (*it)->blocksize();
+  // First sequentially merge the sample logs
   for (++it; it != m_inputWS.end(); ++it) {
     // attempt to merge the sample logs
     try {
       sampleLogsBehaviour.mergeSampleLogs(**it, *temp);
       sampleLogsBehaviour.setUpdatedSampleLogs(*temp);
-      std::vector<double> axisIt = getXAxis(*it);
-      xAxis.insert(xAxis.end(), axisIt.begin(), axisIt.end());
+      outBlockSize += (*it)->blocksize();
     } catch (std::invalid_argument &e) {
       if (sampleLogsFailBehaviour == SKIP_BEHAVIOUR) {
         g_log.error() << "Could not join workspace: " << (*it)->getName()
@@ -366,8 +374,13 @@ void ConjoinXRuns::exec() {
     // the x-axis might need to be changed
   }
 
+  if (!m_logEntry.empty()) {
+    for (const auto &ws : m_inputWS) {
+      m_axisCache[ws->getName()] = getXAxis(ws);
+    }
+  }
+
   // now get the size of the output
-  size_t outBlockSize = xAxis.size();
   size_t numSpec = first->getNumberHistograms();
 
   m_outWS = WorkspaceFactory::Instance().create(first, numSpec, outBlockSize,
@@ -382,7 +395,6 @@ void ConjoinXRuns::exec() {
   PARALLEL_FOR_IF(threadSafe(*m_outWS))
   for (int64_t index = 0; index < static_cast<int64_t>(numSpec); ++index) {
     PARALLEL_START_INTERUPT_REGION
-    m_outWS->mutableX(static_cast<size_t>(index)) = xAxis;
     joinSpectrum(index);
     m_progress->report();
     PARALLEL_END_INTERUPT_REGION
@@ -399,6 +411,8 @@ void ConjoinXRuns::exec() {
   }
 
   setProperty("OutputWorkspace", m_outWS);
+  m_inputWS.clear();
+  m_axisCache.clear();
 }
 } // namespace Algorithms
 } // namespace Mantid

--- a/Framework/Algorithms/test/ConjoinXRunsTest.h
+++ b/Framework/Algorithms/test/ConjoinXRunsTest.h
@@ -16,6 +16,7 @@ using Mantid::Algorithms::AddSampleLog;
 using Mantid::Algorithms::AddTimeSeriesLog;
 using namespace Mantid::API;
 using namespace WorkspaceCreationHelper;
+using namespace Mantid::HistogramData;
 
 class ConjoinXRunsTest : public CxxTest::TestSuite {
 public:
@@ -29,18 +30,24 @@ public:
     MatrixWorkspace_sptr ws2 = create2DWorkspace154(5, 2); // 2 points
     MatrixWorkspace_sptr ws3 = create2DWorkspace123(5, 1); // 1 point
     MatrixWorkspace_sptr ws4 = create2DWorkspace154(5, 1); // 1 point
+    MatrixWorkspace_sptr ws5 = create2DWorkspace123(5, 3); // 3 points
+    MatrixWorkspace_sptr ws6 = create2DWorkspace123(5, 3); // 3 points
 
     ws1->getAxis(0)->setUnit("TOF");
     ws2->getAxis(0)->setUnit("TOF");
     ws3->getAxis(0)->setUnit("TOF");
     ws4->getAxis(0)->setUnit("TOF");
+    ws5->getAxis(0)->setUnit("TOF");
+    ws6->getAxis(0)->setUnit("TOF");
 
     storeWS("ws1", ws1);
     storeWS("ws2", ws2);
     storeWS("ws3", ws3);
     storeWS("ws4", ws4);
+    storeWS("ws5", ws5);
+    storeWS("ws6", ws6);
 
-    m_testWS = {"ws1", "ws2", "ws3", "ws4"};
+    m_testWS = {"ws1", "ws2", "ws3", "ws4", "ws5", "ws6"};
   }
 
   void tearDown() override {
@@ -48,6 +55,8 @@ public:
     removeWS("ws2");
     removeWS("ws3");
     removeWS("ws4");
+    removeWS("ws5");
+    removeWS("ws6");
     m_testWS.clear();
   }
 
@@ -57,7 +66,8 @@ public:
   }
 
   void testHappyCase() {
-    m_testee.setProperty("InputWorkspaces", m_testWS);
+    m_testee.setProperty("InputWorkspaces",
+                         std::vector<std::string>{"ws1", "ws2", "ws3", "ws4"});
     m_testee.setProperty("OutputWorkspace", "out");
     TS_ASSERT_THROWS_NOTHING(m_testee.execute());
     TS_ASSERT(m_testee.isExecuted());
@@ -100,6 +110,92 @@ public:
     TS_ASSERT_EQUALS(xaxis[6], 1.);
   }
 
+  void testFailDifferentNumberBins() {
+    MatrixWorkspace_sptr ws5 =
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("ws5");
+
+    Counts counts{{5, 8}};
+    Points points{{0.4, 0.9}};
+    ws5->setHistogram(3, points, counts);
+
+    m_testee.setProperty("InputWorkspaces",
+                         std::vector<std::string>{"ws1", "ws5"});
+    TS_ASSERT_THROWS(m_testee.execute(), std::runtime_error);
+  }
+
+  void testPassDifferentAxes() {
+      MatrixWorkspace_sptr ws6 =
+          AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("ws6");
+
+      Counts counts{{4, 9, 16}};
+      Points points{{0.4, 0.9, 1.1}};
+      ws6->setHistogram(3, points, counts);
+
+      m_testee.setProperty("InputWorkspaces", std::vector<std::string>{"ws1", "ws6"});
+
+      TS_ASSERT_THROWS_NOTHING(m_testee.execute());
+      TS_ASSERT(m_testee.isExecuted());
+
+      MatrixWorkspace_sptr out =
+          AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("out");
+
+      TS_ASSERT(out);
+      TS_ASSERT_EQUALS(out->getNumberHistograms(), 5);
+      TS_ASSERT_EQUALS(out->blocksize(), 6);
+      TS_ASSERT(!out->isHistogramData());
+      TS_ASSERT_EQUALS(out->getAxis(0)->unit()->unitID(), "TOF");
+
+      auto spectrum0 = out->y(0).rawData();
+      auto error0 = out->e(0).rawData();
+      auto xaxis0 = out->x(0).rawData();
+
+      TS_ASSERT_EQUALS(spectrum0[0], 2.);
+      TS_ASSERT_EQUALS(spectrum0[1], 2.);
+      TS_ASSERT_EQUALS(spectrum0[2], 2.);
+      TS_ASSERT_EQUALS(spectrum0[3], 2.);
+      TS_ASSERT_EQUALS(spectrum0[4], 2.);
+      TS_ASSERT_EQUALS(spectrum0[5], 2.);
+
+      TS_ASSERT_EQUALS(error0[0], 3.);
+      TS_ASSERT_EQUALS(error0[1], 3.);
+      TS_ASSERT_EQUALS(error0[2], 3.);
+      TS_ASSERT_EQUALS(error0[3], 3.);
+      TS_ASSERT_EQUALS(error0[4], 3.);
+      TS_ASSERT_EQUALS(error0[5], 3.);
+
+      TS_ASSERT_EQUALS(xaxis0[0], 1.);
+      TS_ASSERT_EQUALS(xaxis0[1], 2.);
+      TS_ASSERT_EQUALS(xaxis0[2], 3.);
+      TS_ASSERT_EQUALS(xaxis0[3], 1.);
+      TS_ASSERT_EQUALS(xaxis0[4], 2.);
+      TS_ASSERT_EQUALS(xaxis0[5], 3.);
+
+      auto spectrum3 = out->y(3).rawData();
+      auto error3 = out->e(3).rawData();
+      auto xaxis3 = out->x(3).rawData();
+
+      TS_ASSERT_EQUALS(spectrum3[0], 2.);
+      TS_ASSERT_EQUALS(spectrum3[1], 2.);
+      TS_ASSERT_EQUALS(spectrum3[2], 2.);
+      TS_ASSERT_EQUALS(spectrum3[3], 4.);
+      TS_ASSERT_EQUALS(spectrum3[4], 9.);
+      TS_ASSERT_EQUALS(spectrum3[5], 16.);
+
+      TS_ASSERT_EQUALS(error3[0], 3.);
+      TS_ASSERT_EQUALS(error3[1], 3.);
+      TS_ASSERT_EQUALS(error3[2], 3.);
+      TS_ASSERT_EQUALS(error3[3], 2.);
+      TS_ASSERT_EQUALS(error3[4], 3.);
+      TS_ASSERT_EQUALS(error3[5], 4.);
+
+      TS_ASSERT_EQUALS(xaxis3[0], 1.);
+      TS_ASSERT_EQUALS(xaxis3[1], 2.);
+      TS_ASSERT_EQUALS(xaxis3[2], 3.);
+      TS_ASSERT_EQUALS(xaxis3[3], 0.4);
+      TS_ASSERT_EQUALS(xaxis3[4], 0.9);
+      TS_ASSERT_EQUALS(xaxis3[5], 1.1);
+  }
+
   void testFailWithNumLog() {
     AddSampleLog logAdder;
     logAdder.initialize();
@@ -110,7 +206,8 @@ public:
     logAdder.setProperty("LogText", "0.7");
     logAdder.execute();
 
-    m_testee.setProperty("InputWorkspaces", m_testWS);
+    m_testee.setProperty("InputWorkspaces",
+                         std::vector<std::string>{"ws1", "ws2", "ws3", "ws4"});
 
     m_testee.setProperty("SampleLogAsXAxis", "TestNumLog");
 
@@ -169,7 +266,8 @@ public:
     logAdder.setProperty("LogText", "str");
     logAdder.execute();
 
-    m_testee.setProperty("InputWorkspaces", m_testWS);
+    m_testee.setProperty("InputWorkspaces",
+                         std::vector<std::string>{"ws1", "ws2", "ws3", "ws4"});
     m_testee.setProperty("SampleLogAsXAxis", "TestStrLog");
 
     // string log not supported, fail

--- a/Framework/Algorithms/test/ConjoinXRunsTest.h
+++ b/Framework/Algorithms/test/ConjoinXRunsTest.h
@@ -124,76 +124,77 @@ public:
   }
 
   void testPassDifferentAxes() {
-      MatrixWorkspace_sptr ws6 =
-          AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("ws6");
+    MatrixWorkspace_sptr ws6 =
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("ws6");
 
-      Counts counts{{4, 9, 16}};
-      Points points{{0.4, 0.9, 1.1}};
-      ws6->setHistogram(3, points, counts);
+    Counts counts{{4, 9, 16}};
+    Points points{{0.4, 0.9, 1.1}};
+    ws6->setHistogram(3, points, counts);
 
-      m_testee.setProperty("InputWorkspaces", std::vector<std::string>{"ws1", "ws6"});
+    m_testee.setProperty("InputWorkspaces",
+                         std::vector<std::string>{"ws1", "ws6"});
 
-      TS_ASSERT_THROWS_NOTHING(m_testee.execute());
-      TS_ASSERT(m_testee.isExecuted());
+    TS_ASSERT_THROWS_NOTHING(m_testee.execute());
+    TS_ASSERT(m_testee.isExecuted());
 
-      MatrixWorkspace_sptr out =
-          AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("out");
+    MatrixWorkspace_sptr out =
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("out");
 
-      TS_ASSERT(out);
-      TS_ASSERT_EQUALS(out->getNumberHistograms(), 5);
-      TS_ASSERT_EQUALS(out->blocksize(), 6);
-      TS_ASSERT(!out->isHistogramData());
-      TS_ASSERT_EQUALS(out->getAxis(0)->unit()->unitID(), "TOF");
+    TS_ASSERT(out);
+    TS_ASSERT_EQUALS(out->getNumberHistograms(), 5);
+    TS_ASSERT_EQUALS(out->blocksize(), 6);
+    TS_ASSERT(!out->isHistogramData());
+    TS_ASSERT_EQUALS(out->getAxis(0)->unit()->unitID(), "TOF");
 
-      auto spectrum0 = out->y(0).rawData();
-      auto error0 = out->e(0).rawData();
-      auto xaxis0 = out->x(0).rawData();
+    auto spectrum0 = out->y(0).rawData();
+    auto error0 = out->e(0).rawData();
+    auto xaxis0 = out->x(0).rawData();
 
-      TS_ASSERT_EQUALS(spectrum0[0], 2.);
-      TS_ASSERT_EQUALS(spectrum0[1], 2.);
-      TS_ASSERT_EQUALS(spectrum0[2], 2.);
-      TS_ASSERT_EQUALS(spectrum0[3], 2.);
-      TS_ASSERT_EQUALS(spectrum0[4], 2.);
-      TS_ASSERT_EQUALS(spectrum0[5], 2.);
+    TS_ASSERT_EQUALS(spectrum0[0], 2.);
+    TS_ASSERT_EQUALS(spectrum0[1], 2.);
+    TS_ASSERT_EQUALS(spectrum0[2], 2.);
+    TS_ASSERT_EQUALS(spectrum0[3], 2.);
+    TS_ASSERT_EQUALS(spectrum0[4], 2.);
+    TS_ASSERT_EQUALS(spectrum0[5], 2.);
 
-      TS_ASSERT_EQUALS(error0[0], 3.);
-      TS_ASSERT_EQUALS(error0[1], 3.);
-      TS_ASSERT_EQUALS(error0[2], 3.);
-      TS_ASSERT_EQUALS(error0[3], 3.);
-      TS_ASSERT_EQUALS(error0[4], 3.);
-      TS_ASSERT_EQUALS(error0[5], 3.);
+    TS_ASSERT_EQUALS(error0[0], 3.);
+    TS_ASSERT_EQUALS(error0[1], 3.);
+    TS_ASSERT_EQUALS(error0[2], 3.);
+    TS_ASSERT_EQUALS(error0[3], 3.);
+    TS_ASSERT_EQUALS(error0[4], 3.);
+    TS_ASSERT_EQUALS(error0[5], 3.);
 
-      TS_ASSERT_EQUALS(xaxis0[0], 1.);
-      TS_ASSERT_EQUALS(xaxis0[1], 2.);
-      TS_ASSERT_EQUALS(xaxis0[2], 3.);
-      TS_ASSERT_EQUALS(xaxis0[3], 1.);
-      TS_ASSERT_EQUALS(xaxis0[4], 2.);
-      TS_ASSERT_EQUALS(xaxis0[5], 3.);
+    TS_ASSERT_EQUALS(xaxis0[0], 1.);
+    TS_ASSERT_EQUALS(xaxis0[1], 2.);
+    TS_ASSERT_EQUALS(xaxis0[2], 3.);
+    TS_ASSERT_EQUALS(xaxis0[3], 1.);
+    TS_ASSERT_EQUALS(xaxis0[4], 2.);
+    TS_ASSERT_EQUALS(xaxis0[5], 3.);
 
-      auto spectrum3 = out->y(3).rawData();
-      auto error3 = out->e(3).rawData();
-      auto xaxis3 = out->x(3).rawData();
+    auto spectrum3 = out->y(3).rawData();
+    auto error3 = out->e(3).rawData();
+    auto xaxis3 = out->x(3).rawData();
 
-      TS_ASSERT_EQUALS(spectrum3[0], 2.);
-      TS_ASSERT_EQUALS(spectrum3[1], 2.);
-      TS_ASSERT_EQUALS(spectrum3[2], 2.);
-      TS_ASSERT_EQUALS(spectrum3[3], 4.);
-      TS_ASSERT_EQUALS(spectrum3[4], 9.);
-      TS_ASSERT_EQUALS(spectrum3[5], 16.);
+    TS_ASSERT_EQUALS(spectrum3[0], 2.);
+    TS_ASSERT_EQUALS(spectrum3[1], 2.);
+    TS_ASSERT_EQUALS(spectrum3[2], 2.);
+    TS_ASSERT_EQUALS(spectrum3[3], 4.);
+    TS_ASSERT_EQUALS(spectrum3[4], 9.);
+    TS_ASSERT_EQUALS(spectrum3[5], 16.);
 
-      TS_ASSERT_EQUALS(error3[0], 3.);
-      TS_ASSERT_EQUALS(error3[1], 3.);
-      TS_ASSERT_EQUALS(error3[2], 3.);
-      TS_ASSERT_EQUALS(error3[3], 2.);
-      TS_ASSERT_EQUALS(error3[4], 3.);
-      TS_ASSERT_EQUALS(error3[5], 4.);
+    TS_ASSERT_EQUALS(error3[0], 3.);
+    TS_ASSERT_EQUALS(error3[1], 3.);
+    TS_ASSERT_EQUALS(error3[2], 3.);
+    TS_ASSERT_EQUALS(error3[3], 2.);
+    TS_ASSERT_EQUALS(error3[4], 3.);
+    TS_ASSERT_EQUALS(error3[5], 4.);
 
-      TS_ASSERT_EQUALS(xaxis3[0], 1.);
-      TS_ASSERT_EQUALS(xaxis3[1], 2.);
-      TS_ASSERT_EQUALS(xaxis3[2], 3.);
-      TS_ASSERT_EQUALS(xaxis3[3], 0.4);
-      TS_ASSERT_EQUALS(xaxis3[4], 0.9);
-      TS_ASSERT_EQUALS(xaxis3[5], 1.1);
+    TS_ASSERT_EQUALS(xaxis3[0], 1.);
+    TS_ASSERT_EQUALS(xaxis3[1], 2.);
+    TS_ASSERT_EQUALS(xaxis3[2], 3.);
+    TS_ASSERT_EQUALS(xaxis3[3], 0.4);
+    TS_ASSERT_EQUALS(xaxis3[4], 0.9);
+    TS_ASSERT_EQUALS(xaxis3[5], 1.1);
   }
 
   void testFailWithNumLog() {

--- a/docs/source/algorithms/ConjoinXRuns-v1.rst
+++ b/docs/source/algorithms/ConjoinXRuns-v1.rst
@@ -19,6 +19,7 @@ This can be a mixed list of workspaces and workspace groups on AnalysisDataServi
 - the same instrument
 - the same number of histograms
 - the same units
+- each workspace must have the same amount of points per spectrum, however the x-axes may differ
 
 SampleLogAsXAxis
 ----------------
@@ -48,7 +49,7 @@ Usage
 **Example - ConjoinXRuns**
 
 .. testcode:: ConjoinXRunsExample
-   
+
     # Create input workspaces
     list = []
     for i in range(3):
@@ -168,4 +169,3 @@ Related Algorithms
 .. categories::
 
 .. sourcelink::
-

--- a/docs/source/release/v3.12.0/framework.rst
+++ b/docs/source/release/v3.12.0/framework.rst
@@ -45,6 +45,7 @@ Algorithms
 - :ref:`LoadLamp <algm-LoadLamp>` is a new algorithm to load processed HDF5 files produced by LAMP program at ILL.
 - :ref:`SaveNexus <algm-SaveNexus>` will no longer crash when passed a ``PeaksWorkspace`` with integrated peaks that have missing radius information.
 - :ref:`SaveReflections <algm-LoadLamp>` is a new algorithm to save PeaksWorkspaces to Fullprof, Jana, GSAS, and SHELX text formats.
+- :ref:`ConjoinXRuns <algm-ConjoinXRuns>` will now accept workspaces with varying x-axes per spectrum.
 
 Fitting
 -------
@@ -81,7 +82,7 @@ In `mantid.simpleapi`, a keyword has been implemented for function-like algorith
 - The ``isDefault`` attribute for workspace properties now works correctly with workspaces not in the ADS.
 - The previously mentioned ``ConfigObserver`` and ``ConfigPropertyObserver`` classes are also exposed to python.
 - ``mantid.kernel.V3D`` vectors now support negation through the usual ``-`` operator.
-- It is now possible to `pickle <https://docs.python.org/2/library/pickle.html>`_ and de-pickle :ref:`Workspace2D <Workspace2D>` and :ref:`TableWorkspace <Table Workspaces>` in Python. This has been added to make it easier to transfer your workspaces over a network. Only these two workspace types currently supports the pickling process, and there are limitations to be aware of described :ref:`here <Workspace2D>`.  
+- It is now possible to `pickle <https://docs.python.org/2/library/pickle.html>`_ and de-pickle :ref:`Workspace2D <Workspace2D>` and :ref:`TableWorkspace <Table Workspaces>` in Python. This has been added to make it easier to transfer your workspaces over a network. Only these two workspace types currently supports the pickling process, and there are limitations to be aware of described :ref:`here <Workspace2D>`.
 - ``mantid.api.IPeak`` has three new functions:
     - ``getEnergyTransfer`` which returns the difference between the initial and final energy.
     - ``getIntensityOverSigma`` which returns the peak intensity divided by the error in intensity.


### PR DESCRIPTION
The algorithm is extended to support the case when an input workspace has different x-axes for different spectra. However the lengths of the axes must be the same still.

**To test:**
```
CreateSampleWorkspace(OutputWorkspace='w1', Function='Quasielastic', NumBanks=10, NumMonitors=1, BankPixelWidth=1, XUnit='Degrees', XMax=25, BinWidth=8, PixelSpacing=0.0001)
ConvertToPointData(InputWorkspace='w1', OutputWorkspace='w1')

CreateSampleWorkspace(OutputWorkspace='w2', Function='Quasielastic', NumBanks=10, NumMonitors=1, BankPixelWidth=1, XUnit='Degrees', XMax=20, BinWidth=7, PixelSpacing=0.0001)
ConvertToPointData(InputWorkspace='w2', OutputWorkspace='w2')

mtd["w1"].setX(5,[1,2,3])

ConjoinXRuns(InputWorkspaces='w1,w2', OutputWorkspace='w3')
```

Check the x axis of the spectrum 6 (ws index 5) of w3. Should be 1,2,3,3.5,10.5

<!-- Instructions for testing. -->

Fixes #21733 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.