### PR TITLE
Update LoadWAND masking and WAND² IDF

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/LoadWAND.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/LoadWAND.py
@@ -30,7 +30,7 @@ class LoadWAND(DataProcessorAlgorithm):
         Integration(InputWorkspace=outWS, OutputWorkspace=outWS)
 
         if self.getProperty("ApplyMask").value:
-            MaskBTP(outWS, Bank='8', Tube='449-480')
+            MaskBTP(outWS, Bank='8', Tube='475-480')
             MaskBTP(outWS, Pixel='1,2,511,512')
 
         mtd[outWS].getAxis(0).setUnit("Wavelength")

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/LoadWANDTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/LoadWANDTest.py
@@ -22,7 +22,7 @@ class LoadWANDTest(unittest.TestCase):
         self.assertFalse(ws.detectorInfo().isMasked(2))
         self.assertTrue(ws.detectorInfo().isMasked(512))
         self.assertTrue(ws.detectorInfo().isMasked(480*512*8-256))
-        self.assertFalse(ws.detectorInfo().isMasked(480*512*8-256-512*32))
+        self.assertFalse(ws.detectorInfo().isMasked(480*512*8-256-512*6))
 
         # Check x dimension
         x=ws.getXDimension()

--- a/docs/source/algorithms/LoadWAND-v1.rst
+++ b/docs/source/algorithms/LoadWAND-v1.rst
@@ -14,7 +14,7 @@ file after which it will integrate out the events, apply a standard
 mask, change units to wavelength and set the wavelength, set the
 goniometer, and set the proton charge to be the number of monitor
 counts. The standard mask includes the top and bottom 2 rows of pixels
-and the last 32 columns.
+and the last 6 columns.
 
 After this algorithm loads the workspace it can be correctly converted
 to Q sample or HKL using :ref:`algm-ConvertToMD`.

--- a/instrument/WAND_Definition_2018_02_20.xml
+++ b/instrument/WAND_Definition_2018_02_20.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='ASCII'?>
-<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2018-02-20 15:28:39.887585" name="WAND" valid-from="2018-02-20 00:00:00" valid-to="2100-01-31 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
+<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2018-03-01 12:56:31.737829" name="WAND" valid-from="2018-02-20 00:00:00" valid-to="2100-01-31 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
   <!--Created by Ross Whitfield-->
   <defaults>
     <length unit="metre"/>
@@ -34,10 +34,10 @@
           <value val="0.728"/>
         </parameter>
         <parameter name="t-position">
-          <logfile eq="112.5+rint(value*1000)/1000" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
+          <logfile eq="112.3125+rint(value*1000)/1000" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
         </parameter>
         <parameter name="roty">
-          <logfile eq="112.5+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
+          <logfile eq="112.3125+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
         </parameter>
       </location>
     </component>
@@ -56,10 +56,10 @@
           <value val="0.728"/>
         </parameter>
         <parameter name="t-position">
-          <logfile eq="97.5+rint(value*1000)/1000" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
+          <logfile eq="97.3125+rint(value*1000)/1000" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
         </parameter>
         <parameter name="roty">
-          <logfile eq="97.5+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
+          <logfile eq="97.3125+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
         </parameter>
       </location>
     </component>
@@ -78,10 +78,10 @@
           <value val="0.728"/>
         </parameter>
         <parameter name="t-position">
-          <logfile eq="82.5+rint(value*1000)/1000" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
+          <logfile eq="82.3125+rint(value*1000)/1000" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
         </parameter>
         <parameter name="roty">
-          <logfile eq="82.5+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
+          <logfile eq="82.3125+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
         </parameter>
       </location>
     </component>
@@ -100,10 +100,10 @@
           <value val="0.728"/>
         </parameter>
         <parameter name="t-position">
-          <logfile eq="67.5+rint(value*1000)/1000" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
+          <logfile eq="67.3125+rint(value*1000)/1000" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
         </parameter>
         <parameter name="roty">
-          <logfile eq="67.5+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
+          <logfile eq="67.3125+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
         </parameter>
       </location>
     </component>
@@ -122,10 +122,10 @@
           <value val="0.728"/>
         </parameter>
         <parameter name="t-position">
-          <logfile eq="52.5+rint(value*1000)/1000" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
+          <logfile eq="52.3125+rint(value*1000)/1000" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
         </parameter>
         <parameter name="roty">
-          <logfile eq="52.5+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
+          <logfile eq="52.3125+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
         </parameter>
       </location>
     </component>
@@ -144,10 +144,10 @@
           <value val="0.728"/>
         </parameter>
         <parameter name="t-position">
-          <logfile eq="37.5+rint(value*1000)/1000" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
+          <logfile eq="37.3125+rint(value*1000)/1000" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
         </parameter>
         <parameter name="roty">
-          <logfile eq="37.5+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
+          <logfile eq="37.3125+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
         </parameter>
       </location>
     </component>
@@ -166,10 +166,10 @@
           <value val="0.728"/>
         </parameter>
         <parameter name="t-position">
-          <logfile eq="22.5+rint(value*1000)/1000" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
+          <logfile eq="22.3125+rint(value*1000)/1000" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
         </parameter>
         <parameter name="roty">
-          <logfile eq="22.5+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
+          <logfile eq="22.3125+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
         </parameter>
       </location>
     </component>
@@ -188,10 +188,10 @@
           <value val="0.728"/>
         </parameter>
         <parameter name="t-position">
-          <logfile eq="7.5+rint(value*1000)/1000" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
+          <logfile eq="7.3125+rint(value*1000)/1000" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
         </parameter>
         <parameter name="roty">
-          <logfile eq="7.5+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
+          <logfile eq="7.3125+value" extract-single-value-as="mean" id="HB2C:Mot:s2.RBV"/>
         </parameter>
       </location>
     </component>


### PR DESCRIPTION
After the pixel remapping it was found that a shift of 6 pixels is required, that's 0.1875°. Also only 6 columns need masking now.

**To test:**
Load the `HB2C_7000.nxs.h5` from unit test data or any WAND data file


**Release Notes** 
Does not need to be in the release notes. As this was only added this release.


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
