### PR TITLE
Tiled plot does not update if multi fit re-run

### DIFF
--- a/docs/source/release/v3.12.0/ui.rst
+++ b/docs/source/release/v3.12.0/ui.rst
@@ -41,6 +41,7 @@ MultiDataset Fitting Interface
 
 - After a simultaneous fit the parameters are saved in a TableWorkspace made to simplify plotting their values against the datasets.
   The parameters are organised into columns and each row corresponds to a dataset.
+- Changed the behaviour of the exported graphs: on fit re-runs they update instead of closing.
 
 SpectrumView
 ------------

--- a/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.cpp
+++ b/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.cpp
@@ -776,7 +776,7 @@ void MultiDatasetFit::removeOldOutput() {
   auto &ADS = Mantid::API::AnalysisDataService::Instance();
   if (ADS.doesExist(outWS)) {
     if (auto group = ADS.retrieveWS<Mantid::API::WorkspaceGroup>(outWS)) {
-      auto nSpectra = getNumberOfSpectra();
+      auto nSpectra = static_cast<size_t>(getNumberOfSpectra());
       auto groupSize = group->size();
       // If size of output group decreases the extra workspaces will pop out
       // to the top level. Remove them.

--- a/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.cpp
+++ b/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.cpp
@@ -774,19 +774,17 @@ void MultiDatasetFit::setParameterNamesForPlotting() {
 void MultiDatasetFit::removeOldOutput() {
   auto outWS = m_outputWorkspaceName.toStdString();
   auto &ADS = Mantid::API::AnalysisDataService::Instance();
-  if (ADS.doesExist(outWS)) {
-    if (auto group = ADS.retrieveWS<Mantid::API::WorkspaceGroup>(outWS)) {
-      auto nSpectra = static_cast<size_t>(getNumberOfSpectra());
-      auto groupSize = group->size();
-      // If size of output group decreases the extra workspaces will pop out
-      // to the top level. Remove them.
-      if (groupSize > nSpectra) {
-        outWS.erase(outWS.size() - 1);
-        for (auto i = nSpectra; i < groupSize; ++i) {
-          auto wsName = outWS + "_" + std::to_string(i);
-          ADS.remove(wsName);
-        }
-      }
+  boost::shared_ptr<Mantid::API::WorkspaceGroup> group;
+  auto nSpectra = static_cast<size_t>(getNumberOfSpectra());
+  if (ADS.doesExist(outWS) &&
+      (group = ADS.retrieveWS<Mantid::API::WorkspaceGroup>(outWS)) &&
+      group->size() > nSpectra) {
+    // If size of output group decreases the extra workspaces will pop out
+    // to the top level. Remove them.
+    outWS.erase(outWS.size() - 1);
+    for (auto i = nSpectra; i < group->size(); ++i) {
+      auto wsName = outWS + "_" + std::to_string(i);
+      ADS.remove(wsName);
     }
   }
 }

--- a/qt/scientific_interfaces/Muon/MuonAnalysisFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisFitDataPresenter.cpp
@@ -604,7 +604,7 @@ void MuonAnalysisFitDataPresenter::handleFittedWorkspaces(
       const auto fitTable = generateParametersTable(wsName, paramsTable);
       if (fitTable) {
         const std::string fitTableName = newName.str() + "_Parameters";
-        ads.add(fitTableName, fitTable);
+        ads.addOrReplace(fitTableName, fitTable);
         // If user has specified a group to add to, add to that.
         // Otherwise the group is called the same thing as the base name.
         const std::string groupToAddTo =

--- a/qt/widgets/common/src/FunctionBrowser.cpp
+++ b/qt/widgets/common/src/FunctionBrowser.cpp
@@ -2063,7 +2063,11 @@ void FunctionBrowser::removeDatasets(QList<int> indices) {
             "Index of a dataset in FunctionBrowser cannot be negative.");
       }
       if (index < m_numberOfDatasets) {
-        par.value().remove(index);
+        auto &v = par.value();
+        // value may not have been populated
+        if (index < v.size()) {
+          v.remove(index);
+        }
       } else {
         throw std::runtime_error(
             "Index of a dataset in FunctionBrowser is out of range.");

--- a/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
@@ -969,10 +969,6 @@ void MuonFitPropertyBrowser::runFit() {
     const int nWorkspaces = static_cast<int>(m_workspacesToFit.size());
     if (nWorkspaces > 1) {
       alg->setPropertyValue("InputWorkspace", m_workspacesToFit[0]);
-      // Remove existing results with the same name
-      if (AnalysisDataService::Instance().doesExist(outputName())) {
-        AnalysisDataService::Instance().deepRemoveGroup(outputName());
-      }
       for (int i = 1; i < nWorkspaces; i++) {
         std::string suffix = boost::lexical_cast<std::string>(i);
         alg->setPropertyValue("InputWorkspace_" + suffix, m_workspacesToFit[i]);
@@ -1106,13 +1102,10 @@ void MuonFitPropertyBrowser::finishAfterSimultaneousFit(
   // Group output together
   std::string groupName = fitAlg->getPropertyValue("Output");
   const std::string &baseName = groupName;
-  if (ads.doesExist(groupName)) {
-    ads.deepRemoveGroup(groupName);
-  }
 
   // Create a group for label
   try {
-    ads.add(groupName, boost::make_shared<WorkspaceGroup>());
+    ads.addOrReplace(groupName, boost::make_shared<WorkspaceGroup>());
     ads.addToGroup(groupName, baseName + "_NormalisedCovarianceMatrix");
     ads.addToGroup(groupName, baseName + "_Parameters");
     ads.addToGroup(groupName, baseName + "_Workspaces");


### PR DESCRIPTION
Old output workspaces were being deleted before each fit making graphs to close. These changes delete workspaces only when the number of datasets changes. Plots now update normally.

**To test:**

Run Multi-dataset fitting interface and plot the results. See that the plots update on re-runs.

Fixes #21775


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
