### PR TITLE
Add -fno-omit-frame-pointer to RelWithDebInfo config

### DIFF
--- a/buildconfig/CMake/GNUSetup.cmake
+++ b/buildconfig/CMake/GNUSetup.cmake
@@ -63,7 +63,7 @@ elseif ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" )
 endif()
 
 # Add some options for debug build to help the Zoom profiler
-add_compile_options ( $<$<CONFIG:Debug>:-fno-omit-frame-pointer> )
+add_compile_options ( $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:-fno-omit-frame-pointer> )
 
 option(WITH_ASAN "Enable address sanitizer" OFF)
 if(WITH_ASAN)


### PR DESCRIPTION
Description of work.



**To test:**

<!-- Instructions for testing. -->

Build in config `RelWithDebInfo, enable `CMAKE_EXPORT_COMPILE_COMMANDS` and check that `compile_commands.json` contains the option `-fno-omit-frame-pointer`.

There is no GitHub issue associated with this pull request.

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
