### PR TITLE
Fix -only cases in check_for_changes

### DIFF
--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -75,40 +75,31 @@ DO_BUILD_DEVDOCS=true
 DO_BUILD_PKG=true
 DO_SYSTEMTESTS=false
 if [[ ${PRBUILD} == true ]]; then
+  if ${SCRIPT_DIR}/check_for_changes dev-docs-only || ${SCRIPT_DIR}/check_for_changes user-docs-only; then
+    DO_BUILD_CODE=false
+    DO_UNITTESTS=false
+  fi
   DO_DOCTESTS_USER=false
   DO_BUILD_DEVDOCS=false
-  DO_BUILD_PKG=false
+  DO_BUILD_PKG=${BUILD_PACKAGE:-false}
   DO_SYSTEMTESTS=false
 
-  # check job parameter
-  if [[ -n ${BUILD_PACKAGE} ]]; then
-    DO_BUILD_PKG=${BUILD_PACKAGE}
-  fi
-  # ubuntu does docs testing
-  if [[ ${ON_UBUNTU} == true ]]; then
-    DO_DOCTESTS_USER=true
-#    if ${SCRIPT_DIR}/check_for_changes dev-docs-only; then
-#      DO_BUILD_CODE=false
-#      DO_UNITTESTS=false
-#      DO_DOCTESTS_USER=false
-#      DO_BUILD_DEVDOCS=true
-#    fi
-#    if ${SCRIPT_DIR}/check_for_changes user-docs-only; then
-#      DO_BUILD_CODE=true # make sure code is up to date on this node
-#      DO_UNITTESTS=false
-#    fi
-  fi
-  # rhel does system testing
   if [[ ${ON_RHEL7} == true ]]; then
-    if ${SCRIPT_DIR}/check_for_changes docs-gui-only; then
-      DO_SYSTEMTESTS=false
-    else
+    # rhel does system testing
+    if ! ${SCRIPT_DIR}/check_for_changes docs-gui-only; then
       DO_BUILD_PKG=true
       DO_SYSTEMTESTS=true
     fi
+  elif [[ ${ON_UBUNTU} == true ]]; then
+    # ubuntu does the docs build
+    if ${SCRIPT_DIR}/check_for_changes dev-docs-only; then
+      DO_BUILD_CODE=false
+      DO_DOCTESTS_USER=false
+    else
+      DO_BUILD_CODE=true # code needs to be up to date
+      DO_DOCTESTS_USER=true
+    fi
   fi
-
-
 fi
 
 ###############################################################################

--- a/buildconfig/Jenkins/check_for_changes
+++ b/buildconfig/Jenkins/check_for_changes
@@ -24,23 +24,29 @@ case "$TYPE" in
         git diff --quiet ${BRANCH_TIP} ${BRANCH_BASE} -- \*\.tcc || exit $FOUND
         exit $NOTFOUND
     ;;
+    # For the -only cases FOUND=1 means that there were other changes besides the case
+    # Note that these checks CANNOT be replaced with "git diff --quiet ... dev-docs" because this only
+    # checks if there were changes in a given directory and not if they are the ONLY changes
     dev-docs-only)
-        git diff --quiet ${BRANCH_TIP} ${BRANCH_BASE} -- dev-docs || exit $FOUND
-        exit $NOTFOUND
+        if git diff --name-only ${BRANCH_TIP} ${BRANCH_BASE} -- | grep -q -E -v '^dev-docs/'; then
+            exit $FOUND
+        else
+            exit $NOTFOUND
+        fi
     ;;
     user-docs-only)
-        git diff --quiet ${BRANCH_TIP} ${BRANCH_BASE} -- docs || exit $FOUND
-        exit $NOTFOUND
+        if git diff --name-only ${BRANCH_TIP} ${BRANCH_BASE} -- | grep -q -E -v '^docs/'; then
+            exit $FOUND
+        else
+            exit $NOTFOUND
+        fi
     ;;
     docs-gui-only)
-	# FOUND=1 iff changes are limited to docs or GUI only
-	# Find all changed files and grep for required type. -v inverts match so grep=0 means
-	# there are other changes besides this
-	if git diff --name-only ${BRANCH_TIP} ${BRANCH_BASE} -- | grep -q -E -v '^docs/|^dev-docs/|^qt/|^MantidPlot/'; then
-	    exit $FOUND
-	else
-	    exit $NOTFOUND
-	fi
+        if git diff --name-only ${BRANCH_TIP} ${BRANCH_BASE} -- | grep -q -E -v '^docs/|^dev-docs/|^qt/|^MantidPlot/'; then
+            exit $FOUND
+        else
+            exit $NOTFOUND
+        fi
     ;;
     *)
         echo "do not have case for type \"$TYPE\""


### PR DESCRIPTION
Description of work.

Fixes buildscript to skip build steps if there have not been changes in certain areas. 

**To test:**

* Review the code

*No issue*

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
