### PR TITLE
Fix warnings generated by gcc 7.3

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/SpectrumAlgorithm.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SpectrumAlgorithm.h
@@ -3,10 +3,10 @@
 
 #include <tuple>
 
-#include "MantidKernel/IndexSet.h"
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidAlgorithms/DllConfig.h"
+#include "MantidKernel/IndexSet.h"
 
 namespace Mantid {
 
@@ -56,13 +56,13 @@ private:
    *
    * Used for generating a sequence 0,1,2,.... for extracting arguments from
    * tuple. */
-  template <int...> struct seq {};
+  template <std::size_t...> struct seq {};
   // Doxygen does not like recursive types.
-  template <int N, int... S>
+  template <std::size_t N, std::size_t... S>
   struct gens                                     /** @cond */
       : gens<N - 1, N - 1, S...> /** @endcond */ {/** @cond */
   };
-  template <int... S> struct gens<0, S...> {/** @endcond */
+  template <std::size_t... S> struct gens<0, S...> {/** @endcond */
     using type = seq<S...>;
   };
 
@@ -78,7 +78,7 @@ private:
   template <typename Tp> struct contains<Tp> : std::false_type {};
 
   /// Internal implementation of for_each().
-  template <class... Flags, class WS, class T, int... S, class OP>
+  template <class... Flags, class WS, class T, std::size_t... S, class OP>
   void for_each(WS &workspace, T getters, seq<S...>, const OP &operation) {
     // If we get the flag Indices::FromProperty we use a potential user-defined
     // range property, otherwise default to the full range of all histograms.

--- a/Framework/PythonInterface/mantid/api/src/Exports/CompositeFunction.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/CompositeFunction.cpp
@@ -1,5 +1,6 @@
-#include "MantidPythonInterface/kernel/GetPointer.h"
 #include "MantidAPI/CompositeFunction.h"
+#include "MantidKernel/WarningSuppressions.h"
+#include "MantidPythonInterface/kernel/GetPointer.h"
 #include <boost/python/class.hpp>
 #include <boost/python/overloads.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
@@ -23,8 +24,10 @@ using setParameterType2 = void (CompositeFunction::*)(const std::string &,
 #pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
+GCC_DIAG_OFF(conversion)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(setParameterType2_Overloads,
                                        setParameter, 2, 3)
+GCC_DIAG_ON(conversion)
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif


### PR DESCRIPTION
Description of work.

Ubuntu 18.04 ships with gcc 7.3 and generates a few extra warnings than 7.1.

**To test:**

* Code review
* Builds should pas

*No issue*

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
