### PR TITLE
Fix a discrepancy between INTER IDF versions

### DIFF
--- a/instrument/INTER_Definition_2017.xml
+++ b/instrument/INTER_Definition_2017.xml
@@ -113,8 +113,8 @@
 
     <location z="2.663" />  <!-- x= 23.0+2.6 -->
     <parameter name="y">
-      <logfile id="PD1H" eq="(value+201.0)/1000." extract-single-value-as="last_value"/>
-      <!--<logfile id="theta" eq="2.6*sin(value*0.0174533)" extract-single-value-as="last_value"/>-->
+      <!-- <logfile id="PD1H" eq="(value+201.0)/1000." extract-single-value-as="last_value"/> -->
+      <logfile id="theta" eq="2.663*sin(2*value*0.0174533)" extract-single-value-as="last_value"/>
     </parameter>
 
   </component>


### PR DESCRIPTION
- INTER_Definition.xml contains the correct equation for the y position for the point-detector following a recent request from scientists to use the Theta log value
- INTER_Definition_2017.xml was not updated with the above fix and is still using an old equation based on the PD1H log value

This PR updates the latter to match the former.

**To test:**
- Edit the paths in this script to your own repository and .mantid directory (or AppData on Windows) and then run it.
```
import math
LoadISISNexus(Filename='INTER13460', OutputWorkspace='INTER13460')
LoadISISNexus(Filename='INTER44319', OutputWorkspace='INTER44319')

def printResults(idf_file):
    print idf_file
    LoadInstrument(Workspace='INTER13460',Filename=idf_file,RewriteSpectraMap=1)
    LoadInstrument(Workspace='INTER44319',Filename=idf_file,RewriteSpectraMap=1)
    oldRun=mtd['INTER13460']
    newRun=mtd['INTER44319']
    spectrum=3
    print "  INTER13460 twoTheta =",oldRun.detectorTwoTheta(oldRun.getDetector(spectrum)) * 180 / math.pi
    print "  INTER44319 twoTheta =",newRun.detectorTwoTheta(newRun.getDetector(spectrum)) * 180 / math.pi

print "LIVE IDFs"
printResults('~/.mantid/instrument/INTER_Definition.xml')
printResults('~/.mantid/instrument/INTER_Definition_2017.xml')

print
print "FIXED LOCAL IDFs"
printResults('~/work/checkout/mantid/instrument/INTER_Definition.xml')
printResults('~/work/checkout/mantid/instrument/INTER_Definition_2017.xml')
```

- The twoTheta position should be independent of which IDF is used. This is not the case for the current live IDFs but should be fixed by this PR. The expected output is therefore:
```
LIVE IDFs
~/.mantid/instrument/INTER_Definition.xml
  INTER13460 twoTheta = 1.39962281563
  INTER44319 twoTheta = 1.39955088004
~/.mantid/instrument/INTER_Definition_2017.xml
  INTER13460 twoTheta = 1.41938839507
  INTER44319 twoTheta = 1.41940989737

FIXED LOCAL IDFs
~/work/checkout/mantid/instrument/INTER_Definition.xml
  INTER13460 twoTheta = 1.39962281563
  INTER44319 twoTheta = 1.39955088004
~/work/checkout/mantid/instrument/INTER_Definition_2017.xml
  INTER13460 twoTheta = 1.39962281563
  INTER44319 twoTheta = 1.39955088004
```

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
