### PR TITLE
Increase tolerance when running ISIS Powder HRPD system test on OSX

### DIFF
--- a/Testing/SystemTests/tests/analysis/ISIS_PowderHRPDTest.py
+++ b/Testing/SystemTests/tests/analysis/ISIS_PowderHRPDTest.py
@@ -1,6 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 import os
+import platform
 import shutil
 import stresstesting
 
@@ -79,7 +80,10 @@ class FocusTest(stresstesting.MantidStressTest):
         self.focus_results = run_focus()
 
     def validate(self):
-        self.tolerance=0.25  # Required for difference in spline data between operating systems
+        if platform.system() == "Darwin":  # OSX requires higher tolerance for splines
+            self.tolerance = 0.4
+        else:
+            self.tolerance = 0.05
         return self.focus_results.getName(), "HRPD66063_focused.nxs"
 
     def cleanup(self):


### PR DESCRIPTION
**Requires testing on OSX**

Tolerance for `FocusTest` in `ISIS_PowderHRPDTest` was increased to allow for differences in splines on OSX. It was only increased when running on OSX - for any other operating system it was taken back down to where it was before #21502 

**To test:**

Make sure `ISIS_PowderHRPDTest` passes locally and on the build server

Fixes #21795 

**Release Notes** 
Internal change, does not need to be in the release notes

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
