### PR TITLE
Indirect - ISIS Calibration - Check if resolution was included in calibration when plotting result

### DIFF
--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -223,16 +223,16 @@ QString ISISCalibration::backgroundString() const {
          QString::number(m_dblManager->value(m_properties["ResEnd"]));
 }
 
-void ISISCalibration::setPeak(const double &minimumTof,
-                              const double &maximumTof) {
+void ISISCalibration::setPeakRange(const double &minimumTof,
+                                   const double &maximumTof) {
   auto calibrationPeak = m_uiForm.ppCalibration->getRangeSelector("CalPeak");
   setRangeSelector(calibrationPeak, m_properties["CalPeakMin"],
                    m_properties["CalPeakMax"],
                    qMakePair(minimumTof, maximumTof));
 }
 
-void ISISCalibration::setBackground(const double &minimumTof,
-                                    const double &maximumTof) {
+void ISISCalibration::setBackgroundRange(const double &minimumTof,
+                                         const double &maximumTof) {
   auto background = m_uiForm.ppCalibration->getRangeSelector("CalBackground");
   setRangeSelector(background, m_properties["CalBackMin"],
                    m_properties["CalBackMax"],
@@ -248,14 +248,14 @@ void ISISCalibration::setRange(MantidWidgets::RangeSelector *rangeSelector,
                        qMakePair(minimum, maximum));
 }
 
-void ISISCalibration::setPeakRange(const double &peakMin,
-                                   const double &peakMax) {
+void ISISCalibration::setPeakRangeLimits(const double &peakMin,
+                                         const double &peakMax) {
   auto calibrationPeak = m_uiForm.ppCalibration->getRangeSelector("CalPeak");
   setRange(calibrationPeak, peakMin, peakMax, "CalELow", "CalEHigh");
 }
 
-void ISISCalibration::setBackgroundRange(const double &backgroundMin,
-                                         const double &backgroundMax) {
+void ISISCalibration::setBackgroundRangeLimits(const double &backgroundMin,
+                                               const double &backgroundMax) {
   auto background = m_uiForm.ppCalibration->getRangeSelector("CalBackground");
   setRange(background, backgroundMin, backgroundMax, "CalStart", "CalEnd");
 }
@@ -351,8 +351,8 @@ void ISISCalibration::setDefaultInstDetails() {
 
   // Set peak and background ranges
   const auto ranges = getRangesFromInstrument();
-  setPeak(ranges.at("peak-start-tof"), ranges.at("peak-end-tof"));
-  setBackground(ranges.at("back-start-tof"), ranges.at("back-end-tof"));
+  setPeakRange(ranges.at("peak-start-tof"), ranges.at("peak-end-tof"));
+  setBackgroundRange(ranges.at("back-start-tof"), ranges.at("back-end-tof"));
 }
 
 /**
@@ -395,8 +395,8 @@ void ISISCalibration::calPlotRaw() {
   m_uiForm.ppCalibration->resizeX();
 
   const auto &dataX = input->x(0);
-  setPeakRange(dataX.front(), dataX.back());
-  setBackgroundRange(dataX.front(), dataX.back());
+  setPeakRangeLimits(dataX.front(), dataX.back());
+  setBackgroundRangeLimits(dataX.front(), dataX.back());
 
   setDefaultInstDetails();
 
@@ -650,7 +650,8 @@ void ISISCalibration::plotClicked() {
   plotTimeBin(m_outputCalibrationName);
   checkADSForPlotSaveWorkspace(m_outputCalibrationName.toStdString(), true);
   QStringList plotWorkspaces;
-  if (m_uiForm.ckCreateResolution->isChecked()) {
+  if (m_uiForm.ckCreateResolution->isChecked() &&
+      m_outputResolutionName.isEmpty()) {
     checkADSForPlotSaveWorkspace(m_outputResolutionName.toStdString(), true);
     plotWorkspaces.append(m_outputResolutionName);
     if (m_uiForm.ckSmoothResolution->isChecked())
@@ -675,7 +676,7 @@ ISISCalibration::calibrationAlgorithm(const QString &inputFiles) const {
   auto calibrationAlg =
       AlgorithmManager::Instance().create("IndirectCalibration");
   calibrationAlg->initialize();
-  calibrationAlg->setProperty("InputFiles", inputFiles);
+  calibrationAlg->setProperty("InputFiles", inputFiles.toStdString());
   calibrationAlg->setProperty("OutputWorkspace",
                               m_outputCalibrationName.toStdString());
   calibrationAlg->setProperty("DetectorRange",

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -1,8 +1,8 @@
 #include "ISISCalibration.h"
 
+#include "MantidAPI/WorkspaceGroup.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/Logger.h"
-#include "MantidAPI/WorkspaceGroup.h"
 
 #include <QFileInfo>
 
@@ -166,125 +166,116 @@ ISISCalibration::ISISCalibration(IndirectDataReduction *idrUI, QWidget *parent)
  */
 ISISCalibration::~ISISCalibration() {}
 
+std::pair<double, double> ISISCalibration::peakRange() const {
+  return std::make_pair(m_dblManager->value(m_properties["CalPeakMin"]),
+                        m_dblManager->value(m_properties["CalPeakMax"]));
+}
+
+std::pair<double, double> ISISCalibration::backgroundRange() const {
+  return std::make_pair(m_dblManager->value(m_properties["CalBackMin"]),
+                        m_dblManager->value(m_properties["CalBackMax"]));
+}
+
+std::pair<double, double> ISISCalibration::resolutionRange() const {
+  return std::make_pair(m_dblManager->value(m_properties["ResStart"]),
+                        m_dblManager->value(m_properties["ResEnd"]));
+}
+
+QString ISISCalibration::peakRangeString() const {
+  return m_properties["CalPeakMin"]->valueText() + "," +
+         m_properties["CalPeakMax"]->valueText();
+}
+
+QString ISISCalibration::backgroundRangeString() const {
+  return m_properties["CalBackMin"]->valueText() + "," +
+         m_properties["CalBackMax"]->valueText();
+}
+
+QString ISISCalibration::instrumentDetectorRangeString() const {
+  const auto details = getInstrumentDetails();
+  return details["spectra-min"] + "," + details["spectra-max"];
+}
+
+QString ISISCalibration::outputWorkspaceName() const {
+  const auto configuration = getInstrumentConfiguration();
+  auto name = QFileInfo(m_uiForm.leRunNo->getFirstFilename()).baseName();
+
+  if (m_uiForm.leRunNo->getFilenames().size() > 1)
+    name += "_multi";
+
+  return name + QString::fromStdString("_") + configuration->getAnalyserName() +
+         configuration->getReflectionName();
+}
+
+QString ISISCalibration::resolutionDetectorRangeString() const {
+  return QString::number(m_dblManager->value(m_properties["ResSpecMin"])) +
+         "," + QString::number(m_dblManager->value(m_properties["ResSpecMax"]));
+}
+
+QString ISISCalibration::rebinString() const {
+  return QString::number(m_dblManager->value(m_properties["ResELow"])) + "," +
+         QString::number(m_dblManager->value(m_properties["ResEWidth"])) + "," +
+         QString::number(m_dblManager->value(m_properties["ResEHigh"]));
+}
+
+QString ISISCalibration::backgroundString() const {
+  return QString::number(m_dblManager->value(m_properties["ResStart"])) + "," +
+         QString::number(m_dblManager->value(m_properties["ResEnd"]));
+}
+
+void ISISCalibration::setPeakRange(const double &peakMin, const double &peakMax,
+                                   const QString &minPropertyName,
+                                   const QString &maxPropertyName) {
+  auto calibrationPeak = m_uiForm.ppCalibration->getRangeSelector("CalPeak");
+  setRangeSelector(calibrationPeak, m_properties[minPropertyName],
+                   m_properties[maxPropertyName], qMakePair(peakMin, peakMax));
+}
+
+void ISISCalibration::setPeakRange(const double &peakMin,
+                                   const double &peakMax) {
+  setPeakRange(peakMin, peakMax, "CalPeakMin", "CalPeakMax");
+}
+
+void ISISCalibration::setBackgroundRange(const double &backgroundMin,
+                                         const double &backgroundMax,
+                                         const QString &minPropertyName,
+                                         const QString &maxPropertyName) {
+  auto background = m_uiForm.ppCalibration->getRangeSelector("CalBackground");
+  setRangeSelector(background, m_properties[minPropertyName],
+                   m_properties[maxPropertyName],
+                   qMakePair(backgroundMin, backgroundMax));
+}
+
+void ISISCalibration::setBackgroundRange(const double &backgroundMin,
+                                         const double &backgroundMax) {
+  setBackgroundRange(backgroundMin, backgroundMax, "CalBackMin", "CalBackMax");
+}
+
+void ISISCalibration::setResolutionSpectraRange(const double &minimum,
+                                                const double &maximum) {
+  m_dblManager->setValue(m_properties["ResSpecMin"], minimum);
+  m_dblManager->setValue(m_properties["ResSpecMax"], maximum);
+}
+
 void ISISCalibration::setup() {}
 
 void ISISCalibration::run() {
   // Get properties
-  QStringList filenameList = m_uiForm.leRunNo->getFilenames();
-  QString filenames = filenameList.join(",");
-  QString rawFile = m_uiForm.leRunNo->getFirstFilename();
-  QFileInfo rawFileInfo(rawFile);
-  QString name = rawFileInfo.baseName();
+  const auto filenames = m_uiForm.leRunNo->getFilenames().join(",");
+  const auto outputWorkspaceNameStem = outputWorkspaceName().toLower();
 
-  auto instDetails = getInstrumentDetails();
-  QString instDetectorRange =
-      instDetails["spectra-min"] + "," + instDetails["spectra-max"];
-
-  QString peakRange = m_properties["CalPeakMin"]->valueText() + "," +
-                      m_properties["CalPeakMax"]->valueText();
-  QString backgroundRange = m_properties["CalBackMin"]->valueText() + "," +
-                            m_properties["CalBackMax"]->valueText();
-
-  QString outputWorkspaceNameStem =
-      name + QString::fromStdString("_") +
-      getInstrumentConfiguration()->getAnalyserName() +
-      getInstrumentConfiguration()->getReflectionName();
-
-  outputWorkspaceNameStem = outputWorkspaceNameStem.toLower();
-
-  m_outputCalibrationName = outputWorkspaceNameStem;
-  if (filenameList.size() > 1)
-    m_outputCalibrationName += "_multi";
-  m_outputCalibrationName += "_calib";
-
-  bool loadLog = m_uiForm.ckLoadLogFiles->isChecked();
-  // Configure the calibration algorithm
-  IAlgorithm_sptr calibrationAlg =
-      AlgorithmManager::Instance().create("IndirectCalibration");
-  calibrationAlg->initialize();
-
-  calibrationAlg->setProperty("InputFiles", filenames.toStdString());
-  calibrationAlg->setProperty("OutputWorkspace",
-                              m_outputCalibrationName.toStdString());
-  calibrationAlg->setProperty("DetectorRange", instDetectorRange.toStdString());
-  calibrationAlg->setProperty("PeakRange", peakRange.toStdString());
-  calibrationAlg->setProperty("BackgroundRange", backgroundRange.toStdString());
-  calibrationAlg->setProperty("LoadLogFiles", loadLog);
-
-  if (m_uiForm.ckScale->isChecked()) {
-    double scale = m_uiForm.spScale->value();
-    calibrationAlg->setProperty("ScaleFactor", scale);
-  }
-  m_batchAlgoRunner->addAlgorithm(calibrationAlg);
+  m_outputCalibrationName = outputWorkspaceNameStem + "_calib";
+  m_batchAlgoRunner->addAlgorithm(calibrationAlgorithm(filenames));
 
   // Initially take the calibration workspace as the result
   m_pythonExportWsName = m_outputCalibrationName.toStdString();
   // Configure the resolution algorithm
   if (m_uiForm.ckCreateResolution->isChecked()) {
-    m_outputResolutionName = outputWorkspaceNameStem;
-    if (filenameList.size() > 1)
-      m_outputResolutionName += "_multi";
-    m_outputResolutionName += "_res";
+    m_outputResolutionName = outputWorkspaceNameStem + "_res";
+    m_batchAlgoRunner->addAlgorithm(resolutionAlgorithm(filenames));
 
-    QString resDetectorRange =
-        QString::number(m_dblManager->value(m_properties["ResSpecMin"])) + "," +
-        QString::number(m_dblManager->value(m_properties["ResSpecMax"]));
-
-    QString rebinString =
-        QString::number(m_dblManager->value(m_properties["ResELow"])) + "," +
-        QString::number(m_dblManager->value(m_properties["ResEWidth"])) + "," +
-        QString::number(m_dblManager->value(m_properties["ResEHigh"]));
-
-    QString background =
-        QString::number(m_dblManager->value(m_properties["ResStart"])) + "," +
-        QString::number(m_dblManager->value(m_properties["ResEnd"]));
-
-    bool smooth = m_uiForm.ckSmoothResolution->isChecked();
-
-    IAlgorithm_sptr resAlg =
-        AlgorithmManager::Instance().create("IndirectResolution", -1);
-    resAlg->initialize();
-
-    resAlg->setProperty("InputFiles", filenames.toStdString());
-    resAlg->setProperty(
-        "Instrument",
-        getInstrumentConfiguration()->getInstrumentName().toStdString());
-    resAlg->setProperty(
-        "Analyser",
-        getInstrumentConfiguration()->getAnalyserName().toStdString());
-    resAlg->setProperty(
-        "Reflection",
-        getInstrumentConfiguration()->getReflectionName().toStdString());
-    resAlg->setProperty("RebinParam", rebinString.toStdString());
-    resAlg->setProperty("DetectorRange", resDetectorRange.toStdString());
-    resAlg->setProperty("BackgroundRange", background.toStdString());
-    resAlg->setProperty("LoadLogFiles", loadLog);
-
-    if (m_uiForm.ckResolutionScale->isChecked())
-      resAlg->setProperty("ScaleFactor", m_uiForm.spScale->value());
-
-    if (smooth)
-      resAlg->setProperty("OutputWorkspace",
-                          m_outputResolutionName.toStdString() + "_pre_smooth");
-    else
-      resAlg->setProperty("OutputWorkspace",
-                          m_outputResolutionName.toStdString());
-
-    m_batchAlgoRunner->addAlgorithm(resAlg);
-
-    if (smooth) {
-      IAlgorithm_sptr smoothAlg =
-          AlgorithmManager::Instance().create("WienerSmooth");
-      smoothAlg->initialize();
-      smoothAlg->setProperty("OutputWorkspace",
-                             m_outputResolutionName.toStdString());
-
-      BatchAlgorithmRunner::AlgorithmRuntimeProps smoothAlgInputProps;
-      smoothAlgInputProps["InputWorkspace"] =
-          m_outputResolutionName.toStdString() + "_pre_smooth";
-
-      m_batchAlgoRunner->addAlgorithm(smoothAlg, smoothAlgInputProps);
-    }
+    if (m_uiForm.ckSmoothResolution->isChecked())
+      addRuntimeSmoothing(m_outputResolutionName);
 
     // When creating resolution file take the resolution workspace as the result
     m_pythonExportWsName = m_outputResolutionName.toStdString();
@@ -311,22 +302,14 @@ bool ISISCalibration::validate() {
 
   uiv.checkMWRunFilesIsValid("Run", m_uiForm.leRunNo);
 
-  auto peakRange =
-      std::make_pair(m_dblManager->value(m_properties["CalPeakMin"]),
-                     m_dblManager->value(m_properties["CalPeakMax"]));
-  auto backRange =
-      std::make_pair(m_dblManager->value(m_properties["CalBackMin"]),
-                     m_dblManager->value(m_properties["CalBackMax"]));
-
-  uiv.checkValidRange("Peak Range", peakRange);
-  uiv.checkValidRange("Back Range", backRange);
-  uiv.checkRangesDontOverlap(peakRange, backRange);
+  auto rangeOfPeak = peakRange();
+  auto rangeOfBackground = backgroundRange();
+  uiv.checkValidRange("Peak Range", rangeOfPeak);
+  uiv.checkValidRange("Back Range", rangeOfBackground);
+  uiv.checkRangesDontOverlap(rangeOfPeak, rangeOfBackground);
 
   if (m_uiForm.ckCreateResolution->isChecked()) {
-    auto backgroundRange =
-        std::make_pair(m_dblManager->value(m_properties["ResStart"]),
-                       m_dblManager->value(m_properties["ResEnd"]));
-    uiv.checkValidRange("Background", backgroundRange);
+    uiv.checkValidRange("Background", resolutionRange());
 
     double eLow = m_dblManager->value(m_properties["ResELow"]);
     double eHigh = m_dblManager->value(m_properties["ResEHigh"]);
@@ -348,32 +331,19 @@ bool ISISCalibration::validate() {
  */
 void ISISCalibration::setDefaultInstDetails() {
   // Get spectra, peak and background details
-  QMap<QString, QString> instDetails = getInstrumentDetails();
+  const auto instDetails = getInstrumentDetails();
 
   // Set the search instrument for runs
   m_uiForm.leRunNo->setInstrumentOverride(instDetails["instrument"]);
 
   // Set spectra range
-  m_dblManager->setValue(m_properties["ResSpecMin"],
-                         instDetails["spectra-min"].toDouble());
-  m_dblManager->setValue(m_properties["ResSpecMax"],
-                         instDetails["spectra-max"].toDouble());
+  setResolutionSpectraRange(instDetails["spectra-min"].toDouble(),
+                            instDetails["spectra-max"].toDouble());
 
   // Set peak and background ranges
-  std::map<std::string, double> ranges = getRangesFromInstrument();
-
-  QPair<double, double> peakRange(ranges["peak-start-tof"],
-                                  ranges["peak-end-tof"]);
-  QPair<double, double> backgroundRange(ranges["back-start-tof"],
-                                        ranges["back-end-tof"]);
-
-  auto calPeak = m_uiForm.ppCalibration->getRangeSelector("CalPeak");
-  auto calBackground =
-      m_uiForm.ppCalibration->getRangeSelector("CalBackground");
-  setRangeSelector(calPeak, m_properties["CalPeakMin"],
-                   m_properties["CalPeakMax"], peakRange);
-  setRangeSelector(calBackground, m_properties["CalBackMin"],
-                   m_properties["CalBackMax"], backgroundRange);
+  const auto ranges = getRangesFromInstrument();
+  setPeakRange(ranges.at("peak-start-tof"), ranges.at("peak-end-tof"));
+  setBackgroundRange(ranges.at("back-start-tof"), ranges.at("back-end-tof"));
 }
 
 /**
@@ -408,24 +378,17 @@ void ISISCalibration::calPlotRaw() {
     return;
   }
 
-  MatrixWorkspace_sptr input = boost::dynamic_pointer_cast<MatrixWorkspace>(
+  const auto input = boost::dynamic_pointer_cast<MatrixWorkspace>(
       AnalysisDataService::Instance().retrieve(wsname.toStdString()));
-
-  const auto &dataX = input->x(0);
-  QPair<double, double> range(dataX.front(), dataX.back());
 
   m_uiForm.ppCalibration->clear();
   m_uiForm.ppCalibration->addSpectrum("Raw", input, 0);
   m_uiForm.ppCalibration->resizeX();
 
-  auto calPeak = m_uiForm.ppCalibration->getRangeSelector("CalPeak");
-  auto calBackground =
-      m_uiForm.ppCalibration->getRangeSelector("CalBackground");
-  setPlotPropertyRange(calPeak, m_properties["CalELow"],
-                       m_properties["CalEHigh"], range);
-  setPlotPropertyRange(calBackground, m_properties["CalStart"],
-                       m_properties["CalEnd"], range);
-
+  const auto &dataX = input->x(0);
+  setPeakRange(dataX.front(), dataX.back(), "CalELow", "CalEHigh");
+  setBackgroundRange(dataX.front(), dataX.back(), "CalStart", "CalEnd");
+    
   setDefaultInstDetails();
 
   m_uiForm.ppCalibration->replot();
@@ -443,32 +406,8 @@ void ISISCalibration::calPlotEnergy() {
     return;
   }
 
-  QString files = m_uiForm.leRunNo->getFilenames().join(",");
-
-  QFileInfo fi(m_uiForm.leRunNo->getFirstFilename());
-
-  QString detRange =
-      QString::number(m_dblManager->value(m_properties["ResSpecMin"])) + "," +
-      QString::number(m_dblManager->value(m_properties["ResSpecMax"]));
-
-  IAlgorithm_sptr reductionAlg =
-      AlgorithmManager::Instance().create("ISISIndirectEnergyTransfer");
-  reductionAlg->initialize();
-  reductionAlg->setProperty(
-      "Instrument",
-      getInstrumentConfiguration()->getInstrumentName().toStdString());
-  reductionAlg->setProperty(
-      "Analyser",
-      getInstrumentConfiguration()->getAnalyserName().toStdString());
-  reductionAlg->setProperty(
-      "Reflection",
-      getInstrumentConfiguration()->getReflectionName().toStdString());
-  reductionAlg->setProperty("InputFiles", files.toStdString());
-  reductionAlg->setProperty("OutputWorkspace",
-                            "__IndirectCalibration_reduction");
-  reductionAlg->setProperty("SpectraRange", detRange.toStdString());
-  reductionAlg->setProperty("LoadLogFiles",
-                            m_uiForm.ckLoadLogFiles->isChecked());
+  const auto files = m_uiForm.leRunNo->getFilenames().join(",");
+  auto reductionAlg = energyTransferReductionAlgorithm(files);
   reductionAlg->execute();
 
   if (!reductionAlg->isExecuted()) {
@@ -634,11 +573,11 @@ void ISISCalibration::calUpdateRS(QtProperty *prop, double val) {
 }
 
 /**
-* This function enables/disables the display of the options involved in creating
-*the RES file.
-*
-* @param state :: whether checkbox is checked or unchecked
-*/
+ * This function enables/disables the display of the options involved in
+ *creating the RES file.
+ *
+ * @param state :: whether checkbox is checked or unchecked
+ */
 void ISISCalibration::resCheck(bool state) {
   m_uiForm.ppResolution->getRangeSelector("ResPeak")->setVisible(state);
   m_uiForm.ppResolution->getRangeSelector("ResBackground")->setVisible(state);
@@ -710,5 +649,94 @@ void ISISCalibration::plotClicked() {
   }
   plotSpectrum(plotWorkspaces);
 }
+
+void ISISCalibration::addRuntimeSmoothing(const QString &workspaceName) {
+  auto smoothAlg = AlgorithmManager::Instance().create("WienerSmooth");
+  smoothAlg->initialize();
+  smoothAlg->setProperty("OutputWorkspace", workspaceName.toStdString());
+
+  BatchAlgorithmRunner::AlgorithmRuntimeProps smoothAlgInputProps;
+  smoothAlgInputProps["InputWorkspace"] =
+      workspaceName.toStdString() + "_pre_smooth";
+  m_batchAlgoRunner->addAlgorithm(smoothAlg, smoothAlgInputProps);
+}
+
+IAlgorithm_sptr
+ISISCalibration::calibrationAlgorithm(const QString &inputFiles) const {
+  auto calibrationAlg =
+      AlgorithmManager::Instance().create("IndirectCalibration");
+  calibrationAlg->initialize();
+  calibrationAlg->setProperty("InputFiles", inputFiles);
+  calibrationAlg->setProperty("OutputWorkspace",
+                              m_outputCalibrationName.toStdString());
+  calibrationAlg->setProperty("DetectorRange",
+                              instrumentDetectorRangeString().toStdString());
+  calibrationAlg->setProperty("PeakRange", peakRangeString().toStdString());
+  calibrationAlg->setProperty("BackgroundRange",
+                              backgroundRangeString().toStdString());
+  calibrationAlg->setProperty("LoadLogFiles",
+                              m_uiForm.ckLoadLogFiles->isChecked());
+
+  if (m_uiForm.ckScale->isChecked())
+    calibrationAlg->setProperty("ScaleFactor", m_uiForm.spScale->value());
+  return calibrationAlg;
+}
+
+IAlgorithm_sptr
+ISISCalibration::resolutionAlgorithm(const QString &inputFiles) const {
+  auto resAlg = AlgorithmManager::Instance().create("IndirectResolution", -1);
+  resAlg->initialize();
+  resAlg->setProperty("InputFiles", inputFiles.toStdString());
+  resAlg->setProperty(
+      "Instrument",
+      getInstrumentConfiguration()->getInstrumentName().toStdString());
+  resAlg->setProperty(
+      "Analyser",
+      getInstrumentConfiguration()->getAnalyserName().toStdString());
+  resAlg->setProperty(
+      "Reflection",
+      getInstrumentConfiguration()->getReflectionName().toStdString());
+  resAlg->setProperty("RebinParam", rebinString().toStdString());
+  resAlg->setProperty("DetectorRange",
+                      resolutionDetectorRangeString().toStdString());
+  resAlg->setProperty("BackgroundRange", backgroundString().toStdString());
+  resAlg->setProperty("LoadLogFiles", m_uiForm.ckLoadLogFiles->isChecked());
+
+  if (m_uiForm.ckResolutionScale->isChecked())
+    resAlg->setProperty("ScaleFactor", m_uiForm.spScale->value());
+
+  if (m_uiForm.ckSmoothResolution->isChecked())
+    resAlg->setProperty("OutputWorkspace",
+                        m_outputResolutionName.toStdString() + "_pre_smooth");
+  else
+    resAlg->setProperty("OutputWorkspace",
+                        m_outputResolutionName.toStdString());
+  return resAlg;
+}
+
+IAlgorithm_sptr ISISCalibration::energyTransferReductionAlgorithm(
+    const QString &inputFiles) const {
+  IAlgorithm_sptr reductionAlg =
+      AlgorithmManager::Instance().create("ISISIndirectEnergyTransfer");
+  reductionAlg->initialize();
+  reductionAlg->setProperty(
+      "Instrument",
+      getInstrumentConfiguration()->getInstrumentName().toStdString());
+  reductionAlg->setProperty(
+      "Analyser",
+      getInstrumentConfiguration()->getAnalyserName().toStdString());
+  reductionAlg->setProperty(
+      "Reflection",
+      getInstrumentConfiguration()->getReflectionName().toStdString());
+  reductionAlg->setProperty("InputFiles", inputFiles.toStdString());
+  reductionAlg->setProperty("OutputWorkspace",
+                            "__IndirectCalibration_reduction");
+  reductionAlg->setProperty("SpectraRange",
+                            resolutionDetectorRangeString().toStdString());
+  reductionAlg->setProperty("LoadLogFiles",
+                            m_uiForm.ckLoadLogFiles->isChecked());
+  return reductionAlg;
+}
+
 } // namespace CustomInterfaces
-} // namespace Mantid
+} // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -6,11 +6,23 @@
 
 #include <QFileInfo>
 
+#include <stdexcept>
+
 using namespace Mantid::API;
 
 namespace {
 Mantid::Kernel::Logger g_log("ISISCalibration");
+
+template <typename Map, typename Key, typename Value>
+Value getValueOr(const Map &map, const Key &key, const Value &defaultValue) {
+  try {
+    return map.at(key);
+  } catch (std::out_of_range &) {
+    return defaultValue;
+  }
 }
+
+} // namespace
 
 using namespace Mantid::API;
 using MantidQt::API::BatchAlgorithmRunner;
@@ -352,8 +364,10 @@ void ISISCalibration::setDefaultInstDetails() {
 
   // Set peak and background ranges
   const auto ranges = getRangesFromInstrument();
-  setPeakRange(ranges.at("peak-start-tof"), ranges.at("peak-end-tof"));
-  setBackgroundRange(ranges.at("back-start-tof"), ranges.at("back-end-tof"));
+  setPeakRange(getValueOr(ranges, "peak-start-tof", 0.0),
+               getValueOr(ranges, "peak-end-tof", 0.0));
+  setBackgroundRange(getValueOr(ranges, "back-start-tof", 0.0),
+                     getValueOr(ranges, "back-end-tof", 0.0));
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -223,32 +223,41 @@ QString ISISCalibration::backgroundString() const {
          QString::number(m_dblManager->value(m_properties["ResEnd"]));
 }
 
-void ISISCalibration::setPeakRange(const double &peakMin, const double &peakMax,
-                                   const QString &minPropertyName,
-                                   const QString &maxPropertyName) {
+void ISISCalibration::setPeak(const double &minimumTof,
+                              const double &maximumTof) {
   auto calibrationPeak = m_uiForm.ppCalibration->getRangeSelector("CalPeak");
-  setRangeSelector(calibrationPeak, m_properties[minPropertyName],
-                   m_properties[maxPropertyName], qMakePair(peakMin, peakMax));
+  setRangeSelector(calibrationPeak, m_properties["CalPeakMin"],
+                   m_properties["CalPeakMax"],
+                   qMakePair(minimumTof, maximumTof));
+}
+
+void ISISCalibration::setBackground(const double &minimumTof,
+                                    const double &maximumTof) {
+  auto background = m_uiForm.ppCalibration->getRangeSelector("CalBackground");
+  setRangeSelector(background, m_properties["CalBackMin"],
+                   m_properties["CalBackMax"],
+                   qMakePair(minimumTof, maximumTof));
+}
+
+void ISISCalibration::setRange(MantidWidgets::RangeSelector *rangeSelector,
+                               const double &minimum, const double &maximum,
+                               const QString &minPropertyName,
+                               const QString &maxPropertyName) {
+  setPlotPropertyRange(rangeSelector, m_properties[minPropertyName],
+                       m_properties[maxPropertyName],
+                       qMakePair(minimum, maximum));
 }
 
 void ISISCalibration::setPeakRange(const double &peakMin,
                                    const double &peakMax) {
-  setPeakRange(peakMin, peakMax, "CalPeakMin", "CalPeakMax");
-}
-
-void ISISCalibration::setBackgroundRange(const double &backgroundMin,
-                                         const double &backgroundMax,
-                                         const QString &minPropertyName,
-                                         const QString &maxPropertyName) {
-  auto background = m_uiForm.ppCalibration->getRangeSelector("CalBackground");
-  setRangeSelector(background, m_properties[minPropertyName],
-                   m_properties[maxPropertyName],
-                   qMakePair(backgroundMin, backgroundMax));
+  auto calibrationPeak = m_uiForm.ppCalibration->getRangeSelector("CalPeak");
+  setRange(calibrationPeak, peakMin, peakMax, "CalELow", "CalEHigh");
 }
 
 void ISISCalibration::setBackgroundRange(const double &backgroundMin,
                                          const double &backgroundMax) {
-  setBackgroundRange(backgroundMin, backgroundMax, "CalBackMin", "CalBackMax");
+  auto background = m_uiForm.ppCalibration->getRangeSelector("CalBackground");
+  setRange(background, backgroundMin, backgroundMax, "CalStart", "CalEnd");
 }
 
 void ISISCalibration::setResolutionSpectraRange(const double &minimum,
@@ -342,8 +351,8 @@ void ISISCalibration::setDefaultInstDetails() {
 
   // Set peak and background ranges
   const auto ranges = getRangesFromInstrument();
-  setPeakRange(ranges.at("peak-start-tof"), ranges.at("peak-end-tof"));
-  setBackgroundRange(ranges.at("back-start-tof"), ranges.at("back-end-tof"));
+  setPeak(ranges.at("peak-start-tof"), ranges.at("peak-end-tof"));
+  setBackground(ranges.at("back-start-tof"), ranges.at("back-end-tof"));
 }
 
 /**
@@ -386,9 +395,9 @@ void ISISCalibration::calPlotRaw() {
   m_uiForm.ppCalibration->resizeX();
 
   const auto &dataX = input->x(0);
-  setPeakRange(dataX.front(), dataX.back(), "CalELow", "CalEHigh");
-  setBackgroundRange(dataX.front(), dataX.back(), "CalStart", "CalEnd");
-    
+  setPeakRange(dataX.front(), dataX.back());
+  setBackgroundRange(dataX.front(), dataX.back());
+
   setDefaultInstDetails();
 
   m_uiForm.ppCalibration->replot();

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -368,6 +368,14 @@ void ISISCalibration::setDefaultInstDetails() {
                getValueOr(ranges, "peak-end-tof", 0.0));
   setBackgroundRange(getValueOr(ranges, "back-start-tof", 0.0),
                      getValueOr(ranges, "back-end-tof", 0.0));
+
+  if (instDetails.contains("resolution") &&
+      !instDetails["resolution"].isEmpty()) {
+    m_uiForm.ckCreateResolution->setEnabled(true);
+  } else {
+    m_uiForm.ckCreateResolution->setChecked(false);
+    m_uiForm.ckCreateResolution->setEnabled(false);
+  }
 }
 
 /**
@@ -489,7 +497,7 @@ void ISISCalibration::calSetDefaultResolution(MatrixWorkspace_const_sptr ws) {
     auto params = comp->getNumberParameter("resolution", true);
 
     // Set the default instrument resolution
-    if (params.size() > 0) {
+    if (!params.empty()) {
       double res = params[0];
 
       const auto energyRange = m_uiForm.ppResolution->getCurveRange("Energy");

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.h
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.h
@@ -58,11 +58,11 @@ public:
   QString rebinString() const;
   QString backgroundString() const;
 
-  void setPeak(const double &minimumTof, const double &maximumTof);
-  void setBackground(const double &minimumTof, const double &maximumTof);
-  void setPeakRange(const double &peakMin, const double &peakMax);
-  void setBackgroundRange(const double &backgroundMin,
-                          const double &backgroundMax);
+  void setPeakRange(const double &minimumTof, const double &maximumTof);
+  void setBackgroundRange(const double &minimumTof, const double &maximumTof);
+  void setPeakRangeLimits(const double &peakMin, const double &peakMax);
+  void setBackgroundRangeLimits(const double &backgroundMin,
+                                const double &backgroundMax);
   void setResolutionSpectraRange(const double &minimum, const double &maximum);
 
 private slots:

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.h
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.h
@@ -58,14 +58,9 @@ public:
   QString rebinString() const;
   QString backgroundString() const;
 
-  void setPeakRange(const double &peakMin, const double &peakMax,
-                    const QString &minPropertyName,
-                    const QString &maxPropertyName);
+  void setPeak(const double &minimumTof, const double &maximumTof);
+  void setBackground(const double &minimumTof, const double &maximumTof);
   void setPeakRange(const double &peakMin, const double &peakMax);
-  void setBackgroundRange(const double &backgroundMin,
-                          const double &backgroundMax,
-                          const QString &minPropertyName,
-                          const QString &maxPropertyName);
   void setBackgroundRange(const double &backgroundMin,
                           const double &backgroundMax);
   void setResolutionSpectraRange(const double &minimum, const double &maximum);
@@ -93,6 +88,9 @@ private slots:
 private:
   void createRESfile(const QString &file);
   void addRuntimeSmoothing(const QString &workspaceName);
+  void setRange(MantidWidgets::RangeSelector *rangeSelector,
+                const double &minimum, const double &maximum,
+                const QString &minPropertyName, const QString &maxPropertyName);
 
   Mantid::API::IAlgorithm_sptr
   calibrationAlgorithm(const QString &inputFiles) const;

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.h
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.h
@@ -1,10 +1,10 @@
 #ifndef MANTIDQTCUSTOMINTERFACES_ISISCALIBRATION_H_
 #define MANTIDQTCUSTOMINTERFACES_ISISCALIBRATION_H_
 
-#include "IndirectDataReductionTab.h"
-#include "ui_ISISCalibration.h"
-#include "MantidKernel/System.h"
 #include "../General/UserInputValidator.h"
+#include "IndirectDataReductionTab.h"
+#include "MantidKernel/System.h"
+#include "ui_ISISCalibration.h"
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -46,6 +46,30 @@ public:
   void run() override;
   bool validate() override;
 
+  std::pair<double, double> peakRange() const;
+  std::pair<double, double> backgroundRange() const;
+  std::pair<double, double> resolutionRange() const;
+
+  QString peakRangeString() const;
+  QString backgroundRangeString() const;
+  QString instrumentDetectorRangeString() const;
+  QString outputWorkspaceName() const;
+  QString resolutionDetectorRangeString() const;
+  QString rebinString() const;
+  QString backgroundString() const;
+
+  void setPeakRange(const double &peakMin, const double &peakMax,
+                    const QString &minPropertyName,
+                    const QString &maxPropertyName);
+  void setPeakRange(const double &peakMin, const double &peakMax);
+  void setBackgroundRange(const double &backgroundMin,
+                          const double &backgroundMax,
+                          const QString &minPropertyName,
+                          const QString &maxPropertyName);
+  void setBackgroundRange(const double &backgroundMin,
+                          const double &backgroundMax);
+  void setResolutionSpectraRange(const double &minimum, const double &maximum);
+
 private slots:
   void algorithmComplete(bool error);
   void calPlotRaw();
@@ -68,6 +92,14 @@ private slots:
 
 private:
   void createRESfile(const QString &file);
+  void addRuntimeSmoothing(const QString &workspaceName);
+
+  Mantid::API::IAlgorithm_sptr
+  calibrationAlgorithm(const QString &inputFiles) const;
+  Mantid::API::IAlgorithm_sptr
+  resolutionAlgorithm(const QString &inputFiles) const;
+  Mantid::API::IAlgorithm_sptr
+  energyTransferReductionAlgorithm(const QString &inputFiles) const;
 
   Ui::ISISCalibration m_uiForm;
   QString m_lastCalPlotFilename;
@@ -76,6 +108,6 @@ private:
   QString m_outputResolutionName;
 };
 } // namespace CustomInterfaces
-} // namespace Mantid
+} // namespace MantidQt
 
 #endif // MANTIDQTCUSTOMINTERFACES_ISISCALIBRATION_H_

--- a/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.cpp
@@ -84,7 +84,7 @@ IndirectDataReductionTab::loadInstrumentIfNotExist(std::string instrumentName,
  *
  * @return Map of information ID to value
  */
-QMap<QString, QString> IndirectDataReductionTab::getInstrumentDetails() {
+QMap<QString, QString> IndirectDataReductionTab::getInstrumentDetails() const {
   return m_idrUI->getInstrumentDetails();
 }
 
@@ -94,7 +94,7 @@ QMap<QString, QString> IndirectDataReductionTab::getInstrumentDetails() {
  * @return Instrument config widget
  */
 MantidWidgets::IndirectInstrumentConfig *
-IndirectDataReductionTab::getInstrumentConfiguration() {
+IndirectDataReductionTab::getInstrumentConfiguration() const {
   return m_idrUI->m_uiForm.iicInstrumentConfiguration;
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.h
@@ -95,12 +95,12 @@ protected:
                            std::string analyser = "",
                            std::string reflection = "");
   /// Function to get details about the instrumet from a given workspace
-  QMap<QString, QString> getInstrumentDetails();
+  QMap<QString, QString> getInstrumentDetails() const;
   std::map<std::string, double>
   getRangesFromInstrument(QString instName = "", QString analyser = "",
                           QString reflection = "");
   /// Get the instrument config widget
-  MantidWidgets::IndirectInstrumentConfig *getInstrumentConfiguration();
+  MantidWidgets::IndirectInstrumentConfig *getInstrumentConfiguration() const;
 
 private slots:
   void tabExecutionComplete(bool error);


### PR DESCRIPTION
In the Interfaces > Indirect > Data Reduction > ISIS Calibration interface, running the calibration without creating a resolution file and subsequently checking the ```Create RES File``` check-box and clicking ```Plot Result``` produces the error:
```
Error while plotting:
The workspace "" could not be found.
```

This PR fixes this issue, by checking whether the resolution file has been created in the previous calibration run before attempting to plot it.

**To test:**
1. Navigate to ```Interfaces > Indirect > Data Reduction > ISIS Calibration```.
2. Type ```26173``` into the ```Run No``` field and press enter.
3. Click the ```Run``` button.
4. Once the calibration has completed, check the check-box labelled ```Create RES File```.
5. Click the ```Plot Result``` button.
6. Ensure no error/warning is produced and a plot of the calibration is produced.

<!-- Instructions for testing. -->

Fixes #21969. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
