### PR TITLE
Timestamps on source links

### DIFF
--- a/docs/sphinxext/mantiddoc/directives/sourcelink.py
+++ b/docs/sphinxext/mantiddoc/directives/sourcelink.py
@@ -1,18 +1,27 @@
 from __future__ import (absolute_import, division, print_function)
-from .base import AlgorithmBaseDirective #pylint: disable=unused-import
-import mantid
+
 import os
+import subprocess
 from six import iteritems
+
+import mantid
+from .base import AlgorithmBaseDirective #pylint: disable=unused-import
+
+LAST_MODIFIED_UNKNOWN = 'unknown'
+
 
 class SourceLinkError(Exception):
     def __init__(self, value):
         self.value = value
+
     def __str__(self):
         return str(self.value)
 
+
 class SourceLinkDirective(AlgorithmBaseDirective):
     """
-    Obtains the github links to the .cpp and .h or .py files depending on the name and version.
+    Obtains the github links to the .cpp and .h or .py files depending on the
+    name and version.
 
     Example directive usage:
 
@@ -40,16 +49,25 @@ class SourceLinkDirective(AlgorithmBaseDirective):
     """
 
     required_arguments, optional_arguments = 0, 0
-    option_spec = {"filename":str,"sanity_checks":int,"cpp":str, "h":str, "py":str}
+    option_spec = {
+        "filename": str,
+        "sanity_checks": int,
+        "cpp": str,
+        "h": str,
+        "py": str
+    }
 
     #IMPORTANT: keys must match the option spec above
     # - apart from filename and sanity_checks
-    file_types = {"h":"C++ header", "cpp":"C++ source","py":"Python"}
+    file_types = {
+        "h": "C++ header",
+        "cpp": "C++ source",
+        "py": "Python"
+    }
     file_lookup = {}
 
-
     # will be filled in
-    __source_root=None
+    __source_root = None
 
 
     def execute(self):
@@ -60,41 +78,41 @@ class SourceLinkDirective(AlgorithmBaseDirective):
         error_string = ""
         sanity_checks = self.options.get("sanity_checks", 1)
         file_name = self.options.get("filename", None)
+
         if file_name is None:
-            #build a sensible default
+            # build a sensible default
             file_name = self.algorithm_name()
             if (self.algorithm_version() != 1) and (self.algorithm_version() is not None):
                 file_name += str(self.algorithm_version())
-
 
         for extension in self.file_types.keys():
             file_paths[extension] = self.options.get(extension, None)
             if file_paths[extension] is None:
                 try:
-                    file_paths[extension] = self.find_source_file(file_name,extension)
+                    fname = self.find_source_file(file_name, extension)
+                    file_paths[extension] = (fname, self.get_file_last_modified(fname)) \
+                            if fname is not None else None
                 except SourceLinkError as err:
                     error_string += str(err) + "\n"
+
             elif file_paths[extension].lower() == "none":
                 # the users has specifically chosen to suppress this - set it to a "proper" None
-                #but do not search for this file
+                # but do not search for this file
                 file_paths[extension] = None
+
             else:
-                #prepend the base framework directory
-                file_paths[extension] = os.path.join(self.source_root, file_paths[extension])
-                if not os.path.exists(file_paths[extension]):
-                    error_string +="Cannot find " + extension + " file at " + file_paths[extension] + "\n"
+                # prepend the base framework directory
+                fname = os.path.join(self.source_root, file_paths[extension])
+                file_paths[extension] = (fname, self.get_file_last_modified(fname))
+                if not os.path.exists(file_paths[extension][0]):
+                    error_string += "Cannot find {} file at {}\n".format(
+                        extension, file_paths[extension][0])
 
-        #throw accumulated errors now if you have any
+        # throw accumulated errors now if you have any
         if error_string != "":
             raise SourceLinkError(error_string)
 
-        try:
-            self.output_to_page(file_paths,file_name,sanity_checks)
-        except SourceLinkError as err:
-            error_string += str(err) + "\n"
-
-        if error_string != "":
-            raise SourceLinkError(error_string)
+        self.output_to_page(file_paths, file_name, sanity_checks)
 
         return []
 
@@ -103,7 +121,7 @@ class SourceLinkDirective(AlgorithmBaseDirective):
         Searches the source code for a matching filename with the correct extension
         """
         # parse the source tree if it has not already been done
-        if len(self.file_lookup) == 0:
+        if not self.file_lookup:
             self.parse_source_tree()
 
         try:
@@ -126,7 +144,7 @@ class SourceLinkDirective(AlgorithmBaseDirective):
 
             return self.file_lookup[file_name][extension]
         except KeyError:
-            #value is not present
+            # value is not present
             return None
 
     @property
@@ -139,8 +157,8 @@ class SourceLinkDirective(AlgorithmBaseDirective):
             direc = env.srcdir #= C:\Mantid\Code\Mantid\docs\source
             direc = os.path.join(direc, "..", "..") # assume root is two levels up
             direc = os.path.abspath(direc)
-
             self.__source_root = direc #pylint: disable=protected-access
+
         return self.__source_root
 
     def parse_source_tree(self):
@@ -152,24 +170,24 @@ class SourceLinkDirective(AlgorithmBaseDirective):
         builddir = os.path.join(builddir, "..", "..")
         builddir = os.path.abspath(builddir)
 
-        for dirName, dummy_subdirList, fileList in os.walk(self.source_root):
-            if dirName.startswith(builddir):
+        for dir_name, _, file_list in os.walk(self.source_root):
+            if dir_name.startswith(builddir):
                 continue # don't check or add to the cache
-            for fname in fileList:
-                (baseName, fileExtension) = os.path.splitext(fname)
+            for fname in file_list:
+                (base_name, file_extensions) = os.path.splitext(fname)
                 #strip the dot from the extension
-                fileExtension = fileExtension[1:]
+                file_extensions = file_extensions[1:]
                 #build the data object that is e.g.
                 #file_lookup["Rebin2"]["cpp"] = ['C:\Mantid\Code\Mantid\Framework\Algorithms\src\Rebin2.cpp','possible other location']
-                if fileExtension in self.file_types.keys():
-                    if baseName not in self.file_lookup.keys():
-                        self.file_lookup[baseName] = {}
-                    if fileExtension not in self.file_lookup[baseName].keys():
-                        self.file_lookup[baseName][fileExtension] = []
-                    self.file_lookup[baseName][fileExtension].append(os.path.join(dirName,fname))
-        return
+                if file_extensions in self.file_types.keys():
+                    if base_name not in self.file_lookup.keys():
+                        self.file_lookup[base_name] = {}
+                    if file_extensions not in self.file_lookup[base_name].keys():
+                        self.file_lookup[base_name][file_extensions] = []
+                    self.file_lookup[base_name][file_extensions].append(
+                        os.path.join(dir_name, fname))
 
-    def output_to_page(self, file_paths,file_name,sanity_checks):
+    def output_to_page(self, file_paths, file_name, sanity_checks):
         """
         Outputs the sourcelinks and heading to the rst page
         and performs some sanity checks
@@ -179,14 +197,13 @@ class SourceLinkDirective(AlgorithmBaseDirective):
         self.add_rst(self.make_header("Source"))
         for extension, filepath in iteritems(file_paths):
             if filepath is not None:
-                self.output_path_to_page(filepath,extension)
+                self.output_path_to_page(filepath, extension)
                 valid_ext_list.append(extension)
 
-
-        #do some sanity checks - unless suppressed
+        # do some sanity checks - unless suppressed
         if sanity_checks > 0:
             suggested_path = "os_agnostic_path_to_file_from_Code/Mantid"
-            if len(valid_ext_list) == 0:
+            if not valid_ext_list:
                 raise SourceLinkError("No file possibilities for " + file_name + " have been found\n" +
                                       "Please specify a better one using the :filename: opiton or use the " +
                                       str(list(self.file_types.keys())) + " options\n" +
@@ -196,44 +213,61 @@ class SourceLinkDirective(AlgorithmBaseDirective):
                                       "or \n" +
                                       ".. sourcelink:\n" +
                                       "      :filename: " + file_name)
-            #if the have a cpp we should also have a h
-            if ("cpp" in valid_ext_list) or ("h" in valid_ext_list):
-                if ("cpp" not in valid_ext_list) or ("h" not in valid_ext_list):
-                    raise SourceLinkError("Only one of .h and .cpp found for " + file_name + "\n" +
-                                          "valid files found for " + str(valid_ext_list) + "\n" +
-                                          "Please specify the missing one using an " +
-                                          str(list(self.file_types.keys())) + " option\n" +
-                                          "e.g. \n" +
-                                          ".. sourcelink:\n" +
-                                          "      :" + list(self.file_types.keys())[0] + ": " + suggested_path)
-        return
+
+            # if the have a cpp we should also have a h
+            if ("cpp" in valid_ext_list) ^ ("h" in valid_ext_list):
+                raise SourceLinkError("Only one of .h and .cpp found for " + file_name + "\n" +
+                                      "valid files found for " + str(valid_ext_list) + "\n" +
+                                      "Please specify the missing one using an " +
+                                      str(list(self.file_types.keys())) + " option\n" +
+                                      "e.g. \n" +
+                                      ".. sourcelink:\n" +
+                                      "      :" + list(self.file_types.keys())[0] + ": " + suggested_path)
 
     def output_path_to_page(self, filepath, extension):
         """
         Outputs the source link for a file to the rst page
         """
-        dummy_dirName,fName = os.path.split(filepath)
-        self.add_rst(self.file_types[extension] + ": `" + fName + " <" + self.convert_path_to_github_url(filepath) + ">`_\n\n")
-        return
+        _, f_name = os.path.split(filepath[0])
 
+        self.add_rst("{}: `{} <{}>`_ *(last modified: {})*\n\n".format(
+            self.file_types[extension],
+            f_name,
+            self.convert_path_to_github_url(filepath[0]),
+            filepath[1]
+        ))
 
     def convert_path_to_github_url(self, file_path):
         """
         Converts a file path to the github url for that same file
-        """
-        #example path C:\Mantid\Code\Mantid/Framework/Algorithms/inc/MantidAlgorithms/MergeRuns.h
-        #example url  https://github.com/mantidproject/mantid/blob/master/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/MergeRuns.h
 
+        example path C:\Mantid\Code\Mantid/Framework/Algorithms/inc/MantidAlgorithms/MergeRuns.h
+        example url  https://github.com/mantidproject/mantid/blob/master/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/MergeRuns.h
+        """
         url = file_path
         # remove the directory path
         url = url.replace(self.source_root, "")
-        #harmonize slashes
-        url = url.replace("\\","/")
-        #prepend the github part
+        # harmonize slashes
+        url = url.replace("\\", "/")
+        # prepend the github part
         if not url.startswith("/"):
-            url = "/"+url
+            url = "/" + url
         url = "https://github.com/mantidproject/mantid/blob/" + mantid.kernel.revision_full() + url
         return url
+
+    def get_file_last_modified(self, filename):
+        """
+        Gets the commit timestamp of the last commit to modify a given file.
+        """
+        if not filename:
+            return LAST_MODIFIED_UNKNOWN
+
+        proc = subprocess.Popen(
+            ['git', 'log', '-n 1', '--pretty=format:%cd', '--date=short', filename],
+            cwd=self.source_root,
+            stdout=subprocess.PIPE)
+        return proc.stdout.read()
+
 
 def setup(app):
     """


### PR DESCRIPTION
Adds timestamps to links to source files in the documentation (those made by the `sourcelink` directive) that shows the date of the commit that last touched those files.

Dates are shown in `YYYY-MM-DD` format.

**To test:**
- Build documentation
- Look at some algorithm pages
- See that reported date matches last commit date

<!-- Instructions for testing. -->

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
