### PR TITLE
Error reporting of multidata fits

### DIFF
--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionBrowser.h
@@ -128,6 +128,11 @@ public:
   /// Set value of a local parameter
   void setLocalParameterValue(const QString &parName, int i,
                               double value) override;
+  /// Set value and error of a local parameter
+  void setLocalParameterValue(const QString &parName, int i,
+                              double value, double error);
+  /// Get error of a local parameter
+  double getLocalParameterError(const QString &parName, int i) const;
   /// Check if a local parameter is fixed
   bool isLocalParameterFixed(const QString &parName, int i) const override;
   /// Fix/unfix local parameter
@@ -399,8 +404,9 @@ protected:
   boost::optional<QString> m_currentFunctionIndex;
 
   struct LocalParameterData {
-    explicit LocalParameterData(double v = 0.0) : value(v), fixed(false) {}
+    explicit LocalParameterData(double v = 0.0, double e = 0.0) : value(v), error(e), fixed(false) {}
     double value;
+    double error;
     bool fixed;
     QString tie;
   };

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionBrowser.h
@@ -129,8 +129,8 @@ public:
   void setLocalParameterValue(const QString &parName, int i,
                               double value) override;
   /// Set value and error of a local parameter
-  void setLocalParameterValue(const QString &parName, int i,
-                              double value, double error);
+  void setLocalParameterValue(const QString &parName, int i, double value,
+                              double error);
   /// Get error of a local parameter
   double getLocalParameterError(const QString &parName, int i) const;
   /// Check if a local parameter is fixed
@@ -404,7 +404,8 @@ protected:
   boost::optional<QString> m_currentFunctionIndex;
 
   struct LocalParameterData {
-    explicit LocalParameterData(double v = 0.0, double e = 0.0) : value(v), error(e), fixed(false) {}
+    explicit LocalParameterData(double v = 0.0, double e = 0.0)
+        : value(v), error(e), fixed(false) {}
     double value;
     double error;
     bool fixed;

--- a/qt/widgets/common/src/FunctionBrowser.cpp
+++ b/qt/widgets/common/src/FunctionBrowser.cpp
@@ -2283,7 +2283,7 @@ void FunctionBrowser::updateMultiDatasetParameters(
         auto sfun = multiFun->getFunction(0);
         const auto globalParameters = getGlobalParameters();
         for (int j = 0; j < globalParameters.size(); ++j) {
-          auto paramName = globalParameters[j];
+          auto const &paramName = globalParameters[j];
           auto paramIndex = sfun->parameterIndex(paramName.toStdString());
           setParameter(paramName, sfun->getParameter(paramIndex));
           setParamError(paramName, sfun->getError(paramIndex));
@@ -2294,7 +2294,7 @@ void FunctionBrowser::updateMultiDatasetParameters(
       for (size_t i = 0; i < multiFun->nFunctions(); ++i) {
         auto sfun = multiFun->getFunction(i);
         for (int j = 0; j < localParameters.size(); ++j) {
-          auto paramName = localParameters[j];
+          auto const &paramName = localParameters[j];
           auto paramIndex = sfun->parameterIndex(paramName.toStdString());
           auto value = sfun->getParameter(paramIndex);
           auto error = sfun->getError(paramIndex);

--- a/qt/widgets/common/src/FunctionBrowser.cpp
+++ b/qt/widgets/common/src/FunctionBrowser.cpp
@@ -2007,8 +2007,9 @@ void FunctionBrowser::setLocalParameterValue(const QString &parName, int i,
     setParamError(parName, error);
   }
 }
-  /// Get error of a local parameter
-double FunctionBrowser::getLocalParameterError(const QString &parName, int i) const {
+/// Get error of a local parameter
+double FunctionBrowser::getLocalParameterError(const QString &parName,
+                                               int i) const {
   checkLocalParameter(parName);
   return m_localParameterValues[parName][i].error;
 }
@@ -2297,9 +2298,8 @@ void FunctionBrowser::updateMultiDatasetParameters(
           auto paramIndex = sfun->parameterIndex(paramName.toStdString());
           auto value = sfun->getParameter(paramIndex);
           auto error = sfun->getError(paramIndex);
-          setLocalParameterValue(
-              localParameters[j], static_cast<int>(i),
-              value, error);
+          setLocalParameterValue(localParameters[j], static_cast<int>(i), value,
+                                 error);
           if (i == currentIndex) {
             setParameter(paramName, value);
             setParamError(paramName, error);

--- a/qt/widgets/common/src/FunctionBrowser.cpp
+++ b/qt/widgets/common/src/FunctionBrowser.cpp
@@ -1997,6 +1997,22 @@ void FunctionBrowser::setLocalParameterValue(const QString &parName, int i,
   }
 }
 
+void FunctionBrowser::setLocalParameterValue(const QString &parName, int i,
+                                             double value, double error) {
+  checkLocalParameter(parName);
+  m_localParameterValues[parName][i].value = value;
+  m_localParameterValues[parName][i].error = error;
+  if (i == m_currentDataset) {
+    setParameter(parName, value);
+    setParamError(parName, error);
+  }
+}
+  /// Get error of a local parameter
+double FunctionBrowser::getLocalParameterError(const QString &parName, int i) const {
+  checkLocalParameter(parName);
+  return m_localParameterValues[parName][i].error;
+}
+
 /**
  * Init a local parameter. Define initial values for all datasets.
  * @param parName :: Name of parametere to init.
@@ -2042,6 +2058,7 @@ void FunctionBrowser::setCurrentDataset(int i) {
   auto localParameters = getLocalParameters();
   foreach (QString par, localParameters) {
     setParameter(par, getLocalParameterValue(par, m_currentDataset));
+    setParamError(par, getLocalParameterError(par, m_currentDataset));
     updateLocalTie(par);
   }
 }
@@ -2269,9 +2286,10 @@ void FunctionBrowser::updateMultiDatasetParameters(
           updateParameters(*sfun);
         }
         for (int j = 0; j < localParameters.size(); ++j) {
+          auto paramIndex = sfun->parameterIndex(localParameters[j].toStdString());
           setLocalParameterValue(
               localParameters[j], static_cast<int>(i),
-              sfun->getParameter(localParameters[j].toStdString()));
+              sfun->getParameter(paramIndex), sfun->getError(paramIndex));
         }
       }
     } else { // composite function, 1 domain only


### PR DESCRIPTION
Added errors to the local parameter cache. Update them after each fit.

**To test:**

Run the multi-dataset fitting interface. Fit some data. Check that the errors in the property browser updated correctly.

Fixes #21828

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
