### PR TITLE
Allow input workspace of CreatePeaksWorkspace to be MD

### DIFF
--- a/Framework/Algorithms/src/CreatePeaksWorkspace.cpp
+++ b/Framework/Algorithms/src/CreatePeaksWorkspace.cpp
@@ -2,6 +2,7 @@
 #include "MantidKernel/System.h"
 #include "MantidDataObjects/PeaksWorkspace.h"
 #include "MantidGeometry/Instrument/Goniometer.h"
+#include "MantidAPI/IMDEventWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Run.h"
 
@@ -19,7 +20,7 @@ using namespace Mantid::DataObjects;
  */
 void CreatePeaksWorkspace::init() {
   declareProperty(
-      make_unique<WorkspaceProperty<MatrixWorkspace>>(
+      make_unique<WorkspaceProperty<Workspace>>(
           "InstrumentWorkspace", "", Direction::Input, PropertyMode::Optional),
       "An optional input workspace containing the default instrument for peaks "
       "in this workspace.");
@@ -33,18 +34,36 @@ void CreatePeaksWorkspace::init() {
 /** Execute the algorithm.
  */
 void CreatePeaksWorkspace::exec() {
-  MatrixWorkspace_sptr instWS = getProperty("InstrumentWorkspace");
+  Workspace_sptr instWS = this->getProperty("InstrumentWorkspace");
+
+  MultipleExperimentInfos_sptr instMDWS =
+      boost::dynamic_pointer_cast<MultipleExperimentInfos>(instWS);
+
+  ExperimentInfo_sptr ei;
 
   auto out = boost::make_shared<PeaksWorkspace>();
   setProperty("OutputWorkspace", out);
   int NumberOfPeaks = getProperty("NumberOfPeaks");
 
-  if (instWS) {
+  if (instMDWS != nullptr) {
+    if (instMDWS->getNumExperimentInfo() > 0) {
+      out->setInstrument(instMDWS->getExperimentInfo(0)->getInstrument());
+      out->mutableRun().setGoniometer(
+          instMDWS->getExperimentInfo(0)->run().getGoniometer().getR(), false);
+    } else {
+      throw std::invalid_argument("InstrumentWorkspace has no ExperimentInfo");
+    }
+  } else {
+    ei = boost::dynamic_pointer_cast<ExperimentInfo>(instWS);
+    if (ei) {
+      out->setInstrument(ei->getInstrument());
+      out->mutableRun().setGoniometer(ei->run().getGoniometer().getR(), false);
+    }
+  }
+
+  if (instMDWS || ei) {
     Progress progress(this, 0.0, 1.0, NumberOfPeaks);
 
-    out->setInstrument(instWS->getInstrument());
-    out->mutableRun().setGoniometer(instWS->run().getGoniometer().getR(),
-                                    false);
     // Create some default peaks
     for (int i = 0; i < NumberOfPeaks; i++) {
       out->addPeak(Peak(out->getInstrument(),

--- a/docs/source/algorithms/CreatePeaksWorkspace-v1.rst
+++ b/docs/source/algorithms/CreatePeaksWorkspace-v1.rst
@@ -17,6 +17,9 @@ This workspace can serve as a starting point for modifying the
 :ref:`PeaksWorkspace <PeaksWorkspace>`, using the GUI or python scripting,
 for example.
 
+If the input workspace is a MDWorkspace then the instrument from the
+first experiment info is used.
+
 Usage
 -----
 

--- a/docs/source/release/v3.13.0/diffraction.rst
+++ b/docs/source/release/v3.13.0/diffraction.rst
@@ -48,6 +48,8 @@ Single Crystal Diffraction
 
 - :ref:`SaveLauenorm <algm-SaveLauenorm>` now has input options for crystal system and reflection condition for lscale output instead of trying to determine from lattice parameters.
 
+- :ref:`CreatePeaksWorkspace <algm-CreatePeaksWorkspace>` now accepts MD workspaces as input.
+
 Improvements
 ############
 


### PR DESCRIPTION
A MDWorkspace can now be used as input to CreatePeaksWorkspace. The instrument from the first experiment info is used.

**To test:**
Using example from [here](http://docs.mantidproject.org/nightly/algorithms/ConvertToMD-v1.html#usage-examples) to create MD workspace

```python
redWS = CreateSimulationWorkspace(Instrument='MAR',BinParams=[-10,1,10],UnitX='DeltaE',OutputWorkspace='MAR11001')
AddSampleLog(redWS,LogName='Ei',LogText='12.',LogType='Number');
SofQW3(InputWorkspace='MAR11001',OutputWorkspace='MAR11001Qe2',QAxisBinning='0,0.1,7',EMode='Direct')
AddSampleLog(Workspace='MAR11001Qe2',LogName='T',LogText='100.0',LogType='Number Series')
ws=ConvertToMD(InputWorkspace='MAR11001Qe2',OutputWorkspace='MD3',QDimensions='CopyToMD',OtherDimensions='T',MinValues='-10,0,0',MaxValues='10,6,500',SplitInto='50,50,5')
```
then try CreatePeaksWorkspace using the MD workspace
```python
peaks = CreatePeaksWorkspace('MD3')
```


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
