### PR TITLE
22036 make error reports modal

### DIFF
--- a/scripts/ErrorReporter/errorreport.py
+++ b/scripts/ErrorReporter/errorreport.py
@@ -1,5 +1,5 @@
 import sys
-from PyQt4 import QtGui
+from PyQt4 import QtGui, QtCore
 import ui_errorreport
 from PyQt4.QtCore import pyqtSignal
 from mantidqtpython import MantidQt
@@ -11,6 +11,7 @@ class CrashReportPage(QtGui.QWidget, ui_errorreport.Ui_Errorreport):
     def __init__(self, parent=None):
         super(self.__class__, self).__init__(parent)
         self.setupUi(self)
+        self.setFixedSize(self.width(), self.height())
 
         self.action.connect(QtGui.QApplication.instance().errorHandling)
 
@@ -25,6 +26,9 @@ class CrashReportPage(QtGui.QWidget, ui_errorreport.Ui_Errorreport):
         self.fullShareButton.clicked.connect(self.fullShare)
         self.nonIDShareButton.clicked.connect(self.nonIDShare)
         self.noShareButton.clicked.connect(self.noShare)
+
+        self.setWindowFlags(QtCore.Qt.CustomizeWindowHint | QtCore.Qt.WindowTitleHint | QtCore.Qt.WindowStaysOnTopHint)
+        self.setWindowModality(QtCore.Qt.ApplicationModal)
 
     def fullShare(self):
         self.action.emit(self.continue_working, 0, self.input_name, self.input_email)


### PR DESCRIPTION
This makes the error reporting window modal and removes the buttons from the title bar

**To test:**
To test:

This ideally needs to be tested on windows, OSX and linux as how windows behave varies across the operating systems.
   
-  To test you first need to provoke an uncaught exception. One method is here #18990
-     When you provoke an uncaught exception check that the error report window pops up. 
-     Check that whilst it is open you cannot do anything else in mantid

- Check that you can't hide it behind other windows

- Check that the close, minimise maximise buttons do not exist on the title bar. (Apparently on OSX they will be disabled rather than nonexistent.)

<!-- Instructions for testing. -->

Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
