### PR TITLE
Fix ExternalInterfaces install command for macOS

### DIFF
--- a/scripts/ExternalInterfaces/CMakeLists.txt
+++ b/scripts/ExternalInterfaces/CMakeLists.txt
@@ -30,4 +30,4 @@ endif()
 
 # Installation
 install ( DIRECTORY ${_mslice_external_root}/src/mslice/mslice/
-          DESTINATION scripts/ExternalInterfaces/mslice )
+          DESTINATION ${INBUNDLE}scripts/ExternalInterfaces/mslice )


### PR DESCRIPTION
Description of work.

Removes the scripts folder from the macOS drag-n-drop screen. Currently nightly:

![screen shot 2018-03-01 at 11 36 03](https://user-images.githubusercontent.com/733773/36848021-eab68ce6-1d57-11e8-9c5f-47e24513c100.png)

**To test:**

* Build a package on OS X
* Try to install it and observe the scripts folder has gone.

*No issue*

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
