### PR TITLE
Fix a crash pasting into the reflectometry GUI

### DIFF
--- a/qt/widgets/common/src/DataProcessorUI/TwoLevelTreeManager.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/TwoLevelTreeManager.cpp
@@ -332,12 +332,17 @@ void TwoLevelTreeManager::pasteSelected(const QString &text) {
     // Add as many new rows as required
     for (auto i = 0; i < lines.size(); ++i) {
       auto values = lines[i].split("\t");
+      auto const valuesSizeLessOne = static_cast<int>(values.size()) - 1;
+
+      if (valuesSizeLessOne < 1)
+        continue;
 
       auto groupId = parseDenaryInteger(values.front());
       int rowId = numRowsInGroup(groupId);
       if (!m_model->insertRow(rowId, m_model->index(groupId, 0)))
         return;
-      for (int col = 0; col < m_model->columnCount(); col++) {
+      for (int col = 0; col < m_model->columnCount() && col < valuesSizeLessOne;
+           col++) {
         m_model->setData(m_model->index(rowId, col, m_model->index(groupId, 0)),
                          values[col + 1]);
       }


### PR DESCRIPTION
Description of work.

The ISIS Reflectometry GUI is not really designed to have data pasted in from external sources such as excel. However, it should not crash if a user attempts to do this. This PR adds a couple of simple checks to avoid potential problems if users accidentally paste bad data:

- Add an out-of-bounds check to avoid a potential crash
- Add a check for empty values to avoid an unexpected exception

**To test:**

- Open the `ISIS Reflectometry` GUI
- Copy a set of 2 rows with 5 cells containing the following values from excel or similar onto the clipboard. I used LibreOffice Calc, which put 5 tab-separated values for each row, plus a blank line, in the clipboard:
```
0	13460	0.7	13463	0.008
1	13461	2.33	13463	0.008

```
- On the GUI, click the paste button, or press Ctrl-V. Mantid should no longer crash.
- If you expand the group, the values for the first row should have been pasted to a new line at the bottom of the group, excluding the first cell containing `0`, which corresponds to a hidden column (this indicates the index of the group you pasted into). The second row should not have been pasted because there is no group with index `1`.
- Click the Insert Group button to add a second group, then repeat. The values for group `1` should also be pasted this time.

Refs #22050 

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
