### PR TITLE
Fix Dx data handling in ConvertToPointData, ConvertToHistogram

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/XDataConverter.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/XDataConverter.h
@@ -6,6 +6,7 @@
 
 namespace Mantid {
 namespace HistogramData {
+class HistogramDx;
 class HistogramX;
 }
 namespace Algorithms {

--- a/Framework/Algorithms/src/XDataConverter.cpp
+++ b/Framework/Algorithms/src/XDataConverter.cpp
@@ -69,6 +69,9 @@ void XDataConverter::exec() {
     outputWS->setSharedY(i, inputWS->sharedY(i));
     outputWS->setSharedE(i, inputWS->sharedE(i));
     setXData(outputWS, inputWS, i);
+    if (inputWS->hasDx(i)) {
+      outputWS->setSharedDx(i, inputWS->sharedDx(i));
+    }
     prog.report();
 
     PARALLEL_END_INTERUPT_REGION

--- a/Framework/Algorithms/test/ConvertToHistogramTest.h
+++ b/Framework/Algorithms/test/ConvertToHistogramTest.h
@@ -21,7 +21,6 @@ using Mantid::Kernel::make_cow;
 class ConvertToHistogramTest : public CxxTest::TestSuite {
 
 public:
-
   void tearDown() override {
     Mantid::API::AnalysisDataService::Instance().clear();
   }
@@ -82,7 +81,8 @@ public:
     constexpr int numSpectra{2};
     Workspace2D_sptr testWS = WorkspaceCreationHelper::create2DWorkspace123(
         numSpectra, numYPoints, false);
-    double xErrors[numYPoints] = {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0};
+    double xErrors[numYPoints] = {0.1, 0.2, 0.3, 0.4, 0.5,
+                                  0.6, 0.7, 0.8, 0.9, 1.0};
     auto dxs = make_cow<HistogramDx>(xErrors, xErrors + numYPoints);
     // Reset the X data to something reasonable, set Dx.
     Points x(numYPoints, LinearGenerator(0.0, 1.0));

--- a/Framework/Algorithms/test/ConvertToHistogramTest.h
+++ b/Framework/Algorithms/test/ConvertToHistogramTest.h
@@ -13,12 +13,19 @@ using Mantid::API::MatrixWorkspace_sptr;
 using Mantid::Algorithms::ConvertToHistogram;
 using Mantid::DataObjects::Workspace2D_sptr;
 using Mantid::MantidVecPtr;
+using Mantid::HistogramData::HistogramDx;
 using Mantid::HistogramData::LinearGenerator;
 using Mantid::HistogramData::Points;
+using Mantid::Kernel::make_cow;
 
 class ConvertToHistogramTest : public CxxTest::TestSuite {
 
 public:
+
+  void tearDown() override {
+    Mantid::API::AnalysisDataService::Instance().clear();
+  }
+
   void test_That_The_Algorithm_Has_Two_Properties() {
     ConvertToHistogram alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
@@ -38,7 +45,6 @@ public:
 
     // Check that the algorithm just pointed the output data at the input
     TS_ASSERT_EQUALS(&(*testWS), &(*outputWS));
-    Mantid::API::AnalysisDataService::Instance().remove(outputWS->getName());
   }
 
   void test_A_Point_Data_InputWorkspace_Is_Converted_To_A_Histogram() {
@@ -63,43 +69,39 @@ public:
     TS_ASSERT_EQUALS(outputWS->isHistogramData(), true);
     const int numBoundaries = numYPoints + 1;
 
-    // This makes the new X values more readable rather than using a dynamic
-    // array
-    // so I'll live with the hard coding
     const double expectedX[11] = {-0.5, 0.5, 1.5, 2.5, 3.5, 4.5,
                                   5.5,  6.5, 7.5, 8.5, 9.5};
     for (int j = 0; j < numBoundaries; ++j) {
       TS_ASSERT_EQUALS(outputWS->readX(0)[j], expectedX[j]);
     }
+  }
 
-    // for( int i = 0; i < numSpectra; ++i )
-    // {
-    //   const Mantid::MantidVec & yValues = outputWS->readY(i);
-    //   const Mantid::MantidVec & xValues = outputWS->readX(i);
-    //   const Mantid::MantidVec & eValues = outputWS->readE(i);
-
-    //   TS_ASSERT_EQUALS(xValues.size(), numBins);
-    //   // The y and e values sizes be unchanged
-    //   TS_ASSERT_EQUALS(yValues.size(), numYPoints);
-    //   TS_ASSERT_EQUALS(eValues.size(), numYPoints);
-
-    //   for( int j = 0; j < numYPoints; ++j )
-    //   {
-    // 	// Now the data. Y and E unchanged
-    // 	TS_ASSERT_EQUALS(yValues[j], 2.0);
-    // 	TS_ASSERT_EQUALS(eValues[j], M_SQRT2);
-
-    // 	// X data originally was 0->10 in steps of 1. Now it should be the
-    // centre of each bin which is
-    // 	// 1.0 away from the last centre
-    // 	const double expectedX = 0.5 + j*1.0;
-    // 	TS_ASSERT_EQUALS(xValues[j], expectedX);
-    //   }
-    //   // And the final X points
-    //   TS_ASSERT_EQUALS(xValues.back(), 100.);
-    // }
-
-    Mantid::API::AnalysisDataService::Instance().remove(outputWS->getName());
+  void test_Dx_Data_Is_Handled_Correctly() {
+    // Creates a workspace with 10 points
+    constexpr int numYPoints{10};
+    constexpr int numSpectra{2};
+    Workspace2D_sptr testWS = WorkspaceCreationHelper::create2DWorkspace123(
+        numSpectra, numYPoints, false);
+    double xErrors[numYPoints] = {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0};
+    auto dxs = make_cow<HistogramDx>(xErrors, xErrors + numYPoints);
+    // Reset the X data to something reasonable, set Dx.
+    Points x(numYPoints, LinearGenerator(0.0, 1.0));
+    for (int i = 0; i < numSpectra; ++i) {
+      testWS->setPoints(i, x);
+      testWS->setSharedDx(i, dxs);
+    }
+    TS_ASSERT(!testWS->isHistogramData())
+    MatrixWorkspace_sptr outputWS = runAlgorithm(testWS);
+    TS_ASSERT(outputWS);
+    TS_ASSERT(outputWS->isHistogramData())
+    for (size_t i = 0; i < outputWS->getNumberHistograms(); ++i) {
+      TS_ASSERT(outputWS->hasDx(i))
+      const auto &dx = outputWS->dx(i);
+      TS_ASSERT_EQUALS(dx.size(), numYPoints)
+      for (size_t j = 0; j < dx.size(); ++j) {
+        TS_ASSERT_EQUALS(dx[j], xErrors[j])
+      }
+    }
   }
 
 private:

--- a/Framework/Algorithms/test/ConvertToPointDataTest.h
+++ b/Framework/Algorithms/test/ConvertToPointDataTest.h
@@ -19,7 +19,6 @@ using Mantid::Kernel::make_cow;
 class ConvertToPointDataTest : public CxxTest::TestSuite {
 
 public:
-
   void tearDown() override {
     Mantid::API::AnalysisDataService::Instance().clear();
   }
@@ -146,12 +145,13 @@ public:
   void test_Dx_Data_Is_Handled_Correctly() {
     constexpr size_t numBins{11};
     double xBoundaries[numBins] = {0.0,  1.0,  3.0,  5.0,  6.0, 7.0,
-                              10.0, 13.0, 16.0, 17.0, 17.5};
+                                   10.0, 13.0, 16.0, 17.0, 17.5};
     constexpr int numSpectra{2};
     Workspace2D_sptr testWS = WorkspaceCreationHelper::create2DWorkspaceBinned(
         numSpectra, numBins, xBoundaries);
     TS_ASSERT(testWS->isHistogramData())
-    double xErrors[numBins - 1] = {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0};
+    double xErrors[numBins - 1] = {0.1, 0.2, 0.3, 0.4, 0.5,
+                                   0.6, 0.7, 0.8, 0.9, 1.0};
     auto dxs = make_cow<HistogramDx>(xErrors, xErrors + numBins - 1);
     testWS->setSharedDx(0, dxs);
     testWS->setSharedDx(1, dxs);

--- a/Framework/Algorithms/test/ConvertToPointDataTest.h
+++ b/Framework/Algorithms/test/ConvertToPointDataTest.h
@@ -13,10 +13,17 @@ using Mantid::API::IAlgorithm_sptr;
 using Mantid::API::MatrixWorkspace;
 using Mantid::API::MatrixWorkspace_sptr;
 using Mantid::DataObjects::Workspace2D_sptr;
+using Mantid::HistogramData::HistogramDx;
+using Mantid::Kernel::make_cow;
 
 class ConvertToPointDataTest : public CxxTest::TestSuite {
 
 public:
+
+  void tearDown() override {
+    Mantid::API::AnalysisDataService::Instance().clear();
+  }
+
   void test_That_The_Algorithm_Has_Two_Properties() {
     ConvertToPointData alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
@@ -35,7 +42,6 @@ public:
 
     // Check that the algorithm just pointed the output data at the input
     TS_ASSERT_EQUALS(&(*testWS), &(*outputWS));
-    Mantid::API::AnalysisDataService::Instance().remove(outputWS->getName());
   }
 
   void test_A_Uniformly_Binned_Histogram_Is_Transformed_Correctly() {
@@ -94,8 +100,6 @@ public:
     TS_ASSERT_EQUALS((*(outputWS->getAxis(1)))(0), 0);
     TS_ASSERT_EQUALS((*(outputWS->getAxis(1)))(1), 2);
     TS_ASSERT_EQUALS((*(outputWS->getAxis(1)))(2), 4);
-
-    Mantid::API::AnalysisDataService::Instance().remove(outputWS->getName());
   }
 
   void test_A_Non_Uniformly_Binned_Histogram_Is_Transformed_Correctly() {
@@ -135,6 +139,31 @@ public:
         // 1.0 away from the last centre
         const double expectedX = 0.5 * (xBoundaries[j] + xBoundaries[j + 1]);
         TS_ASSERT_EQUALS(xValues[j], expectedX);
+      }
+    }
+  }
+
+  void test_Dx_Data_Is_Handled_Correctly() {
+    constexpr size_t numBins{11};
+    double xBoundaries[numBins] = {0.0,  1.0,  3.0,  5.0,  6.0, 7.0,
+                              10.0, 13.0, 16.0, 17.0, 17.5};
+    constexpr int numSpectra{2};
+    Workspace2D_sptr testWS = WorkspaceCreationHelper::create2DWorkspaceBinned(
+        numSpectra, numBins, xBoundaries);
+    TS_ASSERT(testWS->isHistogramData())
+    double xErrors[numBins - 1] = {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0};
+    auto dxs = make_cow<HistogramDx>(xErrors, xErrors + numBins - 1);
+    testWS->setSharedDx(0, dxs);
+    testWS->setSharedDx(1, dxs);
+    MatrixWorkspace_sptr outputWS = runAlgorithm(testWS);
+    TS_ASSERT(outputWS)
+    TS_ASSERT(!outputWS->isHistogramData())
+    for (size_t i = 0; i < outputWS->getNumberHistograms(); ++i) {
+      TS_ASSERT(outputWS->hasDx(i))
+      const auto &dx = outputWS->dx(i);
+      TS_ASSERT_EQUALS(dx.size(), numBins - 1)
+      for (size_t j = 0; j < dx.size(); ++j) {
+        TS_ASSERT_EQUALS(dx[j], xErrors[j])
       }
     }
   }

--- a/docs/source/release/v3.13.0/framework.rst
+++ b/docs/source/release/v3.13.0/framework.rst
@@ -9,4 +9,9 @@ Framework Changes
     putting new features at the top of the section, followed by
     improvements, followed by bug fixes.
 
+Algorithms
+----------
+
+- :ref:`ConvertToPointData <algm-ConvertToPointData>` and :ref:`ConvertToHistogram <algm-ConvertToHistogram>` now propagate the Dx errors to the output.
+
 :ref:`Release 3.13.0 <v3.13.0>`


### PR DESCRIPTION
Dx data was lost when running `ConvertToPointData` or `ConvertToHistogram`. This PR fixes.

**To test:**

Check that both algorithms don't lose the Dx data.
You can create workspaces with Dx in Python:
```python
ws = CreateWorkspace(DataX=[0,1], DataY=[1])
ws.setDx(0, [0.5])
```

Fixes #22075. 

**Release Notes** 

The changes are mentioned in the Framework release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
