### PR TITLE
Update IMDIterator for greater memory safety

### DIFF
--- a/Framework/API/inc/MantidAPI/CompositeDomainMD.h
+++ b/Framework/API/inc/MantidAPI/CompositeDomainMD.h
@@ -53,8 +53,8 @@ public:
   const FunctionDomain &getDomain(size_t i) const override;
 
 protected:
-  mutable IMDIterator *m_iterator; ///< IMDIterator
-  size_t m_totalSize;              ///< The total size of the domain
+  mutable std::unique_ptr<IMDIterator> m_iterator; ///< IMDIterator
+  size_t m_totalSize; ///< The total size of the domain
   mutable std::vector<FunctionDomainMD *>
       m_domains; ///< smaller parts of the domain
 };

--- a/Framework/API/inc/MantidAPI/FunctionDomainMD.h
+++ b/Framework/API/inc/MantidAPI/FunctionDomainMD.h
@@ -53,7 +53,7 @@ public:
 
 protected:
   /// IMDIterator
-  mutable IMDIterator *m_iterator;
+  mutable std::unique_ptr<IMDIterator> m_iterator;
   /// start of the domain, 0 <= m_startIndex < m_iterator->getDataSize()
   const size_t m_startIndex;
   /// track the iterator's index, 0 <= m_currentIndex < m_size.

--- a/Framework/API/inc/MantidAPI/IMDIterator.h
+++ b/Framework/API/inc/MantidAPI/IMDIterator.h
@@ -5,7 +5,6 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidAPI/DllConfig.h"
-#include "MantidAPI/IMDWorkspace.h"
 #include "MantidGeometry/MDGeometry/IMDDimension.h"
 #include "MantidGeometry/MDGeometry/MDTypes.h"
 #include "MantidKernel/VMD.h"
@@ -14,10 +13,18 @@
 namespace Mantid {
 
 namespace API {
-//----------------------------------------------------------------------
-// Forward declaration
-//----------------------------------------------------------------------
-class IMDWorkspace;
+
+/** Enum describing different ways to normalize the signal
+ * in a MDWorkspace.
+ */
+enum MDNormalization {
+  /// Don't normalize = return raw counts
+  NoNormalization = 0,
+  /// Divide the signal by the volume of the box/bin
+  VolumeNormalization = 1,
+  /// Divide the signal by the number of events that contributed to it.
+  NumEventsNormalization = 2
+};
 
 /** This is an interface to an iterator of an IMDWorkspace
 

--- a/Framework/API/inc/MantidAPI/IMDWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IMDWorkspace.h
@@ -1,6 +1,7 @@
 #ifndef MANTID_API_IMDWORKSPACE_H_
 #define MANTID_API_IMDWORKSPACE_H_
 
+#include "MantidAPI/IMDIterator.h"
 #include "MantidAPI/ITableWorkspace_fwd.h"
 #include "MantidAPI/MDGeometry.h"
 #include "MantidAPI/Workspace.h"
@@ -15,20 +16,6 @@ class MDImplicitFunction;
 }
 
 namespace API {
-
-class IMDIterator;
-
-/** Enum describing different ways to normalize the signal
- * in a MDWorkspace.
- */
-enum MDNormalization {
-  /// Don't normalize = return raw counts
-  NoNormalization = 0,
-  /// Divide the signal by the volume of the box/bin
-  VolumeNormalization = 1,
-  /// Divide the signal by the number of events that contributed to it.
-  NumEventsNormalization = 2
-};
 
 static const signal_t MDMaskValue = std::numeric_limits<double>::quiet_NaN();
 
@@ -106,7 +93,7 @@ public:
   virtual uint64_t getNEvents() const = 0;
 
   /// Creates a new iterator pointing to the first cell in the workspace
-  virtual std::vector<IMDIterator *> createIterators(
+  virtual std::vector<std::unique_ptr<IMDIterator>> createIterators(
       size_t suggestedNumCores = 1,
       Mantid::Geometry::MDImplicitFunction *function = nullptr) const = 0;
 
@@ -126,7 +113,7 @@ public:
                                const Mantid::Kernel::VMD &end,
                                Mantid::API::MDNormalization normalize) const;
 
-  IMDIterator *createIterator(
+  std::unique_ptr<IMDIterator> createIterator(
       Mantid::Geometry::MDImplicitFunction *function = nullptr) const;
 
   std::string getConvention() const;

--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -499,7 +499,7 @@ public:
       const Mantid::API::MDNormalization &normalization) const override;
   /// Create iterators. Partitions the iterators according to the number of
   /// cores.
-  std::vector<IMDIterator *> createIterators(
+  std::vector<std::unique_ptr<IMDIterator>> createIterators(
       size_t suggestedNumCores = 1,
       Mantid::Geometry::MDImplicitFunction *function = nullptr) const override;
 

--- a/Framework/API/src/FunctionDomainMD.cpp
+++ b/Framework/API/src/FunctionDomainMD.cpp
@@ -34,7 +34,7 @@ FunctionDomainMD::FunctionDomainMD(IMDWorkspace_const_sptr ws, size_t start,
 
 /** Destructor.
  */
-FunctionDomainMD::~FunctionDomainMD() { delete m_iterator; }
+FunctionDomainMD::~FunctionDomainMD() = default;
 
 /// Reset the iterator to point to the start of the domain.
 void FunctionDomainMD::reset() const {
@@ -53,14 +53,14 @@ void FunctionDomainMD::reset() const {
 const IMDIterator *FunctionDomainMD::getNextIterator() const {
   if (m_justReset) {
     m_justReset = false;
-    return m_iterator;
+    return m_iterator.get();
   }
   ++m_currentIndex;
   if (!m_iterator->next() || m_currentIndex >= m_size) {
     m_currentIndex = m_size;
     return nullptr;
   }
-  return m_iterator;
+  return m_iterator.get();
 }
 
 /// Returns the pointer to the original workspace

--- a/Framework/API/src/IMDWorkspace.cpp
+++ b/Framework/API/src/IMDWorkspace.cpp
@@ -26,15 +26,16 @@ IMDWorkspace::IMDWorkspace(const Parallel::StorageMode storageMode)
  * @param function :: Implicit function limiting space to look at
  * @return a single IMDIterator pointer
  */
-IMDIterator *IMDWorkspace::createIterator(
+std::unique_ptr<IMDIterator> IMDWorkspace::createIterator(
     Mantid::Geometry::MDImplicitFunction *function) const {
-  std::vector<IMDIterator *> iterators = this->createIterators(1, function);
+  std::vector<std::unique_ptr<IMDIterator>> iterators =
+      this->createIterators(1, function);
   if (iterators.empty())
     throw std::runtime_error("IMDWorkspace::createIterator(): iterator "
                              "creation was not successful. No iterators "
                              "returned by " +
                              this->id());
-  return iterators[0];
+  return std::move(iterators[0]);
 }
 
 //---------------------------------------------------------------------------------------------

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -1466,7 +1466,7 @@ MatrixWorkspace::getDimensionWithId(std::string id) const {
  * @param function :: implicit function to limit range
  * @return MatrixWorkspaceMDIterator vector
  */
-std::vector<IMDIterator *> MatrixWorkspace::createIterators(
+std::vector<std::unique_ptr<IMDIterator>> MatrixWorkspace::createIterators(
     size_t suggestedNumCores,
     Mantid::Geometry::MDImplicitFunction *function) const {
   // Find the right number of cores to use
@@ -1480,13 +1480,14 @@ std::vector<IMDIterator *> MatrixWorkspace::createIterators(
     numCores = 1;
 
   // Create one iterator per core, splitting evenly amongst spectra
-  std::vector<IMDIterator *> out;
+  std::vector<std::unique_ptr<IMDIterator>> out;
   for (size_t i = 0; i < numCores; i++) {
     size_t begin = (i * numElements) / numCores;
     size_t end = ((i + 1) * numElements) / numCores;
     if (end > numElements)
       end = numElements;
-    out.push_back(new MatrixWorkspaceMDIterator(this, function, begin, end));
+    out.push_back(Kernel::make_unique<MatrixWorkspaceMDIterator>(this, function,
+                                                                 begin, end));
   }
   return out;
 }

--- a/Framework/API/test/MatrixWorkspaceMDIteratorTest.h
+++ b/Framework/API/test/MatrixWorkspaceMDIteratorTest.h
@@ -52,7 +52,7 @@ public:
 
   void test_iterating() {
     boost::shared_ptr<MatrixWorkspace> ws = makeFakeWS();
-    IMDIterator *it = nullptr;
+    std::unique_ptr<IMDIterator> it;
     TS_ASSERT_THROWS_NOTHING(it = ws->createIterator(nullptr));
     TS_ASSERT_EQUALS(it->getDataSize(), 20);
     TS_ASSERT_DELTA(it->getSignal(), 0.0, 1e-5);
@@ -83,24 +83,21 @@ public:
     TS_ASSERT_DELTA(it->getError(), 22.0, 1e-5);
     TS_ASSERT_DELTA(it->getCenter()[0], 3.0, 1e-5);
     TS_ASSERT_DELTA(it->getCenter()[1], 2.0, 1e-5);
-    delete it;
   }
 
   /** Create a set of iterators that can be applied in parallel */
   void test_parallel_iterators() {
     boost::shared_ptr<MatrixWorkspace> ws = makeFakeWS();
     // The number of output cannot be larger than the number of histograms
-    std::vector<IMDIterator *> it = ws->createIterators(10, nullptr);
+    auto it = ws->createIterators(10, nullptr);
     TS_ASSERT_EQUALS(it.size(), 4);
-    for (size_t i = 0; i < it.size(); ++i)
-      delete it[i];
 
     // Split in 4 iterators
-    std::vector<IMDIterator *> iterators = ws->createIterators(4, nullptr);
+    auto iterators = ws->createIterators(4, nullptr);
     TS_ASSERT_EQUALS(iterators.size(), 4);
 
     for (size_t i = 0; i < iterators.size(); i++) {
-      IMDIterator *it = iterators[i];
+      IMDIterator *it = iterators[i].get();
       const double i_d = static_cast<double>(i);
       // Only 5 elements per each iterator
       TS_ASSERT_EQUALS(it->getDataSize(), 5);
@@ -116,19 +113,17 @@ public:
       TS_ASSERT(it->next());
       TS_ASSERT(it->next());
       TS_ASSERT(!it->next());
-      delete it;
     }
   }
 
   void test_get_is_masked() {
     boost::shared_ptr<MatrixWorkspace> ws = makeFakeWS();
-    IMDIterator *it = ws->createIterator(nullptr);
+    auto it = ws->createIterator(nullptr);
     const auto &spectrumInfo = ws->spectrumInfo();
     for (size_t i = 0; i < ws->getNumberHistograms(); ++i) {
       TS_ASSERT_EQUALS(spectrumInfo.isMasked(i), it->getIsMasked());
       it->next();
     }
-    delete it;
   }
 
   void testUnequalBins() {
@@ -141,11 +136,11 @@ public:
     TS_ASSERT_THROWS(ws->blocksize(), std::logic_error);
     TS_ASSERT_EQUALS(ws->size(), 17);
     // Split in 4 iterators
-    std::vector<IMDIterator *> iterators = ws->createIterators(4, nullptr);
+    auto iterators = ws->createIterators(4, nullptr);
     TS_ASSERT_EQUALS(iterators.size(), 4);
 
     for (size_t i = 0; i < iterators.size(); i++) {
-      IMDIterator *it = iterators[i];
+      auto it = iterators[i].get();
       const double i_d = static_cast<double>(i);
       if (i == 0) {
         // Only 5 elements per each iterator
@@ -174,7 +169,6 @@ public:
         TS_ASSERT(it->next());
       }
       TS_ASSERT(!it->next());
-      delete it;
     }
   }
 };

--- a/Framework/Crystal/src/ConnectedComponentLabeling.cpp
+++ b/Framework/Crystal/src/ConnectedComponentLabeling.cpp
@@ -288,9 +288,7 @@ ClusterMap ConnectedComponentLabeling::calculateDisjointTree(
   const int nThreadsToUse = getNThreads();
 
   if (nThreadsToUse > 1) {
-    std::vector<API::IMDIterator *> iterators =
-        ws->createIterators(nThreadsToUse);
-
+    auto iterators = ws->createIterators(nThreadsToUse);
     const size_t maxClustersPossible =
         calculateMaxClusters(ws.get(), nThreadsToUse);
 
@@ -303,7 +301,7 @@ ClusterMap ConnectedComponentLabeling::calculateDisjointTree(
     g_log.debug("Parallel solve local CCL");
     // PARALLEL_FOR_NO_WSP_CHECK()
     for (int i = 0; i < nThreadsToUse; ++i) {
-      API::IMDIterator *iterator = iterators[i];
+      API::IMDIterator *iterator = iterators[i].get();
       boost::scoped_ptr<BackgroundStrategy> strategy(
           baseStrategy->clone());                     // local strategy
       VecEdgeIndexPair &edgeVec = parallelEdgeVec[i]; // local edge indexes
@@ -364,12 +362,12 @@ ClusterMap ConnectedComponentLabeling::calculateDisjointTree(
     clusterMap = clusterRegister.clusters(neighbourElements);
 
   } else {
-    API::IMDIterator *iterator = ws->createIterator(nullptr);
+    auto iterator = ws->createIterator(nullptr);
     VecEdgeIndexPair edgeIndexPair; // This should never get filled in a single
                                     // threaded situation.
     size_t endLabelId = doConnectedComponentLabeling(
-        iterator, baseStrategy, neighbourElements, progress, maxNeighbours,
-        m_startId, edgeIndexPair);
+        iterator.get(), baseStrategy, neighbourElements, progress,
+        maxNeighbours, m_startId, edgeIndexPair);
 
     // Create clusters from labels.
     for (size_t labelId = m_startId; labelId != endLabelId; ++labelId) {
@@ -383,7 +381,7 @@ ClusterMap ConnectedComponentLabeling::calculateDisjointTree(
     iterator->jumpTo(0); // Reset
     do {
       const size_t currentIndex = iterator->getLinearIndex();
-      if (!baseStrategy->isBackground(iterator)) {
+      if (!baseStrategy->isBackground(iterator.get())) {
         const int labelAtIndex = neighbourElements[currentIndex].getRoot();
         clusterMap[labelAtIndex]->addIndex(currentIndex);
       }

--- a/Framework/Crystal/src/FindClusterFaces.cpp
+++ b/Framework/Crystal/src/FindClusterFaces.cpp
@@ -331,7 +331,7 @@ void FindClusterFaces::exec() {
   for (int it = 0; it < nIterators; ++it) {
     PARALLEL_START_INTERUPT_REGION
     ClusterFaces &localClusterFaces = clusterFaces[it];
-    auto mdIterator = mdIterators[it];
+    auto mdIterator = mdIterators[it].get();
 
     if (usingFiltering) {
       executeFiltered(mdIterator, localClusterFaces, progress, clusterImage,

--- a/Framework/Crystal/test/HardThresholdBackgroundTest.h
+++ b/Framework/Crystal/test/HardThresholdBackgroundTest.h
@@ -27,7 +27,7 @@ public:
 
     HardThresholdBackground strategy(threshold, Mantid::API::NoNormalization);
 
-    TS_ASSERT(strategy.isBackground(iterator));
+    TS_ASSERT(strategy.isBackground(iterator.get()));
   }
 };
 

--- a/Framework/CurveFitting/test/Algorithms/EvaluateFunctionTest.h
+++ b/Framework/CurveFitting/test/Algorithms/EvaluateFunctionTest.h
@@ -149,7 +149,6 @@ public:
         TS_ASSERT_DELTA((signal - value) / value, 0.0, 1e-6);
       }
     } while (iter->next());
-    delete iter;
   }
 
   void test_set_workspace_twice() {

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.h
@@ -73,7 +73,7 @@ public:
   uint64_t getNEvents() const override { return getNPoints(); }
 
   /// Creates a new iterator pointing to the first cell (box) in the workspace
-  std::vector<Mantid::API::IMDIterator *> createIterators(
+  std::vector<std::unique_ptr<Mantid::API::IMDIterator>> createIterators(
       size_t suggestedNumCores = 1,
       Mantid::Geometry::MDImplicitFunction *function = nullptr) const override;
 

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
@@ -239,7 +239,7 @@ TMDE(std::vector<coord_t> MDEventWorkspace)::estimateResolution() const {
  * @param suggestedNumCores :: split iterator over this many cores.
  * @param function :: Optional MDImplicitFunction limiting the iterator
  */
-TMDE(std::vector<Mantid::API::IMDIterator *> MDEventWorkspace)::createIterators(
+TMDE(std::vector<std::unique_ptr<Mantid::API::IMDIterator>> MDEventWorkspace)::createIterators(
     size_t suggestedNumCores,
     Mantid::Geometry::MDImplicitFunction *function) const {
   // Get all the boxes in this workspaces
@@ -261,13 +261,13 @@ TMDE(std::vector<Mantid::API::IMDIterator *> MDEventWorkspace)::createIterators(
     numCores = 1;
 
   // Create one iterator per core, splitting evenly amongst spectra
-  std::vector<API::IMDIterator *> out;
+  std::vector<std::unique_ptr<API::IMDIterator>> out;
   for (size_t i = 0; i < numCores; i++) {
     size_t begin = (i * numElements) / numCores;
     size_t end = ((i + 1) * numElements) / numCores;
     if (end > numElements)
       end = numElements;
-    out.push_back(new MDBoxIterator<MDE, nd>(boxes, begin, end));
+    out.push_back(Kernel::make_unique<MDBoxIterator<MDE, nd>>(boxes, begin, end));
   }
   return out;
 }

--- a/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
@@ -78,7 +78,7 @@ public:
   uint64_t getNPoints() const override { return m_length; }
   /// get number of contributed events
   uint64_t getNEvents() const override;
-  std::vector<Mantid::API::IMDIterator *> createIterators(
+  std::vector<std::unique_ptr<Mantid::API::IMDIterator>> createIterators(
       size_t suggestedNumCores = 1,
       Mantid::Geometry::MDImplicitFunction *function = nullptr) const override;
 

--- a/Framework/DataObjects/test/FakeMDTest.h
+++ b/Framework/DataObjects/test/FakeMDTest.h
@@ -150,8 +150,6 @@ public:
       it->next();
       ++counter;
     }
-
-    delete it;
   }
 };
 

--- a/Framework/DataObjects/test/MDEventWorkspaceTest.h
+++ b/Framework/DataObjects/test/MDEventWorkspaceTest.h
@@ -42,7 +42,7 @@ private:
   /// Helper function to return the number of masked bins in a workspace. TODO:
   /// move helper into test helpers
   size_t getNumberMasked(Mantid::API::IMDWorkspace_sptr ws) {
-    Mantid::API::IMDIterator *it = ws->createIterator(nullptr);
+    auto it = ws->createIterator(nullptr);
     size_t numberMasked = 0;
     size_t counter = 0;
     for (; counter < it->getDataSize(); ++counter) {
@@ -51,7 +51,6 @@ private:
       }
       it->next(1); // Doesn't perform skipping on masked, bins, but next() does.
     }
-    delete it;
     return numberMasked;
   }
 
@@ -238,42 +237,34 @@ public:
   //-------------------------------------------------------------------------------------
   /** Create an IMDIterator */
   void test_createIterator() {
-    MDEventWorkspace3 *ew = new MDEventWorkspace3();
+    auto ew = boost::make_shared<MDEventWorkspace3>();
     BoxController_sptr bc = ew->getBoxController();
     bc->setSplitInto(4);
     ew->splitBox();
-    IMDIterator *it = ew->createIterator();
+    auto it = ew->createIterator();
     TS_ASSERT(it);
     TS_ASSERT_EQUALS(it->getDataSize(), 4 * 4 * 4);
     TS_ASSERT(it->next());
-    delete it;
-    auto *mdfunction = new MDImplicitFunction();
-    it = ew->createIterator(mdfunction);
+    MDImplicitFunction mdfunction;
+    it = ew->createIterator(&mdfunction);
     TS_ASSERT(it);
     TS_ASSERT_EQUALS(it->getDataSize(), 4 * 4 * 4);
     TS_ASSERT(it->next());
-    delete mdfunction;
-    delete it;
-    delete ew;
   }
 
   //-------------------------------------------------------------------------------------
   /** Create several IMDIterators to run them in parallel */
   void test_createIterators() {
-    MDEventWorkspace3 *ew = new MDEventWorkspace3();
+    auto ew = boost::make_shared<MDEventWorkspace3>();
     BoxController_sptr bc = ew->getBoxController();
     bc->setSplitInto(4);
     ew->splitBox();
-    std::vector<IMDIterator *> iterators = ew->createIterators(3);
+    auto iterators = ew->createIterators(3);
     TS_ASSERT_EQUALS(iterators.size(), 3);
 
     TS_ASSERT_EQUALS(iterators[0]->getDataSize(), 21);
     TS_ASSERT_EQUALS(iterators[1]->getDataSize(), 21);
     TS_ASSERT_EQUALS(iterators[2]->getDataSize(), 22);
-
-    for (size_t i = 0; i < 3; ++i)
-      delete iterators[i];
-    delete ew;
   }
 
   //-------------------------------------------------------------------------------------

--- a/Framework/DataObjects/test/MDHistoWorkspaceIteratorTest.h
+++ b/Framework/DataObjects/test/MDHistoWorkspaceIteratorTest.h
@@ -126,8 +126,7 @@ public:
 
     Mantid::DataObjects::MDHistoWorkspace_sptr ws_sptr(ws);
 
-    MDHistoWorkspaceIterator *histoIt =
-        new MDHistoWorkspaceIterator(ws, function);
+    auto histoIt = Kernel::make_unique<MDHistoWorkspaceIterator>(ws, function);
 
     TSM_ASSERT_EQUALS("The first index hit should be 5 since that is the first "
                       "unmasked and inside function",
@@ -136,8 +135,6 @@ public:
     TSM_ASSERT_EQUALS("The next index hit should be 7 since that is the next "
                       "unmasked and inside function",
                       7, histoIt->getLinearIndex());
-
-    delete histoIt;
   }
 
   void test_getNormalizedSignal_with_mask() {
@@ -167,8 +164,8 @@ public:
 
     Mantid::DataObjects::MDHistoWorkspace_sptr ws_sptr(ws);
 
-    MDHistoWorkspaceIterator *histoIt =
-        dynamic_cast<MDHistoWorkspaceIterator *>(ws->createIterator());
+    auto it = ws->createIterator();
+    auto histoIt = dynamic_cast<MDHistoWorkspaceIterator *>(it.get());
 
     TSM_ASSERT_EQUALS("Should get the signal value here as data at the iterator"
                       " are unmasked",
@@ -180,8 +177,6 @@ public:
     TSM_ASSERT_EQUALS("Should get the signal value here as data at the iterator"
                       " are unmasked",
                       3.0, histoIt->getNormalizedSignal());
-
-    delete histoIt;
   }
 
   void test_iterator_1D() { do_test_iterator(1, 10); }
@@ -202,7 +197,7 @@ public:
         MDEventsTestHelper::makeFakeMDHistoWorkspace(1.0, 2, 10);
     for (size_t i = 0; i < 100; i++)
       ws->setSignalAt(i, double(i));
-    MDHistoWorkspaceIterator *it = new MDHistoWorkspaceIterator(ws, function);
+    auto it = Kernel::make_unique<MDHistoWorkspaceIterator>(ws, function);
     TSM_ASSERT("This iterator is valid at the start.", it->valid());
 
     TS_ASSERT_EQUALS(it->getNormalizedSignal(), 0.);
@@ -225,8 +220,6 @@ public:
     it->next();
     TS_ASSERT_EQUALS(it->getNormalizedSignal(), 30.);
     TS_ASSERT(!it->next());
-
-    delete it;
   }
 
   void test_iterator_2D_implicitFunction_thatExcludesTheStart() {
@@ -239,7 +232,7 @@ public:
         MDEventsTestHelper::makeFakeMDHistoWorkspace(1.0, 2, 10);
     for (size_t i = 0; i < 100; i++)
       ws->setSignalAt(i, double(i));
-    MDHistoWorkspaceIterator *it = new MDHistoWorkspaceIterator(ws, function);
+    auto it = Kernel::make_unique<MDHistoWorkspaceIterator>(ws, function);
     TSM_ASSERT("This iterator is valid at the start.", it->valid());
 
     TS_ASSERT_EQUALS(it->getNormalizedSignal(), 4.);
@@ -257,8 +250,6 @@ public:
     TS_ASSERT_EQUALS(it->getNormalizedSignal(), 13.);
     it->next();
     // And so forth....
-
-    delete it;
   }
 
   void test_iterator_2D_implicitFunction_thatExcludesEverything() {
@@ -270,11 +261,9 @@ public:
         MDEventsTestHelper::makeFakeMDHistoWorkspace(1.0, 2, 10);
     for (size_t i = 0; i < 100; i++)
       ws->setSignalAt(i, double(i));
-    MDHistoWorkspaceIterator *it = new MDHistoWorkspaceIterator(ws, function);
+    auto it = Kernel::make_unique<MDHistoWorkspaceIterator>(ws, function);
 
     TSM_ASSERT("This iterator is not valid at the start.", !it->valid());
-
-    delete it;
   }
 
   /** Create several parallel iterators */
@@ -286,38 +275,35 @@ public:
       ws->setSignalAt(i, double(i));
 
     // Make 3 iterators
-    std::vector<IMDIterator *> iterators = ws->createIterators(3);
+    auto iterators = ws->createIterators(3);
     TS_ASSERT_EQUALS(iterators.size(), 3);
 
     IMDIterator *it;
 
-    it = iterators[0];
+    it = iterators[0].get();
     TS_ASSERT_DELTA(it->getSignal(), 0.0, 1e-5);
     TS_ASSERT_EQUALS(it->getDataSize(), 33);
     TS_ASSERT_DELTA(it->getInnerPosition(0, 0), 0.5, 1e-5);
     TS_ASSERT_DELTA(it->getInnerPosition(0, 1), 0.5, 1e-5);
 
-    it = iterators[1];
+    it = iterators[1].get();
     TS_ASSERT_DELTA(it->getSignal(), 33.0, 1e-5);
     TS_ASSERT_EQUALS(it->getDataSize(), 33);
     TS_ASSERT_DELTA(it->getInnerPosition(0, 0), 3.5, 1e-5);
     TS_ASSERT_DELTA(it->getInnerPosition(0, 1), 3.5, 1e-5);
 
-    it = iterators[2];
+    it = iterators[2].get();
     TS_ASSERT_DELTA(it->getSignal(), 66.0, 1e-5);
     TS_ASSERT_EQUALS(it->getDataSize(), 34);
     TS_ASSERT_DELTA(it->getInnerPosition(0, 0), 6.5, 1e-5);
     TS_ASSERT_DELTA(it->getInnerPosition(0, 1), 6.5, 1e-5);
-
-    for (size_t i = 0; i < 3; ++i)
-      delete iterators[i];
   }
 
   void test_predictable_steps() {
     MDHistoWorkspace_sptr ws =
         MDEventsTestHelper::makeFakeMDHistoWorkspace(1.0, 2, 10);
-    MDHistoWorkspaceIterator *histoIt =
-        dynamic_cast<MDHistoWorkspaceIterator *>(ws->createIterator());
+    auto it = ws->createIterator();
+    auto histoIt = dynamic_cast<MDHistoWorkspaceIterator *>(it.get());
     size_t expected = 0;
     for (size_t i = 0; i < histoIt->getDataSize(); ++i) {
       size_t current = histoIt->getLinearIndex();
@@ -326,7 +312,6 @@ public:
       expected = current + 1;
       histoIt->next();
     }
-    delete histoIt;
   }
 
   void test_skip_masked_detectors() {
@@ -345,8 +330,8 @@ public:
 
     Mantid::DataObjects::MDHistoWorkspace_sptr ws_sptr(ws);
 
-    MDHistoWorkspaceIterator *histoIt =
-        dynamic_cast<MDHistoWorkspaceIterator *>(ws_sptr->createIterator());
+    auto it = ws_sptr->createIterator();
+    auto histoIt = dynamic_cast<MDHistoWorkspaceIterator *>(it.get());
     histoIt->next();
     TSM_ASSERT_EQUALS(
         "The first index hit should be 2 since that is the first unmasked one",
@@ -355,8 +340,6 @@ public:
     TSM_ASSERT_EQUALS(
         "The next index hit should be 5 since that is the next unmasked one", 5,
         histoIt->getLinearIndex());
-
-    delete histoIt;
   }
 
   // template<typename ContainerType, typename ElementType>
@@ -393,7 +376,7 @@ public:
 
      */
 
-    MDHistoWorkspaceIterator *it = new MDHistoWorkspaceIterator(ws);
+    auto it = Kernel::make_unique<MDHistoWorkspaceIterator>(ws);
 
     // At first position
     /*
@@ -401,7 +384,8 @@ public:
      ^
      |
      */
-    std::vector<size_t> neighbourIndexes = findNeighbourMemberFunction(it);
+    std::vector<size_t> neighbourIndexes =
+        findNeighbourMemberFunction(it.get());
     TS_ASSERT_EQUALS(1, neighbourIndexes.size());
     // should be on edge
     TSM_ASSERT("Neighbour at index 0 is 1",
@@ -414,7 +398,7 @@ public:
          |
          */
     it->next();
-    neighbourIndexes = findNeighbourMemberFunction(it);
+    neighbourIndexes = findNeighbourMemberFunction(it.get());
     TS_ASSERT_EQUALS(2, neighbourIndexes.size());
     // should be on edge
     TSM_ASSERT("Neighbours at index 1 includes 0",
@@ -429,11 +413,9 @@ public:
                                          |
                                          */
     it->jumpTo(9);
-    neighbourIndexes = findNeighbourMemberFunction(it);
+    neighbourIndexes = findNeighbourMemberFunction(it.get());
     TSM_ASSERT("Neighbour at index 9 is 8",
                doesContainIndex(neighbourIndexes, 8));
-
-    delete it;
   }
 
   void test_neighbours_1d_face_touching() {
@@ -462,7 +444,7 @@ public:
      8 - 9 -10 -11
      12-13 -14 -15
      */
-    MDHistoWorkspaceIterator *it = new MDHistoWorkspaceIterator(ws);
+    auto it = Kernel::make_unique<MDHistoWorkspaceIterator>(ws);
 
     // At initial position
     /*
@@ -532,8 +514,6 @@ public:
                doesContainIndex(neighbourIndexes, 11));
     TSM_ASSERT("Neighbour at index 15 is 14",
                doesContainIndex(neighbourIndexes, 14));
-
-    delete it;
   }
 
   void test_neighbours_2d_vertex_touching() {
@@ -548,7 +528,7 @@ public:
      8 - 9 -10 -11
      12-13 -14 -15
      */
-    MDHistoWorkspaceIterator *it = new MDHistoWorkspaceIterator(ws);
+    auto it = Kernel::make_unique<MDHistoWorkspaceIterator>(ws);
 
     // At initial position
     /*
@@ -633,8 +613,6 @@ public:
                doesContainIndex(neighbourIndexes, 11));
     TSM_ASSERT("Neighbour at index 15 is 14",
                doesContainIndex(neighbourIndexes, 14));
-
-    delete it;
   }
 
   void test_neighbours_3d_face_touching() {
@@ -665,7 +643,7 @@ public:
      [60 61 62 63]]]
      */
 
-    MDHistoWorkspaceIterator *it = new MDHistoWorkspaceIterator(ws);
+    auto it = Kernel::make_unique<MDHistoWorkspaceIterator>(ws);
 
     // Start at Index = 0
     std::vector<size_t> neighbourIndexes =
@@ -710,8 +688,6 @@ public:
          ++i) {
       TS_ASSERT(doesContainIndex(neighbourIndexes, *i));
     }
-
-    delete it;
   }
 
   void test_neighbours_3d_vertex_touching() {
@@ -742,7 +718,7 @@ public:
      [60 61 62 63]]]
      */
 
-    MDHistoWorkspaceIterator *it = new MDHistoWorkspaceIterator(ws);
+    auto it = Kernel::make_unique<MDHistoWorkspaceIterator>(ws);
 
     // Start at Index = 0
     std::vector<size_t> neighbourIndexes = it->findNeighbourIndexes();
@@ -792,8 +768,6 @@ public:
          ++i) {
       TS_ASSERT(doesContainIndex(neighbourIndexes, *i));
     }
-
-    delete it;
   }
 
   void test_neighbours_1d_with_width() {
@@ -811,7 +785,7 @@ public:
 
      */
 
-    MDHistoWorkspaceIterator *it = new MDHistoWorkspaceIterator(ws);
+    auto it = Kernel::make_unique<MDHistoWorkspaceIterator>(ws);
 
     // At first position
     /*
@@ -859,8 +833,6 @@ public:
                doesContainIndex(neighbourIndexes, 8));
     TSM_ASSERT("Neighbours at index 9 includes 7",
                doesContainIndex(neighbourIndexes, 7));
-
-    delete it;
   }
 
   void test_neighbours_2d_vertex_touching_by_width() {
@@ -876,7 +848,7 @@ public:
      8 - 9 -10 -11
      12-13 -14 -15
      */
-    MDHistoWorkspaceIterator *it = new MDHistoWorkspaceIterator(ws);
+    auto it = Kernel::make_unique<MDHistoWorkspaceIterator>(ws);
 
     // At initial position
     /*
@@ -953,8 +925,6 @@ public:
                doesContainIndex(neighbourIndexes, 13));
     TSM_ASSERT("Neighbour at index is 14",
                doesContainIndex(neighbourIndexes, 14));
-
-    delete it;
   }
 
   void test_neighbours_2d_vertex_touching_by_width_vector() {
@@ -973,7 +943,7 @@ public:
      8 - 9 -10 -11
      12-13 -14 -15
      */
-    MDHistoWorkspaceIterator *it = new MDHistoWorkspaceIterator(ws);
+    auto it = Kernel::make_unique<MDHistoWorkspaceIterator>(ws);
 
     // At initial position
     /*
@@ -1038,8 +1008,6 @@ public:
                doesContainIndex(neighbourIndexes, 13));
     TSM_ASSERT("Neighbour at index is 14",
                doesContainIndex(neighbourIndexes, 14));
-
-    delete it;
   }
 
   void test_neighbours_3d_vertex_touching_width() {
@@ -1071,7 +1039,7 @@ public:
      [60 61 62 63]]]
      */
 
-    MDHistoWorkspaceIterator *it = new MDHistoWorkspaceIterator(ws);
+    auto it = Kernel::make_unique<MDHistoWorkspaceIterator>(ws);
 
     // Start at Index = 0
     std::vector<size_t> neighbourIndexes =
@@ -1095,8 +1063,6 @@ public:
     TS_ASSERT(doesContainIndex(neighbourIndexes, 24));
     TS_ASSERT(doesContainIndex(neighbourIndexes, 25));
     TS_ASSERT(doesContainIndex(neighbourIndexes, 26));
-
-    delete it;
   }
 
   void test_cache() {
@@ -1110,7 +1076,7 @@ public:
 
      */
 
-    MDHistoWorkspaceIterator *it = new MDHistoWorkspaceIterator(ws);
+    auto it = Kernel::make_unique<MDHistoWorkspaceIterator>(ws);
     TSM_ASSERT_EQUALS("Empty cache expected", 0, it->permutationCacheSize());
     it->findNeighbourIndexesByWidth(3);
     TSM_ASSERT_EQUALS("One cache item expected", 1, it->permutationCacheSize());
@@ -1121,15 +1087,13 @@ public:
     it->findNeighbourIndexesByWidth(5);
     TSM_ASSERT_EQUALS("Two cache entries expected", 2,
                       it->permutationCacheSize());
-
-    delete it;
   }
 
   void test_getBoxExtents_1d() {
     const size_t nd = 1;
     MDHistoWorkspace_sptr ws = MDEventsTestHelper::makeFakeMDHistoWorkspace(
         1.0 /*signal*/, nd, 3 /*3 bins*/); // Dimension length defaults to 10
-    MDHistoWorkspaceIterator *it = new MDHistoWorkspaceIterator(ws);
+    auto it = Kernel::make_unique<MDHistoWorkspaceIterator>(ws);
 
     // At zeroth position
     VecMDExtents extents = it->getBoxExtents();
@@ -1149,15 +1113,13 @@ public:
     extents = it->getBoxExtents();
     TS_ASSERT_DELTA(extents[0].get<0>(), 10.0 * 2.0 / 3.0, 1e-4);
     TS_ASSERT_DELTA(extents[0].get<1>(), 10.0 * 3.0 / 3.0, 1e-4);
-
-    delete it;
   }
 
   void test_getBoxExtents_3d() {
     MDHistoWorkspace_sptr ws = MDEventsTestHelper::makeFakeMDHistoWorkspace(
         1.0 /*signal*/, 3 /*nd*/, 4 /*nbins per dim*/, 6 /*max*/,
         1.0 /*error sq*/);
-    MDHistoWorkspaceIterator *it = new MDHistoWorkspaceIterator(ws);
+    auto it = Kernel::make_unique<MDHistoWorkspaceIterator>(ws);
 
     // At zeroth position
     VecMDExtents extents = it->getBoxExtents();
@@ -1181,8 +1143,6 @@ public:
     TS_ASSERT_DELTA(extents[1].get<1>(), 4.0 / 4 * 6.0, 1e-4);
     TS_ASSERT_DELTA(extents[2].get<0>(), 3.0 / 4 * 6.0, 1e-4);
     TS_ASSERT_DELTA(extents[2].get<1>(), 4.0 / 4 * 6.0, 1e-4);
-
-    delete it;
   }
 
   void test_jump_to_nearest_1d() {
@@ -1210,8 +1170,8 @@ public:
 
     */
 
-    MDHistoWorkspaceIterator *itIn = new MDHistoWorkspaceIterator(wsIn);
-    MDHistoWorkspaceIterator *itOut = new MDHistoWorkspaceIterator(wsOut);
+    auto itIn = Kernel::make_unique<MDHistoWorkspaceIterator>(wsIn);
+    auto itOut = Kernel::make_unique<MDHistoWorkspaceIterator>(wsOut);
 
     // First position
     TS_ASSERT_EQUALS(itIn->getLinearIndex(), 0);
@@ -1239,9 +1199,6 @@ public:
     diff = itOut->jumpToNearest(itIn->getCenter());
     TS_ASSERT_EQUALS(itOut->getLinearIndex(), 3); // 10.5 closer to 12 than 8
     TS_ASSERT_DELTA(1.5, diff, 1e-4);
-
-    delete itIn;
-    delete itOut;
   }
 
   void test_neighbours_1d_with_width_including_out_of_bounds() {
@@ -1259,7 +1216,7 @@ public:
 
      */
 
-    MDHistoWorkspaceIterator *it = new MDHistoWorkspaceIterator(ws);
+    auto it = Kernel::make_unique<MDHistoWorkspaceIterator>(ws);
 
     // At first position
     /*
@@ -1348,8 +1305,6 @@ public:
                doesContainIndex(neighbourIndexes, 10)); // Invalid
     TSM_ASSERT("Neighbours include 3",
                doesContainIndex(neighbourIndexes, 11)); // Invalid
-
-    delete it;
   }
 
   void test_neighbours_2d_vertex_touching_by_width_including_out_of_bounds() {
@@ -1366,7 +1321,7 @@ public:
      8 - 9 -10 -11
      12-13 -14 -15
      */
-    MDHistoWorkspaceIterator *it = new MDHistoWorkspaceIterator(ws);
+    auto it = Kernel::make_unique<MDHistoWorkspaceIterator>(ws);
 
     // At initial position
     /*
@@ -1451,8 +1406,6 @@ public:
                doesContainIndex(neighbourIndexes, 19)); // Invalid
     TSM_ASSERT("Neighbour at index is 23",
                doesContainIndex(neighbourIndexes, 23)); // Invalid
-
-    delete it;
   }
 };
 
@@ -1479,21 +1432,20 @@ public:
 
   /** ~Two million iterations */
   void test_iterator_3D_signalAndErrorOnly() {
-    MDHistoWorkspaceIterator *it =
-        new MDHistoWorkspaceIterator(ws, new SkipNothing);
+    auto it =
+        Kernel::make_unique<MDHistoWorkspaceIterator>(ws, new SkipNothing);
     do {
       signal_t sig = it->getNormalizedSignal();
       signal_t err = it->getNormalizedError();
       UNUSED_ARG(sig);
       UNUSED_ARG(err);
     } while (it->next());
-    delete it;
   }
 
   /** ~Two million iterations */
   void test_iterator_3D_withGetVertexes() {
-    MDHistoWorkspaceIterator *it =
-        new MDHistoWorkspaceIterator(ws, new SkipNothing);
+    auto it =
+        Kernel::make_unique<MDHistoWorkspaceIterator>(ws, new SkipNothing);
     size_t numVertices;
     do {
       signal_t sig = it->getNormalizedSignal();
@@ -1503,13 +1455,12 @@ public:
       UNUSED_ARG(sig);
       UNUSED_ARG(err);
     } while (it->next());
-    delete it;
   }
 
   /** ~Two million iterations */
   void test_iterator_3D_withGetCenter() {
-    MDHistoWorkspaceIterator *it =
-        new MDHistoWorkspaceIterator(ws, new SkipNothing);
+    auto it =
+        Kernel::make_unique<MDHistoWorkspaceIterator>(ws, new SkipNothing);
     do {
       signal_t sig = it->getNormalizedSignal();
       signal_t err = it->getNormalizedError();
@@ -1517,13 +1468,12 @@ public:
       UNUSED_ARG(sig);
       UNUSED_ARG(err);
     } while (it->next());
-    delete it;
   }
 
   /** Use jumpTo() */
   void test_iterator_3D_withGetCenter_usingJumpTo() {
-    MDHistoWorkspaceIterator *it =
-        new MDHistoWorkspaceIterator(ws, new SkipNothing);
+    auto it =
+        Kernel::make_unique<MDHistoWorkspaceIterator>(ws, new SkipNothing);
     int max = int(it->getDataSize());
     for (int i = 0; i < max; i++) {
       it->jumpTo(size_t(i));
@@ -1533,7 +1483,6 @@ public:
       UNUSED_ARG(sig);
       UNUSED_ARG(err);
     }
-    delete it;
   }
 
   void test_masked_get_vertexes_call_throws() {

--- a/Framework/DataObjects/test/MDHistoWorkspaceTest.h
+++ b/Framework/DataObjects/test/MDHistoWorkspaceTest.h
@@ -33,7 +33,7 @@ private:
   /// Helper function to return the number of masked bins in a workspace. TODO:
   /// move helper into test helpers
   size_t getNumberMasked(Mantid::API::IMDWorkspace_sptr ws) {
-    Mantid::API::IMDIterator *it = ws->createIterator(nullptr);
+    auto it = ws->createIterator(nullptr);
     size_t numberMasked = 0;
     size_t counter = 0;
     for (; counter < it->getDataSize(); ++counter) {
@@ -42,7 +42,6 @@ private:
       }
       it->next(1);
     }
-    delete it;
     return numberMasked;
   }
 
@@ -413,17 +412,15 @@ public:
     MDHistoDimension_sptr dimZ(
         new MDHistoDimension("Z", "z", frame, -8, 10, 10));
     MDHistoWorkspace ws(dimX, dimY, dimZ);
-    IMDIterator *it = ws.createIterator();
+    auto it = ws.createIterator();
     TS_ASSERT(it);
     MDHistoWorkspaceIterator *hwit =
-        dynamic_cast<MDHistoWorkspaceIterator *>(it);
+        dynamic_cast<MDHistoWorkspaceIterator *>(it.get());
     TS_ASSERT(hwit);
     TS_ASSERT(it->next());
-    delete it;
     boost::scoped_ptr<MDImplicitFunction> mdfunction(new MDImplicitFunction);
     it = ws.createIterator(mdfunction.get());
     TS_ASSERT(it);
-    delete it;
   }
 
   //---------------------------------------------------------------------------------------------------

--- a/Framework/MDAlgorithms/src/ConvertCWPDMDToSpectra.cpp
+++ b/Framework/MDAlgorithms/src/ConvertCWPDMDToSpectra.cpp
@@ -449,7 +449,7 @@ void ConvertCWPDMDToSpectra::binMD(API::IMDEventWorkspace_const_sptr mdws,
                 << sourcepos.Y() << ", " << sourcepos.Z() << "\n";
 
   // Go through all events to find out their positions
-  IMDIterator *mditer = mdws->createIterator();
+  auto mditer = mdws->createIterator();
   bool scancell = true;
   size_t nextindex = 1;
   int currRunIndex = -1;

--- a/Framework/MDAlgorithms/src/ConvertCWSDMDtoHKL.cpp
+++ b/Framework/MDAlgorithms/src/ConvertCWSDMDtoHKL.cpp
@@ -175,7 +175,7 @@ void ConvertCWSDMDtoHKL::exportEvents(
   vec_event_det.resize(numevents);
 
   // Go through to get value
-  IMDIterator *mditer = mdws->createIterator();
+  auto mditer = mdws->createIterator();
   size_t nextindex = 1;
   bool scancell = true;
   size_t currindex = 0;

--- a/Framework/MDAlgorithms/src/FitMD.cpp
+++ b/Framework/MDAlgorithms/src/FitMD.cpp
@@ -97,7 +97,6 @@ void FitMD::createDomain(boost::shared_ptr<API::FunctionDomain> &domain,
   setParameters();
   auto iterator = m_IMDWorkspace->createIterator();
   const size_t n = iterator->getDataSize();
-  delete iterator;
 
   if (m_count == 0) {
     m_count = n;
@@ -233,7 +232,6 @@ boost::shared_ptr<API::Workspace> FitMD::createEventOutputWorkspace(
     }
     ++resultValueIndex;
   } while (inputIter->next());
-  delete inputIter;
 
   // This splits up all the boxes according to split thresholds and sizes.
   auto threadScheduler = new Kernel::ThreadSchedulerFIFO();
@@ -342,7 +340,6 @@ size_t FitMD::getDomainSize() const {
     throw std::runtime_error("FitMD: workspace wasn't defined");
   auto iterator = m_IMDWorkspace->createIterator();
   size_t n = iterator->getDataSize();
-  delete iterator;
   if (m_count != 0) {
     if (m_startIndex + m_count > n)
       throw std::range_error("FitMD: index is out of range");

--- a/Framework/MDAlgorithms/src/GetSpiceDataRawCountsFromMD.cpp
+++ b/Framework/MDAlgorithms/src/GetSpiceDataRawCountsFromMD.cpp
@@ -378,7 +378,7 @@ void GetSpiceDataRawCountsFromMD::getDetCounts(
   vecY.clear();
 
   // Go through all events to find out their positions
-  IMDIterator *mditer = mdws->createIterator();
+  auto mditer = mdws->createIterator();
 
   bool scancell = true;
   size_t nextindex = 1;
@@ -429,8 +429,6 @@ void GetSpiceDataRawCountsFromMD::getDetCounts(
       scancell = false;
     }
   } // ENDOF(while)
-
-  delete (mditer);
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
@@ -359,9 +359,8 @@ void IntegrateMDHistoWorkspace::exec() {
     PARALLEL_FOR_NO_WSP_CHECK()
     for (int i = 0; i < int(outIterators.size()); ++i) { // NOLINT
       PARALLEL_START_INTERUPT_REGION
-      boost::scoped_ptr<MDHistoWorkspaceIterator> outIterator(
-          dynamic_cast<MDHistoWorkspaceIterator *>(outIterators[i]));
-
+      auto outIterator =
+          dynamic_cast<MDHistoWorkspaceIterator *>(outIterators[i].get());
       if (!outIterator) {
         throw std::logic_error(
             "Failed to cast iterator to MDHistoWorkspaceIterator");
@@ -386,8 +385,10 @@ void IntegrateMDHistoWorkspace::exec() {
         double sumNEvents = 0;
 
         // Create a thread-local input iterator.
-        boost::scoped_ptr<MDHistoWorkspaceIterator> inIterator(
-            dynamic_cast<MDHistoWorkspaceIterator *>(inWS->createIterator()));
+
+        auto iterator = inWS->createIterator();
+        auto inIterator =
+            dynamic_cast<MDHistoWorkspaceIterator *>(iterator.get());
         if (!inIterator) {
           throw std::runtime_error(
               "Could not convert IMDIterator to a MDHistoWorkspaceIterator");
@@ -401,7 +402,7 @@ void IntegrateMDHistoWorkspace::exec() {
         rather than iterating over the full set of boxes of the input workspace.
         */
         inIterator->jumpToNearest(outIteratorCenter);
-        performWeightedSum(inIterator.get(), box, sumSignal, sumSQErrors,
+        performWeightedSum(inIterator, box, sumSignal, sumSQErrors,
                            sumNEvents); // Use the present position. neighbours
                                         // below exclude the current position.
         // Look at all of the neighbours of our position. We previously
@@ -410,7 +411,7 @@ void IntegrateMDHistoWorkspace::exec() {
             inIterator->findNeighbourIndexesByWidth(widthVector);
         for (auto neighbourIndex : neighbourIndexes) {
           inIterator->jumpTo(neighbourIndex); // Go to that neighbour
-          performWeightedSum(inIterator.get(), box, sumSignal, sumSQErrors,
+          performWeightedSum(inIterator, box, sumSignal, sumSQErrors,
                              sumNEvents);
         }
 

--- a/Framework/MDAlgorithms/src/IntegratePeaksCWSD.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksCWSD.cpp
@@ -210,7 +210,7 @@ void IntegratePeaksCWSD::simplePeakIntegration(
     throw std::runtime_error("MDEventWorkspace is not defined.");
 
   // Go through to get value
-  API::IMDIterator *mditer = m_inputWS->createIterator();
+  auto mditer = m_inputWS->createIterator();
   size_t nextindex = 1;
   bool scancell = true;
   // size_t currindex = 0;

--- a/Framework/MDAlgorithms/src/Quantification/Resolution/TobyFitResolutionModel.cpp
+++ b/Framework/MDAlgorithms/src/Quantification/Resolution/TobyFitResolutionModel.cpp
@@ -521,7 +521,6 @@ void TobyFitResolutionModel::preprocess(
   } while (iterator->next());
   g_log.debug() << "Done preprocessing loop:" << timer.elapsed()
                 << " seconds\n";
-  delete iterator;
 }
 
 /**

--- a/Framework/MDAlgorithms/src/Quantification/ResolutionConvolvedCrossSection.cpp
+++ b/Framework/MDAlgorithms/src/Quantification/ResolutionConvolvedCrossSection.cpp
@@ -101,7 +101,7 @@ void ResolutionConvolvedCrossSection::function(
         "Expected FunctionDomainMD in ResolutionConvolvedCrossSection");
   }
 
-  std::vector<API::IMDIterator *> iterators = m_inputWS->createIterators(
+  auto iterators = m_inputWS->createIterators(
       API::FrameworkManager::Instance().getNumOMPThreads());
   const int nthreads = static_cast<int>(iterators.size());
   std::vector<size_t> resultOffsets(nthreads, 0);
@@ -126,7 +126,7 @@ void ResolutionConvolvedCrossSection::function(
   bool exceptionThrown = false; // required for *_PARALLEL_* macros
   PARALLEL_FOR_NO_WSP_CHECK()
   for (int i = 0; i < nthreads; ++i) {
-    API::IMDIterator *boxIterator = iterators[i];
+    auto &boxIterator = iterators[i];
     const size_t resultsOffset = resultOffsets[i];
 
     size_t boxIndex(0);
@@ -141,10 +141,6 @@ void ResolutionConvolvedCrossSection::function(
     } while (boxIterator->next());
   }
   CHECK_PARALLEL_EXCEPTIONS // Not standard macros. See top of file for reason
-
-      for (auto boxIterator : iterators) {
-    delete boxIterator;
-  }
 }
 
 /**

--- a/Framework/MDAlgorithms/src/QueryMDWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/QueryMDWorkspace.cpp
@@ -211,7 +211,7 @@ void QueryMDWorkspace::exec() {
   output->getColumn(signalColumnName)->setPlotType(2);
   output->getColumn(errorColumnName)->setPlotType(5);
 
-  IMDIterator *it = input->createIterator();
+  auto it = input->createIterator();
   it->setNormalization(requestedNormalisation);
 
   bool bLimitRows = getProperty("LimitRows");
@@ -251,7 +251,6 @@ void QueryMDWorkspace::exec() {
     rowCounter++;
   }
   setProperty("OutputWorkspace", output);
-  delete it;
 
   //
   IMDEventWorkspace_sptr mdew;

--- a/Framework/MDAlgorithms/src/ReplicateMD.cpp
+++ b/Framework/MDAlgorithms/src/ReplicateMD.cpp
@@ -339,9 +339,6 @@ void ReplicateMD::exec() {
 
   // Create the output workspace from the shape.
   MDHistoWorkspace_sptr outputWS(shapeWS->clone());
-  auto outIt = std::unique_ptr<MDHistoWorkspaceIterator>(
-      dynamic_cast<MDHistoWorkspaceIterator *>(outputWS->createIterator()));
-
   const int nThreads = Mantid::API::FrameworkManager::Instance()
                            .getNumOMPThreads(); // NThreads to Request
 
@@ -352,8 +349,7 @@ void ReplicateMD::exec() {
   for (int it = 0; it < int(iterators.size()); ++it) { // NOLINT
 
     PARALLEL_START_INTERUPT_REGION
-    auto outIt = std::unique_ptr<MDHistoWorkspaceIterator>(
-        dynamic_cast<MDHistoWorkspaceIterator *>(iterators[it]));
+    auto outIt = dynamic_cast<MDHistoWorkspaceIterator *>(iterators[it].get());
 
     // Iterate over the output workspace
     do {

--- a/Framework/MDAlgorithms/src/SmoothMD.cpp
+++ b/Framework/MDAlgorithms/src/SmoothMD.cpp
@@ -192,8 +192,8 @@ SmoothMD::hatSmooth(IMDHistoWorkspace_const_sptr toSmooth,
   for (int it = 0; it < int(iterators.size()); ++it) { // NOLINT
 
     PARALLEL_START_INTERUPT_REGION
-    boost::scoped_ptr<MDHistoWorkspaceIterator> iterator(
-        dynamic_cast<MDHistoWorkspaceIterator *>(iterators[it]));
+    auto iterator =
+        dynamic_cast<MDHistoWorkspaceIterator *>(iterators[it].get());
 
     if (!iterator) {
       throw std::logic_error(
@@ -318,9 +318,8 @@ SmoothMD::gaussianSmooth(IMDHistoWorkspace_const_sptr toSmooth,
     for (int it = 0; it < int(iterators.size()); ++it) { // NOLINT
 
       PARALLEL_START_INTERUPT_REGION
-      boost::scoped_ptr<MDHistoWorkspaceIterator> iterator(
-          dynamic_cast<MDHistoWorkspaceIterator *>(iterators[it]));
-
+      auto iterator =
+          dynamic_cast<MDHistoWorkspaceIterator *>(iterators[it].get());
       if (!iterator) {
         throw std::logic_error(
             "Failed to cast IMDIterator to MDHistoWorkspaceIterator");

--- a/Framework/MDAlgorithms/src/TransposeMD.cpp
+++ b/Framework/MDAlgorithms/src/TransposeMD.cpp
@@ -132,7 +132,7 @@ void TransposeMD::exec() {
   for (int it = 0; it < int(iterators.size()); ++it) { // NOLINT
 
     PARALLEL_START_INTERUPT_REGION
-    auto inIterator = std::unique_ptr<IMDIterator>(iterators[it]);
+    auto inIterator = iterators[it].get();
     do {
       auto center = inIterator->getCenter();
       const coord_t *incoords = center.getBareArray();

--- a/Framework/MDAlgorithms/src/WeightedMeanMD.cpp
+++ b/Framework/MDAlgorithms/src/WeightedMeanMD.cpp
@@ -28,10 +28,10 @@ void WeightedMeanMD::execHistoHisto(
     Mantid::DataObjects::MDHistoWorkspace_sptr out,
     Mantid::DataObjects::MDHistoWorkspace_const_sptr operand) {
   using DataObjects::MDHistoWorkspaceIterator;
-  MDHistoWorkspaceIterator *lhs_it =
-      dynamic_cast<MDHistoWorkspaceIterator *>(out->createIterator());
-  MDHistoWorkspaceIterator *rhs_it =
-      dynamic_cast<MDHistoWorkspaceIterator *>(operand->createIterator());
+  auto lhs = out->createIterator();
+  auto lhs_it = dynamic_cast<MDHistoWorkspaceIterator *>(lhs.get());
+  auto rhs = operand->createIterator();
+  auto rhs_it = dynamic_cast<MDHistoWorkspaceIterator *>(rhs.get());
 
   if (!lhs_it || !rhs_it) {
     throw std::logic_error("Histo iterators have wrong type.");
@@ -63,9 +63,6 @@ void WeightedMeanMD::execHistoHisto(
     out->setSignalAt(pos, signal);
     out->setErrorSquaredAt(pos, error_sq);
   } while (lhs_it->next() && rhs_it->next());
-
-  delete lhs_it;
-  delete rhs_it;
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/MDAlgorithms/test/ConvertCWSDExpToMomentumTest.h
+++ b/Framework/MDAlgorithms/test/ConvertCWSDExpToMomentumTest.h
@@ -118,7 +118,7 @@ public:
             AnalysisDataService::Instance().retrieve("QSampleMDEvents"));
     TS_ASSERT(outws);
 
-    IMDIterator *mditer = outws->createIterator();
+    auto mditer = outws->createIterator();
     TS_ASSERT_EQUALS(mditer->getNumEvents(), 7400);
 
     size_t numexpinfo = outws->getNumExperimentInfo();
@@ -157,7 +157,7 @@ public:
             AnalysisDataService::Instance().retrieve("QSampleMDEvents"));
     TS_ASSERT(outws);
 
-    IMDIterator *mditer = outws->createIterator();
+    auto mditer = outws->createIterator();
     TS_ASSERT_EQUALS(mditer->getNumEvents(), 7400);
 
     size_t numexpinfo = outws->getNumExperimentInfo();

--- a/Framework/MDAlgorithms/test/ConvertSpiceDataToRealSpaceTest.h
+++ b/Framework/MDAlgorithms/test/ConvertSpiceDataToRealSpaceTest.h
@@ -143,7 +143,7 @@ public:
     size_t numevents = mdws->getNEvents();
     TS_ASSERT_EQUALS(numevents, 44 * 61);
 
-    IMDIterator *mditer = mdws->createIterator();
+    auto mditer = mdws->createIterator();
     TS_ASSERT_EQUALS(mditer->getNumEvents(), 44 * 61);
 
     double y0 = mditer->getInnerSignal(0);
@@ -333,7 +333,7 @@ public:
     size_t numevents = mdws->getNEvents();
     TS_ASSERT_EQUALS(numevents, 44 * 61);
 
-    IMDIterator *mditer = mdws->createIterator();
+    auto mditer = mdws->createIterator();
     TS_ASSERT_EQUALS(mditer->getNumEvents(), 44 * 61);
 
     double y0 = mditer->getInnerSignal(0);

--- a/Framework/MDAlgorithms/test/DivideMDTest.h
+++ b/Framework/MDAlgorithms/test/DivideMDTest.h
@@ -64,7 +64,7 @@ public:
     TS_ASSERT(ws);
     if (!ws)
       return;
-    IMDIterator *it = ws->createIterator(nullptr);
+    auto it = ws->createIterator(nullptr);
     do {
       TS_ASSERT_EQUALS(it->getNumEvents(), 1);
       TS_ASSERT_DELTA(it->getInnerSignal(0), expectedSignal, 1e-5);

--- a/Framework/MDAlgorithms/test/FakeMDEventDataTest.h
+++ b/Framework/MDAlgorithms/test/FakeMDEventDataTest.h
@@ -202,8 +202,6 @@ public:
       it->next();
       ++counter;
     }
-
-    delete it;
   }
 };
 

--- a/Framework/MDAlgorithms/test/FitMDTest.h
+++ b/Framework/MDAlgorithms/test/FitMDTest.h
@@ -69,10 +69,15 @@ public:
 
 class IMDWorkspaceTester : public WorkspaceTester {
 public:
-  std::vector<IMDIterator *>
+  std::vector<std::unique_ptr<IMDIterator>>
   createIterators(size_t,
                   Mantid::Geometry::MDImplicitFunction *) const override {
-    return std::vector<IMDIterator *>(1, new IMDWorkspaceTesterIterator(this));
+
+    std::vector<std::unique_ptr<IMDIterator>> ret;
+    auto ptr = std::unique_ptr<IMDIterator>{
+        Kernel::make_unique<IMDWorkspaceTesterIterator>(this)};
+    ret.push_back(std::move(ptr));
+    return ret;
   }
 };
 

--- a/Framework/MDAlgorithms/test/MaskMDTest.h
+++ b/Framework/MDAlgorithms/test/MaskMDTest.h
@@ -37,7 +37,7 @@ private:
     if (!ws)
       return;
 
-    IMDIterator *it = ws->createIterator();
+    auto it = ws->createIterator();
     size_t nMasked = 0;
     for (size_t i = 0; i < it->getDataSize(); ++i) {
       if (it->getIsMasked()) {

--- a/Framework/MDAlgorithms/test/MinusMDTest.h
+++ b/Framework/MDAlgorithms/test/MinusMDTest.h
@@ -105,7 +105,7 @@ public:
       TS_ASSERT_EQUALS(ws->getNPoints(), 10000);
     }
 
-    IMDIterator *it = ws->createIterator();
+    auto it = ws->createIterator();
     if (mask_ws_num == 0) {
       while (it->next()) {
         // Signal of all boxes is zero since they got subtracted

--- a/Framework/MDAlgorithms/test/MultiplyMDTest.h
+++ b/Framework/MDAlgorithms/test/MultiplyMDTest.h
@@ -63,7 +63,7 @@ public:
     TS_ASSERT(ws);
     if (!ws)
       return;
-    IMDIterator *it = ws->createIterator(nullptr);
+    auto it = ws->createIterator(nullptr);
     do {
       TS_ASSERT_EQUALS(it->getNumEvents(), 1);
       TS_ASSERT_DELTA(it->getInnerSignal(0), expectedSignal, 1e-5);

--- a/Framework/MDAlgorithms/test/ResolutionConvolvedCrossSectionTest.h
+++ b/Framework/MDAlgorithms/test/ResolutionConvolvedCrossSectionTest.h
@@ -47,7 +47,7 @@ public:
     using namespace Mantid::MDAlgorithms;
     using namespace Mantid::API;
     Mantid::API::IMDWorkspace_sptr testWS = createTestMDWorkspace();
-    Mantid::API::IMDIterator *box = testWS->createIterator();
+    auto box = testWS->createIterator();
     FunctionDomainMD mdDomain(testWS, 0, box->getDataSize());
     FunctionValues output;
 
@@ -55,7 +55,6 @@ public:
     crossSecResolution->setWorkspace(testWS);
     // TODO: Needs a better input workspace
     // TS_ASSERT_THROWS_NOTHING(crossSecResolution->function(mdDomain, output));
-    delete box;
     delete crossSecResolution;
   }
 

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/Normalization.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/Normalization.h
@@ -4,6 +4,8 @@
 #include "MantidAPI/DllConfig.h"
 #include "MantidGeometry/MDGeometry/MDTypes.h"
 
+#include <memory>
+
 namespace Mantid {
 
 namespace API {
@@ -50,7 +52,7 @@ NormFuncIMDNodePtr makeMDEventNormalizationFunction(
 Determine which normalization function will be called on an IMDIterator of an
 IMDWorkspace
 */
-DLLExport Mantid::API::IMDIterator *
+DLLExport std::unique_ptr<Mantid::API::IMDIterator>
 createIteratorWithNormalization(const VisualNormalization normalizationOption,
                                 Mantid::API::IMDWorkspace const *const ws);
 }

--- a/qt/paraview_ext/VatesAPI/src/Normalization.cpp
+++ b/qt/paraview_ext/VatesAPI/src/Normalization.cpp
@@ -46,7 +46,7 @@ Create iterators with correct normalization normalization to an IMDIterator.
 @param ws : workspace to fetch defaults from if needed
 @return new IMDIterator
 */
-DLLExport Mantid::API::IMDIterator *
+DLLExport std::unique_ptr<Mantid::API::IMDIterator>
 createIteratorWithNormalization(const VisualNormalization normalizationOption,
                                 Mantid::API::IMDWorkspace const *const ws) {
 
@@ -63,7 +63,7 @@ createIteratorWithNormalization(const VisualNormalization normalizationOption,
   }
 
   // Create the iterator
-  IMDIterator *iterator = ws->createIterator();
+  auto iterator = ws->createIterator();
   // Set normalization
   iterator->setNormalization(targetNormalization);
   // Return it

--- a/qt/paraview_ext/VatesAPI/src/vtkMDHistoQuadFactory.cpp
+++ b/qt/paraview_ext/VatesAPI/src/vtkMDHistoQuadFactory.cpp
@@ -88,10 +88,9 @@ vtkMDHistoQuadFactory::create(ProgressAction &progressUpdating) const {
     coord_t incrementX = (maxX - minX) / static_cast<coord_t>(nBinsX);
     coord_t incrementY = (maxY - minY) / static_cast<coord_t>(nBinsY);
 
-    boost::scoped_ptr<MDHistoWorkspaceIterator> iterator(
-        dynamic_cast<MDHistoWorkspaceIterator *>(
-            createIteratorWithNormalization(m_normalizationOption,
-                                            m_workspace.get())));
+    auto it = createIteratorWithNormalization(m_normalizationOption,
+                                              m_workspace.get());
+    auto iterator = dynamic_cast<MDHistoWorkspaceIterator *>(it.get());
     if (!iterator) {
       throw std::runtime_error(
           "Could not convert IMDIterator to a MDHistoWorkspaceIterator");

--- a/qt/paraview_ext/VatesAPI/src/vtkMDLineFactory.cpp
+++ b/qt/paraview_ext/VatesAPI/src/vtkMDLineFactory.cpp
@@ -75,8 +75,8 @@ vtkMDLineFactory::create(ProgressAction &progressUpdating) const {
     }
 
     // Ensure destruction in any event.
-    boost::scoped_ptr<IMDIterator> it(
-        createIteratorWithNormalization(m_normalizationOption, imdws.get()));
+    auto it =
+        createIteratorWithNormalization(m_normalizationOption, imdws.get());
 
     // Create 2 points per box.
     vtkNew<vtkPoints> points;

--- a/qt/paraview_ext/VatesAPI/src/vtkMDQuadFactory.cpp
+++ b/qt/paraview_ext/VatesAPI/src/vtkMDQuadFactory.cpp
@@ -71,8 +71,8 @@ vtkMDQuadFactory::create(ProgressAction &progressUpdating) const {
 
     // Make iterator, which will use the desired normalization. Ensure
     // destruction in any eventuality.
-    boost::scoped_ptr<IMDIterator> it(
-        createIteratorWithNormalization(m_normalizationOption, imdws.get()));
+    auto it =
+        createIteratorWithNormalization(m_normalizationOption, imdws.get());
 
     // Create 4 points per box.
     vtkNew<vtkPoints> points;

--- a/qt/paraview_ext/VatesAPI/test/MockObjects.h
+++ b/qt/paraview_ext/VatesAPI/test/MockObjects.h
@@ -102,7 +102,7 @@ public:
     return line;
   }
 
-  std::vector<Mantid::API::IMDIterator *> createIterators(
+  std::vector<std::unique_ptr<Mantid::API::IMDIterator>> createIterators(
       size_t = 1,
       Mantid::Geometry::MDImplicitFunction * = NULL) const override {
     throw std::runtime_error("Not Implemented");

--- a/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/SignalRange.h
+++ b/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/SignalRange.h
@@ -54,8 +54,8 @@ private:
                      Mantid::Geometry::MDImplicitFunction *function);
 
   /// Get the range of signal, in parallel, given an iterator
-  QwtDoubleInterval
-  getRange(const std::vector<Mantid::API::IMDIterator *> &iterators);
+  QwtDoubleInterval getRange(
+      const std::vector<std::unique_ptr<Mantid::API::IMDIterator>> &iterators);
   /// Get the range of signal given an iterator
   QwtDoubleInterval getRange(Mantid::API::IMDIterator *it);
 

--- a/qt/widgets/legacyqwt/src/SignalRange.cpp
+++ b/qt/widgets/legacyqwt/src/SignalRange.cpp
@@ -65,12 +65,12 @@ void SignalRange::findFullRange(
  * @return the min/max range, or 0-1.0 if not found
  */
 QwtDoubleInterval SignalRange::getRange(
-    const std::vector<Mantid::API::IMDIterator *> &iterators) {
+    const std::vector<std::unique_ptr<Mantid::API::IMDIterator>> &iterators) {
   std::vector<QwtDoubleInterval> intervals(iterators.size());
   // cppcheck-suppress syntaxError
       PRAGMA_OMP( parallel for schedule(dynamic, 1))
       for (int i = 0; i < int(iterators.size()); i++) {
-        Mantid::API::IMDIterator *it = iterators[i];
+        auto it = iterators[i].get();
         intervals[i] = this->getRange(it);
         // don't delete iterator in parallel. MSVC doesn't like it
         // when the iterator points to a mock object.
@@ -80,8 +80,6 @@ QwtDoubleInterval SignalRange::getRange(
       double minSignal = DBL_MAX;
       double maxSignal = -DBL_MAX;
       for (size_t i = 0; i < iterators.size(); i++) {
-        delete iterators[i];
-
         double signal;
         signal = intervals[i].minValue();
         if (!std::isfinite(signal))


### PR DESCRIPTION
Description of work.

The modernizes `IMDWorkspace::createIterator` and `IMDWorkspace::createIterators` to return a `std::unique_ptr<IMDIterator>` and `std::vector<std::unique_ptr<IMDIterator>>`, respectively. This avoids the need to manually delete pointers or arrays of pointers.

**To test:**

<!-- Instructions for testing. -->

I would appreciate comments or suggestions on further improving the interface.

There is no GitHub issue associated with this pull request.

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
