### PR TITLE
multiple fitting in muon analysis

### DIFF
--- a/docs/source/release/v3.12.0/muon.rst
+++ b/docs/source/release/v3.12.0/muon.rst
@@ -27,6 +27,7 @@ Interface
 - The Frequency Domain Analysis GUI now uses :ref:`CalMuonDetectorPhases <algm-CalMuonDetectorPhases>` to create the phase table for PhaseQuad FFTs. 
 - The Frequency Domain Analysis GUI now uses :ref:`MuonMaxent <algm-MuonMaxent>` to calculate the frequency spectrum in MaxEnt mode.
 - The ALC interface now allows background sections with negative values.  
+- Muon analysis no longer disables the "aco add" and "simultaneous" buttons in the multiple fitting interface.
 
 Algorithms
 ----------

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MuonFitDataSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MuonFitDataSelector.h
@@ -132,6 +132,7 @@ private:
   double m_endX;
   QStringList m_chosenGroups;
   QStringList m_chosenPeriods;
+  bool m_multiFit;
 
 private slots:
   /// Set normal cursor and enable input

--- a/qt/widgets/common/src/MuonFitDataSelector.cpp
+++ b/qt/widgets/common/src/MuonFitDataSelector.cpp
@@ -17,7 +17,7 @@ namespace MantidWidgets {
  */
 MuonFitDataSelector::MuonFitDataSelector(QWidget *parent)
     : MantidWidget(parent) {
-	m_multiFit = false;
+  m_multiFit = false;
   m_ui.setupUi(this);
   this->setDefaultValues();
   this->setUpConnections();
@@ -40,7 +40,7 @@ MuonFitDataSelector::MuonFitDataSelector(QWidget *parent, int runNumber,
                                           size_t numPeriods,
                                           const QStringList &groups)*/
     : MuonFitDataSelector(parent) {
-	m_multiFit = false;
+  m_multiFit = false;
   this->setWorkspaceDetails(QString::number(runNumber), instName,
                             boost::optional<QString>{});
   // not used in this case
@@ -91,7 +91,7 @@ void MuonFitDataSelector::userChangedRuns() {
   const auto runs = getRuns();
   if (runs.contains(',') || runs.contains('-')) {
     // record if its multi fit
-	  m_multiFit = true;
+    m_multiFit = true;
   } else {
     setFitType(FitType::Single);
   }
@@ -292,9 +292,9 @@ IMuonFitDataSelector::FitType MuonFitDataSelector::getFitType() const {
  */
 void MuonFitDataSelector::setFitType(IMuonFitDataSelector::FitType type) {
   if (type == FitType::Single) {
-	  m_multiFit = false;
+    m_multiFit = false;
   } else {
-	  m_multiFit = true;
+    m_multiFit = true;
 
     m_ui.rbCoAdd->setChecked(type == FitType::CoAdd);
     m_ui.rbSimultaneous->setChecked(type == FitType::Simultaneous);

--- a/qt/widgets/common/src/MuonFitDataSelector.cpp
+++ b/qt/widgets/common/src/MuonFitDataSelector.cpp
@@ -17,6 +17,7 @@ namespace MantidWidgets {
  */
 MuonFitDataSelector::MuonFitDataSelector(QWidget *parent)
     : MantidWidget(parent) {
+	m_multiFit = false;
   m_ui.setupUi(this);
   this->setDefaultValues();
   this->setUpConnections();
@@ -39,6 +40,7 @@ MuonFitDataSelector::MuonFitDataSelector(QWidget *parent, int runNumber,
                                           size_t numPeriods,
                                           const QStringList &groups)*/
     : MuonFitDataSelector(parent) {
+	m_multiFit = false;
   this->setWorkspaceDetails(QString::number(runNumber), instName,
                             boost::optional<QString>{});
   // not used in this case
@@ -88,9 +90,8 @@ void MuonFitDataSelector::userChangedRuns() {
   // check for single run and enable/disable radio buttons
   const auto runs = getRuns();
   if (runs.contains(',') || runs.contains('-')) {
-    // if buttons are disabled, enable them
-    m_ui.rbCoAdd->setEnabled(true);
-    m_ui.rbSimultaneous->setEnabled(true);
+    // record if its multi fit
+	  m_multiFit = true;
   } else {
     setFitType(FitType::Single);
   }
@@ -269,7 +270,7 @@ void MuonFitDataSelector::setUserInput(const QVariant &value) {
 IMuonFitDataSelector::FitType MuonFitDataSelector::getFitType() const {
   // If radio buttons disabled, it's a single fit unless multiple groups/periods
   // chosen
-  if (!m_ui.rbCoAdd->isEnabled()) {
+  if (!m_multiFit) {
     return m_chosenGroups.size() <= 1 && m_chosenPeriods.size() <= 1
                ? FitType::Single
                : FitType::Simultaneous;
@@ -291,11 +292,10 @@ IMuonFitDataSelector::FitType MuonFitDataSelector::getFitType() const {
  */
 void MuonFitDataSelector::setFitType(IMuonFitDataSelector::FitType type) {
   if (type == FitType::Single) {
-    m_ui.rbCoAdd->setEnabled(false);
-    m_ui.rbSimultaneous->setEnabled(false);
+	  m_multiFit = false;
   } else {
-    m_ui.rbCoAdd->setEnabled(true);
-    m_ui.rbSimultaneous->setEnabled(true);
+	  m_multiFit = true;
+
     m_ui.rbCoAdd->setChecked(type == FitType::CoAdd);
     m_ui.rbSimultaneous->setChecked(type == FitType::Simultaneous);
   }


### PR DESCRIPTION
The multiple fitting in muon analysis originally disabled the selection for co-add and simultaneous until runs had been entered. This PR removes that

**To test:**
Open muon analysis
Load some data (e.g. HIFI00108376)
Go to the settings tab and make sure that the multiple fitting box is ticked
Go to data analysis tab
Check that the co-add and simultaneous buttons are not disabled

Add a fitting function and do a fit - the fit should appear on the plot

Select simultaneous 
In the runs box add "-9" and press enter
The data files for  HIFI00108377, HIFI00108378,HIFI00108379 should appear in the ADS
Do a fit

Select co-add 
A workspace should appear called HIFI00108376-9 
Do a fit


<!-- Instructions for testing. -->

Fixes #22003. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
