### PR TITLE
Add mslice to mantid as an external project

### DIFF
--- a/Framework/Kernel/CMakeLists.txt
+++ b/Framework/Kernel/CMakeLists.txt
@@ -595,10 +595,10 @@ set ( HTML_ROOT ${DOCS_BUILDDIR}/html )
 set ( MANTID_SCRIPTS ${MANTID_ROOT}/scripts )
 # First the required scripts variable...
 # Omitting the following (as of now) empty directories as CMake doesn't copy them on install and you then end up with a warning message....
-# @MANTID_ROOT@/scripts/Crystallography;@MANTID_ROOT@/scripts/DisorderedMaterials;@MANTID_ROOT@/scripts/Engineering;@MANTID_ROOT@/scripts/Muons;@MANTID_ROOT@/scripts/Neutrinos
 set ( REQUIREDSCRIPT_SUBDIRS Engineering Inelastic Reflectometry SANS)
 
-set ( REQUIREDSCRIPT_DIRS ${MANTID_ROOT}/scripts )
+# If other external interfaces are added then we need a better approach here..
+set ( REQUIREDSCRIPT_DIRS ${MANTID_ROOT}/scripts;${CMAKE_BINARY_DIR}/scripts/ExternalInterfaces/mslice/src/mslice )
 foreach ( SUBDIR ${REQUIREDSCRIPT_SUBDIRS} )
   set ( REQUIREDSCRIPT_DIRS "${REQUIREDSCRIPT_DIRS};${MANTID_SCRIPTS}/${SUBDIR}" )
 endforeach()
@@ -704,22 +704,14 @@ set ( DATADIRS "" )
 set ( MANTIDPUBLISHER "http://upload.mantidproject.org/scriptrepository" )
 set ( HTML_ROOT ../share/doc/html )
 
-# Construct script paths by replacing the old MANTID_ROOT with the new one.
-# Unfortunately string (REGEX REPLACE ... )removes the semi-colons so we have to do this in a loop.
-
-# First REQUIREDSCRIPT_DIRS
-set ( WITH_SEMICOLONS "" )
-foreach ( DIR ${REQUIREDSCRIPT_DIRS} )
-  string ( REGEX REPLACE "${MANTID_ROOT_BUILD}" "${MANTID_ROOT}" DIR ${DIR} )
-  if ( WITH_SEMICOLONS )
-    set ( WITH_SEMICOLONS "${WITH_SEMICOLONS};${DIR}" )
-  else()
-    set ( WITH_SEMICOLONS "${DIR}" ) # Avoid first ;
-  endif()
+# script paths
+set ( MANTID_SCRIPTS ${MANTID_ROOT}/scripts )
+set ( REQUIREDSCRIPT_DIRS ${MANTID_SCRIPTS};${MANTID_SCRIPTS}/ExternalInterfaces )
+foreach ( SUBDIR ${REQUIREDSCRIPT_SUBDIRS} )
+  set ( REQUIREDSCRIPT_DIRS "${REQUIREDSCRIPT_DIRS};${MANTID_SCRIPTS}/${SUBDIR}" )
 endforeach()
-set ( REQUIREDSCRIPT_DIRS "${WITH_SEMICOLONS}" )
 
-# Second PYTHONSCRIPT_DIRS
+# PYTHONSCRIPT_DIRS
 set ( WITH_SEMICOLONS "" )
 foreach ( DIR ${PYTHONSCRIPT_DIRS} )
   string ( REGEX REPLACE "${MANTID_ROOT_BUILD}" "${MANTID_ROOT}" DIR ${DIR} )

--- a/Framework/MDAlgorithms/src/ConvertToMD.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToMD.cpp
@@ -378,7 +378,8 @@ void ConvertToMD::copyMetaData(API::IMDEventWorkspace_sptr &mdEventWS) const {
   auto mapping = boost::make_shared<det2group_map>();
   for (size_t i = 0; i < m_InWS2D->getNumberHistograms(); ++i) {
     const auto &dets = m_InWS2D->getSpectrum(i).getDetectorIDs();
-    mapping->emplace(*dets.begin(), dets);
+    if (!dets.empty())
+      mapping->emplace(*dets.begin(), dets);
   }
 
   // The last experiment info should always be the one that refers

--- a/Framework/Properties/Mantid.properties.template
+++ b/Framework/Properties/Mantid.properties.template
@@ -20,7 +20,7 @@ default.instrument =
 Q.convention = Inelastic
 
 # Set of PyQt interfaces to add to the Interfaces menu, separated by a space.  Interfaces are seperated from their respective categories by a "/".
-mantidqt.python_interfaces = Direct/DGS_Reduction.py Direct/DGSPlanner.py Direct/PyChop.py SANS/ORNL_SANS.py Utility/TofConverter.py Reflectometry/ISIS_Reflectometry_Old.py Diffraction/Powder_Diffraction_Reduction.py Utility/FilterEvents.py Diffraction/HFIR_Powder_Diffraction_Reduction.py Diffraction/HFIR_4Circle_Reduction.py Utility/QECoverage.py SANS/ISIS_SANS_v2_experimental.py Muon/Frequency_Domain_Analysis.py
+mantidqt.python_interfaces = Direct/DGS_Reduction.py Direct/DGSPlanner.py Direct/PyChop.py Direct/MSlice.py SANS/ORNL_SANS.py Utility/TofConverter.py Reflectometry/ISIS_Reflectometry_Old.py Diffraction/Powder_Diffraction_Reduction.py Utility/FilterEvents.py Diffraction/HFIR_Powder_Diffraction_Reduction.py Diffraction/HFIR_4Circle_Reduction.py Utility/QECoverage.py SANS/ISIS_SANS_v2_experimental.py Muon/Frequency_Domain_Analysis.py
 
 # Directory containing the above startup scripts
 mantidqt.python_interfaces_directory = @MANTID_ROOT@/scripts

--- a/docs/source/release/v3.12.0/direct_inelastic.rst
+++ b/docs/source/release/v3.12.0/direct_inelastic.rst
@@ -8,6 +8,8 @@ Direct Inelastic Changes
 New features
 ------------
 
+* The `MSlice <https://github.com/mantidproject/mslice>`_ user interface can now be lauched from the MantidPlot Interfaces menu.
+
 Algorithms
 ##########
 

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -26,6 +26,12 @@ set_property ( TARGET CompileUIUI PROPERTY FOLDER "CompilePyUI" )
 set_property ( TARGET CompileUIHFIR_4Circle_Reduction PROPERTY FOLDER "CompilePyUI" )
 set_property ( TARGET CompileUIFrequency_Domain_Analysis PROPERTY FOLDER "CompilePyUI" )
 
+# External GUIs
+add_subdirectory ( ExternalInterfaces )
+
+# -------------------------------------------------------------------
+# Testing
+# -------------------------------------------------------------------
 set ( TEST_PY_FILES
       test/AbinsAtomsDataTest.py
       test/AbinsCalculateDWSingleCrystalTest.py

--- a/scripts/ExternalInterfaces/CMakeLists.txt
+++ b/scripts/ExternalInterfaces/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Fetch any externally-managed interfaces
+include ( ExternalProject )
+
+# mslice
+set ( _mslice_external_root ${CMAKE_CURRENT_BINARY_DIR}/mslice )
+ExternalProject_Add ( mslice
+  PREFIX ${_mslice_external_root}
+  GIT_REPOSITORY "https://github.com/mantidproject/mslice.git"
+  GIT_TAG master
+  GIT_SHALLOW 1
+  GIT_PROGRESS 1
+  EXCLUDE_FROM_ALL 1
+
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  TEST_COMMAND ""
+  INSTALL_COMMAND ""
+)
+
+if ( NOT EXISTS ${_mslice_external_root}/src/mslice/.git )
+  message ( STATUS "Fetching mslice" )
+  execute_process ( COMMAND ${CMAKE_COMMAND} ARGS -P ${_mslice_external_root}/tmp/mslice-gitclone.cmake
+                  RESULT_VARIABLE exit_code ERROR_VARIABLE error_contents )
+  if ( error_code )
+    message ( WARNING "Failed to clone mslice: ${error_contents}" )
+    if ( EXISTS ${_mslice_external_root}/src/.git )
+      # Remove .git to ensure next try succeeds if it can
+      execute_process ( COMMAND ${CMAKE_COMMAND} ARGS -E remove_directory ${_mslice_external_root}/src/.git )
+    endif ()
+  endif ()
+else ()
+  execute_process ( COMMAND ${CMAKE_COMMAND} ARGS -P ${_mslice_external_root}/tmp/mslice-gitupdate.cmake
+                    RESULT_VARIABLE error_code ERROR_VARIABLE error_contents )
+  if ( error_code )
+    message ( WARNING "Failed to update mslice: ${error_contents}" )
+  endif ()
+endif ()
+
+# Installation
+install ( DIRECTORY ${_mslice_external_root}/src/mslice/mslice/
+          DESTINATION scripts/ExternalInterfaces/mslice )

--- a/scripts/ExternalInterfaces/CMakeLists.txt
+++ b/scripts/ExternalInterfaces/CMakeLists.txt
@@ -6,7 +6,7 @@ set ( _mslice_external_root ${CMAKE_CURRENT_BINARY_DIR}/mslice )
 ExternalProject_Add ( mslice
   PREFIX ${_mslice_external_root}
   GIT_REPOSITORY "https://github.com/mantidproject/mslice.git"
-  GIT_TAG master
+  GIT_TAG d8932699da4a76dfd88eb1d3d6dcde580debafce
   EXCLUDE_FROM_ALL 1
 
   CONFIGURE_COMMAND ""

--- a/scripts/ExternalInterfaces/CMakeLists.txt
+++ b/scripts/ExternalInterfaces/CMakeLists.txt
@@ -7,8 +7,6 @@ ExternalProject_Add ( mslice
   PREFIX ${_mslice_external_root}
   GIT_REPOSITORY "https://github.com/mantidproject/mslice.git"
   GIT_TAG master
-  GIT_SHALLOW 1
-  GIT_PROGRESS 1
   EXCLUDE_FROM_ALL 1
 
   CONFIGURE_COMMAND ""

--- a/scripts/MSlice.py
+++ b/scripts/MSlice.py
@@ -1,0 +1,5 @@
+#!/usr/bin/python
+from __future__ import absolute_import
+
+from mslice.app import show_gui
+show_gui()


### PR DESCRIPTION
Description of work.

Adds a rule to fetch `mslice` at cmake time and enables it to be started from the Interfaces menu.

**To test:**

* Build the branch
* See that "Interfaces->Direct->MSlice" now exists and starts mslice

*No associated issue*

[Release Notes](/mantidproject/mantid/commit/fd9469b104e7fc5b5ee16374fe0ccc6bc4322833)



---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
