### PR TITLE
Fix segfault when seeAlso overridden in Python

### DIFF
--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/PySequenceToVector.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/PySequenceToVector.h
@@ -70,7 +70,7 @@ template <typename DestElementType> struct DLLExport PySequenceToVector {
   // Alias definitions
   using TypedVector = std::vector<DestElementType>;
 
-  PySequenceToVector(const boost::python::object &value) : m_obj(value.ptr()) {}
+  PySequenceToVector(const boost::python::object &value) : m_obj(value) {}
 
   /**
    * Converts the Python object to a C++ vector
@@ -78,7 +78,7 @@ template <typename DestElementType> struct DLLExport PySequenceToVector {
    * from the Python sequence
    */
   inline const TypedVector operator()() {
-    TypedVector cvector(PySequence_Size(m_obj));
+    TypedVector cvector(srcSize());
     copyTo(cvector);
     return cvector;
   }
@@ -90,24 +90,29 @@ template <typename DestElementType> struct DLLExport PySequenceToVector {
   inline void copyTo(TypedVector &dest) {
     throwIfSizeMismatched(dest);
     ExtractCType<DestElementType> elementConverter;
-    auto length = static_cast<size_t>(PySequence_Size(m_obj));
+    auto length = srcSize();
     for (size_t i = 0; i < length; ++i) {
-      dest[i] = elementConverter(PySequence_GetItem(m_obj, i));
+      dest[i] = elementConverter(PySequence_GetItem(ptr(), i));
     }
   }
 
 private:
+  inline PyObject *ptr() const { return m_obj.ptr(); }
+
+  inline std::size_t srcSize() const {
+    return static_cast<size_t>(PySequence_Size(ptr()));
+  }
+
   inline void throwIfSizeMismatched(const TypedVector &dest) const {
-    auto length = static_cast<size_t>(PySequence_Size(m_obj));
-    if (length != dest.size()) {
+    if (srcSize() != dest.size()) {
       throw std::invalid_argument(
           "Length mismatch between python list & C array. python=" +
-          std::to_string(length) + ", C=" + std::to_string(dest.size()));
+          std::to_string(srcSize()) + ", C=" + std::to_string(dest.size()));
     }
   }
 
   /// Python object to convert
-  PyObject *m_obj;
+  boost::python::object m_obj;
 };
 }
 }

--- a/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
@@ -101,8 +101,11 @@ template <typename BaseAlgorithm>
 const std::vector<std::string>
 AlgorithmAdapter<BaseAlgorithm>::seeAlso() const {
   try {
-    auto seeAlsoPyList = callMethod<object>(getSelf(), "seeAlso");
-    return Converters::PySequenceToVector<std::string>(seeAlsoPyList)();
+    // The GIL is required so that the the reference count of the
+    // list object can be decremented safely
+    Environment::GlobalInterpreterLock gil;
+    return Converters::PySequenceToVector<std::string>(
+        callMethod<list>(getSelf(), "seeAlso"))();
   } catch (UndefinedAttributeError &) {
     return {};
   }


### PR DESCRIPTION
**Description of work**

Ensures the GIL is acquired for the full duration of  operations that affect python objects when calling `Algorithm::seeAlso`.

Also some minor clean up to ensure `PySeqenceToVector` increments the reference count of the object it holds. This was not required to fix the issue but makes `PySeqenceToVector` work with return values from other functions.

**To test:**

Follow the instructions in the original issue and MantidPlot should no longer crash.

Fixes #22344

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
