### PR TITLE
Postprocess IvsQ unbinned

### DIFF
--- a/qt/python/mantidqtpython/mantidqtpython_def.sip
+++ b/qt/python/mantidqtpython/mantidqtpython_def.sip
@@ -1529,7 +1529,7 @@ class ProcessingAlgorithm
 #include "MantidQtWidgets/Common/DataProcessorUI/ProcessingAlgorithm.h"
 %End
 public:
-ProcessingAlgorithm(const QString &, const QString &, const QString &blacklist = "");
+ProcessingAlgorithm(const QString &, const QString &, int, const QString &blacklist = "");
 };
 
 class PostprocessingAlgorithm

--- a/qt/scientific_interfaces/ISISReflectometry/ReflGenericDataProcessorPresenterFactory.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflGenericDataProcessorPresenterFactory.cpp
@@ -73,7 +73,7 @@ ReflGenericDataProcessorPresenterFactory::create(int group) {
       /*The name of the algorithm */
       "ReflectometryReductionOneAuto",
       /*Prefixes to the output workspaces*/
-      std::vector<QString>{"IvsQ_binned_", "IvsQ_", "IvsLam_"},
+      std::vector<QString>{"IvsQ_binned_", "IvsQ_", "IvsLam_"}, 1,
       /*The blacklist*/
       std::set<QString>{"ThetaIn", "ThetaOut", "InputWorkspace",
                         "OutputWorkspace", "OutputWorkspaceBinned",

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/ProcessingAlgorithm.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/ProcessingAlgorithm.h
@@ -42,9 +42,11 @@ public:
   ProcessingAlgorithm();
   // Constructor
   ProcessingAlgorithm(QString name, std::vector<QString> prefix,
+                      std::size_t postprocessedOutputPrefixIndex,
                       std::set<QString> blacklist = std::set<QString>());
   // Delegating constructor
   ProcessingAlgorithm(QString name, QString const &prefix,
+                      std::size_t postprocessedOutputPrefixIndex,
                       QString const &blacklist = "");
   // Destructor
   virtual ~ProcessingAlgorithm();
@@ -62,6 +64,10 @@ public:
   QString defaultOutputPropertyName() const;
   // The default input ws property
   QString defaultInputPropertyName() const;
+  // The prefix for the postprocessed output ws property
+  QString postprocessedOutputPrefix() const;
+  // The postprocessed output ws property
+  QString postprocessedOutputPropertyName() const;
   // The input properties
   std::vector<QString> inputProperties() const;
   // The output properties
@@ -70,6 +76,9 @@ public:
   std::vector<QString> prefixes() const;
 
 private:
+  bool isValidOutputPrefixIndex(std::size_t outputPrefixIndex) const;
+  void ensureValidPostprocessedOutput() const;
+  std::size_t m_postprocessedOutputPrefixIndex;
   // The prefix of the output workspace(s)
   std::vector<QString> m_prefix;
   // The names of the input workspace properties

--- a/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -622,9 +622,9 @@ void GenericDataProcessorPresenter::postProcessGroup(
     const GroupData &groupData) {
   if (hasPostprocessing()) {
     const auto outputWSName = getPostprocessedWorkspaceName(groupData);
-    m_postprocessing->postProcessGroup(outputWSName,
-                                       m_processor.defaultOutputPropertyName(),
-                                       m_whitelist, groupData);
+    m_postprocessing->postProcessGroup(
+        outputWSName, m_processor.postprocessedOutputPropertyName(),
+        m_whitelist, groupData);
   }
 }
 

--- a/qt/widgets/common/src/DataProcessorUI/ProcessingAlgorithm.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/ProcessingAlgorithm.cpp
@@ -10,11 +10,14 @@ namespace DataProcessor {
 * workspaces' names
 * @param blacklist : The list of properties we do not want to show
 */
-ProcessingAlgorithm::ProcessingAlgorithm(QString name,
-                                         std::vector<QString> prefix,
-                                         std::set<QString> blacklist)
+ProcessingAlgorithm::ProcessingAlgorithm(
+    QString name, std::vector<QString> prefix,
+    std::size_t postprocessedOutputPrefixIndex, std::set<QString> blacklist)
     : ProcessingAlgorithmBase(std::move(name), std::move(blacklist)),
+      m_postprocessedOutputPrefixIndex(postprocessedOutputPrefixIndex),
       m_prefix(std::move(prefix)) {
+
+  ensureValidPostprocessedOutput();
 
   m_inputProperties = getInputWsProperties();
   if (!m_inputProperties.size())
@@ -44,9 +47,11 @@ ProcessingAlgorithm::ProcessingAlgorithm(QString name,
 * workspaces' names, as a string
 * @param blacklist : The list of properties we do not want to show, as a string
 */
-ProcessingAlgorithm::ProcessingAlgorithm(QString name, QString const &prefix,
-                                         QString const &blacklist)
+ProcessingAlgorithm::ProcessingAlgorithm(
+    QString name, QString const &prefix,
+    std::size_t postprocessedOutputPrefixIndex, QString const &blacklist)
     : ProcessingAlgorithm(std::move(name), convertStringToVector(prefix),
+                          postprocessedOutputPrefixIndex,
                           convertStringToSet(blacklist)) {}
 
 /**
@@ -94,6 +99,28 @@ QString ProcessingAlgorithm::defaultOutputPrefix() const { return m_prefix[0]; }
  */
 QString ProcessingAlgorithm::defaultOutputPropertyName() const {
   return m_outputProperties[0];
+}
+
+bool ProcessingAlgorithm::isValidOutputPrefixIndex(
+    std::size_t outputPrefixIndex) const {
+  return outputPrefixIndex < m_prefix.size();
+}
+
+void ProcessingAlgorithm::ensureValidPostprocessedOutput() const {
+  if (!isValidOutputPrefixIndex(m_postprocessedOutputPrefixIndex))
+    throw std::runtime_error("Postprocessed output index must be a valid index "
+                             "into the prefix array.");
+}
+
+QString ProcessingAlgorithm::postprocessedOutputPrefix() const {
+  return m_prefix[m_postprocessedOutputPrefixIndex];
+}
+
+/** Returns the postprocessed output ws property. This is property
+ * name specified on construction.
+ */
+QString ProcessingAlgorithm::postprocessedOutputPropertyName() const {
+  return m_outputProperties[m_postprocessedOutputPrefixIndex];
 }
 
 /** Returns the default input ws property. This is just the first

--- a/qt/widgets/common/src/DataProcessorUI/ProcessingAlgorithm.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/ProcessingAlgorithm.cpp
@@ -8,6 +8,8 @@ namespace DataProcessor {
 * @param name : The name of this algorithm
 * @param prefix : The list of prefixes that will be used for the output
 * workspaces' names
+* @param postprocessedOutputPrefixIndex The zero based index of the prefix for
+* the workspace which should be postprocessed
 * @param blacklist : The list of properties we do not want to show
 */
 ProcessingAlgorithm::ProcessingAlgorithm(
@@ -45,6 +47,8 @@ ProcessingAlgorithm::ProcessingAlgorithm(
 * @param name : The name of this algorithm
 * @param prefix : The list of prefixes that will be used for the output
 * workspaces' names, as a string
+* @param postprocessedOutputPrefixIndex The zero based index of the prefix for
+* the workspace which should be postprocessed
 * @param blacklist : The list of properties we do not want to show, as a string
 */
 ProcessingAlgorithm::ProcessingAlgorithm(

--- a/qt/widgets/common/test/DataProcessorUI/GenerateNotebookTest.h
+++ b/qt/widgets/common/test/DataProcessorUI/GenerateNotebookTest.h
@@ -44,7 +44,7 @@ private:
 
     return ProcessingAlgorithm(
         "ReflectometryReductionOneAuto",
-        std::vector<QString>{"IvsQ_binned_", "IvsQ_", "IvsLam_"},
+        std::vector<QString>{"IvsQ_binned_", "IvsQ_", "IvsLam_"}, 1,
         std::set<QString>{"ThetaIn", "ThetaOut", "InputWorkspace",
                           "OutputWorkspace", "OutputWorkspaceWavelength",
                           "FirstTransmissionRun", "SecondTransmissionRun"});

--- a/qt/widgets/common/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
+++ b/qt/widgets/common/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
@@ -1296,6 +1296,8 @@ public:
     auto ws =
         createPrefilledWorkspace("TestWorkspace", presenter->getWhiteList());
     ws->String(0, ThetaCol) = "";
+    ws->String(1, ThetaCol) = "";
+    ws->String(0, ScaleCol) = "";
     ws->String(1, ScaleCol) = "";
     expectGetWorkspace(mockDataProcessorView, Exactly(1), "TestWorkspace");
     presenter->notify(DataProcessorPresenter::OpenTableFlag);
@@ -1318,6 +1320,8 @@ public:
     TS_ASSERT_EQUALS(ws->String(0, RunCol), "12345");
     TS_ASSERT_EQUALS(ws->String(1, RunCol), "12346");
     TS_ASSERT(ws->String(0, ThetaCol) != "");
+    TS_ASSERT(ws->String(0, ScaleCol) != "");
+    TS_ASSERT(ws->String(1, ThetaCol) != "");
     TS_ASSERT(ws->String(1, ScaleCol) != "");
 
     // Check output and tidy up

--- a/qt/widgets/common/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
+++ b/qt/widgets/common/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
@@ -160,10 +160,9 @@ private:
   }
 
   ProcessingAlgorithm createReflectometryProcessor() {
-
     return ProcessingAlgorithm(
         "ReflectometryReductionOneAuto",
-        std::vector<QString>{"IvsQ_binned_", "IvsQ_", "IvsLam_"},
+        std::vector<QString>{"IvsQ_binned_", "IvsQ_", "IvsLam_"}, 1,
         std::set<QString>{"ThetaIn", "ThetaOut", "InputWorkspace",
                           "OutputWorkspace", "OutputWorkspaceWavelength",
                           "FirstTransmissionRun", "SecondTransmissionRun"});

--- a/qt/widgets/common/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
+++ b/qt/widgets/common/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
@@ -198,7 +198,8 @@ private:
   void createTOFWorkspace(const QString &wsName,
                           const QString &runNumber = "") {
     auto tinyWS =
-        WorkspaceCreationHelper::create2DWorkspaceWithReflectometryInstrument();
+        WorkspaceCreationHelper::create2DWorkspaceWithReflectometryInstrument(
+            2000);
     auto inst = tinyWS->getInstrument();
 
     inst->getParameterMap()->addDouble(inst.get(), "I0MonitorIndex", 1.0);
@@ -3190,16 +3191,16 @@ public:
             "IvsQ_TOF_12345_TOF_12346");
     TSM_ASSERT_DELTA(
         "Logarithmic rebinning should have been applied, with param 0.04",
-        out->x(0)[0], 0.100, 1e-5);
+        out->x(0)[0], 0.01108, 1e-5);
     TSM_ASSERT_DELTA(
         "Logarithmic rebinning should have been applied, with param 0.04",
-        out->x(0)[1], 0.104, 1e-5);
+        out->x(0)[1], 0.01153, 1e-5);
     TSM_ASSERT_DELTA(
         "Logarithmic rebinning should have been applied, with param 0.04",
-        out->x(0)[2], 0.10816, 1e-5);
+        out->x(0)[2], 0.01199, 1e-5);
     TSM_ASSERT_DELTA(
         "Logarithmic rebinning should have been applied, with param 0.04",
-        out->x(0)[3], 0.11248, 1e-5);
+        out->x(0)[3], 0.01247, 1e-5);
 
     // Check output and tidy up
     checkWorkspacesExistInADS(m_defaultWorkspacesNoPrefix);

--- a/qt/widgets/common/test/DataProcessorUI/ProcessingAlgorithmTest.h
+++ b/qt/widgets/common/test/DataProcessorUI/ProcessingAlgorithmTest.h
@@ -58,15 +58,13 @@ public:
     // ReflectometryReductionOneAuto has three output ws properties
     // We should provide three prefixes, one for each ws
     std::vector<QString> prefixes;
-    prefixes.emplace_back("IvsQ_");
     prefixes.emplace_back("IvsQ_binned_");
+    prefixes.emplace_back("IvsQ_");
     // This should throw
     TS_ASSERT_THROWS(
         ProcessingAlgorithm(algName, prefixes, 0, std::set<QString>()),
         std::invalid_argument);
 
-    prefixes.emplace_back("IvsQ_");
-    prefixes.emplace_back("IvsQ_binned_");
     // This should also throw
     TS_ASSERT_THROWS(
         ProcessingAlgorithm(algName, prefixes, 0, std::set<QString>()),

--- a/qt/widgets/common/test/DataProcessorUI/ProcessingAlgorithmTest.h
+++ b/qt/widgets/common/test/DataProcessorUI/ProcessingAlgorithmTest.h
@@ -35,9 +35,9 @@ public:
     // Currently ws must be either MatrixWorkspace or Workspace but this can be
     // changed
     std::vector<QString> prefix = {"run_"};
-    TS_ASSERT_THROWS_NOTHING(ProcessingAlgorithm("Rebin", prefix));
-    TS_ASSERT_THROWS_NOTHING(ProcessingAlgorithm("ExtractSpectra", prefix));
-    TS_ASSERT_THROWS_NOTHING(ProcessingAlgorithm("ConvertUnits", prefix));
+    TS_ASSERT_THROWS_NOTHING(ProcessingAlgorithm("Rebin", prefix, 0));
+    TS_ASSERT_THROWS_NOTHING(ProcessingAlgorithm("ExtractSpectra", prefix, 0));
+    TS_ASSERT_THROWS_NOTHING(ProcessingAlgorithm("ConvertUnits", prefix, 0));
   }
 
   void test_invalid_algorithms() {
@@ -45,10 +45,10 @@ public:
     std::vector<QString> prefix = {"IvsQ_"};
 
     // Algorithms with no input workspace properties
-    TS_ASSERT_THROWS(ProcessingAlgorithm("Stitch1DMany", prefix),
+    TS_ASSERT_THROWS(ProcessingAlgorithm("Stitch1DMany", prefix, 0),
                      std::invalid_argument);
     // Algorithms with no output workspace properties
-    TS_ASSERT_THROWS(ProcessingAlgorithm("SaveAscii", prefix),
+    TS_ASSERT_THROWS(ProcessingAlgorithm("SaveAscii", prefix, 0),
                      std::invalid_argument);
   }
   void test_ReflectometryReductionOneAuto() {
@@ -58,28 +58,33 @@ public:
     // ReflectometryReductionOneAuto has three output ws properties
     // We should provide three prefixes, one for each ws
     std::vector<QString> prefixes;
+    prefixes.emplace_back("IvsQ_");
     prefixes.emplace_back("IvsQ_binned_");
     // This should throw
     TS_ASSERT_THROWS(
-        ProcessingAlgorithm(algName, prefixes, std::set<QString>()),
+        ProcessingAlgorithm(algName, prefixes, 0, std::set<QString>()),
         std::invalid_argument);
 
-    prefixes.push_back("IvsQ_");
+    prefixes.emplace_back("IvsQ_");
+    prefixes.emplace_back("IvsQ_binned_");
     // This should also throw
     TS_ASSERT_THROWS(
-        ProcessingAlgorithm(algName, prefixes, std::set<QString>()),
+        ProcessingAlgorithm(algName, prefixes, 0, std::set<QString>()),
         std::invalid_argument);
     // But this should be OK
-    prefixes.push_back("IvsLam_");
+    prefixes.emplace_back("IvsLam_");
     TS_ASSERT_THROWS_NOTHING(
-        ProcessingAlgorithm(algName, prefixes, std::set<QString>()));
+        ProcessingAlgorithm(algName, prefixes, 0, std::set<QString>()));
 
-    auto alg = ProcessingAlgorithm(algName, prefixes, std::set<QString>());
+    auto const postprocessedOutputPrefixIndex = 1;
+    auto alg = ProcessingAlgorithm(
+        algName, prefixes, postprocessedOutputPrefixIndex, std::set<QString>());
     TS_ASSERT_EQUALS(alg.name(), "ReflectometryReductionOneAuto");
     TS_ASSERT_EQUALS(alg.numberOfOutputProperties(), 3);
     TS_ASSERT_EQUALS(alg.prefix(0), "IvsQ_binned_");
     TS_ASSERT_EQUALS(alg.prefix(1), "IvsQ_");
     TS_ASSERT_EQUALS(alg.prefix(2), "IvsLam_");
+    TS_ASSERT_EQUALS(alg.postprocessedOutputPrefix(), "IvsQ_");
     TS_ASSERT_EQUALS(alg.inputPropertyName(0), "InputWorkspace");
     TS_ASSERT_EQUALS(alg.inputPropertyName(1), "FirstTransmissionRun");
     TS_ASSERT_EQUALS(alg.inputPropertyName(2), "SecondTransmissionRun");

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -322,8 +322,9 @@ class SANSDataProcessorGui(QtGui.QMainWindow, ui_sans_data_processor_window.Ui_S
                                       entry.show_value, entry.prefix)
 
         # Processing algorithm (mandatory)
+        unused_postprocessing_index = 0
         alg = MantidQt.MantidWidgets.DataProcessor.ProcessingAlgorithm(self._gui_algorithm_name,
-                                                                       'unused_', self._black_list)
+                                                                       'unused_', unused_postprocessing_index, self._black_list)
 
         self.data_processor_table = MantidQt.MantidWidgets.DataProcessor.QDataProcessorWidget(white_list, alg, self)
         self.data_processor_table.setForcedReProcessing(True)


### PR DESCRIPTION
The ``IvsQ_{{run_number}}`` workspaces should be passed to `Stitch1DMany` instead of ``IvsQ_binned_{{run_number}}``. This PR applies this change. 

- Added methods `postprocessedOutputPrefix` and
`postprocessedOutputPropertyName` to ProcessingAlgorithm.
- Added index parameter to constructor.
- Specified index 1 as postprocessed output property index in
`ReflGenericDataProcessorPresenterFactory.`
- Updated SANS v2 Interface to cope with API change.

**To test:**
1. Process a group on the Reflectometry interface.
2. Examine the history for `Stitch1DMany` and ensure that the IvsQ workspaces were passed in rather than the `IvsQ_binned` workspaces.
3. Check that the plotting buttons continue to function as expected.
3. Check that the sans gui continues to function as expected.

No issue created.

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
