### PR TITLE
Set transmission runs based on run angle

### DIFF
--- a/Framework/TestHelpers/inc/MantidTestHelpers/DataProcessorTestHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/DataProcessorTestHelper.h
@@ -1,0 +1,40 @@
+#ifndef DATAPROCESSORTESTHELPER_H
+#define DATAPROCESSORTESTHELPER_H
+
+#include "MantidKernel/System.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace MantidQt {
+namespace MantidWidgets {
+namespace DataProcessor {
+class RowData;
+using RowData_sptr = std::shared_ptr<RowData>;
+}
+}
+}
+
+namespace DataProcessorTestHelper {
+
+// Add a property value from a list to the given row data with an optional
+// prefix
+DLLExport void
+addPropertyValue(MantidQt::MantidWidgets::DataProcessor::RowData_sptr rowData,
+                 const std::vector<std::string> &list, const size_t index,
+                 const std::string &property, const std::string &prefix = "");
+
+// Add a property value to the given row data
+DLLExport void
+addPropertyValue(MantidQt::MantidWidgets::DataProcessor::RowData_sptr rowData,
+                 const std::string &property, const std::string &value);
+
+// Utility to create a row data class from a string list of simple inputs
+DLLExport MantidQt::MantidWidgets::DataProcessor::RowData_sptr
+makeRowData(const std::vector<std::string> &list,
+            const std::vector<std::string> &prefixes = {"TOF_", "", "TRANS_"},
+            const size_t numSlices = 0);
+}
+
+#endif /*DATAPROCESSORTESTHELPER_H*/

--- a/Framework/TestHelpers/src/DataProcessorTestHelper.cpp
+++ b/Framework/TestHelpers/src/DataProcessorTestHelper.cpp
@@ -1,0 +1,104 @@
+#include "MantidTestHelpers/DataProcessorTestHelper.h"
+#include "MantidQtWidgets/Common/DataProcessorUI/TreeData.h"
+
+using namespace MantidQt::MantidWidgets::DataProcessor;
+
+namespace DataProcessorTestHelper {
+
+/* Add a property value from a list to the given row data with an optional
+ * prefix
+ */
+void addPropertyValue(RowData_sptr rowData,
+                      const std::vector<std::string> &list, const size_t index,
+                      const std::string &property, const std::string &prefix) {
+  if (index >= list.size() || list[index].empty())
+    return;
+
+  // Set the option based on the row value
+  rowData->setOptionValue(property, list[index]);
+  // Set the preprocessed option based on the value and prefix
+  rowData->setPreprocessedOptionValue(property, prefix + list[index]);
+}
+
+/* Add a property value to the given row data
+ */
+void addPropertyValue(RowData_sptr rowData, const std::string &property,
+                      const std::string &value) {
+  // Set the value and preprocessed value to the given value
+  rowData->setOptionValue(property, value);
+  rowData->setPreprocessedOptionValue(property, value);
+}
+
+/* Append a value from a list to a string. Optionally add a prefix
+ * to the value from a corrsponding list of prefixes before appending
+ * it to the string
+ *
+ * @param stringToEdit [inout] : the string to append to
+ * @param list [in] : the list of values to append
+ * @param prefixes [in] : the list of prefixes
+ * @param i [in] : the index of the value/prefix to use
+ * @separator [in] : optional separator to use when appending the
+ * value
+ */
+void appendStringWithPrefixedValue(std::string &stringToEdit,
+                                   const std::vector<std::string> &list,
+                                   const std::vector<std::string> &prefixes,
+                                   const size_t i,
+                                   const std::string &separator = "") {
+  // do nothing if string to add is empty
+  if (i >= list.size() || list[i].empty())
+    return;
+
+  // add separator and string with/without prefix
+  if (i >= prefixes.size() || prefixes[i].empty())
+    stringToEdit += separator + list[i];
+  else
+    stringToEdit += separator + prefixes[i] + list[i];
+}
+
+// Utility to create a row data class from a string list of simple inputs
+// (does not support multiple input runs or transmission runs, or entries
+// in the options/hidden columns). Assumes input workspaces are prefixed
+// with TOF_ and transmission runs with TRANS_
+RowData_sptr makeRowData(const std::vector<std::string> &list,
+                         const std::vector<std::string> &prefixes,
+                         const size_t numSlices) {
+  // Create the data and add default options
+  auto rowData = std::make_shared<RowData>(list);
+
+  if (list.size() < 1)
+    return rowData;
+
+  std::string reducedName;
+  appendStringWithPrefixedValue(reducedName, list, prefixes, 0);
+  appendStringWithPrefixedValue(reducedName, list, prefixes, 2, "_");
+
+  rowData->setReducedName(QString::fromStdString(reducedName));
+  addPropertyValue(rowData, "OutputWorkspace", "IvsQ_" + reducedName);
+  addPropertyValue(rowData, "OutputWorkspaceBinned",
+                   "IvsQ_binned_" + reducedName);
+  addPropertyValue(rowData, "OutputWorkspaceWavelength",
+                   "IvsLam_" + reducedName);
+
+  // Set other options from the row data values
+  addPropertyValue(rowData, list, 0, "InputWorkspace", "TOF_");
+  addPropertyValue(rowData, list, 1, "ThetaIn");
+  addPropertyValue(rowData, list, 2, "FirstTransmissionRun", "TRANS_");
+  addPropertyValue(rowData, list, 3, "MomentumTransferMin");
+  addPropertyValue(rowData, list, 4, "MomentumTransferMax");
+  addPropertyValue(rowData, list, 5, "MomentumTransferStep");
+  addPropertyValue(rowData, list, 6, "ScaleFactor");
+
+  // Add some slices if requested
+  std::vector<QString> workspaceProperties = {
+      "InputWorkspace", "OutputWorkspace", "OutputWorkspaceBinned",
+      "OutputWorkspaceWavelength"};
+  for (size_t i = 0; i < numSlices; ++i) {
+    QString sliceName =
+        QString("_slice_") + QString::fromStdString(std::to_string(i));
+    rowData->addSlice(sliceName, workspaceProperties);
+  }
+
+  return rowData;
+}
+}

--- a/docs/source/release/v3.12.0/reflectometry.rst
+++ b/docs/source/release/v3.12.0/reflectometry.rst
@@ -16,6 +16,7 @@ ISIS Reflectometry Interface
 New features
 ############
 
+- A new table has been added to the Settings tab to allow default transmission runs to be specified on a per-angle basis. If a row in the Runs tab contains an angle, it will be looked up in this table and those transmission runs will be used if a matching angle is found (the angle does not have to be exact as it will match to within 100th of a degree). If you want to specify transmission runs that will be used by default for all runs, then simply leave the angle empty.
 - Two new boxes have been added to the settings tab of the ISIS Reflectometry interface, 'ReductionType' and 'SummationType' which are passed to the corresponding parameters of :ref:`algm-ReflectometryReductionOneAuto`.
 - The ISIS Reflectometry interface now has a checkbox 'CorrectDetectors' which maps to the corresponding property in :ref:`algm-ReflectometryReductionOneAuto`.
 - The 'Get Defaults' button now looks for values for the following additional properties in the IDF:
@@ -33,11 +34,13 @@ Improvements
 ############
 
 - Grid lines are now displayed in the runs tab.
+- Plotting results in event handling mode now plots the `IvsQ_binned_` workspaces rather than `IvsQ_`, to make the behaviour consistent with non-event mode.
 - Menu items and toolbar buttons are now enabled/disabled when appropriate, e.g. to prevent table modification during processing. Directly editing table rows and settings is also disabled during processing.
 - Removed the 'DirectBeam' box from the settings tab of the ISIS Reflectometry interface because this is not used.
 - Properties on the Runs tab now take precedence over properties on the Settings tab.
 - Output workspace names have been improved. Names now use '+' to indicate preprocessed (i.e. summed) workspaces, rather than '_', which is used to indicate postprocessed (i.e. stitched) workspaces.
 - The Python code generated when you tick `Output Notebook` has been improved to support special characters (e.g. `+`) in workspace names. Output workspaces are now set using the output properties of the algorithm rather than by variable assignment. This avoids the possibility of invalid characters being used in Python variable names.
+- The `Output Notebook` option now works for all groups that are processed as non-event workspaces. Previously, if event handling was enabled but a group contained non-event workspaces, generating the notebook was disabled.
 - Added a new `?` button to the ISIS Reflectometry Interface which links to the documentation page.
 - Added extra tooltips to the ISIS Reflectometry Interface.
 

--- a/docs/source/release/v3.12.0/reflectometry.rst
+++ b/docs/source/release/v3.12.0/reflectometry.rst
@@ -59,6 +59,7 @@ Bug fixes
   - LambdaMax,
   - I0MonitorIndex
   - TransRunStartOverlap and TransRunEndOverlap if on SURF or CRISP.
+- Fixed a bug where the processed state of rows was being reset when transferring additional rows into the table.
 
 
 Algorithms

--- a/qt/scientific_interfaces/CMakeLists.txt
+++ b/qt/scientific_interfaces/CMakeLists.txt
@@ -69,6 +69,7 @@ mtd_add_qt_tests (TARGET_NAME MantidQtScientificInterfacesTest
     inc
   TEST_HELPER_SRCS
     ../../Framework/TestHelpers/src/ComponentCreationHelper.cpp
+    ../../Framework/TestHelpers/src/DataProcessorTestHelper.cpp
     ../../Framework/TestHelpers/src/InstrumentCreationHelper.cpp
     ../../Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
     ../../Framework/TestHelpers/src/ScopedFileHelper.cpp

--- a/qt/scientific_interfaces/ISISReflectometry/IReflMainWindowPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/IReflMainWindowPresenter.h
@@ -49,8 +49,12 @@ public:
   virtual void notifyReductionPaused(int group) = 0;
   virtual void notifyReductionResumed(int group) = 0;
 
+  /// Transmission runs for a specific run angle
+  virtual std::string getTransmissionRunsForAngle(int group,
+                                                  const double angle) const = 0;
+  /// Whether there are per-angle transmission runs specified
+  virtual bool hasPerAngleTransmissionRuns(int group) const = 0;
   /// Pre-processing
-  virtual std::string getTransmissionRuns(int group) const = 0;
   virtual MantidWidgets::DataProcessor::OptionsQMap
   getTransmissionOptions(int group) const = 0;
   /// Processing

--- a/qt/scientific_interfaces/ISISReflectometry/IReflSettingsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/IReflSettingsPresenter.h
@@ -41,6 +41,10 @@ Code Documentation is available at: <http://doxygen.mantidproject.org>
 class IReflSettingsPresenter {
 public:
   virtual ~IReflSettingsPresenter(){};
+  /// Transmission runs for a particular angle
+  virtual std::string getTransmissionRunsForAngle(const double angle) const = 0;
+  /// Whether per-angle transmission runs are set
+  virtual bool hasPerAngleTransmissionRuns() const = 0;
   /// Pre-processing
   virtual MantidWidgets::DataProcessor::OptionsQMap
   getTransmissionOptions() const = 0;
@@ -50,7 +54,7 @@ public:
   getReductionOptions() const = 0;
   /// Post-processing
   virtual std::string getStitchOptions() const = 0;
-  virtual std::string getTransmissionRuns() const = 0;
+  virtual std::string getTransmissionRuns(const double angle) const = 0;
   virtual void acceptTabPresenter(IReflSettingsTabPresenter *tabPresenter) = 0;
 
   enum Flag {

--- a/qt/scientific_interfaces/ISISReflectometry/IReflSettingsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/IReflSettingsPresenter.h
@@ -54,7 +54,6 @@ public:
   getReductionOptions() const = 0;
   /// Post-processing
   virtual std::string getStitchOptions() const = 0;
-  virtual std::string getTransmissionRuns(const double angle) const = 0;
   virtual void acceptTabPresenter(IReflSettingsTabPresenter *tabPresenter) = 0;
 
   enum Flag {

--- a/qt/scientific_interfaces/ISISReflectometry/IReflSettingsTabPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/IReflSettingsTabPresenter.h
@@ -39,8 +39,12 @@ Code Documentation is available at: <http://doxygen.mantidproject.org>
 class IReflSettingsTabPresenter {
 public:
   virtual ~IReflSettingsTabPresenter(){};
+  /// Transmission runs for a particular run angle
+  virtual std::string getTransmissionRunsForAngle(int group,
+                                                  const double angle) const = 0;
+  /// Whether per-angle transmission runs are specified
+  virtual bool hasPerAngleTransmissionRuns(int group) const = 0;
   /// Pre-processing
-  virtual std::string getTransmissionRuns(int group) const = 0;
   virtual MantidWidgets::DataProcessor::OptionsQMap
   getTransmissionOptions(int group) const = 0;
   /// Processing

--- a/qt/scientific_interfaces/ISISReflectometry/IReflSettingsView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/IReflSettingsView.h
@@ -58,7 +58,7 @@ public:
 
   /// Experiment settings
   virtual std::string getAnalysisMode() const = 0;
-  virtual std::string getTransmissionRuns() const = 0;
+  virtual std::map<std::string, std::string> getTransmissionRuns() const = 0;
   virtual std::string getStartOverlap() const = 0;
   virtual std::string getEndOverlap() const = 0;
   virtual std::string getPolarisationCorrections() const = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/QtReflSettingsView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/QtReflSettingsView.cpp
@@ -40,7 +40,7 @@ void QtReflSettingsView::initLayout() {
   int numCols = 2;
   m_ui.transmissionRunsTable->setColumnCount(numCols);
   m_ui.transmissionRunsTable->setColumnWidth(0, 40);
-  m_ui.transmissionRunsTable->setColumnWidth(1, 149);
+  m_ui.transmissionRunsTable->setColumnWidth(1, 133);
   m_ui.transmissionRunsTable->setHorizontalHeaderLabels(
       {QString::fromStdString("Angle"),
        QString::fromStdString("Transmission Run(s)")});
@@ -409,8 +409,7 @@ std::string QtReflSettingsView::getStitchOptions() const {
 }
 
 QLineEdit &QtReflSettingsView::stitchOptionsLineEdit() const {
-  auto widget = m_ui.expSettingsLayout0->itemAtPosition(7, 1)->widget();
-  return *static_cast<QLineEdit *>(widget);
+  return *static_cast<QLineEdit *>(m_stitchEdit);
 }
 
 /** Creates hints for 'Stitch1DMany'
@@ -419,8 +418,21 @@ QLineEdit &QtReflSettingsView::stitchOptionsLineEdit() const {
 void QtReflSettingsView::createStitchHints(
     const std::map<std::string, std::string> &hints) {
 
-  m_ui.expSettingsLayout0->addWidget(new HintingLineEdit(this, hints), 7, 1, 1,
-                                     3);
+  // We want to add the stitch params box next to the stitch
+  // label, so first find the label's position
+  for (int i = 0; i < m_ui.expSettingsLayout0->count(); ++i) {
+    if (m_ui.expSettingsLayout0->itemAt(i)->widget() == m_ui.stitchLabel) {
+      // Get the label's position
+      int row, col, rowSpan, colSpan;
+      m_ui.expSettingsLayout0->getItemPosition(i, &row, &col, &rowSpan,
+                                               &colSpan);
+      // Create the new edit box and add it to the right of the label
+      m_stitchEdit = new HintingLineEdit(this, hints);
+      m_ui.expSettingsLayout0->addWidget(m_stitchEdit, row, col + colSpan, 1,
+                                         3);
+      return;
+    }
+  }
 }
 
 /** Return selected analysis mode

--- a/qt/scientific_interfaces/ISISReflectometry/QtReflSettingsView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/QtReflSettingsView.cpp
@@ -47,7 +47,8 @@ void QtReflSettingsView::initLayout() {
   // Hard code the number of rows for now (typically we'll have 2 or 3 angles)
   int numRows = 3;
   m_ui.transmissionRunsTable->setRowCount(numRows);
-  auto headerHeight = m_ui.transmissionRunsTable->horizontalHeader()->height() + 2;
+  auto headerHeight =
+      m_ui.transmissionRunsTable->horizontalHeader()->height() + 2;
   auto rowHeight = m_ui.transmissionRunsTable->rowHeight(0);
   m_ui.transmissionRunsTable->setMinimumHeight(rowHeight * numRows +
                                                headerHeight);

--- a/qt/scientific_interfaces/ISISReflectometry/QtReflSettingsView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/QtReflSettingsView.cpp
@@ -85,6 +85,11 @@ void QtReflSettingsView::connectSettingsChange(QGroupBox &edit) {
   connect(&edit, SIGNAL(toggled(bool)), this, SLOT(notifySettingsChanged()));
 }
 
+void QtReflSettingsView::connectSettingsChange(QTableWidget &edit) {
+  connect(&edit, SIGNAL(cellChanged(int, int)), this,
+          SLOT(notifySettingsChanged()));
+}
+
 void QtReflSettingsView::disableAll() {
   m_ui.instSettingsGroup->setEnabled(false);
   m_ui.expSettingsGroup->setEnabled(false);
@@ -130,7 +135,7 @@ void QtReflSettingsView::registerExperimentSettingsWidgets(
     Mantid::API::IAlgorithm_sptr alg) {
   connectSettingsChange(*m_ui.expSettingsGroup);
   registerSettingWidget(*m_ui.analysisModeComboBox, "AnalysisMode", alg);
-  registerSettingWidget(*m_ui.transmissionRunsEdit, "FirstTransmissionRun",
+  registerSettingWidget(*m_ui.transmissionRunsTable, "FirstTransmissionRun",
                         alg);
   registerSettingWidget(*m_ui.startOverlapEdit, "StartOverlap", alg);
   registerSettingWidget(*m_ui.endOverlapEdit, "EndOverlap", alg);

--- a/qt/scientific_interfaces/ISISReflectometry/QtReflSettingsView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/QtReflSettingsView.cpp
@@ -346,7 +346,7 @@ void QtReflSettingsView::setPolarisationOptionsEnabled(bool enable) {
 
 /** Add a new row to the transmission runs table
  * */
-void QtReflSettingsView::addTransmissionTableRow() const {
+void QtReflSettingsView::addTransmissionTableRow() {
   auto numRows = m_ui.transmissionRunsTable->rowCount() + 1;
   m_ui.transmissionRunsTable->setRowCount(numRows);
   // Select the first cell in the new row

--- a/qt/scientific_interfaces/ISISReflectometry/QtReflSettingsView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/QtReflSettingsView.h
@@ -8,6 +8,11 @@
 #include "InstrumentOptionDefaults.h"
 
 namespace MantidQt {
+
+namespace MantidWidgets {
+class HintingLineEdit;
+}
+
 namespace CustomInterfaces {
 
 // Forward decs
@@ -168,6 +173,8 @@ private:
   std::unique_ptr<IReflSettingsPresenter> m_presenter;
   /// Whether or not polarisation corrections should be enabled
   mutable bool m_isPolCorrEnabled;
+  /// The stitch params entry widget
+  MantidQt::MantidWidgets::HintingLineEdit *m_stitchEdit;
 };
 } // namespace Mantid
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/QtReflSettingsView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/QtReflSettingsView.h
@@ -135,7 +135,7 @@ public slots:
       std::vector<MissingInstrumentParameterValue> const &missingValues) const;
   QString messageFor(const InstrumentParameterTypeMissmatch &typeError) const;
   /// Adds another row to the transmission runs table
-  void addTransmissionTableRow() const;
+  void addTransmissionTableRow();
 
 private:
   /// Initialise the interface

--- a/qt/scientific_interfaces/ISISReflectometry/QtReflSettingsView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/QtReflSettingsView.h
@@ -51,7 +51,7 @@ public:
   /// Return selected analysis mode
   std::string getAnalysisMode() const override;
   /// Return transmission runs
-  std::string getTransmissionRuns() const override;
+  std::map<std::string, std::string> getTransmissionRuns() const override;
   /// Return start overlap for transmission runs
   std::string getStartOverlap() const override;
   /// Return end overlap for transmission runs
@@ -129,6 +129,8 @@ public slots:
   QString messageFor(
       std::vector<MissingInstrumentParameterValue> const &missingValues) const;
   QString messageFor(const InstrumentParameterTypeMissmatch &typeError) const;
+  /// Adds another row to the transmission runs table
+  void addTransmissionTableRow() const;
 
 private:
   /// Initialise the interface

--- a/qt/scientific_interfaces/ISISReflectometry/QtReflSettingsView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/QtReflSettingsView.h
@@ -149,6 +149,7 @@ private:
   void connectSettingsChange(QComboBox &edit);
   void connectSettingsChange(QCheckBox &edit);
   void connectSettingsChange(QGroupBox &edit);
+  void connectSettingsChange(QTableWidget &edit);
   QLineEdit &stitchOptionsLineEdit() const;
   void setSelected(QComboBox &box, std::string const &str);
   void setText(QLineEdit &lineEdit, int value);

--- a/qt/scientific_interfaces/ISISReflectometry/QtReflSettingsView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/QtReflSettingsView.h
@@ -140,6 +140,7 @@ public slots:
 private:
   /// Initialise the interface
   void initLayout();
+  void initTransmissionRunsTable();
   void registerSettingsWidgets(Mantid::API::IAlgorithm_sptr alg);
   void registerInstrumentSettingsWidgets(Mantid::API::IAlgorithm_sptr alg);
   void registerExperimentSettingsWidgets(Mantid::API::IAlgorithm_sptr alg);

--- a/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.cpp
@@ -225,18 +225,16 @@ bool ReflDataProcessorPresenter::processGroupAsEventWS(
     OptionsMap options = getCanonicalOptions(
         rowData, getProcessingOptions(rowData), m_whitelist, true,
         m_processor.outputProperties(), m_processor.prefixes());
-    // Cache a copy of the unpreprocessed options in the row data
     rowData->setOptions(options);
-    // Perform any preprocessing on the input properties (e.g. multiple
-    // input runs will  be summed into a single workspace). Note that
-    // this also loads the input run(s).
-    preprocessOptionValues(options, rowData);
-    rowData->setPreprocessedOptions(options);
+    // Preprocess the row. Note that this only needs to be done once and
+    // not for each slice because the slice data can be inferred from the
+    // row data
+    preprocessOptionValues(rowData);
     // Get the (preprocessed) input workspace name for the reduction. The
     // input runs are from the first column in the whitelist and we look up
     // the associated algorithm property value in the options.
-    auto const runColumn = *m_whitelist.cbegin();
-    auto const &runName = options[runColumn.algorithmProperty()];
+    auto const &runName = rowData->preprocessedOptionValue(
+        m_processor.defaultInputPropertyName());
 
     // Do time slicing now if using uniform slicing because this is dependant
     // on the start/stop times of the current input workspace.

--- a/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.cpp
@@ -221,9 +221,18 @@ bool ReflDataProcessorPresenter::processGroupAsEventWS(
 
     // Work out and cache the reduced workspace name
     rowData->setReducedName(getReducedWorkspaceName(rowData));
+
     // Get the algorithm input properties for this row
+    OptionsMap processingOptions;
+    try {
+      processingOptions = getProcessingOptions(rowData);
+    } catch (std::runtime_error &e) {
+      // Quit with errors if the user entered invalid settings
+      m_view->giveUserCritical(e.what(), "Error");
+      return true;
+    }
     OptionsMap options = getCanonicalOptions(
-        rowData, getProcessingOptions(rowData), m_whitelist, true,
+        rowData, processingOptions, m_whitelist, true,
         m_processor.outputProperties(), m_processor.prefixes());
     rowData->setOptions(options);
     // Preprocess the row. Note that this only needs to be done once and
@@ -333,8 +342,16 @@ bool ReflDataProcessorPresenter::processGroupAsNonEventWS(int groupID,
     rowData->setReducedName(getReducedWorkspaceName(rowData));
     // Get the algorithm input properties for this row and cache in the row
     // data
+    OptionsMap processingOptions;
+    try {
+      processingOptions = getProcessingOptions(rowData);
+    } catch (std::runtime_error &e) {
+      // Quit with errors if the user entered invalid settings
+      m_view->giveUserCritical(e.what(), "Error");
+      return true;
+    }
     OptionsMap options = getCanonicalOptions(
-        rowData, getProcessingOptions(rowData), m_whitelist, true,
+        rowData, processingOptions, m_whitelist, true,
         m_processor.outputProperties(), m_processor.prefixes());
     rowData->setOptions(std::move(options));
 
@@ -802,6 +819,9 @@ void ReflDataProcessorPresenter::addNumGroupSlicesEntry(int groupID,
 }
 
 /** Get the processing options for a given row
+ *
+ * @param data : the row data
+ * @throws :: if the settings the user entered are invalid
  * */
 OptionsMap ReflDataProcessorPresenter::getProcessingOptions(RowData_sptr data) {
   // Return the global settings but also include the transmission runs,

--- a/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.cpp
@@ -112,7 +112,7 @@ void ReflDataProcessorPresenter::process() {
           /// @todo Implement save notebook for event-sliced workspaces.
           // The per-slice input properties are stored in the RowData but
           // at the moment GenerateNotebook just uses the parent row
-          //saveNotebook(m_selectedData);
+          // saveNotebook(m_selectedData);
           GenericDataProcessorPresenter::giveUserWarning(
               "Notebook not implemented for sliced data yet",
               "Notebook will not be generated");
@@ -215,7 +215,7 @@ bool ReflDataProcessorPresenter::processGroupAsEventWS(
 
   for (const auto &row : group) {
 
-    const auto rowID = row.first;  // Integer ID of this row
+    const auto rowID = row.first;      // Integer ID of this row
     const auto rowData = row.second;   // data values for this row
     auto runNo = row.second->value(0); // The run number
 
@@ -258,7 +258,7 @@ bool ReflDataProcessorPresenter::processGroupAsEventWS(
     // with the slice suffix for each slice.
     // For the input properties, the InputWorkspace is the only one that is
     // sliced
-    auto workspaceProperties = std::vector<QString>{ "InputWorkspace" };
+    auto workspaceProperties = std::vector<QString>{"InputWorkspace"};
     auto outputProperties = m_processor.outputProperties();
     workspaceProperties.insert(workspaceProperties.end(),
                                outputProperties.begin(),

--- a/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.cpp
@@ -219,6 +219,8 @@ bool ReflDataProcessorPresenter::processGroupAsEventWS(
     const auto rowData = row.second;   // data values for this row
     auto runNo = row.second->value(0); // The run number
 
+    // Work out and cache the reduced workspace name
+    rowData->setReducedName(getReducedWorkspaceName(rowData));
     // Get the algorithm input properties for this row
     OptionsMap options = getCanonicalOptions(
         rowData, getProcessingOptions(rowData), m_whitelist, true,
@@ -328,10 +330,11 @@ bool ReflDataProcessorPresenter::processGroupAsNonEventWS(int groupID,
   bool errors = false;
 
   for (auto &row : group) {
-    // Get the algorithm input properties for this row and
-    // cache it in the row data (this is done just once here as
-    // it's required by both reduceRow and saveNotebook)
+    // Work out and cache the reduced workspace name
     auto rowData = row.second;
+    rowData->setReducedName(getReducedWorkspaceName(rowData));
+    // Get the algorithm input properties for this row and cache in the row
+    // data
     OptionsMap options = getCanonicalOptions(
         rowData, getProcessingOptions(rowData), m_whitelist, true,
         m_processor.outputProperties(), m_processor.prefixes());
@@ -719,8 +722,7 @@ void ReflDataProcessorPresenter::plotGroup() {
 
     for (size_t slice = 0; slice < numSlices; slice++) {
 
-      const auto wsName = m_postprocessing->getPostprocessedWorkspaceName(
-          m_processor.defaultInputPropertyName(), groupData, slice);
+      const auto wsName = getPostprocessedWorkspaceName(groupData, slice);
 
       if (workspaceExists(wsName))
         workspaces.insert(wsName, nullptr);

--- a/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.h
@@ -58,8 +58,9 @@ public:
   void addNumSlicesEntry(int groupID, int rowID, size_t numSlices);
   // Add entry for the number of slices for all rows in a group
   void addNumGroupSlicesEntry(int groupID, size_t numSlices);
-
 private:
+  // Get the processing options for this row
+  OptionsMap getProcessingOptions(RowData *data) override;
   // Process selected rows
   void process() override;
   // Plotting

--- a/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.h
@@ -54,8 +54,6 @@ public:
   ~ReflDataProcessorPresenter() override;
 
   // The following methods are public for testing purposes only
-  // Add entry for the number of slices for a row in a group
-  void addNumSlicesEntry(int groupID, int rowID, size_t numSlices);
   // Add entry for the number of slices for all rows in a group
   void addNumGroupSlicesEntry(int groupID, size_t numSlices);
 private:
@@ -69,9 +67,6 @@ private:
   // Loads a run from disk
   QString loadRun(const QString &run, const QString &instrument,
                   const QString &prefix, const QString &loader, bool &runFound);
-  // Get the name of a post-processed workspace
-  QString getPostprocessedWorkspaceName(const GroupData &groupData,
-                                        const QString &prefix, size_t index);
   // Loads a group of runs
   bool loadGroup(const GroupData &group);
   // Process a group of runs which are event workspaces
@@ -114,7 +109,6 @@ private:
       const MantidQt::MantidWidgets::DataProcessor::TreeData &data,
       const bool findEventWS);
 
-  std::map<int, std::map<int, size_t>> m_numSlicesMap;
   std::map<int, size_t> m_numGroupSlicesMap;
 };
 }

--- a/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.h
@@ -56,6 +56,7 @@ public:
   // The following methods are public for testing purposes only
   // Add entry for the number of slices for all rows in a group
   void addNumGroupSlicesEntry(int groupID, size_t numSlices);
+
 private:
   // Get the processing options for this row
   OptionsMap getProcessingOptions(RowData_sptr data) override;

--- a/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.h
@@ -11,6 +11,45 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 
+
+/** Utility class to store information about time slicing
+ */
+class TimeSlicingInfo {
+public:
+  TimeSlicingInfo() = delete;
+  TimeSlicingInfo(QString type, QString values);
+
+  size_t numberOfSlices() { return m_startTimes.size(); }
+  double startTime(const size_t i) { return m_startTimes[i]; }
+  double stopTime(const size_t i) { return m_stopTimes[i]; }
+  QString values() { return m_values; }
+  QString logFilter() { return m_logFilter; }
+
+  bool hasSlicing() const { return !m_values.isEmpty(); }
+  bool isCustom() const { return m_type == "Custom"; }
+  bool isLogValue() const { return m_type == "LogValue"; }
+  bool isUniform() const { return m_type == "Uniform"; }
+  bool isUniformEven() const { return m_type == "UniformEven"; }
+
+  void addSlice(const double startTime, const double stopTime);
+  void clearSlices();
+  void parseCustom();
+  void parseLogValue();
+private:
+  // the slicing type specified by the user
+  QString m_type;
+  // the slicing values specified by the user
+  QString m_values;
+  // The start and stop times for all slices for all rows in all groups. If
+  // using non-even slicing then different runs may have different numbers of
+  // slices. These vectors will contain ALL slices. It is assumed the first n
+  // number of common slices will be the same for all runs and the difference
+  // will be that later slices do not exist for some runs.
+  std::vector<double> m_startTimes;
+  std::vector<double> m_stopTimes;
+  QString m_logFilter;
+};
+
 using namespace MantidQt::MantidWidgets::DataProcessor;
 
 /** @class ReflDataProcessorPresenter
@@ -72,24 +111,16 @@ private:
   bool loadGroup(const GroupData &group);
   // Get the property names of workspaces affected by slicing
   std::vector<QString> getSlicedWorkspacePropertyNames() const;
+  // Reduce a row that is an event workspace
+  bool reduceRowAsEventWS(RowData_sptr rowData, TimeSlicingInfo &slicing);
   // Process a group of runs which are event workspaces
   bool processGroupAsEventWS(int groupID, const GroupData &group,
-                             const QString &timeSlicingType,
-                             const QString &timeSlicingValues);
+                             TimeSlicingInfo &slicingInfo);
   // Process a group of runs which are not event workspaces
   bool processGroupAsNonEventWS(int groupID, GroupData &group);
 
   // Parse uniform / uniform even time slicing from input string
-  void parseUniform(const QString &timeSlicing, const QString &slicingType,
-                    const QString &wsName, std::vector<double> &startTimes,
-                    std::vector<double> &stopTimes);
-  // Parse custom time slicing from input string
-  void parseCustom(const QString &timeSlicing, std::vector<double> &startTimes,
-                   std::vector<double> &stopTimes);
-  // Parse log value slicing and filter from input string
-  void parseLogValue(const QString &inputStr, QString &logFilter,
-                     std::vector<double> &minValues,
-                     std::vector<double> &maxValues);
+  void parseUniform(TimeSlicingInfo &slicing, const QString &wsName);
   bool workspaceExists(QString const &workspaceName) const;
 
   // Load a run as event workspace
@@ -98,8 +129,8 @@ private:
   void loadNonEventRun(const QString &runNo);
 
   // Take a slice from event workspace
-  QString takeSlice(const QString &runNo, size_t sliceIndex, double startTime,
-                    double stopTime, const QString &logFilter = "");
+  QString takeSlice(const QString &runNo, TimeSlicingInfo &slicing,
+                    size_t sliceIndex);
 
   Mantid::API::IEventWorkspace_sptr
   retrieveWorkspaceOrCritical(QString const &name) const;

--- a/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.h
@@ -70,6 +70,8 @@ private:
                   const QString &prefix, const QString &loader, bool &runFound);
   // Loads a group of runs
   bool loadGroup(const GroupData &group);
+  // Get the property names of workspaces affected by slicing
+  std::vector<QString> getSlicedWorkspacePropertyNames() const;
   // Process a group of runs which are event workspaces
   bool processGroupAsEventWS(int groupID, const GroupData &group,
                              const QString &timeSlicingType,

--- a/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.h
@@ -11,7 +11,6 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 
-
 /** Utility class to store information about time slicing
  */
 class TimeSlicingInfo {
@@ -35,6 +34,7 @@ public:
   void clearSlices();
   void parseCustom();
   void parseLogValue();
+
 private:
   // the slicing type specified by the user
   QString m_type;

--- a/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.h
@@ -60,7 +60,7 @@ public:
   void addNumGroupSlicesEntry(int groupID, size_t numSlices);
 private:
   // Get the processing options for this row
-  OptionsMap getProcessingOptions(RowData *data) override;
+  OptionsMap getProcessingOptions(RowData_sptr data) override;
   // Process selected rows
   void process() override;
   // Plotting

--- a/qt/scientific_interfaces/ISISReflectometry/ReflMainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflMainWindowPresenter.cpp
@@ -84,7 +84,6 @@ void ReflMainWindowPresenter::settingsChanged(int group) {
   m_runsPresenter->settingsChanged(group);
 }
 
-
 /** Returns global options for 'CreateTransmissionWorkspaceAuto'
 *
 * @param group :: Index of the group in 'Settings' tab from which to get the

--- a/qt/scientific_interfaces/ISISReflectometry/ReflMainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflMainWindowPresenter.cpp
@@ -153,10 +153,12 @@ std::string ReflMainWindowPresenter::getTimeSlicingType(int group) const {
   return m_eventPresenter->getTimeSlicingType(group);
 }
 
-/** Returns values passed for 'Transmission run(s)'
+/** Returns default values specified for 'Transmission run(s)' for the
+* given angle
 *
 * @param group :: Index of the group in 'Settings' tab from which to get the
 *values
+* @param angle :: the run angle to look up transmission runs for
 * @return :: Values passed for 'Transmission run(s)'
 */
 std::string

--- a/qt/scientific_interfaces/ISISReflectometry/ReflMainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflMainWindowPresenter.cpp
@@ -84,18 +84,6 @@ void ReflMainWindowPresenter::settingsChanged(int group) {
   m_runsPresenter->settingsChanged(group);
 }
 
-/** Returns values passed for 'Transmission run(s)'
-*
-* @param group :: Index of the group in 'Settings' tab from which to get the
-*values
-* @return :: Values passed for 'Transmission run(s)'
-*/
-std::string ReflMainWindowPresenter::getTransmissionRuns(int group) const {
-
-  checkSettingsPtrValid(m_settingsPresenter);
-
-  return m_settingsPresenter->getTransmissionRuns(group);
-}
 
 /** Returns global options for 'CreateTransmissionWorkspaceAuto'
 *
@@ -164,6 +152,29 @@ std::string ReflMainWindowPresenter::getTimeSlicingType(int group) const {
 
   // Request time-slicing type to 'Event Handling' presenter
   return m_eventPresenter->getTimeSlicingType(group);
+}
+
+/** Returns values passed for 'Transmission run(s)'
+*
+* @param group :: Index of the group in 'Settings' tab from which to get the
+*values
+* @return :: Values passed for 'Transmission run(s)'
+*/
+std::string
+ReflMainWindowPresenter::getTransmissionRunsForAngle(int group,
+                                                     const double angle) const {
+
+  checkSettingsPtrValid(m_settingsPresenter);
+
+  return m_settingsPresenter->getTransmissionRunsForAngle(group, angle);
+}
+
+/** Returns whether there are per-angle transmission runs specified
+ * @return :: true if there are per-angle transmission runs
+ * */
+bool ReflMainWindowPresenter::hasPerAngleTransmissionRuns(int group) const {
+  checkSettingsPtrValid(m_settingsPresenter);
+  return m_settingsPresenter->hasPerAngleTransmissionRuns(group);
 }
 
 /**

--- a/qt/scientific_interfaces/ISISReflectometry/ReflMainWindowPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflMainWindowPresenter.h
@@ -52,7 +52,10 @@ public:
   ~ReflMainWindowPresenter() override;
 
   /// Returns values passed for 'Transmission run(s)'
-  std::string getTransmissionRuns(int group) const override;
+  std::string getTransmissionRunsForAngle(int group,
+                                          const double angle) const override;
+  /// Whether there are per-angle transmission runs specified
+  bool hasPerAngleTransmissionRuns(int group) const override;
   /// Returns global options for 'CreateTransmissionWorkspaceAuto'
   MantidWidgets::DataProcessor::OptionsQMap
   getTransmissionOptions(int group) const override;

--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
@@ -471,6 +471,24 @@ QString ReflRunsTabPresenter::getTimeSlicingType() const {
       m_mainPresenter->getTimeSlicingType(m_view->getSelectedGroup()));
 }
 
+/** Requests transmission runs for a particular run angle. Values are supplied
+* by the main presenter
+* @return :: Transmission run(s) as a comma-separated list
+*/
+QString
+ReflRunsTabPresenter::getTransmissionRunsForAngle(const double angle) const {
+  return QString::fromStdString(m_mainPresenter->getTransmissionRunsForAngle(
+      m_view->getSelectedGroup(), angle));
+}
+
+/** Check whether there are per-angle transmission runs in the settings
+ * @return :: true if there are per-angle transmission runs
+ */
+bool ReflRunsTabPresenter::hasPerAngleTransmissionRuns() const {
+  return m_mainPresenter->hasPerAngleTransmissionRuns(
+      m_view->getSelectedGroup());
+}
+
 /** Tells the view to update the enabled/disabled state of all relevant widgets
  * based on whether processing is in progress or not.
  * @param isProcessing :: true if processing is in progress

--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.h
@@ -77,6 +77,8 @@ public:
   QString getPostprocessingOptionsAsString() const override;
   QString getTimeSlicingValues() const override;
   QString getTimeSlicingType() const override;
+  QString getTransmissionRunsForAngle(const double angle) const override;
+  bool hasPerAngleTransmissionRuns() const override;
   /// Handle data reduction paused/resumed
   void pause() const override;
   void resume() const override;

--- a/qt/scientific_interfaces/ISISReflectometry/ReflSettingsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflSettingsPresenter.cpp
@@ -192,6 +192,7 @@ void ReflSettingsPresenter::onReductionPaused() { m_view->enableAll(); }
 
 /** Returns global options for 'ReflectometryReductionOneAuto'
  * @return :: Global options for 'ReflectometryReductionOneAuto'
+ * @throws :: if the settings the user entered are invalid
  */
 OptionsQMap ReflSettingsPresenter::getReductionOptions() const {
 
@@ -282,6 +283,7 @@ bool ReflSettingsPresenter::hasPerAngleTransmissionRuns() const {
 /** Gets the default user-specified transmission runs from the view. Default
 * runs are those without an angle (i.e. the angle is blank)
 * @return :: the transmission run(s) as a string of comma-separated values
+* @throws :: if the settings the user entered are invalid
 */
 std::string
 ReflSettingsPresenter::getDefaultTransmissionRuns() const {

--- a/qt/scientific_interfaces/ISISReflectometry/ReflSettingsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflSettingsPresenter.cpp
@@ -265,7 +265,7 @@ bool ReflSettingsPresenter::hasPerAngleTransmissionRuns() const {
 
   // Check we have some entries in the table
   auto runsPerAngle = m_view->getTransmissionRuns();
-  if (runsPerAngle.size() < 1)
+  if (runsPerAngle.empty())
     return false;
 
   // To save confusion, we only allow EITHER a default transmission runs string

--- a/qt/scientific_interfaces/ISISReflectometry/ReflSettingsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflSettingsPresenter.cpp
@@ -13,6 +13,8 @@
 #include "InstrumentOptionDefaults.h"
 #include <type_traits>
 
+#include <boost/optional.hpp>
+
 namespace MantidQt {
 namespace CustomInterfaces {
 
@@ -208,14 +210,23 @@ OptionsQMap ReflSettingsPresenter::getReductionOptions() const {
                   m_view->getMomentumTransferStep());
     addIfNotEmpty(options, "StartOverlap", m_view->getStartOverlap());
     addIfNotEmpty(options, "EndOverlap", m_view->getEndOverlap());
-    addIfNotEmpty(options, "FirstTransmissionRun",
-                  m_view->getTransmissionRuns());
 
     auto summationType = m_view->getSummationType();
     addIfNotEmpty(options, "SummationType", summationType);
 
     if (hasReductionTypes(summationType))
       addIfNotEmpty(options, "ReductionType", m_view->getReductionType());
+
+    // Add transmission runs. Note that the value here may be
+    // a comma-separated list of multiple values. We return the
+    // string as entered by the user because parsing is done in
+    // the data processor widget. Note also that we can only
+    // return default values here if provided; the user may also
+    // provide per-angle transmission runs, but these need to be
+    // requested on a per-row basis when we know what the angle is
+    // for that row.
+    auto transmissionRuns = getDefaultTransmissionRuns();
+    addIfNotEmpty(options, "FirstTransmissionRun", transmissionRuns);
   }
 
   if (m_view->instrumentSettingsEnabled()) {
@@ -244,11 +255,105 @@ OptionsQMap ReflSettingsPresenter::getReductionOptions() const {
   return options;
 }
 
-std::string ReflSettingsPresenter::getTransmissionRuns() const {
-  if (m_view->experimentSettingsEnabled())
-    return m_view->getTransmissionRuns();
-  else
-    return "";
+/** Check whether per-angle transmission runs are specified
+ */
+bool ReflSettingsPresenter::hasPerAngleTransmissionRuns() const {
+  // Check the setting is enabled
+  if (!m_view->experimentSettingsEnabled())
+    return false;
+
+  // Check we have some entries in the table
+  auto runsPerAngle = m_view->getTransmissionRuns();
+  if (runsPerAngle.size() < 1)
+    return false;
+
+  // To save confusion, we only allow EITHER a default transmission runs string
+  // OR multiple per-angle strings. Therefore if there is a default set there
+  // cannot be per-angle runs.
+  if (!getDefaultTransmissionRuns().empty())
+    return false;
+
+  // Ok, we have some entries and they're not defaults, so assume they're valid
+  // per-angle settings (we'll check that the angles parse ok when we come
+  // to use them).
+  return true;
+}
+
+/** Gets the default user-specified transmission runs from the view. Default
+* runs are those without an angle (i.e. the angle is blank)
+* @return :: the transmission run(s) as a string of comma-separated values
+*/
+std::string
+ReflSettingsPresenter::getDefaultTransmissionRuns() const {
+  if (!m_view->experimentSettingsEnabled())
+    return std::string();
+
+  // Values are entered as a map of angle to transmission runs. Loop
+  // through them, checking for the required angle
+  auto runsPerAngle = m_view->getTransmissionRuns();
+  auto iter = runsPerAngle.find("");
+  if (iter != runsPerAngle.end()) {
+    // We found an empty angle. Check there is only one entry in the
+    // table (to save confusion, if the user specifies a default, it
+    // must be the only item in the table).
+    if (runsPerAngle.size() > 1)
+      throw std::runtime_error("Please only specify one set of transmission "
+                               "runs when using a default (i.e. where the "
+                               "angle is empty)");
+    else
+      return runsPerAngle.begin()->second;
+  }
+
+  // If not found, return an empty string
+  return std::string();
+}
+
+/** Gets the user-specified transmission runs from the view
+* @param angleToFind :: the run angle that transmission runs are valid for
+* @return :: the transmission run(s) as a string of comma-separated values
+*/
+std::string ReflSettingsPresenter::getTransmissionRunsForAngle(
+    const double angleToFind) const {
+  std::string result;
+
+  if (!hasPerAngleTransmissionRuns())
+    return result;
+
+  // Values are entered as a map of angle to transmission runs
+  auto runsPerAngle = m_view->getTransmissionRuns();
+
+  // We use a generous tolerance to check the angle because values
+  // from the log are not that accurate
+  const double tolerance = 0.01 + Mantid::Kernel::Tolerance;
+
+  // Loop through all values and find the closest that is within the tolerance
+  double smallestDist = std::numeric_limits<double>::max();
+  for (auto kvp : runsPerAngle) {
+    auto angleStr = kvp.first;
+    auto runsStr = kvp.second;
+
+    // Convert the angle to a double
+    double angle = 0.0;
+    try {
+      angle = std::stod(angleStr);
+    } catch (std::invalid_argument &e) {
+      throw std::runtime_error(std::string("Error parsing angle: ") + e.what());
+    }
+
+    // Use the closest result to the required angle that meets the given
+    // tolerance
+    double dist = std::abs(angle - angleToFind);
+    if (dist <= tolerance) {
+      if (dist < smallestDist) {
+        result = runsStr;
+        smallestDist = dist;
+      }
+    }
+  }
+
+  // If the angle was not found, return the default (which may be empty
+  // if no default was set in the table).
+  return result;
 }
 
 /** Returns global options for 'Stitch1DMany'

--- a/qt/scientific_interfaces/ISISReflectometry/ReflSettingsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflSettingsPresenter.cpp
@@ -285,8 +285,7 @@ bool ReflSettingsPresenter::hasPerAngleTransmissionRuns() const {
 * @return :: the transmission run(s) as a string of comma-separated values
 * @throws :: if the settings the user entered are invalid
 */
-std::string
-ReflSettingsPresenter::getDefaultTransmissionRuns() const {
+std::string ReflSettingsPresenter::getDefaultTransmissionRuns() const {
   if (!m_view->experimentSettingsEnabled())
     return std::string();
 

--- a/qt/scientific_interfaces/ISISReflectometry/ReflSettingsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflSettingsPresenter.h
@@ -52,6 +52,11 @@ public:
   void notify(IReflSettingsPresenter::Flag flag) override;
   void setInstrumentName(const std::string &instName) override;
 
+  /// Returns per-angle values passed for 'Transmission run(s)'
+  std::string
+  getTransmissionRunsForAngle(const double angleToFind) const override;
+  /// Whether per-angle transmission runs are specified
+  bool hasPerAngleTransmissionRuns() const override;
   /// Returns global options for 'CreateTransmissionWorkspaceAuto'
   MantidWidgets::DataProcessor::OptionsQMap
   getTransmissionOptions() const override;
@@ -60,8 +65,7 @@ public:
   getReductionOptions() const override;
   /// Returns global options for 'Stitch1DMany'
   std::string getStitchOptions() const override;
-  std::string getTransmissionRuns() const override;
-
+  
   void acceptTabPresenter(IReflSettingsTabPresenter *tabPresenter) override;
   void onReductionPaused() override;
   void onReductionResumed() override;
@@ -77,6 +81,9 @@ private:
   static QString asAlgorithmPropertyBool(bool value);
   Mantid::Geometry::Instrument_const_sptr
   createEmptyInstrument(const std::string &instName);
+  /// Returns default values passed for 'Transmission run(s)'
+  std::string getDefaultTransmissionRuns() const;
+
   MantidWidgets::DataProcessor::OptionsQMap transmissionOptionsMap() const;
   void addIfNotEmpty(MantidWidgets::DataProcessor::OptionsQMap &options,
                      const QString &key, const QString &value) const;

--- a/qt/scientific_interfaces/ISISReflectometry/ReflSettingsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflSettingsPresenter.h
@@ -67,7 +67,7 @@ public:
   getReductionOptions() const override;
   /// Returns global options for 'Stitch1DMany'
   std::string getStitchOptions() const override;
-  
+
   void acceptTabPresenter(IReflSettingsTabPresenter *tabPresenter) override;
   void onReductionPaused() override;
   void onReductionResumed() override;

--- a/qt/scientific_interfaces/ISISReflectometry/ReflSettingsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflSettingsPresenter.h
@@ -55,6 +55,8 @@ public:
   /// Returns per-angle values passed for 'Transmission run(s)'
   std::string
   getTransmissionRunsForAngle(const double angleToFind) const override;
+  /// Returns default values passed for 'Transmission run(s)'
+  std::string getDefaultTransmissionRuns() const;
   /// Whether per-angle transmission runs are specified
   bool hasPerAngleTransmissionRuns() const override;
   /// Returns global options for 'CreateTransmissionWorkspaceAuto'
@@ -81,8 +83,6 @@ private:
   static QString asAlgorithmPropertyBool(bool value);
   Mantid::Geometry::Instrument_const_sptr
   createEmptyInstrument(const std::string &instName);
-  /// Returns default values passed for 'Transmission run(s)'
-  std::string getDefaultTransmissionRuns() const;
 
   MantidWidgets::DataProcessor::OptionsQMap transmissionOptionsMap() const;
   void addIfNotEmpty(MantidWidgets::DataProcessor::OptionsQMap &options,

--- a/qt/scientific_interfaces/ISISReflectometry/ReflSettingsTabPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflSettingsTabPresenter.cpp
@@ -62,11 +62,20 @@ void ReflSettingsTabPresenter::onReductionPaused(int group) {
 /** Returns values passed for 'Transmission run(s)'
 *
 * @param group :: The group from which to get the values
+* @param angle :: the run angle to look up transmission runs for
 * @return :: Values passed for 'Transmission run(s)'
 */
-std::string ReflSettingsTabPresenter::getTransmissionRuns(int group) const {
+std::string ReflSettingsTabPresenter::getTransmissionRunsForAngle(
+    int group, const double angle) const {
 
-  return m_settingsPresenters.at(group)->getTransmissionRuns();
+  return m_settingsPresenters.at(group)->getTransmissionRunsForAngle(angle);
+}
+
+/** Check whether per-angle transmission runs are specified
+ * @return :: true if per-angle transmission runs are specified
+ */
+bool ReflSettingsTabPresenter::hasPerAngleTransmissionRuns(int group) const {
+  return m_settingsPresenters.at(group)->hasPerAngleTransmissionRuns();
 }
 
 /** Returns global options for 'CreateTransmissionWorkspaceAuto'

--- a/qt/scientific_interfaces/ISISReflectometry/ReflSettingsTabPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflSettingsTabPresenter.h
@@ -55,7 +55,10 @@ public:
   passSelfToChildren(std::vector<IReflSettingsPresenter *> const &children);
 
   /// Returns values passed for 'Transmission run(s)'
-  std::string getTransmissionRuns(int group) const override;
+  std::string getTransmissionRunsForAngle(int group,
+                                          const double angle) const override;
+  /// Whether per-angle tranmsission runs are set
+  bool hasPerAngleTransmissionRuns(int group) const override;
   /// Returns global options for 'CreateTransmissionWorkspaceAuto'
   MantidWidgets::DataProcessor::OptionsQMap
   getTransmissionOptions(int group) const override;

--- a/qt/scientific_interfaces/ISISReflectometry/ReflSettingsWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflSettingsWidget.ui
@@ -49,7 +49,7 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="10,2">
       <item>
-       <layout class="QGridLayout" name="expSettingsLayout0" rowstretch="1,1,1,1,1,1,1,1" columnstretch="1,1,1,1">
+       <layout class="QGridLayout" name="expSettingsLayout0" rowstretch="1,1,1,1,1,1,1,1,0,0,0,0" columnstretch="1,1,1,1">
         <property name="leftMargin">
          <number>10</number>
         </property>
@@ -62,173 +62,17 @@
         <property name="bottomMargin">
          <number>10</number>
         </property>
-        <item row="0" column="0">
-         <widget class="QLabel" name="analysisModeLabel">
-          <property name="text">
-           <string>AnalysisMode</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="transmissionRunsLabel">
-          <property name="text">
-           <string>Transmission run(s)</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
+        <item row="3" column="2">
          <widget class="QLabel" name="startOverlapLabel">
           <property name="text">
            <string>TransRunStartOverlap</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
-         <widget class="QLineEdit" name="startOverlapEdit"/>
-        </item>
-        <item row="2" column="3">
-         <widget class="QLineEdit" name="endOverlapEdit"/>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="endOverlapLabel">
-          <property name="minimumSize">
-           <size>
-            <width>117</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>TransRunEndOverlap</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="polCorrLabel">
-          <property name="minimumSize">
-           <size>
-            <width>117</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>PolarisationCorrections</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="QLineEdit" name="CRhoEdit"/>
-        </item>
-        <item row="3" column="1">
-         <widget class="QComboBox" name="polCorrComboBox">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <item>
-           <property name="text">
-            <string>None</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>PA</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>PNR</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="CRhoLabel">
-          <property name="text">
-           <string>CRho</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="3">
-         <widget class="QLineEdit" name="CAlphaEdit"/>
-        </item>
-        <item row="4" column="2">
-         <widget class="QLabel" name="CAlphaLabel">
-          <property name="minimumSize">
-           <size>
-            <width>117</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>CAlpha</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
+        <item row="9" column="1">
          <widget class="QLineEdit" name="CApEdit"/>
         </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="CApLabel">
-          <property name="text">
-           <string>CAp</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="3">
-         <widget class="QLineEdit" name="CPpEdit"/>
-        </item>
-        <item row="5" column="2">
-         <widget class="QLabel" name="CPpLabel">
-          <property name="minimumSize">
-           <size>
-            <width>117</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>CPp</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="QLineEdit" name="momentumTransferStepEdit"/>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="momentumTransferStepLabel">
-          <property name="text">
-           <string>dQ/Q</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="3">
-         <widget class="QLineEdit" name="scaleFactorEdit"/>
-        </item>
-        <item row="6" column="2">
-         <widget class="QLabel" name="scaleFactorLabel">
-          <property name="minimumSize">
-           <size>
-            <width>117</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Scale</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="0">
-         <widget class="QLabel" name="stitchLabel">
-          <property name="text">
-           <string>Stitch1DMany</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
+        <item row="1" column="0">
          <widget class="QLabel" name="summationTypeLabel">
           <property name="minimumSize">
            <size>
@@ -241,60 +85,17 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="reductionTypeLabel">
-          <property name="minimumSize">
-           <size>
-            <width>117</width>
-            <height>0</height>
-           </size>
-          </property>
+        <item row="10" column="1">
+         <widget class="QLineEdit" name="momentumTransferStepEdit"/>
+        </item>
+        <item row="9" column="0">
+         <widget class="QLabel" name="CApLabel">
           <property name="text">
-           <string>ReductionType</string>
+           <string>CAp</string>
           </property>
          </widget>
         </item>
-        <item row="0" column="1">
-         <widget class="QComboBox" name="analysisModeComboBox">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <item>
-           <property name="text">
-            <string>PointDetectorAnalysis</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>MultiDetectorAnalysis</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item row="0" column="3">
-         <widget class="QComboBox" name="summationTypeComboBox">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <item>
-           <property name="text">
-            <string>SumInLambda</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>SumInQ</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item row="1" column="3">
+        <item row="2" column="1">
          <widget class="QComboBox" name="reductionTypeComboBox">
           <property name="enabled">
            <bool>false</bool>
@@ -322,8 +123,210 @@
           </item>
          </widget>
         </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="reductionTypeLabel">
+          <property name="minimumSize">
+           <size>
+            <width>117</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>ReductionType</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="3">
+         <widget class="QLineEdit" name="startOverlapEdit"/>
+        </item>
+        <item row="7" column="0">
+         <widget class="QLabel" name="polCorrLabel">
+          <property name="minimumSize">
+           <size>
+            <width>117</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>PolarisationCorrections</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="analysisModeLabel">
+          <property name="text">
+           <string>AnalysisMode</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="transmissionRunsLabel">
+          <property name="text">
+           <string>Transmission run(s)</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+          </property>
+         </widget>
+        </item>
         <item row="1" column="1">
+         <widget class="QComboBox" name="summationTypeComboBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <item>
+           <property name="text">
+            <string>SumInLambda</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>SumInQ</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="4" column="2">
+         <widget class="QLabel" name="endOverlapLabel">
+          <property name="minimumSize">
+           <size>
+            <width>117</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>TransRunEndOverlap</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="3">
+         <widget class="QLineEdit" name="endOverlapEdit"/>
+        </item>
+        <item row="10" column="2">
+         <widget class="QLabel" name="scaleFactorLabel">
+          <property name="minimumSize">
+           <size>
+            <width>117</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Scale</string>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="0">
+         <widget class="QLabel" name="CRhoLabel">
+          <property name="text">
+           <string>CRho</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QComboBox" name="analysisModeComboBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <item>
+           <property name="text">
+            <string>PointDetectorAnalysis</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>MultiDetectorAnalysis</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="7" column="1">
+         <widget class="QComboBox" name="polCorrComboBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <item>
+           <property name="text">
+            <string>None</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>PA</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>PNR</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="9" column="2">
+         <widget class="QLabel" name="CPpLabel">
+          <property name="minimumSize">
+           <size>
+            <width>117</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>CPp</string>
+          </property>
+         </widget>
+        </item>
+        <item row="10" column="0">
+         <widget class="QLabel" name="momentumTransferStepLabel">
+          <property name="text">
+           <string>dQ/Q</string>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="3">
+         <widget class="QLineEdit" name="CAlphaEdit"/>
+        </item>
+        <item row="8" column="2">
+         <widget class="QLabel" name="CAlphaLabel">
+          <property name="minimumSize">
+           <size>
+            <width>117</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>CAlpha</string>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="1">
+         <widget class="QLineEdit" name="CRhoEdit"/>
+        </item>
+        <item row="9" column="3">
+         <widget class="QLineEdit" name="CPpEdit"/>
+        </item>
+        <item row="11" column="0">
+         <widget class="QLabel" name="stitchLabel">
+          <property name="text">
+           <string>Stitch1DMany</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1" rowspan="3">
          <widget class="QTableWidget" name="transmissionRunsTable">
+          <property name="toolTip">
+           <string>Specify which transmission runs to use based on the run angle. Leave the angle empty to specify defaults for all runs.</string>
+          </property>
+          <property name="whatsThis">
+           <string>This table allows you to specify the default transmission runs that should be used for rows that do not have transmission runs specified on Runs tab. You can specify these on a per-angle basis, where the angle from the Runs table will be looked up in the Transmission table and those transmission runs will be used where a match is found. You may also leave the angle blank in the Transmission table to specify the default transmission runs that should be used for all runs.</string>
+          </property>
           <property name="alternatingRowColors">
            <bool>true</bool>
           </property>
@@ -349,8 +352,17 @@
           <column/>
          </widget>
         </item>
-        <item row="1" column="2">
+        <item row="10" column="3">
+         <widget class="QLineEdit" name="scaleFactorEdit"/>
+        </item>
+        <item row="6" column="1">
          <widget class="QPushButton" name="getAddTransmissionRowButton">
+          <property name="toolTip">
+           <string>Add another row to the per-angle Transmission runs table</string>
+          </property>
+          <property name="whatsThis">
+           <string>Adds another row to the Transmission runs table so that additional angles can be added</string>
+          </property>
           <property name="text">
            <string>Add row</string>
           </property>

--- a/qt/scientific_interfaces/ISISReflectometry/ReflSettingsWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflSettingsWidget.ui
@@ -10,6 +10,12 @@
     <height>612</height>
    </rect>
   </property>
+  <property name="baseSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
   <property name="font">
    <font>
     <pointsize>8</pointsize>
@@ -36,7 +42,7 @@
    <item>
     <widget class="QGroupBox" name="expSettingsGroup">
      <property name="title">
-      <string>Experiment Settings</string>
+      <string>E&amp;xperiment Settings</string>
      </property>
      <property name="checkable">
       <bool>true</bool>
@@ -68,10 +74,10 @@
           <property name="text">
            <string>Transmission run(s)</string>
           </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+          </property>
          </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QLineEdit" name="transmissionRunsEdit"/>
         </item>
         <item row="2" column="0">
          <widget class="QLabel" name="startOverlapLabel">
@@ -82,6 +88,9 @@
         </item>
         <item row="2" column="1">
          <widget class="QLineEdit" name="startOverlapEdit"/>
+        </item>
+        <item row="2" column="3">
+         <widget class="QLineEdit" name="endOverlapEdit"/>
         </item>
         <item row="2" column="2">
          <widget class="QLabel" name="endOverlapLabel">
@@ -96,9 +105,6 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="3">
-         <widget class="QLineEdit" name="endOverlapEdit"/>
-        </item>
         <item row="3" column="0">
          <widget class="QLabel" name="polCorrLabel">
           <property name="minimumSize">
@@ -111,6 +117,9 @@
            <string>PolarisationCorrections</string>
           </property>
          </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QLineEdit" name="CRhoEdit"/>
         </item>
         <item row="3" column="1">
          <widget class="QComboBox" name="polCorrComboBox">
@@ -144,8 +153,8 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="1">
-         <widget class="QLineEdit" name="CRhoEdit"/>
+        <item row="4" column="3">
+         <widget class="QLineEdit" name="CAlphaEdit"/>
         </item>
         <item row="4" column="2">
          <widget class="QLabel" name="CAlphaLabel">
@@ -160,8 +169,8 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="3">
-         <widget class="QLineEdit" name="CAlphaEdit"/>
+        <item row="5" column="1">
+         <widget class="QLineEdit" name="CApEdit"/>
         </item>
         <item row="5" column="0">
          <widget class="QLabel" name="CApLabel">
@@ -170,8 +179,8 @@
           </property>
          </widget>
         </item>
-        <item row="5" column="1">
-         <widget class="QLineEdit" name="CApEdit"/>
+        <item row="5" column="3">
+         <widget class="QLineEdit" name="CPpEdit"/>
         </item>
         <item row="5" column="2">
          <widget class="QLabel" name="CPpLabel">
@@ -186,8 +195,8 @@
           </property>
          </widget>
         </item>
-        <item row="5" column="3">
-         <widget class="QLineEdit" name="CPpEdit"/>
+        <item row="6" column="1">
+         <widget class="QLineEdit" name="momentumTransferStepEdit"/>
         </item>
         <item row="6" column="0">
          <widget class="QLabel" name="momentumTransferStepLabel">
@@ -196,8 +205,8 @@
           </property>
          </widget>
         </item>
-        <item row="6" column="1">
-         <widget class="QLineEdit" name="momentumTransferStepEdit"/>
+        <item row="6" column="3">
+         <widget class="QLineEdit" name="scaleFactorEdit"/>
         </item>
         <item row="6" column="2">
          <widget class="QLabel" name="scaleFactorLabel">
@@ -211,9 +220,6 @@
            <string>Scale</string>
           </property>
          </widget>
-        </item>
-        <item row="6" column="3">
-         <widget class="QLineEdit" name="scaleFactorEdit"/>
         </item>
         <item row="7" column="0">
          <widget class="QLabel" name="stitchLabel">
@@ -316,6 +322,40 @@
           </item>
          </widget>
         </item>
+        <item row="1" column="1">
+         <widget class="QTableWidget" name="transmissionRunsTable">
+          <property name="alternatingRowColors">
+           <bool>true</bool>
+          </property>
+          <property name="sortingEnabled">
+           <bool>true</bool>
+          </property>
+          <property name="rowCount">
+           <number>3</number>
+          </property>
+          <property name="columnCount">
+           <number>2</number>
+          </property>
+          <attribute name="horizontalHeaderVisible">
+           <bool>true</bool>
+          </attribute>
+          <attribute name="verticalHeaderVisible">
+           <bool>false</bool>
+          </attribute>
+          <row/>
+          <row/>
+          <row/>
+          <column/>
+          <column/>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="QPushButton" name="getAddTransmissionRowButton">
+          <property name="text">
+           <string>Add row</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
       <item>
@@ -350,7 +390,7 @@
    <item>
     <widget class="QGroupBox" name="instSettingsGroup">
      <property name="title">
-      <string>Instrument Settings</string>
+      <string>&amp;Instrument Settings</string>
      </property>
      <property name="checkable">
       <bool>true</bool>

--- a/qt/scientific_interfaces/ISISReflectometry/ReflSettingsWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflSettingsWidget.ui
@@ -356,7 +356,7 @@
          <widget class="QLineEdit" name="scaleFactorEdit"/>
         </item>
         <item row="6" column="1">
-         <widget class="QPushButton" name="getAddTransmissionRowButton">
+         <widget class="QPushButton" name="addTransmissionRowButton">
           <property name="toolTip">
            <string>Add another row to the per-angle Transmission runs table</string>
           </property>

--- a/qt/scientific_interfaces/test/ReflDataProcessorPresenterTest.h
+++ b/qt/scientific_interfaces/test/ReflDataProcessorPresenterTest.h
@@ -629,12 +629,6 @@ public:
 
     // The following code sets up the desired workspaces without having to
     // process any runs to obtain them
-    presenter->addNumSlicesEntry(0, 0, 3);
-    presenter->addNumSlicesEntry(0, 1, 3);
-    presenter->addNumSlicesEntry(0, 2, 3);
-    presenter->addNumSlicesEntry(1, 0, 3);
-    presenter->addNumSlicesEntry(1, 1, 3);
-    presenter->addNumSlicesEntry(1, 2, 3);
     presenter->addNumGroupSlicesEntry(0, 3);
     presenter->addNumGroupSlicesEntry(1, 3);
 
@@ -705,12 +699,6 @@ public:
 
     // The following code sets up the desired workspaces without having to
     // process any runs to obtain them
-    presenter->addNumSlicesEntry(0, 0, 3);
-    presenter->addNumSlicesEntry(0, 1, 3);
-    presenter->addNumSlicesEntry(0, 2, 3);
-    presenter->addNumSlicesEntry(1, 0, 3);
-    presenter->addNumSlicesEntry(1, 1, 3);
-    presenter->addNumSlicesEntry(1, 2, 3);
     presenter->addNumGroupSlicesEntry(0, 3);
     presenter->addNumGroupSlicesEntry(1, 3);
 
@@ -778,7 +766,6 @@ public:
     TS_ASSERT_THROWS_NOTHING(
         presenter->notify(DataProcessorPresenter::OpenTableFlag));
 
-    presenter->addNumSlicesEntry(0, 0, 1);
     presenter->addNumGroupSlicesEntry(0, 1);
     createSampleEventWS("13460");
 
@@ -823,8 +810,6 @@ public:
     TS_ASSERT_THROWS_NOTHING(
         presenter->notify(DataProcessorPresenter::OpenTableFlag));
 
-    presenter->addNumSlicesEntry(0, 0, 1);
-    presenter->addNumSlicesEntry(0, 1, 1);
     presenter->addNumGroupSlicesEntry(0, 1);
     createSampleEventWS("13460");
     createSampleEventWS("13462");

--- a/qt/scientific_interfaces/test/ReflDataProcessorPresenterTest.h
+++ b/qt/scientific_interfaces/test/ReflDataProcessorPresenterTest.h
@@ -129,18 +129,19 @@ private:
   }
 
   void appendStringWithPrefix(QString &stringToEdit, const QStringList &list,
-                              std::vector<const char *> &prefixes, const int i,
-                              const char *separator = "") {
+                              std::vector<const char *> &prefixes,
+                              const size_t i, const char *separator = "") {
     // do nothing if string to add is empty
-    if (i >= list.size() || list[i].isEmpty())
+    const auto idx = static_cast<int>(i);
+    if (idx >= list.size() || list[idx].isEmpty())
       return;
 
     // add separator and string with/without prefix
-    const long int len = prefixes.size();
+    const auto len = prefixes.size();
     if (i < len && prefixes[i] != 0)
-      stringToEdit += QString(separator) + QString(prefixes[i]) + list[i];
+      stringToEdit += QString(separator) + QString(prefixes[i]) + list[idx];
     else
-      stringToEdit += separator + list[i];
+      stringToEdit += separator + list[idx];
   }
 
   // Utility to create a row data class from a string list of simple inputs

--- a/qt/scientific_interfaces/test/ReflDataProcessorPresenterTest.h
+++ b/qt/scientific_interfaces/test/ReflDataProcessorPresenterTest.h
@@ -695,11 +695,12 @@ public:
     NiceMock<MockDataProcessorView> mockDataProcessorView;
     NiceMock<MockProgressableView> mockProgress;
     NiceMock<MockMainPresenter> mockMainPresenter;
-    auto mockTreeManager = new MockTreeManager;
+    auto mockTreeManager = Mantid::Kernel::make_unique<MockTreeManager>();
+    auto *mockTreeManager_ptr = mockTreeManager.get();
     auto presenter = presenterFactory.create(DEFAULT_GROUP_NUMBER);
     presenter->acceptViews(&mockDataProcessorView, &mockProgress);
     presenter->accept(&mockMainPresenter);
-    presenter->acceptTreeManager(mockTreeManager);
+    presenter->acceptTreeManager(std::move(mockTreeManager));
 
     createPrefilledWorkspace("TestWorkspace", presenter->getWhiteList());
     EXPECT_CALL(mockDataProcessorView, getWorkspaceToOpen())
@@ -729,7 +730,7 @@ public:
     EXPECT_CALL(mockDataProcessorView, giveUserWarning(_, _)).Times(0);
 
     // The user hits "plot rows" with the first group selected
-    EXPECT_CALL(*mockTreeManager, selectedData(false))
+    EXPECT_CALL(*mockTreeManager_ptr, selectedData(false))
         .Times(1)
         .WillOnce(Return(tree));
     EXPECT_CALL(mockMainPresenter, getTimeSlicingValues())
@@ -771,11 +772,12 @@ public:
     NiceMock<MockDataProcessorView> mockDataProcessorView;
     NiceMock<MockProgressableView> mockProgress;
     NiceMock<MockMainPresenter> mockMainPresenter;
-    auto mockTreeManager = new MockTreeManager;
+    auto mockTreeManager = Mantid::Kernel::make_unique<MockTreeManager>();
+    auto *mockTreeManager_ptr = mockTreeManager.get();
     auto presenter = presenterFactory.create(DEFAULT_GROUP_NUMBER);
     presenter->acceptViews(&mockDataProcessorView, &mockProgress);
     presenter->accept(&mockMainPresenter);
-    presenter->acceptTreeManager(mockTreeManager);
+    presenter->acceptTreeManager(std::move(mockTreeManager));
 
     createPrefilledWorkspace("TestWorkspace", presenter->getWhiteList());
     EXPECT_CALL(mockDataProcessorView, getWorkspaceToOpen())
@@ -805,7 +807,7 @@ public:
     EXPECT_CALL(mockDataProcessorView, giveUserWarning(_, _)).Times(0);
 
     // The user hits "plot rows" with the first group selected
-    EXPECT_CALL(*mockTreeManager, selectedData(false))
+    EXPECT_CALL(*mockTreeManager_ptr, selectedData(false))
         .Times(1)
         .WillOnce(Return(tree));
     EXPECT_CALL(mockMainPresenter, getTimeSlicingValues())
@@ -847,11 +849,12 @@ public:
     NiceMock<MockDataProcessorView> mockDataProcessorView;
     NiceMock<MockProgressableView> mockProgress;
     NiceMock<MockMainPresenter> mockMainPresenter;
-    auto mockTreeManager = new MockTreeManager;
+    auto mockTreeManager = Mantid::Kernel::make_unique<MockTreeManager>();
+    auto *mockTreeManager_ptr = mockTreeManager.get();
     auto presenter = presenterFactory.create(DEFAULT_GROUP_NUMBER);
     presenter->acceptViews(&mockDataProcessorView, &mockProgress);
     presenter->accept(&mockMainPresenter);
-    presenter->acceptTreeManager(mockTreeManager);
+    presenter->acceptTreeManager(std::move(mockTreeManager));
 
     createPrefilledWorkspace("TestWorkspace", presenter->getWhiteList());
     EXPECT_CALL(mockDataProcessorView, getWorkspaceToOpen())
@@ -874,7 +877,7 @@ public:
     EXPECT_CALL(mockDataProcessorView, giveUserWarning(_, _)).Times(1);
 
     // The user hits "plot rows" with the first row selected
-    EXPECT_CALL(*mockTreeManager, selectedData(false))
+    EXPECT_CALL(*mockTreeManager_ptr, selectedData(false))
         .Times(1)
         .WillOnce(Return(tree));
     EXPECT_CALL(mockMainPresenter, getTimeSlicingValues())

--- a/qt/scientific_interfaces/test/ReflDataProcessorPresenterTest.h
+++ b/qt/scientific_interfaces/test/ReflDataProcessorPresenterTest.h
@@ -695,7 +695,8 @@ public:
     NiceMock<MockDataProcessorView> mockDataProcessorView;
     NiceMock<MockProgressableView> mockProgress;
     NiceMock<MockMainPresenter> mockMainPresenter;
-    auto presenter = presenterFactory.create();
+    auto mockTreeManager = new MockTreeManager;
+    auto presenter = presenterFactory.create(DEFAULT_GROUP_NUMBER);
     presenter->acceptViews(&mockDataProcessorView, &mockProgress);
     presenter->accept(&mockMainPresenter);
     presenter->acceptTreeManager(mockTreeManager);
@@ -771,7 +772,7 @@ public:
     NiceMock<MockProgressableView> mockProgress;
     NiceMock<MockMainPresenter> mockMainPresenter;
     auto mockTreeManager = new MockTreeManager;
-    auto presenter = presenterFactory.create();
+    auto presenter = presenterFactory.create(DEFAULT_GROUP_NUMBER);
     presenter->acceptViews(&mockDataProcessorView, &mockProgress);
     presenter->accept(&mockMainPresenter);
     presenter->acceptTreeManager(mockTreeManager);
@@ -847,7 +848,7 @@ public:
     NiceMock<MockProgressableView> mockProgress;
     NiceMock<MockMainPresenter> mockMainPresenter;
     auto mockTreeManager = new MockTreeManager;
-    auto presenter = presenterFactory.create();
+    auto presenter = presenterFactory.create(DEFAULT_GROUP_NUMBER);
     presenter->acceptViews(&mockDataProcessorView, &mockProgress);
     presenter->accept(&mockMainPresenter);
     presenter->acceptTreeManager(mockTreeManager);

--- a/qt/scientific_interfaces/test/ReflMainWindowPresenterTest.h
+++ b/qt/scientific_interfaces/test/ReflMainWindowPresenterTest.h
@@ -28,6 +28,7 @@ public:
   ReflMainWindowPresenterTest() {}
 
   void testGetTransmissionValues() {
+    // Test getting transmission run values
     MockMainWindowView mockView;
     MockRunsTabPresenter mockRunsTabPresenter;
     MockEventTabPresenter mockEventTabPresenter;
@@ -37,18 +38,22 @@ public:
         &mockView, &mockRunsTabPresenter, &mockEventTabPresenter,
         &mockSettingsTabPresenter, &mockSaveTabPresenter);
 
-    EXPECT_CALL(mockSettingsTabPresenter, getTransmissionRuns(0))
+    // Should call the settings tab to get the values
+    double angle = 0.5;
+    EXPECT_CALL(mockSettingsTabPresenter, getTransmissionRunsForAngle(0, angle))
         .Times(Exactly(1));
-    presenter.getTransmissionRuns(0);
+    presenter.getTransmissionRunsForAngle(0, angle);
 
-    EXPECT_CALL(mockSettingsTabPresenter, getTransmissionRuns(1))
+    EXPECT_CALL(mockSettingsTabPresenter, getTransmissionRunsForAngle(1, angle))
         .Times(Exactly(1));
-    presenter.getTransmissionRuns(1);
+    presenter.getTransmissionRunsForAngle(1, angle);
 
     TS_ASSERT(Mock::VerifyAndClearExpectations(&mockSettingsTabPresenter));
   }
 
   void testGetTransmissionOptions() {
+    // Test getting options for the preprocessing algorithm that creates
+    // the transmission workspace
     MockMainWindowView mockView;
     MockRunsTabPresenter mockRunsPresenter;
     MockEventTabPresenter mockEventPresenter;
@@ -58,6 +63,7 @@ public:
         &mockView, &mockRunsPresenter, &mockEventPresenter,
         &mockSettingsPresenter, &mockSaveTabPresenter);
 
+    // Should call the settings tab to get the options
     EXPECT_CALL(mockSettingsPresenter, getTransmissionOptions(0))
         .Times(Exactly(1))
         .WillOnce(Return(OptionsQMap()));
@@ -72,6 +78,7 @@ public:
   }
 
   void testGetReductionOptions() {
+    // Test getting the options for the main reduction algorithm
     MockMainWindowView mockView;
     MockRunsTabPresenter mockRunsPresenter;
     MockEventTabPresenter mockEventPresenter;
@@ -81,6 +88,7 @@ public:
         &mockView, &mockRunsPresenter, &mockEventPresenter,
         &mockSettingsPresenter, &mockSaveTabPresenter);
 
+    // Should call the settings tab to get the options
     EXPECT_CALL(mockSettingsPresenter, getReductionOptions(0))
         .Times(Exactly(1))
         .WillOnce(Return(OptionsQMap()));
@@ -95,6 +103,8 @@ public:
   }
 
   void testStitchOptions() {
+    // Test getting the options for the post-processing algorithm for
+    // stitching workspaces
     MockMainWindowView mockView;
     MockRunsTabPresenter mockRunsPresenter;
     MockEventTabPresenter mockEventPresenter;
@@ -104,6 +114,7 @@ public:
         &mockView, &mockRunsPresenter, &mockEventPresenter,
         &mockSettingsPresenter, &mockSaveTabPresenter);
 
+    // Should call the settings tab to get the options
     EXPECT_CALL(mockSettingsPresenter, getStitchOptions(0)).Times(Exactly(1));
     presenter.getStitchOptions(0);
 

--- a/qt/scientific_interfaces/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/test/ReflMockObjects.h
@@ -238,7 +238,8 @@ public:
 
 class MockSettingsTabPresenter : public IReflSettingsTabPresenter {
 public:
-  MOCK_CONST_METHOD2(getTransmissionRunsForAngle, std::string(int, const double));
+  MOCK_CONST_METHOD2(getTransmissionRunsForAngle,
+                     std::string(int, const double));
   MOCK_CONST_METHOD1(hasPerAngleTransmissionRuns, bool(int));
   MOCK_CONST_METHOD0(getTransmissionOptions, OptionsQMap());
   MOCK_CONST_METHOD1(getTransmissionOptions, OptionsQMap(int));
@@ -268,7 +269,8 @@ public:
 
 class MockMainWindowPresenter : public IReflMainWindowPresenter {
 public:
-  MOCK_CONST_METHOD2(getTransmissionRunsForAngle, std::string(int, const double));
+  MOCK_CONST_METHOD2(getTransmissionRunsForAngle,
+                     std::string(int, const double));
   MOCK_CONST_METHOD1(hasPerAngleTransmissionRuns, bool(int));
   MOCK_CONST_METHOD1(getTransmissionOptions, OptionsQMap(int));
   MOCK_CONST_METHOD1(getReductionOptions, OptionsQMap(int));

--- a/qt/scientific_interfaces/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/test/ReflMockObjects.h
@@ -107,6 +107,7 @@ public:
   MOCK_CONST_METHOD0(getProcessingInstructions, std::string());
   MOCK_CONST_METHOD0(getSummationType, std::string());
   MOCK_CONST_METHOD0(getReductionType, std::string());
+  MOCK_CONST_METHOD0(getTransmissionRuns, std::map<std::string, std::string>());
   MOCK_CONST_METHOD1(setIsPolCorrEnabled, void(bool));
   MOCK_METHOD1(setReductionTypeEnabled, void(bool));
   MOCK_METHOD1(setPolarisationOptionsEnabled, void(bool));
@@ -220,7 +221,8 @@ public:
 
 class MockSettingsPresenter : public IReflSettingsPresenter {
 public:
-  MOCK_CONST_METHOD0(getTransmissionRuns, std::string());
+  MOCK_CONST_METHOD1(getTransmissionRunsForAngle, std::string(const double));
+  MOCK_CONST_METHOD0(hasPerAngleTransmissionRuns, bool());
   MOCK_CONST_METHOD0(getTransmissionOptions, OptionsQMap());
   MOCK_CONST_METHOD0(getReductionOptions, OptionsQMap());
   MOCK_CONST_METHOD0(getStitchOptions, std::string());
@@ -237,7 +239,9 @@ public:
 
 class MockSettingsTabPresenter : public IReflSettingsTabPresenter {
 public:
-  MOCK_CONST_METHOD1(getTransmissionRuns, std::string(int));
+  MOCK_CONST_METHOD2(getTransmissionRunsForAngle, std::string(int, const double));
+  MOCK_CONST_METHOD1(hasPerAngleTransmissionRuns, bool(int));
+  MOCK_CONST_METHOD0(getTransmissionOptions, OptionsQMap());
   MOCK_CONST_METHOD1(getTransmissionOptions, OptionsQMap(int));
   MOCK_CONST_METHOD1(getReductionOptions, OptionsQMap(int));
   MOCK_CONST_METHOD1(getStitchOptions, std::string(int));
@@ -265,7 +269,8 @@ public:
 
 class MockMainWindowPresenter : public IReflMainWindowPresenter {
 public:
-  MOCK_CONST_METHOD1(getTransmissionRuns, std::string(int));
+  MOCK_CONST_METHOD2(getTransmissionRunsForAngle, std::string(int, const double));
+  MOCK_CONST_METHOD1(hasPerAngleTransmissionRuns, bool(int));
   MOCK_CONST_METHOD1(getTransmissionOptions, OptionsQMap(int));
   MOCK_CONST_METHOD1(getReductionOptions, OptionsQMap(int));
   MOCK_CONST_METHOD1(getStitchOptions, std::string(int));

--- a/qt/scientific_interfaces/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/test/ReflMockObjects.h
@@ -86,7 +86,6 @@ public:
   MOCK_CONST_METHOD0(getEndOverlap, std::string());
   MOCK_CONST_METHOD0(getReductionOptions, std::string());
   MOCK_CONST_METHOD0(getStitchOptions, std::string());
-  MOCK_CONST_METHOD0(getTransmissionRuns, std::string());
   MOCK_CONST_METHOD0(getAnalysisMode, std::string());
   MOCK_CONST_METHOD0(getDirectBeam, std::string());
   MOCK_CONST_METHOD0(getPolarisationCorrections, std::string());

--- a/qt/scientific_interfaces/test/ReflSettingsPresenterTest.h
+++ b/qt/scientific_interfaces/test/ReflSettingsPresenterTest.h
@@ -574,6 +574,7 @@ public:
   void testInstrumentSettingsDisabled() {
     NiceMock<MockSettingsView> mockView;
     auto presenter = makeReflSettingsPresenter(&mockView);
+    onCallReturnDefaultTransmissionRuns(mockView);
 
     EXPECT_CALL(mockView, experimentSettingsEnabled())
         .Times(4)
@@ -618,7 +619,6 @@ public:
 
   void testDefaultTransmissionRuns() {
     MockSettingsView mockView;
-    onCallReturnDefaultSettings(mockView);
     auto presenter = makeReflSettingsPresenter(&mockView);
 
     // Default transmission runs are specified with a single
@@ -626,6 +626,9 @@ public:
     std::map<std::string, std::string> transmissionRunsMap = {
         {"", "INTER00013463,INTER00013464"}};
 
+    EXPECT_CALL(mockView, experimentSettingsEnabled())
+        .Times(1)
+        .WillRepeatedly(Return(true));
     EXPECT_CALL(mockView, getTransmissionRuns())
         .Times(1)
         .WillOnce(Return(transmissionRunsMap));

--- a/qt/scientific_interfaces/test/ReflSettingsPresenterTest.h
+++ b/qt/scientific_interfaces/test/ReflSettingsPresenterTest.h
@@ -73,7 +73,8 @@ public:
   }
 
   void onCallReturnDefaultTransmissionRuns(MockSettingsView &mockView) {
-    ON_CALL(mockView, getTransmissionRuns()).WillByDefault(Return(""));
+    ON_CALL(mockView, getTransmissionRuns())
+        .WillByDefault(Return(std::map<std::string, std::string>()));
   }
 
   void onCallReturnDefaultScaleFactor(MockSettingsView &mockView) {
@@ -390,9 +391,14 @@ public:
     onCallReturnDefaultSettings(mockView);
     auto presenter = makeReflSettingsPresenter(&mockView);
 
+    // Default transmission runs are specified with a single
+    // entry with an empty angle as the key
+    std::map<std::string, std::string> transmissionRunsMap = {
+        {"", "INTER00013463,INTER00013464"}};
+
     EXPECT_CALL(mockView, getTransmissionRuns())
         .Times(AtLeast(1))
-        .WillOnce(Return("INTER00013463,INTER00013464"));
+        .WillOnce(Return(transmissionRunsMap));
 
     auto options = presenter.getReductionOptions();
 
@@ -618,7 +624,7 @@ public:
 
   void testDefaultTransmissionRuns() {
     MockSettingsView mockView;
-    ReflSettingsPresenter presenter(&mockView);
+    auto presenter = makeReflSettingsPresenter(&mockView);
 
     // Default transmission runs are specified with a single
     // entry with an empty angle as the key
@@ -637,7 +643,7 @@ public:
 
   void testTransmissionRunsForAngle() {
     MockSettingsView mockView;
-    ReflSettingsPresenter presenter(&mockView);
+    auto presenter = makeReflSettingsPresenter(&mockView);
 
     // Set up a table with transmission runs for 2 different angles
     std::map<std::string, std::string> transmissionRunsMap = {

--- a/qt/scientific_interfaces/test/ReflSettingsPresenterTest.h
+++ b/qt/scientific_interfaces/test/ReflSettingsPresenterTest.h
@@ -197,15 +197,9 @@ public:
     onCallReturnDefaultSettings(mockView);
     auto presenter = makeReflSettingsPresenter(&mockView);
 
-    EXPECT_CALL(mockView, experimentSettingsEnabled())
-        .Times(1)
-        .WillOnce(Return(true));
-    EXPECT_CALL(mockView, instrumentSettingsEnabled())
-        .Times(1)
-        .WillOnce(Return(true));
-    EXPECT_CALL(mockView, getAnalysisMode())
-        .Times(Exactly(1))
-        .WillOnce(Return("MultiDetectorAnalysis"));
+    EXPECT_CALL(mockView, getPolarisationCorrections())
+        .Times(AtLeast(1))
+        .WillOnce(Return("PNR"));
     EXPECT_CALL(mockView, getCRho())
         .Times(AtLeast(1))
         .WillOnce(Return("2.5,0.4,1.1"));
@@ -582,7 +576,7 @@ public:
     auto presenter = makeReflSettingsPresenter(&mockView);
 
     EXPECT_CALL(mockView, experimentSettingsEnabled())
-        .Times(3)
+        .Times(4)
         .WillRepeatedly(Return(true));
     EXPECT_CALL(mockView, instrumentSettingsEnabled())
         .Times(2)
@@ -624,6 +618,7 @@ public:
 
   void testDefaultTransmissionRuns() {
     MockSettingsView mockView;
+    onCallReturnDefaultSettings(mockView);
     auto presenter = makeReflSettingsPresenter(&mockView);
 
     // Default transmission runs are specified with a single
@@ -653,17 +648,17 @@ public:
     // Test looking up transmission runs based on the angle. It has
     // quite a generous tolerance so the angle does not have to be
     // exact
+    EXPECT_CALL(mockView, experimentSettingsEnabled())
+        .Times(4)
+        .WillRepeatedly(Return(true));
     EXPECT_CALL(mockView, getTransmissionRuns())
-        .Times(1)
-        .WillOnce(Return(transmissionRunsMap));
+        .Times(6)
+        .WillRepeatedly(Return(transmissionRunsMap));
+
     auto result = presenter.getTransmissionRunsForAngle(0.69);
     TS_ASSERT_EQUALS(result, "INTER00013463,INTER00013464");
-
-    EXPECT_CALL(mockView, getTransmissionRuns())
-        .Times(1)
-        .WillOnce(Return(transmissionRunsMap));
     result = presenter.getTransmissionRunsForAngle(2.34);
-    TS_ASSERT_EQUALS(result, "INTER000013463");
+    TS_ASSERT_EQUALS(result, "INTER00013463");
 
     TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }

--- a/qt/scientific_interfaces/test/ReflSettingsPresenterTest.h
+++ b/qt/scientific_interfaces/test/ReflSettingsPresenterTest.h
@@ -625,7 +625,7 @@ public:
     // entry with an empty angle as the key
     std::map<std::string, std::string> transmissionRunsMap = {
         {"", "INTER00013463,INTER00013464"}};
-    
+
     EXPECT_CALL(mockView, getTransmissionRuns())
         .Times(1)
         .WillOnce(Return(transmissionRunsMap));
@@ -642,8 +642,7 @@ public:
 
     // Set up a table with transmission runs for 2 different angles
     std::map<std::string, std::string> transmissionRunsMap = {
-      {"0.7", "INTER00013463,INTER00013464"},
-      {"2.33", "INTER00013463"}};
+        {"0.7", "INTER00013463,INTER00013464"}, {"2.33", "INTER00013463"}};
 
     // Test looking up transmission runs based on the angle. It has
     // quite a generous tolerance so the angle does not have to be

--- a/qt/scientific_interfaces/test/ReflSettingsTabPresenterTest.h
+++ b/qt/scientific_interfaces/test/ReflSettingsTabPresenterTest.h
@@ -54,9 +54,8 @@ public:
 
   void test_check_transmission_runs_per_angle() {
     // Test checking whether transmission runs are available per angle
-    
   }
-  
+
   void test_get_transmission_runs_for_angle() {
     // Test getting the transmission runs for a particular angle
 
@@ -151,7 +150,7 @@ public:
 
   void test_reduction_options() {
     // Test getting options for the main reduction algorithm
-    
+
     // Set up settings presenters for 3 groups
     MockSettingsPresenter presenter_0;
     MockSettingsPresenter presenter_1;

--- a/qt/scientific_interfaces/test/ReflSettingsTabPresenterTest.h
+++ b/qt/scientific_interfaces/test/ReflSettingsTabPresenterTest.h
@@ -31,7 +31,10 @@ public:
 
   ReflSettingsTabPresenterTest() { FrameworkManager::Instance(); }
 
-  void test_instrument_name() {
+  void test_set_instrument_name() {
+    // Test setting the instrument name
+
+    // Set up settings presenters for 2 groups
     MockSettingsPresenter presenter_1;
     MockSettingsPresenter presenter_2;
     std::vector<IReflSettingsPresenter *> settingsPresenters;
@@ -39,6 +42,8 @@ public:
     settingsPresenters.push_back(&presenter_2);
     ReflSettingsTabPresenter presenter(settingsPresenters);
 
+    // Should set the instrument name on the settings presenters for
+    // all groups
     EXPECT_CALL(presenter_1, setInstrumentName("INSTRUMENT_NAME")).Times(1);
     EXPECT_CALL(presenter_2, setInstrumentName("INSTRUMENT_NAME")).Times(1);
     presenter.setInstrumentName("INSTRUMENT_NAME");
@@ -47,7 +52,15 @@ public:
     TS_ASSERT(Mock::VerifyAndClearExpectations(&presenter_2));
   }
 
-  void test_transmission_runs() {
+  void test_check_transmission_runs_per_angle() {
+    // Test checking whether transmission runs are available per angle
+    
+  }
+  
+  void test_get_transmission_runs_for_angle() {
+    // Test getting the transmission runs for a particular angle
+
+    // Set up settings presenters for 3 groups
     MockSettingsPresenter presenter_0;
     MockSettingsPresenter presenter_1;
     MockSettingsPresenter presenter_2;
@@ -58,33 +71,40 @@ public:
     settingsPresenters.push_back(&presenter_2);
 
     ReflSettingsTabPresenter presenter(settingsPresenters);
+    const double angle = 0.5;
 
-    EXPECT_CALL(presenter_0, getTransmissionRuns()).Times(1);
-    EXPECT_CALL(presenter_1, getTransmissionRuns()).Times(0);
-    EXPECT_CALL(presenter_2, getTransmissionRuns()).Times(0);
-    presenter.getTransmissionRuns(0);
+    // Should only call though to the settings presenter for
+    // the specified group
+    EXPECT_CALL(presenter_0, getTransmissionRunsForAngle(angle)).Times(1);
+    EXPECT_CALL(presenter_1, getTransmissionRunsForAngle(angle)).Times(0);
+    EXPECT_CALL(presenter_2, getTransmissionRunsForAngle(angle)).Times(0);
+    presenter.getTransmissionRunsForAngle(0, angle);
     TS_ASSERT(Mock::VerifyAndClearExpectations(&presenter_0));
     TS_ASSERT(Mock::VerifyAndClearExpectations(&presenter_1));
     TS_ASSERT(Mock::VerifyAndClearExpectations(&presenter_2));
 
-    EXPECT_CALL(presenter_0, getTransmissionRuns()).Times(0);
-    EXPECT_CALL(presenter_1, getTransmissionRuns()).Times(1);
-    EXPECT_CALL(presenter_2, getTransmissionRuns()).Times(0);
-    presenter.getTransmissionRuns(1);
+    EXPECT_CALL(presenter_0, getTransmissionRunsForAngle(angle)).Times(0);
+    EXPECT_CALL(presenter_1, getTransmissionRunsForAngle(angle)).Times(1);
+    EXPECT_CALL(presenter_2, getTransmissionRunsForAngle(angle)).Times(0);
+    presenter.getTransmissionRunsForAngle(1, angle);
     TS_ASSERT(Mock::VerifyAndClearExpectations(&presenter_0));
     TS_ASSERT(Mock::VerifyAndClearExpectations(&presenter_1));
     TS_ASSERT(Mock::VerifyAndClearExpectations(&presenter_2));
 
-    EXPECT_CALL(presenter_0, getTransmissionRuns()).Times(0);
-    EXPECT_CALL(presenter_1, getTransmissionRuns()).Times(0);
-    EXPECT_CALL(presenter_2, getTransmissionRuns()).Times(1);
-    presenter.getTransmissionRuns(2);
+    EXPECT_CALL(presenter_0, getTransmissionRunsForAngle(angle)).Times(0);
+    EXPECT_CALL(presenter_1, getTransmissionRunsForAngle(angle)).Times(0);
+    EXPECT_CALL(presenter_2, getTransmissionRunsForAngle(angle)).Times(1);
+    presenter.getTransmissionRunsForAngle(2, angle);
     TS_ASSERT(Mock::VerifyAndClearExpectations(&presenter_0));
     TS_ASSERT(Mock::VerifyAndClearExpectations(&presenter_1));
     TS_ASSERT(Mock::VerifyAndClearExpectations(&presenter_2));
   }
 
   void test_transmission_options() {
+    // Test getting options for the preprocessing algorithm to
+    // create the transmission workspace
+
+    // Set up settings presenters for 3 groups
     MockSettingsPresenter presenter_0;
     MockSettingsPresenter presenter_1;
     MockSettingsPresenter presenter_2;
@@ -96,6 +116,8 @@ public:
 
     ReflSettingsTabPresenter presenter(settingsPresenters);
 
+    // Should only call though to the settings presenter for
+    // the specified group
     EXPECT_CALL(presenter_0, getTransmissionOptions())
         .Times(1)
         .WillOnce(Return(OptionsQMap()));
@@ -128,6 +150,9 @@ public:
   }
 
   void test_reduction_options() {
+    // Test getting options for the main reduction algorithm
+    
+    // Set up settings presenters for 3 groups
     MockSettingsPresenter presenter_0;
     MockSettingsPresenter presenter_1;
     MockSettingsPresenter presenter_2;
@@ -139,6 +164,8 @@ public:
 
     ReflSettingsTabPresenter presenter(settingsPresenters);
 
+    // Should only call though to the settings presenter for
+    // the specified group
     EXPECT_CALL(presenter_0, getReductionOptions())
         .Times(1)
         .WillOnce(Return(OptionsQMap()));
@@ -171,6 +198,10 @@ public:
   }
 
   void test_stitch_options() {
+    // Test getting options for the postprocessing algorithm
+    // to stitch workspaces
+
+    // Set up settings presenters for 3 groups
     MockSettingsPresenter presenter_0;
     MockSettingsPresenter presenter_1;
     MockSettingsPresenter presenter_2;
@@ -182,6 +213,8 @@ public:
 
     ReflSettingsTabPresenter presenter(settingsPresenters);
 
+    // Should only call though to the settings presenter for
+    // the specified group
     EXPECT_CALL(presenter_0, getStitchOptions()).Times(1);
     EXPECT_CALL(presenter_1, getStitchOptions()).Times(0);
     EXPECT_CALL(presenter_2, getStitchOptions()).Times(0);

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -544,6 +544,7 @@ mtd_add_qt_tests (TARGET_NAME MantidQtWidgetsCommonTest
   TEST_HELPER_SRCS
     ../../../Framework/TestHelpers/src/TearDownWorld.cpp
     ../../../Framework/TestHelpers/src/ComponentCreationHelper.cpp
+    ../../../Framework/TestHelpers/src/DataProcessorTestHelper.cpp
     ../../../Framework/TestHelpers/src/InstrumentCreationHelper.cpp
     ../../../Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
   LINK_LIBS

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -62,6 +62,7 @@ set ( SRC_FILES
 	src/DataProcessorUI/PreprocessMap.cpp
 	src/DataProcessorUI/ProcessingAlgorithm.cpp
 	src/DataProcessorUI/ProcessingAlgorithmBase.cpp
+	src/DataProcessorUI/TreeData.cpp
 	src/DataProcessorUI/TwoLevelTreeManager.cpp
 	src/DataProcessorUI/WhiteList.cpp
         src/DataProcessorUI/WorkspaceNameUtils.cpp

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/AbstractTreeModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/AbstractTreeModel.h
@@ -62,6 +62,9 @@ public:
                             const QModelIndex &parent = QModelIndex()) = 0;
   // Get the row metadata
   virtual RowData_sptr rowData(const QModelIndex &index) = 0;
+  // Transfer rows into the table
+  virtual void
+  transfer(const std::vector<std::map<QString, QString>> &runs) = 0;
 
 protected:
   /// Collection of data for viewing.

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/AbstractTreeModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/AbstractTreeModel.h
@@ -11,6 +11,9 @@ namespace MantidQt {
 namespace MantidWidgets {
 namespace DataProcessor {
 
+class RowData;
+using RowData_sptr = std::shared_ptr<RowData>;
+
 /** AbstractTreeModel is a base class for several tree model
 implementations for processing table data. Full function implementation is
 provided for functions common to all data processing tree models, while
@@ -57,6 +60,8 @@ public:
   // Set the 'processed' status of a data item
   virtual bool setProcessed(bool processed, int position,
                             const QModelIndex &parent = QModelIndex()) = 0;
+  // Get the row metadata
+  virtual RowData_sptr rowData(const QModelIndex &index) = 0;
 
 protected:
   /// Collection of data for viewing.

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/DataProcessorMainPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/DataProcessorMainPresenter.h
@@ -66,6 +66,13 @@ public:
   virtual QString getTimeSlicingValues() const { return QString(); }
   /// Return time-slicing type
   virtual QString getTimeSlicingType() const { return QString(); }
+  /// Return transmission runs for a particular angle
+  virtual QString getTransmissionRunsForAngle(const double angle) const {
+    UNUSED_ARG(angle);
+    return QString();
+  }
+  /// Return true if there are per-angle transmission runs set
+  virtual bool hasPerAngleTransmissionRuns() const { return false; }
 
   /// Handle data reduction paused/resumed
   virtual void pause() const {}

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/DataProcessorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/DataProcessorView.h
@@ -9,7 +9,6 @@
 #include <set>
 #include <string>
 
-class AbstractTreeModel;
 namespace MantidQt {
 namespace MantidWidgets {
 class HintStrategy;
@@ -17,6 +16,7 @@ namespace DataProcessor {
 // Forward dec
 class Command;
 class DataProcessorPresenter;
+class AbstractTreeModel;
 
 /** @class DataProcessorView
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GenerateNotebook.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GenerateNotebook.h
@@ -62,19 +62,16 @@ postprocessGroupString(const GroupData &rowMap, const WhiteList &whitelist,
                        const ProcessingAlgorithm &processor,
                        const PostprocessingStep &postprocessingStep);
 
-QString DLLExport
-plotsString(const std::vector<OptionsMap> &processingOptionsPerRow,
-            const QString &stitched_wsStr,
-            const ProcessingAlgorithm &processor);
+QString DLLExport plotsString(const GroupData &groupData,
+                              const QString &stitched_wsStr,
+                              const ProcessingAlgorithm &processor);
 
 QString DLLExport
-reduceRowString(const RowData &data, const QString &instrument,
+reduceRowString(const RowData_sptr data, const QString &instrument,
                 const WhiteList &whitelist,
                 const std::map<QString, PreprocessingAlgorithm> &preprocessMap,
                 const ProcessingAlgorithm &processor,
-                const ColumnOptionsMap &globalPreprocessingOptionsMap,
-                const OptionsMap &globalProcessingOptions,
-                std::vector<OptionsMap> &processingOptionsPerRow);
+                const ColumnOptionsMap &globalPreprocessingOptionsMap);
 
 boost::tuple<QString, QString> DLLExport
 loadWorkspaceString(const QString &runStr, const QString &instrument,
@@ -101,8 +98,7 @@ public:
                    std::map<QString, PreprocessingAlgorithm> preprocessMap,
                    ProcessingAlgorithm processor,
                    boost::optional<PostprocessingStep> postprocessingStep,
-                   ColumnOptionsMap preprocessingInstructionsMap,
-                   OptionsMap processingInstructions);
+                   ColumnOptionsMap preprocessingInstructionsMap);
   virtual ~GenerateNotebook() = default;
 
   QString generateNotebook(const TreeData &data);
@@ -127,10 +123,6 @@ private:
   // A map containing pre-processing instructions displayed in the view via
   // hinting line edits
   ColumnOptionsMap m_preprocessingOptionsMap;
-  // Options to reduction algorithm specified in the view via hinting line edit
-  OptionsMap m_processingOptions;
-  // Options to post-processing algorithm specified in the view via hinting line
-  // edit
 };
 }
 }

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GenerateNotebook.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GenerateNotebook.h
@@ -57,10 +57,9 @@ tableString(const TreeData &treeData, const WhiteList &whitelist);
 
 QString DLLExport titleString(const QString &wsName);
 
-boost::tuple<QString, QString> DLLExport
-postprocessGroupString(const GroupData &rowMap, const WhiteList &whitelist,
-                       const ProcessingAlgorithm &processor,
-                       const PostprocessingStep &postprocessingStep);
+boost::tuple<QString, QString> DLLExport postprocessGroupString(
+    const GroupData &rowMap, const ProcessingAlgorithm &processor,
+    const PostprocessingStep &postprocessingStep);
 
 QString DLLExport plotsString(const GroupData &groupData,
                               const QString &stitched_wsStr,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GenerateNotebook.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GenerateNotebook.h
@@ -57,9 +57,10 @@ tableString(const TreeData &treeData, const WhiteList &whitelist);
 
 QString DLLExport titleString(const QString &wsName);
 
-boost::tuple<QString, QString> DLLExport postprocessGroupString(
-    const GroupData &rowMap, const ProcessingAlgorithm &processor,
-    const PostprocessingStep &postprocessingStep);
+boost::tuple<QString, QString> DLLExport
+postprocessGroupString(const GroupData &rowMap,
+                       const ProcessingAlgorithm &processor,
+                       const PostprocessingStep &postprocessingStep);
 
 QString DLLExport plotsString(const GroupData &groupData,
                               const QString &stitched_wsStr,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GenericDataProcessorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GenericDataProcessorPresenter.h
@@ -223,7 +223,9 @@ protected:
   virtual void plotGroup();
   void plotWorkspaces(const QOrderedSet<QString> &workspaces);
   // Get the name of a post-processed workspace
-  QString getPostprocessedWorkspaceName(const GroupData &groupData);
+  QString getPostprocessedWorkspaceName(
+      const GroupData &groupData,
+      boost::optional<size_t> sliceIndex = boost::optional<size_t>());
   bool rowOutputExists(RowItem const &row) const;
   // Refl GUI Group.
   int m_group;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GenericDataProcessorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GenericDataProcessorPresenter.h
@@ -156,8 +156,7 @@ public:
   // Get the whitelist
   WhiteList getWhiteList() const { return m_whitelist; };
   // Get the name of the reduced workspace for a given row
-  QString getReducedWorkspaceName(const RowData_sptr data,
-                                  const QString &prefix = "") const;
+  QString getReducedWorkspaceName(const RowData_sptr data) const;
 
   ParentItems selectedParents() const override;
   ChildItems selectedChildren() const override;
@@ -202,7 +201,7 @@ protected:
   void preprocessColumnValue(const QString &columnName, QString &columnValue,
                              RowData_sptr data);
   // Preprocess all option values where applicable
-  void preprocessOptionValues(OptionsMap &options, RowData_sptr data);
+  void preprocessOptionValues(RowData_sptr data);
   // Update the model with results from the algorithm
   void updateModelFromAlgorithm(Mantid::API::IAlgorithm_sptr alg,
                                 RowData_sptr data);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GenericDataProcessorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GenericDataProcessorPresenter.h
@@ -147,7 +147,7 @@ public:
   void acceptViews(DataProcessorView *tableView,
                    ProgressableView *progressView) override;
   void accept(DataProcessorMainPresenter *mainPresenter) override;
-  void acceptTreeManager(TreeManager *manager);
+  void acceptTreeManager(std::unique_ptr<TreeManager> manager);
   void setModel(QString const &name) override;
   bool hasPostprocessing() const;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GenericDataProcessorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GenericDataProcessorPresenter.h
@@ -183,6 +183,11 @@ protected:
   QString m_loader;
   // The list of selected items to reduce
   TreeData m_selectedData;
+  // Get the processing options for this row
+  virtual OptionsMap getProcessingOptions(RowData *data) {
+    UNUSED_ARG(data);
+    return m_processingOptions;
+  }
 
   boost::optional<PostprocessingStep> m_postprocessing;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GenericDataProcessorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GenericDataProcessorPresenter.h
@@ -216,6 +216,8 @@ protected:
   // Sets whether to prompt user when getting selected runs
   void setPromptUser(bool allowPrompt);
 
+  // Set up data required for processing a row
+  bool initRowForProcessing(RowData_sptr rowData);
   // Process selected rows
   virtual void process();
   // Plotting

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GenericDataProcessorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GenericDataProcessorPresenter.h
@@ -38,7 +38,7 @@ class DataProcessorView;
 class TreeManager;
 class GenericDataProcessorPresenterThread;
 
-using RowItem = std::pair<int, RowData>;
+using RowItem = std::pair<int, RowData_sptr>;
 using RowQueue = std::queue<RowItem>;
 using GroupQueue = std::queue<std::pair<int, RowQueue>>;
 
@@ -156,7 +156,7 @@ public:
   // Get the whitelist
   WhiteList getWhiteList() const { return m_whitelist; };
   // Get the name of the reduced workspace for a given row
-  QString getReducedWorkspaceName(const QStringList &data,
+  QString getReducedWorkspaceName(const RowData_sptr data,
                                   const QString &prefix = "") const;
 
   ParentItems selectedParents() const override;
@@ -184,7 +184,7 @@ protected:
   // The list of selected items to reduce
   TreeData m_selectedData;
   // Get the processing options for this row
-  virtual OptionsMap getProcessingOptions(RowData *data) {
+  virtual OptionsMap getProcessingOptions(RowData_sptr data) {
     UNUSED_ARG(data);
     return m_processingOptions;
   }
@@ -200,16 +200,16 @@ protected:
   void postProcessGroup(const GroupData &data);
   // Preprocess the given column value if applicable
   void preprocessColumnValue(const QString &columnName, QString &columnValue,
-                             RowData *data);
+                             RowData_sptr data);
   // Preprocess all option values where applicable
-  void preprocessOptionValues(OptionsMap &options, RowData *data);
+  void preprocessOptionValues(OptionsMap &options, RowData_sptr data);
   // Update the model with results from the algorithm
   void updateModelFromAlgorithm(Mantid::API::IAlgorithm_sptr alg,
-                                RowData *data);
+                                RowData_sptr data);
   // Create and execute the algorithm with the given properties
   Mantid::API::IAlgorithm_sptr createAndRunAlgorithm(const OptionsMap &options);
   // Reduce a row
-  void reduceRow(RowData *data);
+  void reduceRow(RowData_sptr data);
   // Finds a run in the AnalysisDataService
   QString findRunInADS(const QString &run, const QString &prefix,
                        bool &runFound);
@@ -227,6 +227,12 @@ protected:
   bool rowOutputExists(RowItem const &row) const;
   // Refl GUI Group.
   int m_group;
+  // The whitelist
+  WhiteList m_whitelist;
+  // The data processor algorithm
+  ProcessingAlgorithm m_processor;
+  // Save as ipython notebook
+  void saveNotebook(const TreeData &data);
 protected slots:
   void reductionError(QString ex);
   void threadFinished(const int exitCode);
@@ -241,10 +247,6 @@ private:
   Mantid::API::IAlgorithm_sptr createProcessingAlgorithm() const;
   // the name of the workspace/table/model in the ADS, blank if unsaved
   QString m_wsName;
-  // The whitelist
-  WhiteList m_whitelist;
-  // The data processor algorithm
-  ProcessingAlgorithm m_processor;
 
   // The current queue of groups to be reduced
   GroupQueue m_group_queue;
@@ -358,7 +360,6 @@ private:
                     const std::string &newName) override;
   void afterReplaceHandle(const std::string &name,
                           Mantid::API::Workspace_sptr workspace) override;
-  void saveNotebook(const TreeData &data);
   std::vector<std::unique_ptr<Command>> getTableList();
 
   // set/get values in the table

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GenericDataProcessorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GenericDataProcessorPresenter.h
@@ -147,6 +147,7 @@ public:
   void acceptViews(DataProcessorView *tableView,
                    ProgressableView *progressView) override;
   void accept(DataProcessorMainPresenter *mainPresenter) override;
+  void acceptTreeManager(TreeManager *manager);
   void setModel(QString const &name) override;
   bool hasPostprocessing() const;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GenericDataProcessorPresenterRowReducerWorker.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GenericDataProcessorPresenterRowReducerWorker.h
@@ -48,9 +48,9 @@ public:
 private slots:
   void startWorker() {
     try {
-      m_presenter->reduceRow(&m_rowItem->second);
+      m_presenter->reduceRow(m_rowItem->second);
       m_presenter->m_manager->update(m_groupIndex, m_rowItem->first,
-                                     m_rowItem->second);
+                                     m_rowItem->second->data());
       m_presenter->m_manager->setProcessed(true, m_rowItem->first,
                                            m_groupIndex);
       emit finished(0);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/MockObjects.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/MockObjects.h
@@ -196,6 +196,7 @@ public:
   std::vector<std::unique_ptr<Command>> publishCommands() override {
     return std::vector<std::unique_ptr<Command>>();
   };
+  bool isMultiLevel() const override { return false; }
   void appendRow() override{};
   void appendGroup() override{};
   void deleteRow() override{};

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/MockObjects.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/MockObjects.h
@@ -209,12 +209,10 @@ public:
   void newTable(const WhiteList &) override{};
   void newTable(Mantid::API::ITableWorkspace_sptr,
                 const WhiteList &) override{};
-  void transfer(const std::vector<std::map<QString, QString>> &,
-                const WhiteList &) override{};
+  void transfer(const std::vector<std::map<QString, QString>> &) override{};
   void update(int, int, const QStringList &) override{};
   int rowCount() const override { return 0; };
   int rowCount(int) const override { return 0; };
-  bool rowIsEmpty(int, int) const override { return false; };
   bool isProcessed(int) const override { return false; };
   bool isProcessed(int, int) const override { return false; };
   void setProcessed(bool, int) override{};

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/MockObjects.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/MockObjects.h
@@ -3,9 +3,13 @@
 
 #include "MantidKernel/WarningSuppressions.h"
 #include "MantidKernel/make_unique.h"
+#include "MantidQtWidgets/Common/DataProcessorUI/AbstractTreeModel.h"
 #include "MantidQtWidgets/Common/DataProcessorUI/AppendRowCommand.h"
 #include "MantidQtWidgets/Common/DataProcessorUI/DataProcessorMainPresenter.h"
 #include "MantidQtWidgets/Common/DataProcessorUI/DataProcessorView.h"
+#include "MantidQtWidgets/Common/DataProcessorUI/QTwoLevelTreeModel.h"
+#include "MantidQtWidgets/Common/DataProcessorUI/TreeData.h"
+#include "MantidQtWidgets/Common/DataProcessorUI/TreeManager.h"
 
 #include <gmock/gmock.h>
 
@@ -181,6 +185,51 @@ private:
   void clearTable() override {}
 
   std::map<QString, QVariant> m_options;
+};
+
+class MockTreeManager : public TreeManager {
+public:
+  MockTreeManager(){};
+  ~MockTreeManager() override{};
+  MOCK_METHOD1(selectedData, TreeData(bool));
+  // Calls we don't care about
+  std::vector<std::unique_ptr<Command>> publishCommands() override {
+    return std::vector<std::unique_ptr<Command>>();
+  };
+  void appendRow() override{};
+  void appendGroup() override{};
+  void deleteRow() override{};
+  void deleteGroup() override{};
+  void groupRows() override{};
+  std::set<int> expandSelection() override { return std::set<int>(); };
+  void clearSelected() override{};
+  QString copySelected() override { return QString(); };
+  void pasteSelected(const QString &) override{};
+  void newTable(const WhiteList &) override{};
+  void newTable(Mantid::API::ITableWorkspace_sptr,
+                const WhiteList &) override{};
+  void transfer(const std::vector<std::map<QString, QString>> &,
+                const WhiteList &) override{};
+  void update(int, int, const QStringList &) override{};
+  int rowCount() const override { return 0; };
+  int rowCount(int) const override { return 0; };
+  bool isProcessed(int) const override { return false; };
+  bool isProcessed(int, int) const override { return false; };
+  void setProcessed(bool, int) override{};
+  void setProcessed(bool, int, int) override{};
+  void invalidateAllProcessed() override{};
+  void setCell(int, int, int, int, const std::string &) override{};
+  std::string getCell(int, int, int, int) override { return std::string(); };
+  int getNumberOfRows() override { return 0; };
+  bool isValidModel(Mantid::API::Workspace_sptr, size_t) const override {
+    return false;
+  };
+  boost::shared_ptr<AbstractTreeModel> getModel() override {
+    return boost::shared_ptr<QTwoLevelTreeModel>();
+  };
+  Mantid::API::ITableWorkspace_sptr getTableWorkspace() override {
+    return Mantid::API::ITableWorkspace_sptr();
+  };
 };
 
 GCC_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/MockObjects.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/MockObjects.h
@@ -214,13 +214,16 @@ public:
   void update(int, int, const QStringList &) override{};
   int rowCount() const override { return 0; };
   int rowCount(int) const override { return 0; };
+  bool rowIsEmpty(int, int) const override { return false; };
   bool isProcessed(int) const override { return false; };
   bool isProcessed(int, int) const override { return false; };
   void setProcessed(bool, int) override{};
   void setProcessed(bool, int, int) override{};
   void invalidateAllProcessed() override{};
   void setCell(int, int, int, int, const std::string &) override{};
-  std::string getCell(int, int, int, int) override { return std::string(); };
+  std::string getCell(int, int, int, int) const override {
+    return std::string();
+  };
   int getNumberOfRows() override { return 0; };
   bool isValidModel(Mantid::API::Workspace_sptr, size_t) const override {
     return false;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/OneLevelTreeManager.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/OneLevelTreeManager.h
@@ -131,6 +131,7 @@ private:
   /// Validate a table workspace
   void validateModel(Mantid::API::ITableWorkspace_sptr ws,
                      size_t whitelistColumns) const;
+  TreeData constructTreeData(std::set<int> rows);
 };
 }
 }

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/OneLevelTreeManager.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/OneLevelTreeManager.h
@@ -88,11 +88,12 @@ public:
   /// Get the number of rows of a given parent
   int rowCount() const override;
   int rowCount(int parent) const override;
+  bool rowIsEmpty(int row, int parent) const override;
   void setCell(int row, int column, int parentRow, int parentColumn,
                const std::string &value) override;
   int getNumberOfRows() override;
   std::string getCell(int row, int column, int parentRow,
-                      int parentColumn) override;
+                      int parentColumn) const override;
   /// Get the 'processed' status of a data item
   bool isProcessed(int position) const override;
   bool isProcessed(int position, int parent) const override;
@@ -123,8 +124,11 @@ private:
   /// The model
   boost::shared_ptr<QOneLevelTreeModel> m_model;
 
-  /// Insert a row in the model
+  /// Insert an empty row in the model
   void insertRow(int rowIndex);
+  /// Insert a row with values in the model
+  void insertRow(int rowIndex, const std::map<QString, QString> &rowValues,
+                 const WhiteList &whitelist);
   /// Create a default table workspace
   Mantid::API::ITableWorkspace_sptr
   createDefaultWorkspace(const WhiteList &whitelist);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/OneLevelTreeManager.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/OneLevelTreeManager.h
@@ -81,14 +81,12 @@ public:
   /// Return selected data
   TreeData selectedData(bool prompt) override;
   /// Transfer new data to model
-  void transfer(const std::vector<std::map<QString, QString>> &runs,
-                const WhiteList &whitelist) override;
+  void transfer(const std::vector<std::map<QString, QString>> &runs) override;
   /// Update row with new data
   void update(int parent, int child, const QStringList &data) override;
   /// Get the number of rows of a given parent
   int rowCount() const override;
   int rowCount(int parent) const override;
-  bool rowIsEmpty(int row, int parent) const override;
   void setCell(int row, int column, int parentRow, int parentColumn,
                const std::string &value) override;
   int getNumberOfRows() override;
@@ -126,9 +124,6 @@ private:
 
   /// Insert an empty row in the model
   void insertRow(int rowIndex);
-  /// Insert a row with values in the model
-  void insertRow(int rowIndex, const std::map<QString, QString> &rowValues,
-                 const WhiteList &whitelist);
   /// Create a default table workspace
   Mantid::API::ITableWorkspace_sptr
   createDefaultWorkspace(const WhiteList &whitelist);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/PostprocessingStep.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/PostprocessingStep.h
@@ -19,10 +19,14 @@ public:
   PostprocessingStep(QString options, PostprocessingAlgorithm algorithm,
                      std::map<QString, QString> map);
 
-  void postProcessGroup(const QString &processorPrefix,
+  void postProcessGroup(const QString &rowInputWSPropertyName,
+                        const QString &rowOutputWSPropertyName,
                         const WhiteList &whitelist, const GroupData &groupData);
-  QString getPostprocessedWorkspaceName(const WhiteList &whitelist,
+  QString getPostprocessedWorkspaceName(const QString &rowOutputPropertyName,
                                         const GroupData &groupData);
+  QString getPostprocessedWorkspaceName(const QString &rowOutputPropertyName,
+                                        const GroupData &groupData,
+                                        const size_t sliceIndex);
   QString m_options;
   PostprocessingAlgorithm m_algorithm;
   std::map<QString, QString> m_map;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/PostprocessingStep.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/PostprocessingStep.h
@@ -24,7 +24,6 @@ public:
                         const QString &rowOutputWSPropertyName,
                         const WhiteList &whitelist, const GroupData &groupData);
   QString getPostprocessedWorkspaceName(
-      const QString &rowOutputPropertyName, const QString &rowWSPrefix,
       const GroupData &groupData,
       boost::optional<size_t> sliceIndex = boost::optional<size_t>());
   QString m_options;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/PostprocessingStep.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/PostprocessingStep.h
@@ -1,14 +1,15 @@
 #ifndef MANTIDQTWIDGETS_POSTPROCESSINGSTEP
 #define MANTIDQTWIDGETS_POSTPROCESSINGSTEP
-#include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/AlgorithmManager.h"
-#include "MantidQtWidgets/Common/DataProcessorUI/WhiteList.h"
+#include "MantidAPI/AnalysisDataService.h"
 #include "MantidQtWidgets/Common/DataProcessorUI/PostprocessingAlgorithm.h"
 #include "MantidQtWidgets/Common/DataProcessorUI/TreeData.h"
+#include "MantidQtWidgets/Common/DataProcessorUI/WhiteList.h"
 #include "MantidQtWidgets/Common/DllOption.h"
 #include "MantidQtWidgets/Common/ParseKeyValueString.h"
 #include <QString>
 #include <QStringList>
+#include <boost/optional.hpp>
 #include <map>
 namespace MantidQt {
 namespace MantidWidgets {
@@ -19,14 +20,13 @@ public:
   PostprocessingStep(QString options, PostprocessingAlgorithm algorithm,
                      std::map<QString, QString> map);
 
-  void postProcessGroup(const QString &rowInputWSPropertyName,
+  void postProcessGroup(const QString &outputWSName,
                         const QString &rowOutputWSPropertyName,
                         const WhiteList &whitelist, const GroupData &groupData);
-  QString getPostprocessedWorkspaceName(const QString &rowOutputPropertyName,
-                                        const GroupData &groupData);
-  QString getPostprocessedWorkspaceName(const QString &rowOutputPropertyName,
-                                        const GroupData &groupData,
-                                        const size_t sliceIndex);
+  QString getPostprocessedWorkspaceName(
+      const QString &rowOutputPropertyName, const QString &rowWSPrefix,
+      const GroupData &groupData,
+      boost::optional<size_t> sliceIndex = boost::optional<size_t>());
   QString m_options;
   PostprocessingAlgorithm m_algorithm;
   std::map<QString, QString> m_map;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/ProcessingAlgorithm.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/ProcessingAlgorithm.h
@@ -60,6 +60,8 @@ public:
   QString defaultOutputPrefix() const;
   // The default output ws property
   QString defaultOutputPropertyName() const;
+  // The default input ws property
+  QString defaultInputPropertyName() const;
   // The input properties
   std::vector<QString> inputProperties() const;
   // The output properties

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/ProcessingAlgorithm.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/ProcessingAlgorithm.h
@@ -56,6 +56,8 @@ public:
   QString inputPropertyName(size_t index) const;
   // The name of this output property
   QString outputPropertyName(size_t index) const;
+  // The input properties
+  std::vector<QString> inputProperties() const;
   // The output properties
   std::vector<QString> outputProperties() const;
   // The prefixes for the output properties

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/ProcessingAlgorithm.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/ProcessingAlgorithm.h
@@ -56,6 +56,10 @@ public:
   QString inputPropertyName(size_t index) const;
   // The name of this output property
   QString outputPropertyName(size_t index) const;
+  // The prefix for the default output ws property
+  QString defaultOutputPrefix() const;
+  // The default output ws property
+  QString defaultOutputPropertyName() const;
   // The input properties
   std::vector<QString> inputProperties() const;
   // The output properties

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/QOneLevelTreeModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/QOneLevelTreeModel.h
@@ -12,6 +12,9 @@ namespace MantidQt {
 namespace MantidWidgets {
 namespace DataProcessor {
 
+class RowData;
+using RowData_sptr = std::shared_ptr<RowData>;
+
 /** QOneLevelTreeModel : Provides a QAbstractItemModel for a
 DataProcessorUI with no post-processing defined. The first argument to the
 constructor is a Mantid ITableWorkspace containing the values to use in the
@@ -56,6 +59,8 @@ public:
   // Get header data for the table
   QVariant headerData(int section, Qt::Orientation orientation,
                       int role) const override;
+  // Get row metadata
+  RowData_sptr rowData(const QModelIndex &index) override;
   // Row count
   int rowCount(const QModelIndex &parent = QModelIndex()) const override;
   // Get the index for a given column, row and parent
@@ -84,10 +89,13 @@ public:
   // Set the 'processed' status of a row
   bool setProcessed(bool processed, int position,
                     const QModelIndex &parent = QModelIndex()) override;
+private slots:
+  void tableDataUpdated(const QModelIndex &, const QModelIndex &);
 
 private:
+  void updateAllRowData();
   /// Vector containing process status for each row
-  std::vector<bool> m_rows;
+  std::vector<RowData_sptr> m_rows;
 };
 
 /// Typedef for a shared pointer to \c QOneLevelTreeModel

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/QOneLevelTreeModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/QOneLevelTreeModel.h
@@ -89,11 +89,19 @@ public:
   // Set the 'processed' status of a row
   bool setProcessed(bool processed, int position,
                     const QModelIndex &parent = QModelIndex()) override;
+  // Transfer rows into the table
+  void transfer(const std::vector<std::map<QString, QString>> &runs) override;
 private slots:
   void tableDataUpdated(const QModelIndex &, const QModelIndex &);
 
 private:
+  /// Update all cached row data from the table data
   void updateAllRowData();
+  /// Insert a row with given values into the table
+  void insertRowWithValues(int rowIndex,
+                           const std::map<QString, QString> &rowValues);
+  /// Check whether a row's cell values are all empty
+  bool rowIsEmpty(int row) const;
   /// Vector containing process status for each row
   std::vector<RowData_sptr> m_rows;
 };

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/QTwoLevelTreeModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/QTwoLevelTreeModel.h
@@ -97,11 +97,16 @@ public:
                     const QModelIndex &parent = QModelIndex()) override;
   // Insert rows
   bool insertRows(int position, int count, int parent);
+  // Transfer rows into the table
+  void transfer(const std::vector<std::map<QString, QString>> &runs) override;
 private slots:
   void tableDataUpdated(const QModelIndex &, const QModelIndex &);
 
 private:
   void updateAllGroupData();
+  void insertRowWithValues(int groupIndex, int rowIndex,
+                           const std::map<QString, QString> &rowValues);
+  bool rowIsEmpty(int row, int parent) const;
   void setupModelData(Mantid::API::ITableWorkspace_sptr table);
   bool insertGroups(int position, int count);
   bool removeGroups(int position, int count);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/QTwoLevelTreeModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/QTwoLevelTreeModel.h
@@ -12,6 +12,10 @@ namespace MantidQt {
 namespace MantidWidgets {
 namespace DataProcessor {
 
+class GroupInfo;
+class RowData;
+using RowData_sptr = std::shared_ptr<RowData>;
+
 /** QTwoLevelTreeModel : Provides a QAbstractItemModel for a
 DataProcessorUI with post-processing defined. The first argument to the
 constructor is a Mantid ITableWorkspace containing the values to use in the
@@ -59,6 +63,8 @@ public:
   // Get header data for the table
   QVariant headerData(int section, Qt::Orientation orientation,
                       int role) const override;
+  // Get row metadata
+  RowData_sptr rowData(const QModelIndex &index) override;
   // Row count
   int rowCount(const QModelIndex &parent = QModelIndex()) const override;
   // Get the index for a given column, row and parent
@@ -87,19 +93,19 @@ public:
   // Set the 'processed' status of a row / group
   bool setProcessed(bool processed, int position,
                     const QModelIndex &parent = QModelIndex()) override;
+private slots:
+  void tableDataUpdated(const QModelIndex &, const QModelIndex &);
 
 private:
+  void updateAllGroupData();
   void setupModelData(Mantid::API::ITableWorkspace_sptr table);
   bool insertGroups(int position, int count);
   bool insertRows(int position, int count, int parent);
   bool removeGroups(int position, int count);
   bool removeRows(int position, int count, int parent);
 
-  /// Vector containing group names and process status
-  std::vector<std::pair<std::string, bool>> m_groupName;
-  /// Vector containing the (absolute) row indices for a given group and process
-  /// status
-  std::vector<std::vector<std::pair<int, bool>>> m_rowsOfGroup;
+  /// List of all groups ordered by the group's position in the tree
+  std::vector<GroupInfo> m_groups;
 };
 
 template <typename Action>

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/QTwoLevelTreeModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/QTwoLevelTreeModel.h
@@ -78,6 +78,8 @@ public:
 
   // Get the parent
   QModelIndex parent(const QModelIndex &index) const override;
+  // Find or create a group
+  int findOrAddGroup(const std::string &groupName);
 
   // Functions to edit model
 
@@ -93,6 +95,8 @@ public:
   // Set the 'processed' status of a row / group
   bool setProcessed(bool processed, int position,
                     const QModelIndex &parent = QModelIndex()) override;
+  // Insert rows
+  bool insertRows(int position, int count, int parent);
 private slots:
   void tableDataUpdated(const QModelIndex &, const QModelIndex &);
 
@@ -100,7 +104,6 @@ private:
   void updateAllGroupData();
   void setupModelData(Mantid::API::ITableWorkspace_sptr table);
   bool insertGroups(int position, int count);
-  bool insertRows(int position, int count, int parent);
   bool removeGroups(int position, int count);
   bool removeRows(int position, int count, int parent);
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/TreeData.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/TreeData.h
@@ -50,11 +50,10 @@ using RowData_sptr = std::shared_ptr<RowData>;
 class DLLExport RowData {
 public:
   // Constructors
-  RowData() = delete;
-  RowData(const int columnCount);
-  RowData(QStringList data);
-  RowData(const std::vector<std::string> &data);
-  RowData(const RowData *src);
+  explicit RowData(const int columnCount);
+  explicit RowData(QStringList data);
+  explicit RowData(const std::vector<std::string> &data);
+  explicit RowData(const RowData &src);
 
   // Iterators
   QList<QString>::iterator begin();

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/TreeData.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/TreeData.h
@@ -27,16 +27,89 @@
     */
 
 #include "MantidKernel/System.h"
+#include "MantidQtWidgets/Common/DataProcessorUI/OptionsMap.h"
 #include "MantidQtWidgets/Common/DataProcessorUI/PostprocessingAlgorithm.h"
 #include "MantidQtWidgets/Common/DataProcessorUI/PreprocessingAlgorithm.h"
 #include "MantidQtWidgets/Common/DataProcessorUI/ProcessingAlgorithm.h"
-#include "MantidQtWidgets/Common/DataProcessorUI/WhiteList.h"
 #include "MantidQtWidgets/Common/DataProcessorUI/TreeData.h"
+#include "MantidQtWidgets/Common/DataProcessorUI/WhiteList.h"
+
+#include <QStringList>
+
 namespace MantidQt {
 namespace MantidWidgets {
 namespace DataProcessor {
-using RowData = QStringList;
-using GroupData = std::map<int, RowData>;
+class RowData;
+using RowData_sptr = std::shared_ptr<RowData>;
+
+/**
+* A class representing the data and properties for a row in the data processor
+* table. Historically this was just a QStringList and currently this class just
+* wraps the QStringList and adds some metadata.
+*/
+class DLLExport RowData {
+public:
+  // Constructors
+  RowData();
+  RowData(QStringList data);
+  RowData(const RowData *src);
+
+  // Iterators
+  QList<QString>::iterator begin();
+  QList<QString>::iterator end();
+  QList<QString>::const_iterator constBegin() const;
+  QList<QString>::const_iterator constEnd() const;
+  QString back() const;
+  QString operator[](int i) const;
+
+  /// Return all of the data values
+  QStringList data() const;
+  /// Return the data value at the given index
+  QString value(const int i);
+  /// Set the data value at the given index
+  void setValue(const int i, const QString &value);
+
+  /// Get the algorithm input properties
+  OptionsMap options() const;
+  /// Get the preprocessed algorithm input properties
+  OptionsMap preprocessedOptions() const;
+  /// Set the algorithm input properties
+  void setOptions(OptionsMap options);
+  /// Set the preprocessed algorithm properties
+  void setPreprocessedOptions(OptionsMap options);
+
+  // Get the number of fields in the data
+  int size() const;
+
+  /// Check if a property exists
+  bool hasOption(const QString &name) const;
+  /// Return a property value
+  QString optionValue(const QString &name) const;
+  /// Set a property value
+  void setOptionValue(const QString &name, const QString &value);
+  /// Get a child slice
+  RowData_sptr getSlice(const size_t sliceIndex);
+  /// Add a child slice
+  RowData_sptr addSlice(const QString &sliceSuffix,
+                        std::vector<QString> &workspaceProperties);
+
+private:
+  /// Check if a preprocessed property exists
+  bool hasPreprocessedOption(const QString &name) const;
+
+  /// The row data as a list of string values
+  QStringList m_data;
+  /// Original input options for the main reduction algorithm
+  OptionsMap m_options;
+  /// Input options for the main reduction after they have been
+  /// preprocessed
+  OptionsMap m_preprocessedOptions;
+  /// For sliced event data the original row gets split into multiple
+  /// slices
+  std::vector<RowData_sptr> m_slices;
+};
+
+using GroupData = std::map<int, RowData_sptr>;
 using TreeData = std::map<int, GroupData>;
 }
 }

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/TreeData.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/TreeData.h
@@ -53,6 +53,7 @@ public:
   RowData() = delete;
   RowData(const int columnCount);
   RowData(QStringList data);
+  RowData(const std::vector<std::string> &data);
   RowData(const RowData *src);
 
   // Iterators
@@ -92,8 +93,13 @@ public:
   QString preprocessedOptionValue(const QString &name) const;
   /// Set a property value
   void setOptionValue(const QString &name, const QString &value);
+  /// Set a property value
+  void setOptionValue(const std::string &name, const std::string &value);
   /// Set a preprocessed property value
   void setPreprocessedOptionValue(const QString &name, const QString &value);
+  /// Set a preprocessed property value
+  void setPreprocessedOptionValue(const std::string &name,
+                                  const std::string &value);
   /// Get the number of slices for this row
   size_t numberOfSlices() const;
   /// Check whether a slice exists by index

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/TreeData.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/TreeData.h
@@ -102,7 +102,7 @@ public:
   RowData_sptr getSlice(const size_t sliceIndex);
   /// Add a child slice
   RowData_sptr addSlice(const QString &sliceSuffix,
-                        std::vector<QString> &workspaceProperties);
+                        const std::vector<QString> &workspaceProperties);
   /// Clear all slices from the row
   void clearSlices();
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/TreeData.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/TreeData.h
@@ -92,6 +92,8 @@ public:
   QString preprocessedOptionValue(const QString &name) const;
   /// Set a property value
   void setOptionValue(const QString &name, const QString &value);
+  /// Set a preprocessed property value
+  void setPreprocessedOptionValue(const QString &name, const QString &value);
   /// Get the number of slices for this row
   size_t numberOfSlices() const;
   /// Check whether a slice exists by index
@@ -109,6 +111,11 @@ public:
   /// Set whether the row has been processed
   void setProcessed(const bool isProcessed) { m_isProcessed = isProcessed; }
 
+  /// Get the reduced workspace name, optionally adding a prefix
+  QString reducedName(const QString prefix = QString());
+  /// Set the reduced workspace name
+  void setReducedName(const QString &name) { m_reducedName = name; }
+
 private:
   /// Check if a preprocessed property exists
   bool hasPreprocessedOption(const QString &name) const;
@@ -125,6 +132,9 @@ private:
   std::vector<RowData_sptr> m_slices;
   /// Whether the row has been processed
   bool m_isProcessed;
+  /// The canonical reduced workspace name for this row i.e. prior to any
+  /// prefixes being added for specific output workspace properties
+  QString m_reducedName;
 };
 
 using GroupData = std::map<int, RowData_sptr>;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/TreeData.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/TreeData.h
@@ -50,7 +50,8 @@ using RowData_sptr = std::shared_ptr<RowData>;
 class DLLExport RowData {
 public:
   // Constructors
-  RowData();
+  RowData() = delete;
+  RowData(const int columnCount);
   RowData(QStringList data);
   RowData(const RowData *src);
 
@@ -85,13 +86,28 @@ public:
   bool hasOption(const QString &name) const;
   /// Return a property value
   QString optionValue(const QString &name) const;
+  /// Return a property value
+  QString optionValue(const QString &name, const size_t sliceIndex) const;
+  /// Return a preprocessed property value
+  QString preprocessedOptionValue(const QString &name) const;
   /// Set a property value
   void setOptionValue(const QString &name, const QString &value);
+  /// Get the number of slices for this row
+  size_t numberOfSlices() const;
+  /// Check whether a slice exists by index
+  bool hasSlice(const size_t sliceIndex);
   /// Get a child slice
   RowData_sptr getSlice(const size_t sliceIndex);
   /// Add a child slice
   RowData_sptr addSlice(const QString &sliceSuffix,
                         std::vector<QString> &workspaceProperties);
+  /// Clear all slices from the row
+  void clearSlices();
+
+  /// Whether the row has been processed
+  bool isProcessed() const { return m_isProcessed; }
+  /// Set whether the row has been processed
+  void setProcessed(const bool isProcessed) { m_isProcessed = isProcessed; }
 
 private:
   /// Check if a preprocessed property exists
@@ -107,6 +123,8 @@ private:
   /// For sliced event data the original row gets split into multiple
   /// slices
   std::vector<RowData_sptr> m_slices;
+  /// Whether the row has been processed
+  bool m_isProcessed;
 };
 
 using GroupData = std::map<int, RowData_sptr>;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/TreeManager.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/TreeManager.h
@@ -91,6 +91,7 @@ public:
   /// Get the number of rows of a given parent
   virtual int rowCount() const = 0;
   virtual int rowCount(int parent) const = 0;
+  virtual bool rowIsEmpty(int row, int column) const = 0;
   /// Get the 'processed' status of a data item
   virtual bool isProcessed(int position) const = 0;
   virtual bool isProcessed(int position, int parent) const = 0;
@@ -102,7 +103,7 @@ public:
   virtual void setCell(int row, int column, int parentRow, int parentColumn,
                        const std::string &value) = 0;
   virtual std::string getCell(int row, int column, int parentRow,
-                              int parentColumn) = 0;
+                              int parentColumn) const = 0;
   virtual int getNumberOfRows() = 0;
   /// Validate a table workspace
   virtual bool isValidModel(Mantid::API::Workspace_sptr ws,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/TreeManager.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/TreeManager.h
@@ -84,14 +84,13 @@ public:
   /// Return selected data
   virtual TreeData selectedData(bool prompt = false) = 0;
   /// Transfer new data to model
-  virtual void transfer(const std::vector<std::map<QString, QString>> &runs,
-                        const WhiteList &whitelist) = 0;
+  virtual void
+  transfer(const std::vector<std::map<QString, QString>> &runs) = 0;
   /// Update row with new data
   virtual void update(int parent, int child, const QStringList &data) = 0;
   /// Get the number of rows of a given parent
   virtual int rowCount() const = 0;
   virtual int rowCount(int parent) const = 0;
-  virtual bool rowIsEmpty(int row, int column) const = 0;
   /// Get the 'processed' status of a data item
   virtual bool isProcessed(int position) const = 0;
   virtual bool isProcessed(int position, int parent) const = 0;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/TwoLevelTreeManager.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/TwoLevelTreeManager.h
@@ -8,6 +8,8 @@ namespace MantidQt {
 namespace MantidWidgets {
 namespace DataProcessor {
 
+using ChildItems = std::map<int, std::set<int>>;
+
 class DataProcessorPresenter;
 class WhiteList;
 class QTwoLevelTreeModel;
@@ -129,6 +131,7 @@ private:
   /// Validate a table workspace
   void validateModel(Mantid::API::ITableWorkspace_sptr ws,
                      size_t whitelistColumns) const;
+  TreeData constructTreeData(ChildItems rows);
 };
 }
 }

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/TwoLevelTreeManager.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/TwoLevelTreeManager.h
@@ -82,14 +82,12 @@ public:
   /// Return selected data
   TreeData selectedData(bool prompt) override;
   /// Transfer new data to model
-  void transfer(const std::vector<std::map<QString, QString>> &runs,
-                const WhiteList &whitelist) override;
+  void transfer(const std::vector<std::map<QString, QString>> &runs) override;
   /// Update row with new data
   void update(int parent, int child, const QStringList &data) override;
   /// Get the number of rows of a given parent
   int rowCount() const override;
   int rowCount(int parent) const override;
-  bool rowIsEmpty(int row, int column) const override;
   void setCell(int row, int column, int parentRow, int parentColumn,
                const std::string &value) override;
   std::string getCell(int row, int column, int parentRow,
@@ -122,10 +120,6 @@ private:
 
   /// Insert an empty row in the model
   void insertRow(int groupIndex, int rowIndex);
-  /// Insert a row in the model with values
-  void insertRow(int groupIndex, int rowIndex,
-                 const std::map<QString, QString> &rowValues,
-                 const WhiteList &whitelist);
   /// Insert a group in the model
   void insertGroup(int groupIndex);
   /// Get the number of rows in a group

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/TwoLevelTreeManager.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/TwoLevelTreeManager.h
@@ -89,10 +89,11 @@ public:
   /// Get the number of rows of a given parent
   int rowCount() const override;
   int rowCount(int parent) const override;
+  bool rowIsEmpty(int row, int column) const override;
   void setCell(int row, int column, int parentRow, int parentColumn,
                const std::string &value) override;
   std::string getCell(int row, int column, int parentRow,
-                      int parentColumn) override;
+                      int parentColumn) const override;
   int getNumberOfRows() override;
   /// Get the 'processed' status of a data item
   bool isProcessed(int position) const override;
@@ -119,8 +120,12 @@ private:
   /// The model
   boost::shared_ptr<QTwoLevelTreeModel> m_model;
 
-  /// Insert a row in the model
+  /// Insert an empty row in the model
   void insertRow(int groupIndex, int rowIndex);
+  /// Insert a row in the model with values
+  void insertRow(int groupIndex, int rowIndex,
+                 const std::map<QString, QString> &rowValues,
+                 const WhiteList &whitelist);
   /// Insert a group in the model
   void insertGroup(int groupIndex);
   /// Get the number of rows in a group

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/WorkspaceNameUtils.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/WorkspaceNameUtils.h
@@ -46,8 +46,7 @@ QString preprocessingListToString(const QStringList &values,
                                   const QString prefix = QString());
 // Returns the name of the reduced workspace for a given row
 QString DLLExport getReducedWorkspaceName(const RowData_sptr data,
-                                          const WhiteList &whitelist,
-                                          const QString prefix = QString());
+                                          const WhiteList &whitelist);
 // Consolidate global options with row values
 OptionsMap DLLExport getCanonicalOptions(
     const RowData_sptr data, const OptionsMap &globalOptions,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/WorkspaceNameUtils.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/WorkspaceNameUtils.h
@@ -45,12 +45,12 @@ QStringList preprocessingStringToList(const QString &inputStr);
 QString preprocessingListToString(const QStringList &values,
                                   const QString prefix = QString());
 // Returns the name of the reduced workspace for a given row
-QString DLLExport getReducedWorkspaceName(const QStringList &data,
+QString DLLExport getReducedWorkspaceName(const RowData_sptr data,
                                           const WhiteList &whitelist,
                                           const QString prefix = QString());
 // Consolidate global options with row values
 OptionsMap DLLExport getCanonicalOptions(
-    const RowData *data, const OptionsMap &globalOptions,
+    const RowData_sptr data, const OptionsMap &globalOptions,
     const WhiteList &whitelist, const bool allowInsertions,
     const std::vector<QString> &outputProperties = std::vector<QString>(),
     const std::vector<QString> &prefixes = std::vector<QString>());

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/WorkspaceNameUtils.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/WorkspaceNameUtils.h
@@ -45,8 +45,8 @@ QStringList preprocessingStringToList(const QString &inputStr);
 QString preprocessingListToString(const QStringList &values,
                                   const QString prefix = QString());
 // Returns the name of the reduced workspace for a given row
-QString DLLExport getReducedWorkspaceName(const RowData_sptr data,
-                                          const WhiteList &whitelist);
+QString DLLExport
+getReducedWorkspaceName(const RowData_sptr data, const WhiteList &whitelist);
 // Consolidate global options with row values
 OptionsMap DLLExport getCanonicalOptions(
     const RowData_sptr data, const OptionsMap &globalOptions,

--- a/qt/widgets/common/src/DataProcessorUI/GenerateNotebook.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/GenerateNotebook.cpp
@@ -51,14 +51,13 @@ GenerateNotebook::GenerateNotebook(
     std::map<QString, PreprocessingAlgorithm> preprocessMap,
     ProcessingAlgorithm processor,
     boost::optional<PostprocessingStep> postprocessingStep,
-    ColumnOptionsMap preprocessingOptionsMap, OptionsMap processingOptions)
+    ColumnOptionsMap preprocessingOptionsMap)
     : m_wsName(std::move(name)), m_instrument(std::move(instrument)),
       m_whitelist(std::move(whitelist)),
       m_preprocessMap(std::move(preprocessMap)),
       m_processor(std::move(processor)),
       m_postprocessingStep(std::move(postprocessingStep)),
-      m_preprocessingOptionsMap(std::move(preprocessingOptionsMap)),
-      m_processingOptions(std::move(processingOptions)) {
+      m_preprocessingOptionsMap(std::move(preprocessingOptionsMap)) {
 
   if (m_whitelist.size() < 2)
     throw std::invalid_argument(
@@ -93,9 +92,6 @@ QString GenerateNotebook::generateNotebook(const TreeData &data) {
     QString groupTitle = "Group " + QString::number(groupId);
     notebook->markdownCell(groupTitle.toStdString());
 
-    // Record processing options used for each row
-    std::vector<OptionsMap> processingOptionsPerRow;
-
     /**  Reduce all rows **/
 
     // The python code
@@ -105,8 +101,7 @@ QString GenerateNotebook::generateNotebook(const TreeData &data) {
 
       auto reducedRowStr = reduceRowString(
           row.second, m_instrument, m_whitelist, m_preprocessMap, m_processor,
-          m_preprocessingOptionsMap, m_processingOptions,
-          processingOptionsPerRow);
+          m_preprocessingOptionsMap);
 
       // The reduction code
       codeString += reducedRowStr;
@@ -124,9 +119,9 @@ QString GenerateNotebook::generateNotebook(const TreeData &data) {
 
     /** Draw plots **/
 
-    notebook->codeCell(plotsString(processingOptionsPerRow,
-                                   boost::get<1>(postProcessString),
-                                   m_processor).toStdString());
+    notebook->codeCell(
+        plotsString(rowMap, boost::get<1>(postProcessString), m_processor)
+            .toStdString());
   }
 
   return QString::fromStdString(notebook->writeNotebook());
@@ -160,8 +155,7 @@ QString titleString(const QString &wsName) {
   @param processor : the data processor algorithm
   @return string containing the python code
   */
-QString plotsString(const std::vector<OptionsMap> &processingOptionsPerRow,
-                    const QString &stitched_wsStr,
+QString plotsString(const GroupData &groupData, const QString &stitched_wsStr,
                     const ProcessingAlgorithm &processor) {
 
   // First, we have to parse 'output_ws'
@@ -206,9 +200,10 @@ QString plotsString(const std::vector<OptionsMap> &processingOptionsPerRow,
     QStringList wsNames;
 
     // Add the output name for this property from each reduced row
-    for (auto const &processingOptions : processingOptionsPerRow) {
-      if (processingOptions.count(propertyName) > 0)
-        wsNames.append(processingOptions.at(propertyName));
+    for (auto const &groupItem : groupData) {
+      auto row = groupItem.second;
+      if (row->hasOption(propertyName))
+        wsNames.append(row->optionValue(propertyName));
     }
 
     plotString +=
@@ -261,14 +256,14 @@ QString tableString(const TreeData &treeData, const WhiteList &whitelist) {
     auto groupId = group.first;
     auto rowMap = group.second;
 
-    for (const auto &row : rowMap) {
+    for (auto &row : rowMap) {
       QStringList values;
       values.append(QString::number(groupId));
 
-      if (row.second.size() != ncols)
+      if (row.second->size() != ncols)
         throw std::invalid_argument("Can't generate table for notebook");
 
-      for (const auto &datum : row.second)
+      for (const auto &datum : *row.second)
         values.append(datum);
 
       tableString += values.join(QString(" | "));
@@ -389,36 +384,26 @@ void addProperties(QStringList &algProperties, const Map &optionsMap) {
  @param processor : the processing algorithm
  @param globalPreprocessingOptionsMap : a map containing the pre-processing
  options
- @param globalProcessingOptions : the pre-processing options specified via
- hinting
- line edit
- @param processingOptionsPerRow [inout] : the processing options used for each
- row
  @return tuple containing the python string and the output workspace names.
  First item in the tuple is the python code that performs the reduction, and
  second item are the names of the output workspaces.
 */
 QString
-reduceRowString(const RowData &data, const QString &instrument,
+reduceRowString(const RowData_sptr data, const QString &instrument,
                 const WhiteList &whitelist,
                 const std::map<QString, PreprocessingAlgorithm> &preprocessMap,
                 const ProcessingAlgorithm &processor,
-                const ColumnOptionsMap &globalPreprocessingOptionsMap,
-                const OptionsMap &globalProcessingOptions,
-                std::vector<OptionsMap> &processingOptionsPerRow) {
+                const ColumnOptionsMap &globalPreprocessingOptionsMap) {
 
-  if (static_cast<int>(whitelist.size()) != data.size()) {
+  if (static_cast<int>(whitelist.size()) != data->size()) {
     throw std::invalid_argument("Can't generate notebook");
   }
 
   QString preprocessString;
 
-  // Add algorithm properties for the main processing algorithm. Some of
-  // these may get overwritten by preprocessing below
-  OptionsMap processingOptions =
-      getCanonicalOptions(&data, globalProcessingOptions, whitelist, true,
-                          processor.outputProperties(), processor.prefixes());
-  processingOptionsPerRow.push_back(processingOptions);
+  // Create a copy of the processing options, which we'll update with
+  // the results of preprocessing where applicable
+  auto processingOptions = data->options();
 
   // Loop through all columns, excluding 'Options'  and 'Hidden Options'
   int ncols = static_cast<int>(whitelist.size());
@@ -428,37 +413,38 @@ reduceRowString(const RowData &data, const QString &instrument,
     // The algorithm property name linked to this column
     const QString algProp = whitelist.algorithmProperty(col);
 
-    // If the column doesn't have a value, there's nothing to do
-    if (processingOptions.find(algProp) == processingOptions.end())
+    // Nothing to do if there is no value or no preprocessing
+    if (!data->hasOption(algProp) || preprocessMap.count(colName) == 0)
       continue;
 
-    const auto colValue = processingOptions[algProp];
+    // Get the column value. Note that we take this from the cached options,
+    // rather than the row data, so that it includes any default values from
+    // the global settings.
+    const auto colValue = data->optionValue(algProp);
 
-    if (preprocessMap.count(colName) > 0) {
-      // This column was pre-processed. We need to print pre-processing
-      // instructions
+    // This column was pre-processed. We need to print pre-processing
+    // instructions
 
-      // The pre-processing alg
-      const PreprocessingAlgorithm &preprocessor = preprocessMap.at(colName);
+    // The pre-processing alg
+    const PreprocessingAlgorithm &preprocessor = preprocessMap.at(colName);
 
-      // The options for the pre-processing alg
-      // Only include options in the given preprocessing options map,
-      // but override them if they are set in the row data
-      QString options;
-      if (globalPreprocessingOptionsMap.count(colName) > 0) {
-        OptionsMap preprocessingOptions = getCanonicalOptions(
-            &data, globalPreprocessingOptionsMap.at(colName), whitelist, false);
-        options = convertMapToString(preprocessingOptions);
-      }
-
-      // Python code ran to load and pre-process runs
-      const boost::tuple<QString, QString> load_ws_string =
-          loadWorkspaceString(colValue, instrument, preprocessor, options);
-      preprocessString += boost::get<0>(load_ws_string);
-
-      // Update the options map with the result of preprocessing
-      processingOptions[algProp] = boost::get<1>(load_ws_string);
+    // The options for the pre-processing alg
+    // Only include options in the given preprocessing options map,
+    // but override them if they are set in the row data
+    QString options;
+    if (globalPreprocessingOptionsMap.count(colName) > 0) {
+      OptionsMap preprocessingOptions = getCanonicalOptions(
+          data, globalPreprocessingOptionsMap.at(colName), whitelist, false);
+      options = convertMapToString(preprocessingOptions);
     }
+
+    // Python code ran to load and pre-process runs
+    const boost::tuple<QString, QString> load_ws_string =
+        loadWorkspaceString(colValue, instrument, preprocessor, options);
+    preprocessString += boost::get<0>(load_ws_string);
+
+    // Update the options map with the result of preprocessing
+    processingOptions[algProp] = boost::get<1>(load_ws_string);
   }
 
   // Vector to store the algorithm properties with values

--- a/qt/widgets/common/src/DataProcessorUI/GenerateNotebook.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/GenerateNotebook.cpp
@@ -119,9 +119,8 @@ QString GenerateNotebook::generateNotebook(const TreeData &data) {
 
     /** Draw plots **/
 
-    notebook->codeCell(
-        plotsString(rowMap, boost::get<1>(postProcessString), m_processor)
-            .toStdString());
+    notebook->codeCell(plotsString(rowMap, boost::get<1>(postProcessString),
+                                   m_processor).toStdString());
   }
 
   return QString::fromStdString(notebook->writeNotebook());

--- a/qt/widgets/common/src/DataProcessorUI/GenerateNotebook.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/GenerateNotebook.cpp
@@ -42,7 +42,6 @@ corresponding pre-processing algorithms
 @param postprocessingStep : the post-processing algorithm and options for the
 post-processing algorithms specified via hinting line edits in the view
 @param preprocessingOptionsMap : options passed to the preprocessing algorithm.
-@param processingOptions : options to the reduction algorithm specified via
 the corresponding hinting line edit in the view
 @returns ipython notebook string
 */
@@ -147,8 +146,7 @@ QString titleString(const QString &wsName) {
 
 /**
   Create string of python code to call plots() with the required workspaces
-  @param processingOptionsPerRow : the properties that were used in the
-  reduction for each row
+  @param groupData : the group of rows to plot
   @param stitched_wsStr : string containing the name of the stitched
   (post-processed workspace)
   @param processor : the data processor algorithm
@@ -276,7 +274,6 @@ QString tableString(const TreeData &treeData, const WhiteList &whitelist) {
   Create string of python code to post-process rows in the same group
   @param rowMap : map where keys are row indices and values are vectors
   containing the data
-  @param whitelist : the whitelist
   @param processor : the reduction algorithm
   @param postprocessingStep : the algorithm responsible for post-processing
   groups and the options specified for post-processing via HintingLineEdit.

--- a/qt/widgets/common/src/DataProcessorUI/GenerateNotebook.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/GenerateNotebook.cpp
@@ -112,8 +112,8 @@ QString GenerateNotebook::generateNotebook(const TreeData &data) {
     boost::tuple<QString, QString> postProcessString;
     if (hasPostprocessing() && rowMap.size() > 1) {
       // If there was only one run selected, it could not be post-processed
-      postProcessString = postprocessGroupString(
-          rowMap, m_whitelist, m_processor, *m_postprocessingStep);
+      postProcessString =
+          postprocessGroupString(rowMap, m_processor, *m_postprocessingStep);
     }
     notebook->codeCell(boost::get<0>(postProcessString).toStdString());
 
@@ -284,7 +284,7 @@ QString tableString(const TreeData &treeData, const WhiteList &whitelist) {
   @return tuple containing the python code string and the output workspace name
   */
 boost::tuple<QString, QString>
-postprocessGroupString(const GroupData &rowMap, const WhiteList &whitelist,
+postprocessGroupString(const GroupData &rowMap,
                        const ProcessingAlgorithm &processor,
                        const PostprocessingStep &postprocessingStep) {
 
@@ -301,7 +301,7 @@ postprocessGroupString(const GroupData &rowMap, const WhiteList &whitelist,
   // Go through each row and prepare the input and output properties
   for (const auto &row : rowMap) {
     // The reduced ws name without prefix (for example 'TOF_13460_13462')
-    auto suffix = getReducedWorkspaceName(row.second, whitelist);
+    auto suffix = row.second->reducedName();
     // The reduced ws name: 'IvsQ_TOF_13460_13462'
     inputNames.append(processor.defaultOutputPrefix() + suffix);
     // Add the suffix (i.e. 'TOF_13460_13462') to the output ws name

--- a/qt/widgets/common/src/DataProcessorUI/GenerateNotebook.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/GenerateNotebook.cpp
@@ -303,7 +303,7 @@ postprocessGroupString(const GroupData &rowMap, const WhiteList &whitelist,
     // The reduced ws name without prefix (for example 'TOF_13460_13462')
     auto suffix = getReducedWorkspaceName(row.second, whitelist);
     // The reduced ws name: 'IvsQ_TOF_13460_13462'
-    inputNames.append(processor.prefix(0) + suffix);
+    inputNames.append(processor.defaultOutputPrefix() + suffix);
     // Add the suffix (i.e. 'TOF_13460_13462') to the output ws name
     outputName.append(suffix);
   }

--- a/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -580,8 +580,8 @@ Post-processes the workspaces created by the given rows together.
 void GenericDataProcessorPresenter::postProcessGroup(
     const GroupData &groupData) {
   if (hasPostprocessing())
-    m_postprocessing->postProcessGroup(m_processor.prefix(0), m_whitelist,
-                                       groupData);
+    m_postprocessing->postProcessGroup(m_processor.defaultOutputPrefix(),
+                                       m_whitelist, groupData);
 }
 
 /**
@@ -1304,8 +1304,8 @@ void GenericDataProcessorPresenter::plotRow() {
 
     for (const auto &run : item.second) {
 
-      auto const wsName =
-          getReducedWorkspaceName(run.second, m_processor.prefix(0));
+      auto const wsName = getReducedWorkspaceName(
+          run.second, m_processor.defaultOutputPrefix());
 
       if (workspaceExists(wsName))
         workspaces.insert(wsName, nullptr);

--- a/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -1305,7 +1305,7 @@ void GenericDataProcessorPresenter::pasteSelected() {
 void GenericDataProcessorPresenter::transfer(
     const std::vector<std::map<QString, QString>> &runs) {
 
-  m_manager->transfer(runs, m_whitelist);
+  m_manager->transfer(runs);
   m_view->showTable(m_manager->getModel());
 }
 

--- a/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -274,6 +274,13 @@ void GenericDataProcessorPresenter::acceptViews(
   updateWidgetEnabledState(false);
 }
 
+/** Set a different tree manager to the default (only used by tests to set a
+ * mock)
+ */
+void GenericDataProcessorPresenter::acceptTreeManager(TreeManager *manager) {
+  m_manager.reset(manager);
+}
+
 /**
 Returns the name of the reduced workspace for a given row
 @param data :: [input] The data for this row

--- a/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -277,8 +277,9 @@ void GenericDataProcessorPresenter::acceptViews(
 /** Set a different tree manager to the default (only used by tests to set a
  * mock)
  */
-void GenericDataProcessorPresenter::acceptTreeManager(TreeManager *manager) {
-  m_manager.reset(manager);
+void GenericDataProcessorPresenter::acceptTreeManager(
+    std::unique_ptr<TreeManager> manager) {
+  m_manager = std::move(manager);
 }
 
 /**

--- a/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -281,9 +281,8 @@ Returns the name of the reduced workspace for a given row
 @throws std::runtime_error if the workspace could not be prepared
 @returns : The name of the workspace
 */
-QString
-GenericDataProcessorPresenter::getReducedWorkspaceName(const RowData_sptr data,
-                                                       const QString &prefix) {
+QString GenericDataProcessorPresenter::getReducedWorkspaceName(
+    const RowData_sptr data, const QString &prefix) const {
   return MantidQt::MantidWidgets::DataProcessor::getReducedWorkspaceName(
       data, m_whitelist, prefix);
 }

--- a/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -898,7 +898,7 @@ void GenericDataProcessorPresenter::reduceRow(RowData *data) {
 
   // Get the algorithm input properties as an options map
   OptionsMap options = getCanonicalOptions(
-      data, m_processingOptions, m_whitelist, true,
+      data, getProcessingOptions(data), m_whitelist, true,
       m_processor.outputProperties(), m_processor.prefixes());
   // Perform any preprocessing on the input properties
   preprocessOptionValues(options, data);

--- a/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -579,9 +579,12 @@ Post-processes the workspaces created by the given rows together.
 */
 void GenericDataProcessorPresenter::postProcessGroup(
     const GroupData &groupData) {
-  if (hasPostprocessing())
-    m_postprocessing->postProcessGroup(m_processor.defaultOutputPrefix(),
+  if (hasPostprocessing()) {
+    // The name is based on the default input WS names of the individual rows
+    m_postprocessing->postProcessGroup(m_processor.defaultInputPropertyName(),
+                                       m_processor.defaultOutputPropertyName(),
                                        m_whitelist, groupData);
+  }
 }
 
 /**
@@ -675,8 +678,8 @@ QString GenericDataProcessorPresenter::getPostprocessedWorkspaceName(
   if (!hasPostprocessing())
     throw std::runtime_error("Attempted to get postprocessing workspace but no "
                              "postprocessing is specified.");
-  return m_postprocessing->getPostprocessedWorkspaceName(m_whitelist,
-                                                         groupData);
+  return m_postprocessing->getPostprocessedWorkspaceName(
+      m_processor.defaultInputPropertyName(), groupData);
 }
 
 /** Loads a run found from disk or AnalysisDataService

--- a/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -281,8 +281,9 @@ Returns the name of the reduced workspace for a given row
 @throws std::runtime_error if the workspace could not be prepared
 @returns : The name of the workspace
 */
-QString GenericDataProcessorPresenter::getReducedWorkspaceName(
-    const QStringList &data, const QString &prefix) const {
+QString
+GenericDataProcessorPresenter::getReducedWorkspaceName(const RowData_sptr data,
+                                                       const QString &prefix) {
   return MantidQt::MantidWidgets::DataProcessor::getReducedWorkspaceName(
       data, m_whitelist, prefix);
 }
@@ -348,6 +349,14 @@ void GenericDataProcessorPresenter::process() {
     RowQueue rowQueue;
 
     for (const auto &row : group.second) {
+      // Get the algorithm input properties for this row and
+      // cache it in the row data (this is done just once here as
+      // it's required by both reduceRow and saveNotebook)
+      auto rowData = row.second;
+      OptionsMap options = getCanonicalOptions(
+          rowData, getProcessingOptions(rowData), m_whitelist, true,
+          m_processor.outputProperties(), m_processor.prefixes());
+      rowData->setOptions(std::move(options));
 
       // Add all row items to queue
       rowQueue.push(row);
@@ -549,7 +558,7 @@ void GenericDataProcessorPresenter::saveNotebook(const TreeData &data) {
     auto notebook = Mantid::Kernel::make_unique<GenerateNotebook>(
         m_wsName, m_view->getProcessInstrument(), m_whitelist,
         m_preprocessing.m_map, m_processor, m_postprocessing,
-        preprocessingOptionsMap, m_processingOptions);
+        preprocessingOptionsMap);
     auto generatedNotebook =
         std::string(notebook->generateNotebook(data).toStdString());
 
@@ -654,6 +663,8 @@ Workspace_sptr GenericDataProcessorPresenter::prepareRunWorkspace(
   return AnalysisDataService::Instance().retrieveWS<Workspace>(
       outputName.toStdString());
 }
+
+
 /**
 Returns the name of the reduced workspace for a given group
 @param groupData : The data in a given group
@@ -787,7 +798,7 @@ GenericDataProcessorPresenter::createProcessingAlgorithm() const {
  * @param data [in] :: the data in the row
  */
 void GenericDataProcessorPresenter::preprocessColumnValue(
-    const QString &columnName, QString &columnValue, RowData *data) {
+    const QString &columnName, QString &columnValue, RowData_sptr data) {
   // Check if preprocessing is required for this column
   if (!m_preprocessing.hasPreprocessing(columnName))
     return;
@@ -813,7 +824,7 @@ void GenericDataProcessorPresenter::preprocessColumnValue(
  * @param data : the data in the row
 */
 void GenericDataProcessorPresenter::preprocessOptionValues(OptionsMap &options,
-                                                           RowData *data) {
+                                                           RowData_sptr data) {
   // Loop through all columns (excluding the Options and Hidden options
   // columns)
   for (auto columnIt = m_whitelist.cbegin(); columnIt != m_whitelist.cend() - 2;
@@ -833,23 +844,24 @@ void GenericDataProcessorPresenter::preprocessOptionValues(OptionsMap &options,
  * so that the view can be updated show the user what values were used.
  */
 void GenericDataProcessorPresenter::updateModelFromAlgorithm(
-    IAlgorithm_sptr alg, RowData *data) {
+    IAlgorithm_sptr alg, RowData_sptr data) {
 
   auto newData = data;
 
   if (alg->isExecuted()) {
-    auto runNumbersIt2 = data->constBegin();
-    auto newDataIt = newData->begin();
-    auto columnIt2 = m_whitelist.cbegin();
+    /* The reduction is complete. Try to populate any empty fields in the row
+     * with the results of the algorithm. */
 
-    /* The reduction is complete, try to populate the columns */
-    for (; columnIt2 != m_whitelist.cend() - 2;
-         ++columnIt2, ++runNumbersIt2, ++newDataIt) {
+    // Loop through all columns except the options and hidden options columns
+    int i = 0;
+    for (auto columnIt = m_whitelist.cbegin();
+         columnIt != m_whitelist.cend() - 2; ++i, ++columnIt) {
 
-      auto column = *columnIt2;
-      auto runNumbers = *runNumbersIt2;
+      auto column = *columnIt;
 
-      if (runNumbers.isEmpty() && !m_preprocessing.m_map.count(column.name())) {
+      // Only update empty values in the row
+      if (data->value(i).isEmpty() &&
+          !m_preprocessing.hasPreprocessing(column.name())) {
 
         QString propValue = QString::fromStdString(
             alg->getPropertyValue(column.algorithmProperty().toStdString()));
@@ -864,7 +876,7 @@ void GenericDataProcessorPresenter::updateModelFromAlgorithm(
               exp;
         }
 
-        (*newDataIt) = propValue;
+        data->setValue(i, propValue);
       }
     }
   }
@@ -894,14 +906,14 @@ IAlgorithm_sptr GenericDataProcessorPresenter::createAndRunAlgorithm(
  * correspond to column contents
  * @throws std::runtime_error if reduction fails
  */
-void GenericDataProcessorPresenter::reduceRow(RowData *data) {
+void GenericDataProcessorPresenter::reduceRow(RowData_sptr data) {
 
-  // Get the algorithm input properties as an options map
-  OptionsMap options = getCanonicalOptions(
-      data, getProcessingOptions(data), m_whitelist, true,
-      m_processor.outputProperties(), m_processor.prefixes());
-  // Perform any preprocessing on the input properties
+  // Get a copy of the (unpreprocessed) input properties in the row data
+  OptionsMap options = data->options();
+  // Perform any preprocessing on the input properties and cache the results
+  // in the row data
   preprocessOptionValues(options, data);
+  data->setPreprocessedOptions(options);
   // Run the algorithm
   const auto alg = createAndRunAlgorithm(options);
   // Populate any missing values in the model with output from the algorithm

--- a/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -284,7 +284,6 @@ void GenericDataProcessorPresenter::acceptTreeManager(TreeManager *manager) {
 /**
 Returns the name of the reduced workspace for a given row
 @param data :: [input] The data for this row
-@param prefix : A prefix to be appended to the generated ws name
 @throws std::runtime_error if the workspace could not be prepared
 @returns : The name of the workspace
 */
@@ -840,8 +839,6 @@ void GenericDataProcessorPresenter::preprocessColumnValue(
 }
 
 /** Perform preprocessing on algorithm property values where applicable
- * @param options : the algorithm properties as a map of property name
- * to value
  * @param data : the data in the row
 */
 void GenericDataProcessorPresenter::preprocessOptionValues(RowData_sptr data) {

--- a/qt/widgets/common/src/DataProcessorUI/OneLevelTreeManager.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/OneLevelTreeManager.cpp
@@ -259,30 +259,6 @@ void OneLevelTreeManager::insertRow(int rowIndex) {
   m_model->insertRow(rowIndex);
 }
 
-/**
-Inserts a new row with given values to the specified group in the specified
-location
-@param rowIndex :: The index to insert the new row after
-@param rowValues :: the values to set in the row cells
-@param whitelist :: the list of columns
-*/
-void OneLevelTreeManager::insertRow(int rowIndex,
-                                    const std::map<QString, QString> &rowValues,
-                                    const WhiteList &whitelist) {
-
-  m_model->insertRow(rowIndex);
-
-  // Loop through all columns and update the value in the row
-  int colIndex = 0;
-  for (auto const &columnName : whitelist.names()) {
-    if (rowValues.count(columnName)) {
-      const auto value = rowValues.at(columnName);
-      m_model->setData(m_model->index(rowIndex, colIndex), value);
-    }
-    ++colIndex;
-  }
-}
-
 TreeData OneLevelTreeManager::handleEmptyTable(bool prompt) {
   if (prompt)
     m_presenter->giveUserWarning("Cannot process an empty Table", "Warning");
@@ -366,30 +342,10 @@ TreeData OneLevelTreeManager::selectedData(bool prompt) {
 
 /** Transfer data to the model
 * @param runs :: [input] Data to transfer as a vector of maps
-* @param whitelist :: [input] Whitelist containing number of columns
 */
 void OneLevelTreeManager::transfer(
-    const std::vector<std::map<QString, QString>> &runs,
-    const WhiteList &whitelist) {
-
-  if (static_cast<int>(whitelist.size()) != m_model->columnCount()) {
-    throw std::invalid_argument(
-        "Invalid table workspace. Table workspace must "
-        "have the same number of columns as the white list");
-  }
-
-  // If the table only has one row, check if it is empty and if so, remove it.
-  // This is to make things nicer when transferring, as the default table has
-  // one empty row
-  if (rowCount() == 1 && rowCount(0) == 1 && rowIsEmpty(0, 0))
-    m_model->removeRows(0, 1);
-
-  // Loop over the rows (vector elements)
-  for (const auto &row : runs) {
-    // Add a new row to the model at the end of the current list
-    const int rowIndex = rowCount();
-    insertRow(rowIndex, row, whitelist);
-  }
+    const std::vector<std::map<QString, QString>> &runs) {
+  m_model->transfer(runs);
 }
 
 /** Updates a row with new data
@@ -421,22 +377,6 @@ int OneLevelTreeManager::rowCount() const { return m_model->rowCount(); }
 int OneLevelTreeManager::rowCount(int parent) const {
   UNUSED_ARG(parent);
   return m_model->rowCount();
-}
-
-/** Checks whether the existing row is empty
- * @return : true if all of the values in the row are empty
- */
-bool OneLevelTreeManager::rowIsEmpty(int row, int parent) const {
-  // Loop through all columns and return false if any are not empty
-  for (int columnIndex = 0; columnIndex < m_model->columnCount();
-       ++columnIndex) {
-    auto value = getCell(row, columnIndex, parent, 0);
-    if (!value.empty())
-      return false;
-  }
-
-  // All cells in the row were empty
-  return true;
 }
 
 /** Gets the 'process' status of a row

--- a/qt/widgets/common/src/DataProcessorUI/OneLevelTreeManager.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/OneLevelTreeManager.cpp
@@ -433,7 +433,6 @@ bool OneLevelTreeManager::rowIsEmpty(int row, int parent) const {
     auto value = getCell(row, columnIndex, parent, 0);
     if (!value.empty())
       return false;
-    ++columnIndex;
   }
 
   // All cells in the row were empty

--- a/qt/widgets/common/src/DataProcessorUI/OneLevelTreeManager.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/OneLevelTreeManager.cpp
@@ -306,31 +306,40 @@ std::set<int> OneLevelTreeManager::getRowsToProcess(bool shouldPrompt) const {
     return rows;
   }
 }
+
+/**
+* Returns given row data in a format that the presenter can understand and use
+* @return :: All data as a map where keys are units of post-processing (i.e.
+* group indices) and values are a map of row index in the group to row data
+*/
+TreeData OneLevelTreeManager::constructTreeData(std::set<int> rows) {
+
+  // Return data in the format: map<int, set<vector<string>>>, where:
+  // int -> row index
+  // set<vector<string>> -> set of vectors storing the data. Each set is a row
+  // and each element in the vector is a column
+  TreeData tree;
+  for (const auto &row : rows) {
+
+    QStringList data;
+    for (int i = 0; i < m_model->columnCount(); i++)
+      data.append(m_model->data(m_model->index(row, i)).toString());
+    tree[row][row] = std::make_shared<RowData>(std::move(data));
+  }
+  return tree;
+}
+
 /**
 * Returns selected data in a format that the presenter can understand and use
 * @param prompt :: True if warning messages should be displayed. False othewise
-* @return :: Selected data as a map where keys are units of post-processing and
-* values are
+* @return :: All data as a map where keys are units of post-processing (i.e.
+* group indices) and values are a map of row index in the group to row data
 */
 TreeData OneLevelTreeManager::selectedData(bool prompt) {
   if (isEmptyTable()) {
     return handleEmptyTable(prompt);
   } else {
-    auto rows = getRowsToProcess(prompt);
-
-    // Return selected data in the format: map<int, set<vector<string>>>, where:
-    // int -> row index
-    // set<vector<string>> -> set of vectors storing the data. Each set is a row
-    // and each element in the vector is a column
-    TreeData selectedData;
-    for (const auto &row : rows) {
-
-      QStringList data;
-      for (int i = 0; i < m_model->columnCount(); i++)
-        data.append(m_model->data(m_model->index(row, i)).toString());
-      selectedData[row][row] = data;
-    }
-    return selectedData;
+    return constructTreeData(getRowsToProcess(prompt));
   }
 }
 

--- a/qt/widgets/common/src/DataProcessorUI/OneLevelTreeManager.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/OneLevelTreeManager.cpp
@@ -314,17 +314,14 @@ std::set<int> OneLevelTreeManager::getRowsToProcess(bool shouldPrompt) const {
 */
 TreeData OneLevelTreeManager::constructTreeData(std::set<int> rows) {
 
-  // Return data in the format: map<int, set<vector<string>>>, where:
+  // Return data in the format: map<int, set<RowData_sptr>>, where:
   // int -> row index
-  // set<vector<string>> -> set of vectors storing the data. Each set is a row
-  // and each element in the vector is a column
+  // set<RowData_sptr> -> set of vectors storing the data. Each set is a row
+  // and each element is the row data containing column values and metadata
   TreeData tree;
+  const int columnNotUsed = 0; // dummy value required to create index
   for (const auto &row : rows) {
-
-    QStringList data;
-    for (int i = 0; i < m_model->columnCount(); i++)
-      data.append(m_model->data(m_model->index(row, i)).toString());
-    tree[row][row] = std::make_shared<RowData>(std::move(data));
+    tree[row][row] = m_model->rowData(m_model->index(row, columnNotUsed));
   }
   return tree;
 }

--- a/qt/widgets/common/src/DataProcessorUI/PostprocessingStep.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/PostprocessingStep.cpp
@@ -34,25 +34,20 @@ void PostprocessingStep::ensureRowSizeMatchesColumnCount(
 }
 
 QString PostprocessingStep::getPostprocessedWorkspaceName(
-    const QString &rowWSPropertyName, const QString &rowWSPrefix,
     const GroupData &groupData, boost::optional<size_t> sliceIndex) {
   /* This method calculates, for a given set of rows, the name of the output
-  * (post-processed) workspace for a given slice */
+   * (post-processed) workspace for a given slice */
 
   QStringList outputNames;
 
   for (const auto &row : groupData) {
     auto rowData = row.second;
-    // If a slice index was provided, check if the slice exists (nothing to do
-    // otherwise)
+    // If given a slice, check if it exists (nothing to do for slices otherwise)
     if (sliceIndex && rowData->hasSlice(*sliceIndex)) {
-      const auto sliceName =
-          rowData->optionValue(rowWSPropertyName, *sliceIndex);
-      outputNames.append(rowWSPrefix + sliceName);
+      outputNames.append(rowData->getSlice(*sliceIndex)->reducedName());
     } else if (!sliceIndex) {
       // A slice index was not provided, so just use the row's workspace name
-      auto wsName = rowData->optionValue(rowWSPropertyName);
-      outputNames.append(rowWSPrefix + wsName);
+      outputNames.append(rowData->reducedName());
     }
   }
   return m_algorithm.prefix() + outputNames.join("_");

--- a/qt/widgets/common/src/DataProcessorUI/PostprocessingStep.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/PostprocessingStep.cpp
@@ -103,7 +103,7 @@ void PostprocessingStep::postProcessGroup(const QString &processorPrefix,
   for (auto const &prop : m_map) {
     auto const &propName = prop.second;
     auto const &propValueStr =
-        groupData.begin()->second[whitelist.indexFromName(prop.first)];
+        (*groupData.begin()->second)[whitelist.indexFromName(prop.first)];
     if (!propValueStr.isEmpty()) {
       // Warning: we take minus the value of the properties because in
       // Reflectometry this property refers to the rebin step, and they want a

--- a/qt/widgets/common/src/DataProcessorUI/ProcessingAlgorithm.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/ProcessingAlgorithm.cpp
@@ -84,6 +84,12 @@ QString ProcessingAlgorithm::outputPropertyName(size_t index) const {
   return m_outputProperties[index];
 }
 
+/** Returns the list of input property names
+ */
+std::vector<QString> ProcessingAlgorithm::inputProperties() const {
+  return m_inputProperties;
+}
+
 /** Returns the list of output property names
  */
 std::vector<QString> ProcessingAlgorithm::outputProperties() const {

--- a/qt/widgets/common/src/DataProcessorUI/ProcessingAlgorithm.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/ProcessingAlgorithm.cpp
@@ -84,6 +84,18 @@ QString ProcessingAlgorithm::outputPropertyName(size_t index) const {
   return m_outputProperties[index];
 }
 
+/** Returns the prefix that will be added to the default output ws property
+ */
+QString ProcessingAlgorithm::defaultOutputPrefix() const { return m_prefix[0]; }
+
+/** Returns the default output ws property. This is just the first
+ * property declared by the algorithm. Algorithm properties are
+ * extracted in order, so this is the first in our list.
+ */
+QString ProcessingAlgorithm::defaultOutputPropertyName() const {
+  return m_outputProperties[0];
+}
+
 /** Returns the list of input property names
  */
 std::vector<QString> ProcessingAlgorithm::inputProperties() const {

--- a/qt/widgets/common/src/DataProcessorUI/ProcessingAlgorithm.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/ProcessingAlgorithm.cpp
@@ -96,6 +96,14 @@ QString ProcessingAlgorithm::defaultOutputPropertyName() const {
   return m_outputProperties[0];
 }
 
+/** Returns the default input ws property. This is just the first
+ * property declared by the algorithm. Algorithm properties are
+ * extracted in order, so this is the first in our list.
+ */
+QString ProcessingAlgorithm::defaultInputPropertyName() const {
+  return m_inputProperties[0];
+}
+
 /** Returns the list of input property names
  */
 std::vector<QString> ProcessingAlgorithm::inputProperties() const {

--- a/qt/widgets/common/src/DataProcessorUI/QOneLevelTreeModel.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/QOneLevelTreeModel.cpp
@@ -164,7 +164,8 @@ bool QOneLevelTreeModel::insertRows(int position, int count,
   // Update the table workspace and row process status vector
   for (int pos = position; pos < position + count; pos++) {
     m_tWS->insertRow(position);
-    m_rows.insert(m_rows.begin() + position, std::make_shared<RowData>(columnCount()));
+    m_rows.insert(m_rows.begin() + position,
+                  std::make_shared<RowData>(columnCount()));
   }
 
   endInsertRows();

--- a/qt/widgets/common/src/DataProcessorUI/QOneLevelTreeModel.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/QOneLevelTreeModel.cpp
@@ -79,7 +79,6 @@ QVariant QOneLevelTreeModel::headerData(int section,
 /** Returns row data struct (which includes metadata about the row)
  * for specified index
 * @param index : The index
-* @param role : The role
 * @return : The data associated with the given index as a RowData class
 */
 RowData_sptr QOneLevelTreeModel::rowData(const QModelIndex &index) {

--- a/qt/widgets/common/src/DataProcessorUI/QOneLevelTreeModel.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/QOneLevelTreeModel.cpp
@@ -1,6 +1,7 @@
 #include "MantidQtWidgets/Common/DataProcessorUI/QOneLevelTreeModel.h"
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/TableRow.h"
+#include "MantidQtWidgets/Common/DataProcessorUI/TreeData.h"
 
 namespace MantidQt {
 namespace MantidWidgets {
@@ -21,7 +22,17 @@ QOneLevelTreeModel::QOneLevelTreeModel(ITableWorkspace_sptr tableWorkspace,
         "Invalid table workspace. Table workspace must "
         "have the same number of columns as the white list");
 
-  m_rows = std::vector<bool>(tableWorkspace->rowCount(), false);
+  // Create vector for caching row data
+  for (size_t i = 0; i < tableWorkspace->rowCount(); ++i)
+    m_rows.emplace_back(std::make_shared<RowData>(columnCount()));
+
+  // Update cached row data from the table
+  updateAllRowData();
+
+  // This ensures the cached row data is updated when the table changes
+  connect(this, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &)),
+          this,
+          SLOT(tableDataUpdated(const QModelIndex &, const QModelIndex &)));
 }
 
 QOneLevelTreeModel::~QOneLevelTreeModel() {}
@@ -29,7 +40,7 @@ QOneLevelTreeModel::~QOneLevelTreeModel() {}
 /** Returns data for specified index
 * @param index : The index
 * @param role : The role
-* @return : The data associated with the given index
+* @return : The data associated with the given index as a list of strings
 */
 QVariant QOneLevelTreeModel::data(const QModelIndex &index, int role) const {
   if (!index.isValid())
@@ -42,7 +53,7 @@ QVariant QOneLevelTreeModel::data(const QModelIndex &index, int role) const {
     return QString::fromStdString(m_tWS->String(index.row(), index.column()));
   } else if (role == Qt::BackgroundRole) {
     // Highlight if the process status for this row is set
-    if (m_rows.at(index.row()))
+    if (m_rows.at(index.row())->isProcessed())
       return QColor("#00b300");
   }
 
@@ -63,6 +74,25 @@ QVariant QOneLevelTreeModel::headerData(int section,
     return m_whitelist.name(section);
 
   return QVariant();
+}
+
+/** Returns row data struct (which includes metadata about the row)
+ * for specified index
+* @param index : The index
+* @param role : The role
+* @return : The data associated with the given index as a RowData class
+*/
+RowData_sptr QOneLevelTreeModel::rowData(const QModelIndex &index) {
+  RowData_sptr result;
+
+  // Return a null ptr if the index is invalid
+  if (!index.isValid())
+    return result;
+
+  if (parent(index).isValid())
+    return result;
+
+  return m_rows.at(index.row());
 }
 
 /** Returns the index of an element specified by its row, column and parent
@@ -97,7 +127,7 @@ bool QOneLevelTreeModel::isProcessed(int position,
                                 "within the range of the number of rows in "
                                 "this model");
 
-  return m_rows[position];
+  return m_rows[position]->isProcessed();
 }
 
 /** Returns the parent of a given index
@@ -134,7 +164,7 @@ bool QOneLevelTreeModel::insertRows(int position, int count,
   // Update the table workspace and row process status vector
   for (int pos = position; pos < position + count; pos++) {
     m_tWS->insertRow(position);
-    m_rows.insert(m_rows.begin() + position, false);
+    m_rows.insert(m_rows.begin() + position, std::make_shared<RowData>(columnCount()));
   }
 
   endInsertRows();
@@ -230,7 +260,7 @@ bool QOneLevelTreeModel::setProcessed(bool processed, int position,
   if (position < 0 || position >= rowCount())
     return false;
 
-  m_rows[position] = processed;
+  m_rows[position]->setProcessed(processed);
 
   return true;
 }
@@ -244,6 +274,27 @@ ITableWorkspace_sptr QOneLevelTreeModel::getTableWorkspace() const {
   return m_tWS;
 }
 
+/** Update all cached row data from the table data
+ */
+void QOneLevelTreeModel::updateAllRowData() {
+  // Loop through all rows
+  for (int row = 0; row < rowCount(); ++row) {
+    auto rowData = m_rows[row];
+    // Loop through all columns and update the value in the row data
+    for (int col = 0; col < columnCount(); ++col) {
+      auto value = data(index(row, col)).toString();
+      rowData->setValue(col, value);
+    }
+  }
+}
+
+/** Called when the data in the table has changed. Updates the
+ * table values in the cached RowData
+ */
+void QOneLevelTreeModel::tableDataUpdated(const QModelIndex &,
+                                          const QModelIndex &) {
+  updateAllRowData();
+}
 } // namespace DataProcessor
 } // namespace MantidWidgets
 } // namespace Mantid

--- a/qt/widgets/common/src/DataProcessorUI/QTwoLevelTreeModel.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/QTwoLevelTreeModel.cpp
@@ -15,8 +15,8 @@ public:
   // Constructor taking a column count creates an empty data value list of that
   // size
   RowInfo(const size_t absoluteIndex, const int columnCount)
-      : m_absoluteIndex(absoluteIndex), m_rowData(std::make_shared<RowData>(columnCount)) {
-  }
+      : m_absoluteIndex(absoluteIndex),
+        m_rowData(std::make_shared<RowData>(columnCount)) {}
   // Constructor taking a list of data values
   RowInfo(const size_t absoluteIndex, QStringList rowDataValues)
       : m_absoluteIndex(absoluteIndex),
@@ -81,8 +81,10 @@ public:
   // Add a new row to the group at the given local row index
   // Note that new rows have an absolute index of 0 which must then
   // be set correctly by the caller.
-  void insert(const size_t position, const int numToInsert, const int columnCount) {
-    m_rows.insert(m_rows.begin() + position, numToInsert, RowInfo(0, columnCount));
+  void insert(const size_t position, const int numToInsert,
+              const int columnCount) {
+    m_rows.insert(m_rows.begin() + position, numToInsert,
+                  RowInfo(0, columnCount));
   }
   // Remove rows from the group
   void erase(const size_t position, const int numToErase) {

--- a/qt/widgets/common/src/DataProcessorUI/QTwoLevelTreeModel.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/QTwoLevelTreeModel.cpp
@@ -686,6 +686,23 @@ void QTwoLevelTreeModel::tableDataUpdated(const QModelIndex &,
                                           const QModelIndex &) {
   updateAllGroupData();
 }
+
+int QTwoLevelTreeModel::findOrAddGroup(const std::string &groupName) {
+  // Return the index of the group if it exists
+  auto groupIter = std::find_if(m_groups.begin(), m_groups.end(),
+                                [&groupName](const GroupInfo &group) -> bool {
+                                  return group.name() == groupName;
+                                });
+
+  if (groupIter == m_groups.end()) {
+    // Not found. Add a new group and return its index
+    m_groups.emplace_back(GroupInfo(groupName));
+    return static_cast<int>(m_groups.size()) - 1;
+  } else {
+    // Return the existing group's index
+    return static_cast<int>(groupIter - m_groups.begin());
+  }
+}
 } // namespace DataProcessor
 } // namespace MantidWidgets
 } // namespace Mantid

--- a/qt/widgets/common/src/DataProcessorUI/QTwoLevelTreeModel.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/QTwoLevelTreeModel.cpp
@@ -204,7 +204,6 @@ QVariant QTwoLevelTreeModel::headerData(int section,
 /** Returns row data struct (which includes metadata about the row)
  * for specified index
 * @param index : The index
-* @param role : The role
 * @return : The data associated with the given index as a RowData class
 */
 RowData_sptr QTwoLevelTreeModel::rowData(const QModelIndex &index) {

--- a/qt/widgets/common/src/DataProcessorUI/TreeData.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/TreeData.cpp
@@ -198,7 +198,7 @@ RowData_sptr RowData::getSlice(const size_t sliceIndex) {
  * @return : the row data for the new slice
  */
 RowData_sptr RowData::addSlice(const QString &sliceSuffix,
-                               std::vector<QString> &workspaceProperties) {
+                               const std::vector<QString> &workspaceProperties) {
   // Create a copy
   auto sliceData = std::make_shared<RowData>(this);
   for (auto const &propertyName : workspaceProperties) {

--- a/qt/widgets/common/src/DataProcessorUI/TreeData.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/TreeData.cpp
@@ -4,8 +4,7 @@ namespace MantidWidgets {
 namespace DataProcessor {
 
 // Constructors
-RowData::RowData(const int columnCount)
-  : m_isProcessed{false} {
+RowData::RowData(const int columnCount) : m_isProcessed{false} {
   // Create a list of empty column values of the required length
   for (int i = 0; i < columnCount; ++i)
     m_data.append("");

--- a/qt/widgets/common/src/DataProcessorUI/TreeData.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/TreeData.cpp
@@ -1,0 +1,158 @@
+#include "MantidQtWidgets/Common/DataProcessorUI/TreeData.h"
+namespace MantidQt {
+namespace MantidWidgets {
+namespace DataProcessor {
+
+// Constructors
+RowData::RowData() {}
+
+RowData::RowData(QStringList data) : m_data(std::move(data)) {}
+
+RowData::RowData(const RowData *src)
+    : m_data(src->m_data), m_options(src->m_options),
+      m_preprocessedOptions(src->m_preprocessedOptions) {}
+
+// Iterators
+
+QList<QString>::iterator RowData::begin() { return m_data.begin(); }
+
+QList<QString>::iterator RowData::end() { return m_data.end(); }
+
+QList<QString>::const_iterator RowData::constBegin() const {
+  return m_data.constBegin();
+}
+
+QList<QString>::const_iterator RowData::constEnd() const {
+  return m_data.constEnd();
+}
+
+QString RowData::back() const { return m_data.back(); }
+
+QString RowData::operator[](int i) const { return m_data[i]; }
+
+/** Return all of the data values in the row
+ * @return : the values as a string list
+ */
+QStringList RowData::data() const { return m_data; }
+
+/** Return a data value
+ * @param i [in] : the column index of the value
+ * @return : the value in that column
+ */
+QString RowData::value(const int i) {
+  return m_data.size() > i ? m_data.at(i) : "";
+}
+
+/** Set a data value
+ * @param i [in] : the index of the value to set
+ * @param value [in] : the new value
+ */
+void RowData::setValue(const int i, const QString &value) {
+  if (m_data.size() > i)
+    m_data[i] = value;
+}
+
+/** Get the original input options for the main reduction
+ * algorithm before preprocessing i.e. as entered by the
+ * user
+ * @return : the options as a map of property name to value
+ */
+OptionsMap RowData::options() const { return m_options; }
+
+/** Get the input options for the main reduction algorithm
+ * after preprocessing has been performed on them
+ * @return : the options as a map of property name to value
+ */
+OptionsMap RowData::preprocessedOptions() const {
+  return m_preprocessedOptions;
+}
+
+/** Set the options
+ * @param options [in] : the options to set as a map of property
+ * name to value
+ */
+void RowData::setOptions(OptionsMap options) { m_options = std::move(options); }
+
+/** Set the preprocessed options
+ * @param options [in] : the options to set as a map of property
+ * name to value
+ */
+void RowData::setPreprocessedOptions(OptionsMap options) {
+  m_preprocessedOptions = std::move(options);
+}
+
+/** Get the number of fields in the row data
+ * @return : the number of fields
+ */
+int RowData::size() const { return m_data.size(); }
+
+/** Check whether the given property exists in the options
+ * @return : true if the property exists
+ */
+bool RowData::hasOption(const QString &name) const {
+  return m_options.find(name) != m_options.end();
+}
+
+/** Check whether the given property exists in the options
+ * @return : true if the property exists
+ */
+bool RowData::hasPreprocessedOption(const QString &name) const {
+  return m_preprocessedOptions.find(name) != m_preprocessedOptions.end();
+}
+
+/** Get the value for the given property
+ * @param name [in] : the property name to get
+ * @return : the value, or an empty string if the property
+ * doesn't exist
+ */
+QString RowData::optionValue(const QString &name) const {
+  return hasOption(name) ? m_options.at(name) : "";
+}
+
+/** Set the value for the given property
+ * @param name [in] : the property to set
+ * @param value [in] : the value
+ */
+void RowData::setOptionValue(const QString &name, const QString &value) {
+  m_options[name] = value;
+}
+
+/** Get a child slice
+ * @param sliceIndex [in] : the index of the slice
+ * @return : the slice's row data
+ */
+RowData_sptr RowData::getSlice(const size_t sliceIndex) {
+  if (sliceIndex >= m_slices.size())
+    throw std::runtime_error("Attempted to access an invalid slice");
+
+  return m_slices[sliceIndex];
+}
+
+/** Add a child slice for this row with the given name.
+ * The child slice takes the same options and data values
+ * as its parent row except for the input workspace name.
+ * @param sliceSuffix [in] : the suffix to use for the slice workspace name
+ * @param workspaceProperties [in] : a list of algorithm properties that are
+ * workspace names. The property values for these will be updated to include
+ * the slice suffix in the options for the new slice.
+ * @return : the row data for the new slice
+ */
+RowData_sptr RowData::addSlice(const QString &sliceSuffix,
+                               std::vector<QString> &workspaceProperties) {
+  // Create a copy
+  auto sliceData = std::make_shared<RowData>(this);
+  // Override the workspace name in options
+  for (auto const &propertyName : workspaceProperties) {
+    if (hasPreprocessedOption(propertyName)) {
+      auto const sliceName = m_preprocessedOptions[propertyName] + sliceSuffix;
+      sliceData->m_preprocessedOptions[propertyName] = sliceName;
+    }
+  }
+  // Add to list of slices
+  m_slices.push_back(sliceData);
+
+  return sliceData;
+}
+}
+}
+}

--- a/qt/widgets/common/src/DataProcessorUI/TreeData.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/TreeData.cpp
@@ -197,8 +197,9 @@ RowData_sptr RowData::getSlice(const size_t sliceIndex) {
  * the slice suffix in the options for the new slice.
  * @return : the row data for the new slice
  */
-RowData_sptr RowData::addSlice(const QString &sliceSuffix,
-                               const std::vector<QString> &workspaceProperties) {
+RowData_sptr
+RowData::addSlice(const QString &sliceSuffix,
+                  const std::vector<QString> &workspaceProperties) {
   // Create a copy
   auto sliceData = std::make_shared<RowData>(this);
   for (auto const &propertyName : workspaceProperties) {

--- a/qt/widgets/common/src/DataProcessorUI/TreeData.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/TreeData.cpp
@@ -13,6 +13,11 @@ RowData::RowData(const int columnCount) : m_isProcessed{false} {
 RowData::RowData(QStringList data)
     : m_data(std::move(data)), m_isProcessed{false} {}
 
+RowData::RowData(const std::vector<std::string> &data) : m_isProcessed{false} {
+  for (auto &value : data)
+    m_data << QString::fromStdString(value);
+}
+
 RowData::RowData(const RowData *src)
     : m_data(src->m_data), m_options(src->m_options),
       m_preprocessedOptions(src->m_preprocessedOptions), m_isProcessed{false} {}
@@ -155,6 +160,15 @@ void RowData::setOptionValue(const QString &name, const QString &value) {
   m_options[name] = value;
 }
 
+/** Set the value for the given property
+ * @param name [in] : the property to set
+ * @param value [in] : the value
+ */
+void RowData::setOptionValue(const std::string &name,
+                             const std::string &value) {
+  setOptionValue(QString::fromStdString(name), QString::fromStdString(value));
+}
+
 /** Set the preprocessed value for the given property
  * @param name [in] : the property to set
  * @param value [in] : the value
@@ -162,6 +176,16 @@ void RowData::setOptionValue(const QString &name, const QString &value) {
 void RowData::setPreprocessedOptionValue(const QString &name,
                                          const QString &value) {
   m_preprocessedOptions[name] = value;
+}
+
+/** Set the preprocessed value for the given property
+ * @param name [in] : the property to set
+ * @param value [in] : the value
+ */
+void RowData::setPreprocessedOptionValue(const std::string &name,
+                                         const std::string &value) {
+  setPreprocessedOptionValue(QString::fromStdString(name),
+                             QString::fromStdString(value));
 }
 
 /** Get the number of slices for this row

--- a/qt/widgets/common/src/DataProcessorUI/TreeData.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/TreeData.cpp
@@ -15,12 +15,12 @@ RowData::RowData(QStringList data)
 
 RowData::RowData(const std::vector<std::string> &data) : m_isProcessed{false} {
   for (auto &value : data)
-    m_data << QString::fromStdString(value);
+    m_data.append(QString::fromStdString(value));
 }
 
-RowData::RowData(const RowData *src)
-    : m_data(src->m_data), m_options(src->m_options),
-      m_preprocessedOptions(src->m_preprocessedOptions), m_isProcessed{false} {}
+RowData::RowData(const RowData &src)
+    : m_data(src.m_data), m_options(src.m_options),
+      m_preprocessedOptions(src.m_preprocessedOptions), m_isProcessed{false} {}
 
 // Iterators
 
@@ -225,7 +225,7 @@ RowData_sptr
 RowData::addSlice(const QString &sliceSuffix,
                   const std::vector<QString> &workspaceProperties) {
   // Create a copy
-  auto sliceData = std::make_shared<RowData>(this);
+  auto sliceData = std::make_shared<RowData>(*this);
   for (auto const &propertyName : workspaceProperties) {
     // Add the slice suffix to the reduced workspace name
     sliceData->setReducedName(reducedName() + sliceSuffix);

--- a/qt/widgets/common/src/DataProcessorUI/TreeData.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/TreeData.cpp
@@ -156,6 +156,15 @@ void RowData::setOptionValue(const QString &name, const QString &value) {
   m_options[name] = value;
 }
 
+/** Set the preprocessed value for the given property
+ * @param name [in] : the property to set
+ * @param value [in] : the value
+ */
+void RowData::setPreprocessedOptionValue(const QString &name,
+                                         const QString &value) {
+  m_preprocessedOptions[name] = value;
+}
+
 /** Get the number of slices for this row
  * @return : the number of slices
  */
@@ -194,6 +203,8 @@ RowData_sptr RowData::addSlice(const QString &sliceSuffix,
   // Create a copy
   auto sliceData = std::make_shared<RowData>(this);
   for (auto const &propertyName : workspaceProperties) {
+    // Add the slice suffix to the reduced workspace name
+    sliceData->setReducedName(reducedName() + sliceSuffix);
     // Override the workspace names in the preprocessed options with the slice
     // suffix
     if (hasPreprocessedOption(propertyName)) {
@@ -215,6 +226,17 @@ RowData_sptr RowData::addSlice(const QString &sliceSuffix,
 /** Clear all child slices for this row
  */
 void RowData::clearSlices() { m_slices.clear(); }
+
+/** Return the canonical reduced workspace name i.e. before any
+ * prefixes have been applied for specific output properties.
+ * @param prefix [in] : if not empty, apply this prefix to the name
+ */
+QString RowData::reducedName(const QString prefix) {
+  if (prefix.isEmpty())
+    return m_reducedName;
+  else
+    return prefix + m_reducedName;
+}
 }
 }
 }

--- a/qt/widgets/common/src/DataProcessorUI/TwoLevelTreeManager.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/TwoLevelTreeManager.cpp
@@ -424,21 +424,16 @@ int TwoLevelTreeManager::numRowsInGroup(int group) const {
 */
 TreeData TwoLevelTreeManager::constructTreeData(ChildItems rows) {
   TreeData tree;
+  const int columnNotUsed = 0; // dummy value required to create index
   // Return row data in the format: map<int, set<vector<string>>>, where:
   // int -> group index
   // set<vector<string>> -> set of vectors storing the data. Each set is a row
   // and each element in the vector is a column
   for (const auto &item : rows) {
-
     int group = item.first;
-
     for (const auto &row : item.second) {
-      QStringList data;
-      for (int i = 0; i < m_model->columnCount(); i++)
-        data.append(
-            m_model->data(m_model->index(row, i, m_model->index(group, 0)))
-                .toString());
-      tree[group][row] = std::make_shared<RowData>(std::move(data));
+      tree[group][row] = m_model->rowData(
+          m_model->index(row, columnNotUsed, m_model->index(group, 0)));
     }
   }
   return tree;

--- a/qt/widgets/common/src/DataProcessorUI/TwoLevelTreeManager.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/TwoLevelTreeManager.cpp
@@ -418,6 +418,33 @@ int TwoLevelTreeManager::numRowsInGroup(int group) const {
 }
 
 /**
+* Returns given row data in a format that the presenter can understand and use
+* @return :: All data as a map where keys are units of post-processing (i.e.
+* group indices) and values are a map of row index in the group to row data
+*/
+TreeData TwoLevelTreeManager::constructTreeData(ChildItems rows) {
+  TreeData tree;
+  // Return row data in the format: map<int, set<vector<string>>>, where:
+  // int -> group index
+  // set<vector<string>> -> set of vectors storing the data. Each set is a row
+  // and each element in the vector is a column
+  for (const auto &item : rows) {
+
+    int group = item.first;
+
+    for (const auto &row : item.second) {
+      QStringList data;
+      for (int i = 0; i < m_model->columnCount(); i++)
+        data.append(
+            m_model->data(m_model->index(row, i, m_model->index(group, 0)))
+                .toString());
+      tree[group][row] = std::make_shared<RowData>(std::move(data));
+    }
+  }
+  return tree;
+}
+
+/**
 * Returns selected data in a format that the presenter can understand and use
 * @param prompt :: True if warning messages should be displayed. False othewise
 * @return :: Selected data as a map where keys are units of post-processing and
@@ -496,24 +523,7 @@ TreeData TwoLevelTreeManager::selectedData(bool prompt) {
     }
   }
 
-  // Return selected data in the format: map<int, set<vector<string>>>, where:
-  // int -> group index
-  // set<vector<string>> -> set of vectors storing the data. Each set is a row
-  // and each element in the vector is a column
-  for (const auto &item : rows) {
-
-    int group = item.first;
-
-    for (const auto &row : item.second) {
-      QStringList data;
-      for (int i = 0; i < m_model->columnCount(); i++)
-        data.append(
-            m_model->data(m_model->index(row, i, m_model->index(group, 0)))
-                .toString());
-      selectedData[group][row] = data;
-    }
-  }
-  return selectedData;
+  return constructTreeData(rows);
 }
 
 /** Transfer data to the model

--- a/qt/widgets/common/src/DataProcessorUI/TwoLevelTreeManager.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/TwoLevelTreeManager.cpp
@@ -625,7 +625,6 @@ bool TwoLevelTreeManager::rowIsEmpty(int row, int parent) const {
     auto value = getCell(row, columnIndex, parent, 0);
     if (!value.empty())
       return false;
-    ++columnIndex;
   }
 
   // All cells in the row were empty

--- a/qt/widgets/common/src/DataProcessorUI/WorkspaceNameUtils.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/WorkspaceNameUtils.cpp
@@ -21,7 +21,7 @@ namespace { // unnamed namespace
              * @param allowInsertions : if true, allow new keys to be inserted;
              * otherwise, only allow updating of keys that already exist
              */
-void updateRowOptions(OptionsMap &options, const RowData *data,
+void updateRowOptions(OptionsMap &options, const RowData_sptr data,
                       const WhiteList &whitelist, const bool allowInsertions) {
   // Loop through all columns (excluding the Options and Hidden options
   // columns)
@@ -49,10 +49,10 @@ void updateRowOptions(OptionsMap &options, const RowData *data,
  * @param allowInsertions : if true, allow new keys to be inserted;
  * otherwise, only allow updating of keys that already exist
  */
-void updateUserOptions(OptionsMap &options, const RowData *data,
+void updateUserOptions(OptionsMap &options, const RowData_sptr data,
                        const WhiteList &whitelist, const bool allowInsertions) {
   auto userOptions =
-      parseKeyValueQString(data->at(static_cast<int>(whitelist.size()) - 2));
+      parseKeyValueQString(data->value(static_cast<int>(whitelist.size()) - 2));
   for (auto &kvp : userOptions) {
     if (allowInsertions || options.find(kvp.first) != options.end())
       options[kvp.first] = kvp.second;
@@ -66,7 +66,7 @@ void updateUserOptions(OptionsMap &options, const RowData *data,
  * @param allowInsertions : if true, allow new keys to be inserted;
  * otherwise, only allow updating of keys that already exist
  */
-void updateHiddenOptions(OptionsMap &options, const RowData *data,
+void updateHiddenOptions(OptionsMap &options, const RowData_sptr data,
                          const bool allowInsertions) {
   const auto hiddenOptions = parseKeyValueQString(data->back());
   for (auto &kvp : hiddenOptions) {
@@ -80,7 +80,7 @@ void updateHiddenOptions(OptionsMap &options, const RowData *data,
  * @param options : a map of property name to option value to update
  * @param data : the data for this row
  */
-void updateOutputOptions(OptionsMap &options, const RowData *data,
+void updateOutputOptions(OptionsMap &options, const RowData_sptr data,
                          const WhiteList &whitelist, const bool allowInsertions,
                          const std::vector<QString> &outputPropertyNames,
                          const std::vector<QString> &outputNamePrefixes) {
@@ -89,7 +89,7 @@ void updateOutputOptions(OptionsMap &options, const RowData *data,
     const auto propertyName = outputPropertyNames[i];
     if (allowInsertions || options.find(propertyName) != options.end()) {
       options[propertyName] =
-          getReducedWorkspaceName(*data, whitelist, outputNamePrefixes[i]);
+          getReducedWorkspaceName(data, whitelist, outputNamePrefixes[i]);
     }
   }
 }
@@ -133,10 +133,10 @@ Returns the name of the reduced workspace for a given row
 @throws std::runtime_error if the workspace could not be prepared
 @returns : The name of the workspace
 */
-QString getReducedWorkspaceName(const QStringList &data,
+QString getReducedWorkspaceName(const RowData_sptr data,
                                 const WhiteList &whitelist,
                                 const QString prefix) {
-  if (data.size() != static_cast<int>(whitelist.size()))
+  if (data->size() != static_cast<int>(whitelist.size()))
     throw std::invalid_argument("Can't find reduced workspace name");
 
   /* This method calculates, for a given row, the name of the output
@@ -154,7 +154,7 @@ QString getReducedWorkspaceName(const QStringList &data,
   QStringList names;
 
   auto columnIt = whitelist.cbegin();
-  auto runNumbersIt = data.constBegin();
+  auto runNumbersIt = data->constBegin();
   for (; columnIt != whitelist.cend(); ++columnIt, ++runNumbersIt) {
     auto column = *columnIt;
     // Do we want to use this column to generate the name of the output ws?
@@ -188,7 +188,7 @@ QString getReducedWorkspaceName(const QStringList &data,
  * names
  * @return : a map of property names to value
  */
-OptionsMap getCanonicalOptions(const RowData *data,
+OptionsMap getCanonicalOptions(const RowData_sptr data,
                                const OptionsMap &globalOptions,
                                const WhiteList &whitelist,
                                const bool allowInsertions,

--- a/qt/widgets/common/src/DataProcessorUI/WorkspaceNameUtils.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/WorkspaceNameUtils.cpp
@@ -81,15 +81,14 @@ void updateHiddenOptions(OptionsMap &options, const RowData_sptr data,
  * @param data : the data for this row
  */
 void updateOutputOptions(OptionsMap &options, const RowData_sptr data,
-                         const WhiteList &whitelist, const bool allowInsertions,
+                         const bool allowInsertions,
                          const std::vector<QString> &outputPropertyNames,
                          const std::vector<QString> &outputNamePrefixes) {
   // Set the properties for the output workspace names
   for (auto i = 0u; i < outputPropertyNames.size(); i++) {
     const auto propertyName = outputPropertyNames[i];
     if (allowInsertions || options.find(propertyName) != options.end()) {
-      options[propertyName] =
-          getReducedWorkspaceName(data, whitelist, outputNamePrefixes[i]);
+      options[propertyName] = data->reducedName(outputNamePrefixes[i]);
     }
   }
 }
@@ -129,13 +128,11 @@ QString preprocessingListToString(const QStringList &values,
 Returns the name of the reduced workspace for a given row
 @param data :: [input] The data for this row
 @param whitelist :: [input] The list of columns
-@param prefix : A prefix to be appended to the generated ws name
 @throws std::runtime_error if the workspace could not be prepared
 @returns : The name of the workspace
 */
 QString getReducedWorkspaceName(const RowData_sptr data,
-                                const WhiteList &whitelist,
-                                const QString prefix) {
+                                const WhiteList &whitelist) {
   if (data->size() != static_cast<int>(whitelist.size()))
     throw std::invalid_argument("Can't find reduced workspace name");
 
@@ -169,7 +166,7 @@ QString getReducedWorkspaceName(const RowData_sptr data,
     }
   } // Columns
 
-  auto wsname = prefix;
+  QString wsname;
   wsname += names.join("_");
   return wsname;
 }
@@ -201,8 +198,8 @@ OptionsMap getCanonicalOptions(const RowData_sptr data,
   updateHiddenOptions(options, data, allowInsertions);
   updateUserOptions(options, data, whitelist, allowInsertions);
   updateRowOptions(options, data, whitelist, allowInsertions);
-  updateOutputOptions(options, data, whitelist, allowInsertions,
-                      outputProperties, prefixes);
+  updateOutputOptions(options, data, allowInsertions, outputProperties,
+                      prefixes);
   return options;
 }
 }

--- a/qt/widgets/common/test/DataProcessorUI/GenerateNotebookTest.h
+++ b/qt/widgets/common/test/DataProcessorUI/GenerateNotebookTest.h
@@ -91,18 +91,19 @@ private:
   }
 
   void appendStringWithPrefix(QString &stringToEdit, const QStringList &list,
-                              std::vector<const char *> &prefixes, const int i,
-                              const char *separator = "") {
+                              std::vector<const char *> &prefixes,
+                              const size_t i, const char *separator = "") {
     // do nothing if string to add is empty
-    if (i >= list.size() || list[i].isEmpty())
+    const auto idx = static_cast<int>(i);
+    if (idx >= list.size() || list[idx].isEmpty())
       return;
 
     // add separator and string with/without prefix
-    const long int len = prefixes.size();
+    const auto len = prefixes.size();
     if (i < len && prefixes[i] != 0)
-      stringToEdit += QString(separator) + QString(prefixes[i]) + list[i];
+      stringToEdit += QString(separator) + QString(prefixes[i]) + list[idx];
     else
-      stringToEdit += separator + list[i];
+      stringToEdit += separator + list[idx];
   }
 
   // Utility to create a row data class from a string list of simple inputs

--- a/qt/widgets/common/test/DataProcessorUI/GenerateNotebookTest.h
+++ b/qt/widgets/common/test/DataProcessorUI/GenerateNotebookTest.h
@@ -251,7 +251,8 @@ public:
   void testTableStringOneRow() {
 
     // Create some tree data
-    auto rowData = makeRowData({"24682", "1.5", "", "1.4", "2.9", "0.04", "1", "", ""});
+    auto rowData =
+        makeRowData({"24682", "1.5", "", "1.4", "2.9", "0.04", "1", "", ""});
     TreeData treeData = {{1, {{0, rowData}}}};
 
     auto output = tableString(treeData, reflWhitelist());
@@ -366,8 +367,8 @@ public:
         {"Run(s)", OptionsMap()}, {"Transmission Run(s)", OptionsMap()}};
 
     // Create a row
-    const auto rowData = makeRowData({"12346", "1.5", "", "1.4", "2.9",
-          "0.04",  "1",   "", ""});
+    const auto rowData =
+        makeRowData({"12346", "1.5", "", "1.4", "2.9", "0.04", "1", "", ""});
 
     auto output = reduceRowString(rowData, m_instrument, reflWhitelist(),
                                   reflPreprocessMap("TOF_"), reflProcessor(),
@@ -449,8 +450,8 @@ public:
     ColumnOptionsMap emptyPreProcessingOptions;
 
     // Create a row
-    const auto data = makeRowData({"12346", "1.5", "", "1.4", "2.9",
-          "0.04",  "1",   "", ""});
+    const auto data =
+        makeRowData({"12346", "1.5", "", "1.4", "2.9", "0.04", "1", "", ""});
 
     auto output =
         reduceRowString(data, m_instrument, reflWhitelist(), emptyPreProcessMap,
@@ -479,8 +480,8 @@ public:
     whitelist.addElement("Trans", "", "", false, "");
 
     // Create some data
-    const auto data = makeRowData({"1000,1001", "0.5", "2000,2001", "1.4", "2.9",
-          "0.04",      "1",   "",          ""});
+    const auto data = makeRowData(
+        {"1000,1001", "0.5", "2000,2001", "1.4", "2.9", "0.04", "1", "", ""});
     TS_ASSERT_THROWS_ANYTHING(getReducedWorkspaceName(data, whitelist));
   }
 
@@ -499,8 +500,8 @@ public:
     whitelist.addElement("HiddenOptions", "HiddenOptions", "");
 
     // Create some data
-    const auto data = makeRowData({"1000,1001", "0.5", "2000,2001", "1.4", "2.9",
-          "0.04",      "1",   "",          ""});
+    const auto data = makeRowData(
+        {"1000,1001", "0.5", "2000,2001", "1.4", "2.9", "0.04", "1", "", ""});
 
     auto name = getReducedWorkspaceName(data, whitelist);
     TS_ASSERT_EQUALS(name.toStdString(), "run_1000+1001")
@@ -521,8 +522,8 @@ public:
     whitelist.addElement("HiddenOptions", "HiddenOptions", "");
 
     // Create some data
-    const auto data = makeRowData({"1000,1001", "0.5", "2000,2001", "1.4", "2.9",
-          "0.04",      "1",   "",          ""});
+    const auto data = makeRowData(
+        {"1000,1001", "0.5", "2000,2001", "1.4", "2.9", "0.04", "1", "", ""});
 
     auto name = getReducedWorkspaceName(data, whitelist);
     TS_ASSERT_EQUALS(name.toStdString(), "run_1000+1001_trans_2000+2001")
@@ -542,8 +543,8 @@ public:
     whitelist.addElement("Options", "Options", "");
     whitelist.addElement("HiddenOptions", "HiddenOptions", "");
 
-    const auto data = makeRowData({"1000,1001", "0.5", "2000+2001", "1.4", "2.9",
-          "0.04",      "1",   "",          ""});
+    const auto data = makeRowData(
+        {"1000,1001", "0.5", "2000+2001", "1.4", "2.9", "0.04", "1", "", ""});
 
     auto name = getReducedWorkspaceName(data, whitelist);
     TS_ASSERT_EQUALS(name.toStdString(), "2000+2001")

--- a/qt/widgets/common/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
+++ b/qt/widgets/common/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
@@ -419,9 +419,30 @@ private:
         DEFAULT_GROUP_NUMBER);
   }
 
-  // Utility to create a row data class from a string list
+  // Utility to create a row data class from a string list of simple inputs
+  // (does not support multiple input runs or transmission runs, or entries
+  // in the options/hidden columns). Assumes input workspaces are prefixed
+  // with TOF_ and transmission runs with TRANS_
   RowData_sptr makeRowData(const QStringList &list) {
-    return std::make_shared<RowData>(list);
+    // Set the row values
+    auto rowData = std::make_shared<RowData>(list);
+    // Set the options (simply based on the row values)
+    rowData->setOptions({{"InputWorkspace", list[0]},
+                         {"ThetaIn", list[1]},
+                         {"FirstTransmissionRun", list[2]},
+                         {"MomentumTransferMin", list[3]},
+                         {"MomemtumTransferMax", list[4]},
+                         {"MomentumTransferStep", list[5]},
+                         {"ScaleFactor", list[6]}});
+    // Set the preprocessed options based on the input options
+    auto options = rowData->options();
+    // Add the prefixes for preprocessed run values
+    if (!list[0].isEmpty())
+      options["InputWorkspace"] = "TOF_" + list[0];
+    if (!list[2].isEmpty())
+      options["InputWorkspace"] = "TRANS_" + list[2];
+    rowData->setPreprocessedOptions(options);
+    return rowData;
   }
 
   // Expect the view's widgets to be set in a particular state according to

--- a/qt/widgets/common/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
+++ b/qt/widgets/common/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
@@ -3109,11 +3109,11 @@ public:
   void testPlotRowPythonCode() {
     NiceMock<MockDataProcessorView> mockDataProcessorView;
     MockProgressableView mockProgress;
-    auto *mockTreeManager = new MockTreeManager;
-
+    auto mockTreeManager = Mantid::Kernel::make_unique<MockTreeManager>();
+    auto *mockTreeManager_ptr = mockTreeManager.get();
     auto presenter = makeDefaultPresenter();
     presenter->acceptViews(&mockDataProcessorView, &mockProgress);
-    presenter->acceptTreeManager(mockTreeManager);
+    presenter->acceptTreeManager(std::move(mockTreeManager));
 
     createPrefilledWorkspace("TestWorkspace", presenter->getWhiteList());
     expectGetWorkspace(mockDataProcessorView, Exactly(1), "TestWorkspace");
@@ -3130,7 +3130,7 @@ public:
     // The user hits "plot rows" with the first row selected
     expectNoWarningsOrErrors(mockDataProcessorView);
 
-    EXPECT_CALL(*mockTreeManager, selectedData(false))
+    EXPECT_CALL(*mockTreeManager_ptr, selectedData(false))
         .Times(1)
         .WillOnce(Return(tree));
 
@@ -3154,11 +3154,11 @@ public:
   void testPlotGroupPythonCode() {
     NiceMock<MockDataProcessorView> mockDataProcessorView;
     MockProgressableView mockProgress;
-    auto mockTreeManager = new MockTreeManager;
-
+    auto mockTreeManager = Mantid::Kernel::make_unique<MockTreeManager>();
+    auto *mockTreeManager_ptr = mockTreeManager.get();
     auto presenter = makeDefaultPresenter();
     presenter->acceptViews(&mockDataProcessorView, &mockProgress);
-    presenter->acceptTreeManager(mockTreeManager);
+    presenter->acceptTreeManager(std::move(mockTreeManager));
 
     createPrefilledWorkspace("TestWorkspace", presenter->getWhiteList());
     expectGetWorkspace(mockDataProcessorView, Exactly(1), "TestWorkspace");
@@ -3174,7 +3174,7 @@ public:
     // The user hits "plot rows" with the first row selected
     expectNoWarningsOrErrors(mockDataProcessorView);
 
-    EXPECT_CALL(*mockTreeManager, selectedData(false))
+    EXPECT_CALL(*mockTreeManager_ptr, selectedData(false))
         .Times(1)
         .WillOnce(Return(tree));
 

--- a/qt/widgets/common/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
+++ b/qt/widgets/common/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
@@ -3108,12 +3108,11 @@ public:
   void testPlotRowPythonCode() {
     NiceMock<MockDataProcessorView> mockDataProcessorView;
     MockProgressableView mockProgress;
+    auto *mockTreeManager = new MockTreeManager;
 
     auto presenter = makeDefaultPresenter();
     presenter->acceptViews(&mockDataProcessorView, &mockProgress);
-    presenter->m_manager = Mantid::Kernel::make_unique<MockTreeManager>();
-    MockTreeManager *mockTreeManager =
-        static_cast<MockTreeManager *>(presenter->m_manager.get());
+    presenter->acceptTreeManager(mockTreeManager);
 
     createPrefilledWorkspace("TestWorkspace", presenter->getWhiteList());
     expectGetWorkspace(mockDataProcessorView, Exactly(1), "TestWorkspace");
@@ -3154,12 +3153,11 @@ public:
   void testPlotGroupPythonCode() {
     NiceMock<MockDataProcessorView> mockDataProcessorView;
     MockProgressableView mockProgress;
+    auto mockTreeManager = new MockTreeManager;
 
     auto presenter = makeDefaultPresenter();
     presenter->acceptViews(&mockDataProcessorView, &mockProgress);
-    presenter->m_manager = Mantid::Kernel::make_unique<MockTreeManager>();
-    MockTreeManager *mockTreeManager =
-        static_cast<MockTreeManager *>(presenter->m_manager.get());
+    presenter->acceptTreeManager(mockTreeManager);
 
     createPrefilledWorkspace("TestWorkspace", presenter->getWhiteList());
     expectGetWorkspace(mockDataProcessorView, Exactly(1), "TestWorkspace");

--- a/qt/widgets/common/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
+++ b/qt/widgets/common/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
@@ -438,18 +438,19 @@ private:
   }
 
   void appendStringWithPrefix(QString &stringToEdit, const QStringList &list,
-                              std::vector<const char *> &prefixes, const int i,
-                              const char *separator = "") {
+                              std::vector<const char *> &prefixes,
+                              const size_t i, const char *separator = "") {
     // do nothing if string to add is empty
-    if (i >= list.size() || list[i].isEmpty())
+    const auto idx = static_cast<int>(i);
+    if (idx >= list.size() || list[idx].isEmpty())
       return;
 
     // add separator and string with/without prefix
-    const long int len = prefixes.size();
+    const auto len = prefixes.size();
     if (i < len && prefixes[i] != 0)
-      stringToEdit += QString(separator) + QString(prefixes[i]) + list[i];
+      stringToEdit += QString(separator) + QString(prefixes[i]) + list[idx];
     else
-      stringToEdit += separator + list[i];
+      stringToEdit += separator + list[idx];
   }
 
   // Utility to create a row data class from a string list of simple inputs

--- a/qt/widgets/common/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
+++ b/qt/widgets/common/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
@@ -12,10 +12,11 @@
 #include "MantidQtWidgets/Common/DataProcessorUI/MockObjects.h"
 #include "MantidQtWidgets/Common/DataProcessorUI/ProgressableViewMockObject.h"
 #include "MantidQtWidgets/Common/WidgetDllOption.h"
+#include "MantidTestHelpers/DataProcessorTestHelper.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
+using namespace DataProcessorTestHelper;
 using namespace MantidQt::MantidWidgets;
-using namespace MantidQt::MantidWidgets::DataProcessor;
 using namespace Mantid::API;
 using namespace Mantid::Kernel;
 using namespace testing;
@@ -417,74 +418,6 @@ private:
         createReflectometryWhiteList(), createReflectometryPreprocessingStep(),
         createReflectometryProcessor(), createReflectometryPostprocessor(),
         DEFAULT_GROUP_NUMBER);
-  }
-
-  void addRowValue(RowData_sptr rowData, const QStringList &list,
-                   const int index, const char *property,
-                   const char *prefix = "") {
-    if (index >= list.size())
-      return;
-    // Set the option based on the row value
-    rowData->setOptionValue(property, list[index]);
-    // Set the preprocessed option based on the value and prefix
-    rowData->setPreprocessedOptionValue(property, prefix + list[index]);
-  }
-
-  void addRowValue(RowData_sptr rowData, const char *property,
-                   const QString value) {
-    // Set the value and preprocessed value to the given value
-    rowData->setOptionValue(property, value);
-    rowData->setPreprocessedOptionValue(property, value);
-  }
-
-  void appendStringWithPrefix(QString &stringToEdit, const QStringList &list,
-                              std::vector<const char *> &prefixes,
-                              const size_t i, const char *separator = "") {
-    // do nothing if string to add is empty
-    const auto idx = static_cast<int>(i);
-    if (idx >= list.size() || list[idx].isEmpty())
-      return;
-
-    // add separator and string with/without prefix
-    const auto len = prefixes.size();
-    if (i < len && prefixes[i] != 0)
-      stringToEdit += QString(separator) + QString(prefixes[i]) + list[idx];
-    else
-      stringToEdit += separator + list[idx];
-  }
-
-  // Utility to create a row data class from a string list of simple inputs
-  // (does not support multiple input runs or transmission runs, or entries
-  // in the options/hidden columns). Assumes input workspaces are prefixed
-  // with TOF_ and transmission runs with TRANS_
-  RowData_sptr makeRowData(const QStringList &list,
-                           std::vector<const char *> prefixes = {"TOF_", "",
-                                                                 "TRANS_"}) {
-    // Create the data and add default options
-    auto rowData = std::make_shared<RowData>(list);
-
-    if (list.size() < 1)
-      return rowData;
-
-    QString reducedName;
-    appendStringWithPrefix(reducedName, list, prefixes, 0);
-    appendStringWithPrefix(reducedName, list, prefixes, 2, "_");
-
-    rowData->setReducedName(reducedName);
-    addRowValue(rowData, "OutputWorkspace", "IvsQ_" + reducedName);
-    addRowValue(rowData, "OutputWorkspaceBinned", "IvsQ_binned_" + reducedName);
-    addRowValue(rowData, "OutputWorkspaceWavelength", "IvsLam_" + reducedName);
-
-    // Set other options from the row data values
-    addRowValue(rowData, list, 0, "InputWorkspace", "TOF_");
-    addRowValue(rowData, list, 1, "ThetaIn");
-    addRowValue(rowData, list, 2, "FirstTransmissionRun", "TRANS_");
-    addRowValue(rowData, list, 3, "MomentumTransferMin");
-    addRowValue(rowData, list, 4, "MomentumTransferMax");
-    addRowValue(rowData, list, 5, "MomentumTransferStep");
-    addRowValue(rowData, list, 6, "ScaleFactor");
-
-    return rowData;
   }
 
   // Expect the view's widgets to be set in a particular state according to

--- a/qt/widgets/common/test/DataProcessorUI/OneLevelTreeManagerTest.h
+++ b/qt/widgets/common/test/DataProcessorUI/OneLevelTreeManagerTest.h
@@ -263,10 +263,10 @@ public:
     TS_ASSERT(Mock::VerifyAndClearExpectations(&presenter));
 
     TS_ASSERT_EQUALS(data.size(), 4);
-    TS_ASSERT_EQUALS(data[0][0], firstRow);
-    TS_ASSERT_EQUALS(data[1][1], secondRow);
-    TS_ASSERT_EQUALS(data[2][2], thirdRow);
-    TS_ASSERT_EQUALS(data[3][3], fourthRow);
+    TS_ASSERT_EQUALS(data[0][0]->data(), firstRow);
+    TS_ASSERT_EQUALS(data[1][1]->data(), secondRow);
+    TS_ASSERT_EQUALS(data[2][2]->data(), thirdRow);
+    TS_ASSERT_EQUALS(data[3][3]->data(), fourthRow);
   }
 
   void test_transfer_fails_wrong_whitelist() {
@@ -334,10 +334,10 @@ public:
                             "0.4",   "0.01", "3",     ""};
     QStringList fourthRow = {"12348", "0.8",  "20004", "0.4",
                              "0.5",   "0.02", "2",     ""};
-    TS_ASSERT_EQUALS(data[0][0], firstRow);
-    TS_ASSERT_EQUALS(data[1][1], secondRow);
-    TS_ASSERT_EQUALS(data[2][2], thirdRow);
-    TS_ASSERT_EQUALS(data[3][3], fourthRow);
+    TS_ASSERT_EQUALS(data[0][0]->data(), firstRow);
+    TS_ASSERT_EQUALS(data[1][1]->data(), secondRow);
+    TS_ASSERT_EQUALS(data[2][2]->data(), thirdRow);
+    TS_ASSERT_EQUALS(data[3][3]->data(), fourthRow);
   }
 
   void test_update() {
@@ -359,10 +359,10 @@ public:
     auto data = manager.selectedData(false);
     TS_ASSERT(Mock::VerifyAndClearExpectations(&presenter));
 
-    TS_ASSERT_EQUALS(data[0][0], newRow);
-    TS_ASSERT_EQUALS(data[1][1], newRow);
-    TS_ASSERT_EQUALS(data[2][2], newRow);
-    TS_ASSERT_EQUALS(data[3][3], newRow);
+    TS_ASSERT_EQUALS(data[0][0]->data(), newRow);
+    TS_ASSERT_EQUALS(data[1][1]->data(), newRow);
+    TS_ASSERT_EQUALS(data[2][2]->data(), newRow);
+    TS_ASSERT_EQUALS(data[3][3]->data(), newRow);
   }
 };
 #endif /* MANTID_MANTIDWIDGETS_DATAPROCESSORONELEVELTREEMANAGERTEST_H */

--- a/qt/widgets/common/test/DataProcessorUI/OneLevelTreeManagerTest.h
+++ b/qt/widgets/common/test/DataProcessorUI/OneLevelTreeManagerTest.h
@@ -269,14 +269,6 @@ public:
     TS_ASSERT_EQUALS(data[3][3]->data(), fourthRow);
   }
 
-  void test_transfer_fails_wrong_whitelist() {
-    NiceMock<MockDataProcessorPresenter> presenter;
-    OneLevelTreeManager manager(&presenter, reflWhitelist());
-
-    Runs runs = {{{"Group", "0"}, {"Runs", "12345"}}};
-    TS_ASSERT_THROWS_ANYTHING(manager.transfer(runs, WhiteList()));
-  }
-
   void test_transfer_good_data() {
     NiceMock<MockDataProcessorPresenter> presenter;
     OneLevelTreeManager manager(&presenter, reflWhitelist());
@@ -313,7 +305,7 @@ public:
                   {"dQ/Q", "0.02"},
                   {"Scale", "2"},
                   {"Options", ""}}};
-    TS_ASSERT_THROWS_NOTHING(manager.transfer(runs, reflWhitelist()));
+    TS_ASSERT_THROWS_NOTHING(manager.transfer(runs));
 
     // Check that runs have been transferred correctly
     EXPECT_CALL(presenter, selectedParents())

--- a/qt/widgets/common/test/DataProcessorUI/TwoLevelTreeManagerTest.h
+++ b/qt/widgets/common/test/DataProcessorUI/TwoLevelTreeManagerTest.h
@@ -348,15 +348,7 @@ public:
     TwoLevelTreeManager manager(&presenter, reflWhitelist());
 
     Runs runs = {{{"Runs", "12345"}}};
-    TS_ASSERT_THROWS_ANYTHING(manager.transfer(runs, reflWhitelist()));
-  }
-
-  void test_transfer_fails_wrong_whitelist() {
-    NiceMock<MockDataProcessorPresenter> presenter;
-    TwoLevelTreeManager manager(&presenter, reflWhitelist());
-
-    Runs runs = {{{"Group", "0"}, {"Runs", "12345"}}};
-    TS_ASSERT_THROWS_ANYTHING(manager.transfer(runs, WhiteList()));
+    TS_ASSERT_THROWS_ANYTHING(manager.transfer(runs));
   }
 
   void test_transfer_nothing_transferred() {
@@ -364,7 +356,7 @@ public:
     TwoLevelTreeManager manager(&presenter, reflWhitelist());
 
     Runs runs = {{{"Group", "0"}, {"Runs", "12345"}}};
-    TS_ASSERT_THROWS_NOTHING(manager.transfer(runs, reflWhitelist()));
+    TS_ASSERT_THROWS_NOTHING(manager.transfer(runs));
   }
 
   void test_transfer_good_data() {
@@ -407,7 +399,7 @@ public:
                   {"dQ/Q", "0.02"},
                   {"Scale", "2"},
                   {"Options", ""}}};
-    TS_ASSERT_THROWS_NOTHING(manager.transfer(runs, reflWhitelist()));
+    TS_ASSERT_THROWS_NOTHING(manager.transfer(runs));
 
     // Check that runs have been transferred correctly
     EXPECT_CALL(presenter, selectedParents())

--- a/qt/widgets/common/test/DataProcessorUI/TwoLevelTreeManagerTest.h
+++ b/qt/widgets/common/test/DataProcessorUI/TwoLevelTreeManagerTest.h
@@ -312,10 +312,10 @@ public:
     TS_ASSERT(Mock::VerifyAndClearExpectations(&presenter));
 
     TS_ASSERT_EQUALS(data.size(), 2);
-    TS_ASSERT_EQUALS(data[0][0], firstRow);
-    TS_ASSERT_EQUALS(data[0][1], secondRow);
-    TS_ASSERT_EQUALS(data[1][0], thirdRow);
-    TS_ASSERT_EQUALS(data[1][1], fourthRow);
+    TS_ASSERT_EQUALS(data[0][0]->data(), firstRow);
+    TS_ASSERT_EQUALS(data[0][1]->data(), secondRow);
+    TS_ASSERT_EQUALS(data[1][0]->data(), thirdRow);
+    TS_ASSERT_EQUALS(data[1][1]->data(), fourthRow);
   }
 
   void test_new_table_clears_model() {
@@ -431,10 +431,10 @@ public:
     QStringList fourthRow = {"12348", "0.8",  "20004", "0.4",
                              "0.5",   "0.02", "2",     ""};
 
-    TS_ASSERT_EQUALS(data[0][0], firstRow);
-    TS_ASSERT_EQUALS(data[0][1], secondRow);
-    TS_ASSERT_EQUALS(data[1][0], thirdRow);
-    TS_ASSERT_EQUALS(data[1][1], fourthRow);
+    TS_ASSERT_EQUALS(data[0][0]->data(), firstRow);
+    TS_ASSERT_EQUALS(data[0][1]->data(), secondRow);
+    TS_ASSERT_EQUALS(data[1][0]->data(), thirdRow);
+    TS_ASSERT_EQUALS(data[1][1]->data(), fourthRow);
   }
 
   void test_update() {
@@ -458,10 +458,10 @@ public:
     auto data = manager.selectedData(false);
     TS_ASSERT(Mock::VerifyAndClearExpectations(&presenter));
 
-    TS_ASSERT_EQUALS(data[0][0], newRow);
-    TS_ASSERT_EQUALS(data[0][1], newRow);
-    TS_ASSERT_EQUALS(data[1][0], newRow);
-    TS_ASSERT_EQUALS(data[1][1], newRow);
+    TS_ASSERT_EQUALS(data[0][0]->data(), newRow);
+    TS_ASSERT_EQUALS(data[0][1]->data(), newRow);
+    TS_ASSERT_EQUALS(data[1][0]->data(), newRow);
+    TS_ASSERT_EQUALS(data[1][1]->data(), newRow);
   }
 };
 #endif /* MANTID_MANTIDWIDGETS_DATAPROCESSORTWOLEVELTREEMANAGERTEST_H */


### PR DESCRIPTION
This PR adds a table to the Settings tab of the ISIS Reflectometry GUI which allows default transmission runs to be specified on a per-angle basis, so that the transmission runs can be looked up based on the angle of each run.

This replaces the existing text entry box which just allowed for one default set of transmission runs to be specified. Overall defaults can still be specified by entering one row where the angle column is blank. Due to the issues with providing the lookup angle described in the linked issue, for now, to avoid confusion, there is a restriction that per-angle OR overall defaults can be specified, but not both.

This PR also includes the following changes as part of an effort to make the underlying code more maintainable:
- Significant refactoring to cache row metadata, such as properties used in the reduction, the processed state, the reduced workspace names etc. This information was previously being recalculated in many different places whenever required but it was becoming increasingly difficult and error-prone to keep track of all of the information required to recalculate these values. These changes should make it easier going forward to e.g. change the naming convention for workspace slices.
- The `Output Notebook` option now works for all groups that are processed as non-event workspaces. Previously, if event handling was enabled but a group contained non-event workspaces, generating the notebook was being silently skipped.
- Plotting rows in event handling mode now plots the `IvsQ_binned_` workspaces rather than `IvsQ_`, to make the behaviour consistent with non-event mode.

Fixes #20088

**To test:**
Check that the `ISIS Reflectometry` and `ISIS SANS v2 experimental` GUIs still work as expected.

On the reflectometry GUI:
- Try specifying defaults with and/or without angles.
- Try overriding transmission runs in the table on the Runs tab - this should take precedence over anything on the Settings tab.
- Check that other instrument/experiment properties are still picked up ok from the Settings tab and that these also get overridden by the properties on the Runs tab.
- Try overriding properties in the Runs tab using both the normal columns (e.g. `dQ/Q`) as well as the `Options` column (e.g. `WavelengthMax` in here should override `LambdaMax` on the Settings tab).
- Check that properties and defaults are passed through ok to the preprocessing and postprocessing algorithms (i.e. `CreateTransmissionWorkspaceAuto` and `Stitch1DMany`).
- Check that the plotting buttons on the GUI work ok.
- Check that `Output Notebook` still works and that the code generated still runs ok. Check that the plots are the same as those from the GUI (although note that they are shown with error bars in the notebook and without from the GUI. Note also that there's an existing bug where the Params must be set in the stitch properties before first running the reduction because changes aren't picked up.)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
