### PR TITLE
Better error handling for time slicing inputs

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.cpp
@@ -168,11 +168,13 @@ void TimeSlicingInfo::parseUniform() {
  * @throws : runtime_error if input is invalid
  */
 void TimeSlicingInfo::parseUniformEven() {
-  // Set the constant number of slices
-  m_constNumberOfSlices = parseDenaryInteger(values());
+  auto const numberOfSlices = parseDenaryInteger(values());
 
-  if (m_constNumberOfSlices < 1)
+  if (numberOfSlices < 1)
     throw std::runtime_error("The number of slices must be greater than zero");
+
+  // Set the constant number of slices
+  m_constNumberOfSlices = numberOfSlices;
 }
 
 /** Parses the values string to extract custom time slicing

--- a/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.cpp
@@ -3,6 +3,7 @@
 #include "MantidAPI/IEventWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Run.h"
+#include "MantidKernel/Tolerance.h"
 #include "MantidQtWidgets/Common/DataProcessorUI/DataProcessorView.h"
 #include "MantidQtWidgets/Common/DataProcessorUI/OptionsMap.h"
 #include "MantidQtWidgets/Common/DataProcessorUI/TreeData.h"
@@ -66,16 +67,72 @@ double angle(RowData_sptr data) {
 }
 
 TimeSlicingInfo::TimeSlicingInfo(QString type, QString values)
-    : m_type(std::move(type)), m_values(std::move(values)) {
-  // For custom/log value slicing the slices are always the same so we can
-  // set them straight away
-  if (isCustom())
-    parseCustom();
-  if (isLogValue())
-    parseLogValue();
+    : m_type(std::move(type)), m_values(std::move(values)),
+      m_enableSlicing(true), m_constNumberOfSlices(0),
+      m_constSliceDuration(0.0) {
+
+  // If the input is empty, do not perform time slicing
+  if (m_values.isEmpty()) {
+    m_enableSlicing = false;
+    return;
+  }
+
+  try {
+    if (isUniform())
+      parseUniform();
+    else if (isUniformEven())
+      parseUniformEven();
+    else if (isCustom())
+      parseCustom();
+    else if (isLogValue())
+      parseLogValue();
+  } catch (const std::runtime_error &ex) {
+    throw std::runtime_error(
+        std::string("Error parsing time slicing values: ") + ex.what());
+  }
 }
 
+/** Return the number of slices
+ * @throws : runtime_error if the number of slices has not been set
+ */
+size_t TimeSlicingInfo::numberOfSlices() const {
+  // most types of slicing have a constant number of slices set
+  auto numSlices = m_constNumberOfSlices;
+
+  // for uniform slicing, use the number of slices actually created
+  if (isUniform())
+    numSlices = m_startTimes.size();
+
+  // if this function is called before the above are set it is an error
+  if (numSlices < 1)
+    throw std::runtime_error("Number of slices has not been set");
+
+  return numSlices;
+}
+
+/** Return the slice duration. This is only applicable where the duration
+ * is constant for all slices.
+ * @throws : runtime_error if the number of slices is not constant
+ */
+double TimeSlicingInfo::sliceDuration() const {
+  if (!isUniform())
+    throw std::runtime_error("Slice duration is not constant");
+
+  return m_constSliceDuration;
+}
+
+/** Add a slice with the given time range
+ * @param startTime : the start of the slice range
+ * @param stopTime : the end of the slice range
+ * @throws : runtime_error if the input is invalid
+ */
 void TimeSlicingInfo::addSlice(const double startTime, const double stopTime) {
+  if (startTime < 0 || stopTime < 0)
+    throw std::runtime_error("The slice start/stop times cannot be negative");
+  if (startTime >= stopTime)
+    throw std::runtime_error(
+        "The slice stop time should be larger than the start time");
+
   // Add a slice if it doesn't already exist
   if (std::find(m_startTimes.begin(), m_startTimes.end(), startTime) ==
           m_startTimes.end() &&
@@ -86,44 +143,98 @@ void TimeSlicingInfo::addSlice(const double startTime, const double stopTime) {
   }
 }
 
+/** Clear the list of time slices
+ */
 void TimeSlicingInfo::clearSlices() {
   m_startTimes.clear();
   m_stopTimes.clear();
 }
 
+/** Parses the values string for uniform slicing with a constant slice duration.
+ * Note that this means that the number of slices may not be constant (even) as
+ * it will depend on the length of the individual runs.
+ * @throws : runtime_error if input is invalid
+ */
+void TimeSlicingInfo::parseUniform() {
+  // set the constant slice duration
+  m_constSliceDuration = parseDouble(values());
+
+  if (m_constSliceDuration <= Mantid::Kernel::Tolerance)
+    throw std::runtime_error("Slice duration must be greater than zero");
+}
+
+/** Parses the values string for uniform slicing with a constant (even)
+ * number of slices
+ * @throws : runtime_error if input is invalid
+ */
+void TimeSlicingInfo::parseUniformEven() {
+  // Set the constant number of slices
+  m_constNumberOfSlices = parseDenaryInteger(values());
+
+  if (m_constNumberOfSlices < 1)
+    throw std::runtime_error("The number of slices must be greater than zero");
+}
+
 /** Parses the values string to extract custom time slicing
+ * @throws : runtime_error if input is invalid
  */
 void TimeSlicingInfo::parseCustom() {
 
+  // Split the string into a list of doubles
   auto timeStr = values().split(",");
   std::vector<double> times;
   std::transform(timeStr.begin(), timeStr.end(), std::back_inserter(times),
                  [](const QString &astr) { return parseDouble(astr); });
 
-  size_t numSlices = times.size() > 1 ? times.size() - 1 : 1;
+  if (times.size() == 0) {
+    throw std::runtime_error("The number of slices must be greater than zero");
+  }
 
-  // Add the start/stop times
   if (times.size() == 1) {
+    // Only one value was provided: assume a range from 0 to the given value
+    m_constNumberOfSlices = 1;
     addSlice(0, times[0]);
-  } else {
-    for (size_t i = 0; i < numSlices; i++) {
-      addSlice(times[i], times[i + 1]);
-    }
+    return;
+  }
+
+  // More than one value; create ranges for each pair of adjacent values in the
+  // list
+  m_constNumberOfSlices = times.size() - 1;
+  for (size_t i = 0; i < m_constNumberOfSlices; i++) {
+    addSlice(times[i], times[i + 1]);
   }
 }
 
 /** Parses the vlaues string to extract log value filter and time slicing
+ * @throws : runtime_error if input is invalid
  */
 void TimeSlicingInfo::parseLogValue() {
 
   // Extract the slicing and log values from the input which will be of the
   // format e.g. "Slicing=0,10,20,30,LogFilter=proton_charge"
   auto strMap = parseKeyValueQString(values());
-  QString timeSlicing = strMap.at("Slicing");
-  m_values = timeSlicing;
-  m_logFilter = strMap.at("LogFilter");
+  auto const hasSlicingValues = strMap.count("Slicing");
+  auto const hasLogValue = strMap.count("LogFilter");
 
-  parseCustom();
+  if (hasSlicingValues && hasLogValue) {
+    // We need both inputs in order to do slicing
+    QString timeSlicing = strMap.at("Slicing");
+    m_values = timeSlicing;
+    m_logFilter = strMap.at("LogFilter");
+    parseCustom();
+  } else if (hasSlicingValues) {
+    throw std::runtime_error("You have entered a Log name for time slicing "
+                             "but not a python list: please enter both, or "
+                             "neither");
+  } else if (hasLogValue) {
+    throw std::runtime_error("You have entered a python list for time slicing "
+                             "but not a Log name: please enter both, or "
+                             "neither");
+  } else {
+    // Empty input should already have been dealt with so we should not get
+    // here
+    throw std::runtime_error("Invalid input for slicing by Log value");
+  }
 }
 
 /**
@@ -167,9 +278,17 @@ void ReflDataProcessorPresenter::process() {
 
   // If slicing is not specified, process normally, delegating to
   // GenericDataProcessorPresenter
-  TimeSlicingInfo slicing(m_mainPresenter->getTimeSlicingType(),
-                          m_mainPresenter->getTimeSlicingValues());
-  if (!slicing.hasSlicing()) {
+  std::unique_ptr<TimeSlicingInfo> slicing;
+  try {
+    slicing = Mantid::Kernel::make_unique<TimeSlicingInfo>(
+        m_mainPresenter->getTimeSlicingType(),
+        m_mainPresenter->getTimeSlicingValues());
+  } catch (const std::runtime_error &ex) {
+    m_view->giveUserWarning(ex.what(), "Error");
+    return;
+  }
+
+  if (!slicing->hasSlicing()) {
     // Check if any input event workspaces still exist in ADS
     if (proceedIfWSTypeInADS(newSelected, true)) {
       setPromptUser(false); // Prevent prompting user twice
@@ -207,7 +326,7 @@ void ReflDataProcessorPresenter::process() {
 
       if (allEventWS) {
         // Process the group
-        if (processGroupAsEventWS(item.first, group, slicing))
+        if (processGroupAsEventWS(item.first, group, *slicing.get()))
           errors = true;
 
         // Notebook not implemented yet
@@ -500,19 +619,21 @@ void ReflDataProcessorPresenter::parseUniform(TimeSlicingInfo &slicing,
     const auto totalDuration = run.endTime() - run.startTime();
     double totalDurationSec = totalDuration.total_seconds();
     double sliceDuration = .0;
-    int numSlices = 0;
+    size_t numSlices = 0;
 
     if (slicing.isUniformEven()) {
-      numSlices = parseDenaryInteger(slicing.values());
-      sliceDuration = totalDurationSec / numSlices;
+      numSlices = slicing.numberOfSlices();
+      sliceDuration = totalDurationSec / static_cast<double>(numSlices);
     } else if (slicing.isUniform()) {
-      sliceDuration = parseDouble(slicing.values());
+      sliceDuration = slicing.sliceDuration();
       numSlices = static_cast<int>(ceil(totalDurationSec / sliceDuration));
     }
 
     // Add the start/stop times
-    for (int i = 0; i < numSlices; i++) {
-      slicing.addSlice(sliceDuration * i, sliceDuration * (i + 1));
+    for (size_t i = 0; i < numSlices; i++) {
+      auto const indexAsDouble = static_cast<double>(i);
+      slicing.addSlice(sliceDuration * indexAsDouble,
+                       sliceDuration * (indexAsDouble + 1));
     }
   }
 }

--- a/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.h
@@ -18,13 +18,14 @@ public:
   TimeSlicingInfo() = delete;
   TimeSlicingInfo(QString type, QString values);
 
-  size_t numberOfSlices() { return m_startTimes.size(); }
+  size_t numberOfSlices() const;
+  double sliceDuration() const;
   double startTime(const size_t i) { return m_startTimes[i]; }
   double stopTime(const size_t i) { return m_stopTimes[i]; }
   QString values() { return m_values; }
   QString logFilter() { return m_logFilter; }
 
-  bool hasSlicing() const { return !m_values.isEmpty(); }
+  bool hasSlicing() const { return m_enableSlicing && !m_values.isEmpty(); }
   bool isCustom() const { return m_type == "Custom"; }
   bool isLogValue() const { return m_type == "LogValue"; }
   bool isUniform() const { return m_type == "Uniform"; }
@@ -32,6 +33,8 @@ public:
 
   void addSlice(const double startTime, const double stopTime);
   void clearSlices();
+  void parseUniform();
+  void parseUniformEven();
   void parseCustom();
   void parseLogValue();
 
@@ -40,6 +43,12 @@ private:
   QString m_type;
   // the slicing values specified by the user
   QString m_values;
+  // whether time slicing is enabled or not
+  bool m_enableSlicing;
+  // the number of slices (where this is constant for all slices)
+  size_t m_constNumberOfSlices;
+  // the duration of the slices (where this is constant for all slices)
+  double m_constSliceDuration;
   // The start and stop times for all slices for all rows in all groups. If
   // using non-even slicing then different runs may have different numbers of
   // slices. These vectors will contain ALL slices. It is assumed the first n


### PR DESCRIPTION
In the ISIS Reflectometry GUI:

- Fix a regression where an unhandled exception was being thrown when invalid inputs were entered on the Event Handling tab.
- Make error handling more consistent and add additional error handling for parsing of all input values.

**To test:**
- Follow the instructions in the linked issue and check that the bug is fixed.
- Try entering empty / invalid values in all fields on the Event Handling tab. If inputs are empty then runs should be processed in non-event mode. If invalid values are entered, you should get a warning.

Fixes #21989

**Release Notes** 
*Does not need to be in the release notes*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
