### PR TITLE
Add MDFrameValidator to Mantid

### DIFF
--- a/Framework/API/CMakeLists.txt
+++ b/Framework/API/CMakeLists.txt
@@ -96,6 +96,7 @@ set ( SRC_FILES
 	src/LogManager.cpp
 	src/LogarithmScale.cpp
 	src/MDGeometry.cpp
+        src/MDFrameValidator.cpp
 	src/MatrixWorkspace.cpp
 	src/MatrixWorkspaceMDIterator.cpp
 	src/ModeratorModel.cpp
@@ -292,6 +293,7 @@ set ( INC_FILES
 	inc/MantidAPI/LogManager.h
 	inc/MantidAPI/LogarithmScale.h
 	inc/MantidAPI/MDGeometry.h
+        inc/MantidAPI/MDFrameValidator.h
 	inc/MantidAPI/MatrixWorkspace.h
 	inc/MantidAPI/MatrixWorkspaceMDIterator.h
 	inc/MantidAPI/MatrixWorkspaceValidator.h
@@ -420,6 +422,7 @@ set ( TEST_FILES
 	LogFilterGeneratorTest.h
 	LogManagerTest.h
 	MDGeometryTest.h
+	MDFrameValidatorTest.h
 	MatrixWorkspaceMDIteratorTest.h
 	ModeratorModelTest.h
 	MuParserUtilsTest.h

--- a/Framework/API/inc/MantidAPI/IMDWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IMDWorkspace.h
@@ -169,7 +169,6 @@ protected:
 
   const std::string toString() const override;
 
-
 private:
   std::string m_convention;
   IMDWorkspace *doClone() const override = 0;

--- a/Framework/API/inc/MantidAPI/IMDWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IMDWorkspace.h
@@ -169,6 +169,7 @@ protected:
 
   const std::string toString() const override;
 
+
 private:
   std::string m_convention;
   IMDWorkspace *doClone() const override = 0;

--- a/Framework/API/inc/MantidAPI/MDFrameValidator.h
+++ b/Framework/API/inc/MantidAPI/MDFrameValidator.h
@@ -37,14 +37,13 @@ class MANTID_API_DLL MDFrameValidator
 public:
   explicit MDFrameValidator(const std::string &frameName);
   /// Gets the type of the validator
-  inline std::string getType() const { return "mdframe"; }
+  std::string getType() const { return "mdframe"; }
   /// Clone the current state
   Kernel::IValidator_sptr clone() const override;
 
 private:
   /// Check for validity.
-  virtual std::string
-  checkValidity(const IMDWorkspace_sptr &workspace) const override;
+  std::string checkValidity(const IMDWorkspace_sptr &workspace) const override;
 
   /// The name of the required frame
   const std::string m_frameID;

--- a/Framework/API/inc/MantidAPI/MDFrameValidator.h
+++ b/Framework/API/inc/MantidAPI/MDFrameValidator.h
@@ -1,10 +1,9 @@
 #ifndef MANTID_API_MDFRAMEVALIDATOR_H
 #define MANTID_API_MDFRAMEVALIDATOR_H
 
-#include "MantidKernel/TypedValidator.h"
 #include "MantidAPI/DllConfig.h"
 #include "MantidAPI/IMDWorkspace.h"
-
+#include "MantidKernel/TypedValidator.h"
 
 /**
   A validator which checks that the frame of the MDWorkspace referred to
@@ -33,23 +32,25 @@
 */
 namespace Mantid {
 namespace API {
-class MANTID_API_DLL MDFrameValidator : public Kernel::TypedValidator<IMDWorkspace_sptr> {
+class MANTID_API_DLL MDFrameValidator
+    : public Kernel::TypedValidator<IMDWorkspace_sptr> {
 public:
-    explicit MDFrameValidator(const std::string& frameName);
-    /// Gets the type of the validator
-    inline std::string getType() const { return "mdframe"; }
-    /// Clone the current state
-    Kernel::IValidator_sptr clone() const override;
+  explicit MDFrameValidator(const std::string &frameName);
+  /// Gets the type of the validator
+  inline std::string getType() const { return "mdframe"; }
+  /// Clone the current state
+  Kernel::IValidator_sptr clone() const override;
 
 private:
-    /// Check for validity.
-    virtual std::string checkValidity(const IMDWorkspace_sptr &workspace) const override;
+  /// Check for validity.
+  virtual std::string
+  checkValidity(const IMDWorkspace_sptr &workspace) const override;
 
-    /// The name of the required frame
-    const std::string m_frameID;
+  /// The name of the required frame
+  const std::string m_frameID;
 };
 
-} // namespace Kernel
+} // namespace API
 } // namespace Mantid
 
 #endif // MANTID_API_MDFRAMEVALIDATOR_H

--- a/Framework/API/inc/MantidAPI/MDFrameValidator.h
+++ b/Framework/API/inc/MantidAPI/MDFrameValidator.h
@@ -1,0 +1,55 @@
+#ifndef MANTID_API_MDFRAMEVALIDATOR_H
+#define MANTID_API_MDFRAMEVALIDATOR_H
+
+#include "MantidKernel/TypedValidator.h"
+#include "MantidAPI/DllConfig.h"
+#include "MantidAPI/IMDWorkspace.h"
+
+
+/**
+  A validator which checks that the frame of the MDWorkspace referred to
+  by a WorkspaceProperty is the expected one.
+
+  Copyright &copy; 2015 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+namespace Mantid {
+namespace API {
+class MANTID_API_DLL MDFrameValidator : public Kernel::TypedValidator<IMDWorkspace_sptr> {
+public:
+    explicit MDFrameValidator(const std::string& frameName);
+    /// Gets the type of the validator
+    inline std::string getType() const { return "mdframe"; }
+    /// Clone the current state
+    Kernel::IValidator_sptr clone() const override;
+
+private:
+    /// Check for validity.
+    virtual std::string checkValidity(const IMDWorkspace_sptr &workspace) const override;
+
+    /// The name of the required frame
+    const std::string m_frameID;
+};
+
+} // namespace Kernel
+} // namespace Mantid
+
+#endif // MANTID_API_MDFRAMEVALIDATOR_H

--- a/Framework/API/src/MDFrameValidator.cpp
+++ b/Framework/API/src/MDFrameValidator.cpp
@@ -7,11 +7,10 @@ using Mantid::Kernel::IValidator_sptr;
 namespace Mantid {
 namespace API {
 
-
 /** Constructor
-  *
-  * @param frameName :: The name of the frame that the workspace must have.
-  */
+ *
+ * @param frameName :: The name of the frame that the workspace must have.
+ */
 MDFrameValidator::MDFrameValidator(const std::string &frameName)
     : m_frameID{frameName} {}
 
@@ -23,15 +22,15 @@ Kernel::IValidator_sptr MDFrameValidator::clone() const {
 }
 
 /** Checks that the frame of the MDWorkspace matches the expected frame.
-  *
-  * @param value :: The workspace to test
-  * @return A user level description of the error or "" for no error
-  */
+ *
+ * @param value :: The workspace to test
+ * @return A user level description of the error or "" for no error
+ */
 std::string
 MDFrameValidator::checkValidity(const IMDWorkspace_sptr &workspace) const {
 
   for (size_t index = 0; index < workspace->getNumDims(); ++index) {
-    const auto& frame = workspace->getDimension(index)->getMDFrame();
+    const auto &frame = workspace->getDimension(index)->getMDFrame();
     if (frame.name() != m_frameID)
       return "MDWorkspace must be in the " + m_frameID + " frame.";
   }

--- a/Framework/API/src/MDFrameValidator.cpp
+++ b/Framework/API/src/MDFrameValidator.cpp
@@ -1,0 +1,43 @@
+#include "MantidAPI/MDFrameValidator.h"
+#include "MantidKernel/IValidator.h"
+#include <boost/make_shared.hpp>
+
+using Mantid::Kernel::IValidator_sptr;
+
+namespace Mantid {
+namespace API {
+
+
+/** Constructor
+  *
+  * @param frameName :: The name of the frame that the workspace must have.
+  */
+MDFrameValidator::MDFrameValidator(const std::string &frameName)
+    : m_frameID{frameName} {}
+
+/**
+ * Clone the current state
+ */
+Kernel::IValidator_sptr MDFrameValidator::clone() const {
+  return boost::make_shared<MDFrameValidator>(*this);
+}
+
+/** Checks that the frame of the MDWorkspace matches the expected frame.
+  *
+  * @param value :: The workspace to test
+  * @return A user level description of the error or "" for no error
+  */
+std::string
+MDFrameValidator::checkValidity(const IMDWorkspace_sptr &workspace) const {
+
+  for (size_t index = 0; index < workspace->getNumDims(); ++index) {
+    const auto& frame = workspace->getDimension(index)->getMDFrame();
+    if (frame.name() != m_frameID)
+      return "MDWorkspace must be in the " + m_frameID + " frame.";
+  }
+
+  return "";
+}
+
+} // namespace API
+} // namespace Mantid

--- a/Framework/API/src/MDFrameValidator.cpp
+++ b/Framework/API/src/MDFrameValidator.cpp
@@ -23,7 +23,7 @@ Kernel::IValidator_sptr MDFrameValidator::clone() const {
 
 /** Checks that the frame of the MDWorkspace matches the expected frame.
  *
- * @param value :: The workspace to test
+ * @param workspace :: The workspace to test
  * @return A user level description of the error or "" for no error
  */
 std::string

--- a/Framework/API/test/MDFrameValidatorTest.h
+++ b/Framework/API/test/MDFrameValidatorTest.h
@@ -18,6 +18,13 @@ using namespace Mantid::API;
 
 class MDFrameValidatorTest : public CxxTest::TestSuite {
 public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static MDFrameValidatorTest *createSuite() {
+    return new MDFrameValidatorTest();
+  }
+  static void destroySuite(MDFrameValidatorTest *suite) { delete suite; }
+
   void testGetType() {
     MDFrameValidator unitValidator(HKL::HKLName);
     TS_ASSERT_EQUALS(unitValidator.getType(), "mdframe");

--- a/Framework/API/test/MDFrameValidatorTest.h
+++ b/Framework/API/test/MDFrameValidatorTest.h
@@ -15,6 +15,7 @@
 
 using namespace Mantid::Geometry;
 using namespace Mantid::API;
+using namespace Mantid::Kernel;
 
 class MDFrameValidatorTest : public CxxTest::TestSuite {
 public:

--- a/Framework/API/test/MDFrameValidatorTest.h
+++ b/Framework/API/test/MDFrameValidatorTest.h
@@ -10,7 +10,6 @@
 #include "MantidGeometry/MDGeometry/MDFrameFactory.h"
 #include "MantidGeometry/MDGeometry/MDHistoDimension.h"
 #include "MantidGeometry/MDGeometry/QLab.h"
-#include "MantidGeometry/MDGeometry/MDHistoDimension.h"
 #include "MantidKernel/UnitLabelTypes.h"
 #include "MantidTestHelpers/FakeObjects.h"
 
@@ -51,13 +50,13 @@ public:
   void testMixedAxisMDWorkspaceIsNotValidForValidatorWithQLabFrame() {
     MDFrameValidator frameValidator(QLab::QLabName);
 
-    MDFrameArgument axisArgs1 {HKL::HKLName, Units::Symbol::RLU};
-    MDFrameArgument axisArgs2 {QLab::QLabName, Units::Symbol::InverseAngstrom};
+    MDFrameArgument axisArgs1{HKL::HKLName, Units::Symbol::RLU};
+    MDFrameArgument axisArgs2{QLab::QLabName, Units::Symbol::InverseAngstrom};
 
     auto frame1 = HKLFrameFactory().create(axisArgs1);
     auto frame2 = QLabFrameFactory().create(axisArgs2);
     auto dim1 = boost::make_shared<MDHistoDimension>("x", "x", *frame1, 0.0f,
-                                                    100.0f, 10);
+                                                     100.0f, 10);
     auto dim2 = boost::make_shared<MDHistoDimension>("x", "x", *frame1, 0.0f,
                                                      100.0f, 10);
     auto ws = boost::make_shared<MDHistoWorkspaceTester>(dim1, dim2, dim2);

--- a/Framework/API/test/MDFrameValidatorTest.h
+++ b/Framework/API/test/MDFrameValidatorTest.h
@@ -1,0 +1,69 @@
+#ifndef MANTID_MDUNITVALIDATOR_TEST_H
+#define MANTID_MDUNITVALIDATOR_TEST_H
+
+#include <boost/make_shared.hpp>
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAPI/IMDEventWorkspace_fwd.h"
+#include "MantidAPI/MDFrameValidator.h"
+#include "MantidGeometry/MDGeometry/HKL.h"
+#include "MantidGeometry/MDGeometry/MDFrameFactory.h"
+#include "MantidGeometry/MDGeometry/MDHistoDimension.h"
+#include "MantidGeometry/MDGeometry/QLab.h"
+#include "MantidGeometry/MDGeometry/MDHistoDimension.h"
+#include "MantidKernel/UnitLabelTypes.h"
+#include "MantidTestHelpers/FakeObjects.h"
+
+using namespace Mantid::Geometry;
+using namespace Mantid::API;
+
+class MDFrameValidatorTest : public CxxTest::TestSuite {
+public:
+  void testGetType() {
+    MDFrameValidator unitValidator(HKL::HKLName);
+    TS_ASSERT_EQUALS(unitValidator.getType(), "mdframe");
+  }
+
+  void testHKLMDWorkspaceIsValidForValidatorWithHKLFrame() {
+    MDFrameValidator frameValidator(HKL::HKLName);
+
+    HKLFrameFactory factory;
+    auto frame =
+        factory.create(MDFrameArgument{HKL::HKLName, Units::Symbol::RLU});
+    auto dim = boost::make_shared<MDHistoDimension>("x", "x", *frame, 0.0f,
+                                                    100.0f, 10);
+    auto ws = boost::make_shared<MDHistoWorkspaceTester>(dim, dim, dim);
+    TS_ASSERT_EQUALS(frameValidator.isValid(ws), "")
+  };
+
+  void testHKLMDWorkspaceIsNotValidForValidatorWithQLabFrame() {
+    MDFrameValidator frameValidator(QLab::QLabName);
+
+    MDFrameArgument args{HKL::HKLName, Units::Symbol::RLU};
+    auto frame = HKLFrameFactory().create(args);
+    auto dim = boost::make_shared<MDHistoDimension>("x", "x", *frame, 0.0f,
+                                                    100.0f, 10);
+    auto ws = boost::make_shared<MDHistoWorkspaceTester>(dim, dim, dim);
+    TS_ASSERT_EQUALS(frameValidator.isValid(ws),
+                     "MDWorkspace must be in the " + QLab::QLabName + " frame.")
+  };
+
+  void testMixedAxisMDWorkspaceIsNotValidForValidatorWithQLabFrame() {
+    MDFrameValidator frameValidator(QLab::QLabName);
+
+    MDFrameArgument axisArgs1 {HKL::HKLName, Units::Symbol::RLU};
+    MDFrameArgument axisArgs2 {QLab::QLabName, Units::Symbol::InverseAngstrom};
+
+    auto frame1 = HKLFrameFactory().create(axisArgs1);
+    auto frame2 = QLabFrameFactory().create(axisArgs2);
+    auto dim1 = boost::make_shared<MDHistoDimension>("x", "x", *frame1, 0.0f,
+                                                    100.0f, 10);
+    auto dim2 = boost::make_shared<MDHistoDimension>("x", "x", *frame1, 0.0f,
+                                                     100.0f, 10);
+    auto ws = boost::make_shared<MDHistoWorkspaceTester>(dim1, dim2, dim2);
+    TS_ASSERT_EQUALS(frameValidator.isValid(ws),
+                     "MDWorkspace must be in the " + QLab::QLabName + " frame.")
+  };
+};
+
+#endif // MANTID_MDUNITVALIDATOR_TEST_H

--- a/Framework/Kernel/CMakeLists.txt
+++ b/Framework/Kernel/CMakeLists.txt
@@ -219,7 +219,6 @@ set ( INC_FILES
 	inc/MantidKernel/Logger.h
 	inc/MantidKernel/MDAxisValidator.h
 	inc/MantidKernel/MDUnit.h
-	inc/MantidKernel/MDUnitFactory.h
 	inc/MantidKernel/MRUList.h
 	inc/MantidKernel/MagneticFormFactorTable.h
 	inc/MantidKernel/MagneticIon.h

--- a/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceValidators.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceValidators.cpp
@@ -74,7 +74,10 @@ void export_WorkspaceValidators() {
   class_<MDFrameValidator, bases<TypedValidator<IMDWorkspace_sptr>>,
          boost::noncopyable>(
       "MDFrameValidator",
-      init<std::string>(
-          arg("frameName"),
-          "Checks the MD workspace has th given frame along all dimensions"));
+      init<std::string>(arg("frameName"),
+                        "Checks the MD workspace has the given frame along all "
+                        "dimensions. Accepted values for the `frameName` are "
+                        "currently: `HKL`, `QLab`, `QSample`, `Time of "
+                        "Flight`, `Distance`, `General frame`, `Unknown "
+                        "frame` "));
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceValidators.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceValidators.cpp
@@ -53,10 +53,9 @@ void export_WorkspaceValidators() {
       WorkspaceUnitValidator, std::string, "unit",
       "Checks the workspace has the given unit along the X-axis");
   EXPORT_WKSP_VALIDATOR_DEFAULT_ARG(HistogramValidator, bool, "mustBeHistogram",
-                                    true,
-                                    "If mustBeHistogram=True then the "
-                                    "workspace must be a histogram "
-                                    "otherwise it must be point data.");
+                                    true, "If mustBeHistogram=True then the "
+                                          "workspace must be a histogram "
+                                          "otherwise it must be point data.");
   EXPORT_WKSP_VALIDATOR_DEFAULT_ARG(
       RawCountValidator, bool, "mustNotBeDistribution", true,
       "If mustNotBeDistribution=True then the workspace must not have been "

--- a/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceValidators.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceValidators.cpp
@@ -20,15 +20,13 @@ void export_MatrixWorkspaceValidator() {
   using Mantid::API::MatrixWorkspaceValidator;
   TypedValidatorExporter<MatrixWorkspace_sptr>::define(
       "MatrixWorkspaceValidator");
-  TypedValidatorExporter<IMDWorkspace_sptr>::define(
-            "IMDWorkspaceValidator");
+  TypedValidatorExporter<IMDWorkspace_sptr>::define("IMDWorkspaceValidator");
 
   class_<MatrixWorkspaceValidator, bases<TypedValidator<MatrixWorkspace_sptr>>,
          boost::noncopyable>("MatrixWorkspaceValidator", no_init);
 
-    class_<TypedValidator<IMDWorkspace_sptr >,
-            boost::noncopyable>("IMDWorkspaceValidator", no_init);
-
+  class_<TypedValidator<IMDWorkspace_sptr>, boost::noncopyable>(
+      "IMDWorkspaceValidator", no_init);
 }
 /// Export a validator derived from a MatrixWorkspaceValidator that has a no-arg
 /// constructor
@@ -74,6 +72,9 @@ void export_WorkspaceValidators() {
       "Checks whether the axis specified by axisNumber is a NumericAxis");
 
   class_<MDFrameValidator, bases<TypedValidator<IMDWorkspace_sptr>>,
-         boost::noncopyable>("MDFrameValidator", init<std::string>(arg("frameName"),
+         boost::noncopyable>(
+      "MDFrameValidator",
+      init<std::string>(
+          arg("frameName"),
           "Checks the MD workspace has th given frame along all dimensions"));
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceValidators.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceValidators.cpp
@@ -1,5 +1,7 @@
 #include "MantidAPI/CommonBinsValidator.h"
 #include "MantidAPI/HistogramValidator.h"
+#include "MantidAPI/IMDWorkspace.h"
+#include "MantidAPI/MDFrameValidator.h"
 #include "MantidAPI/NumericAxisValidator.h"
 #include "MantidAPI/RawCountValidator.h"
 #include "MantidAPI/SpectraAxisValidator.h"
@@ -7,6 +9,7 @@
 #include "MantidPythonInterface/kernel/TypedValidatorExporter.h"
 #include <boost/python/class.hpp>
 
+using Mantid::API::IMDWorkspace_sptr;
 using Mantid::Kernel::TypedValidator;
 using Mantid::PythonInterface::TypedValidatorExporter;
 using namespace boost::python;
@@ -17,9 +20,15 @@ void export_MatrixWorkspaceValidator() {
   using Mantid::API::MatrixWorkspaceValidator;
   TypedValidatorExporter<MatrixWorkspace_sptr>::define(
       "MatrixWorkspaceValidator");
+  TypedValidatorExporter<IMDWorkspace_sptr>::define(
+            "IMDWorkspaceValidator");
 
   class_<MatrixWorkspaceValidator, bases<TypedValidator<MatrixWorkspace_sptr>>,
          boost::noncopyable>("MatrixWorkspaceValidator", no_init);
+
+    class_<TypedValidator<IMDWorkspace_sptr >,
+            boost::noncopyable>("IMDWorkspaceValidator", no_init);
+
 }
 /// Export a validator derived from a MatrixWorkspaceValidator that has a no-arg
 /// constructor
@@ -46,9 +55,10 @@ void export_WorkspaceValidators() {
       WorkspaceUnitValidator, std::string, "unit",
       "Checks the workspace has the given unit along the X-axis");
   EXPORT_WKSP_VALIDATOR_DEFAULT_ARG(HistogramValidator, bool, "mustBeHistogram",
-                                    true, "If mustBeHistogram=True then the "
-                                          "workspace must be a histogram "
-                                          "otherwise it must be point data.");
+                                    true,
+                                    "If mustBeHistogram=True then the "
+                                    "workspace must be a histogram "
+                                    "otherwise it must be point data.");
   EXPORT_WKSP_VALIDATOR_DEFAULT_ARG(
       RawCountValidator, bool, "mustNotBeDistribution", true,
       "If mustNotBeDistribution=True then the workspace must not have been "
@@ -62,4 +72,8 @@ void export_WorkspaceValidators() {
   EXPORT_WKSP_VALIDATOR_DEFAULT_ARG(
       NumericAxisValidator, int, "axisNumber", 1,
       "Checks whether the axis specified by axisNumber is a NumericAxis");
+
+  class_<MDFrameValidator, bases<TypedValidator<IMDWorkspace_sptr>>,
+         boost::noncopyable>("MDFrameValidator", init<std::string>(arg("frameName"),
+          "Checks the MD workspace has th given frame along all dimensions"));
 }

--- a/Framework/PythonInterface/test/python/mantid/api/WorkspaceValidatorsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/WorkspaceValidatorsTest.py
@@ -9,7 +9,7 @@ from mantid.kernel import IValidator
 from mantid.api import (WorkspaceUnitValidator, HistogramValidator,
                         RawCountValidator, CommonBinsValidator,
                         SpectraAxisValidator, NumericAxisValidator,
-                        InstrumentValidator)
+                        InstrumentValidator, MDFrameValidator)
 
 class WorkspaceValidatorsTest(unittest.TestCase):
 
@@ -66,6 +66,11 @@ class WorkspaceValidatorsTest(unittest.TestCase):
             with no args
         """
         testhelpers.assertRaisesNothing(self, InstrumentValidator)
+
+    def test_MDFrameValidator_construction(self):
+        testhelpers.assertRaisesNothing(self, MDFrameValidator, "HKL")
+        self.assertRaises(Exception, MDFrameValidator)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
@@ -22,6 +22,8 @@
 #include <map>
 #include <string>
 
+#include "MantidAPI/IMDHistoWorkspace.h"
+#include "MantidGeometry/MDGeometry/MDHistoDimension.h"
 #include "MantidAPI/ISpectrum.h"
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
@@ -29,12 +31,17 @@
 #include "MantidAPI/SpectraAxis.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/DetectorGroup.h"
+#include "MantidKernel/SpecialCoordinateSystem.h"
 #include "MantidKernel/cow_ptr.h"
 
 using namespace Mantid::API;
-using Mantid::detid_t;
-using Mantid::specnum_t;
+using namespace Mantid::Kernel;
+using namespace Mantid::Geometry;
 using Mantid::MantidVec;
+using Mantid::coord_t;
+using Mantid::detid_t;
+using Mantid::signal_t;
+using Mantid::specnum_t;
 
 //===================================================================================================================
 /** Helper class that implements ISpectrum */
@@ -409,6 +416,318 @@ protected:
   }
   const void *void_pointer(size_t) const override {
     throw std::runtime_error("void_pointer const not implemented");
+  }
+};
+
+//===================================================================================================================
+class MDHistoWorkspaceTester : public IMDHistoWorkspace {
+
+public:
+  virtual uint64_t getNPoints() const override {
+    throw std::runtime_error("Not Implemented");
+  }
+  virtual uint64_t getNEvents() const override {
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual std::vector<std::unique_ptr<IMDIterator>> createIterators(
+      size_t suggestedNumCores = 1,
+      Mantid::Geometry::MDImplicitFunction *function = nullptr) const override {
+      UNUSED_ARG(suggestedNumCores)
+      UNUSED_ARG(function)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual signal_t
+  getSignalAtCoord(const coord_t *coords,
+                   const Mantid::API::MDNormalization &normalization) const override {
+      UNUSED_ARG(coords);
+      UNUSED_ARG(normalization);
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual signal_t getSignalWithMaskAtCoord(
+      const coord_t *coords,
+      const Mantid::API::MDNormalization &normalization) const override {
+      UNUSED_ARG(coords);
+      UNUSED_ARG(normalization);
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual void
+  setMDMasking(Mantid::Geometry::MDImplicitFunction *maskingRegion) override {
+      UNUSED_ARG(maskingRegion);
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual void clearMDMasking() override { throw std::runtime_error("Not Implemented"); }
+
+  virtual SpecialCoordinateSystem getSpecialCoordinateSystem() const override{
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual coord_t getInverseVolume() const override {
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual signal_t *getSignalArray() const override {
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual signal_t *getErrorSquaredArray() const override {
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual signal_t *getNumEventsArray() const override {
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual void setTo(signal_t signal, signal_t errorSquared,
+                     signal_t numEvents) override {
+      UNUSED_ARG(signal);
+      UNUSED_ARG(errorSquared);
+      UNUSED_ARG(numEvents);
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual Mantid::Kernel::VMD getCenter(size_t linearIndex) const override {
+      UNUSED_ARG(linearIndex);
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual void setSignalAt(size_t index, signal_t value) override {
+      UNUSED_ARG(index)
+      UNUSED_ARG(value)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual void setErrorSquaredAt(size_t index, signal_t value) override {
+      UNUSED_ARG(index)
+      UNUSED_ARG(value)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual signal_t getErrorAt(size_t index) const override {
+      UNUSED_ARG(index)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual signal_t getErrorAt(size_t index1, size_t index2) const override {
+      UNUSED_ARG(index1)
+      UNUSED_ARG(index2)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual signal_t getErrorAt(size_t index1, size_t index2,
+                              size_t index3) const override {
+      UNUSED_ARG(index1)
+      UNUSED_ARG(index2)
+      UNUSED_ARG(index3)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual signal_t getErrorAt(size_t index1, size_t index2, size_t index3,
+                              size_t index4) const override {
+      UNUSED_ARG(index1)
+      UNUSED_ARG(index2)
+      UNUSED_ARG(index3)
+      UNUSED_ARG(index4)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual signal_t getSignalAt(size_t index) const override {
+      UNUSED_ARG(index)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual signal_t getSignalAt(size_t index1, size_t index2) const override {
+      UNUSED_ARG(index1)
+      UNUSED_ARG(index2)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual signal_t getSignalAt(size_t index1, size_t index2,
+                               size_t index3) const override {
+      UNUSED_ARG(index1)
+      UNUSED_ARG(index2)
+      UNUSED_ARG(index3)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual signal_t getSignalAt(size_t index1, size_t index2, size_t index3,
+                               size_t index4) const override {
+      UNUSED_ARG(index1)
+      UNUSED_ARG(index2)
+      UNUSED_ARG(index3)
+      UNUSED_ARG(index4)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual signal_t getSignalNormalizedAt(size_t index) const override {
+      UNUSED_ARG(index)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual signal_t getSignalNormalizedAt(size_t index1,
+                                         size_t index2) const override {
+      UNUSED_ARG(index1)
+      UNUSED_ARG(index2)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual signal_t getSignalNormalizedAt(size_t index1, size_t index2,
+                                         size_t index3) const override {
+      UNUSED_ARG(index1)
+      UNUSED_ARG(index2)
+      UNUSED_ARG(index3)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual signal_t getSignalNormalizedAt(size_t index1, size_t index2,
+                                         size_t index3,
+                                         size_t index4) const override {
+      UNUSED_ARG(index1)
+      UNUSED_ARG(index2)
+      UNUSED_ARG(index3)
+      UNUSED_ARG(index4)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual signal_t getErrorNormalizedAt(size_t index) const override {
+      UNUSED_ARG(index)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual signal_t getErrorNormalizedAt(size_t index1,
+                                        size_t index2) const override {
+      UNUSED_ARG(index1)
+      UNUSED_ARG(index2)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual signal_t getErrorNormalizedAt(size_t index1, size_t index2,
+                                        size_t index3) const override {
+      UNUSED_ARG(index1)
+      UNUSED_ARG(index2)
+      UNUSED_ARG(index3)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual signal_t getErrorNormalizedAt(size_t index1, size_t index2,
+                                        size_t index3,
+                                        size_t index4) const override {
+      UNUSED_ARG(index1)
+      UNUSED_ARG(index2)
+      UNUSED_ARG(index3)
+      UNUSED_ARG(index4)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual signal_t &errorSquaredAt(size_t index) override {
+      UNUSED_ARG(index)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual signal_t &signalAt(size_t index) override {
+      UNUSED_ARG(index)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual size_t getLinearIndex(size_t index1, size_t index2) const override {
+      UNUSED_ARG(index1)
+      UNUSED_ARG(index2)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual size_t getLinearIndex(size_t index1, size_t index2,
+                                size_t index3) const override {
+      UNUSED_ARG(index1)
+      UNUSED_ARG(index2)
+      UNUSED_ARG(index3)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual size_t getLinearIndex(size_t index1, size_t index2, size_t index3,
+                                size_t index4) const override {
+      UNUSED_ARG(index1)
+      UNUSED_ARG(index2)
+      UNUSED_ARG(index3)
+      UNUSED_ARG(index4)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual LinePlot
+  getLineData(const Mantid::Kernel::VMD &start, const Mantid::Kernel::VMD &end,
+              Mantid::API::MDNormalization normalize) const override {
+      UNUSED_ARG(start)
+      UNUSED_ARG(end)
+      UNUSED_ARG(normalize)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual double &operator[](const size_t &index) override {
+      UNUSED_ARG(index)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual void
+  setCoordinateSystem(const SpecialCoordinateSystem coordinateSystem) override {
+      UNUSED_ARG(coordinateSystem)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual void setDisplayNormalization(
+      const Mantid::API::MDNormalization &preferredNormalization) override {
+      UNUSED_ARG(preferredNormalization);
+    throw std::runtime_error("Not Implemented");
+  }
+
+  // Check if this class has an oriented lattice on any sample object
+  virtual bool hasOrientedLattice() const override {
+    return MultipleExperimentInfos::hasOrientedLattice();
+  }
+
+  virtual size_t getMemorySize() const override {
+    throw std::runtime_error("Not Implemented");
+  }
+
+  virtual const std::string id() const override {
+
+    throw std::runtime_error("Not Implemented");
+  }
+  virtual const std::string &getName() const override {
+
+    throw std::runtime_error("Not Implemented");
+  }
+  virtual bool threadSafe() const override {
+
+    throw std::runtime_error("Not Implemented");
+  }
+  virtual const std::string toString() const override {
+
+    throw std::runtime_error("Not Implemented");
+  }
+    MDHistoWorkspaceTester(MDHistoDimension_sptr dimX,
+    MDHistoDimension_sptr dimY,
+    MDHistoDimension_sptr dimZ) {
+
+      m_dimensions.push_back(dimX);
+      m_dimensions.push_back(dimY);
+      m_dimensions.push_back(dimZ);
+
+      initGeometry(m_dimensions);
+  }
+protected:
+
+private:
+    std::vector<IMDDimension_sptr> m_dimensions;
+
+  IMDHistoWorkspace *doClone() const override {
+    throw std::runtime_error("Not Implemented");
+  }
+  IMDHistoWorkspace *doCloneEmpty() const override {
+
+    throw std::runtime_error("Not Implemented");
   }
 };
 

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
@@ -23,7 +23,6 @@
 #include <string>
 
 #include "MantidAPI/IMDHistoWorkspace.h"
-#include "MantidGeometry/MDGeometry/MDHistoDimension.h"
 #include "MantidAPI/ISpectrum.h"
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
@@ -31,6 +30,7 @@
 #include "MantidAPI/SpectraAxis.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/DetectorGroup.h"
+#include "MantidGeometry/MDGeometry/MDHistoDimension.h"
 #include "MantidKernel/SpecialCoordinateSystem.h"
 #include "MantidKernel/cow_ptr.h"
 
@@ -433,36 +433,38 @@ public:
   virtual std::vector<std::unique_ptr<IMDIterator>> createIterators(
       size_t suggestedNumCores = 1,
       Mantid::Geometry::MDImplicitFunction *function = nullptr) const override {
-      UNUSED_ARG(suggestedNumCores)
-      UNUSED_ARG(function)
+    UNUSED_ARG(suggestedNumCores)
+    UNUSED_ARG(function)
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual signal_t
-  getSignalAtCoord(const coord_t *coords,
-                   const Mantid::API::MDNormalization &normalization) const override {
-      UNUSED_ARG(coords);
-      UNUSED_ARG(normalization);
+  virtual signal_t getSignalAtCoord(
+      const coord_t *coords,
+      const Mantid::API::MDNormalization &normalization) const override {
+    UNUSED_ARG(coords);
+    UNUSED_ARG(normalization);
     throw std::runtime_error("Not Implemented");
   }
 
   virtual signal_t getSignalWithMaskAtCoord(
       const coord_t *coords,
       const Mantid::API::MDNormalization &normalization) const override {
-      UNUSED_ARG(coords);
-      UNUSED_ARG(normalization);
+    UNUSED_ARG(coords);
+    UNUSED_ARG(normalization);
     throw std::runtime_error("Not Implemented");
   }
 
   virtual void
   setMDMasking(Mantid::Geometry::MDImplicitFunction *maskingRegion) override {
-      UNUSED_ARG(maskingRegion);
+    UNUSED_ARG(maskingRegion);
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual void clearMDMasking() override { throw std::runtime_error("Not Implemented"); }
+  virtual void clearMDMasking() override {
+    throw std::runtime_error("Not Implemented");
+  }
 
-  virtual SpecialCoordinateSystem getSpecialCoordinateSystem() const override{
+  virtual SpecialCoordinateSystem getSpecialCoordinateSystem() const override {
     throw std::runtime_error("Not Implemented");
   }
 
@@ -484,201 +486,201 @@ public:
 
   virtual void setTo(signal_t signal, signal_t errorSquared,
                      signal_t numEvents) override {
-      UNUSED_ARG(signal);
-      UNUSED_ARG(errorSquared);
-      UNUSED_ARG(numEvents);
+    UNUSED_ARG(signal);
+    UNUSED_ARG(errorSquared);
+    UNUSED_ARG(numEvents);
     throw std::runtime_error("Not Implemented");
   }
 
   virtual Mantid::Kernel::VMD getCenter(size_t linearIndex) const override {
-      UNUSED_ARG(linearIndex);
+    UNUSED_ARG(linearIndex);
     throw std::runtime_error("Not Implemented");
   }
 
   virtual void setSignalAt(size_t index, signal_t value) override {
-      UNUSED_ARG(index)
-      UNUSED_ARG(value)
+    UNUSED_ARG(index)
+    UNUSED_ARG(value)
     throw std::runtime_error("Not Implemented");
   }
 
   virtual void setErrorSquaredAt(size_t index, signal_t value) override {
-      UNUSED_ARG(index)
-      UNUSED_ARG(value)
+    UNUSED_ARG(index)
+    UNUSED_ARG(value)
     throw std::runtime_error("Not Implemented");
   }
 
   virtual signal_t getErrorAt(size_t index) const override {
-      UNUSED_ARG(index)
+    UNUSED_ARG(index)
     throw std::runtime_error("Not Implemented");
   }
 
   virtual signal_t getErrorAt(size_t index1, size_t index2) const override {
-      UNUSED_ARG(index1)
-      UNUSED_ARG(index2)
+    UNUSED_ARG(index1)
+    UNUSED_ARG(index2)
     throw std::runtime_error("Not Implemented");
   }
 
   virtual signal_t getErrorAt(size_t index1, size_t index2,
                               size_t index3) const override {
-      UNUSED_ARG(index1)
-      UNUSED_ARG(index2)
-      UNUSED_ARG(index3)
+    UNUSED_ARG(index1)
+    UNUSED_ARG(index2)
+    UNUSED_ARG(index3)
     throw std::runtime_error("Not Implemented");
   }
 
   virtual signal_t getErrorAt(size_t index1, size_t index2, size_t index3,
                               size_t index4) const override {
-      UNUSED_ARG(index1)
-      UNUSED_ARG(index2)
-      UNUSED_ARG(index3)
-      UNUSED_ARG(index4)
+    UNUSED_ARG(index1)
+    UNUSED_ARG(index2)
+    UNUSED_ARG(index3)
+    UNUSED_ARG(index4)
     throw std::runtime_error("Not Implemented");
   }
 
   virtual signal_t getSignalAt(size_t index) const override {
-      UNUSED_ARG(index)
+    UNUSED_ARG(index)
     throw std::runtime_error("Not Implemented");
   }
 
   virtual signal_t getSignalAt(size_t index1, size_t index2) const override {
-      UNUSED_ARG(index1)
-      UNUSED_ARG(index2)
+    UNUSED_ARG(index1)
+    UNUSED_ARG(index2)
     throw std::runtime_error("Not Implemented");
   }
 
   virtual signal_t getSignalAt(size_t index1, size_t index2,
                                size_t index3) const override {
-      UNUSED_ARG(index1)
-      UNUSED_ARG(index2)
-      UNUSED_ARG(index3)
+    UNUSED_ARG(index1)
+    UNUSED_ARG(index2)
+    UNUSED_ARG(index3)
     throw std::runtime_error("Not Implemented");
   }
 
   virtual signal_t getSignalAt(size_t index1, size_t index2, size_t index3,
                                size_t index4) const override {
-      UNUSED_ARG(index1)
-      UNUSED_ARG(index2)
-      UNUSED_ARG(index3)
-      UNUSED_ARG(index4)
+    UNUSED_ARG(index1)
+    UNUSED_ARG(index2)
+    UNUSED_ARG(index3)
+    UNUSED_ARG(index4)
     throw std::runtime_error("Not Implemented");
   }
 
   virtual signal_t getSignalNormalizedAt(size_t index) const override {
-      UNUSED_ARG(index)
+    UNUSED_ARG(index)
     throw std::runtime_error("Not Implemented");
   }
 
   virtual signal_t getSignalNormalizedAt(size_t index1,
                                          size_t index2) const override {
-      UNUSED_ARG(index1)
-      UNUSED_ARG(index2)
+    UNUSED_ARG(index1)
+    UNUSED_ARG(index2)
     throw std::runtime_error("Not Implemented");
   }
 
   virtual signal_t getSignalNormalizedAt(size_t index1, size_t index2,
                                          size_t index3) const override {
-      UNUSED_ARG(index1)
-      UNUSED_ARG(index2)
-      UNUSED_ARG(index3)
+    UNUSED_ARG(index1)
+    UNUSED_ARG(index2)
+    UNUSED_ARG(index3)
     throw std::runtime_error("Not Implemented");
   }
 
   virtual signal_t getSignalNormalizedAt(size_t index1, size_t index2,
                                          size_t index3,
                                          size_t index4) const override {
-      UNUSED_ARG(index1)
-      UNUSED_ARG(index2)
-      UNUSED_ARG(index3)
-      UNUSED_ARG(index4)
+    UNUSED_ARG(index1)
+    UNUSED_ARG(index2)
+    UNUSED_ARG(index3)
+    UNUSED_ARG(index4)
     throw std::runtime_error("Not Implemented");
   }
 
   virtual signal_t getErrorNormalizedAt(size_t index) const override {
-      UNUSED_ARG(index)
+    UNUSED_ARG(index)
     throw std::runtime_error("Not Implemented");
   }
 
   virtual signal_t getErrorNormalizedAt(size_t index1,
                                         size_t index2) const override {
-      UNUSED_ARG(index1)
-      UNUSED_ARG(index2)
+    UNUSED_ARG(index1)
+    UNUSED_ARG(index2)
     throw std::runtime_error("Not Implemented");
   }
 
   virtual signal_t getErrorNormalizedAt(size_t index1, size_t index2,
                                         size_t index3) const override {
-      UNUSED_ARG(index1)
-      UNUSED_ARG(index2)
-      UNUSED_ARG(index3)
+    UNUSED_ARG(index1)
+    UNUSED_ARG(index2)
+    UNUSED_ARG(index3)
     throw std::runtime_error("Not Implemented");
   }
 
   virtual signal_t getErrorNormalizedAt(size_t index1, size_t index2,
                                         size_t index3,
                                         size_t index4) const override {
-      UNUSED_ARG(index1)
-      UNUSED_ARG(index2)
-      UNUSED_ARG(index3)
-      UNUSED_ARG(index4)
+    UNUSED_ARG(index1)
+    UNUSED_ARG(index2)
+    UNUSED_ARG(index3)
+    UNUSED_ARG(index4)
     throw std::runtime_error("Not Implemented");
   }
 
   virtual signal_t &errorSquaredAt(size_t index) override {
-      UNUSED_ARG(index)
+    UNUSED_ARG(index)
     throw std::runtime_error("Not Implemented");
   }
 
   virtual signal_t &signalAt(size_t index) override {
-      UNUSED_ARG(index)
+    UNUSED_ARG(index)
     throw std::runtime_error("Not Implemented");
   }
 
   virtual size_t getLinearIndex(size_t index1, size_t index2) const override {
-      UNUSED_ARG(index1)
-      UNUSED_ARG(index2)
+    UNUSED_ARG(index1)
+    UNUSED_ARG(index2)
     throw std::runtime_error("Not Implemented");
   }
 
   virtual size_t getLinearIndex(size_t index1, size_t index2,
                                 size_t index3) const override {
-      UNUSED_ARG(index1)
-      UNUSED_ARG(index2)
-      UNUSED_ARG(index3)
+    UNUSED_ARG(index1)
+    UNUSED_ARG(index2)
+    UNUSED_ARG(index3)
     throw std::runtime_error("Not Implemented");
   }
 
   virtual size_t getLinearIndex(size_t index1, size_t index2, size_t index3,
                                 size_t index4) const override {
-      UNUSED_ARG(index1)
-      UNUSED_ARG(index2)
-      UNUSED_ARG(index3)
-      UNUSED_ARG(index4)
+    UNUSED_ARG(index1)
+    UNUSED_ARG(index2)
+    UNUSED_ARG(index3)
+    UNUSED_ARG(index4)
     throw std::runtime_error("Not Implemented");
   }
 
   virtual LinePlot
   getLineData(const Mantid::Kernel::VMD &start, const Mantid::Kernel::VMD &end,
               Mantid::API::MDNormalization normalize) const override {
-      UNUSED_ARG(start)
-      UNUSED_ARG(end)
-      UNUSED_ARG(normalize)
+    UNUSED_ARG(start)
+    UNUSED_ARG(end)
+    UNUSED_ARG(normalize)
     throw std::runtime_error("Not Implemented");
   }
 
   virtual double &operator[](const size_t &index) override {
-      UNUSED_ARG(index)
+    UNUSED_ARG(index)
     throw std::runtime_error("Not Implemented");
   }
 
   virtual void
   setCoordinateSystem(const SpecialCoordinateSystem coordinateSystem) override {
-      UNUSED_ARG(coordinateSystem)
+    UNUSED_ARG(coordinateSystem)
     throw std::runtime_error("Not Implemented");
   }
 
   virtual void setDisplayNormalization(
       const Mantid::API::MDNormalization &preferredNormalization) override {
-      UNUSED_ARG(preferredNormalization);
+    UNUSED_ARG(preferredNormalization);
     throw std::runtime_error("Not Implemented");
   }
 
@@ -707,15 +709,13 @@ public:
 
     throw std::runtime_error("Not Implemented");
   }
-    MDHistoWorkspaceTester(MDHistoDimension_sptr dimX,
-    MDHistoDimension_sptr dimY,
-    MDHistoDimension_sptr dimZ) {
-      std::vector<IMDDimension_sptr> dimensions {dimX, dimY, dimZ};
-      initGeometry(dimensions);
+  MDHistoWorkspaceTester(MDHistoDimension_sptr dimX, MDHistoDimension_sptr dimY,
+                         MDHistoDimension_sptr dimZ) {
+    std::vector<IMDDimension_sptr> dimensions{dimX, dimY, dimZ};
+    initGeometry(dimensions);
   }
 
 private:
-
   IMDHistoWorkspace *doClone() const override {
     throw std::runtime_error("Not Implemented");
   }

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
@@ -710,17 +710,11 @@ public:
     MDHistoWorkspaceTester(MDHistoDimension_sptr dimX,
     MDHistoDimension_sptr dimY,
     MDHistoDimension_sptr dimZ) {
-
-      m_dimensions.push_back(dimX);
-      m_dimensions.push_back(dimY);
-      m_dimensions.push_back(dimZ);
-
-      initGeometry(m_dimensions);
+      std::vector<IMDDimension_sptr> dimensions {dimX, dimY, dimZ};
+      initGeometry(dimensions);
   }
-protected:
 
 private:
-    std::vector<IMDDimension_sptr> m_dimensions;
 
   IMDHistoWorkspace *doClone() const override {
     throw std::runtime_error("Not Implemented");

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
@@ -37,9 +37,9 @@
 using namespace Mantid::API;
 using namespace Mantid::Kernel;
 using namespace Mantid::Geometry;
-using Mantid::MantidVec;
 using Mantid::coord_t;
 using Mantid::detid_t;
+using Mantid::MantidVec;
 using Mantid::signal_t;
 using Mantid::specnum_t;
 
@@ -423,14 +423,14 @@ protected:
 class MDHistoWorkspaceTester : public IMDHistoWorkspace {
 
 public:
-  virtual uint64_t getNPoints() const override {
+  uint64_t getNPoints() const override {
     throw std::runtime_error("Not Implemented");
   }
-  virtual uint64_t getNEvents() const override {
+  uint64_t getNEvents() const override {
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual std::vector<std::unique_ptr<IMDIterator>> createIterators(
+  std::vector<std::unique_ptr<IMDIterator>> createIterators(
       size_t suggestedNumCores = 1,
       Mantid::Geometry::MDImplicitFunction *function = nullptr) const override {
     UNUSED_ARG(suggestedNumCores)
@@ -438,7 +438,7 @@ public:
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual signal_t getSignalAtCoord(
+  signal_t getSignalAtCoord(
       const coord_t *coords,
       const Mantid::API::MDNormalization &normalization) const override {
     UNUSED_ARG(coords);
@@ -446,7 +446,7 @@ public:
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual signal_t getSignalWithMaskAtCoord(
+  signal_t getSignalWithMaskAtCoord(
       const coord_t *coords,
       const Mantid::API::MDNormalization &normalization) const override {
     UNUSED_ARG(coords);
@@ -454,82 +454,82 @@ public:
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual void
+  void
   setMDMasking(Mantid::Geometry::MDImplicitFunction *maskingRegion) override {
     UNUSED_ARG(maskingRegion);
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual void clearMDMasking() override {
+  void clearMDMasking() override {
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual SpecialCoordinateSystem getSpecialCoordinateSystem() const override {
+  SpecialCoordinateSystem getSpecialCoordinateSystem() const override {
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual coord_t getInverseVolume() const override {
+  coord_t getInverseVolume() const override {
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual signal_t *getSignalArray() const override {
+  signal_t *getSignalArray() const override {
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual signal_t *getErrorSquaredArray() const override {
+  signal_t *getErrorSquaredArray() const override {
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual signal_t *getNumEventsArray() const override {
+  signal_t *getNumEventsArray() const override {
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual void setTo(signal_t signal, signal_t errorSquared,
-                     signal_t numEvents) override {
+  void setTo(signal_t signal, signal_t errorSquared,
+             signal_t numEvents) override {
     UNUSED_ARG(signal);
     UNUSED_ARG(errorSquared);
     UNUSED_ARG(numEvents);
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual Mantid::Kernel::VMD getCenter(size_t linearIndex) const override {
+  Mantid::Kernel::VMD getCenter(size_t linearIndex) const override {
     UNUSED_ARG(linearIndex);
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual void setSignalAt(size_t index, signal_t value) override {
+  void setSignalAt(size_t index, signal_t value) override {
     UNUSED_ARG(index)
     UNUSED_ARG(value)
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual void setErrorSquaredAt(size_t index, signal_t value) override {
+  void setErrorSquaredAt(size_t index, signal_t value) override {
     UNUSED_ARG(index)
     UNUSED_ARG(value)
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual signal_t getErrorAt(size_t index) const override {
+  signal_t getErrorAt(size_t index) const override {
     UNUSED_ARG(index)
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual signal_t getErrorAt(size_t index1, size_t index2) const override {
+  signal_t getErrorAt(size_t index1, size_t index2) const override {
     UNUSED_ARG(index1)
     UNUSED_ARG(index2)
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual signal_t getErrorAt(size_t index1, size_t index2,
-                              size_t index3) const override {
+  signal_t getErrorAt(size_t index1, size_t index2,
+                      size_t index3) const override {
     UNUSED_ARG(index1)
     UNUSED_ARG(index2)
     UNUSED_ARG(index3)
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual signal_t getErrorAt(size_t index1, size_t index2, size_t index3,
-                              size_t index4) const override {
+  signal_t getErrorAt(size_t index1, size_t index2, size_t index3,
+                      size_t index4) const override {
     UNUSED_ARG(index1)
     UNUSED_ARG(index2)
     UNUSED_ARG(index3)
@@ -537,27 +537,27 @@ public:
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual signal_t getSignalAt(size_t index) const override {
+  signal_t getSignalAt(size_t index) const override {
     UNUSED_ARG(index)
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual signal_t getSignalAt(size_t index1, size_t index2) const override {
+  signal_t getSignalAt(size_t index1, size_t index2) const override {
     UNUSED_ARG(index1)
     UNUSED_ARG(index2)
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual signal_t getSignalAt(size_t index1, size_t index2,
-                               size_t index3) const override {
+  signal_t getSignalAt(size_t index1, size_t index2,
+                       size_t index3) const override {
     UNUSED_ARG(index1)
     UNUSED_ARG(index2)
     UNUSED_ARG(index3)
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual signal_t getSignalAt(size_t index1, size_t index2, size_t index3,
-                               size_t index4) const override {
+  signal_t getSignalAt(size_t index1, size_t index2, size_t index3,
+                       size_t index4) const override {
     UNUSED_ARG(index1)
     UNUSED_ARG(index2)
     UNUSED_ARG(index3)
@@ -565,29 +565,27 @@ public:
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual signal_t getSignalNormalizedAt(size_t index) const override {
+  signal_t getSignalNormalizedAt(size_t index) const override {
     UNUSED_ARG(index)
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual signal_t getSignalNormalizedAt(size_t index1,
-                                         size_t index2) const override {
+  signal_t getSignalNormalizedAt(size_t index1, size_t index2) const override {
     UNUSED_ARG(index1)
     UNUSED_ARG(index2)
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual signal_t getSignalNormalizedAt(size_t index1, size_t index2,
-                                         size_t index3) const override {
+  signal_t getSignalNormalizedAt(size_t index1, size_t index2,
+                                 size_t index3) const override {
     UNUSED_ARG(index1)
     UNUSED_ARG(index2)
     UNUSED_ARG(index3)
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual signal_t getSignalNormalizedAt(size_t index1, size_t index2,
-                                         size_t index3,
-                                         size_t index4) const override {
+  signal_t getSignalNormalizedAt(size_t index1, size_t index2, size_t index3,
+                                 size_t index4) const override {
     UNUSED_ARG(index1)
     UNUSED_ARG(index2)
     UNUSED_ARG(index3)
@@ -595,53 +593,18 @@ public:
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual signal_t getErrorNormalizedAt(size_t index) const override {
+  signal_t getErrorNormalizedAt(size_t index) const override {
     UNUSED_ARG(index)
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual signal_t getErrorNormalizedAt(size_t index1,
-                                        size_t index2) const override {
+  signal_t getErrorNormalizedAt(size_t index1, size_t index2) const override {
     UNUSED_ARG(index1)
     UNUSED_ARG(index2)
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual signal_t getErrorNormalizedAt(size_t index1, size_t index2,
-                                        size_t index3) const override {
-    UNUSED_ARG(index1)
-    UNUSED_ARG(index2)
-    UNUSED_ARG(index3)
-    throw std::runtime_error("Not Implemented");
-  }
-
-  virtual signal_t getErrorNormalizedAt(size_t index1, size_t index2,
-                                        size_t index3,
-                                        size_t index4) const override {
-    UNUSED_ARG(index1)
-    UNUSED_ARG(index2)
-    UNUSED_ARG(index3)
-    UNUSED_ARG(index4)
-    throw std::runtime_error("Not Implemented");
-  }
-
-  virtual signal_t &errorSquaredAt(size_t index) override {
-    UNUSED_ARG(index)
-    throw std::runtime_error("Not Implemented");
-  }
-
-  virtual signal_t &signalAt(size_t index) override {
-    UNUSED_ARG(index)
-    throw std::runtime_error("Not Implemented");
-  }
-
-  virtual size_t getLinearIndex(size_t index1, size_t index2) const override {
-    UNUSED_ARG(index1)
-    UNUSED_ARG(index2)
-    throw std::runtime_error("Not Implemented");
-  }
-
-  virtual size_t getLinearIndex(size_t index1, size_t index2,
+  signal_t getErrorNormalizedAt(size_t index1, size_t index2,
                                 size_t index3) const override {
     UNUSED_ARG(index1)
     UNUSED_ARG(index2)
@@ -649,7 +612,7 @@ public:
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual size_t getLinearIndex(size_t index1, size_t index2, size_t index3,
+  signal_t getErrorNormalizedAt(size_t index1, size_t index2, size_t index3,
                                 size_t index4) const override {
     UNUSED_ARG(index1)
     UNUSED_ARG(index2)
@@ -658,54 +621,87 @@ public:
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual LinePlot
-  getLineData(const Mantid::Kernel::VMD &start, const Mantid::Kernel::VMD &end,
-              Mantid::API::MDNormalization normalize) const override {
+  signal_t &errorSquaredAt(size_t index) override {
+    UNUSED_ARG(index)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  signal_t &signalAt(size_t index) override {
+    UNUSED_ARG(index)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  size_t getLinearIndex(size_t index1, size_t index2) const override {
+    UNUSED_ARG(index1)
+    UNUSED_ARG(index2)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  size_t getLinearIndex(size_t index1, size_t index2,
+                        size_t index3) const override {
+    UNUSED_ARG(index1)
+    UNUSED_ARG(index2)
+    UNUSED_ARG(index3)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  size_t getLinearIndex(size_t index1, size_t index2, size_t index3,
+                        size_t index4) const override {
+    UNUSED_ARG(index1)
+    UNUSED_ARG(index2)
+    UNUSED_ARG(index3)
+    UNUSED_ARG(index4)
+    throw std::runtime_error("Not Implemented");
+  }
+
+  LinePlot getLineData(const Mantid::Kernel::VMD &start,
+                       const Mantid::Kernel::VMD &end,
+                       Mantid::API::MDNormalization normalize) const override {
     UNUSED_ARG(start)
     UNUSED_ARG(end)
     UNUSED_ARG(normalize)
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual double &operator[](const size_t &index) override {
+  double &operator[](const size_t &index)override {
     UNUSED_ARG(index)
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual void
+  void
   setCoordinateSystem(const SpecialCoordinateSystem coordinateSystem) override {
     UNUSED_ARG(coordinateSystem)
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual void setDisplayNormalization(
+  void setDisplayNormalization(
       const Mantid::API::MDNormalization &preferredNormalization) override {
     UNUSED_ARG(preferredNormalization);
     throw std::runtime_error("Not Implemented");
   }
 
   // Check if this class has an oriented lattice on any sample object
-  virtual bool hasOrientedLattice() const override {
+  bool hasOrientedLattice() const override {
     return MultipleExperimentInfos::hasOrientedLattice();
   }
 
-  virtual size_t getMemorySize() const override {
+  size_t getMemorySize() const override {
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual const std::string id() const override {
+  const std::string id() const override {
 
     throw std::runtime_error("Not Implemented");
   }
-  virtual const std::string &getName() const override {
+  const std::string &getName() const override {
 
     throw std::runtime_error("Not Implemented");
   }
-  virtual bool threadSafe() const override {
+  bool threadSafe() const override {
 
     throw std::runtime_error("Not Implemented");
   }
-  virtual const std::string toString() const override {
+  const std::string toString() const override {
 
     throw std::runtime_error("Not Implemented");
   }

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
@@ -35,8 +35,8 @@
 #include "MantidKernel/cow_ptr.h"
 
 using namespace Mantid::API;
-using namespace Mantid::Kernel;
 using namespace Mantid::Geometry;
+using Mantid::Kernel::SpecialCoordinateSystem;
 using Mantid::coord_t;
 using Mantid::detid_t;
 using Mantid::MantidVec;

--- a/docs/source/release/v3.13.0/framework.rst
+++ b/docs/source/release/v3.13.0/framework.rst
@@ -72,6 +72,11 @@ New
 Python
 ------
 
+New
+###
+
+- Added a new ``MDFrameValidator`` which can check that a MD workspace passed to a python algorithm has the expected MD frame (e.g. HKL, QLab, QSample etc.).
+
 Improved
 ########
 


### PR DESCRIPTION
**Description of work.**

Add a MD workspace validator for checking that a MDWorkspace conforms to a particular frame (e.g. HKL, QLab, QSample...). I want to use this in another PR (#21552) to check that the MD workspace being past is in HKL, but this code can be reviewed separately of that work.

**To test:**

Not much to test that isn't covered by the unit tests. 
 - Code review
 - If you're keen, make a quick python algorithm ([see python course for how to](https://www.mantidproject.org/Workspace_Validators)) that uses the validator and check it works by passing an MD workspace with/without a particular frame.

*No associated issue*

Does this update require release notes?
- [x] Yes
- [ ] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
