### PR TITLE
Fixed categories to remove Python algorithm

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LoadEXED.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadEXED.py
@@ -24,7 +24,7 @@ class LoadEXED(PythonAlgorithm):
     """
 
     def category(self):
-        return "Inelastic;Diffraction;PythonAlgorithms"
+        return "Inelastic;Diffraction"
 
     def name(self):
         return "LoadEXED"

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectSampleChanger.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectSampleChanger.py
@@ -16,7 +16,7 @@ class IndirectSampleChanger(DataProcessorAlgorithm):
     _q1_workspaces = None
 
     def category(self):
-        return "Workflow\\MIDAS;PythonAlgorithms"
+        return "Workflow\\MIDAS"
 
     def summary(self):
         return "Create elastic window scans for sample changer"


### PR DESCRIPTION
Very quick job to remove `LoadEXED.py` and `IndirectSampleChanger.py` from the `Python Algorithms` category. No algorithms should remain in the `Python Algorithms` category in documentation.

**To test:**

* Open Mantid; ensure that `Python Algorithms` does not appear in the menu of the `Algorithms` dialog.
 
* Check `.html` docs:
    * In the build directory go to `docs/` directory
    * `python runsphinx_html.py`
    * `open html/algorithms/LoadEXED.html` and `open html/algorithms/IndirectSampleChanger.html`
    * Check that neither has `Python Algorithms` in `Categories` at the bottom of the page

**Release Notes** 

This does not go in the release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
