### PR TITLE
Added compilation flags for GCC > 5.1

### DIFF
--- a/buildconfig/CMake/GNUSetup.cmake
+++ b/buildconfig/CMake/GNUSetup.cmake
@@ -51,7 +51,10 @@ add_compile_options ( $<$<COMPILE_LANGUAGE:CXX>:-Woverloaded-virtual>
 if ( CMAKE_COMPILER_IS_GNUCXX )
   add_compile_options ( -Wpedantic )
   if (NOT (GCC_COMPILER_VERSION VERSION_LESS "5.1"))
-    add_compile_options ( $<$<COMPILE_LANGUAGE:CXX>:-Wsuggest-override> )
+    # Add flags
+    add_compile_options ( $<$<COMPILE_LANGUAGE:CXX>:-Wsuggest-override>
+                          $<$<COMPILE_LANGUAGE:CXX>:-Wsuggest-final-types>
+                          $<$<COMPILE_LANGUAGE:CXX>:-Wsuggest-final-methods>)
   endif()
   if (NOT (GCC_COMPILER_VERSION VERSION_LESS "7.1"))
     # Consider enabling once [[fallthrough]] is available on all platforms.


### PR DESCRIPTION
Three compilation flags of  -Wsuggest-override, -Wsuggest-final-types and -Wsuggest-final-methods are now present when compiling with GCC > 5.1. 

re #15284

**Description of work.**

The -Wsuggest-override flag was already present. 
Added in -Wsuggest-final-types and -Wsuggest-final-methods flags.
There were no warning messages present during compilation.

"New warnings -Wsuggest-final-types and -Wsuggest-final-methods help developers to annotate programs with final specifiers (or anonymous namespaces) to improve code generation."
https://isocpp.org/blog/2015/04/gcc-5.1-released

**Report to:** @NickDraper . <!--If the original issue was raised by a user they should be named here.-->

**To test:**

<!-- Instructions for testing. -->
Need GCC > 5.1 for testing.
Build with verbose mode to get all the compilation messages.


Fixes #15284. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
