### PR TITLE
Fix bad background colour in Matrix View.

### DIFF
--- a/MantidPlot/src/Mantid/MantidMatrixModel.cpp
+++ b/MantidPlot/src/Mantid/MantidMatrixModel.cpp
@@ -44,8 +44,7 @@ void MantidMatrixModel::setup(const Mantid::API::MatrixWorkspace *ws, int rows,
   m_colNumCorr = 1;
   m_endRow = m_rows - 1;
   m_startRow = start >= 0 ? start : 0;
-  m_mon_color =
-      QApplication::palette().color(QPalette::Active, QPalette::ToolTipBase);
+  m_mon_color = QColor(255, 253, 209);
   m_mask_color =
       QApplication::palette().color(QPalette::Disabled, QPalette::Background);
 


### PR DESCRIPTION
Fixes #21821 
Uses a hard-coded colour value instead of the tooltip colour for the background of the monitor rows in the matrix data view.

**To test:**
Ensure that the monitor cells in the Matrix Data View are readable on both Linux and Windows.

<!-- Instructions for testing. -->

Fixes #21821 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
