### PR TITLE
Applied clang-tidy modernize-use-using fixes for MantidPlot

### DIFF
--- a/MantidPlot/src/ConfigDialog.cpp
+++ b/MantidPlot/src/ConfigDialog.cpp
@@ -1277,8 +1277,8 @@ void ConfigDialog::updateSendToTab() {
   }
 }
 
-typedef std::map<std::string, bool> categoriesType;
-typedef QMap<QString, QTreeWidgetItem *> widgetMap;
+using categoriesType = std::map<std::string, bool>;
+using widgetMap = QMap<QString, QTreeWidgetItem *>;
 
 void ConfigDialog::refreshTreeCategories() {
   treeCategories->clear();

--- a/MantidPlot/src/Fit.h
+++ b/MantidPlot/src/Fit.h
@@ -45,11 +45,10 @@ class Fit : public Filter {
   Q_OBJECT
 
 public:
-  typedef double (*fit_function_simplex)(const gsl_vector *, void *);
-  typedef int (*fit_function)(const gsl_vector *, void *, gsl_vector *);
-  typedef int (*fit_function_df)(const gsl_vector *, void *, gsl_matrix *);
-  typedef int (*fit_function_fdf)(const gsl_vector *, void *, gsl_vector *,
-                                  gsl_matrix *);
+  using fit_function_simplex = double (*)(const gsl_vector *, void *);
+  using fit_function = int (*)(const gsl_vector *, void *, gsl_vector *);
+  using fit_function_df = int (*)(const gsl_vector *, void *, gsl_matrix *);
+  using fit_function_fdf = int (*)(const gsl_vector *, void *, gsl_vector *, gsl_matrix *);
 
   enum Algorithm {
     ScaledLevenbergMarquardt,

--- a/MantidPlot/src/Fit.h
+++ b/MantidPlot/src/Fit.h
@@ -48,7 +48,8 @@ public:
   using fit_function_simplex = double (*)(const gsl_vector *, void *);
   using fit_function = int (*)(const gsl_vector *, void *, gsl_vector *);
   using fit_function_df = int (*)(const gsl_vector *, void *, gsl_matrix *);
-  using fit_function_fdf = int (*)(const gsl_vector *, void *, gsl_vector *, gsl_matrix *);
+  using fit_function_fdf = int (*)(const gsl_vector *, void *, gsl_vector *,
+                                   gsl_matrix *);
 
   enum Algorithm {
     ScaledLevenbergMarquardt,

--- a/MantidPlot/src/Mantid/InputHistory.h
+++ b/MantidPlot/src/Mantid/InputHistory.h
@@ -11,7 +11,7 @@
 namespace Mantid {
 namespace API {
 class IAlgorithm;
-typedef boost::shared_ptr<IAlgorithm> IAlgorithm_sptr;
+using IAlgorithm_sptr = boost::shared_ptr<IAlgorithm>;
 }
 }
 
@@ -88,6 +88,6 @@ private:
   QMap<QString, QList<PropertyData>> m_history;
 };
 
-typedef Mantid::Kernel::SingletonHolder<InputHistoryImpl> InputHistory;
+using InputHistory = Mantid::Kernel::SingletonHolder<InputHistoryImpl>;
 
 #endif /* INPUTHISTORY_H */

--- a/MantidPlot/src/Mantid/MantidMatrix.h
+++ b/MantidPlot/src/Mantid/MantidMatrix.h
@@ -333,7 +333,7 @@ private:
 };
 
 /// Typedef for a shared pointer to a MantidMatrix
-typedef QSharedPointer<MantidMatrix> MantidMatrix_sptr;
+using MantidMatrix_sptr = QSharedPointer<MantidMatrix>;
 
 class ProjectData {
 public:

--- a/MantidPlot/src/MdiSubWindow.h
+++ b/MantidPlot/src/MdiSubWindow.h
@@ -353,7 +353,7 @@ private:
   friend class FloatingWindow;
 };
 
-typedef QList<MdiSubWindow *> MDIWindowList;
+using MDIWindowList = QList<MdiSubWindow *>;
 
 /* Used to register classes into the factory. creates a global object in an
  * anonymous namespace. The object itself does nothing, but the comma operator

--- a/MantidPlot/src/PluginFit.cpp
+++ b/MantidPlot/src/PluginFit.cpp
@@ -161,7 +161,7 @@ bool PluginFit::load(const QString &pluginName) {
   if (!f_eval)
     return false;
 
-  typedef char *(*fitFunc)();
+  using fitFunc = char *(*)();
   ff_union ff;
   ff.ptr = lib.resolve("parameters");
   fitFunc fitFunction = ff.func;

--- a/MantidPlot/src/PluginFit.h
+++ b/MantidPlot/src/PluginFit.h
@@ -48,7 +48,7 @@ public:
 
 private:
   void init();
-  typedef double (*fitFunctionEval)(double, double *);
+  using fitFunctionEval = double (*)(double, double *);
   void calculateFitCurveData(double *X, double *Y) override;
   fitFunctionEval f_eval;
 };

--- a/MantidPlot/src/ScriptingEnv.h
+++ b/MantidPlot/src/ScriptingEnv.h
@@ -169,7 +169,7 @@ public:
   static int numLanguages();
 
 private:
-  typedef ScriptingEnv *(*ScriptingEnvConstructor)(ApplicationWindow *);
+  using ScriptingEnvConstructor = ScriptingEnv *(*)(ApplicationWindow *);
   typedef struct {
     const char *name;
     ScriptingEnvConstructor constructor;

--- a/MantidPlot/src/WindowFactory.h
+++ b/MantidPlot/src/WindowFactory.h
@@ -101,7 +101,8 @@ public:
 
 class WindowFactoryImpl final {
 private:
-  using AbstractFactory = AbstractProjectInstantiator<MantidQt::API::IProjectSerialisable>;
+  using AbstractFactory =
+      AbstractProjectInstantiator<MantidQt::API::IProjectSerialisable>;
 
 public:
   WindowFactoryImpl();
@@ -172,7 +173,8 @@ private:
   }
 
   /// A typedef for the map of registered classes
-  using FactoryMap = Mantid::Kernel::CaseInsensitiveMap<std::unique_ptr<AbstractFactory> >;
+  using FactoryMap =
+      Mantid::Kernel::CaseInsensitiveMap<std::unique_ptr<AbstractFactory>>;
   /// The map holding the registered class names and their instantiators
   FactoryMap _map;
 };

--- a/MantidPlot/src/WindowFactory.h
+++ b/MantidPlot/src/WindowFactory.h
@@ -101,8 +101,7 @@ public:
 
 class WindowFactoryImpl final {
 private:
-  typedef AbstractProjectInstantiator<MantidQt::API::IProjectSerialisable>
-      AbstractFactory;
+  using AbstractFactory = AbstractProjectInstantiator<MantidQt::API::IProjectSerialisable>;
 
 public:
   WindowFactoryImpl();
@@ -173,8 +172,7 @@ private:
   }
 
   /// A typedef for the map of registered classes
-  typedef Mantid::Kernel::CaseInsensitiveMap<std::unique_ptr<AbstractFactory>>
-      FactoryMap;
+  using FactoryMap = Mantid::Kernel::CaseInsensitiveMap<std::unique_ptr<AbstractFactory> >;
   /// The map holding the registered class names and their instantiators
   FactoryMap _map;
 };
@@ -184,7 +182,7 @@ private:
 template class Mantid::Kernel::SingletonHolder<WindowFactoryImpl>;
 #endif /* _WIN32 */
 
-typedef Mantid::Kernel::SingletonHolder<WindowFactoryImpl> WindowFactory;
+using WindowFactory = Mantid::Kernel::SingletonHolder<WindowFactoryImpl>;
 }
 }
 

--- a/MantidPlot/src/origin/tree.hh
+++ b/MantidPlot/src/origin/tree.hh
@@ -66,10 +66,10 @@ tree_node_<T>::tree_node_(const T& val)
 template <class T, class tree_node_allocator = std::allocator<tree_node_<T> > >
 class tree {
 	protected:
-		typedef tree_node_<T> tree_node;
+		using tree_node = tree_node_<T>;
 	public:
 		/// Value of the data stored at a node.
-		typedef T value_type;
+		using value_type = T;
 
 		class iterator_base;
 		class pre_order_iterator;
@@ -91,12 +91,12 @@ class tree {
 		class iterator_base {
 #endif
 			public:
-				typedef T                               value_type;
-				typedef T*                              pointer;
-				typedef T&                              reference;
-				typedef size_t                          size_type;
-				typedef ptrdiff_t                       difference_type;
-				typedef std::bidirectional_iterator_tag iterator_category;
+				using value_type = T;
+				using pointer = T *;
+				using reference = T &;
+				using size_type = size_t;
+				using difference_type = ptrdiff_t;
+				using iterator_category = std::bidirectional_iterator_tag;
 
 				iterator_base();
 				iterator_base(tree_node *);
@@ -175,8 +175,8 @@ class tree {
 		};
 
 		/// The default iterator types throughout the tree class.
-		typedef pre_order_iterator            iterator;
-		typedef breadth_first_queued_iterator breadth_first_iterator;
+		using iterator = pre_order_iterator;
+		using breadth_first_iterator = breadth_first_queued_iterator;
 
 		/// Iterator which traverses only the nodes at a given depth from the root.
 		class fixed_depth_iterator : public iterator_base {


### PR DESCRIPTION
Maintainance PR forming part of #22048.
Applied modernize-use-using fixes for `MantidPlot`.

**To test:**
1. Ensure builds pass.
2. Check for occurrences of typedef not in comments using `grep -rnI '^[^/*]*typedef'` or a similar command of your choice.

**Release Notes** 
*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
