### PR TITLE
Restore default directories for OpenSSL and HDF5 on MacOS

### DIFF
--- a/buildconfig/CMake/DarwinSetup.cmake
+++ b/buildconfig/CMake/DarwinSetup.cmake
@@ -95,6 +95,15 @@ set ( PLUGINS_DIR plugins )
 ###########################################################################
 # Mac-specific installation setup
 ###########################################################################
+# use homebrew OpenSSL package
+if (NOT OPENSSL_ROOT_DIR)
+  set ( OPENSSL_ROOT_DIR /usr/local/opt/openssl )
+endif(NOT OPENSSL_ROOT_DIR)
+
+if (NOT HDF5_ROOT)
+  set ( HDF5_ROOT /usr/local/opt/hdf5 )
+endif()
+
 if ( ENABLE_MANTIDPLOT )
 set ( CMAKE_INSTALL_PREFIX "" )
 set ( CPACK_PACKAGE_EXECUTABLES MantidPlot )
@@ -142,15 +151,6 @@ string(FIND "${SITEPACKAGES_SYMLINK_sipso}" "sip.so" STOPPOS)
 string(SUBSTRING "${SITEPACKAGES_SYMLINK_sipso}" 0 ${STOPPOS} SITEPACKAGES_SYMLINK)
 set  ( SITEPACKAGES ${SITEPACKAGES_PATH}/${SITEPACKAGES_SYMLINK} )
 string(REGEX REPLACE "/$" "" SITEPACKAGES "${SITEPACKAGES}")
-
-# use homebrew OpenSSL package
-if (NOT OPENSSL_ROOT_DIR)
-  set ( OPENSSL_ROOT_DIR /usr/local/opt/openssl )
-endif(NOT OPENSSL_ROOT_DIR)
-
-if (NOT HDF5_ROOT)
-  set ( HDF5_ROOT /usr/local/opt/hdf5 )
-endif()
 
 # Python packages
 


### PR DESCRIPTION
Description of work.

This restores the default directories for OpenSSL and HDF5 on MacOS so builds still "just work" when not building MantidPlot.

**To test:**

<!-- Instructions for testing. -->

Verify conda build still works. You may need to explicitly set `OPENSSL_ROOT_DIR` and `HDF5_ROOT`.

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
