### PR TITLE
Workbench Script Progress Reporting

### DIFF
--- a/qt/python/mantidqt/widgets/codeeditor/interpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/interpreter.py
@@ -164,7 +164,7 @@ class PythonFileInterpreter(QWidget):
         # set a margin large enough for sensible file sizes < 1000 lines
         # and the progress marker
         font_metrics = QFontMetrics(self.font())
-        editor.setMarginWidth(1, font_metrics.averageCharWidth()*3 + 12)
+        editor.setMarginWidth(1, font_metrics.averageCharWidth() * 3 + 20)
 
         # fill with content if supplied and set source filename
         if default_content is not None:

--- a/qt/python/mantidqt/widgets/codeeditor/interpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/interpreter.py
@@ -91,7 +91,6 @@ class EditorIO(object):
 
 
 class PythonFileInterpreter(QWidget):
-
     sig_editor_modified = Signal(bool)
     sig_filename_modified = Signal(str)
 
@@ -233,7 +232,10 @@ class PythonFileInterpreterPresenter(QObject):
         else:
             code_str = editor.text()
             line_from = 0
-        return code_str, line_from
+        # Pad code out with empty lines so that reported line numbers
+        # do not have to be adjusted
+        padded = '\n'*line_from + code_str
+        return padded, line_from
 
     def _on_exec_success(self, task_result):
         self.view.editor.updateCompletionAPI(self.model.generate_calltips())


### PR DESCRIPTION
**Description of work**
Fixes the line number reporting in the editor widget of the new workbench when a selection of code is executed rather than the whole file.

**To test:**

Build and start the new workbench

Add some lines of code that will cause a syntax error, such as:
```python
a = 1
b = 2
c =
```
and try both executing the whole file and executing only a selection. The reported errors should be on the correct line.

Try the same with code that produces a runtime error:
```python
a = 1
b = ['a'] * 4
c = 4
```

Refs #21649

**Release Notes** 
Workbench release will be reported separately when it is ready.

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
