### PR TITLE
IndexProperty now valid if workspace pointer is null

### DIFF
--- a/Framework/API/src/IndexProperty.cpp
+++ b/Framework/API/src/IndexProperty.cpp
@@ -19,6 +19,9 @@ bool IndexProperty::isDefault() const { return m_value.empty(); }
 
 std::string IndexProperty::isValid() const {
   std::string error;
+  // No workspace acts as an empty set and so is considered valid
+  if (!m_workspaceProp.getWorkspace())
+    return error;
 
   try {
     getIndices();


### PR DESCRIPTION
Description of work.

Restores the argument order of `MaskBins` that got mixed up with the introduction of `IndexProperty`. See the commit message for full detail of the change.

**To test:**

I used the script below for testing. It raise an exception before this fix and succeeds afterwards.

```python
import mantid
from mantid.simpleapi import *
a = CreateSampleWorkspace()
b = CreateSampleWorkspace()
group = GroupWorkspaces("a,b")
A1th0p7_Cropped_22530 = MaskBins(mtd['group'], 6.402, 16)
```

Also see the original issue and run the script.

Fixes #22332

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
