### PR TITLE
Error when deleting a workspace group in MantidPlot.

### DIFF
--- a/Framework/API/inc/MantidAPI/WorkspaceGroup.h
+++ b/Framework/API/inc/MantidAPI/WorkspaceGroup.h
@@ -76,6 +76,8 @@ public:
   Workspace_sptr getItem(const size_t index) const;
   /// Return the workspace by name
   Workspace_sptr getItem(const std::string wsName) const;
+  /// Return all workspaces in the group as one call for thread safety
+  std::vector<Workspace_sptr> getAllItems() const;
   /// Remove a workspace from the group
   void removeItem(const size_t index);
   /// Remove all names from the group but do not touch the ADS

--- a/Framework/API/src/WorkspaceGroup.cpp
+++ b/Framework/API/src/WorkspaceGroup.cpp
@@ -195,6 +195,13 @@ Workspace_sptr WorkspaceGroup::getItem(const std::string wsName) const {
                           " not contained in the group");
 }
 
+/** Return all workspaces in the group as one call for thread safety
+ */
+std::vector<Workspace_sptr> WorkspaceGroup::getAllItems() const {
+  std::lock_guard<std::recursive_mutex> _lock(m_mutex);
+  return m_workspaces;
+}
+
 /// Empty all the entries out of the workspace group. Does not remove the
 /// workspaces from the ADS.
 void WorkspaceGroup::removeAll() { m_workspaces.clear(); }

--- a/Framework/API/test/WorkspaceGroupTest.h
+++ b/Framework/API/test/WorkspaceGroupTest.h
@@ -241,6 +241,17 @@ public:
     AnalysisDataService::Instance().clear();
   }
 
+  void test_getAllItems() {
+    WorkspaceGroup_sptr group = makeGroup();
+    auto items = group->getAllItems();
+    TS_ASSERT_EQUALS(group->size(), 3);
+    TS_ASSERT_EQUALS(items.size(), 3);
+    TS_ASSERT_EQUALS(items[0], group->getItem(0));
+    TS_ASSERT_EQUALS(items[1], group->getItem(1));
+    TS_ASSERT_EQUALS(items[2], group->getItem(2));
+    AnalysisDataService::Instance().clear();
+  }
+
   void test_deleting_workspaces() {
     WorkspaceGroup_sptr group = makeGroup();
     TS_ASSERT(AnalysisDataService::Instance().doesExist("group"));

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
@@ -734,7 +734,7 @@ void WorkspaceTreeWidget::populateChildData(QTreeWidgetItem *item) {
 
   if (auto group = boost::dynamic_pointer_cast<WorkspaceGroup>(workspace)) {
     auto members = group->getAllItems();
-    for (auto ws : members) {
+    for (const auto &ws : members) {
       auto *node = addTreeEntry(std::make_pair(ws->getName(), ws), item);
       excludeItemFromSort(node);
       if (shouldBeSelected(node->text(0)))

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
@@ -733,9 +733,8 @@ void WorkspaceTreeWidget::populateChildData(QTreeWidgetItem *item) {
   Workspace_sptr workspace = userData.value<Workspace_sptr>();
 
   if (auto group = boost::dynamic_pointer_cast<WorkspaceGroup>(workspace)) {
-    const size_t nmembers = group->getNumberOfEntries();
-    for (size_t i = 0; i < nmembers; ++i) {
-      auto ws = group->getItem(i);
+    auto members = group->getAllItems();
+    for (auto ws : members) {
       auto *node = addTreeEntry(std::make_pair(ws->getName(), ws), item);
       excludeItemFromSort(node);
       if (shouldBeSelected(node->text(0)))


### PR DESCRIPTION
The error is due to a race condition. The change eliminates one by retrieving all group members in a single call guarded by a mutex.

**To test:**

See the bug description.

Fixes #22225

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
