### PR TITLE
Stop the resetting of group/pair selection in muon analysis

### DIFF
--- a/docs/source/release/v3.12.0/muon.rst
+++ b/docs/source/release/v3.12.0/muon.rst
@@ -21,6 +21,7 @@ Interface
 - Results table in Muon Analysis now sets relevant columns to numeric. 
 - The Frequency Domain Analysis GUI now uses :ref:`CalMuonDetectorPhases <algm-CalMuonDetectorPhases>` to create the phase table for PhaseQuad FFTs. 
 - The Frequency Domain Analysis GUI now uses :ref:`MuonMaxent <algm-MuonMaxent>` to calculate the frequency spectrum in MaxEnt mode.  
+- The group/pair selection in Muon Analysis no longer resets when changing tabs or loading data.
 
 Algorithms
 ----------

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -367,14 +367,7 @@ void MuonAnalysis::setChosenGroupAndPeriods(const QString &wsName) {
   if (!periodToSet.isEmpty() && !periods.contains(periodToSet)) {
     m_uiForm.fitBrowser->setChosenPeriods(periodToSet);
   }
-  return; /*
-  const QString &groupToSet = QString::fromStdString(wsParams.itemName);
-
-const auto &groups = m_dataSelector->getChosenGroups();
-     if (!groups.contains(groupToSet)) {
-     m_uiForm.fitBrowser->setChosenGroup(groupToSet);
-     }
-*/
+  return; 
 }
 
 /**

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -358,25 +358,23 @@ void MuonAnalysis::initLayout() {
 }
 
 void MuonAnalysis::setChosenGroupAndPeriods(const QString &wsName) {
-	const auto wsParams =
-		MuonAnalysisHelper::parseWorkspaceName(wsName.toStdString());
+  const auto wsParams =
+      MuonAnalysisHelper::parseWorkspaceName(wsName.toStdString());
 
-	const QString &groupToSet = QString::fromStdString(wsParams.itemName);
-	auto safd = groupToSet.toStdString();
-	const QString &periodToSet = QString::fromStdString(wsParams.periods);
-	const auto &periods = m_dataSelector->getPeriodSelections();
+  const QString &groupToSet = QString::fromStdString(wsParams.itemName);
+  const QString &periodToSet = QString::fromStdString(wsParams.periods);
+  const auto &periods = m_dataSelector->getPeriodSelections();
 
-	if (!periodToSet.isEmpty() && !periods.contains(periodToSet)) {
-		m_uiForm.fitBrowser->setChosenPeriods(periodToSet);
-	}
-	return;/*
- 
-  const auto &groups = m_dataSelector->getChosenGroups();
-	  if (!groups.contains(groupToSet)) {
-	  m_uiForm.fitBrowser->setChosenGroup(groupToSet);
-	  }
-  */
+  if (!periodToSet.isEmpty() && !periods.contains(periodToSet)) {
+    m_uiForm.fitBrowser->setChosenPeriods(periodToSet);
+  }
+  return; /*
 
+const auto &groups = m_dataSelector->getChosenGroups();
+     if (!groups.contains(groupToSet)) {
+     m_uiForm.fitBrowser->setChosenGroup(groupToSet);
+     }
+*/
 }
 
 /**
@@ -484,8 +482,7 @@ std::string MuonAnalysis::addItem(ItemType itemType, int tableRow,
 void MuonAnalysis::plotItem(ItemType itemType, int tableRow,
                             PlotType plotType) {
   m_updating = true;
-  //m_uiForm.fitBrowser->clearChosenGroups();
-  //m_uiForm.fitBrowser->clearChosenPeriods();
+  m_uiForm.fitBrowser->clearChosenPeriods();
   try {
     auto wsName = addItem(itemType, tableRow, plotType);
 

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -358,12 +358,18 @@ void MuonAnalysis::initLayout() {
 }
 
 void MuonAnalysis::setChosenGroupAndPeriods(const QString &wsName) {
+	return;
   const auto wsParams =
       MuonAnalysisHelper::parseWorkspaceName(wsName.toStdString());
 
   const QString &groupToSet = QString::fromStdString(wsParams.itemName);
+  auto safd = groupToSet.toStdString();
   const QString &periodToSet = QString::fromStdString(wsParams.periods);
   const auto &groups = m_dataSelector->getChosenGroups();
+  std::vector<std::string> fsa;
+  for (auto name : groups) {
+	  fsa.push_back(name.toStdString());
+  }
   const auto &periods = m_dataSelector->getPeriodSelections();
   if (!groups.contains(groupToSet)) {
     m_uiForm.fitBrowser->setChosenGroup(groupToSet);
@@ -478,8 +484,8 @@ std::string MuonAnalysis::addItem(ItemType itemType, int tableRow,
 void MuonAnalysis::plotItem(ItemType itemType, int tableRow,
                             PlotType plotType) {
   m_updating = true;
-  m_uiForm.fitBrowser->clearChosenGroups();
-  m_uiForm.fitBrowser->clearChosenPeriods();
+  //m_uiForm.fitBrowser->clearChosenGroups();
+  //m_uiForm.fitBrowser->clearChosenPeriods();
   try {
     auto wsName = addItem(itemType, tableRow, plotType);
 

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -358,25 +358,25 @@ void MuonAnalysis::initLayout() {
 }
 
 void MuonAnalysis::setChosenGroupAndPeriods(const QString &wsName) {
-	return;
-  const auto wsParams =
-      MuonAnalysisHelper::parseWorkspaceName(wsName.toStdString());
+	const auto wsParams =
+		MuonAnalysisHelper::parseWorkspaceName(wsName.toStdString());
 
-  const QString &groupToSet = QString::fromStdString(wsParams.itemName);
-  auto safd = groupToSet.toStdString();
-  const QString &periodToSet = QString::fromStdString(wsParams.periods);
+	const QString &groupToSet = QString::fromStdString(wsParams.itemName);
+	auto safd = groupToSet.toStdString();
+	const QString &periodToSet = QString::fromStdString(wsParams.periods);
+	const auto &periods = m_dataSelector->getPeriodSelections();
+
+	if (!periodToSet.isEmpty() && !periods.contains(periodToSet)) {
+		m_uiForm.fitBrowser->setChosenPeriods(periodToSet);
+	}
+	return;/*
+ 
   const auto &groups = m_dataSelector->getChosenGroups();
-  std::vector<std::string> fsa;
-  for (auto name : groups) {
-	  fsa.push_back(name.toStdString());
-  }
-  const auto &periods = m_dataSelector->getPeriodSelections();
-  if (!groups.contains(groupToSet)) {
-    m_uiForm.fitBrowser->setChosenGroup(groupToSet);
-  }
-  if (!periodToSet.isEmpty() && !periods.contains(periodToSet)) {
-    m_uiForm.fitBrowser->setChosenPeriods(periodToSet);
-  }
+	  if (!groups.contains(groupToSet)) {
+	  m_uiForm.fitBrowser->setChosenGroup(groupToSet);
+	  }
+  */
+
 }
 
 /**

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -367,7 +367,7 @@ void MuonAnalysis::setChosenGroupAndPeriods(const QString &wsName) {
   if (!periodToSet.isEmpty() && !periods.contains(periodToSet)) {
     m_uiForm.fitBrowser->setChosenPeriods(periodToSet);
   }
-  return; 
+  return;
 }
 
 /**

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -361,7 +361,6 @@ void MuonAnalysis::setChosenGroupAndPeriods(const QString &wsName) {
   const auto wsParams =
       MuonAnalysisHelper::parseWorkspaceName(wsName.toStdString());
 
-  const QString &groupToSet = QString::fromStdString(wsParams.itemName);
   const QString &periodToSet = QString::fromStdString(wsParams.periods);
   const auto &periods = m_dataSelector->getPeriodSelections();
 
@@ -369,6 +368,7 @@ void MuonAnalysis::setChosenGroupAndPeriods(const QString &wsName) {
     m_uiForm.fitBrowser->setChosenPeriods(periodToSet);
   }
   return; /*
+  const QString &groupToSet = QString::fromStdString(wsParams.itemName);
 
 const auto &groups = m_dataSelector->getChosenGroups();
      if (!groups.contains(groupToSet)) {

--- a/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
@@ -386,8 +386,6 @@ void MuonFitPropertyBrowser::enumChanged(QtProperty *prop) {
     } else {
       for (auto iter = m_periodBoxes.constBegin();
            iter != m_periodBoxes.constEnd(); ++iter) {
-		  auto sadf = option.toStdString();
-		  auto fsdaf = iter.key().toStdString();
         if (option == iter.key()) {
           m_boolManager->setValue(iter.value(), true);
         } else {
@@ -440,8 +438,6 @@ void MuonFitPropertyBrowser::updatePeriodDisplay() {
   auto tmp = getChosenPeriods();
   tmp.replaceInStrings(QRegExp(","), "+");
   m_showPeriodValue << tmp.join(",");
-  auto tttt = tmp.size();
-  auto tmmm = m_showPeriodValue[0].toStdString();
   m_enumManager->setEnumNames(m_showPeriods, m_showPeriodValue);
   if (m_periodsToFitOptions.size() > 1) {
     m_multiFitSettingsGroup->property()->addSubProperty(m_showPeriods);
@@ -1251,10 +1247,9 @@ bool MuonFitPropertyBrowser::hasGuess() const {
 * By default sets all unchecked
 * @param groups :: [input] List of group names
 */
-void MuonFitPropertyBrowser::setAvailableGroups(const QStringList &groups){
-//  m_enumManager->setValue(m_groupsToFit, 0);
+void MuonFitPropertyBrowser::setAvailableGroups(const QStringList &groups) {
   // If it's the same list, do nothing
-	auto selected = getChosenGroups();
+  auto selected = getChosenGroups();
   if (groups.size() == m_groupBoxes.size()) {
     auto existingGroups = m_groupBoxes.keys();
     auto newGroups = groups;
@@ -1269,15 +1264,15 @@ void MuonFitPropertyBrowser::setAvailableGroups(const QStringList &groups){
   for (const auto &group : groups) {
     addGroupCheckbox(group);
   }
-  //sets the same selection as before
+  // sets the same selection as before
   for (const auto &group : selected) {
 
-	  for (auto iter = m_groupBoxes.constBegin(); iter != m_groupBoxes.constEnd();
-		  ++iter) {
-		  if (iter.key().toStdString() == group.toStdString()) {
-			  m_boolManager->setValue(iter.value(), true);
-		  }
-	  }
+    for (auto iter = m_groupBoxes.constBegin(); iter != m_groupBoxes.constEnd();
+         ++iter) {
+      if (iter.key().toStdString() == group.toStdString()) {
+        m_boolManager->setValue(iter.value(), true);
+      }
+    }
   }
 }
 /**
@@ -1312,11 +1307,6 @@ void MuonFitPropertyBrowser::addGroupCheckbox(const QString &name) {
   m_groupBoxes.insert(name, m_boolManager->addProperty(name));
   int j = m_enumManager->value(m_groupsToFit);
   auto option = m_groupsToFitOptions[j].toStdString();
-  /*if (option == "All groups") {
-    setAllGroups();
-  } else if (option == "All Pairs") {
-    setAllPairs();
-  }*/
 }
 /**
 * Returns a list of the selected groups (checked boxes)
@@ -1658,55 +1648,46 @@ void MuonFitPropertyBrowser::setSingleFitLabel(std::string name) {
 */
 void MuonFitPropertyBrowser::setAllGroupsOrPairs(const bool isItGroup) {
 
-	auto index = m_enumManager->value(m_groupsToFit);
-	QString name = m_groupsToFitOptions[index];
-	if (name == CUSTOM_LABEL) {
-		bool match = false;
-		auto vals = getChosenGroups();
-		auto tt = vals.size();
-		clearChosenGroups();
-		for (const auto &group : vals) {
+  auto index = m_enumManager->value(m_groupsToFit);
+  QString name = m_groupsToFitOptions[index];
+  if (name == CUSTOM_LABEL) {
+    bool match = false;
+    auto vals = getChosenGroups();
+    clearChosenGroups();
+    for (const auto &group : vals) {
 
-			for (auto iter = m_groupBoxes.constBegin(); iter != m_groupBoxes.constEnd();
-				++iter) {
-				auto a = iter.key().toStdString();
-				auto b = group.toStdString();
-				if (iter.key().toStdString() == group.toStdString()) {
-					m_boolManager->setValue(iter.value(), true);
-					match = true;
-				}
-			}
+      for (auto iter = m_groupBoxes.constBegin();
+           iter != m_groupBoxes.constEnd(); ++iter) {
+        if (iter.key().toStdString() == group.toStdString()) {
+          m_boolManager->setValue(iter.value(), true);
+          match = true;
+        }
+      }
+    }
+  } else if (name == ALL_GROUPS_LABEL) {
+    m_enumManager->setValue(m_groupsToFit, 0);
+    setAllGroups();
+    if (getChosenGroups().size() > 0) {
+      return;
+    }
+  } else if (name == ALL_PAIRS_LABEL) { // all pairs is index 1
+    m_enumManager->setValue(m_groupsToFit, 1);
+    setAllPairs();
+  }
+  if (getChosenGroups().size() > 0) {
+    return;
+  } else {
 
-		}
-	}
-	else if (name == ALL_GROUPS_LABEL) {
-		m_enumManager->setValue(m_groupsToFit, 0);
-		setAllGroups();
-		if (getChosenGroups().size() > 0) { return; }
-	}
-	else if (name == ALL_PAIRS_LABEL)
-	{			// all pairs is index 1
-		m_enumManager->setValue(m_groupsToFit, 1);
-		setAllPairs();
-
-	}
-	if (getChosenGroups().size() > 0) {
-		return;
-	}
-	else {
-
-
-		if (isItGroup) {
-			// all groups is index 0
-			m_enumManager->setValue(m_groupsToFit, 0);
-			setAllGroups();
-		}
-		else {
-			// all pairs is index 1
-			m_enumManager->setValue(m_groupsToFit, 1);
-			setAllPairs();
-		}
-	}
+    if (isItGroup) {
+      // all groups is index 0
+      m_enumManager->setValue(m_groupsToFit, 0);
+      setAllGroups();
+    } else {
+      // all pairs is index 1
+      m_enumManager->setValue(m_groupsToFit, 1);
+      setAllPairs();
+    }
+  }
 }
 void MuonFitPropertyBrowser::setGroupNames(
     std::vector<std::string> groupNames) {

--- a/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
@@ -1651,7 +1651,6 @@ void MuonFitPropertyBrowser::setAllGroupsOrPairs(const bool isItGroup) {
   auto index = m_enumManager->value(m_groupsToFit);
   QString name = m_groupsToFitOptions[index];
   if (name == CUSTOM_LABEL) {
-    bool match = false;
     auto vals = getChosenGroups();
     clearChosenGroups();
     for (const auto &group : vals) {
@@ -1660,7 +1659,6 @@ void MuonFitPropertyBrowser::setAllGroupsOrPairs(const bool isItGroup) {
            iter != m_groupBoxes.constEnd(); ++iter) {
         if (iter.key().toStdString() == group.toStdString()) {
           m_boolManager->setValue(iter.value(), true);
-          match = true;
         }
       }
     }

--- a/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
@@ -171,6 +171,8 @@ void MuonFitPropertyBrowser::init() {
   multiFitSettingsGroup->addSubProperty(m_showGroup);
 
   m_enumManager->setEnumNames(m_showGroup, m_showGroupValue);
+  m_enumManager->setValue(m_groupsToFit, 2);
+  clearChosenGroups();
   QString tmp = "fwd";
   addGroupCheckbox(tmp);
   tmp = "bwd";
@@ -384,6 +386,8 @@ void MuonFitPropertyBrowser::enumChanged(QtProperty *prop) {
     } else {
       for (auto iter = m_periodBoxes.constBegin();
            iter != m_periodBoxes.constEnd(); ++iter) {
+		  auto sadf = option.toStdString();
+		  auto fsdaf = iter.key().toStdString();
         if (option == iter.key()) {
           m_boolManager->setValue(iter.value(), true);
         } else {
@@ -436,6 +440,8 @@ void MuonFitPropertyBrowser::updatePeriodDisplay() {
   auto tmp = getChosenPeriods();
   tmp.replaceInStrings(QRegExp(","), "+");
   m_showPeriodValue << tmp.join(",");
+  auto tttt = tmp.size();
+  auto tmmm = m_showPeriodValue[0].toStdString();
   m_enumManager->setEnumNames(m_showPeriods, m_showPeriodValue);
   if (m_periodsToFitOptions.size() > 1) {
     m_multiFitSettingsGroup->property()->addSubProperty(m_showPeriods);


### PR DESCRIPTION
Fixes a bug which prevented the group/pair selection in muon analysis being kept when changing tabs. 

**To test:**
Load HIFI 108379 into muon analysis
go to the settings tab and make sure multiple fitting is ticked
go to the data analysis tab, the group/pair selection should be "all pairs"
Change the selection to all groups
go to the grouping tab and add a new group (just put "1" for the detectors)
go back to the grouping tab and it should now have the new group in the list of groups

change the groups selection to custom and only have long and the new group ticked
go to the home tab and press the back arrow (load previous run)
go to the data analysis tab and the group selection should be the same (long + new group)
change the group selection to all pairs

go to the home tab and load MUSR 62260 (it does not have any pairs)
go to the data analysis tab and all groups should be selected


<!-- Instructions for testing. -->

Fixes #21812. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->
in release notes
---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
