### PR TITLE
Make sure not to delete input workspace in MR reduction

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/MRFilterCrossSections.py
+++ b/Framework/PythonInterface/plugins/algorithms/MRFilterCrossSections.py
@@ -186,7 +186,6 @@ class MRFilterCrossSections(PythonAlgorithm):
                 api.AddSampleLog(Workspace=ws, LogName='cross_section_id',
                                  LogText=pol_state)
 
-            AnalysisDataService.remove(ws_raw_name)
             self.setProperty("CrossSectionWorkspaces", output_wsg)
 
         # If we don't have a splitter table, it might be because we don't have analyzer/polarizer
@@ -196,7 +195,6 @@ class MRFilterCrossSections(PythonAlgorithm):
             self.setProperty("CrossSectionWorkspaces", api.GroupWorkspaces([ws_raw]))
         else:
             api.logger.error("No events remained after filtering")
-            AnalysisDataService.remove(ws_raw_name)
 
     def load_legacy_cross_Sections(self, file_path):
         """

--- a/Framework/PythonInterface/plugins/algorithms/MRFilterCrossSections.py
+++ b/Framework/PythonInterface/plugins/algorithms/MRFilterCrossSections.py
@@ -186,6 +186,8 @@ class MRFilterCrossSections(PythonAlgorithm):
                 api.AddSampleLog(Workspace=ws, LogName='cross_section_id',
                                  LogText=pol_state)
 
+            if ws_event_data is None:
+                AnalysisDataService.remove(ws_raw_name)
             self.setProperty("CrossSectionWorkspaces", output_wsg)
 
         # If we don't have a splitter table, it might be because we don't have analyzer/polarizer
@@ -195,6 +197,8 @@ class MRFilterCrossSections(PythonAlgorithm):
             self.setProperty("CrossSectionWorkspaces", api.GroupWorkspaces([ws_raw]))
         else:
             api.logger.error("No events remained after filtering")
+            if ws_event_data is None:
+                AnalysisDataService.remove(ws_raw_name)
 
     def load_legacy_cross_Sections(self, file_path):
         """


### PR DESCRIPTION
The MRFilterCrossSections algorithm is used to filter cross-sections out of a data set and return a workspace group. That data set is currently deleted after filtering. This makes sense if the data was loaded by the algorithm, but not if it was passed as an input workspace.

Make sure that the input workspace is not deleted by the algorithm.


**To test:**
- Review the code.
- Make sure the tests pass.

**Release Notes** 
*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
