### PR TITLE
Set matplotlib figure background to white by default in new workbench

### DIFF
--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -27,7 +27,6 @@ import sys
 # -----------------------------------------------------------------------------
 # Constants
 # -----------------------------------------------------------------------------
-MPL_BACKEND = 'module://workbench.plotting.backend_workbench'
 SYSCHECK_INTERVAL = 50
 ORIGINAL_SYS_EXIT = sys.exit
 ORIGINAL_STDOUT = sys.stdout
@@ -380,17 +379,11 @@ def start_workbench(app):
     # changing anything!
     main_window = MainWindow()
 
-    # Load matplotlib as early as possible.
+    # Load matplotlib as early as possible and set our defaults
     # Setup our custom backend and monkey patch in custom current figure manager
     main_window.set_splash('Preloading matplotlib')
-    mpl = importlib.import_module('matplotlib')
-    # Replace vanilla Gcf with our custom instance
-    _pylab_helpers = importlib.import_module('matplotlib._pylab_helpers')
-    currentfigure = importlib.import_module('workbench.plotting.currentfigure')
-    setattr(_pylab_helpers, 'Gcf', getattr(currentfigure, 'CurrentFigure'))
-    # Set up out custom matplotlib backend early. It must be done on
-    # the main thread
-    mpl.use(MPL_BACKEND)
+    from workbench.plotting.setup import setup_matplotlib  # noqa
+    setup_matplotlib()
 
     # Setup widget layouts etc. mantid cannot be imported before this
     # or the log messages don't get through

--- a/qt/applications/workbench/workbench/plotting/setup.py
+++ b/qt/applications/workbench/workbench/plotting/setup.py
@@ -1,0 +1,63 @@
+#  This file is part of the mantid workbench.
+#
+#  Copyright (C) 2017 mantidproject
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import (absolute_import)
+
+# system imports
+
+# 3rd-party imports
+import matplotlib as mpl
+import matplotlib._pylab_helpers as pylab_helpers
+
+# local imports
+from .currentfigure import CurrentFigure
+
+# Our backend. We keep this separate from the rc params as it can only be set once
+MPL_BACKEND = 'module://workbench.plotting.backend_workbench'
+
+# Our style defaults
+DEFAULT_RCPARAMS = {
+    'figure.facecolor':  'w'
+}
+
+
+def setup_matplotlib():
+    """Configures our defaults"""
+    # Replace vanilla Gcf with our custom instance
+    setattr(pylab_helpers, 'Gcf', CurrentFigure)
+    # Our backend
+    mpl.use(MPL_BACKEND)
+    # Set our defaults
+    reset_rcparams_to_default()
+
+
+def reset_rcparams_to_default():
+    """
+    Reset the rcParams to the default settings.
+
+    :param rcp: A dictionary containing new rcparams values
+    """
+    mpl.rcParams.clear()
+    mpl.rc_file_defaults()
+    set_rcparams(DEFAULT_RCPARAMS)
+
+
+def set_rcparams(rcp):
+    """
+    Update the current rcParams with the given set
+    :param rcp: A dictionary containing new rcparams values
+    """
+    mpl.rcParams.update(rcp)


### PR DESCRIPTION
Description of work.

In matplotlib `< v2.1.2` the default figure facecolor is gray but in `>= v2.1.2` it changed to white. White looks cleaner so we set the default figure facecolor to white across the board. Users are of course free to change it with 'matplotlib.rcParams'

**To test:**

* build the branch on a system with matplotlib < v2.1.2
* start the workbench
* make a plot an observe the figure facecolor is white

Refs #21649 

**Release Notes** 

*Does not need to be in the release notes as the workbench is not ready to announce yet.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
