### PR TITLE
SNSPowderReduction sum and filter a single file

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -336,7 +336,8 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
         # get the user-option whether an existing event workspace will be reloaded or not
         reload_event_file = self.getProperty('ReloadIfWorkspaceExists').value
 
-        if self.getProperty("Sum").value:
+        if self.getProperty("Sum").value and len(samRuns) > 1:
+            self.log().information('Ignoring value of "Sum" property')
             # Sum input sample runs and then do reduction
             if self._splittersWS is not None:
                 raise NotImplementedError("Summing spectra and filtering events are not supported simultaneously.")
@@ -674,7 +675,6 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
 
         :param filename_list: list of filenames
         :param outName:
-        :param filterWall:
         :return:
         """
         # Check requirements
@@ -798,7 +798,6 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
         Load, (optional) split and focus data in chunks
         @param filename: integer for run number
         @param filter_wall:  Enabled if splitwksp is defined
-        @param normalisebycurrent: Set to False if summing runs for correct math
         @param splitwksp: SplittersWorkspace (if None then no split)
         @param preserveEvents:
         @return: a string as the returned workspace's name or a list of strings as the returned workspaces' names


### PR DESCRIPTION
Don't sum if it is only one file, but sometimes "people" leave the `Sum` box ticked `True`. This gets around that mistake.

**To test:**

The original script that found the bug was generated by the gui:
```python
from mantid.simpleapi import *
config['default.facility']="SNS"

# Load data's log only
Load(
                       Filename = 'PG3_39902.nxs.h5',
                       OutputWorkspace = 'PG3_39902_meta',
                       MetaDataOnly = '1')

# Construct the event filters
GenerateEventsFilter(
                       InputWorkspace  = 'PG3_39902_meta',
                       OutputWorkspace = 'PG3_39902_splitters',
                       InformationWorkspace = 'PG3_39902_splitinfo',
                       LogName = 'SampleTemp',
                       MinimumLogValue    = '600',
                       MaximumLogValue    = '1100',
                       FilterLogValueByChangingDirection = 'Increase',
                       LogValueInterval       = '50',
                       LogBoundary    = 'Left',
)
SNSPowderReduction(
                       SaveAs = 'gsas',
                       FinalDataUnits = 'dSpacing',
                       Filename = 'PG339902',
                       Sum = '1',
                       Binning = '-0.0008000',
                       OutputDirectory = '/tmp',
                       BinInDspace = '1',
                       CalibrationFile = '/SNS/PG3/shared/CALIBRATION/2017_1_2_11A_CAL/PG3_MICAS_d\
39808_2017_12_06_ALL.h5',
                       CharacterizationRunsFile = '/SNS/PG3/shared/CALIBRATION/2017_1_2_11A_CAL/PG\
3_char_2017_12_06-HR-MICAS.txt,/SNS/PG3/shared/CALIBRATION/2017_1_2_11A_CAL/PG3_char_2017_08_08-HR\
-ALL.txt',
                       StripVanadiumPeaks = '1',
                       RemovePromptPulseWidth = '50.0',
                       FilterBadPulses = '10',
                       PushDataPositive = 'AddMinimum',
                       BackgroundSmoothParams = '5,2',
                       PreserveEvents = '1',
                       ScaleData = '100.0',
                       SplittersWorkspace = 'PG3_39902_splitters',
                       SplitInformationWorkspace='PG3_39902_splitinfo',
                       )
```
This requires having `/SNS/PG3` to test.

*There is no associated issue.*

*Does not need to be in the release notes* because it is a minor issue that has only been recently noticed.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
