### PR TITLE
MWRunFiles - Emit findingFiles() when searchText is not empty

### DIFF
--- a/qt/widgets/common/src/MWRunFiles.cpp
+++ b/qt/widgets/common/src/MWRunFiles.cpp
@@ -550,9 +550,6 @@ void MWRunFiles::findFiles(bool isModified) {
 * @return search text to create search params with
 */
 const QString MWRunFiles::findFilesGetSearchText(QString &searchText) {
-
-  emit findingFiles();
-
   // If we have an override instrument then add it in appropriate places to
   // the search text
   if (!m_defaultInstrumentName.isEmpty()) {
@@ -590,6 +587,8 @@ const QString MWRunFiles::findFilesGetSearchText(QString &searchText) {
 */
 void MWRunFiles::runFindFiles(const QString &searchText) {
   if (!searchText.isEmpty()) {
+    emit findingFiles();
+
     const auto parameters =
         createFindFilesSearchParameters(searchText.toStdString());
     m_pool.createWorker(this, parameters);


### PR DESCRIPTION
In the Interfaces > Indirect > Data Reduction interfaces, the MWRunFiles widget (in all places it occurs) is disabled. Changing the instrument in this interface does not enable the widget. This currently renders many of the Indirect Data Reduction interfaces unusable, including ISISEnergyTransfer.

This PR ensures the emit is moved to the correct place.

**To test:**
1. Test widget in Indirect Data Reduction, Indirect Diffraction, Muon Analysis and all other appropriate places.

<!-- Instructions for testing. -->

Fixes #22074. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
