### PR TITLE
Remove ties when function is removed.

### DIFF
--- a/Framework/API/src/ParameterTie.cpp
+++ b/Framework/API/src/ParameterTie.cpp
@@ -165,17 +165,20 @@ std::string ParameterTie::asString(const IFunction *fun) const {
     }
     res_expression.append(start, end);
   } catch (...) { // parameters are not from function fun
-    res_expression = "";
+    throw std::logic_error("Corrupted tie " + m_expression + " in function " + getLocalFunction()->name());
   }
   return res_expression;
 }
 
-/** This method takes a list of double pointers and checks if any of them match
- * to the variables defined in the internal mu::Parser
+/** This method checks if any of the parameters of a function is used in the tie.
  * @param fun :: A function
- * @return True if any of the parameters is used as a variable in the mu::Parser
+ * @return True if any of the parameters is used as a variable in the mu::Parser or
+ *  it is the tied parameter.
  */
 bool ParameterTie::findParametersOf(const IFunction *fun) const {
+  if (getLocalFunction() == fun) {
+    return true;
+  }
   for (const auto &varPair : m_varMap) {
     if (varPair.second.isParameterOf(fun)) {
       return true;

--- a/Framework/API/src/ParameterTie.cpp
+++ b/Framework/API/src/ParameterTie.cpp
@@ -165,15 +165,17 @@ std::string ParameterTie::asString(const IFunction *fun) const {
     }
     res_expression.append(start, end);
   } catch (...) { // parameters are not from function fun
-    throw std::logic_error("Corrupted tie " + m_expression + " in function " + getLocalFunction()->name());
+    throw std::logic_error("Corrupted tie " + m_expression + " in function " +
+                           getLocalFunction()->name());
   }
   return res_expression;
 }
 
-/** This method checks if any of the parameters of a function is used in the tie.
+/** This method checks if any of the parameters of a function is used in the
+ * tie.
  * @param fun :: A function
- * @return True if any of the parameters is used as a variable in the mu::Parser or
- *  it is the tied parameter.
+ * @return True if any of the parameters is used as a variable in the mu::Parser
+ * or it is the tied parameter.
  */
 bool ParameterTie::findParametersOf(const IFunction *fun) const {
   if (getLocalFunction() == fun) {

--- a/Framework/API/test/CompositeFunctionTest.h
+++ b/Framework/API/test/CompositeFunctionTest.h
@@ -781,6 +781,20 @@ public:
     delete mfun;
   }
 
+  void test_removeFunction_removes_tie() {
+    CompositeFunction mfun;
+    IFunction_sptr g1 = IFunction_sptr(new Gauss());
+    IFunction_sptr g2 = IFunction_sptr(new Gauss());
+
+    mfun.addFunction(g1);
+    mfun.addFunction(g2);
+
+    mfun.tie("f0.h", "1-f1.h");
+    mfun.removeFunction(0);
+    TS_ASSERT_EQUALS(mfun.writeTies(), "");
+
+  }
+
   // replacing function has fewer parameters
   void testReplaceFunction() {
     IFunction_sptr g1 = IFunction_sptr(new Gauss());

--- a/Framework/API/test/CompositeFunctionTest.h
+++ b/Framework/API/test/CompositeFunctionTest.h
@@ -792,7 +792,6 @@ public:
     mfun.tie("f0.h", "1-f1.h");
     mfun.removeFunction(0);
     TS_ASSERT_EQUALS(mfun.writeTies(), "");
-
   }
 
   // replacing function has fewer parameters

--- a/Framework/API/test/ParameterTieTest.h
+++ b/Framework/API/test/ParameterTieTest.h
@@ -179,25 +179,25 @@ public:
     TS_ASSERT_EQUALS(tie1.asString(mf2.get()), "f0.sig=sin(f0.sig)+f1.cen/2");
 
     ParameterTie tie2(&mfun, "f1.f0.sig", "123.4");
-    TS_ASSERT_EQUALS(tie2.asString(mf1.get()), "");
+    TS_ASSERT_THROWS(tie2.asString(mf1.get()), std::logic_error);
     TS_ASSERT_EQUALS(tie2.asString(&mfun), "f1.f0.sig=123.4");
     TS_ASSERT_EQUALS(tie2.asString(mf2.get()), "f0.sig=123.4");
     TS_ASSERT_EQUALS(tie2.asString(g1.get()), "sig=123.4");
 
     ParameterTie tie3(g1.get(), "sig", "123.4");
-    TS_ASSERT_EQUALS(tie3.asString(mf1.get()), "");
+    TS_ASSERT_THROWS(tie3.asString(mf1.get()), std::logic_error);
     TS_ASSERT_EQUALS(tie3.asString(&mfun), "f1.f0.sig=123.4");
     TS_ASSERT_EQUALS(tie3.asString(mf2.get()), "f0.sig=123.4");
     TS_ASSERT_EQUALS(tie3.asString(g1.get()), "sig=123.4");
 
     ParameterTie tie4(mf2.get(), "f0.sig", "123.4");
-    TS_ASSERT_EQUALS(tie4.asString(mf1.get()), "");
+    TS_ASSERT_THROWS(tie4.asString(mf1.get()), std::logic_error);
     TS_ASSERT_EQUALS(tie4.asString(&mfun), "f1.f0.sig=123.4");
     TS_ASSERT_EQUALS(tie4.asString(mf2.get()), "f0.sig=123.4");
     TS_ASSERT_EQUALS(tie4.asString(g1.get()), "sig=123.4");
 
     ParameterTie tie5(nth.get(), "a", "cos(B1e2Ta_)-sin(alpha12)");
-    TS_ASSERT_EQUALS(tie5.asString(mf1.get()), "");
+    TS_ASSERT_THROWS(tie5.asString(mf1.get()), std::logic_error);
     TS_ASSERT_EQUALS(tie5.asString(&mfun),
                      "f1.f2.a=cos(f1.f2.B1e2Ta_)-sin(f1.f2.alpha12)");
     TS_ASSERT_EQUALS(tie5.asString(mf2.get()),


### PR DESCRIPTION
The method that checks if parameters of a function removed from a composite function are involved in a tie didn't check for the tied parameter itself. Now it checks.

**To test:**

Instructions are in the issue description.

Fixes #21919.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
