### PR TITLE
Add KafkaEventListener to ZOOM

### DIFF
--- a/docs/source/release/v3.12.0/framework.rst
+++ b/docs/source/release/v3.12.0/framework.rst
@@ -71,7 +71,7 @@ Core Functionality
 Live Data
 ---------
 
-- `KafkaEventListener` is a new live listener for neutron event and sample environment data which is in development for the ESS, and also for ISIS where it may be used on instruments using event-mode data acquisition and IBEX.
+- `KafkaEventListener` is a new live listener for neutron event and sample environment data which is in development for the ESS and ISIS.
 
 Performance
 -----------

--- a/docs/source/release/v3.12.0/framework.rst
+++ b/docs/source/release/v3.12.0/framework.rst
@@ -71,7 +71,7 @@ Core Functionality
 Live Data
 ---------
 
-- `KafkaEventListener` is a new live listener for neutron event and sample environment data which is in development for the ESS and already in use at ISIS.
+- `KafkaEventListener` is a new live listener for neutron event and sample environment data which is in development for the ESS, and also for ISIS where it may be used on instruments using event-mode data acquisition and IBEX.
 
 Performance
 -----------

--- a/docs/source/release/v3.12.0/framework.rst
+++ b/docs/source/release/v3.12.0/framework.rst
@@ -71,7 +71,7 @@ Core Functionality
 Live Data
 ---------
 
-- `KafkaEventListener` is a new live listener for neutron event and sample environment data which is in development for the ESS and ISIS.
+- ``KafkaEventListener`` is a new live listener for neutron event and sample environment data which is in development for the ESS and ISIS.
 
 Performance
 -----------
@@ -82,8 +82,8 @@ Performance
 
 Python
 ------
-In `mantid.simpleapi`, a keyword has been implemented for function-like algorithm calls to control the storing on the Analysis Data Service.
-`StoreInADS=False` can be passed to function calls to not to store their output on the ADS.
+In ``mantid.simpleapi``, a keyword has been implemented for function-like algorithm calls to control the storing on the Analysis Data Service.
+``StoreInADS=False`` can be passed to function calls to not to store their output on the ADS.
 
 - The standard Python operators, e.g. ``+``, ``+=``, etc., now work also with workspaces not in the ADS.
 - The ``isDefault`` attribute for workspace properties now works correctly with workspaces not in the ADS.

--- a/docs/source/release/v3.12.0/framework.rst
+++ b/docs/source/release/v3.12.0/framework.rst
@@ -68,6 +68,11 @@ Core Functionality
 - Fixed the behaviour of ``UpdateInstrumentDefinitions.OnStartup`` in the :ref:`properties file <Properties File>`. It was not being used correctly for using the updated ``Facilities.xml`` file.
 - ``MultiFileProperty`` now accepts complex summation ranges for run numbers, such as ``111-113+115`` and ``111-115+123-132``.
 
+Live Data
+---------
+
+- `KafkaEventListener` is a new live listener for neutron event and sample environment data which is in development for the ESS and already in use at ISIS.
+
 Performance
 -----------
 

--- a/instrument/Facilities.xml
+++ b/instrument/Facilities.xml
@@ -230,6 +230,7 @@
     <technique>TOF Indirect Geometry Diffraction</technique>
     <livedata>
       <connection name="histo" address="NDXVESUVIO:6789" listener="ISISHistoDataListener" />
+      <connection name="kafka_event" address="livedata.isis.cclrc.ac.uk:9092" listener="KafkaEventListener" />
     </livedata>
   </instrument>
 
@@ -366,6 +367,9 @@
   <instrument name="ZOOM">
     <technique>Small Angle Scattering</technique>
     <zeropadding size="8"/>
+    <livedata>
+      <connection name="kafka_event" address="livedata.isis.cclrc.ac.uk:9092" listener="KafkaEventListener" />
+    </livedata>
   </instrument>
 
 </facility>

--- a/instrument/Facilities.xml
+++ b/instrument/Facilities.xml
@@ -230,7 +230,6 @@
     <technique>TOF Indirect Geometry Diffraction</technique>
     <livedata>
       <connection name="histo" address="NDXVESUVIO:6789" listener="ISISHistoDataListener" />
-      <connection name="kafka_event" address="livedata.isis.cclrc.ac.uk:9092" listener="KafkaEventListener" />
     </livedata>
   </instrument>
 


### PR DESCRIPTION
Added the KafkaEventListener to ZOOM in the `Facilities` file to make it available in the `StartLiveData` interface. As the listener is now visible to users it has been added to the release notes.

**To test:**

With your default facility set to ISIS, in MantidPlot click `Load`->`Live Data` in the "Workspaces" area. In the top left of the "Start Live Data" window select "ZOOM" as the instrument. You should see these settings:
![listener](https://user-images.githubusercontent.com/13455433/36798432-87190822-1ca2-11e8-9fba-988c557ed6f7.png)


Closes #21869

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
