### PR TITLE
Re #22406 Hack to avoid performance issues with bulk updating X values

### DIFF
--- a/docs/source/release/v3.13.0/framework.rst
+++ b/docs/source/release/v3.13.0/framework.rst
@@ -39,6 +39,7 @@ Improved
 
 - :ref:`ConjoinXRuns <algm-ConjoinXRuns>` joins Dx errors if present
 - The algorithm :ref:`SortXAxis <algm-SortXAxis>` has a new input option that allows ascending (default) and descending sorting. Furthermore, Dx values will be considered if present. The documentation needed to be corrected.
+- :ref:`Live Data <algm-StartLiveData>` for events in PreserveEvents mode now produces workspaces that have reasonable bin boundaries.
 
 New
 ###


### PR DESCRIPTION
Workaround for #22406.

**Description of work**

When in PreserveEvents mode, EventListeners were creating workspaces that had incorrect bin boundaries in their X values. This resulted in some algorithms not being able to work with the workspaces as expected, inconsistent behaviour in the Instrument View, etc.

While attempting to address this issue, it became apparent that there was no good way to bulk update X values for many spectra without incurring unreasonable performance costs. This will need to be handled in a separate issue.

As a temporary solution for this problem, I've implemented a quick and dirty workaround in this pull request so that work can progress on another issue:

Since all spectra share the same HistogramX instance via the copy-on-write mechanism, and this is guaranteed to be the case during the live listening process, we can update them all if we by-pass the copy and force a write to the single shared instance.

This should be replaced with something more robust once a better solution is found.

**To test:**

Run `FakeISISEventDAE` with default arguments from sidebar.

Then execute the following in the console:
```python
>>> ConfigService.setFacility('TEST_LIVE')
>>> StartLiveData(Instrument="ISIS_Event", OutputWorkspace="test", UpdateEvery=1, PreserveEvents=True, AccumulationMethod="Replace")
```
Open the Instrument View and observe the Time-of-flight range on the bottom, or view the workspace data and observe the X values.

To check performance, run with Kafka event streaming docker stack.

**Release Notes** 

Release notes updated.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
