### PR TITLE
Clean-up around MeshObject

### DIFF
--- a/Framework/API/src/Sample.cpp
+++ b/Framework/API/src/Sample.cpp
@@ -6,6 +6,7 @@
 #include "MantidGeometry/Crystal/CrystalStructure.h"
 #include "MantidGeometry/Crystal/OrientedLattice.h"
 #include "MantidGeometry/Objects/ShapeFactory.h"
+#include "MantidGeometry/Objects/CSGObject.h"
 #include "MantidGeometry/Instrument/SampleEnvironment.h"
 #include "MantidKernel/Material.h"
 #include "MantidKernel/Strings.h"
@@ -298,7 +299,12 @@ void Sample::saveNexus(::NeXus::File *file, const std::string &group) const {
   file->makeGroup(group, "NXsample", true);
   file->putAttr("name", m_name);
   file->putAttr("version", 1);
-  file->putAttr("shape_xml", m_shape->getShapeXML());
+  std::string shapeXML("");
+  if (auto csgObject =
+          boost::dynamic_pointer_cast<Mantid::Geometry::CSGObject>(m_shape)) {
+    shapeXML = csgObject->getShapeXML();
+  }
+  file->putAttr("shape_xml", shapeXML);
 
   m_shape->material().saveNexus(file, "material");
   // Write out the other (indexes 1+) samples

--- a/Framework/API/test/SampleTest.h
+++ b/Framework/API/test/SampleTest.h
@@ -7,6 +7,7 @@
 #include "MantidGeometry/Instrument/Container.h"
 #include "MantidGeometry/Instrument/SampleEnvironment.h"
 #include "MantidGeometry/Objects/ShapeFactory.h"
+#include "MantidGeometry/Objects/CSGObject.h"
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/Material.h"
 #include "MantidTestHelpers/ComponentCreationHelper.h"
@@ -321,7 +322,8 @@ public:
     auto sample2 = boost::make_shared<Sample>();
     sample2->setName("test name for test_Multiple_Sample - 2");
     sample.addSample(sample2);
-    TS_ASSERT(sample.getShape().getShapeXML() != "");
+    TS_ASSERT(
+        dynamic_cast<const CSGObject &>(sample.getShape()).getShapeXML() != "");
 
     sample.saveNexus(th.file, "sample");
     th.reopenFile();
@@ -339,8 +341,9 @@ public:
     TS_ASSERT_DELTA(loaded.getOrientedLattice().c(), 6.0, 1e-6);
     TS_ASSERT_EQUALS(loaded.getShape().getBoundingBox().xMax(),
                      sample.getShape().getBoundingBox().xMax());
-    TS_ASSERT_EQUALS(loaded.getShape().getShapeXML(),
-                     sample.getShape().getShapeXML());
+    TS_ASSERT_EQUALS(
+        dynamic_cast<const CSGObject &>(loaded.getShape()).getShapeXML(),
+        dynamic_cast<const CSGObject &>(sample.getShape()).getShapeXML());
     // Geometry values
     TS_ASSERT_DELTA(loaded.getWidth(), sample.getWidth(), 1e-6);
   }

--- a/Framework/DataHandling/test/SetSampleTest.h
+++ b/Framework/DataHandling/test/SetSampleTest.h
@@ -213,7 +213,9 @@ public:
     // New shape
     const auto &sampleShape = inputWS->sample().getShape();
     TS_ASSERT(sampleShape.hasValidShape());
-    auto tag = sampleShape.getShapeXML().find("cuboid");
+    auto tag = dynamic_cast<const Mantid::Geometry::CSGObject &>(sampleShape)
+                   .getShapeXML()
+                   .find("cuboid");
     TS_ASSERT(tag != std::string::npos);
 
     // Center
@@ -237,7 +239,9 @@ public:
     // New shape
     const auto &sampleShape = inputWS->sample().getShape();
     TS_ASSERT(sampleShape.hasValidShape());
-    auto tag = sampleShape.getShapeXML().find("cuboid");
+    auto tag = dynamic_cast<const Mantid::Geometry::CSGObject &>(sampleShape)
+                   .getShapeXML()
+                   .find("cuboid");
     TS_ASSERT(tag != std::string::npos);
 
     // Center should be preserved inside the shape
@@ -263,7 +267,9 @@ public:
     // New shape
     const auto &sampleShape = inputWS->sample().getShape();
     TS_ASSERT(sampleShape.hasValidShape());
-    auto tag = sampleShape.getShapeXML().find("cylinder");
+    auto tag = dynamic_cast<const Mantid::Geometry::CSGObject &>(sampleShape)
+                   .getShapeXML()
+                   .find("cylinder");
     TS_ASSERT(tag != std::string::npos);
 
     TS_ASSERT_EQUALS(true, sampleShape.isValid(V3D(0, 0.049, 0.019)));

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/Container.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/Container.h
@@ -12,7 +12,7 @@ namespace Geometry {
 
 /**
   Models a Container is used to hold a sample in the beam. It gets most
-  of its functionality from Geometry::Object but can also hold a
+  of its functionality from wrapped Geometry::IObject but can also hold a
   definition of what the sample geometry itself would be. If the sample shape
   definition is set then we term this a constriained sample geometry.
 
@@ -110,8 +110,6 @@ public:
   boost::shared_ptr<GeometryHandler> getGeometryHandler() const override {
     return m_shape->getGeometryHandler();
   }
-
-  std::string getShapeXML() const override { return m_shape->getShapeXML(); }
 
   void draw() const override { m_shape->draw(); }
   void initDraw() const override { m_shape->initDraw(); }

--- a/Framework/Geometry/inc/MantidGeometry/Objects/CSGObject.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/CSGObject.h
@@ -194,7 +194,7 @@ public:
   void GetObjectGeom(int &type, std::vector<Kernel::V3D> &vectors,
                      double &myradius, double &myheight) const override;
   /// Getter for the shape xml
-  std::string getShapeXML() const override;
+  std::string getShapeXML() const;
 
 private:
   int procPair(std::string &Ln, std::map<int, std::unique_ptr<Rule>> &Rlist,

--- a/Framework/Geometry/inc/MantidGeometry/Objects/IObject.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/IObject.h
@@ -92,9 +92,6 @@ public:
   virtual void GetObjectGeom(int &type, std::vector<Kernel::V3D> &vectors,
                              double &myradius, double &myheight) const = 0;
 
-  /// Getter for the shape xml
-  virtual std::string getShapeXML() const = 0;
-
   // Rendering
   virtual void draw() const = 0;
   virtual void initDraw() const = 0;

--- a/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject.h
@@ -6,7 +6,7 @@
 //----------------------------------------------------------------------
 #include "MantidGeometry/DllConfig.h"
 #include "MantidGeometry/Objects/IObject.h"
-
+#include "MantidKernel/Material.h"
 #include "BoundingBox.h"
 #include <map>
 #include <memory>
@@ -17,7 +17,6 @@ namespace Mantid {
 //----------------------------------------------------------------------
 namespace Kernel {
 class PseudoRandomNumberGenerator;
-class Material;
 class V3D;
 }
 
@@ -63,24 +62,24 @@ Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
 class MANTID_GEOMETRY_DLL MeshObject : public IObject {
 public:
-  /// Flexible constructor
+  /// Constructor
   MeshObject(const std::vector<uint16_t> &faces,
              const std::vector<Mantid::Kernel::V3D> &vertices,
              const Kernel::Material &material);
-  // Efficient constructor
+  /// Constructor
   MeshObject(std::vector<uint16_t> &&faces,
              std::vector<Mantid::Kernel::V3D> &&vertices,
-             const Kernel::Material &material);
+             const Kernel::Material &&material);
 
   /// Copy constructor
   MeshObject(const MeshObject &) = delete;
   /// Assignment operator
   MeshObject &operator=(const MeshObject &) = delete;
   /// Destructor
-  virtual ~MeshObject();
+  virtual ~MeshObject() = default;
   /// Clone
   IObject *clone() const override {
-    return new MeshObject(m_triangles, m_vertices, *m_material);
+    return new MeshObject(m_triangles, m_vertices, m_material);
   }
   IObject *cloneWithMaterial(const Kernel::Material &material) const override {
     return new MeshObject(m_triangles, m_vertices, material);
@@ -142,8 +141,6 @@ public:
 
   void GetObjectGeom(int &type, std::vector<Kernel::V3D> &vectors,
                      double &myradius, double &myheight) const override;
-  /// Getter for the shape xml
-  std::string getShapeXML() const override;
 
   /// Read access to mesh object for rendering
   int numberOfVertices() const;
@@ -154,10 +151,7 @@ public:
   void updateGeometryHandler();
 
 private:
-  /// Default constructor - should never be called
-  MeshObject();
-  // Setup object, called only in constructor
-  void setup(const Kernel::Material &material);
+  void initialize();
   /// Get intersections
   void getIntersections(const Kernel::V3D &start, const Kernel::V3D &direction,
                         std::vector<Kernel::V3D> &intersectionPoints,
@@ -186,9 +180,6 @@ private:
   // String from which object may be defined
   std::string m_string;
 
-  /// material composition
-  std::unique_ptr<Kernel::Material> m_material;
-
   /// string to return as ID
   std::string m_id;
 
@@ -201,6 +192,8 @@ private:
   /// Triangles are specified by indices into a list of vertices.
   std::vector<uint16_t> m_triangles;
   std::vector<Kernel::V3D> m_vertices;
+  /// material composition
+  Kernel::Material m_material;
 };
 
 } // NAMESPACE Geometry

--- a/Framework/Geometry/src/Objects/MeshObject.cpp
+++ b/Framework/Geometry/src/Objects/MeshObject.cpp
@@ -122,19 +122,18 @@ bool MeshObject::isOnSide(const Kernel::V3D &point) const {
       V3D{1, 0, 0}}; // directions to look for intersections
   // We have to look in several directions in case a point is on a face
   // or edge parallel to the first direction or also the second direction.
-  for (size_t i = 0; i < directions.size(); ++i) {
-    std::vector<V3D> intesectionPoints;
+  for (auto direction : directions) {
+    std::vector<V3D> intersectionPoints;
     std::vector<int> entryExitFlags;
 
-    getIntersections(point, directions[i], intesectionPoints, entryExitFlags);
+    getIntersections(point, direction, intersectionPoints, entryExitFlags);
 
-    if (intesectionPoints.empty()) {
+    if (intersectionPoints.empty()) {
       return false;
     }
 
-    size_t k = intesectionPoints.size();
-    for (size_t i = 0; i < k; ++i) {
-      if (point.distance(intesectionPoints[i]) < M_TOLERANCE) {
+    for (auto intersectionPoint : intersectionPoints) {
+      if (point.distance(intersectionPoint) < M_TOLERANCE) {
         return true;
       }
     }
@@ -155,16 +154,16 @@ int MeshObject::interceptSurface(Geometry::Track &UT) const {
     return 0;
   }
 
-  std::vector<V3D> intesectionPoints;
+  std::vector<V3D> intersectionPoints;
   std::vector<int> entryExitFlags;
 
-  getIntersections(UT.startPoint(), UT.direction(), intesectionPoints,
+  getIntersections(UT.startPoint(), UT.direction(), intersectionPoints,
                    entryExitFlags);
-  if (intesectionPoints.empty())
+  if (intersectionPoints.empty())
     return 0; // Quit if no intersections found
 
-  for (size_t i = 0; i < intesectionPoints.size(); ++i) {
-    UT.addPoint(entryExitFlags[i], intesectionPoints[i], *this);
+  for (size_t i = 0; i < intersectionPoints.size(); ++i) {
+    UT.addPoint(entryExitFlags[i], intersectionPoints[i], *this);
   }
   UT.buildLink();
 
@@ -226,11 +225,11 @@ bool MeshObject::rayIntersectsTriangle(const Kernel::V3D &start,
   s = start - v1;
   u = f * (s.scalar_prod(h));
   if (u < 0.0 || u > 1.0)
-    return false; // Intesection with plane outside triangle
+    return false; // Intersection with plane outside triangle
   q = s.cross_prod(edge1);
   v = f * direction.scalar_prod(q);
   if (v < 0.0 || u + v > 1.0)
-    return false; // Intesection with plane outside triangle
+    return false; // Intersection with plane outside triangle
 
   // At this stage we can compute t to find out where the intersection point is
   // on the line.
@@ -382,10 +381,10 @@ double MeshObject::solidAngle(const Kernel::V3D &observer,
 {
   std::vector<V3D> scaledVertices;
   scaledVertices.reserve(m_vertices.size());
-  for (size_t i = 0; i < m_vertices.size(); ++i) {
-    scaledVertices.push_back(V3D(scaleFactor.X() * m_vertices[i].X(),
-                                 scaleFactor.Y() * m_vertices[i].Y(),
-                                 scaleFactor.Z() * m_vertices[i].Z()));
+  for (auto vertex : m_vertices) {
+    scaledVertices.push_back(V3D(scaleFactor.X() * vertex.X(),
+                                 scaleFactor.Y() * vertex.Y(),
+                                 scaleFactor.Z() * vertex.Z()));
   }
   MeshObject scaledObject(m_triangles, scaledVertices, m_material);
   return scaledObject.solidAngle(observer);
@@ -437,10 +436,10 @@ const BoundingBox &MeshObject::getBoundingBox() const {
       maxX = maxY = maxZ = -huge;
 
       // Loop over all vertices and determine minima and maxima on each axis
-      for (size_t i = 0; i < m_vertices.size(); ++i) {
-        auto vx = m_vertices[i].X();
-        auto vy = m_vertices[i].Y();
-        auto vz = m_vertices[i].Z();
+      for (auto vertex : m_vertices) {
+        auto vx = vertex.X();
+        auto vy = vertex.Y();
+        auto vz = vertex.Z();
 
         minX = std::min(minX, vx);
         maxX = std::max(maxX, vx);

--- a/Framework/Geometry/src/Objects/MeshObject.cpp
+++ b/Framework/Geometry/src/Objects/MeshObject.cpp
@@ -77,28 +77,28 @@ bool MeshObject::isValid(const Kernel::V3D &point) const {
   }
 
   V3D direction(0.0, 0.0, 1.0); // direction to look for intersections
-  std::vector<V3D> intesectionPoints;
+  std::vector<V3D> intersectionPoints;
   std::vector<int> entryExitFlags;
 
-  getIntersections(point, direction, intesectionPoints, entryExitFlags);
+  getIntersections(point, direction, intersectionPoints, entryExitFlags);
 
-  if (intesectionPoints.size() == 0) {
+  if (intersectionPoints.empty()) {
     return false;
   }
 
   // True if point is on surface
-  for (size_t i = 0; i < intesectionPoints.size(); ++i) {
-    if (point.distance(intesectionPoints[i]) < M_TOLERANCE) {
+  for (size_t i = 0; i < intersectionPoints.size(); ++i) {
+    if (point.distance(intersectionPoints[i]) < M_TOLERANCE) {
       return true;
     }
   }
 
   // Look for nearest point then check its entry-exit flag
-  double nearestPointDistance = point.distance(intesectionPoints[0]);
+  double nearestPointDistance = point.distance(intersectionPoints[0]);
   size_t nearestPointIndex = 0;
-  for (size_t i = 1; i < intesectionPoints.size(); ++i) {
-    if (point.distance(intesectionPoints[i]) < nearestPointDistance) {
-      nearestPointDistance = point.distance(intesectionPoints[i]);
+  for (size_t i = 1; i < intersectionPoints.size(); ++i) {
+    if (point.distance(intersectionPoints[i]) < nearestPointDistance) {
+      nearestPointDistance = point.distance(intersectionPoints[i]);
       nearestPointIndex = i;
     }
   }

--- a/Framework/Geometry/src/Objects/MeshObject.cpp
+++ b/Framework/Geometry/src/Objects/MeshObject.cpp
@@ -87,7 +87,7 @@ bool MeshObject::isValid(const Kernel::V3D &point) const {
   }
 
   // True if point is on surface
-  for (auto intersectionPoint : intersectionPoints) {
+  for (const auto &intersectionPoint : intersectionPoints) {
     if (point.distance(intersectionPoint) < M_TOLERANCE) {
       return true;
     }
@@ -122,7 +122,7 @@ bool MeshObject::isOnSide(const Kernel::V3D &point) const {
       V3D{1, 0, 0}}; // directions to look for intersections
   // We have to look in several directions in case a point is on a face
   // or edge parallel to the first direction or also the second direction.
-  for (auto direction : directions) {
+  for (const auto &direction : directions) {
     std::vector<V3D> intersectionPoints;
     std::vector<int> entryExitFlags;
 
@@ -132,7 +132,7 @@ bool MeshObject::isOnSide(const Kernel::V3D &point) const {
       return false;
     }
 
-    for (auto intersectionPoint : intersectionPoints) {
+    for (const auto &intersectionPoint : intersectionPoints) {
       if (point.distance(intersectionPoint) < M_TOLERANCE) {
         return true;
       }
@@ -381,7 +381,7 @@ double MeshObject::solidAngle(const Kernel::V3D &observer,
 {
   std::vector<V3D> scaledVertices;
   scaledVertices.reserve(m_vertices.size());
-  for (auto vertex : m_vertices) {
+  for (const auto &vertex : m_vertices) {
     scaledVertices.emplace_back(scaleFactor.X() * vertex.X(),
                                 scaleFactor.Y() * vertex.Y(),
                                 scaleFactor.Z() * vertex.Z());
@@ -436,7 +436,7 @@ const BoundingBox &MeshObject::getBoundingBox() const {
       maxX = maxY = maxZ = -huge;
 
       // Loop over all vertices and determine minima and maxima on each axis
-      for (auto vertex : m_vertices) {
+      for (const auto &vertex : m_vertices) {
         auto vx = vertex.X();
         auto vy = vertex.Y();
         auto vz = vertex.Z();

--- a/Framework/Geometry/src/Objects/MeshObject.cpp
+++ b/Framework/Geometry/src/Objects/MeshObject.cpp
@@ -382,9 +382,9 @@ double MeshObject::solidAngle(const Kernel::V3D &observer,
   std::vector<V3D> scaledVertices;
   scaledVertices.reserve(m_vertices.size());
   for (auto vertex : m_vertices) {
-    scaledVertices.push_back(V3D(scaleFactor.X() * vertex.X(),
-                                 scaleFactor.Y() * vertex.Y(),
-                                 scaleFactor.Z() * vertex.Z()));
+    scaledVertices.emplace_back(scaleFactor.X() * vertex.X(),
+                                scaleFactor.Y() * vertex.Y(),
+                                scaleFactor.Z() * vertex.Z());
   }
   MeshObject scaledObject(m_triangles, scaledVertices, m_material);
   return scaledObject.solidAngle(observer);

--- a/Framework/Geometry/src/Objects/MeshObject.cpp
+++ b/Framework/Geometry/src/Objects/MeshObject.cpp
@@ -87,8 +87,8 @@ bool MeshObject::isValid(const Kernel::V3D &point) const {
   }
 
   // True if point is on surface
-  for (size_t i = 0; i < intersectionPoints.size(); ++i) {
-    if (point.distance(intersectionPoints[i]) < M_TOLERANCE) {
+  for (auto intersectionPoint : intersectionPoints) {
+    if (point.distance(intersectionPoint) < M_TOLERANCE) {
       return true;
     }
   }
@@ -128,7 +128,7 @@ bool MeshObject::isOnSide(const Kernel::V3D &point) const {
 
     getIntersections(point, directions[i], intesectionPoints, entryExitFlags);
 
-    if (intesectionPoints.size() == 0) {
+    if (intesectionPoints.empty()) {
       return false;
     }
 
@@ -160,7 +160,7 @@ int MeshObject::interceptSurface(Geometry::Track &UT) const {
 
   getIntersections(UT.startPoint(), UT.direction(), intesectionPoints,
                    entryExitFlags);
-  if (intesectionPoints.size() == 0)
+  if (intesectionPoints.empty())
     return 0; // Quit if no intersections found
 
   for (size_t i = 0; i < intesectionPoints.size(); ++i) {
@@ -348,8 +348,6 @@ void MeshObject::getBoundingBox(double &xmax, double &ymax, double &zmax,
   ymax = bb.yMax();
   zmin = bb.zMin();
   zmax = bb.zMax();
-
-  return;
 }
 
 /**
@@ -537,7 +535,6 @@ bool MeshObject::searchForObject(Kernel::V3D &point) const {
   // Method - check if point in object, if not search directions along
   // principle axes using interceptSurface
   //
-  Kernel::V3D testPt;
   if (isValid(point))
     return true;
   for (const auto &dir :

--- a/Framework/Geometry/src/Objects/MeshObject.cpp
+++ b/Framework/Geometry/src/Objects/MeshObject.cpp
@@ -32,7 +32,7 @@ MeshObject::MeshObject(std::vector<uint16_t> &&faces,
                        std::vector<V3D> &&vertices,
                        const Kernel::Material &&material)
     : m_boundingBox(), m_id("MeshObject"), m_triangles(std::move(faces)),
-      m_vertices(std::move(vertices)), m_material(std::move(material)) {
+      m_vertices(std::move(vertices)), m_material(material) {
 
   initialize();
 }

--- a/Framework/Geometry/src/Objects/MeshObject.cpp
+++ b/Framework/Geometry/src/Objects/MeshObject.cpp
@@ -211,7 +211,7 @@ bool MeshObject::rayIntersectsTriangle(const Kernel::V3D &start,
                                        const V3D &v1, const V3D &v2,
                                        const V3D &v3, V3D &intersection,
                                        int &entryExit) const {
-  // Implements MˆllerñTrumbore intersection algorithm
+  // Implements Möller–Trumbore intersection algorithm
   V3D edge1, edge2, h, s, q;
   double a, f, u, v;
   edge1 = v2 - v1;

--- a/Framework/Geometry/test/ContainerTest.h
+++ b/Framework/Geometry/test/ContainerTest.h
@@ -38,7 +38,6 @@ public:
                       "</cylinder>";
     Container can(xml);
     TS_ASSERT_EQUALS(false, can.hasSampleShape());
-    TS_ASSERT_EQUALS(xml, can.getShapeXML());
   }
 
   void test_SetSampleShape_Allows_Creating_Sample_Shape_Object() {

--- a/Framework/Geometry/test/ShapeFactoryTest.h
+++ b/Framework/Geometry/test/ShapeFactoryTest.h
@@ -631,7 +631,7 @@ public:
     TS_ASSERT(!shape_sptr->isValid(V3D(0.0, 0.0, 1)));
   }
 
-  IObject_sptr getObject(std::string xmlShape) {
+  boost::shared_ptr<CSGObject> getObject(std::string xmlShape) {
     std::string shapeXML = "<type name=\"userShape\"> " + xmlShape + " </type>";
 
     // Set up the DOM parser and parse xml string


### PR DESCRIPTION
Fixes #21848

Most of these changes are around type safety and cleaning up the API. Largely I have not addressed any performance related issues. This addresses issues that are relevant to the use of `MeshObject` in `NexusGeometry`

**Tester**
A code review should be sufficient.
