### PR TITLE
ISIS Powder change output workspace names to support nice renaming of GroupWorkspaces

### DIFF
--- a/docs/source/release/v3.12.0/diffraction.rst
+++ b/docs/source/release/v3.12.0/diffraction.rst
@@ -40,6 +40,7 @@ Powder Diffraction
 - It is now possible to set beam parameters (height and width) using instrument_object.set_beam_parameters(height=123, width=456).
 - The ``mode`` parameter for POLARIS in ISIS Powder now behaves as described in the documentation - it persists through function calls and is case insensitive
 - For instruments in ISIS Powder, offset files may now be specified by an absolute path. The default behaviour of assuming they live in calibration/label has been retained
+- The names of output workspaces from ISIS Powder for all instruments except PEARL were altered slightly to allow more convenient renaming of GroupWorkspaces
 
 Engineering Diffraction
 -----------------------

--- a/scripts/Diffraction/isis_powder/routines/common_output.py
+++ b/scripts/Diffraction/isis_powder/routines/common_output.py
@@ -30,7 +30,7 @@ def split_into_tof_d_spacing_groups(run_details, processed_spectra):
     # Group the outputs
     d_spacing_group_name = run_number + ext + "-ResultD"
     d_spacing_group = mantid.GroupWorkspaces(InputWorkspaces=d_spacing_output, OutputWorkspace=d_spacing_group_name)
-    tof_group_name = run_number + ext + "-Results-TOF"
+    tof_group_name = run_number + ext + "-ResultTOF"
     tof_group = mantid.GroupWorkspaces(InputWorkspaces=tof_output, OutputWorkspace=tof_group_name)
 
     return d_spacing_group, tof_group

--- a/scripts/Diffraction/isis_powder/routines/common_output.py
+++ b/scripts/Diffraction/isis_powder/routines/common_output.py
@@ -20,17 +20,17 @@ def split_into_tof_d_spacing_groups(run_details, processed_spectra):
     ext = run_details.file_extension if run_details.file_extension else ""
 
     for name_index, ws in enumerate(processed_spectra, start=1):
-        d_spacing_out_name = run_number + ext + "-ResultD-" + str(name_index)
-        tof_out_name = run_number + ext + "-ResultTOF-" + str(name_index)
+        d_spacing_out_name = run_number + ext + "-ResultD_" + str(name_index)
+        tof_out_name = run_number + ext + "-ResultTOF_" + str(name_index)
 
         d_spacing_output.append(mantid.ConvertUnits(InputWorkspace=ws, OutputWorkspace=d_spacing_out_name,
                                                     Target="dSpacing"))
         tof_output.append(mantid.ConvertUnits(InputWorkspace=ws, OutputWorkspace=tof_out_name, Target="TOF"))
 
     # Group the outputs
-    d_spacing_group_name = run_number + ext + "-Results-D-Grp"
+    d_spacing_group_name = run_number + ext + "-ResultD"
     d_spacing_group = mantid.GroupWorkspaces(InputWorkspaces=d_spacing_output, OutputWorkspace=d_spacing_group_name)
-    tof_group_name = run_number + ext + "-Results-TOF-Grp"
+    tof_group_name = run_number + ext + "-Results-TOF"
     tof_group = mantid.GroupWorkspaces(InputWorkspaces=tof_output, OutputWorkspace=tof_group_name)
 
     return d_spacing_group, tof_group


### PR DESCRIPTION
The names of output workspaces in `isis_powder` for all instruments except PEARL were changed slightly to make renaming them and their children more convenient, a la [RenameWorkspaces](http://docs.mantidproject.org/nightly/algorithms/RenameWorkspace-v1.html#id3).

Description of work.

**To test:**

If you already have a focusing script for ISIS Powder then use that (unless it's for PEARL), otherwise use the script below. If you're not at ISIS, you'll need to change the second line - ping me a message about setting up ISIS Powder directories, as it can be fiddly.

```
from isis_powder import Polaris
pol = Polaris(config_file=r"\\olympic\babylon5\Public\JoeRamsay\POLARIS\polaris_shared_config.yaml", 
              do_van_normalisation=False, mode="Rietveld")
pol.focus(run_number="103106")
```
You'll get two output GroupWorkspaces, one for D and one for TOF. Make sure that renaming them also renames their children.

Fixes #21747 

**Release Notes** 
[Here](https://github.com/mantidproject/mantid/compare/21747_isispowder_underscore_groupworkspace_name?expand=1#diff-6d316275f01d64b8113c082a773943ae)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
