### PR TITLE
Add an optional propoerty to control removingDuplicates

### DIFF
--- a/Framework/Algorithms/src/GenerateEventsFilter.cpp
+++ b/Framework/Algorithms/src/GenerateEventsFilter.cpp
@@ -170,6 +170,9 @@ void GenerateEventsFilter::init() {
 
   declareProperty("NumberOfThreads", EMPTY_INT(),
                   "Number of threads forced to use in the parallel mode. ");
+  declareProperty(
+    "RemoveDuplicates", true,
+    "Whether to remove duplicate time entries in the log before processing, this give a more accurate result, but can take longer. This only affects log value filters.");
 }
 
 /** Main execute body
@@ -507,15 +510,20 @@ void GenerateEventsFilter::setFilterByLogValue(std::string logname) {
   }
 
   //  Clear duplicate value and extend to run end
+  bool removeDuplicates = this->getProperty("RemoveDuplicates");
   if (m_dblLog) {
-    g_log.debug("Attempting to remove duplicates in double series log.");
     if (m_runEndTime > m_dblLog->lastTime())
       m_dblLog->addValue(m_runEndTime, 0.);
-    m_dblLog->eliminateDuplicates();
+    if (removeDuplicates) {
+      g_log.debug("Attempting to remove duplicates in double series log.");
+      m_dblLog->eliminateDuplicates();
+    }
   } else {
-    g_log.debug("Attempting to remove duplicates in integer series log.");
     m_intLog->addValue(m_runEndTime, 0);
-    m_intLog->eliminateDuplicates();
+    if (removeDuplicates) {
+      g_log.debug("Attempting to remove duplicates in integer series log.");
+      m_intLog->eliminateDuplicates();
+    }
   }
 
   // Process input properties related to filter with log value

--- a/Framework/Algorithms/src/GenerateEventsFilter.cpp
+++ b/Framework/Algorithms/src/GenerateEventsFilter.cpp
@@ -170,9 +170,10 @@ void GenerateEventsFilter::init() {
 
   declareProperty("NumberOfThreads", EMPTY_INT(),
                   "Number of threads forced to use in the parallel mode. ");
-  declareProperty(
-    "RemoveDuplicates", true,
-    "Whether to remove duplicate time entries in the log before processing, this give a more accurate result, but can take longer. This only affects log value filters.");
+  declareProperty("RemoveDuplicates", true,
+                  "Whether to remove duplicate time entries in the log before "
+                  "processing, this give a more accurate result, but can take "
+                  "longer. This only affects log value filters.");
 }
 
 /** Main execute body


### PR DESCRIPTION

re #22573

Add an optional property to control removing Duplicates

The default behaviour is to always remove duplicates (as before)

**Report to:** Anthony Reid

**To test:**

run this
``` python
ws = Load("ENGINX00284557")
splitws, infows = GenerateEventsFilter(InputWorkspace=ws, UnitOfTime='Nanoseconds', LogName='ADC1_0',
        MinimumLogValue=2200,  MaximumLogValue=4000)
```

if it completes in a minute then success, if it runs for hours FAIL
The splitws should end up with rows with a roughly 7ms separation (although they are in ns).

Fixes #22573

Does this update require release notes?
- [ ] Yes
- [ ] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
