### PR TITLE
Adjust slit positions in LoadILLReflectometry

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLReflectometry.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLReflectometry.h
@@ -78,7 +78,7 @@ private:
   double peakOffsetAngle();
   double detectorRotation();
   void placeDetector();
-  void placeSample();
+  void placeSlits();
   void placeSource();
   double collimationAngle() const;
   double detectorAngle() const;

--- a/Framework/DataHandling/src/LoadILLReflectometry.cpp
+++ b/Framework/DataHandling/src/LoadILLReflectometry.cpp
@@ -817,12 +817,14 @@ void LoadILLReflectometry::placeSlits() {
   double slit1ToSample{0.0};
   double slit2ToSample{0.0};
   if (m_instrument == Supported::Figaro) {
+    const double deflectionAngle = doubleFromRun("CollAngle.actual_coll_angle");
+    const double offset = m_sampleZOffset / std::cos(inRad(deflectionAngle));
     // For the moment, the position information for S3 is missing in the
     // NeXus files of Figaro. Using a hard-coded distance; should be fixed
     // when the NeXus files are
     const double slitSeparation =
         inMeter(doubleFromRun("Theta.inter-slit_distance"));
-    slit2ToSample = 0.368;
+    slit2ToSample = 0.368 + offset;
     slit1ToSample = slit2ToSample + slitSeparation;
   } else {
     slit1ToSample = inMeter(doubleFromRun("Distance.S2toSample"));

--- a/Framework/DataHandling/src/LoadILLReflectometry.cpp
+++ b/Framework/DataHandling/src/LoadILLReflectometry.cpp
@@ -670,8 +670,8 @@ double LoadILLReflectometry::reflectometryPeak() {
   auto maxFwhmIt = std::find_if(maxValueIt, ys.cend(), lessThanHalfMax);
   std::reverse_iterator<IterType> revMaxFwhmIt{maxFwhmIt};
   if (revMinFwhmIt == ys.crend() || maxFwhmIt == ys.cend()) {
-    g_log.warning()
-        << "Couldn't determine fwhm of beam, using position of max value as beam center.\n";
+    g_log.warning() << "Couldn't determine fwhm of beam, using position of max "
+                       "value as beam center.\n";
     return centreByMax;
   }
   const double fwhm =
@@ -820,7 +820,8 @@ void LoadILLReflectometry::placeSlits() {
     // For the moment, the position information for S3 is missing in the
     // NeXus files of Figaro. Using a hard-coded distance; should be fixed
     // when the NeXus files are
-    const double slitSeparation = inMeter(doubleFromRun("Theta.inter-slit_distance"));
+    const double slitSeparation =
+        inMeter(doubleFromRun("Theta.inter-slit_distance"));
     slit2ToSample = 0.368;
     slit1ToSample = slit2ToSample + slitSeparation;
   } else {

--- a/Framework/DataHandling/src/LoadILLReflectometry.cpp
+++ b/Framework/DataHandling/src/LoadILLReflectometry.cpp
@@ -276,10 +276,11 @@ void LoadILLReflectometry::exec() {
   root.close();
   firstEntry.close();
   initPixelWidth();
-  // Move components as if the sample was at the origin (it usually is).
+  // Move components.
   m_sampleZOffset = sampleHorizontalOffset();
   placeSource();
   placeDetector();
+  placeSlits();
   // When other components are in-place
   convertTofToWavelength();
   // Set the output workspace property
@@ -670,7 +671,7 @@ double LoadILLReflectometry::reflectometryPeak() {
   std::reverse_iterator<IterType> revMaxFwhmIt{maxFwhmIt};
   if (revMinFwhmIt == ys.crend() || maxFwhmIt == ys.cend()) {
     g_log.warning()
-        << "Couldn't determine fwhm, using position of max value.\n";
+        << "Couldn't determine fwhm of beam, using position of max value as beam center.\n";
     return centreByMax;
   }
   const double fwhm =
@@ -809,6 +810,27 @@ void LoadILLReflectometry::placeDetector() {
   // apply a local rotation to stay perpendicular to the beam
   const auto rotation = detectorFaceRotation(rotPlane, detectorRotationAngle);
   m_loader.rotateComponent(m_localWorkspace, componentName, rotation);
+}
+
+/// Update the slit positions.
+void LoadILLReflectometry::placeSlits() {
+  double slit1ToSample{0.0};
+  double slit2ToSample{0.0};
+  if (m_instrument == Supported::Figaro) {
+    // For the moment, the position information for S3 is missing in the
+    // NeXus files of Figaro. Using a hard-coded distance; should be fixed
+    // when the NeXus files are
+    const double slitSeparation = inMeter(doubleFromRun("Theta.inter-slit_distance"));
+    slit2ToSample = 0.368;
+    slit1ToSample = slit2ToSample + slitSeparation;
+  } else {
+    slit1ToSample = inMeter(doubleFromRun("Distance.S2toSample"));
+    slit2ToSample = inMeter(doubleFromRun("Distance.S3toSample"));
+  }
+  V3D pos{0.0, 0.0, -slit1ToSample};
+  m_loader.moveComponent(m_localWorkspace, "slit2", pos);
+  pos = {0.0, 0.0, -slit2ToSample};
+  m_loader.moveComponent(m_localWorkspace, "slit3", pos);
 }
 
 /// Update source position.

--- a/Framework/DataHandling/test/LoadILLReflectometryTest.h
+++ b/Framework/DataHandling/test/LoadILLReflectometryTest.h
@@ -514,7 +514,12 @@ public:
     auto slit1 = instrument->getComponentByName("slit2");
     auto slit2 = instrument->getComponentByName("slit3");
     // The S3 position is missing in the NeXus file; use a hard-coded value.
-    const double S3z = -0.368;
+    const double collimationAngle = output->run().getPropertyValueAsType<double>(
+          "CollAngle.actual_coll_angle") / 180. * M_PI;
+    const double sampleOffset = output->run().getPropertyValueAsType<double>(
+          "Theta.sampleHorizontalOffset") * 1e-3;
+    const double slitZOffset = sampleOffset / std::cos(collimationAngle);
+    const double S3z = -0.368 - slitZOffset;
     const double slitSeparation = output->run().getPropertyValueAsType<double>(
                                       "Theta.inter-slit_distance") *
                                   1e-3;

--- a/Framework/DataHandling/test/LoadILLReflectometryTest.h
+++ b/Framework/DataHandling/test/LoadILLReflectometryTest.h
@@ -514,10 +514,13 @@ public:
     auto slit1 = instrument->getComponentByName("slit2");
     auto slit2 = instrument->getComponentByName("slit3");
     // The S3 position is missing in the NeXus file; use a hard-coded value.
-    const double collimationAngle = output->run().getPropertyValueAsType<double>(
-          "CollAngle.actual_coll_angle") / 180. * M_PI;
+    const double collimationAngle =
+        output->run().getPropertyValueAsType<double>(
+            "CollAngle.actual_coll_angle") /
+        180. * M_PI;
     const double sampleOffset = output->run().getPropertyValueAsType<double>(
-          "Theta.sampleHorizontalOffset") * 1e-3;
+                                    "Theta.sampleHorizontalOffset") *
+                                1e-3;
     const double slitZOffset = sampleOffset / std::cos(collimationAngle);
     const double S3z = -0.368 - slitZOffset;
     const double slitSeparation = output->run().getPropertyValueAsType<double>(

--- a/Framework/DataHandling/test/LoadILLReflectometryTest.h
+++ b/Framework/DataHandling/test/LoadILLReflectometryTest.h
@@ -16,8 +16,9 @@
 #include "MantidKernel/Unit.h"
 
 using namespace Mantid::API;
-using Mantid::DataHandling::LoadILLReflectometry;
 using Mantid::DataHandling::LoadEmptyInstrument;
+using Mantid::DataHandling::LoadILLReflectometry;
+using Mantid::Kernel::V3D;
 
 class LoadILLReflectometryTest : public CxxTest::TestSuite {
 private:
@@ -488,6 +489,38 @@ public:
     getWorkspaceFor(output, m_d17File, m_outWSName, prop);
     const auto &spectrumInfo = output->spectrumInfo();
     TS_ASSERT_DELTA(spectrumInfo.twoTheta(42) * 180 / M_PI, 2 * angle, 1e-6)
+  }
+
+  void testSlitConfigurationD17() {
+    MatrixWorkspace_sptr output;
+    getWorkspaceFor(output, m_d17File, m_outWSName, emptyProperties());
+    auto instrument = output->getInstrument();
+    auto slit1 = instrument->getComponentByName("slit2");
+    auto slit2 = instrument->getComponentByName("slit3");
+    const double S2z =
+        -output->run().getPropertyValueAsType<double>("Distance.S2toSample") *
+        1e-3;
+    TS_ASSERT_EQUALS(slit1->getPos(), V3D(0.0, 0.0, S2z))
+    const double S3z =
+        -output->run().getPropertyValueAsType<double>("Distance.S3toSample") *
+        1e-3;
+    TS_ASSERT_EQUALS(slit2->getPos(), V3D(0.0, 0.0, S3z))
+  }
+
+  void testSlitConfigurationFigaro() {
+    MatrixWorkspace_sptr output;
+    getWorkspaceFor(output, m_figaroFile, m_outWSName, emptyProperties());
+    auto instrument = output->getInstrument();
+    auto slit1 = instrument->getComponentByName("slit2");
+    auto slit2 = instrument->getComponentByName("slit3");
+    // The S3 position is missing in the NeXus file; use a hard-coded value.
+    const double S3z = -0.368;
+    const double slitSeparation = output->run().getPropertyValueAsType<double>(
+                                      "Theta.inter-slit_distance") *
+                                  1e-3;
+    const double S2z = S3z - slitSeparation;
+    TS_ASSERT_EQUALS(slit1->getPos(), V3D(0.0, 0.0, S2z))
+    TS_ASSERT_EQUALS(slit2->getPos(), V3D(0.0, 0.0, S3z))
   }
 };
 

--- a/docs/source/release/v3.12.0/reflectometry.rst
+++ b/docs/source/release/v3.12.0/reflectometry.rst
@@ -74,16 +74,14 @@ Improvements
 
 - Removed the ``RegionOfDirectBeam`` property from :ref:`algm-ReflectometryReductionOne` and :ref:`algm-ReflectometryReductionOneAuto` because this is not used.
 - Improvements to :ref:`algm-LoadILLReflectometry`:
-    - Figaro NeXus files are now properly handled.
-    - A new property, *BeamCentre* allows user to manually specify the beam position on the detector.
-    - The *BeamPosition* property was renamed to *DirectBeamPosition* to better reflect its usage.
-    - The *BraggAngle* property of :ref:`algm-LoadILLReflectometry` now works as expected: the detector will be rotated such that the reflected peak on the detector will be at twice *BraggAngle*.
-
+  - Figaro NeXus files are now properly handled.
+  - A new property, *BeamCentre* allows user to manually specify the beam position on the detector.
+  - The *BeamPosition* property was renamed to *DirectBeamPosition* to better reflect its usage.
+  - The *BraggAngle* property of :ref:`algm-LoadILLReflectometry` now works as expected: the detector will be rotated such that the reflected peak on the detector will be at twice *BraggAngle*.
+  - Slits S2 and S3 have been added to D17 and Figaro IDFs; the loader will adjust their positions according to the NeXus files.
 
 Bug fixes
 #########
-
-- The *BraggAngle* property of :ref:`algm-LoadILLReflectometry` now works as expected: the detector will be rotated such that the reflected peak will be at twice *BraggAngle*.
 
 
 :ref:`Release 3.12.0 <v3.12.0>`


### PR DESCRIPTION
This PR adds slit configuration to [`LoadILLReflectometry`](http://docs.mantidproject.org/nightly/algorithms/LoadILLReflectometry-v1.html). The two slits defined in the IDFs of D17 and Figaro are positioned according to the NeXus files. However, Figaro NeXus is missing the S3 (`slit2`) position and a hard-coded value is used at the moment.

**To test:**

Load the D17 and Figaro files from `ExternalData/Testing/Data/UnitTest/ILL/D17` and `ExternalData/Testing/Data/UnitTest/ILLD/Figaro`. Check that `slit1` and `slit2` component positions are on the negative z-axis, corresponding to the sample logs.

D17:
`Distance.S2toSample` (`slit1`)
`Distance.S3toSample` (`slit2`)

Figaro:
`slit2` is hard-coded to 0.368m
The distance between `slit1` and `slit2` is recorded in `Theta.inter-slit_distance`

Fixes #21791. 

**Release Notes** 

Reflectometry release notes were updated accordingly.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
