### PR TITLE
MR reduction: allow passing a direct beam workspace

### DIFF
--- a/Testing/SystemTests/tests/analysis/MagnetismReflectometryReductionTest.py
+++ b/Testing/SystemTests/tests/analysis/MagnetismReflectometryReductionTest.py
@@ -78,6 +78,47 @@ class MRFilterCrossSectionsTest(stresstesting.MantidStressTest):
         return "r_24949", 'MagnetismReflectometryReductionTest.nxs'
 
 
+class MRNormaWorkspaceTest(stresstesting.MantidStressTest):
+    """ Test data loading and cross-section extraction """
+    def runTest(self):
+        wsg = MRFilterCrossSections(Filename="REF_M_24949")
+        ws_norm = LoadEventNexus(Filename="REF_M_24945",
+                                 NXentryName="entry-Off_Off",
+                                 OutputWorkspace="r_24945")
+        MagnetismReflectometryReduction(InputWorkspace=wsg[0],
+                                        NormalizationWorkspace=ws_norm,
+                                        SignalPeakPixelRange=[125, 129],
+                                        SubtractSignalBackground=True,
+                                        SignalBackgroundPixelRange=[15, 105],
+                                        ApplyNormalization=True,
+                                        NormPeakPixelRange=[201, 205],
+                                        SubtractNormBackground=True,
+                                        NormBackgroundPixelRange=[10,127],
+                                        CutLowResDataAxis=True,
+                                        LowResDataAxisPixelRange=[91, 161],
+                                        CutLowResNormAxis=True,
+                                        LowResNormAxisPixelRange=[86, 174],
+                                        CutTimeAxis=True,
+                                        UseWLTimeAxis=False,
+                                        QMin=0.005,
+                                        QStep=-0.01,
+                                        TimeAxisStep=40,
+                                        TimeAxisRange=[25000, 54000],
+                                        SpecularPixel=126.9,
+                                        ConstantQBinning=False,
+                                        EntryName='entry-Off_Off',
+                                        OutputWorkspace="r_24949")
+
+    def validate(self):
+        # Be more tolerant with the output, mainly because of the errors.
+        # The following tolerance check the errors up to the third digit.
+        self.disableChecking.append('Instrument')
+        self.disableChecking.append('Sample')
+        self.disableChecking.append('SpectraMap')
+        self.disableChecking.append('Axes')
+        return "r_24949", 'MagnetismReflectometryReductionTest.nxs'
+
+
 class MRInspectionTest(stresstesting.MantidStressTest):
     def runTest(self):
         nxs_data = LoadEventNexus(Filename="REF_M_24949",


### PR DESCRIPTION
The magnetism reflectometer reduction currently takes in a run number for the direct beam run.
This is inefficient for several reasons:

 - In an application like a UI where the reflectivity might be recalculated often, we don't want to reload the direct beam every time.

 - More importantly, if we have more than a single cross-section to calculate (which is 99% of the time for MR), you don't want to reload the direct beam for each cross-section.

We'll load the data once and pass the workspace as a parameter to the main workflow algorithm.

**To test:**
- Inspect the code.
- Verify that the system tests pass.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [x] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
