### PR TITLE
Indirect Data Analysis - Add I(Q,t) Fit workspace validation

### DIFF
--- a/qt/scientific_interfaces/Indirect/IqtFit.cpp
+++ b/qt/scientific_interfaces/Indirect/IqtFit.cpp
@@ -345,6 +345,11 @@ bool IqtFit::validate() {
   if (isEmptyModel())
     uiv.addErrorMessage("No fit function has been selected");
 
+  if (inputWorkspace()->getXMin() < 0) {
+    uiv.addErrorMessage("Error in input workspace: All X data must be "
+                        "greater than or equal to 0.");
+  }
+
   auto error = uiv.generateErrorMessage();
   emit showMessageBox(error);
   return error.isEmpty();
@@ -364,7 +369,7 @@ void IqtFit::loadSettings(const QSettings &settings) {
 void IqtFit::newDataLoaded(const QString wsName) {
   IndirectFitAnalysisTab::newInputDataLoaded(wsName);
 
-  int maxWsIndex =
+  const auto maxWsIndex =
       static_cast<int>(inputWorkspace()->getNumberHistograms()) - 1;
 
   m_uiForm->spPlotSpectrum->setMaximum(maxWsIndex);


### PR DESCRIPTION
An extra check has been added to the validation of workspaces for `i(q,t) Fit` interface. This checks that the first x bin is of a value greater than or equal to 0.

**To test:**

* Download this test data: 
[isis-indirect-test-files.zip](https://github.com/mantidproject/mantid/files/1803382/isis-indirect-test-files.zip)

* Open `I(Q, t) Fit` - `Interfaces > Indirect > Data Analysis > I(Q, t) Fit`
* Load the `26176_..._iqt` file from the test data
* Add a fit function (just checking the `Stretched Exponential` in the property tree works)
* Click run
* Ensure that it passes validation and has a good fit

* Change the input file to `26176_..._red` file (**note:** if you do this via the file browse you will have to change it to check all file types - by default it only displays file ending in `_iqt.nxs`)
* Add a function as before
* Click Run
* This time a validation window should be displayed with a comment about x range < 0 


Fixes #22029

**Release Notes** 
*Issue found in unscripted testing - does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
