### PR TITLE
Muon Analysis workspace bugs

### DIFF
--- a/docs/source/release/v3.13.0/muon.rst
+++ b/docs/source/release/v3.13.0/muon.rst
@@ -16,6 +16,8 @@ Bug fixes
 
 - Results table can now detect sequential fits.
 - Fit options are not disabled after changing tabs.
+- The run number is now updated before the periods, preventing irrelevant warningsfrom being produced.
+- In single fit the workspace can be changed.
 
 Algorithms
 ----------

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -1975,28 +1975,30 @@ bool MuonAnalysis::plotExists(const QString &wsName) {
  */
 void MuonAnalysis::selectMultiPeak(const QString &wsName,
                                    const boost::optional<QString> &filePath) {
+
   disableAllTools();
   if (!plotExists(wsName)) {
     plotSpectrum(wsName);
     setCurrentDataName(wsName);
   }
+  // go from MUSR data (after a fit) to HIFI 84447 to see errors...
+  // move the below code to be after load??? 
+  	if (wsName != m_fitDataPresenter->getAssignedFirstRun()) {
+	// Set the available groups/pairs and periods
+	const Grouping groups = m_groupingHelper.parseGroupingTable();
+	QStringList groupsAndPairs;
+	groupsAndPairs.reserve(
+	static_cast<int>(groups.groupNames.size() + groups.pairNames.size()));
+	std::transform(groups.groupNames.begin(), groups.groupNames.end(),
+	std::back_inserter(groupsAndPairs), &QString::fromStdString);
+	std::transform(groups.pairNames.begin(), groups.pairNames.end(),
+	std::back_inserter(groupsAndPairs), &QString::fromStdString);
+	setGroupsAndPairs();
 
-  if (wsName != m_fitDataPresenter->getAssignedFirstRun()) {
-    // Set the available groups/pairs and periods
-    const Grouping groups = m_groupingHelper.parseGroupingTable();
-    QStringList groupsAndPairs;
-    groupsAndPairs.reserve(
-        static_cast<int>(groups.groupNames.size() + groups.pairNames.size()));
-    std::transform(groups.groupNames.begin(), groups.groupNames.end(),
-                   std::back_inserter(groupsAndPairs), &QString::fromStdString);
-    std::transform(groups.pairNames.begin(), groups.pairNames.end(),
-                   std::back_inserter(groupsAndPairs), &QString::fromStdString);
-    setGroupsAndPairs();
-
-    // Set the selected run, group/pair and period
-    m_fitDataPresenter->setAssignedFirstRun(wsName, filePath);
-    setChosenGroupAndPeriods(wsName);
-  }
+	// Set the selected run, group/pair and period
+	m_fitDataPresenter->setAssignedFirstRun(wsName, filePath);
+	setChosenGroupAndPeriods(wsName);
+	}
 
   QString code;
 

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -1387,13 +1387,13 @@ void MuonAnalysis::inputFileChanged(const QStringList &files) {
   size_t numPeriods =
       MuonAnalysisHelper::numPeriods(loadResult->loadedWorkspace);
   if (instrumentChanged || numPeriods != m_numPeriods) {
-	  // if some data has been loaded, update the run number
-	  // before updating the periods (stops errors)
-	  if (m_currentDataName != NOT_AVAILABLE) {
-		  const boost::optional<QString> filePath =
-			  m_uiForm.mwRunFiles->getUserInput().toString();
-		  m_fitDataPresenter->setSelectedWorkspace(m_currentDataName, filePath);
-	  }
+    // if some data has been loaded, update the run number
+    // before updating the periods (stops errors)
+    if (m_currentDataName != NOT_AVAILABLE) {
+      const boost::optional<QString> filePath =
+          m_uiForm.mwRunFiles->getUserInput().toString();
+      m_fitDataPresenter->setSelectedWorkspace(m_currentDataName, filePath);
+    }
     updatePeriodWidgets(numPeriods);
   }
 
@@ -1646,7 +1646,6 @@ void MuonAnalysis::updatePeriodWidgets(size_t numPeriods) {
   // cache number of periods
   m_numPeriods = numPeriods;
   m_uiForm.fitBrowser->setNumPeriods(m_numPeriods);
-
 }
 
 /**

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -1116,7 +1116,6 @@ void MuonAnalysis::updatePairTable() {
 void MuonAnalysis::inputFileChanged_MWRunFiles() {
   // Handle changed input, then turn buttons back on.
   handleInputFileChanges();
-  //m_uiForm.fitBrowser->setNumPeriods(m_numPeriods);
   allowLoading(true);
 }
 
@@ -1396,7 +1395,6 @@ void MuonAnalysis::inputFileChanged(const QStringList &files) {
 		  m_fitDataPresenter->setSelectedWorkspace(m_currentDataName, filePath);
 	  }
     updatePeriodWidgets(numPeriods);
-
   }
 
   // Populate bin width info in Plot options
@@ -1882,8 +1880,6 @@ void MuonAnalysis::plotSpectrum(const QString &wsName, bool logScale) {
   // Insert real values
   QString safeWSName(wsName);
   safeWSName.replace("'", "\'");
-  auto fsf = safeWSName.toStdString();
-  auto sadf = m_currentDataName.toStdString();
   pyS.replace("%WSNAME%", safeWSName);
   pyS.replace("%PREV%", m_currentDataName);
   pyS.replace("%USEPREV%", policy == MuonAnalysisOptionTab::PreviousWindow

--- a/qt/scientific_interfaces/Muon/MuonAnalysisFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisFitDataPresenter.cpp
@@ -276,6 +276,7 @@ void MuonAnalysisFitDataPresenter::updateWorkspaceNames(
  */
 std::vector<std::string>
 MuonAnalysisFitDataPresenter::generateWorkspaceNames(bool overwrite) const {
+	//these have not updated
   const auto instrument = m_dataSelector->getInstrumentName().toStdString();
   const auto runs = m_dataSelector->getRuns().toStdString();
   return generateWorkspaceNames(instrument, runs, overwrite);
@@ -848,7 +849,7 @@ bool MuonAnalysisFitDataPresenter::isSimultaneousFit() const {
 void MuonAnalysisFitDataPresenter::setSelectedWorkspace(
     const QString &wsName, const boost::optional<QString> &filePath) {
   updateWorkspaceNames(std::vector<std::string>{wsName.toStdString()});
-  setUpDataSelector(wsName, filePath);
+   setUpDataSelector(wsName, filePath);
 }
 
 /**

--- a/qt/scientific_interfaces/Muon/MuonAnalysisFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisFitDataPresenter.cpp
@@ -276,7 +276,6 @@ void MuonAnalysisFitDataPresenter::updateWorkspaceNames(
  */
 std::vector<std::string>
 MuonAnalysisFitDataPresenter::generateWorkspaceNames(bool overwrite) const {
-	//these have not updated
   const auto instrument = m_dataSelector->getInstrumentName().toStdString();
   const auto runs = m_dataSelector->getRuns().toStdString();
   return generateWorkspaceNames(instrument, runs, overwrite);
@@ -849,7 +848,7 @@ bool MuonAnalysisFitDataPresenter::isSimultaneousFit() const {
 void MuonAnalysisFitDataPresenter::setSelectedWorkspace(
     const QString &wsName, const boost::optional<QString> &filePath) {
   updateWorkspaceNames(std::vector<std::string>{wsName.toStdString()});
-   setUpDataSelector(wsName, filePath);
+  setUpDataSelector(wsName, filePath);
 }
 
 /**

--- a/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
@@ -406,10 +406,11 @@ void MuonFitPropertyBrowser::enumChanged(QtProperty *prop) {
     }
     updatePeriodDisplay();
   } else if (prop == m_workspace) {
-    // make sure the output is updated
-    FitPropertyBrowser::enumChanged(prop);
     int j = m_enumManager->value(m_workspace);
     std::string option = m_workspaceNames[j].toStdString();
+	//update plot
+	emit workspaceNameChanged(QString::fromStdString(option));
+
     setOutputName(option);
     // only do this if in single fit mode
     if (m_periodBoxes.size() > 1 &&
@@ -429,6 +430,30 @@ void MuonFitPropertyBrowser::enumChanged(QtProperty *prop) {
         m_boolManager->setValue(iter.value(), selectedPeriod == iter.key());
       }
     }
+	if (!m_browser->isItemVisible(m_multiFitSettingsGroup)) {
+		size_t end = 0;
+		// assumed structure of name
+		// isolate the group/pair
+		for (int k = 0; k < 2; k++) {
+			end = option.find_first_of(";");
+			option = option.substr(end + 1, option.size());
+		}
+		end = option.find_first_of(";");
+
+		boost::erase_all(option, " ");
+
+		auto tmp = option.substr(0, end-1);
+		QString selectedGroup = QString::fromStdString(tmp);
+		// turn on only the relevant box
+		for (auto iter = m_groupBoxes.constBegin();
+			iter != m_groupBoxes.constEnd(); ++iter) {
+			auto a = selectedGroup.toStdString();
+			auto b = iter.key().toStdString();
+			auto c = selectedGroup == iter.key();
+			m_boolManager->setValue(iter.value(), selectedGroup == iter.key());
+		}
+	}
+
   } else {
     FitPropertyBrowser::enumChanged(prop);
   }

--- a/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
@@ -447,9 +447,6 @@ void MuonFitPropertyBrowser::enumChanged(QtProperty *prop) {
 		// turn on only the relevant box
 		for (auto iter = m_groupBoxes.constBegin();
 			iter != m_groupBoxes.constEnd(); ++iter) {
-			auto a = selectedGroup.toStdString();
-			auto b = iter.key().toStdString();
-			auto c = selectedGroup == iter.key();
 			m_boolManager->setValue(iter.value(), selectedGroup == iter.key());
 		}
 	}

--- a/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
@@ -408,8 +408,8 @@ void MuonFitPropertyBrowser::enumChanged(QtProperty *prop) {
   } else if (prop == m_workspace) {
     int j = m_enumManager->value(m_workspace);
     std::string option = m_workspaceNames[j].toStdString();
-	//update plot
-	emit workspaceNameChanged(QString::fromStdString(option));
+    // update plot
+    emit workspaceNameChanged(QString::fromStdString(option));
 
     setOutputName(option);
     // only do this if in single fit mode
@@ -430,26 +430,26 @@ void MuonFitPropertyBrowser::enumChanged(QtProperty *prop) {
         m_boolManager->setValue(iter.value(), selectedPeriod == iter.key());
       }
     }
-	if (!m_browser->isItemVisible(m_multiFitSettingsGroup)) {
-		size_t end = 0;
-		// assumed structure of name
-		// isolate the group/pair
-		for (int k = 0; k < 2; k++) {
-			end = option.find_first_of(";");
-			option = option.substr(end + 1, option.size());
-		}
-		end = option.find_first_of(";");
+    if (!m_browser->isItemVisible(m_multiFitSettingsGroup)) {
+      size_t end = 0;
+      // assumed structure of name
+      // isolate the group/pair
+      for (int k = 0; k < 2; k++) {
+        end = option.find_first_of(";");
+        option = option.substr(end + 1, option.size());
+      }
+      end = option.find_first_of(";");
 
-		boost::erase_all(option, " ");
+      boost::erase_all(option, " ");
 
-		auto tmp = option.substr(0, end-1);
-		QString selectedGroup = QString::fromStdString(tmp);
-		// turn on only the relevant box
-		for (auto iter = m_groupBoxes.constBegin();
-			iter != m_groupBoxes.constEnd(); ++iter) {
-			m_boolManager->setValue(iter.value(), selectedGroup == iter.key());
-		}
-	}
+      auto tmp = option.substr(0, end - 1);
+      QString selectedGroup = QString::fromStdString(tmp);
+      // turn on only the relevant box
+      for (auto iter = m_groupBoxes.constBegin();
+           iter != m_groupBoxes.constEnd(); ++iter) {
+        m_boolManager->setValue(iter.value(), selectedGroup == iter.key());
+      }
+    }
 
   } else {
     FitPropertyBrowser::enumChanged(prop);


### PR DESCRIPTION
Muon analysis had 2 workspace bugs. The first was that in single fit changing the workspace did not update correctly. The second was that when changing from single to multiple period data Muon Analysis would try to load the old run but with the new periods (and therefore fail and complain). 

**To test:**
Open Muon Analysis.
Load some MUSR data
Change the group/pair option in the home tab a few times
Go to the settings tab and make sure multiple fitting in not selected
Go to data analysis tab
Add a sensible fitting function
Do a fit 
Change the workspace and the plot should update
Do another fit and the output should be for the selected workspace (previously it was always the origianl workspace)

Then go to the Home tab
Load HIFI 84447
It should load without any warnings in the logger (previously it couldn't make some workspaces)
<!-- Instructions for testing. -->

Fixes #22368. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
