### PR TITLE
Muon analysis crashes when loading without data archive 

### DIFF
--- a/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
@@ -1549,6 +1549,10 @@ void MuonFitPropertyBrowser::updatePeriods() {
 void MuonFitPropertyBrowser::updatePeriods(const int j) {
   // this is for switching but has a bug at the moment
   // const QStringList &selected) {
+  if(m_periodsToFitOptions.size() ==0){
+     
+     return;
+  }
   m_enumManager->setEnumNames(m_periodsToFit, m_periodsToFitOptions);
   m_enumManager->setValue(m_periodsToFit, j);
   if (m_periodsToFitOptions[j] == CUSTOM_LABEL) {

--- a/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
@@ -1552,7 +1552,7 @@ void MuonFitPropertyBrowser::updatePeriods(const int j) {
   // const QStringList &selected) {
   if (m_periodsToFitOptions.size() == 0) {
     QMessageBox::warning(this, "Muon Analysis",
-                         "Data not found. Please turn on the data archhive");
+                         "Data not found. Please turn on the data archive, using the Manage Directories button.");
     return;
   }
   m_enumManager->setEnumNames(m_periodsToFit, m_periodsToFitOptions);

--- a/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
@@ -57,7 +57,7 @@
 #include <QSignalMapper>
 #include <QTableWidgetItem>
 #include <QCheckBox>
-#include<QMessageBox>
+#include <QMessageBox>
 
 namespace {
 Mantid::Kernel::Logger g_log("MuonFitPropertyBrowser");
@@ -1550,9 +1550,10 @@ void MuonFitPropertyBrowser::updatePeriods() {
 void MuonFitPropertyBrowser::updatePeriods(const int j) {
   // this is for switching but has a bug at the moment
   // const QStringList &selected) {
-  if(m_periodsToFitOptions.size() ==0){
-     QMessageBox::warning(this,"Muon Analysis","Data not found. Please turn on the data archhive");    
-     return;
+  if (m_periodsToFitOptions.size() == 0) {
+    QMessageBox::warning(this, "Muon Analysis",
+                         "Data not found. Please turn on the data archhive");
+    return;
   }
   m_enumManager->setEnumNames(m_periodsToFit, m_periodsToFitOptions);
   m_enumManager->setValue(m_periodsToFit, j);

--- a/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
@@ -1552,7 +1552,8 @@ void MuonFitPropertyBrowser::updatePeriods(const int j) {
   // const QStringList &selected) {
   if (m_periodsToFitOptions.size() == 0) {
     QMessageBox::warning(this, "Muon Analysis",
-                         "Data not found. Please turn on the data archive, using the Manage Directories button.");
+                         "Data not found. Please turn on the data archive, "
+                         "using the Manage Directories button.");
     return;
   }
   m_enumManager->setEnumNames(m_periodsToFit, m_periodsToFitOptions);

--- a/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
@@ -57,6 +57,7 @@
 #include <QSignalMapper>
 #include <QTableWidgetItem>
 #include <QCheckBox>
+#include<QMessageBox>
 
 namespace {
 Mantid::Kernel::Logger g_log("MuonFitPropertyBrowser");
@@ -1550,7 +1551,7 @@ void MuonFitPropertyBrowser::updatePeriods(const int j) {
   // this is for switching but has a bug at the moment
   // const QStringList &selected) {
   if(m_periodsToFitOptions.size() ==0){
-     
+     QMessageBox::warning(this,"Muon Analysis","Data not found. Please turn on the data archhive");    
      return;
   }
   m_enumManager->setEnumNames(m_periodsToFit, m_periodsToFitOptions);


### PR DESCRIPTION
Turn off data archive

Open muon analysis
Type the run number 62260 into the run box and press enter
It no longer crashes  

**To test:**

<!-- Instructions for testing. -->


**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
