### PR TITLE
Fix LiquidsReflectometryReductionTest on Windows

### DIFF
--- a/Testing/SystemTests/tests/analysis/LiquidsReflectometryReductionTest.py
+++ b/Testing/SystemTests/tests/analysis/LiquidsReflectometryReductionTest.py
@@ -95,11 +95,13 @@ class LRReflectivityOutputTest(stresstesting.MantidStressTest):
         # Read in the first line of the output file to determine success
         self._success = False
         if os.path.isfile(output_path):
-            fd = open(output_path, 'r')
-            content = fd.read()
-            if content.startswith('# Experiment IPTS-11601 Run 119814'):
-                self._success = True
+            with open(output_path, 'r') as fd:
+                content = fd.read()
+                if content.startswith('# Experiment IPTS-11601 Run 119814'):
+                    self._success = True
             os.remove(output_path)
+        else:
+            print("Error: expected output file '{}' not found.".format(output_path))
 
     def validate(self):
         return self._success


### PR DESCRIPTION
Description of work.

Closes a file handle before attempting to delete the file. The [system test](http://builds.mantidproject.org/view/Master%20Pipeline/job/master_systemtests-win7/570/testReport/junit/SystemTests/LiquidsReflectometryReductionTest/LRReflectivityOutputTest/) is currently failing on both `master` and the release branch because it is trying to delete a file that is still open.

**To test:**

This should be verified on Windows.

Run the system test `LRReflectivityOutputTest`:

* `systemtest -C Release -R LRReflectivityOutputTest`
* the test should pass

*No issue*

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
