### PR TITLE
Fix build for glibc 2.27 Replace HUGE with numeric_limits

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/RalNlls/Workspaces.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/RalNlls/Workspaces.h
@@ -183,14 +183,14 @@ struct nlls_inform {
 
   ///  the value of the objective function at the best estimate of the solution
   ///   determined by NLLS_solve
-  double obj = HUGE;
+  double obj = std::numeric_limits<float>::max();
 
   ///  the norm of the gradient of the objective function at the best estimate
   ///   of the solution determined by NLLS_solve
-  double norm_g = HUGE;
+  double norm_g = std::numeric_limits<float>::max();
 
   /// the norm of the gradient, scaled by the norm of the residual
-  double scaled_g = HUGE;
+  double scaled_g = std::numeric_limits<float>::max();
 
 }; //  END TYPE nlls_inform
 


### PR DESCRIPTION
[`HUGE` was removed from math.h in glibc 2.27](https://sourceware.org/ml/libc-announce/2018/msg00000.html). This changes to using `std::numeric_limits<float>::max()` which should be the same value as HUGE.

**To test:**
Code review should do as I don't believe any OSs are currently using glibc `2.27`. I found this testing Ubuntu 18.04 Beta which is using `2.27`.


**Release Notes** 
*Does not need to be in the release notes. Internal change only*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
