### PR TITLE
Indirect - Bayes Stretch - current spectrum maximum

### DIFF
--- a/qt/scientific_interfaces/Indirect/Stretch.cpp
+++ b/qt/scientific_interfaces/Indirect/Stretch.cpp
@@ -277,7 +277,7 @@ void Stretch::handleSampleInputReady(const QString &filename) {
       AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
           filename.toStdString());
   const int spectra = static_cast<int>(sampleWs->getNumberHistograms());
-  m_uiForm.spPreviewSpectrum->setMaximum(spectra-1);
+  m_uiForm.spPreviewSpectrum->setMaximum(spectra - 1);
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/Stretch.cpp
+++ b/qt/scientific_interfaces/Indirect/Stretch.cpp
@@ -62,6 +62,7 @@ Stretch::Stretch(QWidget *parent)
   // Connect preview spectrum spinner to handler
   connect(m_uiForm.spPreviewSpectrum, SIGNAL(valueChanged(int)), this,
           SLOT(previewSpecChanged(int)));
+  m_uiForm.spPreviewSpectrum->setMaximum(0);
 
   // Connect the plot and save push buttons
   connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotWorkspaces()));
@@ -276,7 +277,7 @@ void Stretch::handleSampleInputReady(const QString &filename) {
       AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
           filename.toStdString());
   const int spectra = static_cast<int>(sampleWs->getNumberHistograms());
-  m_uiForm.spPreviewSpectrum->setMaximum(spectra);
+  m_uiForm.spPreviewSpectrum->setMaximum(spectra-1);
 }
 
 /**


### PR DESCRIPTION
The maximum value of the `current spectum` spinbox should now be set correctly. Previously the maximum was set one too high which could cause an uncaught exception.

**To test:**
- Navigate to Interfaces -> Indirect -> Bayes -> Stretch
- Check that the current spectrum value is fixed at zero and cannot be changed
- Provide the sample file [irs26173_graphite002_red.zip](https://github.com/mantidproject/mantid/files/1785856/irs26173_graphite002_red.zip)
- Check that the current spectrum can be set to 9 but no higher.

Fixes #21968

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
