### PR TITLE
Request user input of point group and centering for SaveLaueNorm

### DIFF
--- a/Framework/Crystal/inc/MantidCrystal/SaveLauenorm.h
+++ b/Framework/Crystal/inc/MantidCrystal/SaveLauenorm.h
@@ -44,6 +44,14 @@ private:
 
   DataObjects::PeaksWorkspace_sptr ws;
   void sizeBanks(std::string bankName, int &nCols, int &nRows);
+
+  const std::vector<std::string> m_typeList{ "TRICLINIC",    "MONOCLINIC",
+                                             "ORTHORHOMBIC", "TETRAGONAL",
+                                             "HEXAGONAL",    "RHOMBOHEDRAL",
+                                             "CUBIC" };
+
+  const std::vector<std::string> m_centeringList{ "P", "A", "B", "C",
+                                                  "I", "F", "R" };
 };
 
 } // namespace Mantid

--- a/Framework/Crystal/inc/MantidCrystal/SaveLauenorm.h
+++ b/Framework/Crystal/inc/MantidCrystal/SaveLauenorm.h
@@ -19,14 +19,18 @@ namespace Crystal {
 class DLLExport SaveLauenorm : public API::Algorithm {
 public:
   /// Algorithm's name for identification
-  const std::string name() const override { return "SaveLauenorm"; };
+  const std::string name() const override {
+    return "SaveLauenorm";
+  };
   /// Summary of algorithms purpose
   const std::string summary() const override {
     return "Save a PeaksWorkspace to a ASCII file for each detector.";
   }
 
   /// Algorithm's version for identification
-  int version() const override { return 1; };
+  int version() const override {
+    return 1;
+  };
   /// Algorithm's category for identification
   const std::string category() const override {
     return "Crystal\\DataHandling;DataHandling\\Text";
@@ -40,8 +44,6 @@ private:
 
   DataObjects::PeaksWorkspace_sptr ws;
   void sizeBanks(std::string bankName, int &nCols, int &nRows);
-  std::vector<int> crystalSystem(Geometry::OrientedLattice lattice,
-                                 const std::vector<DataObjects::Peak> &peaks);
 };
 
 } // namespace Mantid

--- a/Framework/Crystal/inc/MantidCrystal/SaveLauenorm.h
+++ b/Framework/Crystal/inc/MantidCrystal/SaveLauenorm.h
@@ -19,18 +19,14 @@ namespace Crystal {
 class DLLExport SaveLauenorm : public API::Algorithm {
 public:
   /// Algorithm's name for identification
-  const std::string name() const override {
-    return "SaveLauenorm";
-  };
+  const std::string name() const override { return "SaveLauenorm"; };
   /// Summary of algorithms purpose
   const std::string summary() const override {
     return "Save a PeaksWorkspace to a ASCII file for each detector.";
   }
 
   /// Algorithm's version for identification
-  int version() const override {
-    return 1;
-  };
+  int version() const override { return 1; };
   /// Algorithm's category for identification
   const std::string category() const override {
     return "Crystal\\DataHandling;DataHandling\\Text";
@@ -45,13 +41,12 @@ private:
   DataObjects::PeaksWorkspace_sptr ws;
   void sizeBanks(std::string bankName, int &nCols, int &nRows);
 
-  const std::vector<std::string> m_typeList{ "TRICLINIC",    "MONOCLINIC",
-                                             "ORTHORHOMBIC", "TETRAGONAL",
-                                             "HEXAGONAL",    "RHOMBOHEDRAL",
-                                             "CUBIC" };
+  const std::vector<std::string> m_typeList{
+      "TRICLINIC", "MONOCLINIC",   "ORTHORHOMBIC", "TETRAGONAL",
+      "HEXAGONAL", "RHOMBOHEDRAL", "CUBIC"};
 
-  const std::vector<std::string> m_centeringList{ "P", "A", "B", "C",
-                                                  "I", "F", "R" };
+  const std::vector<std::string> m_centeringList{"P", "A", "B", "C",
+                                                 "I", "F", "R"};
 };
 
 } // namespace Mantid

--- a/Framework/Crystal/src/SaveLauenorm.cpp
+++ b/Framework/Crystal/src/SaveLauenorm.cpp
@@ -98,15 +98,13 @@ void SaveLauenorm::exec() {
   int widthBorder = getProperty("WidthBorder");
   bool newFormat = getProperty("LaueScaleFormat");
   std::string cellType = getProperty("CrystalSystem");
-  long int cellNo =
+  long int cellNo = 1 +
       std::distance(m_typeList.begin(),
-                    std::find(m_typeList.begin(), m_typeList.end(), cellType)) +
-      1;
+                    std::find(m_typeList.begin(), m_typeList.end(), cellType));
   std::string center = getProperty("Centering");
-  long int centerNo = std::distance(m_centeringList.begin(),
+  long int centerNo = 1 + std::distance(m_centeringList.begin(),
                                     std::find(m_centeringList.begin(),
-                                              m_centeringList.end(), center)) +
-                      1;
+                                              m_centeringList.end(), center));
   // sequenceNo and run number
   int sequenceNo = 0;
   int oldSequence = -1;

--- a/Framework/Crystal/src/SaveLauenorm.cpp
+++ b/Framework/Crystal/src/SaveLauenorm.cpp
@@ -98,13 +98,14 @@ void SaveLauenorm::exec() {
   int widthBorder = getProperty("WidthBorder");
   bool newFormat = getProperty("LaueScaleFormat");
   std::string cellType = getProperty("CrystalSystem");
-  long int cellNo = 1 +
-      std::distance(m_typeList.begin(),
-                    std::find(m_typeList.begin(), m_typeList.end(), cellType));
+  long int cellNo = 1 + std::distance(m_typeList.begin(),
+                                      std::find(m_typeList.begin(),
+                                                m_typeList.end(), cellType));
   std::string center = getProperty("Centering");
-  long int centerNo = 1 + std::distance(m_centeringList.begin(),
-                                    std::find(m_centeringList.begin(),
-                                              m_centeringList.end(), center));
+  long int centerNo =
+      1 + std::distance(m_centeringList.begin(),
+                        std::find(m_centeringList.begin(),
+                                  m_centeringList.end(), center));
   // sequenceNo and run number
   int sequenceNo = 0;
   int oldSequence = -1;

--- a/Framework/Crystal/src/SaveLauenorm.cpp
+++ b/Framework/Crystal/src/SaveLauenorm.cpp
@@ -100,12 +100,12 @@ void SaveLauenorm::exec() {
   std::string cellType = getProperty("CrystalSystem");
   long int cellNo = 1 + std::distance(m_typeList.begin(),
                                       std::find(m_typeList.begin(),
-                                                m_typeList.end(), cellType));
+                                      m_typeList.end(), cellType));
   std::string center = getProperty("Centering");
   long int centerNo =
       1 + std::distance(m_centeringList.begin(),
                         std::find(m_centeringList.begin(),
-                                  m_centeringList.end(), center));
+                        m_centeringList.end(), center));
   // sequenceNo and run number
   int sequenceNo = 0;
   int oldSequence = -1;

--- a/Framework/Crystal/src/SaveLauenorm.cpp
+++ b/Framework/Crystal/src/SaveLauenorm.cpp
@@ -415,10 +415,10 @@ void SaveLauenorm::exec() {
         out << "BULG    0.00000     0.00000     0.00000     0.00000     "
                "0.00000     0.00000 \n";
         out << "CTOF     " << L2 << "\n";
-        out << "YSCA     0.00000     0.00000     0.00000     0.00000     "
-               "0.00000     0.00000\n";
-        out << "CRAT     0.00000     0.00000     0.00000     0.00000     "
-               "0.00000     0.00000\n";
+        out << "YSCA     1.00000     1.00000     1.00000     1.00000     "
+               "1.00000     1.00000\n";
+        out << "CRAT     1.00000     1.00000     1.00000     1.00000     "
+               "1.00000     1.00000\n";
         out << "MINI          ";
         if (minIntensity != EMPTY_DBL()) {
           out << minIntensity << "\n";
@@ -471,7 +471,7 @@ void SaveLauenorm::exec() {
     out << std::setw(10) << std::fixed << std::setprecision(5) << lambda;
     if (newFormat) {
       // mult nodal ovlp close h2 k2 l2 nidx lambda2 ipoint
-      out << " 1 0 0 0 0 0 0 0 0 0 ";
+      out << " 1 0 0 0 0 0 0 0 0.0 0 ";
     }
 
     if (newFormat) {

--- a/Framework/Crystal/src/SaveLauenorm.cpp
+++ b/Framework/Crystal/src/SaveLauenorm.cpp
@@ -99,10 +99,10 @@ void SaveLauenorm::exec() {
   bool newFormat = getProperty("LaueScaleFormat");
   std::string cellType = getProperty("CrystalSystem");
   auto iter = std::find(m_typeList.begin(), m_typeList.end(), cellType);
-  long int cellNo = 1 + std::distance(m_typeList.begin(), iter);
+  auto cellNo = 1 + std::distance(m_typeList.begin(), iter);
   std::string cent = getProperty("Centering");
   auto iter2 = std::find(m_centeringList.begin(), m_centeringList.end(), cent);
-  long int centerNo = 1 + std::distance(m_centeringList.begin(), iter2);
+  auto centerNo = 1 + std::distance(m_centeringList.begin(), iter2);
   // sequenceNo and run number
   int sequenceNo = 0;
   int oldSequence = -1;

--- a/Framework/Crystal/src/SaveLauenorm.cpp
+++ b/Framework/Crystal/src/SaveLauenorm.cpp
@@ -35,13 +35,13 @@ DECLARE_ALGORITHM(SaveLauenorm)
 /** Initialize the algorithm's properties.
  */
 void SaveLauenorm::init() {
-  declareProperty(make_unique<WorkspaceProperty<PeaksWorkspace> >(
+  declareProperty(make_unique<WorkspaceProperty<PeaksWorkspace>>(
                       "InputWorkspace", "", Direction::Input),
                   "An input PeaksWorkspace.");
   declareProperty(
       make_unique<API::FileProperty>("Filename", "", API::FileProperty::Save),
       "Select the directory and base name for the output files.");
-  auto mustBePositive = boost::make_shared<BoundedValidator<double> >();
+  auto mustBePositive = boost::make_shared<BoundedValidator<double>>();
   mustBePositive->setLower(0.0);
   declareProperty("ScalePeaks", 1.0, mustBePositive,
                   "Multiply FSQ and sig(FSQ) by scaleFactor");
@@ -49,8 +49,8 @@ void SaveLauenorm::init() {
   declareProperty("MinWavelength", 0.0, "Minimum wavelength (Angstroms)");
   declareProperty("MaxWavelength", EMPTY_DBL(),
                   "Maximum wavelength (Angstroms)");
-  std::vector<std::string> histoTypes{ "Bank", "RunNumber",
-                                       "Both Bank and RunNumber" };
+  std::vector<std::string> histoTypes{"Bank", "RunNumber",
+                                      "Both Bank and RunNumber"};
   declareProperty("SortFilesBy", histoTypes[0],
                   boost::make_shared<StringListValidator>(histoTypes),
                   "Sort into files by bank(default), run number or both.");
@@ -64,8 +64,8 @@ void SaveLauenorm::init() {
                                         "SetDetScale.\n"
                                         "If false, no change (default).");
   declareProperty(
-      Kernel::make_unique<ArrayProperty<std::string> >("EliminateBankNumbers",
-                                                       Direction::Input),
+      Kernel::make_unique<ArrayProperty<std::string>>("EliminateBankNumbers",
+                                                      Direction::Input),
       "Comma deliminated string of bank numbers to exclude for example 1,2,5");
   declareProperty("LaueScaleFormat", false, "New format for Lauescale");
 
@@ -115,7 +115,7 @@ void SaveLauenorm::exec() {
   std::ostringstream ss;
 
   // We must sort the peaks
-  std::vector<std::pair<std::string, bool> > criteria;
+  std::vector<std::pair<std::string, bool>> criteria;
   if (type.compare(0, 2, "Ba") == 0)
     criteria.push_back(std::pair<std::string, bool>("BankName", true));
   else if (type.compare(0, 2, "Ru") == 0)

--- a/Framework/Crystal/src/SaveLauenorm.cpp
+++ b/Framework/Crystal/src/SaveLauenorm.cpp
@@ -68,31 +68,14 @@ void SaveLauenorm::init() {
                                                        Direction::Input),
       "Comma deliminated string of bank numbers to exclude for example 1,2,5");
   declareProperty("LaueScaleFormat", false, "New format for Lauescale");
-  std::vector<std::string> type_list;
-  type_list.push_back("TRICLINIC");
-  type_list.push_back("MONOCLINIC");
-  type_list.push_back("ORTHORHOMBIC");
-  type_list.push_back("TETRAGONAL");
-  type_list.push_back("HEXAGONAL");
-  type_list.push_back("RHOMBOHEDRAL");
-  type_list.push_back("CUBIC");
 
-  declareProperty("CellType", type_list[0],
-                  boost::make_shared<Kernel::StringListValidator>(type_list),
+  declareProperty("CrystalSystem", m_typeList[0],
+                  boost::make_shared<Kernel::StringListValidator>(m_typeList),
                   "The conventional cell type to use");
 
-  std::vector<std::string> centering_list;
-  centering_list.push_back("P");
-  centering_list.push_back("A");
-  centering_list.push_back("B");
-  centering_list.push_back("C");
-  centering_list.push_back("I");
-  centering_list.push_back("F");
-  centering_list.push_back("R");
-
   declareProperty(
-      "Centering", centering_list[0],
-      boost::make_shared<Kernel::StringListValidator>(centering_list),
+      "Centering", m_centeringList[0],
+      boost::make_shared<Kernel::StringListValidator>(m_centeringList),
       "The centering for the conventional cell");
 }
 
@@ -114,31 +97,15 @@ void SaveLauenorm::exec() {
   double minIntensity = getProperty("MinIntensity");
   int widthBorder = getProperty("WidthBorder");
   bool newFormat = getProperty("LaueScaleFormat");
-  std::string cellType = getProperty("CellType");
-  std::vector<std::string> type_list;
-  type_list.push_back("TRICLINIC");
-  type_list.push_back("MONOCLINIC");
-  type_list.push_back("ORTHORHOMBIC");
-  type_list.push_back("TETRAGONAL");
-  type_list.push_back("HEXAGONAL");
-  type_list.push_back("RHOMBOHEDRAL");
-  type_list.push_back("CUBIC");
+  std::string cellType = getProperty("CrystalSystem");
   long int cellNo =
-      std::distance(type_list.begin(),
-                    std::find(type_list.begin(), type_list.end(), cellType)) +
+      std::distance(m_typeList.begin(),
+                    std::find(m_typeList.begin(), m_typeList.end(), cellType)) +
       1;
   std::string center = getProperty("Centering");
-  std::vector<std::string> centering_list;
-  centering_list.push_back("P");
-  centering_list.push_back("A");
-  centering_list.push_back("B");
-  centering_list.push_back("C");
-  centering_list.push_back("I");
-  centering_list.push_back("F");
-  centering_list.push_back("R");
-  long int centerNo = std::distance(centering_list.begin(),
-                                    std::find(centering_list.begin(),
-                                              centering_list.end(), center)) +
+  long int centerNo = std::distance(m_centeringList.begin(),
+                                    std::find(m_centeringList.begin(),
+                                              m_centeringList.end(), center)) +
                       1;
   // sequenceNo and run number
   int sequenceNo = 0;
@@ -177,7 +144,7 @@ void SaveLauenorm::exec() {
   auto inst = ws->getInstrument();
   OrientedLattice lattice;
   if (newFormat) {
-    type = "RunNumber";
+    type = "Both Bank and RunNumber";
     if (!ws->sample().hasOrientedLattice()) {
 
       const std::string fft("FindUBUsingIndexedPeaks");

--- a/Framework/Crystal/src/SaveLauenorm.cpp
+++ b/Framework/Crystal/src/SaveLauenorm.cpp
@@ -98,14 +98,11 @@ void SaveLauenorm::exec() {
   int widthBorder = getProperty("WidthBorder");
   bool newFormat = getProperty("LaueScaleFormat");
   std::string cellType = getProperty("CrystalSystem");
-  long int cellNo = 1 + std::distance(m_typeList.begin(),
-                                      std::find(m_typeList.begin(),
-                                      m_typeList.end(), cellType));
-  std::string center = getProperty("Centering");
-  long int centerNo =
-      1 + std::distance(m_centeringList.begin(),
-                        std::find(m_centeringList.begin(),
-                        m_centeringList.end(), center));
+  auto iter = std::find(m_typeList.begin(), m_typeList.end(), cellType);
+  long int cellNo = 1 + std::distance(m_typeList.begin(), iter);
+  std::string cent = getProperty("Centering");
+  auto iter2 = std::find(m_centeringList.begin(), m_centeringList.end(), cent);
+  long int centerNo = 1 + std::distance(m_centeringList.begin(), iter2);
   // sequenceNo and run number
   int sequenceNo = 0;
   int oldSequence = -1;

--- a/docs/source/release/v3.13.0/diffraction.rst
+++ b/docs/source/release/v3.13.0/diffraction.rst
@@ -27,6 +27,8 @@ Single Crystal Diffraction
 
 - New algorithm :ref:`LoadDNSSCD <algm-LoadDNSSCD>` to load multiple single crystal diffraction data files from the DNS instrument into MDEventWorkspace.
 
+- :ref:`SaveLauenorm <algm-SaveLauenorm>` now has input options for crystal system and reflection condition for lscale output instead of trying to determine from lattice parameters.
+
 Improvements
 ############
 


### PR DESCRIPTION
Description of work.
SaveLauenorm now has input options for crystal system and reflection condition for lscale output instead of trying to determine from lattice parameters.
**To test:**

Use Mandi data files and LaueScaleFormat=True

Fixes #22320 

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
