### PR TITLE
Fix pessimizing-move warnings from Apple Clang 9

### DIFF
--- a/Framework/Algorithms/test/ReflectometryReductionOne2Test.h
+++ b/Framework/Algorithms/test/ReflectometryReductionOne2Test.h
@@ -587,7 +587,7 @@ public:
 
     ReflectometryReductionOne2 alg;
 
-    auto inputWS = MatrixWorkspace_sptr(std::move(m_multiDetectorWS->clone()));
+    auto inputWS = MatrixWorkspace_sptr(m_multiDetectorWS->clone());
     setYValuesToWorkspace(*inputWS);
 
     alg.setChild(true);
@@ -631,7 +631,7 @@ public:
 
     ReflectometryReductionOne2 alg;
 
-    auto inputWS = MatrixWorkspace_sptr(std::move(m_multiDetectorWS->clone()));
+    auto inputWS = MatrixWorkspace_sptr(m_multiDetectorWS->clone());
     setYValuesToWorkspace(*inputWS);
 
     alg.setChild(true);


### PR DESCRIPTION
**Description of work**

Fixes a few new warnings from Apple Clang 9.

**To test:**

Code review

*No issue number*

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
