### PR TITLE
Indirect - Absorption Corrections - Unify naming convention in Calculate Paalman Pings and Calculate Monte Carlo Absorption

### DIFF
--- a/docs/source/release/v3.12.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.12.0/indirect_inelastic.rst
@@ -111,6 +111,7 @@ Improved
 Bugfixes
 ########
 - In the Calculate Paalman Pings tab of the Indirect Correction interface the container back thickness is now set correctly.
+- Fixed the inconsistent naming styles of the Calculate Paalman Pings and Calculate Monte Carlo Absorption interfaces.
 
 
 Abins

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
@@ -92,7 +92,7 @@ void AbsorptionCorrections::run() {
     monteCarloAbsCor->setProperty("ContainerDensity",
                                   m_uiForm.spCanDensity->value());
 
-    QString canChemicalFormula = m_uiForm.leCanChemicalFormula->text();
+    const auto canChemicalFormula = m_uiForm.leCanChemicalFormula->text();
     monteCarloAbsCor->setProperty("ContainerChemicalFormula",
                                   canChemicalFormula.toStdString());
 
@@ -104,9 +104,8 @@ void AbsorptionCorrections::run() {
   if (nameCutIndex == -1)
     nameCutIndex = sampleWsName.length();
 
-  QString outputBaseName = sampleWsName.left(nameCutIndex);
-
-  QString outputWsName = outputBaseName + "_" + sampleShape + "_Corrections";
+  const auto outputWsName =
+      sampleWsName.left(nameCutIndex) + "_" + sampleShape + "_MC_Corrections";
 
   monteCarloAbsCor->setProperty("CorrectionsWorkspace",
                                 outputWsName.toStdString());

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.ui
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>704</width>
-    <height>591</height>
+    <width>752</width>
+    <height>744</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -76,13 +76,12 @@
         </property>
         <property name="workspaceSuffixes" stdset="0">
          <stringlist>
-          <string>_flt_abs</string>
           <string>_Corrections</string>
          </stringlist>
         </property>
         <property name="fileBrowserSuffixes" stdset="0">
          <stringlist>
-          <string>_flt_abs.nxs</string>
+          <string>_Corrections.nxs</string>
          </stringlist>
         </property>
         <property name="showLoad" stdset="0">
@@ -264,9 +263,7 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
-       <widget class="MantidQt::MantidWidgets::PreviewPlot" name="ppPreview" native="true">
-        <zorder>gbOptions</zorder>
-       </widget>
+       <widget class="MantidQt::MantidWidgets::PreviewPlot" name="ppPreview" native="true"/>
       </item>
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_2">

--- a/qt/scientific_interfaces/Indirect/CalculatePaalmanPings.cpp
+++ b/qt/scientific_interfaces/Indirect/CalculatePaalmanPings.cpp
@@ -149,21 +149,8 @@ void CalculatePaalmanPings::run() {
   if (nameCutIndex == -1)
     nameCutIndex = sampleWsName.length();
 
-  QString correctionType;
-  switch (m_uiForm.cbSampleShape->currentIndex()) {
-  case 0:
-    correctionType = "flt";
-    break;
-  case 1:
-    correctionType = "cyl";
-    break;
-  case 2:
-    correctionType = "ann";
-    break;
-  }
-
   const auto outputWsName =
-      sampleWsName.left(nameCutIndex) + "_" + correctionType + "_abs";
+      sampleWsName.left(nameCutIndex) + "_" + sampleShape + "_PP_Corrections";
 
   absCorAlgo->setProperty("OutputWorkspace", outputWsName.toStdString());
 


### PR DESCRIPTION
The Interfaces > Indirect > Corrections > Calculate Paalman Pings and Interfaces > Indirect > Corrections > Calculate Monte Carlo Absorption do not not currently add an equivalent prefix to their output.

The Calculate Monte Carlo Absorption currently produces the correct output name (minus a qualifier specifying that a Monte Carlo approach was used); Calculate Paalman Pings should be modified. As a result, the Apply Absorption Corrections interface does not automatically recognise and allow selection of the output produced by Calculate Paalman Pings.

This PR unifies the name of output produced by the Calculate Paalman Pings and Calculate Monte Carlo Absorption interfaces.

**To test:**
Calculate Paalman Pings
1. Navigate to the ```Interfaces > Indirect > Corrections > Calculate  Paalman Pings``` interface.
2. Provide the supplied irs26176* file in the ```Sample``` field.
3. Check the check-box labelled ```Use Can``` and provide the irs26173* file.
4. Change the ```Sample Thickness```, ```Container Front Thickness``` and ```Container Back Thickness``` spinners to 0.1.
5. Enter ```H20``` into the ```Sample Details > Chemical Formula``` field.
6. Enter ```Al``` into the ```Can Details > Chemical Formula``` field.
7. Click ```Run```.
8. Ensure a ```*_FlatPlate_PP_Corrections``` workspace is produced.

Calculate Monte Carlo Absorption
1. Navigate to the ```Interfaces > Indirect > Corrections > Calculate  Paalman Pings``` interface.
2. Provide the supplied irs26176* file in the ```Sample``` field.
3. Check the check-box labelled ```Use Container``` and provide the irs26173* file.
4. Change the ```Sample Height```, ```Sample Width```, ```Sample Thickness```, ```Container Front Thickness``` and ```Container Back Thickness``` spinners to 0.1.
5. Enter ```H20``` into the ```Sample Details > Chemical Formula``` field.
6. Enter ```Al``` into the ```Can Details > Chemical Formula``` field.
7. Click ```Run```.
8. Ensure a ```*_FlatPlate_MC_Corrections``` workspace is produced.

Apply Absorption Corrections
1. Navigate to the ```Interfaces > Indirect > Corrections > Apply Absorption Corrections``` interface.
2. Change the ```Corrections``` drop-down menu from ```File``` to ```Workspace```.
3. Ensure the ```*_FlatPlate_PP_Corrections``` and ```*_FlatPlate_MC_Corrections``` workspaces are available for selection.

<!-- Instructions for testing. -->

Fixes #22024 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
Release notes have been updated.
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
