### PR TITLE
Fix path finding for cxxtestgen

### DIFF
--- a/buildconfig/CMake/FindCxxTest.cmake
+++ b/buildconfig/CMake/FindCxxTest.cmake
@@ -206,7 +206,8 @@ endmacro(CXXTEST_ADD_TEST)
 
 find_path(CXXTEST_INCLUDE_DIR cxxtest/TestSuite.h
           PATHS ${PROJECT_SOURCE_DIR}/Testing/Tools/cxxtest
-	        ${PROJECT_SOURCE_DIR}/../Testing/Tools/cxxtest )
+	        ${PROJECT_SOURCE_DIR}/../Testing/Tools/cxxtest 
+                NO_DEFAULT_PATH )
 
 find_program(CXXTEST_TESTGEN_EXECUTABLE python/scripts/cxxtestgen
              PATHS ${CXXTEST_INCLUDE_DIR})


### PR DESCRIPTION
**Description of work.**

This prevents cmake from finding a cxxtestgen installed on the system
path rather than the one shipped with Mantid. For example, I had cxxtest installed via homebrew and cmake found the includes for that before the mantid one.

**To test:**

 - Configuring a fresh build with mantid should work as before.
 - They only known way to reproduce this is to install cxxtest somewhere on your path and then run a fresh cmake. For example I installed cxxtest via homebrew which first showed this issue. 

*No associated issue*

Does this update require release notes?
- [ ] Yes
- [x] No

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
