### PR TITLE
Add wavelength parameter to WAND²

### DIFF
--- a/Framework/MDAlgorithms/src/FindPeaksMD.cpp
+++ b/Framework/MDAlgorithms/src/FindPeaksMD.cpp
@@ -197,7 +197,8 @@ void FindPeaksMD::init() {
   auto nonNegativeDbl = boost::make_shared<BoundedValidator<double>>();
   nonNegativeDbl->setLower(0);
   declareProperty("Wavelength", DBL_MAX, nonNegativeDbl,
-                  "Wavelength to use when calculating goniometer angle");
+                  "Wavelength to use when calculating goniometer angle. If not"
+                  "set will use the wavelength parameter on the instrument.");
 
   setPropertySettings("Wavelength",
                       make_unique<EnabledWhenProperty>(
@@ -296,6 +297,16 @@ FindPeaksMD::createPeak(const Mantid::Kernel::V3D &Q, const double binCount,
     if (calcGoniometer) {
       // Calculate Q lab from Q sample and wavelength
       double wavelength = getProperty("Wavelength");
+      if (wavelength == DBL_MAX) {
+        if (inst->hasParameter("wavelength")) {
+          wavelength = inst->getNumberParameter("wavelength").at(0);
+        } else {
+          throw std::runtime_error(
+              "Could not get wavelength, neither Wavelength algorithm property "
+              "set nor instrument wavelength parameter");
+        }
+      }
+
       Geometry::Goniometer goniometer;
       goniometer.calcFromQSampleAndWavelength(Q, wavelength);
       g_log.information() << "Found goniometer rotation to be "
@@ -756,11 +767,6 @@ std::map<std::string, std::string> FindPeaksMD::validateInputs() {
                                     "can only be used with an MDEventWorkspace "
                                     "as the input.";
   }
-
-  double wavelength = getProperty("Wavelength");
-  if (getProperty("CalculateGoniometerForCW") && wavelength == DBL_MAX)
-    result["Wavelength"] =
-        "Must set wavelength when using CalculateGoniometerForCW option";
 
   return result;
 }

--- a/docs/source/concepts/PeaksWorkspace.rst
+++ b/docs/source/concepts/PeaksWorkspace.rst
@@ -53,14 +53,15 @@ Calculate Goniometer For Constant Wavelength
 --------------------------------------------
 
 If you set the `wavelength` (in Å) or `energy` (in meV) property on a
-PeaksWorkspace when the createPeak method is used the goniometer
-rotation with be calculated. This allows you to use one instrument
-definition for multiple goniometer rotations, for example adding peaks
-in Slice Viewer from multiple combined MD workspaces. It only works
-for a constant wavelength source and only for Q sample workspaces. It
-also assumes the goniometer rotation is around the y-axis only. For
-details on the calculation see "Calculate Goniometer For Constant
-Wavelength" at :ref:`FindPeaksMD <algm-FindPeaksMD>`.
+PeaksWorkspace, or if the instrument on the PeaksWorkspace has the
+`wavelength` parameter, the goniometer rotation will be calculated
+when the createPeak method is used. This allows you to use one
+instrument definition for multiple goniometer rotations, for example
+adding peaks in Slice Viewer from multiple combined MD workspaces. It
+only works for a constant wavelength source and only for Q sample
+workspaces. It also assumes the goniometer rotation is around the
+y-axis only. For details on the calculation see "Calculate Goniometer
+For Constant Wavelength" at :ref:`FindPeaksMD <algm-FindPeaksMD>`.
 
 .. code-block:: python
 

--- a/instrument/WAND_Parameters.xml
+++ b/instrument/WAND_Parameters.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <parameter-file instrument="WAND" valid-from="2017-12-01 00:00:00">
   <component-link name="WAND">
+    <parameter name="wavelength" type="float">
+      <value val="1.488" />
+    </parameter>
     <parameter name="sample_logs_sum" type="string">
       <value val="duration" />
     </parameter>


### PR DESCRIPTION
And make use of the wavelength parameter in FindPeaksMD and PeaksWorkspace when calculating the goniometer.

**To test FindPeaksMD:**
```python
LoadMD(Filename='/SNS/users/rwp/NaCl_q.nxs',  OutputWorkspace='md')
FindPeaksMD(InputWorkspace='md', PeakDistanceThreshold=2, CalculateGoniometerForCW=True, OutputWorkspace='peaks')
```
FindPeaksMD should now work without setting the `Wavelength` property unlike originally in #21726

**To test PeaksWorkspace:**
Using the same `md` workspace above

```python
LoadEventNexus(Filename='/HFIR/HB2C/IPTS-7776/nexus/HB2C_26640.nxs.h5', OutputWorkspace='ws',MetaDataOnly=True)
peaks2 = CreatePeaksWorkspace(InstrumentWorkspace='ws', NumberOfPeaks=0)
```
From here open up slice viewer, overlay `peaks2` workspace, then add peaks using the Add HKL Peaks button. The peaks added should now have the correct wavelength, d-spacing, Q lab, Q sample and detector information. You no longer have to set the wavelength unlike originally in #22330


**Release Notes** 

Does not need to be in the release notes as this functionality was only add in the release.


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
