### PR TITLE
Change conversion to seconds

### DIFF
--- a/scripts/FilterEvents/eventFilterGUI.py
+++ b/scripts/FilterEvents/eventFilterGUI.py
@@ -707,17 +707,13 @@ class MainWindow(QtGui.QMainWindow):
 
         #Convert absolute time to relative time in seconds
         t0 = self._dataWS.getRun().getProperty("proton_charge").times[0]
-        t0ns = t0.totalNanoseconds()
 
         # append 1 more log if original log only has 1 value
         tf = self._dataWS.getRun().getProperty("proton_charge").times[-1]
         vectimes.append(tf)
         vecvalue = numpy.append(vecvalue, vecvalue[-1])
 
-        vecreltimes = []
-        for t in vectimes:
-            rt = float(t.totalNanoseconds() - t0ns) * 1.0E-9
-            vecreltimes.append(rt)
+        vecreltimes = [float(t - t0) / numpy.timedelta64(1, 's') for t in vectimes]
 
         # Set to plot
         xlim = [min(vecreltimes), max(vecreltimes)]


### PR DESCRIPTION
`np.datetime64` has better methods than mantid's `DateAndTime` object so this uses those.

**To test:**

Try out the test from the original issue. 

Fixes #21935.

*Does not need to be in the release notes* because it fixes a bug introduced during this release cycle.
---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
