### PR TITLE
Replace deprecated member function removed in HDF5 1.10.2

### DIFF
--- a/Framework/DataHandling/src/LoadDiffCal.cpp
+++ b/Framework/DataHandling/src/LoadDiffCal.cpp
@@ -400,7 +400,12 @@ void LoadDiffCal::exec() {
   try {
     calibrationGroup = file.openGroup("calibration");
   } catch (FileIException &e) {
-    e.printError();
+#if H5_VERSION_GE(1, 8, 13)
+    UNUSED_ARG(e);
+    H5::Exception::printErrorStack();
+#else
+    e.printError(stderr);
+#endif
     throw std::runtime_error("Did not find group \"/calibration\"");
   }
 


### PR DESCRIPTION
Description of work.

`void H5::Exception::printError( FILE* stream = NULL ) const` was [removed in HDF5 1.10.2](https://portal.hdfgroup.org/display/support/HDF5+1.10.2), preventing Mantid from building. This replaces it with `static void printErrorStack(FILE* stream = stderr, hid_t err_stack = H5E_DEFAULT);`

**To test:**

<!-- Instructions for testing. -->

Code review should be sufficient.

There is no GitHub issue associated with this pull request.

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
