### PR TITLE
Applied clang-tidy modernize-use-nullptr fixes for MantidPlot/

### DIFF
--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -14858,7 +14858,8 @@ void ApplicationWindow::showScriptWindow(bool forceVisible, bool quitting) {
     // it doesn't respect the always on top
     // flag, it is treated as a sub window of its parent
     const bool capturePrint = !quitting;
-    scriptingWindow = new ScriptingWindow(scriptingEnv(), capturePrint, nullptr);
+    scriptingWindow =
+        new ScriptingWindow(scriptingEnv(), capturePrint, nullptr);
     scriptingWindow->setObjectName("ScriptingWindow");
     scriptingWindow->setAttribute(Qt::WA_DeleteOnClose, false);
     connect(scriptingWindow, SIGNAL(closeMe()), this,

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -2446,7 +2446,7 @@ Graph3D *ApplicationWindow::dataPlot3D(const QString &caption,
   posX = formula.indexOf("(", pos);
   QString yCol = formula.mid(pos + 1, posX - pos - 1);
 
-  Graph3D *plot = new Graph3D("", this, 0);
+  Graph3D *plot = new Graph3D("", this, nullptr);
   plot->addData(w, xCol, yCol, xl, xr, yl, yr, zl, zr);
   plot->update();
 
@@ -2466,7 +2466,7 @@ Graph3D *ApplicationWindow::newPlot3D() {
 
   QString label = generateUniqueName(tr("Graph"));
 
-  Graph3D *plot = new Graph3D("", this, 0);
+  Graph3D *plot = new Graph3D("", this, nullptr);
   plot->setWindowTitle(label);
   plot->setName(label);
 
@@ -2486,7 +2486,7 @@ Graph3D *ApplicationWindow::plotXYZ(Table *table, const QString &zColName,
 
   QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
 
-  Graph3D *plot = new Graph3D("", this, 0);
+  Graph3D *plot = new Graph3D("", this, nullptr);
   QString label = generateUniqueName(tr("Graph"));
   plot->setWindowTitle(label);
   plot->setName(label);
@@ -2531,7 +2531,7 @@ Graph3D *ApplicationWindow::openPlotXYZ(const QString &caption,
   int yCol = w->colIndex(yColName);
   int zCol = w->colIndex(zColName);
 
-  Graph3D *plot = new Graph3D("", this, 0);
+  Graph3D *plot = new Graph3D("", this, nullptr);
   plot->loadData(w, xCol, yCol, zCol, xl, xr, yl, yr, zl, zr);
 
   QString label = caption;
@@ -2584,7 +2584,7 @@ void ApplicationWindow::exportMatrix() {
     return;
 
   ImageExportDialog *ied =
-      new ImageExportDialog(this, m != NULL, d_extended_export_dialog);
+      new ImageExportDialog(this, m != nullptr, d_extended_export_dialog);
   ied->setDirectory(workingDir);
   ied->selectFilter(d_image_export_filter);
   if (ied->exec() != QDialog::Accepted)
@@ -3051,7 +3051,7 @@ void ApplicationWindow::setPreferences(Graph *g) {
  *creates a new empty table
  */
 Table *ApplicationWindow::newTable() {
-  Table *w = new Table(scriptingEnv(), 30, 2, "", this, 0);
+  Table *w = new Table(scriptingEnv(), 30, 2, "", this, nullptr);
   initTable(w, generateUniqueName(tr("Table")));
   w->showNormal();
   return w;
@@ -3061,7 +3061,7 @@ Table *ApplicationWindow::newTable() {
  *used when opening a project file
  */
 Table *ApplicationWindow::newTable(const QString &caption, int r, int c) {
-  Table *w = new Table(scriptingEnv(), r, c, "", this, 0);
+  Table *w = new Table(scriptingEnv(), r, c, "", this, nullptr);
   initTable(w, caption);
   if (w->objectName() != caption) { // the table was renamed
     renamedTables << caption << w->objectName();
@@ -3083,7 +3083,7 @@ bool ApplicationWindow::isDeleteWorkspacePromptEnabled() {
 
 Table *ApplicationWindow::newTable(int r, int c, const QString &name,
                                    const QString &legend) {
-  Table *w = new Table(scriptingEnv(), r, c, legend, this, 0);
+  Table *w = new Table(scriptingEnv(), r, c, legend, this, nullptr);
   initTable(w, name);
   return w;
 }
@@ -3095,7 +3095,7 @@ Table *ApplicationWindow::newTable(const QString &caption, int r, int c,
   if (lst.count() == 2)
     legend = lst[1];
 
-  Table *w = new Table(scriptingEnv(), r, c, legend, this, 0);
+  Table *w = new Table(scriptingEnv(), r, c, legend, this, nullptr);
 
   QStringList rows = text.split("\n", QString::SkipEmptyParts);
   QString rlist = rows[0];
@@ -3117,7 +3117,7 @@ Table *ApplicationWindow::newTable(const QString &caption, int r, int c,
 Table *ApplicationWindow::newHiddenTable(const QString &name,
                                          const QString &label, int r, int c,
                                          const QString &text) {
-  Table *w = new Table(scriptingEnv(), r, c, label, this, 0);
+  Table *w = new Table(scriptingEnv(), r, c, label, this, nullptr);
 
   if (!text.isEmpty()) {
     QStringList rows = text.split("\n", QString::SkipEmptyParts);
@@ -3194,14 +3194,14 @@ Note *ApplicationWindow::newNote(const QString &caption) {
 }
 
 Matrix *ApplicationWindow::newMatrix(int rows, int columns) {
-  Matrix *m = new Matrix(scriptingEnv(), rows, columns, "", this, 0);
+  Matrix *m = new Matrix(scriptingEnv(), rows, columns, "", this, nullptr);
   initMatrix(m, generateUniqueName(tr("Matrix")));
   m->showNormal();
   return m;
 }
 
 Matrix *ApplicationWindow::newMatrix(const QString &caption, int r, int c) {
-  Matrix *w = new Matrix(scriptingEnv(), r, c, "", this, 0);
+  Matrix *w = new Matrix(scriptingEnv(), r, c, "", this, nullptr);
   initMatrix(w, caption);
   if (w->objectName() != caption) // the matrix was renamed
     renamedTables << caption << w->objectName();
@@ -3397,14 +3397,14 @@ ApplicationWindow::matrixToTable(Matrix *m,
 
   Table *w = nullptr;
   if (conversionType == Direct) {
-    w = new Table(scriptingEnv(), rows, cols, "", this, 0);
+    w = new Table(scriptingEnv(), rows, cols, "", this, nullptr);
     for (int i = 0; i < rows; i++) {
       for (int j = 0; j < cols; j++)
         w->setCell(i, j, m->cell(i, j));
     }
   } else if (conversionType == XYZ) {
     int tableRows = rows * cols;
-    w = new Table(scriptingEnv(), tableRows, 3, "", this, 0);
+    w = new Table(scriptingEnv(), tableRows, 3, "", this, nullptr);
     for (int i = 0; i < rows; i++) {
       for (int j = 0; j < cols; j++) {
         int cell = i * cols + j;
@@ -3415,7 +3415,7 @@ ApplicationWindow::matrixToTable(Matrix *m,
     }
   } else if (conversionType == YXZ) {
     int tableRows = rows * cols;
-    w = new Table(scriptingEnv(), tableRows, 3, "", this, 0);
+    w = new Table(scriptingEnv(), tableRows, 3, "", this, nullptr);
     for (int i = 0; i < cols; i++) {
       for (int j = 0; j < rows; j++) {
         int cell = i * rows + j;
@@ -3600,7 +3600,7 @@ Matrix *ApplicationWindow::tableToMatrix(Table *t) {
   int cols = t->numCols();
 
   QString caption = generateUniqueName(tr("Matrix"));
-  Matrix *m = new Matrix(scriptingEnv(), rows, cols, "", this, 0);
+  Matrix *m = new Matrix(scriptingEnv(), rows, cols, "", this, nullptr);
   initMatrix(m, caption);
 
   for (int i = 0; i < rows; i++) {
@@ -5701,7 +5701,7 @@ void ApplicationWindow::exportGraph() {
     return;
 
   ImageExportDialog *ied =
-      new ImageExportDialog(this, plot2D != NULL, d_extended_export_dialog);
+      new ImageExportDialog(this, plot2D != nullptr, d_extended_export_dialog);
   ied->setDirectory(workingDir);
   ied->selectFilter(d_image_export_filter);
   if (ied->exec() != QDialog::Accepted)
@@ -5764,7 +5764,7 @@ void ApplicationWindow::exportLayer() {
     return;
 
   ImageExportDialog *ied =
-      new ImageExportDialog(this, g != NULL, d_extended_export_dialog);
+      new ImageExportDialog(this, g != nullptr, d_extended_export_dialog);
   ied->setDirectory(workingDir);
   ied->selectFilter(d_image_export_filter);
   if (ied->exec() != QDialog::Accepted)
@@ -5837,7 +5837,7 @@ void ApplicationWindow::exportAllGraphs() {
   foreach (MdiSubWindow *w, windows) {
     const std::string windowClassName = w->metaObject()->className();
     if (windowClassName == "MultiLayer") {
-      plot3D = 0;
+      plot3D = nullptr;
       plot2D = dynamic_cast<MultiLayer *>(w);
       if (!plot2D)
         continue;
@@ -5851,7 +5851,7 @@ void ApplicationWindow::exportAllGraphs() {
         continue;
       }
     } else if (windowClassName == "Graph3D") {
-      plot2D = 0;
+      plot2D = nullptr;
       plot3D = dynamic_cast<Graph3D *>(w);
       if (!plot3D)
         continue;
@@ -6137,7 +6137,7 @@ void ApplicationWindow::savetoNexusFile() {
 void ApplicationWindow::loadDataFile() {
   // Ask user for file
   QString fn = QFileDialog::getOpenFileName(
-      0, tr("Mantidplot - Open file to load"),
+      nullptr, tr("Mantidplot - Open file to load"),
       AlgorithmInputHistory::Instance().getPreviousDirectory());
   if (fn != "") {
     loadDataFileByName(fn);
@@ -6438,7 +6438,7 @@ void ApplicationWindow::showTitleDialog() {
 
     Graph *g = ml->activeGraph();
     if (g) {
-      TextDialog *td = new TextDialog(TextDialog::LayerTitle, this, 0);
+      TextDialog *td = new TextDialog(TextDialog::LayerTitle, this, nullptr);
       td->setGraph(g);
       td->exec();
     }
@@ -6462,7 +6462,7 @@ void ApplicationWindow::showAxisTitleDialog() {
   if (!g)
     return;
 
-  TextDialog *td = new TextDialog(TextDialog::AxisTitle, this, 0);
+  TextDialog *td = new TextDialog(TextDialog::AxisTitle, this, nullptr);
   td->setGraph(g);
   td->exec();
 }
@@ -7606,7 +7606,7 @@ void ApplicationWindow::removePoints() {
         this, tr("MantidPlot"), // Mantid
         tr("This will modify the data in the worksheets!\nAre you sure you "
            "want to continue?"),
-        tr("Continue"), tr("Cancel"), 0, 1)) {
+        tr("Continue"), tr("Cancel"), nullptr, 1)) {
     case 0:
       g->setActiveTool(new DataPickerTool(g, this, DataPickerTool::Remove, info,
                                           SLOT(setText(const QString &))));
@@ -7651,7 +7651,7 @@ void ApplicationWindow::movePoints() {
         this, tr("MantidPlot"), // Mantid
         tr("This will modify the data in the worksheets!\nAre you sure you "
            "want to continue?"),
-        tr("Continue"), tr("Cancel"), 0, 1)) {
+        tr("Continue"), tr("Cancel"), nullptr, 1)) {
     case 0:
       if (g) {
         g->setActiveTool(new DataPickerTool(g, this, DataPickerTool::Move, info,
@@ -8345,7 +8345,7 @@ void ApplicationWindow::showTextDialog() {
     if (!l)
       return;
 
-    TextDialog *td = new TextDialog(TextDialog::TextMarker, this, 0);
+    TextDialog *td = new TextDialog(TextDialog::TextMarker, this, nullptr);
     td->setLegendWidget(l);
     td->exec();
   }
@@ -10467,7 +10467,7 @@ void ApplicationWindow::chooseHelpFolder() {
   QFileInfo hfi(helpFilePath);
   QString dir = QFileDialog::getExistingDirectory(
       this, tr("Choose the location of the MantidPlot help folder!"),
-      hfi.dir().absolutePath(), 0 /**QFileDialog::ShowDirsOnly*/);
+      hfi.dir().absolutePath(), nullptr /**QFileDialog::ShowDirsOnly*/);
 
   if (!dir.isEmpty()) {
     helpFilePath = dir + "index.html";
@@ -10522,7 +10522,7 @@ void ApplicationWindow::showHelp() {
 void ApplicationWindow::showPlotWizard() {
   QStringList lst = tableNames();
   if (lst.count() > 0) {
-    PlotWizard *pw = new PlotWizard(this, 0);
+    PlotWizard *pw = new PlotWizard(this, nullptr);
     pw->setAttribute(Qt::WA_DeleteOnClose);
     connect(pw, SIGNAL(plot(const QStringList &)), this,
             SLOT(multilayerPlot(const QStringList &)));
@@ -13366,7 +13366,7 @@ Graph3D *ApplicationWindow::openMatrixPlot3D(const QString &caption,
   if (!m)
     return nullptr;
 
-  Graph3D *plot = new Graph3D("", this, 0, 0);
+  Graph3D *plot = new Graph3D("", this, nullptr, nullptr);
   plot->setWindowTitle(caption);
   plot->setName(caption);
   plot->addMatrixData(m, xl, xr, yl, yr, zl, zr);
@@ -13390,7 +13390,7 @@ Graph3D *ApplicationWindow::plot3DMatrix(Matrix *m, int style) {
   QApplication::setOverrideCursor(Qt::WaitCursor);
   QString label = generateUniqueName(tr("Graph"));
 
-  Graph3D *plot = new Graph3D("", this, 0);
+  Graph3D *plot = new Graph3D("", this, nullptr);
   plot->addMatrixData(m);
   plot->customPlotStyle(style);
   customPlot3D(plot);
@@ -14409,7 +14409,7 @@ bool ApplicationWindow::deleteFolder(Folder *f) {
           this, tr("MantidPlot - Delete folder?"), // Mantid
           tr("Delete folder '%1' and all the windows it contains?")
               .arg(f->objectName()),
-          tr("Yes"), tr("No"), 0, 0))
+          tr("Yes"), tr("No"), nullptr, 0))
     return false;
   else {
     Folder *parent = projectFolder();
@@ -14858,7 +14858,7 @@ void ApplicationWindow::showScriptWindow(bool forceVisible, bool quitting) {
     // it doesn't respect the always on top
     // flag, it is treated as a sub window of its parent
     const bool capturePrint = !quitting;
-    scriptingWindow = new ScriptingWindow(scriptingEnv(), capturePrint, NULL);
+    scriptingWindow = new ScriptingWindow(scriptingEnv(), capturePrint, nullptr);
     scriptingWindow->setObjectName("ScriptingWindow");
     scriptingWindow->setAttribute(Qt::WA_DeleteOnClose, false);
     connect(scriptingWindow, SIGNAL(closeMe()), this,

--- a/MantidPlot/src/ConfigDialog.cpp
+++ b/MantidPlot/src/ConfigDialog.cpp
@@ -3105,7 +3105,7 @@ void ConfigDialog::chooseTranslationsFolder() {
   QFileInfo tfi(app->d_translations_folder);
   QString dir = QFileDialog::getExistingDirectory(
       this, tr("Choose the location of the MantidPlot translations folder!"),
-      tfi.dir().absolutePath(), 0 /**QFileDialog::ShowDirsOnly*/);
+      tfi.dir().absolutePath(), nullptr /**QFileDialog::ShowDirsOnly*/);
 
   if (!dir.isEmpty()) {
     app->d_translations_folder = dir;
@@ -3130,7 +3130,7 @@ void ConfigDialog::chooseHelpFolder() {
 void ConfigDialog::addPythonScriptsDirs() {
   QString dir = QFileDialog::getExistingDirectory(
       this, tr("Add a python scripts directory"), "",
-      0 /**QFileDialog::ShowDirsOnly*/);
+      nullptr /**QFileDialog::ShowDirsOnly*/);
   if (!dir.isEmpty()) {
     QString dirs = lePythonScriptsDirs->text();
     if (!dirs.isEmpty()) {
@@ -3144,7 +3144,7 @@ void ConfigDialog::addPythonScriptsDirs() {
 void ConfigDialog::addPythonPluginDirs() {
   QString dir = QFileDialog::getExistingDirectory(
       this, tr("Add a python extension directory"), "",
-      0 /**QFileDialog::ShowDirsOnly*/);
+      nullptr /**QFileDialog::ShowDirsOnly*/);
   if (!dir.isEmpty()) {
     QString dirs = lePythonPluginsDirs->text();
     if (!dirs.isEmpty()) {
@@ -3157,7 +3157,7 @@ void ConfigDialog::addPythonPluginDirs() {
 
 void ConfigDialog::addInstrumentDir() {
   QString dir = QFileDialog::getExistingDirectory(
-      this, tr("Select new instrument definition directory"), "", 0);
+      this, tr("Select new instrument definition directory"), "", nullptr);
   if (!dir.isEmpty()) {
     leInstrumentDir->setText(dir);
   }

--- a/MantidPlot/src/Graph.cpp
+++ b/MantidPlot/src/Graph.cpp
@@ -3094,7 +3094,7 @@ void Graph::removePie() {
 
   QList<PieLabel *> labels = pieCurve->labelsList();
   foreach (PieLabel *l, labels)
-    l->setPieCurve(0);
+    l->setPieCurve(nullptr);
 
   d_plot->removeCurve(c_keys[0]);
   d_plot->replot();

--- a/MantidPlot/src/Graph3D.cpp
+++ b/MantidPlot/src/Graph3D.cpp
@@ -2497,7 +2497,7 @@ MantidQt::API::IProjectSerialisable *
 Graph3D::loadFromProject(const std::string &lines, ApplicationWindow *app,
                          const int fileVersion) {
   Q_UNUSED(fileVersion);
-  auto graph = new Graph3D("", app, "", 0);
+  auto graph = new Graph3D("", app, "", nullptr);
 
   std::vector<std::string> lineVec, valVec;
   boost::split(lineVec, lines, boost::is_any_of("\n"));

--- a/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.cpp
+++ b/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.cpp
@@ -23,7 +23,7 @@ using namespace MantidQt::MantidWidgets;
 InstrumentWindow::InstrumentWindow(const QString &wsName, const QString &label,
                                    ApplicationWindow *parent,
                                    const QString &name)
-    : MdiSubWindow(parent, label, name, 0) {
+    : MdiSubWindow(parent, label, name, nullptr) {
 
   m_instrumentWidget = new InstrumentWidget(wsName, this);
   this->setWidget(m_instrumentWidget);

--- a/MantidPlot/src/Mantid/MantidMatrix.cpp
+++ b/MantidPlot/src/Mantid/MantidMatrix.cpp
@@ -210,7 +210,7 @@ void MantidMatrix::viewChanged(int index) {
 void MantidMatrix::setup(Mantid::API::MatrixWorkspace_const_sptr ws, int start,
                          int end) {
   if (!ws) {
-    QMessageBox::critical(0, "WorkspaceMatrixModel error",
+    QMessageBox::critical(nullptr, "WorkspaceMatrixModel error",
                           "2D workspace expected.");
     m_rows = 0;
     m_cols = 0;
@@ -468,7 +468,7 @@ void MantidMatrix::setRange(double min, double max) {
 double **MantidMatrix::allocateMatrixData(int rows, int columns) {
   double **data = (double **)malloc(rows * sizeof(double *));
   if (!data) {
-    QMessageBox::critical(0, tr("MantidPlot") + " - " +
+    QMessageBox::critical(nullptr, tr("MantidPlot") + " - " +
                                  tr("Memory Allocation Error"),
                           tr("Not enough memory, operation aborted!"));
     return nullptr;
@@ -481,7 +481,7 @@ double **MantidMatrix::allocateMatrixData(int rows, int columns) {
         free(data[j]);
       free(data);
 
-      QMessageBox::critical(0, tr("MantidPlot") + " - " +
+      QMessageBox::critical(nullptr, tr("MantidPlot") + " - " +
                                    tr("Memory Allocation Error"),
                             tr("Not enough memory, operation aborted!"));
       return nullptr;
@@ -736,7 +736,7 @@ void MantidMatrix::attachMultilayer(MultiLayer *ml) {
 */
 MultiLayer *MantidMatrix::plotGraph2D(GraphOptions::CurveType type) {
   if (numRows() == 1) {
-    QMessageBox::critical(0, "MantidPlot - Error",
+    QMessageBox::critical(nullptr, "MantidPlot - Error",
                           "Cannot plot a workspace with only one spectrum.");
     return nullptr;
   }

--- a/MantidPlot/src/Mantid/MantidMatrix.cpp
+++ b/MantidPlot/src/Mantid/MantidMatrix.cpp
@@ -469,7 +469,7 @@ double **MantidMatrix::allocateMatrixData(int rows, int columns) {
   double **data = (double **)malloc(rows * sizeof(double *));
   if (!data) {
     QMessageBox::critical(nullptr, tr("MantidPlot") + " - " +
-                                 tr("Memory Allocation Error"),
+                                       tr("Memory Allocation Error"),
                           tr("Not enough memory, operation aborted!"));
     return nullptr;
   }
@@ -482,7 +482,7 @@ double **MantidMatrix::allocateMatrixData(int rows, int columns) {
       free(data);
 
       QMessageBox::critical(nullptr, tr("MantidPlot") + " - " +
-                                   tr("Memory Allocation Error"),
+                                         tr("Memory Allocation Error"),
                             tr("Not enough memory, operation aborted!"));
       return nullptr;
     }

--- a/MantidPlot/src/Mantid/MantidTable.cpp
+++ b/MantidPlot/src/Mantid/MantidTable.cpp
@@ -35,7 +35,7 @@ MantidTable::MantidTable(ScriptingEnv *env,
                            : static_cast<int>(ws->rowCount()),
             transpose ? static_cast<int>(ws->rowCount() + 1)
                       : static_cast<int>(ws->columnCount()),
-            label, parent, "", 0),
+            label, parent, "", nullptr),
       m_ws(ws), m_wsName(ws->getName()), m_transposed(transpose) {
   d_table->blockResizing(true);
 

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -1314,8 +1314,8 @@ Table *MantidUI::createDetectorTable(
   const int nrows = indices.empty()
                         ? static_cast<int>(ws->getNumberHistograms())
                         : static_cast<int>(indices.size());
-  Table *t =
-      new Table(appWindow()->scriptingEnv(), nrows, ncols, "", appWindow(), nullptr);
+  Table *t = new Table(appWindow()->scriptingEnv(), nrows, ncols, "",
+                       appWindow(), nullptr);
   appWindow()->initTable(
       t, appWindow()->generateUniqueName(wsName + "-Detectors-"));
   // Set the column names
@@ -2220,8 +2220,9 @@ void MantidUI::saveProject(bool saved) {
   if (!saved) {
     QString savemsg =
         tr("Save changes to project: <p><b> %1 </b> ?").arg("untitled");
-    int result = QMessageBox::information(appWindow(), tr("MantidPlot"),
-                                          savemsg, tr("Yes"), tr("No"), nullptr, 2);
+    int result =
+        QMessageBox::information(appWindow(), tr("MantidPlot"), savemsg,
+                                 tr("Yes"), tr("No"), nullptr, 2);
     if (result == 0)
       appWindow()->saveProject();
   }
@@ -2441,8 +2442,8 @@ void MantidUI::importStrSeriesLog(const QString &logName, const QString &data,
   QStringList loglines = data.split("\n", QString::SkipEmptyParts);
 
   int rowcount(loglines.count());
-  Table *t =
-      new Table(appWindow()->scriptingEnv(), rowcount, 2, "", appWindow(), nullptr);
+  Table *t = new Table(appWindow()->scriptingEnv(), rowcount, 2, "",
+                       appWindow(), nullptr);
   if (!t)
     return;
   QString label;

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -213,9 +213,9 @@ MantidUI::MantidUI(ApplicationWindow *aw)
     : m_finishedLoadDAEObserver(*this,
                                 &MantidUI::handleLoadDAEFinishedNotification),
       m_configServiceObserver(*this, &MantidUI::handleConfigServiceUpdate),
-      m_appWindow(aw), m_lastShownInstrumentWin(NULL),
-      m_lastShownSliceViewWin(NULL), m_lastShownSpectrumViewerWin(NULL),
-      m_lastShownColorFillWin(NULL), m_lastShown1DPlotWin(NULL),
+      m_appWindow(aw), m_lastShownInstrumentWin(nullptr),
+      m_lastShownSliceViewWin(nullptr), m_lastShownSpectrumViewerWin(nullptr),
+      m_lastShownColorFillWin(nullptr), m_lastShown1DPlotWin(nullptr),
       m_vatesSubWindow(nullptr)
 //, m_spectrumViewWindow(NULL)
 {
@@ -925,7 +925,7 @@ void MantidUI::showSpectrumViewer() {
       try {
         viewer = new MantidQt::SpectrumView::SpectrumView(m_appWindow);
       } catch (std::runtime_error &e) {
-        m_lastShownSpectrumViewerWin = NULL;
+        m_lastShownSpectrumViewerWin = nullptr;
         g_log.error() << "Could not create spectrum viewer: " << e.what()
                       << "\n";
         throw std::runtime_error(e);
@@ -981,7 +981,7 @@ void MantidUI::showSliceViewer() {
       w = MantidQt::Factory::WidgetFactory::Instance()->createSliceViewerWindow(
           wsName, "");
     } catch (std::runtime_error &e) {
-      m_lastShownSliceViewWin = NULL;
+      m_lastShownSliceViewWin = nullptr;
       g_log.error() << "Could not create slice viewer: " << e.what() << "\n";
       throw std::runtime_error(e);
     }
@@ -1025,7 +1025,7 @@ Show Algorithm History Details in a window .
 void MantidUI::showAlgorithmHistory() {
   QString wsName = getSelectedWorkspaceName();
   Mantid::API::Workspace_const_sptr wsptr = getWorkspace(wsName);
-  if (NULL != wsptr) {
+  if (nullptr != wsptr) {
     // If the workspace has any AlgorithHistory ...
     if (!wsptr->getHistory().empty()) {
       // ... create and display the window.
@@ -1315,7 +1315,7 @@ Table *MantidUI::createDetectorTable(
                         ? static_cast<int>(ws->getNumberHistograms())
                         : static_cast<int>(indices.size());
   Table *t =
-      new Table(appWindow()->scriptingEnv(), nrows, ncols, "", appWindow(), 0);
+      new Table(appWindow()->scriptingEnv(), nrows, ncols, "", appWindow(), nullptr);
   appWindow()->initTable(
       t, appWindow()->generateUniqueName(wsName + "-Detectors-"));
   // Set the column names
@@ -2140,7 +2140,7 @@ void MantidUI::showMantidInstrument(const QString &wsName) {
   InstrumentWindow *insWin = getInstrumentView(wsName);
 
   if (!insWin) {
-    m_lastShownInstrumentWin = NULL;
+    m_lastShownInstrumentWin = nullptr;
     return;
   }
 
@@ -2221,7 +2221,7 @@ void MantidUI::saveProject(bool saved) {
     QString savemsg =
         tr("Save changes to project: <p><b> %1 </b> ?").arg("untitled");
     int result = QMessageBox::information(appWindow(), tr("MantidPlot"),
-                                          savemsg, tr("Yes"), tr("No"), 0, 2);
+                                          savemsg, tr("Yes"), tr("No"), nullptr, 2);
     if (result == 0)
       appWindow()->saveProject();
   }
@@ -2405,7 +2405,7 @@ void MantidUI::importString(const QString &logName, const QString &data,
   }
 
   Table *t = new Table(appWindow()->scriptingEnv(), loglines.size(), 1, "",
-                       appWindow(), 0);
+                       appWindow(), nullptr);
   if (!t)
     return;
   // Have to replace "_" since the legend widget uses them to separate things
@@ -2442,7 +2442,7 @@ void MantidUI::importStrSeriesLog(const QString &logName, const QString &data,
 
   int rowcount(loglines.count());
   Table *t =
-      new Table(appWindow()->scriptingEnv(), rowcount, 2, "", appWindow(), 0);
+      new Table(appWindow()->scriptingEnv(), rowcount, 2, "", appWindow(), nullptr);
   if (!t)
     return;
   QString label;
@@ -2541,7 +2541,7 @@ void MantidUI::importNumSeriesLog(const QString &wsName, const QString &logName,
   int colCount = 2;
 
   Table *t = new Table(appWindow()->scriptingEnv(), rowcount, colCount, "",
-                       appWindow(), 0);
+                       appWindow(), nullptr);
   if (!t)
     return;
   // Have to replace "_" since the legend widget uses them to separate things
@@ -2857,7 +2857,7 @@ Table *MantidUI::createTableFromSpectraList(const QString &tableName,
   bool isHistogram = workspace->isHistogramData();
   int no_cols = static_cast<int>(indexList.size());
   Table *t = new Table(appWindow()->scriptingEnv(), numRows, (1 + c) * no_cols,
-                       "", appWindow(), 0);
+                       "", appWindow(), nullptr);
   appWindow()->initTable(t, appWindow()->generateUniqueName(tableName + "-"));
   // t->askOnCloseEvent(false);
 
@@ -3127,7 +3127,7 @@ MultiLayer *MantidUI::plot1D(const QMultiMap<QString, int> &toPlot,
       return nullptr;
   }
   // Force waterfall option to false if only 1 curve
-  if ((NULL == plotWindow || clearWindow) && toPlot.size() == 1)
+  if ((nullptr == plotWindow || clearWindow) && toPlot.size() == 1)
     waterfallPlot = false;
 
   ScopedOverrideCursor waitCursor;
@@ -3325,7 +3325,7 @@ void MantidUI::drawColorFillPlots(const QStringList &wsNames,
          cit != wsNames.end(); ++cit) {
       const bool hidden = true;
       MultiLayer *plot =
-          this->drawSingleColorFillPlot(*cit, curveType, NULL, hidden);
+          this->drawSingleColorFillPlot(*cit, curveType, nullptr, hidden);
       if (plot)
         plots.append(plot);
     }
@@ -3391,7 +3391,7 @@ MultiLayer *MantidUI::drawSingleColorFillPlot(const QString &wsName,
   ScopedOverrideCursor waitCursor;
 
   bool reusePlots = workspacesDockPlot1To1();
-  if ((!reusePlots && NULL == window) ||
+  if ((!reusePlots && nullptr == window) ||
       (reusePlots && !m_lastShownColorFillWin)) // needs to create a new window
   {
     try {
@@ -3401,7 +3401,7 @@ MultiLayer *MantidUI::drawSingleColorFillPlot(const QString &wsName,
         window->hide();
       }
     } catch (std::runtime_error &e) {
-      m_lastShownColorFillWin = NULL;
+      m_lastShownColorFillWin = nullptr;
       g_log.error() << "Could not create color fill plot: " << e.what() << "\n";
       throw std::runtime_error(e);
     }
@@ -3409,7 +3409,7 @@ MultiLayer *MantidUI::drawSingleColorFillPlot(const QString &wsName,
     m_lastShownColorFillWin = window;
   } else {
     if (nullptr == window) {
-      if (NULL == m_lastShownColorFillWin)
+      if (nullptr == m_lastShownColorFillWin)
         return nullptr;
       window = m_lastShownColorFillWin;
     }
@@ -3736,7 +3736,7 @@ Table *MantidUI::createTableFromBins(
     return nullptr;
 
   Table *t = new Table(appWindow()->scriptingEnv(), numRows,
-                       c * bins.size() + 1, "", appWindow(), 0);
+                       c * bins.size() + 1, "", appWindow(), nullptr);
   appWindow()->initTable(t, appWindow()->generateUniqueName(wsName + "-"));
 
   for (int i = 0; i < bins.size(); i++) {

--- a/MantidPlot/src/PythonScript.cpp
+++ b/MantidPlot/src/PythonScript.cpp
@@ -556,7 +556,7 @@ QVariant PythonScript::evaluateImpl() {
     if (pystring) {
       PyObject *asUTF8 =
           PyUnicode_EncodeUTF8(PyUnicode_AS_UNICODE(pystring),
-                               (int)PyUnicode_GET_DATA_SIZE(pystring), NULL);
+                               (int)PyUnicode_GET_DATA_SIZE(pystring), nullptr);
       Py_DECREF(pystring);
       if (asUTF8) {
         qret = QVariant(QString::fromUtf8(PyString_AS_STRING(asUTF8)));

--- a/MantidPlot/src/TiledWindow.cpp
+++ b/MantidPlot/src/TiledWindow.cpp
@@ -911,7 +911,7 @@ void TiledWindow::selectRange(int row1, int col1, int row2, int col2) {
 void TiledWindow::removeSelectionTo(TiledWindow::RemoveDestination to) {
   foreach (Tile *tile, m_selection) {
     MdiSubWindow *widget = removeTile(tile);
-    if (widget == NULL) {
+    if (widget == nullptr) {
       throw std::logic_error("TiledWindow: Empty tile is found in slection.");
     }
     sendWidgetTo(widget, to);

--- a/MantidPlot/src/importOPJ.cpp
+++ b/MantidPlot/src/importOPJ.cpp
@@ -1175,7 +1175,7 @@ bool ImportOPJ::importGraphs(const OPJFile &opj) {
       vector<text> texts = opj.layerTexts(g, l);
       if (style != GraphOptions::Pie) {
         for (size_t i = 0; i < texts.size(); ++i) {
-          addText(texts[i], graph, 0, layerRect, fFontScaleFactor, fXScale,
+          addText(texts[i], graph, nullptr, layerRect, fFontScaleFactor, fXScale,
                   fYScale);
         }
       }

--- a/MantidPlot/src/importOPJ.cpp
+++ b/MantidPlot/src/importOPJ.cpp
@@ -1175,8 +1175,8 @@ bool ImportOPJ::importGraphs(const OPJFile &opj) {
       vector<text> texts = opj.layerTexts(g, l);
       if (style != GraphOptions::Pie) {
         for (size_t i = 0; i < texts.size(); ++i) {
-          addText(texts[i], graph, nullptr, layerRect, fFontScaleFactor, fXScale,
-                  fYScale);
+          addText(texts[i], graph, nullptr, layerRect, fFontScaleFactor,
+                  fXScale, fYScale);
         }
       }
 

--- a/MantidPlot/src/origin/tree.hh
+++ b/MantidPlot/src/origin/tree.hh
@@ -713,7 +713,7 @@ typename tree<T, tree_node_allocator>::fixed_depth_iterator tree<T, tree_node_al
 template <class T, class tree_node_allocator>
 typename tree<T, tree_node_allocator>::sibling_iterator tree<T, tree_node_allocator>::begin(const iterator_base& pos) const
 	{
-	assert(pos.node!=0);
+	assert(pos.node!=nullptr);
 	if(pos.node->first_child==nullptr) {
 		return end(pos);
 		}
@@ -764,7 +764,7 @@ template <class T, class tree_node_allocator>
 template <typename iter>
 iter tree<T, tree_node_allocator>::parent(iter position) 
 	{
-	assert(position.node!=0);
+	assert(position.node!=nullptr);
 	return iter(position.node->parent);
 	}
 
@@ -1667,7 +1667,7 @@ template <class T, class tree_node_allocator>
 int tree<T, tree_node_allocator>::depth(const iterator_base& it) 
 	{
 	tree_node* pos=it.node;
-	assert(pos!=0);
+	assert(pos!=nullptr);
 	int ret=0;
 	while(pos->parent!=nullptr) {
 		pos=pos->parent;
@@ -2119,7 +2119,7 @@ tree<T, tree_node_allocator>::pre_order_iterator::pre_order_iterator(const sibli
 template <class T, class tree_node_allocator>
 typename tree<T, tree_node_allocator>::pre_order_iterator& tree<T, tree_node_allocator>::pre_order_iterator::operator++()
 	{
-	assert(this->node!=0);
+	assert(this->node!=nullptr);
 	if(!this->skip_current_children_ && this->node->first_child != nullptr) {
 		this->node=this->node->first_child;
 		}


### PR DESCRIPTION
Applied automatic fixes for uses of the `NULL` macro in MantidPlot code.

**To test:**
Ensure builds pass.
<!-- Instructions for testing. -->

Refs #22169 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
