### PR TITLE
Fix bug when using StartLiveData through Python API

### DIFF
--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -266,6 +266,10 @@ def StartLiveData(*args, **kwargs):
         try:
             if value is None:
                 value = kwargs.pop(name)
+            else:
+                # We don't need the value, but still need to remove from kwargs
+                # so that this property isn't set again later
+                kwargs.pop(name, None)
             algm.setProperty(name, value)
 
         except ValueError as ve:


### PR DESCRIPTION
Fixes #22213 

*Based on release-v3.12 as candidate for inclusion in patch*

`StartLiveData` has some special treatment in `simpleapi.py` so that it sets some algorithm properties in a particular order. When the python code was updated to make use of dict `pop()` it resulted in the "Instrument" property not being removed from `kwargs` and thus being set twice, once before all other properties (correctly) and again later when `set_properties` is called. This second `setProperty` causes the Listener properties to be wiped. The fix is to always call `pop` in `handleSpecialProperty` whether or not the value of the property is required.

**To test:**

Depends on python dictionary order so not easy to test, please review code.

You could also try running the following:
```python
StartLiveData(FromStartOfRun=True,
                       FromNow=False,
                       FromTime=False,
                       UpdateEvery=5,
                       Instrument='LARMOR',
                       Listener='KafkaEventListener',
                       Address='livedata.isis.cclrc.ac.uk:9092',
                       AccumulationMethod='Add',
                       PreserveEvents=True,
                       RunTransitionBehavior='Stop',
                       OutputWorkspace='outWS',
                       InstrumentName='LARMOR')
```

**Release Notes** 

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
