### PR TITLE
Fixed multi fit bug in muon analysis when changing fit function

### DIFF
--- a/docs/source/release/v3.13.0/muon.rst
+++ b/docs/source/release/v3.13.0/muon.rst
@@ -18,6 +18,7 @@ Bug fixes
 - Fit options are not disabled after changing tabs.
 - The run number is now updated before the periods, preventing irrelevant warningsfrom being produced.
 - In single fit the workspace can be changed.
+- In multiple fitting the function can be replaced without causing a crash.
 
 Algorithms
 ----------

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtpropertybrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtpropertybrowser.h
@@ -153,7 +153,6 @@ public:
   void propertyRemoved(QtProperty *property, QtProperty *parentProperty) const;
   void propertyInserted(QtProperty *property, QtProperty *parentProperty,
                         QtProperty *afterProperty) const;
-
   QSet<QtProperty *> m_properties;
 };
 
@@ -165,6 +164,7 @@ public:
 
   QSet<QtProperty *> properties() const;
   void clear() const;
+  bool hasProperty(QtProperty*const prop) const;
 
   QtProperty *addProperty(const QString &name = QString());
 Q_SIGNALS:

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtpropertybrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtpropertybrowser.h
@@ -164,7 +164,7 @@ public:
 
   QSet<QtProperty *> properties() const;
   void clear() const;
-  bool hasProperty(QtProperty*const prop) const;
+  bool hasProperty(QtProperty *const prop) const;
 
   QtProperty *addProperty(const QString &name = QString());
 Q_SIGNALS:

--- a/qt/widgets/common/src/QtPropertyBrowser/ParameterPropertyManager.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/ParameterPropertyManager.cpp
@@ -79,7 +79,6 @@ void ParameterPropertyManager::setDescription(QtProperty *property,
 void ParameterPropertyManager::clearError(QtProperty *property) {
   m_errors.remove(property);
   emit propertyChanged(property);
-  updateTooltip(property);
 }
 
 /**

--- a/qt/widgets/common/src/QtPropertyBrowser/ParameterPropertyManager.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/ParameterPropertyManager.cpp
@@ -77,8 +77,9 @@ void ParameterPropertyManager::setDescription(QtProperty *property,
  * @param property :: Property to clear error for
  */
 void ParameterPropertyManager::clearError(QtProperty *property) {
-  m_errors.remove(property);
-  emit propertyChanged(property);
+		m_errors.remove(property);
+		emit propertyChanged(property);
+		updateTooltip(property);
 }
 
 /**

--- a/qt/widgets/common/src/QtPropertyBrowser/ParameterPropertyManager.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/ParameterPropertyManager.cpp
@@ -77,11 +77,11 @@ void ParameterPropertyManager::setDescription(QtProperty *property,
  * @param property :: Property to clear error for
  */
 void ParameterPropertyManager::clearError(QtProperty *property) {
-		m_errors.remove(property);
-		if (hasProperty(property)) {
-			emit propertyChanged(property);
-			updateTooltip(property);
-		}
+  m_errors.remove(property);
+  if (hasProperty(property)) {
+    emit propertyChanged(property);
+    updateTooltip(property);
+  }
 }
 
 /**

--- a/qt/widgets/common/src/QtPropertyBrowser/ParameterPropertyManager.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/ParameterPropertyManager.cpp
@@ -78,8 +78,10 @@ void ParameterPropertyManager::setDescription(QtProperty *property,
  */
 void ParameterPropertyManager::clearError(QtProperty *property) {
 		m_errors.remove(property);
-		emit propertyChanged(property);
-		updateTooltip(property);
+		if (hasProperty(property)) {
+			emit propertyChanged(property);
+			updateTooltip(property);
+		}
 }
 
 /**

--- a/qt/widgets/common/src/QtPropertyBrowser/qtpropertybrowser.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtpropertybrowser.cpp
@@ -207,7 +207,13 @@ QList<QtProperty *> QtProperty::subProperties() const {
 QtAbstractPropertyManager *QtProperty::propertyManager() const {
   return d_ptr->m_manager;
 }
-
+/**
+   Checks if a property exists
+   @return if the property exists
+*/
+bool QtAbstractPropertyManager::hasProperty(QtProperty*const prop) const {
+	return d_ptr->m_properties.contains(prop);
+}
 /**
     Returns the property's  tool tip.
 

--- a/qt/widgets/common/src/QtPropertyBrowser/qtpropertybrowser.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtpropertybrowser.cpp
@@ -211,8 +211,8 @@ QtAbstractPropertyManager *QtProperty::propertyManager() const {
    Checks if a property exists
    @return if the property exists
 */
-bool QtAbstractPropertyManager::hasProperty(QtProperty*const prop) const {
-	return d_ptr->m_properties.contains(prop);
+bool QtAbstractPropertyManager::hasProperty(QtProperty *const prop) const {
+  return d_ptr->m_properties.contains(prop);
 }
 /**
     Returns the property's  tool tip.


### PR DESCRIPTION
In muon analysis the multiple fitting would crash if the user changed the fitting function or used undo fit

**To test:**
Open muon analysis
Load some data
Go to settings and make sure multiple fitting is ticked
Go to data analysis
Add a fitting function and do a fit
Remove the fitting function
Add a different fitting function
Do another fit (this is where it would crash)

Do undo fit (this would also crash)

Go to settings tab and untick multiple fit
Go to data analysis
Try a few different fits.

<!-- Instructions for testing. -->

Fixes #22495. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->
In release notes
---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
