### PR TITLE
Incorrect angle used in conversion to Q in RRO

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOne2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOne2.h
@@ -141,10 +141,6 @@ private:
   void verifySpectrumMaps(API::MatrixWorkspace_const_sptr ws1,
                           API::MatrixWorkspace_const_sptr ws2,
                           const bool severe);
-  // Correct the detector angle
-  Mantid::API::MatrixWorkspace_sptr
-  correctDetectorAngle(Mantid::API::MatrixWorkspace_sptr inputWS);
-
 
   // Find and cache constants
   void findDetectorGroups();

--- a/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOne2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOne2.h
@@ -141,6 +141,10 @@ private:
   void verifySpectrumMaps(API::MatrixWorkspace_const_sptr ws1,
                           API::MatrixWorkspace_const_sptr ws2,
                           const bool severe);
+  // Correct the detector angle
+  Mantid::API::MatrixWorkspace_sptr
+  correctDetectorAngle(Mantid::API::MatrixWorkspace_sptr inputWS);
+
 
   // Find and cache constants
   void findDetectorGroups();
@@ -162,6 +166,7 @@ private:
   bool m_normaliseMonitors;     // normalise by monitors and direct beam
   bool m_normaliseTransmission; // transmission or algorithmic correction
   bool m_sum;                   // whether to do summation
+  bool m_correctAngleInLambda;  // whether to correct the angle of detectors
   double m_theta0;              // horizon angle
   // groups of spectrum indices of the detectors of interest
   std::vector<std::vector<size_t>> m_detectorGroups;

--- a/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOne2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOne2.h
@@ -162,7 +162,6 @@ private:
   bool m_normaliseMonitors;     // normalise by monitors and direct beam
   bool m_normaliseTransmission; // transmission or algorithmic correction
   bool m_sum;                   // whether to do summation
-  bool m_correctAngleInLambda;  // whether to correct the angle of detectors
   double m_theta0;              // horizon angle
   // groups of spectrum indices of the detectors of interest
   std::vector<std::vector<size_t>> m_detectorGroups;

--- a/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
@@ -366,7 +366,8 @@ void ReflectometryReductionOne2::init() {
   // Angle correction type
   const std::vector<std::string> correctionType{"VerticalShift",
                                                 "RotateAroundSample"};
-  auto correctionTypeValidator = boost::make_shared<StringListValidator>(correctionType);
+  auto correctionTypeValidator =
+      boost::make_shared<StringListValidator>(correctionType);
   declareProperty(
       "DetectorCorrectionType", correctionType[0], correctionTypeValidator,
       "Whether detectors should be shifted vertically or rotated around the "
@@ -473,7 +474,8 @@ void ReflectometryReductionOne2::exec() {
     m_sum = false;
   }
   // Angle correction must be done if ThetaIn is set
-  m_correctAngleInLambda = !(*getProperty("ThetaIn")).isDefault() && !summingInQ();
+  m_correctAngleInLambda =
+      !(*getProperty("ThetaIn")).isDefault() && !summingInQ();
 
   // Create the output workspace in wavelength
   MatrixWorkspace_sptr IvsLam = makeIvsLam();

--- a/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
@@ -808,6 +808,10 @@ ReflectometryReductionOne2::convertToQ(MatrixWorkspace_sptr inputWS) {
     double const factor = 4.0 * M_PI * sin(theta * M_PI / 180.0);
     std::transform(XIn0.rbegin(), XIn0.rend(), XOut0.begin(),
                    [factor](double x) { return factor / x; });
+    auto &Y0 = IvsQ->mutableY(0);
+    auto &E0 = IvsQ->mutableE(0);
+    std::reverse(Y0.begin(), Y0.end());
+    std::reverse(E0.begin(), E0.end());
     IvsQ->getAxis(0)->unit() =
         UnitFactory::Instance().create("MomentumTransfer");
     return IvsQ;

--- a/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
@@ -801,6 +801,13 @@ ReflectometryReductionOne2::convertToQ(MatrixWorkspace_sptr inputWS) {
   bool const shouldCorrectAngle =
       !(*getProperty("ThetaIn")).isDefault() && !summingInQ();
   if (shouldCorrectAngle && moreThanOneDetector) {
+    if (inputWS->getNumberHistograms() > 1) {
+      throw std::invalid_argument(
+          "Expected a single group in "
+          "ProcessingInstructions to be able to "
+          "perform angle correction, found " +
+          std::to_string(inputWS->getNumberHistograms()));
+    }
     MatrixWorkspace_sptr IvsQ = inputWS->clone();
     auto &XOut0 = IvsQ->mutableX(0);
     const auto &XIn0 = inputWS->x(0);

--- a/Framework/Algorithms/test/ReflectometryReductionOne2Test.h
+++ b/Framework/Algorithms/test/ReflectometryReductionOne2Test.h
@@ -605,6 +605,27 @@ public:
     }
   }
 
+  void test_no_angle_correction() {
+
+    ReflectometryReductionOne2 alg;
+    setupAlgorithm(alg, 1.5, 15.0, "2");
+    alg.setProperty("ThetaIn", 22.0);
+    alg.execute();
+    MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspaceWavelength");
+    MatrixWorkspace_sptr outQ = alg.getProperty("OutputWorkspace");
+
+    auto const &qX = outQ->x(0);
+    auto const &lamX = outLam->x(0);
+
+    std::vector<double> lamXinv(lamX.size() + 3);
+    std::reverse_copy(lamX.begin(), lamX.end(), lamXinv.begin());
+
+    auto factor = 4.0 * M_PI * sin(22.5 * M_PI / 180.0);
+    for (size_t i = 0; i < qX.size(); ++i) {
+      TS_ASSERT_DELTA(qX[i], factor / lamXinv[i], 1e-14);
+    }
+  }
+
 private:
   // Do standard algorithm setup
   void setupAlgorithm(ReflectometryReductionOne2 &alg,

--- a/Framework/Algorithms/test/ReflectometryReductionOne2Test.h
+++ b/Framework/Algorithms/test/ReflectometryReductionOne2Test.h
@@ -685,7 +685,6 @@ private:
 
     return outQ;
   }
-
 };
 
 #endif /* ALGORITHMS_TEST_REFLECTOMETRYREDUCTIONONE2TEST_H_ */

--- a/Framework/Algorithms/test/ReflectometryReductionOne2Test.h
+++ b/Framework/Algorithms/test/ReflectometryReductionOne2Test.h
@@ -625,7 +625,6 @@ public:
     TS_ASSERT_DELTA(qY[0], 84, 1e-2);
     TS_ASSERT_DELTA(qY[6], 54, 1e-2);
     TS_ASSERT_DELTA(qY[13], 19, 1e-2);
-
   }
 
   void test_no_angle_correction() {
@@ -753,14 +752,13 @@ private:
   }
 
   void setYValuesToWorkspace(MatrixWorkspace &ws) {
-    for(size_t i = 0; i < ws.getNumberHistograms(); ++i) {
+    for (size_t i = 0; i < ws.getNumberHistograms(); ++i) {
       auto &y = ws.mutableY(i);
-      for(size_t j = 0; j < y.size(); ++j) {
+      for (size_t j = 0; j < y.size(); ++j) {
         y[j] += double(j + 1) * double(i + 1);
       }
     }
   }
-
 };
 
 #endif /* ALGORITHMS_TEST_REFLECTOMETRYREDUCTIONONE2TEST_H_ */

--- a/Framework/Algorithms/test/ReflectometryReductionOne2Test.h
+++ b/Framework/Algorithms/test/ReflectometryReductionOne2Test.h
@@ -670,6 +670,21 @@ public:
     TS_ASSERT_DELTA(qY[13], 11, 1e-2);
   }
 
+  void test_angle_correction_multi_group() {
+    ReflectometryReductionOne2 alg;
+    alg.setChild(true);
+    alg.setRethrows(true);
+    alg.initialize();
+    alg.setProperty("InputWorkspace", m_multiDetectorWS);
+    alg.setProperty("WavelengthMin", 1.5);
+    alg.setProperty("WavelengthMax", 15.0);
+    alg.setPropertyValue("ProcessingInstructions", "1+2, 3");
+    alg.setPropertyValue("OutputWorkspace", "IvsQ");
+    alg.setPropertyValue("OutputWorkspaceWavelength", "IvsLam");
+    alg.setProperty("ThetaIn", 22.0);
+    TS_ASSERT_THROWS(alg.execute(), std::invalid_argument);
+  }
+
 private:
   // Do standard algorithm setup
   void setupAlgorithm(ReflectometryReductionOne2 &alg,

--- a/Framework/Algorithms/test/SpecularReflectionPositionCorrect2Test.h
+++ b/Framework/Algorithms/test/SpecularReflectionPositionCorrect2Test.h
@@ -20,7 +20,7 @@ private:
   // Initialise the algorithm and set the properties
   void setupAlgorithm(SpecularReflectionPositionCorrect2 &alg,
                       const double twoTheta, const std::string &correctionType,
-                      const std::string &detectorName) {
+                      const std::string &detectorName, int detectorID = 0) {
     if (!alg.isInitialized())
       alg.initialize();
     alg.setChild(true);
@@ -30,6 +30,8 @@ private:
       alg.setProperty("DetectorCorrectionType", correctionType);
     if (!detectorName.empty())
       alg.setProperty("DetectorComponentName", detectorName);
+    if (detectorID > 0)
+      alg.setProperty("DetectorID", detectorID);
     alg.setPropertyValue("OutputWorkspace", "test_out");
   }
 
@@ -107,6 +109,17 @@ public:
     alg.initialize();
     alg.setChild(true);
     alg.setProperty("InputWorkspace", m_interWS);
+    alg.setProperty("DetectorID", 222222222);
+    alg.setProperty("TwoTheta", 1.4);
+    alg.setPropertyValue("OutputWorkspace", "test_out");
+    TS_ASSERT_THROWS_ANYTHING(alg.execute());
+  }
+
+  void test_detector_id_is_valid() {
+    SpecularReflectionPositionCorrect2 alg;
+    alg.initialize();
+    alg.setChild(true);
+    alg.setProperty("InputWorkspace", m_interWS);
     alg.setProperty("DetectorComponentName", "invalid-detector-name");
     alg.setProperty("TwoTheta", 1.4);
     alg.setPropertyValue("OutputWorkspace", "test_out");
@@ -147,9 +160,56 @@ public:
     TS_ASSERT_DELTA(detOut.Y(), 0.06508, 1e-5);
   }
 
+  void test_correct_point_detector_via_detid_vertical_shift_default() {
+    try {
+    // Omit the DetectorCorrectionType property to check that a vertical shift
+    // is done by default
+    SpecularReflectionPositionCorrect2 alg;
+    setupAlgorithm(alg, 1.4, "", "", 4);
+    MatrixWorkspace_const_sptr outWS = runAlgorithm(alg);
+
+    auto instrIn = m_interWS->getInstrument();
+    auto instrOut = outWS->getInstrument();
+
+    // Sample should not have moved
+    auto sampleIn = instrIn->getSample()->getPos();
+    auto sampleOut = instrOut->getSample()->getPos();
+    TS_ASSERT_EQUALS(sampleIn, sampleOut);
+    // 'point-detector' should have been moved vertically only
+    auto detIn = instrIn->getComponentByName("point-detector")->getPos();
+    auto detOut = instrOut->getComponentByName("point-detector")->getPos();
+    TS_ASSERT_EQUALS(detIn.X(), detOut.X());
+    TS_ASSERT_EQUALS(detIn.Z(), detOut.Z());
+    TS_ASSERT_DELTA(detOut.Y(), 0.06508, 1e-5);
+    } catch (std::exception &e) {
+      std::cerr << "Exception " << e.what() << std::endl;
+    }
+  }
+
   void test_correct_point_detector_rotation() {
     SpecularReflectionPositionCorrect2 alg;
     setupAlgorithm(alg, 1.4, "RotateAroundSample", "point-detector");
+    MatrixWorkspace_const_sptr outWS = runAlgorithm(alg);
+
+    auto instrIn = m_interWS->getInstrument();
+    auto instrOut = outWS->getInstrument();
+
+    // Sample should not have moved
+    auto sampleIn = instrIn->getSample()->getPos();
+    auto sampleOut = instrOut->getSample()->getPos();
+    TS_ASSERT_EQUALS(sampleIn, sampleOut);
+    // 'point-detector' should have been moved  both vertically and in
+    // the beam direction
+    auto detIn = instrIn->getComponentByName("point-detector")->getPos();
+    auto detOut = instrOut->getComponentByName("point-detector")->getPos();
+    TS_ASSERT_EQUALS(detIn.X(), detOut.X());
+    TS_ASSERT_DELTA(detOut.Z(), 2.66221, 1e-5);
+    TS_ASSERT_DELTA(detOut.Y(), 0.06506, 1e-5);
+  }
+
+  void test_correct_point_detector_by_detid_rotation() {
+    SpecularReflectionPositionCorrect2 alg;
+    setupAlgorithm(alg, 1.4, "RotateAroundSample", "", 4);
     MatrixWorkspace_const_sptr outWS = runAlgorithm(alg);
 
     auto instrIn = m_interWS->getInstrument();

--- a/Framework/Algorithms/test/SpecularReflectionPositionCorrect2Test.h
+++ b/Framework/Algorithms/test/SpecularReflectionPositionCorrect2Test.h
@@ -161,7 +161,6 @@ public:
   }
 
   void test_correct_point_detector_via_detid_vertical_shift_default() {
-    try {
     // Omit the DetectorCorrectionType property to check that a vertical shift
     // is done by default
     SpecularReflectionPositionCorrect2 alg;
@@ -181,9 +180,6 @@ public:
     TS_ASSERT_EQUALS(detIn.X(), detOut.X());
     TS_ASSERT_EQUALS(detIn.Z(), detOut.Z());
     TS_ASSERT_DELTA(detOut.Y(), 0.06508, 1e-5);
-    } catch (std::exception &e) {
-      std::cerr << "Exception " << e.what() << std::endl;
-    }
   }
 
   void test_correct_point_detector_rotation() {

--- a/docs/source/release/v3.13.0/reflectometry.rst
+++ b/docs/source/release/v3.13.0/reflectometry.rst
@@ -21,6 +21,8 @@ Improvements
 Bug fixes
 #########
 
+* Correct the angle to the value of ``ThetaIn`` property if summing in lambda in ``ReflectometryReductionOne-v2``.
+
 Features Removed
 ################
 

--- a/docs/source/release/v3.13.0/reflectometry.rst
+++ b/docs/source/release/v3.13.0/reflectometry.rst
@@ -21,8 +21,6 @@ Improvements
 Bug fixes
 #########
 
-* Correct the angle to the value of ``ThetaIn`` property if summing in lambda in ``ReflectometryReductionOne-v2``.
-
 Features Removed
 ################
 
@@ -40,5 +38,7 @@ Improvements
 
 Bug fixes
 #########
+
+* Correct the angle to the value of ``ThetaIn`` property if summing in lambda in ``ReflectometryReductionOne-v2``.
 
 :ref:`Release 3.13.0 <v3.13.0>`


### PR DESCRIPTION
Use input property `ThetaIn` to convert to Q if summing in lambda

**To test:**

```
import numpy as np

def printResults(nameLam, nameQ, thetaIn):
  wsLam=mtd[nameLam]
  wsQ=mtd[nameQ]
  
  xLam = 4 * np.pi * np.sin(thetaIn * np.pi / 180) / wsLam.readX(0)[-1::-1]
  xQ = wsQ.readX(0)
  print np.all(xLam - xQ) == 0

# OFFSPEC example - TOF workspace detectors are NOT in the correct position on load so ARE corrected by RROA
LoadISISNexus(Filename='OFFSPEC44684', OutputWorkspace='TOF_44684')
LoadISISNexus(Filename='OFFSPEC44683', OutputWorkspace='TRANS_44683')
ReflectometryReductionOneAuto(InputWorkspace='TOF_44684',
    ProcessingInstructions='390-410',
    ThetaIn=0.3,
    CorrectDetectors='1',
    DetectorCorrectionType='RotateAroundSample',
    WavelengthMin=1.2,
    WavelengthMax=14,
    I0MonitorIndex=1,
    MonitorBackgroundWavelengthMin=15,
    MonitorBackgroundWavelengthMax=20,
    MonitorIntegrationWavelengthMin=2,
    MonitorIntegrationWavelengthMax=14,
    FirstTransmissionRun='TRANS_44683',
    MomentumTransferStep=0.02,
    ScaleFactor=1,
    OutputWorkspaceBinned='IvsQ_binned_44684',
    OutputWorkspace='IvsQ_44684',
    OutputWorkspaceWavelength='IvsLam_44684')
printResults('IvsLam_44684', 'IvsQ_44684', 0.3)

# INTER example - TOF workspace detectors ARE in the correct position on load so are NOT corrected by RROA
LoadISISNexus(Filename='INTER00043583', OutputWorkspace='TOF_43583')
ReflectometryReductionOneAuto(InputWorkspace='TOF_43583',
    CorrectDetectors='0',
    AnalysisMode='MultiDetectorAnalysis',
    ProcessingInstructions='45-69',
    ThetaIn=1.3,
    MomentumTransferStep=-0.0001,
    ScaleFactor=1,
    OutputWorkspaceBinned='IvsQ_binned_43583',
    OutputWorkspace='IvsQ_43583',
    OutputWorkspaceWavelength='IvsLam_43583')
printResults('IvsLam_43583', 'IvsQ_43583', 1.3)
```

Fixes #21742.


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
