### PR TITLE
Fix Counts/Frequencies conversion in HistogramIterator

### DIFF
--- a/Framework/HistogramData/inc/MantidHistogramData/HistogramItem.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/HistogramItem.h
@@ -84,7 +84,7 @@ public:
     if (yModeIsCounts()) {
       return y[m_index];
     } else {
-      return y[m_index] / binWidth();
+      return y[m_index] * binWidth();
     }
   }
 
@@ -111,7 +111,7 @@ public:
   double frequency() const {
     const auto &y = m_histogram.y();
     if (yModeIsCounts()) {
-      return y[m_index] * binWidth();
+      return y[m_index] / binWidth();
     } else {
       return y[m_index];
     }

--- a/Framework/HistogramData/test/HistogramIteratorTest.h
+++ b/Framework/HistogramData/test/HistogramIteratorTest.h
@@ -25,20 +25,20 @@ public:
   }
 
   void test_iterator_begin() {
-    Histogram hist(Points{1, 2, 3}, Frequencies{2, 3, 4});
+    Histogram hist(Points{1.1, 1.2, 1.4}, Frequencies{2, 3, 4});
     auto iter = hist.begin();
     TS_ASSERT(iter != hist.end());
     TS_ASSERT_EQUALS(iter->frequency(), 2);
   }
 
   void test_iterator_end() {
-    Histogram hist(Points{1, 2, 3}, Frequencies{2, 3, 4});
+    Histogram hist(Points{1.1, 1.2, 1.4}, Frequencies{2, 3, 4});
     auto iter = hist.end();
     TS_ASSERT(iter != hist.begin());
   }
 
   void test_iterator_increment() {
-    Histogram hist(Points{1, 2, 3}, Frequencies{2, 3, 4});
+    Histogram hist(Points{1.1, 1.2, 1.4}, Frequencies{2, 3, 4});
     auto iter = hist.begin();
     TS_ASSERT(iter != hist.end());
     TS_ASSERT_EQUALS(iter->frequency(), 2);
@@ -53,7 +53,7 @@ public:
   }
 
   void test_iterator_decrement() {
-    Histogram hist(Points{1, 2, 3}, Frequencies{2, 3, 4});
+    Histogram hist(Points{1.1, 1.2, 1.4}, Frequencies{2, 3, 4});
     auto iter = hist.end();
     --iter;
     TS_ASSERT_DIFFERS(iter, hist.begin());
@@ -67,7 +67,7 @@ public:
   }
 
   void test_iterator_advance() {
-    Histogram hist(Points{1, 2, 3}, Frequencies{2, 3, 4});
+    Histogram hist(Points{1.1, 1.2, 1.4}, Frequencies{2, 3, 4});
     auto iter = hist.begin();
 
     std::advance(iter, 2);
@@ -83,7 +83,7 @@ public:
   }
 
   void test_iterator_distance() {
-    Histogram hist(Points{1, 2, 3}, Frequencies{2, 3, 4});
+    Histogram hist(Points{1.1, 1.2, 1.4}, Frequencies{2, 3, 4});
     auto begin = hist.begin();
     auto end = hist.end();
 
@@ -100,7 +100,7 @@ public:
 
   void test_iterate_over_histogram_counts() {
     Counts expectedCounts{2, 3, 4};
-    Histogram hist(Points{1, 2, 3}, expectedCounts);
+    Histogram hist(Points{1.1, 1.2, 1.4}, expectedCounts);
 
     TS_ASSERT(std::equal(hist.begin(), hist.end(), expectedCounts.begin(),
                          [](const HistogramItem &item, const double &counts) {
@@ -109,7 +109,7 @@ public:
   }
 
   void test_iterate_over_histogram_counts_when_histogram_has_frequencies() {
-    Histogram hist(Points{1, 2, 3}, Frequencies{2, 3, 4});
+    Histogram hist(BinEdges{1.0, 1.1, 1.2, 1.5}, Frequencies{2, 3, 4});
     Counts expectedCounts = hist.counts();
 
     TS_ASSERT(std::equal(hist.begin(), hist.end(), expectedCounts.begin(),
@@ -120,7 +120,7 @@ public:
 
   void test_iterate_over_histogram_frequencies() {
     Frequencies expectedFrequencies{2, 3, 4};
-    Histogram hist(Points{1, 2, 3}, expectedFrequencies);
+    Histogram hist(Points{1.1, 1.2, 1.4}, expectedFrequencies);
 
     TS_ASSERT(
         std::equal(hist.begin(), hist.end(), expectedFrequencies.begin(),
@@ -130,7 +130,7 @@ public:
   }
 
   void test_iterate_over_histogram_frequencies_when_histogram_has_counts() {
-    Histogram hist(Points{1, 2, 3}, Counts{2, 3, 4});
+    Histogram hist(BinEdges{1.1, 1.2, 1.3, 1.5}, Counts{2, 3, 4});
     Frequencies expectedFrequencies = hist.frequencies();
 
     TS_ASSERT(
@@ -141,7 +141,7 @@ public:
   }
 
   void test_iterate_over_histogram_center_when_histogram_has_bins() {
-    Histogram hist(BinEdges{1, 2, 3, 4}, Counts{2, 3, 4});
+    Histogram hist(BinEdges{1.1, 1.2, 1.3, 1.4}, Counts{2, 3, 4});
     Points expectedPoints = hist.points();
 
     TS_ASSERT(std::equal(hist.begin(), hist.end(), expectedPoints.begin(),
@@ -151,7 +151,7 @@ public:
   }
 
   void test_iterate_over_histogram_center_when_histogram_has_points() {
-    Histogram hist(Points{1, 2, 3}, Counts{2, 3, 4});
+    Histogram hist(Points{1.1, 1.2, 1.4}, Counts{2, 3, 4});
     Points expectedPoints = hist.points();
 
     TS_ASSERT(std::equal(hist.begin(), hist.end(), expectedPoints.begin(),


### PR DESCRIPTION
Swapped multiplication/division by bin width when accessing counts and frequencies via `HistogramIterator`. This did not affect the respective errors (standard deviation and variance getters).

Existing tests were updated to catch the bug.

**To test:**

Code review.

Not in the release notes: This bug effected only the recently added `HistogramIterator` which has not been used in many places. `Histogram` itself is unaffected.

Fixes #22508.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
