### PR TITLE
Prevent crash - missing error handling in `RunCombinationHelper`

### DIFF
--- a/Framework/Algorithms/src/ConjoinXRuns.cpp
+++ b/Framework/Algorithms/src/ConjoinXRuns.cpp
@@ -113,8 +113,15 @@ std::map<std::string, std::string> ConjoinXRuns::validateInputs() {
       getProperty(INPUT_WORKSPACE_PROPERTY);
   m_logEntry = getPropertyValue(SAMPLE_LOG_X_AXIS_PROPERTY);
 
+  std::vector<std::string> workspaces;
+  try {
+    workspaces = RunCombinationHelper::unWrapGroups(inputs_given);
+  } catch (const std::exception &e) {
+    issues[INPUT_WORKSPACE_PROPERTY] = std::string(e.what());
+  }
+
   // find if there are workspaces that are not Matrix or not a point-data
-  for (const auto &input : RunCombinationHelper::unWrapGroups(inputs_given)) {
+  for (const auto &input : workspaces) {
     MatrixWorkspace_sptr ws =
         AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(input);
     if (ws->isHistogramData()) {

--- a/Framework/Algorithms/src/ConjoinXRuns.cpp
+++ b/Framework/Algorithms/src/ConjoinXRuns.cpp
@@ -117,10 +117,7 @@ std::map<std::string, std::string> ConjoinXRuns::validateInputs() {
   for (const auto &input : RunCombinationHelper::unWrapGroups(inputs_given)) {
     MatrixWorkspace_sptr ws =
         AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(input);
-    if (!ws) {
-      issues[INPUT_WORKSPACE_PROPERTY] +=
-          "Workspace " + ws->getName() + " is not a MatrixWorkspace\n";
-    } else if (ws->isHistogramData()) {
+    if (ws->isHistogramData()) {
       issues[INPUT_WORKSPACE_PROPERTY] +=
           "Workspace " + ws->getName() + " is not a point-data\n";
     } else {

--- a/Framework/Algorithms/src/RunCombinationHelpers/RunCombinationHelper.cpp
+++ b/Framework/Algorithms/src/RunCombinationHelpers/RunCombinationHelper.cpp
@@ -21,6 +21,7 @@ using namespace Kernel;
 * @param inputs : input workspaces vector [including] group workspaces (all must
 * be on ADS)
 * @return : the flat vector of the input workspaces
+* @throw : std::runtime_error if the input workspaces are neither groups nor MatrixWorkspaces
 */
 std::vector<std::string>
 RunCombinationHelper::unWrapGroups(const std::vector<std::string> &inputs) {

--- a/Framework/Algorithms/src/RunCombinationHelpers/RunCombinationHelper.cpp
+++ b/Framework/Algorithms/src/RunCombinationHelpers/RunCombinationHelper.cpp
@@ -33,8 +33,14 @@ RunCombinationHelper::unWrapGroups(const std::vector<std::string> &inputs) {
       std::vector<std::string> group = wsgroup->getNames();
       outputs.insert(outputs.end(), group.begin(), group.end());
     } else {
-      // single workspace
-      outputs.push_back(input);
+      // MatrixWorkspace
+      MatrixWorkspace_sptr matrixws =
+          AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(input);
+      if (matrixws)
+        outputs.push_back(matrixws->getName());
+      else
+        throw(std::runtime_error(
+            "The input is neither a WorkspaceGroup nor a MatrixWorkspace"));
     }
   }
   return outputs;

--- a/Framework/Algorithms/src/RunCombinationHelpers/RunCombinationHelper.cpp
+++ b/Framework/Algorithms/src/RunCombinationHelpers/RunCombinationHelper.cpp
@@ -40,7 +40,8 @@ RunCombinationHelper::unWrapGroups(const std::vector<std::string> &inputs) {
         outputs.push_back(matrixws->getName());
       else
         throw(std::runtime_error(
-            "The input is neither a WorkspaceGroup nor a MatrixWorkspace"));
+            "The input " + input +
+            " is neither a WorkspaceGroup nor a MatrixWorkspace"));
     }
   }
   return outputs;

--- a/Framework/Algorithms/src/RunCombinationHelpers/RunCombinationHelper.cpp
+++ b/Framework/Algorithms/src/RunCombinationHelpers/RunCombinationHelper.cpp
@@ -21,7 +21,8 @@ using namespace Kernel;
 * @param inputs : input workspaces vector [including] group workspaces (all must
 * be on ADS)
 * @return : the flat vector of the input workspaces
-* @throw : std::runtime_error if the input workspaces are neither groups nor MatrixWorkspaces
+* @throw : std::runtime_error if the input workspaces are neither groups nor
+* MatrixWorkspaces
 */
 std::vector<std::string>
 RunCombinationHelper::unWrapGroups(const std::vector<std::string> &inputs) {

--- a/Framework/Algorithms/test/ConjoinXRunsTest.h
+++ b/Framework/Algorithms/test/ConjoinXRunsTest.h
@@ -4,6 +4,7 @@
 #include <cxxtest/TestSuite.h>
 
 #include "MantidAPI/Axis.h"
+#include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAlgorithms/AddSampleLog.h"

--- a/Framework/Algorithms/test/ConjoinXRunsTest.h
+++ b/Framework/Algorithms/test/ConjoinXRunsTest.h
@@ -5,9 +5,11 @@
 
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAlgorithms/AddSampleLog.h"
 #include "MantidAlgorithms/AddTimeSeriesLog.h"
 #include "MantidAlgorithms/ConjoinXRuns.h"
+#include "MantidAlgorithms/GroupWorkspaces.h"
 #include "MantidHistogramData/Counts.h"
 #include "MantidHistogramData/HistogramDx.h"
 #include "MantidHistogramData/HistogramE.h"
@@ -20,6 +22,7 @@
 using Mantid::Algorithms::ConjoinXRuns;
 using Mantid::Algorithms::AddSampleLog;
 using Mantid::Algorithms::AddTimeSeriesLog;
+using Mantid::Algorithms::GroupWorkspaces;
 using Mantid::HistogramData::Counts;
 using Mantid::HistogramData::HistogramDx;
 using Mantid::HistogramData::HistogramE;
@@ -94,6 +97,23 @@ public:
     TS_ASSERT_EQUALS(out->y(0).rawData(), y);
     TS_ASSERT_EQUALS(out->e(0).rawData(), e);
     TSM_ASSERT_EQUALS("Dx and y values are the same", out->dx(0).rawData(), y);
+  }
+
+  void testTableInputWorkspaceInGroup() {
+    auto table = WorkspaceFactory::Instance().createTable("TableWorkspace");
+    storeWS("table", table);
+
+    GroupWorkspaces group;
+    group.initialize();
+    group.setProperty("InputWorkspaces",
+                      std::vector<std::string>{"table", "ws1"});
+    group.setProperty("OutputWorkspace", "group");
+    group.execute();
+    m_testee.setProperty("InputWorkspaces", "group");
+    m_testee.setProperty("OutputWorkspace", "out");
+    TS_ASSERT_THROWS_EQUALS(m_testee.execute(), const std::runtime_error &e,
+                            std::string(e.what()),
+                            "Some invalid Properties found");
   }
 
   void testWSWithoutDxValues() {

--- a/Framework/Algorithms/test/RunCombinationHelperTest.h
+++ b/Framework/Algorithms/test/RunCombinationHelperTest.h
@@ -40,6 +40,20 @@ public:
     m_testee.setReferenceProperties(m_reference);
   }
 
+  void testUnwraping_throws() {
+
+    MatrixWorkspace_sptr ws1 = create2DWorkspace(2, 3);
+    storeWS("ws1", ws1);
+
+    TS_ASSERT_THROWS_EQUALS(
+        m_testee.unWrapGroups(std::vector<std::string>{"ws1", "ws?"}),
+        const std::exception &e, std::string(e.what()),
+        "Unable to find workspace type with name 'ws?': data service  search "
+        "object ws?");
+
+    removeWS("ws1");
+  }
+
   void testUnwraping() {
 
     MatrixWorkspace_sptr ws1 = create2DWorkspace(2, 3);

--- a/Framework/Algorithms/test/RunCombinationHelperTest.h
+++ b/Framework/Algorithms/test/RunCombinationHelperTest.h
@@ -27,7 +27,6 @@ using namespace Mantid::HistogramData;
 using namespace Mantid::Kernel;
 using namespace WorkspaceCreationHelper;
 
-
 class RunCombinationHelperTest : public CxxTest::TestSuite {
 public:
   // This pair of boilerplate methods prevent the suite being created statically

--- a/Framework/Algorithms/test/RunCombinationHelperTest.h
+++ b/Framework/Algorithms/test/RunCombinationHelperTest.h
@@ -47,7 +47,7 @@ public:
 
     TS_ASSERT_THROWS_EQUALS(
         m_testee.unWrapGroups(std::vector<std::string>{"ws1", "ws?"}),
-        const std::exception &e, std::string(e.what()),
+        const std::runtime_error &e, std::string(e.what()),
         "Unable to find workspace type with name 'ws?': data service  search "
         "object ws?");
 

--- a/Framework/Algorithms/test/RunCombinationHelperTest.h
+++ b/Framework/Algorithms/test/RunCombinationHelperTest.h
@@ -7,7 +7,9 @@
 #include "MantidAPI/FrameworkManager.h"
 
 #include "MantidAPI/Axis.h"
+#include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidHistogramData/HistogramDx.h"
 #include "MantidAlgorithms/CreateSampleWorkspace.h"
@@ -20,9 +22,11 @@ using Mantid::Algorithms::RunCombinationHelper;
 using Mantid::Algorithms::GroupWorkspaces;
 using Mantid::Algorithms::CreateSampleWorkspace;
 using namespace Mantid::API;
+using namespace Mantid::DataObjects;
 using namespace Mantid::HistogramData;
 using namespace Mantid::Kernel;
 using namespace WorkspaceCreationHelper;
+
 
 class RunCombinationHelperTest : public CxxTest::TestSuite {
 public:
@@ -42,14 +46,15 @@ public:
 
   void testUnwraping_throws() {
 
-    MatrixWorkspace_sptr ws1 = create2DWorkspace(2, 3);
+    auto ws1 = create2DWorkspace(2, 3);
     storeWS("ws1", ws1);
+    auto table = WorkspaceFactory::Instance().createTable("TableWorkspace");
+    storeWS("table", table);
 
     TS_ASSERT_THROWS_EQUALS(
-        m_testee.unWrapGroups(std::vector<std::string>{"ws1", "ws?"}),
+        m_testee.unWrapGroups(std::vector<std::string>{"ws1", "table"}),
         const std::runtime_error &e, std::string(e.what()),
-        "Unable to find workspace type with name 'ws?': data service  search "
-        "object ws?");
+        "The input table is neither a WorkspaceGroup nor a MatrixWorkspace");
 
     removeWS("ws1");
   }

--- a/Framework/SINQ/test/PoldiIndexKnownCompoundsTest.h
+++ b/Framework/SINQ/test/PoldiIndexKnownCompoundsTest.h
@@ -670,8 +670,8 @@ private:
 
   void storeRandomWorkspaces(const std::vector<std::string> &wsNames) {
     for (const auto &wsName : wsNames) {
-      auto ws = WorkspaceCreationHelper::create1DWorkspaceRand(10, true)
-          WorkspaceCreationHelper::storeWS(wsName, ws);
+      auto ws = WorkspaceCreationHelper::create1DWorkspaceRand(10, true);
+      WorkspaceCreationHelper::storeWS(wsName, ws);
     }
   }
 

--- a/Framework/SINQ/test/PoldiIndexKnownCompoundsTest.h
+++ b/Framework/SINQ/test/PoldiIndexKnownCompoundsTest.h
@@ -37,13 +37,13 @@ public:
     /* In this test, peaks from PoldiMockInstrumentHelpers (Silicon)
      * are indexed using theoretical Si-peaks.
      */
-    WorkspaceCreationHelper::storeWS(
-        "measured_SI",
-        PoldiPeakCollectionHelpers::createPoldiPeakTableWorkspace());
-    WorkspaceCreationHelper::storeWS(
-        "Si",
+    auto wsMeasuredSi =
+        PoldiPeakCollectionHelpers::createPoldiPeakTableWorkspace();
+    WorkspaceCreationHelper::storeWS("measured_SI", wsMeasuredSi);
+    auto wsSi =
         PoldiPeakCollectionHelpers::createTheoreticalPeakCollectionSilicon()
-            ->asTableWorkspace());
+            ->asTableWorkspace();
+    WorkspaceCreationHelper::storeWS("Si", wsSi);
 
     std::string outWSName("PoldiIndexKnownCompoundsTest_OutputWS");
 
@@ -670,8 +670,8 @@ private:
 
   void storeRandomWorkspaces(const std::vector<std::string> &wsNames) {
     for (const auto &wsName : wsNames) {
-      WorkspaceCreationHelper::storeWS(
-          wsName, WorkspaceCreationHelper::create1DWorkspaceRand(10, true));
+      auto ws = WorkspaceCreationHelper::create1DWorkspaceRand(10, true)
+          WorkspaceCreationHelper::storeWS(wsName, ws);
     }
   }
 

--- a/Framework/TestHelpers/inc/MantidTestHelpers/WorkspaceCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/WorkspaceCreationHelper.h
@@ -106,8 +106,14 @@ struct EPPTableRow {
   FitStatus fitStatus = FitStatus::SUCCESS;
 };
 
-/// Adds a workspace to the ADS
-void storeWS(const std::string &name, Mantid::API::Workspace_sptr ws);
+/**
+ * Adds a workspace to the ADS
+ * @param name :: The name of the workspace
+ * @param ws :: The workspace object
+ */
+template <typename WSType> void storeWS(const std::string &name, WSType &ws) {
+  Mantid::API::AnalysisDataService::Instance().add(name, ws);
+}
 /// Deletes a workspace
 void removeWS(const std::string &name);
 /// Returns a workspace of a given type

--- a/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+++ b/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
@@ -73,14 +73,6 @@ EPPTableRow::EPPTableRow(const int index, const double peakCentre_,
       height(height_), fitStatus(fitStatus_) {}
 
 /**
- * @param name :: The name of the workspace
- * @param ws :: The workspace object
- */
-void storeWS(const std::string &name, Mantid::API::Workspace_sptr ws) {
-  Mantid::API::AnalysisDataService::Instance().add(name, ws);
-}
-
-/**
  * Deletes a workspace
  * @param name :: The name of the workspace
  */


### PR DESCRIPTION
`RunCombinationHelper` did not check, if the input workspaces represent either a GroupWorkspace or alternatively a MatrixWorkspace. This affects today the algorithms `ConjoinXRuns`, `MergeRuns`, and `SumOverlappingTubes`.

Now, it throws a std::runtime_error that need to be catched during input validation in `ConjoinXRuns` (otherwise the GUI freezes). It may be ok for `MergeRuns` and `SumOverlappingTubes` to just throw an error.

If the input workspace is not a group, I added the check if it is a MatrixWorkspace instead. It may be enough to add the workspace name to the std::vector as implemented before.
In `ConjoinXRuns`, I think it is not good to get the name of a workspace if the corresponding pointer does not exist.

**To test:**

```Python
CreateSampleWorkspace(OutputWorkspace='ws')
CreateEmptyTableWorkspace(OutputWorkspace='table')
out = ConjoinXRuns(mtd["table"], mtd["ws"])
```

Fixes #22383.


*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
