### PR TITLE
MR: Update filter to take in workspace

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/MRFilterCrossSections.py
+++ b/Framework/PythonInterface/plugins/algorithms/MRFilterCrossSections.py
@@ -198,7 +198,6 @@ class MRFilterCrossSections(PythonAlgorithm):
             api.logger.error("No events remained after filtering")
             AnalysisDataService.remove(ws_raw_name)
 
-
     def load_legacy_cross_Sections(self, file_path):
         """
             For legacy MR data, we need to load each cross-section independently.

--- a/Framework/PythonInterface/plugins/algorithms/MRFilterCrossSections.py
+++ b/Framework/PythonInterface/plugins/algorithms/MRFilterCrossSections.py
@@ -23,7 +23,10 @@ class MRFilterCrossSections(PythonAlgorithm):
         return "This algorithm loads a Magnetism Reflectometer file and returns workspaces for each cross-section."
 
     def PyInit(self):
-        self.declareProperty(FileProperty("Filename", "", action=FileAction.Load, extensions=[".nxs", ".nxs.h5"]))
+        self.declareProperty(FileProperty("Filename", "", action=FileAction.OptionalLoad, extensions=[".nxs", ".nxs.h5"]))
+        self.declareProperty(WorkspaceProperty("InputWorkspace", "",
+                                               Direction.Input, PropertyMode.Optional),
+                             "Optionally, we can provide a scattering workspace directly")
         self.declareProperty("PolState", "SF1",
                              doc="Name of the log entry determining the polarizer state")
         self.declareProperty("AnaState", "SF2",
@@ -84,9 +87,14 @@ class MRFilterCrossSections(PythonAlgorithm):
         pol_veto = self.getProperty("PolVeto").value
         ana_state = self.getProperty("AnaState").value
         ana_veto = self.getProperty("AnaVeto").value
+        ws_event_data = self.getProperty("InputWorkspace").value
 
-        ws_raw_name = os.path.basename(file_path)
-        ws_raw = api.LoadEventNexus(Filename=file_path, OutputWorkspace=ws_raw_name)
+        if ws_event_data is not None:
+            ws_raw_name = str(ws_event_data)
+            ws_raw = ws_event_data
+        else:
+            ws_raw_name = os.path.basename(file_path)
+            ws_raw = api.LoadEventNexus(Filename=file_path, OutputWorkspace=ws_raw_name)
 
         # Check whether we have a polarizer
         polarizer = ws_raw.getRun().getProperty("Polarizer").value[0]
@@ -158,6 +166,7 @@ class MRFilterCrossSections(PythonAlgorithm):
         split_table_ws = self.create_table(change_list, start_time,
                                            has_polarizer=polarizer>0, has_analyzer=analyzer>0)
 
+        # Filter events if we found enough information to do so
         if split_table_ws.rowCount()>0:
             outputs = api.FilterEvents(InputWorkspace=ws_raw,
                                        SplitterWorkspace=split_table_ws,
@@ -176,11 +185,19 @@ class MRFilterCrossSections(PythonAlgorithm):
                 pol_state = str(ws).replace(output_wsg+'_', '')
                 api.AddSampleLog(Workspace=ws, LogName='cross_section_id',
                                  LogText=pol_state)
+
+            AnalysisDataService.remove(ws_raw_name)
+            self.setProperty("CrossSectionWorkspaces", output_wsg)
+
+        # If we don't have a splitter table, it might be because we don't have analyzer/polarizer
+        # information. In this case don't filter and return the raw workspace.
+        elif polarizer <= 0 and analyzer <=0:
+            api.logger.warning("No polarizer/analyzer information available")
+            self.setProperty("CrossSectionWorkspaces", api.GroupWorkspaces([ws_raw]))
         else:
             api.logger.error("No events remained after filtering")
-        AnalysisDataService.remove(ws_raw_name)
+            AnalysisDataService.remove(ws_raw_name)
 
-        self.setProperty("CrossSectionWorkspaces", output_wsg)
 
     def load_legacy_cross_Sections(self, file_path):
         """

--- a/Testing/SystemTests/tests/analysis/MagnetismReflectometryReductionTest.py
+++ b/Testing/SystemTests/tests/analysis/MagnetismReflectometryReductionTest.py
@@ -78,6 +78,57 @@ class MRFilterCrossSectionsTest(stresstesting.MantidStressTest):
         return "r_24949", 'MagnetismReflectometryReductionTest.nxs'
 
 
+class MRFilterCrossSectionsWithWorkspaceTest(stresstesting.MantidStressTest):
+    """ Test data loading and cross-section extraction """
+    def runTest(self):
+        ws_input = LoadEventNexus(Filename="REF_M_24949",
+                                  NXentryName="entry-Off_Off",
+                                  OutputWorkspace="r_24949")
+        # Since we are using a older data file for testing, add the
+        # polarizer/analyzer info. This will also test the edge case where
+        # there is no analyzer or polarizer, which should just be the
+        # same as a simple load.
+        AddSampleLog(Workspace=ws_input, LogName='polarizer',
+                     LogText="0",
+                     LogType='Number Series', LogUnit='')
+        AddSampleLog(Workspace=ws_input, LogName='analyzer',
+                     LogText="0",
+                     LogType='Number Series', LogUnit='')
+        wsg = MRFilterCrossSections(InputWorkspace=ws_input)
+        MagnetismReflectometryReduction(InputWorkspace=wsg[0],
+                                        NormalizationRunNumber=24945,
+                                        SignalPeakPixelRange=[125, 129],
+                                        SubtractSignalBackground=True,
+                                        SignalBackgroundPixelRange=[15, 105],
+                                        ApplyNormalization=True,
+                                        NormPeakPixelRange=[201, 205],
+                                        SubtractNormBackground=True,
+                                        NormBackgroundPixelRange=[10,127],
+                                        CutLowResDataAxis=True,
+                                        LowResDataAxisPixelRange=[91, 161],
+                                        CutLowResNormAxis=True,
+                                        LowResNormAxisPixelRange=[86, 174],
+                                        CutTimeAxis=True,
+                                        UseWLTimeAxis=False,
+                                        QMin=0.005,
+                                        QStep=-0.01,
+                                        TimeAxisStep=40,
+                                        TimeAxisRange=[25000, 54000],
+                                        SpecularPixel=126.9,
+                                        ConstantQBinning=False,
+                                        EntryName='entry-Off_Off',
+                                        OutputWorkspace="r_24949")
+
+    def validate(self):
+        # Be more tolerant with the output, mainly because of the errors.
+        # The following tolerance check the errors up to the third digit.
+        self.disableChecking.append('Instrument')
+        self.disableChecking.append('Sample')
+        self.disableChecking.append('SpectraMap')
+        self.disableChecking.append('Axes')
+        return "r_24949", 'MagnetismReflectometryReductionTest.nxs'
+
+
 class MRNormaWorkspaceTest(stresstesting.MantidStressTest):
     """ Test data loading and cross-section extraction """
     def runTest(self):


### PR DESCRIPTION
To use in live reduction, the `MRFilterCrossSections` algorithm needs to be able to take in a workspace. Also, it should return the full unfiltered workspace if no polarizer/analyzer information is in the data file. 

**To test:**
- Review the code
- Review the new system test and make sure it passes.

**Release Notes** 
*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
