### PR TITLE
macOS try copy over mpl_toolkits

### DIFF
--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -325,7 +325,7 @@ end
 system_python_extras = "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python"
 modules = ["matplotlib", "mpl_toolkits"]
 modules.each do |directory|
-  addPythonLibrary("#{{system_python_extras}}/#{directory}","Contents/MacOS/")
+  addPythonLibrary("#{system_python_extras}/#{directory}","Contents/MacOS/")
 end
 
 if( "@MAKE_VATES@" == "ON" )

--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -322,11 +322,15 @@ directories.each do |directory|
   addPythonLibrary("#{path}/#{directory}","Contents/MacOS/")
 end
 
+# System mpl_toolkits in macOS 10.12 and above do not have __init__.py which causes a problem importing
+# So we pack the mpl_toolkits and touch an empty file to temporarily work around it
+#TODO: consider installing mpl_toolkits (thus matplotlib) with pip
 system_python_extras = "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python"
-modules = ["matplotlib", "mpl_toolkits"]
+modules = ["mpl_toolkits"]
 modules.each do |directory|
   addPythonLibrary("#{system_python_extras}/#{directory}","Contents/MacOS/")
 end
+`touch Contents/MacOS/mpl_toolkits/__init__.py`
 
 if( "@MAKE_VATES@" == "ON" )
   addPythonLibrariesInDirectory("#{ParaView_dir}/lib/site-packages","Contents/Python/")

--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -317,9 +317,15 @@ end
 #Copy over python libraries not included with OSX.
 #currently missing epics
 path = "/Library/Python/2.7/site-packages"
-directories = ["sphinx","sphinx_bootstrap_theme","IPython","zmq","pygments","backports","certifi","tornado","markupsafe","jinja2","psutil","jsonschema","functools32","ptyprocess","CifFile","yaml", "matplotlib", "mpl_toolkits"]
+directories = ["sphinx","sphinx_bootstrap_theme","IPython","zmq","pygments","backports","certifi","tornado","markupsafe","jinja2","psutil","jsonschema","functools32","ptyprocess","CifFile","yaml"]
 directories.each do |directory|
   addPythonLibrary("#{path}/#{directory}","Contents/MacOS/")
+end
+
+system_python_extras = "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python"
+modules = ["matplotlib", "mpl_toolkits"]
+modules.each do |directory|
+  addPythonLibrary("#{{system_python_extras}}/#{directory}","Contents/MacOS/")
 end
 
 if( "@MAKE_VATES@" == "ON" )

--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -165,7 +165,7 @@ if( "@MAKE_VATES@" == "ON" )
         currentname = dependency.strip.split(" ")
         filename = currentname[0]
         if filename.include? "#{ParaView_dir}"
-          #p "fixing #{library} #{filename}" 
+          #p "fixing #{library} #{filename}"
           issues_found = issues_found + 1
           name_split_on_slash = filename.strip.split("/")
           filename_no_dir = name_split_on_slash[-1]
@@ -209,7 +209,7 @@ end
 
 #We'll use macdeployqt to fix qt dependencies.
 Qt_Executables = "-executable=Contents/MacOS/mantidqtpython.so -executable=Contents/MacOS/libqwtplot3d.dylib -executable=Contents/MacOS/libqwt.dylib "
-Qt_Executables << "-executable=Contents/MacOS/#{findQScintilla2(lib_dir)}" 
+Qt_Executables << "-executable=Contents/MacOS/#{findQScintilla2(lib_dir)}"
 
 if( "@MAKE_VATES@" == "ON" )
   list = ["Contents/Libraries/vtkParaViewWebCorePython.so",
@@ -314,10 +314,10 @@ end
 `install_name_tool -change #{QtLinkingDir[0]}/QtCore.framework/Versions/4/QtCore @loader_path/../../Frameworks/QtCore.framework/Versions/4/QtCore Contents/MacOS/PyQt4/QtXml.so`
 
 
-#Copy over python libraries not included with OSX. 
+#Copy over python libraries not included with OSX.
 #currently missing epics
 path = "/Library/Python/2.7/site-packages"
-directories = ["sphinx","sphinx_bootstrap_theme","IPython","zmq","pygments","backports","certifi","tornado","markupsafe","jinja2","psutil","jsonschema","functools32","ptyprocess","CifFile","yaml"]
+directories = ["sphinx","sphinx_bootstrap_theme","IPython","zmq","pygments","backports","certifi","tornado","markupsafe","jinja2","psutil","jsonschema","functools32","ptyprocess","CifFile","yaml", "matplotlib", "mpl_toolkits"]
 directories.each do |directory|
   addPythonLibrary("#{path}/#{directory}","Contents/MacOS/")
 end


### PR DESCRIPTION
Download and install the macOS package. 
Make sure there is no problem starting MantidPlot, particularly:

```
ImportError: No module named mpl_toolkits.mplot3d.axes3d
Error running init file "/Applications/MantidPlot.app/Contents/MacOS/mantidplotrc.py"
```

**To test:**

<!-- Instructions for testing. -->

No issue, no notes. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
