### PR TITLE
Fix workbench for IPython 6

### DIFF
--- a/qt/applications/workbench/workbench/plugins/jupyterconsole.py
+++ b/qt/applications/workbench/workbench/plugins/jupyterconsole.py
@@ -21,7 +21,11 @@ import sys
 
 # third-party library imports
 from mantidqt.widgets.jupyterconsole import InProcessJupyterConsole
-from IPython.core.usage import quick_guide, release as ipy_release
+try:
+    from IPython.core.usage import quick_guide
+except ImportError: # quick_guide was removed in IPython 6.0
+    quick_guide = ''
+from IPython.core.usage import release as ipy_release
 from matplotlib import __version__ as mpl_version
 from numpy.version import version as np_version
 from qtpy.QtWidgets import QVBoxLayout

--- a/qt/python/mantidqt/widgets/codeeditor/execution.py
+++ b/qt/python/mantidqt/widgets/codeeditor/execution.py
@@ -149,7 +149,7 @@ class PythonCodeExecution(QObject):
         self._task = task
         return task
 
-    def execute(self, code_str, filename=''):
+    def execute(self, code_str, filename=None):
         """Execute the given code on the calling thread
         within the provided context.
 

--- a/qt/python/mantidqt/widgets/codeeditor/inputsplitter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/inputsplitter.py
@@ -68,7 +68,10 @@ class InputSplitter(IPyInputSplitter):
         if source.endswith('\\\n'):
             return False
 
-        self._update_indent(lines)
+        try:
+            self._update_indent(lines)
+        except TypeError: # _update_indent was changed in IPython 6.0
+            self._update_indent()
         try:
             self.code = self._compile(source, symbol="exec")
         # Invalid syntax can produce any of a number of different errors from

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_execution.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_execution.py
@@ -111,7 +111,7 @@ class PythonCodeExecutionTest(unittest.TestCase):
         code = """
 def foo():
     def bar():
-        # raises a NameError
+        \"""raises a NameError\"""
         y = _local + 1
     # call inner
     bar()
@@ -220,7 +220,7 @@ squared = sum*sum
         executor = PythonCodeExecution()
         self.assertRaises(expected_exc_type, executor.execute, code)
 
-    def _run_async_code(self, code, with_progress=False, filename=''):
+    def _run_async_code(self, code, with_progress=False, filename=None):
         executor = PythonCodeExecution()
         if with_progress:
             recv = ReceiverWithProgress()


### PR DESCRIPTION
`._update_indent()` was changed not to take arguments and `IPython.core.usage.quick_guide` was removed.

In test_execute_async_returns_failure_on_runtime_error_and_captures_expected_stack the comment was causing an IndentationError, changing it to a docstring fixes the problem. I don't think this is related to IPython but probably a python 3.6 problem.

This fixes two of the issues in #21649

**To test:**
Look at the original issue then code review should be enough. To really test this you will need IPython >=6. The build http://builds.mantidproject.org/job/master_clean-archlinux_python3/ will check that all is fixed once it's in master.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
