### PR TITLE
Fix failing ConvertWANDSCDtoQTest on OSX

### DIFF
--- a/Testing/SystemTests/tests/analysis/ConvertWANDSCDtoQTest.py
+++ b/Testing/SystemTests/tests/analysis/ConvertWANDSCDtoQTest.py
@@ -15,15 +15,22 @@ class ConvertWANDSCDtoQTest(stresstesting.MantidStressTest):
 
         ConvertWANDSCDtoQTest_peaks=FindPeaksMD(InputWorkspace=ConvertWANDSCDtoQTest_Q, PeakDistanceThreshold=2,
                                                 CalculateGoniometerForCW=True, Wavelength=1.488)
-        FindUBUsingLatticeParameters(ConvertWANDSCDtoQTest_peaks, a=5.64, b=5.64, c=5.64, alpha=90, beta=90, gamma=90)
-        UB = ConvertWANDSCDtoQTest_peaks.sample().getOrientedLattice().getUB()
-        self.assertTrue(np.allclose(UB, [[-2.73152432e-17,  1.77061974e-01, -9.27942487e-03],
-                                         [ 1.77304965e-01,  0.00000000e+00,  0.00000000e+00],
-                                         [ 1.23032284e-17, -9.27942487e-03, -1.77061974e-01]]))
+
+        self.assertEqual(ConvertWANDSCDtoQTest_peaks.getNumberPeaks(), 14)
+
+        peak = ConvertWANDSCDtoQTest_peaks.getPeak(0)
+        self.assertTrue(np.allclose(peak.getQSampleFrame(), [2.40072,0.00130686,4.32033]))
+        self.assertDelta(peak.getWavelength(), 1.488, 1e-5)
+
+        peak = ConvertWANDSCDtoQTest_peaks.getPeak(13)
+        self.assertTrue(np.allclose(peak.getQSampleFrame(), [6.56011,0.00130687,-2.52058]))
+        self.assertDelta(peak.getWavelength(), 1.488, 1e-5)
+
+        SetUB('ConvertWANDSCDtoQTest_data', UB="-2.7315243158024499e-17,1.7706197424726486e-01,-9.2794248657701375e-03,"
+              "1.773049645390071e-01,0.,0.,1.2303228382369809e-17,-9.2794248657701254e-03,-1.7706197424726489e-01")
 
         ConvertWANDSCDtoQ(InputWorkspace='ConvertWANDSCDtoQTest_data',
                           NormalisationWorkspace='ConvertWANDSCDtoQTest_norm',
-                          UBWorkspace=ConvertWANDSCDtoQTest_peaks,
                           Frame='HKL',
                           BinningDim0='-0.62,0.62,31',
                           BinningDim1='-2.02,7.02,226',


### PR DESCRIPTION
ConvertWANDSCDtoQTest systemtest [fails on OSX](http://builds.mantidproject.org/job/master_systemtests-osx/581/testReport/)

Change ConvertWANDSCDtoQTest to not depend on UB determination. Because cubic cell is used a different orientation on the U matrix was found on OSX. This changes the test that should work everywhere.

**To test:**
Run the ConvertWANDSCDtoQTest systemtest on OSX

Does this update require release notes?
- [ ] Yes
- [x] No

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
