### PR TITLE
Fix GroupDetectors crash when input doesn't have SpectraAxis

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/GroupDetectors2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/GroupDetectors2.h
@@ -171,7 +171,8 @@ private:
                  std::vector<int64_t> &unUsedSpec);
   /// gets the list of spectra _index_ _numbers_ from a file of _spectra_
   /// _numbers_
-  void processFile(const std::string &fname, API::MatrixWorkspace_const_sptr workspace,
+  void processFile(const std::string &fname,
+                   API::MatrixWorkspace_const_sptr workspace,
                    std::vector<int64_t> &unUsedSpec);
   /// gets groupings from XML file
   void processXMLFile(const std::string &fname,
@@ -194,7 +195,8 @@ private:
 
   /// used while reading the file reads reads spectra numbers from the string
   /// and returns spectra indexes
-  void readSpectraIndexes(const std::string &line, const spec2index_map &specs2index,
+  void readSpectraIndexes(const std::string &line,
+                          const spec2index_map &specs2index,
                           std::vector<size_t> &output,
                           std::vector<int64_t> &unUsedSpec,
                           const std::string &seperator = "#");

--- a/Framework/DataHandling/inc/MantidDataHandling/GroupDetectors2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/GroupDetectors2.h
@@ -171,10 +171,10 @@ private:
                  std::vector<int64_t> &unUsedSpec);
   /// gets the list of spectra _index_ _numbers_ from a file of _spectra_
   /// _numbers_
-  void processFile(std::string fname, API::MatrixWorkspace_const_sptr workspace,
+  void processFile(const std::string &fname, API::MatrixWorkspace_const_sptr workspace,
                    std::vector<int64_t> &unUsedSpec);
   /// gets groupings from XML file
-  void processXMLFile(std::string fname,
+  void processXMLFile(const std::string &fname,
                       API::MatrixWorkspace_const_sptr workspace,
                       std::vector<int64_t> &unUsedSpec);
   void
@@ -186,18 +186,18 @@ private:
                               std::vector<int64_t> &unUsedSpec);
   /// used while reading the file turns the string into an integer number (if
   /// possible), white space and # comments ignored
-  int readInt(std::string line);
+  int readInt(const std::string &line);
 
-  void readFile(spec2index_map &specs2index, std::istream &File,
+  void readFile(const spec2index_map &specs2index, std::istream &File,
                 size_t &lineNum, std::vector<int64_t> &unUsedSpec,
-                bool ignoreGroupNumber);
+                const bool ignoreGroupNumber);
 
   /// used while reading the file reads reads spectra numbers from the string
   /// and returns spectra indexes
-  void readSpectraIndexes(std::string line, spec2index_map &specs2index,
+  void readSpectraIndexes(const std::string &line, const spec2index_map &specs2index,
                           std::vector<size_t> &output,
                           std::vector<int64_t> &unUsedSpec,
-                          std::string seperator = "#");
+                          const std::string &seperator = "#");
 
   /// Estimate how much what has been read from the input file constitutes
   /// progress for the algorithm
@@ -232,7 +232,7 @@ private:
     /// spectrum will be included in a group, any other
     /// value and it isn't. Spectra numbers should always
     /// be positive so we shouldn't accidientally set a
-    /// spectrum number to the this
+    /// spectrum number to this
     EMPTY_LINE = 1001 - INT_MAX, ///< when reading from the input file this
     /// value means that we found any empty line
     IGNORE_SPACES = Mantid::Kernel::StringTokenizer::TOK_TRIM ///< equal to

--- a/Framework/DataHandling/src/GroupDetectors2.cpp
+++ b/Framework/DataHandling/src/GroupDetectors2.cpp
@@ -892,8 +892,8 @@ int GroupDetectors2::readInt(const std::string &line) {
 * @param ignoreGroupNumber :: ignore group numbers when numbering spectra
 * @throw invalid_argument if there is any problem with the file
 */
-void GroupDetectors2::readFile(const spec2index_map &specs2index, std::istream &File,
-                               size_t &lineNum,
+void GroupDetectors2::readFile(const spec2index_map &specs2index,
+                               std::istream &File, size_t &lineNum,
                                std::vector<int64_t> &unUsedSpec,
                                const bool ignoreGroupNumber) {
   // go through the rest of the file reading in lists of spectra number to group

--- a/Framework/DataHandling/src/GroupDetectors2.cpp
+++ b/Framework/DataHandling/src/GroupDetectors2.cpp
@@ -51,9 +51,9 @@ void translateAdd(const std::string &instructions,
   outSpectra.reserve(spectra.count());
   for (const auto &spectrum : spectra) {
     // add this spectrum to the group we're about to add
-    outSpectra.push_back(boost::lexical_cast<int>(spectrum));
+    outSpectra.emplace_back(boost::lexical_cast<int>(spectrum));
   }
-  outGroups.push_back(std::move(outSpectra));
+  outGroups.emplace_back(std::move(outSpectra));
 }
 
 // A range summation, i.e. "3-6" -> [3+4+5+6]
@@ -74,9 +74,9 @@ void translateSumRange(const std::string &instructions,
   std::vector<int> outSpectra;
   outSpectra.reserve(last - first + 1);
   for (int i = first; i <= last; ++i)
-    outSpectra.push_back(i);
+    outSpectra.emplace_back(i);
   if (!outSpectra.empty())
-    outGroups.push_back(std::move(outSpectra));
+    outGroups.emplace_back(std::move(outSpectra));
 }
 
 // A range insertion, i.e. "3:6" -> [3,4,5,6]
@@ -144,14 +144,14 @@ translateInstructions(const std::string &instructions, unsigned options) {
  * @param axis : The spectra axis of the workspace
  * @param commands : A stringstream to be filled
  */
-void convertGroupsToMapFile(std::vector<std::vector<int>> groups,
-                            const SpectraAxis *axis,
+void convertGroupsToMapFile(const std::vector<std::vector<int>> &groups,
+                            const SpectraAxis &axis,
                             std::stringstream &commands) {
   // The input gives the groups as a vector of a vector of ints. Turn
   // this into a string, just like the contents of a map file.
   commands << groups.size() << "\n";
   for (auto &group : groups) {
-    const int groupId = axis->spectraNo(group[0]);
+    const int groupId = axis.spectraNo(group[0]);
     const int groupSize = static_cast<int>(group.size());
 
     // Comment the output for readability
@@ -165,11 +165,23 @@ void convertGroupsToMapFile(std::vector<std::vector<int>> groups,
     // The input is in 0-indexed workspace ids, but the mapfile syntax expects
     // spectrum ids
     for (size_t j = 0; j < group.size(); ++j) {
-      commands << (j > 0 ? " " : "") << axis->spectraNo(group[j]);
+      commands << (j > 0 ? " " : "") << axis.spectraNo(group[j]);
     }
     commands << "\n";
   }
 }
+
+/**
+ * Replace the vertical axis to by a SpectraAxis.
+ * @param ws a workspace
+ */
+void forceSpectraAxis(MatrixWorkspace &ws) {
+  if (dynamic_cast<SpectraAxis *>(ws.getAxis(1))) {
+    return;
+  }
+  ws.replaceAxis(1, new SpectraAxis(&ws));
+}
+
 } // anonymous namespace
 
 // progress estimates
@@ -322,8 +334,10 @@ void GroupDetectors2::exec() {
 
   outputWS->setIndexInfo(indexInfo);
 
-  g_log.information() << name() << " algorithm has finished\n";
-
+  // Make sure output workspace has spectra axis.
+  // Numeric axis copied from the input workspace would be initialized with
+  // zeros only and contain no information in it.
+  forceSpectraAxis(*outputWS);
   setProperty("OutputWorkspace", outputWS);
 }
 
@@ -393,14 +407,15 @@ void GroupDetectors2::execEvent() {
   // Set all X bins on the output
   outputWS->setAllX(inputWS->binEdges(0));
 
-  g_log.information() << name() << " algorithm has finished\n";
-
+  // Make sure output workspace has spectra axis.
+  // Numeric axis copied from the input workspace would be initialized with
+  // zeros only and contain no information in it.
+  forceSpectraAxis(*outputWS);
   setProperty("OutputWorkspace", outputWS);
 }
 
 /** Make a map containing spectra indexes to group, the indexes could have come
-* from
-*  file, or an array, spectra numbers ...
+*  from a file, or an array, spectra numbers ...
 *  @param workspace :: the user selected input workspace
 *  @param unUsedSpec :: spectra indexes that are not members of any group
 */
@@ -456,11 +471,8 @@ void GroupDetectors2::getGroups(API::MatrixWorkspace_const_sptr workspace,
 
   const std::string instructions = getProperty("GroupingPattern");
   if (!instructions.empty()) {
-    spec2index_map specs2index;
-    const SpectraAxis *axis =
-        dynamic_cast<const SpectraAxis *>(workspace->getAxis(1));
-    if (axis)
-      specs2index = axis->getSpectraIndexMap();
+    const SpectraAxis axis(workspace.get());
+    const auto specs2index = axis.getSpectraIndexMap();
 
     // Translate the instructions into a vector of groups
     auto groups = translateInstructions(instructions, IGNORE_SPACES);
@@ -547,7 +559,7 @@ void GroupDetectors2::getGroups(API::MatrixWorkspace_const_sptr workspace,
 * group (so far)
 *  @throw FileError if there's any problem with the file or its format
 */
-void GroupDetectors2::processFile(std::string fname,
+void GroupDetectors2::processFile(const std::string &fname,
                                   API::MatrixWorkspace_const_sptr workspace,
                                   std::vector<int64_t> &unUsedSpec) {
   // tring to open the file the user told us exists, skip down 20 lines to find
@@ -638,7 +650,7 @@ void GroupDetectors2::processFile(std::string fname,
 * group (so far)
 *  @throw FileError if there's any problem with the file or its format
 */
-void GroupDetectors2::processXMLFile(std::string fname,
+void GroupDetectors2::processXMLFile(const std::string &fname,
                                      API::MatrixWorkspace_const_sptr workspace,
                                      std::vector<int64_t> &unUsedSpec) {
   // 1. Get maps for spectrum No and detector ID
@@ -838,7 +850,7 @@ void GroupDetectors2::processMatrixWorkspace(
 *  @throw boost::bad_lexical_cast when the string can't be interpreted as an
 * integer
 */
-int GroupDetectors2::readInt(std::string line) {
+int GroupDetectors2::readInt(const std::string &line) {
   // remove comments and white space (TOK_TRIM)
   Mantid::Kernel::StringTokenizer dataComment(
       line, "#", Mantid::Kernel::StringTokenizer::TOK_TRIM);
@@ -880,10 +892,10 @@ int GroupDetectors2::readInt(std::string line) {
 * @param ignoreGroupNumber :: ignore group numbers when numbering spectra
 * @throw invalid_argument if there is any problem with the file
 */
-void GroupDetectors2::readFile(spec2index_map &specs2index, std::istream &File,
+void GroupDetectors2::readFile(const spec2index_map &specs2index, std::istream &File,
                                size_t &lineNum,
                                std::vector<int64_t> &unUsedSpec,
-                               bool ignoreGroupNumber) {
+                               const bool ignoreGroupNumber) {
   // go through the rest of the file reading in lists of spectra number to group
   int oldSpectrumNo = 1;
   while (File) {
@@ -946,8 +958,7 @@ void GroupDetectors2::readFile(spec2index_map &specs2index, std::istream &File,
   }
 }
 /** The function expects that the string passed to it contains a series of
-* integers,
-*  ranges specified with a '-' are possible
+*  integers, ranges specified with a '-' are possible
 *  @param line :: a line read from the file, we'll interpret this
 *  @param specs2index :: a map with spectra numbers as indexes and index numbers
 * as values
@@ -958,11 +969,11 @@ void GroupDetectors2::readFile(spec2index_map &specs2index, std::istream &File,
 *  @throw invalid_argument when a number couldn't be found or the number is not
 * in the spectra map
 */
-void GroupDetectors2::readSpectraIndexes(std::string line,
-                                         spec2index_map &specs2index,
+void GroupDetectors2::readSpectraIndexes(const std::string &line,
+                                         const spec2index_map &specs2index,
                                          std::vector<size_t> &output,
                                          std::vector<int64_t> &unUsedSpec,
-                                         std::string seperator) {
+                                         const std::string &seperator) {
   // remove comments and white space
   Mantid::Kernel::StringTokenizer dataComment(line, seperator, IGNORE_SPACES);
   for (const auto &itr : dataComment) {

--- a/Framework/DataHandling/test/GroupDetectors2Test.h
+++ b/Framework/DataHandling/test/GroupDetectors2Test.h
@@ -60,9 +60,7 @@ public:
     FrameworkManager::Instance();
   }
 
-  void tearDown() override {
-    AnalysisDataService::Instance().clear();
-  }
+  void tearDown() override { AnalysisDataService::Instance().clear(); }
 
   void testSetup() {
     GroupDetectors2 gd;
@@ -932,7 +930,9 @@ public:
     createTestWorkspace(inputWSName, 0);
     // Use ConvertSpectrumAxis to replace the vertical axis with a
     // NumericAxis.
-    auto convertAxis = Mantid::API::AlgorithmManager::Instance().createUnmanaged("ConvertSpectrumAxis");
+    auto convertAxis =
+        Mantid::API::AlgorithmManager::Instance().createUnmanaged(
+            "ConvertSpectrumAxis");
     convertAxis->initialize();
     convertAxis->setChild(true);
     convertAxis->setRethrows(true);
@@ -974,9 +974,10 @@ public:
     const int numBanks{1};
     const int bankWidthInPixels{3};
     const bool clearEvents{false};
-    auto ws = WorkspaceCreationHelper::createEventWorkspaceWithFullInstrument(numBanks, bankWidthInPixels, clearEvents);
+    auto ws = WorkspaceCreationHelper::createEventWorkspaceWithFullInstrument(
+        numBanks, bankWidthInPixels, clearEvents);
     // Number of events from WorkspaceCreationHelpers::
-    //createEventWorkspaceWithStartTime, numEvents = 100, eventPatter = 2.
+    // createEventWorkspaceWithStartTime, numEvents = 100, eventPatter = 2.
     const int numEvents{200};
     auto newAxis = new NumericAxis(ws->getNumberHistograms());
     for (size_t i = 0; i < newAxis->length(); ++i) {
@@ -990,7 +991,8 @@ public:
 
     // Set the properties
     TS_ASSERT_THROWS_NOTHING(group.setProperty("InputWorkspace", ws))
-    TS_ASSERT_THROWS_NOTHING(group.setPropertyValue("OutputWorkspace", "GDEventsOut"))
+    TS_ASSERT_THROWS_NOTHING(
+        group.setPropertyValue("OutputWorkspace", "GDEventsOut"))
     TS_ASSERT_THROWS_NOTHING(group.setPropertyValue("GroupingPattern", "2-4"))
     TS_ASSERT_THROWS_NOTHING(group.setPropertyValue("Behaviour", "Average"))
     TS_ASSERT_THROWS_NOTHING(group.setProperty("PreserveEvents", true))

--- a/Framework/DataHandling/test/GroupDetectors2Test.h
+++ b/Framework/DataHandling/test/GroupDetectors2Test.h
@@ -2,18 +2,22 @@
 #define GROUPDETECTORS2TEST_H_
 
 #include "MantidDataHandling/GroupDetectors2.h"
+#include "MantidTestHelpers/ComponentCreationHelper.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 #include <cxxtest/TestSuite.h>
 
+#include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/FrameworkManager.h"
-#include "MantidGeometry/Instrument/DetectorInfo.h"
+#include "MantidAPI/NumericAxis.h"
+#include "MantidAPI/SpectraAxis.h"
 #include "MantidAPI/SpectrumInfo.h"
 #include "MantidDataHandling/LoadMuonNexus1.h"
 #include "MantidDataHandling/MaskDetectors.h"
 #include "MantidDataObjects/ScanningWorkspaceBuilder.h"
 #include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/Instrument/DetectorGroup.h"
+#include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidHistogramData/LinearGenerator.h"
 #include "MantidIndexing/IndexInfo.h"
 #include "MantidKernel/DateAndTime.h"
@@ -54,12 +58,10 @@ public:
     // This is needed to load in the plugin algorithms (specifically Divide,
     // which is a Child Algorithm of GroupDetectors)
     FrameworkManager::Instance();
-    createTestWorkspace(inputWSName, 0);
-    createTestWorkspace(offsetWSName, 1);
   }
 
-  ~GroupDetectors2Test() override {
-    AnalysisDataService::Instance().remove(inputWSName);
+  void tearDown() override {
+    AnalysisDataService::Instance().clear();
   }
 
   void testSetup() {
@@ -68,13 +70,11 @@ public:
     TS_ASSERT_EQUALS(gd.version(), 2);
     TS_ASSERT_THROWS_NOTHING(gd.initialize());
     TS_ASSERT(gd.isInitialized());
-
+    createTestWorkspace(inputWSName, 0);
     gd.setPropertyValue("InputWorkspace", inputWSName);
     gd.setPropertyValue("OutputWorkspace", outputWSNameBase);
     TS_ASSERT_THROWS_NOTHING(gd.execute());
     TS_ASSERT(!gd.isExecuted());
-
-    AnalysisDataService::Instance().remove(outputWSNameBase);
   }
 
   void testAveragingWithNoInstrument() {
@@ -99,6 +99,7 @@ public:
   void testSpectraList() {
     GroupDetectors2 grouper3;
     grouper3.initialize();
+    createTestWorkspace(inputWSName, 0);
     grouper3.setPropertyValue("InputWorkspace", inputWSName);
     std::string output(outputWSNameBase + "Specs");
     grouper3.setPropertyValue("OutputWorkspace", output);
@@ -124,12 +125,12 @@ public:
     TS_ASSERT(spectrumInfo.hasDetectors(0));
     TS_ASSERT(!spectrumInfo.hasUniqueDetector(0));
     TS_ASSERT_THROWS_ANYTHING(spectrumInfo.detector(1));
-    AnalysisDataService::Instance().remove(output);
   }
 
   void testIndexList() {
     GroupDetectors2 grouper3;
     grouper3.initialize();
+    createTestWorkspace(inputWSName, 0);
     grouper3.setPropertyValue("InputWorkspace", inputWSName);
     std::string output(outputWSNameBase + "Indices");
     grouper3.setPropertyValue("OutputWorkspace", output);
@@ -148,7 +149,6 @@ public:
             AnalysisDataService::Instance().retrieve(output));
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 1);
     HistogramX tens{10, 11, 12, 13, 14};
-    std::vector<double> ones(NBINS, 1.0);
     TS_ASSERT_EQUALS(outputWS->x(0), tens);
     TS_ASSERT_EQUALS(outputWS->y(0), HistogramY(NBINS, (3 + 4 + 5 + 6)));
     for (int i = 0; i < NBINS; ++i) {
@@ -158,12 +158,12 @@ public:
     const auto &spectrumInfo = outputWS->spectrumInfo();
     TS_ASSERT(spectrumInfo.hasDetectors(0));
     TS_ASSERT_THROWS_ANYTHING(spectrumInfo.detector(1));
-    AnalysisDataService::Instance().remove(output);
   }
 
   void testGroupingPattern() {
     GroupDetectors2 grouper3;
     grouper3.initialize();
+    createTestWorkspace(inputWSName, 0);
     grouper3.setPropertyValue("InputWorkspace", inputWSName);
     std::string output(outputWSNameBase + "Indices");
     grouper3.setPropertyValue("OutputWorkspace", output);
@@ -199,6 +199,7 @@ public:
     // Check that the algorithm still works if spectrum numbers are not 1-based
     GroupDetectors2 grouper3;
     grouper3.initialize();
+    createTestWorkspace(offsetWSName, 1);
     grouper3.setPropertyValue("InputWorkspace", offsetWSName);
     std::string output(outputWSNameBase + "Indices");
     grouper3.setPropertyValue("OutputWorkspace", output);
@@ -217,7 +218,6 @@ public:
             AnalysisDataService::Instance().retrieve(output));
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 1);
     HistogramX tens{10, 11, 12, 13, 14};
-    std::vector<double> ones(NBINS, 1.0);
     TS_ASSERT_EQUALS(outputWS->x(0), tens);
     TS_ASSERT_EQUALS(outputWS->y(0), HistogramY(NBINS, (3 + 4 + 5 + 6)));
     for (int i = 0; i < NBINS; ++i) {
@@ -227,13 +227,13 @@ public:
     const auto &spectrumInfo = outputWS->spectrumInfo();
     TS_ASSERT(spectrumInfo.hasDetectors(0));
     TS_ASSERT_THROWS_ANYTHING(spectrumInfo.detector(1));
-    AnalysisDataService::Instance().remove(output);
   }
 
   void testGroupingPatternOffsetSpectra() {
     // Check that the algorithm still works if spectrum numbers are not 1-based
     GroupDetectors2 grouper3;
     grouper3.initialize();
+    createTestWorkspace(offsetWSName, 1);
     grouper3.setPropertyValue("InputWorkspace", offsetWSName);
     std::string output(outputWSNameBase + "Indices");
     grouper3.setPropertyValue("OutputWorkspace", output);
@@ -252,7 +252,6 @@ public:
             AnalysisDataService::Instance().retrieve(output));
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 1);
     HistogramX tens{10, 11, 12, 13, 14};
-    std::vector<double> ones(NBINS, 1.0);
     TS_ASSERT_EQUALS(outputWS->x(0), tens);
     TS_ASSERT_EQUALS(outputWS->y(0), HistogramY(NBINS, (3 + 4 + 5 + 6)));
     for (int i = 0; i < NBINS; ++i) {
@@ -262,12 +261,12 @@ public:
     const auto &spectrumInfo = outputWS->spectrumInfo();
     TS_ASSERT(spectrumInfo.hasDetectors(0));
     TS_ASSERT_THROWS_ANYTHING(spectrumInfo.detector(1));
-    AnalysisDataService::Instance().remove(output);
   }
 
   void testDetectorList() {
     GroupDetectors2 grouper3;
     grouper3.initialize();
+    createTestWorkspace(inputWSName, 0);
     grouper3.setPropertyValue("InputWorkspace", inputWSName);
     std::string output(outputWSNameBase + "Detects");
     grouper3.setPropertyValue("OutputWorkspace", output);
@@ -282,7 +281,6 @@ public:
             AnalysisDataService::Instance().retrieve(output));
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 1);
     HistogramX tens{10, 11, 12, 13, 14};
-    std::vector<double> ones(NBINS, 1.0);
     TS_ASSERT_EQUALS(outputWS->x(0), tens);
     TS_ASSERT_EQUALS(outputWS->y(0),
                      HistogramY(NBINS, (3 + 1) + (1 + 1) + (4 + 1) + (0 + 1) +
@@ -295,8 +293,6 @@ public:
     const auto &spectrumInfo = outputWS->spectrumInfo();
     TS_ASSERT(spectrumInfo.hasDetectors(0));
     TS_ASSERT_THROWS_ANYTHING(spectrumInfo.detector(1));
-
-    AnalysisDataService::Instance().remove(output);
   }
 
   void testFileList() {
@@ -305,6 +301,7 @@ public:
 
     GroupDetectors2 grouper;
     grouper.initialize();
+    createTestWorkspace(inputWSName, 0);
     grouper.setPropertyValue("InputWorkspace", inputWSName);
     std::string output(outputWSNameBase + "File");
     grouper.setPropertyValue("OutputWorkspace", output);
@@ -369,7 +366,6 @@ public:
     TS_ASSERT(spectrumInfo.hasDetectors(4));
     TS_ASSERT(spectrumInfo.hasUniqueDetector(4));
 
-    AnalysisDataService::Instance().remove(output);
     remove(inputFile.c_str());
   }
 
@@ -379,6 +375,7 @@ public:
 
     GroupDetectors2 grouper;
     grouper.initialize();
+    createTestWorkspace(inputWSName, 0);
     grouper.setPropertyValue("InputWorkspace", inputWSName);
     std::string output(outputWSNameBase + "File");
     grouper.setPropertyValue("OutputWorkspace", output);
@@ -420,8 +417,6 @@ public:
     }
     TS_ASSERT_EQUALS(outputWS->getAxis(1)->spectraNo(2), 3);
     TS_ASSERT_EQUALS(outputWS->getSpectrum(2).getSpectrumNo(), 3);
-
-    AnalysisDataService::Instance().remove(output);
     remove(inputFile.c_str());
   }
 
@@ -470,7 +465,7 @@ public:
     AnalysisDataService::Instance().remove("boevs");
   }
 
-  void testReadingFromXMLCheckDublicateIndex() {
+  void testReadingFromXMLCheckDuplicateIndex() {
     Mantid::DataHandling::LoadMuonNexus1 nxLoad;
     nxLoad.initialize();
 
@@ -587,6 +582,7 @@ public:
   }
 
   void testAverageBehaviour() {
+    createTestWorkspace(inputWSName, 0);
     Mantid::DataHandling::MaskDetectors mask;
     mask.initialize();
     mask.setPropertyValue("Workspace", inputWSName);
@@ -607,9 +603,6 @@ public:
 
     // Result should be 1 + 2  / 2 = 1.5
     TS_ASSERT_EQUALS(output->y(0)[1], 1.5);
-
-    AnalysisDataService::Instance().remove(
-        "GroupDetectors2_testAverageBehaviour_Output");
   }
 
   void testEvents() {
@@ -633,6 +626,7 @@ public:
     alg2.execute();
     TS_ASSERT(alg2.isExecuted());
 
+    TS_ASSERT(AnalysisDataService::Instance().doesExist("GDEventsOut"))
     EventWorkspace_sptr output;
     output = AnalysisDataService::Instance().retrieveWS<EventWorkspace>(
         "GDEventsOut");
@@ -642,7 +636,6 @@ public:
     TS_ASSERT_EQUALS(input->x(0).size(), output->x(0).size());
     TS_ASSERT_DELTA((input->y(2)[0] + input->y(3)[0] + input->y(4)[0]) / 3,
                     output->y(0)[0], 0.00001);
-    AnalysisDataService::Instance().remove("GDEventsOut");
   }
 
   void
@@ -876,6 +869,7 @@ public:
     GroupDetectors2 groupAlg;
     groupAlg.initialize();
     groupAlg.setRethrows(true);
+    createTestWorkspace(inputWSName, 0);
     groupAlg.setPropertyValue("InputWorkspace", inputWSName);
     groupAlg.setPropertyValue("OutputWorkspace", outputWSNameBase);
     groupAlg.setPropertyValue("GroupingPattern", "-1, 0");
@@ -912,8 +906,6 @@ public:
     TS_ASSERT_EQUALS(spectrumDefinitions[1][1].second, 3);
     TS_ASSERT_EQUALS(spectrumDefinitions[1][2].second, 4);
     TS_ASSERT_EQUALS(spectrumDefinitions[1][3].second, 5);
-
-    AnalysisDataService::Instance().remove(outputWSNameBase);
   }
 
   void test_grouping_with_time_indexes_in_event_workspace_throws() {
@@ -936,11 +928,94 @@ public:
                             "EventWorkspaces with detector scans.")
   }
 
+  void test_GroupingPattern_histogram_workspace_without_SpectraAxis_works() {
+    createTestWorkspace(inputWSName, 0);
+    // Use ConvertSpectrumAxis to replace the vertical axis with a
+    // NumericAxis.
+    auto convertAxis = Mantid::API::AlgorithmManager::Instance().createUnmanaged("ConvertSpectrumAxis");
+    convertAxis->initialize();
+    convertAxis->setChild(true);
+    convertAxis->setRethrows(true);
+    convertAxis->setProperty("InputWorkspace", inputWSName);
+    convertAxis->setProperty("OutputWorkspace", "unused_for_child");
+    convertAxis->setProperty("Target", "Theta");
+    convertAxis->execute();
+    MatrixWorkspace_sptr inputWS = convertAxis->getProperty("OutputWorkspace");
+    GroupDetectors2 group;
+    group.initialize();
+    group.setRethrows(false);
+    TS_ASSERT_THROWS_NOTHING(group.setProperty("InputWorkspace", inputWS))
+    const std::string output(outputWSNameBase + "withoutSpectraAxis");
+    TS_ASSERT_THROWS_NOTHING(group.setPropertyValue("OutputWorkspace", output))
+    TS_ASSERT_THROWS_NOTHING(group.setPropertyValue("GroupingPattern", "2-5"))
+    TS_ASSERT_THROWS_NOTHING(group.execute())
+    TS_ASSERT(group.isExecuted())
+
+    MatrixWorkspace_sptr outputWS =
+        boost::dynamic_pointer_cast<MatrixWorkspace>(
+            AnalysisDataService::Instance().retrieve(output));
+    // The output should have SpectrumAxis.
+    const Axis *axis = outputWS->getAxis(1);
+    TS_ASSERT(dynamic_cast<const Mantid::API::SpectraAxis *>(axis) != nullptr);
+    TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 1);
+    const HistogramX tens{10, 11, 12, 13, 14};
+    TS_ASSERT_EQUALS(outputWS->x(0), tens);
+    TS_ASSERT_EQUALS(outputWS->y(0), HistogramY(NBINS, (3 + 4 + 5 + 6)));
+    for (int i = 0; i < NBINS; ++i) {
+      TS_ASSERT_DELTA(outputWS->e(0)[i], std::sqrt(4.0), 0.0001);
+    }
+
+    const auto &spectrumInfo = outputWS->spectrumInfo();
+    TS_ASSERT(spectrumInfo.hasDetectors(0));
+    TS_ASSERT_THROWS_ANYTHING(spectrumInfo.detector(1));
+  }
+
+  void test_GroupingPattern_event_workspace_without_SpectraAxis_works() {
+    const int numBanks{1};
+    const int bankWidthInPixels{3};
+    const bool clearEvents{false};
+    auto ws = WorkspaceCreationHelper::createEventWorkspaceWithFullInstrument(numBanks, bankWidthInPixels, clearEvents);
+    // Number of events from WorkspaceCreationHelpers::
+    //createEventWorkspaceWithStartTime, numEvents = 100, eventPatter = 2.
+    const int numEvents{200};
+    auto newAxis = new NumericAxis(ws->getNumberHistograms());
+    for (size_t i = 0; i < newAxis->length(); ++i) {
+      newAxis->setValue(i, static_cast<double>(i + 1));
+    }
+    ws->replaceAxis(1, newAxis);
+    GroupDetectors2 group;
+    TS_ASSERT_THROWS_NOTHING(group.initialize())
+    TS_ASSERT(group.isInitialized());
+    group.setRethrows(true);
+
+    // Set the properties
+    TS_ASSERT_THROWS_NOTHING(group.setProperty("InputWorkspace", ws))
+    TS_ASSERT_THROWS_NOTHING(group.setPropertyValue("OutputWorkspace", "GDEventsOut"))
+    TS_ASSERT_THROWS_NOTHING(group.setPropertyValue("GroupingPattern", "2-4"))
+    TS_ASSERT_THROWS_NOTHING(group.setPropertyValue("Behaviour", "Average"))
+    TS_ASSERT_THROWS_NOTHING(group.setProperty("PreserveEvents", true))
+
+    group.execute();
+    TS_ASSERT(group.isExecuted());
+
+    EventWorkspace_sptr output;
+    output = AnalysisDataService::Instance().retrieveWS<EventWorkspace>(
+        "GDEventsOut");
+    TS_ASSERT(output);
+    const Axis *axis = output->getAxis(1);
+    TS_ASSERT(dynamic_cast<const Mantid::API::SpectraAxis *>(axis) != nullptr);
+    TS_ASSERT_EQUALS(output->getNumberHistograms(), 1);
+    TS_ASSERT_EQUALS(output->getNumberEvents(), 3 * numEvents);
+    TS_ASSERT_EQUALS(ws->x(0).size(), output->x(0).size());
+    TS_ASSERT_DELTA((ws->y(2)[0] + ws->y(3)[0] + ws->y(4)[0]) / 3,
+                    output->y(0)[0], 0.00001);
+  }
+
 private:
   const std::string inputWSName, offsetWSName, outputWSNameBase, inputFile;
   enum constants { NHIST = 6, NBINS = 4 };
 
-  void createTestWorkspace(std::string name, const int offset) {
+  void createTestWorkspace(const std::string &name, const int offset) {
     // Set up a small workspace for testing
     auto space2D = createWorkspace<Workspace2D>(NHIST, NBINS + 1, NBINS);
     space2D->getAxis(0)->unit() = UnitFactory::Instance().create("TOF");
@@ -962,6 +1037,8 @@ private:
       instr->add(d);
       instr->markAsDetector(d);
     }
+    ComponentCreationHelper::addSampleToInstrument(instr, V3D{0., 0., 0.});
+    ComponentCreationHelper::addSourceToInstrument(instr, V3D{0., 0., -2.});
     space2D->setInstrument(instr);
 
     // Register the workspace in the data service
@@ -969,6 +1046,7 @@ private:
   }
 
   MatrixWorkspace_sptr createTestScanWorkspace() {
+    createTestWorkspace(inputWSName, 0);
     MatrixWorkspace_sptr inputWS = boost::dynamic_pointer_cast<MatrixWorkspace>(
         AnalysisDataService::Instance().retrieve(inputWSName));
 

--- a/Framework/TestHelpers/inc/MantidTestHelpers/ComponentCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/ComponentCreationHelper.h
@@ -77,10 +77,12 @@ createCappedCylinder(double radius, double height,
                      const Mantid::Kernel::V3D &axis, const std::string &id);
 
 /// Add a spherical sample at samplePos to given instrument.
-void addSampleToInstrument(Mantid::Geometry::Instrument_sptr &instrument, const Mantid::Kernel::V3D &samplePos);
+void addSampleToInstrument(Mantid::Geometry::Instrument_sptr &instrument,
+                           const Mantid::Kernel::V3D &samplePos);
 
 /// Add a source with given name and sourcePos to given instrument
-void addSourceToInstrument(Mantid::Geometry::Instrument_sptr &instrument, const Mantid::Kernel::V3D &sourcePos,
+void addSourceToInstrument(Mantid::Geometry::Instrument_sptr &instrument,
+                           const Mantid::Kernel::V3D &sourcePos,
                            const std::string &name = "moderator");
 
 /**

--- a/Framework/TestHelpers/inc/MantidTestHelpers/ComponentCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/ComponentCreationHelper.h
@@ -75,6 +75,14 @@ boost::shared_ptr<Mantid::Geometry::CSGObject>
 createCappedCylinder(double radius, double height,
                      const Mantid::Kernel::V3D &baseCentre,
                      const Mantid::Kernel::V3D &axis, const std::string &id);
+
+/// Add a spherical sample at samplePos to given instrument.
+void addSampleToInstrument(Mantid::Geometry::Instrument_sptr &instrument, const Mantid::Kernel::V3D &samplePos);
+
+/// Add a source with given name and sourcePos to given instrument
+void addSourceToInstrument(Mantid::Geometry::Instrument_sptr &instrument, const Mantid::Kernel::V3D &sourcePos,
+                           const std::string &name = "moderator");
+
 /**
  * Return the XML for a sphere.
  */

--- a/Framework/TestHelpers/src/ComponentCreationHelper.cpp
+++ b/Framework/TestHelpers/src/ComponentCreationHelper.cpp
@@ -70,7 +70,7 @@ boost::shared_ptr<CSGObject> createCappedCylinder(double radius, double height,
 }
 
 void addSourceToInstrument(Instrument_sptr &instrument, const V3D &sourcePos,
-                           std::string name = "moderator") {
+                           const std::string &name) {
   ObjComponent *source =
       new ObjComponent(name, IObject_sptr(new CSGObject), instrument.get());
   source->setPos(sourcePos);

--- a/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+++ b/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
@@ -497,13 +497,12 @@ createEventWorkspaceWithFullInstrument(int numBanks, int numPixels,
   ws->replaceAxis(0, ax0);
 
   // re-assign detector IDs to the rectangular detector
-  int detID = numPixels * numPixels;
-  for (int wi = 0; wi < static_cast<int>(ws->getNumberHistograms()); wi++) {
+  const auto detIds = inst->getDetectorIDs();
+  for (int wi = 0; wi < static_cast<int>(ws->getNumberHistograms()); ++wi) {
     ws->getSpectrum(wi).clearDetectorIDs();
     if (clearEvents)
       ws->getSpectrum(wi).clear(true);
-    ws->getSpectrum(wi).setDetectorID(detID);
-    detID++;
+    ws->getSpectrum(wi).setDetectorID(detIds[wi]);
   }
   return ws;
 }

--- a/docs/source/algorithms/GroupDetectors-v2.rst
+++ b/docs/source/algorithms/GroupDetectors-v2.rst
@@ -116,6 +116,16 @@ workspace indices. This can be achieved with the following operators:
 One could combine these operations, for example :literal:`10+12,13:89` would
 list the sum of 10 and 12 followed by 13 to 89.
 
+Vertical Axis on Output
+#######################
+
+The OutputWorkspace of this algorithm will always have spectrum numbers as the
+vertical axis, independent of the vertical axis units in InputWorkspace. This
+is because after grouping, the vertical axis can have meaningless values and
+generally, there is not enough information available to rebuild the axis. The
+vertical axis can be manually restored afterwards by e.g.
+:ref:`ConvertSpectrumAxis <algm-ConvertSpectrumAxis>`.
+
 Previous Versions
 -----------------
 

--- a/docs/source/release/v3.13.0/framework.rst
+++ b/docs/source/release/v3.13.0/framework.rst
@@ -37,5 +37,6 @@ Bug fixes
 
 - The documentation of the algorithm :ref:`algm-CreateSampleWorkspace` did not match its implementation. The axis in beam direction will now be correctly described as Z instead of X.
 - The :ref:`ExtractMask <algm-ExtractMask>` algorithm now returns a non-empty list of detector ID's when given a MaskWorkspace.
+- Fixed a crash when the input workspace for :ref:`GroupDetectors <algm-GroupDetectors>` contained any other units than spectrum numbers.
 
 :ref:`Release 3.13.0 <v3.13.0>`


### PR DESCRIPTION
`GroupDetectors` could segfault when *InputWorkspace* had any other vertical axis units than spectrum numbers, i.e. the vertical axis type was not `SpectraAxis`. This PR fixes the issue.

**To test:**

The following script segfaults if these changes are not applied:
```python
ws = CreateSampleWorkspace()
ws = ConvertSpectrumAxis(ws, 'Theta')
ws = GroupDetectors(ws, GroupingPattern='0-199')
```

Fixes #22296. 

**Release Notes** 

Framework release notes were updated accordingly.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [x] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
