### PR TITLE
Engineering Diffraction GUI save GSAS-II fit results to HDF5

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/EnggSaveGSASIIFitResultsToHDF5.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggSaveGSASIIFitResultsToHDF5.py
@@ -1,0 +1,154 @@
+from __future__ import (absolute_import, division, print_function)
+
+from mantid.api import *
+from mantid.kernel import *
+import h5py
+import numpy
+
+
+class EnggSaveGSASIIFitResultsToHDF5(PythonAlgorithm):
+
+    PROP_BANKID = "BankID"
+    PROP_LATTICE_PARAMS = "LatticeParams"
+    PROP_SIGMA = "Sigma"
+    PROP_GAMMA = "Gamma"
+    PROP_RWP = "Rwp"
+    PROP_XMIN = "XMin"
+    PROP_XMAX = "XMax"
+    PROP_PAWLEY_DMIN = "PawleyDMin"
+    PROP_PAWLEY_NEGATIVE_WEIGHT = "PawleyNegativeWeight"
+    PROP_REFINE_GAMMA = "RefineGamma"
+    PROP_REFINE_SIGMA = "RefineSigma"
+    PROP_REFINEMENT_METHOD = "RefinementMethod"
+    PROP_FILENAME = "Filename"
+
+    BANK_GROUP_NAME = "Bank {}".format
+    LATTICE_PARAMS_DATASET_NAME = "Lattice parameters"
+    REFINEMENT_PARAMS_DATASET_NAME = "Refinement Parameters"
+    FIT_RESULTS_GROUP_NAME = "GSAS-II Fitting"
+    LATTICE_PARAMS = ["a", "b", "c", "alpha", "beta", "gamma", "volume"]
+    PAWLEY_REFINEMENT = "Pawley refinement"
+    RIETVELD_REFINEMENT = "Rietveld refinement"
+    RWP_DATASET_NAME = "Rwp"
+    PROFILE_COEFFS_DATASET_NAME = "Profile Coefficients"
+
+    def category(self):
+        return "DataHandling"
+
+    def name(self):
+        return "EnggSaveGSASIIFitResultsToHDF5"
+
+    def summary(self):
+        return "Save input parameters and fit results from GSASIIRefineFitPeaks to an HDF5 file, indexed by bank ID"
+
+    def PyInit(self):
+        self.declareProperty(ITableWorkspaceProperty(name=self.PROP_LATTICE_PARAMS, defaultValue="",
+                                                     direction=Direction.Input),
+                             doc="Table workspace containing lattice parameters")
+
+        self.declareProperty(name=self.PROP_BANKID, validator=IntMandatoryValidator(),
+                             doc="ID of the bank associated with this data (1 for North, 2 for South)", defaultValue=1)
+
+        self.declareProperty(name=self.PROP_REFINEMENT_METHOD, defaultValue=self.PAWLEY_REFINEMENT,
+                             validator=StringListValidator([self.PAWLEY_REFINEMENT, self.RIETVELD_REFINEMENT]),
+                             doc="Which refinement method was used")
+
+        self.declareProperty(name=self.PROP_XMIN, defaultValue=0.0, doc="Minimum TOF value used for refinement")
+
+        self.declareProperty(name=self.PROP_XMAX, defaultValue=0.0, doc="Maximum TOF value used for refinement")
+
+        self.declareProperty(name=self.PROP_PAWLEY_DMIN, defaultValue=0.0,
+                             doc="Minimum d spacing used for Pawley refinement")
+
+        self.declareProperty(name=self.PROP_PAWLEY_NEGATIVE_WEIGHT, defaultValue=0.0,
+                             doc="Negative weight penalty used in Pawley refinement")
+
+        self.declareProperty(name=self.PROP_REFINE_SIGMA, defaultValue=False,
+                             doc="Whether to sigma profile coefficient was refined")
+
+        self.declareProperty(name=self.PROP_REFINE_GAMMA, defaultValue=False,
+                             doc="Whether gamma profile coefficient was refined")
+
+        self.declareProperty(name=self.PROP_SIGMA, defaultValue=0.0, doc="GSAS-II profile coefficient sigma")
+
+        self.declareProperty(name=self.PROP_GAMMA, defaultValue=0.0, doc="GSAS-II profile coefficient gamma")
+
+        self.declareProperty(name=self.PROP_RWP, defaultValue=0.0,
+                             doc="Weighted profile R-factor, 'goodness-of-fit' measure")
+
+        self.declareProperty(FileProperty(name=self.PROP_FILENAME, defaultValue="", action=FileAction.Save,
+                                          extensions=[".hdf5", ".h5", ".hdf"]), doc="HDF5 file to save to")
+
+    def PyExec(self):
+        output_file_name = self.getProperty(self.PROP_FILENAME).value
+
+        with h5py.File(output_file_name, "a") as output_file:
+            bankID = self.getProperty(self.PROP_BANKID).value
+
+            bank_group = output_file.require_group(self.BANK_GROUP_NAME(bankID))
+            if self.FIT_RESULTS_GROUP_NAME in bank_group:
+                del bank_group[self.FIT_RESULTS_GROUP_NAME]
+
+            fit_results_group = bank_group.create_group(self.FIT_RESULTS_GROUP_NAME)
+
+            self._save_refinement_params(fit_results_group)
+            self._save_lattice_params(fit_results_group)
+            self._save_rwp(fit_results_group)
+            self._save_profile_coefficients(fit_results_group)
+
+    def _save_lattice_params(self, results_group):
+        lattice_params_dataset = results_group.create_dataset(name=self.LATTICE_PARAMS_DATASET_NAME, shape=(1,),
+                                                              dtype=[(param, "f") for param in self.LATTICE_PARAMS])
+        lattice_params = self.getProperty(self.PROP_LATTICE_PARAMS).value.row(0)
+
+        lattice_params_dataset[0] = tuple(lattice_params[param] for param in self.LATTICE_PARAMS)
+
+    def _save_profile_coefficients(self, results_group):
+        refine_sigma = self.getProperty(self.PROP_REFINE_SIGMA)
+        refine_gamma = self.getProperty(self.PROP_REFINE_GAMMA)
+
+        if refine_sigma or refine_gamma:
+            if refine_sigma and refine_gamma:
+                dtype = [(self.PROP_SIGMA, "f"), (self.PROP_GAMMA, "f")]
+                values = self.getProperty(self.PROP_SIGMA).value, self.getProperty(self.PROP_GAMMA).value
+            elif refine_sigma:
+                dtype = [(self.PROP_SIGMA, "f")]
+                values = self.getProperty(self.PROP_SIGMA).value,
+            elif refine_gamma:
+                dtype = [(self.PROP_GAMMA, "f")]
+                values = self.getProperty(self.PROP_GAMMA).value,
+
+            coefficients_dataset = results_group.create_dataset(name=self.PROFILE_COEFFS_DATASET_NAME, shape=(1,),
+                                                                dtype=dtype)
+            coefficients_dataset[0] = values
+
+    def _save_refinement_params(self, results_group):
+        refinement_params_dtype = [(self.PROP_REFINEMENT_METHOD, "S19"),
+                                   (self.PROP_REFINE_SIGMA, "b"),
+                                   (self.PROP_REFINE_GAMMA, "b"),
+                                   (self.PROP_XMIN, "f"),
+                                   (self.PROP_XMAX, "f")]
+
+        refinement_method = self.getProperty(self.PROP_REFINEMENT_METHOD).value
+        refinement_params_list = [refinement_method,
+                                  self.getProperty(self.PROP_REFINE_SIGMA).value,
+                                  self.getProperty(self.PROP_REFINE_GAMMA).value,
+                                  self.getProperty(self.PROP_XMIN).value,
+                                  self.getProperty(self.PROP_XMAX).value]
+
+        if refinement_method == self.PAWLEY_REFINEMENT:
+            refinement_params_dtype += [(self.PROP_PAWLEY_DMIN, "f"),
+                                        (self.PROP_PAWLEY_NEGATIVE_WEIGHT, "f")]
+            refinement_params_list += [self.getProperty(self.PROP_PAWLEY_DMIN).value,
+                                       self.getProperty(self.PROP_PAWLEY_NEGATIVE_WEIGHT).value]
+
+        refinement_params_dataset = results_group.create_dataset(name=self.REFINEMENT_PARAMS_DATASET_NAME, shape=(1,),
+                                                                 dtype=refinement_params_dtype)
+
+        refinement_params_dataset[0] = tuple(refinement_params_list)
+
+    def _save_rwp(self, results_group):
+        results_group.create_dataset(self.RWP_DATASET_NAME, data=numpy.array(self.getProperty(self.PROP_RWP).value))
+
+
+AlgorithmFactory.subscribe(EnggSaveGSASIIFitResultsToHDF5)

--- a/Framework/PythonInterface/plugins/algorithms/EnggSaveGSASIIFitResultsToHDF5.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggSaveGSASIIFitResultsToHDF5.py
@@ -23,7 +23,7 @@ class EnggSaveGSASIIFitResultsToHDF5(PythonAlgorithm):
     PROP_FILENAME = "Filename"
 
     BANK_GROUP_NAME = "Bank {}".format
-    LATTICE_PARAMS_DATASET_NAME = "Lattice parameters"
+    LATTICE_PARAMS_DATASET_NAME = "Lattice Parameters"
     REFINEMENT_PARAMS_DATASET_NAME = "Refinement Parameters"
     FIT_RESULTS_GROUP_NAME = "GSAS-II Fitting"
     LATTICE_PARAMS = ["a", "b", "c", "alpha", "beta", "gamma", "volume"]

--- a/Framework/PythonInterface/plugins/algorithms/EnggSaveGSASIIFitResultsToHDF5.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggSaveGSASIIFitResultsToHDF5.py
@@ -104,8 +104,8 @@ class EnggSaveGSASIIFitResultsToHDF5(PythonAlgorithm):
         lattice_params_dataset[0] = tuple(lattice_params[param] for param in self.LATTICE_PARAMS)
 
     def _save_profile_coefficients(self, results_group):
-        refine_sigma = self.getProperty(self.PROP_REFINE_SIGMA)
-        refine_gamma = self.getProperty(self.PROP_REFINE_GAMMA)
+        refine_sigma = self.getProperty(self.PROP_REFINE_SIGMA).value
+        refine_gamma = self.getProperty(self.PROP_REFINE_GAMMA).value
 
         if refine_sigma or refine_gamma:
             if refine_sigma and refine_gamma:

--- a/Framework/PythonInterface/plugins/algorithms/GSASIIRefineFitPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/GSASIIRefineFitPeaks.py
@@ -171,6 +171,8 @@ class GSASIIRefineFitPeaks(PythonAlgorithm):
         if not x_max:
             x_max = max(input_ws.readX(0))
         x_min = max(pawley_tmin, min(input_ws.readX(0)), self.getProperty(self.PROP_XMIN).value)
+        self.setProperty(self.PROP_XMIN, x_min)
+        self.setProperty(self.PROP_XMAX, x_max)
         basic_refinement["set"].update({"Limits": [x_min, x_max]})
 
         scale_refinement = {"set": {"Scale": True},

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
@@ -35,6 +35,7 @@ set ( TEST_PY_FILES
   EnggFitDIFCFromPeaksTest.py
   EnggFitPeaksTest.py
   EnggFocusTest.py
+  EnggSaveGSASIIFitResultsToHDF5Test.py
   EnggSaveSinglePeakFitResultsToHDF5Test.py
   EnggVanadiumCorrectionsTest.py
   ExportSpectraMaskTest.py

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggSaveGSASIIFitResultsToHDF5Test.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggSaveGSASIIFitResultsToHDF5Test.py
@@ -1,0 +1,183 @@
+from __future__ import (absolute_import, division, print_function)
+
+import h5py
+import os
+import random
+import tempfile
+import unittest
+
+import mantid.simpleapi as mantid
+from testhelpers import run_algorithm
+
+
+class EnggSaveGSASIIFitResultsToHDF5Test(unittest.TestCase):
+
+    ALG_NAME = "EnggSaveGSASIIFitResultsToHDF5"
+    FIT_RESULTS_TABLE_NAME = "FitResults"
+    LATTICE_PARAMS_TABLE_NAME = "LatticeParams"
+    LATTICE_PARAMS = ["a", "b", "c", "alpha", "beta", "gamma", "volume"]
+    TEMP_FILE_NAME = os.path.join(tempfile.gettempdir(),
+                                  "EnggSaveGSASIIFitResultsToHDF5Test.hdf5")
+
+    def tearDown(self):
+        try:
+            os.remove(self.TEMP_FILE_NAME)
+
+        except OSError:
+            pass
+
+        self._remove_ws_if_exists(self.FIT_RESULTS_TABLE_NAME)
+        self._remove_ws_if_exists(self.LATTICE_PARAMS_TABLE_NAME)
+
+    def test_saveLatticeParams(self):
+        lattice_params = self._create_lattice_params_table()
+
+        test_alg = run_algorithm(self.ALG_NAME,
+                                 LatticeParams=lattice_params,
+                                 BankID=1,
+                                 Filename=self.TEMP_FILE_NAME)
+        self.assertTrue(test_alg.isExecuted())
+
+        with h5py.File(self.TEMP_FILE_NAME, "r") as output_file:
+            self.assertTrue("Bank 1" in output_file)
+            bank_group = output_file["Bank 1"]
+            self.assertTrue("GSAS-II Fitting" in bank_group)
+            fit_results_group = bank_group["GSAS-II Fitting"]
+
+            self.assertTrue("Lattice Parameters" in fit_results_group)
+            lattice_params_dataset = fit_results_group["Lattice Parameters"]
+            lattice_params_row = [lattice_params.row(0)[param] for param in self.LATTICE_PARAMS]
+
+            for val_from_file, val_from_input in zip(lattice_params_row, lattice_params_dataset[0]):
+                self.assertAlmostEqual(val_from_file, val_from_input)
+
+    def test_saveRefinementParameters(self):
+        lattice_params = self._create_lattice_params_table()
+
+        refinement_method = "Rietveld refinement"
+        refine_sigma = True
+        refine_gamma = False
+        x_min = 10000
+        x_max = 40000
+
+        test_alg = run_algorithm(self.ALG_NAME,
+                                 LatticeParams=lattice_params,
+                                 RefinementMethod=refinement_method,
+                                 XMin=x_min,
+                                 XMax=x_max,
+                                 RefineSigma=refine_sigma,
+                                 RefineGamma=refine_gamma,
+                                 Filename=self.TEMP_FILE_NAME)
+        self.assertTrue(test_alg.isExecuted())
+
+        with h5py.File(self.TEMP_FILE_NAME, "r") as output_file:
+            fit_results_group = output_file["Bank 1"]["GSAS-II Fitting"]
+            self.assertTrue("Refinement Parameters" in fit_results_group)
+            refinement_params = fit_results_group["Refinement Parameters"][0]
+
+            self.assertEquals(len(refinement_params), 5)
+
+            # refinement_params is a tuple, so test that parameters are at the correct index
+            self.assertEquals(refinement_params[0], refinement_method)
+            self.assertTrue(refinement_params[1])  # RefineSigma
+            self.assertFalse(refinement_params[2])  # RefineGamma
+            self.assertEquals(refinement_params[3], x_min)
+            self.assertEquals(refinement_params[4], x_max)
+
+    def test_saveProfileCoefficients(self):
+        lattice_params = self._create_lattice_params_table()
+        sigma = 13
+        gamma = 14
+
+        test_alg = run_algorithm(self.ALG_NAME,
+                                 LatticeParams=lattice_params,
+                                 RefineSigma=True,
+                                 RefineGamma=True,
+                                 Sigma=sigma,
+                                 Gamma=gamma,
+                                 Filename=self.TEMP_FILE_NAME)
+        self.assertTrue(test_alg.isExecuted())
+
+        with h5py.File(self.TEMP_FILE_NAME, "r") as output_file:
+            fit_results_group = output_file["Bank 1"]["GSAS-II Fitting"]
+            self.assertTrue("Profile Coefficients" in fit_results_group)
+            profile_coeffs = fit_results_group["Profile Coefficients"][0]
+
+            self.assertEquals(len(profile_coeffs), 2)
+            self.assertEquals(profile_coeffs[0], sigma)
+            self.assertEquals(profile_coeffs[1], gamma)
+
+    def test_profileCoeffsNotSavedWhenNotRefined(self):
+        lattice_params = self._create_lattice_params_table()
+        run_algorithm(self.ALG_NAME,
+                      LatticeParams=lattice_params,
+                      RefineSigma=False,
+                      RefineGamma=False,
+                      Filename=self.TEMP_FILE_NAME)
+
+        with h5py.File(self.TEMP_FILE_NAME, "r") as output_file:
+            fit_results_group = output_file["Bank 1"]["GSAS-II Fitting"]
+            self.assertFalse("Profile Coefficients" in fit_results_group)
+
+    def test_pawleyRefinementSavesPawleyParams(self):
+        lattice_params = self._create_lattice_params_table()
+        d_min = 1.0
+        negative_weight = 1.5
+
+        run_algorithm(self.ALG_NAME,
+                      BankID=2,
+                      LatticeParams=lattice_params,
+                      RefinementMethod="Pawley refinement",
+                      PawleyDMin=d_min,
+                      PawleyNegativeWeight=negative_weight,
+                      Filename=self.TEMP_FILE_NAME)
+
+        with h5py.File(self.TEMP_FILE_NAME, "r") as output_file:
+            fit_results_group = output_file["Bank 2"]["GSAS-II Fitting"]
+            refinement_params = fit_results_group["Refinement Parameters"][0]
+            self.assertEquals(len(refinement_params), 7)
+            self.assertEquals(refinement_params[5], d_min)
+            self.assertEquals(refinement_params[6], negative_weight)
+
+    def test_saveRwp(self):
+        lattice_params = self._create_lattice_params_table()
+        rwp = 75
+
+        run_algorithm(self.ALG_NAME,
+                      LatticeParams=lattice_params,
+                      Rwp=rwp,
+                      Filename=self.TEMP_FILE_NAME)
+
+        with h5py.File(self.TEMP_FILE_NAME, "r") as output_file:
+            fit_results_group = output_file["Bank 1"]["GSAS-II Fitting"]
+            self.assertTrue("Rwp" in fit_results_group)
+            rwp_from_file = fit_results_group["Rwp"]
+            self.assertEquals(rwp_from_file.value, rwp)
+
+    def test_saveToExistingFileDoesNotOverwrite(self):
+        lattice_params = self._create_lattice_params_table()
+        run_algorithm(self.ALG_NAME,
+                      LatticeParams=lattice_params,
+                      BankID=1,
+                      Filename=self.TEMP_FILE_NAME)
+        run_algorithm(self.ALG_NAME,
+                      LatticeParams=lattice_params,
+                      BankID=2,
+                      Filename=self.TEMP_FILE_NAME)
+
+        with h5py.File(self.TEMP_FILE_NAME, "r") as output_file:
+            self.assertTrue("Bank 1" in output_file)
+            self.assertTrue("Bank 2" in output_file)
+
+    def _create_lattice_params_table(self):
+        lattice_params = mantid.CreateEmptyTableWorkspace(OutputWorkspace=self.LATTICE_PARAMS_TABLE_NAME)
+        [lattice_params.addColumn("double", param) for param in self.LATTICE_PARAMS]
+        lattice_params.addRow([random.random() for _ in self.LATTICE_PARAMS])
+        return lattice_params
+
+    def _remove_ws_if_exists(self, name):
+        if mantid.mtd.doesExist(name):
+            mantid.mtd.remove(name)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/source/algorithms/EnggSaveGSASIIFitResultsToHDF5-v1.rst
+++ b/docs/source/algorithms/EnggSaveGSASIIFitResultsToHDF5-v1.rst
@@ -1,0 +1,114 @@
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+Exports the results of a :ref:`GSASIIRefineFitPeaks
+<algm-GSASIIRefineFitPeaks-v1>` refinement, as well as the refinement
+parameters used, to an HDF5 file indexed by bank ID. The results go in
+a sub-group of the **Bank** group called **GSAS-II Fitting**. The
+subgroups of this are the following:
+
+Refinement Parameters
+#####################
+
+Settings passed to :ref:`GSASIIRefineFitPeaks
+<algm-GSASIIRefineFitPeaks-v1>` to generate this refinement.
+
+- **RefinementMethod** - either Pawley or Rietveld refinement
+- **RefineSigma** - whether sigma (Gaussian broadening term) was
+  refined
+- **RefineGamma** - whether gamma (Lorentzian broadening term) was
+  refined
+- **XMin** - the minimum TOF value used for refinement. Note this may
+  not be the same as the **XMin** that you passed to
+  GSASIIRefineFitPeaks, as **XMin** in GSASIIRefineFitPeaks will be
+  overriden by **PawleyDMin** if the latter corresponds to a greater
+  TOF value
+- **XMax** - the maximum TOF value used for refinement
+
+Additionally, if **RefinementMethod** is ``Pawley refinement``, the
+two Pawley parameters will be saved:
+
+- **PawleyDMin** - the minimum D spacing to use for refinement
+- **PawleyNegativeWeight** - a weight penalty used in Pawley
+  refinement
+
+Lattice Parameters
+##################
+
+The lattice parameters of the refined structure: **alpha**, **beta**,
+**gamma**, **a**, **b**, **c** and **volume**.
+
+Profile Coefficients
+####################
+
+Only saved if either **RefineSigma** or **RefineGamma** were turned
+on.
+
+- **Gamma** - Lorentzian broadening term of the GSAS-II peak
+  profile. Only saved if it was refined
+- **Sigma** - Gaussian broadening term of the GSAS-II peak
+  profile. Only saved if it was refined
+
+Rwp (weighted-profile R-factor)
+###############################
+
+A measure of 'goodness of fit', as a percentage
+
+Usage
+-----
+
+.. warning::
+
+   Due to a reliance on GSAS-II, this example is not run on the build
+   servers, so may not be correct. Please inform Mantid developers if
+   you spot something awry
+
+**Example - Export refinement results to a new HDF5 file:**
+
+.. code-block:: python
+
+   import os
+
+   path_to_gsas = r"C:\g2conda\GSASII"
+
+   gsas_proj_file = r"C:\mantid-data\280625.gpx"
+
+   data_dir = r"C:\mantid-data"
+   input_file = lambda file: os.path.join(data_dir, file)
+
+   phase_file = input_file("Fe-alpha.cif")
+   iparams_file = input_file("template_ENGINX_241391_236516_North_bank.prm")
+   input_ws = Load(Filename=input_file("ENGINX_280625_focused_bank_1.nxs"))
+
+   fitted_peaks, lattice_params, rwp, sigma, gamma = \
+       GSASIIRefineFitPeaks(InputWorkspace=input_ws,
+                            PhaseInfoFiles=phase_file,
+                            InstrumentFile=iparams_file,
+                            RefinementMethod="Rietveld refinement",
+                            SaveGSASIIProjectFile=gsas_proj_file,
+                            PathToGSASII=path_to_gsas,
+                            RefineSigma=True,
+                            RefineGamma=False)
+
+   EnggSaveGSASIIFitResultsToHDF5(LatticeParams=lattice_params,
+                                  Filename=r"D:\doctest.hdf5",
+                                  BankID=input_ws.run()["bankid"].value,
+                                  RefinementMethod="Rietveld refinement",
+                                  XMin=min(fitted_peaks.readX(0)),
+                                  XMax=max(fitted_peaks.readX(0)),
+                                  RefineSigma=True,
+                                  RefineGamma=False,
+                                  Sigma=sigma,
+				  Rwp=rwp)
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/interfaces/Engineering Diffraction.rst
+++ b/docs/source/interfaces/Engineering Diffraction.rst
@@ -372,7 +372,6 @@ Peaks:
   peaks. These peaks can be manually written or imported by selecting a
   (*CSV*) file.
 
-
 Output
 ^^^^^^
 
@@ -523,6 +522,13 @@ To do a refinement, take the following steps:
 
    - You can also click **Refine All** to run refinement on all runs
      loaded into GSAS tab
+
+During the Fit process, :ref:`EnggSaveGSASIIFitResultsToHDF5
+<algm-EnggSaveGSASIIFitResultsToHDF5>` algorithm will be utilised to
+save the fit results, and also the parameters used, as a `hdf5`
+file. There will be one file per run, indexed by bank ID, and the file
+will be found in the **Runs** directory of the user's output
+directory.
 
 You can toggle the fitted peaks on and off with the **Plot Fitted
 Peaks** checkbox, remove runs from the list with the **Remove Run**

--- a/docs/source/release/v3.13.0/diffraction.rst
+++ b/docs/source/release/v3.13.0/diffraction.rst
@@ -26,9 +26,13 @@ Engineering Diffraction
     loaded into the tab
 
 - :ref:`GSASIIRefineFitPeaks <algm-GSASIIRefineFitPeaks>` now supports Pawley refinement as well as Rietveld
-- Single peak fitting output is now saved as HDF5 instead of CSV,
-  using :ref:`EnggSaveSinglePeakFitResultsToHDF5
-  <algm-EnggSaveSinglePeakFitResultsToHDF5>`.
+- HDF5 is now the standard format for saving data from the GUI:
+
+  - Single peak fitting output is now saved as HDF5 instead of CSV,
+    using :ref:`EnggSaveSinglePeakFitResultsToHDF5
+    <algm-EnggSaveSinglePeakFitResultsToHDF5>`
+  - Fit results and parameters are saved to HDF5 from the **GSAS
+    Refinement** tab
 
 
 :ref:`Release 3.13.0 <v3.13.0>`

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -192,8 +192,13 @@ EnggDiffFittingPresenter::currentCalibration() const {
 }
 
 Poco::Path
-EnggDiffFittingPresenter::outFilesUserDir(const std::string &addToDir) {
+EnggDiffFittingPresenter::outFilesUserDir(const std::string &addToDir) const {
   return m_mainParam->outFilesUserDir(addToDir);
+}
+
+std::string
+EnggDiffFittingPresenter::userHDFRunFilename(const int runNumber) const {
+  return m_mainParam->userHDFRunFilename(runNumber);
 }
 
 void EnggDiffFittingPresenter::startAsyncFittingWorker(
@@ -496,10 +501,8 @@ void EnggDiffFittingPresenter::doFitting(const RunLabel &runLabel,
     return;
   }
 
-  const auto outFilename = std::to_string(runLabel.runNumber) + ".hdf5";
-  auto saveDirectory = outFilesUserDir("Runs");
-  saveDirectory.append(outFilename);
-  m_model->saveFitResultsToHDF5(runLabel, saveDirectory.toString());
+  const auto outFilename = userHDFRunFilename(runLabel.runNumber);
+  m_model->saveFitResultsToHDF5(runLabel, outFilename);
 
   m_model->createFittedPeaksWS(runLabel);
   m_fittingFinishedOK = true;

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.h
@@ -68,8 +68,10 @@ public:
 
   /// From the IEnggDiffractionCalibration interface
   //@{
-  Poco::Path outFilesUserDir(const std::string &addToDir) override;
+  Poco::Path outFilesUserDir(const std::string &addToDir) const override;
   //@}
+
+  std::string userHDFRunFilename(const int runNumber) const override;
 
   /// the fitting hard work that a worker / thread will run
   void doFitting(const RunLabel &runLabel, const std::string &expectedPeaks);

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
@@ -1,10 +1,10 @@
 #include "EnggDiffFittingViewQtWidget.h"
+#include "EnggDiffFittingModel.h"
+#include "EnggDiffFittingPresenter.h"
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/IPeakFunction.h"
 #include "MantidKernel/make_unique.h"
 #include "MantidQtWidgets/Common/AlgorithmInputHistory.h"
-#include "EnggDiffFittingModel.h"
-#include "EnggDiffFittingPresenter.h"
 #include "MantidQtWidgets/LegacyQwt/PeakPicker.h"
 
 #include <array>

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
@@ -1,10 +1,10 @@
 #ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFFITTINGVIEWQTWIDGET_H_
 #define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFFITTINGVIEWQTWIDGET_H_
 
-#include "MantidAPI/IPeakFunction.h"
 #include "DllConfig.h"
 #include "IEnggDiffFittingPresenter.h"
 #include "IEnggDiffFittingView.h"
+#include "MantidAPI/IPeakFunction.h"
 
 #include "ui_EnggDiffractionQtTabFitting.h"
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
@@ -8,6 +8,8 @@
 #include "IEnggDiffGSASFittingObserver.h"
 #include "RunMap.h"
 
+#include "MantidAPI/IAlgorithm_fwd.h"
+
 #include <QObject>
 #include <QThread>
 
@@ -45,6 +47,11 @@ public:
   Mantid::API::MatrixWorkspace_sptr
   loadFocusedRun(const std::string &filename) const override;
 
+  void saveRefinementResultsToHDF5(
+      const Mantid::API::IAlgorithm_sptr successfulAlgorithm,
+      const GSASIIRefineFitPeaksOutputProperties &refinementResults,
+      const std::string &filename) const override;
+
 protected:
   /// The following methods are marked as protected so that they can be exposed
   /// by a helper class in the tests
@@ -68,6 +75,7 @@ protected slots:
   void processRefinementFailed(const std::string &failureMessage);
 
   void processRefinementSuccessful(
+      Mantid::API::IAlgorithm_sptr alg,
       const GSASIIRefineFitPeaksOutputProperties &refinementResults);
 
   void processRefinementCancelled();
@@ -96,7 +104,7 @@ private:
   void deleteWorkerThread();
 
   /// Run GSASIIRefineFitPeaks
-  GSASIIRefineFitPeaksOutputProperties
+  std::pair<Mantid::API::IAlgorithm_sptr, GSASIIRefineFitPeaksOutputProperties>
   doGSASRefinementAlgorithm(const GSASIIRefineFitPeaksParameters &params);
 
   template <typename T>

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
@@ -183,15 +183,12 @@ void EnggDiffGSASFittingPresenter::notifyRefinementSuccessful(
     const GSASIIRefineFitPeaksOutputProperties &refinementResults) {
   if (!m_viewHasClosed) {
     m_view->showStatus("Saving refinement results");
-    auto filename = m_mainSettings->outFilesUserDir("Runs");
-    filename.append(std::to_string(refinementResults.runLabel.runNumber) +
-                    ".hdf5");
+    const auto filename = m_mainSettings->userHDFRunFilename(
+        refinementResults.runLabel.runNumber);
 
-    try{
-      m_model->saveRefinementResultsToHDF5(alg, refinementResults,
-                                           filename.toString());
-    }
-    catch (std::exception &e){
+    try {
+      m_model->saveRefinementResultsToHDF5(alg, refinementResults, filename);
+    } catch (std::exception &e) {
       m_view->userWarning(
           "Could not save refinement results",
           std::string("Refinement was successful but saving results to "

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.h
@@ -7,6 +7,7 @@
 #include "IEnggDiffGSASFittingPresenter.h"
 #include "IEnggDiffGSASFittingView.h"
 #include "IEnggDiffMultiRunFittingWidgetPresenter.h"
+#include "IEnggDiffractionParam.h"
 
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 
@@ -24,8 +25,8 @@ public:
   EnggDiffGSASFittingPresenter(
       std::unique_ptr<IEnggDiffGSASFittingModel> model,
       IEnggDiffGSASFittingView *view,
-      boost::shared_ptr<IEnggDiffMultiRunFittingWidgetPresenter>
-          multiRunWidget);
+      boost::shared_ptr<IEnggDiffMultiRunFittingWidgetPresenter> multiRunWidget,
+      boost::shared_ptr<IEnggDiffractionParam> mainSettings);
 
   EnggDiffGSASFittingPresenter(EnggDiffGSASFittingPresenter &&other) = default;
 
@@ -39,6 +40,7 @@ public:
   void notifyRefinementsComplete() override;
 
   void notifyRefinementSuccessful(
+      const Mantid::API::IAlgorithm_sptr alg,
       const GSASIIRefineFitPeaksOutputProperties &refinementResults) override;
 
   void notifyRefinementFailed(const std::string &failureMessage) override;
@@ -78,6 +80,8 @@ private:
   std::unique_ptr<IEnggDiffGSASFittingModel> m_model;
 
   boost::shared_ptr<IEnggDiffMultiRunFittingWidgetPresenter> m_multiRunWidget;
+
+  boost::shared_ptr<IEnggDiffractionParam> m_mainSettings;
 
   IEnggDiffGSASFittingView *m_view;
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.cpp
@@ -16,7 +16,8 @@ namespace CustomInterfaces {
 
 EnggDiffGSASFittingViewQtWidget::EnggDiffGSASFittingViewQtWidget(
     boost::shared_ptr<IEnggDiffractionUserMsg> userMessageProvider,
-    boost::shared_ptr<IEnggDiffractionPythonRunner> pythonRunner)
+    boost::shared_ptr<IEnggDiffractionPythonRunner> pythonRunner,
+    boost::shared_ptr<IEnggDiffractionParam> mainSettings)
     : m_userMessageProvider(userMessageProvider) {
 
   auto multiRunWidgetModel =
@@ -37,7 +38,7 @@ EnggDiffGSASFittingViewQtWidget::EnggDiffGSASFittingViewQtWidget(
   auto model = Mantid::Kernel::make_unique<EnggDiffGSASFittingModel>();
   auto *model_ptr = model.get();
   m_presenter = boost::make_shared<EnggDiffGSASFittingPresenter>(
-      std::move(model), this, multiRunWidgetPresenter);
+      std::move(model), this, multiRunWidgetPresenter, mainSettings);
   model_ptr->setObserver(m_presenter);
   m_presenter->notify(IEnggDiffGSASFittingPresenter::Start);
 }

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.h
@@ -5,6 +5,7 @@
 #include "EnggDiffMultiRunFittingQtWidget.h"
 #include "IEnggDiffGSASFittingPresenter.h"
 #include "IEnggDiffGSASFittingView.h"
+#include "IEnggDiffractionParam.h"
 #include "IEnggDiffractionPythonRunner.h"
 #include "IEnggDiffractionUserMsg.h"
 
@@ -25,7 +26,8 @@ class MANTIDQT_ENGGDIFFRACTION_DLL EnggDiffGSASFittingViewQtWidget
 public:
   EnggDiffGSASFittingViewQtWidget(
       boost::shared_ptr<IEnggDiffractionUserMsg> userMessageProvider,
-      boost::shared_ptr<IEnggDiffractionPythonRunner> pythonRunner);
+      boost::shared_ptr<IEnggDiffractionPythonRunner> pythonRunner,
+      boost::shared_ptr<IEnggDiffractionParam> mainSettings);
 
   ~EnggDiffGSASFittingViewQtWidget() override;
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingWorker.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingWorker.cpp
@@ -3,6 +3,8 @@
 
 #include "MantidAPI/Algorithm.h"
 
+Q_DECLARE_METATYPE(Mantid::API::IAlgorithm_sptr)
+
 namespace MantidQt {
 namespace CustomInterfaces {
 
@@ -16,9 +18,10 @@ void EnggDiffGSASFittingWorker::doRefinements() {
     qRegisterMetaType<
         MantidQt::CustomInterfaces::GSASIIRefineFitPeaksOutputProperties>(
         "GSASIIRefineFitPeaksOutputProperties");
+    qRegisterMetaType<Mantid::API::IAlgorithm_sptr>("IAlgorithm_sptr");
     for (const auto params : m_refinementParams) {
       const auto fitResults = m_model->doGSASRefinementAlgorithm(params);
-      emit refinementSuccessful(fitResults);
+      emit refinementSuccessful(fitResults.first, fitResults.second);
     }
     emit refinementsComplete();
   } catch (const Mantid::API::Algorithm::CancelException &) {

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingWorker.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingWorker.h
@@ -4,6 +4,8 @@
 #include "GSASIIRefineFitPeaksOutputProperties.h"
 #include "GSASIIRefineFitPeaksParameters.h"
 
+#include "MantidAPI/IAlgorithm_fwd.h"
+
 #include <QObject>
 
 /**
@@ -29,7 +31,8 @@ public slots:
 signals:
   void refinementsComplete();
 
-  void refinementSuccessful(GSASIIRefineFitPeaksOutputProperties);
+  void refinementSuccessful(Mantid::API::IAlgorithm_sptr alg,
+                            GSASIIRefineFitPeaksOutputProperties);
 
   void refinementFailed(std::string);
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -1,4 +1,6 @@
 #include "EnggDiffractionPresenter.h"
+#include "EnggDiffractionPresWorker.h"
+#include "IEnggDiffractionView.h"
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/ITableWorkspace.h"
@@ -7,8 +9,6 @@
 #include "MantidKernel/Property.h"
 #include "MantidKernel/StringTokenizer.h"
 #include "MantidQtWidgets/Common/PythonRunner.h"
-#include "EnggDiffractionPresWorker.h"
-#include "IEnggDiffractionView.h"
 
 #include <algorithm>
 #include <cctype>
@@ -253,7 +253,8 @@ void EnggDiffractionPresenter::grabCalibParms(const std::string &fname) {
             g_log.warning()
                 << "Error when trying to extract parameters from this line:  "
                 << line << ". This calibration file may not load correctly. "
-                           "Error details: " << rexc.what() << '\n';
+                           "Error details: "
+                << rexc.what() << '\n';
           }
         } else {
           g_log.warning() << "Could not parse correctly a parameters "
@@ -970,7 +971,8 @@ void EnggDiffractionPresenter::doNewCalibration(const std::string &outFilename,
         << "The calibration calculations failed. One of the "
            "algorithms did not execute correctly. See log messages for "
            "further details. Error: " +
-               std::string(rexc.what()) << '\n';
+               std::string(rexc.what())
+        << '\n';
   } catch (std::invalid_argument &) {
     g_log.error()
         << "The calibration calculations failed. Some input properties "
@@ -1513,7 +1515,8 @@ void EnggDiffractionPresenter::doFocusRun(const std::string &dir,
   g_lastValidRun = runNo;
 
   g_log.notice() << "Generating new focusing workspace(s) and file(s) into "
-                    "this directory: " << dir << '\n';
+                    "this directory: "
+                 << dir << '\n';
 
   // TODO: this is almost 100% common with doNewCalibrate() - refactor
   EnggDiffCalibSettings cs = m_view->currentCalibSettings();
@@ -1558,7 +1561,8 @@ void EnggDiffractionPresenter::doFocusRun(const std::string &dir,
         loadDetectorGroupingCSV(dgFile, bankIDs, specs);
       } catch (std::runtime_error &re) {
         g_log.error() << "Error loading detector grouping file: " + dgFile +
-                             ". Detailed error: " + re.what() << '\n';
+                             ". Detailed error: " + re.what()
+                      << '\n';
         bankIDs.clear();
         specs.clear();
       }
@@ -1574,8 +1578,8 @@ void EnggDiffractionPresenter::doFocusRun(const std::string &dir,
         fpath.append(effectiveFilenames[idx]).toString();
     g_log.notice() << "Generating new focused file (bank " +
                           boost::lexical_cast<std::string>(bankIDs[idx]) +
-                          ") for run " + runNo +
-                          " into: " << effectiveFilenames[idx] << '\n';
+                          ") for run " + runNo + " into: "
+                   << effectiveFilenames[idx] << '\n';
     try {
       m_focusFinishedOK = false;
       doFocusing(cs, fullFilename, runNo, bankIDs[idx], specs[idx], dgFile);
@@ -1584,12 +1588,13 @@ void EnggDiffractionPresenter::doFocusRun(const std::string &dir,
       g_log.error() << "The focusing calculations failed. One of the algorithms"
                        "did not execute correctly. See log messages for "
                        "further details. Error: " +
-                           std::string(rexc.what()) << '\n';
+                           std::string(rexc.what())
+                    << '\n';
     } catch (std::invalid_argument &ia) {
       g_log.error() << "The focusing failed. Some input properties "
                        "were not valid. "
-                       "See log messages for details. Error: " << ia.what()
-                    << '\n';
+                       "See log messages for details. Error: "
+                    << ia.what() << '\n';
     }
   }
 
@@ -1686,7 +1691,8 @@ void EnggDiffractionPresenter::focusingFinished() {
     if (lastRun != lastValid) {
       g_log.warning()
           << "Focussing process has been stopped, last successful "
-             "run number: " << g_lastValidRun
+             "run number: "
+          << g_lastValidRun
           << " , total number of focus run that could not be processed: "
           << (lastRun - lastValid) << '\n';
       m_view->showStatus("Focusing stopped. Ready");
@@ -1929,7 +1935,8 @@ void EnggDiffractionPresenter::loadOrCalcVanadiumWorkspaces(
                        "This is possibly because some of the settings are not "
                        "consistent. Please check the log messages for "
                        "details. Details: " +
-                           std::string(ia.what()) << '\n';
+                           std::string(ia.what())
+                    << '\n';
       throw;
     } catch (std::runtime_error &re) {
       g_log.error() << "Failed to calculate Vanadium corrections. "
@@ -1938,14 +1945,15 @@ void EnggDiffractionPresenter::loadOrCalcVanadiumWorkspaces(
                        "There was no obvious error in the input properties "
                        "but the algorithm failed. Please check the log "
                        "messages for details." +
-                           std::string(re.what()) << '\n';
+                           std::string(re.what())
+                    << '\n';
       throw;
     }
   } else {
     g_log.notice() << "Found precalculated Vanadium correction features for "
-                      "Vanadium run " << vanNo
-                   << ". Re-using these files: " << preIntegFilename << ", and "
-                   << preCurvesFilename << '\n';
+                      "Vanadium run "
+                   << vanNo << ". Re-using these files: " << preIntegFilename
+                   << ", and " << preCurvesFilename << '\n';
     try {
       loadVanadiumPrecalcWorkspaces(preIntegFilename, preCurvesFilename,
                                     vanIntegWS, vanCurvesWS, vanNo, specNos);
@@ -2823,7 +2831,7 @@ std::string EnggDiffractionPresenter::outFitParamsTblNameGenerator(
 * "Focus"
 */
 Poco::Path
-EnggDiffractionPresenter::outFilesUserDir(const std::string &addToDir) {
+EnggDiffractionPresenter::outFilesUserDir(const std::string &addToDir) const {
   std::string rbn = m_view->getRBNumber();
   Poco::Path dir = outFilesRootDir();
 
@@ -2838,13 +2846,20 @@ EnggDiffractionPresenter::outFilesUserDir(const std::string &addToDir) {
     }
   } catch (Poco::FileAccessDeniedException &e) {
     g_log.error() << "Error caused by file access/permission, path to user "
-                     "directory: " << dir.toString()
-                  << ". Error details: " << e.what() << '\n';
+                     "directory: "
+                  << dir.toString() << ". Error details: " << e.what() << '\n';
   } catch (std::runtime_error &re) {
     g_log.error() << "Error while finding/creating a user path: "
                   << dir.toString() << ". Error details: " << re.what() << '\n';
   }
   return dir;
+}
+
+std::string
+EnggDiffractionPresenter::userHDFRunFilename(const int runNumber) const {
+  auto userOutputDir = outFilesUserDir("Runs");
+  userOutputDir.append(std::to_string(runNumber) + ".hdf5");
+  return userOutputDir.toString();
 }
 
 /**
@@ -2870,8 +2885,8 @@ EnggDiffractionPresenter::outFilesGeneralDir(const std::string &addComponent) {
     }
   } catch (Poco::FileAccessDeniedException &e) {
     g_log.error() << "Error caused by file access/permission, path to "
-                     "general directory: " << dir.toString()
-                  << ". Error details: " << e.what() << '\n';
+                     "general directory: "
+                  << dir.toString() << ". Error details: " << e.what() << '\n';
   } catch (std::runtime_error &re) {
     g_log.error() << "Error while finding/creating a general path: "
                   << dir.toString() << ". Error details: " << re.what() << '\n';
@@ -2882,7 +2897,7 @@ EnggDiffractionPresenter::outFilesGeneralDir(const std::string &addComponent) {
 /**
  * Produces the root path where output files are going to be written.
  */
-Poco::Path EnggDiffractionPresenter::outFilesRootDir() {
+Poco::Path EnggDiffractionPresenter::outFilesRootDir() const {
   // TODO decide whether to move into settings or use mantid's default directory
   // after discussion with users
   const std::string rootDir = "EnginX_Mantid";

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -272,9 +272,10 @@ private:
 
   // returns a directory as a path, creating it if not found, and checking
   // errors
-  Poco::Path outFilesUserDir(const std::string &addToDir) override;
+  Poco::Path outFilesUserDir(const std::string &addToDir) const override;
+  std::string userHDFRunFilename(const int runNumber) const override;
   Poco::Path outFilesGeneralDir(const std::string &addComponent);
-  Poco::Path outFilesRootDir();
+  Poco::Path outFilesRootDir() const;
 
   std::string appendToPath(const std::string &path,
                            const std::string &toAppend) const;

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -92,7 +92,8 @@ void EnggDiffractionViewQtGUI::initLayout() {
       m_ui.tabMain, sharedView, sharedView, fullPres, fullPres, sharedView);
   m_ui.tabMain->addTab(m_fittingWidget, QString("Fitting"));
 
-  m_gsasWidget = new EnggDiffGSASFittingViewQtWidget(sharedView, sharedView);
+  m_gsasWidget =
+      new EnggDiffGSASFittingViewQtWidget(sharedView, sharedView, fullPres);
   m_ui.tabMain->addTab(m_gsasWidget, QString("GSAS-II Refinement"));
 
   QWidget *wSettings = new QWidget(m_ui.tabMain);

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
@@ -5,6 +5,7 @@
 #include "IEnggDiffGSASFittingObserver.h"
 #include "RunLabel.h"
 
+#include "MantidAPI/IAlgorithm_fwd.h"
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 
@@ -66,6 +67,17 @@ public:
    */
   virtual Mantid::API::MatrixWorkspace_sptr
   loadFocusedRun(const std::string &filename) const = 0;
+
+  /**
+   Save results of refinement (and refinement settings used) to HDF5 file
+   @param successfulAlgorithm The completed refinement algorithm
+   @param refinementResults Results of refinement
+   @param filename Name of the HDF5 file to save to
+  */
+  virtual void saveRefinementResultsToHDF5(
+      const Mantid::API::IAlgorithm_sptr successfulAlgorithm,
+      const GSASIIRefineFitPeaksOutputProperties &refinementResults,
+      const std::string &filename) const = 0;
 
   /// set the observer for refinement
   virtual void

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingObserver.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingObserver.h
@@ -3,6 +3,8 @@
 
 #include "GSASIIRefineFitPeaksOutputProperties.h"
 
+#include "MantidAPI/IAlgorithm_fwd.h"
+
 namespace MantidQt {
 namespace CustomInterfaces {
 
@@ -16,6 +18,7 @@ public:
 
   /// Notify the observer that a single refinement has terminated successfully
   virtual void notifyRefinementSuccessful(
+      const Mantid::API::IAlgorithm_sptr alg,
       const GSASIIRefineFitPeaksOutputProperties &refinementResults) = 0;
 
   /// Notify the observer that a refinement has failed

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingPresenter.h
@@ -34,8 +34,9 @@ public:
 
   void notifyRefinementsComplete() override = 0;
 
-  void notifyRefinementSuccessful(const GSASIIRefineFitPeaksOutputProperties &
-                                      refinementResults) override = 0;
+  void notifyRefinementSuccessful(const Mantid::API::IAlgorithm_sptr alg,
+                                  const GSASIIRefineFitPeaksOutputProperties
+                                      &refinementResults) override = 0;
 
   void notifyRefinementFailed(const std::string &failureMessage) override = 0;
 

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffractionParam.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffractionParam.h
@@ -40,7 +40,10 @@ class IEnggDiffractionParam {
 public:
   virtual ~IEnggDiffractionParam() = default;
 
-  virtual Poco::Path outFilesUserDir(const std::string &addToDir) = 0;
+  virtual Poco::Path outFilesUserDir(const std::string &addToDir) const = 0;
+
+  /// Get the name of a HDF file for a given run number to save to
+  virtual std::string userHDFRunFilename(const int runNumber) const = 0;
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
@@ -33,6 +33,12 @@ public:
   MOCK_CONST_METHOD1(loadFocusedRun, Mantid::API::MatrixWorkspace_sptr(
                                          const std::string &filename));
 
+  MOCK_CONST_METHOD3(
+      saveRefinementResultsToHDF5,
+      void(Mantid::API::IAlgorithm_sptr successfulAlgorithm,
+           const GSASIIRefineFitPeaksOutputProperties &refinementResults,
+           const std::string &filename));
+
   MOCK_METHOD1(setObserver,
                void(boost::shared_ptr<IEnggDiffGSASFittingObserver> observer));
 };

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelTest.h
@@ -3,6 +3,7 @@
 
 #include "../EnggDiffraction/EnggDiffGSASFittingModel.h"
 
+#include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/TableRow.h"
@@ -98,8 +99,9 @@ void TestEnggDiffGSASFittingModel::doRefinements(
       WorkspaceCreationHelper::create2DWorkspaceBinned(4, 4, 0.5);
   ADS.add("FITTEDPEAKS", ws);
 
-  processRefinementSuccessful(GSASIIRefineFitPeaksOutputProperties(
-      1, 2, 3, ws, latticeParams, params[0].runLabel));
+  processRefinementSuccessful(
+      nullptr, GSASIIRefineFitPeaksOutputProperties(1, 2, 3, ws, latticeParams,
+                                                    params[0].runLabel));
 }
 
 } // Anonymous namespace

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
@@ -5,6 +5,7 @@
 #include "EnggDiffGSASFittingModelMock.h"
 #include "EnggDiffGSASFittingViewMock.h"
 #include "EnggDiffMultiRunFittingWidgetPresenterMock.h"
+#include "EnggDiffractionParamMock.h"
 
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidKernel/make_unique.h"
@@ -54,7 +55,8 @@ public:
         .WillOnce(Throw(std::runtime_error("Failure reason")));
 
     EXPECT_CALL(*m_mockViewPtr,
-                userWarning("Could not load file", "Failure reason")).Times(1);
+                userWarning("Could not load file", "Failure reason"))
+        .Times(1);
 
     presenter->notify(IEnggDiffGSASFittingPresenter::LoadRun);
     assertMocksUsedCorrectly();
@@ -197,9 +199,23 @@ public:
     const RunLabel runLabel(123, 1);
     const GSASIIRefineFitPeaksOutputProperties refinementResults(
         1, 2, 3, fittedPeaks, latticeParams, runLabel);
+    const Mantid::API::IAlgorithm_sptr alg(nullptr);
+
+    const Poco::Path saveDirectory("directory/path");
+    ON_CALL(*m_mockParamPtr, outFilesUserDir(testing::_))
+        .WillByDefault(Return(saveDirectory));
 
     EXPECT_CALL(*m_mockMultiRunWidgetPtr,
                 addFittedPeaks(runLabel, fittedPeaks));
+    EXPECT_CALL(*m_mockViewPtr, showStatus("Saving refinement results"));
+
+    Poco::Path saveFilename(saveDirectory);
+    saveFilename.append(std::to_string(runLabel.runNumber) + ".hdf5");
+    EXPECT_CALL(*m_mockModelPtr,
+                saveRefinementResultsToHDF5(alg, refinementResults,
+                                            saveFilename.toString()));
+    EXPECT_CALL(*m_mockViewPtr, setEnabled(true));
+    EXPECT_CALL(*m_mockViewPtr, showStatus("Ready"));
 
     // make sure displayFitResults(runLabel) is getting called
     EXPECT_CALL(*m_mockModelPtr, getLatticeParams(runLabel))
@@ -209,7 +225,7 @@ public:
     ON_CALL(*m_mockModelPtr, getSigma(runLabel)).WillByDefault(Return(1));
     ON_CALL(*m_mockModelPtr, getGamma(runLabel)).WillByDefault(Return(1));
 
-    presenter->notifyRefinementSuccessful(refinementResults);
+    presenter->notifyRefinementSuccessful(alg, refinementResults);
     assertMocksUsedCorrectly();
   }
 
@@ -304,6 +320,7 @@ private:
   MockEnggDiffGSASFittingModel *m_mockModelPtr;
   MockEnggDiffGSASFittingView *m_mockViewPtr;
   MockEnggDiffMultiRunFittingWidgetPresenter *m_mockMultiRunWidgetPtr;
+  MockEnggDiffractionParam *m_mockParamPtr;
 
   std::unique_ptr<EnggDiffGSASFittingPresenter> setUpPresenter() {
     auto mockModel = Mantid::Kernel::make_unique<
@@ -316,8 +333,13 @@ private:
         testing::NiceMock<MockEnggDiffMultiRunFittingWidgetPresenter>>();
     m_mockMultiRunWidgetPtr = mockMultiRunWidgetPresenter_sptr.get();
 
+    auto mockParam_sptr =
+        boost::make_shared<testing::NiceMock<MockEnggDiffractionParam>>();
+    m_mockParamPtr = mockParam_sptr.get();
+
     auto pres_uptr = Mantid::Kernel::make_unique<EnggDiffGSASFittingPresenter>(
-        std::move(mockModel), m_mockViewPtr, mockMultiRunWidgetPresenter_sptr);
+        std::move(mockModel), m_mockViewPtr, mockMultiRunWidgetPresenter_sptr,
+        mockParam_sptr);
     return pres_uptr;
   }
 

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
@@ -201,19 +201,16 @@ public:
         1, 2, 3, fittedPeaks, latticeParams, runLabel);
     const Mantid::API::IAlgorithm_sptr alg(nullptr);
 
-    const Poco::Path saveDirectory("directory/path");
-    ON_CALL(*m_mockParamPtr, outFilesUserDir(testing::_))
-        .WillByDefault(Return(saveDirectory));
+    const std::string hdfFilename = "directory/path/run.hdf5";
+    ON_CALL(*m_mockParamPtr, userHDFRunFilename(testing::_))
+        .WillByDefault(Return(hdfFilename));
 
     EXPECT_CALL(*m_mockMultiRunWidgetPtr,
                 addFittedPeaks(runLabel, fittedPeaks));
     EXPECT_CALL(*m_mockViewPtr, showStatus("Saving refinement results"));
 
-    Poco::Path saveFilename(saveDirectory);
-    saveFilename.append(std::to_string(runLabel.runNumber) + ".hdf5");
-    EXPECT_CALL(*m_mockModelPtr,
-                saveRefinementResultsToHDF5(alg, refinementResults,
-                                            saveFilename.toString()));
+    EXPECT_CALL(*m_mockModelPtr, saveRefinementResultsToHDF5(
+                                     alg, refinementResults, hdfFilename));
     EXPECT_CALL(*m_mockViewPtr, setEnabled(true));
     EXPECT_CALL(*m_mockViewPtr, showStatus("Ready"));
 

--- a/qt/scientific_interfaces/test/EnggDiffractionParamMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffractionParamMock.h
@@ -12,7 +12,9 @@ using namespace MantidQt::CustomInterfaces;
 
 class MockEnggDiffractionParam : public IEnggDiffractionParam {
 public:
-  MOCK_METHOD1(outFilesUserDir, Poco::Path(const std::string &addToDir));
+  MOCK_CONST_METHOD1(outFilesUserDir, Poco::Path(const std::string &addToDir));
+
+  MOCK_CONST_METHOD1(userHDFRunFilename, std::string(const int runNumber));
 };
 
 GCC_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/EnggDiffractionParamMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffractionParamMock.h
@@ -1,0 +1,20 @@
+#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONPARAMMOCK_H_
+#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONPARAMMOCK_H_
+
+#include "../EnggDiffraction/IEnggDiffractionParam.h"
+#include "MantidKernel/WarningSuppressions.h"
+
+#include <gmock/gmock.h>
+
+GCC_DIAG_OFF_SUGGEST_OVERRIDE
+
+using namespace MantidQt::CustomInterfaces;
+
+class MockEnggDiffractionParam : public IEnggDiffractionParam {
+public:
+  MOCK_METHOD1(outFilesUserDir, Poco::Path(const std::string &addToDir));
+};
+
+GCC_DIAG_ON_SUGGEST_OVERRIDE
+
+#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONPARAMMOCK_H_


### PR DESCRIPTION
**Note: cannot be merged before #22350**

A new algorithm, `EnggSaveGSASIIFitResultsToHDF5` (along with all the trimmings) was implemented, and integrated in the *GSAS-II Refinement** tab of the ED GUI. Now the lattice parameters, profile coefficients, fit settings used and Rwp index are saved to an HD5 file after running a refinement from the GUI.

**To test:**

Code review, make sure unit tests and documentation pass locally.

Some sample data is [here](https://github.com/mantidproject/mantid/files/1894002/GSASIIRefineFitPeaks.zip). You'll also need GSASII installed - go [here](http://docs.mantidproject.org/nightly/algorithms/GSASIIRefineFitPeaks-v1.html#installing-gsasii) for how to install GSASII.

Select the two Nexus files for **Focused Run Files** and click **Load**. Select the `.prm` file for **Instrument Parameter File**, the three `.cif`s for **Phase Files**, the location of `GSASIIscriptable.py` (part of GSASII) for **GSAS-II Installation Directory**, and choose somewhere to save out the GSAS-II project files for **New GSAS-II Project**. Fiddle with any other parameters and click **Refine All**.

Go to your output directory (on Windows `C:\EnginX_Mantid\User\<rb_number>\Runs`, on Linux `~/EnginX_Mantid/User/<rb_number>/Runs`. There should be two new `.hdf5` files, one for 280625 and one for 280626. Open them up and make sure things looks sensible - there should be a **GSAS-II Refinement** subgroup of **Bank 1** in both files. You should see datasets for **Lattice Parameters**, **Refinement Parameters** and **Rwp**.

**Refinement Parameters:**

Make sure these are the same as the ones you entered into the GUI. **XMin** and **XMax** may be different - they should be the limits of the fitted data. Make sure that the two Pawley parameters were saved, if you selected **Pawley refinement**

**Profile coefficients**

If you selected to refine either Sigma or Gamma (or both), you should see whichever profile coefficients you refined in the dataset **Profile Coefficients**

Partially address #21446 

**Release Notes** 

[Here](https://github.com/mantidproject/mantid/commit/afaa018155beed151110419ea0edee0a4f8ac9ac#diff-b2bd2540c595f643521322a749fbd5dc)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
