### PR TITLE
Convert the workspace into distribution in DirectILLReduction

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/DirectILLReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/DirectILLReductionTest.py
@@ -78,6 +78,22 @@ class DirectILLReductionTest(unittest.TestCase):
         groupIds = groupedWS.getDetector(0).getDetectorIDs()
         self.assertEqual(collections.Counter(detectorIds), collections.Counter(groupIds))
 
+    def testOutputIsDistribution(self):
+        outWSName = 'outWS'
+        algProperties = {
+            'InputWorkspace': self._TEST_WS_NAME,
+            'OutputWorkspace': outWSName,
+            'OutputSofThetaEnergyWorkspace': 'SofThetaE',
+            'rethrow': True
+        }
+        run_algorithm('DirectILLReduction', **algProperties)
+        self.assertTrue(mtd.doesExist(outWSName))
+        ws = mtd[outWSName]
+        self.assertTrue(ws.isDistribution())
+        self.assertTrue(mtd.doesExist('SofThetaE'))
+        ws = mtd['SofThetaE']
+        self.assertTrue(ws.isDistribution())
+
     def _checkAlgorithmsInHistory(self, ws, *args):
         """Return true if algorithm names listed in *args are found in the
         workspace's history.

--- a/docs/source/diagrams/DirectILLReduction-v1_wkflw.dot
+++ b/docs/source/diagrams/DirectILLReduction-v1_wkflw.dot
@@ -23,6 +23,7 @@ digraph DirectILLReduction {
     $algorithm_style
     AbsoluteUnits [label="Scale to absolute units"]
     ApplyDiagnostics [label="Mask spectra"]
+    ConvertToDistribution [label="ConvertToDistribution"]
     ConvertToEnergy [label="Convert TOF to energy transfer"]
     CorrectKiKf [label="CorrectKiKf"]
     DetectorEfficiency [label="DetectorEfficiencyCorUser"]
@@ -49,7 +50,8 @@ digraph DirectILLReduction {
   ConvertToEnergy -> CorrectKiKf
   CorrectKiKf -> Rebin
   wRebinParams -> Rebin
-  Rebin -> DetectorEfficiency
+  Rebin -> ConvertToDistribution
+  ConvertToDistribution -> DetectorEfficiency
   DetectorEfficiency -> GroupDetectors
   GroupDetectors -> outputOptionalWS
   GroupDetectors -> SofQW

--- a/docs/source/release/v3.13.0/direct_inelastic.rst
+++ b/docs/source/release/v3.13.0/direct_inelastic.rst
@@ -20,6 +20,8 @@ New features
 Improvements
 ############
 
+- :ref:`DirectILLReduction <algm-DirectILLReduction>` now converts all its output workspaces to distributions, i.e. divides the histograms by the bin width.
+
 Bug fixes
 #########
 


### PR DESCRIPTION
This PR adds a convert-to-distribution step into `DirectILLReduction`. At ILL, the scientists are more comfortable when working with distributions.

**To test:**

With the unit test data directories in MantidPlot's data search directories, try running the following script:

```python
DirectILLCollectData('ILL/IN4/084447.nxs', OutputWorkspace='ws')
DirectILLReduction('ws', OutputWorkspace='SofQW', OutputSofThetaEnergyWorkspace='SofThetaW')
```

Check that both output workspaces are distributions.

Fixes #21967.

**Release Notes** 

Direct inelastic notes were updated accordingly.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [x] Are the unit tests small and test the class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
