### PR TITLE
Add progress to LoadWAND using progress of child algorithms

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/LoadWAND.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/LoadWAND.py
@@ -44,9 +44,11 @@ class LoadWAND(DataProcessorAlgorithm):
         outWS = self.getPropertyValue("OutputWorkspace")
         group_names = []
 
-        for run in runs:
-            LoadEventNexus(Filename=run, OutputWorkspace='__tmp_load', LoadMonitors=True, EnableLogging=False)
-            Integration(InputWorkspace='__tmp_load', OutputWorkspace='__tmp_load', EnableLogging=False)
+        for i, run in enumerate(runs):
+            LoadEventNexus(Filename=run, OutputWorkspace='__tmp_load', LoadMonitors=True, EnableLogging=False,
+                           startProgress=i/len(runs), endProgress=(i+0.8)/len(runs))
+            Integration(InputWorkspace='__tmp_load', OutputWorkspace='__tmp_load', EnableLogging=False,
+                        startProgress=(i+0.8)/len(runs), endProgress=(i+1)/len(runs))
 
             if self.getProperty("ApplyMask").value:
                 MaskBTP('__tmp_load', Pixel='1,2,511,512', EnableLogging=False)


### PR DESCRIPTION
The 80/20 split is an approximation between Loading and Integration that depends a lot of which files you actually load. Most of the other parts of the algorithm take minimal time in comparison.


**To test:**
Load some files and see that the progress bar make a bit of sense. These are large files, ~12GB each, but after integration of each file it shrinks dramatically.
```python
ws=LoadWAND(IPTS=20086,RunNumbers='39920-39922')
```
For a test with lots of small files try:
```python
ws=LoadWAND(IPTS=7776,RunNumbers='26640-26740')
```

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
