### PR TITLE
Fix dev-docs-html target for fc26

### DIFF
--- a/dev-docs/CMakeLists.txt
+++ b/dev-docs/CMakeLists.txt
@@ -12,14 +12,15 @@ set ( DOCTREE_DIR ${CMAKE_CURRENT_BINARY_DIR}/doctree )
 # Sphinx dont't allow python -m execution. Assume
 # we are running on Linux and `sphinx-build` is available in these cases
 if ( EXISTS ${SPHINX_PACKAGE_DIR}/__main__.py )
-  set ( SPHINX_BUILD "python -m sphinx" )
+  add_custom_target ( dev-docs-${BUILDER}
+                      COMMAND ${PYTHON_EXECUTABLE} -m sphinx -b ${BUILDER} -d ${DOCTREE_DIR} ${CMAKE_CURRENT_LIST_DIR}/source ${OUT_DIR}
+                      COMMENT "Building html developer documentation" )
 else ()
-  set ( SPHINX_BUILD "sphinx-build" )
+  add_custom_target ( dev-docs-${BUILDER}
+                      COMMAND sphinx-build -b ${BUILDER} -d ${DOCTREE_DIR} ${CMAKE_CURRENT_LIST_DIR}/source ${OUT_DIR}
+                      COMMENT "Building html developer documentation" )
 endif ()
 
-add_custom_target ( dev-docs-${BUILDER}
-                    COMMAND ${SPHINX_BUILD} -b ${BUILDER} -d ${DOCTREE_DIR} ${CMAKE_CURRENT_LIST_DIR}/source ${OUT_DIR}
-                    COMMENT "Building html developer documentation" )
 # Group within VS and exclude from whole build
 set_target_properties ( dev-docs-html PROPERTIES FOLDER "Documentation"
                        EXCLUDE_FROM_DEFAULT_BUILD 1


### PR DESCRIPTION
Fix call in `python -m sphinx` branch. The issue is how the `SPHINX_BUILD` variable is expanded in the custom target. Duplicating the `add_custom_target` call was the easiest solution.

The bug was accidentally introduced in #22156.

**To test:**

`cmake --build , --target dev-docs-html` on your platform of choice.

*There is no associated issue.*

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
