### PR TITLE
Fix missing spaces in ArrayProperty reference pages in Python documentation

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayProperty.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayProperty.cpp
@@ -32,20 +32,20 @@ using return_cloned_numpy =
          boost::noncopyable>(#prefix "ArrayProperty", no_init)                 \
       .def(init<const std::string &, const unsigned int>(                      \
           (arg("self"), arg("name"), arg("direction") = Direction::Input),     \
-          "Construct an ArrayProperty of type" #type))                         \
+          "Construct an ArrayProperty of type " #type))                        \
                                                                                \
       .def(init<const std::string &, IValidator_sptr, const unsigned int>(     \
           (arg("self"), arg("name"), arg("validator"),                         \
            arg("direction") = Direction::Input),                               \
-          "Construct an ArrayProperty of type" #type "with a validator"))      \
+          "Construct an ArrayProperty of type " #type " with a validator"))    \
                                                                                \
       .def(init<const std::string &, const std::string &, IValidator_sptr,     \
                 const unsigned int>(                                           \
           (arg("self"), arg("name"), arg("values"),                            \
            arg("validator") = IValidator_sptr(new NullValidator),              \
            arg("direction") = Direction::Input),                               \
-          "Construct an ArrayProperty of type" #type                           \
-          "with a validator giving the values as a string"))                   \
+          "Construct an ArrayProperty of type " #type                          \
+          " with a validator giving the values as a string"))                  \
       .def("__init__",                                                         \
            make_constructor(                                                   \
                &createArrayPropertyFromList<type>, default_call_policies(),    \


### PR DESCRIPTION
**Description of work**

This PR adds some missing spaces to the Python API reference.

**To test:**

Check that the docs for, e.g. `CIntArrayProperty` and `IntArrayProperty`, look fine.

No associated issue.

**Release Notes** 

No need to be in the release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
