### PR TITLE
Fix right-click segfault in new workbench

### DIFF
--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -22,7 +22,6 @@ import functools
 # third-party library imports
 from mantid.api import AnalysisDataService, MatrixWorkspace, WorkspaceGroup
 from mantid.kernel import Logger
-from mantidqt.widgets.workspacewidget.mantidtreemodel import MantidTreeModel
 from mantidqt.widgets.workspacewidget.plotselectiondialog import get_plot_selection
 from mantidqt.widgets.workspacewidget.workspacetreewidget import WorkspaceTreeWidget
 from qtpy.QtWidgets import QVBoxLayout
@@ -72,18 +71,17 @@ class WorkspaceWidget(PluginWidget):
         super(WorkspaceWidget, self).__init__(parent)
 
         # layout
-        workspacewidget = WorkspaceTreeWidget(MantidTreeModel())
-        self.workspacewidget = workspacewidget
+        self.workspacewidget = WorkspaceTreeWidget()
         layout = QVBoxLayout()
         layout.addWidget(self.workspacewidget)
         self.setLayout(layout)
 
         # behaviour
-        workspacewidget.plotSpectrumClicked.connect(functools.partial(self._do_plot_spectrum,
-                                                                      errors=False))
-        workspacewidget.plotSpectrumWithErrorsClicked.connect(functools.partial(self._do_plot_spectrum,
-                                                                                errors=True))
-        workspacewidget.plotColorfillClicked.connect(self._do_plot_colorfill)
+        self.workspacewidget.plotSpectrumClicked.connect(functools.partial(self._do_plot_spectrum,
+                                                                           errors=False))
+        self.workspacewidget.plotSpectrumWithErrorsClicked.connect(functools.partial(self._do_plot_spectrum,
+                                                                                     errors=True))
+        self.workspacewidget.plotColorfillClicked.connect(self._do_plot_colorfill)
 
     # ----------------- Plugin API --------------------
 

--- a/qt/python/mantidqt/widgets/src/_widgetscore.sip
+++ b/qt/python/mantidqt/widgets/src/_widgetscore.sip
@@ -214,8 +214,7 @@ class WorkspaceTreeWidgetSimple : WorkspaceTreeWidget {
 #include "MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidgetSimple.h"
 %End
 public:
-  WorkspaceTreeWidgetSimple(MantidDisplayBase *mdb /Transfer/,
-                            QWidget *parent /TransferThis/ = nullptr);
+  WorkspaceTreeWidgetSimple(QWidget *parent /TransferThis/ = nullptr);
 
 signals:
   void plotSpectrumClicked(const QStringList & workspaceName);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidgetSimple.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidgetSimple.h
@@ -50,9 +50,7 @@ class EXPORT_OPT_MANTIDQT_COMMON WorkspaceTreeWidgetSimple
     : public WorkspaceTreeWidget {
   Q_OBJECT
 public:
-  explicit WorkspaceTreeWidgetSimple(
-      MantidQt::MantidWidgets::MantidDisplayBase *mdb,
-      QWidget *parent = nullptr);
+  explicit WorkspaceTreeWidgetSimple(QWidget *parent = nullptr);
   ~WorkspaceTreeWidgetSimple();
 
   // Context Menu Handlers

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
@@ -1,6 +1,7 @@
 #include "MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidgetSimple.h"
 #include <MantidQtWidgets/Common/MantidTreeWidget.h>
 #include <MantidQtWidgets/Common/MantidTreeWidgetItem.h>
+#include "MantidQtWidgets/Common/MantidTreeModel.h"
 
 #include <MantidAPI/AlgorithmManager.h>
 #include <MantidAPI/FileProperty.h>
@@ -17,9 +18,8 @@ using namespace Mantid::Kernel;
 namespace MantidQt {
 namespace MantidWidgets {
 
-WorkspaceTreeWidgetSimple::WorkspaceTreeWidgetSimple(MantidDisplayBase *mdb,
-                                                     QWidget *parent)
-    : WorkspaceTreeWidget(mdb, parent),
+WorkspaceTreeWidgetSimple::WorkspaceTreeWidgetSimple(QWidget *parent)
+    : WorkspaceTreeWidget(new MantidTreeModel(), parent),
       m_plotSpectrum(new QAction("spectrum...", this)),
       m_plotSpectrumWithErrs(new QAction("spectrum with errors...", this)),
       m_plotColorfill(new QAction("colorfill", this)) {


### PR DESCRIPTION
**Description of work**

The error appears to be solved in newer versions of sip / python-qt5,
but that isn't what is available on rhel7. This removes the ability to
have a different `MantidDisplayBase` from the workbench, but it doesn't
appear to be a necessary abstraction for now.

**To test:**

Build the new workbench on RHEL7 and try to right-click plot a workspace. If you can, then this did it.

*There is no associated issue.*

*Does not need to be in the release notes* because it fixes a bug in the new workbench that nobody can use yet.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
