### PR TITLE
Remove duplicate instrument name property from kafka event listener

### DIFF
--- a/Framework/LiveData/inc/MantidLiveData/Kafka/KafkaEventListener.h
+++ b/Framework/LiveData/inc/MantidLiveData/Kafka/KafkaEventListener.h
@@ -1,5 +1,5 @@
-#ifndef MANTID_LIVEDATA_ISISKAFKAEVENTLISTENER_H_
-#define MANTID_LIVEDATA_ISISKAFKAEVENTLISTENER_H_
+#ifndef MANTID_LIVEDATA_KAFKAEVENTLISTENER_H_
+#define MANTID_LIVEDATA_KAFKAEVENTLISTENER_H_
 //----------------------------------------------------------------------
 // Includes
 //----------------------------------------------------------------------
@@ -10,6 +10,11 @@
 //----------------------------------------------------------------------
 
 namespace Mantid {
+
+namespace API {
+class IAlgorithm;
+}
+
 namespace LiveData {
 class KafkaEventStreamDecoder;
 
@@ -38,8 +43,7 @@ class KafkaEventStreamDecoder;
  */
 class DLLExport KafkaEventListener : public API::LiveListener {
 public:
-  KafkaEventListener();
-  /// Destructor. Should handle termination of any socket connections.
+  KafkaEventListener() = default;
   ~KafkaEventListener() override = default;
 
   //----------------------------------------------------------------------
@@ -61,6 +65,7 @@ public:
   void start(
       Types::Core::DateAndTime startTime = Types::Core::DateAndTime()) override;
   boost::shared_ptr<API::Workspace> extractData() override;
+  void setAlgorithm(const Mantid::API::IAlgorithm &callingAlgorithm) override;
 
   //----------------------------------------------------------------------
   // State flags
@@ -71,9 +76,10 @@ public:
 
 private:
   std::unique_ptr<KafkaEventStreamDecoder> m_decoder = nullptr;
+  std::string m_instrumentName;
 };
 
 } // namespace LiveData
 } // namespace Mantid
 
-#endif /*MANTID_LIVEDATA_ISISKAFKAEVENTLISTENER_H_*/
+#endif /*MANTID_LIVEDATA_KAFKAEVENTLISTENER_H_*/

--- a/Framework/LiveData/src/Kafka/KafkaEventListener.cpp
+++ b/Framework/LiveData/src/Kafka/KafkaEventListener.cpp
@@ -62,8 +62,7 @@ void KafkaEventListener::start(Types::Core::DateAndTime startTime) {
     startNow = false;
   } else if (startTime != 0) {
     g_log.warning() << "KafkaLiveListener does not currently support starting "
-                       "from arbitrary time."
-                    << std::endl;
+                       "from arbitrary time." << std::endl;
   }
   m_decoder->startCapture(startNow);
 }

--- a/Framework/LiveData/src/Kafka/KafkaEventListener.cpp
+++ b/Framework/LiveData/src/Kafka/KafkaEventListener.cpp
@@ -1,4 +1,5 @@
 #include "MantidLiveData/Kafka/KafkaEventListener.h"
+#include "MantidAPI/IAlgorithm.h"
 #include "MantidAPI/LiveListenerFactory.h"
 #include "MantidLiveData/Kafka/KafkaEventStreamDecoder.h"
 #include "MantidLiveData/Kafka/KafkaBroker.h"
@@ -13,21 +14,29 @@ namespace LiveData {
 
 DECLARE_LISTENER(KafkaEventListener)
 
-KafkaEventListener::KafkaEventListener() {
-  declareProperty("InstrumentName", "");
+void KafkaEventListener::setAlgorithm(const Mantid::API::IAlgorithm &callingAlgorithm) {
+  this->updatePropertyValues(callingAlgorithm);
+  // Get the instrument name from StartLiveData so we can sub to correct topics
+  if (callingAlgorithm.existsProperty("Instrument")) {
+    m_instrumentName = callingAlgorithm.getPropertyValue("Instrument");
+  } else {
+    g_log.error("KafkaEventListener requires Instrument property to be set in calling algorithm");
+  }
 }
 
 /// @copydoc ILiveListener::connect
 bool KafkaEventListener::connect(const Poco::Net::SocketAddress &address) {
+  if (m_instrumentName.empty()) {
+    g_log.error("KafkaEventListener::connect requires a non-empty instrument name");
+  }
   auto broker = std::make_shared<KafkaBroker>(address.toString());
   try {
-    std::string instrumentName = getProperty("InstrumentName");
-    const std::string eventTopic(instrumentName +
+    const std::string eventTopic(m_instrumentName +
                                  KafkaTopicSubscriber::EVENT_TOPIC_SUFFIX),
-        runInfoTopic(instrumentName + KafkaTopicSubscriber::RUN_TOPIC_SUFFIX),
-        spDetInfoTopic(instrumentName +
+        runInfoTopic(m_instrumentName + KafkaTopicSubscriber::RUN_TOPIC_SUFFIX),
+        spDetInfoTopic(m_instrumentName +
                        KafkaTopicSubscriber::DET_SPEC_TOPIC_SUFFIX),
-        sampleEnvTopic(instrumentName +
+        sampleEnvTopic(m_instrumentName +
                        KafkaTopicSubscriber::SAMPLE_ENV_TOPIC_SUFFIX);
     m_decoder = Kernel::make_unique<KafkaEventStreamDecoder>(
         broker, eventTopic, runInfoTopic, spDetInfoTopic, sampleEnvTopic);

--- a/Framework/LiveData/src/Kafka/KafkaEventListener.cpp
+++ b/Framework/LiveData/src/Kafka/KafkaEventListener.cpp
@@ -1,8 +1,8 @@
 #include "MantidLiveData/Kafka/KafkaEventListener.h"
 #include "MantidAPI/IAlgorithm.h"
 #include "MantidAPI/LiveListenerFactory.h"
-#include "MantidLiveData/Kafka/KafkaEventStreamDecoder.h"
 #include "MantidLiveData/Kafka/KafkaBroker.h"
+#include "MantidLiveData/Kafka/KafkaEventStreamDecoder.h"
 #include "MantidLiveData/Kafka/KafkaTopicSubscriber.h"
 
 namespace {
@@ -14,20 +14,23 @@ namespace LiveData {
 
 DECLARE_LISTENER(KafkaEventListener)
 
-void KafkaEventListener::setAlgorithm(const Mantid::API::IAlgorithm &callingAlgorithm) {
+void KafkaEventListener::setAlgorithm(
+    const Mantid::API::IAlgorithm &callingAlgorithm) {
   this->updatePropertyValues(callingAlgorithm);
   // Get the instrument name from StartLiveData so we can sub to correct topics
   if (callingAlgorithm.existsProperty("Instrument")) {
     m_instrumentName = callingAlgorithm.getPropertyValue("Instrument");
   } else {
-    g_log.error("KafkaEventListener requires Instrument property to be set in calling algorithm");
+    g_log.error("KafkaEventListener requires Instrument property to be set in "
+                "calling algorithm");
   }
 }
 
 /// @copydoc ILiveListener::connect
 bool KafkaEventListener::connect(const Poco::Net::SocketAddress &address) {
   if (m_instrumentName.empty()) {
-    g_log.error("KafkaEventListener::connect requires a non-empty instrument name");
+    g_log.error(
+        "KafkaEventListener::connect requires a non-empty instrument name");
   }
   auto broker = std::make_shared<KafkaBroker>(address.toString());
   try {
@@ -59,7 +62,8 @@ void KafkaEventListener::start(Types::Core::DateAndTime startTime) {
     startNow = false;
   } else if (startTime != 0) {
     g_log.warning() << "KafkaLiveListener does not currently support starting "
-                       "from arbitrary time." << std::endl;
+                       "from arbitrary time."
+                    << std::endl;
   }
   m_decoder->startCapture(startNow);
 }


### PR DESCRIPTION
Removes "InstrumentName" property from the KafkaEventListener. Since the changes in #19320 the algorithm can instead access the "Instrument" property of StartLiveData.

**To test:**
Open Live Data Interface with ISIS as your default facility and select ZOOM as the instrument. There should not be an "InstrumentName" field in the bottom left of the interface and the algorithm should start without error using the following options:
"Starting Time": "Start of Run"
"At Run Transition": "Stop"
"Output Workspace": "outWs"
Leaving other settings as default is fine.

Fixes #19342.

**Release Notes** 

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
