### PR TITLE
Simplify Component to ComponentInfo forwarding

### DIFF
--- a/Framework/API/test/ExperimentInfoTest.h
+++ b/Framework/API/test/ExperimentInfoTest.h
@@ -82,7 +82,7 @@ public:
     TS_ASSERT_EQUALS(ws.getInstrument()->type(), "Instrument");
 
     // Should be set even though we have just an empty instrument.
-    TS_ASSERT(i->getParameterMap()->hasDetectorInfo(i->baseInstrument().get()));
+    TS_ASSERT(i->getParameterMap()->hasDetectorInfo());
   }
 
   void test_GetSetInstrument_default() {

--- a/Framework/Algorithms/test/DetectorEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/DetectorEfficiencyCorTest.h
@@ -56,6 +56,7 @@ public:
     inputWS->getSpectrum(0).setDetectorID(1);
 
     Mantid::Algorithms::DetectorEfficiencyCor grouper;
+    grouper.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(grouper.initialize());
     TS_ASSERT(grouper.isInitialized());
     grouper.setChild(true);
@@ -136,6 +137,7 @@ private:
     }
     ObjComponent *sample = new ObjComponent("sample", shape, nullptr);
     sample->setPos(0, 0, 0);
+    instrument->add(sample);
     instrument->markAsSamplePos(sample);
 
     const int nspecs(1);

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -213,6 +213,7 @@ public:
   // where the physical instrument differs from the 'neutronic' one
   boost::shared_ptr<const Instrument> getPhysicalInstrument() const;
   void setPhysicalInstrument(std::unique_ptr<Instrument>);
+  bool isPhysicalInstrument() const;
 
   void getInstrumentParameters(double &l1, Kernel::V3D &beamline,
                                double &beamline_norm,

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
@@ -338,7 +338,7 @@ public:
   pmap_cit end() const { return m_map.end(); }
 
   bool hasDetectorInfo(const Instrument *instrument) const;
-  bool hasComponentInfo(const Instrument *instrument) const;
+  bool hasComponentInfo() const;
   const Geometry::DetectorInfo &detectorInfo() const;
   Geometry::DetectorInfo &mutableDetectorInfo();
   const Geometry::ComponentInfo &componentInfo() const;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
@@ -337,7 +337,7 @@ public:
   pmap_it end() { return m_map.end(); }
   pmap_cit end() const { return m_map.end(); }
 
-  bool hasDetectorInfo(const Instrument *instrument) const;
+  bool hasDetectorInfo() const;
   bool hasComponentInfo() const;
   const Geometry::DetectorInfo &detectorInfo() const;
   Geometry::DetectorInfo &mutableDetectorInfo();

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -829,7 +829,7 @@ std::vector<detid_t> Instrument::getMonitors() const {
 void Instrument::getBoundingBox(BoundingBox &assemblyBox) const {
   if (m_map) {
 
-    if (m_map->hasComponentInfo(this->baseInstrument().get())) {
+    if (m_map->hasComponentInfo()) {
       assemblyBox = m_map->componentInfo().boundingBox(index(), &assemblyBox);
       return;
     }
@@ -1270,7 +1270,7 @@ boost::shared_ptr<ParameterMap> Instrument::makeLegacyParameterMap() const {
 
   const auto &baseInstr = m_map ? *m_instr : *this;
 
-  if (!getParameterMap()->hasComponentInfo(&baseInstr))
+  if (!getParameterMap()->hasComponentInfo())
     return pmap;
 
   // Tolerance 1e-9 m with rotation center at a distance of L = 1000 m as in
@@ -1388,7 +1388,7 @@ void Instrument::parseTreeAndCacheBeamline() {
 std::pair<std::unique_ptr<ComponentInfo>, std::unique_ptr<DetectorInfo>>
 Instrument::makeBeamline(ParameterMap &pmap, const ParameterMap *source) const {
   // If we have source and it has Beamline objects just copy them
-  if (source && source->hasComponentInfo(this))
+  if (source && source->hasComponentInfo())
     return makeWrappers(pmap, source->componentInfo(), source->detectorInfo());
   // If pmap is empty and base instrument has Beamline objects just copy them
   if (pmap.empty() && m_componentInfo)

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -202,6 +202,10 @@ void Instrument::setPhysicalInstrument(std::unique_ptr<Instrument> physInst) {
                              "parametrized instrument.");
 }
 
+bool Instrument::isPhysicalInstrument() const {
+  return this->m_isPhysicalInstrument;
+}
+
 //------------------------------------------------------------------------------------------
 /**	Fills a copy of the detector cache
 * @returns a map of the detectors hold by the instrument

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -521,6 +521,8 @@ auto find(T &map, const detid_t key) -> decltype(map.begin()) {
 *  @throw   NotFoundError If no detector is found for the detector ID given
 */
 IDetector_const_sptr Instrument::getDetector(const detid_t &detector_id) const {
+  if (m_isPhysicalInstrument)
+    throw std::runtime_error("Cannot fetch detector from physical instrument");
   const auto &baseInstr = m_map ? *m_instr : *this;
   const auto it = find(baseInstr.m_detectorCache, detector_id);
   if (it == baseInstr.m_detectorCache.end()) {

--- a/Framework/Geometry/src/Instrument/Component.cpp
+++ b/Framework/Geometry/src/Instrument/Component.cpp
@@ -311,13 +311,7 @@ size_t Component::index() const {
   return m_map->componentIndex(this->getComponentID());
 }
 
-bool Component::hasComponentInfo() const {
-  const IComponent *root = m_base;
-  while (auto parent = root->getBareParent())
-    root = parent;
-  auto instrument = dynamic_cast<const Instrument *>(root);
-  return m_map->hasComponentInfo(instrument);
-}
+bool Component::hasComponentInfo() const { return m_map->hasComponentInfo(); }
 
 /// Return the relative position to the parent Component
 Kernel::V3D Component::getRelativePos() const {

--- a/Framework/Geometry/src/Instrument/Component.cpp
+++ b/Framework/Geometry/src/Instrument/Component.cpp
@@ -316,7 +316,6 @@ bool Component::hasComponentInfo() const { return m_map->hasComponentInfo(); }
 /// Return the relative position to the parent Component
 Kernel::V3D Component::getRelativePos() const {
   if (m_map) {
-
     if (hasComponentInfo()) {
       return m_map->componentInfo().relativePosition(index());
     } else {

--- a/Framework/Geometry/src/Instrument/Detector.cpp
+++ b/Framework/Geometry/src/Instrument/Detector.cpp
@@ -138,13 +138,7 @@ size_t Detector::registerContents(ComponentVisitor &componentVisitor) const {
   return componentVisitor.registerDetector(*this);
 }
 
-bool Detector::hasDetectorInfo() const {
-  const IComponent *root = m_base;
-  while (auto parent = root->getBareParent())
-    root = parent;
-  auto instrument = dynamic_cast<const Instrument *>(root);
-  return m_map->hasDetectorInfo(instrument);
-}
+bool Detector::hasDetectorInfo() const { return m_map->hasDetectorInfo(); }
 
 } // Namespace Geometry
 } // Namespace Mantid

--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -1197,7 +1197,7 @@ size_t ParameterMap::componentIndex(const ComponentID componentId) const {
 
 /// Only for use by Instrument. Sets the pointer to the owning instrument.
 void ParameterMap::setInstrument(const Instrument *instrument) {
-  if (instrument->isPhysicalInstrument()) {
+  if (instrument != nullptr && instrument->isPhysicalInstrument()) {
     throw std::runtime_error("A ParameterMap cannot be associated with a "
                              "Physical Instrument, only a neturonic one");
   }

--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -1197,6 +1197,11 @@ size_t ParameterMap::componentIndex(const ComponentID componentId) const {
 
 /// Only for use by Instrument. Sets the pointer to the owning instrument.
 void ParameterMap::setInstrument(const Instrument *instrument) {
+  if (instrument->isPhysicalInstrument()) {
+    throw std::runtime_error("A ParameterMap cannot be associated with a "
+                             "Physical Instrument, only a neturonic one");
+  }
+
   if (instrument == m_instrument)
     return;
   if (!instrument) {

--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -1135,35 +1135,24 @@ ParameterMap::create(const std::string &className,
   return ParameterFactory::create(className, name);
 }
 
-/** Only for use by ExperimentInfo. Returns returns true if this instrument
- contains a DetectorInfo.
-
- The `instrument` argument is needed for the special case of having a neutronic
- *and* a physical instrument. `Instrument` uses the same parameter map for both,
- but the DetectorInfo is only for the neutronic instrument. */
-bool ParameterMap::hasDetectorInfo(const Instrument *instrument) const {
-  if (instrument != m_instrument)
-    return false;
+bool ParameterMap::hasDetectorInfo() const {
   return static_cast<bool>(m_detectorInfo);
 }
 
-/** Only for use by ExperimentInfo. Returns returns true if this instrument
- contains a ComponentInfo.
-*/
 bool ParameterMap::hasComponentInfo() const {
   return static_cast<bool>(m_componentInfo);
 }
 
 /// Only for use by ExperimentInfo. Returns a reference to the DetectorInfo.
 const Geometry::DetectorInfo &ParameterMap::detectorInfo() const {
-  if (!hasDetectorInfo(m_instrument))
+  if (!hasDetectorInfo())
     throw std::runtime_error("Cannot return reference to NULL DetectorInfo");
   return *m_detectorInfo;
 }
 
 /// Only for use by ExperimentInfo. Returns a reference to the DetectorInfo.
 Geometry::DetectorInfo &ParameterMap::mutableDetectorInfo() {
-  if (!hasDetectorInfo(m_instrument))
+  if (!hasDetectorInfo())
     throw std::runtime_error("Cannot return reference to NULL DetectorInfo");
   return *m_detectorInfo;
 }

--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -1150,9 +1150,7 @@ bool ParameterMap::hasDetectorInfo(const Instrument *instrument) const {
 /** Only for use by ExperimentInfo. Returns returns true if this instrument
  contains a ComponentInfo.
 */
-bool ParameterMap::hasComponentInfo(const Instrument *instrument) const {
-  if (instrument != m_instrument)
-    return false;
+bool ParameterMap::hasComponentInfo() const {
   return static_cast<bool>(m_componentInfo);
 }
 
@@ -1172,7 +1170,7 @@ Geometry::DetectorInfo &ParameterMap::mutableDetectorInfo() {
 
 /// Only for use by ExperimentInfo. Returns a reference to the ComponentInfo.
 const Geometry::ComponentInfo &ParameterMap::componentInfo() const {
-  if (!hasComponentInfo(m_instrument)) {
+  if (!hasComponentInfo()) {
     throw std::runtime_error("Cannot return reference to NULL ComponentInfo");
   }
   return *m_componentInfo;
@@ -1180,7 +1178,7 @@ const Geometry::ComponentInfo &ParameterMap::componentInfo() const {
 
 /// Only for use by ExperimentInfo. Returns a reference to the ComponentInfo.
 Geometry::ComponentInfo &ParameterMap::mutableComponentInfo() {
-  if (!hasComponentInfo(m_instrument)) {
+  if (!hasComponentInfo()) {
     throw std::runtime_error("Cannot return reference to NULL ComponentInfo");
   }
   return *m_componentInfo;

--- a/Framework/Geometry/test/InstrumentTest.h
+++ b/Framework/Geometry/test/InstrumentTest.h
@@ -575,7 +575,7 @@ public:
     const auto legacyMap = instr->makeLegacyParameterMap();
     // 3 bank parameters + 2 det parameters + 1 scale parameter
     TS_ASSERT_EQUALS(legacyMap->size(), 6);
-    TS_ASSERT(!legacyMap->hasDetectorInfo(baseInstrument.get()));
+    TS_ASSERT(!legacyMap->hasDetectorInfo());
     Instrument legacyInstrument(baseInstrument, legacyMap);
 
     TS_ASSERT_EQUALS(legacyInstrument.getDetector(1)->getPos(),
@@ -642,7 +642,7 @@ public:
 
     // 2 bank parameters + 0 det parameters
     TS_ASSERT_EQUALS(legacyMap->size(), 2);
-    TS_ASSERT(!legacyMap->hasDetectorInfo(baseInstrument.get()));
+    TS_ASSERT(!legacyMap->hasDetectorInfo());
     Instrument legacyInstrument(baseInstrument, legacyMap);
 
     TS_ASSERT_EQUALS(legacyInstrument.getDetector(4)->getPos(),

--- a/Framework/Geometry/test/ParameterMapTest.h
+++ b/Framework/Geometry/test/ParameterMapTest.h
@@ -5,10 +5,12 @@
 #include "MantidGeometry/Instrument/ParameterFactory.h"
 #include "MantidGeometry/Instrument/ParameterMap.h"
 #include "MantidGeometry/Instrument/Detector.h"
+#include "MantidGeometry/Instrument.h"
 #include "MantidBeamline/ComponentInfo.h"
 #include "MantidBeamline/DetectorInfo.h"
 #include "MantidTestHelpers/ComponentCreationHelper.h"
 #include "MantidKernel/V3D.h"
+#include "MantidKernel/make_unique.h"
 #include <cxxtest/TestSuite.h>
 
 #include <boost/function.hpp>
@@ -630,6 +632,21 @@ public:
     TS_ASSERT_EQUALS(a->value<bool>(), true);
     auto oldA = oldPMap.get(oldComp.get(), "A");
     TS_ASSERT_EQUALS(oldA->value<bool>(), false);
+  }
+
+  void test_cannot_set_physical_instrument_on_pmap() {
+    auto neutronicInstrument =
+        Mantid::Kernel::make_unique<Mantid::Geometry::Instrument>();
+    neutronicInstrument->setPhysicalInstrument(
+        Mantid::Kernel::make_unique<Mantid::Geometry::Instrument>());
+    ParameterMap map1;
+    TSM_ASSERT_THROWS_NOTHING("Setting neutronic instrument is OK",
+                              map1.setInstrument(neutronicInstrument.get()));
+    ParameterMap map2;
+    TSM_ASSERT_THROWS(
+        "Should not be able to set a physical instrument on a parameter map",
+        map2.setInstrument(neutronicInstrument->getPhysicalInstrument().get()),
+        std::runtime_error &);
   }
 
 private:


### PR DESCRIPTION
Fixes #20266 contains a description of the problem

**WIP**

Description of fix approach

1. `ParameterMap` can only be associated with a neutronic Instrument (ParameterMap::setInstrument) because `ExperimentInfo` only created for neturonic Instruments
1. Component etc, can therefore reason that their associated ParameterMap has the neutronic `ComponentInfo` attached.
1. `Component` NOT used in anything via physical instrument, so no danger of getting the wrong `ComponentInfo` and attributed when doing things via `Component`

**Discussion Points**

This makes position access x2 faster, so for those bits of the codebase not ported to use `DetectorInfo`/`ComponentInfo` we get an automatic speedup. Also, I think this does make the code more readable and makes client code simpler too. However I have some concerns that there are edge cases I have not considered with this, i.e. there is a genuine need to compare instrument pointers beyond the physical instrument case I have put this PR in for.
