### PR TITLE
Indirect Data Reduction - sum files in calibration

### DIFF
--- a/docs/source/release/v3.13.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.13.0/indirect_inelastic.rst
@@ -11,6 +11,11 @@ Indirect Inelastic Changes
 
 :ref:`Release 3.13.0 <v3.13.0>`
 
+Data Reduction Interfaces
+--------------
+
+- Added 'Sum Files' checkbox to ISIS Calibration, to sum a specified range of input files on load.
+
 Algorithms
 ----------
 

--- a/docs/source/release/v3.13.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.13.0/indirect_inelastic.rst
@@ -12,7 +12,7 @@ Indirect Inelastic Changes
 :ref:`Release 3.13.0 <v3.13.0>`
 
 Data Reduction Interfaces
---------------
+-------------------------
 
 - Added 'Sum Files' checkbox to ISIS Calibration, to sum a specified range of input files on load.
 

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -311,11 +311,10 @@ void ISISCalibration::run() {
  * @param error If the algorithms failed.
  */
 void ISISCalibration::algorithmComplete(bool error) {
-  if (error)
-    return;
-
-  m_uiForm.pbSave->setEnabled(true);
-  m_uiForm.pbPlot->setEnabled(true);
+  if (!error) {
+    m_uiForm.pbSave->setEnabled(true);
+    m_uiForm.pbPlot->setEnabled(true);
+  }
 }
 
 bool ISISCalibration::validate() {
@@ -341,11 +340,10 @@ bool ISISCalibration::validate() {
 
   QString error = uiv.generateErrorMessage();
 
-  if (error != "") {
+  if (error != "")
     g_log.warning(error.toStdString());
-    return false;
-  }
-  return true;
+
+  return (error == "");
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -3,7 +3,7 @@
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/Logger.h"
-
+#include <QDebug>
 #include <QFileInfo>
 #include <stdexcept>
 
@@ -756,6 +756,7 @@ IAlgorithm_sptr ISISCalibration::energyTransferReductionAlgorithm(
       "Reflection",
       getInstrumentConfiguration()->getReflectionName().toStdString());
   reductionAlg->setProperty("InputFiles", inputFiles.toStdString());
+  reductionAlg->setProperty("SumFiles", m_uiForm.ckSumFiles->isChecked());
   reductionAlg->setProperty("OutputWorkspace",
                             "__IndirectCalibration_reduction");
   reductionAlg->setProperty("SpectraRange",

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -5,7 +5,6 @@
 #include "MantidKernel/Logger.h"
 
 #include <QFileInfo>
-
 #include <stdexcept>
 
 using namespace Mantid::API;
@@ -390,11 +389,6 @@ void ISISCalibration::calPlotRaw() {
     return;
 
   m_lastCalPlotFilename = filename;
-
-  if (filename.isEmpty()) {
-    emit showMessageBox("Cannot plot raw data without filename");
-    return;
-  }
 
   QFileInfo fi(filename);
   QString wsname = fi.baseName();

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -341,10 +341,11 @@ bool ISISCalibration::validate() {
 
   QString error = uiv.generateErrorMessage();
 
-  if (error != "")
+  if (error != "") {
     g_log.warning(error.toStdString());
-
-  return (error == "");
+    return false;
+  }
+  return true;
 }
 
 /**
@@ -427,10 +428,6 @@ void ISISCalibration::calPlotRaw() {
  * Replots the energy mini plot
  */
 void ISISCalibration::calPlotEnergy() {
-  if (!m_uiForm.leRunNo->isValid()) {
-    emit showMessageBox("Run number not valid.");
-    return;
-  }
 
   const auto files = m_uiForm.leRunNo->getFilenames().join(",");
   auto reductionAlg = energyTransferReductionAlgorithm(files);
@@ -444,7 +441,7 @@ void ISISCalibration::calPlotEnergy() {
   WorkspaceGroup_sptr reductionOutputGroup =
       AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
           "__IndirectCalibration_reduction");
-  if (reductionOutputGroup->size() == 0) {
+  if (reductionOutputGroup->isEmpty()) {
     g_log.warning("No result workspaces, cannot plot energy preview.");
     return;
   }

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.ui
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.ui
@@ -103,6 +103,13 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="ckSumFiles">
+          <property name="text">
+           <string>Sum Files</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <spacer name="horizontalSpacer_2">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.ui
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.ui
@@ -62,6 +62,16 @@
           </property>
          </widget>
         </item>
+        <item>
+         <widget class="QCheckBox" name="ckSumFiles">
+          <property name="text">
+           <string>Sum Files</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
       <item>
@@ -99,13 +109,6 @@
           </property>
           <property name="checked">
            <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="ckSumFiles">
-          <property name="text">
-           <string>Sum Files</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
Adds sum files checkbox to ISIS calibration (like the one in energy transfer).

**To test:**
- Go to Interfaces -> Indirect -> Data Reduction -> ISIS Calibration
- Check sum files is ticked
- Enter a range in Run No box e.g. 26173-6
- click plot raw
- check result in ADS is a single workspace with `_multi_` in the name.

<!-- Instructions for testing. -->

Fixes #22432  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->



---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
