### PR TITLE
Update mslice to fix issue with matplotlib < 1.5

### DIFF
--- a/scripts/ExternalInterfaces/CMakeLists.txt
+++ b/scripts/ExternalInterfaces/CMakeLists.txt
@@ -6,7 +6,7 @@ set ( _mslice_external_root ${CMAKE_CURRENT_BINARY_DIR}/mslice )
 ExternalProject_Add ( mslice
   PREFIX ${_mslice_external_root}
   GIT_REPOSITORY "https://github.com/mantidproject/mslice.git"
-  GIT_TAG 560cc9351596b0078b201b9e1785e3c5a745f375
+  GIT_TAG 01292c88ccc508acb16735aa5f96450e076161bb
   EXCLUDE_FROM_ALL 1
 
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
Description of work.

Updates `sha1` for mslice to fix bug with `matplotlib < 1.5`. Changes in mantidproject/mslice#292.

**To test:**

* Start MantidPlot
* Interfaces -> MSlice
* See that it starts

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
