### PR TITLE
Indirect - IqtFit - Ensure Constrain Intensities is enabled for one Exponential function and Background

### DIFF
--- a/qt/scientific_interfaces/Indirect/IqtFit.cpp
+++ b/qt/scientific_interfaces/Indirect/IqtFit.cpp
@@ -253,13 +253,11 @@ IAlgorithm_sptr IqtFit::iqtFitAlgorithm(const size_t &specMin,
 std::string IqtFit::createIntensityTie(IFunction_sptr function) const {
   std::string tieString = "1";
   const auto backIndex = backgroundIndex();
-
-  if (backIndex)
-    tieString += "-f" + std::to_string(backIndex.get()) + ".A0";
-
   const auto intensityParameters = getParameters(function, "Height");
 
-  if (intensityParameters.size() < 2)
+  if (backIndex && !intensityParameters.empty())
+    tieString += "-f" + std::to_string(backIndex.get()) + ".A0";
+  else if (intensityParameters.size() < 2)
     return "";
 
   for (auto i = 1u; i < intensityParameters.size(); ++i)


### PR DESCRIPTION
In the Interfaces > Indirect > Data Analysis > IqtFit interface, the Constrain Intensities option is not enabled when a single exponential function and a background have been included in the composite.

This PR ensures Constrain Intensities is enabled and works as intended.

**To test:**
1. Navigate to Interfaces > Indirect > Data Analysis > IqtFit
2. Change the ```Exponential``` Spinner to 1.
3. Select a Background function from the ```Background``` drop-down menu.
4. Ensure ```Constrain Intensities``` is enabled.
5. Select "None" in the ```Background``` drop-down menu.
6. Ensure ```Constrain Intensities``` is disabled.

<!-- Instructions for testing. -->

Fixes #21992. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
