### PR TITLE
Fix bin width normalization in HistogramItem

### DIFF
--- a/Framework/HistogramData/inc/MantidHistogramData/HistogramItem.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/HistogramItem.h
@@ -81,16 +81,18 @@ public:
 
   double counts() const {
     const auto &y = m_histogram.y();
-    if (yModeIsCounts()) {
+    if (!yModeIsFrequencies()) {
+      // Follow the convention in Histogram::counts():
+      // YMode::Uninitialized is handled as counts.
       return y[m_index];
     } else {
-      return y[m_index] / binWidth();
+      return y[m_index] * binWidth();
     }
   }
 
   double countVariance() const {
     const auto &e = m_histogram.e();
-    if (yModeIsCounts()) {
+    if (!yModeIsFrequencies()) {
       return e[m_index] * e[m_index];
     } else {
       const auto width = binWidth();
@@ -100,7 +102,7 @@ public:
 
   double countStandardDeviation() const {
     const auto &e = m_histogram.e();
-    if (yModeIsCounts()) {
+    if (!yModeIsFrequencies()) {
       return e[m_index];
     } else {
       const auto width = binWidth();
@@ -111,19 +113,21 @@ public:
   double frequency() const {
     const auto &y = m_histogram.y();
     if (yModeIsCounts()) {
-      return y[m_index] * binWidth();
+      return y[m_index] / binWidth();
     } else {
+      // Follow the convention in Histogram::frequency():
+      // YMode::Uninitialized is handled as frequencies.
       return y[m_index];
     }
   }
 
   double frequencyVariance() const {
     const auto &e = m_histogram.e();
-    if (!yModeIsCounts()) {
-      return e[m_index] * e[m_index];
-    } else {
+    if (yModeIsCounts()) {
       const auto width = binWidth();
       return (e[m_index] * e[m_index]) / (width * width);
+    } else {
+      return e[m_index] * e[m_index];
     }
   }
 
@@ -174,6 +178,11 @@ private:
   bool yModeIsCounts() const {
     return Histogram::YMode::Counts == m_histogram.yMode();
   }
+
+  bool yModeIsFrequencies() const {
+    return Histogram::YMode::Frequencies == m_histogram.yMode();
+  }
+
   // Deleted assignment operator as a HistogramItem is not copyable
   HistogramItem operator=(const HistogramItem &) = delete;
 

--- a/Framework/HistogramData/test/HistogramIteratorTest.h
+++ b/Framework/HistogramData/test/HistogramIteratorTest.h
@@ -100,7 +100,7 @@ public:
 
   void test_iterate_over_histogram_counts() {
     Counts expectedCounts{2, 3, 4};
-    Histogram hist(Points{1, 2, 3}, expectedCounts);
+    Histogram hist(Points{-1, 2, 3.3}, expectedCounts);
 
     TS_ASSERT(std::equal(hist.begin(), hist.end(), expectedCounts.begin(),
                          [](const HistogramItem &item, const double &counts) {
@@ -109,7 +109,7 @@ public:
   }
 
   void test_iterate_over_histogram_counts_when_histogram_has_frequencies() {
-    Histogram hist(Points{1, 2, 3}, Frequencies{2, 3, 4});
+    Histogram hist(Points{-1, 2, 3.3}, Frequencies{2, 3, 4});
     Counts expectedCounts = hist.counts();
 
     TS_ASSERT(std::equal(hist.begin(), hist.end(), expectedCounts.begin(),
@@ -120,7 +120,7 @@ public:
 
   void test_iterate_over_histogram_frequencies() {
     Frequencies expectedFrequencies{2, 3, 4};
-    Histogram hist(Points{1, 2, 3}, expectedFrequencies);
+    Histogram hist(Points{-1, 2, 3.3}, expectedFrequencies);
 
     TS_ASSERT(
         std::equal(hist.begin(), hist.end(), expectedFrequencies.begin(),
@@ -130,7 +130,7 @@ public:
   }
 
   void test_iterate_over_histogram_frequencies_when_histogram_has_counts() {
-    Histogram hist(Points{1, 2, 3}, Counts{2, 3, 4});
+    Histogram hist(Points{-1, 2, 3.2}, Counts{2, 3, 4});
     Frequencies expectedFrequencies = hist.frequencies();
 
     TS_ASSERT(
@@ -141,7 +141,7 @@ public:
   }
 
   void test_iterate_over_histogram_center_when_histogram_has_bins() {
-    Histogram hist(BinEdges{1, 2, 3, 4}, Counts{2, 3, 4});
+    Histogram hist(BinEdges{-1, 2, 3.3, 4.2}, Counts{2, 3, 4});
     Points expectedPoints = hist.points();
 
     TS_ASSERT(std::equal(hist.begin(), hist.end(), expectedPoints.begin(),
@@ -151,7 +151,7 @@ public:
   }
 
   void test_iterate_over_histogram_center_when_histogram_has_points() {
-    Histogram hist(Points{1, 2, 3}, Counts{2, 3, 4});
+    Histogram hist(Points{-1, 2, 3.2}, Counts{2, 3, 4});
     Points expectedPoints = hist.points();
 
     TS_ASSERT(std::equal(hist.begin(), hist.end(), expectedPoints.begin(),
@@ -161,8 +161,8 @@ public:
   }
 
   void test_iterate_over_histogram_width_when_histogram_has_bins() {
-    Histogram hist(BinEdges{1, 2, 3, 5}, Counts{2, 3, 4});
-    std::vector<double> expectedWidths = {1, 1, 2};
+    Histogram hist(BinEdges{-1, 2, 3.3, 5}, Counts{2, 3, 4});
+    std::vector<double> expectedWidths = {2 + 1, 3.3 - 2, 5 - 3.3};
 
     TS_ASSERT(std::equal(hist.begin(), hist.end(), expectedWidths.begin(),
                          [](const HistogramItem &item, const double &width) {
@@ -171,8 +171,8 @@ public:
   }
 
   void test_iterate_over_histogram_width_when_histogram_has_points() {
-    Histogram hist(Points{1, 3, 5}, Counts{2, 3, 4});
-    std::vector<double> expectedWidths = {2, 2, 2};
+    Histogram hist(Points{1, 3, 7}, Counts{2, 3, 4});
+    std::vector<double> expectedWidths = {2, 3, 4};
 
     TS_ASSERT(std::equal(hist.begin(), hist.end(), expectedWidths.begin(),
                          [](const HistogramItem &item, const double &width) {
@@ -181,7 +181,7 @@ public:
   }
 
   void test_iterate_over_histogram_count_variances_when_histogram_has_counts() {
-    Histogram hist(BinEdges{1, 2, 3, 5}, Counts{2, 3, 4});
+    Histogram hist(BinEdges{-1, 2, 3.3, 5}, Counts{2, 3, 4});
     auto expectedCountVariances = hist.countVariances();
 
     TS_ASSERT(std::equal(hist.begin(), hist.end(),
@@ -193,18 +193,19 @@ public:
 
   void
   test_iterate_over_histogram_count_variances_when_histogram_has_frequencies() {
-    Histogram hist(BinEdges{1, 2, 3, 5}, Frequencies{2, 3, 4});
+    Histogram hist(BinEdges{-1, 2, 3.3, 5}, Frequencies{2, 3, 4});
     auto expectedCountVariances = hist.countVariances();
 
     TS_ASSERT(std::equal(hist.begin(), hist.end(),
                          expectedCountVariances.begin(),
                          [](const HistogramItem &item, const double &variance) {
-                           return item.countVariance() == variance;
+                           constexpr double delta{1e-12};
+                           return std::abs(item.countVariance() - variance) < delta;
                          }));
   }
 
   void test_iterate_over_histogram_count_std_when_histogram_has_counts() {
-    Histogram hist(BinEdges{1, 2, 3, 5}, Counts{2, 3, 4});
+    Histogram hist(BinEdges{-1, 2, 3.3, 5}, Counts{2, 3, 4});
     auto expectedCountStd = hist.countStandardDeviations();
 
     TS_ASSERT(std::equal(hist.begin(), hist.end(), expectedCountStd.begin(),
@@ -214,7 +215,7 @@ public:
   }
 
   void test_iterate_over_histogram_count_std_when_histogram_has_frequencies() {
-    Histogram hist(BinEdges{1, 2, 3, 5}, Frequencies{2, 3, 4});
+    Histogram hist(BinEdges{-1, 2, 3.3, 5}, Frequencies{2, 3, 4});
     auto expectedCountStd = hist.countStandardDeviations();
 
     TS_ASSERT(std::equal(hist.begin(), hist.end(), expectedCountStd.begin(),
@@ -224,20 +225,21 @@ public:
   }
 
   void
-  test_iterate_over_histogram_frequency_variances_when_histogram_has_frequencys() {
-    Histogram hist(BinEdges{1, 2, 3, 5}, Counts{2, 3, 4});
+  test_iterate_over_histogram_frequency_variances_when_histogram_has_counts() {
+    Histogram hist(BinEdges{-1, 2, 3.3, 5}, Counts{2, 3, 4});
     auto expectedFrequencyVariances = hist.frequencyVariances();
 
     TS_ASSERT(std::equal(hist.begin(), hist.end(),
                          expectedFrequencyVariances.begin(),
                          [](const HistogramItem &item, const double &variance) {
-                           return item.frequencyVariance() == variance;
+                           constexpr double delta{1e-12};
+                           return std::abs(item.frequencyVariance() - variance) < delta;
                          }));
   }
 
   void
   test_iterate_over_histogram_frequency_variances_when_histogram_has_frequencies() {
-    Histogram hist(BinEdges{1, 2, 3, 5}, Frequencies{2, 3, 4});
+    Histogram hist(BinEdges{-1, 2, 3.3, 5}, Frequencies{2, 3, 4});
     auto expectedFrequencyVariances = hist.frequencyVariances();
 
     TS_ASSERT(std::equal(hist.begin(), hist.end(),
@@ -248,8 +250,8 @@ public:
   }
 
   void
-  test_iterate_over_histogram_frequency_std_when_histogram_has_frequencys() {
-    Histogram hist(BinEdges{1, 2, 3, 5}, Counts{2, 3, 4});
+  test_iterate_over_histogram_frequency_std_when_histogram_has_counts() {
+    Histogram hist(BinEdges{-1, 2, 3.3, 5}, Counts{2, 3, 4});
     auto expectedFrequencyStd = hist.frequencyStandardDeviations();
 
     TS_ASSERT(std::equal(hist.begin(), hist.end(), expectedFrequencyStd.begin(),
@@ -260,7 +262,7 @@ public:
 
   void
   test_iterate_over_histogram_frequency_std_when_histogram_has_frequencies() {
-    Histogram hist(BinEdges{1, 2, 3, 5}, Frequencies{2, 3, 4});
+    Histogram hist(BinEdges{-1, 2, 3.3, 5}, Frequencies{2, 3, 4});
     auto expectedFrequencyStd = hist.frequencyStandardDeviations();
 
     TS_ASSERT(std::equal(hist.begin(), hist.end(), expectedFrequencyStd.begin(),

--- a/Framework/HistogramData/test/HistogramIteratorTest.h
+++ b/Framework/HistogramData/test/HistogramIteratorTest.h
@@ -196,12 +196,12 @@ public:
     Histogram hist(BinEdges{-1, 2, 3.3, 5}, Frequencies{2, 3, 4});
     auto expectedCountVariances = hist.countVariances();
 
-    TS_ASSERT(std::equal(hist.begin(), hist.end(),
-                         expectedCountVariances.begin(),
-                         [](const HistogramItem &item, const double &variance) {
-                           constexpr double delta{1e-12};
-                           return std::abs(item.countVariance() - variance) < delta;
-                         }));
+    TS_ASSERT(
+        std::equal(hist.begin(), hist.end(), expectedCountVariances.begin(),
+                   [](const HistogramItem &item, const double &variance) {
+                     constexpr double delta{1e-12};
+                     return std::abs(item.countVariance() - variance) < delta;
+                   }));
   }
 
   void test_iterate_over_histogram_count_std_when_histogram_has_counts() {
@@ -229,12 +229,12 @@ public:
     Histogram hist(BinEdges{-1, 2, 3.3, 5}, Counts{2, 3, 4});
     auto expectedFrequencyVariances = hist.frequencyVariances();
 
-    TS_ASSERT(std::equal(hist.begin(), hist.end(),
-                         expectedFrequencyVariances.begin(),
-                         [](const HistogramItem &item, const double &variance) {
-                           constexpr double delta{1e-12};
-                           return std::abs(item.frequencyVariance() - variance) < delta;
-                         }));
+    TS_ASSERT(std::equal(
+        hist.begin(), hist.end(), expectedFrequencyVariances.begin(),
+        [](const HistogramItem &item, const double &variance) {
+          constexpr double delta{1e-12};
+          return std::abs(item.frequencyVariance() - variance) < delta;
+        }));
   }
 
   void
@@ -249,8 +249,7 @@ public:
                          }));
   }
 
-  void
-  test_iterate_over_histogram_frequency_std_when_histogram_has_counts() {
+  void test_iterate_over_histogram_frequency_std_when_histogram_has_counts() {
     Histogram hist(BinEdges{-1, 2, 3.3, 5}, Counts{2, 3, 4});
     auto expectedFrequencyStd = hist.frequencyStandardDeviations();
 


### PR DESCRIPTION
**Description of work**

This PR fixes `HistogramItem::counts()` and `HistogramItem::frequencies()` in the case when a conversion from frequencies -> counts or counts -> frequencies was needed. The methods were using the wrong operator (`/` instead of `*` and vice versa) when normalizing by the bin width.

**To test:**

Code review.

Fixes #22508.

**Release Notes** 

Don't know if this has any user-facing effects because the iterator stuff is brand new so release notes were not updated.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
