### PR TITLE
Minor fix to default in calibration script

### DIFF
--- a/scripts/Calibration/tube.py
+++ b/scripts/Calibration/tube.py
@@ -420,7 +420,7 @@ def calibrate(ws, tubeSet, knownPositions, funcForm, **kwargs):
         margin = param_helper.get_parameter(MARGIN, kwargs)
         fit_par.setMargin(margin)
 
-    range_list = param_helper.get_parameter(RANGELIST, kwargs, default_range_list=tubeSet.getNumTubes())
+    range_list = param_helper.get_parameter(RANGELIST, kwargs, default_range_list=range(tubeSet.getNumTubes()))
     calib_table = param_helper.get_parameter(CALIBTABLE, kwargs)
     plot_tube = param_helper.get_parameter(PLOTTUBE, kwargs)
     exclude_short_tubes = param_helper.get_parameter(EXCLUDESHORT, kwargs)

--- a/scripts/Calibration/tube.py
+++ b/scripts/Calibration/tube.py
@@ -420,7 +420,7 @@ def calibrate(ws, tubeSet, knownPositions, funcForm, **kwargs):
         margin = param_helper.get_parameter(MARGIN, kwargs)
         fit_par.setMargin(margin)
 
-    range_list = param_helper.get_parameter(RANGELIST, kwargs, default_range_list=range(tubeSet.getNumTubes()))
+    range_list = param_helper.get_parameter(RANGELIST, kwargs, default_range_list=list(range(tubeSet.getNumTubes())))
     calib_table = param_helper.get_parameter(CALIBTABLE, kwargs)
     plot_tube = param_helper.get_parameter(PLOTTUBE, kwargs)
     exclude_short_tubes = param_helper.get_parameter(EXCLUDESHORT, kwargs)


### PR DESCRIPTION
The calibration script was not working if the range_list was using the default.
This was the error
```
<tube_spec.TubeSpec instance at 0x0000000022776448>
Looking for MAPS/B2_window
Number of tubes = 52
TypeError: 'int' object is not iterable
  at line 21 in 'New script'
  caused by line 432 in 'C:/MantidInstall/scripts/Calibration\tube.py'
  caused by line 498 in 'C:/MantidInstall/scripts/Calibration\tube_calib.py'
```

This PR sets the default for range_list to be a range
not a single int as it was before, which would fail in the calibration routine

**To test:**

<!-- Instructions for testing. -->
Run this script if it runs all is well.
``` python
from tube_calib_fit_params import TubeCalibFitParams
import tube
from tube_spec import TubeSpec

#Load the calibration workspace
wsIn=Load('MAP26840.raw')
#remove the previous calibration
empty_instr = LoadEmptyInstrument("c:/mantidinstall/instrument/MAPS_definition.xml")
CopyInstrumentParameters(empty_instr,wsIn)
#integrate the data
ws=Integration("wsIn", RangeLower=2000,RangeUpper=10000)

#Set the Tube specfication
tubeSet = TubeSpec(ws)
tubeSet.setTubeSpecByString("MAPS/B2_window")
#Starting positions for fits
ExpectedPositions = [15.0, 50.0, 90.0, 126.0, 200.0, 240.0]
fitPar = TubeCalibFitParams(ExpectedPositions)

#position in metres along the tube where the bands should be
knownPositions = [-0.5, -0.30, -0.15, 0.0, 0.30, 0.5] 
# the shape of these points: edge, gaussian, gaussian, gaussian, edge
funcForm = [2, 1, 1, 1,1, 2]

calibTable = tube.calibrate(ws, 'MAPS/B2_window', knownPositions, funcForm, margin=30, plotTube=range(0,52), fitPar=fitPar, outputPeak=True)
ApplyCalibration(ws, calibTable)
```

**Release Notes** 

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
