### PR TITLE
Live Spectrum Viewer Issue

### DIFF
--- a/qt/widgets/spectrumviewer/inc/MantidQtWidgets/SpectrumViewer/SpectrumView.h
+++ b/qt/widgets/spectrumviewer/inc/MantidQtWidgets/SpectrumViewer/SpectrumView.h
@@ -4,6 +4,7 @@
 #include <QMainWindow>
 #include <QMdiSubWindow>
 #include <QList>
+#include <vector>
 
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidQtWidgets/Common/WorkspaceObserver.h"
@@ -117,8 +118,11 @@ private:
   void updateHandlers();
   void loadSettings();
   void saveSettings() const;
+  bool
+  replaceExistingWorkspace(const std::string &wsName,
+                           const boost::shared_ptr<Mantid::API::Workspace> ws);
 
-  QList<MatrixWSDataSource_sptr> m_dataSource;
+  std::vector<MatrixWSDataSource_sptr> m_dataSource;
   QList<boost::shared_ptr<SpectrumDisplay>> m_spectrumDisplay;
   boost::shared_ptr<GraphDisplay> m_hGraph;
   boost::shared_ptr<GraphDisplay> m_vGraph;

--- a/qt/widgets/spectrumviewer/inc/MantidQtWidgets/SpectrumViewer/SpectrumView.h
+++ b/qt/widgets/spectrumviewer/inc/MantidQtWidgets/SpectrumViewer/SpectrumView.h
@@ -118,9 +118,9 @@ private:
   void updateHandlers();
   void loadSettings();
   void saveSettings() const;
-  bool
-  replaceExistingWorkspace(const std::string &wsName,
-                           const boost::shared_ptr<Mantid::API::Workspace> ws);
+  bool replaceExistingWorkspace(
+      const std::string &wsName,
+      boost::shared_ptr<const Mantid::API::MatrixWorkspace> ws);
 
   std::vector<MatrixWSDataSource_sptr> m_dataSource;
   QList<boost::shared_ptr<SpectrumDisplay>> m_spectrumDisplay;

--- a/qt/widgets/spectrumviewer/src/SpectrumView.cpp
+++ b/qt/widgets/spectrumviewer/src/SpectrumView.cpp
@@ -87,14 +87,20 @@ void SpectrumView::resizeEvent(QResizeEvent *event) {
 }
 
 /**
- * Renders a new workspace on the spectrum viewer.
+ * Renders a new workspace on the spectrum viewer. If there is a workspace being
+ *tracked, update that data source.
  *
  * @param wksp The matrix workspace to render
  */
 void SpectrumView::renderWorkspace(
     Mantid::API::MatrixWorkspace_const_sptr wksp) {
+
+  // Handle rendering of a workspace we already track
+  if (replaceExistingWorkspace(wksp->getName(), wksp))
+    return;
+
   auto dataSource = MatrixWSDataSource_sptr(new MatrixWSDataSource(wksp));
-  m_dataSource.append(dataSource);
+  m_dataSource.push_back(dataSource);
 
   // If we have a MatrixWSDataSource give it the handler for the
   // EMode, so the user can set EMode and EFixed.  NOTE: we could avoid
@@ -206,10 +212,47 @@ void SpectrumView::preDeleteHandle(
 void SpectrumView::afterReplaceHandle(
     const std::string &wsName,
     const boost::shared_ptr<Mantid::API::Workspace> ws) {
-  if (m_spectrumDisplay.front()->hasData(wsName, ws)) {
-    renderWorkspace(
-        boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(ws));
+  // We would only ever be replacing a workspace here
+  replaceExistingWorkspace(wsName, ws);
+}
+
+/**
+ * Replace and existing workspace by finding the data source matching the
+ *workspace name and updating the data source. Returns true only if replacment
+ *is made.
+ *
+ * @param wsName : Name of the workspace to replace
+ * @param ws : Pointer to the workspace object
+ * @return : True only if a replacement was completed
+ */
+bool SpectrumView::replaceExistingWorkspace(
+    const std::string &wsName,
+    const boost::shared_ptr<Mantid::API::Workspace> ws) {
+
+  bool replacementMade = false;
+  if (auto matrixWorkspace =
+          boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(ws)) {
+
+    auto existingDataSource =
+        std::find_if(m_dataSource.begin(), m_dataSource.end(), [&](auto &item) {
+          return wsName == item->getWorkspace()->getName();
+        });
+    if (existingDataSource != m_dataSource.end()) {
+      auto index = std::distance(m_dataSource.begin(), existingDataSource);
+      auto targetSpectrumDisplay = m_spectrumDisplay[static_cast<int>(index)];
+      // Keep the current coordinates
+      const auto xPoint = targetSpectrumDisplay->getPointedAtX();
+      const auto yPoint = targetSpectrumDisplay->getPointedAtY();
+      auto newDataSource =
+          MatrixWSDataSource_sptr(new MatrixWSDataSource(matrixWorkspace));
+      targetSpectrumDisplay->setDataSource(newDataSource);
+      targetSpectrumDisplay->setPointedAtXY(xPoint, yPoint);
+      // Handle range and image updates
+      targetSpectrumDisplay->updateRange();
+      replacementMade = true;
+    }
   }
+  return replacementMade;
 }
 
 void SpectrumView::dropEvent(QDropEvent *de) {
@@ -217,6 +260,7 @@ void SpectrumView::dropEvent(QDropEvent *de) {
   auto ws =
       Mantid::API::AnalysisDataService::Instance()
           .retrieveWS<Mantid::API::MatrixWorkspace>(words[1].toStdString());
+
   renderWorkspace(ws);
 }
 

--- a/qt/widgets/spectrumviewer/src/SpectrumView.cpp
+++ b/qt/widgets/spectrumviewer/src/SpectrumView.cpp
@@ -213,7 +213,8 @@ void SpectrumView::afterReplaceHandle(
     const std::string &wsName,
     const boost::shared_ptr<Mantid::API::Workspace> ws) {
   // We would only ever be replacing a workspace here
-  replaceExistingWorkspace(wsName, ws);
+  replaceExistingWorkspace(
+      wsName, boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(ws));
 }
 
 /**
@@ -222,35 +223,32 @@ void SpectrumView::afterReplaceHandle(
  *is made.
  *
  * @param wsName : Name of the workspace to replace
- * @param ws : Pointer to the workspace object
+ * @param matrixWorkspace : Pointer to the workspace object
  * @return : True only if a replacement was completed
  */
 bool SpectrumView::replaceExistingWorkspace(
     const std::string &wsName,
-    const boost::shared_ptr<Mantid::API::Workspace> ws) {
+    boost::shared_ptr<const Mantid::API::MatrixWorkspace> matrixWorkspace) {
 
   bool replacementMade = false;
-  if (auto matrixWorkspace =
-          boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(ws)) {
 
-    auto existingDataSource =
-        std::find_if(m_dataSource.begin(), m_dataSource.end(), [&](auto &item) {
-          return wsName == item->getWorkspace()->getName();
-        });
-    if (existingDataSource != m_dataSource.end()) {
-      auto index = std::distance(m_dataSource.begin(), existingDataSource);
-      auto targetSpectrumDisplay = m_spectrumDisplay[static_cast<int>(index)];
-      // Keep the current coordinates
-      const auto xPoint = targetSpectrumDisplay->getPointedAtX();
-      const auto yPoint = targetSpectrumDisplay->getPointedAtY();
-      auto newDataSource =
-          MatrixWSDataSource_sptr(new MatrixWSDataSource(matrixWorkspace));
-      targetSpectrumDisplay->setDataSource(newDataSource);
-      targetSpectrumDisplay->setPointedAtXY(xPoint, yPoint);
-      // Handle range and image updates
-      targetSpectrumDisplay->updateRange();
-      replacementMade = true;
-    }
+  auto existingDataSource =
+      std::find_if(m_dataSource.begin(), m_dataSource.end(), [&](auto &item) {
+        return wsName == item->getWorkspace()->getName();
+      });
+  if (existingDataSource != m_dataSource.end()) {
+    auto index = std::distance(m_dataSource.begin(), existingDataSource);
+    auto targetSpectrumDisplay = m_spectrumDisplay[static_cast<int>(index)];
+    // Keep the current coordinates
+    const auto xPoint = targetSpectrumDisplay->getPointedAtX();
+    const auto yPoint = targetSpectrumDisplay->getPointedAtY();
+    auto newDataSource =
+        MatrixWSDataSource_sptr(new MatrixWSDataSource(matrixWorkspace));
+    targetSpectrumDisplay->setDataSource(newDataSource);
+    targetSpectrumDisplay->setPointedAtXY(xPoint, yPoint);
+    // Handle range and image updates
+    targetSpectrumDisplay->updateRange();
+    replacementMade = true;
   }
   return replacementMade;
 }

--- a/qt/widgets/spectrumviewer/src/SpectrumView.cpp
+++ b/qt/widgets/spectrumviewer/src/SpectrumView.cpp
@@ -233,9 +233,10 @@ bool SpectrumView::replaceExistingWorkspace(
   bool replacementMade = false;
 
   auto existingDataSource =
-      std::find_if(m_dataSource.begin(), m_dataSource.end(), [&](auto &item) {
-        return wsName == item->getWorkspace()->getName();
-      });
+      std::find_if(m_dataSource.begin(), m_dataSource.end(),
+                   [&wsName](const MatrixWSDataSource_sptr &item) {
+                     return wsName == item->getWorkspace()->getName();
+                   });
   if (existingDataSource != m_dataSource.end()) {
     auto index = std::distance(m_dataSource.begin(), existingDataSource);
     auto targetSpectrumDisplay = m_spectrumDisplay[static_cast<int>(index)];

--- a/qt/widgets/spectrumviewer/src/SpectrumView.cpp
+++ b/qt/widgets/spectrumviewer/src/SpectrumView.cpp
@@ -297,6 +297,7 @@ void SpectrumView::respondToTabCloseReqest(int tab) {
     m_svConnections->removeSpectrumDisplay(displayToRemove.get());
     m_spectrumDisplay.removeAll(displayToRemove);
     m_ui->imageTabs->removeTab(tab);
+    m_dataSource.erase(m_dataSource.begin() + tab);
     m_hGraph->clear();
     m_vGraph->clear();
   }

--- a/qt/widgets/spectrumviewer/src/SpectrumView.cpp
+++ b/qt/widgets/spectrumviewer/src/SpectrumView.cpp
@@ -243,7 +243,7 @@ bool SpectrumView::replaceExistingWorkspace(
     const auto xPoint = targetSpectrumDisplay->getPointedAtX();
     const auto yPoint = targetSpectrumDisplay->getPointedAtY();
     auto newDataSource =
-        MatrixWSDataSource_sptr(new MatrixWSDataSource(matrixWorkspace));
+        boost::make_shared<MatrixWSDataSource>(matrixWorkspace);
     targetSpectrumDisplay->setDataSource(newDataSource);
     targetSpectrumDisplay->setPointedAtXY(xPoint, yPoint);
     // Handle range and image updates


### PR DESCRIPTION
Fixes #21574 

Fixes ECP related bug described in 21574. 

After replace hook was used to call `renderWorkspace`, which is built for display of new workspaces. Dealing with the updates to the numerous objects involved in the SpectrumViewer was tricky, but this should be fully working.

This PR does not address the existing scaling issues described in #21574. However it would now allow end users to correctly visualise single updating MatrixWorkspace. I suggest that the scaling issue is investigated as part of another PR.
