### PR TITLE
Use unique_ptr for safer getVertexesArray function.

### DIFF
--- a/Framework/API/inc/MantidAPI/IMDIterator.h
+++ b/Framework/API/inc/MantidAPI/IMDIterator.h
@@ -90,13 +90,14 @@ public:
   virtual signal_t getError() const = 0;
 
   /// Return a list of vertexes defining the volume pointed to
-  virtual coord_t *getVertexesArray(size_t &numVertices) const = 0;
+  virtual std::unique_ptr<coord_t[]>
+  getVertexesArray(size_t &numVertices) const = 0;
 
   /// Return a list of vertexes defining the volume pointed to, enable masking
   /// of dimensions.
-  virtual coord_t *getVertexesArray(size_t &numVertices,
-                                    const size_t outDimensions,
-                                    const bool *maskDim) const = 0;
+  virtual std::unique_ptr<coord_t[]>
+  getVertexesArray(size_t &numVertices, const size_t outDimensions,
+                   const bool *maskDim) const = 0;
 
   /// Returns the position of the center of the box pointed to.
   virtual Mantid::Kernel::VMD getCenter() const = 0;

--- a/Framework/API/inc/MantidAPI/IMDNode.h
+++ b/Framework/API/inc/MantidAPI/IMDNode.h
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <string>
+#include <memory>
 #include <vector>
 #include "MantidKernel/VMD.h"
 #include "MantidGeometry/MDGeometry/MDTypes.h"
@@ -277,10 +278,11 @@ public:
   // -------------------------------- Geometry/vertexes-Related
   // -------------------------------------------
   virtual std::vector<Mantid::Kernel::VMD> getVertexes() const = 0;
-  virtual coord_t *getVertexesArray(size_t &numVertices) const = 0;
-  virtual coord_t *getVertexesArray(size_t &numVertices,
-                                    const size_t outDimensions,
-                                    const bool *maskDim) const = 0;
+  virtual std::unique_ptr<coord_t[]>
+  getVertexesArray(size_t &numVertices) const = 0;
+  virtual std::unique_ptr<coord_t[]>
+  getVertexesArray(size_t &numVertices, const size_t outDimensions,
+                   const bool *maskDim) const = 0;
   virtual void transformDimensions(std::vector<double> &scaling,
                                    std::vector<double> &offset) = 0;
 

--- a/Framework/API/inc/MantidAPI/MatrixWorkspaceMDIterator.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspaceMDIterator.h
@@ -60,10 +60,12 @@ public:
 
   signal_t getError() const override;
 
-  coord_t *getVertexesArray(size_t &numVertices) const override;
+  std::unique_ptr<coord_t[]>
+  getVertexesArray(size_t &numVertices) const override;
 
-  coord_t *getVertexesArray(size_t &numVertices, const size_t outDimensions,
-                            const bool *maskDim) const override;
+  std::unique_ptr<coord_t[]>
+  getVertexesArray(size_t &numVertices, const size_t outDimensions,
+                   const bool *maskDim) const override;
 
   Mantid::Kernel::VMD getCenter() const override;
 

--- a/Framework/API/src/MatrixWorkspaceMDIterator.cpp
+++ b/Framework/API/src/MatrixWorkspaceMDIterator.cpp
@@ -204,13 +204,13 @@ signal_t MatrixWorkspaceMDIterator::getError() const {
 
 //----------------------------------------------------------------------------------------------
 /// Return a list of vertexes defining the volume pointed to
-coord_t *
+std::unique_ptr<coord_t[]>
 MatrixWorkspaceMDIterator::getVertexesArray(size_t & /*numVertices*/) const {
   throw std::runtime_error(
       "MatrixWorkspaceMDIterator::getVertexesArray() not implemented yet");
 }
 
-coord_t *
+std::unique_ptr<coord_t[]>
 MatrixWorkspaceMDIterator::getVertexesArray(size_t & /*numVertices*/,
                                             const size_t /*outDimensions*/,
                                             const bool * /*maskDim*/) const {

--- a/Framework/Crystal/test/PeakBackgroundTest.h
+++ b/Framework/Crystal/test/PeakBackgroundTest.h
@@ -48,10 +48,12 @@ public:
   MOCK_CONST_METHOD0(getNormalizedSignalWithMask, signal_t());
   MOCK_CONST_METHOD0(getSignal, signal_t());
   MOCK_CONST_METHOD0(getError, signal_t());
-  MOCK_CONST_METHOD1(getVertexesArray, coord_t *(size_t &numVertices));
+  MOCK_CONST_METHOD1(getVertexesArray,
+                     std::unique_ptr<coord_t[]>(size_t &numVertices));
   MOCK_CONST_METHOD3(getVertexesArray,
-                     coord_t *(size_t &numVertices, const size_t outDimensions,
-                               const bool *maskDim));
+                     std::unique_ptr<coord_t[]>(size_t &numVertices,
+                                                const size_t outDimensions,
+                                                const bool *maskDim));
   MOCK_CONST_METHOD0(getCenter, Mantid::Kernel::VMD());
   MOCK_CONST_METHOD0(getNumEvents, size_t());
   MOCK_CONST_METHOD1(getInnerRunIndex, uint16_t(size_t index));

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBoxBase.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBoxBase.h
@@ -158,9 +158,11 @@ public:
   // -------------------------------------------
 
   std::vector<Mantid::Kernel::VMD> getVertexes() const override;
-  coord_t *getVertexesArray(size_t &numVertices) const override;
-  coord_t *getVertexesArray(size_t &numVertices, const size_t outDimensions,
-                            const bool *maskDim) const override;
+  std::unique_ptr<coord_t[]>
+  getVertexesArray(size_t &numVertices) const override;
+  std::unique_ptr<coord_t[]>
+  getVertexesArray(size_t &numVertices, const size_t outDimensions,
+                   const bool *maskDim) const override;
   void transformDimensions(std::vector<double> &scaling,
                            std::vector<double> &offset) override;
 

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBoxBase.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBoxBase.tcc
@@ -1,11 +1,10 @@
 #include "MantidDataObjects/MDBoxBase.h"
 #include "MantidDataObjects/MDEvent.h"
+#include "MantidKernel/make_unique.h"
 #include "MantidKernel/System.h"
 #include "MantidKernel/VMD.h"
 #include <boost/make_shared.hpp>
 #include <limits>
-
-//using NeXus::File;
 
 namespace Mantid {
 namespace DataObjects {
@@ -135,13 +134,13 @@ TMDE(std::vector<Mantid::Kernel::VMD> MDBoxBase)::getVertexes() const {
  * @param[out] numVertices :: returns the number of vertices in the array.
  * @return the bare array. This should be deleted by the caller!
  * */
-TMDE(coord_t *MDBoxBase)::getVertexesArray(size_t &numVertices) const {
+TMDE(std::unique_ptr<coord_t[]> MDBoxBase)::getVertexesArray(size_t &numVertices) const {
   // How many vertices does one box have? 2^nd, or bitwise shift left 1 by nd
   // bits
   numVertices = 1 << nd;
 
   // Allocate the array of the right size
-  auto out = new coord_t[nd * numVertices];
+  auto out = Kernel::make_unique<coord_t[]>(nd * numVertices);
 
   // For each vertex, increase an integeer
   for (size_t i = 0; i < numVertices; ++i) {
@@ -184,7 +183,7 @@ TMDE(coord_t *MDBoxBase)::getVertexesArray(size_t &numVertices) const {
  *caller!
  * @throw if outDimensions == 0
  * */
-TMDE(coord_t *MDBoxBase)::getVertexesArray(size_t &numVertices,
+TMDE(std::unique_ptr<coord_t[]> MDBoxBase)::getVertexesArray(size_t &numVertices,
                                            const size_t outDimensions,
                                            const bool *maskDim) const {
   if (outDimensions == 0)
@@ -195,7 +194,7 @@ TMDE(coord_t *MDBoxBase)::getVertexesArray(size_t &numVertices,
   numVertices = (size_t)1 << outDimensions;
 
   // Allocate the array of the right size
-  auto out = new coord_t[outDimensions * numVertices];
+  auto out = Kernel::make_unique<coord_t[]>(outDimensions * numVertices);
 
   // For each vertex, increase an integeer
   for (size_t i = 0; i < numVertices; ++i) {

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBoxIterator.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBoxIterator.h
@@ -54,10 +54,12 @@ public:
 
   signal_t getError() const override;
 
-  coord_t *getVertexesArray(size_t &numVertices, const size_t outDimensions,
-                            const bool *maskDim) const override;
+  std::unique_ptr<coord_t[]>
+  getVertexesArray(size_t &numVertices, const size_t outDimensions,
+                   const bool *maskDim) const override;
 
-  coord_t *getVertexesArray(size_t &numVertices) const override;
+  std::unique_ptr<coord_t[]>
+  getVertexesArray(size_t &numVertices) const override;
 
   Mantid::Kernel::VMD getCenter() const override;
 

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBoxIterator.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBoxIterator.tcc
@@ -258,11 +258,11 @@ TMDE(signal_t MDBoxIterator)::getSignal() const {
 TMDE(signal_t MDBoxIterator)::getError() const { return m_current->getError(); }
 
 /// Return a list of vertexes defining the volume pointed to
-TMDE(coord_t *MDBoxIterator)::getVertexesArray(size_t &numVertices) const {
+TMDE(std::unique_ptr<coord_t[]> MDBoxIterator)::getVertexesArray(size_t &numVertices) const {
   return m_current->getVertexesArray(numVertices);
 }
 
-TMDE(coord_t *MDBoxIterator)::getVertexesArray(size_t &numVertices,
+TMDE(std::unique_ptr<coord_t[]> MDBoxIterator)::getVertexesArray(size_t &numVertices,
                                                const size_t outDimensions,
                                                const bool *maskDim) const {
   return m_current->getVertexesArray(numVertices, outDimensions, maskDim);

--- a/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
@@ -174,7 +174,8 @@ public:
   void applyImplicitFunction(Mantid::Geometry::MDImplicitFunction *function,
                              signal_t signal, signal_t errorSquared);
 
-  coord_t *getVertexesArray(size_t linearIndex, size_t &numVertices) const;
+  std::unique_ptr<coord_t[]> getVertexesArray(size_t linearIndex,
+                                              size_t &numVertices) const;
 
   Kernel::VMD getCenter(size_t linearIndex) const override;
 

--- a/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspaceIterator.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspaceIterator.h
@@ -95,10 +95,12 @@ public:
 
   signal_t getError() const override;
 
-  coord_t *getVertexesArray(size_t &numVertices) const override;
+  std::unique_ptr<coord_t[]>
+  getVertexesArray(size_t &numVertices) const override;
 
-  coord_t *getVertexesArray(size_t &numVertices, const size_t outDimensions,
-                            const bool *maskDim) const override;
+  std::unique_ptr<coord_t[]>
+  getVertexesArray(size_t &numVertices, const size_t outDimensions,
+                   const bool *maskDim) const override;
 
   Mantid::Kernel::VMD getCenter() const override;
 

--- a/Framework/DataObjects/src/MDHistoWorkspace.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspace.cpp
@@ -304,8 +304,9 @@ void MDHistoWorkspace::applyImplicitFunction(
  * @param[out] numVertices :: returns the number of vertices in the array.
  * @return the bare array. This should be deleted by the caller!
  * */
-coord_t *MDHistoWorkspace::getVertexesArray(size_t linearIndex,
-                                            size_t &numVertices) const {
+std::unique_ptr<coord_t[]>
+MDHistoWorkspace::getVertexesArray(size_t linearIndex,
+                                   size_t &numVertices) const {
   // How many vertices does one box have? 2^nd, or bitwise shift left 1 by nd
   // bits
   numVertices = static_cast<size_t>(1)
@@ -320,7 +321,7 @@ coord_t *MDHistoWorkspace::getVertexesArray(size_t linearIndex,
       numDimensions, linearIndex, m_indexMaker, m_indexMax, dimIndexes);
 
   // The output vertexes coordinates
-  auto out = new coord_t[numDimensions * numVertices];
+  auto out = Kernel::make_unique<coord_t[]>(numDimensions * numVertices);
   for (size_t i = 0; i < numVertices; ++i) {
     size_t outIndex = i * numDimensions;
     // Offset the 0th box by the position of this linear index, in each

--- a/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
@@ -384,14 +384,16 @@ signal_t MDHistoWorkspaceIterator::getError() const {
 }
 //----------------------------------------------------------------------------------------------
 /// Return a list of vertexes defining the volume pointed to
-coord_t *MDHistoWorkspaceIterator::getVertexesArray(size_t &numVertices) const {
+std::unique_ptr<coord_t[]>
+MDHistoWorkspaceIterator::getVertexesArray(size_t &numVertices) const {
   // The MDHistoWorkspace takes care of this
   return m_ws->getVertexesArray(m_pos, numVertices);
 }
 
-coord_t *MDHistoWorkspaceIterator::getVertexesArray(size_t &numVertices,
-                                                    const size_t outDimensions,
-                                                    const bool *maskDim) const {
+std::unique_ptr<coord_t[]>
+MDHistoWorkspaceIterator::getVertexesArray(size_t &numVertices,
+                                           const size_t outDimensions,
+                                           const bool *maskDim) const {
   // Do the same thing as is done in the MDBoxBase
   UNUSED_ARG(numVertices);
   UNUSED_ARG(outDimensions);

--- a/Framework/DataObjects/test/MDBoxBaseTest.h
+++ b/Framework/DataObjects/test/MDBoxBaseTest.h
@@ -326,7 +326,7 @@ public:
     b.setExtents(0, -10.0, 10.0);
     b.setExtents(1, -4.0, 6.0);
     size_t numVertexes = 0;
-    coord_t *v = b.getVertexesArray(numVertexes);
+    auto v = b.getVertexesArray(numVertexes);
     TS_ASSERT_EQUALS(numVertexes, 4);
     TS_ASSERT_EQUALS(v[0], -10.0);
     TS_ASSERT_EQUALS(v[0 + 1], -4.0);
@@ -336,7 +336,6 @@ public:
     TS_ASSERT_EQUALS(v[4 + 1], 6.0);
     TS_ASSERT_EQUALS(v[6], 10.0);
     TS_ASSERT_EQUALS(v[6 + 1], 6.0);
-    delete[] v;
   }
 
   /** Get vertexes as a bare array,
@@ -346,21 +345,18 @@ public:
     b.setExtents(0, -10.0, 10.0);
     b.setExtents(1, -4.0, 6.0);
     size_t numVertexes = 0;
-    coord_t *v;
 
     bool maskDim[2] = {true, false};
-    v = b.getVertexesArray(numVertexes, 1, maskDim);
+    auto v = b.getVertexesArray(numVertexes, 1, maskDim);
     TS_ASSERT_EQUALS(numVertexes, 2);
     TS_ASSERT_EQUALS(v[0], -10.0);
     TS_ASSERT_EQUALS(v[1], 10.0);
-    delete[] v;
 
     bool maskDim2[2] = {false, true};
     v = b.getVertexesArray(numVertexes, 1, maskDim2);
     TS_ASSERT_EQUALS(numVertexes, 2);
     TS_ASSERT_EQUALS(v[0], -4.0);
     TS_ASSERT_EQUALS(v[1], 6.0);
-    delete[] v;
   }
 
   /** Get vertexes as a bare array,
@@ -371,11 +367,10 @@ public:
     b.setExtents(1, -4.0, 6.0);
     b.setExtents(2, -2.0, 8.0);
     size_t numVertexes = 0;
-    coord_t *v;
 
     // 3D projected down to 2D in X/Y
     bool maskDim[3] = {true, true, false};
-    v = b.getVertexesArray(numVertexes, 2, maskDim);
+    auto v = b.getVertexesArray(numVertexes, 2, maskDim);
     TS_ASSERT_EQUALS(numVertexes, 4);
     TS_ASSERT_EQUALS(v[0], -10.0);
     TS_ASSERT_EQUALS(v[0 + 1], -4.0);
@@ -385,7 +380,6 @@ public:
     TS_ASSERT_EQUALS(v[4 + 1], 6.0);
     TS_ASSERT_EQUALS(v[6], 10.0);
     TS_ASSERT_EQUALS(v[6 + 1], 6.0);
-    delete[] v;
 
     // Can't give 0 dimensions.
     TS_ASSERT_THROWS_ANYTHING(v = b.getVertexesArray(numVertexes, 0, maskDim));
@@ -396,7 +390,6 @@ public:
     TS_ASSERT_EQUALS(numVertexes, 2);
     TS_ASSERT_EQUALS(v[0], -4.0);
     TS_ASSERT_EQUALS(v[1], 6.0);
-    delete[] v;
 
     // 3D projected down to 2D in Y/Z
     bool maskDim3[3] = {false, true, true};
@@ -410,7 +403,6 @@ public:
     TS_ASSERT_EQUALS(v[4 + 1], 8.0);
     TS_ASSERT_EQUALS(v[6], 6.0);
     TS_ASSERT_EQUALS(v[6 + 1], 8.0);
-    delete[] v;
   }
 
   void xtest_sortBoxesByFilePos() {
@@ -456,8 +448,7 @@ public:
     b.setExtents(2, -7.0, 7.0);
     for (size_t i = 0; i < 1000000; i++) {
       size_t numVertexes;
-      coord_t *v = b.getVertexesArray(numVertexes);
-      delete[] v;
+      auto v = b.getVertexesArray(numVertexes);
     }
   }
 
@@ -469,8 +460,7 @@ public:
     bool maskDim[3] = {true, true, false};
     for (size_t i = 0; i < 1000000; i++) {
       size_t numVertexes;
-      coord_t *v = b.getVertexesArray(numVertexes, 2, maskDim);
-      delete[] v;
+      auto v = b.getVertexesArray(numVertexes, 2, maskDim);
     }
   }
 
@@ -482,8 +472,7 @@ public:
     b.setExtents(3, -6.0, 6.0);
     for (size_t i = 0; i < 1000000; i++) {
       size_t numVertexes;
-      coord_t *v = b.getVertexesArray(numVertexes);
-      delete[] v;
+      auto v = b.getVertexesArray(numVertexes);
     }
   }
   void test_getVertexesArray_4D_projected_to_3D() {
@@ -495,8 +484,7 @@ public:
     b.setExtents(3, -6.0, 6.0);
     for (size_t i = 0; i < 1000000; i++) {
       size_t numVertexes;
-      coord_t *v = b.getVertexesArray(numVertexes, 3, maskDim);
-      delete[] v;
+      auto v = b.getVertexesArray(numVertexes, 3, maskDim);
     }
   }
 };

--- a/Framework/DataObjects/test/MDHistoWorkspaceIteratorTest.h
+++ b/Framework/DataObjects/test/MDHistoWorkspaceIteratorTest.h
@@ -79,9 +79,8 @@ public:
       TS_ASSERT_DELTA(it->getNormalizedSignal(), double(i) / 1.0, 1e-5);
       TS_ASSERT_DELTA(it->getNormalizedError(), 1.0, 1e-5);
       size_t numVertices;
-      coord_t *vertexes = it->getVertexesArray(numVertices);
+      auto vertexes = it->getVertexesArray(numVertices);
       TS_ASSERT(vertexes);
-      delete[] vertexes;
       TS_ASSERT_EQUALS(it->getNumEvents(), 1);
       TS_ASSERT_EQUALS(it->getInnerDetectorID(0), 0);
       TS_ASSERT_EQUALS(it->getInnerRunIndex(0), 0);
@@ -1450,8 +1449,7 @@ public:
     do {
       signal_t sig = it->getNormalizedSignal();
       signal_t err = it->getNormalizedError();
-      coord_t *vertexes = it->getVertexesArray(numVertices);
-      delete[] vertexes;
+      auto vertexes = it->getVertexesArray(numVertices);
       UNUSED_ARG(sig);
       UNUSED_ARG(err);
     } while (it->next());

--- a/Framework/DataObjects/test/MDHistoWorkspaceTest.h
+++ b/Framework/DataObjects/test/MDHistoWorkspaceTest.h
@@ -286,16 +286,14 @@ public:
         new MDHistoDimension("X", "x", frame, -10, 10, 5));
     MDHistoWorkspace ws(dimX);
     size_t numVertices;
-    coord_t *v1 = ws.getVertexesArray(0, numVertices);
+    auto v1 = ws.getVertexesArray(0, numVertices);
     TS_ASSERT_EQUALS(numVertices, 2);
     TS_ASSERT_DELTA(v1[0], -10.0, 1e-5);
     TS_ASSERT_DELTA(v1[1], -6.0, 1e-5);
-    delete[] v1;
 
-    coord_t *v2 = ws.getVertexesArray(4, numVertices);
+    auto v2 = ws.getVertexesArray(4, numVertices);
     TS_ASSERT_DELTA(v2[0], 6.0, 1e-5);
     TS_ASSERT_DELTA(v2[1], 10.0, 1e-5);
-    delete[] v2;
   }
 
   //---------------------------------------------------------------------------------------------------
@@ -308,7 +306,7 @@ public:
     MDHistoWorkspace ws(dimX, dimY);
     size_t numVertices, i;
 
-    boost::scoped_array<coord_t> v1(ws.getVertexesArray(0, numVertices));
+    auto v1 = ws.getVertexesArray(0, numVertices);
     TS_ASSERT_EQUALS(numVertices, 4);
     i = 0 * 2;
     TS_ASSERT_DELTA(v1[i + 0], -10.0, 1e-5);
@@ -317,7 +315,7 @@ public:
     TS_ASSERT_DELTA(v1[i + 0], -6.0, 1e-5);
     TS_ASSERT_DELTA(v1[i + 1], -6.0, 1e-5);
     // The opposite corner
-    boost::scoped_array<coord_t> v2(ws.getVertexesArray(24, numVertices));
+    auto v2 = ws.getVertexesArray(24, numVertices);
     i = 0 * 2;
     TS_ASSERT_DELTA(v2[i + 0], 6.0, 1e-5);
     TS_ASSERT_DELTA(v2[i + 1], 6.0, 1e-5);
@@ -338,7 +336,7 @@ public:
     MDHistoWorkspace ws(dimX, dimY, dimZ);
     size_t numVertices, i;
 
-    boost::scoped_array<coord_t> v(ws.getVertexesArray(0, numVertices));
+    auto v = ws.getVertexesArray(0, numVertices);
     TS_ASSERT_EQUALS(numVertices, 8);
     i = 0;
     TS_ASSERT_DELTA(v[i + 0], -10.0, 1e-5);

--- a/Framework/MDAlgorithms/src/BinMD.cpp
+++ b/Framework/MDAlgorithms/src/BinMD.cpp
@@ -103,7 +103,7 @@ inline void BinMD::binMDBox(MDBox<MDE, nd> *box, const size_t *const chunkMin,
     // There is a check that the number of events is enough for it to make sense
     // to do all this processing.
     size_t numVertexes = 0;
-    coord_t *vertexes = box->getVertexesArray(numVertexes);
+    auto vertexes = box->getVertexesArray(numVertexes);
 
     // All vertexes have to be within THE SAME BIN = have the same linear index.
     size_t lastLinearIndex = 0;
@@ -111,7 +111,7 @@ inline void BinMD::binMDBox(MDBox<MDE, nd> *box, const size_t *const chunkMin,
 
     for (size_t i = 0; i < numVertexes; i++) {
       // Cache the center of the event (again for speed)
-      const coord_t *inCenter = vertexes + i * nd;
+      const coord_t *inCenter = vertexes.get() + i * nd;
 
       // Now transform to the output dimensions
       m_transform->apply(inCenter, outCenter);
@@ -153,8 +153,6 @@ inline void BinMD::binMDBox(MDBox<MDE, nd> *box, const size_t *const chunkMin,
       if (badOne)
         break;
     } // (for each vertex)
-
-    delete[] vertexes;
 
     if (!badOne) {
       // Yes, the entire box is within a single bin

--- a/Framework/MDAlgorithms/test/FitMDTest.h
+++ b/Framework/MDAlgorithms/test/FitMDTest.h
@@ -36,9 +36,11 @@ public:
   signal_t getNormalizedError() const override;
   signal_t getSignal() const override { return 0; }
   signal_t getError() const override { return 0; }
-  coord_t *getVertexesArray(size_t &) const override { return nullptr; }
-  coord_t *getVertexesArray(size_t &, const size_t,
-                            const bool *) const override {
+  std::unique_ptr<coord_t[]> getVertexesArray(size_t &) const override {
+    return nullptr;
+  }
+  std::unique_ptr<coord_t[]> getVertexesArray(size_t &, const size_t,
+                                              const bool *) const override {
     return nullptr;
   }
   Mantid::Kernel::VMD getCenter() const override;

--- a/buildconfig/CMake/GoogleTest.in
+++ b/buildconfig/CMake/GoogleTest.in
@@ -15,6 +15,7 @@ ExternalProject_Add(googletest
   PATCH_COMMAND     "@GIT_EXECUTABLE@" reset --hard ${_tag}
             COMMAND "@GIT_EXECUTABLE@" apply --whitespace fix "@CMAKE_SOURCE_DIR@/buildconfig/CMake/googletest_override.patch"
             COMMAND "@GIT_EXECUTABLE@" apply --whitespace fix "@CMAKE_SOURCE_DIR@/buildconfig/CMake/googletest_static.patch"
+            COMMAND "@GIT_EXECUTABLE@" apply --whitespace fix "@CMAKE_SOURCE_DIR@/buildconfig/CMake/googletest_msvc_cpp11.patch"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
   INSTALL_COMMAND   ""

--- a/buildconfig/CMake/googletest_msvc_cpp11.patch
+++ b/buildconfig/CMake/googletest_msvc_cpp11.patch
@@ -1,0 +1,41 @@
+diff --git a/googletest/include/gtest/internal/gtest-port.h b/googletest/include/gtest/internal/gtest-port.h
+index 5529ba544..331483e73 100644
+--- a/googletest/include/gtest/internal/gtest-port.h
++++ b/googletest/include/gtest/internal/gtest-port.h
+@@ -325,7 +325,7 @@
+ // -std={c,gnu}++{0x,11} is passed.  The C++11 standard specifies a
+ // value for __cplusplus, and recent versions of clang, gcc, and
+ // probably other compilers set that too in C++11 mode.
+-# if __GXX_EXPERIMENTAL_CXX0X__ || __cplusplus >= 201103L
++# if __GXX_EXPERIMENTAL_CXX0X__ || __cplusplus >= 201103L || _MSC_VER >= 1900
+ // Compiling in at least C++11 mode.
+ #  define GTEST_LANG_CXX11 1
+ # else
+@@ -357,12 +357,16 @@
+ #if GTEST_STDLIB_CXX11
+ # define GTEST_HAS_STD_BEGIN_AND_END_ 1
+ # define GTEST_HAS_STD_FORWARD_LIST_ 1
+-# define GTEST_HAS_STD_FUNCTION_ 1
++# if !defined(_MSC_VER) || (_MSC_FULL_VER >= 190023824) // works only with VS2015U2 and better
++#   define GTEST_HAS_STD_FUNCTION_ 1
++# endif
+ # define GTEST_HAS_STD_INITIALIZER_LIST_ 1
+ # define GTEST_HAS_STD_MOVE_ 1
+ # define GTEST_HAS_STD_SHARED_PTR_ 1
+ # define GTEST_HAS_STD_TYPE_TRAITS_ 1
+ # define GTEST_HAS_STD_UNIQUE_PTR_ 1
++# define GTEST_HAS_UNORDERED_MAP_ 1
++# define GTEST_HAS_UNORDERED_SET_ 1
+ #endif
+ 
+ // C++11 specifies that <tuple> provides std::tuple.
+@@ -660,7 +664,8 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
+ // support TR1 tuple.  libc++ only provides std::tuple, in C++11 mode,
+ // and it can be used with some compilers that define __GNUC__.
+ # if (defined(__GNUC__) && !defined(__CUDACC__) && (GTEST_GCC_VER_ >= 40000) \
+-      && !GTEST_OS_QNX && !defined(_LIBCPP_VERSION)) || _MSC_VER >= 1600
++      && !GTEST_OS_QNX && !defined(_LIBCPP_VERSION)) \
++      || (_MSC_VER >= 1600 && _MSC_VER < 1900)
+ #  define GTEST_ENV_HAS_TR1_TUPLE_ 1
+ # endif
+ 

--- a/qt/paraview_ext/PVPlugins/Sources/MDEWSource/vtkMDEWSource.cxx
+++ b/qt/paraview_ext/PVPlugins/Sources/MDEWSource/vtkMDEWSource.cxx
@@ -38,7 +38,7 @@ vtkStandardNewMacro(vtkMDEWSource)
 }
 
 /// Destructor
-vtkMDEWSource::~vtkMDEWSource() {}
+vtkMDEWSource::~vtkMDEWSource() = default;
 
 /*
  Setter for the recursion depth

--- a/qt/paraview_ext/VatesAPI/src/vtkMDHexFactory.cpp
+++ b/qt/paraview_ext/VatesAPI/src/vtkMDHexFactory.cpp
@@ -128,11 +128,9 @@ void vtkMDHexFactory::doCreate(
 
         // If slicing down to 3D, specify which dimensions to keep.
         if (this->slice) {
-          coords = std::unique_ptr<coord_t[]>(
-              box->getVertexesArray(numVertexes, 3, this->sliceMask.get()));
+          coords = box->getVertexesArray(numVertexes, 3, this->sliceMask.get());
         } else {
-          coords =
-              std::unique_ptr<coord_t[]>(box->getVertexesArray(numVertexes));
+          coords = box->getVertexesArray(numVertexes);
         }
         if (numVertexes == 8) {
           std::copy_n(coords.get(), 24, std::next(pointsPtr, i * 24));

--- a/qt/paraview_ext/VatesAPI/src/vtkMDLineFactory.cpp
+++ b/qt/paraview_ext/VatesAPI/src/vtkMDLineFactory.cpp
@@ -116,8 +116,8 @@ vtkMDLineFactory::create(ProgressAction &progressUpdating) const {
         useBox[iBox] = true;
         signals->InsertNextValue(static_cast<float>(signal_normalized));
 
-        auto coords = std::unique_ptr<coord_t[]>(
-            it->getVertexesArray(nVertexes, nNonIntegrated, masks.get()));
+        auto coords =
+            it->getVertexesArray(nVertexes, nNonIntegrated, masks.get());
 
         // Iterate through all coordinates. Candidate for speed improvement.
         for (size_t v = 0; v < nVertexes; ++v) {

--- a/qt/paraview_ext/VatesAPI/src/vtkMDQuadFactory.cpp
+++ b/qt/paraview_ext/VatesAPI/src/vtkMDQuadFactory.cpp
@@ -112,9 +112,8 @@ vtkMDQuadFactory::create(ProgressAction &progressUpdating) const {
         useBox[iBox] = true;
         signals->InsertNextValue(static_cast<float>(signal));
 
-        auto coords = std::unique_ptr<coord_t[]>(
-            it->getVertexesArray(nVertexes, nNonIntegrated, masks.get()));
-
+        auto coords =
+            it->getVertexesArray(nVertexes, nNonIntegrated, masks.get());
         // Iterate through all coordinates. Candidate for speed improvement.
         for (size_t v = 0; v < nVertexes; ++v) {
           coord_t *coord = coords.get() + v * 2;


### PR DESCRIPTION
Description of work.

This uses std::unique_ptr<coord_t[]> to automatically delete memory returned from `IMDNode::getVertexesArray(....)` and `IMDIterator::::getVertexesArray(....)`.

The alternative would be to use `std::vector<coord_t>`, though I'm hesitant to add the zero-initialization overhead. 

**To test:**

<!-- Instructions for testing. -->

I would appreciate comments or suggestions on further improving the interface.

There is no GitHub issue associated with this pull request.

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
