### PR TITLE
Auto background and Muon analysis

### DIFF
--- a/docs/source/release/v3.12.0/muon.rst
+++ b/docs/source/release/v3.12.0/muon.rst
@@ -28,7 +28,8 @@ Interface
 - The Frequency Domain Analysis GUI now uses :ref:`MuonMaxent <algm-MuonMaxent>` to calculate the frequency spectrum in MaxEnt mode.
 - The ALC interface now allows background sections with negative values.
 - If data is loaded with 0 good frames into Muon Analysis then it will try to load the data without dead time correction (does not need number of good frames).
-- Muon analysis no longer disables the "aco add" and "simultaneous" buttons in the multiple fitting interface.
+- Muon analysis no longer disables the "co add" and "simultaneous" buttons in the multiple fitting interface.
+- Muon analysis now handles the "auto background" gracefully in single and multiple fitting modes.
 
 Algorithms
 ----------

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -2654,7 +2654,8 @@ void MuonAnalysis::changeTab(int newTabIndex) {
       m_uiForm.fitBrowser->setTFAsymm(true);
     } else {
       m_uiForm.fitBrowser->setTFAsymm(false);
-    }  m_uiForm.fitBrowser->checkFitEnabled();
+    }
+    m_uiForm.fitBrowser->checkFitEnabled();
 
   } else if (newTab == m_uiForm.ResultsTable) {
     m_resultTableTab->refresh();

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -2654,7 +2654,8 @@ void MuonAnalysis::changeTab(int newTabIndex) {
       m_uiForm.fitBrowser->setTFAsymm(true);
     } else {
       m_uiForm.fitBrowser->setTFAsymm(false);
-    }
+    }  m_uiForm.fitBrowser->checkFitEnabled();
+
   } else if (newTab == m_uiForm.ResultsTable) {
     m_resultTableTab->refresh();
   }

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MuonFitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MuonFitPropertyBrowser.h
@@ -118,6 +118,7 @@ public:
   void setChosenPeriods(const QString &period);
   void setSingleFitLabel(std::string name);
   void setNormalization(const std::string name);
+  void checkFitEnabled();
 public slots:
   /// Perform the fit algorithm
   void fit() override;
@@ -230,6 +231,7 @@ private:
   QDialog *m_comboWindow;
 
   std::vector<std::string> m_groupsList;
+  QString m_autoBackground;
 };
 
 std::map<std::string, double> readMultipleNormalization();

--- a/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
@@ -287,6 +287,7 @@ void MuonFitPropertyBrowser::init() {
   connect(this, SIGNAL(functionChanged()), SLOT(updateStructureTooltips()));
   // disable TFAsymm mode by default
   setTFAsymmMode(TFAsymmMode);
+  m_autoBackground = getAutoBackgroundString();
 }
 // Set up the execution of the muon fit menu
 void MuonFitPropertyBrowser::executeFitMenu(const QString &item) {
@@ -331,6 +332,18 @@ void MuonFitPropertyBrowser::setFitEnabled(bool yes) {
   } else {
     m_fitActionTFAsymm->setEnabled(false);
   }
+}
+
+void MuonFitPropertyBrowser::checkFitEnabled() {
+	if (m_reselectGroupBtn->isVisible()) {
+		setFitEnabled(false);
+	}
+	else if(getAutoBackgroundString() != "") {
+		setFitEnabled(true);
+	}
+	else {
+		setFitEnabled(false);
+	}
 }
 /**
 * Set the input workspace name
@@ -1184,7 +1197,13 @@ void MuonFitPropertyBrowser::setMultiFittingMode(bool enabled) {
   if (enabled) {
     setAllGroups();
     setAllPeriods();
+	setAutoBackgroundName("");
+
   } else { // clear current selection
+	  if (m_autoBackground != "") {
+		  setAutoBackgroundName(m_autoBackground);
+		  addAutoBackground();
+	  }
     clearChosenGroups();
     clearChosenPeriods();
   }
@@ -1199,6 +1218,7 @@ void MuonFitPropertyBrowser::setMultiFittingMode(bool enabled) {
       widget->setVisible(enabled);
     }
   }
+  if (enabled){ setFitEnabled(false); }
 }
 /**
 * Set TF asymmetry mode on or off.

--- a/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
@@ -335,15 +335,13 @@ void MuonFitPropertyBrowser::setFitEnabled(bool yes) {
 }
 
 void MuonFitPropertyBrowser::checkFitEnabled() {
-	if (m_reselectGroupBtn->isVisible()) {
-		setFitEnabled(false);
-	}
-	else if(getAutoBackgroundString() != "") {
-		setFitEnabled(true);
-	}
-	else {
-		setFitEnabled(false);
-	}
+  if (m_reselectGroupBtn->isVisible()) {
+    setFitEnabled(false);
+  } else if (getAutoBackgroundString() != "") {
+    setFitEnabled(true);
+  } else {
+    setFitEnabled(false);
+  }
 }
 /**
 * Set the input workspace name
@@ -1197,13 +1195,13 @@ void MuonFitPropertyBrowser::setMultiFittingMode(bool enabled) {
   if (enabled) {
     setAllGroups();
     setAllPeriods();
-	setAutoBackgroundName("");
+    setAutoBackgroundName("");
 
   } else { // clear current selection
-	  if (m_autoBackground != "") {
-		  setAutoBackgroundName(m_autoBackground);
-		  addAutoBackground();
-	  }
+    if (m_autoBackground != "") {
+      setAutoBackgroundName(m_autoBackground);
+      addAutoBackground();
+    }
     clearChosenGroups();
     clearChosenPeriods();
   }
@@ -1218,7 +1216,9 @@ void MuonFitPropertyBrowser::setMultiFittingMode(bool enabled) {
       widget->setVisible(enabled);
     }
   }
-  if (enabled){ setFitEnabled(false); }
+  if (enabled) {
+    setFitEnabled(false);
+  }
 }
 /**
 * Set TF asymmetry mode on or off.


### PR DESCRIPTION
Auto background would add a function in the background of muon analysis. Doing a a multiple fit would then be possible without seeing any fitting functions and it would then be unable to update the browser and throw an error. 

**To test:**
With auto background set

Open Muon analysis
Go to the settings tab and make sure that multiple fitting is ticked 
Load some data
Go to data analysis and the fit browse should be empty
Check that the fit menu items are disabled as expected
Add a fitting function and do a fit 

Go to the settings tab and untick multiple fitting
Go back to data analysis
This time the fit browser should include the auto background
Do a fit

<!-- Instructions for testing. -->

Fixes #22023. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
