### PR TITLE
Fix LoadEventNexus and LoadNexusMonitors for OFFSPEC 44754+

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNexusMonitors2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNexusMonitors2.h
@@ -102,6 +102,14 @@ private:
   bool isEventMonitor(::NeXus::File &monitorFileHandle) const;
   std::size_t sizeOfUnopenedEntry(::NeXus::File &file,
                                   const std::string &entryName) const;
+  bool eventIdNotEmptyIfExists(
+      ::NeXus::File &monitorFileHandle,
+      std::map<std::string, std::string> const &entries) const;
+  bool hasAllEventLikeAttributes(
+      std::map<std::string, std::string> const &entries) const;
+  bool keyExists(std::string const &key,
+                 std::map<std::string, std::string> const &entries) const;
+
   bool
   createOutputWorkspace(size_t numHistMon, size_t numEventMon,
                         bool monitorsAsEvents,

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNexusMonitors2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNexusMonitors2.h
@@ -99,6 +99,9 @@ private:
                         std::map<int, std::string> &monitorNumber2Name,
                         std::vector<bool> &isEventMonitors);
 
+  bool isEventMonitor(::NeXus::File &monitorFileHandle) const;
+  std::size_t sizeOfUnopenedEntry(::NeXus::File &file,
+                                  const std::string &entryName) const;
   bool
   createOutputWorkspace(size_t numHistMon, size_t numEventMon,
                         bool monitorsAsEvents,

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -1155,7 +1155,7 @@ bool LoadEventNexus::hasEventMonitors() {
     }
     bool hasTotalCounts = false;
     bool oldNeXusFileNames = false;
-    result = numEvents(*m_file, hasTotalCounts, oldNeXusFileNames) == 0;
+    result = numEvents(*m_file, hasTotalCounts, oldNeXusFileNames) > 0;
     m_file->closeGroup();
   } catch (::NeXus::Exception &) {
     result = false;

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -1153,9 +1153,10 @@ bool LoadEventNexus::hasEventMonitors() {
         break;
       }
     }
-    m_file->openData("event_id");
+    bool hasTotalCounts = false;
+    bool oldNeXusFileNames = false;
+    result = numEvents(*m_file, hasTotalCounts, oldNeXusFileNames) == 0;
     m_file->closeGroup();
-    result = true;
   } catch (::NeXus::Exception &) {
     result = false;
   }


### PR DESCRIPTION
Loading of runs for OFFSPEC 44754+ fails due to an empty `event_id` array being generated in the nexus file alongside the histogram data for the monitor. This PR patches this in order to allow these runs to be properly loaded.

**To test:**
Attempt to load a combination of event and histogram files using `LoadEventNexus` and `LoadNexusMonitors`.

<!-- Instructions for testing. -->

Fixes #21818 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
