### PR TITLE
SANS V2 Simplified PrintParser

### DIFF
--- a/scripts/SANS/sans/user_file/user_file_parser.py
+++ b/scripts/SANS/sans/user_file/user_file_parser.py
@@ -2084,11 +2084,11 @@ class PrintParser(UserFileComponentParser):
 
         setting = line.strip()
 
-        if setting.upper().startswith('PRINT'):
-            setting = setting[len('PRINT'):]
+        if setting.upper().startswith(PrintParser.Type):
+            setting = setting[len(PrintParser.Type):]
             setting = setting.strip()
         else:
-            raise RuntimeError("PrintParser: Failed to extract line {} it does not start with PRINT".format(line))
+            raise RuntimeError("PrintParser: Failed to extract line {} it does not start with {}".format(line, PrintParser.Type))
 
         return {PrintId.print_line: setting}
 

--- a/scripts/SANS/sans/user_file/user_file_parser.py
+++ b/scripts/SANS/sans/user_file/user_file_parser.py
@@ -2079,10 +2079,6 @@ class PrintParser(UserFileComponentParser):
     def __init__(self):
         super(PrintParser, self).__init__()
 
-        # Print
-        self._print = "\\s*PRINT\\s+"
-        self._print_pattern = re.compile(start_string + self._print + "\\s*.*\\s*" + end_string)
-
     def parse_line(self, line):
         # Get the settings, ie remove command
 

--- a/scripts/SANS/sans/user_file/user_file_parser.py
+++ b/scripts/SANS/sans/user_file/user_file_parser.py
@@ -2085,11 +2085,16 @@ class PrintParser(UserFileComponentParser):
 
     def parse_line(self, line):
         # Get the settings, ie remove command
-        setting = UserFileComponentParser.get_settings(line, PrintParser.get_type_pattern())
 
-        # Determine the qualifier and extract the user setting
-        original_setting = re.search(setting.strip(), line, re.IGNORECASE).group(0)
-        return {PrintId.print_line: original_setting}
+        setting = line.strip()
+
+        if setting.upper().startswith('PRINT'):
+            setting = setting[len('PRINT'):]
+            setting = setting.strip()
+        else:
+            raise RuntimeError("PrintParser: Failed to extract line {} it does not start with PRINT".format(line))
+
+        return {PrintId.print_line: setting}
 
     @staticmethod
     def get_type():

--- a/scripts/test/SANS/user_file/user_file_parser_test.py
+++ b/scripts/test/SANS/user_file/user_file_parser_test.py
@@ -888,9 +888,13 @@ class PrintParserTest(unittest.TestCase):
         self.assertTrue(PrintParser.get_type(), "PRINT")
 
     def test_that_print_is_parsed_correctly(self):
-        valid_settings = {"PRINT OdlfP slsk 23lksdl2 34l": {PrintId.print_line: "OdlfP slsk 23lksdl2 34l"}}
+        valid_settings = {"PRINT OdlfP slsk 23lksdl2 34l": {PrintId.print_line: "OdlfP slsk 23lksdl2 34l"},
+                          "PRiNt OdlfP slsk 23lksdl2 34l": {PrintId.print_line: "OdlfP slsk 23lksdl2 34l"},
+                          "  PRINT Loaded: USER_LOQ_174J, 12/03/18, Xuzhi (Lu), 12mm, Sample Changer, Banjo cells":
+                          {PrintId.print_line: "Loaded: USER_LOQ_174J, 12/03/18, Xuzhi (Lu), 12mm, Sample Changer, Banjo cells"}
+                          }
 
-        invalid_settings = {}
+        invalid_settings = {"j PRINT OdlfP slsk 23lksdl2 34l ": RuntimeError,}
 
         print_parser = PrintParser()
         do_test(print_parser, valid_settings, invalid_settings, self.assertTrue, self.assertRaises)


### PR DESCRIPTION
This fixes an issue where the user file import was failing if any print statements contained regexp special characters. 

**To test:**
Check that you can successfully load the following LOQ user file in the new sans GUI. 
[USER_LOQ_174J_M3_Lu_12mm_Changer_MAIN.TXT](https://github.com/mantidproject/mantid/files/1811048/USER_LOQ_174J_M3_Lu_12mm_Changer_MAIN.TXT)

Note that the new GUI currently does not do anything with print statements put inside the user file. This may or may not be by intention I need to check with the instrument scientists. 

<!-- Instructions for testing. -->

Fixes #22076 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [x] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
