### PR TITLE
Fix value of PV_PLUGINS_DIR in app bundle.

### DIFF
--- a/Framework/Kernel/CMakeLists.txt
+++ b/Framework/Kernel/CMakeLists.txt
@@ -735,7 +735,7 @@ if ( ${CMAKE_PROJECT_NAME} MATCHES "MantidFramework" )
   set ( IGNORE_PARAVIEW "1" )
 else ()
   set ( QT_PLUGINS_DIR "${MANTID_ROOT}/plugins/qt%V" )
-  set ( PV_PLUGINS_DIR "${MANTID_ROOT}/${PLUGINS_DIR}/${PVPLUGINS_SUBDIR}/qt%V" )
+  set ( PV_PLUGINS_DIR "${MANTID_ROOT}/plugins/${PVPLUGINS_SUBDIR}/qt%V" )
   set ( COLORMAPS_FOLDER ${MANTID_ROOT}/colormaps )
 endif ()
 

--- a/docs/source/release/v3.13.0/ui.rst
+++ b/docs/source/release/v3.13.0/ui.rst
@@ -21,6 +21,7 @@ Bugfixes
 --------
 
 - A bug in the load dialog where bad filename input would cause the last file to be loaded has been fixed.
+- Fix crash when starting the Mantid VSI on MacOS.
 
 Improvements
 ------------


### PR DESCRIPTION
**Description of work.**

The `pvplugins.directory` value in the .app bundle was incorrect, causing MantidPlot to segfault. This updates the value in the bundled `Mantid.properties` file.

**Report to:**  @Jon-Taylor <!--If the original issue was raised by a user they should be named here.-->

**To test:**

<!-- Instructions for testing. -->

1. Download and install .app bundle from build servers.
1. Verify that `pvplugins.directory = ../../plugins/paraview/qt%V`
1. Open MantidPlot
1. Run the script below
1. Try to open the VSI using `to_display` as the workspace

```python
CreateMDWorkspace(Dimensions=3, Extents='-10,10,-10,10,-10,10', Names='A,B,C', Units='U,U,U', OutputWorkspace='ws')
BinMD(InputWorkspace='ws', AlignedDim0='A,-10,10,10', AlignedDim1='B,-10,10,10', AlignedDim2='C,-10,10,10', OutputWorkspace='to_display')
```

Fixes #22552. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

Does this update require release notes?
- [x] Yes
- [ ] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
