### PR TITLE
Allow PeaksWorkspace createPeakQSample to calculate goniometer for CW

### DIFF
--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -40,6 +40,8 @@ namespace DataObjects {
 /// Register the workspace as a type
 DECLARE_WORKSPACE(PeaksWorkspace)
 
+Mantid::Kernel::Logger g_log("PeaksWorkspace");
+
 //---------------------------------------------------------------------------------------------
 /** Constructor. Create a table with all the required columns.
  *
@@ -296,6 +298,9 @@ Peak *PeaksWorkspace::createPeakQSample(const V3D &position) const {
       wavelength = props->getPropertyValueAsType<double>("wavelength");
     }
     goniometer.calcFromQSampleAndWavelength(position, wavelength);
+    g_log.information() << "Found goniometer rotation to be "
+                        << goniometer.getEulerAngles()[0]
+                        << " degrees for Q sample = " << position << "\n";
   } else {
     goniometer = run().getGoniometer();
   }

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/Goniometer.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/Goniometer.h
@@ -91,6 +91,10 @@ public:
   // Set rotation angle for an axis in the units the angle is set (default --
   // degrees)
   void setRotationAngle(size_t axisnumber, double value);
+  // Calculate goniometer for rotation around y-axis for constant wavelength
+  // from Q Sample
+  void calcFromQSampleAndWavelength(const Mantid::Kernel::V3D &Q,
+                                    double wavelength);
   // Get axis object
   const GoniometerAxis &getAxis(size_t axisnumber) const;
   // Get axis object

--- a/Framework/Geometry/src/Instrument/Goniometer.cpp
+++ b/Framework/Geometry/src/Instrument/Goniometer.cpp
@@ -204,8 +204,6 @@ void Goniometer::calcFromQSampleAndWavelength(
   std::vector<double> B{Q_lab[0], Q_lab[2]};
   std::vector<double> X = A * B;
   double rot = atan2(X[1], X[0]);
-  g_log.information() << "Found goniometer rotation to be " << rot * 180 / M_PI
-                      << " degrees for Q sample = " << Q << "\n";
 
   Matrix<double> goniometer(3, 3, true);
   goniometer[0][0] = cos(rot);

--- a/Framework/Geometry/src/Instrument/Goniometer.cpp
+++ b/Framework/Geometry/src/Instrument/Goniometer.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <boost/algorithm/string.hpp>
 #include <cstdlib>
+#include "MantidKernel/ConfigService.h"
 #include "MantidKernel/Strings.h"
 #include "MantidKernel/Logger.h"
 
@@ -180,11 +181,15 @@ void Goniometer::setRotationAngle(size_t axisnumber, double value) {
 
 /**Calculate goniometer for rotation around y-asix for constant wavelength from
  * Q Sample
- * @param Q :: Q Sample position in reciprocal space
+ * @param position :: Q Sample position in reciprocal space
  * @param wavelength :: wavelength
 */
-void Goniometer::calcFromQSampleAndWavelength(const Mantid::Kernel::V3D &Q,
-                                              double wavelength) {
+void Goniometer::calcFromQSampleAndWavelength(
+    const Mantid::Kernel::V3D &position, double wavelength) {
+  V3D Q(position);
+  if (Kernel::ConfigService::Instance().getString("Q.convention") ==
+      "Crystallography")
+    Q *= -1;
   double wv = 2.0 * M_PI / wavelength;
   double norm_q2 = Q.norm2();
   double theta = acos(1 - norm_q2 / (2 * wv * wv)); // [0, pi]

--- a/Framework/Geometry/test/GoniometerTest.h
+++ b/Framework/Geometry/test/GoniometerTest.h
@@ -179,6 +179,56 @@ public:
         }
   }
 
+  void test_calcFromQSampleAndWavelength() {
+    Goniometer G;
+    double wavelength = 2 * M_PI; // k=1
+    DblMatrix R;
+    V3D Q;
+
+    // 0 degree rotation
+    Q = V3D(-1, 0, 1);
+    G.calcFromQSampleAndWavelength(Q, wavelength);
+    R = G.getR();
+    TS_ASSERT_DELTA(R[0][0], 1.0, 0.001);
+    TS_ASSERT_DELTA(R[0][1], 0.0, 0.001);
+    TS_ASSERT_DELTA(R[0][2], 0.0, 0.001);
+    TS_ASSERT_DELTA(R[1][0], 0.0, 0.001);
+    TS_ASSERT_DELTA(R[1][1], 1.0, 0.001);
+    TS_ASSERT_DELTA(R[1][2], 0.0, 0.001);
+    TS_ASSERT_DELTA(R[2][0], 0.0, 0.001);
+    TS_ASSERT_DELTA(R[2][1], 0.0, 0.001);
+    TS_ASSERT_DELTA(R[2][2], 1.0, 0.001);
+
+    // -90 degree rotation
+    Q = V3D(1, 0, 1);
+    G.calcFromQSampleAndWavelength(Q, wavelength);
+    R = G.getR();
+    TS_ASSERT_DELTA(R[0][0], 0.0, 0.001);
+    TS_ASSERT_DELTA(R[0][1], 0.0, 0.001);
+    TS_ASSERT_DELTA(R[0][2], -1.0, 0.001);
+    TS_ASSERT_DELTA(R[1][0], 0.0, 0.001);
+    TS_ASSERT_DELTA(R[1][1], 1.0, 0.001);
+    TS_ASSERT_DELTA(R[1][2], 0.0, 0.001);
+    TS_ASSERT_DELTA(R[2][0], 1.0, 0.001);
+    TS_ASSERT_DELTA(R[2][1], 0.0, 0.001);
+    TS_ASSERT_DELTA(R[2][2], 0.0, 0.001);
+
+    // 30 degree rotation
+    wavelength = 1.54;
+    Q = V3D(-0.63523489, -0.12302677, -0.29517982);
+    G.calcFromQSampleAndWavelength(Q, wavelength);
+    R = G.getR();
+    TS_ASSERT_DELTA(R[0][0], 0.866, 0.001);
+    TS_ASSERT_DELTA(R[0][1], 0.0, 0.001);
+    TS_ASSERT_DELTA(R[0][2], 0.5, 0.01);
+    TS_ASSERT_DELTA(R[1][0], 0.0, 0.001);
+    TS_ASSERT_DELTA(R[1][1], 1.0, 0.001);
+    TS_ASSERT_DELTA(R[1][2], 0.0, 0.001);
+    TS_ASSERT_DELTA(R[2][0], -0.5, 0.01);
+    TS_ASSERT_DELTA(R[2][1], 0.0, 0.001);
+    TS_ASSERT_DELTA(R[2][2], 0.866, 0.001);
+  }
+
   /** Save and load to NXS file */
   void test_nexus() {
     NexusTestHelper th(true);

--- a/Framework/MDAlgorithms/src/FindPeaksMD.cpp
+++ b/Framework/MDAlgorithms/src/FindPeaksMD.cpp
@@ -4,6 +4,7 @@
 #include "MantidDataObjects/MDHistoWorkspace.h"
 #include "MantidDataObjects/PeaksWorkspace.h"
 #include "MantidGeometry/Crystal/EdgePixel.h"
+#include "MantidGeometry/Instrument/Goniometer.h"
 #include "MantidGeometry/Objects/InstrumentRayTracer.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/EnabledWhenProperty.h"
@@ -295,30 +296,9 @@ FindPeaksMD::createPeak(const Mantid::Kernel::V3D &Q, const double binCount,
     if (calcGoniometer) {
       // Calculate Q lab from Q sample and wavelength
       double wavelength = getProperty("Wavelength");
-      double wv = 2.0 * M_PI / wavelength;
-      double norm_q2 = Q.norm2();
-      double theta = acos(1 - norm_q2 / (2 * wv * wv));
-      double phi = asin(-Q[1] / wv * sin(theta));
-      V3D Q_lab(-wv * sin(theta) * cos(phi), -wv * sin(theta) * sin(phi),
-                wv * (1 - cos(theta)));
-
-      // Solve to find rotation matrix, assuming only rotation around y-axis
-      // A * X = B
-      Matrix<double> A({Q[0], Q[2], Q[2], -Q[0]}, 2, 2);
-      A.Invert();
-      std::vector<double> B{Q_lab[0], Q_lab[2]};
-      std::vector<double> X = A * B;
-      double rot = atan2(X[1], X[0]);
-      g_log.information() << "Found goniometer rotation to be "
-                          << rot * 180 / M_PI
-                          << " degrees for peak at Q sample = " << Q << "\n";
-
-      Matrix<double> goniometer(3, 3, true);
-      goniometer[0][0] = cos(rot);
-      goniometer[0][2] = sin(rot);
-      goniometer[2][0] = -sin(rot);
-      goniometer[2][2] = cos(rot);
-      p = boost::make_shared<Peak>(inst, Q, goniometer);
+      Geometry::Goniometer goniometer;
+      goniometer.calcFromQSampleAndWavelength(Q, wavelength);
+      p = boost::make_shared<Peak>(inst, Q, goniometer.getR());
 
     } else {
       p = boost::make_shared<Peak>(inst, Q, m_goniometer);

--- a/Framework/MDAlgorithms/src/FindPeaksMD.cpp
+++ b/Framework/MDAlgorithms/src/FindPeaksMD.cpp
@@ -298,6 +298,9 @@ FindPeaksMD::createPeak(const Mantid::Kernel::V3D &Q, const double binCount,
       double wavelength = getProperty("Wavelength");
       Geometry::Goniometer goniometer;
       goniometer.calcFromQSampleAndWavelength(Q, wavelength);
+      g_log.information() << "Found goniometer rotation to be "
+                          << goniometer.getEulerAngles()[0]
+                          << " degrees for Q sample = " << Q << "\n";
       p = boost::make_shared<Peak>(inst, Q, goniometer.getR());
 
     } else {

--- a/docs/source/algorithms/FindPeaksMD-v1.rst
+++ b/docs/source/algorithms/FindPeaksMD-v1.rst
@@ -85,6 +85,8 @@ First calculate the :math:`\textbf{Q}_{lab}` using
 
 .. math:: \phi = \sin^{-1}(-\textbf{Q}_{sample}^y \sin(\theta)/k)
 
+where :math:`\theta` is from 0 to :math:`\pi` and  :math:`\phi` is from :math:`-\pi/2` to :math:`\pi/2`. This means that it will assume your detector position is on the left of the beam even it it's not.
+
 Now you have :math:`\theta`, :math:`\phi` and k you can get :math:`\textbf{Q}_{lab}` using (1).
 
 We need to now solve :math:`G \textbf{Q}_{sample} =

--- a/docs/source/concepts/PeaksWorkspace.rst
+++ b/docs/source/concepts/PeaksWorkspace.rst
@@ -49,6 +49,27 @@ Each Peak object contains a PeakShape. Only the integration algorithms which act
 Subtypes of PeakShape will then provide additional information. For example PeakShapeSpherical provides the radius as well as background inner, and background outer radius.
 
 
+Calculate Goniometer For Constant Wavelength
+--------------------------------------------
+
+If you set the `wavelength` (in Å) or `energy` (in meV) property on a
+PeaksWorkspace when the createPeak method is used the goniometer
+rotation with be calculated. This allows you to use one instrument
+definition for multiple goniometer rotations, for example adding peaks
+in Slice Viewer from multiple combined MD workspaces. It only works
+for a constant wavelength source and only for Q sample workspaces. It
+also assumes the goniometer rotation is around the y-axis only. For
+details on the calculation see "Calculate Goniometer For Constant
+Wavelength" at :ref:`FindPeaksMD <algm-FindPeaksMD>`.
+
+.. code-block:: python
+
+    pws = mtd['name_of_peaks_workspace']
+    pws.run().addProperty('wavelength', 1.54, True)
+    # or
+    pws.run().addProperty('energy', 34.48, True)
+
+
 Using PeaksWorkspaces in Python
 ---------------------------------
 


### PR DESCRIPTION
This involves moving the code implement in #21726 from [FindPeaksMD](http://docs.mantidproject.org/nightly/algorithms/FindPeaksMD-v1.html#calculate-goniometer-for-constant-wavelength) into new method on Goniometer. And added option onto peaks workspace where by the property `wavelength` exist it will calculate the goniometer.

**To test:**
```
LoadMD(Filename='/SNS/users/rwp/IPTS-20367_Q_sample_slice.nxs', LoadHistory=False, OutputWorkspace='q')

LoadEventNexus(Filename='/HFIR/HB2C/IPTS-20367/nexus/HB2C_15954.nxs.h5', OutputWorkspace='ws',MetaDataOnly=True)
peaks = CreatePeaksWorkspace(InstrumentWorkspace='ws', NumberOfPeaks=0)
peaks.run().addProperty('wavelength', 1.488, True)
# or
peaks.run().addProperty('energy', 36.94, True)
```
From here open up slice viewer, overlay peaks workspace, then add peaks using the `Add HKL Peaks` button. The peaks added should now have the correct wavelength, d-spacing, Q lab, Q sample and detector information.


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
