### PR TITLE
Change LD_PRELOAD to use only major link version of tcmalloc

### DIFF
--- a/buildconfig/CMake/LinuxPackageScripts.cmake
+++ b/buildconfig/CMake/LinuxPackageScripts.cmake
@@ -136,6 +136,8 @@ endif()
 # .so symlink is only present when a -dev/-devel package is present
 if ( TCMALLOC_FOUND )
   get_filename_component ( TCMALLOC_RUNTIME_LIB ${TCMALLOC_LIBRARIES} REALPATH )
+  # We only want to use the major version number
+  string( REGEX REPLACE "([0-9]+)\.[0-9]+\.[0-9]+$" "\\1" TCMALLOC_RUNTIME_LIB ${TCMALLOC_RUNTIME_LIB} )
 endif ()
 
 # Local dev version


### PR DESCRIPTION
When the gperftools version changes the LD_PRELOAD would be wrong, this makes the launch script less strict.

**To test:**
Check the generated `launch_mantidplot.sh` and `mantidpython` for `LOCAL_PRELOAD`. It should now be `/usr/lib64/libtcmalloc_minimal.so.4`

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
