### PR TITLE
Eliminate workbench warning about the order of initialization

### DIFF
--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -43,7 +43,7 @@ requirements.check_qt()
 # -----------------------------------------------------------------------------
 # Qt
 # -----------------------------------------------------------------------------
-from qtpy.QtCore import (QEventLoop, Qt, QTimer)  # noqa
+from qtpy.QtCore import (QEventLoop, Qt, QTimer, QCoreApplication)  # noqa
 from qtpy.QtGui import (QColor, QPixmap)  # noqa
 from qtpy.QtWidgets import (QApplication, QDesktopWidget, QFileDialog,
                             QMainWindow, QSplashScreen)  # noqa
@@ -65,6 +65,7 @@ def qapplication():
     """
     app = QApplication.instance()
     if app is None:
+        QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
         app = QApplication(['Mantid Workbench'])
     return app
 


### PR DESCRIPTION
**Description of work**

Eliminates the warning `Qt WebEngine seems to be initialized from a plugin. Please set Qt::AA_ShareOpenGLContexts using QCoreApplication::setAttribute before constructing QGuiApplication.` when starting workbench

https://forum.kde.org/viewtopic.php?f=18&t=137811
https://cgit.kde.org/konqueror.git/commit/?id=4c6575a9852e3dfcf85bd849fa953dcc083029d9

**To test:**

<!-- Instructions for testing. -->

1. Build Mantid with `-DENABLE_WORKBENCH=ON`.
2. Start `workbench` and check for warnings.

Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
