### PR TITLE
Bugfix UpdateInstrumentDefinitions.OnStartup and loading Facilities.xml

### DIFF
--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1781,8 +1781,8 @@ std::string ConfigServiceImpl::getFacilityFilename(const std::string &fName) {
   // update the iterator, this means we will skip the folder in HOME and
   // look in the instrument folder in mantid install directory or mantid source
   // code directory
-  if (updateInstrStr != "1" || updateInstrStr != "on" ||
-      updateInstrStr != "On") {
+  if (!(updateInstrStr == "1" || updateInstrStr == "on" ||
+        updateInstrStr == "On")) {
     instrDir++;
   }
 

--- a/docs/source/concepts/PropertiesFile.rst
+++ b/docs/source/concepts/PropertiesFile.rst
@@ -8,14 +8,15 @@ The ``*.properties`` Files
 
 The Mantid framework is configured using up to three simple text ``*.properties`` files that are read an interpreted every time the framework is started. These properties are not the same as the properties of algorithms. All three have the same format. The three files are read from first to last, with the values in subsequent ``*.properties`` overriding those in previous ones.
 
-1. ``/etc/mantid.local.properties`` is an optional, linux only file that sets shared defaults on a shared system. This is commonly used for setting the ``default.facility``, ``default.instrument``, and ``datasearch.searcharchive`` properties.
-2. Install directory ``Mantid.properties`` defines the default configuration that the development team suggest as sensible defaults. This file should not be altered by users as it will be replaced with every new install or upgrade of Mantid.
+1. Install directory ``Mantid.properties`` defines the default configuration that the development team suggest as sensible defaults. This file should not be altered by users as it will be replaced with every new install or upgrade of Mantid.
+2. ``/etc/mantid.local.properties`` is an optional, linux only file that sets shared defaults on a shared system. This is commonly used for setting the ``default.facility``, ``default.instrument``, and ``datasearch.searcharchive`` properties.
 3. Home directory ``Mantid.user.properties`` is where users may override any property setting in Mantid. Any Property setting in this file will override anything set in the ``Mantid.properties`` file. Simply either enter the property you wish to override in this file together with it's new value. The change will take effect the next time Mantid is started. Subsequent installs or upgrades of Mantid will never alter this file.
 
 The Properties
 --------------
 
-Note: Use forward slash (/) or double up on the number of backslash (\) characters for all paths
+.. note:: Use forward slash (``/``) or double up on the number of backslash (``\``) characters for all paths
+
 
 General properties
 ******************
@@ -163,23 +164,37 @@ MantidPlot Properties
 Network Properties
 ******************
 
-+----------------------------------------+---------------------------------------------------+---------------------------------+
-|Property                                |Description                                        |Example value                    |
-+========================================+===================================================+=================================+
-| ``network.default.timeout``            |Defines the default timeout for all network        | ``30``                          |
-|                                        |operations (in seconds).                           |                                 |
-+----------------------------------------+---------------------------------------------------+---------------------------------+
-| ``network.scriptrepo.timeout``         |The timeout for network operations in the script   | ``5``                           |
-|                                        |repository, this overrides the deafault timeout.   |                                 |
-+----------------------------------------+---------------------------------------------------+---------------------------------+
-| ``proxy.host``                         | Allows the system proxy to be overridden, if not  | ``http://www.proxy.org``        |
-|                                        | set mantid will use the system proxy              |                                 |
-+----------------------------------------+---------------------------------------------------+---------------------------------+
-| ``proxy.port``                         | Must be set if proxy.host is set                  | ``8080``                        |
-+----------------------------------------+---------------------------------------------------+---------------------------------+
-| ``proxy.httpsTargetUrl``               | A sample url used to determine the system proxy to| ``http://www.google.com``       |
-|                                        | use on windows.                                   |                                 |
-+----------------------------------------+---------------------------------------------------+---------------------------------+
++-------------------------------------------+---------------------------------------------------+---------------------------------+
+|Property                                   |Description                                        |Example value                    |
++===========================================+===================================================+=================================+
+| ``CheckMantidVersion.OnStartup``          | Check if there is a newer version available and   |                                 |
+|                                           | logs a message at ``information`` level           | ``1``                           |
++-------------------------------------------+---------------------------------------------------+---------------------------------+
+| ``network.default.timeout``               |Defines the default timeout for all network        | ``30``                          |
+|                                           |operations (in seconds).                           |                                 |
++-------------------------------------------+---------------------------------------------------+---------------------------------+
+| ``network.scriptrepo.timeout``            |The timeout for network operations in the script   | ``5``                           |
+|                                           |repository, this overrides the deafault timeout.   |                                 |
++-------------------------------------------+---------------------------------------------------+---------------------------------+
+| ``proxy.host``                            | Allows the system proxy to be overridden, if not  | ``http://www.proxy.org``        |
+|                                           | set mantid will use the system proxy              |                                 |
++-------------------------------------------+---------------------------------------------------+---------------------------------+
+| ``proxy.port``                            | Must be set if proxy.host is set                  | ``8080``                        |
++-------------------------------------------+---------------------------------------------------+---------------------------------+
+| ``proxy.httpsTargetUrl``                  | A sample url used to determine the system proxy to| ``http://www.google.com``       |
+|                                           | use on windows.                                   |                                 |
++-------------------------------------------+---------------------------------------------------+---------------------------------+
+| ``UpdateInstrumentDefinitions.OnStartup`` | Download new instrument definition files and      |                                 |
+|                                           | ``Facilities.xml`` to ``~/.mantid/instruments``   |                                 |
+|                                           | on linux or ``APPDATA`` directory on windows. If  |                                 |
+|                                           | this is disabled, previously downloaded           |                                 |
+|                                           | instruments are ignored and only those in the     |                                 |
+|                                           | installation are used.                            | ``1``                           |
++-------------------------------------------+---------------------------------------------------+---------------------------------+
+| ``usagereports.enabled``                  | Enable usage reporting                            | ``1``                           |
++-------------------------------------------+---------------------------------------------------+---------------------------------+
+
+
 
 
 ScriptRepository Properties

--- a/docs/source/release/v3.12.0/framework.rst
+++ b/docs/source/release/v3.12.0/framework.rst
@@ -64,6 +64,7 @@ Core Functionality
 - TableWorkspaces can new be converted to a python dictionary by calling the ``table.toDict()`` function.
 - Added new classes ``ConfigObserver`` for listening for changes to any configuration property and ``ConfigPropertyObserver`` for listening to changes to an individual config property of interest.
 - Fixed the calculation of scattering length and scattering length squared for :py:obj:`Material <mantid.kernel.Material>`
+- Fixed the behaviour of ``UpdateInstrumentDefinitions.OnStartup`` in the :ref:`properties file <Properties File>`. It was not being used correctly for using the updated ``Facilities.xml`` file.
 
 Performance
 -----------
@@ -81,7 +82,7 @@ In `mantid.simpleapi`, a keyword has been implemented for function-like algorith
 - The ``isDefault`` attribute for workspace properties now works correctly with workspaces not in the ADS.
 - The previously mentioned ``ConfigObserver`` and ``ConfigPropertyObserver`` classes are also exposed to python.
 - ``mantid.kernel.V3D`` vectors now support negation through the usual ``-`` operator.
-- It is now possible to `pickle <https://docs.python.org/2/library/pickle.html>`_ and de-pickle :ref:`Workspace2D <Workspace2D>` and :ref:`TableWorkspace <Table Workspaces>` in Python. This has been added to make it easier to transfer your workspaces over a network. Only these two workspace types currently supports the pickling process, and there are limitations to be aware of described :ref:`here <Workspace2D>`.  
+- It is now possible to `pickle <https://docs.python.org/2/library/pickle.html>`_ and de-pickle :ref:`Workspace2D <Workspace2D>` and :ref:`TableWorkspace <Table Workspaces>` in Python. This has been added to make it easier to transfer your workspaces over a network. Only these two workspace types currently supports the pickling process, and there are limitations to be aware of described :ref:`here <Workspace2D>`.
 - ``mantid.api.IPeak`` has three new functions:
     - ``getEnergyTransfer`` which returns the difference between the initial and final energy.
     - ``getIntensityOverSigma`` which returns the peak intensity divided by the error in intensity.


### PR DESCRIPTION
People were modifying their `~/.mantid/instruments/Facilities.xml` file without effect. This documents the magic user property and fixes the bug.

**To test:**

Modify an instrument name in your `~/.mantid/instruments/Facilities.xml` and see that the change is picked up by a restart of mantid.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
