### PR TITLE
Improve handling of TableColumns with non-numerical entries

### DIFF
--- a/Framework/API/inc/MantidAPI/Column.h
+++ b/Framework/API/inc/MantidAPI/Column.h
@@ -100,6 +100,9 @@ public:
   /// Specialized type check
   virtual bool isBool() const = 0;
 
+  /// Are elements of the column interpretable as a number?
+  virtual bool isNumber() const = 0;
+
   /// Must return overall memory size taken by the column.
   virtual long int sizeOfData() const = 0;
 

--- a/Framework/API/test/FunctionDomainGeneralTest.h
+++ b/Framework/API/test/FunctionDomainGeneralTest.h
@@ -29,6 +29,7 @@ public:
   }
   /// Specialized type check
   bool isBool() const override { return false; }
+  bool isNumber() const override { return false; }
   /// Must return overall memory size taken by the column.
   long int sizeOfData() const override {
     throw std::logic_error("Not implemented");

--- a/Framework/DataObjects/inc/MantidDataObjects/PeakColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakColumn.h
@@ -47,6 +47,8 @@ public:
   /// Specialized type check
   bool isBool() const override;
 
+  bool isNumber() const override;
+
   /// Must return overall memory size taken by the column.
   long int sizeOfData() const override;
 

--- a/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
@@ -127,7 +127,7 @@ public:
   /// Type check
   bool isBool() const override { return typeid(Type) == typeid(API::Boolean); }
   bool isNumber() const override {
-    return std::is_convertible<double, Type>::value;
+    return std::is_convertible<Type, double>::value;
   }
   /// Memory used by the column
   long int sizeOfData() const override {

--- a/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
@@ -126,6 +126,9 @@ public:
   void read(const size_t index, std::istringstream &in) override;
   /// Type check
   bool isBool() const override { return typeid(Type) == typeid(API::Boolean); }
+  bool isNumber() const override {
+    return std::is_convertible<double, Type>::value;
+  }
   /// Memory used by the column
   long int sizeOfData() const override {
     return static_cast<long int>(m_data.size() * sizeof(Type));

--- a/Framework/DataObjects/inc/MantidDataObjects/VectorColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/VectorColumn.h
@@ -102,6 +102,8 @@ public:
   /// Specialized type check
   bool isBool() const override { return false; }
 
+  bool isNumber() const override { return false; }
+
   /// Overall memory size taken by the column (bytes)
   long int sizeOfData() const override {
     long int size(0);

--- a/Framework/DataObjects/src/PeakColumn.cpp
+++ b/Framework/DataObjects/src/PeakColumn.cpp
@@ -214,6 +214,8 @@ bool PeakColumn::getReadOnly() const {
 /// Specialized type check
 bool PeakColumn::isBool() const { return false; }
 
+bool PeakColumn::isNumber() const { return false; }
+
 /// @returns overall memory size taken by the column.
 long int PeakColumn::sizeOfData() const {
   return sizeof(double) * static_cast<long int>(m_peaks.size());

--- a/Framework/DataObjects/test/PeakColumnTest.h
+++ b/Framework/DataObjects/test/PeakColumnTest.h
@@ -151,6 +151,11 @@ public:
     }
   }
 
+  void test_cannot_be_converted_to_double() {
+    PeakColumn col(m_peaks, "DetID");
+    TS_ASSERT(!col.isNumber());
+  }
+
 private:
   /// A locale facet mocking non-english numerical punctuation.
   class TestingNumpunctFacet : public std::numpunct<char> {

--- a/Framework/DataObjects/test/TableColumnTest.h
+++ b/Framework/DataObjects/test/TableColumnTest.h
@@ -299,6 +299,18 @@ public:
     TS_ASSERT_EQUALS(data2[8], "twelve (1)");
     TS_ASSERT_EQUALS(data2[9], "twelve (2)");
   }
+  void test_strCannotBeConvertedToDouble() {
+    TableWorkspace ws;
+    ws.addColumn("str", "col");
+    const auto col = ws.getColumn("col");
+    TS_ASSERT(!col->isNumber());
+  }
+  void test_intCanBeConvertedToDouble() {
+    TableWorkspace ws;
+    ws.addColumn("int", "col");
+    const auto col = ws.getColumn("col");
+    TS_ASSERT(col->isNumber());
+  }
 
 private:
   std::vector<size_t> makeIndexVector(size_t n) {

--- a/Framework/DataObjects/test/VectorColumnTest.h
+++ b/Framework/DataObjects/test/VectorColumnTest.h
@@ -108,6 +108,11 @@ public:
 
     TS_ASSERT_EQUALS(col.sizeOfData(), 10 * sizeof(int));
   }
+
+  void test_cannotBeConvertedToDouble() {
+    VectorColumnTestHelper<int> col;
+    TS_ASSERT(!col.isNumber());
+  }
 };
 
 #endif /* MANTID_DATAOBJECTS_VECTORCOLUMNTEST_H_ */

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
@@ -374,6 +374,10 @@ class ColumnTester : public Column {
     throw std::runtime_error("isBool not implemented");
   }
 
+  bool isNumber() const override {
+    throw std::runtime_error("isNumber not implemented");
+  }
+
   long int sizeOfData() const override {
     throw std::runtime_error("sizeOfData not implemented");
   }

--- a/MantidPlot/src/Mantid/MantidTable.cpp
+++ b/MantidPlot/src/Mantid/MantidTable.cpp
@@ -297,7 +297,7 @@ void MantidTable::cellEdited(int row, int col) {
     oldText.remove(QRegExp("\\s"));
   }
 
-  if (c->type() == "str" || c->type() == "V3D") {
+  if (c->isNumber()) {
     std::istringstream textStream(oldText.toStdString());
     c->read(index, textStream);
   } else {

--- a/MantidPlot/src/Mantid/MantidTable.cpp
+++ b/MantidPlot/src/Mantid/MantidTable.cpp
@@ -298,9 +298,6 @@ void MantidTable::cellEdited(int row, int col) {
   }
 
   if (c->isNumber()) {
-    std::istringstream textStream(oldText.toStdString());
-    c->read(index, textStream);
-  } else {
     // We must be dealing with numerical data. Since there semms to be no way
     // convert between QLocale and std::locale, get the number out
     // of the Qt locale and put it into default std::locale format.
@@ -319,6 +316,9 @@ void MantidTable::cellEdited(int row, int col) {
                                     1) << number;
     std::istringstream stream(textStream.str());
     c->read(index, stream);
+  } else {
+    std::istringstream textStream(oldText.toStdString());
+    c->read(index, textStream);
   }
 }
 

--- a/docs/source/concepts/TableWorkspaces.rst
+++ b/docs/source/concepts/TableWorkspaces.rst
@@ -198,6 +198,10 @@ the second argument is the name of the column. The predefined types are:
 +-----------------+-------------------------+
 | long64          | int64\_t                |
 +-----------------+-------------------------+
+| vector_int      | std::vector<int>        |
++-----------------+-------------------------+
+| vector_double   | std::vector<double>     |
++-----------------+-------------------------+
 
 The data in the table can be accessed in a number of ways. The most
 simple way is to call templated method T& cell(row,col), where col is

--- a/docs/source/release/v3.13.0/framework.rst
+++ b/docs/source/release/v3.13.0/framework.rst
@@ -53,5 +53,6 @@ Bug fixes
 - Fixed a crash when the input workspace for :ref:`GroupDetectors <algm-GroupDetectors>` contained any other units than spectrum numbers.
 - :ref:`ConvertToMD <algm-ConvertToMD>` can now be used with workspaces that aren't in the ADS. 
 - Fixed :ref:`SumSpectra <algm-SumSpectra>` to avoid a crash when validation of inputs was called with a WorkspaceGroup.
+- Fixed a bug in TableWorkspaces where vector column data was set to 0 when the table was viewed    
 
 :ref:`Release 3.13.0 <v3.13.0>`


### PR DESCRIPTION
Fixes a bug where the cell values of a VectorColumn were reset to 0 if the table was viewed. The check that column data is numerical in the handler `MantidTable::cellEdited` was improved to cover all column types. This means the handler doesn't try to interpret the text value as a number (which it was doing before), and instead just reads it as a string

**To test:**

```
t = CreateEmptyTableWorkspace()
t.addColumn("vector_int", "r")
t.addRow([[1,2,3]])
```

Double-click on `t` to view it, then close the table view. Double-click to view again, and the row should still be `1,2,3`, not 0.

Fixes #22394 

**Release Notes** 

[Here](https://github.com/mantidproject/mantid/commit/4c6b211b96a1c127836085041ab5f0ed1b5a6e8f#diff-d41279afe39cfbf234c3ca92983d1c5c)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
