### PR TITLE
Fix FindBoostPython for Boost 1.67

### DIFF
--- a/buildconfig/CMake/DarwinSetup.cmake
+++ b/buildconfig/CMake/DarwinSetup.cmake
@@ -54,6 +54,18 @@ else ()
   set ( PY_VER 2.7 )
 endif ()
 
+execute_process(COMMAND python${PY_VER}-config --prefix OUTPUT_VARIABLE PYTHON_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+if(${PYTHON_VERSION_MAJOR} GREATER 2)
+  execute_process(COMMAND python${PY_VER}-config --abiflags OUTPUT_VARIABLE PY_ABI OUTPUT_STRIP_TRAILING_WHITESPACE)
+else()
+  # --abiflags option not available in python 2
+  set(PY_ABI "")
+endif()
+
+set( PYTHON_LIBRARY "${PYTHON_PREFIX}/lib/libpython${PY_VER}${PY_ABI}.dylib" CACHE FILEPATH "PYTHON_LIBRARY" FORCE )
+set( PYTHON_INCLUDE_DIR "${PYTHON_PREFIX}/include/python${PY_VER}${PY_ABI}" CACHE PATH "PYTHON_INCLUDE_DIR" FORCE )
+
 find_package ( PythonLibs REQUIRED )
 # If found, need to add debug library into libraries variable
 if ( PYTHON_DEBUG_LIBRARIES )

--- a/buildconfig/CMake/FindBoostPython.cmake
+++ b/buildconfig/CMake/FindBoostPython.cmake
@@ -11,19 +11,26 @@ else ()
     # Try a known set of suffixes plus a user-defined set
     # Define a cache variable to supply additional suffxies. These are tried first
     set ( BOOST_PYTHON_ADDITIONAL_SUFFIXES "" CACHE STRING "Additional suffixes to try when searching for the boost python3 library. These are prepended to the default list" )
-    set ( _suffixes ${BOOST_PYTHON_ADDITIONAL_SUFFIXES} ${PYTHON_VERSION_MAJOR} -py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR} )
+    set ( _suffixes "${BOOST_PYTHON_ADDITIONAL_SUFFIXES};${PYTHON_VERSION_MAJOR};-py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR};${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
     foreach ( _suffix ${_suffixes})
       find_package ( Boost COMPONENTS python${_suffix} )
       if ( Boost_FOUND )
         break ()
-      endif()
+      endif ()
     endforeach ()
     if ( NOT Boost_FOUND )
       message ( FATAL_ERROR "Cannot find appropriate boost python version after trying with the "
                 "following library suffixes: ${_suffixes}" )
     endif ()
   else ()
-    # Assumes that the default version is 2
-    find_package ( Boost COMPONENTS python REQUIRED )
+    # Assumes that the default version is 27
+    find_package ( Boost COMPONENTS python )
+    if ( NOT Boost_FOUND )
+      find_package ( Boost COMPONENTS python27 )
+    endif ()
+    if ( NOT Boost_FOUND )
+      message ( FATAL_ERROR "Cannot find appropriate boost python version after trying with the "
+                "following library suffixes: ;27" )
+    endif ()
   endif ()
 endif ()

--- a/buildconfig/CMake/Packaging/osx/mantidpython_osx
+++ b/buildconfig/CMake/Packaging/osx/mantidpython_osx
@@ -26,7 +26,7 @@ fi
 
 if [ -n "$1" ] && [ "$1" = "--classic" ]; then
     shift
-    PROG=$(command -v python@PYTHON_VERSION_MAJOR@.@PYTHON_VERSION_MINOR@)
+    PROG=@PYTHON_EXECUTABLE@
 fi
 
 # Define MANTIDPATH


### PR DESCRIPTION
Boost 1.67 changes [how one looks up `boost::python`](https://github.com/Kitware/CMake/commit/1673923c303c6a4184904c4c5849911feddb87e7#diff-555801259d7df67368f7deab1f9deacd). This also brings back code on MacOS to ensure consistency between the python interpreter, libraries and headers.

Description of work.

**To test:**

<!-- Instructions for testing. -->



There is no GitHub issue associated with this pull request.

**Release Notes** 

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
