### PR TITLE
SANS GUI V2 Enable buttons on failure

### DIFF
--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -304,6 +304,7 @@ class RunTabPresenter(object):
 
         except Exception as e:
             self._view.halt_process_flag()
+            self._view.enable_buttons()
             self.sans_logger.error("Process halted due to: {}".format(str(e)))
 
     def on_processing_finished(self):


### PR DESCRIPTION
Description of work.

Steps to reproduce the behavior see issue #21948 

    Set the instrument to SANS2D
    Use the loqdemo data from #21799
    Add the extracted directory to the mantid directories path
    Load the user file "MaskFile.txt"
    Load the batch file "batch_mode_reduction.csv"
    Click process
    The processing fails because it is the wrong instrument but the user file/batch file and process buttons at the top are left disabled.

**To test:**

Do the steps described above and confirm that the buttons on the top of the GUI remain functional.

<!-- Instructions for testing. -->

Fixes #21948. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
No release notes needed as fixes a bug introduced with this release.
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
