### PR TITLE
Add WAND_Parameters.xml so that MergeRuns does the right thing

### DIFF
--- a/instrument/WAND_Parameters.xml
+++ b/instrument/WAND_Parameters.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<parameter-file instrument="WAND" valid-from="2017-12-01 00:00:00">
+  <component-link name="WAND">
+    <parameter name="sample_logs_sum" type="string">
+      <value val="duration" />
+    </parameter>
+    <parameter name="sample_logs_list" type="string">
+      <value val="run_number" />
+    </parameter>
+  </component-link>
+</parameter-file>


### PR DESCRIPTION
MergeRuns will now sum the duration and list all run numbers for WAND²

**To test:**
```python
silicon = LoadWAND(IPTS=7776,RunNumbers='26506-26507')
merged = MergeRuns(silicon)
```
Then compare the duration and run_number logs of the input and output

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
