### PR TITLE
Removed temperature filtering from Muon Analysis

### DIFF
--- a/docs/source/release/v3.12.0/muon.rst
+++ b/docs/source/release/v3.12.0/muon.rst
@@ -14,6 +14,7 @@ MuSR Changes
 Bug Fixes
 ---------
 - :ref:`CalMuonDetectorPhases <algm-CalMuonDetectorPhases>` has had the sign of the phase shift changed, this produces data with a positive frequency spike as expected.
+- Log values are no longer filtered by start time when loaded into muon analysis.
 
 Interface
 ---------

--- a/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
@@ -176,7 +176,7 @@ void printRunInfo(MatrixWorkspace_sptr runWs, std::ostringstream &out) {
     auto Temp = run.getProperty("Temp_Sample");
     auto *log = dynamic_cast<TimeSeriesProperty<double> *>(Temp);
     auto logTemp = log->clone();
-    
+
     logTemp->filterByTime(start, end);
     double average = logTemp->timeAverageValue();
 

--- a/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
@@ -173,12 +173,11 @@ void printRunInfo(MatrixWorkspace_sptr runWs, std::ostringstream &out) {
   out << "\nAverage Temperature: ";
   if (run.hasProperty("Temp_Sample")) {
     // Filter the temperatures by the start and end times for the run.
-    auto Temp = run.getProperty("Temp_Sample");
-    auto *log = dynamic_cast<TimeSeriesProperty<double> *>(Temp);
-    auto logTemp = log->clone();
-
-    logTemp->filterByTime(start, end);
-    double average = logTemp->timeAverageValue();
+    Mantid::Kernel::SplittingInterval time_split(start, end);
+    std::vector<Mantid::Kernel::SplittingInterval> splitVector = {time_split};
+    auto Temp_Sample = run.getProperty("Temp_Sample");
+    auto *Temp_Sample_TimeSeries = dynamic_cast<TimeSeriesProperty<double> *>(Temp_Sample);
+    double average = Temp_Sample_TimeSeries->averageValueInFilter(splitVector);
 
     if (average != 0.0) {
       out << average;

--- a/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
@@ -168,20 +168,18 @@ void printRunInfo(MatrixWorkspace_sptr runWs, std::ostringstream &out) {
   // output this number to three decimal places
   out << std::setprecision(3);
   out << counts / 1000000 << " MEv";
-  out << std::setprecision(12);
   // Add average temperature.
   out << "\nAverage Temperature: ";
   if (run.hasProperty("Temp_Sample")) {
     // Filter the temperatures by the start and end times for the run.
     Mantid::Kernel::SplittingInterval time_split(start, end);
     std::vector<Mantid::Kernel::SplittingInterval> splitVector = {time_split};
-    auto Temp_Sample = run.getProperty("Temp_Sample");
-    const auto *Temp_Sample_TimeSeries =
-        dynamic_cast<const TimeSeriesProperty<double> *>(Temp_Sample);
-    double average = Temp_Sample_TimeSeries->averageValueInFilter(splitVector);
+    auto tempSample = run.getProperty("Temp_Sample");
+    const auto *tempSampleTimeSeries =
+        dynamic_cast<const TimeSeriesProperty<double> *>(tempSample);
 
-    if (average != 0.0) {
-      out << average;
+    if (tempSampleTimeSeries) {
+      out << tempSampleTimeSeries->averageValueInFilter(splitVector);
     } else {
       out << "Not set";
     }
@@ -193,7 +191,9 @@ void printRunInfo(MatrixWorkspace_sptr runWs, std::ostringstream &out) {
   // Could be stored as a double or as a string (range e.g. "1000.0 - 1020.0")
   out << "\nSample Temperature: ";
   if (run.hasProperty("sample_temp")) {
-    out << run.getProperty("sample_temp")->value();
+    //extract as string, then convert to double to allow precision to apply
+    std::string valueAsString = run.getProperty("sample_temp")->value();
+    out << std::stod(valueAsString);
   } else {
     out << "Not found";
   }
@@ -202,7 +202,8 @@ void printRunInfo(MatrixWorkspace_sptr runWs, std::ostringstream &out) {
   // Could be stored as a double or as a string (range e.g. "1000.0 - 1020.0")
   out << "\nSample Magnetic Field: ";
   if (run.hasProperty("sample_magn_field")) {
-    out << run.getProperty("sample_magn_field")->value();
+    std::string valueAsString = run.getProperty("sample_magn_field")->value();
+    out << std::stod(valueAsString);
   } else {
     out << "Not found";
   }

--- a/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
@@ -172,8 +172,12 @@ void printRunInfo(MatrixWorkspace_sptr runWs, std::ostringstream &out) {
   // Add average temperature.
   out << "\nAverage Temperature: ";
   if (run.hasProperty("Temp_Sample")) {
+    // Filter the temperatures by the start and end times for the run.
+    Mantid::API::Run runTemp(run);
+    runTemp.getProperty("Temp_Sample")->filterByTime(start, end);
+
     // Get average of the values
-    double average = run.getPropertyAsSingleValue("Temp_Sample");
+    double average = runTemp.getPropertyAsSingleValue("Temp_Sample");
 
     if (average != 0.0) {
       out << average;

--- a/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
@@ -176,7 +176,8 @@ void printRunInfo(MatrixWorkspace_sptr runWs, std::ostringstream &out) {
     Mantid::Kernel::SplittingInterval time_split(start, end);
     std::vector<Mantid::Kernel::SplittingInterval> splitVector = {time_split};
     auto Temp_Sample = run.getProperty("Temp_Sample");
-    auto *Temp_Sample_TimeSeries = dynamic_cast<TimeSeriesProperty<double> *>(Temp_Sample);
+    const auto *Temp_Sample_TimeSeries =
+        dynamic_cast<const TimeSeriesProperty<double> *>(Temp_Sample);
     double average = Temp_Sample_TimeSeries->averageValueInFilter(splitVector);
 
     if (average != 0.0) {

--- a/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
@@ -191,12 +191,12 @@ void printRunInfo(MatrixWorkspace_sptr runWs, std::ostringstream &out) {
   // Could be stored as a double or as a string (range e.g. "1000.0 - 1020.0")
   out << "\nSample Temperature: ";
   if (run.hasProperty("sample_temp")) {
-    //extract as string, then convert to double to allow precision to apply
+    // extract as string, then convert to double to allow precision to apply
     std::string valueAsString = run.getProperty("sample_temp")->value();
     try {
       out << std::stod(valueAsString);
-    } catch (const std::invalid_argument&) {
-      //problem converting to double, output as string
+    } catch (const std::invalid_argument &) {
+      // problem converting to double, output as string
       out << valueAsString;
     }
   } else {
@@ -207,12 +207,12 @@ void printRunInfo(MatrixWorkspace_sptr runWs, std::ostringstream &out) {
   // Could be stored as a double or as a string (range e.g. "1000.0 - 1020.0")
   out << "\nSample Magnetic Field: ";
   if (run.hasProperty("sample_magn_field")) {
-    //extract as string, then convert to double to allow precision to apply
+    // extract as string, then convert to double to allow precision to apply
     std::string valueAsString = run.getProperty("sample_magn_field")->value();
     try {
       out << std::stod(valueAsString);
-    } catch (const std::invalid_argument&) {
-      //problem converting to double, output as string
+    } catch (const std::invalid_argument &) {
+      // problem converting to double, output as string
       out << valueAsString;
     }
   } else {

--- a/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
@@ -173,11 +173,12 @@ void printRunInfo(MatrixWorkspace_sptr runWs, std::ostringstream &out) {
   out << "\nAverage Temperature: ";
   if (run.hasProperty("Temp_Sample")) {
     // Filter the temperatures by the start and end times for the run.
-    Mantid::API::Run runTemp(run);
-    runTemp.getProperty("Temp_Sample")->filterByTime(start, end);
-
-    // Get average of the values
-    double average = runTemp.getPropertyAsSingleValue("Temp_Sample");
+    auto Temp = run.getProperty("Temp_Sample");
+    auto *log = dynamic_cast<TimeSeriesProperty<double> *>(Temp);
+    auto logTemp = log->clone();
+    
+    logTemp->filterByTime(start, end);
+    double average = logTemp->timeAverageValue();
 
     if (average != 0.0) {
       out << average;

--- a/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
@@ -172,9 +172,6 @@ void printRunInfo(MatrixWorkspace_sptr runWs, std::ostringstream &out) {
   // Add average temperature.
   out << "\nAverage Temperature: ";
   if (run.hasProperty("Temp_Sample")) {
-    // Filter the temperatures by the start and end times for the run.
-    run.getProperty("Temp_Sample")->filterByTime(start, end);
-
     // Get average of the values
     double average = run.getPropertyAsSingleValue("Temp_Sample");
 

--- a/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
@@ -193,7 +193,12 @@ void printRunInfo(MatrixWorkspace_sptr runWs, std::ostringstream &out) {
   if (run.hasProperty("sample_temp")) {
     //extract as string, then convert to double to allow precision to apply
     std::string valueAsString = run.getProperty("sample_temp")->value();
-    out << std::stod(valueAsString);
+    try {
+      out << std::stod(valueAsString);
+    } catch (const std::invalid_argument&) {
+      //problem converting to double, output as string
+      out << valueAsString;
+    }
   } else {
     out << "Not found";
   }
@@ -202,8 +207,14 @@ void printRunInfo(MatrixWorkspace_sptr runWs, std::ostringstream &out) {
   // Could be stored as a double or as a string (range e.g. "1000.0 - 1020.0")
   out << "\nSample Magnetic Field: ";
   if (run.hasProperty("sample_magn_field")) {
+    //extract as string, then convert to double to allow precision to apply
     std::string valueAsString = run.getProperty("sample_magn_field")->value();
-    out << std::stod(valueAsString);
+    try {
+      out << std::stod(valueAsString);
+    } catch (const std::invalid_argument&) {
+      //problem converting to double, output as string
+      out << valueAsString;
+    }
   } else {
     out << "Not found";
   }


### PR DESCRIPTION
The muon Analysis interface was filtering the temperature sample logs for some data and not for others. This removes the temperature filtering from all cases.

**To test:**

- Open muon analysis
- Load MUSR 67909
- Look at the Temp_sample of the sample logs (has data for t<0)
- go to the settings tab and make sure multi fitting is ticked
- Go to data analysis and some new groups will be added to the ADS - these will have sample logs with values for t<0

<!-- Instructions for testing. -->

Fixes #21827. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

[Release Notes](/mantidproject/mantid/commit/ea58511ede53cab0481c900429ccfc3ba83d27eb) 


<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
