### PR TITLE
Fix a bug where threads don't exit

### DIFF
--- a/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -524,7 +524,10 @@ Handle thread completion
 */
 void GenericDataProcessorPresenter::threadFinished(const int exitCode) {
 
-  m_workerThread.release();
+  if (m_workerThread) {
+    m_workerThread->exit();
+    m_workerThread.release();
+  }
 
   if (exitCode == 0) { // Success
     m_progressReporter->report();


### PR DESCRIPTION
The reflectometry GUI creates many threads and was not calling exit() on them, so you could end up with several hundred threads hanging around.

**To test:**

- Run MantidPlot in a debugger
- Open the `ISIS Reflectometry` GUI
- Run a reduction with many rows, e.g. select the instrument `POLREF`, search for investigation `1520249`, select all the rows apart from the first 3, click `Transfer` and then click `Process`.
- After the reduction is finished, check how many threads there are still running. Before this fix it was 700+. After the fix it should be more like 10 or 15.

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
)