### PR TITLE
Add force-overwrite option to GSAS-II installation scripts

### DIFF
--- a/scripts/GSAS-II/install_gsas_common.bat
+++ b/scripts/GSAS-II/install_gsas_common.bat
@@ -1,25 +1,31 @@
+setlocal enableextensions enabledelayedexpansion
+
 @echo off
 @echo Running install_gsas_latest.bat
 @echo Run with -b flag for non-interactive (quiet) mode
 @echo (don't pause after installation and install in Python user site package directory)
 
+:: find python
 @set DEV_PYTHON_EXE=%~dp0..\..\external\src\ThirdParty\lib\python2.7\python.exe
 @set RELEASE_PYTHON_EXE=%~dp0..\..\bin\python.exe
+@set PATH_PYTHON_EXE=
+python --version 2>nul
+if %ERRORLEVEL%==0 @set PATH_PYTHON_EXE=python
 
-if exist %DEV_PYTHON_EXE% goto runDev
+if not "!PATH_PYTHON_EXE!" == "" (
+  set PYTHON_EXE=!PATH_PYTHON_EXE!
+) else (
+  if EXIST "%DEV_PYTHON_EXE%" (
+    @set PYTHON_EXE=%DEV_PYTHON_EXE%
+  ) else if EXIST %RELEASE_PYTHON_EXE% (
+    @set PYTHON_EXE=%RELEASE_PYTHON_EXE%
+  ) else (
+    @echo Cannot find python executable
+    exit /b 1
+  )
+) 
 
-if exist %RELEASE_PYTHON_EXE% goto runRelease
+@echo Using '!PYTHON_EXE!' to install GSAS
+!PYTHON_EXE! %~dp0install_gsas_proxy.py %*
 
-@echo Could not find Mantid Python executable
-goto commonExit
-
-:runDev
-%DEV_PYTHON_EXE% %~dp0install_gsas_proxy.py %*
-goto commonExit
-
-:runRelease
-%RELEASE_PYTHON_EXE% %~dp0install_gsas_proxy.py %*
-goto commonExit
-
-:commonExit
 if not "%1"=="-b" pause

--- a/scripts/GSAS-II/install_gsas_common.bat
+++ b/scripts/GSAS-II/install_gsas_common.bat
@@ -14,11 +14,11 @@ if exist %RELEASE_PYTHON_EXE% goto runRelease
 goto commonExit
 
 :runDev
-%DEV_PYTHON_EXE% install_gsas_proxy.py %*
+%DEV_PYTHON_EXE% %~dp0install_gsas_proxy.py %*
 goto commonExit
 
 :runRelease
-%RELEASE_PYTHON_EXE% install_gsas_proxy.py %*
+%RELEASE_PYTHON_EXE% %~dp0install_gsas_proxy.py %*
 goto commonExit
 
 :commonExit

--- a/scripts/GSAS-II/install_gsas_latest.bat
+++ b/scripts/GSAS-II/install_gsas_latest.bat
@@ -1,2 +1,2 @@
 @echo off
-install_gsas_common.bat %*
+%~dp0install_gsas_common.bat %*

--- a/scripts/GSAS-II/install_gsas_proxy.py
+++ b/scripts/GSAS-II/install_gsas_proxy.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import pip
+import shutil
 import site
 import subprocess
 import urllib2
@@ -53,8 +54,12 @@ def install_package(package_name):
     pip.main(["install", package_name])
 
 
-def install_gsasii(install_directory, revision_number):
+def install_gsasii(install_directory, revision_number, force_overwrite):
     gsas_home_dir = os.path.join(install_directory, GSAS_HOME_DIR_NAME)
+
+    if force_overwrite and os.path.exists(gsas_home_dir):
+        print("Removing {}".format(gsas_home_dir))
+        shutil.rmtree(gsas_home_dir)
 
     if not os.path.exists(gsas_home_dir):
         # This is the first time installing GSAS-II, so we have to make a home directory and download the SVN kit
@@ -107,6 +112,13 @@ if __name__ == "__main__":
                         help="Build server mode. Install GSAS-II in Python user site package directory "
                              "and don't wait for prompt before exiting")
 
+    parser.add_argument("-f", "--force-overwrite",
+                        action="store_true",
+                        default=False,
+                        dest="force_overwrite",
+                        help="Force overwrite mode. If a GSAS-II installation is found at the requested "
+                             "directory, remove it and perform a fresh install")
+
     args = parser.parse_args()
 
     if args.build_server_mode:
@@ -114,4 +126,4 @@ if __name__ == "__main__":
     else:
         install_dir = args.install_dir
 
-    install_gsasii(install_directory=install_dir, revision_number=args.version)
+    install_gsasii(install_directory=install_dir, revision_number=args.version, force_overwrite=args.force_overwrite)

--- a/scripts/GSAS-II/install_gsas_proxy.py
+++ b/scripts/GSAS-II/install_gsas_proxy.py
@@ -86,7 +86,8 @@ def install_gsasii(install_directory, revision_number, force_overwrite):
         install_package("wxPython")
 
     print("Installing GSAS-II")
-    subprocess.call(["python", bootstrap_file_name])
+    bootstrap_process = subprocess.Popen(["python", bootstrap_file_name], stdin=subprocess.PIPE)
+    bootstrap_process.communicate(input="\n\n")
 
 
 if __name__ == "__main__":

--- a/scripts/GSAS-II/install_gsas_vetted.bat
+++ b/scripts/GSAS-II/install_gsas_vetted.bat
@@ -1,3 +1,3 @@
 @echo off
 @set VETTED_REVISION_NUMBER=3216
-install_gsas_common.bat -v %VETTED_REVISION_NUMBER% %*
+%~dp0install_gsas_common.bat -v %VETTED_REVISION_NUMBER% %*


### PR DESCRIPTION
A force-overwrite option was added to the GSAS-II installation script. When enabled, this deletes the old installation and runs a fresh one

**To test:**

Instructions are for Windows - ENGINX primarily use Windows, so it would be best to test on that.

Install GSAS-II with one of either `install_gsas_vetted.bat` or `install_gsas_latest.bat` (if at ISIS you'll need to run as your 03 account, if somewhere else you might need to run with admin privileges). Make a note of where GSAS-II was installed (unless you used the `-d` flag it will be in `C:\g2conda\GSASII`). Run either of the scripts again (it doesn't have to be the same one) with the `-f` flag. Go to the installation directory and verify that everything from before was overwritten (look at the 'Date Modified' field)

As a bonus, make sure the installed GSAS-II actually works - you can run it from `<wherever you installed GSAS-II>/g2conda/GSASII/RunGSASII.bat`

No issue associated with this PR

**Release Notes** 
No-one uses the script as yet, so improvements to it don't need to go in the release notes

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
