### PR TITLE
Fix unhandled exception in MuonAnalysis fit tab

### DIFF
--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -1966,7 +1966,6 @@ bool MuonAnalysis::plotExists(const QString &wsName) {
 void MuonAnalysis::selectMultiPeak(const QString &wsName,
                                    const boost::optional<QString> &filePath) {
   disableAllTools();
-
   if (!plotExists(wsName)) {
     plotSpectrum(wsName);
     setCurrentDataName(wsName);

--- a/qt/scientific_interfaces/Muon/MuonAnalysisFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisFitDataPresenter.cpp
@@ -314,10 +314,10 @@ std::vector<std::string> MuonAnalysisFitDataPresenter::generateWorkspaceNames(
   const std::string instRuns = instrument + runNumber;
   std::vector<int> selectedRuns;
   try {
-	  MuonAnalysisHelper::parseRunLabel(instRuns, params.instrument, selectedRuns);
-  }
-  catch (...) {
-	  throw std::invalid_argument("Failed to parse run label: " + instRuns);
+    MuonAnalysisHelper::parseRunLabel(instRuns, params.instrument,
+                                      selectedRuns);
+  } catch (...) {
+    throw std::invalid_argument("Failed to parse run label: " + instRuns);
   }
   params.version = 1;
   params.plotType = m_plotType;

--- a/qt/scientific_interfaces/Muon/MuonAnalysisFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisFitDataPresenter.cpp
@@ -836,8 +836,7 @@ bool MuonAnalysisFitDataPresenter::isSimultaneousFit() const {
  */
 void MuonAnalysisFitDataPresenter::setSelectedWorkspace(
     const QString &wsName, const boost::optional<QString> &filePath) {
-	auto tm = wsName.toStdString();
-  updateWorkspaceNames(std::vector<std::string>{wsName.toStdString()});
+	updateWorkspaceNames(std::vector<std::string>{wsName.toStdString()});
   setUpDataSelector(wsName, filePath);
 }
 

--- a/qt/scientific_interfaces/Muon/MuonAnalysisFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisFitDataPresenter.cpp
@@ -306,10 +306,10 @@ std::vector<std::string> MuonAnalysisFitDataPresenter::generateWorkspaceNames(
   std::string runNumber = runString;
   auto index = runString.find(instrument);
   if (index != std::string::npos) {
-	  // trim path
-	  runNumber = runString.substr(index+instrument.size());
-	  // trim extension
-	  runNumber = runNumber.substr(0, runNumber.find_first_of("."));
+    // trim path
+    runNumber = runString.substr(index + instrument.size());
+    // trim extension
+    runNumber = runNumber.substr(0, runNumber.find_first_of("."));
   }
   const std::string instRuns = instrument + runNumber;
   std::vector<int> selectedRuns;
@@ -836,7 +836,7 @@ bool MuonAnalysisFitDataPresenter::isSimultaneousFit() const {
  */
 void MuonAnalysisFitDataPresenter::setSelectedWorkspace(
     const QString &wsName, const boost::optional<QString> &filePath) {
-	updateWorkspaceNames(std::vector<std::string>{wsName.toStdString()});
+  updateWorkspaceNames(std::vector<std::string>{wsName.toStdString()});
   setUpDataSelector(wsName, filePath);
 }
 

--- a/qt/scientific_interfaces/Muon/MuonAnalysisFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisFitDataPresenter.cpp
@@ -303,7 +303,15 @@ std::vector<std::string> MuonAnalysisFitDataPresenter::generateWorkspaceNames(
   const auto periods = m_dataSelector->getPeriodSelections();
 
   Muon::DatasetParams params;
-  const std::string instRuns = instrument + runString;
+  std::string runNumber = runString;
+  auto index = runString.find(instrument);
+  if (index != std::string::npos) {
+	  // trim path
+	  runNumber = runString.substr(index+instrument.size());
+	  // trim extension
+	  runNumber = runNumber.substr(0, runNumber.find_first_of("."));
+  }
+  const std::string instRuns = instrument + runNumber;
   std::vector<int> selectedRuns;
   MuonAnalysisHelper::parseRunLabel(instRuns, params.instrument, selectedRuns);
   params.version = 1;
@@ -828,6 +836,7 @@ bool MuonAnalysisFitDataPresenter::isSimultaneousFit() const {
  */
 void MuonAnalysisFitDataPresenter::setSelectedWorkspace(
     const QString &wsName, const boost::optional<QString> &filePath) {
+	auto tm = wsName.toStdString();
   updateWorkspaceNames(std::vector<std::string>{wsName.toStdString()});
   setUpDataSelector(wsName, filePath);
 }

--- a/qt/scientific_interfaces/Muon/MuonAnalysisFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisFitDataPresenter.cpp
@@ -313,7 +313,12 @@ std::vector<std::string> MuonAnalysisFitDataPresenter::generateWorkspaceNames(
   }
   const std::string instRuns = instrument + runNumber;
   std::vector<int> selectedRuns;
-  MuonAnalysisHelper::parseRunLabel(instRuns, params.instrument, selectedRuns);
+  try {
+	  MuonAnalysisHelper::parseRunLabel(instRuns, params.instrument, selectedRuns);
+  }
+  catch (...) {
+	  throw std::invalid_argument("Failed to parse run label: " + instRuns);
+  }
   params.version = 1;
   params.plotType = m_plotType;
 

--- a/qt/scientific_interfaces/Muon/MuonAnalysisFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisFitDataPresenter.cpp
@@ -317,7 +317,14 @@ std::vector<std::string> MuonAnalysisFitDataPresenter::generateWorkspaceNames(
     MuonAnalysisHelper::parseRunLabel(instRuns, params.instrument,
                                       selectedRuns);
   } catch (...) {
-    throw std::invalid_argument("Failed to parse run label: " + instRuns);
+	  params.instrument = instrument;
+	  try {
+		  MuonAnalysisHelper::parseRunLabel(instRuns, params.instrument,
+			  selectedRuns);
+	  }
+	  catch (...) {
+		  g_log.error("Cannot Parse workspace " + instRuns);
+	  }
   }
   params.version = 1;
   params.plotType = m_plotType;

--- a/qt/scientific_interfaces/Muon/MuonAnalysisFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisFitDataPresenter.cpp
@@ -317,14 +317,13 @@ std::vector<std::string> MuonAnalysisFitDataPresenter::generateWorkspaceNames(
     MuonAnalysisHelper::parseRunLabel(instRuns, params.instrument,
                                       selectedRuns);
   } catch (...) {
-	  params.instrument = instrument;
-	  try {
-		  MuonAnalysisHelper::parseRunLabel(instRuns, params.instrument,
-			  selectedRuns);
-	  }
-	  catch (...) {
-		  g_log.error("Cannot Parse workspace " + instRuns);
-	  }
+    params.instrument = instrument;
+    try {
+      MuonAnalysisHelper::parseRunLabel(instRuns, params.instrument,
+                                        selectedRuns);
+    } catch (...) {
+      g_log.error("Cannot Parse workspace " + instRuns);
+    }
   }
   params.version = 1;
   params.plotType = m_plotType;

--- a/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
@@ -1016,11 +1016,14 @@ void parseRunLabel(const std::string &label, std::string &instrument,
           // Single run
           runNumbers.push_back(boost::lexical_cast<int>(pairTokenizer[0]));
         } else {
-          throw std::invalid_argument("Failed to parse run label: " + label);
+          throw std::invalid_argument("Failed to parse run label: " + label +" too many tokens ");
         }
       } catch (const boost::bad_lexical_cast &) {
-        throw std::invalid_argument("Failed to parse run label: " + label);
-      }
+        throw std::invalid_argument("Failed to parse run label: " + label +" not a good run number");
+	  }
+	  catch(...) {
+		  throw std::invalid_argument("Failed to parse run label: " + label);
+	  }
     }
   } else {
     // The string was "INST000" or similar...

--- a/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
@@ -1016,14 +1016,15 @@ void parseRunLabel(const std::string &label, std::string &instrument,
           // Single run
           runNumbers.push_back(boost::lexical_cast<int>(pairTokenizer[0]));
         } else {
-          throw std::invalid_argument("Failed to parse run label: " + label +" too many tokens ");
+          throw std::invalid_argument("Failed to parse run label: " + label +
+                                      " too many tokens ");
         }
       } catch (const boost::bad_lexical_cast &) {
-        throw std::invalid_argument("Failed to parse run label: " + label +" not a good run number");
-	  }
-	  catch(...) {
-		  throw std::invalid_argument("Failed to parse run label: " + label);
-	  }
+        throw std::invalid_argument("Failed to parse run label: " + label +
+                                    " not a good run number");
+      } catch (...) {
+        throw std::invalid_argument("Failed to parse run label: " + label);
+      }
     }
   } else {
     // The string was "INST000" or similar...

--- a/qt/widgets/common/src/MuonFitDataSelector.cpp
+++ b/qt/widgets/common/src/MuonFitDataSelector.cpp
@@ -179,7 +179,8 @@ void MuonFitDataSelector::setWorkspaceDetails(
   // Set initial run to be run number of the workspace loaded in Home tab
   // and search for filenames. Use busy cursor until search finished.
   setBusyState();
-  if (filePath) { // load current run: use special file path
+ 
+  if (filePath) { // load current run: use special file path 
     m_ui.runs->setUserInput(filePath.get());
     m_ui.runs->setText(runs);
   } else { // default

--- a/qt/widgets/common/src/MuonFitDataSelector.cpp
+++ b/qt/widgets/common/src/MuonFitDataSelector.cpp
@@ -179,8 +179,8 @@ void MuonFitDataSelector::setWorkspaceDetails(
   // Set initial run to be run number of the workspace loaded in Home tab
   // and search for filenames. Use busy cursor until search finished.
   setBusyState();
- 
-  if (filePath) { // load current run: use special file path 
+
+  if (filePath) { // load current run: use special file path
     m_ui.runs->setUserInput(filePath.get());
     m_ui.runs->setText(runs);
   } else { // default


### PR DESCRIPTION
Muon analysis was crashing when a user directory was selected. This fixes the issue.

**To test:**
Open muon analysis
click manage user directories 
Turn off the search the data archive 
Make sure that the location of the file you are going to load is added to the search paths
Load your file via the browser
Go to data analysis (this would throw an uncaught exception in 3.12 branch) and it should be ok
Go back to home tab
Open manage user directories and remove the path to the file
Go to the data analysis tab (This works in 3.12)

<!-- Instructions for testing. -->

Fixes #22042. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->
Not in release notes as it was broken between January and now.
---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
