### PR TITLE
Add SpectrumInfo and twoTheta python exports

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -85,6 +85,6 @@ void export_ExperimentInfo() {
            "object.")
       .def("spectrumInfo", &ExperimentInfo::spectrumInfo,
            return_value_policy<reference_existing_object>(), args("self"),
-          "Return a const reference to the :class:`~mantid.api.SpectrumInfo` "
-          "object.");
+           "Return a const reference to the :class:`~mantid.api.SpectrumInfo` "
+           "object.");
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -1,4 +1,5 @@
 #include "MantidAPI/ExperimentInfo.h"
+#include "MantidAPI/SpectrumInfo.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/Sample.h"
@@ -81,5 +82,9 @@ void export_ExperimentInfo() {
       .def("detectorInfo", &ExperimentInfo::detectorInfo,
            return_value_policy<reference_existing_object>(), args("self"),
            "Return a const reference to the :class:`~mantid.api.DetectorInfo` "
-           "object.");
+           "object.")
+      .def("spectrumInfo", &ExperimentInfo::spectrumInfo,
+           return_value_policy<reference_existing_object>(), args("self"),
+          "Return a const reference to the :class:`~mantid.api.SpectrumInfo` "
+          "object.");
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -243,11 +243,6 @@ void export_MatrixWorkspace() {
       .def("YUnitLabel", &MatrixWorkspace::YUnitLabel, arg("self"),
            "Returns the caption for the Y axis")
 
-      .def("spectrumInfo", &MatrixWorkspace::spectrumInfo,
-           return_value_policy<reference_existing_object>(), args("self"),
-           "Return a const reference to the :class:`~mantid.api.SpectrumInfo` "
-           "object.")
-
       // Deprecated
       .def("getNumberBins", &getNumberBinsDeprecated, arg("self"),
            "Returns size of the Y data array (deprecated, use "

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -1,7 +1,6 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/Run.h"
-#include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/WorkspaceOpOverloads.h"
 #include "MantidGeometry/IDetector.h"
 #include "MantidKernel/WarningSuppressions.h"

--- a/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
@@ -18,5 +18,8 @@ void export_SpectrumInfo() {
            "masked.")
       .def("hasDetectors", &SpectrumInfo::hasDetectors, (arg("self")),
            "Returns true if the spectrum is associated with detectors in the "
-           "instrument.");
+           "instrument.")
+      .def("twoTheta", &SpectrumInfo::twoTheta, (arg("self"), arg("index")),
+           "Returns the scattering angle 2 theta in radians w.r.t. beam "
+            "direction.");
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
@@ -21,5 +21,5 @@ void export_SpectrumInfo() {
            "instrument.")
       .def("twoTheta", &SpectrumInfo::twoTheta, (arg("self"), arg("index")),
            "Returns the scattering angle 2 theta in radians w.r.t. beam "
-            "direction.");
+           "direction.");
 }


### PR DESCRIPTION
[Mslice](https://github.com/mantidproject/mslice) recently required access to scattering angle information through `SpectrumInfo` (due to using a non-matrix workspace). This PR adds the required exports.

**To test:**
Test `SpectrumInfo` and `twoTheta` can be used in python e.g. `workspace.spectrumInfo().twoTheta(x)`

Fixes #21817

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
