### PR TITLE
Fix signed two theta not respecting the IDF

### DIFF
--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -803,9 +803,8 @@ MatrixWorkspace::detectorSignedTwoTheta(const Geometry::IDetector &det) const {
         "Source and sample are at same position!");
   }
   // Get the instrument up axis.
-  const V3D &instrumentUpAxis =
-      instrument->getReferenceFrame()->vecPointingUp();
-  return det.getSignedTwoTheta(samplePos, beamLine, instrumentUpAxis);
+  const V3D &thetaSignAxis = instrument->getReferenceFrame()->vecThetaSign();
+  return det.getSignedTwoTheta(samplePos, beamLine, thetaSignAxis);
 }
 
 /** Returns the 2Theta scattering angle for a detector

--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -15,6 +15,7 @@
 #include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/Detector.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
+#include "MantidGeometry/Instrument/ReferenceFrame.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/make_cow.h"
 #include "MantidKernel/TimeSeriesProperty.h"
@@ -49,6 +50,7 @@ using Mantid::Types::Core::DateAndTime;
 // Declare into the factory.
 DECLARE_WORKSPACE(WorkspaceTester)
 
+namespace {
 /** Create a workspace with numSpectra, with
  * each spectrum having one detector, at id = workspace index.
  * @param numSpectra
@@ -76,7 +78,6 @@ boost::shared_ptr<MatrixWorkspace> makeWorkspaceWithDetectors(size_t numSpectra,
   return ws2;
 }
 
-namespace {
 void run_legacy_setting_spectrum_numbers_with_MPI(
     const Parallel::Communicator &comm) {
   using namespace Parallel;
@@ -1703,7 +1704,62 @@ public:
         run_legacy_setting_spectrum_numbers_with_MPI);
   }
 
+  void test_detectorSignedTwoTheta() {
+    checkDetectorSignedTwoTheta(Geometry::Y, {{1., 1., -1., -1.}});
+    checkDetectorSignedTwoTheta(Geometry::X, {{1., -1., -1., 1.}});
+  }
+
 private:
+  void checkDetectorSignedTwoTheta(const Geometry::PointingAlong thetaSignAxis,
+                                   const std::array<double, 4> &signs) {
+    constexpr size_t numDets{4};
+    constexpr size_t numBins{1};
+    const auto frameUp = Geometry::Y;
+    const auto frameAlongBeam = Geometry::Z;
+    const auto frameSideways = Geometry::X;
+    const auto frameThetaSign = thetaSignAxis;
+    const auto frameHandedness = Geometry::Right;
+    const std::string frameOrigin{"source"};
+    auto refFrame = boost::make_shared<ReferenceFrame>(
+        frameUp, frameAlongBeam, frameThetaSign, frameHandedness, frameOrigin);
+    boost::shared_ptr<MatrixWorkspace> ws =
+        boost::make_shared<WorkspaceTester>();
+    ws->initialize(numDets, numBins, numBins);
+    // Create instrument with four detectors to play with.
+    auto instrument = boost::make_shared<Instrument>("TestInstrument");
+    instrument->setReferenceFrame(refFrame);
+    constexpr double twoTheta{4.2 / 180. * M_PI};
+    for (size_t i = 0; i < numDets; ++i) {
+      Detector *det =
+          new Detector("pixel", static_cast<detid_t>(i), instrument.get());
+      constexpr double r{1.};
+      const double rotation =
+          (45. + 90. * static_cast<double>(i)) / 180. * M_PI;
+      const double x = r * std::sin(twoTheta) * std::cos(rotation);
+      const double y = r * std::sin(twoTheta) * std::sin(rotation);
+      const double z = r * std::cos(twoTheta);
+      V3D pos;
+      pos[frameUp] = y;
+      pos[frameAlongBeam] = z;
+      pos[frameSideways] = x;
+      det->setShape(ComponentCreationHelper::createSphere(0.01, pos, "1"));
+      det->setPos(pos);
+      instrument->add(det);
+      instrument->markAsDetector(det);
+      ws->getSpectrum(i).addDetectorID(static_cast<detid_t>(i));
+    }
+    V3D pos(0., 0., 0.);
+    ComponentCreationHelper::addSampleToInstrument(instrument, pos);
+    pos[frameAlongBeam] = -1.;
+    ComponentCreationHelper::addSourceToInstrument(instrument, pos);
+    ws->setInstrument(instrument);
+    for (detid_t detid = 0; static_cast<size_t>(detid) < numDets; ++detid) {
+      auto det = instrument->getDetector(detid);
+      const auto signedTwoTheta = ws->detectorSignedTwoTheta(*det);
+      TS_ASSERT_DELTA(signedTwoTheta, signs[detid] * twoTheta, 1e-12)
+    }
+  }
+
   Mantid::API::MantidImage_sptr createImage(const size_t width,
                                             const size_t height) {
     auto image =

--- a/docs/source/release/v3.13.0/framework.rst
+++ b/docs/source/release/v3.13.0/framework.rst
@@ -54,4 +54,12 @@ Bug fixes
 - :ref:`ConvertToMD <algm-ConvertToMD>` can now be used with workspaces that aren't in the ADS. 
 - Fixed :ref:`SumSpectra <algm-SumSpectra>` to avoid a crash when validation of inputs was called with a WorkspaceGroup.
 
+Python
+------
+
+Bug fixes
+#########
+
+- Fixed a bug in ``detectorSignedTwoTheta`` method in ``MatrixWorkspace`` where the sign of the angle depended on the axis pointing up, not on the actual theta-sing axis defined in the IDF.
+
 :ref:`Release 3.13.0 <v3.13.0>`


### PR DESCRIPTION
This PR fixes a bug in `MatrixWorkspace::detectorSignedTwoTheta()` where the axis pointing up was accidentally used as the reference axis when determining the sign of a detector's 2theta.

**To test:**

Choose some instrument where the signed 2theta makes sense. One example is D17 where the theta-sign axis should be x. Make sure the `theta-sing` axis is defined in the IDF. The file should contain something like this:
```xml
  <defaults>
    <length unit="metre"/>
    <angle unit="degree"/>
    <reference-frame>
      <along-beam axis="z"/>
      <pointing-up axis="y"/>
      <handedness val="right"/>
      <theta-sign axis="x"/>
    </reference-frame>
  </defaults>
```

In MantidPlot, load the instrument using `LoadEmptyInstrument`. Check the signed two theta in Python:
```python
ws = mtd['ws']
ws.detectorSignedTwoTheta(ws.getDetector(33))
```

Make sure the signs are correct, for example for D17, detector 0 should have a positive signed two theta and detector 250 negative when the theta-sing axis is x.

Fixes #22415 . 

**Release Notes** 

The fix is mentioned in the Framework release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
