### PR TITLE
Workbench: Replace active/hold functionality with overplotting

### DIFF
--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -385,8 +385,8 @@ def start_workbench(app):
     mpl = importlib.import_module('matplotlib')
     # Replace vanilla Gcf with our custom instance
     _pylab_helpers = importlib.import_module('matplotlib._pylab_helpers')
-    currentfigure = importlib.import_module('workbench.plotting.currentfigure')
-    setattr(_pylab_helpers, 'Gcf', getattr(currentfigure, 'CurrentFigure'))
+    currentfigure = importlib.import_module('workbench.plotting.globalfiguremanager')
+    setattr(_pylab_helpers, 'Gcf', getattr(currentfigure, 'GlobalFigureManager'))
     # Set up out custom matplotlib backend early. It must be done on
     # the main thread
     mpl.use(MPL_BACKEND)

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -150,9 +150,6 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
             self.window.addToolBar(self.toolbar)
             self.toolbar.message.connect(self.statusbar_label.setText)
             self.toolbar.sig_grid_toggle_triggered.connect(self.grid_toggle)
-            if hasattr(Gcf, 'set_hold'):
-                self.toolbar.sig_hold_triggered.connect(functools.partial(Gcf.set_hold, self))
-                self.toolbar.sig_active_triggered.connect(functools.partial(Gcf.set_active, self))
             tbs_height = self.toolbar.sizeHint().height()
         else:
             tbs_height = 0

--- a/qt/applications/workbench/workbench/plotting/functions.py
+++ b/qt/applications/workbench/workbench/plotting/functions.py
@@ -68,7 +68,8 @@ def _validate_pcolormesh_inputs(workspaces):
         raise_if_not_sequence(workspaces, 'Workspaces')
 
 
-def plot(workspaces, spectrum_nums=None, wksp_indices=None, errors=False):
+def plot(workspaces, spectrum_nums=None, wksp_indices=None, errors=False,
+         overplot=False):
     """
     Create a figure with a single subplot and for each workspace/index add a
     line plot to the new axes. show() is called before returning the figure instance. A legend
@@ -78,6 +79,7 @@ def plot(workspaces, spectrum_nums=None, wksp_indices=None, errors=False):
     :param spectrum_nums: A list of spectrum number identifiers (general start from 1)
     :param wksp_indices: A list of workspace indexes (starts from 0)
     :param errors: If true then error bars are added for each plot
+    :param overplot: If true then overplot over the current figure if one exists
     :returns: The figure containing the plots
     """
     # check inputs
@@ -86,17 +88,25 @@ def plot(workspaces, spectrum_nums=None, wksp_indices=None, errors=False):
         kw, nums = 'specNum', spectrum_nums
     else:
         kw, nums = 'wkspIndex', wksp_indices
-    # create figure
-    fig = plt.figure()
-    fig.clf()
-    ax = fig.add_subplot(111, projection=PROJECTION)
+
+    # get/create the axes to hold the plot
+    if overplot:
+        ax = plt.gca(projection=PROJECTION)
+        fig = ax.figure
+    else:
+        fig = plt.figure()
+        ax = fig.add_subplot(111, projection=PROJECTION)
+
+    # do the plotting
     plot_fn = ax.errorbar if errors else ax.plot
     for ws in workspaces:
         for num in nums:
             plot_fn(ws, **{kw: num})
 
     ax.legend()
-    ax.set_title(workspaces[0].name())
+    title = workspaces[0].name()
+    ax.set_title(title)
+    fig.canvas.set_window_title(title)
     fig.canvas.draw()
     fig.show()
     return fig

--- a/qt/applications/workbench/workbench/plotting/globalfiguremanager.py
+++ b/qt/applications/workbench/workbench/plotting/globalfiguremanager.py
@@ -24,12 +24,8 @@ import gc
 from six import itervalues
 
 
-class CurrentFigure(object):
+class GlobalFigureManager(object):
     """A singleton manager of all figures created through it. Analogous to _pylab_helpers.Gcf.
-
-    Each figure has a hold/active button attached to it:
-      - active toggled = next plot operation should replace this figure
-      - hold toggled = next plot operation should produce a new figure
 
     Attributes:
 
@@ -155,4 +151,5 @@ class CurrentFigure(object):
         if cls._active == manager:
             cls._active = None
 
-atexit.register(CurrentFigure.destroy_all)
+
+atexit.register(GlobalFigureManager.destroy_all)

--- a/qt/applications/workbench/workbench/plotting/globalfiguremanager.py
+++ b/qt/applications/workbench/workbench/plotting/globalfiguremanager.py
@@ -21,30 +21,41 @@ import atexit
 import gc
 
 # 3rdparty imports
-from six import itervalues
+import six
 
 
 class GlobalFigureManager(object):
-    """A singleton manager of all figures created through it. Analogous to _pylab_helpers.Gcf.
+    """
+    Singleton to manage a set of integer-numbered figures. It replaces
+    matplotlib._pylab_helpers.Gcf as the global figure manager.
+
+    This class is never instantiated; it consists of two class
+    attributes (a list and a dictionary), and a set of static
+    methods that operate on those attributes, accessing them
+    directly as class attributes.
 
     Attributes:
 
-        *_active*:
-          A reference to the figure that is set as active, can be None
-
         *figs*:
           dictionary of the form {*num*: *manager*, ...}
+
+        *_activeQue*:
+          list of *managers*, with active one at the end
+
     """
-    _active = None
+    _activeQue = []
     figs = {}
 
     @classmethod
-    def get_fig_manager(cls, _):
+    def get_fig_manager(cls, num):
         """
-        If an active figure manager exists return it; otherwise
-        return *None*.
+        If figure manager *num* exists, make it the active
+        figure and return the manager; otherwise return *None*.
         """
-        return cls.get_active()
+        manager = cls.figs.get(num, None)
+        if manager is not None:
+            cls.set_active(manager)
+        return manager
 
     @classmethod
     def destroy(cls, num):
@@ -59,8 +70,14 @@ class GlobalFigureManager(object):
         manager = cls.figs[num]
         manager.canvas.mpl_disconnect(manager._cidgcf)
 
-        if cls._active.num == num:
-            cls._active = None
+        # There must be a good reason for the following careful
+        # rebuilding of the activeQue; what is it?
+        oldQue = cls._activeQue[:]
+        cls._activeQue = []
+        for f in oldQue:
+            if f != manager:
+                cls._activeQue.append(f)
+
         del cls.figs[num]
         manager.destroy()
         gc.collect(1)
@@ -69,7 +86,7 @@ class GlobalFigureManager(object):
     def destroy_fig(cls, fig):
         "*fig* is a Figure instance"
         num = None
-        for manager in itervalues(cls.figs):
+        for manager in six.itervalues(cls.figs):
             if manager.canvas.figure == fig:
                 num = manager.num
                 break
@@ -85,7 +102,7 @@ class GlobalFigureManager(object):
             manager.canvas.mpl_disconnect(manager._cidgcf)
             manager.destroy()
 
-        cls._active = None
+        cls._activeQue = []
         cls.figs.clear()
         gc.collect(1)
 
@@ -115,23 +132,23 @@ class GlobalFigureManager(object):
         """
         Return the manager of the active figure, or *None*.
         """
-        if cls._active is not None:
-            cls._active.canvas.figure.clf()
-        return cls._active
+        if len(cls._activeQue) == 0:
+            return None
+        else:
+            return cls._activeQue[-1]
 
     @classmethod
     def set_active(cls, manager):
         """
         Make the figure corresponding to *manager* the active one.
-
-        Notifies all other figures to disable their active status.
         """
-        cls._active = manager
-        active_num = manager.num
-        cls.figs[active_num] = manager
-        for manager in itervalues(cls.figs):
-            if manager.num != active_num:
-                manager.hold()
+        oldQue = cls._activeQue[:]
+        cls._activeQue = []
+        for m in oldQue:
+            if m != manager:
+                cls._activeQue.append(m)
+        cls._activeQue.append(manager)
+        cls.figs[manager.num] = manager
 
     @classmethod
     def draw_all(cls, force=False):
@@ -142,14 +159,6 @@ class GlobalFigureManager(object):
         for f_mgr in cls.get_all_fig_managers():
             if force or f_mgr.canvas.figure.stale:
                 f_mgr.canvas.draw_idle()
-
-    # ------------------ Our additional interface -----------------
-
-    @classmethod
-    def set_hold(cls, manager):
-        """If this manager is active then set inactive"""
-        if cls._active == manager:
-            cls._active = None
 
 
 atexit.register(GlobalFigureManager.destroy_all)

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -40,10 +40,6 @@ class WorkbenchNavigationToolbar(NavigationToolbar2QT):
         ('Zoom', 'Zoom to rectangle', 'fa.search-plus', 'zoom', False),
         (None, None, None, None, None),
         ('Grid', 'Toggle grid on/off', None, 'toggle_grid', False),
-        (None, None, None, None, None),
-        ('Active', 'When enabled future plots will overwrite this figure', None, 'active', True),
-        ('Hold', 'When enabled this holds this figure open ', None, 'hold', False),
-        (None, None, None, None, None),
         ('Save', 'Save the figure', 'fa.save', 'save_figure', None),
         ('Print','Print the figure', 'fa.print', 'print_figure', None),
         (None, None, None, None, None),
@@ -89,16 +85,6 @@ class WorkbenchNavigationToolbar(NavigationToolbar2QT):
 
     def toggle_grid(self):
         self.sig_grid_toggle_triggered.emit()
-
-    def hold(self, *args):
-        self._actions['hold'].setChecked(True)
-        self._actions['active'].setChecked(False)
-        self.sig_hold_triggered.emit()
-
-    def active(self, *args):
-        self._actions['active'].setChecked(True)
-        self._actions['hold'].setChecked(False)
-        self.sig_active_triggered.emit()
 
     def print_figure(self):
         printer = QtPrintSupport.QPrinter(QtPrintSupport.QPrinter.HighResolution)

--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -31,7 +31,6 @@ from qtpy.QtWidgets import QVBoxLayout
 from workbench.plugins.base import PluginWidget
 from workbench.plotting.functions import pcolormesh, plot
 
-
 LOGGER = Logger(b"workspacewidget")
 
 
@@ -80,9 +79,13 @@ class WorkspaceWidget(PluginWidget):
 
         # behaviour
         workspacewidget.plotSpectrumClicked.connect(functools.partial(self._do_plot_spectrum,
-                                                                      errors=False))
+                                                                      errors=False, overplot=False))
+        workspacewidget.overplotSpectrumClicked.connect(functools.partial(self._do_plot_spectrum,
+                                                                          errors=False, overplot=True))
         workspacewidget.plotSpectrumWithErrorsClicked.connect(functools.partial(self._do_plot_spectrum,
-                                                                                errors=True))
+                                                                                errors=True, overplot=False))
+        workspacewidget.overplotSpectrumWithErrorsClicked.connect(functools.partial(self._do_plot_spectrum,
+                                                                                    errors=True, overplot=True))
         workspacewidget.plotColorfillClicked.connect(self._do_plot_colorfill)
 
     # ----------------- Plugin API --------------------
@@ -98,19 +101,21 @@ class WorkspaceWidget(PluginWidget):
 
     # ----------------- Behaviour --------------------
 
-    def _do_plot_spectrum(self, names, errors):
+    def _do_plot_spectrum(self, names, errors, overplot):
         """
         Plot spectra from the selected workspaces
 
         :param names: A list of workspace names
         :param errors: If true then error bars will be plotted on the points
+        :param overplot: If true then the add to the current figure if one
+                         exists
         """
         try:
             selection = get_plot_selection(_workspaces_from_names(names), self)
             if selection is not None:
                 plot(selection.workspaces, spectrum_nums=selection.spectra,
                      wksp_indices=selection.wksp_indices,
-                     errors=errors)
+                     errors=errors, overplot=overplot)
         except BaseException:
             import traceback
             traceback.print_exc()

--- a/qt/python/mantidqt/widgets/src/_widgetscore.sip
+++ b/qt/python/mantidqt/widgets/src/_widgetscore.sip
@@ -218,9 +218,11 @@ public:
                             QWidget *parent /TransferThis/ = nullptr);
 
 signals:
-  void plotSpectrumClicked(const QStringList & workspaceName);
-  void plotSpectrumWithErrorsClicked(const QStringList & workspaceName);
-  void plotColorfillClicked(const QStringList &workspaceName);
+  void plotSpectrumClicked(const QStringList & workspaceNames);
+  void overplotSpectrumClicked(const QStringList & workspaceNames);
+  void plotSpectrumWithErrorsClicked(const QStringList & workspaceNames);
+  void overplotSpectrumWithErrorsClicked(const QStringList & workspaceNames);
+  void plotColorfillClicked(const QStringList &workspaceNames);
 };
 
 // ---------------------------------

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidgetSimple.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidgetSimple.h
@@ -6,8 +6,8 @@
 
 #include <MantidAPI/MatrixWorkspace_fwd.h>
 
-#include <QWidget>
 #include <QMenu>
+#include <QWidget>
 
 class QTreeWidgetItem;
 class QSignalMapper;
@@ -60,17 +60,22 @@ public:
 
 signals:
   void plotSpectrumClicked(const QStringList &workspaceName);
+  void overplotSpectrumClicked(const QStringList &workspaceName);
   void plotSpectrumWithErrorsClicked(const QStringList &workspaceName);
+  void overplotSpectrumWithErrorsClicked(const QStringList &workspaceName);
   void plotColorfillClicked(const QStringList &workspaceName);
 
 private slots:
   void onPlotSpectrumClicked();
+  void onOverplotSpectrumClicked();
   void onPlotSpectrumWithErrorsClicked();
+  void onOverplotSpectrumWithErrorsClicked();
   void onPlotColorfillClicked();
 
 private:
-  QAction *m_plotSpectrum, *m_plotSpectrumWithErrs, *m_plotColorfill;
+  QAction *m_plotSpectrum, *m_overplotSpectrum, *m_plotSpectrumWithErrs,
+      *m_overplotSpectrumWithErrs, *m_plotColorfill;
 };
-}
-}
+} // namespace MantidWidgets
+} // namespace MantidQt
 #endif // MANTIDQT_MANTIDWIDGETS_WORKSPACETREEWIDGETSIMPLE_H

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
@@ -4,9 +4,9 @@
 
 #include <MantidAPI/AlgorithmManager.h>
 #include <MantidAPI/FileProperty.h>
+#include <MantidAPI/ITableWorkspace.h>
 #include <MantidAPI/MatrixWorkspace.h>
 #include <MantidAPI/WorkspaceGroup.h>
-#include <MantidAPI/ITableWorkspace.h>
 
 #include <QMenu>
 #include <QSignalMapper>
@@ -21,13 +21,20 @@ WorkspaceTreeWidgetSimple::WorkspaceTreeWidgetSimple(MantidDisplayBase *mdb,
                                                      QWidget *parent)
     : WorkspaceTreeWidget(mdb, parent),
       m_plotSpectrum(new QAction("spectrum...", this)),
+      m_overplotSpectrum(new QAction("overplot spectrum...", this)),
       m_plotSpectrumWithErrs(new QAction("spectrum with errors...", this)),
+      m_overplotSpectrumWithErrs(
+          new QAction("overplot spectrum with errors...", this)),
       m_plotColorfill(new QAction("colorfill", this)) {
   // connections
   connect(m_plotSpectrum, SIGNAL(triggered()), this,
           SLOT(onPlotSpectrumClicked()));
+  connect(m_overplotSpectrum, SIGNAL(triggered()), this,
+          SLOT(onOverplotSpectrumClicked()));
   connect(m_plotSpectrumWithErrs, SIGNAL(triggered()), this,
           SLOT(onPlotSpectrumWithErrorsClicked()));
+  connect(m_overplotSpectrumWithErrs, SIGNAL(triggered()), this,
+          SLOT(onOverplotSpectrumWithErrorsClicked()));
   connect(m_plotColorfill, SIGNAL(triggered()), this,
           SLOT(onPlotColorfillClicked()));
 }
@@ -54,7 +61,9 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
     // plot submenu first
     QMenu *plotSubMenu(new QMenu("Plot", menu));
     plotSubMenu->addAction(m_plotSpectrum);
+    plotSubMenu->addAction(m_overplotSpectrum);
     plotSubMenu->addAction(m_plotSpectrumWithErrs);
+    plotSubMenu->addAction(m_overplotSpectrumWithErrs);
     plotSubMenu->addAction(m_plotColorfill);
     menu->addMenu(plotSubMenu);
 
@@ -74,8 +83,16 @@ void WorkspaceTreeWidgetSimple::onPlotSpectrumClicked() {
   emit plotSpectrumClicked(getSelectedWorkspaceNamesAsQList());
 }
 
+void WorkspaceTreeWidgetSimple::onOverplotSpectrumClicked() {
+  emit overplotSpectrumClicked(getSelectedWorkspaceNamesAsQList());
+}
+
 void WorkspaceTreeWidgetSimple::onPlotSpectrumWithErrorsClicked() {
   emit plotSpectrumWithErrorsClicked(getSelectedWorkspaceNamesAsQList());
+}
+
+void WorkspaceTreeWidgetSimple::onOverplotSpectrumWithErrorsClicked() {
+  emit overplotSpectrumWithErrorsClicked(getSelectedWorkspaceNamesAsQList());
 }
 
 void WorkspaceTreeWidgetSimple::onPlotColorfillClicked() {


### PR DESCRIPTION
**Description of work**

Feedback from the January 2018 user meeting gave universal disapproval for the active/hold facility of plot management. Users wanted to decide at the point of plotting the workspace whether it should open in a new figure or overplot on the existing one.

This work removes the active/hold functionality and adds separate items to overplot on to existing figures if they exist.

**To test:**

Start the workbench and either load some data or create some fake data with `CreateSampleWorkspace`. Examine the plot menu of the workspace and check you are happy with the layout and text.

Try all of the options. The behaviour is intended to be as follows:
* plot will always open a new figure
* overplot will add to an existing active figure if one exists and create a new one if one doesn't exist
  * if two or more plot windows are open then clicking on the window makes it active and the next overplot request will go there.

*No associated issue*

**Release Notes** 

*Does not need to be in the release notes. The workbench will be advertised separately.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
