### PR TITLE
Fix RPATH for Vates widgets library

### DIFF
--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/CMakeLists.txt
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/CMakeLists.txt
@@ -136,7 +136,7 @@ mtd_add_qt_library (TARGET_NAME VatesSimpleGuiViewWidgets
     @loader_path/../../Contents/MacOS
     @loader_path/../../Contents/Libraries
   LINUX_INSTALL_RPATH
-    "\$ORIGIN/../../${LIB_DIR}"
+    "\$ORIGIN/../../${LIB_DIR};\$ORIGIN"
 )
 
 # Set the name of the generated library


### PR DESCRIPTION
See commit message.

**To test:**

Must be done on Linux.

- Run this script on an install of the latest nightly build and try to launch the VSI (via the context menu of `output_md`), notice the option is grayed out.
- Build, package and install Mantid (with ParaView) with this fix applied and see that the option for the VSI is working again.

```python
CreateSimulationWorkspace(Instrument='MARI', BinParams='-10,0.1,10', OutputWorkspace='data')
AddSampleLog(Workspace='data', LogName='ei', LogText='12', LogType='Number', NumberType='Double')
ConvertToMD(InputWorkspace='data', QDimensions='Q3D', OutputWorkspace='output_md')
```

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
