### PR TITLE
Fix  a date time string error in SaveVulcanGSS. 

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SaveVulcanGSS.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SaveVulcanGSS.py
@@ -371,7 +371,7 @@ class SaveVulcanGSS(PythonAlgorithm):
 
             # property run_start and duration exist
             utctime = numpy.datetime64(run.getProperty('run_start').value)
-            time0 = numpy.datetime64("1990-01-01T0:0:0")
+            time0 = numpy.datetime64("1990-01-01T00:00:00")
             total_nanosecond_start = int((utctime - time0) / numpy.timedelta64(1, 'ns'))
             total_nanosecond_stop = total_nanosecond_start + int(duration*1.0E9)
 


### PR DESCRIPTION
The time string **T0:0:0** is not accepted by numpy.datetime64.  It shall be changed to **T00:00:00**

**To test:**

By reviewing the change of the code.

<!-- Instructions for testing. -->

Fixes #22282. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
