### PR TITLE
Indirect - ISISEnergyTransfer - Custom Detector Grouping Option

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
@@ -39,6 +39,7 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
     _fold_multiple_frames = None
     _grouping_method = None
     _grouping_ws = None
+    _grouping_string = None
     _grouping_map_file = None
     _output_x_units = None
     _output_ws = None
@@ -99,7 +100,7 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
 
         # Spectra grouping options
         self.declareProperty(name='GroupingMethod', defaultValue='IPF',
-                             validator=StringListValidator(['Individual', 'All', 'File', 'Workspace', 'IPF']),
+                             validator=StringListValidator(['Individual', 'All', 'File', 'Workspace', 'IPF', 'Custom']),
                              doc='Method used to group spectra.')
         self.declareProperty(WorkspaceProperty('GroupingWorkspace', '',
                                                direction=Direction.Input,
@@ -107,9 +108,7 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
                              doc='Workspace containing spectra grouping.')
         self.declareProperty(name='GroupingString', defaultValue='',
                              direction=Direction.Input,
-                             optional=PropertyMode.Optional,
-                             doc='Spectra to group as string',
-                             )
+                             doc='Spectra to group as string')
         self.declareProperty(FileProperty('MapFile', '',
                                           action=FileAction.OptionalLoad,
                                           extensions=['.map']),
@@ -354,6 +353,7 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
 
         self._grouping_method = self.getPropertyValue('GroupingMethod')
         self._grouping_ws = _ws_or_none(self.getPropertyValue('GroupingWorkspace'))
+        self._grouping_string = _str_or_none(self.getPropertyValue('GroupingString'))
         self._grouping_map_file = _str_or_none(self.getPropertyValue('MapFile'))
 
         self._output_x_units = self.getPropertyValue('UnitX')

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
@@ -105,6 +105,11 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
                                                direction=Direction.Input,
                                                optional=PropertyMode.Optional),
                              doc='Workspace containing spectra grouping.')
+        self.declareProperty(name='GroupingString', defaultValue='',
+                             direction=Direction.Input,
+                             optional=PropertyMode.Optional,
+                             doc='Spectra to group as string',
+                             )
         self.declareProperty(FileProperty('MapFile', '',
                                           action=FileAction.OptionalLoad,
                                           extensions=['.map']),
@@ -249,7 +254,8 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
                               masked_detectors=masked_detectors,
                               method=self._grouping_method,
                               group_file=self._grouping_map_file,
-                              group_ws=self._grouping_ws)
+                              group_ws=self._grouping_ws,
+                              group_string=self._grouping_string)
 
             if self._fold_multiple_frames and is_multi_frame:
                 fold_chopped(c_ws_name)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
@@ -360,6 +360,9 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
 
         self._output_ws = self.getPropertyValue('OutputWorkspace')
 
+        if self._grouping_string is not None:
+            self._grouping_string = self._grouping_string.replace('-', ':')
+
         # Disable sum files if there is only one file
         if len(self._data_files) == 1:
             if self._sum_files:

--- a/docs/source/interfaces/Indirect Data Reduction.rst
+++ b/docs/source/interfaces/Indirect Data Reduction.rst
@@ -135,16 +135,15 @@ Grouping
 
 The following options are available for grouping output data:
 
-Default
-  The data will be grouped according to the Workflow.GroupingMethod parameter in
-  the instrument's parameter file. If this value is not set then Individual is
-  used.
+Custom
+  A comma separated list can be entered to specify the groups, e.g. 1, 3-5, 6-8, 10.
 
 Individual
   All detectors will remain on individual spectra.
 
 Groups
-  The detectors will automatically be divided into a given number of gorups.
+  The detectors will automatically be divided into a given number of equal size groups. Any
+  left over will be added as an additional group.
 
 All
   All detectors will be grouped into a single spectra.
@@ -165,7 +164,7 @@ Single
 .. interface:: Data Reduction
   :widget: pgSingleRebin
 
-In this mode only a single binning range is defined as  a range and width.
+In this mode only a single binning range is defined as a range and width.
 
 Multiple
 ########
@@ -173,7 +172,7 @@ Multiple
 .. interface:: Data Reduction
   :widget: pgMultipleRebin
 
-In this mode multiple binning ranges can be defined using he rebin string syntax
+In this mode multiple binning ranges can be defined using the rebin string syntax
 used by the :ref:`Rebin <algm-Rebin>` algorithm.
 
 ILL Energy Transfer

--- a/docs/source/release/v3.13.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.13.0/indirect_inelastic.rst
@@ -15,7 +15,7 @@ Data Reduction Interfaces
 -------------------------
 
 - Added 'Sum Files' checkbox to ISIS Calibration, to sum a specified range of input files on load.
-- Detector grouping in ISISEnergyTransfer:  add custom grouping method to allow specific spectra or ranges, and
+- Detector grouping in ISISEnergyTransfer:  added custom grouping method to allow specific spectra or ranges, and
   the 'groups' method now includes all spectra including remainder.
 
 

--- a/docs/source/release/v3.13.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.13.0/indirect_inelastic.rst
@@ -15,6 +15,7 @@ Data Reduction Interfaces
 -------------------------
 
 - Added 'Sum Files' checkbox to ISIS Calibration, to sum a specified range of input files on load.
+- Add custom method to specify detector grouping in ISISEnergyTransfer as individual spectra or a range.
 
 Algorithms
 ----------

--- a/docs/source/release/v3.13.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.13.0/indirect_inelastic.rst
@@ -15,7 +15,9 @@ Data Reduction Interfaces
 -------------------------
 
 - Added 'Sum Files' checkbox to ISIS Calibration, to sum a specified range of input files on load.
-- Add custom method to specify detector grouping in ISISEnergyTransfer as individual spectra or a range.
+- Detector grouping in ISISEnergyTransfer:  add custom grouping method to allow specific spectra or ranges, and
+  the 'groups' method now includes all spectra including remainder.
+
 
 Algorithms
 ----------

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -48,7 +48,7 @@ ISISEnergyTransfer::ISISEnergyTransfer(IndirectDataReduction *idrUI,
   mappingOptionSelected(m_uiForm.cbGroupingOptions->currentText());
 
   // Add validation to custom detector grouping
-  QRegExp re("([0-9]+[-]?[0-9]*,[ ])*[0-9]+[-]?[0-9]*");
+  QRegExp re("([0-9]+[-]?[0-9]*,[ ]?)*[0-9]+[-]?[0-9]*");
   m_uiForm.leCustomGroups->setValidator(new QRegExpValidator(re, this));
 
   // Validate to remove invalid markers

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -269,14 +269,14 @@ void ISISEnergyTransfer::run() {
   if (m_uiForm.ckCm1Units->isChecked())
     reductionAlg->setProperty("UnitX", "DeltaE_inWavenumber");
 
-  QPair<QString, QString> grouping =
-      createMapFile(m_uiForm.cbGroupingOptions->currentText());
-  reductionAlg->setProperty("GroupingMethod", grouping.first.toStdString());
+  std::pair<std::string, std::string> grouping =
+      createMapFile(m_uiForm.cbGroupingOptions->currentText().toStdString());
+  reductionAlg->setProperty("GroupingMethod", grouping.first);
 
   if (grouping.first == "File")
-    reductionAlg->setProperty("MapFile", grouping.second.toStdString());
+    reductionAlg->setProperty("MapFile", grouping.second);
   else if (grouping.first == "Custom")
-    reductionAlg->setProperty("GroupingString", grouping.second.toStdString());
+    reductionAlg->setProperty("GroupingString", grouping.second);
 
   reductionAlg->setProperty("FoldMultipleFrames", m_uiForm.ckFold->isChecked());
   reductionAlg->setProperty("OutputWorkspace",
@@ -452,16 +452,16 @@ ISISEnergyTransfer::createMapFile(const std::string &groupType) {
       emit showMessageBox("You must enter a path to the .map file.");
 
     return std::make_pair("File", groupFile.toStdString());
-  } else if (groupType == "Groups") {
+  } else if (groupType == "Groups")
     return std::make_pair("Custom", createDetectorGroupingString());
-  } else if (groupType == "Default")
+  else if (groupType == "Default")
     return std::make_pair("IPF", "");
   else if (groupType == "Custom")
     return std::make_pair("Custom",
                           m_uiForm.leCustomGroups->text().toStdString());
   else {
     // Catch All and Individual
-    return qMakePair(groupType, QString());
+    return std::make_pair(groupType, "");
   }
 }
 

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -46,7 +46,8 @@ ISISEnergyTransfer::ISISEnergyTransfer(IndirectDataReduction *idrUI,
 
   // Update UI widgets to show default values
   mappingOptionSelected(m_uiForm.cbGroupingOptions->currentText());
-
+  QRegExp re("([0-9]+[-]?[0-9]*,[ ])*[0-9]+[-]?[0-9]*");
+  m_uiForm.leCustomGroups->setValidator(new QRegExpValidator(re, this));
   // Validate to remove invalid markers
   validateTab();
 }
@@ -72,11 +73,9 @@ bool ISISEnergyTransfer::validate() {
     uiv.addErrorMessage("Calibration file/workspace is invalid.");
   }
 
-  // Mapping file
-  if ((m_uiForm.cbGroupingOptions->currentText() == "File") &&
-      (!m_uiForm.dsMapFile->isValid())) {
-    uiv.addErrorMessage("Mapping file is invalid.");
-  }
+  QString groupingError = validateDetectorGrouping();
+  if (!groupingError.isEmpty())
+    uiv.addErrorMessage(groupingError);
 
   // Rebinning
   if (!m_uiForm.ckDoNotRebin->isChecked()) {
@@ -185,6 +184,15 @@ bool ISISEnergyTransfer::validate() {
   showMessageBox(error);
 
   return uiv.isAllInputValid();
+}
+
+QString ISISEnergyTransfer::validateDetectorGrouping() {
+  if (m_uiForm.cbGroupingOptions->currentText() == "File") {
+    if (!m_uiForm.dsMapFile->isValid()) {
+      return "Mapping file is invalid.";
+    }
+  }
+  return "";
 }
 
 void ISISEnergyTransfer::run() {

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -419,10 +419,10 @@ void ISISEnergyTransfer::mappingOptionSelected(const QString &groupType) {
     m_uiForm.swGrouping->setCurrentIndex(0);
   } else if (groupType == "Groups") {
     m_uiForm.swGrouping->setCurrentIndex(1);
-  } else if (groupType == "All" || groupType == "Individual" ||
-             groupType == "Default") {
+  } else if (groupType =="Custom") {
     m_uiForm.swGrouping->setCurrentIndex(2);
-  }
+  } else
+      m_uiForm.swGrouping->setCurrentIndex(3);
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -191,9 +191,8 @@ bool ISISEnergyTransfer::validate() {
 
 QString ISISEnergyTransfer::validateDetectorGrouping() {
   if (m_uiForm.cbGroupingOptions->currentText() == "File") {
-    if (!m_uiForm.dsMapFile->isValid()) {
+    if (!m_uiForm.dsMapFile->isValid())
       return "Mapping file is invalid.";
-    }
   }
   return "";
 }
@@ -428,13 +427,13 @@ void ISISEnergyTransfer::setInstrumentDefault() {
  * @param groupType :: Value of selection made by user.
  */
 void ISISEnergyTransfer::mappingOptionSelected(const QString &groupType) {
-  if (groupType == "File") {
+  if (groupType == "File")
     m_uiForm.swGrouping->setCurrentIndex(0);
-  } else if (groupType == "Groups") {
+  else if (groupType == "Groups")
     m_uiForm.swGrouping->setCurrentIndex(1);
-  } else if (groupType == "Custom") {
+  else if (groupType == "Custom")
     m_uiForm.swGrouping->setCurrentIndex(2);
-  } else
+  else
     m_uiForm.swGrouping->setCurrentIndex(3);
 }
 

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -432,10 +432,10 @@ void ISISEnergyTransfer::mappingOptionSelected(const QString &groupType) {
     m_uiForm.swGrouping->setCurrentIndex(0);
   } else if (groupType == "Groups") {
     m_uiForm.swGrouping->setCurrentIndex(1);
-  } else if (groupType =="Custom") {
+  } else if (groupType == "Custom") {
     m_uiForm.swGrouping->setCurrentIndex(2);
   } else
-      m_uiForm.swGrouping->setCurrentIndex(3);
+    m_uiForm.swGrouping->setCurrentIndex(3);
 }
 
 /**
@@ -477,8 +477,7 @@ ISISEnergyTransfer::createMapFile(const QString &groupType) {
     return qMakePair(QString("Workspace"), groupWS);
   } else if (groupType == "Default") {
     return qMakePair(QString("IPF"), QString());
-  }
-  else if (groupType == "Custom") {
+  } else if (groupType == "Custom") {
     return qMakePair(QString("Custom"), m_uiForm.leCustomGroups->text());
   } else {
     // Catch All and Individual

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -467,10 +467,10 @@ ISISEnergyTransfer::createMapFile(const std::string &groupType) {
 
 const std::string ISISEnergyTransfer::createDetectorGroupingString() {
 
-  const int nGroups = m_uiForm.spNumberGroups->value();
-  const int nSpectra =
+  const unsigned int nGroups = m_uiForm.spNumberGroups->value();
+  const unsigned int nSpectra =
       m_uiForm.spSpectraMax->value() - m_uiForm.spSpectraMin->value();
-  const int groupSize = nSpectra / nGroups;
+  const unsigned int groupSize = nSpectra / nGroups;
   auto n = groupSize;
   std::stringstream groupingString;
   groupingString << "0-" << std::to_string(n);

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -455,10 +455,11 @@ ISISEnergyTransfer::createMapFile(const std::string &groupType) {
   } else if (groupType == "Groups") {
     return std::make_pair("Custom", createDetectorGroupingString());
   } else if (groupType == "Default")
-      return std::make_pair("IPF", "");
-    else if (groupType == "Custom")
-      return std::make_pair("Custom", m_uiForm.leCustomGroups->text().toStdString());
-    else {
+    return std::make_pair("IPF", "");
+  else if (groupType == "Custom")
+    return std::make_pair("Custom",
+                          m_uiForm.leCustomGroups->text().toStdString());
+  else {
     // Catch All and Individual
     return qMakePair(groupType, QString());
   }
@@ -467,7 +468,8 @@ ISISEnergyTransfer::createMapFile(const std::string &groupType) {
 const std::string ISISEnergyTransfer::createDetectorGroupingString() {
 
   const int nGroups = m_uiForm.spNumberGroups->value();
-  const int nSpectra = m_uiForm.spSpectraMax->value() - m_uiForm.spSpectraMin->value();
+  const int nSpectra =
+      m_uiForm.spSpectraMax->value() - m_uiForm.spSpectraMin->value();
   const int groupSize = nSpectra / nGroups;
   auto n = groupSize;
   std::stringstream groupingString;
@@ -477,8 +479,9 @@ const std::string ISISEnergyTransfer::createDetectorGroupingString() {
     n += groupSize;
     groupingString << std::to_string(n);
   }
-  if ( n != nSpectra) // add remainder as extra group
-    groupingString << ", " << std::to_string(n + 1) << "-" << std::to_string(nSpectra);
+  if (n != nSpectra) // add remainder as extra group
+    groupingString << ", " << std::to_string(n + 1) << "-"
+                   << std::to_string(nSpectra);
 
   return groupingString.str();
 }

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -46,8 +46,11 @@ ISISEnergyTransfer::ISISEnergyTransfer(IndirectDataReduction *idrUI,
 
   // Update UI widgets to show default values
   mappingOptionSelected(m_uiForm.cbGroupingOptions->currentText());
+
+  // Add validation to custom detector grouping
   QRegExp re("([0-9]+[-]?[0-9]*,[ ])*[0-9]+[-]?[0-9]*");
   m_uiForm.leCustomGroups->setValidator(new QRegExpValidator(re, this));
+
   // Validate to remove invalid markers
   validateTab();
 }
@@ -275,6 +278,8 @@ void ISISEnergyTransfer::run() {
     reductionRuntimeProps["GroupingWorkspace"] = grouping.second.toStdString();
   else if (grouping.first == "File")
     reductionAlg->setProperty("MapFile", grouping.second.toStdString());
+  else if (grouping.first == "Custom")
+    reductionAlg->setProperty("GroupingString", grouping.second.toStdString());
 
   reductionAlg->setProperty("FoldMultipleFrames", m_uiForm.ckFold->isChecked());
   reductionAlg->setProperty("OutputWorkspace",
@@ -472,6 +477,9 @@ ISISEnergyTransfer::createMapFile(const QString &groupType) {
     return qMakePair(QString("Workspace"), groupWS);
   } else if (groupType == "Default") {
     return qMakePair(QString("IPF"), QString());
+  }
+  else if (groupType == "Custom") {
+    return qMakePair(QString("Custom"), m_uiForm.leCustomGroups->text());
   } else {
     // Catch All and Individual
     return qMakePair(groupType, QString());

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -455,33 +455,38 @@ ISISEnergyTransfer::createMapFile(const QString &groupType) {
 
     return qMakePair(QString("File"), groupFile);
   } else if (groupType == "Groups") {
-    QString groupWS = "__Grouping";
-
-    IAlgorithm_sptr groupingAlg =
-        AlgorithmManager::Instance().create("CreateGroupingWorkspace");
-    groupingAlg->initialize();
-
-    groupingAlg->setProperty("FixedGroupCount",
-                             m_uiForm.spNumberGroups->value());
-    groupingAlg->setProperty(
-        "InstrumentName",
-        getInstrumentConfiguration()->getInstrumentName().toStdString());
-    groupingAlg->setProperty(
-        "ComponentName",
-        getInstrumentConfiguration()->getAnalyserName().toStdString());
-    groupingAlg->setProperty("OutputWorkspace", groupWS.toStdString());
-
-    m_batchAlgoRunner->addAlgorithm(groupingAlg);
-
+    QString groupWS = "Grouping";
+    createDetectorGroupingWorkspace(groupWS);
     return qMakePair(QString("Workspace"), groupWS);
-  } else if (groupType == "Default") {
-    return qMakePair(QString("IPF"), QString());
-  } else if (groupType == "Custom") {
-    return qMakePair(QString("Custom"), m_uiForm.leCustomGroups->text());
-  } else {
+  } else if (groupType == "Default")
+      return qMakePair(QString("IPF"), QString());
+    else if (groupType == "Custom")
+      return qMakePair(QString("Custom"), m_uiForm.leCustomGroups->text());
+    else {
     // Catch All and Individual
     return qMakePair(groupType, QString());
   }
+}
+
+void ISISEnergyTransfer::createDetectorGroupingWorkspace(const QString &groupWS) {
+
+  IAlgorithm_sptr groupingAlg =
+    AlgorithmManager::Instance().create("CreateGroupingWorkspace");
+  groupingAlg->initialize();
+
+  groupingAlg->setProperty("FixedGroupCount",
+    m_uiForm.spNumberGroups->value());
+  groupingAlg->setProperty(
+    "InstrumentName",
+    getInstrumentConfiguration()->getInstrumentName().toStdString());
+  groupingAlg->setProperty(
+    "ComponentName",
+    getInstrumentConfiguration()->getAnalyserName().toStdString());
+  groupingAlg->setProperty("OutputWorkspace", groupWS.toStdString());
+
+  groupingAlg->execute();
+
+  //m_batchAlgoRunner->addAlgorithm(groupingAlg);
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
@@ -70,7 +70,7 @@ private:
   Ui::ISISEnergyTransfer m_uiForm;
 
   std::pair<std::string, std::string> createMapFile(
-       const std::string &
+      const std::string &
           groupType); ///< create the mapping file with which to group results
   std::vector<std::string> getSaveFormats(); ///< get a vector of save formats
   std::vector<std::string>

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
@@ -75,6 +75,7 @@ private:
   std::vector<std::string> getSaveFormats(); ///< get a vector of save formats
   std::vector<std::string>
       m_outputWorkspaces; ///< get a vector of workspaces to plot
+  QString validateDetectorGrouping();
 };
 } // namespace CustomInterfaces
 } // namespace Mantid

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
@@ -69,14 +69,14 @@ private slots:
 private:
   Ui::ISISEnergyTransfer m_uiForm;
 
-  QPair<QString, QString> createMapFile(
-      const QString &
+  std::pair<std::string, std::string> createMapFile(
+       const std::string &
           groupType); ///< create the mapping file with which to group results
   std::vector<std::string> getSaveFormats(); ///< get a vector of save formats
   std::vector<std::string>
       m_outputWorkspaces; ///< get a vector of workspaces to plot
   QString validateDetectorGrouping();
-  void createDetectorGroupingWorkspace(const QString &groupWS);
+  const std::string createDetectorGroupingString();
 };
 } // namespace CustomInterfaces
 } // namespace Mantid

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
@@ -76,6 +76,7 @@ private:
   std::vector<std::string>
       m_outputWorkspaces; ///< get a vector of workspaces to plot
   QString validateDetectorGrouping();
+  void createDetectorGroupingWorkspace(const QString &groupWS);
 };
 } // namespace CustomInterfaces
 } // namespace Mantid

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.ui
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.ui
@@ -215,7 +215,7 @@
         </property>
         <item>
          <property name="text">
-          <string>Default</string>
+          <string>Custom</string>
          </property>
         </item>
         <item>
@@ -246,7 +246,7 @@
          <number>0</number>
         </property>
         <property name="currentIndex">
-         <number>0</number>
+         <number>2</number>
         </property>
         <widget class="QWidget" name="pgMapFile">
          <layout class="QHBoxLayout" name="horizontalLayout_5">
@@ -303,6 +303,29 @@
              </size>
             </property>
            </spacer>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="pgMappingCustom">
+         <layout class="QHBoxLayout" name="horizontalLayout_8">
+          <item>
+           <widget class="QLineEdit" name="leCustomGroups">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="layoutDirection">
+             <enum>Qt::LeftToRight</enum>
+            </property>
+            <property name="maxLength">
+             <number>6000</number>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>

--- a/scripts/Inelastic/IndirectReductionCommon.py
+++ b/scripts/Inelastic/IndirectReductionCommon.py
@@ -575,7 +575,7 @@ def scale_detectors(workspace_name, e_mode='Indirect'):
 # -------------------------------------------------------------------------------
 
 
-def group_spectra(workspace_name, masked_detectors, method, group_file=None, group_ws=None):
+def group_spectra(workspace_name, masked_detectors, method, group_file=None, group_ws=None, group_string=None):
     """
     Groups spectra in a given workspace according to the Workflow.GroupingMethod and
     Workflow.GroupingFile parameters and GroupingPolicy property.
@@ -586,7 +586,7 @@ def group_spectra(workspace_name, masked_detectors, method, group_file=None, gro
     @param group_file File for File method
     @param group_ws Workspace for Workspace method
     """
-    grouped_ws = group_spectra_of(mtd[workspace_name], masked_detectors, method, group_file, group_ws)
+    grouped_ws = group_spectra_of(mtd[workspace_name], masked_detectors, method, group_file, group_ws, group_string)
 
     if grouped_ws is not None:
         mtd.addOrReplace(workspace_name, grouped_ws)

--- a/scripts/Inelastic/IndirectReductionCommon.py
+++ b/scripts/Inelastic/IndirectReductionCommon.py
@@ -592,7 +592,7 @@ def group_spectra(workspace_name, masked_detectors, method, group_file=None, gro
         mtd.addOrReplace(workspace_name, grouped_ws)
 
 
-def group_spectra_of(workspace, masked_detectors, method, group_file=None, group_ws=None):
+def group_spectra_of(workspace, masked_detectors, method, group_file=None, group_ws=None, group_string=None):
     """
     Groups spectra in a given workspace according to the Workflow.GroupingMethod and
     Workflow.GroupingFile parameters and GroupingPolicy property.
@@ -602,6 +602,7 @@ def group_spectra_of(workspace, masked_detectors, method, group_file=None, group
     @param method Grouping method (IPF, All, Individual, File, Workspace)
     @param group_file File for File method
     @param group_ws Workspace for Workspace method
+    @param group_string String for custom method
     """
     instrument = workspace.getInstrument()
     group_detectors = AlgorithmManager.create("GroupDetectors")
@@ -663,6 +664,9 @@ def group_spectra_of(workspace, masked_detectors, method, group_file=None, group
     elif grouping_method == 'Workspace':
         # Apply the grouping
         group_detectors.setProperty("CopyGroupingFromWorkspace", group_ws)
+
+    elif grouping_method == 'Custom':
+        group_detectors.setProperty("GroupingPattern", group_string)
 
     else:
         raise RuntimeError('Invalid grouping method %s for workspace %s' % (grouping_method, workspace.getName()))

--- a/scripts/Inelastic/IndirectReductionCommon.py
+++ b/scripts/Inelastic/IndirectReductionCommon.py
@@ -585,6 +585,7 @@ def group_spectra(workspace_name, masked_detectors, method, group_file=None, gro
     @param method Grouping method (IPF, All, Individual, File, Workspace)
     @param group_file File for File method
     @param group_ws Workspace for Workspace method
+    @param group_string String for custom method - comma separated list or range
     """
     grouped_ws = group_spectra_of(mtd[workspace_name], masked_detectors, method, group_file, group_ws, group_string)
 
@@ -602,7 +603,7 @@ def group_spectra_of(workspace, masked_detectors, method, group_file=None, group
     @param method Grouping method (IPF, All, Individual, File, Workspace)
     @param group_file File for File method
     @param group_ws Workspace for Workspace method
-    @param group_string String for custom method
+    @param group_string String for custom method - comma separated list or range
     """
     instrument = workspace.getInstrument()
     group_detectors = AlgorithmManager.create("GroupDetectors")


### PR DESCRIPTION
Replaces default option for detector grouping in the `ISISEnergyTransfer' interface with a 'Custom' option that allows specific spectra or ranges to be entered.
Also fixes the 'Group' option which didn't work.

**Report to:**  @brandonhewer
 
**To test:**
- Navigate to Interfaces -> Indirect -> Data Reduction
- Enter a file to load e.g. `IRS26176`
- In Detector Grouping, check 'Custom' is selected by default
- Check the line edit box next to 'Custom' is only present when 'Custom' is selected
- Enter spectra and/or a range in this box: `1, 2, 4-7`
- The resulting workspace should contain only the spectra specified (+ spectra min): `55, 56, 58-61`

Group option:
- Run again using the 'Group' option in Detector grouping (with any number of groups) and check there are no errors. Result workspace should contain all spectra (54-104).

<!-- Instructions for testing. -->


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
