### PR TITLE
Make sphinx optional again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,12 +217,12 @@ if ( SPHINX_FOUND )
     message (STATUS "${SPHINX_BOOTSTRAP_THEME_ERR}")
     message (FATAL_ERROR " Install instructions at https://pypi.python.org/pypi/sphinx-bootstrap-theme/")
   endif ()
-endif ()
 
-add_subdirectory ( dev-docs )
-if ( ENABLE_MANTIDPLOT )
-  add_subdirectory ( docs )
-endif()
+  add_subdirectory ( dev-docs )
+  if ( ENABLE_MANTIDPLOT )
+    add_subdirectory ( docs )
+  endif()
+endif ()
 
 # System test data target
 add_subdirectory ( Testing/SystemTests/scripts )

--- a/buildconfig/CMake/FindSphinx.cmake
+++ b/buildconfig/CMake/FindSphinx.cmake
@@ -14,18 +14,22 @@
 
 FIND_FILE(_find_sphinx_py FindSphinx.py PATHS ${CMAKE_MODULE_PATH})
 
+if (version_string)   # chop out the version number
+  string (REGEX REPLACE ".*([0-9]+\\.[0-9]+\\.[0-9]+).*" "\\1" SPHINX_VERSION ${version_string})
+endif()
+
+
 # import sphinx-build to attempt to get the version
 execute_process (COMMAND ${PYTHON_EXECUTABLE} ${_find_sphinx_py} OUTPUT_VARIABLE sphinx_output
                                                                  RESULT_VARIABLE sphinx_result)
 
-if (${sphinx_result} STREQUAL "0" AND version_string)
-  # chop out the version number
-  string (REGEX REPLACE ".*([0-9]+\\.[0-9]+\\.[0-9]+).*" "\\1" SPHINX_VERSION ${version_string})
-
-  list(GET sphinx_output 0 version_string)
+if (${sphinx_result} STREQUAL "0")# AND version_string)
+  if (version_string)
+    list(GET sphinx_output 0 version_string)
+  endif()
   list(GET sphinx_output 1 SPHINX_PACKAGE_DIR)
 else()
-  message(STATUS "failed to run FindSphinx.py")
+  message(STATUS "failed to run FindSphinx.py returned ${sphinx_result}")
 endif ()
 
 include(FindPackageHandleStandardArgs)

--- a/buildconfig/CMake/FindSphinx.cmake
+++ b/buildconfig/CMake/FindSphinx.cmake
@@ -17,15 +17,17 @@ FIND_FILE(_find_sphinx_py FindSphinx.py PATHS ${CMAKE_MODULE_PATH})
 # import sphinx-build to attempt to get the version
 execute_process (COMMAND ${PYTHON_EXECUTABLE} ${_find_sphinx_py} OUTPUT_VARIABLE sphinx_output
                                                                  RESULT_VARIABLE sphinx_result)
-list(GET sphinx_output 0 version_string)
-list(GET sphinx_output 1 SPHINX_PACKAGE_DIR)
 
 if (${sphinx_result} STREQUAL "0" AND version_string)
   # chop out the version number
   string (REGEX REPLACE ".*([0-9]+\\.[0-9]+\\.[0-9]+).*" "\\1" SPHINX_VERSION ${version_string})
+
+  list(GET sphinx_output 0 version_string)
+  list(GET sphinx_output 1 SPHINX_PACKAGE_DIR)
+else()
+  message(STATUS "failed to run FindSphinx.py")
 endif ()
 
 include(FindPackageHandleStandardArgs)
 
 find_package_handle_standard_args(Sphinx DEFAULT_MSG SPHINX_PACKAGE_DIR)
-


### PR DESCRIPTION
The developer site accidentally added a hard requirement of sphinx which broke the conda builds. This makes it optional again.

**To test:**

See if this branch can be build with conda. Alternatively, change the `buildconfig/CMake/FindSphinx.py` script to try to `import sphinxx` and see that cmake now completes and doesn't give the `docs-html` or `dev-docs-html`.

*There is no associated issue.*

*Does not need to be in the release notes* because it is only for developers and should only be exercised with the conda builds.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
