### PR TITLE
Save end time in SNS live listener

### DIFF
--- a/Framework/LiveData/src/SNSLiveEventDataListener.cpp
+++ b/Framework/LiveData/src/SNSLiveEventDataListener.cpp
@@ -740,9 +740,8 @@ bool SNSLiveEventDataListener::rxPacket(const ADARA::RunStatusPkt &pkt) {
     }
 
   } else if (pkt.status() == ADARA::RunStatus::END_RUN) {
-    // Run has ended:  update m_status and set the flag to stop parsing network
-    // packets.  (see comments below for why)
-
+    // Run has ended:  update m_status, set the end time and set the flag
+    // to stop parsing network packets.  (see comments below for why)
     if ((m_status != Running) && (m_status != BeginRun)) {
       // Previous status should have been Running or BeginRun.  Spit out a
       // warning if it's not.  (If it's BeginRun, that's fine.  It just means
@@ -752,6 +751,10 @@ bool SNSLiveEventDataListener::rxPacket(const ADARA::RunStatusPkt &pkt) {
     }
     m_status = EndRun;
 
+    // Add the run_end property
+    m_eventBuffer->mutableRun().addProperty(
+        "run_end", timeFromPacket(pkt).toISO8601String());
+    
     // Set the flag to make us stop reading from the network.
     // Stopping network reads solves a number of problems:
     // 1) We don't need to manage a second buffer in order to keep the events

--- a/Framework/LiveData/src/SNSLiveEventDataListener.cpp
+++ b/Framework/LiveData/src/SNSLiveEventDataListener.cpp
@@ -1102,18 +1102,15 @@ bool SNSLiveEventDataListener::rxPacket(const ADARA::DeviceDescriptorPkt &pkt) {
               prop->setUnits(pvUnits);
             }
             {
-              // Note: it's possible for us receive device descriptor packets in
-              // the middle
-              // of a run (after the call to initWorkspacePart2), so we really
-              // do need to
-              // the lock the mutex here.
+              // Note: it's possible for us receive device descriptor packets
+              // in the middle of a run (after the call to initWorkspacePart2),
+              // so we really do need to the lock the mutex here.
               std::lock_guard<std::mutex> scopedLock(m_mutex);
               m_eventBuffer->mutableRun().addLogData(prop);
             }
 
             // Add the pv id, device id and pv name to the name map so we can
-            // find the
-            // name when we process the variable value packets
+            // find the name when we process the variable value packets
             m_nameMap[std::make_pair(pkt.devId(), pvIdNum)] = pvName;
           }
         }
@@ -1207,10 +1204,8 @@ void SNSLiveEventDataListener::initWorkspacePart1() {
   // down in initWorkspacePart2() when we load the instrument definition.
 
   // We also know we'll need 3 time series properties on the workspace.  Create
-  // them
-  // now. (We may end up adding values to the pause and scan properties before
-  // we
-  // can call initWorkspacePart2().)
+  // them now. (We may end up adding values to the pause and scan properties
+  // before we can call initWorkspacePart2().)
   Property *prop = new TimeSeriesProperty<int>(PAUSE_PROPERTY);
   m_eventBuffer->mutableRun().addLogData(prop);
   prop = new TimeSeriesProperty<int>(SCAN_PROPERTY);
@@ -1239,8 +1234,8 @@ void SNSLiveEventDataListener::initWorkspacePart2() {
 
   loadInst->execute();
 
-  m_requiredLogs.clear(); // Clear the list.  If we have to initialize the
-                          // workspace again,
+  m_requiredLogs.clear();
+  // Clear the list.  If we have to initialize the workspace again,
   // (at the start of another run, for example), the list will be
   // repopulated when we receive the next geometry packet.
 
@@ -1261,10 +1256,9 @@ void SNSLiveEventDataListener::initWorkspacePart2() {
       true /* bool throwIfMultipleDets */);
 
   // We always want to have at least one value for the the scan index time
-  // series.  We may have
-  // already gotten a scan start packet by the time we get here and therefor
-  // don't need to do
-  // anything.  If not, we need to put a 0 into the time series.
+  // series.  We may have already gotten a scan start packet by the time we
+  // get here and therefor don't need to do anything.  If not, we need to put
+  // a 0 into the time series.
   if (m_eventBuffer->mutableRun()
           .getTimeSeriesProperty<int>(SCAN_PROPERTY)
           ->size() == 0) {
@@ -1300,8 +1294,7 @@ void SNSLiveEventDataListener::initMonitorWorkspace() {
 // NOTE: This function does not lock the mutex!  The calling function must
 // ensure that m_eventBuffer won't change while the function runs (either by
 // locking the mutex, or by the simple fact of never calling it once the
-// workspace
-// has been initialized...)
+// workspace has been initialized...)
 bool SNSLiveEventDataListener::haveRequiredLogs() {
   bool allFound = true;
   Run &run = m_eventBuffer->mutableRun();

--- a/Framework/LiveData/src/SNSLiveEventDataListener.cpp
+++ b/Framework/LiveData/src/SNSLiveEventDataListener.cpp
@@ -754,7 +754,7 @@ bool SNSLiveEventDataListener::rxPacket(const ADARA::RunStatusPkt &pkt) {
     // Add the run_end property
     m_eventBuffer->mutableRun().addProperty(
         "run_end", timeFromPacket(pkt).toISO8601String());
-    
+
     // Set the flag to make us stop reading from the network.
     // Stopping network reads solves a number of problems:
     // 1) We don't need to manage a second buffer in order to keep the events


### PR DESCRIPTION
SNS Live Listener now saves the run end time.

**To test:**

<!-- Instructions for testing. -->

Fire up the SNS Live Listener (either with 'real' data or replay some historical data) and capture an entire run.  After the run ends, click on the workspace in MantidPlot and note that run end time is valid.

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->
*Does not need to be in the release notes.*
---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
