### PR TITLE
OSX Muon Interface (No need for data)

### DIFF
--- a/docs/source/release/v3.12.0/muon.rst
+++ b/docs/source/release/v3.12.0/muon.rst
@@ -38,6 +38,7 @@ Bug fixes
 #########
 
 - Log values are no longer filtered by start time when loaded into muon analysis.
+- Different options under `Settings`>`Data Binning` give different options for input (OSX bug, see Issue ##22167). Fixed in patch.
 
 Algorithms
 ----------

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.ui
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.ui
@@ -51,7 +51,7 @@
        <string/>
       </property>
       <property name="currentIndex">
-       <number>4</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="Home">
        <attribute name="title">

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.ui
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.ui
@@ -51,7 +51,7 @@
        <string/>
       </property>
       <property name="currentIndex">
-       <number>0</number>
+       <number>4</number>
       </property>
       <widget class="QWidget" name="Home">
        <attribute name="title">
@@ -2260,7 +2260,7 @@ p, li { white-space: pre-wrap; }
             <property name="minimumSize">
              <size>
               <width>0</width>
-              <height>100</height>
+              <height>140</height>
              </size>
             </property>
             <property name="title">
@@ -2660,8 +2660,8 @@ p, li { white-space: pre-wrap; }
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>131</width>
-                     <height>23</height>
+                     <width>165</width>
+                     <height>26</height>
                     </rect>
                    </property>
                    <layout class="QHBoxLayout" name="horizontalLayout_KeepNPlots">

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.ui
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.ui
@@ -2389,6 +2389,12 @@ p, li { white-space: pre-wrap; }
                       <layout class="QGridLayout" name="gridLayout_29">
                        <item row="0" column="0">
                         <widget class="QLabel" name="optionBinStep_3">
+                         <property name="minimumSize">
+                          <size>
+                           <width>20</width>
+                           <height>30</height>
+                          </size>
+                         </property>
                          <property name="toolTip">
                           <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
@@ -2407,7 +2413,14 @@ p, li { white-space: pre-wrap; }
                         </widget>
                        </item>
                        <item row="0" column="1">
-                        <widget class="QLineEdit" name="binBoundaries"/>
+                        <widget class="QLineEdit" name="binBoundaries">
+                         <property name="minimumSize">
+                          <size>
+                           <width>10</width>
+                           <height>10</height>
+                          </size>
+                         </property>
+                        </widget>
                        </item>
                        <item row="0" column="2">
                         <spacer name="horizontalSpacer_8">
@@ -2432,6 +2445,12 @@ p, li { white-space: pre-wrap; }
                            <horstretch>0</horstretch>
                            <verstretch>0</verstretch>
                           </sizepolicy>
+                         </property>
+                         <property name="minimumSize">
+                          <size>
+                           <width>10</width>
+                           <height>10</height>
+                          </size>
                          </property>
                          <property name="maximumSize">
                           <size>


### PR DESCRIPTION
Description of work.

Fixing #22167. This is to ensure that the correct options appear in the `Muon Analysis` GUI, when switching between re-bin methods in the GUI under OSX.

**To test:**

* Test on OSX.
* Does not require data loading.
* Open `Interfaces`>`Muon`>`Muon Analysis`.
* Switch to the `Settings` tab.
* In `Data Binning` cycle through the options available from the drop down menu; you should see the following:
    * `None` results in a blank space on the right of the box.
    * `Fixed` results in an input space named `Steps`.
    * `Variable` results in an input space named `Bin Boundaries` and a `?` help button. 

Fixes #22167. 

**Release Notes** 

Edited `docs/source/release/v3.12.0/muon.rst`

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
