### PR TITLE
Fix DirectToolsTest for matplotlib v2

### DIFF
--- a/scripts/test/directtools/DirectToolsTest.py
+++ b/scripts/test/directtools/DirectToolsTest.py
@@ -259,8 +259,10 @@ class DirectTest(unittest.TestCase):
         ws = CreateWorkspace(DataX=xs, DataY=ys, NSpec=1, StoreInADS=False)
         kwargs = {'workspaces': ws}
         figure, axes = testhelpers.assertRaisesNothing(self, directtools.plotprofiles, **kwargs)
-        # For some reason one plotting operation creates three lines on the axes.
-        self.assertEqual(len(axes.get_lines()), 3)
+        self.assertEquals(axes.get_xlabel(), '')
+        self.assertEquals(axes.get_ylabel(), '$S(Q,E)$')
+        numpy.testing.assert_equal(axes.get_lines()[0].get_data()[0], (xs[1:] + xs[:-1])/2)
+        numpy.testing.assert_equal(axes.get_lines()[0].get_data()[1], ys)
 
     def test_plotprofiles_DeltaEXUnitsExecutes(self):
         xs = numpy.linspace(-3., 10., 12)
@@ -268,7 +270,10 @@ class DirectTest(unittest.TestCase):
         ws = CreateWorkspace(DataX=xs, DataY=ys, NSpec=1, UnitX='DeltaE', StoreInADS=False)
         kwargs = {'workspaces': ws}
         figure, axes = testhelpers.assertRaisesNothing(self, directtools.plotprofiles, **kwargs)
-        self.assertEqual(len(axes.get_lines()), 3)
+        self.assertEquals(axes.get_xlabel(), 'Energy (meV)')
+        self.assertEquals(axes.get_ylabel(), '$S(Q,E)$')
+        numpy.testing.assert_equal(axes.get_lines()[0].get_data()[0], (xs[1:] + xs[:-1])/2)
+        numpy.testing.assert_equal(axes.get_lines()[0].get_data()[1], ys)
 
     def test_plotprofiles_MomentumTransferXUnitsExecutes(self):
         xs = numpy.linspace(-3., 10., 12)
@@ -276,7 +281,10 @@ class DirectTest(unittest.TestCase):
         ws = CreateWorkspace(DataX=xs, DataY=ys, NSpec=1, UnitX='MomentumTransfer', StoreInADS=False)
         kwargs = {'workspaces': ws}
         figure, axes = testhelpers.assertRaisesNothing(self, directtools.plotprofiles, **kwargs)
-        self.assertEqual(len(axes.get_lines()), 3)
+        self.assertEquals(axes.get_xlabel(), '$Q$ (\\AA$^{-1}$)')
+        self.assertEquals(axes.get_ylabel(), '$S(Q,E)$')
+        numpy.testing.assert_equal(axes.get_lines()[0].get_data()[0], (xs[1:] + xs[:-1])/2)
+        numpy.testing.assert_equal(axes.get_lines()[0].get_data()[1], ys)
 
     def test_plotSofQW(self):
         ws = LoadILLTOF('ILL/IN4/084446.nxs')


### PR DESCRIPTION
The behaviour of axes.errorbar change at some point in matplotlib v2 to add only 1 Line2D object not 3.

The DirectTools unittests fail with 
```
02:51:31 FAIL [0.108s]: test_plotprofiles_DeltaEXUnitsExecutes (DirectToolsTest.DirectTest)
02:51:31 ----------------------------------------------------------------------
02:51:31 Traceback (most recent call last):
02:51:31   File "/home/builder/jenkins-linode/workspace/master_clean-archlinux_python3/scripts/test/directtools/DirectToolsTest.py", line 271, in test_plotprofiles_DeltaEXUnitsExecutes
02:51:31     self.assertEqual(len(axes.get_lines()), 3)
02:51:31 AssertionError: 1 != 3
```

I changed the tests to actually check some values of axes which should work for all matplotlib version.

**To test:**
`DirectTools` unittests with matplotlib v2 should now pass.

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
