### PR TITLE
Fix Reflectometry GUI Default Value for IntegratedMonitors Checkbox

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/ReflSettingsWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflSettingsWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>764</width>
-    <height>631</height>
+    <width>858</width>
+    <height>679</height>
    </rect>
   </property>
   <property name="baseSize">
@@ -605,7 +605,11 @@
          <widget class="QLineEdit" name="lamMaxEdit"/>
         </item>
         <item row="0" column="1">
-         <widget class="QCheckBox" name="intMonCheckBox"/>
+         <widget class="QCheckBox" name="intMonCheckBox">
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
         </item>
         <item row="2" column="0">
          <widget class="QLabel" name="monBgMinLabel">


### PR DESCRIPTION
Set default value in UI file

**To test:**
1. Open Reflectometry GUI.
2. Navigate to the settings tab.
3. Ensure that the Integrated Monitors checkbox is checked.

<!-- Instructions for testing. -->

Fixes #22107. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
