### PR TITLE
ISIS Powder prevent infinite recursion when deep-copying instrument settings object

### DIFF
--- a/scripts/Diffraction/isis_powder/routines/instrument_settings.py
+++ b/scripts/Diffraction/isis_powder/routines/instrument_settings.py
@@ -42,6 +42,9 @@ class InstrumentSettings(object):
     # __getattr__ is only called if the attribute was not set so we already know
     #  were going to throw at this point unless the attribute was optional.
     def __getattr__(self, item):
+        if item == "__setstate__":
+            raise AttributeError(item)
+
         # Check if it is in our parameter mapping
         known_param = next((param_entry for param_entry in self._param_map if item == param_entry.int_name), None)
 


### PR DESCRIPTION
When running Python3 system tests for Pearl, deep-copying the instrument settings object went into an infinite recursion. This change fixes this.

**To test:**

On a Python 3 build, run the Pearl system tests (`./systemtest -R ISIS_PowderPearl`), and make sure they all pass

Fixes #22381 

**Release Notes** 

Internal change, doesn't need to be in the release notes

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
