### PR TITLE
Disables the share non-identifiable button when the user has entered a name or email

### DIFF
--- a/scripts/ErrorReporter/errorreport.py
+++ b/scripts/ErrorReporter/errorreport.py
@@ -19,6 +19,9 @@ class CrashReportPage(QtGui.QWidget, ui_errorreport.Ui_Errorreport):
 
         self.requestTextBrowser.anchorClicked.connect(MantidQt.API.MantidDesktopServices.openUrl)
 
+        self.input_name_line_edit.textChanged.connect(self.set_button_status)
+        self.input_email_line_edit.textChanged.connect(self.set_button_status)
+
 #  The options on what to do after closing the window (exit/continue)
         self.radioButtonContinue.setChecked(True)     # Set continue to be checked by default
 
@@ -46,6 +49,12 @@ class CrashReportPage(QtGui.QWidget, ui_errorreport.Ui_Errorreport):
         gui_element = getattr(self, line_edit)
         value_as_string = gui_element.text()
         return expected_type(value_as_string) if value_as_string else None
+
+    def set_button_status(self):
+        if not self.input_name and not self.input_email:
+            self.nonIDShareButton.setEnabled(True)
+        else:
+            self.nonIDShareButton.setEnabled(False)
 
     @property
     def input_name(self):


### PR DESCRIPTION
Description of work.

**To test:**
In the error report dialog try entering some text in either of the two text boxes and confirm that the middle button greys out. Confirm it then remains greyed out until all text has been removed from both boxes.
<!-- Instructions for testing. -->

Fixes #22119 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
