### PR TITLE
POWGEN and SNAP geometry bugfix

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/CreateGroupingWorkspace.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CreateGroupingWorkspace.h
@@ -36,6 +36,8 @@ public:
 private:
   /// Initialise the properties
   void init() override;
+  /// Cross-check properties with each other @see IAlgorithm::validateInputs
+  std::map<std::string, std::string> validateInputs() override;
   /// Run the algorithm
   void exec() override;
 };

--- a/Framework/Algorithms/src/CreateGroupingWorkspace.cpp
+++ b/Framework/Algorithms/src/CreateGroupingWorkspace.cpp
@@ -110,6 +110,54 @@ void CreateGroupingWorkspace::init() {
                   Direction::Output);
 }
 
+std::map<std::string, std::string> CreateGroupingWorkspace::validateInputs() {
+  std::map<std::string, std::string> result;
+
+  // only allow specifying the instrument in one way
+  int numInstrument = 0;
+  if (!isDefault("InputWorkspace"))
+    numInstrument += 1;
+  if (!isDefault("InstrumentName"))
+    numInstrument += 1;
+  if (!isDefault("InstrumentFilename"))
+    numInstrument += 1;
+  if (numInstrument == 0) {
+    std::string msg("Must supply an instrument");
+    result["InputWorkspace"] = msg;
+    result["InstrumentName"] = msg;
+    result["InstrumentFilename"] = msg;
+  } else if (numInstrument > 1) {
+    std::string msg("Must supply an instrument only one way");
+
+    if (!isDefault("InputWorkspace"))
+      result["InputWorkspace"] = msg;
+    if (!isDefault("InstrumentName"))
+      result["InstrumentName"] = msg;
+    if (!isDefault("InstrumentFilename"))
+      result["InstrumentFilename"] = msg;
+  }
+
+  // only allow specifying the grouping one way
+  int numGroupings = 0;
+  if (!isDefault("GroupNames"))
+    numGroupings += 1;
+  if (!isDefault("GroupDetectorsBy"))
+    numGroupings += 1;
+  if (!isDefault("ComponentName"))
+    numGroupings += 1;
+  if (numGroupings != 1) {
+    std::string msg("Must supply grouping only one way");
+    if (!isDefault("GroupNames"))
+      result["GroupNames"] = msg;
+    if (!isDefault("GroupDetectorsBy"))
+      result["GroupDetectorsBy"] = msg;
+    if (!isDefault("ComponentName"))
+      result["ComponentName"] = msg;
+  }
+
+  return result;
+}
+
 //------------------------------------------------------------------------------------------------
 /** Read old-style .cal file to get the grouping
  *

--- a/Framework/Algorithms/src/CreateGroupingWorkspace.cpp
+++ b/Framework/Algorithms/src/CreateGroupingWorkspace.cpp
@@ -74,11 +74,9 @@ void CreateGroupingWorkspace::init() {
 
   std::vector<std::string> grouping{"", "All", "Group", "2_4Grouping", "Column",
                                     "bank"};
-  declareProperty(
-      "GroupDetectorsBy", "", boost::make_shared<StringListValidator>(grouping),
-      "Only used if GroupNames is empty: All detectors as one group, Groups "
-      "(Group or East,West for SNAP), 2_4Grouping (SNAP), Columns, detector "
-      "banks");
+  declareProperty("GroupDetectorsBy", "",
+                  boost::make_shared<StringListValidator>(grouping),
+                  "Only used if GroupNames is empty");
   declareProperty("MaxRecursionDepth", 5,
                   "Number of levels to search into the instrument (default=5)");
 
@@ -370,6 +368,8 @@ void CreateGroupingWorkspace::exec() {
       GroupNames = inst->getName();
     } else if (inst->getName() == "SNAP" && grouping == "Group") {
       GroupNames = "East,West";
+    } else if (inst->getName() == "POWGEN" && grouping == "Group") {
+      GroupNames = "South,North";
     } else if (inst->getName() == "SNAP" && grouping == "2_4Grouping") {
       GroupNames = "Column1,Column2,Column3,Column4,Column5,Column6,";
     } else {

--- a/docs/source/algorithms/CreateGroupingWorkspace-v1.rst
+++ b/docs/source/algorithms/CreateGroupingWorkspace-v1.rst
@@ -9,36 +9,41 @@
 Description
 -----------
 
-A GroupingWorkspace is a simple workspace with
-one value per detector pixel; this value corresponds to the group number
-that will be used when focussing or summing another workspace.
+A ``GroupingWorkspace`` is a simple workspace with one value per
+detector pixel; this value corresponds to the group number that will
+be used when focussing or summing another workspace.
 
-This algorithm creates a blank GroupingWorkspace. It uses the
-InputWorkspace, InstrumentName, OR InstrumentFilename parameterto
-determine which Instrument to create.
+This algorithm creates a blank ``GroupingWorkspace``. It uses the
+``InputWorkspace``, ``InstrumentName``, OR ``InstrumentFilename``
+parameter to determine which Instrument to create.
 
-If the OldCalFilename parameter is given, the .cal ASCII file will be
-loaded to fill the group data.
+If the ``OldCalFilename`` parameter is given, the ``.cal`` ASCII file
+will be loaded to fill the group data.
 
-If the GroupNames parameter is given, the names of banks matching the
-comma-separated strings in the parameter will be used to sequentially
-number the groups in the output.
+If the ``GroupNames parameter`` is given, the names of banks matching
+the comma-separated strings in the parameter will be used to
+sequentially number the groups in the output.
 
-If both the FixedGroupCount and ComponentName parameter are given then
-the detectors for the given component will be grouped into the number
-of groups specified, detectors will be left ungrouped in the event that
-the number of detectors does not divide equally into the number of groups.
+If both the ``FixedGroupCount`` and ``ComponentName`` parameter are
+given then the detectors for the given component will be grouped into
+the number of groups specified, detectors will be left ungrouped in
+the event that the number of detectors does not divide equally into
+the number of groups.
 
-GroupDetectorsBy has a new option, 2_4Grouping, to create one group of 4 
-columns of SNAP detectors and another with the remaining 2 columns. This 
-grouping is used frequently in their reduction.
+``GroupDetectorsBy`` has five options
+
+* ``All`` create one group for the whole instrument
+* ``bank`` Creates one group per instrument component that starts with the word ``bank``
+* ``Group`` Creates one group per instrument component that starts with the word ``Group``. POWGEN will create groups for ``North`` and ``South``. SNAP will create groups for ``East`` and ``West``.
+* ``Column`` Creates one group per instrument component that starts with the word ``Column``
+* ``2_4Grouping`` (SNAP only) creates one group of 4 columns of SNAP detectors and another with the remaining 2 columns. This grouping is used frequently in their reduction.
 
 Usage
 -----
 
 **Example - CreateGroupingWorkspace for MUSR Instrument**
 
-.. include:: ../usagedata-note.txt 
+.. include:: ../usagedata-note.txt
 
 .. testcode:: ExCreateGroupingWorkspaceSimple
 
@@ -99,13 +104,13 @@ Output:
 .. testoutput:: ExCreateGroupingWorkspaceFromIDF
 
    Instrument name = GEM
-   
+
 **Example - CreateGroupingWorkspace for IRIS graphite component**
 
 .. testcode:: ExCreateGroupingWorkspaceFromComponent
 
    grouping_ws, spectra_count, group_count = CreateGroupingWorkspace(InstrumentName='IRIS', ComponentName='graphite', FixedGroupCount=5)
-  
+
    print("Number of grouped spectra: {}".format(spectra_count))
    print("Number of groups: {}".format(group_count))
 

--- a/instrument/POWGEN_Definition_2018-05-05.xml
+++ b/instrument/POWGEN_Definition_2018-05-05.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='ASCII'?>
-<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2018-05-10 16:16:42.588652" name="PG3" valid-from="2018-05-05 00:00:01" valid-to="2100-01-31 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
+<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2018-06-04 16:59:33.567432" name="PG3" valid-from="2018-05-05 00:00:01" valid-to="2100-01-31 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
   <!--Created by Peter Peterson, Stuart Campbell, Vickie Lynch, Janik Zikovsky-->
   <!--DEFAULTS-->
   <defaults>
@@ -30,426 +30,491 @@
       <location name="monitor1" z="-1.5077"/>
     </component>
   </type>
-  <component type="A">
+  <component type="North">
     <location/>
   </component>
-  <component type="SA">
+  <component type="South">
     <location/>
   </component>
-  <component type="SB">
-    <location/>
-  </component>
-  <component type="SC">
-    <location/>
-  </component>
-  <component type="SD">
-    <location/>
-  </component>
-  <component type="SE">
-    <location/>
-  </component>
-  <component type="SF">
-    <location/>
-  </component>
-  <component type="SG">
-    <location/>
-  </component>
-  <component type="SH">
-    <location/>
-  </component>
-  <component type="SI">
-    <location/>
-  </component>
-  <component type="SJ">
-    <location/>
-  </component>
-  <component type="SK">
-    <location/>
-  </component>
-  <component type="SL">
-    <location/>
-  </component>
-  <type name="SA">
+  <type name="North">
+    <component type="Column13">
+      <location/>
+    </component>
+    <component type="Column14">
+      <location/>
+    </component>
+    <component type="Column15">
+      <location/>
+    </component>
+    <component type="Column16">
+      <location/>
+    </component>
+    <component type="Column17">
+      <location/>
+    </component>
+    <component type="Column18">
+      <location/>
+    </component>
+    <component type="Column19">
+      <location/>
+    </component>
+    <component type="Column20">
+      <location/>
+    </component>
+    <component type="Column21">
+      <location/>
+    </component>
+    <component type="Column22">
+      <location/>
+    </component>
+    <component type="Column23">
+      <location/>
+    </component>
+    <component type="Column24">
+      <location/>
+    </component>
+  </type>
+  <type name="South">
+    <component type="Column1">
+      <location/>
+    </component>
+    <component type="Column2">
+      <location/>
+    </component>
+    <component type="Column3">
+      <location/>
+    </component>
+    <component type="Column4">
+      <location/>
+    </component>
+    <component type="Column5">
+      <location/>
+    </component>
+    <component type="Column6">
+      <location/>
+    </component>
+    <component type="Column7">
+      <location/>
+    </component>
+    <component type="Column8">
+      <location/>
+    </component>
+    <component type="Column9">
+      <location/>
+    </component>
+    <component type="Column10">
+      <location/>
+    </component>
+    <component type="Column11">
+      <location/>
+    </component>
+    <component type="Column12">
+      <location/>
+    </component>
+  </type>
+  <type name="Column1">
     <component idfillbyfirst="y" idstart="15000" idstepbyrow="7" type="panel_v2">
-      <location name="bank2" x="-0.7395815" y="-0.4102375" z="-1.997611">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-248.092344247">
-          <rot val="-0.159140805275">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-108.22211052"/>
+      <location name="bank2" x="-0.7395815" y="-0.4102375" z="-1.997611000000001">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-248.09234424715788">
+          <rot val="-0.15914080527463983">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-108.22211051950599"/>
           </rot>
         </rot>
       </location>
     </component>
     <component idfillbyfirst="y" idstart="30000" idstepbyrow="7" type="panel_v2">
-      <location name="bank3" x="-0.7384485" y="-0.00334675" z="-1.995525">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-21.9845356053">
-          <rot val="-0.20174549551">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-334.102436652"/>
+      <location name="bank3" x="-0.7384485000000001" y="-0.0033467499999999956" z="-1.9955250000000007">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-21.984535605272168">
+          <rot val="-0.20174549551021412">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-334.10243665176796"/>
           </rot>
         </rot>
       </location>
     </component>
     <component idfillbyfirst="y" idstart="45000" idstepbyrow="7" type="panel_v2">
-      <location name="bank4" x="-0.7393245" y="0.40585725" z="-1.996414">
+      <location name="bank4" x="-0.7393244999999999" y="0.40585725000000006" z="-1.9964139999999997">
         <rot axis-x="0" axis-y="1" axis-z="0" val="-90.0">
-          <rot val="-0.076965977547">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-266.027400928"/>
+          <rot val="-0.07696597754703226">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-266.02740092804135"/>
           </rot>
         </rot>
       </location>
     </component>
   </type>
-  <type name="SB">
+  <type name="Column2">
     <component idfillbyfirst="y" idstart="90000" idstepbyrow="7" type="panel_v2">
       <location name="bank7" x="-1.4981475" y="-0.41126725" z="-1.813485">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-8.47357850501">
-          <rot val="-0.0715310382983">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-328.450171259"/>
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-8.473578505008637">
+          <rot val="-0.07153103829829169">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-328.45017125906173"/>
           </rot>
         </rot>
       </location>
     </component>
     <component idfillbyfirst="y" idstart="105000" idstepbyrow="7" type="panel_v2">
-      <location name="bank8" x="-1.49673875" y="-0.0024805" z="-1.81505625">
+      <location name="bank8" x="-1.49673875" y="-0.0024804999999999966" z="-1.8150562500000014">
         <rot axis-x="0" axis-y="1" axis-z="0" val="0.0">
-          <rot val="-0.00975526506503">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-336.887798804"/>
+          <rot val="-0.009755265065034909">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-336.88779880384124"/>
           </rot>
         </rot>
       </location>
     </component>
     <component idfillbyfirst="y" idstart="120000" idstepbyrow="7" type="panel_v2">
-      <location name="bank9" x="-1.49670575" y="0.40656575" z="-1.81423725">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-239.560642886">
-          <rot val="-0.200624965876">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-97.2292744758"/>
+      <location name="bank9" x="-1.49670575" y="0.40656574999999995" z="-1.8142372500000015">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-239.56064288589786">
+          <rot val="-0.2006249658763217">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-97.2292744757991"/>
           </rot>
         </rot>
       </location>
     </component>
   </type>
-  <type name="SC">
+  <type name="Column3">
     <component idfillbyfirst="y" idstart="150000" idstepbyrow="7" type="panel_v2">
-      <location name="bank11" x="-2.160215" y="-0.411611" z="-1.39893575">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-110.47227952">
-          <rot val="-0.0289085423667">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-208.935220509"/>
+      <location name="bank11" x="-2.160215" y="-0.41161100000000006" z="-1.3989357499999997">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-110.47227952018976">
+          <rot val="-0.028908542366684907">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-208.93522050948957"/>
           </rot>
         </rot>
       </location>
     </component>
     <component idfillbyfirst="y" idstart="165000" idstepbyrow="7" type="panel_v2">
-      <location name="bank12" x="-2.162071" y="-0.00275275" z="-1.3995505">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-55.0160252665">
-          <rot val="-0.168691015004">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-264.328446742"/>
+      <location name="bank12" x="-2.162071" y="-0.0027527499999999913" z="-1.3995505000000001">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-55.01602526651199">
+          <rot val="-0.16869101500407638">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-264.32844674232365"/>
           </rot>
         </rot>
       </location>
     </component>
     <component idfillbyfirst="y" idstart="180000" idstepbyrow="7" type="panel_v2">
-      <location name="bank13" x="-2.161607" y="0.40649425" z="-1.399101">
+      <location name="bank13" x="-2.1616069999999996" y="0.40649425" z="-1.3991009999999982">
         <rot axis-x="0" axis-y="1" axis-z="0" val="0.0">
-          <rot val="-0.0503837129317">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-319.253875843"/>
+          <rot val="-0.05038371293168056">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-319.2538758427011"/>
           </rot>
         </rot>
       </location>
     </component>
   </type>
-  <type name="SD">
+  <type name="Column4">
     <component idfillbyfirst="y" idstart="195000" idstepbyrow="7" type="panel_v2">
-      <location name="bank14" x="-2.6752895" y="-0.4119855" z="-0.80590125">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-7.59361175567">
-          <rot val="-0.265635069724">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-295.294310681"/>
+      <location name="bank14" x="-2.6752895000000003" y="-0.4119855" z="-0.805901249999998">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-7.593611755674668">
+          <rot val="-0.2656350697236119">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-295.29431068104907"/>
           </rot>
         </rot>
       </location>
     </component>
     <component idfillbyfirst="y" idstart="210000" idstepbyrow="7" type="panel_v2">
-      <location name="bank15" x="-2.67603825" y="-0.003183" z="-0.8076035">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-259.49647485">
-          <rot val="-0.0876965659647">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-43.2252787227"/>
+      <location name="bank15" x="-2.67603825" y="-0.0031830000000000053" z="-0.8076035000000008">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-259.49647485010036">
+          <rot val="-0.08769656596472865">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-43.225278722674815"/>
           </rot>
         </rot>
       </location>
     </component>
     <component idfillbyfirst="y" idstart="225000" idstepbyrow="7" type="panel_v2">
-      <location name="bank16" x="-2.67614475" y="0.4069395" z="-0.80604575">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-237.435549147">
-          <rot val="-0.272886676774">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-65.6425485041"/>
+      <location name="bank16" x="-2.6761447499999997" y="0.40693949999999995" z="-0.8060457500000009">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-237.43554914734017">
+          <rot val="-0.2728866767743531">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-65.64254850405557"/>
           </rot>
         </rot>
       </location>
     </component>
   </type>
-  <type name="SE">
+  <type name="Column5">
     <component idfillbyfirst="y" idstart="240000" idstepbyrow="7" type="panel_v2">
-      <location name="bank17" x="-3.012676" y="-0.4117715" z="-0.09640275">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-328.98611594">
-          <rot val="-0.0991226590352">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-318.978598301"/>
+      <location name="bank17" x="-3.012676" y="-0.4117715" z="-0.09640275000000109">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-328.98611593966064">
+          <rot val="-0.09912265903524094">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-318.97859830068023"/>
           </rot>
         </rot>
       </location>
     </component>
     <component idfillbyfirst="y" idstart="255000" idstepbyrow="7" type="panel_v2">
-      <location name="bank18" x="-3.01414" y="-0.0016465" z="-0.09651475">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-237.052270308">
-          <rot val="-0.0433751366478">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-51.0685515408"/>
+      <location name="bank18" x="-3.0141400000000003" y="-0.0016465000000000021" z="-0.09651474999999898">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-237.05227030754523">
+          <rot val="-0.043375136647820306">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-51.06855154079377"/>
           </rot>
         </rot>
       </location>
     </component>
     <component idfillbyfirst="y" idstart="270000" idstepbyrow="7" type="panel_v2">
-      <location name="bank19" x="-3.01392675" y="0.406411" z="-0.09860525">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-324.491815572">
-          <rot val="-0.0982329908629">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-323.50660542"/>
+      <location name="bank19" x="-3.01392675" y="0.406411" z="-0.09860524999999853">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-324.491815571602">
+          <rot val="-0.09823299086293387">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-323.50660542024997"/>
           </rot>
         </rot>
       </location>
     </component>
   </type>
-  <type name="SF">
+  <type name="Column6">
     <component idfillbyfirst="y" idstart="285000" idstepbyrow="7" type="panel_v2">
-      <location name="bank20" x="-3.162008" y="-0.411905" z="0.6771515">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-292.159006796">
-          <rot val="-0.038715242253">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-342.050092207"/>
+      <location name="bank20" x="-3.1620079999999997" y="-0.41190499999999997" z="0.6771515000000008">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-292.1590067957214">
+          <rot val="-0.038715242252951025">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-342.05009220717045"/>
           </rot>
         </rot>
       </location>
     </component>
     <component idfillbyfirst="y" idstart="300000" idstepbyrow="7" type="panel_v2">
-      <location name="bank21" x="-3.162478" y="-0.002053" z="0.67561275">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-297.356379027">
-          <rot val="-0.0587913590109">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-336.692870716"/>
+      <location name="bank21" x="-3.162478" y="-0.0020529999999999993" z="0.6756127499999991">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-297.3563790274869">
+          <rot val="-0.058791359010903155">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-336.69287071649734"/>
           </rot>
         </rot>
       </location>
     </component>
     <component idfillbyfirst="y" idstart="315000" idstepbyrow="7" type="panel_v2">
-      <location name="bank22" x="-3.16293425" y="0.404794" z="0.675672">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-16.8583987678">
-          <rot val="-0.331991511595">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-257.169392039"/>
+      <location name="bank22" x="-3.1629342499999997" y="0.404794" z="0.6756720000000005">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-16.858398767767884">
+          <rot val="-0.3319915115945276">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-257.1693920391006"/>
           </rot>
         </rot>
       </location>
     </component>
   </type>
-  <type name="SG">
+  <type name="Column7">
     <component idfillbyfirst="y" idstart="330000" idstepbyrow="7" type="panel_v2">
-      <location name="bank23" x="-3.12830675" y="-0.411247" z="1.4622695">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-324.010543034">
-          <rot val="-0.225101818311">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-297.067790035"/>
+      <location name="bank23" x="-3.1283067499999997" y="-0.41124700000000003" z="1.4622695000000014">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-324.0105430335716">
+          <rot val="-0.22510181831126547">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-297.0677900353081"/>
           </rot>
         </rot>
       </location>
     </component>
     <component idfillbyfirst="y" idstart="345000" idstepbyrow="7" type="panel_v2">
-      <location name="bank24" x="-3.12870025" y="-0.00212225" z="1.46520975">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-292.667406129">
-          <rot val="-0.0738162753662">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-328.59938431"/>
+      <location name="bank24" x="-3.12870025" y="-0.002122250000000006" z="1.4652097499999996">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-292.6674061286442">
+          <rot val="-0.0738162753661605">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-328.5993843096226"/>
           </rot>
         </rot>
       </location>
     </component>
     <component idfillbyfirst="y" idstart="360000" idstepbyrow="7" type="panel_v2">
-      <location name="bank25" x="-3.131831" y="0.40695875" z="1.46199975">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-140.376932458">
-          <rot val="-0.151527336503">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-120.75562437"/>
+      <location name="bank25" x="-3.131831" y="0.40695875" z="1.4619997499999986">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-140.37693245810476">
+          <rot val="-0.15152733650293815">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-120.75562437023515"/>
           </rot>
         </rot>
       </location>
     </component>
   </type>
-  <type name="SH">
+  <type name="Column8">
     <component idfillbyfirst="y" idstart="375000" idstepbyrow="7" type="panel_v2">
-      <location name="bank26" x="-2.92700025" y="-0.412328" z="2.22329025">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-297.195089337">
-          <rot val="-0.185854196496">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-311.655187146"/>
+      <location name="bank26" x="-2.9270002500000003" y="-0.41232800000000003" z="2.22329025">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-297.1950893371998">
+          <rot val="-0.1858541964959804">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-311.65518714591934"/>
           </rot>
         </rot>
       </location>
     </component>
     <component idfillbyfirst="y" idstart="390000" idstepbyrow="7" type="panel_v2">
-      <location name="bank27" x="-2.92640375" y="-0.00424125" z="2.2249635">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-328.302263179">
-          <rot val="-0.421937944041">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-280.535174873"/>
+      <location name="bank27" x="-2.9264037500000004" y="-0.004241250000000002" z="2.2249634999999994">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-328.3022631792651">
+          <rot val="-0.42193794404135126">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-280.5351748729246"/>
           </rot>
         </rot>
       </location>
     </component>
   </type>
-  <type name="SI">
+  <type name="Column9">
     <component idfillbyfirst="y" idstart="420000" idstepbyrow="7" type="panel_v2">
-      <location name="bank29" x="-2.5654625" y="-0.41229675" z="2.92516325">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-343.809212516">
-          <rot val="-0.0812208993013">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-253.562313467"/>
+      <location name="bank29" x="-2.5654624999999998" y="-0.41229675" z="2.925163249999999">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-343.80921251551587">
+          <rot val="-0.08122089930134542">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-253.56231346652444"/>
           </rot>
         </rot>
       </location>
     </component>
     <component idfillbyfirst="y" idstart="435000" idstepbyrow="7" type="panel_v2">
-      <location name="bank30" x="-2.56693825" y="-0.002701" z="2.926053">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-320.833790053">
-          <rot val="-0.0639589613408">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-276.439485343"/>
+      <location name="bank30" x="-2.5669382499999998" y="-0.002700999999999995" z="2.9260529999999996">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-320.8337900527159">
+          <rot val="-0.06395896134082621">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-276.4394853432617"/>
           </rot>
         </rot>
       </location>
     </component>
   </type>
-  <type name="SJ">
+  <type name="Column10">
     <component idfillbyfirst="y" idstart="480000" idstepbyrow="7" type="panel_v2">
-      <location name="bank33" x="-2.0809715" y="-0.0024505" z="3.5501205">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-275.57520057">
-          <rot val="-0.13393852438">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-310.920820082"/>
+      <location name="bank33" x="-2.0809715" y="-0.0024504999999999943" z="3.5501204999999985">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-275.5752005700303">
+          <rot val="-0.1339385243797445">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-310.9208200820357"/>
           </rot>
         </rot>
       </location>
     </component>
   </type>
-  <type name="SK">
+  <type name="Column11">
     <component idfillbyfirst="y" idstart="525000" idstepbyrow="7" type="panel_v2">
-      <location name="bank36" x="-1.4875845" y="-0.003188" z="4.07093">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-197.709724524">
-          <rot val="-0.162979832664">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-18.5161133513"/>
+      <location name="bank36" x="-1.4875845" y="-0.0031879999999999964" z="4.070929999999999">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-197.70972452384754">
+          <rot val="-0.1629798326644371">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-18.516113351260667"/>
           </rot>
         </rot>
       </location>
     </component>
   </type>
-  <type name="SL">
+  <type name="Column12">
     <component idfillbyfirst="y" idstart="570000" idstepbyrow="7" type="panel_v2">
-      <location name="bank39" x="-0.8139335" y="-0.00202475" z="4.4808475">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-253.084239916">
-          <rot val="-0.0586673095562">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-313.160124121"/>
+      <location name="bank39" x="-0.8139335" y="-0.0020247499999999988" z="4.480847499999999">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-253.0842399164535">
+          <rot val="-0.058667309556189116">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-313.16012412126577"/>
           </rot>
         </rot>
       </location>
     </component>
   </type>
-  <type name="A">
+  <type name="Column13">
     <component idfillbyfirst="y" idstart="630000" idstepbyrow="7" type="panel_v2">
-      <location name="bank43" x="0.73829375" y="-0.0023845" z="-1.99970725">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-212.032916017">
-          <rot val="-0.0159340363344">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-152.225654756"/>
+      <location name="bank43" x="0.73829375" y="-0.0023844999999999977" z="-1.99970725">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-212.0329160167726">
+          <rot val="-0.015934036334377295">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-152.22565475612254"/>
           </rot>
         </rot>
       </location>
     </component>
+  </type>
+  <type name="Column14">
     <component idfillbyfirst="y" idstart="705000" idstepbyrow="7" type="panel_v2">
-      <location name="bank48" x="1.499995" y="-0.00324925" z="-1.81232825">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-92.4337749097">
-          <rot val="-0.183994169594">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-290.681885867"/>
+      <location name="bank48" x="1.499995" y="-0.003249250000000002" z="-1.81232825">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-92.43377490965888">
+          <rot val="-0.1839941695938486">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-290.68188586713"/>
           </rot>
         </rot>
       </location>
     </component>
+  </type>
+  <type name="Column15">
     <component idfillbyfirst="y" idstart="765000" idstepbyrow="7" type="panel_v2">
-      <location name="bank52" x="2.160184" y="-0.00318325" z="-1.398954">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-163.385575511">
-          <rot val="-0.0374090162194">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-237.650567097"/>
+      <location name="bank52" x="2.1601839999999997" y="-0.0031832499999999986" z="-1.398954">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-163.3855755108478">
+          <rot val="-0.03740901621935985">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-237.65056709682256"/>
           </rot>
         </rot>
       </location>
     </component>
+  </type>
+  <type name="Column16">
     <component idfillbyfirst="y" idstart="810000" idstepbyrow="7" type="panel_v2">
-      <location name="bank55" x="2.67649875" y="-0.0029795" z="-0.8035895">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-134.710820334">
-          <rot val="-0.234178795373">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-282.31662431"/>
+      <location name="bank55" x="2.6764987499999995" y="-0.002979499999999996" z="-0.8035895000000001">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-134.71082033378104">
+          <rot val="-0.2341787953727182">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-282.3166243098243"/>
           </rot>
         </rot>
       </location>
     </component>
+  </type>
+  <type name="Column17">
     <component idfillbyfirst="y" idstart="855000" idstepbyrow="7" type="panel_v2">
-      <location name="bank58" x="3.012846" y="-0.0002255" z="-0.094475">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-354.557065626">
-          <rot val="-0.150971483389">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-77.6075190542"/>
+      <location name="bank58" x="3.0128459999999997" y="-0.00022550000000000348" z="-0.09447499999999998">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-354.5570656262832">
+          <rot val="-0.15097148338885208">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-77.60751905423362"/>
           </rot>
         </rot>
       </location>
     </component>
+  </type>
+  <type name="Column18">
     <component idfillbyfirst="y" idstart="900000" idstepbyrow="7" type="panel_v2">
-      <location name="bank61" x="3.163332" y="-0.001557" z="0.677613">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-57.7611151625">
-          <rot val="-0.120373668035">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-28.1407923079"/>
+      <location name="bank61" x="3.163332" y="-0.0015570000000000028" z="0.677613">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-57.76111516253787">
+          <rot val="-0.12037366803470045">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-28.140792307909468"/>
           </rot>
         </rot>
       </location>
     </component>
+  </type>
+  <type name="Column19">
     <component idfillbyfirst="y" idstart="945000" idstepbyrow="7" type="panel_v2">
-      <location name="bank64" x="3.12909225" y="-0.0025335" z="1.46325375">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-227.862405226">
-          <rot val="-0.0348258479558">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-231.363668527"/>
+      <location name="bank64" x="3.12909225" y="-0.002533500000000001" z="1.4632537499999998">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-227.86240522620878">
+          <rot val="-0.03482584795584898">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-231.36366852720275"/>
           </rot>
         </rot>
       </location>
     </component>
+  </type>
+  <type name="Column20">
     <component idfillbyfirst="y" idstart="990000" idstepbyrow="7" type="panel_v2">
-      <location name="bank67" x="2.925454" y="-0.00121325" z="2.22259675">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-335.435290642">
-          <rot val="-0.218489078386">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-135.798379642"/>
+      <location name="bank67" x="2.925454" y="-0.001213249999999999" z="2.22259675">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-335.43529064206797">
+          <rot val="-0.2184890783861804">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-135.79837964195806"/>
           </rot>
         </rot>
       </location>
     </component>
+  </type>
+  <type name="Column21">
     <component idfillbyfirst="y" idstart="1035000" idstepbyrow="7" type="panel_v2">
-      <location name="bank70" x="2.5679975" y="-0.002491" z="2.928798">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-102.657624083">
-          <rot val="-0.195821578452">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-20.1307048965"/>
+      <location name="bank70" x="2.5679975" y="-0.0024909999999999932" z="2.9287979999999996">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-102.65762408326187">
+          <rot val="-0.19582157845186596">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-20.13070489646615"/>
           </rot>
         </rot>
       </location>
     </component>
+  </type>
+  <type name="Column22">
     <component idfillbyfirst="y" idstart="1080000" idstepbyrow="7" type="panel_v2">
-      <location name="bank73" x="2.08063175" y="-0.00079625" z="3.55287475">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-106.309588537">
-          <rot val="-0.204650897536">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-27.1621985902"/>
+      <location name="bank73" x="2.0806317500000002" y="-0.0007962499999999983" z="3.55287475">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-106.30958853667516">
+          <rot val="-0.2046508975364438">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-27.162198590183067"/>
           </rot>
         </rot>
       </location>
     </component>
+  </type>
+  <type name="Column23">
     <component idfillbyfirst="y" idstart="1125000" idstepbyrow="7" type="panel_v2">
-      <location name="bank76" x="1.48752725" y="-0.00307125" z="4.0684955">
-        <rot axis-x="0" axis-y="1" axis-z="0" val="-224.134064394">
-          <rot val="-0.104823130903">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-280.181064026"/>
+      <location name="bank76" x="1.4875272499999999" y="-0.0030712499999999976" z="4.068495499999999">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-224.13406439401712">
+          <rot val="-0.1048231309033551">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-280.18106402569146"/>
           </rot>
         </rot>
       </location>
     </component>
+  </type>
+  <type name="Column24">
     <component idfillbyfirst="y" idstart="1170000" idstepbyrow="7" type="panel_v2">
-      <location name="bank79" x="0.812355" y="-0.00264075" z="4.4807255">
+      <location name="bank79" x="0.8123550000000002" y="-0.0026407499999999973" z="4.4807255">
         <rot axis-x="0" axis-y="1" axis-z="0" val="-270.0">
-          <rot val="-0.0088598837769">
-            <rot axis-x="0" axis-y="1" axis-z="0" val="-243.871932599"/>
+          <rot val="-0.008859883776899136">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-243.87193259907926"/>
           </rot>
         </rot>
       </location>

--- a/instrument/SNAP_Definition.xml
+++ b/instrument/SNAP_Definition.xml
@@ -111,102 +111,102 @@
   </type>
 
   <type name="Column1">
-    <component type="panel"   idstart="131072" idfillbyfirst="y" idstepbyrow="256" > <!-- bank13 - 131072 -->
+    <component type="panel"   idstart="131072" idfillbyfirst="y" idstepbyrow="256" >
       <location name="bank13">  <!-- was bank1 - 720896 -->
         <trans x="-0.167548" y="0.167548" />
       </location>
     </component>
-    <component type="panel"   idstart="65536" idfillbyfirst="y" idstepbyrow="256" > <!-- bank12 - 65536-->
+    <component type="panel"   idstart="65536" idfillbyfirst="y" idstepbyrow="256" >
       <location name="bank12">  <!-- was bank4 - 655360 -->
         <trans x="-0.167548" y="0.0" />
       </location>
     </component>
-    <component type="panel"   idstart="0" idfillbyfirst="y" idstepbyrow="256" > <!-- bank11 - 0 -->
+    <component type="panel"   idstart="0" idfillbyfirst="y" idstepbyrow="256" >
       <location name="bank11">  <!-- was bank7 - 589824 -->
         <trans x="-0.167548" y="-0.167548" />
       </location>
     </component>
   </type>
   <type name="Column2">
-    <component type="panel"   idstart="327680" idfillbyfirst="y" idstepbyrow="256" > <!-- bank23 - 327680 -->
+    <component type="panel"   idstart="327680" idfillbyfirst="y" idstepbyrow="256" >
       <location name="bank23">  <!-- was bank2 - 917504 -->
         <trans x="0.0" y="0.167548" />
       </location>
     </component>
-    <component type="panel"  idstart="262144" idfillbyfirst="y" idstepbyrow="256" > <!-- bank22 - 262144 -->
+    <component type="panel"  idstart="262144" idfillbyfirst="y" idstepbyrow="256" >
       <location name="bank22">  <!-- was bank5 - 851968 -->
         <trans x="0.0" y="0.0" />
       </location>
     </component>
-    <component type="panel"   idstart="196608" idfillbyfirst="y" idstepbyrow="256" > <!-- bank21 - 196608 -->
+    <component type="panel"   idstart="196608" idfillbyfirst="y" idstepbyrow="256" >
       <location name="bank21">  <!-- was bank8 - 786432 -->
         <trans x="0.0" y="-0.167548" />
       </location>
     </component>
   </type>
   <type name="Column3">
-    <component type="panel"   idstart="524288" idfillbyfirst="y" idstepbyrow="256" > <!-- bank33 - 524288 -->
+    <component type="panel"   idstart="524288" idfillbyfirst="y" idstepbyrow="256" >
       <location name="bank33">  <!-- was bank3 - 1114112 -->
         <trans x="0.167548" y="0.167548" />
       </location>
     </component>
-    <component type="panel"   idstart="458752" idfillbyfirst="y" idstepbyrow="256" > <!-- bank32 - 458752 -->
+    <component type="panel"   idstart="458752" idfillbyfirst="y" idstepbyrow="256" >
       <location name="bank32">  <!-- was bank6 - 1048576 -->
         <trans x="0.167548" y="0.0" />
       </location>
     </component>
-    <component type="panel"   idstart="3933216" idfillbyfirst="y" idstepbyrow="256" > <!-- bank31 - 3933216 -->
+    <component type="panel"   idstart="393216" idfillbyfirst="y" idstepbyrow="256" >
       <location name="bank31">  <!-- was bank9 - 983040 -->
         <trans x="0.167548" y="-0.167548" />
       </location>
     </component>
   </type>
   <type name="Column4">
-    <component type="panel"   idstart="1114112" idfillbyfirst="y" idstepbyrow="256" > <!-- bank63 - 1114112 -->
+    <component type="panel"   idstart="1114112" idfillbyfirst="y" idstepbyrow="256" >
       <location name="bank63">  <!-- was bank10 - 524288 -->
         <trans x="0.167548" y="0.167548" />
       </location>
     </component>
-    <component type="panel"   idstart="1048576" idfillbyfirst="y" idstepbyrow="256" > <!-- bank62 - 1048576 -->
+    <component type="panel"   idstart="1048576" idfillbyfirst="y" idstepbyrow="256" >
       <location name="bank62">  <!-- was bank13 - 458752 -->
         <trans x="0.167548" y="0.0" />
       </location>
     </component>
-    <component type="panel"   idstart="983040" idfillbyfirst="y" idstepbyrow="256" > <!-- bank61 - 983040 -->
+    <component type="panel"   idstart="983040" idfillbyfirst="y" idstepbyrow="256" >
       <location name="bank61">  <!-- was bank16 - 393216 -->
         <trans x="0.167548" y="-0.167548" />
       </location>
     </component>
   </type>
   <type name="Column5">
-    <component type="panel"   idstart="917504" idfillbyfirst="y" idstepbyrow="256" > <!-- bank53 - 917504 -->
+    <component type="panel"   idstart="917504" idfillbyfirst="y" idstepbyrow="256" >
       <location name="bank53">  <!-- was bank11 - 327680 -->
         <trans x="0.0" y="0.167548" />
       </location>
     </component>
-    <component type="panel"   idstart="851968" idfillbyfirst="y" idstepbyrow="256" > <!-- bank52 - 851968 -->
+    <component type="panel"   idstart="851968" idfillbyfirst="y" idstepbyrow="256" >
       <location name="bank52">  <!-- was bank14 - 262144 -->
         <trans x="0.0" y="0.0" />
       </location>
     </component>
-    <component type="panel"   idstart="786432" idfillbyfirst="y" idstepbyrow="256" > <!-- bank51 - 786432 -->
+    <component type="panel"   idstart="786432" idfillbyfirst="y" idstepbyrow="256" >
       <location name="bank51">  <!-- was bank17 - 196608 -->
         <trans x="0.0" y="-0.167548" />
       </location>
     </component>
   </type>
   <type name="Column6">
-    <component type="panel"   idstart="720896" idfillbyfirst="y" idstepbyrow="256" > <!-- bank43 - 720896 -->
+    <component type="panel"   idstart="720896" idfillbyfirst="y" idstepbyrow="256" >
       <location name="bank43">  <!-- was bank12 - 131072 -->
         <trans x="-0.167548" y="0.167548" />
       </location>
     </component>
-    <component type="panel"   idstart="655360" idfillbyfirst="y" idstepbyrow="256" > <!-- bank42 - 655360 -->
+    <component type="panel"   idstart="655360" idfillbyfirst="y" idstepbyrow="256" >
       <location name="bank42">  <!-- was bank15 - 65536 -->
         <trans x="-0.167548" y="0.0" />
       </location>
     </component>
-    <component type="panel"  idstart="589824" idfillbyfirst="y" idstepbyrow="256" > <!-- bank41 - 589824 -->
+    <component type="panel"  idstart="589824" idfillbyfirst="y" idstepbyrow="256" >
       <location name="bank41">  <!-- was bank18 - 0 -->
         <trans x="-0.167548" y="-0.167548" />
       </location>


### PR DESCRIPTION
**Description of work.**

Add additional levels to the instrument tree for POWGEN to aid in creating different groupings. Also fix a small an error in the SNAP geometry.

**Report to:** POWGEN team, SNAP team, Marie Yao.

**To test:**

* Look at the tree in the instrument view for POWGEN.
* `CreateGroupingWorkspace` for POWGEN with "bank", "Column", and "Group"
* SNAP had a typo in detector ids for bank31. It should start at 393216 rather than 3933216.

*There is no associated issue.*

*This does not need to be in the release notes* because it is already covered by existing release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
