### PR TITLE
Fix invalid date string in catalog search

### DIFF
--- a/qt/widgets/common/src/CatalogHelper.cpp
+++ b/qt/widgets/common/src/CatalogHelper.cpp
@@ -236,7 +236,7 @@ time_t CatalogHelper::getTimevalue(const std::string &inputDate) {
   boost::algorithm::split_regex(dateSegments, inputDate, boost::regex("/"));
   // Reorganise the date to be ISO format.
   std::string isoDate = dateSegments.at(2) + "-" + dateSegments.at(1) + "-" +
-                        dateSegments.at(0) + " 0:00:00.000";
+                        dateSegments.at(0) + " 00:00:00.000";
   // Return the date as time_t value.
   return Mantid::Types::Core::DateAndTime(isoDate).to_time_t();
 }


### PR DESCRIPTION
This PR fixes a regression where stricter date string validation was causing catalog search to fail.

**To test:**

Follow the instructions in the linked issue and check that the exception is no longer thrown. Note that you must enter both the start and end dates because entering only one or the other goes through a different code path that was not subject to this error.

Fixes #21770

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
