### PR TITLE
Fix broken performance test

### DIFF
--- a/Framework/Algorithms/test/DiffractionFocussing2Test.h
+++ b/Framework/Algorithms/test/DiffractionFocussing2Test.h
@@ -264,7 +264,7 @@ public:
         AlgorithmFactory::Instance().create("LoadEmptyInstrument", 1);
     alg->initialize();
     alg->setRethrows(true);
-    alg->setPropertyValue("Filename", "SNAP_Definition.xml");
+    alg->setPropertyValue("Filename", "SNAP_Definition_2011-09-07.xml");
     alg->setPropertyValue("OutputWorkspace", "SNAP_empty");
     alg->setPropertyValue("MakeEventWorkspace", "1");
     alg->execute();


### PR DESCRIPTION
This is a bug that got introduced when #22427 was merged into master.

**To test:**

1. Enable building performance tests
2. `ctest -R DiffractionFocussing2`

*There is no associated issue.*

*Does not need to be in the release notes* because it is fixing a bug that was introduced during the development cycle.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
