### PR TITLE
Frequency domain analysis produces warning if no data

### DIFF
--- a/docs/source/release/v3.12.0/muon.rst
+++ b/docs/source/release/v3.12.0/muon.rst
@@ -32,6 +32,7 @@ Improvements
 - The period summation/subtraction can now be used in multiple fitting. 
 - Muon analysis now handles the "auto background" gracefully in single and multiple fitting modes.
 - We have disabled some non functional graph right click context menu items or adding functions when in multi data fitting mode, in the Data Analysis tab of the Muon Analysis Interface.
+- Frequency domain analysis will produce a warning if there is no data to load.
 
 Bug fixes
 #########

--- a/scripts/Frequency_Domain_Analysis.py
+++ b/scripts/Frequency_Domain_Analysis.py
@@ -37,7 +37,12 @@ def qapp():
 
 
 app = qapp()
-ex= FrequencyDomainAnalysisGui()
-ex.resize(700,700)
-ex.show()
-app.exec_()
+try:
+    ex= FrequencyDomainAnalysisGui()
+    ex.resize(700,700)
+    ex.show()
+    app.exec_()
+except RuntimeError as error:
+    ex = QtGui.QWidget()
+    QtGui.QMessageBox.warning(ex,"Frequency Domain Analysis",str(error))
+

--- a/scripts/Frequency_Domain_Analysis.py
+++ b/scripts/Frequency_Domain_Analysis.py
@@ -45,4 +45,3 @@ try:
 except RuntimeError as error:
     ex = QtGui.QWidget()
     QtGui.QMessageBox.warning(ex,"Frequency Domain Analysis",str(error))
-

--- a/scripts/Muon/load_utils.py
+++ b/scripts/Muon/load_utils.py
@@ -13,7 +13,7 @@ class LoadUtils(object):
         if exists:
             self.setUp(tmpWS)
         else:
-            mantid.logger.error("Muon Analysis workspace does not exist - no data loaded")
+            raise RuntimeError("No data loaded. \n Please load data using Muon Analysis")
 
     def setUp(self,tmpWS):
         # get everything from the ADS


### PR DESCRIPTION
Frequency domain analysis will now produce a warning message box if no data is present in the ADS (i.e. have not loaded data using muon analysis). 

**To test:**
Open frequency domain analysis
A warning message should apper
Open muon analysis and load some data
Open frequency domain analysis - it should open this time

<!-- Instructions for testing. -->



**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->
In release notes
---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
