### PR TITLE
Only package MantidQt for Qt 4

### DIFF
--- a/buildconfig/CMake/QtTargetFunctions.cmake
+++ b/buildconfig/CMake/QtTargetFunctions.cmake
@@ -216,7 +216,10 @@ function (mtd_add_qt_target)
     else()
       set ( _install_dir ${LIB_DIR} )
     endif()
-    install ( TARGETS ${_target} ${SYSTEM_PACKAGE_TARGET} DESTINATION ${_install_dir} )
+    # Hack: Only install Qt4 to packages for now...
+    if (${PARSED_QT_VERSION} EQUAL 4)
+      install ( TARGETS ${_target} ${SYSTEM_PACKAGE_TARGET} DESTINATION ${_install_dir} )
+    endif()
   endif()
 
   # Group into folder for VS


### PR DESCRIPTION
Description of work.

The workbench is not being shipped but it turned out that the MantidQtWidgetsCommonQt5 library was being shipped in the package. On macOS this causes all of Qt 5 to be dragged in and vastly increases the size of the bundle. For now we only ship the old Qt 4 libraries.

**To test:**

* Build the package on OS X and observer there are no Qt 5 libraries anywhere.

*No issue *

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
