### PR TITLE
Indirect  - Files update when instrument is selected

### DIFF
--- a/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.cpp
@@ -65,12 +65,12 @@ void IndirectDiffractionReduction::initLayout() {
                                         const QString &)));
 
   // Update run button based on state of raw files field
-  connect(m_uiForm.rfSampleFiles, SIGNAL(fileTextChanged(const QString &)),
-          this, SLOT(runFilesChanged()));
-  connect(m_uiForm.rfSampleFiles, SIGNAL(findingFiles()), this,
-          SLOT(runFilesFinding()));
-  connect(m_uiForm.rfSampleFiles, SIGNAL(fileFindingFinished()), this,
-          SLOT(runFilesFound()));
+  connectRunButtonValidation(m_uiForm.rfSampleFiles);
+  connectRunButtonValidation(m_uiForm.rfCanFiles);
+  connectRunButtonValidation(m_uiForm.rfCalFile);
+  connectRunButtonValidation(m_uiForm.rfCalFile_only);
+  connectRunButtonValidation(m_uiForm.rfVanadiumFile);
+  connectRunButtonValidation(m_uiForm.rfVanFile_only);
 
   m_valDbl = new QDoubleValidator(this);
 
@@ -100,6 +100,18 @@ void IndirectDiffractionReduction::initLayout() {
 
   // Update instrument dependant widgets
   m_uiForm.iicInstrumentConfiguration->newInstrumentConfiguration();
+}
+
+/**
+* Make file finding status display on the run button and enable/disable it
+*/
+void IndirectDiffractionReduction::connectRunButtonValidation(const MantidQt::API::MWRunFiles *file_field) {
+  connect(file_field, SIGNAL(fileTextChanged(const QString &)),
+    this, SLOT(runFilesChanged()));
+  connect(file_field, SIGNAL(findingFiles()), this,
+    SLOT(runFilesFinding()));
+  connect(file_field, SIGNAL(fileFindingFinished()), this,
+    SLOT(runFilesFound()));
 }
 
 /**
@@ -624,7 +636,7 @@ void IndirectDiffractionReduction::instrumentSelected(
   // Set the search instrument for runs
   m_uiForm.rfSampleFiles->setInstrumentOverride(instrumentName);
   m_uiForm.rfCanFiles->setInstrumentOverride(instrumentName);
-  m_uiForm.rfVanFile_only->setInstrumentOverride(instrumentName);
+  m_uiForm.rfVanadiumFile->setInstrumentOverride(instrumentName);
 
   MatrixWorkspace_sptr instWorkspace = loadInstrument(
       instrumentName.toStdString(), reflectionName.toStdString());

--- a/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.cpp
@@ -105,13 +105,13 @@ void IndirectDiffractionReduction::initLayout() {
 /**
 * Make file finding status display on the run button and enable/disable it
 */
-void IndirectDiffractionReduction::connectRunButtonValidation(const MantidQt::API::MWRunFiles *file_field) {
-  connect(file_field, SIGNAL(fileTextChanged(const QString &)),
-    this, SLOT(runFilesChanged()));
-  connect(file_field, SIGNAL(findingFiles()), this,
-    SLOT(runFilesFinding()));
+void IndirectDiffractionReduction::connectRunButtonValidation(
+    const MantidQt::API::MWRunFiles *file_field) {
+  connect(file_field, SIGNAL(fileTextChanged(const QString &)), this,
+          SLOT(runFilesChanged()));
+  connect(file_field, SIGNAL(findingFiles()), this, SLOT(runFilesFinding()));
   connect(file_field, SIGNAL(fileFindingFinished()), this,
-    SLOT(runFilesFound()));
+          SLOT(runFilesFound()));
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.h
@@ -72,6 +72,7 @@ private:
                  const std::string &reflection = "");
 
   void runGenericReduction(QString instName, QString mode);
+  void connectRunButtonValidation(const MantidQt::API::MWRunFiles *file_field);
   void runOSIRISdiffonlyReduction();
   void createGroupingWorkspace(const std::string &outputWsName);
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MWRunFiles.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MWRunFiles.h
@@ -231,9 +231,6 @@ private:
   void setValidatorDisplay(bool display);
   /// gets text to use for find files search parameters
   const QString findFilesGetSearchText(QString &searchText);
-  /// Checks if the find files search text is a directory and handles relevant
-  /// errors
-  boost::optional<QString> findFilesDirectory(const QString &searchText);
   /// handles findFiles background thread
   void runFindFiles(const QString &searchText);
   /// Helper method to create a FindFilesSearchParameters object

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MWRunFiles.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MWRunFiles.h
@@ -229,11 +229,12 @@ private:
   void refreshValidator();
   /// Turn on/off display of validator red star (default is on)
   void setValidatorDisplay(bool display);
-  ///gets text to use for find files search parameters
+  /// gets text to use for find files search parameters
   const QString findFilesGetSearchText(QString &searchText);
-  ///Checks if the find files search text is a directory and handles relevant errors 
+  /// Checks if the find files search text is a directory and handles relevant
+  /// errors
   boost::optional<QString> findFilesDirectory(const QString &searchText);
-  ///handles findFiles background thread
+  /// handles findFiles background thread
   void runFindFiles(const QString &searchText);
   /// Helper method to create a FindFilesSearchParameters object
   FindFilesSearchParameters

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MWRunFiles.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MWRunFiles.h
@@ -11,6 +11,7 @@
 #include <QString>
 #include <QStringList>
 #include <boost/shared_ptr.hpp>
+#include <boost/optional.hpp>
 
 namespace Mantid {
 namespace API {
@@ -196,8 +197,10 @@ public slots:
   void setFileTextWithoutSearch(const QString &text);
   /// Clear the search from the widget
   void clear();
-  /// Find the files within the text edit field and cache their full paths
+  /// Find the files if the text edit field is modified
   void findFiles();
+  /// Find the files within the text edit field and cache their full paths
+  void findFiles(bool isModified);
   boost::shared_ptr<const Mantid::API::IAlgorithm> stopLiveAlgorithm();
 
 public:
@@ -226,6 +229,12 @@ private:
   void refreshValidator();
   /// Turn on/off display of validator red star (default is on)
   void setValidatorDisplay(bool display);
+  ///gets text to use for find files search parameters
+  const QString findFilesGetSearchText(QString &searchText);
+  ///Checks if the find files search text is a directory and handles relevant errors 
+  boost::optional<QString> findFilesDirectory(const QString &searchText);
+  ///handles findFiles background thread
+  void runFindFiles(const QString &searchText);
   /// Helper method to create a FindFilesSearchParameters object
   FindFilesSearchParameters
   createFindFilesSearchParameters(const std::string &text) const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MWRunFiles.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MWRunFiles.h
@@ -175,7 +175,7 @@ signals:
   void fileTextChanged(const QString &);
   /// Emitted when the editing has finished
   void fileEditingFinished();
-  // Emitted when files finding starts.
+  /// Emitted when files finding starts.
   void findingFiles();
   /// Emitted when files have been found
   void filesFound();

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MWRunFiles.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MWRunFiles.h
@@ -11,7 +11,6 @@
 #include <QString>
 #include <QStringList>
 #include <boost/shared_ptr.hpp>
-#include <boost/optional.hpp>
 
 namespace Mantid {
 namespace API {

--- a/qt/widgets/common/src/MWRunFiles.cpp
+++ b/qt/widgets/common/src/MWRunFiles.cpp
@@ -524,15 +524,18 @@ void MWRunFiles::findFiles(bool isModified) {
   const auto directory = findFilesDirectory(searchText);
 
   // Set the values for the thread, and start it running.
-  if (directory)
-    m_foundFiles.append(directory.get());
-  else {
+  if (directory) {
+    if (directory.get().isEmpty())
+      return;
+    else
+      m_foundFiles.append(directory.get());
+  } else {
     if (isModified) {
       // Reset modified flag.
       m_uiForm.fileEditor->setModified(false);
       searchText = findFilesGetSearchText(searchText);
+      runFindFiles(searchText);
     }
-    runFindFiles(searchText);
   }
 }
 
@@ -592,6 +595,7 @@ MWRunFiles::findFilesDirectory(const QString &searchText) {
       setFileProblem("");
       return searchText;
     }
+    return "";
   }
   return boost::none;
 }

--- a/qt/widgets/common/src/MWRunFiles.cpp
+++ b/qt/widgets/common/src/MWRunFiles.cpp
@@ -538,6 +538,9 @@ void MWRunFiles::findFiles(bool isModified) {
     m_uiForm.fileEditor->setModified(false);
     searchText = findFilesGetSearchText(searchText);
     runFindFiles(searchText);
+  } else {
+    // Make sure errors are correctly set if we didn't run
+    inspectThreadResult(m_cachedResults);
   }
 }
 
@@ -586,15 +589,10 @@ const QString MWRunFiles::findFilesGetSearchText(QString &searchText) {
 * @param searchText :: text to create search parameters from
 */
 void MWRunFiles::runFindFiles(const QString &searchText) {
-
   if (!searchText.isEmpty()) {
     const auto parameters =
         createFindFilesSearchParameters(searchText.toStdString());
     m_pool.createWorker(this, parameters);
-
-  } else {
-    // Make sure errors are correctly set if we didn't run
-    inspectThreadResult(m_cachedResults);
   }
 }
 

--- a/qt/widgets/common/src/MWRunFiles.cpp
+++ b/qt/widgets/common/src/MWRunFiles.cpp
@@ -46,7 +46,7 @@ MWRunFiles::MWRunFiles(QWidget *parent)
   connect(m_uiForm.fileEditor, SIGNAL(textChanged(const QString &)), this,
           SIGNAL(fileTextChanged(const QString &)));
   connect(m_uiForm.fileEditor, SIGNAL(editingFinished()), this,
-          SIGNAL(fileEditingFinished()));
+    SIGNAL(fileEditingFinished()));
   connect(m_uiForm.browseBtn, SIGNAL(clicked()), this, SLOT(browseClicked()));
   connect(m_uiForm.browseIco, SIGNAL(clicked()), this, SLOT(browseClicked()));
 
@@ -514,9 +514,7 @@ void MWRunFiles::clear() {
 /**
 * Finds the files if the user has changed the parameter text.
 */
-void MWRunFiles::findFiles() {
-  findFiles(m_uiForm.fileEditor->isModified());
-}
+void MWRunFiles::findFiles() { findFiles(m_uiForm.fileEditor->isModified()); }
 
 /**
 * Finds the files specified by the user in a background thread.
@@ -553,12 +551,11 @@ const QString MWRunFiles::findFilesGetSearchText(QString &searchText) {
     // Regex to match a selection of run numbers as defined here:
     // mantidproject.org/MultiFileLoading
     // Also allowing spaces between delimiters as this seems to work fine
-    const std::string runNumberString =
-      "([0-9]+)([:+-] ?[0-9]+)? ?(:[0-9]+)?";
+    const std::string runNumberString = "([0-9]+)([:+-] ?[0-9]+)? ?(:[0-9]+)?";
     boost::regex runNumbers(runNumberString, boost::regex::extended);
     // Regex to match a list of run numbers delimited by commas
     const std::string runListString =
-      "(" + runNumberString + ")(, ?(" + runNumberString + "))*";
+        "(" + runNumberString + ")(, ?(" + runNumberString + "))*";
     boost::regex runNumberList(runListString, boost::regex::extended);
 
     // See if we can just prepend the instrument and be done
@@ -580,17 +577,18 @@ const QString MWRunFiles::findFilesGetSearchText(QString &searchText) {
 }
 
 /**
-* Checks if the find files search text is a directory and handles relevant errors
+* Checks if the find files search text is a directory and handles relevant
+* errors
 * @param searchText :: text entered by user
 * @return string to append to foundFiles or none
 */
-boost::optional<QString> MWRunFiles::findFilesDirectory(const QString &searchText) {
+boost::optional<QString>
+MWRunFiles::findFilesDirectory(const QString &searchText) {
   if (m_isForDirectory) {
     m_foundFiles.clear();
     if (searchText.isEmpty()) {
       setFileProblem("A directory must be provided");
-    }
-    else {
+    } else {
       setFileProblem("");
       return searchText;
     }
@@ -600,22 +598,20 @@ boost::optional<QString> MWRunFiles::findFilesDirectory(const QString &searchTex
 
 /**
 * creates background thread for find files
-* @param searchText :: text to create search parameters from 
+* @param searchText :: text to create search parameters from
 */
 void MWRunFiles::runFindFiles(const QString &searchText) {
 
   if (!searchText.isEmpty()) {
     const auto parameters =
-      createFindFilesSearchParameters(searchText.toStdString());
+        createFindFilesSearchParameters(searchText.toStdString());
     m_pool.createWorker(this, parameters);
 
-  }
-  else {
+  } else {
     // Make sure errors are correctly set if we didn't run
     inspectThreadResult(m_cachedResults);
   }
 }
-
 
 /** Calls cancel on a running instance of MonitorLiveData.
  *  Requires that a handle to the MonitorLiveData instance has been set via

--- a/qt/widgets/common/src/MWRunFiles.cpp
+++ b/qt/widgets/common/src/MWRunFiles.cpp
@@ -595,7 +595,7 @@ MWRunFiles::findFilesDirectory(const QString &searchText) {
       setFileProblem("");
       return searchText;
     }
-    return "";
+    return QString("");
   }
   return boost::none;
 }

--- a/qt/widgets/common/src/MWRunFiles.cpp
+++ b/qt/widgets/common/src/MWRunFiles.cpp
@@ -46,7 +46,7 @@ MWRunFiles::MWRunFiles(QWidget *parent)
   connect(m_uiForm.fileEditor, SIGNAL(textChanged(const QString &)), this,
           SIGNAL(fileTextChanged(const QString &)));
   connect(m_uiForm.fileEditor, SIGNAL(editingFinished()), this,
-    SIGNAL(fileEditingFinished()));
+          SIGNAL(fileEditingFinished()));
   connect(m_uiForm.browseBtn, SIGNAL(clicked()), this, SLOT(browseClicked()));
   connect(m_uiForm.browseIco, SIGNAL(clicked()), this, SLOT(browseClicked()));
 

--- a/qt/widgets/common/src/MWRunFiles.cpp
+++ b/qt/widgets/common/src/MWRunFiles.cpp
@@ -521,21 +521,23 @@ void MWRunFiles::findFiles() { findFiles(m_uiForm.fileEditor->isModified()); }
 */
 void MWRunFiles::findFiles(bool isModified) {
   auto searchText = m_uiForm.fileEditor->text();
-  const auto directory = findFilesDirectory(searchText);
 
-  // Set the values for the thread, and start it running.
-  if (directory) {
-    if (directory.get().isEmpty())
-      return;
-    else
-      m_foundFiles.append(directory.get());
-  } else {
-    if (isModified) {
-      // Reset modified flag.
-      m_uiForm.fileEditor->setModified(false);
-      searchText = findFilesGetSearchText(searchText);
-      runFindFiles(searchText);
+  if (m_isForDirectory) {
+    m_foundFiles.clear();
+    if (searchText.isEmpty()) {
+      setFileProblem("A directory must be provided");
+    } else {
+      setFileProblem("");
+      m_foundFiles.append(searchText);
     }
+    return;
+  }
+
+  if (isModified) {
+    // Reset modified flag.
+    m_uiForm.fileEditor->setModified(false);
+    searchText = findFilesGetSearchText(searchText);
+    runFindFiles(searchText);
   }
 }
 
@@ -577,27 +579,6 @@ const QString MWRunFiles::findFilesGetSearchText(QString &searchText) {
     }
   }
   return searchText;
-}
-
-/**
-* Checks if the find files search text is a directory and handles relevant
-* errors
-* @param searchText :: text entered by user
-* @return string to append to foundFiles or none
-*/
-boost::optional<QString>
-MWRunFiles::findFilesDirectory(const QString &searchText) {
-  if (m_isForDirectory) {
-    m_foundFiles.clear();
-    if (searchText.isEmpty()) {
-      setFileProblem("A directory must be provided");
-    } else {
-      setFileProblem("");
-      return searchText;
-    }
-    return QString("");
-  }
-  return boost::none;
 }
 
 /**


### PR DESCRIPTION
MWRunFiles did not re-find files after the instrument selection was changed. This caused a bug in the diffraction reduction interface.

**To test:**

- Navigate to Interfaces -> Indirect -> Diffraction
- Ensure Instrument Selection is **not** OSIRIS (If it is then change it)
- Enter 119976, 119977, 119981 as the Run numbers.
- Enter 71988, 71991, 71990 into the 'Container' field.
- Change the instrument selection to OSIRIS (the run button at the bottom should change to 'Finding files' briefly).
- Enter 119965, 119967 into the 'Vanadium' field.
- Enter calibration file [osiris_041_RES10.zip](https://github.com/mantidproject/mantid/files/1784938/osiris_041_RES10.zip)
- Click 'Run'
- Should run without errors and give *_dRange and *_tof workspaces in the ADS

Fixes #21634

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
