### PR TITLE
Fake dae responsive cancel

### DIFF
--- a/Framework/LiveData/inc/MantidLiveData/ISIS/FakeISISEventDAE.h
+++ b/Framework/LiveData/inc/MantidLiveData/ISIS/FakeISISEventDAE.h
@@ -6,23 +6,14 @@
 //----------------------------------------------------------------------
 #include "MantidAPI/Algorithm.h"
 
-#include <mutex>
-
-namespace Poco {
-namespace Net {
-class TCPServer;
-}
-}
-
 namespace Mantid {
 namespace LiveData {
 /**
     Simulates ISIS histogram DAE. It runs continuously until canceled and
-   listens to port 6789 for
-    ISIS DAE commands.
+    listens to port 6789 for ISIS DAE commands.
 
     Copyright &copy; 2008-9 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
-   National Laboratory & European Spallation Source
+    National Laboratory & European Spallation Source
 
     This file is part of Mantid.
 
@@ -44,9 +35,6 @@ namespace LiveData {
 */
 class FakeISISEventDAE : public API::Algorithm {
 public:
-  FakeISISEventDAE();
-  ~FakeISISEventDAE() override;
-
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "FakeISISEventDAE"; }
   /// Algorithm's version for identification overriding a virtual method
@@ -67,10 +55,6 @@ public:
 private:
   void init() override;
   void exec() override;
-  /// Poco TCP server
-  Poco::Net::TCPServer *m_server;
-  /// Mutex
-  std::mutex m_mutex;
 };
 
 } // namespace LiveData

--- a/Framework/LiveData/inc/MantidLiveData/ISIS/FakeISISHistoDAE.h
+++ b/Framework/LiveData/inc/MantidLiveData/ISIS/FakeISISHistoDAE.h
@@ -5,30 +5,22 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidAPI/Algorithm.h"
-#include <mutex>
-
-namespace Poco {
-namespace Net {
-class TCPServer;
-}
-}
 
 namespace Mantid {
 namespace LiveData {
 /**
     Simulates ISIS histogram DAE. It runs continuously until canceled and
-   listens to port 6789 for
-    ISIS DAE commands.
+    listens to port 6789 for ISIS DAE commands.
 
     Data is generated starting at 10000 microseconds Time of flight, and each
-   bin requested covers 100 microseconds.
+    bin requested covers 100 microseconds.
     The algorithm silently defines three additional spectra with numbers
-   NSpectra+1, NSpectra+2 and NSpectra+3 in a
+    NSpectra+1, NSpectra+2 and NSpectra+3 in a
     different time regime (they have different binning to the rest of the
-   spectra).
+    spectra).
 
     Copyright &copy; 2008-9 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
-   National Laboratory & European Spallation Source
+    National Laboratory & European Spallation Source
 
     This file is part of Mantid.
 
@@ -50,13 +42,10 @@ namespace LiveData {
 */
 class DLLExport FakeISISHistoDAE : public API::Algorithm {
 public:
-  FakeISISHistoDAE();
-  ~FakeISISHistoDAE() override;
-
   /// Algorithm's name for identification overriding a virtual method
-  const std::string name() const override { return "FakeISISHistoDAE"; };
+  const std::string name() const override { return "FakeISISHistoDAE"; }
   /// Algorithm's version for identification overriding a virtual method
-  int version() const override { return 1; };
+  int version() const override { return 1; }
   /// Algorithm's category for identification overriding a virtual method
   const std::string category() const override {
     return "DataHandling\\DataAcquisition";
@@ -73,10 +62,6 @@ private:
   // Implement abstract Algorithm methods
   void init() override;
   void exec() override;
-  /// Poco TCP server
-  Poco::Net::TCPServer *m_server;
-  /// Mutex
-  std::mutex m_mutex;
 };
 
 } // namespace LiveData

--- a/Framework/LiveData/inc/MantidLiveData/ISIS/ISISLiveEventDataListener.h
+++ b/Framework/LiveData/inc/MantidLiveData/ISIS/ISISLiveEventDataListener.h
@@ -19,7 +19,7 @@
 const long RECV_TIMEOUT = 30;
 // Sleep time in case we need to wait for the data to become available (in
 // milliseconds)
-const long RECV_WAIT = 1;
+const long RECV_WAIT = 10;
 
 //----------------------------------------------------------------------
 // Forward declarations
@@ -164,6 +164,8 @@ protected:
   void Receive(T &buffer, const std::string &head, const std::string &msg) {
     long timeout = 0;
     while (m_socket.available() < static_cast<int>(sizeof(buffer))) {
+      if (m_stopThread)
+        return;
       Poco::Thread::sleep(RECV_WAIT);
       timeout += RECV_WAIT;
       if (timeout > RECV_TIMEOUT * 1000)
@@ -190,7 +192,7 @@ protected:
   /// Thread that reads events from the DAE in the background
   Poco::Thread m_thread;
   /// background thread checks this periodically.  If true, the thread exits
-  bool m_stopThread;
+  std::atomic<bool> m_stopThread;
   /// Holds on to any exceptions that were thrown in the background thread so
   /// that we
   /// can re-throw them in the forground thread

--- a/Framework/LiveData/src/ISIS/FakeISISEventDAE.cpp
+++ b/Framework/LiveData/src/ISIS/FakeISISEventDAE.cpp
@@ -7,14 +7,11 @@
 #include "MantidKernel/MersenneTwister.h"
 #include "MantidKernel/Timer.h"
 
+#include <Poco/ActiveResult.h>
 #include <Poco/Net/TCPServer.h>
 #include <Poco/Net/StreamSocket.h>
-#include <Poco/ActiveResult.h>
-#include <Poco/Thread.h>
 
 #include <boost/random/uniform_int.hpp>
-
-#include <numeric>
 
 namespace Mantid {
 namespace LiveData {
@@ -147,17 +144,6 @@ public:
 };
 } // end anonymous
 
-/// (Empty) Constructor
-FakeISISEventDAE::FakeISISEventDAE() : m_server(nullptr) {}
-
-/// Destructor
-FakeISISEventDAE::~FakeISISEventDAE() {
-  if (m_server) {
-    m_server->stop();
-    delete m_server;
-  }
-}
-
 /**
 * Declare the algorithm properties
 */
@@ -198,19 +184,18 @@ void FakeISISEventDAE::exec() {
   histoDAE->setProperty("NPeriods", nper);
   histoDAE->setProperty("NSpectra", nspec);
   histoDAE->setProperty("Port", port + 1);
-  Poco::ActiveResult<bool> histoDAEHandle = histoDAE->executeAsync();
+  auto histoDAEHandle = histoDAE->executeAsync();
 
   auto prog = boost::make_shared<Progress>(this, 0.0, 1.0, 100);
   prog->setNotifyStep(0);
   prog->report(0, "Waiting for client");
-  std::lock_guard<std::mutex> lock(m_mutex);
   Poco::Net::ServerSocket socket(static_cast<Poco::UInt16>(port));
   socket.listen();
-  m_server = new Poco::Net::TCPServer(
+  Poco::Net::TCPServer server(
       TestServerConnectionFactory::Ptr(
           new TestServerConnectionFactory(nper, nspec, rate, nevents, prog)),
       socket);
-  m_server->start();
+  server.start();
   // Keep going until you get cancelled
   while (true) {
     try {
@@ -223,19 +208,12 @@ void FakeISISEventDAE::exec() {
     // Sleep for 50 msec
     Poco::Thread::sleep(50);
   }
+  // It's most likely that we got here from a cancel request
+  // so calling prog->report after this point
+  // will generate another CancelException
   histoDAE->cancel();
   histoDAEHandle.wait();
-  if (m_server) {
-    m_server->stop();
-    m_server = nullptr;
-  }
   socket.close();
-
-  prog->report(90, "Closing ISIS event DAE");
-  histoDAE->setLogging(false); // hide the final closedown message to the log it
-                               // is confusing as it is a child alg.
-  histoDAE->cancel();
-  histoDAEHandle.wait();
 }
 
 } // namespace LiveData

--- a/Framework/LiveData/src/ISIS/ISISLiveEventDataListener.cpp
+++ b/Framework/LiveData/src/ISIS/ISISLiveEventDataListener.cpp
@@ -286,8 +286,7 @@ void ISISLiveEventDataListener::run() {
       saveEvents(events.data, pulseTime, events.head_n.period);
     }
 
-  } catch (std::runtime_error &
-               e) { // exception handler for generic runtime exceptions
+  } catch (std::runtime_error &e) {
 
     g_log.error() << "Caught a runtime exception.\nException message: "
                   << e.what() << '\n';
@@ -295,8 +294,8 @@ void ISISLiveEventDataListener::run() {
 
     m_backgroundException = boost::make_shared<std::runtime_error>(e);
 
-  } catch (std::invalid_argument &
-               e) { // TimeSeriesProperty (and possibly some other things) can
+  } catch (std::invalid_argument &e) {
+    // TimeSeriesProperty (and possibly some other things) can
     // can throw these errors
     g_log.error()
         << "Caught an invalid argument exception.\nException message: "
@@ -307,7 +306,7 @@ void ISISLiveEventDataListener::run() {
     newMsg += e.what();
     m_backgroundException = boost::make_shared<std::runtime_error>(newMsg);
 
-  } catch (...) { // Default exception handler
+  } catch (...) {
     g_log.error() << "Uncaught exception in ISISLiveEventDataListener network "
                      "read thread.\n";
     m_isConnected = false;

--- a/Framework/LiveData/src/ISIS/ISISLiveEventDataListener.cpp
+++ b/Framework/LiveData/src/ISIS/ISISLiveEventDataListener.cpp
@@ -235,6 +235,8 @@ void ISISLiveEventDataListener::run() {
       // get the header with the type of the packet
       Receive(events.head, "Events header",
               "Corrupt stream - you should reconnect.");
+      if (m_stopThread)
+        break;
       if (!(events.head.type == TCPStreamEventHeader::Neutron)) {
         // don't know what to do with it - stop
         throw std::runtime_error("Unknown packet type.");
@@ -244,6 +246,8 @@ void ISISLiveEventDataListener::run() {
       // get the header with the sream size
       Receive(events.head_n, "Neutrons header",
               "Corrupt stream - you should reconnect.");
+      if (m_stopThread)
+        break;
       CollectJunk(events.head_n);
 
       // absolute pulse (frame) time

--- a/docs/source/algorithms/FakeISISEventDAE-v1.rst
+++ b/docs/source/algorithms/FakeISISEventDAE-v1.rst
@@ -25,10 +25,7 @@ Usage
 
 **Example:**
 
-.. This test is currently hanging on macOS as the MonitorLiveData algorithm
-   is taking a long time to cancel
-
-.. code-block:: python
+.. testcode:: exFakeISISEventDAE
 
     from threading import Thread
     import time

--- a/docs/source/algorithms/FakeISISEventDAE-v1.rst
+++ b/docs/source/algorithms/FakeISISEventDAE-v1.rst
@@ -45,20 +45,22 @@ Usage
     def captureLive():
         ConfigService.setFacility("TEST_LIVE")
 
-        # start a Live data listener updating every second, that rebins the data
-        # and replaces the results each time with those of the last second.
-        StartLiveData(Instrument='ISIS_Event', OutputWorkspace='wsOut', UpdateEvery=1,
-                      ProcessingAlgorithm='Rebin', ProcessingProperties='Params=10000,1000,20000;PreserveEvents=1',
-                      AccumulationMethod='Add', PreserveEvents=True)
+        try:
+            # start a Live data listener updating every second, that rebins the data
+            # and replaces the results each time with those of the last second.
+            StartLiveData(Instrument='ISIS_Event', OutputWorkspace='wsOut', UpdateEvery=1,
+                          ProcessingAlgorithm='Rebin', ProcessingProperties='Params=10000,1000,20000;PreserveEvents=1',
+                          AccumulationMethod='Add', PreserveEvents=True)
 
-        # give it a couple of seconds before stopping it
-        time.sleep(2)
-
-        # This will cancel both algorithms
-        # you can do the same in the GUI
-        # by clicking on the details button on the bottom right
-        AlgorithmManager.newestInstanceOf("MonitorLiveData").cancel()
-        AlgorithmManager.newestInstanceOf("FakeISISEventDAE").cancel()
+            # give it a couple of seconds before stopping it
+            time.sleep(2)
+        finally:
+            # This will cancel both algorithms
+            # you can do the same in the GUI
+            # by clicking on the details button on the bottom right
+            AlgorithmManager.newestInstanceOf("MonitorLiveData").cancel()
+            AlgorithmManager.newestInstanceOf("FakeISISEventDAE").cancel()
+            time.sleep(1)
     #--------------------------------------------------------------------------------------------------
 
     oldFacility = ConfigService.getFacility().name()

--- a/docs/source/algorithms/FakeISISHistoDAE-v1.rst
+++ b/docs/source/algorithms/FakeISISHistoDAE-v1.rst
@@ -36,20 +36,21 @@ Usage
     def captureLive():
         ConfigService.setFacility("TEST_LIVE")
 
-        # start a Live data listener updating every second, that rebins the data
-        # and replaces the results each time with those of the last second.
-        StartLiveData(Instrument='ISIS_Histogram', OutputWorkspace='wsOut', UpdateEvery=1,
-                      AccumulationMethod='Replace')
+        try:
+            # start a Live data listener updating every second, that rebins the data
+            # and replaces the results each time with those of the last second.
+            StartLiveData(Instrument='ISIS_Histogram', OutputWorkspace='wsOut', UpdateEvery=1,
+                          AccumulationMethod='Replace')
 
-        # give it a couple of seconds before stopping it
-        time.sleep(2)
-
-        # This will cancel both algorithms
-        # you can do the same in the GUI
-        # by clicking on the details button on the bottom right
-        AlgorithmManager.newestInstanceOf("MonitorLiveData").cancel()
-        AlgorithmManager.newestInstanceOf("FakeISISHistoDAE").cancel()
-        time.sleep(1) # give them time to cancel
+            # give it a couple of seconds before stopping it
+            time.sleep(2)
+        finally:
+            # This will cancel both algorithms
+            # you can do the same in the GUI
+            # by clicking on the details button on the bottom right
+            AlgorithmManager.newestInstanceOf("MonitorLiveData").cancel()
+            AlgorithmManager.newestInstanceOf("FakeISISHistoDAE").cancel()
+            time.sleep(1)
     #--------------------------------------------------------------------------------------------------
 
     oldFacility = ConfigService.getFacility().name()

--- a/docs/source/algorithms/StartLiveData-v1.rst
+++ b/docs/source/algorithms/StartLiveData-v1.rst
@@ -123,20 +123,22 @@ Usage
     def captureLive():
         ConfigService.setFacility("TEST_LIVE")
 
-        # start a Live data listener updating every second, that rebins the data
-        # and replaces the results each time with those of the last second.
-        StartLiveData(Instrument='ISIS_Event', OutputWorkspace='wsOut', UpdateEvery=1,
-                      ProcessingAlgorithm='Rebin', ProcessingProperties='Params=10000,1000,20000;PreserveEvents=1',
-                      AccumulationMethod='Add', PreserveEvents=True)
+        try:
+            # start a Live data listener updating every second, that rebins the data
+            # and replaces the results each time with those of the last second.
+            StartLiveData(Instrument='ISIS_Event', OutputWorkspace='wsOut', UpdateEvery=1,
+                          ProcessingAlgorithm='Rebin', ProcessingProperties='Params=10000,1000,20000;PreserveEvents=1',
+                          AccumulationMethod='Add', PreserveEvents=True)
 
-        # give it a couple of seconds before stopping it
-        time.sleep(2)
-
-        # This will cancel both algorithms
-        # you can do the same in the GUI
-        # by clicking on the details button on the bottom right
-        AlgorithmManager.newestInstanceOf("MonitorLiveData").cancel()
-        AlgorithmManager.newestInstanceOf("FakeISISEventDAE").cancel()
+            # give it a couple of seconds before stopping it
+            time.sleep(2)
+        finally:
+            # This will cancel both algorithms
+            # you can do the same in the GUI
+            # by clicking on the details button on the bottom right
+            AlgorithmManager.newestInstanceOf("MonitorLiveData").cancel()
+            AlgorithmManager.newestInstanceOf("FakeISISEventDAE").cancel()
+            time.sleep(1)
     #--------------------------------------------------------------------------------------------------
 
     oldFacility = ConfigService.getFacility().name()
@@ -187,20 +189,22 @@ Output:
     def captureLive():
         ConfigService.setFacility("TEST_LIVE")
 
-        # Start a Live data listener updating every second,
-        # that replaces the results each time with those of the last second.
-        # Load only spectra 2,4, and 6 from periods 1 and 3
-        StartLiveData(Instrument='ISIS_Histogram', OutputWorkspace='wsOut', UpdateEvery=1,
-                            AccumulationMethod='Replace', PeriodList=[1,3],SpectraList=[2,4,6])
+        try:
+            # Start a Live data listener updating every second,
+            # that replaces the results each time with those of the last second.
+            # Load only spectra 2,4, and 6 from periods 1 and 3
+            StartLiveData(Instrument='ISIS_Histogram', OutputWorkspace='wsOut', UpdateEvery=1,
+                          AccumulationMethod='Replace', PeriodList=[1,3],SpectraList=[2,4,6])
 
-        # give it a couple of seconds before stopping it
-        time.sleep(2)
-
-        # This will cancel both algorithms
-        # you can do the same in the GUI
-        # by clicking on the details button on the bottom right
-        AlgorithmManager.newestInstanceOf("MonitorLiveData").cancel()
-        AlgorithmManager.newestInstanceOf("FakeISISHistoDAE").cancel()
+            # give it a couple of seconds before stopping it
+            time.sleep(2)
+        finally:
+            # This will cancel both algorithms
+            # you can do the same in the GUI
+            # by clicking on the details button on the bottom right
+            AlgorithmManager.newestInstanceOf("MonitorLiveData").cancel()
+            AlgorithmManager.newestInstanceOf("FakeISISHistoDAE").cancel()
+            time.sleep(1)
     #--------------------------------------------------------------------------------------------------
 
     oldFacility = ConfigService.getFacility().name()


### PR DESCRIPTION
**Description of work**

Fixes an issue that has been causing the doc tests to hang on macOS. The `MonitorLiveData` algorithm for the ISIS event listener could not be cancelled quick enough and the next test would then run into an exception that checked whether its workspace was being used anywhere. This exception, raised by `StartLiveData` meant that the `FakeISISEventDAE` algorithm was not cancelled properly and just continued running.

I am unsure why macOS was particularly but it is a timing issue so not guaranteed to cause a problem.

**To test:**

The following script reproduced the problem for me:

```python
def fake_isis_event_dae():

    from threading import Thread
    import time

    def startFakeDAE():
        # This will generate 2000 events roughly every 20ms, so about 50,000 events/sec
        # They will be randomly shared across the 100 spectra
        # and have a time of flight between 10,000 and 20,000
        try:
            FakeISISEventDAE(NPeriods=1,NSpectra=100,Rate=20,NEvents=1000)
        except RuntimeError:
            pass

    def captureLive():
        ConfigService.setFacility("TEST_LIVE")

        # start a Live data listener updating every second, that rebins the data
        # and replaces the results each time with those of the last second.
        StartLiveData(Instrument='ISIS_Event', OutputWorkspace='wsOut', UpdateEvery=1,
                      ProcessingAlgorithm='Rebin', ProcessingProperties='Params=10000,1000,20000;PreserveEvents=1',
                      AccumulationMethod='Add', PreserveEvents=True)

        # give it a couple of seconds before stopping it
        time.sleep(2)

        # This will cancel both algorithms
        # you can do the same in the GUI
        # by clicking on the details button on the bottom right
        AlgorithmManager.newestInstanceOf("MonitorLiveData").cancel()
        AlgorithmManager.newestInstanceOf("FakeISISEventDAE").cancel()
    #--------------------------------------------------------------------------------------------------

    oldFacility = ConfigService.getFacility().name()
    thread = Thread(target = startFakeDAE)
    thread.start()
    time.sleep(2) # give it a small amount of time to get ready
    if not thread.is_alive():
        raise RuntimeError("Unable to start FakeDAE")

    try:
        captureLive()
    except:
        print("Error occurred starting live data")
    finally:
        thread.join() # this must get hit

    # put back the facility
    ConfigService.setFacility(oldFacility)

    #get the ouput workspace
    wsOut = mtd["wsOut"]
    print("The workspace contains %i events" % wsOut.getNumberEvents())

# --------------------------

def fake_isis_histo_dae():
    from threading import Thread
    import time

    def startFakeHistoDAE():
        # This will generate 100 spectra with 100 bins
        try:
            FakeISISHistoDAE(NPeriods=1,NSpectra=100,nBins=100)
        except RuntimeError:
            pass

    def captureLive():
        ConfigService.setFacility("TEST_LIVE")

        # start a Live data listener updating every second, that rebins the data
        # and replaces the results each time with those of the last second.
        StartLiveData(Instrument='ISIS_Histogram', OutputWorkspace='wsOut', UpdateEvery=1,
                      AccumulationMethod='Replace')

        # give it a couple of seconds before stopping it
        time.sleep(2)

        # This will cancel both algorithms
        # you can do the same in the GUI
        # by clicking on the details button on the bottom right
        AlgorithmManager.newestInstanceOf("MonitorLiveData").cancel()
        AlgorithmManager.newestInstanceOf("FakeISISHistoDAE").cancel()
        time.sleep(1) # give them time to cancel
    #--------------------------------------------------------------------------------------------------

    oldFacility = ConfigService.getFacility().name()
    thread = Thread(target = startFakeHistoDAE)
    thread.start()
    time.sleep(2) # give it a small amount of time to get ready
    if not thread.is_alive():
        raise RuntimeError("Unable to start FakeDAE")

    try:
        captureLive()
    except:
        print("Error occurred starting live data")
    finally:
        thread.join() # this must get hit

    # put back the facility
    ConfigService.setFacility(oldFacility)

    #get the ouput workspace
    wsOut = mtd["wsOut"]
    print("The workspace contains %i histograms" % wsOut.getNumberHistograms())

# ------------------------------------------

def start_live_data_1():
    from threading import Thread
    import time

    def startFakeDAE():
        # This will generate 2000 events roughly every 20ms, so about 50,000 events/sec
        # They will be randomly shared across the 100 spectra
        # and have a time of flight between 10,000 and 20,000
        try:
            FakeISISEventDAE(NPeriods=1,NSpectra=100,Rate=20,NEvents=1000)
        except RuntimeError:
            pass

    def captureLive():
        ConfigService.setFacility("TEST_LIVE")

        # start a Live data listener updating every second, that rebins the data
        # and replaces the results each time with those of the last second.
        StartLiveData(Instrument='ISIS_Event', OutputWorkspace='wsOut', UpdateEvery=1,
                      ProcessingAlgorithm='Rebin', ProcessingProperties='Params=10000,1000,20000;PreserveEvents=1',
                      AccumulationMethod='Add', PreserveEvents=True)

        # give it a couple of seconds before stopping it
        time.sleep(2)

        # This will cancel both algorithms
        # you can do the same in the GUI
        # by clicking on the details button on the bottom right
        AlgorithmManager.newestInstanceOf("MonitorLiveData").cancel()
        AlgorithmManager.newestInstanceOf("FakeISISEventDAE").cancel()
    #--------------------------------------------------------------------------------------------------

    oldFacility = ConfigService.getFacility().name()
    thread = Thread(target = startFakeDAE)
    thread.start()
    time.sleep(2) # give it a small amount of time to get ready
    if not thread.is_alive():
        raise RuntimeError("Unable to start FakeDAE")

    try:
        captureLive()
    except Exception:
        print("Error occurred starting live data")
    finally:
        thread.join() # this must get hit

    # put back the facility
    ConfigService.setFacility(oldFacility)

    #get the ouput workspace
    wsOut = mtd["wsOut"]
    print("The workspace contains %i events" % wsOut.getNumberEvents())

# ---------------------------

def start_live_data_2():
    from threading import Thread
    import time

    def startFakeDAE():
        # This will generate 5 periods of histogram data, 10 spectra in each period,
        # 100 bins in each spectrum
        try:
            FakeISISHistoDAE(NPeriods=5,NSpectra=10,NBins=100)
        except RuntimeError:
            pass

    def captureLive():
        ConfigService.setFacility("TEST_LIVE")

        # Start a Live data listener updating every second,
        # that replaces the results each time with those of the last second.
        # Load only spectra 2,4, and 6 from periods 1 and 3
        StartLiveData(Instrument='ISIS_Histogram', OutputWorkspace='wsOut', UpdateEvery=1,
                            AccumulationMethod='Replace', PeriodList=[1,3],SpectraList=[2,4,6])

        # give it a couple of seconds before stopping it
        time.sleep(2)

        # This will cancel both algorithms
        # you can do the same in the GUI
        # by clicking on the details button on the bottom right
        AlgorithmManager.newestInstanceOf("MonitorLiveData").cancel()
        AlgorithmManager.newestInstanceOf("FakeISISHistoDAE").cancel()
    #--------------------------------------------------------------------------------------------------

    oldFacility = ConfigService.getFacility().name()
    thread = Thread(target = startFakeDAE)
    thread.start()
    time.sleep(2) # give it a small amount of time to get ready
    if not thread.is_alive():
        raise RuntimeError("Unable to start FakeDAE")

    try:
        captureLive()
    except Exception:
        print("Error occurred starting live data")
    finally:
        thread.join() # this must get hit

    # put back the facility
    ConfigService.setFacility(oldFacility)

    #get the ouput workspace
    wsOut = mtd["wsOut"]
    print("The workspace contains %i periods" % wsOut.getNumberOfEntries())
    print("Each period   contains %i spectra" % wsOut.getItem(0).getNumberHistograms())
    time.sleep(1)

for i in range(5):
    fake_isis_event_dae()
    FrameworkManager.clear()
    fake_isis_histo_dae()
    FrameworkManager.clear()
```

*No associated issue*

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
