### PR TITLE
Fix and simplify error handling for external interfaces

### DIFF
--- a/scripts/ExternalInterfaces/CMakeLists.txt
+++ b/scripts/ExternalInterfaces/CMakeLists.txt
@@ -14,25 +14,19 @@ ExternalProject_Add ( mslice
   TEST_COMMAND ""
   INSTALL_COMMAND ""
 )
-
-if ( NOT EXISTS ${_mslice_external_root}/src/mslice/.git )
-  message ( STATUS "Fetching mslice" )
-  execute_process ( COMMAND ${CMAKE_COMMAND} ARGS -P ${_mslice_external_root}/tmp/mslice-gitclone.cmake
-                  RESULT_VARIABLE exit_code ERROR_VARIABLE error_contents )
-  if ( error_code )
-    message ( WARNING "Failed to clone mslice: ${error_contents}" )
-    if ( EXISTS ${_mslice_external_root}/src/.git )
-      # Remove .git to ensure next try succeeds if it can
-      execute_process ( COMMAND ${CMAKE_COMMAND} ARGS -E remove_directory ${_mslice_external_root}/src/.git )
-    endif ()
+set ( _mslice_src ${_mslice_external_root}/src/mslice )
+message ( STATUS "Fetching/updating mslice" )
+execute_process ( COMMAND ${CMAKE_COMMAND} ARGS -P ${_mslice_external_root}/tmp/mslice-gitclone.cmake
+                  RESULT_VARIABLE _exit_code )
+if ( _exit_code EQUAL 0 )
+  execute_process ( COMMAND ${CMAKE_COMMAND} ARGS -P ${_mslice_external_root}/tmp/mslice-gitupdate.cmake
+                    RESULT_VARIABLE _exit_code )
+  if ( NOT _exit_code EQUAL 0 )
+      message ( FATAL_ERROR "Unable to update mslice." )
   endif ()
 else ()
-  execute_process ( COMMAND ${CMAKE_COMMAND} ARGS -P ${_mslice_external_root}/tmp/mslice-gitupdate.cmake
-                    RESULT_VARIABLE error_code ERROR_VARIABLE error_contents )
-  if ( error_code )
-    message ( WARNING "Failed to update mslice: ${error_contents}" )
-  endif ()
-endif ()
+  message ( FATAL_ERROR "Unable to clone mslice" )
+endif()
 
 # Installation
 install ( DIRECTORY ${_mslice_external_root}/src/mslice/mslice/


### PR DESCRIPTION
**Description of work**

A recent pull request failed with an odd error related to cloning the [external interfaces](http://builds.mantidproject.org/job/pull_requests-osx/19483/consoleFull). The issue is around the error handling for the external interfaces clone/update step. This simplifies the mechanism and leaves it to CMake to do most checks.

**To test:**

#### Check it doesn't clone multiple times

* run cmake and see that it reports the stamp file is update to date for mslice and doesn't try to clone again.

#### Check errors are caught when trying to update

* remove the directory `build/scripts/ExternalInterfaces/mslice/src/mslice/.git`
* re-run cmake and see it fall over with an error

*No issue*

**Release Notes** 
*Internal change. Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
