### PR TITLE
SANS beam centre crashes with no find direction

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinder.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinder.py
@@ -203,7 +203,8 @@ class SANSBeamCentreFinder(DataProcessorAlgorithm):
                 logger.notice("Itr " + str(j) + ": (" + str(self.scale_1 * centre1) + ", " + str(self.scale_2 * centre2) + ")  SX="
                               + str(residueLR[j]) + "  SY=" + str(residueTB[j]))
 
-                if (residueLR[j]+residueTB[j]) < (residueLR[j-1]+residueTB[j-1]) or state.compatibility.use_compatibility_mode:
+                combined_residual = [sum(x) for x in zip(residueLR, residueTB)]
+                if combined_residual[j] is min(combined_residual) or state.compatibility.use_compatibility_mode:
                     centre_1_hold = centre1
                     centre_2_hold = centre2
 

--- a/scripts/Interface/ui/sans_isis/beam_centre.py
+++ b/scripts/Interface/ui/sans_isis/beam_centre.py
@@ -176,7 +176,7 @@ class BeamCentre(QtGui.QWidget, ui_beam_centre.Ui_BeamCentre):
 
     @property
     def up_down(self):
-        return self.left_right_check_box.isChecked()
+        return self.up_down_check_box.isChecked()
 
     @up_down.setter
     def up_down(self, value):

--- a/scripts/SANS/sans/gui_logic/models/beam_centre_model.py
+++ b/scripts/SANS/sans/gui_logic/models/beam_centre_model.py
@@ -1,4 +1,5 @@
 from sans.common.enums import (SANSInstrument, FindDirectionEnum)
+from mantid.kernel import (Logger)
 
 
 class BeamCentreModel(object):
@@ -53,9 +54,13 @@ class BeamCentreModel(object):
         if self.up_down and self.left_right:
             find_direction = FindDirectionEnum.All
         elif self.up_down:
-            find_direction = FindDirectionEnum.Left_Right
-        elif self.left_right:
             find_direction = FindDirectionEnum.Up_Down
+        elif self.left_right:
+            find_direction = FindDirectionEnum.Left_Right
+        else:
+            logger = Logger("CentreFinder")
+            logger.notice("Have chosen no find direction exiting early")
+            return {"pos1": self.lab_pos_1, "pos2": self.lab_pos_2}
 
         if self.q_min:
             state.convert_to_q.q_min = self.q_min


### PR DESCRIPTION
The sans beam centre finder currently throws an error when neither find direction is selected. It also returns the latest result rather than the best. This fixes both these issues

**To test:**
Get this data
[loqdemo.zip](https://github.com/mantidproject/mantid/files/1819094/loqdemo.zip)

Open the sans GUI V2 and load in the maskfile.txt as the user file and the .csv file as the batch file.
Go to the beam centre finder tab and unselect both finds direction confirm that no crash occurs.
Select both find directions and click run confirm the center coordinates are updated to [324.80375, 327.49]


<!-- Instructions for testing. -->

Fixes #22124 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
