### PR TITLE
Fix numerical error in UnitCell/ OrientedLattice

### DIFF
--- a/Framework/Geometry/src/Crystal/UnitCell.cpp
+++ b/Framework/Geometry/src/Crystal/UnitCell.cpp
@@ -452,7 +452,13 @@ double UnitCell::recAngle(double h1, double k1, double l1, double h2, double k2,
   double E, ang;
   Q1 = Gstar * Q1;
   E = Q1.scalar_prod(Q2);
-  ang = acos(E / dstar(h1, k1, l1) / dstar(h2, k2, l2));
+  double temp = E / dstar(h1, k1, l1) / dstar(h2, k2, l2);
+  if (temp>1)
+    ang = 0.;
+  else if (temp<-1)
+    ang = M_PI;
+  else
+    ang = acos(temp);
   if (angleunit == angDegrees)
     return rad2deg * ang;
   else

--- a/Framework/Geometry/src/Crystal/UnitCell.cpp
+++ b/Framework/Geometry/src/Crystal/UnitCell.cpp
@@ -453,9 +453,9 @@ double UnitCell::recAngle(double h1, double k1, double l1, double h2, double k2,
   Q1 = Gstar * Q1;
   E = Q1.scalar_prod(Q2);
   double temp = E / dstar(h1, k1, l1) / dstar(h2, k2, l2);
-  if (temp>1)
+  if (temp > 1)
     ang = 0.;
-  else if (temp<-1)
+  else if (temp < -1)
     ang = M_PI;
   else
     ang = acos(temp);

--- a/Framework/Geometry/test/UnitCellTest.h
+++ b/Framework/Geometry/test/UnitCellTest.h
@@ -142,6 +142,12 @@ public:
     }
   }
 
+  void testReciprocalAngle0() {
+    UnitCell cell(5.45, 5.45, 5.45);
+    TS_ASSERT_EQUALS(cell.recAngle(0., 4., 0., 0., 4., 0.), 0.);
+    TS_ASSERT_EQUALS(cell.recAngle(0., -4., 0., 0., 4., 0.), 180.);
+  }
+
   void testStrToUnitCell() {
     UnitCell cell(2.0, 4.0, 5.0, 90.0, 100.0, 102.0);
     std::string cellString = unitCellToStr(cell);


### PR DESCRIPTION
Numerical error for the argument or acos function makes the output `NaN` in certain cases (the argument is 1.0000002 instead of 1.) 
Fixes #22134
**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
