### PR TITLE
Convert from byte array in py3

### DIFF
--- a/docs/sphinxext/mantiddoc/directives/sourcelink.py
+++ b/docs/sphinxext/mantiddoc/directives/sourcelink.py
@@ -266,7 +266,7 @@ class SourceLinkDirective(AlgorithmBaseDirective):
             ['git', 'log', '-n 1', '--pretty=format:%cd', '--date=short', filename],
             cwd=self.source_root,
             stdout=subprocess.PIPE)
-        return proc.stdout.read()
+        return str(proc.stdout.read().decode('utf-8'))
 
 
 def setup(app):


### PR DESCRIPTION
#21847 generates the wrong text in python3. The result of the system call to git in python3 is a byte array that needs to be converted to a string. This does that in a way that should work in python2 and python3.

**To test:**

Build the docs and look at the "last modified" text on any algorithm. It should be sensible independent of what version of python you're using.

*There is no associated issue.*

*Does not need to be in the release notes* because it is fixing an error in functionality introduced during this release cycle.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
