### PR TITLE
Make OSX mantidpython more consistent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,9 @@ set ( SYSTEM_PACKAGE_TARGET "" )
 
 # Add the path to our custom 'find' modules
 set ( CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/buildconfig/CMake")
+# Send libraries to common place, reference in several places so must be at top level
+set ( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin )
+set ( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin )
 
 set ( ENABLE_MANTIDPLOT ON CACHE BOOL "Enable Qt4-based gui & components" )
 set ( ENABLE_WORKBENCH OFF CACHE BOOL "Enable Qt5-based gui & components" )

--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -17,9 +17,6 @@ endif()
 # We want shared libraries everywhere
 set ( BUILD_SHARED_LIBS On )
 
-# Send libraries to common place
-set ( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin )
-set ( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin )
 if ( CMAKE_GENERATOR MATCHES "Visual Studio" OR CMAKE_GENERATOR MATCHES "Xcode" )
   set ( PVPLUGINS_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/$<CONFIG>/plugins/paraview )
 else ()

--- a/buildconfig/CMake/DarwinSetup.cmake
+++ b/buildconfig/CMake/DarwinSetup.cmake
@@ -79,11 +79,11 @@ if ( NOT TARGET mantidpython )
   else ()
     set ( PARAVIEW_PYTHON_PATHS "" )
   endif ()
-  configure_file ( ${CMAKE_MODULE_PATH}/Packaging/osx/mantidpython_osx ${CMAKE_CURRENT_BINARY_DIR}/mantidpython_osx @ONLY )
+  configure_file ( ${CMAKE_MODULE_PATH}/Packaging/osx/mantidpython.in ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/mantidpython @ONLY )
 
   add_custom_target ( mantidpython ALL
       COMMAND ${CMAKE_COMMAND} -E copy_if_different
-      ${CMAKE_CURRENT_BINARY_DIR}/mantidpython_osx
+      ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/mantidpython
       ${PROJECT_BINARY_DIR}/bin/${CMAKE_CFG_INTDIR}/mantidpython
       COMMENT "Generating mantidpython" )
   #Configure install script at the same time. Doing it later causes a warning from ninja.
@@ -93,7 +93,7 @@ if ( NOT TARGET mantidpython )
     set ( PARAVIEW_PYTHON_PATHS "" )
   endif ()
 
-  configure_file ( ${CMAKE_MODULE_PATH}/Packaging/osx/mantidpython_osx ${CMAKE_BINARY_DIR}/mantidpython_osx_install @ONLY )
+  configure_file ( ${CMAKE_MODULE_PATH}/Packaging/osx/mantidpython.in ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/mantidpython_osx_install @ONLY )
 endif ()
 
 

--- a/buildconfig/CMake/Packaging/osx/mantidpython.in
+++ b/buildconfig/CMake/Packaging/osx/mantidpython.in
@@ -2,6 +2,7 @@
 #
 # For OS X only
 # Launch IPython with paths set for the Mantid environment
+# Find out where we are
 
 # Get the path of this script so that we know where Mantid is installed
 # This method should be robust; work through nested symlinks etc
@@ -15,7 +16,7 @@ cd "`dirname "${SCRIPT_PATH}"`" > /dev/null
 SCRIPT_PATH="`pwd`";
 popd  > /dev/null
 
-PROG=${SCRIPT_PATH}/bin/ipython@PYTHON_VERSION_MAJOR@
+INSTALLDIR=${SCRIPT_PATH%/*}
 
 # Define extra libraries for python
 LOCAL_PYTHONPATH=${SCRIPT_PATH}
@@ -24,14 +25,22 @@ if [ -n "${PYTHONPATH}" ]; then
 	LOCAL_PYTHONPATH=${LOCAL_PYTHONPATH}:${PYTHONPATH}
 fi
 
+# Define MANTIDPATH
+MANTIDPATH="${INSTALLDIR}"
 if [ -n "$1" ] && [ "$1" = "--classic" ]; then
     shift
-    PROG=@PYTHON_EXECUTABLE@
+
+    set -- @WRAPPER_PREFIX@@PYTHON_EXECUTABLE@ $*@WRAPPER_POSTFIX@
+
+else
+    IPYTHON_STARTUP="import IPython;IPython.start_ipython()"
+
+    set -- @WRAPPER_PREFIX@@PYTHON_EXECUTABLE@ -c "${IPYTHON_STARTUP}" $*@WRAPPER_POSTFIX@
+
 fi
 
-# Define MANTIDPATH
-MANTIDPATH="${SCRIPT_PATH}"
 
-PYTHONPATH=${LOCAL_PYTHONPATH} \
-    MANTIDPATH=$MANTIDPATH \
-    ${PROG} $*
+PV_PLUGIN_PATH=${PV_PLUGIN_PATH} \
+  MANTIDPATH=${MANTIDPATH} \
+  PYTHONPATH=${LOCAL_PYTHONPATH} \
+  exec "$@"


### PR DESCRIPTION
**Requires and OSX tester**

**Description of work.**

This make several changes to the mantid python executable:
  - Changes the templated executable to be called mantidpython.in to follow the conventions we've followed elsewhere
  - Moves the executable into the bin folder
  - Fixes the start script so that it can be run in a developer build.

**To test:**

 - Build mantid.
   - The mantid python executable should now be called `mantidpython` instead of 
`mantidpython_osx`
   - This executable should now be located in the `./bin` folder of the build folder.
  - Run `mantidpython` and then `import mantid`. Both should work fine
  - Compile the installer for mantid (`make package`) and install Mantid
    - Check that running python from the command line still works in the installed version 
    - Check that python is still available in installed Mantid.

*No associated issue*

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
