### PR TITLE
Applied clang-tidy modernize-use-nullptr fixes for Framework/

### DIFF
--- a/Framework/API/test/AlgorithmManagerTest.h
+++ b/Framework/API/test/AlgorithmManagerTest.h
@@ -139,13 +139,13 @@ public:
     TS_ASSERT_THROWS_NOTHING(
         alg = AlgorithmManager::Instance().create("AlgTest", 1));
     TS_ASSERT_DIFFERS(dynamic_cast<AlgorithmProxy *>(alg.get()),
-                      static_cast<AlgorithmProxy *>(0));
+                      static_cast<AlgorithmProxy *>(nullptr));
     TS_ASSERT_THROWS_NOTHING(
         alg = AlgorithmManager::Instance().create("AlgTestSecond", 1));
     TS_ASSERT_DIFFERS(dynamic_cast<AlgorithmProxy *>(alg.get()),
-                      static_cast<AlgorithmProxy *>(0));
+                      static_cast<AlgorithmProxy *>(nullptr));
     TS_ASSERT_DIFFERS(dynamic_cast<IAlgorithm *>(alg.get()),
-                      static_cast<IAlgorithm *>(0));
+                      static_cast<IAlgorithm *>(nullptr));
     TS_ASSERT_EQUALS(AlgorithmManager::Instance().size(),
                      2); // To check that crea is called on local objects
   }
@@ -157,8 +157,8 @@ public:
     Bptr = AlgorithmManager::Instance().createUnmanaged("AlgTest");
     TS_ASSERT_DIFFERS(Aptr, Bptr);
     TS_ASSERT_EQUALS(AlgorithmManager::Instance().size(), 1);
-    TS_ASSERT_DIFFERS(Aptr.get(), static_cast<Algorithm *>(0));
-    TS_ASSERT_DIFFERS(Bptr.get(), static_cast<Algorithm *>(0));
+    TS_ASSERT_DIFFERS(Aptr.get(), static_cast<Algorithm *>(nullptr));
+    TS_ASSERT_DIFFERS(Bptr.get(), static_cast<Algorithm *>(nullptr));
   }
 
   void testCreateNoProxy() {
@@ -169,7 +169,7 @@ public:
     TSM_ASSERT("Was created as a AlgorithmProxy",
                dynamic_cast<AlgorithmProxy *>(Aptr.get()));
     TSM_ASSERT("Was NOT created as a AlgorithmProxy",
-               dynamic_cast<AlgorithmProxy *>(Bptr.get()) == NULL);
+               dynamic_cast<AlgorithmProxy *>(Bptr.get()) == nullptr);
   }
 
   // This will be called back when an algo starts

--- a/Framework/API/test/AlgorithmTest.h
+++ b/Framework/API/test/AlgorithmTest.h
@@ -808,10 +808,10 @@ public:
     IAlgorithm_sptr algNonConst;
     TS_ASSERT_THROWS_NOTHING(
         algConst = manager.getValue<IAlgorithm_const_sptr>(algName));
-    TS_ASSERT(algConst != NULL);
+    TS_ASSERT(algConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(algNonConst =
                                  manager.getValue<IAlgorithm_sptr>(algName));
-    TS_ASSERT(algNonConst != NULL);
+    TS_ASSERT(algNonConst != nullptr);
     TS_ASSERT_EQUALS(algConst, algNonConst);
 
     // Check TypedValue can be cast to const_sptr or to sptr
@@ -819,9 +819,9 @@ public:
     IAlgorithm_const_sptr algCastConst;
     IAlgorithm_sptr algCastNonConst;
     TS_ASSERT_THROWS_NOTHING(algCastConst = (IAlgorithm_const_sptr)val);
-    TS_ASSERT(algCastConst != NULL);
+    TS_ASSERT(algCastConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(algCastNonConst = (IAlgorithm_sptr)val);
-    TS_ASSERT(algCastNonConst != NULL);
+    TS_ASSERT(algCastNonConst != nullptr);
     TS_ASSERT_EQUALS(algCastConst, algCastNonConst);
   }
 

--- a/Framework/API/test/ExperimentInfoTest.h
+++ b/Framework/API/test/ExperimentInfoTest.h
@@ -129,7 +129,7 @@ public:
   void test_Setting_A_New_Chopper_With_NULL_Ptr_Throws() {
     ExperimentInfo_sptr ws = createTestInfoWithChopperPoints(1);
 
-    TS_ASSERT_THROWS(ws->setChopperModel(NULL), std::invalid_argument);
+    TS_ASSERT_THROWS(ws->setChopperModel(nullptr), std::invalid_argument);
   }
 
   void test_Setting_A_New_Chopper_To_Point_Lower_Point_Succeeds() {
@@ -729,10 +729,10 @@ public:
     ExperimentInfo_sptr eiNonConst;
     TS_ASSERT_THROWS_NOTHING(
         eiConst = manager.getValue<ExperimentInfo_const_sptr>(eiName));
-    TS_ASSERT(eiConst != NULL);
+    TS_ASSERT(eiConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(eiNonConst =
                                  manager.getValue<ExperimentInfo_sptr>(eiName));
-    TS_ASSERT(eiNonConst != NULL);
+    TS_ASSERT(eiNonConst != nullptr);
     TS_ASSERT_EQUALS(eiConst, eiNonConst);
 
     // Check TypedValue can be cast to const_sptr or to sptr
@@ -740,9 +740,9 @@ public:
     ExperimentInfo_const_sptr eiCastConst;
     ExperimentInfo_sptr eiCastNonConst;
     TS_ASSERT_THROWS_NOTHING(eiCastConst = (ExperimentInfo_const_sptr)val);
-    TS_ASSERT(eiCastConst != NULL);
+    TS_ASSERT(eiCastConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(eiCastNonConst = (ExperimentInfo_sptr)val);
-    TS_ASSERT(eiCastNonConst != NULL);
+    TS_ASSERT(eiCastNonConst != nullptr);
     TS_ASSERT_EQUALS(eiCastConst, eiCastNonConst);
   }
 

--- a/Framework/API/test/FunctionTest.h
+++ b/Framework/API/test/FunctionTest.h
@@ -411,10 +411,10 @@ public:
     IFunction_sptr funcNonConst;
     TS_ASSERT_THROWS_NOTHING(
         funcConst = manager.getValue<IFunction_const_sptr>(funcName));
-    TS_ASSERT(funcConst != NULL);
+    TS_ASSERT(funcConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(funcNonConst =
                                  manager.getValue<IFunction_sptr>(funcName));
-    TS_ASSERT(funcNonConst != NULL);
+    TS_ASSERT(funcNonConst != nullptr);
     TS_ASSERT_EQUALS(funcConst, funcNonConst);
 
     // Check TypedValue can be cast to const_sptr or to sptr
@@ -422,9 +422,9 @@ public:
     IFunction_const_sptr funcCastConst;
     IFunction_sptr funcCastNonConst;
     TS_ASSERT_THROWS_NOTHING(funcCastConst = (IFunction_const_sptr)val);
-    TS_ASSERT(funcCastConst != NULL);
+    TS_ASSERT(funcCastConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(funcCastNonConst = (IFunction_sptr)val);
-    TS_ASSERT(funcCastNonConst != NULL);
+    TS_ASSERT(funcCastNonConst != nullptr);
     TS_ASSERT_EQUALS(funcCastConst, funcCastNonConst);
   }
 

--- a/Framework/API/test/IMDWorkspaceTest.h
+++ b/Framework/API/test/IMDWorkspaceTest.h
@@ -125,10 +125,10 @@ public:
     IMDWorkspace_sptr wsNonConst;
     TS_ASSERT_THROWS_NOTHING(
         wsConst = manager.getValue<IMDWorkspace_const_sptr>(wsName));
-    TS_ASSERT(wsConst != NULL);
+    TS_ASSERT(wsConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(wsNonConst =
                                  manager.getValue<IMDWorkspace_sptr>(wsName));
-    TS_ASSERT(wsNonConst != NULL);
+    TS_ASSERT(wsNonConst != nullptr);
     TS_ASSERT_EQUALS(wsConst, wsNonConst);
 
     // Check TypedValue can be cast to const_sptr or to sptr
@@ -136,9 +136,9 @@ public:
     IMDWorkspace_const_sptr wsCastConst;
     IMDWorkspace_sptr wsCastNonConst;
     TS_ASSERT_THROWS_NOTHING(wsCastConst = (IMDWorkspace_const_sptr)val);
-    TS_ASSERT(wsCastConst != NULL);
+    TS_ASSERT(wsCastConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(wsCastNonConst = (IMDWorkspace_sptr)val);
-    TS_ASSERT(wsCastNonConst != NULL);
+    TS_ASSERT(wsCastNonConst != nullptr);
     TS_ASSERT_EQUALS(wsCastConst, wsCastNonConst);
   }
 };

--- a/Framework/API/test/MatrixWorkspaceMDIteratorTest.h
+++ b/Framework/API/test/MatrixWorkspaceMDIteratorTest.h
@@ -53,7 +53,7 @@ public:
   void test_iterating() {
     boost::shared_ptr<MatrixWorkspace> ws = makeFakeWS();
     IMDIterator *it = nullptr;
-    TS_ASSERT_THROWS_NOTHING(it = ws->createIterator(NULL));
+    TS_ASSERT_THROWS_NOTHING(it = ws->createIterator(nullptr));
     TS_ASSERT_EQUALS(it->getDataSize(), 20);
     TS_ASSERT_DELTA(it->getSignal(), 0.0, 1e-5);
     it->next();
@@ -90,13 +90,13 @@ public:
   void test_parallel_iterators() {
     boost::shared_ptr<MatrixWorkspace> ws = makeFakeWS();
     // The number of output cannot be larger than the number of histograms
-    std::vector<IMDIterator *> it = ws->createIterators(10, NULL);
+    std::vector<IMDIterator *> it = ws->createIterators(10, nullptr);
     TS_ASSERT_EQUALS(it.size(), 4);
     for (size_t i = 0; i < it.size(); ++i)
       delete it[i];
 
     // Split in 4 iterators
-    std::vector<IMDIterator *> iterators = ws->createIterators(4, NULL);
+    std::vector<IMDIterator *> iterators = ws->createIterators(4, nullptr);
     TS_ASSERT_EQUALS(iterators.size(), 4);
 
     for (size_t i = 0; i < iterators.size(); i++) {
@@ -122,7 +122,7 @@ public:
 
   void test_get_is_masked() {
     boost::shared_ptr<MatrixWorkspace> ws = makeFakeWS();
-    IMDIterator *it = ws->createIterator(NULL);
+    IMDIterator *it = ws->createIterator(nullptr);
     const auto &spectrumInfo = ws->spectrumInfo();
     for (size_t i = 0; i < ws->getNumberHistograms(); ++i) {
       TS_ASSERT_EQUALS(spectrumInfo.isMasked(i), it->getIsMasked());

--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -1018,7 +1018,7 @@ public:
   void test_setMDMasking() {
     WorkspaceTester ws;
     TSM_ASSERT_THROWS("Characterisation test. This is not implemented.",
-                      ws.setMDMasking(NULL), std::runtime_error);
+                      ws.setMDMasking(nullptr), std::runtime_error);
   }
 
   void test_clearMDMasking() {
@@ -1569,10 +1569,10 @@ public:
     MatrixWorkspace_sptr wsNonConst;
     TS_ASSERT_THROWS_NOTHING(
         wsConst = manager.getValue<MatrixWorkspace_const_sptr>(wsName));
-    TS_ASSERT(wsConst != NULL);
+    TS_ASSERT(wsConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(
         wsNonConst = manager.getValue<MatrixWorkspace_sptr>(wsName));
-    TS_ASSERT(wsNonConst != NULL);
+    TS_ASSERT(wsNonConst != nullptr);
     TS_ASSERT_EQUALS(wsConst, wsNonConst);
 
     // Check TypedValue can be cast to const_sptr or to sptr
@@ -1580,9 +1580,9 @@ public:
     MatrixWorkspace_const_sptr wsCastConst;
     MatrixWorkspace_sptr wsCastNonConst;
     TS_ASSERT_THROWS_NOTHING(wsCastConst = (MatrixWorkspace_const_sptr)val);
-    TS_ASSERT(wsCastConst != NULL);
+    TS_ASSERT(wsCastConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(wsCastNonConst = (MatrixWorkspace_sptr)val);
-    TS_ASSERT(wsCastNonConst != NULL);
+    TS_ASSERT(wsCastNonConst != nullptr);
     TS_ASSERT_EQUALS(wsCastConst, wsCastNonConst);
   }
 

--- a/Framework/API/test/MultiPeriodGroupAlgorithmTest.h
+++ b/Framework/API/test/MultiPeriodGroupAlgorithmTest.h
@@ -214,7 +214,7 @@ public:
     WorkspaceGroup_sptr wsgroup =
         Mantid::API::AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
             "outWS");
-    TS_ASSERT(wsgroup != NULL);
+    TS_ASSERT(wsgroup != nullptr);
     TS_ASSERT_EQUALS(a->size(), wsgroup->size());
   }
 
@@ -241,7 +241,7 @@ public:
     WorkspaceGroup_sptr wsgroup =
         Mantid::API::AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
             "outWS");
-    TS_ASSERT(wsgroup != NULL);
+    TS_ASSERT(wsgroup != nullptr);
     TS_ASSERT_EQUALS(a->size(), wsgroup->size());
   }
 };

--- a/Framework/API/test/WorkspaceGroupTest.h
+++ b/Framework/API/test/WorkspaceGroupTest.h
@@ -368,10 +368,10 @@ public:
     WorkspaceGroup_sptr wsNonConst;
     TS_ASSERT_THROWS_NOTHING(
         wsConst = manager.getValue<WorkspaceGroup_const_sptr>(wsName));
-    TS_ASSERT(wsConst != NULL);
+    TS_ASSERT(wsConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(wsNonConst =
                                  manager.getValue<WorkspaceGroup_sptr>(wsName));
-    TS_ASSERT(wsNonConst != NULL);
+    TS_ASSERT(wsNonConst != nullptr);
     TS_ASSERT_EQUALS(wsConst, wsNonConst);
 
     // Check TypedValue can be cast to const_sptr or to sptr
@@ -379,9 +379,9 @@ public:
     WorkspaceGroup_const_sptr wsCastConst;
     WorkspaceGroup_sptr wsCastNonConst;
     TS_ASSERT_THROWS_NOTHING(wsCastConst = (WorkspaceGroup_const_sptr)val);
-    TS_ASSERT(wsCastConst != NULL);
+    TS_ASSERT(wsCastConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(wsCastNonConst = (WorkspaceGroup_sptr)val);
-    TS_ASSERT(wsCastNonConst != NULL);
+    TS_ASSERT(wsCastNonConst != nullptr);
     TS_ASSERT_EQUALS(wsCastConst, wsCastNonConst);
   }
 
@@ -400,10 +400,10 @@ public:
     Workspace_sptr wsNonConst;
     TS_ASSERT_THROWS_NOTHING(
         wsConst = manager.getValue<Workspace_const_sptr>(wsName));
-    TS_ASSERT(wsConst != NULL);
+    TS_ASSERT(wsConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(wsNonConst =
                                  manager.getValue<Workspace_sptr>(wsName));
-    TS_ASSERT(wsNonConst != NULL);
+    TS_ASSERT(wsNonConst != nullptr);
     TS_ASSERT_EQUALS(wsConst, wsNonConst);
 
     // Check TypedValue can be cast to const_sptr or to sptr
@@ -411,9 +411,9 @@ public:
     Workspace_const_sptr wsCastConst;
     Workspace_sptr wsCastNonConst;
     TS_ASSERT_THROWS_NOTHING(wsCastConst = (Workspace_const_sptr)val);
-    TS_ASSERT(wsCastConst != NULL);
+    TS_ASSERT(wsCastConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(wsCastNonConst = (Workspace_sptr)val);
-    TS_ASSERT(wsCastNonConst != NULL);
+    TS_ASSERT(wsCastNonConst != nullptr);
     TS_ASSERT_EQUALS(wsCastConst, wsCastNonConst);
   }
 };

--- a/Framework/Algorithms/test/BinaryOperateMasksTest.h
+++ b/Framework/Algorithms/test/BinaryOperateMasksTest.h
@@ -72,7 +72,7 @@ public:
 
     std::cout << "\nTest I Is Completed\n";
 
-    if (ws1 == NULL) {
+    if (ws1 == nullptr) {
       std::cout << "\nWorkspace1 is NULL\n";
     }
 
@@ -100,13 +100,13 @@ public:
       ws4 = AnalysisDataService::Instance()
                 .retrieveWS<DataObjects::MaskWorkspace>(ws4name);
 
-      if (ws4 == NULL) {
+      if (ws4 == nullptr) {
         std::cout << "Workspace4 is NULL\n";
       } else {
         std::cout << "Workspace4 is good at output of NOT.  Number Histogram = "
                   << ws4->getNumberHistograms() << '\n';
       }
-      if (ws1 == NULL) {
+      if (ws1 == nullptr) {
         std::cout << "Workspace1 is NULL\n";
       } else {
         std::cout << "Workspace1 is good at output of NOT.  Number Histogram = "

--- a/Framework/Algorithms/test/ConvertUnitsTest.h
+++ b/Framework/Algorithms/test/ConvertUnitsTest.h
@@ -714,7 +714,7 @@ public:
         WorkspaceCreationHelper::createEventWorkspaceWithFullInstrument(1, 10,
                                                                         false);
     ws->getAxis(0)->setUnit("TOF");
-    ws->sortAll(sortType, NULL);
+    ws->sortAll(sortType, nullptr);
 
     if (sortType == TOF_SORT) {
       // Only threadsafe if all the event lists are sorted

--- a/Framework/Algorithms/test/CorelliCrossCorrelateTest.h
+++ b/Framework/Algorithms/test/CorelliCrossCorrelateTest.h
@@ -62,7 +62,7 @@ public:
 
     ws->getAxis(0)->setUnit("TOF");
 
-    ws->sortAll(PULSETIME_SORT, NULL);
+    ws->sortAll(PULSETIME_SORT, nullptr);
 
     // Add some chopper TDCs to the workspace.
     double period = 1 / 293.383;

--- a/Framework/Algorithms/test/DetectorEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/DetectorEfficiencyCorTest.h
@@ -128,13 +128,13 @@ private:
     const int ndets(2);
     std::vector<Detector *> detectors;
     for (int i = 0; i < ndets; ++i) {
-      Detector *detector = new Detector("det", i + 1, shape, NULL);
+      Detector *detector = new Detector("det", i + 1, shape, nullptr);
       detector->setPos(i * 0.2, i * 0.2, 5);
       instrument->add(detector);
       instrument->markAsDetector(detector);
       detectors.push_back(detector);
     }
-    ObjComponent *sample = new ObjComponent("sample", shape, NULL);
+    ObjComponent *sample = new ObjComponent("sample", shape, nullptr);
     sample->setPos(0, 0, 0);
     instrument->markAsSamplePos(sample);
 

--- a/Framework/Algorithms/test/DiffractionFocussing2Test.h
+++ b/Framework/Algorithms/test/DiffractionFocussing2Test.h
@@ -270,7 +270,7 @@ public:
     alg->execute();
     ws = AnalysisDataService::Instance().retrieveWS<EventWorkspace>(
         "SNAP_empty");
-    ws->sortAll(TOF_SORT, NULL);
+    ws->sortAll(TOF_SORT, nullptr);
 
     // Fill a whole bunch of events
     PARALLEL_FOR_NO_WSP_CHECK()

--- a/Framework/Algorithms/test/GenerateIPythonNotebookTest.h
+++ b/Framework/Algorithms/test/GenerateIPythonNotebookTest.h
@@ -156,7 +156,7 @@ public:
     history.addHistory(boost::make_shared<AlgorithmHistory>(
         API::AlgorithmHistory(pAlg.get())));
 
-    pAlg.reset(NULL);
+    pAlg.reset(nullptr);
   }
 };
 

--- a/Framework/Algorithms/test/GeneratePythonScriptTest.h
+++ b/Framework/Algorithms/test/GeneratePythonScriptTest.h
@@ -159,7 +159,7 @@ public:
     history.addHistory(boost::make_shared<AlgorithmHistory>(
         API::AlgorithmHistory(pAlg.get())));
 
-    pAlg.reset(NULL);
+    pAlg.reset(nullptr);
   }
 };
 

--- a/Framework/Algorithms/test/LorentzCorrectionTest.h
+++ b/Framework/Algorithms/test/LorentzCorrectionTest.h
@@ -126,7 +126,7 @@ public:
     alg.setPropertyValue("OutputWorkspace", "temp");
     alg.execute();
     MatrixWorkspace_sptr out_ws = alg.getProperty("OutputWorkspace");
-    TS_ASSERT(out_ws != NULL);
+    TS_ASSERT(out_ws != nullptr);
 
     const std::string unitID = out_ws->getAxis(0)->unit()->unitID();
     TS_ASSERT_EQUALS(unitID, "Wavelength");

--- a/Framework/Algorithms/test/MergeRunsTest.h
+++ b/Framework/Algorithms/test/MergeRunsTest.h
@@ -281,7 +281,7 @@ private:
     TS_ASSERT_THROWS_NOTHING(alg.execute());
     MatrixWorkspace_sptr wsOut = Mantid::API::AnalysisDataService::Instance()
                                      .retrieveWS<MatrixWorkspace>("out");
-    TS_ASSERT(wsOut != NULL);
+    TS_ASSERT(wsOut != nullptr);
     for (size_t j = 0; j < wsOut->getNumberHistograms(); ++j) {
       using Mantid::MantidVec;
       auto &xValues = wsOut->x(j);
@@ -930,13 +930,13 @@ public:
     WorkspaceGroup_sptr wsgroup =
         Mantid::API::AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
             "outer");
-    TS_ASSERT(wsgroup != NULL);
+    TS_ASSERT(wsgroup != nullptr);
     TS_ASSERT_EQUALS(input->size(), wsgroup->size());
     // Loop through each workspace in the group
     for (size_t i = 0; i < wsgroup->size(); ++i) {
       MatrixWorkspace_sptr ws =
           boost::dynamic_pointer_cast<MatrixWorkspace>(wsgroup->getItem(i));
-      TS_ASSERT(ws != NULL);
+      TS_ASSERT(ws != nullptr);
       TS_ASSERT_EQUALS(expectedNumHistograms, ws->getNumberHistograms());
       // Loop through each histogram in each workspace
       for (size_t j = 0; j < ws->getNumberHistograms(); ++j) {

--- a/Framework/Algorithms/test/NormaliseByDetectorTest.h
+++ b/Framework/Algorithms/test/NormaliseByDetectorTest.h
@@ -51,7 +51,7 @@ do_test_doesnt_throw_on_execution(MatrixWorkspace_sptr inputWS,
   TS_ASSERT_THROWS_NOTHING(alg.execute());
   MatrixWorkspace_sptr outWS =
       AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("out");
-  TS_ASSERT(outWS != NULL);
+  TS_ASSERT(outWS != nullptr);
   return outWS;
 }
 
@@ -225,7 +225,7 @@ private:
   create_workspace_with_incomplete_detector_level_only_fit_functions(
       MatrixWorkspace_sptr original = boost::shared_ptr<MatrixWorkspace>()) {
     MatrixWorkspace_sptr ws = original;
-    if (original == NULL) {
+    if (original == nullptr) {
       // Create a default workspace with no-fitting functions.
       ws = create_workspace_with_no_fitting_functions();
     }
@@ -649,7 +649,7 @@ public:
 private:
   /// Helper method to run common sanity checks.
   void do_basic_checks(MatrixWorkspace_sptr normalisedWS) {
-    TS_ASSERT(normalisedWS != NULL);
+    TS_ASSERT(normalisedWS != nullptr);
     TS_ASSERT(ws->getNumberHistograms() == normalisedWS->getNumberHistograms());
     TS_ASSERT(ws->x(0).size() == normalisedWS->x(0).size());
     TS_ASSERT(ws->y(0).size() == normalisedWS->y(0).size());

--- a/Framework/Algorithms/test/RebinByTimeBaseTest.h
+++ b/Framework/Algorithms/test/RebinByTimeBaseTest.h
@@ -526,7 +526,7 @@ public:
     // Simple tests. Functionality tests cover this much better.
     MatrixWorkspace_sptr outWS =
         AnalysisDataService::Instance().retrieveWS<Workspace2D>("outWS");
-    TS_ASSERT(outWS != NULL);
+    TS_ASSERT(outWS != nullptr);
   }
 };
 

--- a/Framework/Algorithms/test/SANSCollimationLengthEstimatorTest.h
+++ b/Framework/Algorithms/test/SANSCollimationLengthEstimatorTest.h
@@ -51,7 +51,7 @@ createTestInstrument(const Mantid::detid_t id,
   Detector *det0(nullptr);
   if (!detShapeXML.empty()) {
     auto shape = ShapeFactory().createShape(detShapeXML);
-    det0 = new Detector("det0", id, shape, NULL);
+    det0 = new Detector("det0", id, shape, nullptr);
   } else {
     det0 = new Detector("det0", id, nullptr);
   }

--- a/Framework/Algorithms/test/TOFSANSResolutionByPixelTest.h
+++ b/Framework/Algorithms/test/TOFSANSResolutionByPixelTest.h
@@ -62,7 +62,7 @@ createTestInstrument(const Mantid::detid_t id,
   Detector *det0(nullptr);
   if (!detShapeXML.empty()) {
     auto shape = ShapeFactory().createShape(detShapeXML);
-    det0 = new Detector("det0", id, shape, NULL);
+    det0 = new Detector("det0", id, shape, nullptr);
   } else {
     det0 = new Detector("det0", id, nullptr);
   }

--- a/Framework/Crystal/test/HardThresholdBackgroundTest.h
+++ b/Framework/Crystal/test/HardThresholdBackgroundTest.h
@@ -23,7 +23,7 @@ public:
   void test_isBackground() {
     const double threshold = 1;
     MDHistoWorkspace_sptr ws = makeFakeMDHistoWorkspace(threshold, 1, 1);
-    auto iterator = ws->createIterator(NULL);
+    auto iterator = ws->createIterator(nullptr);
 
     HardThresholdBackground strategy(threshold, Mantid::API::NoNormalization);
 

--- a/Framework/CurveFitting/test/Algorithms/ConvertToYSpaceTest.h
+++ b/Framework/CurveFitting/test/Algorithms/ConvertToYSpaceTest.h
@@ -57,13 +57,13 @@ public:
 
     // Get the y-Space output workspace
     MatrixWorkspace_sptr ySpOutputWs = alg->getProperty("OutputWorkspace");
-    TS_ASSERT(ySpOutputWs != 0)
+    TS_ASSERT(ySpOutputWs != nullptr)
     TS_ASSERT_EQUALS(testWS->getNumberHistograms(),
                      ySpOutputWs->getNumberHistograms());
 
     // Get the q-Space output workspace
     MatrixWorkspace_sptr qSpOutputWs = alg->getProperty("QWorkspace");
-    TS_ASSERT(qSpOutputWs != 0)
+    TS_ASSERT(qSpOutputWs != nullptr)
     TS_ASSERT_EQUALS(testWS->getNumberHistograms(),
                      qSpOutputWs->getNumberHistograms());
 

--- a/Framework/CurveFitting/test/Algorithms/NormaliseByPeakAreaTest.h
+++ b/Framework/CurveFitting/test/Algorithms/NormaliseByPeakAreaTest.h
@@ -60,10 +60,10 @@ public:
     MatrixWorkspace_sptr fittedWS = alg->getProperty("FittedWorkspace");
     MatrixWorkspace_sptr symmetrisedWS =
         alg->getProperty("SymmetrisedWorkspace");
-    TS_ASSERT(outputWS != 0);
-    TS_ASSERT(yspaceWS != 0);
-    TS_ASSERT(fittedWS != 0);
-    TS_ASSERT(symmetrisedWS != 0);
+    TS_ASSERT(outputWS != nullptr);
+    TS_ASSERT(yspaceWS != nullptr);
+    TS_ASSERT(fittedWS != nullptr);
+    TS_ASSERT(symmetrisedWS != nullptr);
 
     // Dimensions
     TS_ASSERT_EQUALS(testWS->getNumberHistograms(),
@@ -171,10 +171,10 @@ public:
     MatrixWorkspace_sptr fittedWS = alg->getProperty("FittedWorkspace");
     MatrixWorkspace_sptr symmetrisedWS =
         alg->getProperty("SymmetrisedWorkspace");
-    TS_ASSERT(outputWS != 0);
-    TS_ASSERT(yspaceWS != 0);
-    TS_ASSERT(fittedWS != 0);
-    TS_ASSERT(symmetrisedWS != 0);
+    TS_ASSERT(outputWS != nullptr);
+    TS_ASSERT(yspaceWS != nullptr);
+    TS_ASSERT(fittedWS != nullptr);
+    TS_ASSERT(symmetrisedWS != nullptr);
 
     // Dimensions
     TS_ASSERT_EQUALS(testWS->getNumberHistograms(),

--- a/Framework/CurveFitting/test/Algorithms/VesuvioCalculateGammaBackgroundTest.h
+++ b/Framework/CurveFitting/test/Algorithms/VesuvioCalculateGammaBackgroundTest.h
@@ -31,8 +31,8 @@ public:
 
     MatrixWorkspace_sptr backgroundWS = alg->getProperty("BackgroundWorkspace");
     MatrixWorkspace_sptr correctedWS = alg->getProperty("CorrectedWorkspace");
-    TS_ASSERT(backgroundWS != 0);
-    TS_ASSERT(correctedWS != 0);
+    TS_ASSERT(backgroundWS != nullptr);
+    TS_ASSERT(correctedWS != nullptr);
     TS_ASSERT(backgroundWS != correctedWS);
 
     // Test some values in the range
@@ -81,8 +81,8 @@ public:
 
     MatrixWorkspace_sptr backgroundWS = alg->getProperty("BackgroundWorkspace");
     MatrixWorkspace_sptr correctedWS = alg->getProperty("CorrectedWorkspace");
-    TS_ASSERT(backgroundWS != 0);
-    TS_ASSERT(correctedWS != 0);
+    TS_ASSERT(backgroundWS != nullptr);
+    TS_ASSERT(correctedWS != nullptr);
     TS_ASSERT(backgroundWS != correctedWS);
 
     // Test some values in the range
@@ -125,8 +125,8 @@ public:
 
     MatrixWorkspace_sptr backgroundWS = alg->getProperty("BackgroundWorkspace");
     MatrixWorkspace_sptr correctedWS = alg->getProperty("CorrectedWorkspace");
-    TS_ASSERT(backgroundWS != 0);
-    TS_ASSERT(correctedWS != 0);
+    TS_ASSERT(backgroundWS != nullptr);
+    TS_ASSERT(correctedWS != nullptr);
     TS_ASSERT(backgroundWS != correctedWS);
 
     TS_ASSERT_EQUALS(1, backgroundWS->getNumberHistograms());

--- a/Framework/CurveFitting/test/Algorithms/VesuvioCalculateMSTest.h
+++ b/Framework/CurveFitting/test/Algorithms/VesuvioCalculateMSTest.h
@@ -78,7 +78,7 @@ createTestWorkspace(const bool detShape = true,
     if (groupedDets) {
       // Add another detector in the same position as the first
       auto shape = ShapeFactory().createShape(shapeXML);
-      Mantid::Geometry::Detector *det2 = new Detector("det1", 2, shape, NULL);
+      Mantid::Geometry::Detector *det2 = new Detector("det1", 2, shape, nullptr);
       // Setting detectors should normally go via DetectorInfo, but here we need
       // to set a position as we are adding a new detector. In general getPos
       // should not be called as this tries to set the position of the base

--- a/Framework/CurveFitting/test/Algorithms/VesuvioCalculateMSTest.h
+++ b/Framework/CurveFitting/test/Algorithms/VesuvioCalculateMSTest.h
@@ -78,7 +78,8 @@ createTestWorkspace(const bool detShape = true,
     if (groupedDets) {
       // Add another detector in the same position as the first
       auto shape = ShapeFactory().createShape(shapeXML);
-      Mantid::Geometry::Detector *det2 = new Detector("det1", 2, shape, nullptr);
+      Mantid::Geometry::Detector *det2 =
+          new Detector("det1", 2, shape, nullptr);
       // Setting detectors should normally go via DetectorInfo, but here we need
       // to set a position as we are adding a new detector. In general getPos
       // should not be called as this tries to set the position of the base

--- a/Framework/CurveFitting/test/Functions/ComptonProfileTestHelpers.h
+++ b/Framework/CurveFitting/test/Functions/ComptonProfileTestHelpers.h
@@ -154,7 +154,7 @@ createTestInstrumentWithNoFoilChanger(const Mantid::detid_t id,
   Detector *det0(nullptr);
   if (!detShapeXML.empty()) {
     auto shape = ShapeFactory().createShape(detShapeXML);
-    det0 = new Detector("det0", id, shape, NULL);
+    det0 = new Detector("det0", id, shape, nullptr);
   } else {
     det0 = new Detector("det0", id, nullptr);
   }

--- a/Framework/DataHandling/test/LoadEmptyInstrumentTest.h
+++ b/Framework/DataHandling/test/LoadEmptyInstrumentTest.h
@@ -180,7 +180,7 @@ public:
     TS_ASSERT_DELTA(param->value<double>(), 32.0, 0.0001);
 
     param = paramMap.get(&det, "boevs");
-    TS_ASSERT(param == NULL);
+    TS_ASSERT(param == nullptr);
 
     param = paramMap.getRecursive(&det, "boevs", "double");
     TS_ASSERT_DELTA(param->value<double>(), 8.0, 0.0001);
@@ -780,7 +780,7 @@ public:
     // And finally demonstrate that the get() method does not perform recursive
     // look-up
     param = paramMap.get(&det1, "tube_pressure2");
-    TS_ASSERT(param == NULL);
+    TS_ASSERT(param == nullptr);
 
     AnalysisDataService::Instance().remove(wsName);
   }

--- a/Framework/DataHandling/test/LoadISISNexusTest.h
+++ b/Framework/DataHandling/test/LoadISISNexusTest.h
@@ -483,8 +483,8 @@ public:
         boost::dynamic_pointer_cast<MatrixWorkspace>(grpWs->getItem(0));
     MatrixWorkspace_sptr ws2 =
         boost::dynamic_pointer_cast<MatrixWorkspace>(grpWs->getItem(1));
-    TS_ASSERT(ws1 != NULL);
-    TS_ASSERT(ws2 != NULL);
+    TS_ASSERT(ws1 != nullptr);
+    TS_ASSERT(ws2 != nullptr);
     // Check that workspace 1 has the correct period data, and no other period
     // log data
     checkPeriodLogData(ws1, 1);

--- a/Framework/DataHandling/test/LoadInstrumentTest.h
+++ b/Framework/DataHandling/test/LoadInstrumentTest.h
@@ -636,7 +636,7 @@ private:
     // IDFs_for_UNIT_TESTING/HRPD_Parameters_Test4.xml
     Parameter_sptr param = paramMap.getRecursive(&(*comp), par, "fitting");
     TS_ASSERT(param);
-    if (param != 0) {
+    if (param != nullptr) {
       const FitParameter &fitParam4 = param->value<FitParameter>();
       TS_ASSERT(fitParam4.getTie().compare("") == 0);
       TS_ASSERT(fitParam4.getFunction().compare("BackToBackExponential") == 0);

--- a/Framework/DataHandling/test/LoadNexusProcessedTest.h
+++ b/Framework/DataHandling/test/LoadNexusProcessedTest.h
@@ -280,8 +280,8 @@ public:
     TS_ASSERT_EQUALS(ws->getSpectrum(4).getNumberEvents(), 100);
 
     // Do the comparison algo to check that they really are the same
-    origWS->sortAll(TOF_SORT, NULL);
-    ws->sortAll(TOF_SORT, NULL);
+    origWS->sortAll(TOF_SORT, nullptr);
+    ws->sortAll(TOF_SORT, nullptr);
 
     IAlgorithm_sptr alg2 =
         AlgorithmManager::Instance().createUnmanaged("CompareWorkspaces");
@@ -724,7 +724,7 @@ public:
         "IDFs_for_UNIT_TESTING/MINITOPAZ_Definition.xml");
     InstrumentDefinitionParser parser(filename, "MINITOPAZ",
                                       Strings::loadFile(filename));
-    auto instrument = parser.parseXML(NULL);
+    auto instrument = parser.parseXML(nullptr);
     peaksTestWS->populateInstrumentParameters();
     peaksTestWS->setInstrument(instrument);
 
@@ -769,7 +769,7 @@ public:
         "IDFs_for_UNIT_TESTING/MINITOPAZ_Definition.xml");
     InstrumentDefinitionParser parser(filename, "MINITOPAZ",
                                       Strings::loadFile(filename));
-    auto instrument = parser.parseXML(NULL);
+    auto instrument = parser.parseXML(nullptr);
     peaksTestWS->populateInstrumentParameters();
     peaksTestWS->setInstrument(instrument);
 

--- a/Framework/DataHandling/test/LoadRawSaveNxsLoadNxsTest.h
+++ b/Framework/DataHandling/test/LoadRawSaveNxsLoadNxsTest.h
@@ -150,8 +150,8 @@ public:
 
     // std::cerr << "Count = " << i.use_count();
     boost::shared_ptr<const IComponent> source = i->getSource();
-    TS_ASSERT(source != NULL);
-    if (source != NULL) {
+    TS_ASSERT(source != nullptr);
+    if (source != nullptr) {
       TS_ASSERT_EQUALS(source->getName(), "source");
       TS_ASSERT_DELTA(detectorInfo.sourcePosition().Y(), 0.0, 0.01);
 

--- a/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
@@ -426,7 +426,7 @@ private:
   }
 
   MDHistoWorkspace *doCloneEmpty() const override {
-    return new MDHistoWorkspace(0);
+    return new MDHistoWorkspace(nullptr);
   }
 
   void makeSingleBinWithNaN(std::vector<coord_t> &x, std::vector<signal_t> &y,

--- a/Framework/DataObjects/test/EventListTest.h
+++ b/Framework/DataObjects/test/EventListTest.h
@@ -1434,7 +1434,7 @@ public:
   void test_convertUnitsViaTof_failures() {
     DummyUnit1 fromUnit;
     DummyUnit2 toUnit;
-    TS_ASSERT_THROWS_ANYTHING(el.convertUnitsViaTof(NULL, NULL));
+    TS_ASSERT_THROWS_ANYTHING(el.convertUnitsViaTof(nullptr, nullptr));
     // Not initalized
     TS_ASSERT_THROWS_ANYTHING(el.convertUnitsViaTof(&fromUnit, &toUnit));
   }

--- a/Framework/DataObjects/test/EventWorkspaceTest.h
+++ b/Framework/DataObjects/test/EventWorkspaceTest.h
@@ -691,10 +691,10 @@ public:
     EventWorkspace_sptr wsNonConst;
     TS_ASSERT_THROWS_NOTHING(
         wsConst = manager.getValue<EventWorkspace_const_sptr>(wsName));
-    TS_ASSERT(wsConst != NULL);
+    TS_ASSERT(wsConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(wsNonConst =
                                  manager.getValue<EventWorkspace_sptr>(wsName));
-    TS_ASSERT(wsNonConst != NULL);
+    TS_ASSERT(wsNonConst != nullptr);
     TS_ASSERT_EQUALS(wsConst, wsNonConst);
 
     // Check TypedValue can be cast to const_sptr or to sptr
@@ -702,9 +702,9 @@ public:
     EventWorkspace_const_sptr wsCastConst;
     EventWorkspace_sptr wsCastNonConst;
     TS_ASSERT_THROWS_NOTHING(wsCastConst = (EventWorkspace_const_sptr)val);
-    TS_ASSERT(wsCastConst != NULL);
+    TS_ASSERT(wsCastConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(wsCastNonConst = (EventWorkspace_sptr)val);
-    TS_ASSERT(wsCastNonConst != NULL);
+    TS_ASSERT(wsCastNonConst != nullptr);
     TS_ASSERT_EQUALS(wsCastConst, wsCastNonConst);
   }
 
@@ -722,10 +722,10 @@ public:
     IEventWorkspace_sptr wsNonConst;
     TS_ASSERT_THROWS_NOTHING(
         wsConst = manager.getValue<IEventWorkspace_const_sptr>(wsName));
-    TS_ASSERT(wsConst != NULL);
+    TS_ASSERT(wsConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(
         wsNonConst = manager.getValue<IEventWorkspace_sptr>(wsName));
-    TS_ASSERT(wsNonConst != NULL);
+    TS_ASSERT(wsNonConst != nullptr);
     TS_ASSERT_EQUALS(wsConst, wsNonConst);
 
     // Check TypedValue can be cast to const_sptr or to sptr
@@ -733,9 +733,9 @@ public:
     IEventWorkspace_const_sptr wsCastConst;
     IEventWorkspace_sptr wsCastNonConst;
     TS_ASSERT_THROWS_NOTHING(wsCastConst = (IEventWorkspace_const_sptr)val);
-    TS_ASSERT(wsCastConst != NULL);
+    TS_ASSERT(wsCastConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(wsCastNonConst = (IEventWorkspace_sptr)val);
-    TS_ASSERT(wsCastNonConst != NULL);
+    TS_ASSERT(wsCastNonConst != nullptr);
     TS_ASSERT_EQUALS(wsCastConst, wsCastNonConst);
   }
 

--- a/Framework/DataObjects/test/GroupingWorkspaceTest.h
+++ b/Framework/DataObjects/test/GroupingWorkspaceTest.h
@@ -109,10 +109,10 @@ public:
     GroupingWorkspace_sptr wsNonConst;
     TS_ASSERT_THROWS_NOTHING(
         wsConst = manager.getValue<GroupingWorkspace_const_sptr>(wsName));
-    TS_ASSERT(wsConst != NULL);
+    TS_ASSERT(wsConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(
         wsNonConst = manager.getValue<GroupingWorkspace_sptr>(wsName));
-    TS_ASSERT(wsNonConst != NULL);
+    TS_ASSERT(wsNonConst != nullptr);
     TS_ASSERT_EQUALS(wsConst, wsNonConst);
 
     // Check TypedValue can be cast to const_sptr or to sptr
@@ -120,9 +120,9 @@ public:
     GroupingWorkspace_const_sptr wsCastConst;
     GroupingWorkspace_sptr wsCastNonConst;
     TS_ASSERT_THROWS_NOTHING(wsCastConst = (GroupingWorkspace_const_sptr)val);
-    TS_ASSERT(wsCastConst != NULL);
+    TS_ASSERT(wsCastConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(wsCastNonConst = (GroupingWorkspace_sptr)val);
-    TS_ASSERT(wsCastNonConst != NULL);
+    TS_ASSERT(wsCastNonConst != nullptr);
     TS_ASSERT_EQUALS(wsCastConst, wsCastNonConst);
   }
 };

--- a/Framework/DataObjects/test/MDBoxIteratorTest.h
+++ b/Framework/DataObjects/test/MDBoxIteratorTest.h
@@ -83,7 +83,7 @@ public:
   //--------------------------------------------------------------------------------------
   void test_ctor_with_null_box_fails() {
     using boxit_t = MDBoxIterator<MDLeanEvent<1>, 1>;
-    TS_ASSERT_THROWS_ANYTHING(new boxit_t(NULL, 10, false););
+    TS_ASSERT_THROWS_ANYTHING(new boxit_t(nullptr, 10, false););
   }
 
   //--------------------------------------------------------------------------------------

--- a/Framework/DataObjects/test/MDBoxSaveableTest.h
+++ b/Framework/DataObjects/test/MDBoxSaveableTest.h
@@ -254,7 +254,7 @@ public:
     MDBox<MDLeanEvent<3>, 3> *b =
         dynamic_cast<MDBox<MDLeanEvent<3>, 3> *>(gb->getChild(22));
     TSM_ASSERT_EQUALS("Child has 8 events", b->getNPoints(), 8);
-    TSM_ASSERT("The child is also saveabele", b->getISaveable() != NULL);
+    TSM_ASSERT("The child is also saveabele", b->getISaveable() != nullptr);
     if (!b->getISaveable())
       return;
 
@@ -753,7 +753,7 @@ public:
         bin.m_max[d] = 4.0;
         bin.m_signal = 0;
       }
-      c.centerpointBin(bin, NULL);
+      c.centerpointBin(bin, nullptr);
       TS_ASSERT_DELTA(bin.m_signal, 8.0, 1e-4);
       TS_ASSERT_DELTA(bin.m_errorSquared, 8.0, 1e-4);
     }
@@ -847,7 +847,7 @@ public:
       TS_ASSERT(mdbox);
 
       auto pIO = mdbox->getISaveable();
-      TS_ASSERT(pIO != NULL);
+      TS_ASSERT(pIO != nullptr);
       if (!pIO)
         continue;
 

--- a/Framework/DataObjects/test/MDBoxTest.h
+++ b/Framework/DataObjects/test/MDBoxTest.h
@@ -407,7 +407,7 @@ public:
     // First, a bin object that holds everything
     MDBin<MDLeanEvent<2>, 2> bin;
     // Perform the centerpoint binning
-    box.centerpointBin(bin, NULL);
+    box.centerpointBin(bin, nullptr);
     // 100 events = 100 weight.
     TS_ASSERT_DELTA(bin.m_signal, 100.0, 1e-4);
     TS_ASSERT_DELTA(bin.m_errorSquared, 150.0, 1e-4);
@@ -419,7 +419,7 @@ public:
     bin.m_max[0] = 6.0;
     bin.m_min[1] = 1.0;
     bin.m_max[1] = 3.0;
-    box.centerpointBin(bin, NULL);
+    box.centerpointBin(bin, nullptr);
     TS_ASSERT_DELTA(bin.m_signal, 4.0, 1e-4);
     TS_ASSERT_DELTA(bin.m_errorSquared, 6.0, 1e-4);
   }

--- a/Framework/DataObjects/test/MDEventWorkspaceTest.h
+++ b/Framework/DataObjects/test/MDEventWorkspaceTest.h
@@ -42,7 +42,7 @@ private:
   /// Helper function to return the number of masked bins in a workspace. TODO:
   /// move helper into test helpers
   size_t getNumberMasked(Mantid::API::IMDWorkspace_sptr ws) {
-    Mantid::API::IMDIterator *it = ws->createIterator(NULL);
+    Mantid::API::IMDIterator *it = ws->createIterator(nullptr);
     size_t numberMasked = 0;
     size_t counter = 0;
     for (; counter < it->getDataSize(); ++counter) {
@@ -123,7 +123,7 @@ public:
 
     /*Test that the boxes were deep copied and that their BoxController pointers
      * have been updated too.*/
-    std::vector<API::IMDNode *> originalBoxes(0, NULL);
+    std::vector<API::IMDNode *> originalBoxes(0, nullptr);
     ew3.getBox()->getBoxes(originalBoxes, 10000, false);
 
     std::vector<API::IMDNode *> copiedBoxes;
@@ -379,7 +379,7 @@ public:
     for (size_t i = 0; i < 50; i++) {
       ew->addEvent(ev);
     }
-    ew->splitAllIfNeeded(NULL);
+    ew->splitAllIfNeeded(nullptr);
     ew->refreshCache();
 
     // Create dimension-aligned line through the workspace
@@ -792,10 +792,10 @@ public:
     IMDEventWorkspace_sptr wsNonConst;
     TS_ASSERT_THROWS_NOTHING(
         wsConst = manager.getValue<IMDEventWorkspace_const_sptr>(wsName));
-    TS_ASSERT(wsConst != NULL);
+    TS_ASSERT(wsConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(
         wsNonConst = manager.getValue<IMDEventWorkspace_sptr>(wsName));
-    TS_ASSERT(wsNonConst != NULL);
+    TS_ASSERT(wsNonConst != nullptr);
     TS_ASSERT_EQUALS(wsConst, wsNonConst);
 
     // Check TypedValue can be cast to const_sptr or to sptr
@@ -803,9 +803,9 @@ public:
     IMDEventWorkspace_const_sptr wsCastConst;
     IMDEventWorkspace_sptr wsCastNonConst;
     TS_ASSERT_THROWS_NOTHING(wsCastConst = (IMDEventWorkspace_const_sptr)val);
-    TS_ASSERT(wsCastConst != NULL);
+    TS_ASSERT(wsCastConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(wsCastNonConst = (IMDEventWorkspace_sptr)val);
-    TS_ASSERT(wsCastNonConst != NULL);
+    TS_ASSERT(wsCastNonConst != nullptr);
     TS_ASSERT_EQUALS(wsCastConst, wsCastNonConst);
   }
 };
@@ -855,7 +855,7 @@ public:
     std::cout << "Starting Workspace splitting performance test, single "
                  "threaded with " << nBoxes << " events \n";
     Kernel::Timer clock;
-    m_ws->splitAllIfNeeded(NULL);
+    m_ws->splitAllIfNeeded(nullptr);
     std::cout
         << "Finished Workspace splitting performance test, single threaded in "
         << clock.elapsed() << " sec\n";

--- a/Framework/DataObjects/test/MDGridBoxTest.h
+++ b/Framework/DataObjects/test/MDGridBoxTest.h
@@ -445,7 +445,7 @@ public:
     }
 
     // You must refresh the cache after adding individual events.
-    superbox->refreshCache(NULL);
+    superbox->refreshCache(nullptr);
     // superbox->refreshCentroid(NULL);
 
     TS_ASSERT_EQUALS(superbox->getNPoints(), 3);
@@ -473,7 +473,7 @@ public:
     }
     TS_ASSERT_EQUALS(superbox->getNPoints(), 3);
 
-    superbox->refreshCache(NULL);
+    superbox->refreshCache(nullptr);
     TS_ASSERT_EQUALS(superbox->getNPoints(), 6);
 
     // Retrieve the 0th grid box
@@ -801,7 +801,7 @@ public:
           }
         }
       // You must refresh the cache after adding individual events.
-      box->refreshCache(NULL);
+      box->refreshCache(nullptr);
     }
   }
 
@@ -824,7 +824,7 @@ public:
     size_t numbad = 0;
     TS_ASSERT_THROWS_NOTHING(numbad = b->addEvents(events););
     // Get the right totals again
-    b->refreshCache(NULL);
+    b->refreshCache(nullptr);
     TS_ASSERT_EQUALS(numbad, 0);
     TS_ASSERT_EQUALS(b->getNPoints(), 100);
     TS_ASSERT_EQUALS(b->getSignal(), 100 * 2.0);
@@ -851,7 +851,7 @@ public:
         events.push_back(MDLeanEvent<2>(2.0, 2.0, centers));
       }
     // Get the right totals again
-    b->refreshCache(NULL);
+    b->refreshCache(nullptr);
     // All 4 points get rejected
     TS_ASSERT_THROWS_NOTHING(numbad = b->addEvents(events););
     TS_ASSERT_EQUALS(numbad, 4);
@@ -886,7 +886,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(numbad = b->addEvents(events));
     TS_ASSERT_EQUALS(numbad, 3);
 
-    b->refreshCache(NULL);
+    b->refreshCache(nullptr);
     TS_ASSERT_EQUALS(b->getNPoints(), 1);
     TS_ASSERT_EQUALS(b->getSignal(), 2.0);
     TS_ASSERT_EQUALS(b->getErrorSquared(), 2.0);
@@ -1006,7 +1006,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(b0->addEvents(events););
 
     // Split into sub-grid boxes
-    TS_ASSERT_THROWS_NOTHING(b0->splitAllIfNeeded(NULL);)
+    TS_ASSERT_THROWS_NOTHING(b0->splitAllIfNeeded(nullptr);)
 
     // Dig recursively into the gridded box hierarchies
     std::vector<ibox_t *> boxes;
@@ -1128,7 +1128,7 @@ public:
 
     MDBin<MDLeanEvent<2>, 2> bin;
     bin = makeMDBin2(minX, maxX, minY, maxY);
-    b->centerpointBin(bin, NULL);
+    b->centerpointBin(bin, nullptr);
     TSM_ASSERT_DELTA(message, bin.m_signal, expectedSignal, 1e-5);
   }
 

--- a/Framework/DataObjects/test/MDHistoWorkspaceIteratorTest.h
+++ b/Framework/DataObjects/test/MDHistoWorkspaceIteratorTest.h
@@ -374,7 +374,7 @@ public:
 
     size_t begin = 1;
     size_t end = 5;
-    MDHistoWorkspaceIterator iterator(ws.get(), NULL, begin, end);
+    MDHistoWorkspaceIterator iterator(ws.get(), nullptr, begin, end);
 
     TS_ASSERT(iterator.isWithinBounds(begin));
     TS_ASSERT(iterator.isWithinBounds(end - 1));

--- a/Framework/DataObjects/test/MDHistoWorkspaceTest.h
+++ b/Framework/DataObjects/test/MDHistoWorkspaceTest.h
@@ -33,7 +33,7 @@ private:
   /// Helper function to return the number of masked bins in a workspace. TODO:
   /// move helper into test helpers
   size_t getNumberMasked(Mantid::API::IMDWorkspace_sptr ws) {
-    Mantid::API::IMDIterator *it = ws->createIterator(NULL);
+    Mantid::API::IMDIterator *it = ws->createIterator(nullptr);
     size_t numberMasked = 0;
     size_t counter = 0;
     for (; counter < it->getDataSize(); ++counter) {
@@ -1263,10 +1263,10 @@ public:
     IMDHistoWorkspace_sptr wsNonConst;
     TS_ASSERT_THROWS_NOTHING(
         wsConst = manager.getValue<IMDHistoWorkspace_const_sptr>(wsName));
-    TS_ASSERT(wsConst != NULL);
+    TS_ASSERT(wsConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(
         wsNonConst = manager.getValue<IMDHistoWorkspace_sptr>(wsName));
-    TS_ASSERT(wsNonConst != NULL);
+    TS_ASSERT(wsNonConst != nullptr);
     TS_ASSERT_EQUALS(wsConst, wsNonConst);
 
     // Check TypedValue can be cast to const_sptr or to sptr
@@ -1274,9 +1274,9 @@ public:
     IMDHistoWorkspace_const_sptr wsCastConst;
     IMDHistoWorkspace_sptr wsCastNonConst;
     TS_ASSERT_THROWS_NOTHING(wsCastConst = (IMDHistoWorkspace_const_sptr)val);
-    TS_ASSERT(wsCastConst != NULL);
+    TS_ASSERT(wsCastConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(wsCastNonConst = (IMDHistoWorkspace_sptr)val);
-    TS_ASSERT(wsCastNonConst != NULL);
+    TS_ASSERT(wsCastNonConst != nullptr);
     TS_ASSERT_EQUALS(wsCastConst, wsCastNonConst);
   }
 };

--- a/Framework/DataObjects/test/MaskWorkspaceTest.h
+++ b/Framework/DataObjects/test/MaskWorkspaceTest.h
@@ -129,10 +129,10 @@ public:
     MaskWorkspace_sptr wsNonConst;
     TS_ASSERT_THROWS_NOTHING(
         wsConst = manager.getValue<MaskWorkspace_const_sptr>(wsName));
-    TS_ASSERT(wsConst != NULL);
+    TS_ASSERT(wsConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(wsNonConst =
                                  manager.getValue<MaskWorkspace_sptr>(wsName));
-    TS_ASSERT(wsNonConst != NULL);
+    TS_ASSERT(wsNonConst != nullptr);
     TS_ASSERT_EQUALS(wsConst, wsNonConst);
 
     // Check TypedValue can be cast to const_sptr or to sptr
@@ -140,9 +140,9 @@ public:
     MaskWorkspace_const_sptr wsCastConst;
     MaskWorkspace_sptr wsCastNonConst;
     TS_ASSERT_THROWS_NOTHING(wsCastConst = (MaskWorkspace_const_sptr)val);
-    TS_ASSERT(wsCastConst != NULL);
+    TS_ASSERT(wsCastConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(wsCastNonConst = (MaskWorkspace_sptr)val);
-    TS_ASSERT(wsCastNonConst != NULL);
+    TS_ASSERT(wsCastNonConst != nullptr);
     TS_ASSERT_EQUALS(wsCastConst, wsCastNonConst);
   }
 };

--- a/Framework/DataObjects/test/OffsetsWorkspaceTest.h
+++ b/Framework/DataObjects/test/OffsetsWorkspaceTest.h
@@ -38,10 +38,10 @@ public:
     OffsetsWorkspace_sptr wsNonConst;
     TS_ASSERT_THROWS_NOTHING(
         wsConst = manager.getValue<OffsetsWorkspace_const_sptr>(wsName));
-    TS_ASSERT(wsConst != NULL);
+    TS_ASSERT(wsConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(
         wsNonConst = manager.getValue<OffsetsWorkspace_sptr>(wsName));
-    TS_ASSERT(wsNonConst != NULL);
+    TS_ASSERT(wsNonConst != nullptr);
     TS_ASSERT_EQUALS(wsConst, wsNonConst);
 
     // Check TypedValue can be cast to const_sptr or to sptr
@@ -49,9 +49,9 @@ public:
     OffsetsWorkspace_const_sptr wsCastConst;
     OffsetsWorkspace_sptr wsCastNonConst;
     TS_ASSERT_THROWS_NOTHING(wsCastConst = (OffsetsWorkspace_const_sptr)val);
-    TS_ASSERT(wsCastConst != NULL);
+    TS_ASSERT(wsCastConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(wsCastNonConst = (OffsetsWorkspace_sptr)val);
-    TS_ASSERT(wsCastNonConst != NULL);
+    TS_ASSERT(wsCastNonConst != nullptr);
     TS_ASSERT_EQUALS(wsCastConst, wsCastNonConst);
   }
 };

--- a/Framework/DataObjects/test/PeaksWorkspaceTest.h
+++ b/Framework/DataObjects/test/PeaksWorkspaceTest.h
@@ -481,10 +481,10 @@ public:
     PeaksWorkspace_sptr wsNonConst;
     TS_ASSERT_THROWS_NOTHING(
         wsConst = manager.getValue<PeaksWorkspace_const_sptr>(wsName));
-    TS_ASSERT(wsConst != NULL);
+    TS_ASSERT(wsConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(wsNonConst =
                                  manager.getValue<PeaksWorkspace_sptr>(wsName));
-    TS_ASSERT(wsNonConst != NULL);
+    TS_ASSERT(wsNonConst != nullptr);
     TS_ASSERT_EQUALS(wsConst, wsNonConst);
 
     // Check TypedValue can be cast to const_sptr or to sptr
@@ -492,9 +492,9 @@ public:
     PeaksWorkspace_const_sptr wsCastConst;
     PeaksWorkspace_sptr wsCastNonConst;
     TS_ASSERT_THROWS_NOTHING(wsCastConst = (PeaksWorkspace_const_sptr)val);
-    TS_ASSERT(wsCastConst != NULL);
+    TS_ASSERT(wsCastConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(wsCastNonConst = (PeaksWorkspace_sptr)val);
-    TS_ASSERT(wsCastNonConst != NULL);
+    TS_ASSERT(wsCastNonConst != nullptr);
     TS_ASSERT_EQUALS(wsCastConst, wsCastNonConst);
   }
 
@@ -513,10 +513,10 @@ public:
     IPeaksWorkspace_sptr wsNonConst;
     TS_ASSERT_THROWS_NOTHING(
         wsConst = manager.getValue<IPeaksWorkspace_const_sptr>(wsName));
-    TS_ASSERT(wsConst != NULL);
+    TS_ASSERT(wsConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(
         wsNonConst = manager.getValue<IPeaksWorkspace_sptr>(wsName));
-    TS_ASSERT(wsNonConst != NULL);
+    TS_ASSERT(wsNonConst != nullptr);
     TS_ASSERT_EQUALS(wsConst, wsNonConst);
 
     // Check TypedValue can be cast to const_sptr or to sptr
@@ -524,9 +524,9 @@ public:
     IPeaksWorkspace_const_sptr wsCastConst;
     IPeaksWorkspace_sptr wsCastNonConst;
     TS_ASSERT_THROWS_NOTHING(wsCastConst = (IPeaksWorkspace_const_sptr)val);
-    TS_ASSERT(wsCastConst != NULL);
+    TS_ASSERT(wsCastConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(wsCastNonConst = (IPeaksWorkspace_sptr)val);
-    TS_ASSERT(wsCastNonConst != NULL);
+    TS_ASSERT(wsCastNonConst != nullptr);
     TS_ASSERT_EQUALS(wsCastConst, wsCastNonConst);
   }
 

--- a/Framework/DataObjects/test/SpecialWorkspace2DTest.h
+++ b/Framework/DataObjects/test/SpecialWorkspace2DTest.h
@@ -231,10 +231,10 @@ public:
     SpecialWorkspace2D_sptr wsNonConst;
     TS_ASSERT_THROWS_NOTHING(
         wsConst = manager.getValue<SpecialWorkspace2D_const_sptr>(wsName));
-    TS_ASSERT(wsConst != NULL);
+    TS_ASSERT(wsConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(
         wsNonConst = manager.getValue<SpecialWorkspace2D_sptr>(wsName));
-    TS_ASSERT(wsNonConst != NULL);
+    TS_ASSERT(wsNonConst != nullptr);
     TS_ASSERT_EQUALS(wsConst, wsNonConst);
 
     // Check TypedValue can be cast to const_sptr or to sptr
@@ -242,9 +242,9 @@ public:
     SpecialWorkspace2D_const_sptr wsCastConst;
     SpecialWorkspace2D_sptr wsCastNonConst;
     TS_ASSERT_THROWS_NOTHING(wsCastConst = (SpecialWorkspace2D_const_sptr)val);
-    TS_ASSERT(wsCastConst != NULL);
+    TS_ASSERT(wsCastConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(wsCastNonConst = (SpecialWorkspace2D_sptr)val);
-    TS_ASSERT(wsCastNonConst != NULL);
+    TS_ASSERT(wsCastNonConst != nullptr);
     TS_ASSERT_EQUALS(wsCastConst, wsCastNonConst);
   }
 };

--- a/Framework/DataObjects/test/Workspace2DTest.h
+++ b/Framework/DataObjects/test/Workspace2DTest.h
@@ -250,10 +250,10 @@ public:
     Workspace2D_sptr wsNonConst;
     TS_ASSERT_THROWS_NOTHING(
         wsConst = manager.getValue<Workspace2D_const_sptr>(wsName));
-    TS_ASSERT(wsConst != NULL);
+    TS_ASSERT(wsConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(wsNonConst =
                                  manager.getValue<Workspace2D_sptr>(wsName));
-    TS_ASSERT(wsNonConst != NULL);
+    TS_ASSERT(wsNonConst != nullptr);
     TS_ASSERT_EQUALS(wsConst, wsNonConst);
 
     // Check TypedValue can be cast to const_sptr or to sptr
@@ -261,9 +261,9 @@ public:
     Workspace2D_const_sptr wsCastConst;
     Workspace2D_sptr wsCastNonConst;
     TS_ASSERT_THROWS_NOTHING(wsCastConst = (Workspace2D_const_sptr)val);
-    TS_ASSERT(wsCastConst != NULL);
+    TS_ASSERT(wsCastConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(wsCastNonConst = (Workspace2D_sptr)val);
-    TS_ASSERT(wsCastNonConst != NULL);
+    TS_ASSERT(wsCastNonConst != nullptr);
     TS_ASSERT_EQUALS(wsCastConst, wsCastNonConst);
   }
 };

--- a/Framework/DataObjects/test/WorkspaceSingleValueTest.h
+++ b/Framework/DataObjects/test/WorkspaceSingleValueTest.h
@@ -78,10 +78,10 @@ public:
     WorkspaceSingleValue_sptr wsNonConst;
     TS_ASSERT_THROWS_NOTHING(
         wsConst = manager.getValue<WorkspaceSingleValue_const_sptr>(wsName));
-    TS_ASSERT(wsConst != NULL);
+    TS_ASSERT(wsConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(
         wsNonConst = manager.getValue<WorkspaceSingleValue_sptr>(wsName));
-    TS_ASSERT(wsNonConst != NULL);
+    TS_ASSERT(wsNonConst != nullptr);
     TS_ASSERT_EQUALS(wsConst, wsNonConst);
 
     // Check TypedValue can be cast to const_sptr or to sptr
@@ -90,9 +90,9 @@ public:
     WorkspaceSingleValue_sptr wsCastNonConst;
     TS_ASSERT_THROWS_NOTHING(wsCastConst =
                                  (WorkspaceSingleValue_const_sptr)val);
-    TS_ASSERT(wsCastConst != NULL);
+    TS_ASSERT(wsCastConst != nullptr);
     TS_ASSERT_THROWS_NOTHING(wsCastNonConst = (WorkspaceSingleValue_sptr)val);
-    TS_ASSERT(wsCastNonConst != NULL);
+    TS_ASSERT(wsCastNonConst != nullptr);
     TS_ASSERT_EQUALS(wsCastConst, wsCastNonConst);
   }
 };

--- a/Framework/Geometry/test/ParameterMapTest.h
+++ b/Framework/Geometry/test/ParameterMapTest.h
@@ -513,7 +513,7 @@ public:
     Parameter_sptr fetchedValue =
         pmap.getByType(comp.get(), ParameterMap::pDouble());
     TSM_ASSERT("Should not be able to find a double type parameter",
-               fetchedValue == NULL);
+               fetchedValue == nullptr);
   }
 
   void test_lookup_via_type() {
@@ -551,7 +551,7 @@ public:
     // Find it via the component
     Parameter_sptr fetchedValue =
         pmap.getRecursiveByType(component.get(), ParameterMap::pBool());
-    TS_ASSERT(fetchedValue != NULL);
+    TS_ASSERT(fetchedValue != nullptr);
     TS_ASSERT_EQUALS("A", fetchedValue->name());
     TS_ASSERT_EQUALS(ParameterMap::pBool(), fetchedValue->type());
     TS_ASSERT_EQUALS(true, fetchedValue->value<bool>());
@@ -568,7 +568,7 @@ public:
     // Find it via the child
     Parameter_sptr fetchedValue =
         pmap.getRecursiveByType(childComponent.get(), ParameterMap::pBool());
-    TS_ASSERT(fetchedValue != NULL);
+    TS_ASSERT(fetchedValue != nullptr);
     TS_ASSERT_EQUALS("A", fetchedValue->name());
     TS_ASSERT_EQUALS(ParameterMap::pBool(), fetchedValue->type());
     TS_ASSERT_EQUALS(true, fetchedValue->value<bool>());
@@ -589,7 +589,7 @@ public:
     // Find it via the child
     Parameter_sptr fetchedValue =
         pmap.getRecursiveByType(childComponent.get(), ParameterMap::pBool());
-    TS_ASSERT(fetchedValue != NULL);
+    TS_ASSERT(fetchedValue != nullptr);
     TSM_ASSERT_EQUALS(
         "Has not searched through parameters with the correct priority", "A",
         fetchedValue->name());
@@ -639,7 +639,7 @@ private:
                                           const ValueType &newValue) {
     ParameterMap pmap;
     const std::string name = "Parameter";
-    pmap.add<ValueType>(type, m_testInstrument.get(), name, origValue, NULL);
+    pmap.add<ValueType>(type, m_testInstrument.get(), name, origValue, nullptr);
 
     ParameterMap copy(pmap); // invoke copy constructor
 

--- a/Framework/ICat/inc/MantidICat/ICat3/ICat3Helper.h
+++ b/Framework/ICat/inc/MantidICat/ICat3/ICat3Helper.h
@@ -134,7 +134,7 @@ private:
    */
   template <class T>
   void savetoTableWorkspace(const T *input, Mantid::API::TableRow &t) {
-    if (input != 0) {
+    if (input != nullptr) {
       t << *input;
 
     } else {

--- a/Framework/Kernel/test/DiskBufferISaveableTest.h
+++ b/Framework/Kernel/test/DiskBufferISaveableTest.h
@@ -92,12 +92,12 @@ public:
   void tearDown() override {
     for (size_t i = 0; i < data.size(); i++) {
       delete data[i];
-      data[i] = NULL;
+      data[i] = nullptr;
     }
 
     for (size_t i = 0; i < bigData.size(); i++) {
       delete bigData[i];
-      bigData[i] = NULL;
+      bigData[i] = nullptr;
     }
     ISaveableTester::fakeFile = "";
   }

--- a/Framework/Kernel/test/DiskBufferTest.h
+++ b/Framework/Kernel/test/DiskBufferTest.h
@@ -117,7 +117,7 @@ public:
   void tearDown() override {
     for (size_t i = 0; i < data.size(); i++) {
       delete data[i];
-      data[i] = NULL;
+      data[i] = nullptr;
     }
   }
   void xest_nothing() {

--- a/Framework/MDAlgorithms/test/BinMDTest.h
+++ b/Framework/MDAlgorithms/test/BinMDTest.h
@@ -1111,7 +1111,7 @@ public:
   BinMDTestPerformance() {
     in_ws = MDEventsTestHelper::makeMDEW<3>(10, 0.0, 10.0, 0);
     in_ws->getBoxController()->setSplitThreshold(2000);
-    in_ws->splitAllIfNeeded(NULL);
+    in_ws->splitAllIfNeeded(nullptr);
     AnalysisDataService::Instance().addOrReplace("BinMDTest_ws", in_ws);
     FrameworkManager::Instance().exec("FakeMDEventData", 4, "InputWorkspace",
                                       "BinMDTest_ws", "UniformParams",

--- a/Framework/MDAlgorithms/test/ConvertToReflectometryQTest.h
+++ b/Framework/MDAlgorithms/test/ConvertToReflectometryQTest.h
@@ -153,7 +153,7 @@ public:
     auto ws = boost::dynamic_pointer_cast<Mantid::API::IMDEventWorkspace>(
         Mantid::API::AnalysisDataService::Instance().retrieve(
             "OutputTransformedWorkspace"));
-    TS_ASSERT(ws != NULL);
+    TS_ASSERT(ws != nullptr);
     TS_ASSERT_EQUALS(2, ws->getExperimentInfo(0)->run().getLogData().size());
     // Assert that dimensions should be a general frame
     const auto &frame0 = ws->getDimension(0)->getMDFrame();
@@ -170,7 +170,7 @@ public:
     auto ws = boost::dynamic_pointer_cast<Mantid::API::IMDEventWorkspace>(
         Mantid::API::AnalysisDataService::Instance().retrieve(
             "OutputTransformedWorkspace"));
-    TS_ASSERT(ws != NULL);
+    TS_ASSERT(ws != nullptr);
     // Assert that dimensions should be a general frame
     const auto &frame0 = ws->getDimension(0)->getMDFrame();
     TSM_ASSERT_EQUALS("Should be a general frame", "KiKf", frame0.name());
@@ -185,7 +185,7 @@ public:
     auto ws = boost::dynamic_pointer_cast<Mantid::API::IMDEventWorkspace>(
         Mantid::API::AnalysisDataService::Instance().retrieve(
             "OutputTransformedWorkspace"));
-    TS_ASSERT(ws != NULL);
+    TS_ASSERT(ws != nullptr);
     // Assert that dimensions should be a general frame
     const auto &frame0 = ws->getDimension(0)->getMDFrame();
     TSM_ASSERT_EQUALS("Should be a general frame", "P", frame0.name());
@@ -201,7 +201,7 @@ public:
     auto ws = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(
         Mantid::API::AnalysisDataService::Instance().retrieve(
             "OutputTransformedWorkspace"));
-    TS_ASSERT(ws != NULL);
+    TS_ASSERT(ws != nullptr);
     TS_ASSERT_EQUALS(2, ws->run().getLogData().size());
   }
 
@@ -213,7 +213,7 @@ public:
     auto ws = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(
         Mantid::API::AnalysisDataService::Instance().retrieve(
             "OutputTransformedWorkspace"));
-    TS_ASSERT(ws != NULL);
+    TS_ASSERT(ws != nullptr);
     TS_ASSERT_EQUALS(2, ws->run().getLogData().size());
   }
 
@@ -225,7 +225,7 @@ public:
     auto ws = boost::dynamic_pointer_cast<Mantid::API::IMDHistoWorkspace>(
         Mantid::API::AnalysisDataService::Instance().retrieve(
             "OutputTransformedWorkspace"));
-    TS_ASSERT(ws != NULL);
+    TS_ASSERT(ws != nullptr);
     TS_ASSERT_EQUALS(2, ws->getExperimentInfo(0)->run().getLogData().size());
   }
 
@@ -236,7 +236,7 @@ public:
     auto ws = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(
         Mantid::API::AnalysisDataService::Instance().retrieve(
             "OutputTransformedWorkspace"));
-    TS_ASSERT(ws != NULL);
+    TS_ASSERT(ws != nullptr);
   }
 
   void test_execute_pipf_2D() {
@@ -246,7 +246,7 @@ public:
     auto ws = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(
         Mantid::API::AnalysisDataService::Instance().retrieve(
             "OutputTransformedWorkspace"));
-    TS_ASSERT(ws != NULL);
+    TS_ASSERT(ws != nullptr);
   }
 
   void test_box_controller_defaults() {
@@ -342,7 +342,7 @@ public:
     IMDWorkspace_sptr out =
         AnalysisDataService::Instance().retrieveWS<IMDWorkspace>(
             "OutputTransformedWorkspace");
-    TS_ASSERT(out != NULL);
+    TS_ASSERT(out != nullptr);
     TS_ASSERT_EQUALS(out->getNumDims(), 2);
   }
 
@@ -363,7 +363,7 @@ public:
     auto out = AnalysisDataService::Instance()
                    .retrieveWS<Mantid::DataObjects::Workspace2D>(
                        "OutputTransformedWorkspace");
-    TS_ASSERT(out != NULL);
+    TS_ASSERT(out != nullptr);
     TS_ASSERT_EQUALS(out->getNumDims(), 2);
   }
 };

--- a/Framework/MDAlgorithms/test/DivideMDTest.h
+++ b/Framework/MDAlgorithms/test/DivideMDTest.h
@@ -64,7 +64,7 @@ public:
     TS_ASSERT(ws);
     if (!ws)
       return;
-    IMDIterator *it = ws->createIterator(NULL);
+    IMDIterator *it = ws->createIterator(nullptr);
     do {
       TS_ASSERT_EQUALS(it->getNumEvents(), 1);
       TS_ASSERT_DELTA(it->getInnerSignal(0), expectedSignal, 1e-5);

--- a/Framework/MDAlgorithms/test/ImportMDHistoWorkspaceTest.h
+++ b/Framework/MDAlgorithms/test/ImportMDHistoWorkspaceTest.h
@@ -228,7 +228,7 @@ public:
     IMDHistoWorkspace_sptr outWs =
         boost::dynamic_pointer_cast<IMDHistoWorkspace>(
             ADS.retrieve("test_workspace"));
-    TS_ASSERT(outWs != NULL);
+    TS_ASSERT(outWs != nullptr);
 
     // Check the dimensionality
     TS_ASSERT_EQUALS(2, outWs->getNumDims());
@@ -290,7 +290,7 @@ public:
     IMDHistoWorkspace_sptr outWs =
         boost::dynamic_pointer_cast<IMDHistoWorkspace>(
             ADS.retrieve("test_workspace"));
-    TS_ASSERT(outWs != NULL);
+    TS_ASSERT(outWs != nullptr);
 
     // Check the dimensionality
     TS_ASSERT_EQUALS(3, outWs->getNumDims());

--- a/Framework/MDAlgorithms/test/LoadMDTest.h
+++ b/Framework/MDAlgorithms/test/LoadMDTest.h
@@ -307,7 +307,7 @@ public:
       ev.setCenter(d, 0.5);
     box->addEvent(ev);
     // CHANGE from AB: 20/01/2013: you have to split to identify changes!
-    box->splitAllIfNeeded(NULL);
+    box->splitAllIfNeeded(nullptr);
 
     // Modify a different box by accessing the events
     MDBox<MDLeanEvent<nd>, nd> *box8 =

--- a/Framework/MDAlgorithms/test/MDWSTransfTest.h
+++ b/Framework/MDAlgorithms/test/MDWSTransfTest.h
@@ -78,7 +78,7 @@ public:
         WorkspaceCreationHelper::create2DWorkspaceBinned(10, 10);
     std::vector<double> minVal(4, -3), maxVal(4, 3);
     TargWSDescription.setMinMax(minVal, maxVal);
-    spws->mutableSample().setOrientedLattice(NULL);
+    spws->mutableSample().setOrientedLattice(nullptr);
 
     TargWSDescription.buildFromMatrixWS(spws, "Q3D", "Direct");
 

--- a/Framework/MDAlgorithms/test/MultiplyMDTest.h
+++ b/Framework/MDAlgorithms/test/MultiplyMDTest.h
@@ -63,7 +63,7 @@ public:
     TS_ASSERT(ws);
     if (!ws)
       return;
-    IMDIterator *it = ws->createIterator(NULL);
+    IMDIterator *it = ws->createIterator(nullptr);
     do {
       TS_ASSERT_EQUALS(it->getNumEvents(), 1);
       TS_ASSERT_DELTA(it->getInnerSignal(0), expectedSignal, 1e-5);

--- a/Framework/MDAlgorithms/test/QueryMDWorkspaceTest.h
+++ b/Framework/MDAlgorithms/test/QueryMDWorkspaceTest.h
@@ -154,7 +154,7 @@ public:
     ITableWorkspace_sptr table =
         AnalysisDataService::Instance().retrieveWS<ITableWorkspace>("QueryWS");
 
-    TSM_ASSERT("Workspace output is not an ITableWorkspace", table != NULL);
+    TSM_ASSERT("Workspace output is not an ITableWorkspace", table != nullptr);
     size_t expectedCount =
         3 + in_ws->getNumDims(); // 3 fixed columns are Signal, Error, nEvents
     TSM_ASSERT_EQUALS("Four columns expected", expectedCount,
@@ -176,7 +176,7 @@ public:
     ITableWorkspace_sptr table =
         AnalysisDataService::Instance().retrieveWS<ITableWorkspace>("QueryWS");
 
-    TSM_ASSERT("Workspace output is not an ITableWorkspace", table != NULL);
+    TSM_ASSERT("Workspace output is not an ITableWorkspace", table != nullptr);
     size_t expectedCount =
         3 + in_ws->getNumDims(); // 3 fixed columns are Signal, Error, nEvents
     TSM_ASSERT_EQUALS("Five columns expected", expectedCount,
@@ -199,7 +199,7 @@ public:
     ITableWorkspace_sptr table =
         AnalysisDataService::Instance().retrieveWS<ITableWorkspace>("QueryWS");
 
-    TSM_ASSERT("Workspace output is not an ITableWorkspace", table != NULL);
+    TSM_ASSERT("Workspace output is not an ITableWorkspace", table != nullptr);
     size_t expectedCount =
         3 + in_ws->getNumDims(); // 3 fixed columns are Signal, Error, nEvents
     TSM_ASSERT_EQUALS("Five columns expected", expectedCount,
@@ -253,7 +253,7 @@ public:
     query.execute();
     ITableWorkspace_sptr table = query.getProperty("OutputWorkspace");
 
-    TSM_ASSERT("Workspace output is not an ITableWorkspace", table != NULL);
+    TSM_ASSERT("Workspace output is not an ITableWorkspace", table != nullptr);
     size_t expectedCount =
         3 + 2; // 3 fixed columns are Signal, Error, nEvents and then data is 2D
     TSM_ASSERT_EQUALS("Six columns expected", expectedCount,
@@ -292,7 +292,7 @@ public:
     query.execute();
     ITableWorkspace_sptr table = query.getProperty("OutputWorkspace");
 
-    TSM_ASSERT("Workspace output is not an ITableWorkspace", table != NULL);
+    TSM_ASSERT("Workspace output is not an ITableWorkspace", table != nullptr);
     size_t expectedCount =
         3 + 2; // 3 fixed columns are Signal, Error, nEvents and then data is 2D
     TSM_ASSERT_EQUALS("Six columns expected", expectedCount,

--- a/Framework/MDAlgorithms/test/SaveMD2Test.h
+++ b/Framework/MDAlgorithms/test/SaveMD2Test.h
@@ -109,7 +109,7 @@ public:
       ev.setCenter(0, double(i) * 0.01 + 0.4);
       ws->addEvent(ev);
     }
-    ws->splitAllIfNeeded(NULL);
+    ws->splitAllIfNeeded(nullptr);
     ws->refreshCache();
     // Manually set the flag that the algo would set
     ws->setFileNeedsUpdating(true);

--- a/Framework/MDAlgorithms/test/SaveMDTest.h
+++ b/Framework/MDAlgorithms/test/SaveMDTest.h
@@ -114,7 +114,7 @@ public:
       ev.setCenter(0, double(i) * 0.01 + 0.4);
       ws->addEvent(ev);
     }
-    ws->splitAllIfNeeded(NULL);
+    ws->splitAllIfNeeded(nullptr);
     ws->refreshCache();
     // Manually set the flag that the algo would set
     ws->setFileNeedsUpdating(true);

--- a/Framework/MDAlgorithms/test/SlicingAlgorithmTest.h
+++ b/Framework/MDAlgorithms/test/SlicingAlgorithmTest.h
@@ -332,7 +332,8 @@ public:
   void test_aligned_ImplicitFunction() {
     SlicingAlgorithmImpl *alg = do_createAlignedTransform(
         "Axis0, 2.0,8.0, 6", "Axis1, 2.0,8.0, 3", "Axis2, 2.0,8.0, 3", "");
-    MDImplicitFunction *func = alg->getImplicitFunctionForChunk(nullptr, nullptr);
+    MDImplicitFunction *func =
+        alg->getImplicitFunctionForChunk(nullptr, nullptr);
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 6);
     TS_ASSERT(func->isPointContained(VMD(3, 4, 5)));
@@ -681,7 +682,8 @@ public:
     TS_ASSERT_EQUALS(VMD(3, in), VMD(3.0, 1.0, 2.6));
 
     // The implicit function
-    MDImplicitFunction *func = alg->getImplicitFunctionForChunk(nullptr, nullptr);
+    MDImplicitFunction *func =
+        alg->getImplicitFunctionForChunk(nullptr, nullptr);
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 6);
     TS_ASSERT(func->isPointContained(VMD(1.5, 1.5, 2)));
@@ -738,7 +740,8 @@ public:
     TS_ASSERT_EQUALS(VMD(3, in), VMD(3.0, -1.0, 2.6));
 
     // The implicit function
-    MDImplicitFunction *func = alg->getImplicitFunctionForChunk(nullptr, nullptr);
+    MDImplicitFunction *func =
+        alg->getImplicitFunctionForChunk(nullptr, nullptr);
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 6);
     TS_ASSERT(func->isPointContained(VMD(1.5, -1.5, 2)));
@@ -756,8 +759,8 @@ public:
 
     // The implicit function
     MDImplicitFunction *func(nullptr);
-    TS_ASSERT_THROWS_NOTHING(func =
-                                 alg->getImplicitFunctionForChunk(nullptr, nullptr));
+    TS_ASSERT_THROWS_NOTHING(
+        func = alg->getImplicitFunctionForChunk(nullptr, nullptr));
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 6);
     TS_ASSERT(func->isPointContained(VMD(1.5, 1.5, 2, 234)));
@@ -777,8 +780,8 @@ public:
 
     // The implicit function
     MDImplicitFunction *func(nullptr);
-    TS_ASSERT_THROWS_NOTHING(func =
-                                 alg->getImplicitFunctionForChunk(nullptr, nullptr));
+    TS_ASSERT_THROWS_NOTHING(
+        func = alg->getImplicitFunctionForChunk(nullptr, nullptr));
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 8);
     TS_ASSERT(func->isPointContained(VMD(1.5, 1.5, 1.5, 1.5)));
@@ -796,8 +799,8 @@ public:
 
     // The implicit function
     MDImplicitFunction *func(nullptr);
-    TS_ASSERT_THROWS_NOTHING(func =
-                                 alg->getImplicitFunctionForChunk(nullptr, nullptr));
+    TS_ASSERT_THROWS_NOTHING(
+        func = alg->getImplicitFunctionForChunk(nullptr, nullptr));
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 8);
     TS_ASSERT(func->isPointContained(VMD(1.5, -1.5, 1.5, 1.5)));
@@ -814,8 +817,8 @@ public:
 
     // The implicit function
     MDImplicitFunction *func(nullptr);
-    TS_ASSERT_THROWS_NOTHING(func =
-                                 alg->getImplicitFunctionForChunk(nullptr, nullptr));
+    TS_ASSERT_THROWS_NOTHING(
+        func = alg->getImplicitFunctionForChunk(nullptr, nullptr));
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 6);
     TS_ASSERT(func->isPointContained(VMD(1.5, 1.5, 2, 234, 456)));
@@ -835,8 +838,8 @@ public:
 
     // The implicit function
     MDImplicitFunction *func(nullptr);
-    TS_ASSERT_THROWS_NOTHING(func =
-                                 alg->getImplicitFunctionForChunk(nullptr, nullptr));
+    TS_ASSERT_THROWS_NOTHING(
+        func = alg->getImplicitFunctionForChunk(nullptr, nullptr));
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 4);
     TS_ASSERT(func->isPointContained(VMD(1.5, 1.5, 2, 234)));
@@ -854,8 +857,8 @@ public:
 
     // The implicit function
     MDImplicitFunction *func(nullptr);
-    TS_ASSERT_THROWS_NOTHING(func =
-                                 alg->getImplicitFunctionForChunk(nullptr, nullptr));
+    TS_ASSERT_THROWS_NOTHING(
+        func = alg->getImplicitFunctionForChunk(nullptr, nullptr));
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 4);
     TS_ASSERT(func->isPointContained(VMD(1.5, 1.5, 2)));
@@ -873,8 +876,8 @@ public:
 
     // The implicit function
     MDImplicitFunction *func(nullptr);
-    TS_ASSERT_THROWS_NOTHING(func =
-                                 alg->getImplicitFunctionForChunk(nullptr, nullptr));
+    TS_ASSERT_THROWS_NOTHING(
+        func = alg->getImplicitFunctionForChunk(nullptr, nullptr));
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 4);
     TS_ASSERT(func->isPointContained(VMD(1.5, 1.5)));
@@ -932,7 +935,8 @@ public:
     TS_ASSERT_EQUALS(VMD(2, in), VMD(3., -11.));
 
     // The implicit function
-    MDImplicitFunction *func = alg->getImplicitFunctionForChunk(nullptr, nullptr);
+    MDImplicitFunction *func =
+        alg->getImplicitFunctionForChunk(nullptr, nullptr);
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 4);
     TS_ASSERT(func->isPointContained(VMD(-8.9, -18.9)));
@@ -997,7 +1001,8 @@ public:
     TS_ASSERT_EQUALS(VMD(2, in), VMD(3., -11.));
 
     // The implicit function
-    MDImplicitFunction *func = alg->getImplicitFunctionForChunk(nullptr, nullptr);
+    MDImplicitFunction *func =
+        alg->getImplicitFunctionForChunk(nullptr, nullptr);
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 4);
     TS_ASSERT(func->isPointContained(VMD(-18.9, -98.9)));
@@ -1026,8 +1031,8 @@ public:
 
     // The implicit function
     MDImplicitFunction *func(nullptr);
-    TS_ASSERT_THROWS_NOTHING(func =
-                                 alg->getImplicitFunctionForChunk(nullptr, nullptr));
+    TS_ASSERT_THROWS_NOTHING(
+        func = alg->getImplicitFunctionForChunk(nullptr, nullptr));
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 4);
     TS_ASSERT(func->isPointContained(VMD(2., 1.)));
@@ -1048,8 +1053,8 @@ public:
 
     // The implicit function
     MDImplicitFunction *func(nullptr);
-    TS_ASSERT_THROWS_NOTHING(func =
-                                 alg->getImplicitFunctionForChunk(nullptr, nullptr));
+    TS_ASSERT_THROWS_NOTHING(
+        func = alg->getImplicitFunctionForChunk(nullptr, nullptr));
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 4);
     TS_ASSERT(func->isPointContained(VMD(2., 1., 0.)));
@@ -1072,8 +1077,8 @@ public:
 
     // The implicit function
     MDImplicitFunction *func(nullptr);
-    TS_ASSERT_THROWS_NOTHING(func =
-                                 alg->getImplicitFunctionForChunk(nullptr, nullptr));
+    TS_ASSERT_THROWS_NOTHING(
+        func = alg->getImplicitFunctionForChunk(nullptr, nullptr));
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 8);
     TS_ASSERT(func->isPointContained(VMD(2., 1., 0., 0.)));
@@ -1093,8 +1098,8 @@ public:
 
     // The implicit function
     MDImplicitFunction *func(nullptr);
-    TS_ASSERT_THROWS_NOTHING(func =
-                                 alg->getImplicitFunctionForChunk(nullptr, nullptr));
+    TS_ASSERT_THROWS_NOTHING(
+        func = alg->getImplicitFunctionForChunk(nullptr, nullptr));
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 6);
     TS_ASSERT(func->isPointContained(VMD(2., 1., 0., 0.)));
@@ -1112,7 +1117,8 @@ public:
     TS_ASSERT_EQUALS(alg->m_bases.size(), 1);
 
     // The implicit function
-    MDImplicitFunction *func = alg->getImplicitFunctionForChunk(nullptr, nullptr);
+    MDImplicitFunction *func =
+        alg->getImplicitFunctionForChunk(nullptr, nullptr);
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 2);
     TS_ASSERT(func->isPointContained(VMD(1.5, 1.5, 2, 345)));
@@ -1127,7 +1133,8 @@ public:
     TS_ASSERT_EQUALS(alg->m_bases.size(), 1);
 
     // The implicit function
-    MDImplicitFunction *func = alg->getImplicitFunctionForChunk(nullptr, nullptr);
+    MDImplicitFunction *func =
+        alg->getImplicitFunctionForChunk(nullptr, nullptr);
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 2);
     TS_ASSERT(func->isPointContained(VMD(1.5, 1.5, 2)));
@@ -1142,7 +1149,8 @@ public:
     TS_ASSERT_EQUALS(alg->m_bases.size(), 1);
 
     // The implicit function
-    MDImplicitFunction *func = alg->getImplicitFunctionForChunk(nullptr, nullptr);
+    MDImplicitFunction *func =
+        alg->getImplicitFunctionForChunk(nullptr, nullptr);
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 2);
     TS_ASSERT(func->isPointContained(VMD(1.5, 1.5)));
@@ -1159,7 +1167,8 @@ public:
     TS_ASSERT_EQUALS(alg->m_bases.size(), 1);
 
     // The implicit function
-    MDImplicitFunction *func = alg->getImplicitFunctionForChunk(nullptr, nullptr);
+    MDImplicitFunction *func =
+        alg->getImplicitFunctionForChunk(nullptr, nullptr);
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 2);
     VMD point(1);

--- a/Framework/MDAlgorithms/test/SlicingAlgorithmTest.h
+++ b/Framework/MDAlgorithms/test/SlicingAlgorithmTest.h
@@ -332,7 +332,7 @@ public:
   void test_aligned_ImplicitFunction() {
     SlicingAlgorithmImpl *alg = do_createAlignedTransform(
         "Axis0, 2.0,8.0, 6", "Axis1, 2.0,8.0, 3", "Axis2, 2.0,8.0, 3", "");
-    MDImplicitFunction *func = alg->getImplicitFunctionForChunk(NULL, NULL);
+    MDImplicitFunction *func = alg->getImplicitFunctionForChunk(nullptr, nullptr);
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 6);
     TS_ASSERT(func->isPointContained(VMD(3, 4, 5)));
@@ -681,7 +681,7 @@ public:
     TS_ASSERT_EQUALS(VMD(3, in), VMD(3.0, 1.0, 2.6));
 
     // The implicit function
-    MDImplicitFunction *func = alg->getImplicitFunctionForChunk(NULL, NULL);
+    MDImplicitFunction *func = alg->getImplicitFunctionForChunk(nullptr, nullptr);
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 6);
     TS_ASSERT(func->isPointContained(VMD(1.5, 1.5, 2)));
@@ -738,7 +738,7 @@ public:
     TS_ASSERT_EQUALS(VMD(3, in), VMD(3.0, -1.0, 2.6));
 
     // The implicit function
-    MDImplicitFunction *func = alg->getImplicitFunctionForChunk(NULL, NULL);
+    MDImplicitFunction *func = alg->getImplicitFunctionForChunk(nullptr, nullptr);
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 6);
     TS_ASSERT(func->isPointContained(VMD(1.5, -1.5, 2)));
@@ -757,7 +757,7 @@ public:
     // The implicit function
     MDImplicitFunction *func(nullptr);
     TS_ASSERT_THROWS_NOTHING(func =
-                                 alg->getImplicitFunctionForChunk(NULL, NULL));
+                                 alg->getImplicitFunctionForChunk(nullptr, nullptr));
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 6);
     TS_ASSERT(func->isPointContained(VMD(1.5, 1.5, 2, 234)));
@@ -778,7 +778,7 @@ public:
     // The implicit function
     MDImplicitFunction *func(nullptr);
     TS_ASSERT_THROWS_NOTHING(func =
-                                 alg->getImplicitFunctionForChunk(NULL, NULL));
+                                 alg->getImplicitFunctionForChunk(nullptr, nullptr));
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 8);
     TS_ASSERT(func->isPointContained(VMD(1.5, 1.5, 1.5, 1.5)));
@@ -797,7 +797,7 @@ public:
     // The implicit function
     MDImplicitFunction *func(nullptr);
     TS_ASSERT_THROWS_NOTHING(func =
-                                 alg->getImplicitFunctionForChunk(NULL, NULL));
+                                 alg->getImplicitFunctionForChunk(nullptr, nullptr));
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 8);
     TS_ASSERT(func->isPointContained(VMD(1.5, -1.5, 1.5, 1.5)));
@@ -815,7 +815,7 @@ public:
     // The implicit function
     MDImplicitFunction *func(nullptr);
     TS_ASSERT_THROWS_NOTHING(func =
-                                 alg->getImplicitFunctionForChunk(NULL, NULL));
+                                 alg->getImplicitFunctionForChunk(nullptr, nullptr));
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 6);
     TS_ASSERT(func->isPointContained(VMD(1.5, 1.5, 2, 234, 456)));
@@ -836,7 +836,7 @@ public:
     // The implicit function
     MDImplicitFunction *func(nullptr);
     TS_ASSERT_THROWS_NOTHING(func =
-                                 alg->getImplicitFunctionForChunk(NULL, NULL));
+                                 alg->getImplicitFunctionForChunk(nullptr, nullptr));
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 4);
     TS_ASSERT(func->isPointContained(VMD(1.5, 1.5, 2, 234)));
@@ -855,7 +855,7 @@ public:
     // The implicit function
     MDImplicitFunction *func(nullptr);
     TS_ASSERT_THROWS_NOTHING(func =
-                                 alg->getImplicitFunctionForChunk(NULL, NULL));
+                                 alg->getImplicitFunctionForChunk(nullptr, nullptr));
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 4);
     TS_ASSERT(func->isPointContained(VMD(1.5, 1.5, 2)));
@@ -874,7 +874,7 @@ public:
     // The implicit function
     MDImplicitFunction *func(nullptr);
     TS_ASSERT_THROWS_NOTHING(func =
-                                 alg->getImplicitFunctionForChunk(NULL, NULL));
+                                 alg->getImplicitFunctionForChunk(nullptr, nullptr));
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 4);
     TS_ASSERT(func->isPointContained(VMD(1.5, 1.5)));
@@ -932,7 +932,7 @@ public:
     TS_ASSERT_EQUALS(VMD(2, in), VMD(3., -11.));
 
     // The implicit function
-    MDImplicitFunction *func = alg->getImplicitFunctionForChunk(NULL, NULL);
+    MDImplicitFunction *func = alg->getImplicitFunctionForChunk(nullptr, nullptr);
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 4);
     TS_ASSERT(func->isPointContained(VMD(-8.9, -18.9)));
@@ -997,7 +997,7 @@ public:
     TS_ASSERT_EQUALS(VMD(2, in), VMD(3., -11.));
 
     // The implicit function
-    MDImplicitFunction *func = alg->getImplicitFunctionForChunk(NULL, NULL);
+    MDImplicitFunction *func = alg->getImplicitFunctionForChunk(nullptr, nullptr);
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 4);
     TS_ASSERT(func->isPointContained(VMD(-18.9, -98.9)));
@@ -1027,7 +1027,7 @@ public:
     // The implicit function
     MDImplicitFunction *func(nullptr);
     TS_ASSERT_THROWS_NOTHING(func =
-                                 alg->getImplicitFunctionForChunk(NULL, NULL));
+                                 alg->getImplicitFunctionForChunk(nullptr, nullptr));
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 4);
     TS_ASSERT(func->isPointContained(VMD(2., 1.)));
@@ -1049,7 +1049,7 @@ public:
     // The implicit function
     MDImplicitFunction *func(nullptr);
     TS_ASSERT_THROWS_NOTHING(func =
-                                 alg->getImplicitFunctionForChunk(NULL, NULL));
+                                 alg->getImplicitFunctionForChunk(nullptr, nullptr));
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 4);
     TS_ASSERT(func->isPointContained(VMD(2., 1., 0.)));
@@ -1073,7 +1073,7 @@ public:
     // The implicit function
     MDImplicitFunction *func(nullptr);
     TS_ASSERT_THROWS_NOTHING(func =
-                                 alg->getImplicitFunctionForChunk(NULL, NULL));
+                                 alg->getImplicitFunctionForChunk(nullptr, nullptr));
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 8);
     TS_ASSERT(func->isPointContained(VMD(2., 1., 0., 0.)));
@@ -1094,7 +1094,7 @@ public:
     // The implicit function
     MDImplicitFunction *func(nullptr);
     TS_ASSERT_THROWS_NOTHING(func =
-                                 alg->getImplicitFunctionForChunk(NULL, NULL));
+                                 alg->getImplicitFunctionForChunk(nullptr, nullptr));
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 6);
     TS_ASSERT(func->isPointContained(VMD(2., 1., 0., 0.)));
@@ -1112,7 +1112,7 @@ public:
     TS_ASSERT_EQUALS(alg->m_bases.size(), 1);
 
     // The implicit function
-    MDImplicitFunction *func = alg->getImplicitFunctionForChunk(NULL, NULL);
+    MDImplicitFunction *func = alg->getImplicitFunctionForChunk(nullptr, nullptr);
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 2);
     TS_ASSERT(func->isPointContained(VMD(1.5, 1.5, 2, 345)));
@@ -1127,7 +1127,7 @@ public:
     TS_ASSERT_EQUALS(alg->m_bases.size(), 1);
 
     // The implicit function
-    MDImplicitFunction *func = alg->getImplicitFunctionForChunk(NULL, NULL);
+    MDImplicitFunction *func = alg->getImplicitFunctionForChunk(nullptr, nullptr);
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 2);
     TS_ASSERT(func->isPointContained(VMD(1.5, 1.5, 2)));
@@ -1142,7 +1142,7 @@ public:
     TS_ASSERT_EQUALS(alg->m_bases.size(), 1);
 
     // The implicit function
-    MDImplicitFunction *func = alg->getImplicitFunctionForChunk(NULL, NULL);
+    MDImplicitFunction *func = alg->getImplicitFunctionForChunk(nullptr, nullptr);
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 2);
     TS_ASSERT(func->isPointContained(VMD(1.5, 1.5)));
@@ -1159,7 +1159,7 @@ public:
     TS_ASSERT_EQUALS(alg->m_bases.size(), 1);
 
     // The implicit function
-    MDImplicitFunction *func = alg->getImplicitFunctionForChunk(NULL, NULL);
+    MDImplicitFunction *func = alg->getImplicitFunctionForChunk(nullptr, nullptr);
     TS_ASSERT(func);
     TS_ASSERT_EQUALS(func->getNumPlanes(), 2);
     VMD point(1);

--- a/Framework/MDAlgorithms/test/WeightedMeanMDTest.h
+++ b/Framework/MDAlgorithms/test/WeightedMeanMDTest.h
@@ -134,7 +134,7 @@ public:
     MDHistoWorkspace_sptr c =
         boost::dynamic_pointer_cast<MDHistoWorkspace>(ADS.retrieve(outName));
 
-    TS_ASSERT(c != NULL);
+    TS_ASSERT(c != nullptr);
     // Since A and B are equivalent, the mean Signal in C should be the same as
     // both A and B.
     double expectedSignalResults[10] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
@@ -157,7 +157,7 @@ public:
     MDHistoWorkspace_sptr out;
     out = BinaryOperationMDTestHelper::doTest("WeightedMeanMD", "histo_A",
                                               "histo_B", "out");
-    TS_ASSERT(out != NULL);
+    TS_ASSERT(out != nullptr);
   }
 
   /**

--- a/Framework/SINQ/test/PoldiInstrumentAdapterTest.h
+++ b/Framework/SINQ/test/PoldiInstrumentAdapterTest.h
@@ -195,7 +195,7 @@ public:
     TestablePoldiInstrumentAdapter instrumentAdapter;
 
     // Throw on null-pointer
-    TS_ASSERT_THROWS(instrumentAdapter.getExtractorForProperty(0),
+    TS_ASSERT_THROWS(instrumentAdapter.getExtractorForProperty(nullptr),
                      std::invalid_argument);
     TS_ASSERT_THROWS_NOTHING(instrumentAdapter.getExtractorForProperty(
         m_run.getProperty("chopperspeed_double")));

--- a/Framework/TestHelpers/inc/MantidTestHelpers/MDEventsTestHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/MDEventsTestHelper.h
@@ -423,7 +423,7 @@ static void feedMDBox(MDBoxBase<MDLeanEvent<nd>, nd> *box, size_t repeat = 1,
     allDone = Mantid::Kernel::Utils::NestedForLoop::Increment(nd, counters,
                                                               index_max);
   }
-  box->refreshCache(NULL);
+  box->refreshCache(nullptr);
 }
 
 //-------------------------------------------------------------------------------------

--- a/Framework/Types/test/DateAndTimeTest.h
+++ b/Framework/Types/test/DateAndTimeTest.h
@@ -279,7 +279,7 @@ public:
 
   void test_time_t_support() {
     DateAndTime t;
-    std::time_t current = time(NULL);
+    std::time_t current = time(nullptr);
     t.set_from_time_t(current);
     //    if (cur.day() < 28) // Annoying bug at the end of a month
     { TS_ASSERT_EQUALS(current, t.to_time_t()); }


### PR DESCRIPTION
Applied automatic and some manual fixes for uses of the `NULL` macro in Framework code.

**To test:**
Ensure builds pass.
<!-- Instructions for testing. -->

Refs #22169 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
