### PR TITLE
Make SumSpectra::validateInputs aware of WorkspaceGroups

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/SumSpectra.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SumSpectra.h
@@ -70,6 +70,8 @@ public:
   }
   /// Algorithm's category for identification overriding a virtual method
   const std::string category() const override { return "Transforms\\Grouping"; }
+  /// Cross-input validation
+  std::map<std::string, std::string> validateInputs() override;
 
 private:
   /// Handle logic for RebinnedOutput workspaces
@@ -83,7 +85,6 @@ private:
 
   // Overridden Algorithm methods
   void init() override;
-  std::map<std::string, std::string> validateInputs() override;
   void exec() override;
   void execEvent(API::MatrixWorkspace_sptr outputWorkspace,
                  API::Progress &progress, size_t &numSpectra, size_t &numMasked,

--- a/docs/source/release/v3.13.0/framework.rst
+++ b/docs/source/release/v3.13.0/framework.rst
@@ -43,5 +43,6 @@ Bug fixes
 - The documentation of the algorithm :ref:`algm-CreateSampleWorkspace` did not match its implementation. The axis in beam direction will now be correctly described as Z instead of X.
 - The :ref:`ExtractMask <algm-ExtractMask>` algorithm now returns a non-empty list of detector ID's when given a MaskWorkspace.
 - Fixed a crash when the input workspace for :ref:`GroupDetectors <algm-GroupDetectors>` contained any other units than spectrum numbers.
+- Fixed :ref:`SumSpectra <algm-SumSpectra>` to avoid a crash when validation of inputs was called with a WorkspaceGroup.
 
 :ref:`Release 3.13.0 <v3.13.0>`


### PR DESCRIPTION
*Description of work*

Checks for a possible `WorkspaceGroup` input in `SumSpectra::validateInputs`. Without this check the code would segfault.

**To test:**

* Look over the unit tests
* Try the steps in the linked issue to verify they no longer crash MantidPlot

Fixes #22326 

[Release Notes](https://github.com/mantidproject/mantid/pull/22334/commits/d6c8fa991ab8d5c213a5b2fcc60a5df60226fd97)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [x] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
