### PR TITLE
Indirect - Data Analysis - MSD Fit - None fit type

### DIFF
--- a/qt/scientific_interfaces/Indirect/MSDFit.cpp
+++ b/qt/scientific_interfaces/Indirect/MSDFit.cpp
@@ -153,8 +153,9 @@ bool MSDFit::validate() {
   auto specRange = std::make_pair(specMin, specMax + 1);
   uiv.checkValidRange("Spectrum Range", specRange);
 
-  if (isEmptyModel())
-    uiv.addErrorMessage("No fit function has been selected");
+  // In the future the MSDFit algorithm should be modified to allow this
+  if (selectedFitType() == "None")
+    uiv.addErrorMessage("No fit type has been selected");
 
   QString errors = uiv.generateErrorMessage();
   showMessageBox(errors);


### PR DESCRIPTION
Prevents a none fit type causing an uncaught exception in MSD Fit. This is a temporary fix until the none fit type is supported in the MSD Fit algorithm in the future (issue #21994)

**To test:**
- Navigate to Interfaces -> Indirect -> Data Analysis -> MSD Fit
- Enter functions and a none fit type like in [the issue](https://github.com/mantidproject/mantid/issues/21984)
- Click run or fit single spectrum
- Should get error message "no fit type has been selected."
<!-- Instructions for testing. -->

Fixes #21984

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
