### PR TITLE
Instructions on accessing the ISIS archive with OSX

### DIFF
--- a/dev-docs/source/GettingStarted.rst
+++ b/dev-docs/source/GettingStarted.rst
@@ -95,3 +95,21 @@ See :ref:`BuildingWithCMake` for information about building Mantid.
 Building VATES
 ##############
 See :ref:`BuildingVATES` for infromation about building VATES.
+
+Archive access
+##############
+
+It is very convenient to be able to access the data archive directly.
+At ISIS, this is automatically done on the Windows machines, however OSX
+requires some extra setup.
+
+OSX
+---
+
+* In Finder "command"+k opens a mounting dialogue
+* For `Server address` enter `smb://isisdatar80/inst$/` hit Connect
+* This should prompt you for federal ID `clrc\....` and password
+* After completing this the drive is now mounted
+* It can be found at `/Volumes/inst$`
+
+**NB** the address in step 2 sometimes changes - if it does not work, replace `80` with `55` or `3`.


### PR DESCRIPTION
**Description of work.**

This is an addition of a short section to the Developer Docs "Getting Started" section. It details how to connect to the data archive at ISIS using OSX. The connection is automatic on windows machines, but not on OSX. These instructions were previously (and incompletely) available at the [Reflectometry page](https://www.mantidproject.org/ISIS_Reflectometry_GUI#Archive_Access), but the scope is more general than just Reflectometry.

**Report to:** n/a. <!--If the original issue was raised by a user they should be named here.-->

**To test:**

<!-- Instructions for testing. -->

On an OSX machine connected to the ISIS network (reduces the number of possible reviewers 😛):
* Follow the instructions for connecting to the archive (at the end of `dev-docs/source/GettingStarted.rst`)
* Make sure that you can achieve archive access with these instructions

Does this update require release notes?
- [ ] Yes
- [X] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
