### PR TITLE
Fix Load Dialog Using Cached Result When Invalid Filename is supplied 

### DIFF
--- a/docs/source/release/v3.13.0/ui.rst
+++ b/docs/source/release/v3.13.0/ui.rst
@@ -16,3 +16,8 @@ MantidPlot
 ----------
 
 - MantidPlot's pyplot API has been removed.
+
+Bugfixes
+--------
+
+- A bug in the load dialog where bad filename input would cause the last file to be loaded has been fixed.


### PR DESCRIPTION
**Description of work**

Moves location of updates to the result cache in the file finder widget to ensure that it is always up to date.

**To test:**

* open the Load dialog
* click browse and find a file to load and then click run to load the file
* delete the new workspace
* open the Load dialog again
* clear the filename text and type anything random text
* click run
* the dialog should stop on error and not load the last file

Fixes #22232 

**Release Notes** 
Release notes have been updated.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
