### PR TITLE
Prevent script window crash

### DIFF
--- a/MantidPlot/src/PythonScript.cpp
+++ b/MantidPlot/src/PythonScript.cpp
@@ -647,7 +647,6 @@ bool PythonScript::executeString() {
   }
   // If an error has occurred we need to construct the error message
   // before any other python code is run
-  QString msg;
   if (!result) {
     emit_error();
     // If a script was aborted we both raise a KeyboardInterrupt and
@@ -658,9 +657,9 @@ bool PythonScript::executeString() {
   } else {
     emit finished(MSG_FINISHED);
     success = true;
-  }
-  if (isInteractive()) {
-    generateAutoCompleteList();
+    if (isInteractive() && !isExecuting()) {
+      generateAutoCompleteList();
+    }
   }
 
   Py_XDECREF(compiledCode);

--- a/MantidPlot/src/PythonScript.cpp
+++ b/MantidPlot/src/PythonScript.cpp
@@ -657,7 +657,7 @@ bool PythonScript::executeString() {
   } else {
     emit finished(MSG_FINISHED);
     success = true;
-    if (isInteractive() && !isExecuting()) {
+    if (isInteractive()) {
       generateAutoCompleteList();
     }
   }


### PR DESCRIPTION
Fixes a bug. See issue(s) for more information.

**To test:**
Make sure this does not crash MantidPlot.

```
A = CreateSampleWorkspace()
B = A.getRun().getProperty('run_title')
A = CreateSampleWorkspace()
A.setTitle(B)
```

**Try to provoke a crash using the Python script window.**

Fixes #22009 

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
