### PR TITLE
Applied clang-tidy modernize-use-nullptr fixes for qt/

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
@@ -426,7 +426,7 @@ private:
   }
 
   MDHistoWorkspace *doCloneEmpty() const override {
-    return new MDHistoWorkspace(0);
+    return new MDHistoWorkspace(nullptr);
   }
 
   void makeSingleBinWithNaN(std::vector<coord_t> &x, std::vector<signal_t> &y,

--- a/qt/scientific_interfaces/General/DataComparison.cpp
+++ b/qt/scientific_interfaces/General/DataComparison.cpp
@@ -108,7 +108,7 @@ void DataComparison::addData() {
   m_uiForm.twCurrentData->blockSignals(true);
 
   // If this is a WorkspaceGroup then add all items
-  if (wsGroup != NULL) {
+  if (wsGroup != nullptr) {
     size_t numWs = wsGroup->size();
     for (size_t wsIdx = 0; wsIdx < numWs; wsIdx++) {
       addDataItem(wsGroup->getItem(wsIdx));
@@ -278,7 +278,7 @@ void DataComparison::removeSelectedData() {
 
     // Detach the old curve from the plot if it exists
     if (m_curves.contains(workspaceName))
-      m_curves[workspaceName]->attach(NULL);
+      m_curves[workspaceName]->attach(nullptr);
 
     selectedItems = m_uiForm.twCurrentData->selectedItems();
   }
@@ -304,7 +304,7 @@ void DataComparison::removeAllData() {
 
     // Detach the old curve from the plot if it exists
     if (m_curves.contains(workspaceName))
-      m_curves[workspaceName]->attach(NULL);
+      m_curves[workspaceName]->attach(nullptr);
   }
 
   // Replot the workspaces
@@ -353,7 +353,7 @@ void DataComparison::plotWorkspaces() {
 
       // Detech the curve from the plot
       if (m_curves.contains(workspaceName))
-        m_curves[workspaceName]->attach(NULL);
+        m_curves[workspaceName]->attach(nullptr);
 
       continue;
     }
@@ -369,7 +369,7 @@ void DataComparison::plotWorkspaces() {
 
     // Detach the old curve from the plot if it exists
     if (m_curves.contains(workspaceName))
-      m_curves[workspaceName]->attach(NULL);
+      m_curves[workspaceName]->attach(nullptr);
 
     QComboBox *colourSelector = dynamic_cast<QComboBox *>(
         m_uiForm.twCurrentData->cellWidget(row, COLOUR));
@@ -452,8 +452,8 @@ void DataComparison::workspaceIndexChanged() {
  */
 void DataComparison::plotDiffWorkspace() {
   // Detach old curve
-  if (m_diffCurve != NULL)
-    m_diffCurve->attach(NULL);
+  if (m_diffCurve != nullptr)
+    m_diffCurve->attach(nullptr);
 
   // Do nothing if there are not two workspaces
   if (m_diffWorkspaceNames.first.isEmpty() ||
@@ -682,7 +682,7 @@ void DataComparison::preDeleteHandle(
 
   // Detach the old curve from the plot if it exists
   if (m_curves.contains(oldWsName))
-    m_curves[oldWsName]->attach(NULL);
+    m_curves[oldWsName]->attach(nullptr);
 
   // Update the plot
   plotWorkspaces();
@@ -713,7 +713,7 @@ void DataComparison::renameHandle(const std::string &oldName,
 
   // Detach the old curve from the plot if it exists
   if (m_curves.contains(oldWsName))
-    m_curves[oldWsName]->attach(NULL);
+    m_curves[oldWsName]->attach(nullptr);
 
   // Update the plot
   plotWorkspaces();

--- a/qt/scientific_interfaces/General/MantidEV.cpp
+++ b/qt/scientific_interfaces/General/MantidEV.cpp
@@ -495,7 +495,7 @@ void MantidEV::setDefaultState_slot() {
  */
 void MantidEV::help_slot() {
   MantidQt::API::HelpWindow::showCustomInterface(
-      NULL, QString("SCD Event Data Reduction"));
+      nullptr, QString("SCD Event Data Reduction"));
 }
 
 /**

--- a/qt/scientific_interfaces/General/StepScan.cpp
+++ b/qt/scientific_interfaces/General/StepScan.cpp
@@ -410,7 +410,7 @@ void StepScan::expandPlotVarCombobox(
     // Try to cast to an ITimeSeriesProperty
     auto tsp = dynamic_cast<const ITimeSeriesProperty *>(*log);
     // Move on to the next one if this is not a TSP
-    if (tsp == NULL)
+    if (tsp == nullptr)
       continue;
     // Don't keep ones with only one entry
     if (tsp->realSize() < 2)

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
@@ -255,7 +255,7 @@ void ApplyAbsorptionCorrections::run() {
                            "Would you like to interpolate this workspace to "
                            "match the sample?";
 
-        result = QMessageBox::question(NULL, tr("Interpolate corrections?"),
+        result = QMessageBox::question(nullptr, tr("Interpolate corrections?"),
                                        tr(text.c_str()), QMessageBox::YesToAll,
                                        QMessageBox::Yes, QMessageBox::No);
       }

--- a/qt/scientific_interfaces/Indirect/ConvFit.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFit.cpp
@@ -709,7 +709,7 @@ double ConvFit::getInstrumentResolution(MatrixWorkspace_sptr workspace) const {
 
     // If the analyser component is not already in the data file then load it
     // from the parameter file
-    if (inst->getComponentByName(analyser) == NULL ||
+    if (inst->getComponentByName(analyser) == nullptr ||
         inst->getComponentByName(analyser)
                 ->getNumberParameter("resolution")
                 .size() == 0) {
@@ -729,7 +729,7 @@ double ConvFit::getInstrumentResolution(MatrixWorkspace_sptr workspace) const {
 
       inst = workspace->getInstrument();
     }
-    if (inst->getComponentByName(analyser) != NULL) {
+    if (inst->getComponentByName(analyser) != nullptr) {
       resolution = inst->getComponentByName(analyser)
                        ->getNumberParameter("resolution")[0];
     } else {

--- a/qt/scientific_interfaces/Indirect/IndirectDataReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReduction.cpp
@@ -177,9 +177,9 @@ void IndirectDataReduction::instrumentSetupChanged(
   m_instWorkspace = loadInstrumentIfNotExist(instrumentName.toStdString(),
                                              analyser.toStdString(),
                                              reflection.toStdString());
-  instrumentLoadingDone(m_instWorkspace == NULL);
+  instrumentLoadingDone(m_instWorkspace == nullptr);
 
-  if (m_instWorkspace != NULL)
+  if (m_instWorkspace != nullptr)
     emit newInstrumentConfiguration();
 }
 
@@ -270,14 +270,14 @@ QMap<QString, QString> IndirectDataReduction::getInstrumentDetails() {
   if (instrumentName == "IRIS" && analyser == "fmica")
     analyser = "mica";
 
-  if (m_instWorkspace == NULL) {
+  if (m_instWorkspace == nullptr) {
     g_log.warning("Instrument workspace not loaded");
     return instDetails;
   }
 
   // Get the instrument
   auto instrument = m_instWorkspace->getInstrument();
-  if (instrument == NULL) {
+  if (instrument == nullptr) {
     g_log.warning("Instrument workspace has no instrument");
     return instDetails;
   }
@@ -292,7 +292,7 @@ QMap<QString, QString> IndirectDataReduction::getInstrumentDetails() {
 
       QString value = getInstrumentParameterFrom(instrument, key);
 
-      if (value.isEmpty() && component != NULL)
+      if (value.isEmpty() && component != nullptr)
         value = getInstrumentParameterFrom(component, key);
 
       instDetails[QString::fromStdString(key)] = value;

--- a/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.cpp
@@ -163,7 +163,7 @@ void IndirectDiffractionReduction::run() {
  */
 void IndirectDiffractionReduction::algorithmComplete(bool error) {
   // Handles completion of the diffraction algorithm chain
-  disconnect(m_batchAlgoRunner, 0, this, SLOT(algorithmComplete(bool)));
+  disconnect(m_batchAlgoRunner, nullptr, this, SLOT(algorithmComplete(bool)));
 
   // Delete grouping workspace, if created.
   if (AnalysisDataService::Instance().doesExist(m_groupingWsName)) {

--- a/qt/scientific_interfaces/Indirect/IndirectTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTab.cpp
@@ -112,7 +112,7 @@ void IndirectTab::exportPythonScript() {
   // Create an algorithm dialog for the script export algorithm
   MantidQt::API::InterfaceManager interfaceManager;
   MantidQt::API::AlgorithmDialog *dlg = interfaceManager.createDialogFromName(
-      "GeneratePythonScript", -1, NULL, false, props, "", enabled);
+      "GeneratePythonScript", -1, nullptr, false, props, "", enabled);
 
   // Show the dialog
   dlg->show();

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -2591,7 +2591,7 @@ void MuonAnalysis::changeTab(int newTabIndex) {
   if (m_currentTab == m_uiForm.DataAnalysis) // Leaving DA tab
   {
     // Say MantidPlot to use default fit prop. browser
-    emit setFitPropertyBrowser(NULL);
+    emit setFitPropertyBrowser(nullptr);
 
     // Reset cached config option
     ConfigService::Instance().setString(PEAK_RADIUS_CONFIG, m_cachedPeakRadius);
@@ -2909,7 +2909,7 @@ void MuonAnalysis::hideEvent(QHideEvent *) {
 
   // If closed while on DA tab, reassign fit property browser to default one
   if (m_currentTab == m_uiForm.DataAnalysis)
-    emit setFitPropertyBrowser(NULL);
+    emit setFitPropertyBrowser(nullptr);
 }
 
 /**

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GridDelegate.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GridDelegate.h
@@ -7,7 +7,8 @@ namespace DataProcessor {
 
 class GridDelegate : public QStyledItemDelegate {
 public:
-  explicit GridDelegate(QObject *parent = nullptr) : QStyledItemDelegate(parent){};
+  explicit GridDelegate(QObject *parent = nullptr)
+      : QStyledItemDelegate(parent){};
 
   void paint(QPainter *painter, const QStyleOptionViewItem &option,
              const QModelIndex &index) const override {

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GridDelegate.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/GridDelegate.h
@@ -7,7 +7,7 @@ namespace DataProcessor {
 
 class GridDelegate : public QStyledItemDelegate {
 public:
-  explicit GridDelegate(QObject *parent = 0) : QStyledItemDelegate(parent){};
+  explicit GridDelegate(QObject *parent = nullptr) : QStyledItemDelegate(parent){};
 
   void paint(QPainter *painter, const QStyleOptionViewItem &option,
              const QModelIndex &index) const override {

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FindFilesThreadPoolManagerMockObjects.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FindFilesThreadPoolManagerMockObjects.h
@@ -19,7 +19,7 @@ void qSleep(int ms) {
   Sleep(uint(ms));
 #else
   struct timespec ts = {ms / 1000, (ms % 1000) * 1000 * 1000};
-  nanosleep(&ts, NULL);
+  nanosleep(&ts, nullptr);
 #endif
 }
 } // namespace

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MantidHelpWindow.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MantidHelpWindow.h
@@ -20,7 +20,7 @@ class EXPORT_OPT_MANTIDQT_COMMON MantidHelpWindow
   Q_OBJECT
 
 public:
-  MantidHelpWindow(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  MantidHelpWindow(QWidget *parent = nullptr, Qt::WindowFlags flags = nullptr);
   ~MantidHelpWindow() override;
 
   void showPage(const std::string &url = std::string()) override;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtpropertymanager.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtpropertymanager.h
@@ -1138,7 +1138,7 @@ static void setMinimumValue(
     QtProperty *property, const Value &minVal) {
   void (PropertyManagerPrivate::*setSubPropertyRange)(
       QtProperty *, ValueChangeParameter, ValueChangeParameter,
-      ValueChangeParameter) = 0;
+      ValueChangeParameter) = nullptr;
   setBorderValue<ValueChangeParameter, PropertyManagerPrivate, PropertyManager,
                  Value, PrivateData>(
       manager, managerPrivate, propertyChangedSignal, valueChangedSignal,
@@ -1160,7 +1160,7 @@ static void setMaximumValue(
     QtProperty *property, const Value &maxVal) {
   void (PropertyManagerPrivate::*setSubPropertyRange)(
       QtProperty *, ValueChangeParameter, ValueChangeParameter,
-      ValueChangeParameter) = 0;
+      ValueChangeParameter) = nullptr;
   setBorderValue<ValueChangeParameter, PropertyManagerPrivate, PropertyManager,
                  Value, PrivateData>(
       manager, managerPrivate, propertyChangedSignal, valueChangedSignal,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/pqHelpWindow.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/pqHelpWindow.h
@@ -75,8 +75,8 @@ class EXPORT_OPT_MANTIDQT_COMMON pqHelpWindow : public QMainWindow {
   using Superclass = QMainWindow;
 
 public:
-  pqHelpWindow(QHelpEngine *engine, QWidget *parent = 0,
-               Qt::WindowFlags flags = 0);
+  pqHelpWindow(QHelpEngine *engine, QWidget *parent = nullptr,
+               Qt::WindowFlags flags = nullptr);
 
 public slots:
   /// Requests showing of a particular page. The url must begin with "qthelp:"

--- a/qt/widgets/common/src/AlgorithmSelectorWidget.cpp
+++ b/qt/widgets/common/src/AlgorithmSelectorWidget.cpp
@@ -293,7 +293,7 @@ void AlgorithmTreeWidget::update() {
         this->addTopLevelItem(catItem);
       } else {
         QString cn = subCats[0];
-        QTreeWidgetItem *catItem = NULL;
+        QTreeWidgetItem *catItem = nullptr;
         int n = subCats.size();
         for (int j = 0; j < n; j++) {
           if (categories.contains(cn)) {

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1784,8 +1784,8 @@ void FitPropertyBrowser::postDeleteHandle(const std::string &wsName) {
  */
 bool FitPropertyBrowser::isWorkspaceValid(
     Mantid::API::Workspace_sptr ws) const {
-  return (dynamic_cast<Mantid::API::MatrixWorkspace *>(ws.get()) != 0 ||
-          dynamic_cast<Mantid::API::ITableWorkspace *>(ws.get()) != 0);
+  return (dynamic_cast<Mantid::API::MatrixWorkspace *>(ws.get()) != nullptr ||
+          dynamic_cast<Mantid::API::ITableWorkspace *>(ws.get()) != nullptr);
 }
 
 bool FitPropertyBrowser::isWorkspaceAGroup() const {

--- a/qt/widgets/common/src/MantidWSIndexDialog.cpp
+++ b/qt/widgets/common/src/MantidWSIndexDialog.cpp
@@ -207,7 +207,7 @@ QMultiMap<QString, std::set<int>> MantidWSIndexWidget::getPlots() const {
           boost::dynamic_pointer_cast<const Mantid::API::MatrixWorkspace>(
               Mantid::API::AnalysisDataService::Instance().retrieve(
                   m_wsNames[i].toStdString()));
-      if (NULL == ws)
+      if (nullptr == ws)
         continue;
 
       const Mantid::spec2index_map spec2index =
@@ -690,7 +690,7 @@ void MantidWSIndexWidget::checkForSpectraAxes() {
         boost::dynamic_pointer_cast<const Mantid::API::MatrixWorkspace>(
             Mantid::API::AnalysisDataService::Instance().retrieve(
                 (*it).toStdString()));
-    if (NULL == ws)
+    if (nullptr == ws)
       continue;
     bool hasSpectra = false;
     for (int i = 0; i < ws->axes(); i++) {
@@ -718,7 +718,7 @@ void MantidWSIndexWidget::generateWsIndexIntervals() {
         boost::dynamic_pointer_cast<const Mantid::API::MatrixWorkspace>(
             Mantid::API::AnalysisDataService::Instance().retrieve(
                 (*it).toStdString()));
-    if (NULL == ws)
+    if (nullptr == ws)
       continue;
 
     const int endWs = static_cast<int>(ws->getNumberHistograms() -

--- a/qt/widgets/common/src/MultifitSetupDialog.cpp
+++ b/qt/widgets/common/src/MultifitSetupDialog.cpp
@@ -32,7 +32,7 @@ MultifitSetupDialog::MultifitSetupDialog(FitPropertyBrowser *fitBrowser)
     ui.paramTable->insertRow(ui.paramTable->rowCount());
     model->setData(model->index(j, 0),
                    QString::fromStdString(f->parameterName(i)));
-    ui.paramTable->item(j, 0)->setFlags(0);
+    ui.paramTable->item(j, 0)->setFlags(nullptr);
     model->setData(model->index(j, 1), "");
     ui.paramTable->item(j, 1)->setCheckState(Qt::Unchecked);
   }

--- a/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
@@ -1042,7 +1042,7 @@ bool MuonFitPropertyBrowser::isWorkspaceValid(Workspace_sptr ws) const {
   if (workspaceName.endsWith("_Workspace"))
     return false;
 
-  return dynamic_cast<MatrixWorkspace *>(ws.get()) != 0;
+  return dynamic_cast<MatrixWorkspace *>(ws.get()) != nullptr;
 }
 
 void MuonFitPropertyBrowser::finishHandle(const IAlgorithm *alg) {

--- a/qt/widgets/common/src/PropertyHandler.cpp
+++ b/qt/widgets/common/src/PropertyHandler.cpp
@@ -927,9 +927,9 @@ Mantid::API::IFunction_sptr PropertyHandler::changeType(QtProperty *prop) {
       f = Mantid::API::FunctionFactory::Instance().createFunction(
           fnName.toStdString());
     } catch (std::exception &e) {
-      QMessageBox::critical(nullptr, "Mantid - Error", "Cannot create function " +
-                                                        fnName + "\n" +
-                                                        e.what());
+      QMessageBox::critical(nullptr, "Mantid - Error",
+                            "Cannot create function " + fnName + "\n" +
+                                e.what());
       return Mantid::API::IFunction_sptr();
     }
 

--- a/qt/widgets/common/src/PropertyHandler.cpp
+++ b/qt/widgets/common/src/PropertyHandler.cpp
@@ -44,7 +44,7 @@ PropertyHandler::~PropertyHandler() {}
 /// overrides virtual init() which is called from IFunction::setHandler(...)
 void PropertyHandler::init() {
   m_browser->m_changeSlotsEnabled = false;
-  if (m_parent == NULL) { // the root composite function
+  if (m_parent == nullptr) { // the root composite function
     m_item = m_browser->m_functionsGroup;
   } else if (m_item == nullptr) {
     if (!m_parent->getHandler()) {
@@ -538,7 +538,7 @@ PropertyHandler::findCompositeFunction(QtBrowserItem *item) const {
   for (size_t i = 0; i < m_cf->nFunctions(); i++) {
     Mantid::API::CompositeFunction_const_sptr res =
         getHandler(i)->findCompositeFunction(item);
-    if (res != NULL)
+    if (res != nullptr)
       return res;
   }
   return Mantid::API::CompositeFunction_sptr();
@@ -555,7 +555,7 @@ PropertyHandler::findFunction(QtBrowserItem *item) const {
     return Mantid::API::IFunction_sptr();
   for (size_t i = 0; i < m_cf->nFunctions(); i++) {
     Mantid::API::IFunction_const_sptr res = getHandler(i)->findFunction(item);
-    if (res != NULL)
+    if (res != nullptr)
       return res;
   }
   return Mantid::API::IFunction_sptr();
@@ -927,7 +927,7 @@ Mantid::API::IFunction_sptr PropertyHandler::changeType(QtProperty *prop) {
       f = Mantid::API::FunctionFactory::Instance().createFunction(
           fnName.toStdString());
     } catch (std::exception &e) {
-      QMessageBox::critical(NULL, "Mantid - Error", "Cannot create function " +
+      QMessageBox::critical(nullptr, "Mantid - Error", "Cannot create function " +
                                                         fnName + "\n" +
                                                         e.what());
       return Mantid::API::IFunction_sptr();

--- a/qt/widgets/common/src/QtPropertyBrowser/qteditorfactory.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qteditorfactory.cpp
@@ -841,7 +841,7 @@ void QtLineEditFactoryPrivate::slotRegExpChanged(QtProperty *property,
     QLineEdit *editor = itEditor.next();
     editor->blockSignals(true);
     const QValidator *oldValidator = editor->validator();
-    QValidator *newValidator = 0;
+    QValidator *newValidator = nullptr;
     if (regExp.isValid()) {
       newValidator = new QRegExpValidator(regExp, editor);
     }

--- a/qt/widgets/common/src/QtPropertyBrowser/qtpropertybrowser.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtpropertybrowser.cpp
@@ -1783,7 +1783,7 @@ QtAbstractPropertyBrowser::insertProperty(QtProperty *property,
   while (pos < pendingList.count()) {
     QtProperty *prop = pendingList.at(pos);
     if (prop == property)
-      return 0;
+      return nullptr;
     if (prop == afterProperty) {
       newPos = pos + 1;
     }
@@ -1819,10 +1819,10 @@ void QtAbstractPropertyBrowser::removeProperty(QtProperty *property) {
     if (pendingList.at(pos) == property) {
       d_ptr->m_subItems.removeAt(pos); // perhaps this two lines
       d_ptr->removeSubTree(
-          property, 0); // should be moved down after propertyRemoved call.
+          property, nullptr); // should be moved down after propertyRemoved call.
       // propertyRemoved(property, 0);
 
-      d_ptr->removeBrowserIndexes(property, 0);
+      d_ptr->removeBrowserIndexes(property, nullptr);
 
       // when item is deleted, item will call removeItem for top level items,
       // and itemRemoved for nested items.

--- a/qt/widgets/common/src/QtPropertyBrowser/qtpropertybrowser.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtpropertybrowser.cpp
@@ -1819,7 +1819,8 @@ void QtAbstractPropertyBrowser::removeProperty(QtProperty *property) {
     if (pendingList.at(pos) == property) {
       d_ptr->m_subItems.removeAt(pos); // perhaps this two lines
       d_ptr->removeSubTree(
-          property, nullptr); // should be moved down after propertyRemoved call.
+          property,
+          nullptr); // should be moved down after propertyRemoved call.
       // propertyRemoved(property, 0);
 
       d_ptr->removeBrowserIndexes(property, nullptr);

--- a/qt/widgets/common/src/QtPropertyBrowser/qtpropertybrowserutils.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtpropertybrowserutils.cpp
@@ -97,7 +97,7 @@
 namespace {
 // Translation function for Qt4/Qt5. Qt5 has no encoding option
 QString translateUtf8Encoded(const char *context, const char *key,
-                             const char *disambiguation = 0, int n = -1) {
+                             const char *disambiguation = nullptr, int n = -1) {
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   return QApplication::translate(context, key, disambiguation,
                                  QApplication::UnicodeUTF8, n);

--- a/qt/widgets/common/src/QtPropertyBrowser/qttreepropertybrowser.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qttreepropertybrowser.cpp
@@ -103,7 +103,7 @@
 namespace {
 // Translation function for Qt4/Qt5. Qt5 has no encoding option
 QString translateUtf8Encoded(const char *context, const char *key,
-                             const char *disambiguation = 0, int n = -1) {
+                             const char *disambiguation = nullptr, int n = -1) {
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   return QApplication::translate(context, key, disambiguation,
                                  QApplication::UnicodeUTF8, n);
@@ -483,8 +483,8 @@ QtBrowserItem *QtTreePropertyBrowserPrivate::currentItem() const {
 void QtTreePropertyBrowserPrivate::setCurrentItem(QtBrowserItem *browserItem,
                                                   bool block) {
   const bool blocked = block ? m_treeWidget->blockSignals(true) : false;
-  if (browserItem == 0)
-    m_treeWidget->setCurrentItem(0);
+  if (browserItem == nullptr)
+    m_treeWidget->setCurrentItem(nullptr);
   else
     m_treeWidget->setCurrentItem(m_indexToItem.value(browserItem));
   if (block)
@@ -575,7 +575,7 @@ void QtTreePropertyBrowserPrivate::propertyRemoved(QtBrowserItem *index) {
   QTreeWidgetItem *item = m_indexToItem.value(index);
 
   if (m_treeWidget->currentItem() == item) {
-    m_treeWidget->setCurrentItem(0);
+    m_treeWidget->setCurrentItem(nullptr);
   }
 
   delete item;

--- a/qt/widgets/common/src/SaveWorkspaces.cpp
+++ b/qt/widgets/common/src/SaveWorkspaces.cpp
@@ -446,7 +446,7 @@ void SaveWorkspaces::saveFileBrowse() {
                                     ? QFileDialog::DontConfirmOverwrite
                                     : static_cast<QFileDialog::Option>(0);
   QString oFile = QFileDialog::getSaveFileName(this, title, prevPath, filter,
-                                               NULL, userCon);
+                                               nullptr, userCon);
 
   if (!oFile.isEmpty()) {
     m_fNameEdit->setText(oFile);

--- a/qt/widgets/common/src/SlitCalculator.cpp
+++ b/qt/widgets/common/src/SlitCalculator.cpp
@@ -62,8 +62,8 @@ void SlitCalculator::setupSlitCalculatorWithInstrumentValues(
   auto slit2Component = instrument->getComponentByName("slit2");
   auto sampleComponent = instrument->getComponentByName("some-surface-holder");
   // check that they have been fetched from the IDF
-  if (slit1Component.get() != NULL && slit2Component.get() != NULL &&
-      sampleComponent.get() != NULL) {
+  if (slit1Component.get() != nullptr && slit2Component.get() != nullptr &&
+      sampleComponent.get() != nullptr) {
     // convert from meters to millimeters
     const double s1s2 = 1e3 * (slit1Component->getDistance(*slit2Component));
     // set value in field of slitCalculator

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
@@ -491,7 +491,7 @@ void WorkspaceTreeWidget::filterWorkspaces(const std::string &filterText) {
               item->setHidden(false);
             }
 
-            if (item->parent() == NULL) {
+            if (item->parent() == nullptr) {
               // No parent, I am a top level workspace - show me
               item->setHidden(false);
             } else {

--- a/qt/widgets/common/src/WorkspaceSelector.cpp
+++ b/qt/widgets/common/src/WorkspaceSelector.cpp
@@ -145,7 +145,7 @@ void WorkspaceSelector::setValidatingAlgorithm(const QString &algName) {
         // try to cast property to WorkspaceProperty
         Mantid::API::WorkspaceProperty<> *wsProp =
             dynamic_cast<Mantid::API::WorkspaceProperty<> *>(*it);
-        if (wsProp != NULL) {
+        if (wsProp != nullptr) {
           m_algPropName = QString::fromStdString((*it)->name());
           break;
         }

--- a/qt/widgets/common/src/pqHelpWindow.cxx
+++ b/qt/widgets/common/src/pqHelpWindow.cxx
@@ -146,7 +146,7 @@ public:
   pqNetworkAccessManager(QHelpEngineCore *helpEngine,
                          QNetworkAccessManager *manager, QObject *parentObject)
       : Superclass(parentObject), Engine(helpEngine) {
-    Q_ASSERT(manager != NULL && helpEngine != NULL);
+    Q_ASSERT(manager != nullptr && helpEngine != nullptr);
 
     this->setCache(manager->cache());
     this->setCookieJar(manager->cookieJar());
@@ -205,7 +205,7 @@ private:
 pqHelpWindow::pqHelpWindow(QHelpEngine *engine, QWidget *parentObject,
                            Qt::WindowFlags parentFlags)
     : Superclass(parentObject, parentFlags), m_helpEngine(engine) {
-  Q_ASSERT(engine != NULL);
+  Q_ASSERT(engine != nullptr);
 
   Ui::pqHelpWindow ui;
   ui.setupUi(this);

--- a/qt/widgets/instrumentview/src/ProjectionSurface.cpp
+++ b/qt/widgets/instrumentview/src/ProjectionSurface.cpp
@@ -767,7 +767,7 @@ void ProjectionSurface::clearComparisonPeaks() {
 */
 void ProjectionSurface::setPeakLabelPrecision(int n) {
   if (n < 1) {
-    QMessageBox::critical(NULL, "MantidPlot - Error",
+    QMessageBox::critical(nullptr, "MantidPlot - Error",
                           "Precision must be a positive number");
     return;
   }

--- a/qt/widgets/legacyqwt/src/MWView.cpp
+++ b/qt/widgets/legacyqwt/src/MWView.cpp
@@ -185,7 +185,7 @@ void MWView::loadSettings() {
   // used.
   // If the user selected a unified color map for the SliceViewer and the VSI,
   // then this is loaded.
-  if (m_mdSettings != NULL && m_mdSettings->getUsageGeneralMdColorMap()) {
+  if (m_mdSettings != nullptr && m_mdSettings->getUsageGeneralMdColorMap()) {
     m_currentColorMapFile = m_mdSettings->getGeneralMdColorMapFile();
   } else {
     m_currentColorMapFile = settings.value("ColormapFile", "").toString();

--- a/qt/widgets/legacyqwt/src/MantidQwtIMDWorkspaceData.cpp
+++ b/qt/widgets/legacyqwt/src/MantidQwtIMDWorkspaceData.cpp
@@ -316,7 +316,7 @@ void MantidQwtIMDWorkspaceData::choosePlotAxis() {
         regularBinnedMDWorkspace = atLeastOneDimNotIntegrated;
       }
 
-      if (NULL !=
+      if (nullptr !=
               boost::dynamic_pointer_cast<const Mantid::API::IMDHistoWorkspace>(
                   originalWS) ||
           regularBinnedMDWorkspace) {

--- a/qt/widgets/plugins/algorithm_dialogs/src/LoadDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/LoadDialog.cpp
@@ -216,7 +216,7 @@ void LoadDialog::tieStaticWidgets(const bool readHistory) {
   }
   tie(m_form.workspaceEdit, "OutputWorkspace", m_form.workspaceLayout,
       readHistory);
-  tie(m_form.fileWidget, "Filename", NULL, readHistory);
+  tie(m_form.fileWidget, "Filename", nullptr, readHistory);
 }
 
 /**
@@ -386,7 +386,7 @@ int LoadDialog::createWidgetsForProperty(const Mantid::Kernel::Property *prop,
   if (addValidator)
     tie(inputWidget, propName, widgetLayout);
   else
-    tie(inputWidget, propName, NULL);
+    tie(inputWidget, propName, nullptr);
 
   return inputWidget->geometry().height();
 }

--- a/qt/widgets/sliceviewer/src/ConcretePeaksPresenter.cpp
+++ b/qt/widgets/sliceviewer/src/ConcretePeaksPresenter.cpp
@@ -286,7 +286,7 @@ bool ConcretePeaksPresenter::isDimensionNameOfFreeAxis(
  Request that each owned view makes its self visible.
  */
 void ConcretePeaksPresenter::showAll() {
-  if (m_viewPeaks != NULL)
+  if (m_viewPeaks != nullptr)
     m_viewPeaks->showView();
 }
 
@@ -295,7 +295,7 @@ void ConcretePeaksPresenter::showAll() {
  */
 void ConcretePeaksPresenter::hideAll() {
   // Hide all views.
-  if (m_viewPeaks != NULL)
+  if (m_viewPeaks != nullptr)
     m_viewPeaks->hideView();
 }
 
@@ -319,7 +319,7 @@ PeakViewColor ConcretePeaksPresenter::getForegroundPeakViewColor() const {
 
 void ConcretePeaksPresenter::setForegroundColor(const PeakViewColor color) {
   // Change foreground colors
-  if (m_viewPeaks != NULL) {
+  if (m_viewPeaks != nullptr) {
     m_viewPeaks->changeForegroundColour(color);
     m_viewPeaks->updateView();
   }
@@ -329,7 +329,7 @@ void ConcretePeaksPresenter::setForegroundColor(const PeakViewColor color) {
 
 void ConcretePeaksPresenter::setBackgroundColor(const PeakViewColor color) {
   // Change background colours
-  if (m_viewPeaks != NULL) {
+  if (m_viewPeaks != nullptr) {
     m_viewPeaks->changeBackgroundColour(color);
     m_viewPeaks->updateView();
   }
@@ -343,7 +343,7 @@ std::string ConcretePeaksPresenter::getTransformName() const {
 
 void ConcretePeaksPresenter::showBackgroundRadius(const bool show) {
   // Change background colours
-  if (m_viewPeaks != NULL) {
+  if (m_viewPeaks != nullptr) {
     m_viewPeaks->showBackgroundRadius(show);
     doFindPeaksInRegion();
   }
@@ -353,7 +353,7 @@ void ConcretePeaksPresenter::showBackgroundRadius(const bool show) {
 
 void ConcretePeaksPresenter::setShown(const bool shown) {
   m_isHidden = !shown;
-  if (m_viewPeaks != NULL) {
+  if (m_viewPeaks != nullptr) {
     if (shown) {
       m_viewPeaks->showView();
     } else {
@@ -417,7 +417,7 @@ void ConcretePeaksPresenter::setPeakSizeIntoProjection(const double fraction) {
 
 double ConcretePeaksPresenter::getPeakSizeOnProjection() const {
   double result = 0;
-  if (m_viewPeaks != NULL && m_peaksWS->getNumberPeaks() > 0) {
+  if (m_viewPeaks != nullptr && m_peaksWS->getNumberPeaks() > 0) {
     result = m_viewPeaks->getOccupancyInView();
   }
   return result;
@@ -425,7 +425,7 @@ double ConcretePeaksPresenter::getPeakSizeOnProjection() const {
 
 double ConcretePeaksPresenter::getPeakSizeIntoProjection() const {
   double result = 0;
-  if (m_viewPeaks != NULL && m_peaksWS->getNumberPeaks() > 0) {
+  if (m_viewPeaks != nullptr && m_peaksWS->getNumberPeaks() > 0) {
     result = m_viewPeaks->getOccupancyIntoView();
   }
   return result;

--- a/qt/widgets/sliceviewer/src/SliceViewer.cpp
+++ b/qt/widgets/sliceviewer/src/SliceViewer.cpp
@@ -261,7 +261,7 @@ void SliceViewer::loadSettings() {
   // used.
   // If the user selected a unified color map for the SliceViewer and the VSI,
   // then this is loaded.
-  if (m_mdSettings != NULL && m_mdSettings->getUsageGeneralMdColorMap()) {
+  if (m_mdSettings != nullptr && m_mdSettings->getUsageGeneralMdColorMap()) {
     m_currentColorMapFile = m_mdSettings->getGeneralMdColorMapFile();
   } else {
     m_currentColorMapFile = settings.value("ColormapFile", "").toString();

--- a/qt/widgets/sliceviewer/src/SliceViewerWindow.cpp
+++ b/qt/widgets/sliceviewer/src/SliceViewerWindow.cpp
@@ -32,7 +32,7 @@ namespace SliceViewer {
  */
 SliceViewerWindow::SliceViewerWindow(const QString &wsName,
                                      const QString &label, Qt::WindowFlags f)
-    : QMainWindow(NULL, f), WorkspaceObserver(), m_lastLinerWidth(0),
+    : QMainWindow(nullptr, f), WorkspaceObserver(), m_lastLinerWidth(0),
       m_lastPeaksViewerWidth(0) {
 
 #ifdef Q_OS_MAC

--- a/qt/widgets/spectrumviewer/src/MatrixWSDataSource.cpp
+++ b/qt/widgets/spectrumviewer/src/MatrixWSDataSource.cpp
@@ -262,7 +262,7 @@ std::vector<std::string> MatrixWSDataSource::getInfoList(double x, double y) {
 
   try {
 
-    if (old_unit) {
+    if (!old_unit) {
       g_log.debug("No UNITS on MatrixWorkspace X-axis");
       return list;
     }

--- a/qt/widgets/spectrumviewer/src/MatrixWSDataSource.cpp
+++ b/qt/widgets/spectrumviewer/src/MatrixWSDataSource.cpp
@@ -242,7 +242,7 @@ std::vector<std::string> MatrixWSDataSource::getInfoList(double x, double y) {
 
   std::string x_label = "";
   Unit_sptr &old_unit = m_matWs->getAxis(0)->unit();
-  if (old_unit != 0) {
+  if (old_unit != nullptr) {
     x_label = old_unit->caption();
     SVUtils::PushNameValue(x_label, 8, 3, x, list);
   }
@@ -262,7 +262,7 @@ std::vector<std::string> MatrixWSDataSource::getInfoList(double x, double y) {
 
   try {
 
-    if (old_unit == 0) {
+    if (old_unit == nullptr) {
       g_log.debug("No UNITS on MatrixWorkspace X-axis");
       return list;
     }

--- a/qt/widgets/spectrumviewer/src/MatrixWSDataSource.cpp
+++ b/qt/widgets/spectrumviewer/src/MatrixWSDataSource.cpp
@@ -242,7 +242,7 @@ std::vector<std::string> MatrixWSDataSource::getInfoList(double x, double y) {
 
   std::string x_label = "";
   Unit_sptr &old_unit = m_matWs->getAxis(0)->unit();
-  if (old_unit != nullptr) {
+  if (old_unit) {
     x_label = old_unit->caption();
     SVUtils::PushNameValue(x_label, 8, 3, x, list);
   }
@@ -262,7 +262,7 @@ std::vector<std::string> MatrixWSDataSource::getInfoList(double x, double y) {
 
   try {
 
-    if (old_unit == nullptr) {
+    if (old_unit) {
       g_log.debug("No UNITS on MatrixWorkspace X-axis");
       return list;
     }


### PR DESCRIPTION
Applied automatic fixes for uses of the `NULL` macro in `qt/` code.

**To test:**
Ensure builds pass.
<!-- Instructions for testing. -->

Refs #22169 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
