### PR TITLE
SANS user file parse mask time

### DIFF
--- a/scripts/SANS/sans/user_file/state_director.py
+++ b/scripts/SANS/sans/user_file/state_director.py
@@ -666,8 +666,8 @@ class StateDirectorISIS(object):
                     start_times_hab.append(times.start)
                     stop_times_hab.append(times.stop)
                 elif times.detector_type is DetectorType.LAB:
-                    start_times_hab.append(times.start)
-                    stop_times_hab.append(times.stop)
+                    start_times_lab.append(times.start)
+                    stop_times_lab.append(times.stop)
                 else:
                     RuntimeError("UserFileStateDirector: The specified detector {0} is not "
                                  "known".format(times.detector_type))

--- a/scripts/SANS/sans/user_file/user_file_parser.py
+++ b/scripts/SANS/sans/user_file/user_file_parser.py
@@ -894,9 +894,6 @@ class MaskParser(UserFileComponentParser):
     def _is_time_mask(self, line):
         return does_pattern_match(self._time_pattern, line)
 
-    def _is_time_mask_2(self, line):
-        return does_pattern_match(self._time_pattern_2, line)
-
     def _is_clear_mask(self, line):
         return does_pattern_match(self._clear_pattern, line)
 

--- a/scripts/SANS/sans/user_file/user_file_parser.py
+++ b/scripts/SANS/sans/user_file/user_file_parser.py
@@ -839,9 +839,10 @@ class MaskParser(UserFileComponentParser):
 
         # Time Mask
         self._time_or_t = "\\s*(TIME|T)\\s*"
-        self._detector_time = "\\s*((" + self._hab + "|" + self._lab + ")"+"\\s*/\\s*)?\\s*"
-        self._time_pattern = re.compile(start_string + self._detector_time + self._time_or_t + space_string +
-                                        self._two_floats + end_string)
+        self._detector_time = "\\s*((" + self._hab + "|" + self._lab + ")"+"\\s*)?\\s*"
+        self._time_pattern = re.compile(start_string + self._detector_time + "/?" + self._time_or_t + space_string +
+                                        self._two_floats + end_string + "|" + start_string + self._time_or_t +
+                                        "/?" + self._detector_time + space_string + self._two_floats + end_string)
 
         # Block mask
         self._v_plus_h = "\\s*" + self._v + integer_number + "\\s*\\+\\s*" + self._h + integer_number
@@ -859,7 +860,6 @@ class MaskParser(UserFileComponentParser):
     def parse_line(self, line):
         # Get the settings, ie remove command
         setting = UserFileComponentParser.get_settings(line, MaskParser.get_type_pattern())
-
         # Determine the qualifier and extract the user setting
         if self._is_block_mask(setting):
             output = self._extract_block_mask(setting)
@@ -893,6 +893,9 @@ class MaskParser(UserFileComponentParser):
 
     def _is_time_mask(self, line):
         return does_pattern_match(self._time_pattern, line)
+
+    def _is_time_mask_2(self, line):
+        return does_pattern_match(self._time_pattern_2, line)
 
     def _is_clear_mask(self, line):
         return does_pattern_match(self._clear_pattern, line)
@@ -983,12 +986,13 @@ class MaskParser(UserFileComponentParser):
         if has_hab is not None or has_lab is not None:
             key = MaskId.time_detector
             detector_type = DetectorType.HAB if has_hab is not None else DetectorType.LAB
-            regex_string = "\s*(" + self._hab + ")\s*/\s*" if has_hab else "\s*(" + self._lab + ")\s*/\s*"
+            regex_string = "\s*(" + self._hab + ")\s*" if has_hab else "\s*(" + self._lab + ")\s*"
             min_and_max_time_range = re.sub(regex_string, "", line)
         else:
             key = MaskId.time
             detector_type = None
             min_and_max_time_range = line
+        min_and_max_time_range = re.sub("\s*/\s*", "", min_and_max_time_range)
         min_and_max_time_range = re.sub(self._time_or_t, "", min_and_max_time_range)
         min_and_max_time = extract_float_range(min_and_max_time_range)
         return {key: range_entry_with_detector(start=min_and_max_time[0], stop=min_and_max_time[1],

--- a/scripts/test/SANS/user_file/user_file_parser_test.py
+++ b/scripts/test/SANS/user_file/user_file_parser_test.py
@@ -8,7 +8,7 @@ from sans.user_file.user_file_parser import (DetParser, LimitParser, MaskParser,
                                              MaskFileParser, MonParser, PrintParser, BackParser, SANS2DParser, LOQParser,
                                              UserFileParser, LARMORParser, CompatibilityParser)
 from sans.user_file.settings_tags import (DetectorId, BackId, range_entry, back_single_monitor_entry,
-                                          single_entry_with_detector, mask_angle_entry, LimitsId, rebin_string_values,
+                                          single_entry_with_detector, mask_angle_entry, LimitsId,
                                           simple_range, complex_range, MaskId, mask_block, mask_block_cross,
                                           mask_line, range_entry_with_detector, SampleId, SetId, set_scales_entry,
                                           position_entry, TransId, TubeCalibrationFileId, QResolutionId, FitId,
@@ -318,9 +318,9 @@ class MaskParserTest(unittest.TestCase):
                           "MASK/FRONT/TIME 33 35": {MaskId.time_detector: range_entry_with_detector(start=33, stop=35,
                                                     detector_type=DetectorType.HAB)},
                           "MASK/TIME/REAR 13 35": {MaskId.time_detector: range_entry_with_detector(start=13, stop=35,
-                                                detector_type=DetectorType.LAB)},
+                                                   detector_type=DetectorType.LAB)},
                           "MASK/T/FRONT 33 35": {MaskId.time_detector: range_entry_with_detector(start=33, stop=35,
-                                                    detector_type=DetectorType.HAB)}
+                                                 detector_type=DetectorType.HAB)}
                           }
 
         invalid_settings = {"MASK/TIME 12 34 4 ": RuntimeError,
@@ -1072,6 +1072,7 @@ class UserFileParserTest(unittest.TestCase):
 
         # Act + Assert
         self.assertRaises(ValueError, user_file_parser.parse_line, "DetT/DKDK/ 23 23")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test/SANS/user_file/user_file_parser_test.py
+++ b/scripts/test/SANS/user_file/user_file_parser_test.py
@@ -316,6 +316,10 @@ class MaskParserTest(unittest.TestCase):
                           "MASK/REAR/T 13 35": {MaskId.time_detector: range_entry_with_detector(start=13, stop=35,
                                                 detector_type=DetectorType.LAB)},
                           "MASK/FRONT/TIME 33 35": {MaskId.time_detector: range_entry_with_detector(start=33, stop=35,
+                                                    detector_type=DetectorType.HAB)},
+                          "MASK/TIME/REAR 13 35": {MaskId.time_detector: range_entry_with_detector(start=13, stop=35,
+                                                detector_type=DetectorType.LAB)},
+                          "MASK/T/FRONT 33 35": {MaskId.time_detector: range_entry_with_detector(start=33, stop=35,
                                                     detector_type=DetectorType.HAB)}
                           }
 


### PR DESCRIPTION
The user file is used to set the masks to be used for a given run. One of the types of mask which is set are time masks which can apply to any of the detector banks in the instrument. Currently two different commands are used in the user file for this MASK/DETECTOR/TIME and MASK/TIME/DETECTOR. The parser only supports the latter of these currently this upgrades it to support both. 

**To test:**
Get the data from here 
[loqdemo.zip](https://github.com/mantidproject/mantid/files/1951964/loqdemo.zip)

- In Mantid open the ISIS SANS 2 interface.
- Load maskfile.txt as the userfile
- Load batch_mode_reduction.csv as the batch file
- On the left goto the settings tab then select the mask tab from across the top.
- Confirm that there is a time mask present on the HAB between 39354.5 41348.5
- Confirm that there is a time mask present on the main detector between 19711.5 21228.5

<!-- Instructions for testing. -->

Fixes #22338 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
