### PR TITLE
Workbench explicit overplot

### DIFF
--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -382,8 +382,8 @@ def start_workbench(app):
     # Load matplotlib as early as possible and set our defaults
     # Setup our custom backend and monkey patch in custom current figure manager
     main_window.set_splash('Preloading matplotlib')
-    from workbench.plotting.setup import setup_matplotlib  # noqa
-    setup_matplotlib()
+    from workbench.plotting.config import initialize_matplotlib  # noqa
+    initialize_matplotlib()
 
     # Setup widget layouts etc. mantid cannot be imported before this
     # or the log messages don't get through

--- a/qt/applications/workbench/workbench/plotting/config.py
+++ b/qt/applications/workbench/workbench/plotting/config.py
@@ -20,7 +20,7 @@ from __future__ import (absolute_import)
 
 # 3rd-party imports
 import matplotlib as mpl
-import matplotlib._pylab_helpers as pylab_helpers
+import matplotlib._pylab_helpers as _pylab_helpers
 
 # local imports
 from .globalfiguremanager import GlobalFigureManager
@@ -34,12 +34,10 @@ DEFAULT_RCPARAMS = {
 }
 
 
-def setup_matplotlib():
+def initialize_matplotlib():
     """Configures our defaults"""
-    # Replace vanilla Gcf with our custom instance
-    setattr(pylab_helpers, 'Gcf', GlobalFigureManager)
-    # Our backend
-    mpl.use(MPL_BACKEND)
+    # Replace vanilla Gcf with our custom manager
+    setattr(_pylab_helpers, 'Gcf', GlobalFigureManager)
     # Set our defaults
     reset_rcparams_to_default()
 
@@ -47,12 +45,12 @@ def setup_matplotlib():
 def reset_rcparams_to_default():
     """
     Reset the rcParams to the default settings.
-
-    :param rcp: A dictionary containing new rcparams values
     """
     mpl.rcParams.clear()
     mpl.rc_file_defaults()
     set_rcparams(DEFAULT_RCPARAMS)
+    # We must keep our backend
+    mpl.use(MPL_BACKEND)
 
 
 def set_rcparams(rcp):
@@ -60,4 +58,6 @@ def set_rcparams(rcp):
     Update the current rcParams with the given set
     :param rcp: A dictionary containing new rcparams values
     """
+    # We must keep our backend
+    assert 'backend' not in rcp
     mpl.rcParams.update(rcp)

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -150,9 +150,6 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
             self.window.addToolBar(self.toolbar)
             self.toolbar.message.connect(self.statusbar_label.setText)
             self.toolbar.sig_grid_toggle_triggered.connect(self.grid_toggle)
-            if hasattr(Gcf, 'set_hold'):
-                self.toolbar.sig_hold_triggered.connect(functools.partial(Gcf.set_hold, self))
-                self.toolbar.sig_active_triggered.connect(functools.partial(Gcf.set_active, self))
             tbs_height = self.toolbar.sizeHint().height()
         else:
             tbs_height = 0

--- a/qt/applications/workbench/workbench/plotting/figuretype.py
+++ b/qt/applications/workbench/workbench/plotting/figuretype.py
@@ -1,0 +1,75 @@
+#  This file is part of the mantid workbench.
+#
+#  Copyright (C) 2017 mantidproject
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Provides facilities to check plot types
+"""
+from __future__ import absolute_import
+
+from mantidqt.py3compat import Enum
+
+
+class FigureType(Enum):
+    """Enumerate possible types of Figure"""
+    # The values are irrelevant
+
+    # A figure with no axes
+    Empty = 0
+    # Line plot without error bars
+    Line = 1
+    # Line plot with error bars
+    Errorbar = 2
+    # An image plot from imshow, pcolor
+    Image = 3
+    # Any other type of plot
+    Other = 100
+
+
+def axes_type(ax):
+    """Return the plot type contained in the axes
+
+    :param ax: A matplotlib.axes.Axes instance
+    :return: An enumeration defining the plot type
+    """
+    try:
+        nrows, ncols, _ = ax.get_geometry()
+    except AttributeError:
+        nrows, ncols = 1, 1
+
+    axtype = FigureType.Other
+    if nrows == 1 and ncols == 1:
+        if len(ax.lines) > 0:
+            axtype = FigureType.Line
+        elif len(ax.images) > 0:
+            axtype = FigureType.Image
+
+    return axtype
+
+
+def figure_type(fig):
+    """Return the type of the figure
+
+    :param fig: A matplotlib figure instance
+    :return: An enumeration defining the plot type
+    """
+    all_axes = fig.axes
+    all_axes_length = len(all_axes)
+    if all_axes_length == 0:
+        return FigureType.Empty
+    elif all_axes_length == 1:
+        return axes_type(all_axes[0])
+    else:
+        return FigureType.Other

--- a/qt/applications/workbench/workbench/plotting/functions.py
+++ b/qt/applications/workbench/workbench/plotting/functions.py
@@ -68,6 +68,17 @@ def _validate_pcolormesh_inputs(workspaces):
         raise_if_not_sequence(workspaces, 'Workspaces')
 
 
+def current_figure_or_none():
+    """If an active figure exists then return it otherwise return None
+
+    :return: An active figure or None
+    """
+    if len(plt.get_fignums()) > 0:
+        return plt.gcf()
+    else:
+        return None
+
+
 def plot(workspaces, spectrum_nums=None, wksp_indices=None, errors=False,
          overplot=False):
     """

--- a/qt/applications/workbench/workbench/plotting/functions.py
+++ b/qt/applications/workbench/workbench/plotting/functions.py
@@ -68,7 +68,8 @@ def _validate_pcolormesh_inputs(workspaces):
         raise_if_not_sequence(workspaces, 'Workspaces')
 
 
-def plot(workspaces, spectrum_nums=None, wksp_indices=None, errors=False):
+def plot(workspaces, spectrum_nums=None, wksp_indices=None, errors=False,
+         overplot=False):
     """
     Create a figure with a single subplot and for each workspace/index add a
     line plot to the new axes. show() is called before returning the figure instance. A legend
@@ -78,6 +79,7 @@ def plot(workspaces, spectrum_nums=None, wksp_indices=None, errors=False):
     :param spectrum_nums: A list of spectrum number identifiers (general start from 1)
     :param wksp_indices: A list of workspace indexes (starts from 0)
     :param errors: If true then error bars are added for each plot
+    :param overplot: If true then overplot over the current figure if one exists
     :returns: The figure containing the plots
     """
     # check inputs
@@ -86,17 +88,25 @@ def plot(workspaces, spectrum_nums=None, wksp_indices=None, errors=False):
         kw, nums = 'specNum', spectrum_nums
     else:
         kw, nums = 'wkspIndex', wksp_indices
-    # create figure
-    fig = plt.figure()
-    fig.clf()
-    ax = fig.add_subplot(111, projection=PROJECTION)
+
+    # get/create the axes to hold the plot
+    if overplot:
+        ax = plt.gca(projection=PROJECTION)
+        fig = ax.figure
+    else:
+        fig = plt.figure()
+        ax = fig.add_subplot(111, projection=PROJECTION)
+
+    # do the plotting
     plot_fn = ax.errorbar if errors else ax.plot
     for ws in workspaces:
         for num in nums:
             plot_fn(ws, **{kw: num})
 
     ax.legend()
-    ax.set_title(workspaces[0].name())
+    title = workspaces[0].name()
+    ax.set_title(title)
+    fig.canvas.set_window_title(title)
     fig.canvas.draw()
     fig.show()
     return fig

--- a/qt/applications/workbench/workbench/plotting/functions.py
+++ b/qt/applications/workbench/workbench/plotting/functions.py
@@ -19,11 +19,13 @@ our custom window.
 """
 
 # std imports
+import collections
 import math
 
 # 3rd party imports
 from mantid.api import MatrixWorkspace
 import matplotlib.pyplot as plt
+from mantidqt.py3compat import is_text_string
 
 # local imports
 
@@ -79,6 +81,28 @@ def current_figure_or_none():
         return None
 
 
+def figure_title(workspaces, fig_num):
+    """Create a default figure title from a single workspace, list of workspaces or
+    workspace names and a figure number. The name of the first workspace in the list
+    is concatenated with the figure number.
+
+    :param workspaces: A single workspace, list of workspaces or workspace name/list of workspace names
+    :param fig_num: An integer denoting the figure number
+    :return: A title for the figure
+    """
+    def wsname(w):
+        return w.name() if hasattr(w, 'name') else w
+
+    if is_text_string(workspaces) or not isinstance(workspaces, collections.Sequence):
+        # assume a single workspace
+        first = workspaces
+    else:
+        assert len(workspaces) > 0
+        first = workspaces[0]
+
+    return wsname(first) + '-' + str(fig_num)
+
+
 def plot(workspaces, spectrum_nums=None, wksp_indices=None, errors=False,
          overplot=False):
     """
@@ -117,7 +141,7 @@ def plot(workspaces, spectrum_nums=None, wksp_indices=None, errors=False,
     ax.legend()
     title = workspaces[0].name()
     ax.set_title(title)
-    fig.canvas.set_window_title(title)
+    fig.canvas.set_window_title(figure_title(workspaces, fig.number))
     fig.canvas.draw()
     fig.show()
     return fig
@@ -171,6 +195,7 @@ def pcolormesh(workspaces):
     # Adjust locations to ensure the plots don't overlap
     fig.subplots_adjust(wspace=SUBPLOT_WSPACE, hspace=SUBPLOT_HSPACE)
     fig.colorbar(pcm, ax=axes.ravel().tolist(), pad=0.06)
+    fig.canvas.set_window_title(figure_title(workspaces, fig.number))
     fig.canvas.draw()
     fig.show()
     return fig

--- a/qt/applications/workbench/workbench/plotting/globalfiguremanager.py
+++ b/qt/applications/workbench/workbench/plotting/globalfiguremanager.py
@@ -24,12 +24,8 @@ import gc
 from six import itervalues
 
 
-class CurrentFigure(object):
+class GlobalFigureManager(object):
     """A singleton manager of all figures created through it. Analogous to _pylab_helpers.Gcf.
-
-    Each figure has a hold/active button attached to it:
-      - active toggled = next plot operation should replace this figure
-      - hold toggled = next plot operation should produce a new figure
 
     Attributes:
 
@@ -155,4 +151,5 @@ class CurrentFigure(object):
         if cls._active == manager:
             cls._active = None
 
-atexit.register(CurrentFigure.destroy_all)
+
+atexit.register(GlobalFigureManager.destroy_all)

--- a/qt/applications/workbench/workbench/plotting/globalfiguremanager.py
+++ b/qt/applications/workbench/workbench/plotting/globalfiguremanager.py
@@ -21,30 +21,41 @@ import atexit
 import gc
 
 # 3rdparty imports
-from six import itervalues
+import six
 
 
 class GlobalFigureManager(object):
-    """A singleton manager of all figures created through it. Analogous to _pylab_helpers.Gcf.
+    """
+    Singleton to manage a set of integer-numbered figures. It replaces
+    matplotlib._pylab_helpers.Gcf as the global figure manager.
+
+    This class is never instantiated; it consists of two class
+    attributes (a list and a dictionary), and a set of static
+    methods that operate on those attributes, accessing them
+    directly as class attributes.
 
     Attributes:
 
-        *_active*:
-          A reference to the figure that is set as active, can be None
-
         *figs*:
           dictionary of the form {*num*: *manager*, ...}
+
+        *_activeQue*:
+          list of *managers*, with active one at the end
+
     """
-    _active = None
+    _activeQue = []
     figs = {}
 
     @classmethod
-    def get_fig_manager(cls, _):
+    def get_fig_manager(cls, num):
         """
-        If an active figure manager exists return it; otherwise
-        return *None*.
+        If figure manager *num* exists, make it the active
+        figure and return the manager; otherwise return *None*.
         """
-        return cls.get_active()
+        manager = cls.figs.get(num, None)
+        if manager is not None:
+            cls.set_active(manager)
+        return manager
 
     @classmethod
     def destroy(cls, num):
@@ -59,8 +70,14 @@ class GlobalFigureManager(object):
         manager = cls.figs[num]
         manager.canvas.mpl_disconnect(manager._cidgcf)
 
-        if cls._active.num == num:
-            cls._active = None
+        # There must be a good reason for the following careful
+        # rebuilding of the activeQue; what is it?
+        oldQue = cls._activeQue[:]
+        cls._activeQue = []
+        for f in oldQue:
+            if f != manager:
+                cls._activeQue.append(f)
+
         del cls.figs[num]
         manager.destroy()
         gc.collect(1)
@@ -69,7 +86,7 @@ class GlobalFigureManager(object):
     def destroy_fig(cls, fig):
         "*fig* is a Figure instance"
         num = None
-        for manager in itervalues(cls.figs):
+        for manager in six.itervalues(cls.figs):
             if manager.canvas.figure == fig:
                 num = manager.num
                 break
@@ -85,7 +102,7 @@ class GlobalFigureManager(object):
             manager.canvas.mpl_disconnect(manager._cidgcf)
             manager.destroy()
 
-        cls._active = None
+        cls._activeQue = []
         cls.figs.clear()
         gc.collect(1)
 
@@ -115,23 +132,23 @@ class GlobalFigureManager(object):
         """
         Return the manager of the active figure, or *None*.
         """
-        if cls._active is not None:
-            cls._active.canvas.figure.clf()
-        return cls._active
+        if len(cls._activeQue) == 0:
+            return None
+        else:
+            return cls._activeQue[-1]
 
     @classmethod
     def set_active(cls, manager):
         """
         Make the figure corresponding to *manager* the active one.
-
-        Notifies all other figures to disable their active status.
         """
-        cls._active = manager
-        active_num = manager.num
-        cls.figs[active_num] = manager
-        for manager in itervalues(cls.figs):
-            if manager.num != active_num:
-                manager.hold()
+        oldQue = cls._activeQue[:]
+        cls._activeQue = []
+        for m in oldQue:
+            if m != manager:
+                cls._activeQue.append(m)
+        cls._activeQue.append(manager)
+        cls.figs[manager.num] = manager
 
     @classmethod
     def draw_all(cls, force=False):
@@ -142,14 +159,6 @@ class GlobalFigureManager(object):
         for f_mgr in cls.get_all_fig_managers():
             if force or f_mgr.canvas.figure.stale:
                 f_mgr.canvas.draw_idle()
-
-    # ------------------ Our additional interface -----------------
-
-    @classmethod
-    def set_hold(cls, manager):
-        """If this manager is active then set inactive"""
-        if cls._active == manager:
-            cls._active = None
 
 
 atexit.register(GlobalFigureManager.destroy_all)

--- a/qt/applications/workbench/workbench/plotting/setup.py
+++ b/qt/applications/workbench/workbench/plotting/setup.py
@@ -23,7 +23,7 @@ import matplotlib as mpl
 import matplotlib._pylab_helpers as pylab_helpers
 
 # local imports
-from .currentfigure import CurrentFigure
+from .globalfiguremanager import GlobalFigureManager
 
 # Our backend. We keep this separate from the rc params as it can only be set once
 MPL_BACKEND = 'module://workbench.plotting.backend_workbench'
@@ -37,7 +37,7 @@ DEFAULT_RCPARAMS = {
 def setup_matplotlib():
     """Configures our defaults"""
     # Replace vanilla Gcf with our custom instance
-    setattr(pylab_helpers, 'Gcf', CurrentFigure)
+    setattr(pylab_helpers, 'Gcf', GlobalFigureManager)
     # Our backend
     mpl.use(MPL_BACKEND)
     # Set our defaults

--- a/qt/applications/workbench/workbench/plotting/test/__init__.py
+++ b/qt/applications/workbench/workbench/plotting/test/__init__.py
@@ -1,0 +1,16 @@
+#  This file is part of the mantid workbench.
+#
+#  Copyright (C) 2018 mantidproject
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/qt/applications/workbench/workbench/plotting/test/test_figuretype.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figuretype.py
@@ -1,0 +1,52 @@
+#  This file is part of the mantid workbench.
+#
+#  Copyright (C) 2018 mantidproject
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__  import absolute_import
+
+# std imports
+from unittest import TestCase, main
+
+# thirdparty imports
+import matplotlib
+matplotlib.use('AGG')  # noqa
+import matplotlib.pyplot as plt
+
+# local imports
+from workbench.plotting.figuretype import figure_type, FigureType
+
+
+class FigureTypeTest(TestCase):
+
+    def test_figure_type_empty_figure_returns_empty(self):
+        self.assertEqual(FigureType.Empty, figure_type(plt.figure()))
+
+    def test_subplot_with_multiple_plots_returns_other(self):
+        ax = plt.subplot(221)
+        self.assertEqual(FigureType.Other, figure_type(ax.figure))
+
+    def test_line_plot_returns_line(self):
+        ax = plt.subplot(111)
+        ax.plot([1])
+        self.assertEqual(FigureType.Line, figure_type(ax.figure))
+
+    def test_image_plot_returns_image(self):
+        ax = plt.subplot(111)
+        ax.imshow([[1],[1]])
+        self.assertEqual(FigureType.Image, figure_type(ax.figure))
+
+
+if __name__ == '__main__':
+    main()

--- a/qt/applications/workbench/workbench/plotting/test/test_functions.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_functions.py
@@ -1,0 +1,66 @@
+#  This file is part of the mantid workbench.
+#
+#  Copyright (C) 2018 mantidproject
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__  import absolute_import
+
+# std imports
+from unittest import TestCase, main
+
+# thirdparty imports
+import matplotlib
+matplotlib.use('AGG')  # noqa
+import matplotlib.pyplot as plt
+
+# local imports
+from workbench.plotting.functions import current_figure_or_none, figure_title
+
+
+# Avoid importing the whole of mantid for a single mock of the workspace class
+class FakeWorkspace(object):
+
+    def __init__(self, name):
+        self._name = name
+
+    def name(self):
+        return self._name
+
+
+class FunctionsTest(TestCase):
+
+    def test_current_figure_or_none_returns_none_if_no_figures_exist(self):
+        plt.close('all')
+        self.assertTrue(current_figure_or_none() is None)
+
+    def test_figure_title_with_single_string(self):
+        self.assertEqual("test-1", figure_title("test", 1))
+
+    def test_figure_title_with_list_of_strings(self):
+        self.assertEqual("first-10", figure_title(["first", "second"], 10))
+
+    def test_figure_title_with_single_workspace(self):
+        self.assertEqual("fake-5", figure_title(FakeWorkspace("fake"), 5))
+
+    def test_figure_title_with_workspace_list(self):
+        self.assertEqual("fake-10", figure_title((FakeWorkspace("fake"),
+                                                  FakeWorkspace("nextfake")), 10))
+
+    def test_figure_title_with_empty_list_raises_assertion(self):
+        with self.assertRaises(AssertionError):
+            figure_title([], 5)
+
+
+if __name__ == '__main__':
+    main()

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -40,10 +40,6 @@ class WorkbenchNavigationToolbar(NavigationToolbar2QT):
         ('Zoom', 'Zoom to rectangle', 'fa.search-plus', 'zoom', False),
         (None, None, None, None, None),
         ('Grid', 'Toggle grid on/off', None, 'toggle_grid', False),
-        (None, None, None, None, None),
-        ('Active', 'When enabled future plots will overwrite this figure', None, 'active', True),
-        ('Hold', 'When enabled this holds this figure open ', None, 'hold', False),
-        (None, None, None, None, None),
         ('Save', 'Save the figure', 'fa.save', 'save_figure', None),
         ('Print','Print the figure', 'fa.print', 'print_figure', None),
         (None, None, None, None, None),
@@ -89,16 +85,6 @@ class WorkbenchNavigationToolbar(NavigationToolbar2QT):
 
     def toggle_grid(self):
         self.sig_grid_toggle_triggered.emit()
-
-    def hold(self, *args):
-        self._actions['hold'].setChecked(True)
-        self._actions['active'].setChecked(False)
-        self.sig_hold_triggered.emit()
-
-    def active(self, *args):
-        self._actions['active'].setChecked(True)
-        self._actions['hold'].setChecked(False)
-        self.sig_active_triggered.emit()
 
     def print_figure(self):
         printer = QtPrintSupport.QPrinter(QtPrintSupport.QPrinter.HighResolution)

--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -30,7 +30,6 @@ from qtpy.QtWidgets import QVBoxLayout
 from workbench.plugins.base import PluginWidget
 from workbench.plotting.functions import pcolormesh, plot
 
-
 LOGGER = Logger(b"workspacewidget")
 
 
@@ -78,9 +77,13 @@ class WorkspaceWidget(PluginWidget):
 
         # behaviour
         self.workspacewidget.plotSpectrumClicked.connect(functools.partial(self._do_plot_spectrum,
-                                                                           errors=False))
+                                                                           errors=False, overplot=False))
+        self.workspacewidget.overplotSpectrumClicked.connect(functools.partial(self._do_plot_spectrum,
+                                                                               errors=False, overplot=True))
         self.workspacewidget.plotSpectrumWithErrorsClicked.connect(functools.partial(self._do_plot_spectrum,
-                                                                                     errors=True))
+                                                                                     errors=True, overplot=False))
+        self.workspacewidget.overplotSpectrumWithErrorsClicked.connect(functools.partial(self._do_plot_spectrum,
+                                                                                         errors=True, overplot=True))
         self.workspacewidget.plotColorfillClicked.connect(self._do_plot_colorfill)
 
     # ----------------- Plugin API --------------------
@@ -96,19 +99,21 @@ class WorkspaceWidget(PluginWidget):
 
     # ----------------- Behaviour --------------------
 
-    def _do_plot_spectrum(self, names, errors):
+    def _do_plot_spectrum(self, names, errors, overplot):
         """
         Plot spectra from the selected workspaces
 
         :param names: A list of workspace names
         :param errors: If true then error bars will be plotted on the points
+        :param overplot: If true then the add to the current figure if one
+                         exists
         """
         try:
             selection = get_plot_selection(_workspaces_from_names(names), self)
             if selection is not None:
                 plot(selection.workspaces, spectrum_nums=selection.spectra,
                      wksp_indices=selection.wksp_indices,
-                     errors=errors)
+                     errors=errors, overplot=overplot)
         except BaseException:
             import traceback
             traceback.print_exc()

--- a/qt/python/mantidqt/py3compat/__init__.py
+++ b/qt/python/mantidqt/py3compat/__init__.py
@@ -1,6 +1,6 @@
 #  This file is part of the mantid workbench.
 #
-#  Copyright (C) 2017 mantidproject
+#  Copyright (C) 2018 mantidproject
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -27,10 +27,17 @@ This module should be fully compatible with:
     * Python 3
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import (absolute_import, print_function, unicode_literals)
 
 import six
-from six import * # noqa
+from six import *  # noqa
+
+# Enumerations are built in with Python 3
+try:
+    from enum import Enum
+except ImportError:
+    # use a compatability layer
+    from mantidqt.py3compat.enum import Enum  # noqa
 
 # -----------------------------------------------------------------------------
 # Globals and constants

--- a/qt/python/mantidqt/py3compat/enum.py
+++ b/qt/python/mantidqt/py3compat/enum.py
@@ -1,0 +1,351 @@
+# Copyright (C) 2004-2017 Barry Warsaw
+#
+# This file is part of flufl.enum
+#
+# flufl.enum is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# flufl.enum is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with flufl.enum.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Author: Barry Warsaw <barry@python.org>
+#
+# Used to provide backwards compatability with Python 2
+"""Python enumerations.
+"""
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+import re
+import sys
+import warnings
+
+from operator import itemgetter
+
+
+__metaclass__ = type
+__all__ = [
+    'Enum',
+    'EnumValue',
+    'IntEnum',
+    'make',
+    ]
+
+
+COMMASPACE = ', '
+SPACE = ' '
+IDENTIFIER_RE = r'^[a-zA-Z_][a-zA-Z0-9_]*$'
+
+
+class EnumMetaclass(type):
+    """Meta class for Enums."""
+
+    def __init__(cls, name, bases, attributes):
+        """Create an Enum class.
+
+        :param cls: The class being defined.
+        :param name: The name of the class.
+        :param bases: The class's base classes.
+        :param attributes: The class attributes.
+        """
+        super(EnumMetaclass, cls).__init__(name, bases, attributes)
+        # Store EnumValues here for easy access.
+        cls._enums = {}
+        # Figure out if this class has a custom factory for building enum
+        # values.  The default is EnumValue, but the class (or one of its
+        # bases) can declare a custom one with a special attribute.
+        factory = attributes.get('__value_factory__')
+        # Figure out the set of enum values on the base classes, to ensure
+        # that we don't get any duplicate values.  At the same time, check the
+        # base classes for the special attribute.
+        for basecls in cls.__mro__:
+            if hasattr(basecls, '_enums'):
+                cls._enums.update(basecls._enums)
+            if hasattr(basecls, '__value_factory__'):
+                basecls_factory = basecls.__value_factory__
+                if factory is not None and basecls_factory != factory:
+                    raise TypeError(
+                        'Conflicting enum factory in base class: {}'.format(
+                            basecls_factory))
+                factory = basecls_factory
+        # Set the factory default if necessary.
+        if factory is None:
+            factory = EnumValue
+        # For each class attribute, create an enum value and store that back
+        # on the class instead of the original value.  Skip Python reserved
+        # names.  Also add a mapping from the original value to the enum value
+        # instance so we can return the same object on conversion.
+        for attr in attributes:
+            if not (attr.startswith('__') and attr.endswith('__')):
+                value  = attributes[attr]
+                enumval = factory(cls, value, attr)
+                if value in cls._enums:
+                    other = cls._enums[value]
+                    # Without this, sort order is undefined and causes
+                    # unpredictable results for the test suite.
+                    first = (attr if attr < other else other)
+                    second = (other if attr < other else attr)
+                    raise ValueError("Conflicting enum value '{}' "
+                                     "for names: '{}' and '{}'".format(
+                                         value, first, second))
+                # Store as an attribute on the class, and save the attr name.
+                setattr(cls, attr, enumval)
+                cls._enums[value] = attr
+
+    def __dir__(cls):
+        # For Python 3.2, we must explicitly convert the dict view to a list.
+        # Order is not guaranteed, so don't sort it.
+        return list(cls._enums.values())
+
+    def __repr__(cls):
+        # We want predictable reprs.  Because base Enum items can have any
+        # value, the only reliable way to sort the keys for the repr is based
+        # on the attribute name, which must be Python identifiers.
+        return '<{0} {{{1}}}>'.format(cls.__name__, COMMASPACE.join(
+            '{0}: {1}'.format(value, key)
+            for key, value in sorted(cls._enums.items(), key=itemgetter(1))))
+
+    def __iter__(cls):
+        for value in sorted(cls._enums.values()):
+            yield getattr(cls, value)
+
+    def __getitem__(cls, item):
+        attr = cls._enums.get(item)
+        if attr is None:
+            # If this is an EnumValue, try it's .value attribute.
+            if hasattr(item, 'value'):
+                attr = cls._enums.get(item.value)
+            if attr is None:
+                # It wasn't value-ish -- try the attribute name.  This was
+                # deprecated in LP: #1167091.
+                try:
+                    warnings.warn('Enum[item_name] is deprecated; '
+                                  'use getattr(Enum, item_name)',
+                                  DeprecationWarning, 2)
+                    return getattr(cls, item)
+                except (AttributeError, TypeError):
+                    raise ValueError(item)
+        return getattr(cls, attr)
+
+    def __call__(cls, *args):
+        # One-argument calling is a deprecated synonym for getitem.
+        if len(args) == 1:
+            warnings.warn('MyEnum(arg) is deprecated; use MyEnum[arg]',
+                          DeprecationWarning, 2)
+            return cls.__getitem__(args[0])
+        name, source = args
+        return _make(cls, name, source)
+
+
+class EnumValue:
+    """Class to represent an enumeration value.
+
+    EnumValue('Color', 'red', 12) prints as 'Color.red' and can be converted
+    to the integer 12.
+    """
+    def __init__(self, enum, value, name):
+        self._enum = enum
+        self._value = value
+        self._name = name
+
+    def __repr__(self):
+        return '<EnumValue: {0}.{1} [value={2}]>'.format(
+            self._enum.__name__, self._name, self._value)
+
+    def __str__(self):
+        return '{0}.{1}'.format(self._enum.__name__, self._name)
+
+    def __int__(self):
+        warnings.warn('int() is deprecated; use IntEnums',
+                      DeprecationWarning, 2)
+        return self._value
+
+    def __reduce__(self):
+        return getattr, (self._enum, self._name)
+
+    @property
+    def enum(self):
+        """Return the class associated with the enum value."""
+        return self._enum
+
+    @property
+    def name(self):
+        """Return the name of the enum value."""
+        return self._name
+
+    @property
+    def value(self):
+        """Return the underlying value."""
+        return self._value
+
+    # Support only comparison by identity and equality.  Ordered comparisions
+    # are not supported.
+    def __eq__(self, other):
+        return self is other
+
+    def __ne__(self, other):
+        return self is not other
+
+    def __lt__(self, other):
+        # In Python 3, returning NotImplemented from an ordered comparison
+        # operator will cause a TypeError to be raised.  This doesn't work in
+        # Python 2 though, and you'd end up with working, but incorrect,
+        # ordered comparisons.  In Python 2 we raise the TypeError explicitly.
+        if sys.version_info[0] < 3:
+            raise TypeError(
+                'unorderable types: {}() < {}()'.format(
+                    self.__class__.__name__, other.__class__.__name__))
+        return NotImplemented
+
+    def __gt__(self, other):
+        if sys.version_info[0] < 3:
+            raise TypeError(
+                'unorderable types: {}() > {}()'.format(
+                    self.__class__.__name__, other.__class__.__name__))
+        return NotImplemented
+
+    def __le__(self, other):
+        if sys.version_info[0] < 3:
+            raise TypeError(
+                'unorderable types: {}() <= {}()'.format(
+                    self.__class__.__name__, other.__class__.__name__))
+        return NotImplemented
+
+    def __ge__(self, other):
+        if sys.version_info[0] < 3:
+            raise TypeError(
+                'unorderable types: {}() >= {}()'.format(
+                    self.__class__.__name__, other.__class__.__name__))
+        return NotImplemented
+
+    __hash__ = object.__hash__
+
+
+# Define the Enum class using metaclass syntax compatible with both Python 2
+# and Python 3.
+Enum = EnumMetaclass(str('Enum'), (), {
+    '__doc__': 'The public API Enum class.',
+    })
+
+
+class IntEnumValue(int, EnumValue):
+    """An EnumValue that is also an integer."""
+
+    def __new__(cls, enum, value, attr):
+        return super(IntEnumValue, cls).__new__(cls, value)
+
+    __repr__ = EnumValue.__repr__
+    __str__ = EnumValue.__str__
+
+    # For Python 2 (Python 3 doesn't need this to work).
+    __eq__ = int.__eq__
+    __ne__ = int.__ne__
+    __le__ = int.__le__
+    __lt__ = int.__lt__
+    __gt__ = int.__gt__
+    __ge__ = int.__ge__
+
+    # The non-deprecated version of this method.
+    def __int__(self):
+        return self._value
+
+    # For slices and index().
+    __index__ = __int__
+
+
+class IntEnumMetaclass(EnumMetaclass):
+    # Define an iteration over the integer values instead of the attribute
+    # names.
+    def __iter__(cls):
+        for key in sorted(cls._enums):
+            yield getattr(cls, cls._enums[key])
+
+
+IntEnum = IntEnumMetaclass(str('IntEnum'), (Enum,), {
+    '__doc__': 'A specialized enumeration with values that are also integers.',
+    '__value_factory__': IntEnumValue,
+    })
+
+
+if str is bytes:
+    # Python 2
+    STRING_TYPE = basestring
+else:
+    # Python 3
+    STRING_TYPE = str
+
+
+def _swap(sequence):
+    for key, value in sequence:
+        yield value, key
+
+
+def _make(enum_class, name, source):
+    """The common implementation for `Enum()` and `IntEnum()`."""
+    namespace = {}
+    illegals = []
+    have_strings = None
+    # Auto-splitting of strings.
+    if isinstance(source, STRING_TYPE):
+        source = source.split()
+    # Look for dict-like arguments.  Specifically, it must have a callable
+    # .items() attribute.  Because of the way enumerate() works, here we have
+    # to swap the key/values.
+    try:
+        source = _swap(source.items())
+    except (TypeError, AttributeError):
+        source = enumerate(source, start=1)
+    for i, item in source:
+        if isinstance(item, STRING_TYPE):
+            if have_strings is None:
+                have_strings = True
+            elif not have_strings:
+                raise ValueError('heterogeneous source')
+            namespace[item] = i
+            if re.match(IDENTIFIER_RE, item) is None:
+                illegals.append(item)
+        else:
+            if have_strings is None:
+                have_strings = False
+            elif have_strings:
+                raise ValueError('heterogeneous source')
+            item_name, item_value = item
+            namespace[item_name] = item_value
+            if re.match(IDENTIFIER_RE, item_name) is None:
+                illegals.append(item_name)
+    if len(illegals) > 0:
+        raise ValueError('non-identifiers: {0}'.format(SPACE.join(illegals)))
+    return EnumMetaclass(str(name), (enum_class,), namespace)
+
+
+def make(name, source):
+    """Return an Enum class from a name and source.
+
+    This is a convenience function for defining a new enumeration given an
+    existing sequence.  When an sequence is used, it is iterated over to get
+    the enumeration value items.  The sequence iteration can either return
+    strings or 2-tuples.  When strings are used, values are automatically
+    assigned starting from 1.  When 2-tuples are used, the first item of the
+    tuple is a string and the second item is the integer value.
+
+    `source` must be homogeneous.  You cannot mix string-only and 2-tuple
+    items in the sequence.
+
+    :param name: The resulting enum's class name.
+    :type name: byte string (or ASCII-only unicode string)
+    :param source: An object giving the enumeration value items.
+    :type source: A sequence of strings or 2-tuples.
+    :return: The new enumeration class.
+    :rtype: instance of `EnumMetaClass`
+    :raises ValueError: when a heterogeneous source is given, or when
+        non-identifiers are used as enumeration value names.
+    """
+    warnings.warn('make() is deprecated; use Enum(name, source)',
+                  DeprecationWarning, 2)
+    return _make(Enum, name, source)

--- a/qt/python/mantidqt/widgets/src/_widgetscore.sip
+++ b/qt/python/mantidqt/widgets/src/_widgetscore.sip
@@ -217,9 +217,11 @@ public:
   WorkspaceTreeWidgetSimple(QWidget *parent /TransferThis/ = nullptr);
 
 signals:
-  void plotSpectrumClicked(const QStringList & workspaceName);
-  void plotSpectrumWithErrorsClicked(const QStringList & workspaceName);
-  void plotColorfillClicked(const QStringList &workspaceName);
+  void plotSpectrumClicked(const QStringList & workspaceNames);
+  void overplotSpectrumClicked(const QStringList & workspaceNames);
+  void plotSpectrumWithErrorsClicked(const QStringList & workspaceNames);
+  void overplotSpectrumWithErrorsClicked(const QStringList & workspaceNames);
+  void plotColorfillClicked(const QStringList &workspaceNames);
 };
 
 // ---------------------------------

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidgetSimple.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidgetSimple.h
@@ -6,8 +6,8 @@
 
 #include <MantidAPI/MatrixWorkspace_fwd.h>
 
-#include <QWidget>
 #include <QMenu>
+#include <QWidget>
 
 class QTreeWidgetItem;
 class QSignalMapper;
@@ -58,17 +58,22 @@ public:
 
 signals:
   void plotSpectrumClicked(const QStringList &workspaceName);
+  void overplotSpectrumClicked(const QStringList &workspaceName);
   void plotSpectrumWithErrorsClicked(const QStringList &workspaceName);
+  void overplotSpectrumWithErrorsClicked(const QStringList &workspaceName);
   void plotColorfillClicked(const QStringList &workspaceName);
 
 private slots:
   void onPlotSpectrumClicked();
+  void onOverplotSpectrumClicked();
   void onPlotSpectrumWithErrorsClicked();
+  void onOverplotSpectrumWithErrorsClicked();
   void onPlotColorfillClicked();
 
 private:
-  QAction *m_plotSpectrum, *m_plotSpectrumWithErrs, *m_plotColorfill;
+  QAction *m_plotSpectrum, *m_overplotSpectrum, *m_plotSpectrumWithErrs,
+      *m_overplotSpectrumWithErrs, *m_plotColorfill;
 };
-}
-}
+} // namespace MantidWidgets
+} // namespace MantidQt
 #endif // MANTIDQT_MANTIDWIDGETS_WORKSPACETREEWIDGETSIMPLE_H

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
@@ -5,9 +5,9 @@
 
 #include <MantidAPI/AlgorithmManager.h>
 #include <MantidAPI/FileProperty.h>
+#include <MantidAPI/ITableWorkspace.h>
 #include <MantidAPI/MatrixWorkspace.h>
 #include <MantidAPI/WorkspaceGroup.h>
-#include <MantidAPI/ITableWorkspace.h>
 
 #include <QMenu>
 #include <QSignalMapper>
@@ -21,13 +21,20 @@ namespace MantidWidgets {
 WorkspaceTreeWidgetSimple::WorkspaceTreeWidgetSimple(QWidget *parent)
     : WorkspaceTreeWidget(new MantidTreeModel(), parent),
       m_plotSpectrum(new QAction("spectrum...", this)),
+      m_overplotSpectrum(new QAction("overplot spectrum...", this)),
       m_plotSpectrumWithErrs(new QAction("spectrum with errors...", this)),
+      m_overplotSpectrumWithErrs(
+          new QAction("overplot spectrum with errors...", this)),
       m_plotColorfill(new QAction("colorfill", this)) {
   // connections
   connect(m_plotSpectrum, SIGNAL(triggered()), this,
           SLOT(onPlotSpectrumClicked()));
+  connect(m_overplotSpectrum, SIGNAL(triggered()), this,
+          SLOT(onOverplotSpectrumClicked()));
   connect(m_plotSpectrumWithErrs, SIGNAL(triggered()), this,
           SLOT(onPlotSpectrumWithErrorsClicked()));
+  connect(m_overplotSpectrumWithErrs, SIGNAL(triggered()), this,
+          SLOT(onOverplotSpectrumWithErrorsClicked()));
   connect(m_plotColorfill, SIGNAL(triggered()), this,
           SLOT(onPlotColorfillClicked()));
 }
@@ -54,7 +61,10 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
     // plot submenu first
     QMenu *plotSubMenu(new QMenu("Plot", menu));
     plotSubMenu->addAction(m_plotSpectrum);
+    plotSubMenu->addAction(m_overplotSpectrum);
     plotSubMenu->addAction(m_plotSpectrumWithErrs);
+    plotSubMenu->addAction(m_overplotSpectrumWithErrs);
+    plotSubMenu->addSeparator();
     plotSubMenu->addAction(m_plotColorfill);
     menu->addMenu(plotSubMenu);
 
@@ -74,8 +84,16 @@ void WorkspaceTreeWidgetSimple::onPlotSpectrumClicked() {
   emit plotSpectrumClicked(getSelectedWorkspaceNamesAsQList());
 }
 
+void WorkspaceTreeWidgetSimple::onOverplotSpectrumClicked() {
+  emit overplotSpectrumClicked(getSelectedWorkspaceNamesAsQList());
+}
+
 void WorkspaceTreeWidgetSimple::onPlotSpectrumWithErrorsClicked() {
   emit plotSpectrumWithErrorsClicked(getSelectedWorkspaceNamesAsQList());
+}
+
+void WorkspaceTreeWidgetSimple::onOverplotSpectrumWithErrorsClicked() {
+  emit overplotSpectrumWithErrorsClicked(getSelectedWorkspaceNamesAsQList());
 }
 
 void WorkspaceTreeWidgetSimple::onPlotColorfillClicked() {


### PR DESCRIPTION
**Description of work**

Feedback from the January 2018 user meeting gave universal disapproval for the active/hold facility of plot management. Users wanted to decide at the point of plotting the workspace whether it should open in a new figure or overplot on the existing one.

This work removes the active/hold functionality and adds separate items to overplot on to existing figures if they exist.

**To test:**

Start the workbench and either load some data or create some fake data with `CreateSampleWorkspace`. Examine the plot menu of the workspace and check you are happy with the layout and text.

Try all of the options. The behaviour is intended to be as follows:
* plot will always open a new figure
* overplot will add to an existing active figure if one exists and create a new one if one doesn't exist
  * if two or more plot windows are open then clicking on the window makes it active and the next overplot request will go there.

*No associated issue*

**Release Notes** 

*Does not need to be in the release notes. The workbench will be advertised separately.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
