### PR TITLE
Importing i and val from simpleapi

### DIFF
--- a/Framework/PythonInterface/mantid/fitfunctions.py
+++ b/Framework/PythonInterface/mantid/fitfunctions.py
@@ -746,6 +746,10 @@ def _create_wrapper_function(name):
     wrapper_function.__name__ = name
     globals()[name] = wrapper_function
 
-fnames = FunctionFactory.getFunctionNames()
-for i, val in enumerate(fnames):
-    _create_wrapper_function(val)
+
+def _create_wrappers_for_all_fit_functions():
+    for name in FunctionFactory.getFunctionNames():
+        _create_wrapper_function(name)
+
+
+_create_wrappers_for_all_fit_functions()


### PR DESCRIPTION
Following suggestion by @AntonPiccardoSelg the code was hidden inside a private function.

**To test:**

`from mantid.simpleapi import i`

Fixes #21753

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
