### PR TITLE
Muon analysis handles 0 good frames gracefully

### DIFF
--- a/Framework/Algorithms/src/EstimateMuonAsymmetryFromCounts.cpp
+++ b/Framework/Algorithms/src/EstimateMuonAsymmetryFromCounts.cpp
@@ -97,8 +97,11 @@ void EstimateMuonAsymmetryFromCounts::exec() {
   double startX = getProperty("StartX");
   double endX = getProperty("EndX");
   const Mantid::API::Run &run = inputWS->run();
-  const double numGoodFrames = std::stod(run.getProperty("goodfrm")->value());
-
+  double numGoodFrames = std::stod(run.getProperty("goodfrm")->value());
+  if (numGoodFrames == 0) {
+	  g_log.warning("The data has no good frames, assuming a value of 1");
+	  numGoodFrames = 1;
+  }
   // Share the X values
   for (size_t i = 0; i < static_cast<size_t>(numSpectra); ++i) {
     outputWS->setSharedX(i, inputWS->sharedX(i));

--- a/Framework/Algorithms/src/EstimateMuonAsymmetryFromCounts.cpp
+++ b/Framework/Algorithms/src/EstimateMuonAsymmetryFromCounts.cpp
@@ -99,8 +99,8 @@ void EstimateMuonAsymmetryFromCounts::exec() {
   const Mantid::API::Run &run = inputWS->run();
   double numGoodFrames = std::stod(run.getProperty("goodfrm")->value());
   if (numGoodFrames == 0) {
-	  g_log.warning("The data has no good frames, assuming a value of 1");
-	  numGoodFrames = 1;
+    g_log.warning("The data has no good frames, assuming a value of 1");
+    numGoodFrames = 1;
   }
   // Share the X values
   for (size_t i = 0; i < static_cast<size_t>(numSpectra); ++i) {

--- a/docs/source/release/v3.12.0/muon.rst
+++ b/docs/source/release/v3.12.0/muon.rst
@@ -27,10 +27,12 @@ Interface
 - The Frequency Domain Analysis GUI now uses :ref:`CalMuonDetectorPhases <algm-CalMuonDetectorPhases>` to create the phase table for PhaseQuad FFTs. 
 - The Frequency Domain Analysis GUI now uses :ref:`MuonMaxent <algm-MuonMaxent>` to calculate the frequency spectrum in MaxEnt mode.
 - The ALC interface now allows background sections with negative values.  
+- If data is loaded with 0 good frames into Muon Analysis then it will try to load the data without dead time correction (does not need number of good frames). 
 
 Algorithms
 ----------
 - :ref:`MuonProcess <algm-MuonProcess>` now has a flag to determine if to crop the input workspace (default is true). In the Muon Analysis interface this flag has been set to false.
 - :ref:`MuonMaxent <algm-MuonMaxent>` calculates a single frequency spectrum from multiple time domain spectra. 
+-  :ref:`EstimateMuonAsymmetryFromCounts <algm-EstimateMuonAsymmetryFromCounts-v1>`: if the number of good frames is zero, then a value of 1 is assumed for the number of good frames.
 
 :ref:`Release 3.12.0 <v3.12.0>`

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -136,7 +136,7 @@ MuonAnalysis::MuonAnalysis(QWidget *parent)
       m_dataTimeZero(0.0), m_dataFirstGoodData(0.0),
       m_currentLabel("NoLabelSet"), m_numPeriods(0),
       m_groupingHelper(this->m_uiForm), m_functionBrowser(nullptr),
-      m_dataSelector(nullptr),
+      m_dataSelector(nullptr),m_deadTimeIndex(-1),m_useDeadTime(true),
       m_dataLoader(Muon::DeadTimesType::None, // will be replaced by correct
                                               // instruments later
                    {"MUSR", "HIFI", "EMU", "ARGUS", "CHRONUS"}) {}
@@ -1218,6 +1218,12 @@ MuonAnalysis::getGrouping(boost::shared_ptr<LoadResult> loadResult) const {
  * @param files :: All file names for the files loading.
  */
 void MuonAnalysis::inputFileChanged(const QStringList &files) {
+	if (m_deadTimeIndex != -1 && m_useDeadTime) {
+		QMessageBox::warning(this, "Restoring dead time correction",
+			"Will use previous dead time correction");
+		m_uiForm.deadTimeType->setCurrentIndex(m_deadTimeIndex);
+		m_deadTimeIndex = -1;
+	}
   if (files.size() <= 0)
     return;
 
@@ -1252,6 +1258,19 @@ void MuonAnalysis::inputFileChanged(const QStringList &files) {
         m_dataLoader.correctAndGroup(*loadResult, *groupResult->groupingUsed);
 
   } catch (const std::exception &e) {
+	  // if it failed try again with no dead time correction
+	  if (m_deadTimeIndex == -1) {
+		  m_deadTimeIndex =m_uiForm.deadTimeType->currentIndex();
+		  if (m_deadTimeIndex != 0) {
+			  QMessageBox::warning(this, "Loading failed",
+				  "Will try without dead time correction");
+		     m_uiForm.deadTimeType->setCurrentIndex(0);
+			 // dont use dead time for next run
+			 m_useDeadTime = false;
+			  inputFileChanged(files);
+			  return;
+		  }
+	  }
     g_log.error(e.what());
     QMessageBox::critical(this, "Loading failed",
                           "Unable to load the file[s]. See log for details.");
@@ -1261,6 +1280,8 @@ void MuonAnalysis::inputFileChanged(const QStringList &files) {
 
     return;
   }
+  //load worked so lets turn dead time on
+  m_useDeadTime = true;
   // At this point we are sure that new data was loaded successfully, so we can
   // safely overwrite
   // previous one.

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -136,10 +136,11 @@ MuonAnalysis::MuonAnalysis(QWidget *parent)
       m_dataTimeZero(0.0), m_dataFirstGoodData(0.0),
       m_currentLabel("NoLabelSet"), m_numPeriods(0),
       m_groupingHelper(this->m_uiForm), m_functionBrowser(nullptr),
-      m_dataSelector(nullptr), 
+      m_dataSelector(nullptr),
       m_dataLoader(Muon::DeadTimesType::None, // will be replaced by correct
                                               // instruments later
-                   {"MUSR", "HIFI", "EMU", "ARGUS", "CHRONUS"}), m_deadTimeIndex(-1), m_useDeadTime(true) {}
+                   {"MUSR", "HIFI", "EMU", "ARGUS", "CHRONUS"}),
+      m_deadTimeIndex(-1), m_useDeadTime(true) {}
 
 /**
  * Destructor

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -136,10 +136,10 @@ MuonAnalysis::MuonAnalysis(QWidget *parent)
       m_dataTimeZero(0.0), m_dataFirstGoodData(0.0),
       m_currentLabel("NoLabelSet"), m_numPeriods(0),
       m_groupingHelper(this->m_uiForm), m_functionBrowser(nullptr),
-      m_dataSelector(nullptr), m_deadTimeIndex(-1), m_useDeadTime(true),
+      m_dataSelector(nullptr), 
       m_dataLoader(Muon::DeadTimesType::None, // will be replaced by correct
                                               // instruments later
-                   {"MUSR", "HIFI", "EMU", "ARGUS", "CHRONUS"}) {}
+                   {"MUSR", "HIFI", "EMU", "ARGUS", "CHRONUS"}), m_deadTimeIndex(-1), m_useDeadTime(true) {}
 
 /**
  * Destructor

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -136,7 +136,7 @@ MuonAnalysis::MuonAnalysis(QWidget *parent)
       m_dataTimeZero(0.0), m_dataFirstGoodData(0.0),
       m_currentLabel("NoLabelSet"), m_numPeriods(0),
       m_groupingHelper(this->m_uiForm), m_functionBrowser(nullptr),
-      m_dataSelector(nullptr),m_deadTimeIndex(-1),m_useDeadTime(true),
+      m_dataSelector(nullptr), m_deadTimeIndex(-1), m_useDeadTime(true),
       m_dataLoader(Muon::DeadTimesType::None, // will be replaced by correct
                                               // instruments later
                    {"MUSR", "HIFI", "EMU", "ARGUS", "CHRONUS"}) {}
@@ -1218,12 +1218,12 @@ MuonAnalysis::getGrouping(boost::shared_ptr<LoadResult> loadResult) const {
  * @param files :: All file names for the files loading.
  */
 void MuonAnalysis::inputFileChanged(const QStringList &files) {
-	if (m_deadTimeIndex != -1 && m_useDeadTime) {
-		QMessageBox::warning(this, "Restoring dead time correction",
-			"Will use previous dead time correction");
-		m_uiForm.deadTimeType->setCurrentIndex(m_deadTimeIndex);
-		m_deadTimeIndex = -1;
-	}
+  if (m_deadTimeIndex != -1 && m_useDeadTime) {
+    QMessageBox::warning(this, "Restoring dead time correction",
+                         "Will use previous dead time correction");
+    m_uiForm.deadTimeType->setCurrentIndex(m_deadTimeIndex);
+    m_deadTimeIndex = -1;
+  }
   if (files.size() <= 0)
     return;
 
@@ -1258,19 +1258,19 @@ void MuonAnalysis::inputFileChanged(const QStringList &files) {
         m_dataLoader.correctAndGroup(*loadResult, *groupResult->groupingUsed);
 
   } catch (const std::exception &e) {
-	  // if it failed try again with no dead time correction
-	  if (m_deadTimeIndex == -1) {
-		  m_deadTimeIndex =m_uiForm.deadTimeType->currentIndex();
-		  if (m_deadTimeIndex != 0) {
-			  QMessageBox::warning(this, "Loading failed",
-				  "Will try without dead time correction");
-		     m_uiForm.deadTimeType->setCurrentIndex(0);
-			 // dont use dead time for next run
-			 m_useDeadTime = false;
-			  inputFileChanged(files);
-			  return;
-		  }
-	  }
+    // if it failed try again with no dead time correction
+    if (m_deadTimeIndex == -1) {
+      m_deadTimeIndex = m_uiForm.deadTimeType->currentIndex();
+      if (m_deadTimeIndex != 0) {
+        QMessageBox::warning(this, "Loading failed",
+                             "Will try without dead time correction");
+        m_uiForm.deadTimeType->setCurrentIndex(0);
+        // dont use dead time for next run
+        m_useDeadTime = false;
+        inputFileChanged(files);
+        return;
+      }
+    }
     g_log.error(e.what());
     QMessageBox::critical(this, "Loading failed",
                           "Unable to load the file[s]. See log for details.");
@@ -1280,7 +1280,7 @@ void MuonAnalysis::inputFileChanged(const QStringList &files) {
 
     return;
   }
-  //load worked so lets turn dead time on
+  // load worked so lets turn dead time on
   m_useDeadTime = true;
   // At this point we are sure that new data was loaded successfully, so we can
   // safely overwrite

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.h
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.h
@@ -300,7 +300,7 @@ private:
   /// Creates workspace ready for analysis and plotting
   Mantid::API::Workspace_sptr createAnalysisWorkspace(Muon::ItemType itemType,
                                                       int tableRow,
-                                                      Muon::PlotType type,
+                                                      Muon::PlotType plotType,
                                                       bool isRaw = false);
 
   /// Returns PlotType as chosen using given selector

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.h
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.h
@@ -580,8 +580,8 @@ private:
 
   /// set the group/pair name
   std::string m_groupPairName;
-  bool m_useDeadTime;
   int m_deadTimeIndex;
+  bool m_useDeadTime;
 };
 }
 }

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.h
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.h
@@ -580,6 +580,8 @@ private:
 
   /// set the group/pair name
   std::string m_groupPairName;
+  int m_deadTimeIndex;
+  bool m_useDeadTime;
 };
 }
 }

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.h
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.h
@@ -580,8 +580,8 @@ private:
 
   /// set the group/pair name
   std::string m_groupPairName;
-  int m_deadTimeIndex;
   bool m_useDeadTime;
+  int m_deadTimeIndex;
 };
 }
 }


### PR DESCRIPTION
Muon analysis would fail to load the current run if it had multiple periods. The changes will allow muon analysis to handle this gracefully. 

**To test:**
This needs someone at ISIS. The data is located

\\Olympic\Babylon5\Public\Steve Cottrell 

and is called EMUauto_E.tmp

Open muon analysis and make sure that the dead time correction is set to from file
Load  EMUauto_E.tmp (this is our fake current run with multiple periods). You will need to show all files to find it in the browser
It should give a warning but load the data
The dead time correction box is now none

Change from long to a group fwd
It should produce a warning in the mantid dialog box and produce some data

Go to the settings tab and change the finish value to 1 (makes the next bit easier)
Go back to the home page
Change the run to HIFI00108379
A warning should appear about restoring the dead time correction
Some data should appear and the dead time selection will be from file
Check that the data changes if you change the dead time selection to None



Fixes #22000. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->
In the release notes
---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
