### PR TITLE
Fix tab ordering in Isis SANS

### DIFF
--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -207,17 +207,17 @@ class SANSDataProcessorGui(QtGui.QMainWindow, ui_sans_data_processor_window.Ui_S
         settings_icon = QtGui.QIcon(settings_icon_path)
         _ = QtGui.QListWidgetItem(settings_icon, "Settings", self.tab_choice_list)  # noqa
 
+        centre_icon_path = os.path.join(path, "icons", "centre.png")
+        centre_icon = QtGui.QIcon(centre_icon_path)
+        _ = QtGui.QListWidgetItem(centre_icon, "Beam Centre", self.tab_choice_list)  # noqa
+
         add_runs_page_icon_path = os.path.join(path, "icons", "sum.png")
         add_runs_page_icon = QtGui.QIcon(add_runs_page_icon_path)
         _ = QtGui.QListWidgetItem(add_runs_page_icon, "Sum Runs", self.tab_choice_list)  # noqa
 
-        settings_icon_path = os.path.join(path, "icons", "centre.png")
-        settings_icon = QtGui.QIcon(settings_icon_path)
-        _ = QtGui.QListWidgetItem(settings_icon, "Beam Centre", self.tab_choice_list)  # noqa
-
-        settings_icon_path = os.path.join(path, "icons", "diagnostic.png")
-        settings_icon = QtGui.QIcon(settings_icon_path)
-        _ = QtGui.QListWidgetItem(settings_icon, "Diagnostic Page", self.tab_choice_list)  # noqa
+        diagnostic_icon_path = os.path.join(path, "icons", "diagnostic.png")
+        diagnostic_icon = QtGui.QIcon(diagnostic_icon_path)
+        _ = QtGui.QListWidgetItem(diagnostic_icon, "Diagnostic Page", self.tab_choice_list)  # noqa
 
         # Set the 0th row enabled
         self.tab_choice_list.setCurrentRow(0)

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
@@ -433,7 +433,6 @@ QGroupBox::title {
           </item>
          </layout>
         </widget>
-        <widget class="AddRunsPage" name="add_runs_page"/>
         <widget class="QWidget" name="settings_page">
          <layout class="QHBoxLayout" name="horizontalLayout">
           <item>
@@ -2009,6 +2008,7 @@ QGroupBox::title {
          </layout>
         </widget>
         <widget class="BeamCentre" name="beam_centre"/>
+        <widget class="AddRunsPage" name="add_runs_page"/>
         <widget class="DiagnosticsPage" name="diagnostic_page"/>
        </widget>
       </item>


### PR DESCRIPTION
On the release branch the tab ordering on the left hand side of the SANS GUI currently does not correspond to the pages shown with settings displaying the add runs tab and add runs displaying the settings tab.

**To test:**
Check that the Correct tabs are displayed for the correct selections. What the various tabs should look like can be found here https://github.com/mantidproject/mantid/blob/master/docs/source/interfaces/ISIS%20SANS%20v2.rst.
<!-- Instructions for testing. -->

**Release Notes** 
Bug introduced in this release so no notes.
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
