### PR TITLE
SofQW3 segfault

### DIFF
--- a/Framework/Algorithms/test/SofQWCutTest.h
+++ b/Framework/Algorithms/test/SofQWCutTest.h
@@ -246,8 +246,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(sqw.setProperty("InputWorkspace", inWS));
     TS_ASSERT_THROWS_NOTHING(
         sqw.setPropertyValue("OutputWorkspace", "__unused"));
-    TS_ASSERT_THROWS_NOTHING(
-        sqw.setPropertyValue("QAxisBinning", "0,10,10"));
+    TS_ASSERT_THROWS_NOTHING(sqw.setPropertyValue("QAxisBinning", "0,10,10"));
     TS_ASSERT_THROWS_NOTHING(sqw.setPropertyValue("EMode", "Direct"));
     TS_ASSERT_THROWS_NOTHING(sqw.setPropertyValue("EFixed", "25"));
     TS_ASSERT_THROWS_NOTHING(

--- a/Framework/Algorithms/test/SofQWCutTest.h
+++ b/Framework/Algorithms/test/SofQWCutTest.h
@@ -12,6 +12,7 @@
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidKernel/Unit.h"
 #include "MantidDataHandling/LoadNexusProcessed.h"
+#include "MantidDataHandling/CreateSimulationWorkspace.h"
 
 #include <boost/make_shared.hpp>
 
@@ -220,6 +221,48 @@ public:
     TS_ASSERT_DELTA(ws_e->readE(0)[78], 0.009076805, delta);
     TS_ASSERT_DELTA(ws_e->readY(0)[119], 0.045373095, delta);
     TS_ASSERT_DELTA(ws_e->readE(0)[119], 0.005462714, delta);
+  }
+
+  void test_sofqw3_zerobinwidth() {
+    // This test sets up a workspace which can yield a bin with zero width
+    // to check the code FractionalRebinning code handles this correctly
+    const double delta(1e-08);
+    Mantid::DataHandling::CreateSimulationWorkspace create_ws;
+    create_ws.initialize();
+    create_ws.setChild(true);
+    create_ws.setPropertyValue("Instrument", "MARI");
+    create_ws.setPropertyValue("BinParams", "-5,0.5,24");
+    create_ws.setPropertyValue("OutputWorkspace", "__unused");
+    create_ws.execute();
+
+    MatrixWorkspace_sptr createdWS = create_ws.getProperty("OutputWorkspace");
+    auto inWS = boost::dynamic_pointer_cast<MatrixWorkspace>(createdWS);
+    // Sets one spectrum to zero so final value is not unity.
+    inWS->setCounts(300, std::vector<double>(58, 0.));
+
+    Mantid::Algorithms::SofQWNormalisedPolygon sqw;
+    sqw.initialize();
+    sqw.setChild(true);
+    TS_ASSERT_THROWS_NOTHING(sqw.setProperty("InputWorkspace", inWS));
+    TS_ASSERT_THROWS_NOTHING(
+        sqw.setPropertyValue("OutputWorkspace", "__unused"));
+    TS_ASSERT_THROWS_NOTHING(
+        sqw.setPropertyValue("QAxisBinning", "0,10,10"));
+    TS_ASSERT_THROWS_NOTHING(sqw.setPropertyValue("EMode", "Direct"));
+    TS_ASSERT_THROWS_NOTHING(sqw.setPropertyValue("EFixed", "25"));
+    TS_ASSERT_THROWS_NOTHING(
+        sqw.setPropertyValue("EAxisBinning", "-1.5,3,1.5"));
+    TS_ASSERT_THROWS_NOTHING(sqw.execute());
+    TS_ASSERT(sqw.isExecuted());
+
+    MatrixWorkspace_sptr ws = sqw.getProperty("OutputWorkspace");
+    TS_ASSERT_EQUALS(ws->getAxis(0)->length(), 2);
+    TS_ASSERT_EQUALS(ws->getAxis(0)->unit()->unitID(), "DeltaE");
+    TS_ASSERT_EQUALS((*(ws->getAxis(0)))(0), -1.5);
+    TS_ASSERT_EQUALS((*(ws->getAxis(0)))(1), 1.5);
+    TS_ASSERT_EQUALS(ws->getAxis(1)->length(), 2);
+    TS_ASSERT_EQUALS(ws->getAxis(1)->unit()->unitID(), "MomentumTransfer");
+    TS_ASSERT_DELTA(ws->readY(0)[0], 0.998910675, delta);
   }
 };
 

--- a/Framework/DataObjects/src/FractionalRebinning.cpp
+++ b/Framework/DataObjects/src/FractionalRebinning.cpp
@@ -203,7 +203,7 @@ void calcTrapezoidYIntersections(
   const double NaN = std::numeric_limits<double>::quiet_NaN();
   const double DBL_EPS = std::numeric_limits<double>::epsilon();
   std::vector<double> leftLim((nx + 1) * (ny + 1), NaN);
-  std::vector<double> rightLim((nx + 1)* (ny + 1), NaN);
+  std::vector<double> rightLim((nx + 1) * (ny + 1), NaN);
   auto x0_it = xAxis.begin() + x_start;
   auto x1_it = xAxis.begin() + x_end + 1;
   auto y0_it = yAxis.begin() + y_start;

--- a/Framework/DataObjects/src/FractionalRebinning.cpp
+++ b/Framework/DataObjects/src/FractionalRebinning.cpp
@@ -185,8 +185,8 @@ void calcTrapezoidYIntersections(
     ur = V2D(xAxis[x_end], mTop * xAxis[x_end] + cTop);
   }
 
-  const size_t nx = x_end - x_start + 1;
-  const size_t ny = y_end - y_start + 1;
+  const size_t nx = x_end - x_start;
+  const size_t ny = y_end - y_start;
   const double ll_x(ll.X()), ll_y(ll.Y()), ul_y(ul.Y());
   const double lr_x(lr.X()), lr_y(lr.Y()), ur_y(ur.Y());
   // Check if there is only a output single bin and inputQ is fully enclosed
@@ -202,17 +202,18 @@ void calcTrapezoidYIntersections(
   // Step 1 - construct the left/right bin lims on the lines of the y-grid.
   const double NaN = std::numeric_limits<double>::quiet_NaN();
   const double DBL_EPS = std::numeric_limits<double>::epsilon();
-  std::vector<double> leftLim(nx * (ny + 1), NaN);
-  std::vector<double> rightLim(nx * (ny + 1), NaN);
+  std::vector<double> leftLim((nx + 1) * (ny + 1), NaN);
+  std::vector<double> rightLim((nx + 1)* (ny + 1), NaN);
   auto x0_it = xAxis.begin() + x_start;
   auto x1_it = xAxis.begin() + x_end + 1;
   auto y0_it = yAxis.begin() + y_start;
   auto y1_it = yAxis.begin() + y_end + 1;
+  const size_t ymax = (y_end == yAxis.size()) ? ny : (ny + 1);
   if ((mTop >= 0 && mBot >= 0) || (mTop < 0 && mBot < 0)) {
     // Diagonals in same direction: For a given x-parallel line,
     // Left limit given by one diagonal, right limit given by other
     double left_val, right_val;
-    for (size_t yj = 0; yj < ny; ++yj) {
+    for (size_t yj = 0; yj < ymax; ++yj) {
       const size_t yjx = yj * nx;
       // First, find the far left/right limits, given by the inputQ
       if (mTop >= 0) {
@@ -238,9 +239,9 @@ void calcTrapezoidYIntersections(
       auto right_it = std::upper_bound(x0_it, x1_it, right_val);
       if (right_it != x1_it) {
         rightLim[right_it - x0_it - 1 + yjx] = right_val;
-      } else if (yAxis[yj + y_start] < ur_y && nx > 1) {
+      } else if (yAxis[yj + y_start] < ur_y && nx > 0) {
         right_it = x1_it - 1;
-        rightLim[nx - 2 + yjx] = lr_x;
+        rightLim[nx - 1 + yjx] = lr_x;
       }
       // Now populate the bin boundaries in between
       if (left_it < right_it && right_it != x1_it) {
@@ -257,7 +258,7 @@ void calcTrapezoidYIntersections(
     const size_t y3 =
         std::upper_bound(y0_it, y1_it, (mTop >= 0) ? ul_y : ur_y) - y0_it;
     double val;
-    for (size_t yj = 0; yj < ny; ++yj) {
+    for (size_t yj = 0; yj < ymax; ++yj) {
       const size_t yjx = yj * nx;
       if (yj < y2) {
         val = (yAxis[yj + y_start] - cBot) / mBot;


### PR DESCRIPTION
Fixes an out-of-bounds index error in `FractionalRebinning` which causes a segmentation fault when `SofQW3` is called with certain parameters.

**To test:**

Run the following script:

```
ws = CreateSampleWorkspace(binWidth = 0.75, XMin = 0, XMax = 300, XUnit = 'DeltaE')
ws = ScaleX(ws, -150, "Add")
LoadInstrument(ws, InstrumentName='MARI', RewriteSpectraMap = True)
ws_sqw = SofQW3(ws, '0,10,10', 'Direct', 150, EAxisBinning='60,0.75,90')
```

And check that no segfault occurs.

Fixes #22191. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
