### PR TITLE
Re #21798 Added preservation of reduction mode

### DIFF
--- a/docs/source/release/v3.12.0/lowq.rst
+++ b/docs/source/release/v3.12.0/lowq.rst
@@ -25,10 +25,11 @@ Small Angle Scattering
 - Added functionality to specify q values between which merged data is used and outside of which pure HAB and LAB are used.
 - Have added the functionality to show diagnostic transmission workspaces to new GUI.
 - Have added functionality to continually plot latest results to new GUI.
+- Added find beam centre tab to SANS GUI V2.
+- Fixed an issue where merged or all reductions were overwriting each other as they were being given the same name.
 - Fixed a bug where specifying fit range was not working for merged reductions. Previously the user specified range was being ignored.
 - Fixed a bug in the old GUI where loading files on UNIX systems would not work unless the file name was in uppercase letters.
 - Fixed a bug in the old GUI where merged reductions of time sliced data was not working.
-- Added find beam centre tab to SANS GUI V2.
-- Fixed an issue where merged or all reductions were overwriting each other as they were being given the same name.
+- Fixed a bug where 2D reductions were being run in 1D if a new user file was specified in a batch file.
 
 :ref:`Release 3.12.0 <v3.12.0>`

--- a/scripts/SANS/SANSBatchMode.py
+++ b/scripts/SANS/SANSBatchMode.py
@@ -250,8 +250,8 @@ def BatchReduce(filename, format, plotresults=False, saveAlgs={'SaveRKH':'txt'},
                     new_combineDet = ReductionSingleton().instrument.get_detector_selection()
                     combineDet = su.get_correct_combinDet_setting(ins_name, new_combineDet)
         except (RuntimeError, ValueError) as e:
-            sanslog.warning("Error in Batchmode user files: Could not reset the specified user file %s. More info: %s" %(
-                str(run['user_file']), str(e)))
+            raise RuntimeError("Error in Batchmode user files: Could not reset the specified user file {0}. More info: {1}"
+                               .format(str(run['user_file']), str(e)))
 
         local_settings = copy.deepcopy(ReductionSingleton().reference())
         local_prop_man_settings = ReductionSingleton().settings.clone("TEMP_SETTINGS")
@@ -575,7 +575,9 @@ def setUserFileInBatchMode(new_user_file, current_user_file, original_user_file,
                 break
 
         if not os.path.isfile(user_file):
-            user_file_to_set = original_user_file
+            message = "Error could not find specified user file {0}"\
+                .format(new_user_file)
+            raise RuntimeError(message)
         else:
             user_file_to_set = user_file
     else:
@@ -590,9 +592,11 @@ def setUserFileInBatchMode(new_user_file, current_user_file, original_user_file,
             ReductionSingleton().settings = original_prop_man_settings.clone(REDUCTION_SETTINGS_OBJ_NAME)
         else:
             instrument = copy.deepcopy(ReductionSingleton().get_instrument())
+            output_type = ReductionSingleton().to_Q.output_type
             ReductionSingleton().clean(isis_reducer.ISISReducer)
             ReductionSingleton().set_instrument(instrument)
             ReductionSingleton().user_settings = UserFile(user_file_to_set)
+            ReductionSingleton().to_Q.output_type = output_type
             ReductionSingleton().user_settings.execute(ReductionSingleton())
         current_user_file = user_file_to_set
     return current_user_file

--- a/scripts/SANS/SANSBatchMode.py
+++ b/scripts/SANS/SANSBatchMode.py
@@ -565,23 +565,26 @@ def setUserFileInBatchMode(new_user_file, current_user_file, original_user_file,
     """
     user_file_to_set = ""
 
-    # Try to find the user file in the default paths
-    if not os.path.isfile(new_user_file):
-        # Find the user file in the Mantid path. we make sure that the user file has a txt extension.
-        user_file_names_with_extension = su.get_user_file_name_options_with_txt_extension(new_user_file)
-        for user_file_name_with_extension in user_file_names_with_extension:
-            user_file = FileFinder.getFullPath(user_file_name_with_extension)
-            if user_file:
-                break
-
-        if not os.path.isfile(user_file):
-            message = "Error could not find specified user file {0}"\
-                .format(new_user_file)
-            raise RuntimeError(message)
-        else:
-            user_file_to_set = user_file
+    if new_user_file == '':
+        user_file_to_set = original_user_file
     else:
-        user_file_to_set = new_user_file
+        # Try to find the user file in the default paths
+        if not os.path.isfile(new_user_file):
+            # Find the user file in the Mantid path. we make sure that the user file has a txt extension.
+            user_file_names_with_extension = su.get_user_file_name_options_with_txt_extension(new_user_file)
+            for user_file_name_with_extension in user_file_names_with_extension:
+                user_file = FileFinder.getFullPath(user_file_name_with_extension)
+                if user_file:
+                    break
+
+            if not os.path.isfile(user_file):
+                message = "Error could not find specified user file {0}"\
+                    .format(new_user_file)
+                raise RuntimeError(message)
+            else:
+                user_file_to_set = user_file
+        else:
+            user_file_to_set = new_user_file
 
     # Set the user file in the reducer and load the user file
     if user_file_to_set != current_user_file:

--- a/scripts/test/SANSBatchModeTest.py
+++ b/scripts/test/SANSBatchModeTest.py
@@ -73,7 +73,7 @@ class TestSettingUserFileInBatchMode(unittest.TestCase):
         # Clean up
         self._delete_minimal_user_files(user_files)
 
-    def test_user_file_is_set_to_new__user_file_when_it_exists_and_is_different_from_orig_and_current(self):
+    def test_user_file_is_set_to_new_user_file_when_it_exists_and_is_different_from_orig_and_current(self):
         #Arrange
         user_files = self._create_minimal_user_files(3)
         new_user_file = user_files[0]
@@ -93,6 +93,28 @@ class TestSettingUserFileInBatchMode(unittest.TestCase):
                         "The physical reducer should not change.")
         self.assertEqual(ReductionSingleton().user_settings.filename, new_user_file,
                          "The reducer should use the new user file.")
+        # Clean up
+        self._delete_minimal_user_files(user_files)
+
+    def test_user_file_is_set_to_new_user_file_when_it_exists_but_reduction_dimensionality_remains_unchanged(self):
+        #Arrange
+        user_files = self._create_minimal_user_files(3)
+        new_user_file = user_files[0]
+        current_user_file = user_files[1]
+        original_user_file = user_files[2]
+        original_settings, original_prop_man_settings = self._prepare_reducer(current_user_file = current_user_file,
+                                                                              original_user_file = original_user_file)
+        ReductionSingleton().to_Q.output_type = "2D"
+        # Act
+        
+        bm.setUserFileInBatchMode(new_user_file=new_user_file,
+                                  current_user_file=current_user_file,
+                                  original_user_file=original_user_file,
+                                  original_settings = original_settings,
+                                  original_prop_man_settings = original_prop_man_settings)
+        # Assert
+        self.assertTrue(ReductionSingleton().to_Q.output_type=="2D",
+                        "The reducer should retain the same dimensionality.")
         # Clean up
         self._delete_minimal_user_files(user_files)
 


### PR DESCRIPTION
The old sans GUI was when reducing in batch mode always reducing in 1D if a user file was specified even if the reduce 2D button was clicked. The user file had to be different from the specified user file for this to proc.

**To test:**



- Download this
Removed as contained some erroneous data.

- In mantid open the old sans GUI, load MaskFile.txt as the user file.
- Switch to batch mode (There is a radio button below Current IDF line)
- Load the batch file from the folder.
- Click 2D reduce and confirm that the output workspaces (called first_time_hab, first_time_main e.c.t.) have more than one spectrum.


<!-- Instructions for testing. -->

Fixes #21798 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
