### PR TITLE
Improve user error message when GSAS-II installation scripts crash because SSL is out of date

### DIFF
--- a/scripts/GSAS-II/install_gsas_proxy.py
+++ b/scripts/GSAS-II/install_gsas_proxy.py
@@ -28,7 +28,7 @@ GSAS_HOME_DIR_NAME = "g2conda"
 def download_zip_file(target_location):
     try:
         response = urllib2.urlopen(GSAS_SVN_URL)
-    except urllib2.URLError as e:
+    except urllib2.URLError:
         raise RuntimeError(FAILED_DOWNLOAD_MESSAGE)
     zip_file = response.read()
     response.close()

--- a/scripts/GSAS-II/install_gsas_proxy.py
+++ b/scripts/GSAS-II/install_gsas_proxy.py
@@ -8,6 +8,17 @@ import urllib2
 import zipfile
 
 
+FAILED_DOWNLOAD_MESSAGE = "Could not download the GSAS installation package. " \
+                          "This can occur for many reasons, one of which is " \
+                          "that your computer is not connected to the internet.\n" \
+                          "A common reason is that your version of SSL is out of date " \
+                          "(often seen on OSX). From a Python shell, run " \
+                          "'import ssl; print(ssl.OPENSSL_VERSION)'\n" \
+                          "If you see a version number less than 1.0, you need to either " \
+                          "upgrade SSL (contact the Mantid team or seek help online) " \
+                          "or do a manual installation from the GSAS-II website.\n" \
+                          "If neither of these solutions yield anything useful, please " \
+                          "get in contact with the Mantid team."
 GSAS_SVN_URL = "https://subversion.xray.aps.anl.gov/pyGSAS/install/GSASIIproxy.zip"
 GSAS_BOOTSTRAP_URL = "https://subversion.xray.aps.anl.gov/pyGSAS/install/bootstrap.py"
 GSAS_PROXY_FILE_NAME = "GSASIIProxy.zip"
@@ -15,7 +26,10 @@ GSAS_HOME_DIR_NAME = "g2conda"
 
 
 def download_zip_file(target_location):
-    response = urllib2.urlopen(GSAS_SVN_URL)
+    try:
+        response = urllib2.urlopen(GSAS_SVN_URL)
+    except urllib2.URLError as e:
+        raise RuntimeError(FAILED_DOWNLOAD_MESSAGE)
     zip_file = response.read()
     response.close()
 

--- a/scripts/GSAS-II/install_gsas_proxy.py
+++ b/scripts/GSAS-II/install_gsas_proxy.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import argparse
 import os
 import pip

--- a/scripts/GSAS-II/install_gsas_vetted.bat
+++ b/scripts/GSAS-II/install_gsas_vetted.bat
@@ -1,3 +1,3 @@
 @echo off
-@set VETTED_REVISION_NUMBER=3216
+@set VETTED_REVISION_NUMBER=3392
 %~dp0install_gsas_common.bat -v %VETTED_REVISION_NUMBER% %*


### PR DESCRIPTION
Previously, if a user's version of openssl was pre-1.0, the GSAS-II installation scripts would fail with an unhelpful error message. The user is now advised to make sure that their computer is connected to the internet and that their openssl version is recent enough.

Note, I've not added any documentation for how to upgrade openssl, as there is plenty of help on StackOverflow that will be more valuable than anything I can come up with, but feel free to object if you think that more detail would be better.

The latest vetted GSAS-II revision number was also change to 3392, as several features have been added since the old one (3216) which we use.

**To test:**

From a computer with a pre-1.0 version of openssl (possibly most macs?) try running `python scripts/GSAS-II/install_gsas_proxy.py`. You should see a useful error message. (Run on master first to make sure the message `urllib2.URLError: <urlopen error EOF occurred in violation of protocol (_ssl.c:590)>`)

Fixes #22357

Does this update require release notes?
No, as the change is minor and no users use the installation script anyway

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
