### PR TITLE
Indirect - IqtFitMultiple - Find indices of stretched exponentials in function

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IqtFitMultiple.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IqtFitMultiple.py
@@ -257,6 +257,7 @@ class IqtFitMultiple(PythonAlgorithm):
         self.setProperty('OutputWorkspaceGroup', self._fit_group_name)
         conclusion_prog.report('Algorithm complete')
 
+
 def _create_multi_domain_func(function, input_ws):
     multi = 'composite=MultiDomainFunction,NumDeriv=true;'
     comp = '(composite=CompositeFunction,NumDeriv=true,$domains=i;' + str(function) + ');'

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IqtFitMultiple.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IqtFitMultiple.py
@@ -291,7 +291,7 @@ def _find_indices_of_stretched_exponentials(composite):
 
     for index in range(0, len(composite)):
         if composite.getFunction(index).name() == "StretchExp":
-            return indices.append(index)
+            indices.append(index)
     return indices
 
 


### PR DESCRIPTION
Currently, the IqtFitMultiple algorithm assumes that the Stretched Exponential function will be found at index 1 in the fit function. With the introduction of the new IndirectFitPropertyBrowser, this order is not guaranteed.

This PR ensures the IqtFitMultiple algorithm first finds the indices of Stretched Exponential functions, before creating the ties on their ```Stretching``` (Beta) parameter.

**To test:**
1. Navigate to Interfaces > Indirect > Data Analysis > IqtFit
2. Provide the supplied file in the ```Input``` field.
3. Change the ```Exponential``` spinner to 2.
4. Check the ```Stretched Exponential``` check-box.
5. Check the ```Make Beta Global``` check-box.
6. Click ```Run```.
7. Ensure the ```StretchExp``` function in the function browser is expanded.
8. Change the ```Plot Spectrum``` spinner and ensure the ```Stretching``` parameter remains constant throughout all spectra.

**Test File:**
[irs26176_graphite002_iqt.zip](https://github.com/mantidproject/mantid/files/1790013/irs26176_graphite002_iqt.zip)

<!-- Instructions for testing. -->

Fixes #21991. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
