### PR TITLE
Bad graph title sans diagnostics when no range

### DIFF
--- a/qt/scientific_interfaces/ISISSANS/SANSDiagnostics.cpp
+++ b/qt/scientific_interfaces/ISISSANS/SANSDiagnostics.cpp
@@ -1450,7 +1450,7 @@ QString SANSDiagnostics::createOutputWorkspaceName(
   // Detector, Min value,  and Max values,
   QString appendix = "-" + detectorName + "-" + integrationType + min + "-" +
                      integrationType + max;
-  if (min == max)     {
+  if (min == max) {
     // special case which means that it is all of the range
     appendix = "-" + detectorName + "-" + integrationType + "_ALL";
   }

--- a/qt/scientific_interfaces/ISISSANS/SANSDiagnostics.cpp
+++ b/qt/scientific_interfaces/ISISSANS/SANSDiagnostics.cpp
@@ -1450,6 +1450,10 @@ QString SANSDiagnostics::createOutputWorkspaceName(
   // Detector, Min value,  and Max values,
   QString appendix = "-" + detectorName + "-" + integrationType + min + "-" +
                      integrationType + max;
+  if (min == max)     {
+    // special case which means that it is all of the range
+    appendix = "-" + detectorName + "-" + integrationType + "_ALL";
+  }
   outputWorkspaceName += appendix;
 
   outputWorkspaceName.replace("-", "_");


### PR DESCRIPTION
Adds a special case for the workspace and thus graph title when no range is provided

**To test:**
1. see the issue for an image of the before case
1. Start SANS->ISIS SANS
1. Instrument LOQ
1. Diagnostics Tab
1. Load LOQ102735
1. Click each integral button without supplying any range
1. The graphs should have more sensible titles
1. Enter some ranges (2-15 etc) and do it again
1. The change should not affect them.
<!-- Instructions for testing. -->



Fixes #22069 

**Release Notes** 
*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
