### PR TITLE
Corrected Rendering of Rectangular Detectors

### DIFF
--- a/qt/widgets/instrumentview/src/InstrumentRenderer.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentRenderer.cpp
@@ -144,10 +144,16 @@ void InstrumentRenderer::drawRectangularBank(size_t bankIndex, bool picking) {
 
   auto bank = compInfo.quadrilateralComponent(bankIndex);
   auto pos = compInfo.position(bank.bottomLeft);
-
   auto scale = compInfo.scaleFactor(bankIndex);
   glTranslated(pos.X(), pos.Y(), pos.Z());
   glScaled(scale[0], scale[1], scale[2]);
+
+  auto rot = compInfo.rotation(bankIndex);
+  if (!(rot.isNull())) {
+    double deg, ax0, ax1, ax2;
+    rot.getAngleAxis(deg, ax0, ax1, ax2);
+    glRotated(deg, ax0, ax1, ax2);
+  }
 
   auto ti = m_reverseTextureIndexMap[bankIndex];
   glBindTexture(GL_TEXTURE_2D, m_textureIDs[ti]);


### PR DESCRIPTION
Added correction to the rendering of rectangular detectors. Offsets and rotations were not handled correctly. This was highlighted by the D33 ILL instrument.

**To test:**

Ensure the D33 Instrument and other instruments which use `RectangularDetector` are rendered correctly. (LOQ, SANS2D etc).

Fixes #22242 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 

*Internal fix does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
