### PR TITLE
MR filtering for cross-section extraction

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/MRFilterCrossSections.py
+++ b/Framework/PythonInterface/plugins/algorithms/MRFilterCrossSections.py
@@ -1,0 +1,167 @@
+#pylint: disable=no-init,invalid-name
+from __future__ import (absolute_import, division, print_function)
+import os
+from mantid.api import *
+from mantid.kernel import *
+import mantid.simpleapi as api
+
+
+class MRFilterCrossSections(PythonAlgorithm):
+
+    def category(self):
+        return "Reflectometry\\SNS"
+
+    def name(self):
+        return "MRFilterCrossSections"
+
+    def summary(self):
+        return "This algorithm loads a Magnetism Reflectometer file and returns workspaces for each cross-section."
+
+    def PyInit(self):
+        self.declareProperty(FileProperty("Filename", "", action=FileAction.Load, extensions=[".nxs", ".nxs.h5"]))
+        self.declareProperty("PolState", "SF1",
+                             doc="Name of the log entry determining the polarizer state")
+        self.declareProperty("AnaState", "SF2",
+                             doc="Name of the log entry determining the analyzer state")
+        self.declareProperty("PolVeto", "",
+                             doc="Name of the log entry determining the polarizer veto [optional]")
+        self.declareProperty("AnaVeto", "",
+                             doc="Name of the log entry determining the analyzer veto [optional]")
+        self.declareProperty(WorkspaceGroupProperty("CrossSectionWorkspaces", "",
+                                                    direction=Direction.Output,
+                                                    optional=PropertyMode.Optional),
+                             doc="Workspace group containing cross-sections")
+    def PyExec(self):
+        """ Execute filtering """
+        file_path = self.getProperty("Filename").value
+
+        # Allow for the processing of legacy data
+        if file_path.endswith('.nxs'):
+            cross_sections = self.load_legacy_cross_Sections(file_path)
+        else:
+            cross_sections = self.filter_cross_sections(file_path)
+        output_wsg = self.getPropertyValue("CrossSectionWorkspaces")
+
+        api.GroupWorkspaces(InputWorkspaces=cross_sections,
+                            OutputWorkspace=output_wsg)
+        self.setProperty("CrossSectionWorkspaces", output_wsg)
+
+    def filter_cross_sections(self, file_path):
+        """
+            Filter events according to the polarization states
+            :param str file_path: data file path
+        """
+        pol_state = self.getProperty("PolState").value
+        pol_veto = self.getProperty("PolVeto").value
+        raw_ws = os.path.basename(file_path)
+        ws = api.LoadEventNexus(Filename=file_path, OutputWorkspace=raw_ws)
+        run_number = ws.getRunNumber()
+
+        # Check whether we have a polarizer
+        polarizer = ws.getRun().getProperty("Polarizer").value[0]
+    
+        # Determine cross-sections
+        cross_sections = list()
+        if polarizer > 0:
+            xs_name = "%s_Off" % run_number
+            ws_off = api.FilterByLogValue(InputWorkspace=ws, LogName=pol_state, TimeTolerance=0.1,
+                                      MinimumValue=-.01, MaximumValue=0.01, LogBoundary='Left',
+                                      OutputWorkspace=xs_name)
+            if not pol_veto == '':
+                ws_off = api.FilterByLogValue(InputWorkspace=ws_off, LogName=pol_veto, TimeTolerance=0.1,
+                                          MinimumValue=-.01, MaximumValue=0.01, LogBoundary='Left',
+                                          OutputWorkspace=xs_name)
+
+            xs_events = self.filter_analyzer(ws_off, 'Off')
+            cross_sections.extend(xs_events)
+
+            xs_name = "%s_On" % run_number
+            ws_on = api.FilterByLogValue(InputWorkspace=ws, LogName=pol_state, TimeTolerance=0.1,
+                                     MinimumValue=0.99, MaximumValue=1.01, LogBoundary='Left',
+                                     OutputWorkspace=xs_name)
+            if not pol_veto == '':
+                ws_on = api.FilterByLogValue(InputWorkspace=ws_on, LogName=pol_veto, TimeTolerance=0.1,
+                                         MinimumValue=-.01, MaximumValue=0.01, LogBoundary='Left',
+                                         OutputWorkspace=xs_name)
+
+            xs_events = self.filter_analyzer(ws_on, 'On')
+            cross_sections.extend(xs_events)
+        else:
+            xs_events = self.filter_analyzer(ws, 'Off')
+            cross_sections.extend(xs_events)
+
+        AnalysisDataService.remove(raw_ws)
+
+        return cross_sections
+
+    def filter_analyzer(self, ws, pol_state='Off'):
+        """
+            Filter events according to the analyzer.
+            :param Workspace ws: Mantid workspace
+            :param str pol_state: polarization state On/Off
+        """
+        ana_state = self.getProperty("AnaState").value
+        ana_veto = self.getProperty("AnaVeto").value
+        run_number = ws.getRunNumber()
+        cross_sections = list()
+
+        analyzer = ws.getRun().getProperty("Analyzer").value[0]
+        if analyzer > 0:
+            try:
+                xs_name = "%s_%s_Off" % (run_number, pol_state)
+                ws_ana_off = api.FilterByLogValue(InputWorkspace=ws, LogName=ana_state,
+                                              MinimumValue=-0.01, MaximumValue=0.01, LogBoundary='Left',
+                                              OutputWorkspace=xs_name)
+                if not ana_veto == '':
+                    ws_ana_off = api.FilterByLogValue(InputWorkspace=ws_ana_off, LogName=ana_veto, TimeTolerance=0.1,
+                                                  MinimumValue=-.01, MaximumValue=0.01, LogBoundary='Left',
+                                                  OutputWorkspace=xs_name)
+                api.AddSampleLog(Workspace=ws_ana_off, LogName='cross_section_id',
+                                      LogText="%s_Off" % pol_state)
+                cross_sections.append(xs_name)
+            except:
+                api.logger.error("Could not filter %s-Off" % pol_state)
+
+            try:
+                xs_name = "%s_%s_On" % (run_number, pol_state)
+                ws_ana_on = api.FilterByLogValue(InputWorkspace=ws, LogName=ana_state,
+                                             MinimumValue=1, MaximumValue=1, LogBoundary='Left',
+                                             OutputWorkspace=xs_name)
+                if not ana_veto == '':
+                    ws_ana_on = api.FilterByLogValue(InputWorkspace=ws_ana_on, LogName=ana_veto, TimeTolerance=0.1,
+                                                 MinimumValue=-.01, MaximumValue=0.01, LogBoundary='Left',
+                                                 OutputWorkspace=xs_name)
+                api.AddSampleLog(Workspace=ws_ana_on, LogName='cross_section_id',
+                                      LogText="%s_On" % pol_state)
+                cross_sections.append(xs_name)
+            except:
+                api.logger.error("Could not filter %s-On" % pol_state)
+            AnalysisDataService.remove(str(ws))
+        else:
+            api.AddSampleLog(Workspace=ws, LogName='cross_section_id',
+                                      LogText="%s_Off" % pol_state)
+            cross_sections.append(str(ws))
+
+        return cross_sections
+
+    def load_legacy_cross_Sections(self, file_path):
+        """
+            For legacy MR data, we need to load each cross-section independently.
+            :param str file_path: data file path
+        """
+        ws_base_name = os.path.basename(file_path)
+        cross_sections = list()
+
+        for entry in ['Off_Off', 'On_Off', 'Off_On', 'On_On']:
+            ws_name = "%s_%s" % (ws_base_name, entry)
+            ws = api.LoadEventNexus(Filename=file_path,
+                                    NXentryName='entry-%s' % entry,
+                                    OutputWorkspace=ws_name)
+            api.AddSampleLog(Workspace=ws, LogName='cross_section_id',
+                                      LogText=entry)
+            cross_sections.append(ws_name)
+
+        return cross_sections
+
+# Register
+api.AlgorithmFactory.subscribe(MRFilterCrossSections)

--- a/Framework/PythonInterface/plugins/algorithms/MRFilterCrossSections.py
+++ b/Framework/PythonInterface/plugins/algorithms/MRFilterCrossSections.py
@@ -31,6 +31,7 @@ class MRFilterCrossSections(PythonAlgorithm):
                                                     direction=Direction.Output,
                                                     optional=PropertyMode.Optional),
                              doc="Workspace group containing cross-sections")
+
     def PyExec(self):
         """ Execute filtering """
         file_path = self.getProperty("Filename").value
@@ -59,7 +60,7 @@ class MRFilterCrossSections(PythonAlgorithm):
 
         # Check whether we have a polarizer
         polarizer = ws.getRun().getProperty("Polarizer").value[0]
-    
+
         # Determine cross-sections
         cross_sections = list()
         if polarizer > 0:

--- a/Framework/PythonInterface/plugins/algorithms/MRFilterCrossSections.py
+++ b/Framework/PythonInterface/plugins/algorithms/MRFilterCrossSections.py
@@ -6,8 +6,10 @@ from mantid.api import *
 from mantid.kernel import *
 import mantid.simpleapi as api
 
+
 def extract_times(times, is_start, is_sf1=False, is_sf2=False, is_veto1=False, is_veto2=False):
     return [(times[i], is_start, [is_sf1, is_sf2, is_veto1, is_veto2]) for i in range(len(times))]
+
 
 class MRFilterCrossSections(PythonAlgorithm):
 
@@ -149,7 +151,6 @@ class MRFilterCrossSections(PythonAlgorithm):
                 time_dict = splitws.toDict()
                 change_list.extend(extract_times(time_dict['start'], True, is_veto2=True))
                 change_list.extend(extract_times(time_dict['stop'], False, is_veto2=True))
-
 
         start_time = ws_raw.run().startTime().total_nanoseconds()
 

--- a/Framework/PythonInterface/plugins/algorithms/MRFilterCrossSections.py
+++ b/Framework/PythonInterface/plugins/algorithms/MRFilterCrossSections.py
@@ -65,24 +65,24 @@ class MRFilterCrossSections(PythonAlgorithm):
         if polarizer > 0:
             xs_name = "%s_Off" % run_number
             ws_off = api.FilterByLogValue(InputWorkspace=ws, LogName=pol_state, TimeTolerance=0.1,
-                                      MinimumValue=-.01, MaximumValue=0.01, LogBoundary='Left',
-                                      OutputWorkspace=xs_name)
-            if not pol_veto == '':
-                ws_off = api.FilterByLogValue(InputWorkspace=ws_off, LogName=pol_veto, TimeTolerance=0.1,
                                           MinimumValue=-.01, MaximumValue=0.01, LogBoundary='Left',
                                           OutputWorkspace=xs_name)
+            if not pol_veto == '':
+                ws_off = api.FilterByLogValue(InputWorkspace=ws_off, LogName=pol_veto, TimeTolerance=0.1,
+                                              MinimumValue=-.01, MaximumValue=0.01, LogBoundary='Left',
+                                              OutputWorkspace=xs_name)
 
             xs_events = self.filter_analyzer(ws_off, 'Off')
             cross_sections.extend(xs_events)
 
             xs_name = "%s_On" % run_number
             ws_on = api.FilterByLogValue(InputWorkspace=ws, LogName=pol_state, TimeTolerance=0.1,
-                                     MinimumValue=0.99, MaximumValue=1.01, LogBoundary='Left',
-                                     OutputWorkspace=xs_name)
+                                         MinimumValue=0.99, MaximumValue=1.01, LogBoundary='Left',
+                                         OutputWorkspace=xs_name)
             if not pol_veto == '':
                 ws_on = api.FilterByLogValue(InputWorkspace=ws_on, LogName=pol_veto, TimeTolerance=0.1,
-                                         MinimumValue=-.01, MaximumValue=0.01, LogBoundary='Left',
-                                         OutputWorkspace=xs_name)
+                                             MinimumValue=-.01, MaximumValue=0.01, LogBoundary='Left',
+                                             OutputWorkspace=xs_name)
 
             xs_events = self.filter_analyzer(ws_on, 'On')
             cross_sections.extend(xs_events)
@@ -110,14 +110,14 @@ class MRFilterCrossSections(PythonAlgorithm):
             try:
                 xs_name = "%s_%s_Off" % (run_number, pol_state)
                 ws_ana_off = api.FilterByLogValue(InputWorkspace=ws, LogName=ana_state,
-                                              MinimumValue=-0.01, MaximumValue=0.01, LogBoundary='Left',
-                                              OutputWorkspace=xs_name)
+                                                  MinimumValue=-0.01, MaximumValue=0.01, LogBoundary='Left',
+                                                  OutputWorkspace=xs_name)
                 if not ana_veto == '':
                     ws_ana_off = api.FilterByLogValue(InputWorkspace=ws_ana_off, LogName=ana_veto, TimeTolerance=0.1,
-                                                  MinimumValue=-.01, MaximumValue=0.01, LogBoundary='Left',
-                                                  OutputWorkspace=xs_name)
+                                                      MinimumValue=-.01, MaximumValue=0.01, LogBoundary='Left',
+                                                      OutputWorkspace=xs_name)
                 api.AddSampleLog(Workspace=ws_ana_off, LogName='cross_section_id',
-                                      LogText="%s_Off" % pol_state)
+                                 LogText="%s_Off" % pol_state)
                 cross_sections.append(xs_name)
             except:
                 api.logger.error("Could not filter %s-Off" % pol_state)
@@ -125,21 +125,21 @@ class MRFilterCrossSections(PythonAlgorithm):
             try:
                 xs_name = "%s_%s_On" % (run_number, pol_state)
                 ws_ana_on = api.FilterByLogValue(InputWorkspace=ws, LogName=ana_state,
-                                             MinimumValue=1, MaximumValue=1, LogBoundary='Left',
-                                             OutputWorkspace=xs_name)
+                                                 MinimumValue=1, MaximumValue=1, LogBoundary='Left',
+                                                 OutputWorkspace=xs_name)
                 if not ana_veto == '':
                     ws_ana_on = api.FilterByLogValue(InputWorkspace=ws_ana_on, LogName=ana_veto, TimeTolerance=0.1,
-                                                 MinimumValue=-.01, MaximumValue=0.01, LogBoundary='Left',
-                                                 OutputWorkspace=xs_name)
+                                                     MinimumValue=-.01, MaximumValue=0.01, LogBoundary='Left',
+                                                     OutputWorkspace=xs_name)
                 api.AddSampleLog(Workspace=ws_ana_on, LogName='cross_section_id',
-                                      LogText="%s_On" % pol_state)
+                                 LogText="%s_On" % pol_state)
                 cross_sections.append(xs_name)
             except:
                 api.logger.error("Could not filter %s-On" % pol_state)
             AnalysisDataService.remove(str(ws))
         else:
             api.AddSampleLog(Workspace=ws, LogName='cross_section_id',
-                                      LogText="%s_Off" % pol_state)
+                             LogText="%s_Off" % pol_state)
             cross_sections.append(str(ws))
 
         return cross_sections
@@ -158,7 +158,7 @@ class MRFilterCrossSections(PythonAlgorithm):
                                     NXentryName='entry-%s' % entry,
                                     OutputWorkspace=ws_name)
             api.AddSampleLog(Workspace=ws, LogName='cross_section_id',
-                                      LogText=entry)
+                             LogText=entry)
             cross_sections.append(ws_name)
 
         return cross_sections

--- a/Framework/PythonInterface/plugins/algorithms/MRFilterCrossSections.py
+++ b/Framework/PythonInterface/plugins/algorithms/MRFilterCrossSections.py
@@ -154,13 +154,16 @@ class MRFilterCrossSections(PythonAlgorithm):
         cross_sections = list()
 
         for entry in ['Off_Off', 'On_Off', 'Off_On', 'On_On']:
-            ws_name = "%s_%s" % (ws_base_name, entry)
-            ws = api.LoadEventNexus(Filename=file_path,
-                                    NXentryName='entry-%s' % entry,
-                                    OutputWorkspace=ws_name)
-            api.AddSampleLog(Workspace=ws, LogName='cross_section_id',
-                             LogText=entry)
-            cross_sections.append(ws_name)
+            try:
+                ws_name = "%s_%s" % (ws_base_name, entry)
+                ws = api.LoadEventNexus(Filename=file_path,
+                                        NXentryName='entry-%s' % entry,
+                                        OutputWorkspace=ws_name)
+                api.AddSampleLog(Workspace=ws, LogName='cross_section_id',
+                                 LogText=entry)
+                cross_sections.append(ws_name)
+            except:
+                api.logger.information("Could not load %s from legacy data file" % entry)
 
         return cross_sections
 

--- a/Framework/PythonInterface/plugins/algorithms/MRInspectData.py
+++ b/Framework/PythonInterface/plugins/algorithms/MRInspectData.py
@@ -195,6 +195,7 @@ class DataInfo(object):
         self.update_peak_range = update_peak_range
 
         self.tof_range = self.get_tof_range(ws)
+        self.calculated_scattering_angle = 0.0
         self.determine_data_type(ws)
 
     def log(self):

--- a/Framework/PythonInterface/plugins/algorithms/MRInspectData.py
+++ b/Framework/PythonInterface/plugins/algorithms/MRInspectData.py
@@ -107,7 +107,27 @@ class MRInspectData(PythonAlgorithm):
         mantid.simpleapi.AddSampleLog(Workspace=nxs_data, LogName='low_res_max',
                                       LogText=str(data_info.low_res_range[1]),
                                       LogType='Number', LogUnit='pixel')
+        # Add process ROI information
+        mantid.simpleapi.AddSampleLog(Workspace=nxs_data, LogName='roi_peak_min',
+                                      LogText=str(data_info.roi_peak[0]),
+                                      LogType='Number', LogUnit='pixel')
+        mantid.simpleapi.AddSampleLog(Workspace=nxs_data, LogName='roi_peak_max',
+                                      LogText=str(data_info.roi_peak[1]),
+                                      LogType='Number', LogUnit='pixel')
 
+        mantid.simpleapi.AddSampleLog(Workspace=nxs_data, LogName='roi_low_res_min',
+                                      LogText=str(data_info.roi_low_res[0]),
+                                      LogType='Number', LogUnit='pixel')
+        mantid.simpleapi.AddSampleLog(Workspace=nxs_data, LogName='roi_low_res_max',
+                                      LogText=str(data_info.roi_low_res[1]),
+                                      LogType='Number', LogUnit='pixel')
+
+        mantid.simpleapi.AddSampleLog(Workspace=nxs_data, LogName='roi_background_min',
+                                      LogText=str(data_info.roi_background[0]),
+                                      LogType='Number', LogUnit='pixel')
+        mantid.simpleapi.AddSampleLog(Workspace=nxs_data, LogName='roi_background_max',
+                                      LogText=str(data_info.roi_background[1]),
+                                      LogType='Number', LogUnit='pixel')
 
 def _as_ints(a): return [int(a[0]), int(a[1])]
 

--- a/Framework/PythonInterface/plugins/algorithms/MRInspectData.py
+++ b/Framework/PythonInterface/plugins/algorithms/MRInspectData.py
@@ -188,6 +188,7 @@ class DataInfo(object):
     def get_tof_range(self, ws):
             """
                 Determine TOF range from the data
+                :param workspace ws: workspace to work with
             """
             run_object = ws.getRun()
             sample_detector_distance = run_object['SampleDetDis'].getStatistics().mean / 1000.0
@@ -210,6 +211,7 @@ class DataInfo(object):
         """
             Process the ROI information and determine the peak
             range, the low-resolution range, and the background range.
+            :param workspace ws: workspace to work with
         """
         roi_peak = [0,0]
         roi_low_res = [0,0]
@@ -294,6 +296,12 @@ class DataInfo(object):
             self.roi_background = self.forced_bck_roi
 
     def determine_peak_range(self, ws, specular=True, max_pixel=250):
+        """
+            Find the reflectivity peak
+            :param workspace ws: workspace to work with
+            :param bool specular: if True, we are looking for a specular peak
+            :param int max_pixel: max pixel above which to exclude peaks
+        """
         ws_summed = mantid.simpleapi.RefRoi(InputWorkspace=ws, IntegrateY=specular,
                                             NXPixel=self.n_x_pixel, NYPixel=self.n_y_pixel,
                                             ConvertToQ=False,
@@ -330,6 +338,12 @@ class DataInfo(object):
 
     @classmethod
     def fit_peak(cls, signal_x, signal_y, peak):
+        """
+            Fit a Gaussian peak to a curve
+            :param array signal_x: list of x values
+            :param array signal_y: list of y values
+            :param array peak: initial guess for the peak (one-sigma min and max)
+        """
         def gauss(x, *p):
             A, mu, sigma, bck = p
             if A < 0 or sigma < 5:
@@ -348,6 +362,8 @@ class DataInfo(object):
     def scattering_angle(cls, ws, peak_position=None):
         """
             Determine the scattering angle
+            :param workspace ws: Workspace to inspect
+            :param float peak_position: reflectivity peak position
         """
         dangle = ws.getRun().getProperty("DANGLE").getStatistics().mean
         dangle0 = ws.getRun().getProperty("DANGLE0").getStatistics().mean
@@ -362,6 +378,8 @@ class DataInfo(object):
     def check_direct_beam(self, ws, peak_position=None):
         """
             Determine whether this data is a direct beam
+            :param workspace ws: Workspace to inspect
+            :param float peak_position: reflectivity peak position
         """
         huber_x = ws.getRun().getProperty("HuberX").getStatistics().mean
         #dangle = ws.getRun().getProperty("DANGLE").getStatistics().mean
@@ -373,6 +391,7 @@ class DataInfo(object):
         """
             Inspect the data and determine peak locations
             and data type.
+            :param workspace ws: Workspace to inspect
         """
         # Skip empty data entries
         if ws.getNumberEvents() < self.n_events_cutoff:

--- a/Framework/PythonInterface/plugins/algorithms/MRInspectData.py
+++ b/Framework/PythonInterface/plugins/algorithms/MRInspectData.py
@@ -129,6 +129,7 @@ class MRInspectData(PythonAlgorithm):
                                       LogText=str(data_info.roi_background[1]),
                                       LogType='Number', LogUnit='pixel')
 
+
 def _as_ints(a): return [int(a[0]), int(a[1])]
 
 

--- a/Testing/SystemTests/tests/analysis/MagnetismReflectometryReductionTest.py
+++ b/Testing/SystemTests/tests/analysis/MagnetismReflectometryReductionTest.py
@@ -40,6 +40,44 @@ class MagnetismReflectometryReductionTest(stresstesting.MantidStressTest):
         return "r_24949", 'MagnetismReflectometryReductionTest.nxs'
 
 
+class MRFilterCrossSectionsTest(stresstesting.MantidStressTest):
+    """ Test data loading and cross-section extraction """
+    def runTest(self):
+        wsg = MRFilterCrossSections(Filename="REF_M_24949")
+        MagnetismReflectometryReduction(InputWorkspace=wsg[0],
+                                        NormalizationRunNumber=24945,
+                                        SignalPeakPixelRange=[125, 129],
+                                        SubtractSignalBackground=True,
+                                        SignalBackgroundPixelRange=[15, 105],
+                                        ApplyNormalization=True,
+                                        NormPeakPixelRange=[201, 205],
+                                        SubtractNormBackground=True,
+                                        NormBackgroundPixelRange=[10,127],
+                                        CutLowResDataAxis=True,
+                                        LowResDataAxisPixelRange=[91, 161],
+                                        CutLowResNormAxis=True,
+                                        LowResNormAxisPixelRange=[86, 174],
+                                        CutTimeAxis=True,
+                                        UseWLTimeAxis=False,
+                                        QMin=0.005,
+                                        QStep=-0.01,
+                                        TimeAxisStep=40,
+                                        TimeAxisRange=[25000, 54000],
+                                        SpecularPixel=126.9,
+                                        ConstantQBinning=False,
+                                        EntryName='entry-Off_Off',
+                                        OutputWorkspace="r_24949")
+
+    def validate(self):
+        # Be more tolerant with the output, mainly because of the errors.
+        # The following tolerance check the errors up to the third digit.
+        self.disableChecking.append('Instrument')
+        self.disableChecking.append('Sample')
+        self.disableChecking.append('SpectraMap')
+        self.disableChecking.append('Axes')
+        return "r_24949", 'MagnetismReflectometryReductionTest.nxs'
+
+
 class MRInspectionTest(stresstesting.MantidStressTest):
     def runTest(self):
         nxs_data = LoadEventNexus(Filename="REF_M_24949",

--- a/docs/source/algorithms/MRFilterCrossSections-v1.rst
+++ b/docs/source/algorithms/MRFilterCrossSections-v1.rst
@@ -1,0 +1,32 @@
+.. algorithm::
+
+.. summary::
+
+.. alias::
+
+.. properties::
+
+Description
+-----------
+
+Use by the Magnetism Reflectometer reduction. This algorithm takes in a data file and returns a workspace
+group containing a workspace for each cross-section.
+
+Users can provide log entry names for the logs defining the initial and final polarization states.
+The output workspace group will contain a workspace for each combination of the initial and final
+states with values 1 or 0 (on or off). Whether on and off correspond to spin up or down will
+depend on the hardware used at the instrument, which can be determined from the logs.
+
+The algorithm will read the "Analyzer" and "Polarizer" logs to determine whether those
+devices were used. Filtering of the initial (final) state will only be done if the "Polarizer"
+("Analyzer") log is greater than 0. A value of 0 means that the device was not in use.
+
+Finally, a veto log can be provided for each of the initial and final state logs. Events with
+a veto log other than 0 will be rejected.
+
+For data files created using the legacy data acquisition system (pre-2018), the workspace group will
+contain the four nexus entries of the original nexus file.
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/release/v3.12.0/reflectometry.rst
+++ b/docs/source/release/v3.12.0/reflectometry.rst
@@ -63,6 +63,7 @@ New features
 
 - The new algorithm :ref:`algm-LoadILLPolarizationFactors` can load the polarization efficiency files used on D17 at ILL.
 - The new algorithm :ref:`algm-MRInspectData` takes in raw event data and determines reduction parameters.
+- The new algorithm :ref:`algm-MRFilterCrossSections` loads a MR (SNS) data file into a workspace group comprising of a workspace for each cross-section.
 
 
 Improvements


### PR DESCRIPTION
With the MR (REF_M) DAS upgrade, the cross-sections will be extracted from the data using log entries that define the initial and final polarization states.
Before the upgrade, the four cross-sections were saved in separate entries in the nexus file.

We need a filtering algorithm that will load a file and inspect the logs to extract the cross-sections, which will be returned in a workspace group. Since we need the reduction to be backward compatible, the algorithm needs to be able to process the legacy format too.

**To test:**
- Make sure the tests pass.
- Inspect code.

There is no "issue" for this PR, all the info is here.

**Release Notes** 
A note has been added to the reflectivity section of the 3.12 release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
