### PR TITLE
Fixed results table in muon analysis to always use numeric values when needed

### DIFF
--- a/qt/scientific_interfaces/Muon/MuonAnalysisResultTableCreator.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisResultTableCreator.cpp
@@ -115,7 +115,7 @@ ITableWorkspace_sptr MuonAnalysisResultTableCreator::createTable() const {
 
     auto val = valMap[log];
     // multiple files use strings due to x-y format
-    if (val.canConvert<double>() && !log.endsWith(" (text)") ) {
+    if (val.canConvert<double>() && !log.endsWith(" (text)")) {
       addColumnToTable(table, "double", log.toStdString(), PLOT_TYPE_X);
 
     } else {
@@ -542,12 +542,10 @@ void MuonAnalysisResultTableCreator::writeDataForMultipleFits(
           auto seconds =
               val.toDouble() - static_cast<double>(m_firstStart_ns) * 1.e-9;
           valuesPerWorkspace.append(QString::number(seconds));
-        }
-		else if (val.canConvert<double>() && !log.endsWith(" (text)")) {
-			valuesPerWorkspace.append(QString::number(val.toDouble()));
+        } else if (val.canConvert<double>() && !log.endsWith(" (text)")) {
+          valuesPerWorkspace.append(QString::number(val.toDouble()));
 
-		}
-		else {
+        } else {
           valuesPerWorkspace.append(logValues[log].toString());
         }
       }

--- a/qt/scientific_interfaces/Muon/MuonAnalysisResultTableCreator.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisResultTableCreator.cpp
@@ -512,11 +512,12 @@ void MuonAnalysisResultTableCreator::writeDataForSingleFit(
   }
 }
 /**
-* Write log and parameter values to the table for the case of multiple fits.
+* Add column for a log to the table for the case of multiple fits.
+* Have to check multiple values are not returned
 * @param table :: [input, output] Table to write to
 * @param paramsByLabel :: [input] Map of <label name, <workspace name,
 * <parameter, value>>>
-* @param paramsToDisplay :: [input] List of parameters to display in table
+* @param log :: [input] the log we are going to add to the table
 */
 void MuonAnalysisResultTableCreator::addColumnToResultsTable(
     ITableWorkspace_sptr &table,

--- a/qt/scientific_interfaces/Muon/MuonAnalysisResultTableCreator.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisResultTableCreator.cpp
@@ -115,7 +115,7 @@ ITableWorkspace_sptr MuonAnalysisResultTableCreator::createTable() const {
 
     auto val = valMap[log];
     // multiple files use strings due to x-y format
-    if (val.canConvert<double>() && !log.endsWith(" (text)") && !m_multiple) {
+    if (val.canConvert<double>() && !log.endsWith(" (text)") ) {
       addColumnToTable(table, "double", log.toStdString(), PLOT_TYPE_X);
 
     } else {
@@ -542,7 +542,12 @@ void MuonAnalysisResultTableCreator::writeDataForMultipleFits(
           auto seconds =
               val.toDouble() - static_cast<double>(m_firstStart_ns) * 1.e-9;
           valuesPerWorkspace.append(QString::number(seconds));
-        } else {
+        }
+		else if (val.canConvert<double>() && !log.endsWith(" (text)")) {
+			valuesPerWorkspace.append(QString::number(val.toDouble()));
+
+		}
+		else {
           valuesPerWorkspace.append(logValues[log].toString());
         }
       }
@@ -551,8 +556,8 @@ void MuonAnalysisResultTableCreator::writeDataForMultipleFits(
       // Why not use std::minmax_element? To avoid MSVC warning: QT bug 41092
       // (https://bugreports.qt.io/browse/QTBUG-41092)
       valuesPerWorkspace.sort();
-      const auto &min = valuesPerWorkspace.front().toStdString();
-      const auto &max = valuesPerWorkspace.back().toStdString();
+      const auto &min = valuesPerWorkspace.front().toDouble();
+      const auto &max = valuesPerWorkspace.back().toDouble();
       if (min == max) {
         row << min;
       } else {

--- a/qt/scientific_interfaces/Muon/MuonAnalysisResultTableCreator.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisResultTableCreator.cpp
@@ -559,7 +559,7 @@ void MuonAnalysisResultTableCreator::addColumnToResultsTable(
 				addColumnToTable(table, "double", log.toStdString(), PLOT_TYPE_X);
 				return;
 			}
-			addColumnToTable(table, "string", log.toStdString(), PLOT_TYPE_X);
+			addColumnToTable(table, "str", log.toStdString(), PLOT_TYPE_X);
 		}
 
 		
@@ -622,7 +622,7 @@ void MuonAnalysisResultTableCreator::writeDataForMultipleFits(
         row << min;
       } else {
         std::ostringstream oss;
-        oss << min << "-" << max;
+        oss << valuesPerWorkspace.front().toStdString() << "-" << valuesPerWorkspace.back().toStdString();
         row << oss.str();
       }
       columnIndex++;

--- a/qt/scientific_interfaces/Muon/MuonAnalysisResultTableCreator.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisResultTableCreator.cpp
@@ -110,24 +110,28 @@ ITableWorkspace_sptr MuonAnalysisResultTableCreator::createTable() const {
   } else {
     addColumnToTable(table, "str", "workspace_Name", PLOT_TYPE_LABEL);
   }
-  const auto valMap = m_logValues->value(m_logValues->keys()[0]);
-  for (const auto &log : m_logs) {
-
-    auto val = valMap[log];
-    // multiple files use strings due to x-y format
-    if (val.canConvert<double>() && !log.endsWith(" (text)")) {
-      addColumnToTable(table, "double", log.toStdString(), PLOT_TYPE_X);
-
-    } else {
-      addColumnToTable(table, "str", log.toStdString(), PLOT_TYPE_X);
-    }
-  }
+ 
 
   // Cache the start time of the first run
   m_firstStart_ns = getFirstStartTimeNanosec(workspacesByLabel);
 
   // Get param information and add columns to table
   const auto &wsParamsByLabel = getParametersByLabel(workspacesByLabel);
+
+  const auto valMap = m_logValues->value(m_logValues->keys()[0]);
+  for (const auto &log : m_logs) {
+
+	  auto val = valMap[log];
+	  // multiple files use strings due to x-y format
+	  if (val.canConvert<double>() && !log.endsWith(" (text)")) {
+
+		  addColumnToResultsTable(table, wsParamsByLabel, log);//
+
+	  }
+	  else {
+		  addColumnToTable(table, "str", log.toStdString(), PLOT_TYPE_X);
+	  }
+  }
   const auto &paramsToDisplay = addParameterColumns(table, wsParamsByLabel);
 
   // Write log and parameter data to the table
@@ -507,6 +511,61 @@ void MuonAnalysisResultTableCreator::writeDataForSingleFit(
     }
   }
 }
+/**
+* Write log and parameter values to the table for the case of multiple fits.
+* @param table :: [input, output] Table to write to
+* @param paramsByLabel :: [input] Map of <label name, <workspace name,
+* <parameter, value>>>
+* @param paramsToDisplay :: [input] List of parameters to display in table
+*/
+void MuonAnalysisResultTableCreator::addColumnToResultsTable(
+	ITableWorkspace_sptr &table,
+	const QMap<QString, WSParameterList> &paramsByLabel, const QString &log) const{
+	// if its a single fit we know its a double
+	if (!m_multiple) {
+		addColumnToTable(table, "double", log.toStdString(), PLOT_TYPE_X);
+		return;
+	}
+	// loop over workspaces
+	for (const auto &labelName : m_items) {
+
+		    
+			QStringList valuesPerWorkspace;
+			for (const auto &wsName : paramsByLabel[labelName].keys()) {
+				const auto &logValues = m_logValues->value(wsName);
+				const auto &val = logValues[log];
+
+				// Special case: if log is time in sec, subtract the first start time
+				if (log.endsWith(" (s)")) {
+					auto seconds =
+						val.toDouble() - static_cast<double>(m_firstStart_ns) * 1.e-9;
+					valuesPerWorkspace.append(QString::number(seconds));
+				}
+				else if (val.canConvert<double>() && !log.endsWith(" (text)")) {
+					std::string aaa = log.toStdString();
+					auto asdf = val.toDouble();
+					auto gfdgdsgds = wsName.toStdString();
+					valuesPerWorkspace.append(QString::number(val.toDouble()));
+
+				}
+				else {
+					valuesPerWorkspace.append(logValues[log].toString());
+				}
+			}
+			valuesPerWorkspace.sort();
+			const auto &min = valuesPerWorkspace.front().toDouble();
+			const auto &max = valuesPerWorkspace.back().toDouble();
+			if (min == max) {
+				addColumnToTable(table, "double", log.toStdString(), PLOT_TYPE_X);
+				return;
+			}
+			addColumnToTable(table, "string", log.toStdString(), PLOT_TYPE_X);
+		}
+
+		
+
+
+}
 
 /**
  * Write log and parameter values to the table for the case of multiple fits.
@@ -543,6 +602,9 @@ void MuonAnalysisResultTableCreator::writeDataForMultipleFits(
               val.toDouble() - static_cast<double>(m_firstStart_ns) * 1.e-9;
           valuesPerWorkspace.append(QString::number(seconds));
         } else if (val.canConvert<double>() && !log.endsWith(" (text)")) {
+			std::string aaa = log.toStdString();
+			auto asdf = val.toDouble();
+			auto gfdgdsgds = wsName.toStdString();
           valuesPerWorkspace.append(QString::number(val.toDouble()));
 
         } else {

--- a/qt/scientific_interfaces/Muon/MuonAnalysisResultTableCreator.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisResultTableCreator.cpp
@@ -528,8 +528,6 @@ void MuonAnalysisResultTableCreator::addColumnToResultsTable(
 		addColumnToTable(table, "double", log.toStdString(), PLOT_TYPE_X);
 		return;
 	}
-	// loop over workspaces
-	//for (const auto &labelName : m_items) {
         const auto &labelName = m_items[0];
 
 		    
@@ -545,9 +543,7 @@ void MuonAnalysisResultTableCreator::addColumnToResultsTable(
 					valuesPerWorkspace.append(QString::number(seconds));
 				}
 				else if (val.canConvert<double>() && !log.endsWith(" (text)")) {
-					std::string aaa = log.toStdString();
-					auto asdf = val.toDouble();
-					auto gfdgdsgds = wsName.toStdString();
+
 					valuesPerWorkspace.append(QString::number(val.toDouble()));
 
 				}
@@ -563,10 +559,6 @@ void MuonAnalysisResultTableCreator::addColumnToResultsTable(
 				return;
 			}
 			addColumnToTable(table, "str", log.toStdString(), PLOT_TYPE_X);
-	
-
-		
-
 
 }
 
@@ -605,9 +597,7 @@ void MuonAnalysisResultTableCreator::writeDataForMultipleFits(
               val.toDouble() - static_cast<double>(m_firstStart_ns) * 1.e-9;
           valuesPerWorkspace.append(QString::number(seconds));
         } else if (val.canConvert<double>() && !log.endsWith(" (text)")) {
-			std::string aaa = log.toStdString();
-			auto asdf = val.toDouble();
-			auto gfdgdsgds = wsName.toStdString();
+			
           valuesPerWorkspace.append(QString::number(val.toDouble()));
 
         } else {

--- a/qt/scientific_interfaces/Muon/MuonAnalysisResultTableCreator.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisResultTableCreator.cpp
@@ -112,7 +112,6 @@ ITableWorkspace_sptr MuonAnalysisResultTableCreator::createTable() const {
   } else {
     addColumnToTable(table, "str", "workspace_Name", PLOT_TYPE_LABEL);
   }
- 
 
   // Cache the start time of the first run
   m_firstStart_ns = getFirstStartTimeNanosec(workspacesByLabel);
@@ -123,16 +122,15 @@ ITableWorkspace_sptr MuonAnalysisResultTableCreator::createTable() const {
   const auto valMap = m_logValues->value(m_logValues->keys()[0]);
   for (const auto &log : m_logs) {
 
-	  auto val = valMap[log];
-	  // multiple files use strings due to x-y format
-	  if (val.canConvert<double>() && !log.endsWith(" (text)")) {
+    auto val = valMap[log];
+    // multiple files use strings due to x-y format
+    if (val.canConvert<double>() && !log.endsWith(" (text)")) {
 
-		  addColumnToResultsTable(table, wsParamsByLabel, log);//
+      addColumnToResultsTable(table, wsParamsByLabel, log); //
 
-	  }
-	  else {
-		  addColumnToTable(table, "str", log.toStdString(), PLOT_TYPE_X);
-	  }
+    } else {
+      addColumnToTable(table, "str", log.toStdString(), PLOT_TYPE_X);
+    }
   }
   const auto &paramsToDisplay = addParameterColumns(table, wsParamsByLabel);
 
@@ -521,45 +519,42 @@ void MuonAnalysisResultTableCreator::writeDataForSingleFit(
 * @param paramsToDisplay :: [input] List of parameters to display in table
 */
 void MuonAnalysisResultTableCreator::addColumnToResultsTable(
-	ITableWorkspace_sptr &table,
-	const QMap<QString, WSParameterList> &paramsByLabel, const QString &log) const{
-	// if its a single fit we know its a double
-	if (!m_multiple) {
-		addColumnToTable(table, "double", log.toStdString(), PLOT_TYPE_X);
-		return;
-	}
-        const auto &labelName = m_items[0];
+    ITableWorkspace_sptr &table,
+    const QMap<QString, WSParameterList> &paramsByLabel,
+    const QString &log) const {
+  // if its a single fit we know its a double
+  if (!m_multiple) {
+    addColumnToTable(table, "double", log.toStdString(), PLOT_TYPE_X);
+    return;
+  }
+  const auto &labelName = m_items[0];
 
-		    
-			QStringList valuesPerWorkspace;
-			for (const auto &wsName : paramsByLabel[labelName].keys()) {
-				const auto &logValues = m_logValues->value(wsName);
-				const auto &val = logValues[log];
+  QStringList valuesPerWorkspace;
+  for (const auto &wsName : paramsByLabel[labelName].keys()) {
+    const auto &logValues = m_logValues->value(wsName);
+    const auto &val = logValues[log];
 
-				// Special case: if log is time in sec, subtract the first start time
-				if (log.endsWith(" (s)")) {
-					auto seconds =
-						val.toDouble() - static_cast<double>(m_firstStart_ns) * 1.e-9;
-					valuesPerWorkspace.append(QString::number(seconds));
-				}
-				else if (val.canConvert<double>() && !log.endsWith(" (text)")) {
+    // Special case: if log is time in sec, subtract the first start time
+    if (log.endsWith(" (s)")) {
+      auto seconds =
+          val.toDouble() - static_cast<double>(m_firstStart_ns) * 1.e-9;
+      valuesPerWorkspace.append(QString::number(seconds));
+    } else if (val.canConvert<double>() && !log.endsWith(" (text)")) {
 
-					valuesPerWorkspace.append(QString::number(val.toDouble()));
+      valuesPerWorkspace.append(QString::number(val.toDouble()));
 
-				}
-				else {
-					valuesPerWorkspace.append(logValues[log].toString());
-				}
-			}
-			valuesPerWorkspace.sort();
-			const auto &min = valuesPerWorkspace.front().toDouble();
-			const auto &max = valuesPerWorkspace.back().toDouble();
-			if (min == max) {
-				addColumnToTable(table, "double", log.toStdString(), PLOT_TYPE_X);
-				return;
-			}
-			addColumnToTable(table, "str", log.toStdString(), PLOT_TYPE_X);
-
+    } else {
+      valuesPerWorkspace.append(logValues[log].toString());
+    }
+  }
+  valuesPerWorkspace.sort();
+  const auto &min = valuesPerWorkspace.front().toDouble();
+  const auto &max = valuesPerWorkspace.back().toDouble();
+  if (min == max) {
+    addColumnToTable(table, "double", log.toStdString(), PLOT_TYPE_X);
+    return;
+  }
+  addColumnToTable(table, "str", log.toStdString(), PLOT_TYPE_X);
 }
 
 /**
@@ -597,7 +592,7 @@ void MuonAnalysisResultTableCreator::writeDataForMultipleFits(
               val.toDouble() - static_cast<double>(m_firstStart_ns) * 1.e-9;
           valuesPerWorkspace.append(QString::number(seconds));
         } else if (val.canConvert<double>() && !log.endsWith(" (text)")) {
-			
+
           valuesPerWorkspace.append(QString::number(val.toDouble()));
 
         } else {
@@ -615,7 +610,8 @@ void MuonAnalysisResultTableCreator::writeDataForMultipleFits(
         row << min;
       } else {
         std::ostringstream oss;
-        oss << valuesPerWorkspace.front().toStdString() << "-" << valuesPerWorkspace.back().toStdString();
+        oss << valuesPerWorkspace.front().toStdString() << "-"
+            << valuesPerWorkspace.back().toStdString();
         row << oss.str();
       }
       columnIndex++;

--- a/qt/scientific_interfaces/Muon/MuonAnalysisResultTableCreator.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisResultTableCreator.cpp
@@ -18,6 +18,7 @@ using Mantid::API::WorkspaceFactory;
 using Mantid::API::WorkspaceGroup;
 
 namespace {
+
 /**
  * Converts QStringList -> std::vector<std::string>
  * @param qsl :: [input] QStringList to convert
@@ -40,6 +41,7 @@ std::vector<std::string> qStringListToVector(const QStringList &qsl) {
  */
 void addColumnToTable(ITableWorkspace_sptr &table, const std::string &dataType,
                       const std::string &name, const int plotType) {
+
   auto column = table->addColumn(dataType, name);
   column->setPlotType(plotType);
   column->setReadOnly(false);
@@ -527,7 +529,8 @@ void MuonAnalysisResultTableCreator::addColumnToResultsTable(
 		return;
 	}
 	// loop over workspaces
-	for (const auto &labelName : m_items) {
+	//for (const auto &labelName : m_items) {
+        const auto &labelName = m_items[0];
 
 		    
 			QStringList valuesPerWorkspace;
@@ -560,7 +563,7 @@ void MuonAnalysisResultTableCreator::addColumnToResultsTable(
 				return;
 			}
 			addColumnToTable(table, "str", log.toStdString(), PLOT_TYPE_X);
-		}
+	
 
 		
 

--- a/qt/scientific_interfaces/Muon/MuonAnalysisResultTableCreator.h
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisResultTableCreator.h
@@ -104,9 +104,10 @@ private:
                            const QMap<QString, WSParameterList> &paramsByLabel,
                            const QStringList &paramsToDisplay) const;
 
-  void addColumnToResultsTable(Mantid::API::ITableWorkspace_sptr &table,
-	  const QMap<QString, WSParameterList> &paramsByLabel,
-	 const QString &log) const;
+  void
+  addColumnToResultsTable(Mantid::API::ITableWorkspace_sptr &table,
+                          const QMap<QString, WSParameterList> &paramsByLabel,
+                          const QString &log) const;
 
   /// Items selected by user (fitted workspaces or fit labels)
   const QStringList m_items;

--- a/qt/scientific_interfaces/Muon/MuonAnalysisResultTableCreator.h
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisResultTableCreator.h
@@ -104,6 +104,10 @@ private:
                            const QMap<QString, WSParameterList> &paramsByLabel,
                            const QStringList &paramsToDisplay) const;
 
+  void addColumnToResultsTable(Mantid::API::ITableWorkspace_sptr &table,
+	  const QMap<QString, WSParameterList> &paramsByLabel,
+	 const QString &log) const;
+
   /// Items selected by user (fitted workspaces or fit labels)
   const QStringList m_items;
   /// Log names selected by used

--- a/qt/scientific_interfaces/test/MuonAnalysisResultTableCreatorTest.h
+++ b/qt/scientific_interfaces/test/MuonAnalysisResultTableCreatorTest.h
@@ -264,10 +264,10 @@ public:
     MuonAnalysisResultTableCreator creator(labels, m_logs, &m_logValues, true);
     ITableWorkspace_sptr resultTable;
     TS_ASSERT_THROWS_NOTHING(resultTable = creator.createTable());
-    TS_ASSERT(resultTable);
-    const auto &expected = getExpectedOutputMultiple();
-    // compare workspaces
-    TS_ASSERT(compareTables(resultTable, expected));
+//    TS_ASSERT(resultTable);
+//    const auto &expected = getExpectedOutputMultiple();
+//    // compare workspaces
+//    TS_ASSERT(compareTables(resultTable, expected));
   }
 
   void test_createTable_multiple_throws_differentNumberDatasets() {

--- a/qt/scientific_interfaces/test/MuonAnalysisResultTableCreatorTest.h
+++ b/qt/scientific_interfaces/test/MuonAnalysisResultTableCreatorTest.h
@@ -504,13 +504,13 @@ private:
         "f1.SigmaError", "f0.f1.Tau",      "f0.f1.TauError",
         "f1.f1.Tau",     "f1.f1.TauError", "Cost function value"};
     table->addColumn("str", "Label");
-    int k =0;
+    int k = 0;
     for (const auto &log : m_logs) {
-      if( k == 2){
+      if (k == 2) {
 
-      table->addColumn("double", log.toStdString());
-      }else{
-          table->addColumn("str", log.toStdString());
+        table->addColumn("double", log.toStdString());
+      } else {
+        table->addColumn("str", log.toStdString());
       }
       k++;
     }
@@ -523,16 +523,14 @@ private:
 
     firstRow << "Label"
              << "20918-20919"
-             << "0-1310"
-             << 100.0
-             << "190-200" << 0.1 << err << 1.1 << err << 0.2 << err << 0.3
-             << 0.4 << err << 0.5 << err << 0.6 << err << 1.6 << err << 0.03;
+             << "0-1310" << 100.0 << "190-200" << 0.1 << err << 1.1 << err
+             << 0.2 << err << 0.3 << 0.4 << err << 0.5 << err << 0.6 << err
+             << 1.6 << err << 0.03;
     secondRow << "Label#2"
               << "20920-20921"
-              << "2620-3930"
-              << 100.0
-              << "170-180" << 0.1 << err << 1.1 << err << 0.2 << err << 0.3
-              << 0.4 << err << 0.5 << err << 0.6 << err << 1.6 << err << 0.03;
+              << "2620-3930" << 100.0 << "170-180" << 0.1 << err << 1.1 << err
+              << 0.2 << err << 0.3 << 0.4 << err << 0.5 << err << 0.6 << err
+              << 1.6 << err << 0.03;
 
     return table;
   }

--- a/qt/scientific_interfaces/test/MuonAnalysisResultTableCreatorTest.h
+++ b/qt/scientific_interfaces/test/MuonAnalysisResultTableCreatorTest.h
@@ -264,10 +264,10 @@ public:
     MuonAnalysisResultTableCreator creator(labels, m_logs, &m_logValues, true);
     ITableWorkspace_sptr resultTable;
     TS_ASSERT_THROWS_NOTHING(resultTable = creator.createTable());
-//    TS_ASSERT(resultTable);
-//    const auto &expected = getExpectedOutputMultiple();
-//    // compare workspaces
-//    TS_ASSERT(compareTables(resultTable, expected));
+    //    TS_ASSERT(resultTable);
+    //    const auto &expected = getExpectedOutputMultiple();
+    //    // compare workspaces
+    //    TS_ASSERT(compareTables(resultTable, expected));
   }
 
   void test_createTable_multiple_throws_differentNumberDatasets() {

--- a/qt/scientific_interfaces/test/MuonAnalysisResultTableCreatorTest.h
+++ b/qt/scientific_interfaces/test/MuonAnalysisResultTableCreatorTest.h
@@ -264,10 +264,10 @@ public:
     MuonAnalysisResultTableCreator creator(labels, m_logs, &m_logValues, true);
     ITableWorkspace_sptr resultTable;
     TS_ASSERT_THROWS_NOTHING(resultTable = creator.createTable());
-    //    TS_ASSERT(resultTable);
-    //    const auto &expected = getExpectedOutputMultiple();
-    //    // compare workspaces
-    //    TS_ASSERT(compareTables(resultTable, expected));
+    TS_ASSERT(resultTable);
+    const auto &expected = getExpectedOutputMultiple();
+    // compare workspaces
+    TS_ASSERT(compareTables(resultTable, expected));
   }
 
   void test_createTable_multiple_throws_differentNumberDatasets() {
@@ -504,8 +504,15 @@ private:
         "f1.SigmaError", "f0.f1.Tau",      "f0.f1.TauError",
         "f1.f1.Tau",     "f1.f1.TauError", "Cost function value"};
     table->addColumn("str", "Label");
+    int k =0;
     for (const auto &log : m_logs) {
-      table->addColumn("str", log.toStdString());
+      if( k == 2){
+
+      table->addColumn("double", log.toStdString());
+      }else{
+          table->addColumn("str", log.toStdString());
+      }
+      k++;
     }
     for (const auto &title : titles) {
       table->addColumn("double", title);
@@ -517,13 +524,13 @@ private:
     firstRow << "Label"
              << "20918-20919"
              << "0-1310"
-             << "100"
+             << 100.0
              << "190-200" << 0.1 << err << 1.1 << err << 0.2 << err << 0.3
              << 0.4 << err << 0.5 << err << 0.6 << err << 1.6 << err << 0.03;
     secondRow << "Label#2"
               << "20920-20921"
               << "2620-3930"
-              << "100"
+              << 100.0
               << "170-180" << 0.1 << err << 1.1 << err << 0.2 << err << 0.3
               << 0.4 << err << 0.5 << err << 0.6 << err << 1.6 << err << 0.03;
 


### PR DESCRIPTION
Multiple fitting was not producing numeric values in the results table. 

**To test:**
to set up the test:

Open muon analysis
Select the EMU instrument
Load 20717

The first test
Go to the settings tab and make sure that multiple fitting is selected
Go to the Data analysis tab and add a fitting function.
Do a fit
Change the run number to 20722.
Do another fit
Change the run number to 20724.
Do another fit
Change the run number to 20728.
Do another fit
Go to the results table tab
Click the multiple option in the middle of the page
Select sample_Temp from the log values
Create the results table.
Plot the sample_Temp and a parameter and a nice plot should pop up

Second
Go to the settings tab and make sure that multiple fitting is selected
Go to the Data analysis tab and add a fitting function (share some parameters but not all).
Make sure 'all groups' is selected in the group/pair drop down menu
Run a fit
Change the run number (see test 1 for values). Then do a fit. Do this a couple time.
Go to the results table tab and select the multiple button and generate a table.
For the non-shared parameters there should be 2 occurrence of each (e.g. f0.A and f1.A).
For shared parameters should only be in the table once.

Third Test
Go to the settings tab and make sure that multiple fitting is selected
Go to the Data analysis tab and add a fitting function (doesnt matter which).
In the runs box add a -20 (it should read 20717-20)
Run a fit
Go to the results table tab
select the multiple option from the middle of the page
Make sure Temp_sample is selected
Click create table
The table should have a range for the Temp_Sample (10.6-6.9 I have rounded)



<!-- Instructions for testing. -->

Fixes #21803. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
