### PR TITLE
Fix dev-docs-html target for old Sphinx versions

### DIFF
--- a/buildconfig/CMake/FindSphinx.cmake
+++ b/buildconfig/CMake/FindSphinx.cmake
@@ -11,22 +11,14 @@
 # main()
 #=============================================================
 
-
-FIND_FILE(_find_sphinx_py FindSphinx.py PATHS ${CMAKE_MODULE_PATH})
-
-if (version_string)   # chop out the version number
-  string (REGEX REPLACE ".*([0-9]+\\.[0-9]+\\.[0-9]+).*" "\\1" SPHINX_VERSION ${version_string})
-endif()
-
+find_file (_find_sphinx_py FindSphinx.py PATHS ${CMAKE_MODULE_PATH})
 
 # import sphinx-build to attempt to get the version
 execute_process (COMMAND ${PYTHON_EXECUTABLE} ${_find_sphinx_py} OUTPUT_VARIABLE sphinx_output
                                                                  RESULT_VARIABLE sphinx_result)
+string (STRIP "${sphinx_output}" sphinx_output)
 
-if (${sphinx_result} STREQUAL "0")# AND version_string)
-  if (version_string)
-    list(GET sphinx_output 0 version_string)
-  endif()
+if (${sphinx_result} STREQUAL "0")
   list(GET sphinx_output 1 SPHINX_PACKAGE_DIR)
 else()
   message(STATUS "failed to run FindSphinx.py returned ${sphinx_result}")

--- a/buildconfig/CMake/FindSphinx.py
+++ b/buildconfig/CMake/FindSphinx.py
@@ -1,2 +1,3 @@
+import os.path as osp
 import sphinx
-print('{0};{1}'.format(sphinx.__version__, sphinx.package_dir))
+print('{0};{1}'.format(sphinx.__version__, osp.dirname(sphinx.__file__)))

--- a/dev-docs/CMakeLists.txt
+++ b/dev-docs/CMakeLists.txt
@@ -6,9 +6,20 @@ set ( BUILDER html )
 set ( OUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/${BUILDER} )
 set ( DOCTREE_DIR ${CMAKE_CURRENT_BINARY_DIR}/doctree )
 
+# We try to execute Sphinx directly through python -m to avoid problems
+# with the startup scripts on Windows. They are not always reliable
+# as they can have hardcoded paths in them. However, older versions of
+# Sphinx dont't allow python -m execution. Assume
+# we are running on Linux and `sphinx-build` is available in these cases
+if ( EXISTS ${SPHINX_PACKAGE_DIR}/__main__.py )
+  set ( SPHINX_BUILD "python -m sphinx" )
+else ()
+  set ( SPHINX_BUILD "sphinx-build" )
+endif ()
+
 add_custom_target ( dev-docs-${BUILDER}
-                   COMMAND python -m sphinx -b ${BUILDER} -d ${DOCTREE_DIR} ${CMAKE_CURRENT_LIST_DIR}/source ${OUT_DIR}
-                   COMMENT "Building html developer documentation" )
+                    COMMAND ${SPHINX_BUILD} -b ${BUILDER} -d ${DOCTREE_DIR} ${CMAKE_CURRENT_LIST_DIR}/source ${OUT_DIR}
+                    COMMENT "Building html developer documentation" )
 # Group within VS and exclude from whole build
 set_target_properties ( dev-docs-html PROPERTIES FOLDER "Documentation"
                        EXCLUDE_FROM_DEFAULT_BUILD 1


### PR DESCRIPTION
Description of work.

See commit message.

**To test:**

* On Ubuntu 14.04 run `make dev-docs-html` and see that is it succesful.

*No issue*

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
