### PR TITLE
MRInspectData: Fix logger bug

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/MRInspectData.py
+++ b/Framework/PythonInterface/plugins/algorithms/MRInspectData.py
@@ -344,7 +344,7 @@ class DataInfo(object):
         try:
             specular_peak, low_res, _ = mantid.simpleapi.LRPeakSelection(InputWorkspace=ws_short)
         except:
-            logger.notice("Peak finding error [specular=%s]: %s" % (specular, sys.exc_value))
+            logger.notice("Peak finding error [specular=%s]: %s" % (specular, sys.exc_info()[1]))
             return integrated, [0,0], [0,0]
         if specular:
             peak = [specular_peak[0]+self.peak_range_offset, specular_peak[1]+self.peak_range_offset]
@@ -478,7 +478,7 @@ class DataInfo(object):
             # what we currently have (which is probably given by the ROI).
             logger.notice("Run %s [%s]: Could not fit a peak in the supplied peak range" %
                           (self.run_number, self.cross_section))
-            logger.notice(str(sys.exc_value))
+            logger.notice(str(sys.exc_info()[1]))
             try:
                 # Define a good default that is wide enough for the fit to work
                 default_width = (self.found_peak[1]-self.found_peak[0])/2.0
@@ -498,7 +498,7 @@ class DataInfo(object):
                 logger.notice("Run %s [%s]: Peak position: %s  Peak width: %s" %
                               (self.run_number, self.cross_section, peak_position, peak_width))
             except:
-                logger.notice(str(sys.exc_value))
+                logger.notice(str(sys.exc_info()[1]))
                 logger.notice("Run %s [%s]: Gaussian fit failed to determine peak position" %
                               (self.run_number, self.cross_section))
 

--- a/Framework/PythonInterface/plugins/algorithms/MRInspectData.py
+++ b/Framework/PythonInterface/plugins/algorithms/MRInspectData.py
@@ -478,7 +478,7 @@ class DataInfo(object):
             # what we currently have (which is probably given by the ROI).
             logger.notice("Run %s [%s]: Could not fit a peak in the supplied peak range" %
                           (self.run_number, self.cross_section))
-            logger.notice(sys.exc_value)
+            logger.notice(str(sys.exc_value))
             try:
                 # Define a good default that is wide enough for the fit to work
                 default_width = (self.found_peak[1]-self.found_peak[0])/2.0
@@ -498,7 +498,7 @@ class DataInfo(object):
                 logger.notice("Run %s [%s]: Peak position: %s  Peak width: %s" %
                               (self.run_number, self.cross_section, peak_position, peak_width))
             except:
-                logger.notice(sys.exc_value)
+                logger.notice(str(sys.exc_value))
                 logger.notice("Run %s [%s]: Gaussian fit failed to determine peak position" %
                               (self.run_number, self.cross_section))
 


### PR DESCRIPTION
A mistake was made in error processing while moving MRInspectData from using `logging` to Mantid's `logger`. `logger.notice()` can only take a string and does not transform an object to a string.

**To test:**
- Inspect code.

**Release Notes** 

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
