### PR TITLE
9816 force instrument masking

### DIFF
--- a/docs/source/release/v3.13.0/sans.rst
+++ b/docs/source/release/v3.13.0/sans.rst
@@ -17,6 +17,7 @@ New features
 
 Improvements
 ############
+* Updated old backend to mask by detector ID rather than spectrum number, improving reliability. 
 
 Bug fixes
 #########

--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -573,7 +573,7 @@ def mask_detectors_with_masking_ws(ws_name, masking_ws_name):
 
     masked_det_ids = list(_yield_masked_det_ids(masking_ws))
 
-    MaskDetectors(Workspace=ws, DetectorList=masked_det_ids)
+    MaskDetectors(Workspace=ws, DetectorList=masked_det_ids, ForceInstrumentMasking=True)
 
 
 def check_child_ws_for_name_and_type_for_added_eventdata(wsGroup, number_of_entries=None):
@@ -2180,7 +2180,7 @@ def MaskBySpecNumber(workspace, speclist):
     speclist = speclist.rstrip(',')
     if speclist == '':
         return ''
-    MaskDetectors(Workspace=workspace, SpectraList = speclist)
+    MaskDetectors(Workspace=workspace, SpectraList = speclist, ForceInstrumentMasking=True)
 
 
 @deprecated

--- a/scripts/SANS/isis_reduction_steps.py
+++ b/scripts/SANS/isis_reduction_steps.py
@@ -1053,7 +1053,7 @@ class Mask_ISIS(ReductionStep):
                     raise RuntimeError("Invalid input for mask file. (%s)" % mask_file)
 
         if len(self.spec_list) > 0:
-            MaskDetectors(Workspace=workspace, SpectraList=self.spec_list)
+            MaskDetectors(Workspace=workspace, SpectraList=self.spec_list, ForceInstrumentMasking=True)
 
         if self._lim_phi_xml != '' and self.mask_phi:
             MaskDetectorsInShape(Workspace=workspace, ShapeXML=self._lim_phi_xml)


### PR DESCRIPTION
**Description of work**
Masking by detector ID rather than spectrum number prevents some issue which occur when these misalign. This chance has already been made on the new backend. This implements it on the old backend.

**To test:**

- Code review

- Get some sans data the loqdemo folder in the ISISSample data at downloads.mantidproject.org will do.
- In the old sans GUI load MaskFile.txt as the userfile. 
- In the sample data box type 74044
- Click load.
- Go to the masking tab and click display mask, check that the masks applied are the same both before and after this PR is applied. 

<!-- Instructions for testing. -->

Fixes #9816. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
Added to release notes.
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
