### PR TITLE
Fix broken logic when selecting Facilities.xml file to use.

### DIFF
--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1781,8 +1781,8 @@ std::string ConfigServiceImpl::getFacilityFilename(const std::string &fName) {
   // update the iterator, this means we will skip the folder in HOME and
   // look in the instrument folder in mantid install directory or mantid source
   // code directory
-  if (updateInstrStr != "1" || updateInstrStr != "on" ||
-      updateInstrStr != "On") {
+  if (!(updateInstrStr == "1" || updateInstrStr == "on" ||
+        updateInstrStr == "On")) {
     instrDir++;
   }
 


### PR DESCRIPTION
The old condition was never true, i.e., an updated file (such as when
instruments are added) was never used.

See also discussion on Slack `#tech-qa`.

TODO: Figure out why it seems to work on a build of `master` (on Linux), but not on an installed OSX version.

**To test:**

The `V20_IMAGING` instrument was added recently. Due to this bug it is not possible to load this in Mantid 3.11 or later:

```python
ws = LoadEmptyInstrument(InstrumentName='V20_IMAGING')
```

Mantid build from this PR should succeed loading the instrument.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
