### PR TITLE
Ensure the correct SDK is set for msbuild

### DIFF
--- a/buildconfig/Jenkins/buildscript.bat
+++ b/buildconfig/Jenkins/buildscript.bat
@@ -28,6 +28,7 @@ set VS_VERSION=14
 :: externally and cannot be supplied in the cmake configuration
 set SDK_VERSION=8.1
 call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" amd64 %SDK_VERSION%
+set UseEnv=true
 set CM_GENERATOR=Visual Studio 14 2015 Win64
 set PARAVIEW_DIR=%PARAVIEW_DIR%
 

--- a/buildconfig/windows/command-prompt.bat
+++ b/buildconfig/windows/command-prompt.bat
@@ -7,4 +7,4 @@
 call %~dp0buildenv.bat
 set VCVARS=@MSVC_VAR_LOCATION@
 :: Start command line
-%COMSPEC% /k ""%VCVARS%\vcvarsall.bat"" amd64
+%COMSPEC% /k ""%VCVARS%\vcvarsall.bat"" amd64 @CMAKE_SYSTEM_VERSION@


### PR DESCRIPTION
Description of work.

Forces msbuild to respect its environment. This is required when trying to build with `msbuild` using the `8.1` Windows SDK on Windows 10.

**To test:**

* Builders should pass on Windows

*No issue*

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
