### PR TITLE
Updated print statement to python 3 in SaveWorkspaces

### DIFF
--- a/qt/widgets/common/src/SaveWorkspaces.cpp
+++ b/qt/widgets/common/src/SaveWorkspaces.cpp
@@ -342,7 +342,7 @@ void SaveWorkspaces::saveSel() {
     } // end if save in this format
   }   // end loop over formats
 
-  saveCommands += "print 'success'";
+  saveCommands += "print('success')";
   QString status(runPythonCode(saveCommands).trimmed());
 
   if (m_saveAsZeroErrorFree) {


### PR DESCRIPTION
A python 2 print statement was throwing a syntax error causing the saving of workspaces to fail. This updates the print statement to a python 3 one compatible with future imports.

**To test:**

Get the data from here
[loqdemo.zip](https://github.com/mantidproject/mantid/files/1812127/loqdemo.zip)

Load the userfile maskfile.txt

Enter the following numbers in the boxes

SANS Sample 74044
TRANS Sample 74024
Direct Sample 74014
Sans Can 74019
Trans Can 74020
Direct Can 74014

Click on load data 
Click on 1D reduce

Click on the save other button on the bottom right of the window. Select a file to save and browse to a save location. Select the NXcanSAS option and click save. Confirm that a h5 file is saved to the location and that no error is produced. 

<!-- Instructions for testing. -->

Fixes #22289. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->
Need to update patch release notes.
---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
