### PR TITLE
Add option to PredictPeaks to Calculate Goniometer For CW

### DIFF
--- a/Framework/Crystal/test/PredictPeaksTest.h
+++ b/Framework/Crystal/test/PredictPeaksTest.h
@@ -245,6 +245,52 @@ public:
   void test_edge() {
     do_test_exec("Primitive", 5, std::vector<V3D>(), 1, false, false, 10);
   }
+
+  void test_exec_with_CalculateGoniometerForCW() {
+    // Name of the output workspace.
+    std::string outWSName("PredictPeaksTest_OutputWS");
+
+    // Make the fake input workspace
+    MatrixWorkspace_sptr inWS =
+        WorkspaceCreationHelper::create2DWorkspace(10000, 1);
+    Instrument_sptr inst =
+        ComponentCreationHelper::createTestInstrumentRectangular(1, 100);
+    inWS->setInstrument(inst);
+
+    // Set ub and Goniometer rotation
+    WorkspaceCreationHelper::setOrientedLattice(inWS, 12.0, 12.0, 12.0);
+    WorkspaceCreationHelper::setGoniometer(inWS, 0., 0., 0.);
+
+    PredictPeaks alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty(
+        "InputWorkspace", boost::dynamic_pointer_cast<Workspace>(inWS)));
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", outWSName));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("CalculateGoniometerForCW", true));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Wavelength", "1.5"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("MinAngle", "0"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("MaxAngle", "10.0"));
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+
+    // Retrieve the workspace from data service.
+    PeaksWorkspace_sptr ws;
+    TS_ASSERT_THROWS_NOTHING(
+        ws = AnalysisDataService::Instance().retrieveWS<PeaksWorkspace>(
+            outWSName));
+    TS_ASSERT(ws);
+    if (!ws)
+      return;
+
+    TS_ASSERT_EQUALS(ws->getNumberPeaks(), 1);
+    TS_ASSERT_EQUALS(ws->getPeak(0).getHKL(), V3D(1, 0, 0));
+    TS_ASSERT_DELTA(ws->getPeak(0).getWavelength(), 1.5, 1e-6);
+
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(outWSName);
+  }
 };
 
 class PredictPeaksTestPerformance : public CxxTest::TestSuite {

--- a/docs/source/algorithms/PredictPeaks-v1.rst
+++ b/docs/source/algorithms/PredictPeaks-v1.rst
@@ -111,7 +111,15 @@ with the desired number of peaks. Use python or the GUI to enter the
 desired HKLs. If these are fraction (e.g. magnetic peaks) then make sure
 RoundHKL=False.
 
-.. seealso :: Algorithm :ref:`algm-PredictFractionalPeaks`
+Calculate Goniometer For Constant Wavelength
+############################################
+
+If you select the "CalculateGoniometerForCW" option instead of using
+the goniometer from the input workspace it will calculate the
+goniometer rotation, assuming a constant wavelength and that the
+rotation is around the y-axis only. For details on the calculation see
+"Calculate Goniometer For Constant Wavelength" at :ref:`FindPeaksMD
+<algm-FindPeaksMD>`.
 
 .. categories::
 


### PR DESCRIPTION
**To test:**
```python
md=LoadMD('/SNS/users/rwp/q2_norm.nxs')
# To find all peaks
peaks=PredictPeaks(md, MinDSpacing=0.8,ReflectionCondition="All-face centred", CalculateGoniometerForCW=True)
# Just the peaks over the data range
peaks2=PredictPeaks(md, MinDSpacing=0.8,ReflectionCondition="All-face centred", CalculateGoniometerForCW=True,MaxAngle=-50)
```
Plot the peaks over the data in slice viewer and check they look good.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
