### PR TITLE
Updating issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!-- TEMPLATE FOR BUG REPORTS -->
 
-**Original reporter:** [username]/[nobody]. <!--If the issue was raised by a user they should be named here.-->
+**Original reporter:** [username facility]/[nobody]. <!--If the issue was raised by a user they should be named here.-->
 
 ### Expected behavior
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,7 @@
 <!-- TEMPLATE FOR BUG REPORTS -->
 
+[username/email]/[nobody]. <!--If the issue was raised by a user they should be named here.-->
+
 ### Expected behavior
 
 ### Actual behavior

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!-- TEMPLATE FOR BUG REPORTS -->
 
-[username/email]/[nobody]. <!--If the issue was raised by a user they should be named here.-->
+**Original reporter:** [username/email]/[nobody]. <!--If the issue was raised by a user they should be named here.-->
 
 ### Expected behavior
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!-- TEMPLATE FOR BUG REPORTS -->
 
-**Original reporter:** [username/email]/[nobody]. <!--If the issue was raised by a user they should be named here.-->
+**Original reporter:** [username]/[nobody]. <!--If the issue was raised by a user they should be named here.-->
 
 ### Expected behavior
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ Does this update require release notes?
 - [ ] Yes
 - [ ] No
 <!--
-If yes, edit the file docs/source/release/... or state release notes.
+If yes, edit the file docs/source/release/... 
 -->
 
 ---

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ Does this update require release notes?
 - [ ] Yes
 - [ ] No
 <!--
-Either edit the file in docs/source/release/... and it will be in your pull request or state
+If yes, edit the file docs/source/release/... or state release notes.
 -->
 
 ---

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,6 @@
-**Description of work**
+Description of work.
+
+**Report to:** [user name/email]/[nobody]. <!--If the original issue was raised by a user they should be named here.-->
 
 **To test:**
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Description of work.
+**Description of work.**
 
 **Report to:** [user name/email]/[nobody]. <!--If the original issue was raised by a user they should be named here.-->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 **Description of work.**
 
-**Report to:** [user name/email]/[nobody]. <!--If the original issue was raised by a user they should be named here.-->
+**Report to:** [user name]/[nobody]. <!--If the original issue was raised by a user they should be named here.-->
 
 **To test:**
 
@@ -8,10 +8,11 @@
 
 Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
 
-**Release Notes** 
+Does this update require release notes?
+- [ ] Yes
+- [ ] No
 <!--
 Either edit the file in docs/source/release/... and it will be in your pull request or state
-*Does not need to be in the release notes.*
 -->
 
 ---

--- a/dev-docs/source/GitWorkflow.rst
+++ b/dev-docs/source/GitWorkflow.rst
@@ -85,7 +85,7 @@ When creating a pull request you should:
 
   - The title should **not** contain the issue number
 - `Reference the issue which the pull request is closing  <https://github.com/blog/1506-closing-issues-via-pull-requests>`_, using one of `these <https://help.github.com/articles/closing-issues-via-commit-messages>`_ keywords
-- State the user who initiated the original issue, if they are named in the issue
+- State the user who initiated the original issue, if they are named in the issue. Please do not put full email addresses on the Pull Request, as it is publicly accessible.
 - Ensure the description follows the format described by the `PR
   template
   <https://github.com/mantidproject/mantid/blob/master/.github/PULL_REQUEST_TEMPLATE.md>`_

--- a/dev-docs/source/GitWorkflow.rst
+++ b/dev-docs/source/GitWorkflow.rst
@@ -85,7 +85,8 @@ When creating a pull request you should:
 
   - The title should **not** contain the issue number
 - `Reference the issue which the pull request is closing  <https://github.com/blog/1506-closing-issues-via-pull-requests>`_, using one of `these <https://help.github.com/articles/closing-issues-via-commit-messages>`_ keywords
-- State the user who initiated the original issue, if they are named in the issue. Please do not put full email addresses on the Pull Request, as it is publicly accessible.
+- State the user and facility (if relevant) who initiated the original issue, if they are named in the issue. Please do not put full email addresses on the Pull Request, as it is publicly accessible. 
+  If the user would not be easily identified by someone picking up the ticket, be prepared to act as a point of contact with the reporter.
 - Ensure the description follows the format described by the `PR
   template
   <https://github.com/mantidproject/mantid/blob/master/.github/PULL_REQUEST_TEMPLATE.md>`_

--- a/dev-docs/source/GitWorkflow.rst
+++ b/dev-docs/source/GitWorkflow.rst
@@ -85,6 +85,7 @@ When creating a pull request you should:
 
   - The title should **not** contain the issue number
 - `Reference the issue which the pull request is closing  <https://github.com/blog/1506-closing-issues-via-pull-requests>`_, using one of `these <https://help.github.com/articles/closing-issues-via-commit-messages>`_ keywords
+- State the user who initiated the original issue, if they are named in the issue
 - Ensure the description follows the format described by the `PR
   template
   <https://github.com/mantidproject/mantid/blob/master/.github/PULL_REQUEST_TEMPLATE.md>`_

--- a/dev-docs/source/IssueTracking.rst
+++ b/dev-docs/source/IssueTracking.rst
@@ -90,7 +90,16 @@ to refer to either an issue or a PR on this page*)
 
   - **Priority: High** - use this if your ticket needs picking up
     right away, for instance if it relates to a bug which affects a
-    large number of users
+    large number of users. If you are unsure about an issue that could
+    be high priority, discuss with a senior developer. Issues marked
+    high priority must also have a justification for the priority 
+    stated in the ticket
+  - **No priority set** - use this for tickets of intermediate priority
+    this will probably be your default setting, most issues will fall 
+    into this category
+  - **Priority: Low** - use this for the "nice to have" tickets
+    this means that they are not necessarily urgent but can be
+    worked on if there is spare time
 - **Patch candidate** - following a release, low-risk tickets with
   high impact on users will be considered for a follow-up (or *patch*
   release). If your ticket matches this description, consider


### PR DESCRIPTION
Fixes #22410. 

The work is to change the issue and PR templates to try to ensure that feedback is given to the original problem reporter. Eg if an instrument scientist reports a bug to developer, the developer raises the issue, but when the final PR is merged the instrument scientist should be notified.

ISSUE and PULL_REQUEST templates modified

**To test:**

Make sure that the new templates make sense.

Is it clear that the person must be notified when the issue is closed.

**Release Notes** 

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
