### PR TITLE
Engineering GUI hook up GSAS tab to GSASIIRefineFitPeaks

### DIFF
--- a/qt/scientific_interfaces/EnggDiffraction/CMakeLists.txt
+++ b/qt/scientific_interfaces/EnggDiffraction/CMakeLists.txt
@@ -11,6 +11,7 @@ set ( SRC_FILES
 	EnggDiffMultiRunFittingWidgetPresenter.cpp
 	EnggDiffractionPresenter.cpp
 	EnggDiffractionViewQtGUI.cpp
+	GSASIIRefineFitPeaksOutputProperties.cpp
 	GSASIIRefineFitPeaksParameters.cpp
 	RunLabel.cpp
 )
@@ -34,6 +35,7 @@ set ( INC_FILES
 	EnggDiffractionPresWorker.h
 	EnggDiffractionPresenter.h
 	EnggDiffractionViewQtGUI.h
+	GSASIIRefineFitPeaksOutputProperties.cpp
 	GSASIIRefineFitPeaksParameters.h
 	IEnggDiffFittingModel.h
 	IEnggDiffFittingPresenter.h

--- a/qt/scientific_interfaces/EnggDiffraction/CMakeLists.txt
+++ b/qt/scientific_interfaces/EnggDiffraction/CMakeLists.txt
@@ -11,6 +11,7 @@ set ( SRC_FILES
 	EnggDiffMultiRunFittingWidgetPresenter.cpp
 	EnggDiffractionPresenter.cpp
 	EnggDiffractionViewQtGUI.cpp
+	GSASIIRefineFitPeaksParameters.cpp
 	RunLabel.cpp
 )
 
@@ -33,6 +34,7 @@ set ( INC_FILES
 	EnggDiffractionPresWorker.h
 	EnggDiffractionPresenter.h
 	EnggDiffractionViewQtGUI.h
+	GSASIIRefineFitPeaksParameters.h
 	IEnggDiffFittingModel.h
 	IEnggDiffFittingPresenter.h
 	IEnggDiffGSASFittingModel.h

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.cpp
@@ -167,6 +167,12 @@ EnggDiffGSASFittingModel::getSigma(const RunLabel &runLabel) const {
   return getFromRunMapOptional(m_sigmaMap, runLabel);
 }
 
+bool EnggDiffGSASFittingModel::hasFitResultsForRun(
+    const RunLabel &runLabel) const {
+  return m_rwpMap.contains(runLabel) && m_sigmaMap.contains(runLabel) &&
+         m_gammaMap.contains(runLabel);
+}
+
 Mantid::API::MatrixWorkspace_sptr
 EnggDiffGSASFittingModel::loadFocusedRun(const std::string &filename) const {
   const auto wsName = stripWSNameFromFilename(filename);

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.cpp
@@ -4,6 +4,8 @@
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace.h"
 
+#include <boost/algorithm/string/join.hpp>
+
 using namespace Mantid;
 
 namespace {
@@ -92,7 +94,7 @@ double EnggDiffGSASFittingModel::doGSASRefinementAlgorithm(
   gsasAlg->setProperty("OutputWorkspace", outputWorkspaceName);
   gsasAlg->setProperty("LatticeParameters", latticeParamsName);
   gsasAlg->setProperty("InstrumentFile", instParamFile);
-  gsasAlg->setProperty("PhaseInfoFiles", phaseFiles);
+  gsasAlg->setProperty("PhaseInfoFiles", boost::algorithm::join(phaseFiles, ","));
   gsasAlg->setProperty("PathToGSASII", pathToGSASII);
   gsasAlg->setProperty("SaveGSASIIProjectFile", GSASIIProjectFile);
   gsasAlg->setProperty("PawleyDMin", dMin);

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
@@ -28,6 +28,8 @@ public:
 
   boost::optional<double> getSigma(const RunLabel &runLabel) const override;
 
+  bool hasFitResultsForRun(const RunLabel &runLabel) const override;
+
   Mantid::API::MatrixWorkspace_sptr
   loadFocusedRun(const std::string &filename) const override;
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
@@ -2,6 +2,7 @@
 #define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_GSASFITTINGMODEL_H_
 
 #include "DllConfig.h"
+#include "GSASIIRefineFitPeaksOutputProperties.h"
 #include "IEnggDiffGSASFittingModel.h"
 #include "RunMap.h"
 
@@ -21,7 +22,11 @@ public:
   boost::optional<Mantid::API::ITableWorkspace_sptr>
   getLatticeParams(const RunLabel &runLabel) const override;
 
+  boost::optional<double> getGamma(const RunLabel &runLabel) const override;
+
   boost::optional<double> getRwp(const RunLabel &runLabel) const override;
+
+  boost::optional<double> getSigma(const RunLabel &runLabel) const override;
 
   Mantid::API::MatrixWorkspace_sptr
   loadFocusedRun(const std::string &filename) const override;
@@ -34,20 +39,29 @@ protected:
   void addLatticeParams(const RunLabel &runLabel,
                         Mantid::API::ITableWorkspace_sptr table);
 
+  /// Add a gamma value to the gamma map
+  void addGamma(const RunLabel &runLabel, const double gamma);
+
   /// Add an rwp value to the rwp map
   void addRwp(const RunLabel &runLabel, const double rwp);
+
+  /// Add a sigma value to the sigma map
+  void addSigma(const RunLabel &runLabel, const double sigma);
 
 private:
   static constexpr double DEFAULT_PAWLEY_DMIN = 1;
   static constexpr double DEFAULT_PAWLEY_NEGATIVE_WEIGHT = 0;
   static const size_t MAX_BANKS = 2;
 
+  RunMap<MAX_BANKS, double> m_gammaMap;
   RunMap<MAX_BANKS, Mantid::API::ITableWorkspace_sptr> m_latticeParamsMap;
   RunMap<MAX_BANKS, double> m_rwpMap;
+  RunMap<MAX_BANKS, double> m_sigmaMap;
 
-  /// Add Rwp and lattice params table to their
+  /// Add Rwp, sigma, gamma and lattice params table to their
   /// respective RunMaps
   void addFitResultsToMaps(const RunLabel &runLabel, const double rwp,
+                           const double sigma, const double gamma,
                            const std::string &latticeParamsTableName);
 
   template <typename T>
@@ -62,12 +76,11 @@ private:
   /// Run GSASIIRefineFitPeaks
   /// Note this must be virtual so that it can be mocked out by the helper class
   /// in EnggDiffGSASFittingModelTest
-  /// Returns Rwp of the fit
-  virtual double
+  virtual GSASIIRefineFitPeaksOutputProperties
   doGSASRefinementAlgorithm(const std::string &fittedPeaksWSName,
                             const std::string &latticeParamsWSName,
                             const GSASIIRefineFitPeaksParameters &params,
-			    const std::string &refinementMethod);
+                            const std::string &refinementMethod);
 };
 
 } // CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
@@ -13,20 +13,10 @@ class MANTIDQT_ENGGDIFFRACTION_DLL EnggDiffGSASFittingModel
 
 public:
   Mantid::API::MatrixWorkspace_sptr
-  doPawleyRefinement(const Mantid::API::MatrixWorkspace_sptr inputWS,
-                     const RunLabel &runLabel, const std::string &instParamFile,
-                     const std::vector<std::string> &phaseFiles,
-                     const std::string &pathToGSASII,
-                     const std::string &GSASIIProjectFile, const double dMin,
-                     const double negativeWeight) override;
+  doPawleyRefinement(const GSASIIRefineFitPeaksParameters &params) override;
 
   Mantid::API::MatrixWorkspace_sptr
-  doRietveldRefinement(const Mantid::API::MatrixWorkspace_sptr inputWS,
-                       const RunLabel &runLabel,
-                       const std::string &instParamFile,
-                       const std::vector<std::string> &phaseFiles,
-                       const std::string &pathToGSASII,
-                       const std::string &GSASIIProjectFile) override;
+  doRietveldRefinement(const GSASIIRefineFitPeaksParameters &params) override;
 
   boost::optional<Mantid::API::ITableWorkspace_sptr>
   getLatticeParams(const RunLabel &runLabel) const override;
@@ -73,14 +63,11 @@ private:
   /// Note this must be virtual so that it can be mocked out by the helper class
   /// in EnggDiffGSASFittingModelTest
   /// Returns Rwp of the fit
-  virtual double doGSASRefinementAlgorithm(
-      Mantid::API::MatrixWorkspace_sptr inputWorkspace,
-      const std::string &outputWorkspaceName,
-      const std::string &latticeParamsName, const std::string &refinementMethod,
-      const std::string &instParamFile,
-      const std::vector<std::string> &phaseFiles,
-      const std::string &pathToGSASII, const std::string &GSASIIProjectFile,
-      const double dMin, const double negativeWeight);
+  virtual double
+  doGSASRefinementAlgorithm(const std::string &fittedPeaksWSName,
+                            const std::string &latticeParamsWSName,
+                            const GSASIIRefineFitPeaksParameters &params,
+			    const std::string &refinementMethod);
 };
 
 } // CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
@@ -89,6 +89,11 @@ EnggDiffGSASFittingPresenter::doRietveldRefinement(
 }
 
 void EnggDiffGSASFittingPresenter::processDoRefinement() {
+  if (!m_multiRunWidget->hasSelectedRunLabel()){
+    m_view->userWarning("No run selected",
+                        "Please select a run to do refinement on");
+    return;
+  }
   const auto runLabel = m_multiRunWidget->getSelectedRunLabel();
   const auto inputWSOptional = m_multiRunWidget->getFocusedRun(runLabel);
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
@@ -120,6 +120,7 @@ void EnggDiffGSASFittingPresenter::processDoRefinement() {
     return;
   }
 
+  m_view->showStatus("Refining run");
   const auto refinementMethod = m_view->getRefinementMethod();
   const auto refinementParams =
       collectInputParameters(runLabel, *inputWSOptional, refinementMethod);
@@ -140,9 +141,11 @@ void EnggDiffGSASFittingPresenter::processDoRefinement() {
 
     m_multiRunWidget->addFittedPeaks(runLabel, fittedPeaks);
     displayFitResults(runLabel);
-  } catch (const std::runtime_error &ex) {
+  } catch (const std::exception &ex) {
+    m_view->showStatus("An error occurred in refinement");
     m_view->userError("Refinement failed", ex.what());
   }
+  m_view->showStatus("Ready");
 }
 
 void EnggDiffGSASFittingPresenter::processLoadRun() {
@@ -170,6 +173,7 @@ void EnggDiffGSASFittingPresenter::processSelectRun() {
 void EnggDiffGSASFittingPresenter::processStart() {
   auto addMultiRunWidget = m_multiRunWidget->getWidgetAdder();
   (*addMultiRunWidget)(*m_view);
+  m_view->showStatus("Ready");
 }
 
 void EnggDiffGSASFittingPresenter::processShutDown() { m_viewHasClosed = true; }

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
@@ -70,8 +70,10 @@ EnggDiffGSASFittingPresenter::collectInputParameters(
 void EnggDiffGSASFittingPresenter::displayFitResults(const RunLabel &runLabel) {
   const auto latticeParams = m_model->getLatticeParams(runLabel);
   const auto rwp = m_model->getRwp(runLabel);
+  const auto sigma = m_model->getSigma(runLabel);
+  const auto gamma = m_model->getGamma(runLabel);
 
-  if (!latticeParams || !rwp) {
+  if (!latticeParams || !rwp || !sigma || !gamma) {
     m_view->userError("Invalid run identifier",
                       "Unexpectedly tried to display fit results for invalid "
                       "run, run number = " +
@@ -83,6 +85,8 @@ void EnggDiffGSASFittingPresenter::displayFitResults(const RunLabel &runLabel) {
 
   m_view->displayLatticeParams(*latticeParams);
   m_view->displayRwp(*rwp);
+  m_view->displaySigma(*sigma);
+  m_view->displayGamma(*gamma);
 }
 
 Mantid::API::MatrixWorkspace_sptr
@@ -135,6 +139,7 @@ void EnggDiffGSASFittingPresenter::processDoRefinement() {
     }
 
     m_multiRunWidget->addFittedPeaks(runLabel, fittedPeaks);
+    displayFitResults(runLabel);
   } catch (const std::runtime_error &ex) {
     m_view->userError("Refinement failed", ex.what());
   }
@@ -156,20 +161,7 @@ void EnggDiffGSASFittingPresenter::processLoadRun() {
 void EnggDiffGSASFittingPresenter::processSelectRun() {
   if (m_multiRunWidget->showFitResultsSelected()) {
     const auto runLabel = m_multiRunWidget->getSelectedRunLabel();
-    const auto rwp = m_model->getRwp(runLabel);
-    const auto latticeParams = m_model->getLatticeParams(runLabel);
-
-    if (!rwp || !latticeParams) {
-      m_view->userError(
-          "Invalid run label",
-          "Tried to display fit results for run number " +
-              std::to_string(runLabel.runNumber) + " and bank ID " +
-              std::to_string(runLabel.bank) +
-              ". Please contact the development team with this message");
-      return;
-    }
-    m_view->displayRwp(*rwp);
-    m_view->displayLatticeParams(*latticeParams);
+    displayFitResults(runLabel);
   }
 }
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
@@ -159,9 +159,11 @@ void EnggDiffGSASFittingPresenter::processLoadRun() {
 }
 
 void EnggDiffGSASFittingPresenter::processSelectRun() {
-  if (m_multiRunWidget->showFitResultsSelected()) {
+  if (m_multiRunWidget->hasSelectedRunLabel()) {
     const auto runLabel = m_multiRunWidget->getSelectedRunLabel();
-    displayFitResults(runLabel);
+    if (m_model->hasFitResultsForRun(runLabel)) {
+      displayFitResults(runLabel);
+    }
   }
 }
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
@@ -102,20 +102,20 @@ EnggDiffGSASFittingPresenter::doRietveldRefinement(
 }
 
 void EnggDiffGSASFittingPresenter::processDoRefinement() {
-  if (!m_multiRunWidget->hasSelectedRunLabel()) {
+  const auto runLabel = m_multiRunWidget->getSelectedRunLabel();
+  if (!runLabel) {
     m_view->userWarning("No run selected",
                         "Please select a run to do refinement on");
     return;
   }
-  const auto runLabel = m_multiRunWidget->getSelectedRunLabel();
-  const auto inputWSOptional = m_multiRunWidget->getFocusedRun(runLabel);
 
+  const auto inputWSOptional = m_multiRunWidget->getFocusedRun(*runLabel);
   if (!inputWSOptional) {
     m_view->userError(
         "Invalid run selected for refinement",
         "Tried to run refinement on invalid focused run, run number " +
-            std::to_string(runLabel.runNumber) + " and bank ID " +
-            std::to_string(runLabel.bank) +
+            std::to_string(runLabel->runNumber) + " and bank ID " +
+            std::to_string(runLabel->bank) +
             ". Please contact the development team with this message");
     return;
   }
@@ -123,7 +123,7 @@ void EnggDiffGSASFittingPresenter::processDoRefinement() {
   m_view->showStatus("Refining run");
   const auto refinementMethod = m_view->getRefinementMethod();
   const auto refinementParams =
-      collectInputParameters(runLabel, *inputWSOptional, refinementMethod);
+      collectInputParameters(*runLabel, *inputWSOptional, refinementMethod);
 
   try {
     Mantid::API::MatrixWorkspace_sptr fittedPeaks;
@@ -139,8 +139,8 @@ void EnggDiffGSASFittingPresenter::processDoRefinement() {
       break;
     }
 
-    m_multiRunWidget->addFittedPeaks(runLabel, fittedPeaks);
-    displayFitResults(runLabel);
+    m_multiRunWidget->addFittedPeaks(*runLabel, fittedPeaks);
+    displayFitResults(*runLabel);
   } catch (const std::exception &ex) {
     m_view->showStatus("An error occurred in refinement");
     m_view->userError("Refinement failed", ex.what());
@@ -162,11 +162,9 @@ void EnggDiffGSASFittingPresenter::processLoadRun() {
 }
 
 void EnggDiffGSASFittingPresenter::processSelectRun() {
-  if (m_multiRunWidget->hasSelectedRunLabel()) {
-    const auto runLabel = m_multiRunWidget->getSelectedRunLabel();
-    if (m_model->hasFitResultsForRun(runLabel)) {
-      displayFitResults(runLabel);
-    }
+  const auto runLabel = m_multiRunWidget->getSelectedRunLabel();
+  if (runLabel && m_model->hasFitResultsForRun(*runLabel)) {
+    displayFitResults(*runLabel);
   }
 }
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.h
@@ -42,42 +42,28 @@ private:
   void processShutDown();
   void processStart();
 
+  /// Collect GSASIIRefineFitPeaks input parameters for a given run from the
+  /// presenter's various children
+  GSASIIRefineFitPeaksParameters
+  collectInputParameters(const RunLabel &runLabel,
+                         const Mantid::API::MatrixWorkspace_sptr ws,
+                         const GSASRefinementMethod refinementMethod) const;
+
   /**
    Perform a Pawley refinement on a run
-   @param inputWS Workspace to run refinement on
-   @param runLabel Run number and bank ID of the workspace to refine
-   @param instParamFile The instrument parameter file name (.prm) to use for
-   refinement
-   @param phaseFiles Vector of file paths to phases to use in refinement
-   @param pathToGSASII Location of the directory containing GSASIIscriptable.py
-   (and GSAS-II executables)
-   @param GSASIIProjectFile Location to save the .gpx project to
+   @param params Input parameters for GSASIIRefineFitPeaks
    @return Fitted peaks workspace resulting from refinement
    */
   Mantid::API::MatrixWorkspace_sptr
-  doPawleyRefinement(const Mantid::API::MatrixWorkspace_sptr inputWS,
-                     const RunLabel &runLabel, const std::string &instParamFile,
-                     const std::vector<std::string> &phaseFiles,
-                     const std::string &pathToGSASII,
-                     const std::string &GSASIIProjectFile);
+  doPawleyRefinement(const GSASIIRefineFitPeaksParameters &params);
 
   /**
    Perform a Rietveld refinement on a run
-   @param inputWS Workspace to run refinement on
-   @param runLabel Run number and bank ID of the workspace to refine
-   @param instParamFile The instrument parameter file name (.prm) to use for
-   refinement
-   @param phaseFiles Vector of file paths to phases to use in refinement
-   @param pathToGSASII Location of the directory containing GSASIIscriptable.py
-   (and GSAS-II executables)
-   @param GSASIIProjectFile Location to save the .gpx project to
+   @param params Input parameters for GSASIIRefineFitPeaks
    @return Fitted peaks workspace resulting from refinement
    */
-  Mantid::API::MatrixWorkspace_sptr doRietveldRefinement(
-      const Mantid::API::MatrixWorkspace_sptr inputWS, const RunLabel &runLabel,
-      const std::string &instParamFile,
-      const std::vector<std::string> &phaseFiles,
-      const std::string &pathToGSASII, const std::string &GSASIIProjectFile);
+  Mantid::API::MatrixWorkspace_sptr
+  doRietveldRefinement(const GSASIIRefineFitPeaksParameters &params);
 
   /**
    Overplot fitted peaks for a run, and display lattice parameters and Rwp in

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
@@ -91,7 +91,7 @@ void EnggDiffGSASFittingViewQtWidget::browsePhaseFiles() {
 void EnggDiffGSASFittingViewQtWidget::disableLoadIfInputEmpty() {
   setLoadEnabled(!runFileLineEditEmpty());
 }
-  
+
 void EnggDiffGSASFittingViewQtWidget::displayLatticeParams(
     const Mantid::API::ITableWorkspace_sptr latticeParams) const {
   double length_a, length_b, length_c, angle_alpha, angle_beta, angle_gamma;

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
@@ -5,10 +5,11 @@
 #include "EnggDiffMultiRunFittingWidgetModel.h"
 #include "EnggDiffMultiRunFittingWidgetPresenter.h"
 
-#include <boost/make_shared.hpp>
+#include "MantidAPI/TableRow.h"
 
 #include <QFileDialog>
 #include <QSettings>
+#include <boost/make_shared.hpp>
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -93,13 +94,28 @@ void EnggDiffGSASFittingViewQtWidget::disableLoadIfInputEmpty() {
   
 void EnggDiffGSASFittingViewQtWidget::displayLatticeParams(
     const Mantid::API::ITableWorkspace_sptr latticeParams) const {
-  UNUSED_ARG(latticeParams);
-  throw std::runtime_error("displayLatticeParams not yet implemented");
+  double length_a, length_b, length_c, angle_alpha, angle_beta, angle_gamma;
+  Mantid::API::TableRow row = latticeParams->getFirstRow();
+  row >> length_a >> length_b >> length_c >> angle_alpha >> angle_beta >>
+      angle_gamma;
+  m_ui.lineEdit_latticeParamA->setText(QString::number(length_a));
+  m_ui.lineEdit_latticeParamB->setText(QString::number(length_b));
+  m_ui.lineEdit_latticeParamC->setText(QString::number(length_c));
+  m_ui.lineEdit_latticeParamAlpha->setText(QString::number(angle_alpha));
+  m_ui.lineEdit_latticeParamBeta->setText(QString::number(angle_beta));
+  m_ui.lineEdit_latticeParamGamma->setText(QString::number(angle_gamma));
+}
+
+void EnggDiffGSASFittingViewQtWidget::displayGamma(const double gamma) const {
+  m_ui.lineEdit_gamma->setText(QString::number(gamma));
 }
 
 void EnggDiffGSASFittingViewQtWidget::displayRwp(const double rwp) const {
-  UNUSED_ARG(rwp);
-  throw std::runtime_error("displayRwp not yet implemented");
+  m_ui.lineEdit_rwp->setText(QString::number(rwp));
+}
+
+void EnggDiffGSASFittingViewQtWidget::displaySigma(const double sigma) const {
+  m_ui.lineEdit_sigma->setText(QString::number(sigma));
 }
 
 void EnggDiffGSASFittingViewQtWidget::doRefinement() {

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
@@ -54,6 +54,12 @@ void EnggDiffGSASFittingViewQtWidget::browseFocusedRun() {
   setFocusedRunFileNames(filenames);
 }
 
+void EnggDiffGSASFittingViewQtWidget::browseGSASHome() {
+  auto directoryName(QFileDialog::getExistingDirectory(
+      this, tr("GSAS-II installation directory")));
+  m_ui.lineEdit_gsasHome->setText(directoryName);
+}
+
 void EnggDiffGSASFittingViewQtWidget::browseGSASProj() {
   auto filename(QFileDialog::getSaveFileName(
       this, tr("Output GSAS-II project file"), "", "GSAS-II Project (*.gpx)"));
@@ -199,6 +205,8 @@ void EnggDiffGSASFittingViewQtWidget::setupUI() {
           SLOT(browsePhaseFiles()));
   connect(m_ui.pushButton_gsasProjPath, SIGNAL(clicked()), this,
           SLOT(browseGSASProj()));
+  connect(m_ui.pushButton_browseGSASHome, SIGNAL(clicked()), this,
+          SLOT(browseGSASHome()));
 
   connect(m_multiRunWidgetView.get(), SIGNAL(runSelected()), this,
           SLOT(selectRun()));

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
@@ -97,6 +97,10 @@ void EnggDiffGSASFittingViewQtWidget::displayRwp(const double rwp) const {
   throw std::runtime_error("displayRwp not yet implemented");
 }
 
+void EnggDiffGSASFittingViewQtWidget::doRefinement() {
+  m_presenter->notify(IEnggDiffGSASFittingPresenter::DoRefinement);
+}
+
 std::vector<std::string>
 EnggDiffGSASFittingViewQtWidget::getFocusedFileNames() const {
   const auto filenamesQStringList = m_ui.lineEdit_runFile->text().split(",");
@@ -207,6 +211,9 @@ void EnggDiffGSASFittingViewQtWidget::setupUI() {
           SLOT(browseGSASProj()));
   connect(m_ui.pushButton_browseGSASHome, SIGNAL(clicked()), this,
           SLOT(browseGSASHome()));
+
+  connect(m_ui.pushButton_doRefinement, SIGNAL(clicked()), this,
+          SLOT(doRefinement()));
 
   connect(m_multiRunWidgetView.get(), SIGNAL(runSelected()), this,
           SLOT(selectRun()));

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
@@ -129,34 +129,42 @@ std::string EnggDiffGSASFittingViewQtWidget::getPathToGSASII() const {
   return m_ui.lineEdit_gsasHome->text().toStdString();
 }
 
-double EnggDiffGSASFittingViewQtWidget::getPawleyDMin() const {
+boost::optional<double> EnggDiffGSASFittingViewQtWidget::getPawleyDMin() const {
   const auto pawleyDMinString = m_ui.lineEdit_pawleyDMin->text();
+  if (pawleyDMinString.isEmpty()) {
+    return boost::none;
+  }
+
   bool conversionSuccessful(false);
   const auto pawleyDMin = pawleyDMinString.toDouble(&conversionSuccessful);
-  if (conversionSuccessful) {
-    return pawleyDMin;
-  } else {
+  if (!conversionSuccessful) {
     userWarning("Invalid Pawley DMin", "Invalid entry for Pawley DMin \"" +
                                            pawleyDMinString.toStdString() +
-                                           "\". Using default (1");
-    return 1;
+                                           "\". Using default");
+    return boost::none;
   }
+
+  return pawleyDMin;
 }
 
-double EnggDiffGSASFittingViewQtWidget::getPawleyNegativeWeight() const {
+boost::optional<double>
+EnggDiffGSASFittingViewQtWidget::getPawleyNegativeWeight() const {
   const auto pawleyNegWeightString = m_ui.lineEdit_pawleyNegativeWeight->text();
+  if (pawleyNegWeightString.isEmpty()) {
+    return boost::none;
+  }
+
   bool conversionSuccessful(false);
   const auto pawleyNegWeight =
       pawleyNegWeightString.toDouble(&conversionSuccessful);
-  if (conversionSuccessful) {
-    return pawleyNegWeight;
-  } else {
+  if (!conversionSuccessful) {
     userWarning("Invalid Pawley negative weight",
                 "Invalid entry for negative weight \"" +
-                    pawleyNegWeightString.toStdString() +
-                    "\". Using default (0)");
-    return 0;
+                    pawleyNegWeightString.toStdString() + "\". Using default");
+    return boost::none;
   }
+
+  return pawleyNegWeight;
 }
 
 std::vector<std::string>
@@ -168,6 +176,14 @@ EnggDiffGSASFittingViewQtWidget::getPhaseFileNames() const {
     fileNameStrings.push_back(fileNameQString.toStdString());
   }
   return fileNameStrings;
+}
+
+bool EnggDiffGSASFittingViewQtWidget::getRefineGamma() const {
+  return m_ui.checkBox_refineGamma->isChecked();
+}
+
+bool EnggDiffGSASFittingViewQtWidget::getRefineSigma() const {
+  return m_ui.checkBox_refineSigma->isChecked();
 }
 
 GSASRefinementMethod
@@ -185,6 +201,42 @@ EnggDiffGSASFittingViewQtWidget::getRefinementMethod() const {
                   "message. If you choose to continue, Pawley will be used");
     return GSASRefinementMethod::PAWLEY;
   }
+}
+
+boost::optional<double> EnggDiffGSASFittingViewQtWidget::getXMax() const {
+  const auto xMaxString = m_ui.lineEdit_xMax->text();
+  if (xMaxString.isEmpty()) {
+    return boost::none;
+  }
+
+  bool conversionSuccessful(false);
+  const auto xMax = xMaxString.toDouble(&conversionSuccessful);
+  if (!conversionSuccessful) {
+    userWarning("Invalid XMax", "Invalid entry for XMax \"" +
+                                    xMaxString.toStdString() +
+                                    "\". Using default");
+    return boost::none;
+  }
+
+  return xMax;
+}
+
+boost::optional<double> EnggDiffGSASFittingViewQtWidget::getXMin() const {
+  const auto xMinString = m_ui.lineEdit_xMin->text();
+  if (xMinString.isEmpty()) {
+    return boost::none;
+  }
+
+  bool conversionSuccessful(false);
+  const auto xMin = xMinString.toDouble(&conversionSuccessful);
+  if (!conversionSuccessful) {
+    userWarning("Invalid XMin", "Invalid entry for XMin \"" +
+                                    xMinString.toStdString() +
+                                    "\". Using default");
+    return boost::none;
+  }
+
+  return xMin;
 }
 
 void EnggDiffGSASFittingViewQtWidget::loadFocusedRun() {

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
@@ -54,6 +54,15 @@ void EnggDiffGSASFittingViewQtWidget::browseFocusedRun() {
   setFocusedRunFileNames(filenames);
 }
 
+void EnggDiffGSASFittingViewQtWidget::browseGSASProj() {
+  auto filename(QFileDialog::getSaveFileName(
+      this, tr("Output GSAS-II project file"), "", "GSAS-II Project (*.gpx)"));
+  if (!filename.endsWith(".gpx")) {
+    filename.append(".gpx");
+  }
+  m_ui.lineEdit_gsasProjPath->setText(filename);
+}
+
 void EnggDiffGSASFittingViewQtWidget::browseInstParams() {
   const auto filename(
       QFileDialog::getOpenFileName(this, tr("Instrument parameter file"), "",
@@ -188,6 +197,8 @@ void EnggDiffGSASFittingViewQtWidget::setupUI() {
           SLOT(browseInstParams()));
   connect(m_ui.pushButton_browsePhaseFiles, SIGNAL(clicked()), this,
           SLOT(browsePhaseFiles()));
+  connect(m_ui.pushButton_gsasProjPath, SIGNAL(clicked()), this,
+          SLOT(browseGSASProj()));
 
   connect(m_multiRunWidgetView.get(), SIGNAL(runSelected()), this,
           SLOT(selectRun()));

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
@@ -338,6 +338,11 @@ void EnggDiffGSASFittingViewQtWidget::setupUI() {
   }
 }
 
+void EnggDiffGSASFittingViewQtWidget::showStatus(
+    const std::string &status) const {
+  m_userMessageProvider->showStatus(status);
+}
+
 void EnggDiffGSASFittingViewQtWidget::userError(
     const std::string &errorTitle, const std::string &errorDescription) const {
   m_userMessageProvider->userError(errorTitle, errorDescription);

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
@@ -54,6 +54,13 @@ void EnggDiffGSASFittingViewQtWidget::browseFocusedRun() {
   setFocusedRunFileNames(filenames);
 }
 
+void EnggDiffGSASFittingViewQtWidget::browseInstParams() {
+  const auto filename =
+      QFileDialog::getOpenFileName(this, tr("Instrument parameter file"), "",
+                                   "Instrument parameter file (*.par *.prm)");
+  m_ui.lineEdit_instParamsFile->setText(filename);
+}
+
 void EnggDiffGSASFittingViewQtWidget::disableLoadIfInputEmpty() {
   setLoadEnabled(!runFileLineEditEmpty());
 }
@@ -170,6 +177,9 @@ void EnggDiffGSASFittingViewQtWidget::setupUI() {
           SLOT(loadFocusedRun()));
   connect(m_ui.lineEdit_runFile, SIGNAL(textChanged(const QString &)), this,
           SLOT(disableLoadIfInputEmpty()));
+
+  connect(m_ui.pushButton_browseInstParams, SIGNAL(clicked()), this,
+          SLOT(browseInstParams()));
 
   connect(m_multiRunWidgetView.get(), SIGNAL(runSelected()), this,
           SLOT(selectRun()));

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
@@ -8,6 +8,7 @@
 #include <boost/make_shared.hpp>
 
 #include <QFileDialog>
+#include <QSettings>
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -39,6 +40,10 @@ EnggDiffGSASFittingViewQtWidget::EnggDiffGSASFittingViewQtWidget(
 }
 
 EnggDiffGSASFittingViewQtWidget::~EnggDiffGSASFittingViewQtWidget() {
+  QSettings settings(tr(SETTINGS_NAME));
+  const auto gsasHome = m_ui.lineEdit_gsasHome->text();
+  settings.setValue(tr(GSAS_HOME_SETTING_NAME), gsasHome);
+
   m_presenter->notify(IEnggDiffGSASFittingPresenter::ShutDown);
 }
 
@@ -257,6 +262,12 @@ void EnggDiffGSASFittingViewQtWidget::setupUI() {
 
   connect(m_multiRunWidgetView.get(), SIGNAL(runSelected()), this,
           SLOT(selectRun()));
+
+  QSettings settings(tr(SETTINGS_NAME));
+  if (settings.contains(tr(GSAS_HOME_SETTING_NAME))) {
+    m_ui.lineEdit_gsasHome->setText(
+        settings.value(tr(GSAS_HOME_SETTING_NAME)).toString());
+  }
 }
 
 void EnggDiffGSASFittingViewQtWidget::userError(
@@ -269,6 +280,11 @@ void EnggDiffGSASFittingViewQtWidget::userWarning(
     const std::string &warningDescription) const {
   m_userMessageProvider->userWarning(warningTitle, warningDescription);
 }
+
+const char EnggDiffGSASFittingViewQtWidget::GSAS_HOME_SETTING_NAME[] =
+    "GSAS_HOME";
+const char EnggDiffGSASFittingViewQtWidget::SETTINGS_NAME[] =
+    "EnggGUIGSASTabSettings";
 
 } // CustomInterfaces
 } // MantidQt

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
@@ -113,33 +113,73 @@ EnggDiffGSASFittingViewQtWidget::getFocusedFileNames() const {
 }
 
 std::string EnggDiffGSASFittingViewQtWidget::getGSASIIProjectPath() const {
-  throw std::runtime_error("getGSASIIProjectPath not yet implemented");
+  return m_ui.lineEdit_gsasProjPath->text().toStdString();
 }
 
 std::string EnggDiffGSASFittingViewQtWidget::getInstrumentFileName() const {
-  throw std::runtime_error("getInstrumentFileName not yet implemented");
+  return m_ui.lineEdit_instParamsFile->text().toStdString();
 }
 
 std::string EnggDiffGSASFittingViewQtWidget::getPathToGSASII() const {
-  throw std::runtime_error("getPathToGSASII not yet implemented");
+  return m_ui.lineEdit_gsasHome->text().toStdString();
 }
 
 double EnggDiffGSASFittingViewQtWidget::getPawleyDMin() const {
-  throw std::runtime_error("getPawleyDMin not yet implemented");
+  const auto pawleyDMinString = m_ui.lineEdit_pawleyDMin->text();
+  bool conversionSuccessful(false);
+  const auto pawleyDMin = pawleyDMinString.toDouble(&conversionSuccessful);
+  if (conversionSuccessful) {
+    return pawleyDMin;
+  } else {
+    userWarning("Invalid Pawley DMin", "Invalid entry for Pawley DMin \"" +
+                                           pawleyDMinString.toStdString() +
+                                           "\". Using default (1");
+    return 1;
+  }
 }
 
 double EnggDiffGSASFittingViewQtWidget::getPawleyNegativeWeight() const {
-  throw std::runtime_error("getPawleyNegativeWeight not yet implemented");
+  const auto pawleyNegWeightString = m_ui.lineEdit_pawleyNegativeWeight->text();
+  bool conversionSuccessful(false);
+  const auto pawleyNegWeight =
+      pawleyNegWeightString.toDouble(&conversionSuccessful);
+  if (conversionSuccessful) {
+    return pawleyNegWeight;
+  } else {
+    userWarning("Invalid Pawley negative weight",
+                "Invalid entry for negative weight \"" +
+                    pawleyNegWeightString.toStdString() +
+                    "\". Using default (0)");
+    return 0;
+  }
 }
 
 std::vector<std::string>
 EnggDiffGSASFittingViewQtWidget::getPhaseFileNames() const {
-  throw std::runtime_error("getPhaseFileNames not yet implemented");
+  std::vector<std::string> fileNameStrings;
+  const auto fileNameQStrings = m_ui.lineEdit_phaseFiles->text().split(",");
+  fileNameStrings.reserve(fileNameQStrings.size());
+  for (const auto &fileNameQString : fileNameQStrings) {
+    fileNameStrings.push_back(fileNameQString.toStdString());
+  }
+  return fileNameStrings;
 }
 
 GSASRefinementMethod
 EnggDiffGSASFittingViewQtWidget::getRefinementMethod() const {
-  throw std::runtime_error("getRefinementMethod not yet implemented");
+  const auto refinementMethod =
+      m_ui.comboBox_refinementMethod->currentText().toStdString();
+  if (refinementMethod == "Pawley") {
+    return GSASRefinementMethod::PAWLEY;
+  } else if (refinementMethod == "Rietveld") {
+    return GSASRefinementMethod::RIETVELD;
+  } else {
+    userError("Unexpected refinement method",
+              "Unexpected refinement method \"" + refinementMethod +
+                  "\" selected. Please contact development team with this "
+                  "message. If you choose to continue, Pawley will be used");
+    return GSASRefinementMethod::PAWLEY;
+  }
 }
 
 void EnggDiffGSASFittingViewQtWidget::loadFocusedRun() {

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
@@ -55,16 +55,22 @@ void EnggDiffGSASFittingViewQtWidget::browseFocusedRun() {
 }
 
 void EnggDiffGSASFittingViewQtWidget::browseInstParams() {
-  const auto filename =
+  const auto filename(
       QFileDialog::getOpenFileName(this, tr("Instrument parameter file"), "",
-                                   "Instrument parameter file (*.par *.prm)");
+                                   "Instrument parameter file (*.par *.prm)"));
   m_ui.lineEdit_instParamsFile->setText(filename);
+}
+
+void EnggDiffGSASFittingViewQtWidget::browsePhaseFiles() {
+  const auto filenames(QFileDialog::getOpenFileNames(
+      this, tr("Phase files"), "", "Phase files (*.cif)"));
+  m_ui.lineEdit_phaseFiles->setText(filenames.join(tr(",")));
 }
 
 void EnggDiffGSASFittingViewQtWidget::disableLoadIfInputEmpty() {
   setLoadEnabled(!runFileLineEditEmpty());
 }
-
+  
 void EnggDiffGSASFittingViewQtWidget::displayLatticeParams(
     const Mantid::API::ITableWorkspace_sptr latticeParams) const {
   UNUSED_ARG(latticeParams);
@@ -180,6 +186,8 @@ void EnggDiffGSASFittingViewQtWidget::setupUI() {
 
   connect(m_ui.pushButton_browseInstParams, SIGNAL(clicked()), this,
           SLOT(browseInstParams()));
+  connect(m_ui.pushButton_browsePhaseFiles, SIGNAL(clicked()), this,
+          SLOT(browsePhaseFiles()));
 
   connect(m_multiRunWidgetView.get(), SIGNAL(runSelected()), this,
           SLOT(selectRun()));

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.h
@@ -61,6 +61,7 @@ public:
 
 private slots:
   void browseFocusedRun();
+  void browseGSASProj();
   void browseInstParams();
   void browsePhaseFiles();
   void disableLoadIfInputEmpty();

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.h
@@ -43,13 +43,21 @@ public:
 
   std::string getPathToGSASII() const override;
 
-  double getPawleyDMin() const override;
+  boost::optional<double> getPawleyDMin() const override;
 
-  double getPawleyNegativeWeight() const override;
+  boost::optional<double> getPawleyNegativeWeight() const override;
 
   std::vector<std::string> getPhaseFileNames() const override;
 
   GSASRefinementMethod getRefinementMethod() const override;
+
+  bool getRefineGamma() const override;
+
+  bool getRefineSigma() const override;
+
+  boost::optional<double> getXMax() const override;
+
+  boost::optional<double> getXMin() const override;
 
   void setEnabled(const bool enabled);
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.h
@@ -62,6 +62,7 @@ public:
 private slots:
   void browseFocusedRun();
   void browseInstParams();
+  void browsePhaseFiles();
   void disableLoadIfInputEmpty();
   void loadFocusedRun();
   void selectRun();

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.h
@@ -61,6 +61,7 @@ public:
 
 private slots:
   void browseFocusedRun();
+  void browseGSASHome();
   void browseGSASProj();
   void browseInstParams();
   void browsePhaseFiles();

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.h
@@ -33,7 +33,11 @@ public:
   void displayLatticeParams(
       const Mantid::API::ITableWorkspace_sptr latticeParams) const override;
 
+  void displayGamma(const double gamma) const override;
+
   void displayRwp(const double rwp) const override;
+
+  void displaySigma(const double sigma) const override;
 
   std::vector<std::string> getFocusedFileNames() const override;
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.h
@@ -75,6 +75,9 @@ private:
 
   void setLoadEnabled(const bool enabled);
 
+  static const char GSAS_HOME_SETTING_NAME[];
+  static const char SETTINGS_NAME[];
+
   boost::shared_ptr<EnggDiffMultiRunFittingQtWidget> m_multiRunWidgetView;
 
   std::unique_ptr<IEnggDiffGSASFittingPresenter> m_presenter;

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.h
@@ -65,6 +65,8 @@ public:
 
   void setEnabled(const bool enabled);
 
+  void showStatus(const std::string &status) const override;
+
   void userError(const std::string &errorTitle,
                  const std::string &errorDescription) const override;
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.h
@@ -61,6 +61,7 @@ public:
 
 private slots:
   void browseFocusedRun();
+  void browseInstParams();
   void disableLoadIfInputEmpty();
   void loadFocusedRun();
   void selectRun();

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.h
@@ -66,6 +66,7 @@ private slots:
   void browseInstParams();
   void browsePhaseFiles();
   void disableLoadIfInputEmpty();
+  void doRefinement();
   void loadFocusedRun();
   void selectRun();
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingQtWidget.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingQtWidget.h
@@ -26,9 +26,7 @@ public:
 
   ~EnggDiffMultiRunFittingQtWidget() override;
 
-  RunLabel getSelectedRunLabel() const override;
-
-  bool hasSelectedRunLabel() const override;
+  boost::optional<RunLabel> getSelectedRunLabel() const override;
 
   void plotFittedPeaks(
       const std::vector<boost::shared_ptr<QwtData>> &curve) override;
@@ -71,12 +69,16 @@ private slots:
 private:
   void cleanUpPlot();
 
+  bool hasSelectedRunLabel() const;
+
   void resetPlotZoomLevel();
 
   void setupUI();
 
   void userError(const std::string &errorTitle,
                  const std::string &errorDescription);
+
+  std::vector<std::unique_ptr<QwtPlotCurve>> m_fittedPeaksCurves;
 
   std::vector<std::unique_ptr<QwtPlotCurve>> m_focusedRunCurves;
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidget.ui
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidget.ui
@@ -83,6 +83,9 @@
        <property name="text">
         <string>Plot Fitted Peaks</string>
        </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
      <item>

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
@@ -114,6 +114,10 @@ RunLabel EnggDiffMultiRunFittingWidgetPresenter::getSelectedRunLabel() const {
   return m_view->getSelectedRunLabel();
 }
 
+bool EnggDiffMultiRunFittingWidgetPresenter::hasSelectedRunLabel() const {
+  return m_view->hasSelectedRunLabel();
+}
+
 void EnggDiffMultiRunFittingWidgetPresenter::notify(
     IEnggDiffMultiRunFittingWidgetPresenter::Notification notif) {
   switch (notif) {

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
@@ -161,7 +161,8 @@ void EnggDiffMultiRunFittingWidgetPresenter::processPlotToSeparateWindow() {
   ADS.add(focusedRunName, *focusedRun);
 
   boost::optional<std::string> fittedPeaksName = boost::none;
-  if (showFitResultsSelected() && m_model->hasFittedPeaksForRun(runLabel)) {
+  if (m_view->showFitResultsSelected() &&
+      m_model->hasFittedPeaksForRun(runLabel)) {
     fittedPeaksName = generateFittedPeaksName(runLabel);
     const auto fittedPeaks = m_model->getFittedPeaks(runLabel);
     ADS.add(*fittedPeaksName, *fittedPeaks);
@@ -189,10 +190,6 @@ void EnggDiffMultiRunFittingWidgetPresenter::processSelectRun() {
     const auto selectedRunLabel = m_view->getSelectedRunLabel();
     updatePlot(selectedRunLabel);
   }
-}
-
-bool EnggDiffMultiRunFittingWidgetPresenter::showFitResultsSelected() const {
-  return m_view->showFitResultsSelected();
 }
 
 void EnggDiffMultiRunFittingWidgetPresenter::updatePlot(

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
@@ -30,9 +30,7 @@ public:
   boost::optional<Mantid::API::MatrixWorkspace_sptr>
   getFocusedRun(const RunLabel &runLabel) const override;
 
-  RunLabel getSelectedRunLabel() const override;
-
-  bool hasSelectedRunLabel() const override;
+  boost::optional<RunLabel> getSelectedRunLabel() const override;
 
   std::unique_ptr<IEnggDiffMultiRunFittingWidgetAdder>
   getWidgetAdder() const override;

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
@@ -32,6 +32,8 @@ public:
 
   RunLabel getSelectedRunLabel() const override;
 
+  bool hasSelectedRunLabel() const override;
+
   std::unique_ptr<IEnggDiffMultiRunFittingWidgetAdder>
   getWidgetAdder() const override;
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
@@ -40,8 +40,6 @@ public:
   void
   notify(IEnggDiffMultiRunFittingWidgetPresenter::Notification notif) override;
 
-  bool showFitResultsSelected() const override;
-
 private:
   void processPlotPeaksStateChanged();
   void processPlotToSeparateWindow();

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionQtTabGSAS.ui
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionQtTabGSAS.ui
@@ -49,12 +49,12 @@
        <widget class="QComboBox" name="comboBox_refinementMethod">
         <item>
          <property name="text">
-          <string>Pawley</string>
+          <string>Rietveld</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Rietveld</string>
+          <string>Pawley</string>
          </property>
         </item>
        </widget>

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionQtTabGSAS.ui
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionQtTabGSAS.ui
@@ -156,7 +156,7 @@
       <item row="5" column="3">
        <widget class="QPushButton" name="pushButton_doRefinement">
         <property name="text">
-         <string>Do Refinement</string>
+         <string>Run Refinement</string>
         </property>
        </widget>
       </item>

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionQtTabGSAS.ui
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionQtTabGSAS.ui
@@ -65,7 +65,7 @@
          <string>Nexus file containing a spectrum focused using EnggFocus or the Focus tab</string>
         </property>
         <property name="text">
-         <string>Focused Run File</string>
+         <string>Focused Run Files</string>
         </property>
        </widget>
       </item>

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionQtTabGSAS.ui
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionQtTabGSAS.ui
@@ -32,46 +32,6 @@
       <string>General Parameters</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_phaseFiles">
-        <property name="toolTip">
-         <string>*.cif files containing the phases to refine</string>
-        </property>
-        <property name="text">
-         <string>Phase Files</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_gsasProjPath">
-        <property name="toolTip">
-         <string>The name of a new *.gpx project to write refinement results out to. This can be opened and used for more complex refinements in GSAS-II</string>
-        </property>
-        <property name="text">
-         <string>New GSAS-II Project</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="2">
-       <widget class="QPushButton" name="pushButton_gsasProjPath">
-        <property name="text">
-         <string>Browse</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_runFile">
-        <property name="toolTip">
-         <string>Nexus file containing a spectrum focused using EnggFocus or the Focus tab</string>
-        </property>
-        <property name="text">
-         <string>Focused Run Files</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QLineEdit" name="lineEdit_gsasProjPath"/>
-      </item>
       <item row="1" column="1">
        <widget class="QLineEdit" name="lineEdit_instParamsFile"/>
       </item>
@@ -85,6 +45,30 @@
         </property>
        </widget>
       </item>
+      <item row="5" column="1">
+       <widget class="QComboBox" name="comboBox_refinementMethod">
+        <item>
+         <property name="text">
+          <string>Pawley</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Rietveld</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_phaseFiles">
+        <property name="toolTip">
+         <string>*.cif files containing the phases to refine</string>
+        </property>
+        <property name="text">
+         <string>Phase Files</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="2">
        <widget class="QPushButton" name="pushButton_browseRunFile">
         <property name="text">
@@ -92,25 +76,18 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="3">
-       <widget class="QPushButton" name="pushButton_loadRun">
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_gsasHome">
+        <property name="toolTip">
+         <string>Directory containing GSAS-II installation. This directory must contain GSASIIscriptable.py</string>
+        </property>
         <property name="text">
-         <string>Load</string>
+         <string>GSAS-II Installation Directory</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
-       <widget class="QPushButton" name="pushButton_browseInstParams">
-        <property name="text">
-         <string>Browse</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLineEdit" name="lineEdit_runFile"/>
-      </item>
-      <item row="4" column="2">
-       <widget class="QPushButton" name="pushButton_browseGSASHome">
+      <item row="3" column="2">
+       <widget class="QPushButton" name="pushButton_gsasProjPath">
         <property name="text">
          <string>Browse</string>
         </property>
@@ -126,19 +103,6 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
-       <widget class="QLineEdit" name="lineEdit_gsasHome"/>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_gsasHome">
-        <property name="toolTip">
-         <string>Directory containing GSAS-II installation. This directory must contain GSASIIscriptable.py</string>
-        </property>
-        <property name="text">
-         <string>GSAS-II Installation Directory</string>
-        </property>
-       </widget>
-      </item>
       <item row="2" column="2">
        <widget class="QPushButton" name="pushButton_browsePhaseFiles">
         <property name="text">
@@ -146,22 +110,112 @@
         </property>
        </widget>
       </item>
+      <item row="0" column="3">
+       <widget class="QPushButton" name="pushButton_loadRun">
+        <property name="text">
+         <string>Load</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_gsasProjPath">
+        <property name="toolTip">
+         <string>The name of a new *.gpx project to write refinement results out to. This can be opened and used for more complex refinements in GSAS-II</string>
+        </property>
+        <property name="text">
+         <string>New GSAS-II Project</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QLineEdit" name="lineEdit_gsasHome"/>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_runFile">
+        <property name="toolTip">
+         <string>Nexus file containing a spectrum focused using EnggFocus or the Focus tab</string>
+        </property>
+        <property name="text">
+         <string>Focused Run Files</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="lineEdit_runFile"/>
+      </item>
       <item row="2" column="1">
        <widget class="QLineEdit" name="lineEdit_phaseFiles"/>
       </item>
-      <item row="5" column="1">
-       <widget class="QComboBox" name="comboBox_refinementMethod">
-        <item>
-         <property name="text">
-          <string>Pawley</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Rietveld</string>
-         </property>
-        </item>
+      <item row="3" column="1">
+       <widget class="QLineEdit" name="lineEdit_gsasProjPath"/>
+      </item>
+      <item row="1" column="2">
+       <widget class="QPushButton" name="pushButton_browseInstParams">
+        <property name="text">
+         <string>Browse</string>
+        </property>
        </widget>
+      </item>
+      <item row="4" column="2">
+       <widget class="QPushButton" name="pushButton_browseGSASHome">
+        <property name="text">
+         <string>Browse</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_xMax">
+        <item>
+         <widget class="QLabel" name="label_xMax">
+          <property name="text">
+           <string>XMax</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="lineEdit_xMax"/>
+        </item>
+       </layout>
+      </item>
+      <item row="6" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_xMin">
+        <item>
+         <widget class="QLabel" name="label_xMin">
+          <property name="text">
+           <string>XMin</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="lineEdit_xMin"/>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionQtTabGSAS.ui
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionQtTabGSAS.ui
@@ -254,6 +254,9 @@
         <property name="layoutDirection">
          <enum>Qt::LeftToRight</enum>
         </property>
+        <property name="text">
+         <string>1</string>
+        </property>
        </widget>
       </item>
       <item>
@@ -280,7 +283,11 @@
        </widget>
       </item>
       <item>
-       <widget class="QLineEdit" name="lineEdit_pawleyNegativeWeight"/>
+       <widget class="QLineEdit" name="lineEdit_pawleyNegativeWeight">
+        <property name="text">
+         <string>0</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionQtTabGSAS.ui
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionQtTabGSAS.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>580</width>
+    <width>553</width>
     <height>658</height>
    </rect>
   </property>
@@ -21,7 +21,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QGroupBox" name="groupBox_generalParams">
+    <widget class="QGroupBox" name="groupBox_inputFiles">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
@@ -29,7 +29,7 @@
       </sizepolicy>
      </property>
      <property name="title">
-      <string>General Parameters</string>
+      <string>Input Files</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="1" column="1">
@@ -93,16 +93,6 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="label_refinementMethod">
-        <property name="toolTip">
-         <string>Rietveld or Pawley</string>
-        </property>
-        <property name="text">
-         <string>Refinement Method</string>
-        </property>
-       </widget>
-      </item>
       <item row="2" column="2">
        <widget class="QPushButton" name="pushButton_browsePhaseFiles">
         <property name="text">
@@ -140,14 +130,14 @@
         </property>
        </widget>
       </item>
+      <item row="3" column="1">
+       <widget class="QLineEdit" name="lineEdit_gsasProjPath"/>
+      </item>
       <item row="0" column="1">
        <widget class="QLineEdit" name="lineEdit_runFile"/>
       </item>
       <item row="2" column="1">
        <widget class="QLineEdit" name="lineEdit_phaseFiles"/>
-      </item>
-      <item row="3" column="1">
-       <widget class="QLineEdit" name="lineEdit_gsasProjPath"/>
       </item>
       <item row="1" column="2">
        <widget class="QPushButton" name="pushButton_browseInstParams">
@@ -163,60 +153,6 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_xMax">
-        <item>
-         <widget class="QLabel" name="label_xMax">
-          <property name="text">
-           <string>XMax</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="lineEdit_xMax"/>
-        </item>
-       </layout>
-      </item>
-      <item row="6" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_xMin">
-        <item>
-         <widget class="QLabel" name="label_xMin">
-          <property name="text">
-           <string>XMin</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="lineEdit_xMin"/>
-        </item>
-       </layout>
-      </item>
       <item row="5" column="3">
        <widget class="QPushButton" name="pushButton_doRefinement">
         <property name="text">
@@ -224,43 +160,44 @@
         </property>
        </widget>
       </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_refinementMethod">
+        <property name="toolTip">
+         <string>Rietveld or Pawley</string>
+        </property>
+        <property name="text">
+         <string>Refinement Method</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox_pawleyParams">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
+    <widget class="QGroupBox" name="groupBox_algorithmControls">
      <property name="title">
-      <string>Pawley Parameters</string>
+      <string>GSASIIRefineFitPeaks Controls</string>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <item>
-       <widget class="QLabel" name="label_pawleyDMin">
-        <property name="toolTip">
-         <string>The minimum d-spacing to use. Leave empty to use the default (1)</string>
-        </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_xMin">
         <property name="text">
-         <string>DMin</string>
+         <string>XMin</string>
         </property>
        </widget>
       </item>
-      <item>
-       <widget class="QLineEdit" name="lineEdit_pawleyDMin">
-        <property name="layoutDirection">
-         <enum>Qt::LeftToRight</enum>
-        </property>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="lineEdit_xMin"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_xMax">
         <property name="text">
-         <string>1</string>
+         <string>XMax</string>
         </property>
        </widget>
       </item>
-      <item>
-       <spacer name="horizontalSpacer_8">
+      <item row="1" column="2">
+       <spacer name="horizontalSpacer_2">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
@@ -272,7 +209,7 @@
         </property>
        </spacer>
       </item>
-      <item>
+      <item row="1" column="3">
        <widget class="QLabel" name="label_pawleyNegativeWeight">
         <property name="toolTip">
          <string>The weight of the penalty function for negative intensities. Leave empty to use default (0)</string>
@@ -282,12 +219,88 @@
         </property>
        </widget>
       </item>
-      <item>
-       <widget class="QLineEdit" name="lineEdit_pawleyNegativeWeight">
+      <item row="0" column="3">
+       <widget class="QLabel" name="label_pawleyDMin">
+        <property name="toolTip">
+         <string>The minimum d-spacing to use. Leave empty to use the default (1)</string>
+        </property>
         <property name="text">
-         <string>0</string>
+         <string>DMin</string>
         </property>
        </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="lineEdit_xMax"/>
+      </item>
+      <item row="0" column="4">
+       <widget class="QLineEdit" name="lineEdit_pawleyDMin">
+        <property name="layoutDirection">
+         <enum>Qt::LeftToRight</enum>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="4">
+       <widget class="QLineEdit" name="lineEdit_pawleyNegativeWeight">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="6">
+       <widget class="QCheckBox" name="checkBox_refineSigma">
+        <property name="text">
+         <string>Refine Sigma</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="6">
+       <widget class="QCheckBox" name="checkBox_refineGamma">
+        <property name="text">
+         <string>Refine Gamma</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="5">
+       <spacer name="horizontalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="5">
+       <spacer name="horizontalSpacer_4">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
       </item>
      </layout>
     </widget>
@@ -335,6 +348,47 @@
            </size>
           </property>
          </spacer>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_sigma">
+          <property name="text">
+           <string>Sigma</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="lineEdit_sigma">
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_5">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_gamma">
+          <property name="text">
+           <string>Gamma</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="lineEdit_gamma">
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+         </widget>
         </item>
        </layout>
       </item>

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionQtTabGSAS.ui
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionQtTabGSAS.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>549</width>
+    <width>580</width>
     <height>658</height>
    </rect>
   </property>
@@ -216,6 +216,13 @@
          <widget class="QLineEdit" name="lineEdit_xMin"/>
         </item>
        </layout>
+      </item>
+      <item row="5" column="3">
+       <widget class="QPushButton" name="pushButton_doRefinement">
+        <property name="text">
+         <string>Do Refinement</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/qt/scientific_interfaces/EnggDiffraction/GSASIIRefineFitPeaksOutputProperties.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/GSASIIRefineFitPeaksOutputProperties.cpp
@@ -1,0 +1,21 @@
+#include "GSASIIRefineFitPeaksOutputProperties.h"
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+GSASIIRefineFitPeaksOutputProperties::GSASIIRefineFitPeaksOutputProperties(
+    const double _rwp, const double _sigma, const double _gamma)
+    : rwp(_rwp), sigma(_sigma), gamma(_gamma) {}
+
+bool operator==(const GSASIIRefineFitPeaksOutputProperties &lhs,
+                const GSASIIRefineFitPeaksOutputProperties &rhs) {
+  return lhs.rwp == rhs.rwp && lhs.sigma == rhs.sigma && lhs.gamma == rhs.gamma;
+}
+
+bool operator!=(const GSASIIRefineFitPeaksOutputProperties &lhs,
+                const GSASIIRefineFitPeaksOutputProperties &rhs) {
+  return !(lhs == rhs);
+}
+
+} // MantidQt
+} // CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/GSASIIRefineFitPeaksOutputProperties.h
+++ b/qt/scientific_interfaces/EnggDiffraction/GSASIIRefineFitPeaksOutputProperties.h
@@ -1,0 +1,29 @@
+#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_GSASIIREFINEFITPEAKSOUTPUTPROPERTIES_H_
+#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_GSASIIREFINEFITPEAKSOUTPUTPROPERTIES_H_
+
+#include "DllConfig.h"
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+struct MANTIDQT_ENGGDIFFRACTION_DLL GSASIIRefineFitPeaksOutputProperties {
+  GSASIIRefineFitPeaksOutputProperties(const double _rwp, const double _sigma,
+                                       const double _gamma);
+
+  const double rwp;
+  const double sigma;
+  const double gamma;
+};
+
+MANTIDQT_ENGGDIFFRACTION_DLL bool
+operator==(const GSASIIRefineFitPeaksOutputProperties &lhs,
+           const GSASIIRefineFitPeaksOutputProperties &rhs);
+
+MANTIDQT_ENGGDIFFRACTION_DLL bool
+operator!=(const GSASIIRefineFitPeaksOutputProperties &lhs,
+           const GSASIIRefineFitPeaksOutputProperties &rhs);
+
+} // MantidQt
+} // CustomInterfaces
+
+#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_GSASIIREFINEFITPEAKSOUTPUTPROPERTIES_H_

--- a/qt/scientific_interfaces/EnggDiffraction/GSASIIRefineFitPeaksParameters.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/GSASIIRefineFitPeaksParameters.cpp
@@ -5,7 +5,7 @@ namespace CustomInterfaces {
 
 GSASIIRefineFitPeaksParameters::GSASIIRefineFitPeaksParameters(
     const Mantid::API::MatrixWorkspace_sptr &_inputWorkspace,
-    const RunLabel &_runLabel, const GSASRefinementMethod _refinementMethod,
+    const RunLabel &_runLabel, const GSASRefinementMethod &_refinementMethod,
     const std::string &_instParamsFile,
     const std::vector<std::string> &_phaseFiles, const std::string &_gsasHome,
     const std::string &_gsasProjectFile, const boost::optional<double> _dMin,
@@ -18,6 +18,24 @@ GSASIIRefineFitPeaksParameters::GSASIIRefineFitPeaksParameters(
       gsasProjectFile(_gsasProjectFile), dMin(_dMin),
       negativeWeight(_negativeWeight), xMin(_xMin), xMax(_xMax),
       refineSigma(_refineSigma), refineGamma(_refineGamma) {}
+
+bool operator==(const GSASIIRefineFitPeaksParameters &lhs,
+                const GSASIIRefineFitPeaksParameters &rhs) {
+  return lhs.inputWorkspace == rhs.inputWorkspace &&
+         lhs.runLabel == rhs.runLabel &&
+         lhs.refinementMethod == rhs.refinementMethod &&
+         lhs.instParamsFile == rhs.instParamsFile &&
+         lhs.phaseFiles == rhs.phaseFiles && lhs.gsasHome == rhs.gsasHome &&
+         lhs.gsasProjectFile == rhs.gsasProjectFile && lhs.dMin == rhs.dMin &&
+         lhs.negativeWeight == rhs.negativeWeight && lhs.xMin == rhs.xMin &&
+         lhs.xMax == rhs.xMax && lhs.refineSigma == rhs.refineSigma &&
+         lhs.refineGamma == rhs.refineGamma;
+}
+
+bool operator!=(const GSASIIRefineFitPeaksParameters &lhs,
+                const GSASIIRefineFitPeaksParameters &rhs) {
+  return !(lhs == rhs);
+}
 
 } // MantidQt
 } // CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/GSASIIRefineFitPeaksParameters.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/GSASIIRefineFitPeaksParameters.cpp
@@ -1,0 +1,23 @@
+#include "GSASIIRefineFitPeaksParameters.h"
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+GSASIIRefineFitPeaksParameters::GSASIIRefineFitPeaksParameters(
+    const Mantid::API::MatrixWorkspace_sptr &_inputWorkspace,
+    const RunLabel &_runLabel, const GSASRefinementMethod _refinementMethod,
+    const std::string &_instParamsFile,
+    const std::vector<std::string> &_phaseFiles, const std::string &_gsasHome,
+    const std::string &_gsasProjectFile, const boost::optional<double> _dMin,
+    const boost::optional<double> _negativeWeight,
+    const boost::optional<double> _xMin, const boost::optional<double> _xMax,
+    const bool _refineSigma, const bool _refineGamma)
+    : inputWorkspace(_inputWorkspace), runLabel(_runLabel),
+      refinementMethod(_refinementMethod), instParamsFile(_instParamsFile),
+      phaseFiles(_phaseFiles), gsasHome(_gsasHome),
+      gsasProjectFile(_gsasProjectFile), dMin(_dMin),
+      negativeWeight(_negativeWeight), xMin(_xMin), xMax(_xMax),
+      refineSigma(_refineSigma), refineGamma(_refineGamma) {}
+
+} // MantidQt
+} // CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/GSASIIRefineFitPeaksParameters.h
+++ b/qt/scientific_interfaces/EnggDiffraction/GSASIIRefineFitPeaksParameters.h
@@ -1,0 +1,47 @@
+#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_GSASIIREFINEFITPEAKSPARAMETERS_H_
+#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_GSASIIREFINEFITPEAKSPARAMETERS_H_
+
+#include "EnggDiffGSASRefinementMethod.h"
+#include "RunLabel.h"
+
+#include "MantidAPI/MatrixWorkspace.h"
+
+#include <boost/optional.hpp>
+#include <vector>
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+struct GSASIIRefineFitPeaksParameters {
+  GSASIIRefineFitPeaksParameters(
+      const Mantid::API::MatrixWorkspace_sptr &_inputWorkspace,
+      const RunLabel &_runLabel,
+      const GSASRefinementMethod _refinementMethod,
+      const std::string &_instParamsFile,
+      const std::vector<std::string> &_phaseFiles, const std::string &_gsasHome,
+      const std::string &_gsasProjectFile, const boost::optional<double> _dMin,
+      const boost::optional<double> _negativeWeight,
+      const boost::optional<double> _xMin, const boost::optional<double> _xMax,
+      const bool _refineSigma, const bool _refineGamma);
+
+  const Mantid::API::MatrixWorkspace_sptr inputWorkspace;
+  const RunLabel runLabel;
+  const GSASRefinementMethod refinementMethod;
+  const std::string instParamsFile;
+  const std::vector<std::string> phaseFiles;
+  const std::string gsasHome;
+  const std::string gsasProjectFile;
+
+  const boost::optional<double> dMin;
+  const boost::optional<double> negativeWeight;
+  const boost::optional<double> xMin;
+  const boost::optional<double> xMax;
+
+  const bool refineSigma;
+  const bool refineGamma;
+};
+
+} // MantidQt
+} // CustomInterfaces
+
+#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_GSASIIREFINEFITPEAKSPARAMETERS_H_

--- a/qt/scientific_interfaces/EnggDiffraction/GSASIIRefineFitPeaksParameters.h
+++ b/qt/scientific_interfaces/EnggDiffraction/GSASIIRefineFitPeaksParameters.h
@@ -1,6 +1,7 @@
 #ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_GSASIIREFINEFITPEAKSPARAMETERS_H_
 #define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_GSASIIREFINEFITPEAKSPARAMETERS_H_
 
+#include "DllConfig.h"
 #include "EnggDiffGSASRefinementMethod.h"
 #include "RunLabel.h"
 
@@ -12,11 +13,10 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 
-struct GSASIIRefineFitPeaksParameters {
+struct MANTIDQT_ENGGDIFFRACTION_DLL GSASIIRefineFitPeaksParameters {
   GSASIIRefineFitPeaksParameters(
       const Mantid::API::MatrixWorkspace_sptr &_inputWorkspace,
-      const RunLabel &_runLabel,
-      const GSASRefinementMethod _refinementMethod,
+      const RunLabel &_runLabel, const GSASRefinementMethod &_refinementMethod,
       const std::string &_instParamsFile,
       const std::vector<std::string> &_phaseFiles, const std::string &_gsasHome,
       const std::string &_gsasProjectFile, const boost::optional<double> _dMin,
@@ -40,6 +40,14 @@ struct GSASIIRefineFitPeaksParameters {
   const bool refineSigma;
   const bool refineGamma;
 };
+
+MANTIDQT_ENGGDIFFRACTION_DLL bool
+operator==(const GSASIIRefineFitPeaksParameters &lhs,
+           const GSASIIRefineFitPeaksParameters &rhs);
+
+MANTIDQT_ENGGDIFFRACTION_DLL bool
+operator!=(const GSASIIRefineFitPeaksParameters &lhs,
+           const GSASIIRefineFitPeaksParameters &rhs);
 
 } // MantidQt
 } // CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
@@ -65,6 +65,9 @@ public:
   /// that run
   virtual boost::optional<double> getSigma(const RunLabel &runLabel) const = 0;
 
+  /// Get whether the model contains fit results for a given run
+  virtual bool hasFitResultsForRun(const RunLabel &runLabel) const = 0;
+
   /**
    Load a focused run from a file
    @param filename The name of the file to load

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
@@ -1,6 +1,7 @@
 #ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFGSASFITTINGMODEL_H_
 #define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFGSASFITTINGMODEL_H_
 
+#include "GSASIIRefineFitPeaksParameters.h"
 #include "RunLabel.h"
 
 #include "MantidAPI/ITableWorkspace.h"
@@ -22,47 +23,21 @@ public:
 
   /**
    Perform a Pawley refinement on a run
-   @param inputWS The workspace to run refinement on
-   @param runLabel Run number and bank ID of the workspace to refine
-   @param instParamFile The instrument parameter file name (.prm) to use for
-   refinement
-   @param phaseFiles Vector of file paths to phases to use in refinement
-   @param pathToGSASII Location of the directory containing GSASIIscriptable.py
-   (and GSAS-II executables)
-   @param GSASIIProjectFile Location to save the .gpx project to
-   @param dMin The minimum d-spacing to use for refinement
-   @param negativeWeight The weight of the penalty function
+   @param params Parameters to be passed to GSASIIRefineFitPeaks
    @return Fitted peaks workspace resulting from refinement
    @throws If GSASIIRefineFitPeaks throws
    */
   virtual Mantid::API::MatrixWorkspace_sptr
-  doPawleyRefinement(const Mantid::API::MatrixWorkspace_sptr inputWS,
-                     const RunLabel &runLabel, const std::string &instParamFile,
-                     const std::vector<std::string> &phaseFiles,
-                     const std::string &pathToGSASII,
-                     const std::string &GSASIIProjectFile, const double dMin,
-                     const double negativeWeight) = 0;
+  doPawleyRefinement(const GSASIIRefineFitPeaksParameters &params) = 0;
 
   /**
    Perform a Rietveld refinement on a run
-   @param inputWS The workspace to run refinement on
-   @param runLabel Run number and bank ID of the workspace to refine
-   @param instParamFile The instrument parameter file name (.prm) to use for
-   refinement
-   @param phaseFiles Vector of file paths to phases to use in refinement
-   @param pathToGSASII Location of the directory containing GSASIIscriptable.py
-   (and GSAS-II executables)
-   @param GSASIIProjectFile Location to save the .gpx project to
+   @param params Parameters to be passed to GSASIIRefineFitPeaks
    @return Fitted peaks workspace resulting from refinement
    @throws If GSASIIRefineFitPeaks throws
    */
   virtual Mantid::API::MatrixWorkspace_sptr
-  doRietveldRefinement(const Mantid::API::MatrixWorkspace_sptr inputWS,
-                       const RunLabel &runLabel,
-                       const std::string &instParamFile,
-                       const std::vector<std::string> &phaseFiles,
-                       const std::string &pathToGSASII,
-                       const std::string &GSASIIProjectFile) = 0;
+  doRietveldRefinement(const GSASIIRefineFitPeaksParameters &params) = 0;
 
   /**
    Get refined lattice parameters for a run

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
@@ -48,6 +48,10 @@ public:
   virtual boost::optional<Mantid::API::ITableWorkspace_sptr>
   getLatticeParams(const RunLabel &runLabel) const = 0;
 
+  /// Get gamma peak broadening term for a given run, if a fit has been done on
+  /// that run
+  virtual boost::optional<double> getGamma(const RunLabel &runLabel) const = 0;
+
   /**
    Get the weighted profile R-factor discrepancy index for goodness of fit on a
    run
@@ -56,6 +60,10 @@ public:
    been performed on this run)
   */
   virtual boost::optional<double> getRwp(const RunLabel &runLabel) const = 0;
+
+  /// Get sigma peak broadening term for a given run, if a fit has been done on
+  /// that run
+  virtual boost::optional<double> getSigma(const RunLabel &runLabel) const = 0;
 
   /**
    Load a focused run from a file

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingView.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingView.h
@@ -7,6 +7,7 @@
 #include "MantidAPI/ITableWorkspace.h"
 #include "RunLabel.h"
 
+#include <boost/optional.hpp>
 #include <string>
 #include <utility>
 #include <vector>
@@ -62,14 +63,15 @@ public:
   virtual std::string getPathToGSASII() const = 0;
 
   /**
-   @return The minimum d-spacing to use in Pawley refinement
+   @return The minimum d-spacing to use in Pawley refinement, if it is set
    */
-  virtual double getPawleyDMin() const = 0;
+  virtual boost::optional<double> getPawleyDMin() const = 0;
 
   /**
-   @return The weight for penalty function applied during Pawley refinement
+   @return The weight for penalty function applied during Pawley refinement, if
+   it is set
    */
-  virtual double getPawleyNegativeWeight() const = 0;
+  virtual boost::optional<double> getPawleyNegativeWeight() const = 0;
 
   /**
    Get paths to all phase files selected for refinement
@@ -77,11 +79,23 @@ public:
    */
   virtual std::vector<std::string> getPhaseFileNames() const = 0;
 
+  /// Get whether the user has selected to refine gamma broadening term
+  virtual bool getRefineGamma() const = 0;
+
+  /// Get whether the user has selected to refine sigma broadening term
+  virtual bool getRefineSigma() const = 0;
+
   /**
    Get the selected refinement method (Pawley or Rietveld)
    @return Refinement method
    */
   virtual GSASRefinementMethod getRefinementMethod() const = 0;
+
+  /// Get XMax parameter, if it is set
+  virtual boost::optional<double> getXMax() const = 0;
+
+  /// Get XMin parameter, if it is set
+  virtual boost::optional<double> getXMin() const = 0;
 
   /**
    Display an error to the user

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingView.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingView.h
@@ -32,11 +32,17 @@ public:
   virtual void displayLatticeParams(
       const Mantid::API::ITableWorkspace_sptr latticeParams) const = 0;
 
+  /// Display gamma broadening term to the user
+  virtual void displayGamma(const double gamma) const = 0;
+
   /**
    Display Rwp value to the user
    @param rwp for the run to display
   */
   virtual void displayRwp(const double rwp) const = 0;
+
+  /// Display sigma broadening term to the user
+  virtual void displaySigma(const double sigma) const = 0;
 
   /**
    Get the names of the focused run files the user has requested to load

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingView.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingView.h
@@ -103,6 +103,9 @@ public:
   /// Get XMin parameter, if it is set
   virtual boost::optional<double> getXMin() const = 0;
 
+  /// Update the view with current status
+  virtual void showStatus(const std::string &status) const = 0;
+
   /**
    Display an error to the user
    @param errorTitle Title of the error

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
@@ -65,6 +65,9 @@ public:
   virtual std::unique_ptr<IEnggDiffMultiRunFittingWidgetAdder>
   getWidgetAdder() const = 0;
 
+  /// Get whether the user has selected a run from the list
+  virtual bool hasSelectedRunLabel() const = 0;
+
   /**
    * Notifications sent through the presenter when something changes
    * in the view. This plays the role of signals emitted by the view

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
@@ -59,14 +59,11 @@ public:
   getFocusedRun(const RunLabel &runLabel) const = 0;
 
   /// Get run number and bank ID of the run currently selected in the list
-  virtual RunLabel getSelectedRunLabel() const = 0;
+  virtual boost::optional<RunLabel> getSelectedRunLabel() const = 0;
 
   /// Get functor to add this widget to a parent
   virtual std::unique_ptr<IEnggDiffMultiRunFittingWidgetAdder>
   getWidgetAdder() const = 0;
-
-  /// Get whether the user has selected a run from the list
-  virtual bool hasSelectedRunLabel() const = 0;
 
   /**
    * Notifications sent through the presenter when something changes

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
@@ -77,9 +77,6 @@ public:
    */
   virtual void
   notify(IEnggDiffMultiRunFittingWidgetPresenter::Notification notif) = 0;
-
-  /// Get whether the user has selected to show fit results
-  virtual bool showFitResultsSelected() const = 0;
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
@@ -20,10 +20,7 @@ public:
   virtual ~IEnggDiffMultiRunFittingWidgetView() = default;
 
   /// Get run number and bank ID of the run currently selected in the list
-  virtual RunLabel getSelectedRunLabel() const = 0;
-
-  /// Get whether the user has selected a run from the list
-  virtual bool hasSelectedRunLabel() const = 0;
+  virtual boost::optional<RunLabel> getSelectedRunLabel() const = 0;
 
   /// Plot a Qwt curve representing a fitted peaks workspace to the canvas
   virtual void

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
@@ -21,11 +21,17 @@ public:
                Mantid::API::MatrixWorkspace_sptr(
                    const GSASIIRefineFitPeaksParameters &params));
 
+  MOCK_CONST_METHOD1(getGamma,
+                     boost::optional<double>(const RunLabel &runLabel));
+
   MOCK_CONST_METHOD1(getLatticeParams,
                      boost::optional<Mantid::API::ITableWorkspace_sptr>(
                          const RunLabel &runLabel));
 
   MOCK_CONST_METHOD1(getRwp, boost::optional<double>(const RunLabel &runLabel));
+
+  MOCK_CONST_METHOD1(getSigma,
+                     boost::optional<double>(const RunLabel &runLabel));
 
   MOCK_CONST_METHOD1(loadFocusedRun, Mantid::API::MatrixWorkspace_sptr(
                                          const std::string &filename));

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
@@ -13,22 +13,13 @@ using namespace MantidQt::CustomInterfaces;
 class MockEnggDiffGSASFittingModel : public IEnggDiffGSASFittingModel {
 
 public:
-  MOCK_METHOD8(doPawleyRefinement,
+  MOCK_METHOD1(doPawleyRefinement,
                Mantid::API::MatrixWorkspace_sptr(
-                   const Mantid::API::MatrixWorkspace_sptr inputWS,
-                   const RunLabel &runLabel, const std::string &instParamFile,
-                   const std::vector<std::string> &phaseFiles,
-                   const std::string &pathToGSASII,
-                   const std::string &GSASIIProjectFile, const double dMin,
-                   const double negativeWeight));
+                   const GSASIIRefineFitPeaksParameters &params));
 
-  MOCK_METHOD6(doRietveldRefinement,
+  MOCK_METHOD1(doRietveldRefinement,
                Mantid::API::MatrixWorkspace_sptr(
-                   const Mantid::API::MatrixWorkspace_sptr inputWS,
-                   const RunLabel &runLabel, const std::string &instParamFile,
-                   const std::vector<std::string> &phaseFiles,
-                   const std::string &pathToGSASII,
-                   const std::string &GSASIIProjectFile));
+                   const GSASIIRefineFitPeaksParameters &params));
 
   MOCK_CONST_METHOD1(getLatticeParams,
                      boost::optional<Mantid::API::ITableWorkspace_sptr>(

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
@@ -33,6 +33,8 @@ public:
   MOCK_CONST_METHOD1(getSigma,
                      boost::optional<double>(const RunLabel &runLabel));
 
+  MOCK_CONST_METHOD1(hasFitResultsForRun, bool(const RunLabel &runLabel));
+
   MOCK_CONST_METHOD1(loadFocusedRun, Mantid::API::MatrixWorkspace_sptr(
                                          const std::string &filename));
 };

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelTest.h
@@ -44,18 +44,28 @@ API::ITableWorkspace_sptr createDummyTable(
 // Helper class with some protected methods exposed
 class TestEnggDiffGSASFittingModel : public EnggDiffGSASFittingModel {
 public:
+  void addGammaValue(const RunLabel &runLabel, const double gamma);
+
   void addLatticeParamTable(const RunLabel &runLabel,
                             API::ITableWorkspace_sptr table);
 
   void addRwpValue(const RunLabel &runLabel, const double rwp);
 
+  void addSigmaValue(const RunLabel &runLabel, const double sigma);
+
 private:
-  inline double
+  inline GSASIIRefineFitPeaksOutputProperties
   doGSASRefinementAlgorithm(const std::string &fittedPeaksWSName,
                             const std::string &latticeParamsWSName,
                             const GSASIIRefineFitPeaksParameters &params,
                             const std::string &refinementMethod) override;
 };
+
+inline void
+TestEnggDiffGSASFittingModel::addGammaValue(const RunLabel &runLabel,
+                                            const double gamma) {
+  addGamma(runLabel, gamma);
+}
 
 inline void TestEnggDiffGSASFittingModel::addLatticeParamTable(
     const RunLabel &runLabel, API::ITableWorkspace_sptr table) {
@@ -67,7 +77,14 @@ inline void TestEnggDiffGSASFittingModel::addRwpValue(const RunLabel &runLabel,
   addRwp(runLabel, rwp);
 }
 
-inline double TestEnggDiffGSASFittingModel::doGSASRefinementAlgorithm(
+inline void
+TestEnggDiffGSASFittingModel::addSigmaValue(const RunLabel &runLabel,
+                                            const double sigma) {
+  addSigma(runLabel, sigma);
+}
+
+inline GSASIIRefineFitPeaksOutputProperties
+TestEnggDiffGSASFittingModel::doGSASRefinementAlgorithm(
     const std::string &fittedPeaksWSName,
     const std::string &latticeParamsWSName,
     const GSASIIRefineFitPeaksParameters &params,
@@ -89,7 +106,7 @@ inline double TestEnggDiffGSASFittingModel::doGSASRefinementAlgorithm(
       WorkspaceCreationHelper::create2DWorkspaceBinned(4, 4, 0.5);
   ADS.add(fittedPeaksWSName, ws);
 
-  return 75;
+  return GSASIIRefineFitPeaksOutputProperties(1, 2, 3);
 }
 
 } // Anonymous namespace
@@ -140,6 +157,40 @@ public:
     const RunLabel invalid(456, 2);
     TS_ASSERT_THROWS_NOTHING(retrievedRwp = model.getRwp(invalid));
     TS_ASSERT_EQUALS(retrievedRwp, boost::none);
+  }
+
+  void test_getGamma() {
+    TestEnggDiffGSASFittingModel model;
+
+    const RunLabel valid(123, 1);
+    const double gamma = 75.5;
+    model.addGammaValue(valid, gamma);
+
+    auto retrievedGamma = boost::make_optional<double>(false, double());
+    TS_ASSERT_THROWS_NOTHING(retrievedGamma = model.getGamma(valid));
+    TS_ASSERT(retrievedGamma);
+    TS_ASSERT_EQUALS(gamma, *retrievedGamma);
+
+    const RunLabel invalid(456, 2);
+    TS_ASSERT_THROWS_NOTHING(retrievedGamma = model.getGamma(invalid));
+    TS_ASSERT_EQUALS(retrievedGamma, boost::none);
+  }
+
+  void test_getSigma() {
+    TestEnggDiffGSASFittingModel model;
+
+    const RunLabel valid(123, 1);
+    const double sigma = 75.5;
+    model.addSigmaValue(valid, sigma);
+
+    auto retrievedSigma = boost::make_optional<double>(false, double());
+    TS_ASSERT_THROWS_NOTHING(retrievedSigma = model.getSigma(valid));
+    TS_ASSERT(retrievedSigma);
+    TS_ASSERT_EQUALS(sigma, *retrievedSigma);
+
+    const RunLabel invalid(456, 2);
+    TS_ASSERT_THROWS_NOTHING(retrievedSigma = model.getSigma(invalid));
+    TS_ASSERT_EQUALS(retrievedSigma, boost::none);
   }
 
   void test_getLatticeParams() {
@@ -196,6 +247,12 @@ public:
     const auto rwp = model.getRwp(runLabel);
     TS_ASSERT(rwp);
 
+    const auto sigma = model.getSigma(runLabel);
+    TS_ASSERT(sigma);
+
+    const auto gamma = model.getGamma(runLabel);
+    TS_ASSERT(gamma);
+
     const auto latticeParams = model.getLatticeParams(runLabel);
     TS_ASSERT(latticeParams);
 
@@ -221,6 +278,12 @@ public:
 
     const auto rwp = model.getRwp(runLabel);
     TS_ASSERT(rwp);
+
+    const auto sigma = model.getSigma(runLabel);
+    TS_ASSERT(sigma);
+
+    const auto gamma = model.getGamma(runLabel);
+    TS_ASSERT(gamma);
 
     const auto latticeParams = model.getLatticeParams(runLabel);
     TS_ASSERT(latticeParams);

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
@@ -70,6 +70,9 @@ public:
     const auto pathToGSASII = "GSASHOME";
     const auto GSASIIProjectFile = "GPX.gpx";
 
+    EXPECT_CALL(*m_mockMultiRunWidgetPtr, hasSelectedRunLabel())
+        .Times(1)
+        .WillOnce(Return(true));
     EXPECT_CALL(*m_mockMultiRunWidgetPtr, getSelectedRunLabel())
         .Times(1)
         .WillOnce(Return(runLabel));
@@ -121,6 +124,9 @@ public:
     const auto dmin = 1.0;
     const auto negativeWeight = 2.0;
 
+    EXPECT_CALL(*m_mockMultiRunWidgetPtr, hasSelectedRunLabel())
+        .Times(1)
+        .WillOnce(Return(true));
     EXPECT_CALL(*m_mockMultiRunWidgetPtr, getSelectedRunLabel())
         .Times(1)
         .WillOnce(Return(runLabel));

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
@@ -187,16 +187,19 @@ public:
     assertMocksUsedCorrectly();
   }
 
-  void test_selectValidRunFitResultsRequested() {
+  void test_selectValidRunFitResultsAvailable() {
     auto presenter = setUpPresenter();
     const RunLabel runLabel(123, 1);
 
-    EXPECT_CALL(*m_mockMultiRunWidgetPtr, showFitResultsSelected())
+    EXPECT_CALL(*m_mockMultiRunWidgetPtr, hasSelectedRunLabel())
         .Times(1)
         .WillOnce(Return(true));
     EXPECT_CALL(*m_mockMultiRunWidgetPtr, getSelectedRunLabel())
         .Times(1)
         .WillOnce(Return(runLabel));
+    EXPECT_CALL(*m_mockModelPtr, hasFitResultsForRun(runLabel))
+        .Times(1)
+        .WillOnce(Return(true));
 
     const double rwp = 50;
     EXPECT_CALL(*m_mockModelPtr, getRwp(runLabel))
@@ -229,43 +232,32 @@ public:
     assertMocksUsedCorrectly();
   }
 
-  void test_selectRunInvalid() {
+  void test_selectRunNoFitResults() {
     auto presenter = setUpPresenter();
     const RunLabel runLabel(123, 1);
 
-    EXPECT_CALL(*m_mockMultiRunWidgetPtr, showFitResultsSelected())
+    EXPECT_CALL(*m_mockMultiRunWidgetPtr, hasSelectedRunLabel())
         .Times(1)
         .WillOnce(Return(true));
     EXPECT_CALL(*m_mockMultiRunWidgetPtr, getSelectedRunLabel())
         .Times(1)
         .WillOnce(Return(runLabel));
+    EXPECT_CALL(*m_mockModelPtr, hasFitResultsForRun(runLabel))
+        .Times(1)
+        .WillOnce(Return(false));
 
-    EXPECT_CALL(*m_mockModelPtr, getRwp(runLabel))
-        .Times(1)
-        .WillOnce(Return(50));
-    EXPECT_CALL(*m_mockModelPtr, getLatticeParams(runLabel))
-        .Times(1)
-        .WillOnce(Return(boost::none));
-    EXPECT_CALL(*m_mockModelPtr, getSigma(runLabel))
-        .Times(1)
-        .WillOnce(Return(30));
-    EXPECT_CALL(*m_mockModelPtr, getGamma(runLabel))
-        .Times(1)
-        .WillOnce(Return(40));
-
-    EXPECT_CALL(*m_mockViewPtr,
-                userError("Invalid run identifier",
-                          "Unexpectedly tried to display fit results for "
-                          "invalid run, run number = 123, bank ID = 1. Please "
-                          "contact the development team"));
+    EXPECT_CALL(*m_mockModelPtr, getRwp(testing::_)).Times(0);
+    EXPECT_CALL(*m_mockModelPtr, getLatticeParams(testing::_)).Times(0);
+    EXPECT_CALL(*m_mockModelPtr, getSigma(testing::_)).Times(0);
+    EXPECT_CALL(*m_mockModelPtr, getGamma(testing::_)).Times(0);
 
     presenter->notify(IEnggDiffGSASFittingPresenter::SelectRun);
     assertMocksUsedCorrectly();
   }
 
-  void test_selectRunFitResultsNotRequested() {
+  void test_selectRunNoLabelSelected() {
     auto presenter = setUpPresenter();
-    EXPECT_CALL(*m_mockMultiRunWidgetPtr, showFitResultsSelected())
+    EXPECT_CALL(*m_mockMultiRunWidgetPtr, hasSelectedRunLabel())
         .Times(1)
         .WillOnce(Return(false));
     EXPECT_CALL(*m_mockMultiRunWidgetPtr, getSelectedRunLabel()).Times(0);

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
@@ -70,9 +70,6 @@ public:
         {"Phase1", "Phase2"}, "GSASHOME", "GPX.gpx", boost::none, boost::none,
         10000, 40000, true, false);
 
-    EXPECT_CALL(*m_mockMultiRunWidgetPtr, hasSelectedRunLabel())
-        .Times(1)
-        .WillOnce(Return(true));
     EXPECT_CALL(*m_mockMultiRunWidgetPtr, getSelectedRunLabel())
         .Times(1)
         .WillOnce(Return(params.runLabel));
@@ -133,9 +130,6 @@ public:
         {"Phase1", "Phase2"}, "GSASHOME", "GPX.gpx", 1, 2, 10000, 40000, true,
         false);
 
-    EXPECT_CALL(*m_mockMultiRunWidgetPtr, hasSelectedRunLabel())
-        .Times(1)
-        .WillOnce(Return(true));
     EXPECT_CALL(*m_mockMultiRunWidgetPtr, getSelectedRunLabel())
         .Times(1)
         .WillOnce(Return(params.runLabel));
@@ -191,9 +185,6 @@ public:
     auto presenter = setUpPresenter();
     const RunLabel runLabel(123, 1);
 
-    EXPECT_CALL(*m_mockMultiRunWidgetPtr, hasSelectedRunLabel())
-        .Times(1)
-        .WillOnce(Return(true));
     EXPECT_CALL(*m_mockMultiRunWidgetPtr, getSelectedRunLabel())
         .Times(1)
         .WillOnce(Return(runLabel));
@@ -236,9 +227,6 @@ public:
     auto presenter = setUpPresenter();
     const RunLabel runLabel(123, 1);
 
-    EXPECT_CALL(*m_mockMultiRunWidgetPtr, hasSelectedRunLabel())
-        .Times(1)
-        .WillOnce(Return(true));
     EXPECT_CALL(*m_mockMultiRunWidgetPtr, getSelectedRunLabel())
         .Times(1)
         .WillOnce(Return(runLabel));
@@ -257,10 +245,9 @@ public:
 
   void test_selectRunNoLabelSelected() {
     auto presenter = setUpPresenter();
-    EXPECT_CALL(*m_mockMultiRunWidgetPtr, hasSelectedRunLabel())
+    EXPECT_CALL(*m_mockMultiRunWidgetPtr, getSelectedRunLabel())
         .Times(1)
-        .WillOnce(Return(false));
-    EXPECT_CALL(*m_mockMultiRunWidgetPtr, getSelectedRunLabel()).Times(0);
+        .WillOnce(Return(boost::none));
     presenter->notify(IEnggDiffGSASFittingPresenter::SelectRun);
     assertMocksUsedCorrectly();
   }

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
@@ -54,8 +54,7 @@ public:
         .WillOnce(Throw(std::runtime_error("Failure reason")));
 
     EXPECT_CALL(*m_mockViewPtr,
-                userWarning("Could not load file", "Failure reason"))
-        .Times(1);
+                userWarning("Could not load file", "Failure reason")).Times(1);
 
     presenter->notify(IEnggDiffGSASFittingPresenter::LoadRun);
     assertMocksUsedCorrectly();

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
@@ -140,13 +140,6 @@ public:
         .Times(1)
         .WillOnce(Return(params.runLabel));
 
-    EXPECT_CALL(*m_mockMultiRunWidgetPtr, hasSelectedRunLabel())
-        .Times(1)
-        .WillOnce(Return(true));
-    EXPECT_CALL(*m_mockMultiRunWidgetPtr, getSelectedRunLabel())
-        .Times(1)
-        .WillOnce(Return(params.runLabel));
-
     EXPECT_CALL(*m_mockMultiRunWidgetPtr, getFocusedRun(params.runLabel))
         .Times(1)
         .WillOnce(Return(params.inputWorkspace));
@@ -210,6 +203,16 @@ public:
         .Times(1)
         .WillOnce(Return(rwp));
 
+    const double sigma = 30;
+    EXPECT_CALL(*m_mockModelPtr, getSigma(runLabel))
+        .Times(1)
+        .WillOnce(Return(sigma));
+
+    const double gamma = 40;
+    EXPECT_CALL(*m_mockModelPtr, getGamma(runLabel))
+        .Times(1)
+        .WillOnce(Return(gamma));
+
     const auto latticeParams =
         Mantid::API::WorkspaceFactory::Instance().createTable();
     EXPECT_CALL(*m_mockModelPtr, getLatticeParams(runLabel))
@@ -218,6 +221,8 @@ public:
 
     EXPECT_CALL(*m_mockViewPtr, userError(testing::_, testing::_)).Times(0);
     EXPECT_CALL(*m_mockViewPtr, displayRwp(rwp)).Times(1);
+    EXPECT_CALL(*m_mockViewPtr, displaySigma(sigma)).Times(1);
+    EXPECT_CALL(*m_mockViewPtr, displayGamma(gamma)).Times(1);
     EXPECT_CALL(*m_mockViewPtr, displayLatticeParams(latticeParams)).Times(1);
 
     presenter->notify(IEnggDiffGSASFittingPresenter::SelectRun);
@@ -241,12 +246,18 @@ public:
     EXPECT_CALL(*m_mockModelPtr, getLatticeParams(runLabel))
         .Times(1)
         .WillOnce(Return(boost::none));
+    EXPECT_CALL(*m_mockModelPtr, getSigma(runLabel))
+        .Times(1)
+        .WillOnce(Return(30));
+    EXPECT_CALL(*m_mockModelPtr, getGamma(runLabel))
+        .Times(1)
+        .WillOnce(Return(40));
 
-    EXPECT_CALL(*m_mockViewPtr, userError("Invalid run label",
-                                          "Tried to display fit results "
-                                          "for run number 123 and bank ID 1. "
-                                          "Please contact the development "
-                                          "team with this message"));
+    EXPECT_CALL(*m_mockViewPtr,
+                userError("Invalid run identifier",
+                          "Unexpectedly tried to display fit results for "
+                          "invalid run, run number = 123, bank ID = 1. Please "
+                          "contact the development team"));
 
     presenter->notify(IEnggDiffGSASFittingPresenter::SelectRun);
     assertMocksUsedCorrectly();

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
@@ -54,7 +54,8 @@ public:
         .WillOnce(Throw(std::runtime_error("Failure reason")));
 
     EXPECT_CALL(*m_mockViewPtr,
-                userWarning("Could not load file", "Failure reason")).Times(1);
+                userWarning("Could not load file", "Failure reason"))
+        .Times(1);
 
     presenter->notify(IEnggDiffGSASFittingPresenter::LoadRun);
     assertMocksUsedCorrectly();
@@ -63,46 +64,57 @@ public:
   void test_doRietveldRefinement() {
     auto presenter = setUpPresenter();
 
-    const RunLabel runLabel(123, 1);
-    const auto refinementMethod = GSASRefinementMethod::RIETVELD;
-    const auto instParams = "Instrument file";
-    const std::vector<std::string> phaseFiles({"phase1", "phase2"});
-    const auto pathToGSASII = "GSASHOME";
-    const auto GSASIIProjectFile = "GPX.gpx";
+    const GSASIIRefineFitPeaksParameters params(
+        WorkspaceCreationHelper::create2DWorkspaceBinned(1, 100),
+        RunLabel(123, 1), GSASRefinementMethod::RIETVELD, "Instrument file",
+        {"Phase1", "Phase2"}, "GSASHOME", "GPX.gpx", boost::none, boost::none,
+        10000, 40000, true, false);
 
     EXPECT_CALL(*m_mockMultiRunWidgetPtr, hasSelectedRunLabel())
         .Times(1)
         .WillOnce(Return(true));
     EXPECT_CALL(*m_mockMultiRunWidgetPtr, getSelectedRunLabel())
         .Times(1)
-        .WillOnce(Return(runLabel));
+        .WillOnce(Return(params.runLabel));
 
-    const boost::optional<Mantid::API::MatrixWorkspace_sptr> inputWorkspace(
-        WorkspaceCreationHelper::create2DWorkspaceBinned(1, 100));
-    EXPECT_CALL(*m_mockMultiRunWidgetPtr, getFocusedRun(runLabel))
+    EXPECT_CALL(*m_mockMultiRunWidgetPtr, getFocusedRun(params.runLabel))
         .Times(1)
-        .WillOnce(Return(inputWorkspace));
-
+        .WillOnce(Return(params.inputWorkspace));
     EXPECT_CALL(*m_mockViewPtr, getRefinementMethod())
         .Times(1)
-        .WillOnce(Return(refinementMethod));
+        .WillOnce(Return(params.refinementMethod));
     EXPECT_CALL(*m_mockViewPtr, getInstrumentFileName())
         .Times(1)
-        .WillOnce(Return(instParams));
+        .WillOnce(Return(params.instParamsFile));
     EXPECT_CALL(*m_mockViewPtr, getPhaseFileNames())
         .Times(1)
-        .WillOnce(Return(phaseFiles));
+        .WillOnce(Return(params.phaseFiles));
     EXPECT_CALL(*m_mockViewPtr, getPathToGSASII())
         .Times(1)
-        .WillOnce(Return(pathToGSASII));
+        .WillOnce(Return(params.gsasHome));
     EXPECT_CALL(*m_mockViewPtr, getGSASIIProjectPath())
         .Times(1)
-        .WillOnce(Return(GSASIIProjectFile));
+        .WillOnce(Return(params.gsasProjectFile));
+    EXPECT_CALL(*m_mockViewPtr, getPawleyDMin())
+        .Times(1)
+        .WillOnce(Return(params.dMin));
+    EXPECT_CALL(*m_mockViewPtr, getPawleyNegativeWeight())
+        .Times(1)
+        .WillOnce(Return(params.negativeWeight));
+    EXPECT_CALL(*m_mockViewPtr, getXMin())
+        .Times(1)
+        .WillOnce(Return(params.xMin));
+    EXPECT_CALL(*m_mockViewPtr, getXMax())
+        .Times(1)
+        .WillOnce(Return(params.xMax));
+    EXPECT_CALL(*m_mockViewPtr, getRefineSigma())
+        .Times(1)
+        .WillOnce(Return(params.refineSigma));
+    EXPECT_CALL(*m_mockViewPtr, getRefineGamma())
+        .Times(1)
+        .WillOnce(Return(params.refineGamma));
 
-    EXPECT_CALL(*m_mockModelPtr,
-                doRietveldRefinement(*inputWorkspace, runLabel, instParams,
-                                     phaseFiles, pathToGSASII,
-                                     GSASIIProjectFile))
+    EXPECT_CALL(*m_mockModelPtr, doRietveldRefinement(params))
         .Times(1)
         .WillOnce(Throw(std::runtime_error("Failure reason")));
     EXPECT_CALL(*m_mockViewPtr,
@@ -115,54 +127,64 @@ public:
   void test_doPawleyRefinement() {
     auto presenter = setUpPresenter();
 
-    const RunLabel runLabel(123, 1);
-    const auto refinementMethod = GSASRefinementMethod::PAWLEY;
-    const auto instParams = "Instrument file";
-    const std::vector<std::string> phaseFiles({"phase1", "phase2"});
-    const auto pathToGSASII = "GSASHOME";
-    const auto GSASIIProjectFile = "GPX.gpx";
-    const auto dmin = 1.0;
-    const auto negativeWeight = 2.0;
+    const GSASIIRefineFitPeaksParameters params(
+        WorkspaceCreationHelper::create2DWorkspaceBinned(1, 100),
+        RunLabel(123, 1), GSASRefinementMethod::PAWLEY, "Instrument file",
+        {"Phase1", "Phase2"}, "GSASHOME", "GPX.gpx", 1, 2, 10000, 40000, true,
+        false);
 
     EXPECT_CALL(*m_mockMultiRunWidgetPtr, hasSelectedRunLabel())
         .Times(1)
         .WillOnce(Return(true));
     EXPECT_CALL(*m_mockMultiRunWidgetPtr, getSelectedRunLabel())
         .Times(1)
-        .WillOnce(Return(runLabel));
+        .WillOnce(Return(params.runLabel));
 
-    const boost::optional<Mantid::API::MatrixWorkspace_sptr> inputWorkspace(
-        WorkspaceCreationHelper::create2DWorkspaceBinned(1, 100));
-    EXPECT_CALL(*m_mockMultiRunWidgetPtr, getFocusedRun(runLabel))
+    EXPECT_CALL(*m_mockMultiRunWidgetPtr, hasSelectedRunLabel())
         .Times(1)
-        .WillOnce(Return(inputWorkspace));
+        .WillOnce(Return(true));
+    EXPECT_CALL(*m_mockMultiRunWidgetPtr, getSelectedRunLabel())
+        .Times(1)
+        .WillOnce(Return(params.runLabel));
 
+    EXPECT_CALL(*m_mockMultiRunWidgetPtr, getFocusedRun(params.runLabel))
+        .Times(1)
+        .WillOnce(Return(params.inputWorkspace));
     EXPECT_CALL(*m_mockViewPtr, getRefinementMethod())
         .Times(1)
-        .WillOnce(Return(refinementMethod));
+        .WillOnce(Return(params.refinementMethod));
     EXPECT_CALL(*m_mockViewPtr, getInstrumentFileName())
         .Times(1)
-        .WillOnce(Return(instParams));
+        .WillOnce(Return(params.instParamsFile));
     EXPECT_CALL(*m_mockViewPtr, getPhaseFileNames())
         .Times(1)
-        .WillOnce(Return(phaseFiles));
+        .WillOnce(Return(params.phaseFiles));
     EXPECT_CALL(*m_mockViewPtr, getPathToGSASII())
         .Times(1)
-        .WillOnce(Return(pathToGSASII));
+        .WillOnce(Return(params.gsasHome));
     EXPECT_CALL(*m_mockViewPtr, getGSASIIProjectPath())
         .Times(1)
-        .WillOnce(Return(GSASIIProjectFile));
+        .WillOnce(Return(params.gsasProjectFile));
     EXPECT_CALL(*m_mockViewPtr, getPawleyDMin())
         .Times(1)
-        .WillOnce(Return(dmin));
+        .WillOnce(Return(params.dMin));
     EXPECT_CALL(*m_mockViewPtr, getPawleyNegativeWeight())
         .Times(1)
-        .WillOnce(Return(negativeWeight));
+        .WillOnce(Return(params.negativeWeight));
+    EXPECT_CALL(*m_mockViewPtr, getXMin())
+        .Times(1)
+        .WillOnce(Return(params.xMin));
+    EXPECT_CALL(*m_mockViewPtr, getXMax())
+        .Times(1)
+        .WillOnce(Return(params.xMax));
+    EXPECT_CALL(*m_mockViewPtr, getRefineSigma())
+        .Times(1)
+        .WillOnce(Return(params.refineSigma));
+    EXPECT_CALL(*m_mockViewPtr, getRefineGamma())
+        .Times(1)
+        .WillOnce(Return(params.refineGamma));
 
-    EXPECT_CALL(*m_mockModelPtr,
-                doPawleyRefinement(*inputWorkspace, runLabel, instParams,
-                                   phaseFiles, pathToGSASII, GSASIIProjectFile,
-                                   dmin, negativeWeight))
+    EXPECT_CALL(*m_mockModelPtr, doPawleyRefinement(params))
         .Times(1)
         .WillOnce(Throw(std::runtime_error("Failure reason")));
     EXPECT_CALL(*m_mockViewPtr,

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingViewMock.h
@@ -36,9 +36,17 @@ public:
 
   MOCK_CONST_METHOD0(getRefinementMethod, GSASRefinementMethod());
 
-  MOCK_CONST_METHOD0(getPawleyDMin, double());
+  MOCK_CONST_METHOD0(getRefineGamma, bool());
 
-  MOCK_CONST_METHOD0(getPawleyNegativeWeight, double());
+  MOCK_CONST_METHOD0(getRefineSigma, bool());
+
+  MOCK_CONST_METHOD0(getPawleyDMin, boost::optional<double>());
+
+  MOCK_CONST_METHOD0(getPawleyNegativeWeight, boost::optional<double>());
+
+  MOCK_CONST_METHOD0(getXMax, boost::optional<double>());
+
+  MOCK_CONST_METHOD0(getXMin, boost::optional<double>());
 
   MOCK_METHOD1(plotCurve,
                void(const std::vector<boost::shared_ptr<QwtData>> &curve));

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingViewMock.h
@@ -15,10 +15,14 @@ class MockEnggDiffGSASFittingView : public IEnggDiffGSASFittingView {
 public:
   MOCK_METHOD1(addWidget, void(IEnggDiffMultiRunFittingWidgetView *widget));
 
+  MOCK_CONST_METHOD1(displayGamma, void(const double gamma));
+
   MOCK_CONST_METHOD1(displayLatticeParams,
                      void(const Mantid::API::ITableWorkspace_sptr));
 
   MOCK_CONST_METHOD1(displayRwp, void(const double rwp));
+
+  MOCK_CONST_METHOD1(displaySigma, void(const double sigma));
 
   MOCK_CONST_METHOD0(getFocusedFileNames, std::vector<std::string>());
 

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingViewMock.h
@@ -59,6 +59,8 @@ public:
 
   MOCK_CONST_METHOD0(showRefinementResultsSelected, bool());
 
+  MOCK_CONST_METHOD1(showStatus, void(const std::string &status));
+
   MOCK_METHOD1(updateRunList, void(const std::vector<RunLabel> &runLabels));
 
   MOCK_CONST_METHOD2(userError, void(const std::string &errorTitle,

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterMock.h
@@ -30,8 +30,6 @@ public:
 
   MOCK_CONST_METHOD0(getSelectedRunLabel, RunLabel());
 
-  MOCK_CONST_METHOD0(hasSelectedRunLabel, bool());
-
   // Must be faked so that we can return a unique_ptr out of it
   std::unique_ptr<IEnggDiffMultiRunFittingWidgetAdder>
   getWidgetAdder() const override;
@@ -41,8 +39,6 @@ public:
   MOCK_METHOD1(
       notify,
       void(IEnggDiffMultiRunFittingWidgetPresenter::Notification notif));
-
-  MOCK_CONST_METHOD0(showFitResultsSelected, bool());
 };
 
 std::unique_ptr<IEnggDiffMultiRunFittingWidgetAdder>

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterMock.h
@@ -30,6 +30,8 @@ public:
 
   MOCK_CONST_METHOD0(getSelectedRunLabel, RunLabel());
 
+  MOCK_CONST_METHOD0(hasSelectedRunLabel, bool());
+
   // Must be faked so that we can return a unique_ptr out of it
   std::unique_ptr<IEnggDiffMultiRunFittingWidgetAdder>
   getWidgetAdder() const override;

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterMock.h
@@ -28,7 +28,7 @@ public:
                      boost::optional<Mantid::API::MatrixWorkspace_sptr>(
                          const RunLabel &runLabel));
 
-  MOCK_CONST_METHOD0(getSelectedRunLabel, RunLabel());
+  MOCK_CONST_METHOD0(getSelectedRunLabel, boost::optional<RunLabel>());
 
   // Must be faked so that we can return a unique_ptr out of it
   std::unique_ptr<IEnggDiffMultiRunFittingWidgetAdder>

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterMock.h
@@ -34,6 +34,8 @@ public:
   std::unique_ptr<IEnggDiffMultiRunFittingWidgetAdder>
   getWidgetAdder() const override;
 
+  MOCK_CONST_METHOD0(hasSelectedRunLabel, bool());
+
   MOCK_METHOD1(
       notify,
       void(IEnggDiffMultiRunFittingWidgetPresenter::Notification notif));

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
@@ -118,10 +118,6 @@ public:
   void test_selectValidRunWithoutFittedPeaks() {
     auto presenter = setUpPresenter();
 
-    EXPECT_CALL(*m_mockView, hasSelectedRunLabel())
-        .Times(1)
-        .WillOnce(Return(true));
-
     const RunLabel runLabel(123, 1);
     EXPECT_CALL(*m_mockView, getSelectedRunLabel())
         .Times(1)
@@ -147,10 +143,6 @@ public:
   void test_selectRunInvalid() {
     auto presenter = setUpPresenter();
 
-    EXPECT_CALL(*m_mockView, hasSelectedRunLabel())
-        .Times(1)
-        .WillOnce(Return(true));
-
     const RunLabel runLabel(123, 1);
     EXPECT_CALL(*m_mockView, getSelectedRunLabel())
         .Times(1)
@@ -168,10 +160,6 @@ public:
 
   void test_selectValidRunWithFittedPeaks() {
     auto presenter = setUpPresenter();
-
-    EXPECT_CALL(*m_mockView, hasSelectedRunLabel())
-        .Times(1)
-        .WillOnce(Return(true));
 
     const RunLabel runLabel(123, 1);
     ON_CALL(*m_mockView, getSelectedRunLabel()).WillByDefault(Return(runLabel));
@@ -196,10 +184,10 @@ public:
 
   void test_selectRunDoesNothingWhenNoRunSelected() {
     auto presenter = setUpPresenter();
-    EXPECT_CALL(*m_mockView, hasSelectedRunLabel())
+
+    EXPECT_CALL(*m_mockView, getSelectedRunLabel())
         .Times(1)
-        .WillOnce(Return(false));
-    EXPECT_CALL(*m_mockView, getSelectedRunLabel()).Times(0);
+        .WillOnce(Return(boost::none));
     presenter->notify(
         IEnggDiffMultiRunFittingWidgetPresenter::Notification::SelectRun);
     assertMocksUsedCorrectly();
@@ -231,12 +219,23 @@ public:
     assertMocksUsedCorrectly();
   }
 
+  void test_plotPeaksStateChangedDoesNotCrashWhenNoRunSelected() {
+    auto presenter = setUpPresenter();
+
+    EXPECT_CALL(*m_mockView, getSelectedRunLabel())
+        .Times(1)
+        .WillOnce(Return(boost::none));
+    EXPECT_CALL(*m_mockModel, getFocusedRun(testing::_)).Times(0);
+
+    presenter->notify(IEnggDiffMultiRunFittingWidgetPresenter::Notification::
+                          PlotPeaksStateChanged);
+    assertMocksUsedCorrectly();
+  }
+
   void test_removeRun() {
     auto presenter = setUpPresenter();
+
     const RunLabel runLabel(123, 1);
-    EXPECT_CALL(*m_mockView, hasSelectedRunLabel())
-        .Times(1)
-        .WillOnce(Return(true));
     EXPECT_CALL(*m_mockView, getSelectedRunLabel())
         .Times(1)
         .WillOnce(Return(runLabel));
@@ -256,10 +255,9 @@ public:
 
   void test_removeRunDoesNothingWhenNoRunSelected() {
     auto presenter = setUpPresenter();
-    const RunLabel runLabel(123, 1);
-    EXPECT_CALL(*m_mockView, hasSelectedRunLabel())
+    EXPECT_CALL(*m_mockView, getSelectedRunLabel())
         .Times(1)
-        .WillOnce(Return(false));
+        .WillOnce(Return(boost::none));
     EXPECT_CALL(*m_mockModel, removeRun(testing::_)).Times(0);
     presenter->notify(
         IEnggDiffMultiRunFittingWidgetPresenter::Notification::RemoveRun);
@@ -269,9 +267,9 @@ public:
   void test_plotToSeparateWindowDoesNothingWhenNoRunSelected() {
     auto presenter = setUpPresenter();
 
-    EXPECT_CALL(*m_mockView, hasSelectedRunLabel())
+    EXPECT_CALL(*m_mockView, getSelectedRunLabel())
         .Times(1)
-        .WillOnce(Return(false));
+        .WillOnce(Return(boost::none));
     EXPECT_CALL(*m_mockView, reportNoRunSelectedForPlot()).Times(1);
 
     presenter->notify(IEnggDiffMultiRunFittingWidgetPresenter::Notification::
@@ -283,9 +281,6 @@ public:
     auto presenter = setUpPresenter();
     const RunLabel runLabel(123, 1);
 
-    EXPECT_CALL(*m_mockView, hasSelectedRunLabel())
-        .Times(1)
-        .WillOnce(Return(true));
     EXPECT_CALL(*m_mockView, getSelectedRunLabel())
         .Times(1)
         .WillOnce(Return(runLabel));
@@ -321,9 +316,6 @@ public:
     auto presenter = setUpPresenter();
     const RunLabel runLabel(123, 1);
 
-    EXPECT_CALL(*m_mockView, hasSelectedRunLabel())
-        .Times(1)
-        .WillOnce(Return(true));
     EXPECT_CALL(*m_mockView, getSelectedRunLabel())
         .Times(1)
         .WillOnce(Return(runLabel));

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
@@ -205,13 +205,6 @@ public:
     assertMocksUsedCorrectly();
   }
 
-  void test_showFitResultsSelected() {
-    auto presenter = setUpPresenter();
-    EXPECT_CALL(*m_mockView, showFitResultsSelected()).Times(1);
-    presenter->showFitResultsSelected();
-    assertMocksUsedCorrectly();
-  }
-
   void test_plotPeaksStateChangedUpdatesPlot() {
     auto presenter = setUpPresenter();
 

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
@@ -16,9 +16,7 @@ class MockEnggDiffMultiRunFittingWidgetView
     : public IEnggDiffMultiRunFittingWidgetView {
 
 public:
-  MOCK_CONST_METHOD0(hasSelectedRunLabel, bool());
-
-  MOCK_CONST_METHOD0(getSelectedRunLabel, RunLabel());
+  MOCK_CONST_METHOD0(getSelectedRunLabel, boost::optional<RunLabel>());
 
   MOCK_METHOD1(plotFittedPeaks,
                void(const std::vector<boost::shared_ptr<QwtData>> &curve));


### PR DESCRIPTION
The GSAS tab of the ED GUI was hooked up to the algorithm GSASIIRefineFitPeaks, allowing Rietveld refinement on multiple runs from the GUI.

**To test:**

You'll need GSAS-II installed. Install it using one of the scripts in `scripts/GSAS-II` or follow the instructions [here](https://subversion.xray.aps.anl.gov/trac/pyGSAS). Test data is in [GSASIIRefineFitPeaks.zip](https://github.com/mantidproject/mantid/files/1739753/GSASIIRefineFitPeaks.zip)

Start the ED GUI by going to `Interfaces -> Diffraction -> Engineering Diffraction`. You'll be prompted to enter an RB number if you haven't opened the GUI before - do so then go to the `GSAS-II Refinement` tab.

Load the run by clicking the first **Browse** button, selecting `ENGINX_280625_focused_bank_1.nxs` from the zip, and clicking **Load**. `280625_1` should appear in the list in the bottom right of the GUI - click this and the run should appear in the plot.

Select `template_ENGINX_241391_236516_North_bank.prm` for the instrument parameter file, all three `.cif` files for the phase files, a new location to save the gsas project (`.gpx`) to, and your GSAS-II installation directory (containing `GSASIIscriptable.py`), all with their respective browse buttons.

Enter 10000 for **XMin**, 40000 for **XMax**, and select to refine sigma and gamma. Click **Do Refinement**. The fitted peaks should appear in the plot, and the fit output values should appear in the **Fit Results** box. They should be:

![capture](https://user-images.githubusercontent.com/29916298/36488975-bd9df582-171c-11e8-8368-20d753da2f2c.PNG)

Try zooming in and out on the plot, removing the run, plotting, and generally just fiddle with the parameters and see if you can break anything. In particular, make sure that putting garbage into any of the inputs is handled nicely.

Fixes #15552 

**Release Notes** 
[Here](https://github.com/mantidproject/mantid/pull/21804/commits/feed6005bcffbda4fa3bdbd346e06ffcac1cb463)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
