### PR TITLE
`FractionalRebinning` binwidth normalisation

### DIFF
--- a/Framework/Algorithms/test/SofQWCutTest.h
+++ b/Framework/Algorithms/test/SofQWCutTest.h
@@ -188,16 +188,16 @@ public:
     TS_ASSERT_EQUALS((*(ws_q->getAxis(1)))(0), 0.0);
     TS_ASSERT_DELTA((*(ws_q->getAxis(1)))(400), 5.0, delta);
     TS_ASSERT_EQUALS((*(ws_q->getAxis(1)))(800), 10.);
-    TS_ASSERT_DELTA(ws_q->readY(64)[0], 0.144715421, delta);
-    TS_ASSERT_DELTA(ws_q->readE(64)[0], 0.007981350, delta);
-    TS_ASSERT_DELTA(ws_q->readY(345)[0], 0.658678386, delta);
-    TS_ASSERT_DELTA(ws_q->readE(345)[0], 0.029371568, delta);
-    TS_ASSERT_DELTA(ws_q->readY(595)[0], 0.159563545, delta);
-    TS_ASSERT_DELTA(ws_q->readE(595)[0], 0.012046158, delta);
-    TS_ASSERT_DELTA(ws_q->readY(683)[0], 0.178108225, delta);
-    TS_ASSERT_DELTA(ws_q->readE(683)[0], 0.019119298, delta);
-    TS_ASSERT_DELTA(ws_q->readY(745)[0], 2.086237760, delta);
-    TS_ASSERT_DELTA(ws_q->readE(745)[0], 0.048837503, delta);
+    TS_ASSERT_DELTA(ws_q->readY(64)[0], 1.447154208, delta);
+    TS_ASSERT_DELTA(ws_q->readE(64)[0], 0.079813500, delta);
+    TS_ASSERT_DELTA(ws_q->readY(345)[0], 6.586783859, delta);
+    TS_ASSERT_DELTA(ws_q->readE(345)[0], 0.293715678, delta);
+    TS_ASSERT_DELTA(ws_q->readY(595)[0], 1.595635453, delta);
+    TS_ASSERT_DELTA(ws_q->readE(595)[0], 0.120461583, delta);
+    TS_ASSERT_DELTA(ws_q->readY(683)[0], 1.781082246, delta);
+    TS_ASSERT_DELTA(ws_q->readE(683)[0], 0.191192978, delta);
+    TS_ASSERT_DELTA(ws_q->readY(745)[0], 20.862377605, delta);
+    TS_ASSERT_DELTA(ws_q->readE(745)[0], 0.488375031, delta);
 
     auto ws_e =
         boost::dynamic_pointer_cast<MatrixWorkspace>(result->getItem(1));
@@ -210,16 +210,16 @@ public:
     TS_ASSERT_EQUALS(ws_e->getAxis(1)->unit()->unitID(), "MomentumTransfer");
     TS_ASSERT_EQUALS((*(ws_e->getAxis(1)))(0), 5.);
     TS_ASSERT_EQUALS((*(ws_e->getAxis(1)))(1), 10.);
-    TS_ASSERT_DELTA(ws_e->readY(0)[3], 2.003485282, delta);
-    TS_ASSERT_DELTA(ws_e->readE(0)[3], 0.013726709, delta);
-    TS_ASSERT_DELTA(ws_e->readY(0)[20], 0.136945077, delta);
-    TS_ASSERT_DELTA(ws_e->readE(0)[20], 0.003767914, delta);
-    TS_ASSERT_DELTA(ws_e->readY(0)[27], 0.158356991, delta);
-    TS_ASSERT_DELTA(ws_e->readE(0)[27], 0.004113822, delta);
-    TS_ASSERT_DELTA(ws_e->readY(0)[78], 0.197240860, delta);
-    TS_ASSERT_DELTA(ws_e->readE(0)[78], 0.005446083, delta);
-    TS_ASSERT_DELTA(ws_e->readY(0)[119], 0.027223857, delta);
-    TS_ASSERT_DELTA(ws_e->readE(0)[119], 0.003277629, delta);
+    TS_ASSERT_DELTA(ws_e->readY(0)[3], 3.339142136, delta);
+    TS_ASSERT_DELTA(ws_e->readE(0)[3], 0.022877849, delta);
+    TS_ASSERT_DELTA(ws_e->readY(0)[20], 0.228241794, delta);
+    TS_ASSERT_DELTA(ws_e->readE(0)[20], 0.006279856, delta);
+    TS_ASSERT_DELTA(ws_e->readY(0)[27], 0.263928319, delta);
+    TS_ASSERT_DELTA(ws_e->readE(0)[27], 0.006856371, delta);
+    TS_ASSERT_DELTA(ws_e->readY(0)[78], 0.328734767, delta);
+    TS_ASSERT_DELTA(ws_e->readE(0)[78], 0.009076805, delta);
+    TS_ASSERT_DELTA(ws_e->readY(0)[119], 0.045373095, delta);
+    TS_ASSERT_DELTA(ws_e->readE(0)[119], 0.005462714, delta);
   }
 };
 

--- a/Framework/DataObjects/src/FractionalRebinning.cpp
+++ b/Framework/DataObjects/src/FractionalRebinning.cpp
@@ -479,7 +479,7 @@ void normaliseOutput(MatrixWorkspace_sptr outputWS,
                      MatrixWorkspace_const_sptr inputWS,
                      boost::shared_ptr<Progress> progress) {
   const bool removeBinWidth(inputWS->isDistribution() &&
-                            inputWS->id() != "RebinnedOutput");
+                            outputWS->id() != "RebinnedOutput");
   for (int64_t i = 0; i < static_cast<int64_t>(outputWS->getNumberHistograms());
        ++i) {
     const auto &outputX = outputWS->x(i);
@@ -604,10 +604,12 @@ void rebinToFractionalOutput(const Quadrilateral &inputQ,
   // Don't do the overlap removal if already RebinnedOutput.
   // This wreaks havoc on the data.
   double error = inE[j];
-  if (inputWS->isDistribution() && inputWS->id() != "RebinnedOutput") {
+  double inputWeight = 1.;
+  if (inputWS->isDistribution() && !inputRB) {
     const double overlapWidth = inX[j + 1] - inX[j];
     signal *= overlapWidth;
     error *= overlapWidth;
+    inputWeight = overlapWidth;
   }
 
   // The intersection overlap algorithm is relatively costly. The outputQ is
@@ -630,7 +632,6 @@ void rebinToFractionalOutput(const Quadrilateral &inputQ,
 
   // If the input is a RebinnedOutput workspace with frac. area we need
   // to account for the weight of the input bin in the output bin weights
-  double inputWeight = 1.;
   if (inputRB) {
     const auto &inF = inputRB->dataF(i);
     inputWeight = inF[j];


### PR DESCRIPTION
Reinstated correct handling of binwidth normalisation which was wrongly removed in PR #20953 with an additional change for output to `RebinnedOutput` (which has fraction area weight information) where the original distribution data binwidths are incorporated into the new fractional areas.

**To test:**

Download the data from the zip from the issue #22114 and run the script shown there. Cuts `*1[ab]` and `*3[ab]` should agree and cuts `*2[ab]` and `*4[ab]` should agree. Also, run this script and data file, 

```
# Loads a PrAl3 dataset normalised to absolute units and convert it to |Q|
Load('mar21337_ei15.nxspe', OutputWorkspace='MAR21337Reduced')
SofQWNormalisedPolygon(InputWorkspace='MAR21337Reduced', OutputWorkspace='MAR21337Reduced_SQW', QAxisBinning='0.154919,0.0176662,5.03488', EMode='Direct')
Transpose(InputWorkspace='MAR21337Reduced_SQW', OutputWorkspace='MAR21337Reduced_SQW')

# Makes line-cuts of all data, integrating between 0 and 2/Ang
Rebin2D('MAR21337Reduced_SQW',OutputWorkspace='line150Hz',Axis1Binning=[0,2,2],Axis2Binning=[-5,0.05,13],UseFractionalArea=True,Transpose=True)

# Now integrate over the CF peak, by extracting the data, summing over the counts between 2 and 7meV, and multiplying by the mean energy bin size
ws='line150Hz'; x=mtd[ws].extractX(); y=mtd[ws].extractY(); e=mtd[ws].extractE(); 
id = np.where((x>2)*(x<7)); I150=np.sum(y[id])*np.mean(np.diff(x[id])); E150=np.sum(e[id])*np.mean(np.diff(x[id]));

# Estimate the cross-section by using Rebin2D to do the integration:
Rebin2D('MAR21337Reduced_SQW',OutputWorkspace='int150Hz',Axis1Binning=[0,2,2],Axis2Binning=[2,5,7],UseFractionalArea=True,Transpose=True)
IntRB2D = mtd['int150Hz'].extractY() * 5  # Output in milibarn/sr/meV. Multiply by energy range of integral to get it in mB/sr
ErrRB2D = mtd['int150Hz'].extractE() * 5

# Estimate the cross-section by using SofQW to do the integration:
SofQW3('MAR21337Reduced',OutputWorkspace='int150Hz_sofqw',QAxisBinning=[0,2,2], EAxisBinning=[2,5,7], EMode='Direct')
IntSofQW = mtd['int150Hz_sofqw'].extractY() * 5  # Output in milibarn/sr/meV. Multiply by energy range of integral to get it in mB/sr
ErrSofQW = mtd['int150Hz_sofqw'].extractE() * 5

# NB. data is milibarn, so divide by 1000 to get numbers in barn
print "PrAl3, 150Hz, measured cross-section from line cut (%7.4f +/- %7.4f) barn/sr, expected: 0.61996 barn/sr" % (I150/1000, E150/1000)
print "PrAl3, 150Hz, measured cross-section from Rebin2D  (%7.4f +/- %7.4f) barn/sr, expected: 0.61996 barn/sr" % (IntRB2D/1000, ErrRB2D/1000)
print "PrAl3, 150Hz, measured cross-section from SofQW3   (%7.4f +/- %7.4f) barn/sr, expected: 0.61996 barn/sr" % (IntSofQW/1000, ErrSofQW/1000)
```

This tests the output intensity versus a dataset in absolute intensity.
[mar21337_ei15.zip](https://github.com/mantidproject/mantid/files/1816420/mar21337_ei15.zip)

The output should look like:

```
PrAl3, 150Hz, measured cross-section from line cut ( 0.6132 +/-  0.0230) barn/sr, expected: 0.61996 barn/sr
PrAl3, 150Hz, measured cross-section from Rebin2D  ( 0.6027 +/-  0.0035) barn/sr, expected: 0.61996 barn/sr
PrAl3, 150Hz, measured cross-section from SofQW3   ( 0.6146 +/-  0.0036) barn/sr, expected: 0.61996 barn/sr
```

Fixes #22114

*Does not need to be in the release notes.*
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
