### PR TITLE
Force higher compression xz format

### DIFF
--- a/buildconfig/CMake/CPackLinuxSetup.cmake
+++ b/buildconfig/CMake/CPackLinuxSetup.cmake
@@ -6,7 +6,7 @@
 string ( TOLOWER "${CPACK_PACKAGE_NAME}" CPACK_PACKAGE_NAME )
 
 # define the source generators
-set ( CPACK_SOURCE_GENERATOR TGZ )
+set ( CPACK_SOURCE_GENERATOR "TGZ;TXZ" )
 set ( CPACK_SOURCE_IGNORE_FILES "/\\\\.git*")
 if (CMAKE_BINARY_DIR MATCHES "^${CMAKE_SOURCE_DIR}/.+")
   # In-source build add the binary directory to files to ignore for the tarball
@@ -21,6 +21,7 @@ if ( "${UNIX_DIST}" MATCHES "Ubuntu" )
   find_program (DPKG_CMD dpkg)
   if ( DPKG_CMD )
     set ( CPACK_GENERATOR "DEB" )
+    set ( CPACK_DEBIAN_COMPRESSION_TYPE "xz" )
     execute_process( COMMAND ${DPKG_CMD} --print-architecture
       OUTPUT_VARIABLE CPACK_DEBIAN_PACKAGE_ARCHITECTURE
       OUTPUT_STRIP_TRAILING_WHITESPACE )
@@ -38,6 +39,7 @@ if ( "${UNIX_DIST}" MATCHES "RedHatEnterprise" OR "${UNIX_DIST}" MATCHES "Fedora
     set ( CPACK_GENERATOR "RPM" )
     set ( CPACK_RPM_PACKAGE_ARCHITECTURE "${CMAKE_SYSTEM_PROCESSOR}" )
     set ( CPACK_RPM_PACKAGE_URL "http://www.mantidproject.org" )
+    set ( CPACK_RPM_COMPRESSION_TYPE "xz" )
 
     # determine the distribution number
     if(NOT CPACK_RPM_DIST)

--- a/docs/source/release/v3.12.0/framework.rst
+++ b/docs/source/release/v3.12.0/framework.rst
@@ -79,6 +79,7 @@ New
 
 Improved
 ########
+- DEB and RPM package sizes reduced by 17% and 6% respectively.
 - :class:`mantid.kernel.FloatTimeSeriesProperty` now returns :class:`numpy.datetime64` for the log times.
 - The duration reported by a running algorithm now includes time spent for validation of properties and inputs. This fixes a discrepancy between observed and reported timings if validation is expensive, e.g., when checking if a file exists. More detailed timing information is now available when setting the log level to ``debug``.
 - The status of a fit in the fit window is now at the top of the of the dialog instead of the bottom.


### PR DESCRIPTION
Description of work.

This follows a [tip from twitter](https://twitter.com/Kitware/status/983420604664643585) to use the `xz` compression option. This creates a second source tarball and forces a higher level of compression for both RPM and DEB packages. 

source package went from 78MB to 65MB (17% improvement)
The RHEL package went from 198MB to 186MB. (6% improvement)
The Ubuntu package went from 248MB to 205MB. (17% improvement)

**To test:**

<!-- Instructions for testing. -->

There is no GitHub issue associated with this pull request.

**Release Notes** 

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
