### PR TITLE
Add script to build dev site

### DIFF
--- a/buildconfig/Jenkins/dev_site.sh
+++ b/buildconfig/Jenkins/dev_site.sh
@@ -1,0 +1,77 @@
+if [ -z "$BUILD_DIR" ]; then
+ if [ -z "$WORKSPACE" ]; then
+     echo "WORKSPACE not set. Cannot continue"
+     exit 1
+ fi
+
+ BUILD_DIR=$WORKSPACE/build
+ echo "Setting BUILD_DIR to $BUILD_DIR"
+fi
+
+if [ -d $BUILD_DIR ]; then
+  echo "$BUILD_DIR exists"
+else
+  mkdir $BUILD_DIR
+fi
+
+###############################################################################
+# Print out the versions of things we are using
+###############################################################################
+# we use cmake3 on rhel because cmake is too old
+if [ $(command -v cmake3) ]; then
+    CMAKE_EXE=cmake3
+else
+    CMAKE_EXE=cmake
+fi
+${CMAKE_EXE} --version
+
+###############################################################################
+# Generator
+###############################################################################
+if [ "$(command -v ninja)" ]; then
+  CMAKE_GENERATOR="-G Ninja"
+elif [ "$(command -v ninja-build)" ]; then
+  CMAKE_GENERATOR="-G Ninja"
+fi
+##### set up the build directory
+cd $BUILD_DIR
+if [ -e $BUILD_DIR/CMakeCache.txt ]; then
+  ${CMAKE_EXE} .
+else
+  ${CMAKE_EXE} ${CMAKE_GENERATOR} ..
+fi
+
+if [ -d dev-docs/html ]; then
+  echo "Updating existing checkout"
+  cd dev-docs/html
+  git pull --rebase
+  cd -
+else
+  echo "Cloning developer site"
+  #git clone git@github.com-mantid-builder:mantidproject/developer.git dev-docs/html || exit -1
+  git clone git@github.com:mantidproject/developer.git dev-docs/html || exit -1
+  cd dev-docs/html
+  git checkout gh-pages
+  cd -
+fi
+
+##### build the developer site
+${CMAKE_EXE} --build . --target dev-docs-html
+
+cd dev-docs/html
+
+if [ "builder" == "$USER" ]; then
+    echo "Setting username"
+    git config user.name mantid-builder
+    git config user.email "mantid-buildserver@mantidproject.org"
+fi
+
+##### push the results
+if [ $(git diff --quiet) ]; then
+    echo "Committing new site"
+    git add .
+    git commit -m "Automatic update of developer site"
+    git push
+else
+    echo "Nothing has changed"
+fi

--- a/buildconfig/Jenkins/dev_site.sh
+++ b/buildconfig/Jenkins/dev_site.sh
@@ -1,3 +1,4 @@
+#!/bin/bash -ex
 if [ -z "$BUILD_DIR" ]; then
  if [ -z "$WORKSPACE" ]; then
      echo "WORKSPACE not set. Cannot continue"
@@ -48,7 +49,6 @@ if [ -d dev-docs/html ]; then
   cd -
 else
   echo "Cloning developer site"
-  #git clone git@github.com-mantid-builder:mantidproject/developer.git dev-docs/html || exit -1
   git clone git@github.com:mantidproject/developer.git dev-docs/html || exit -1
   cd dev-docs/html
   git checkout gh-pages


### PR DESCRIPTION
This script should build the developer site once credentials are installed somewhere that can run cmake and sphinx. The intent is to review the buildscript then (likely) modify slightly once a build server is configured.

**To test:**

It really needs to be run on a build server, but for the moment you can (in your build directory) run

```sh
BUILD_DIR=`pwd` ~/code/mantid/buildconfig/Jenkins/dev_site.sh ;echo $?
```

*There is no associated issue.*

*Does not need to be in the release notes* because it is a build script.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
