### PR TITLE
Fixed instrument view crash bug

### DIFF
--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentActor.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentActor.h
@@ -132,7 +132,7 @@ public:
   bool wholeRange() const;
 
   /// Get the number of detectors in the instrument.
-  size_t ndetectors() const; // { return m_detIDs.size(); }
+  size_t ndetectors() const; 
   /// Get a detector index by a detector ID.
   size_t getDetectorByDetID(Mantid::detid_t detID) const;
   /// Get a detector ID by a pick ID converted form a color in the pick image.

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentActor.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentActor.h
@@ -132,7 +132,7 @@ public:
   bool wholeRange() const;
 
   /// Get the number of detectors in the instrument.
-  size_t ndetectors() const; 
+  size_t ndetectors() const;
   /// Get a detector index by a detector ID.
   size_t getDetectorByDetID(Mantid::detid_t detID) const;
   /// Get a detector ID by a pick ID converted form a color in the pick image.

--- a/qt/widgets/instrumentview/src/InstrumentActor.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentActor.cpp
@@ -726,7 +726,9 @@ bool InstrumentActor::wholeRange() const {
          m_BinMaxValue == m_WkspBinMaxValue;
 }
 
-size_t InstrumentActor::ndetectors() const { return detectorInfo().size(); }
+size_t InstrumentActor::ndetectors() const {
+  return m_detIndex2WsIndex.size() - m_components.size();
+}
 
 /**
  * Set autoscaling of the y axis. If autoscaling is on the minValue() and

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -1230,7 +1230,7 @@ void InstrumentWidget::handleWorkspaceReplacement(
       // the same name)
       auto matrixWS =
           boost::dynamic_pointer_cast<const MatrixWorkspace>(workspace);
-      if (!matrixWS) {
+      if (!matrixWS || matrixWS->detectorInfo().size() == 0) {
         emit preDeletingHandle();
         close();
         return;

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -8,6 +8,7 @@
 #include "MantidQtWidgets/InstrumentView/InstrumentWidgetRenderTab.h"
 #include "MantidQtWidgets/InstrumentView/InstrumentWidgetTreeTab.h"
 #include "MantidGeometry/Instrument/ComponentInfo.h"
+#include "MantidGeometry/Instrument/DetectorInfo.h"
 
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/IMaskWorkspace.h"
@@ -1234,24 +1235,17 @@ void InstrumentWidget::handleWorkspaceReplacement(
         close();
         return;
       }
-      bool sameWS = false;
-      try {
-        sameWS = (matrixWS == m_instrumentActor->getWorkspace());
-      } catch (std::runtime_error &) {
-        // Carry on, sameWS should stay false
-      }
-
       // try to detect if the instrument changes (unlikely if the workspace
       // hasn't, but theoretically possible)
-      bool resetGeometry = matrixWS->getInstrument()->getNumberDetectors() !=
-                           m_instrumentActor->ndetectors();
-
-      // if workspace and instrument don't change keep the scaling
-      if (sameWS && !resetGeometry) {
-        m_instrumentActor->updateColors();
-        setupColorMap();
-        updateInstrumentView();
-      } else {
+      bool resetGeometry =
+          matrixWS->detectorInfo().size() != m_instrumentActor->ndetectors();
+      try {
+        if (matrixWS == m_instrumentActor->getWorkspace() && !resetGeometry) {
+          m_instrumentActor->updateColors();
+          setupColorMap();
+          updateInstrumentView();
+        }
+      } catch (std::runtime_error &) {
         resetInstrument(resetGeometry);
       }
     }

--- a/qt/widgets/instrumentview/src/PanelsSurface.cpp
+++ b/qt/widgets/instrumentview/src/PanelsSurface.cpp
@@ -178,6 +178,7 @@ void PanelsSurface::init() {
   if (ndet == 0)
     return;
 
+  clearBanks();
   constructFromComponentInfo();
   spreadBanks();
 


### PR DESCRIPTION
There was a bug when reloading the instrument view with a workspace which already existed. See #22349 

**To test:**

- Load the mantid instrument view with any data or empty instrument
- Load another data set or empty instrument with an identical workspace name.
- The instrument view should successfully load the new geometry without crashing.

Fixes #22349 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
