### PR TITLE
Gracefully abort if ws doesn't load during project loading

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/DataService.h
+++ b/Framework/Kernel/inc/MantidKernel/DataService.h
@@ -398,13 +398,12 @@ public:
 
   /// Checks all elements within the specified vector exist in the ADS
   bool doAllWsExist(const std::vector<std::string> &listOfNames) {
-	  for (const auto &wsName : listOfNames) {
-		  if (!doesExist(wsName))
-			  return false;
-	  }
-	  return true;
+    for (const auto &wsName : listOfNames) {
+      if (!doesExist(wsName))
+        return false;
+    }
+    return true;
   }
-
 
   /// Check to see if a data object exists in the store
   bool doesExist(const std::string &name) const {

--- a/Framework/Kernel/inc/MantidKernel/DataService.h
+++ b/Framework/Kernel/inc/MantidKernel/DataService.h
@@ -396,6 +396,16 @@ public:
     }
   }
 
+  /// Checks all elements within the specified vector exist in the ADS
+  bool doAllWsExist(const std::vector<std::string> &listOfNames) {
+	  for (const auto &wsName : listOfNames) {
+		  if (!doesExist(wsName))
+			  return false;
+	  }
+	  return true;
+  }
+
+
   /// Check to see if a data object exists in the store
   bool doesExist(const std::string &name) const {
     // Make DataService access thread-safe

--- a/Framework/Kernel/test/DataServiceTest.h
+++ b/Framework/Kernel/test/DataServiceTest.h
@@ -229,6 +229,50 @@ public:
     TS_ASSERT(!svc.doesExist("NOTone"));
   }
 
+  void test_does_all_exist() {
+	  auto one = boost::make_shared<int>(1);
+	  auto two = boost::make_shared<int>(2);
+
+	  const std::string oneName = "one";
+	  const std::string twoName = "two";
+
+	  svc.add(oneName, one);
+	  svc.add(twoName, two);
+
+	  std::vector<std::string> expectedNames{ oneName, twoName };
+
+	  TS_ASSERT(svc.doAllWsExist(expectedNames));
+  }
+
+  void test_does_all_exist_partial() {
+	  auto one = boost::make_shared<int>(1);
+
+	  const std::string oneName = "one";
+
+	  svc.add(oneName, one);
+
+	  std::vector<std::string> expectedNames{ oneName };
+
+	  TS_ASSERT(svc.doAllWsExist(expectedNames));
+  }
+
+  void test_does_all_exist_missing_ws() {
+	  auto one = boost::make_shared<int>(1);
+	  auto two = boost::make_shared<int>(2);
+
+	  const std::string oneName = "one";
+	  const std::string twoName = "two";
+	  const std::string threeName = "three";
+
+	  svc.add(oneName, one);
+	  svc.add(twoName, two);
+
+	  std::vector<std::string> expectedNames{ oneName, twoName, threeName };
+
+	  TS_ASSERT(!svc.doAllWsExist(expectedNames));
+  }
+
+
   void test_size() {
     TS_ASSERT_EQUALS(svc.size(), 0);
     svc.add("something", boost::make_shared<int>(-1));

--- a/Framework/Kernel/test/DataServiceTest.h
+++ b/Framework/Kernel/test/DataServiceTest.h
@@ -230,48 +230,47 @@ public:
   }
 
   void test_does_all_exist() {
-	  auto one = boost::make_shared<int>(1);
-	  auto two = boost::make_shared<int>(2);
+    auto one = boost::make_shared<int>(1);
+    auto two = boost::make_shared<int>(2);
 
-	  const std::string oneName = "one";
-	  const std::string twoName = "two";
+    const std::string oneName = "one";
+    const std::string twoName = "two";
 
-	  svc.add(oneName, one);
-	  svc.add(twoName, two);
+    svc.add(oneName, one);
+    svc.add(twoName, two);
 
-	  std::vector<std::string> expectedNames{ oneName, twoName };
+    std::vector<std::string> expectedNames{oneName, twoName};
 
-	  TS_ASSERT(svc.doAllWsExist(expectedNames));
+    TS_ASSERT(svc.doAllWsExist(expectedNames));
   }
 
   void test_does_all_exist_partial() {
-	  auto one = boost::make_shared<int>(1);
+    auto one = boost::make_shared<int>(1);
 
-	  const std::string oneName = "one";
+    const std::string oneName = "one";
 
-	  svc.add(oneName, one);
+    svc.add(oneName, one);
 
-	  std::vector<std::string> expectedNames{ oneName };
+    std::vector<std::string> expectedNames{oneName};
 
-	  TS_ASSERT(svc.doAllWsExist(expectedNames));
+    TS_ASSERT(svc.doAllWsExist(expectedNames));
   }
 
   void test_does_all_exist_missing_ws() {
-	  auto one = boost::make_shared<int>(1);
-	  auto two = boost::make_shared<int>(2);
+    auto one = boost::make_shared<int>(1);
+    auto two = boost::make_shared<int>(2);
 
-	  const std::string oneName = "one";
-	  const std::string twoName = "two";
-	  const std::string threeName = "three";
+    const std::string oneName = "one";
+    const std::string twoName = "two";
+    const std::string threeName = "three";
 
-	  svc.add(oneName, one);
-	  svc.add(twoName, two);
+    svc.add(oneName, one);
+    svc.add(twoName, two);
 
-	  std::vector<std::string> expectedNames{ oneName, twoName, threeName };
+    std::vector<std::string> expectedNames{oneName, twoName, threeName};
 
-	  TS_ASSERT(!svc.doAllWsExist(expectedNames));
+    TS_ASSERT(!svc.doAllWsExist(expectedNames));
   }
-
 
   void test_size() {
     TS_ASSERT_EQUALS(svc.size(), 0);

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -4670,12 +4670,11 @@ ApplicationWindow *ApplicationWindow::openProject(const QString &filename,
   // Open as a top level folder
   ProjectSerialiser serialiser(this);
   try {
-	  serialiser.load(lines, fileVersion);
-  }
-  catch (std::runtime_error &e) {
-	  g_log.error(e.what());
-	  // We failed to load - bail out
-	  return this;
+    serialiser.load(lines, fileVersion);
+  } catch (std::runtime_error &e) {
+    g_log.error(e.what());
+    // We failed to load - bail out
+    return this;
   }
 
   if (d_loaded_current)
@@ -14157,12 +14156,11 @@ Folder *ApplicationWindow::appendProject(const QString &fn,
   ProjectSerialiser serialiser(this);
 
   try {
-	  serialiser.load(lines, fileVersion);
-  }
-  catch (std::runtime_error &e) {
-	  g_log.error(e.what());
-	  // We failed to load - bail out
-	  return nullptr;
+    serialiser.load(lines, fileVersion);
+  } catch (std::runtime_error &e) {
+    g_log.error(e.what());
+    // We failed to load - bail out
+    return nullptr;
   }
 
   // Restore the selected folder

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -4669,7 +4669,14 @@ ApplicationWindow *ApplicationWindow::openProject(const QString &filename,
 
   // Open as a top level folder
   ProjectSerialiser serialiser(this);
-  serialiser.load(lines, fileVersion);
+  try {
+	  serialiser.load(lines, fileVersion);
+  }
+  catch (std::runtime_error &e) {
+	  g_log.error(e.what());
+	  // We failed to load - bail out
+	  return this;
+  }
 
   if (d_loaded_current)
     curFolder = d_loaded_current;
@@ -14148,7 +14155,15 @@ Folder *ApplicationWindow::appendProject(const QString &fn,
 
   // Open folders
   ProjectSerialiser serialiser(this);
-  serialiser.load(lines, fileVersion);
+
+  try {
+	  serialiser.load(lines, fileVersion);
+  }
+  catch (std::runtime_error &e) {
+	  g_log.error(e.what());
+	  // We failed to load - bail out
+	  return nullptr;
+  }
 
   // Restore the selected folder
   folders->setCurrentItem(curFolder->folderListItem());

--- a/MantidPlot/src/ProjectSerialiser.cpp
+++ b/MantidPlot/src/ProjectSerialiser.cpp
@@ -721,7 +721,8 @@ void ProjectSerialiser::populateMantidTreeWidget(const QString &lines) {
     // Check everything was loaded before continuing, as we might need to open a
     // window
     // for a workspace which did not load in
-    if (!Mantid::API::AnalysisDataService::Instance().doAllWsExist(expectedWorkspaces)) {
+    if (!Mantid::API::AnalysisDataService::Instance().doAllWsExist(
+            expectedWorkspaces)) {
       QMessageBox::critical(window, "MantidPlot - Algorithm error",
                             " The workspaces associated with this project "
                             "could not be loaded. Aborting project loading.");

--- a/MantidPlot/src/ProjectSerialiser.cpp
+++ b/MantidPlot/src/ProjectSerialiser.cpp
@@ -46,19 +46,18 @@ ProjectSerialiser::ProjectSerialiser(ApplicationWindow *window, Folder *folder)
     : window(window), m_currentFolder(folder), m_windowCount(0),
       m_saveAll(true) {}
 
-bool MantidQt::API::ProjectSerialiser::checkAllWorkspacesInAds(const std::vector<std::string>& expectedWsNames) const
-{
-	bool allInAds = true;
-	for (const auto &wsName : expectedWsNames) {
-		if (!Mantid::API::AnalysisDataService::Instance().doesExist(wsName)) {
-			allInAds = false;
-			break;
-		}
-	}
+bool MantidQt::API::ProjectSerialiser::checkAllWorkspacesInAds(
+    const std::vector<std::string> &expectedWsNames) const {
+  bool allInAds = true;
+  for (const auto &wsName : expectedWsNames) {
+    if (!Mantid::API::AnalysisDataService::Instance().doesExist(wsName)) {
+      allInAds = false;
+      break;
+    }
+  }
 
-	return allInAds;
+  return allInAds;
 }
-
 
 void ProjectSerialiser::save(const QString &projectName,
                              const std::vector<std::string> &wsNames,
@@ -670,7 +669,7 @@ void ProjectSerialiser::populateMantidTreeWidget(const QString &lines) {
       // vectorgroup (ignore group name, start at 1)
       for (int i = 1; i < groupWorkspaces.size(); i++) {
         std::string wsName = groupWorkspaces[i].toStdString();
-		expectedWorkspaces.push_back(wsName);
+        expectedWorkspaces.push_back(wsName);
         loadWsToMantidTree(wsName);
         inputWsVec.push_back(wsName);
       }
@@ -727,18 +726,21 @@ void ProjectSerialiser::populateMantidTreeWidget(const QString &lines) {
       }
     } else // ...not a group so just load the workspace
     {
-		std::string wsName = line->toStdString();
-		expectedWorkspaces.push_back(wsName);
-		loadWsToMantidTree(wsName);
+      std::string wsName = line->toStdString();
+      expectedWorkspaces.push_back(wsName);
+      loadWsToMantidTree(wsName);
     }
 
-	// Check everything was loaded before continuing, as we might need to open a window
-	// for a workspace which did not load in
-	if (!checkAllWorkspacesInAds(expectedWorkspaces)) {
-		QMessageBox::critical(window, "MantidPlot - Algorithm error",
-			" The workspaces associated with this project could not be loaded. Aborting project loading.");
-		throw std::runtime_error("Failed to load all required workspaces. Aborting project loading.");
-	}
+    // Check everything was loaded before continuing, as we might need to open a
+    // window
+    // for a workspace which did not load in
+    if (!checkAllWorkspacesInAds(expectedWorkspaces)) {
+      QMessageBox::critical(window, "MantidPlot - Algorithm error",
+                            " The workspaces associated with this project "
+                            "could not be loaded. Aborting project loading.");
+      throw std::runtime_error(
+          "Failed to load all required workspaces. Aborting project loading.");
+    }
   }
 }
 

--- a/MantidPlot/src/ProjectSerialiser.cpp
+++ b/MantidPlot/src/ProjectSerialiser.cpp
@@ -46,19 +46,6 @@ ProjectSerialiser::ProjectSerialiser(ApplicationWindow *window, Folder *folder)
     : window(window), m_currentFolder(folder), m_windowCount(0),
       m_saveAll(true) {}
 
-bool MantidQt::API::ProjectSerialiser::checkAllWorkspacesInAds(
-    const std::vector<std::string> &expectedWsNames) const {
-  bool allInAds = true;
-  for (const auto &wsName : expectedWsNames) {
-    if (!Mantid::API::AnalysisDataService::Instance().doesExist(wsName)) {
-      allInAds = false;
-      break;
-    }
-  }
-
-  return allInAds;
-}
-
 void ProjectSerialiser::save(const QString &projectName,
                              const std::vector<std::string> &wsNames,
                              const std::vector<std::string> &windowNames,
@@ -734,7 +721,7 @@ void ProjectSerialiser::populateMantidTreeWidget(const QString &lines) {
     // Check everything was loaded before continuing, as we might need to open a
     // window
     // for a workspace which did not load in
-    if (!checkAllWorkspacesInAds(expectedWorkspaces)) {
+    if (!Mantid::API::AnalysisDataService::Instance().doAllWsExist(expectedWorkspaces)) {
       QMessageBox::critical(window, "MantidPlot - Algorithm error",
                             " The workspaces associated with this project "
                             "could not be loaded. Aborting project loading.");

--- a/MantidPlot/src/ProjectSerialiser.h
+++ b/MantidPlot/src/ProjectSerialiser.h
@@ -2,6 +2,7 @@
 #define PROJECT_SERIALISER_H
 
 #include <string>
+#include <vector>
 
 #include <QFile>
 #include <QFileInfo>
@@ -55,6 +56,8 @@ public:
   /// Create a new serialiser with the current application window
   explicit ProjectSerialiser(ApplicationWindow *window);
   explicit ProjectSerialiser(ApplicationWindow *window, Folder *folder);
+
+  bool checkAllWorkspacesInAds(const std::vector<std::string> &expectedWsNames) const;
 
   /// Save the current state of the project to disk
   void save(const QString &projectName, const std::vector<std::string> &wsNames,

--- a/MantidPlot/src/ProjectSerialiser.h
+++ b/MantidPlot/src/ProjectSerialiser.h
@@ -57,9 +57,6 @@ public:
   explicit ProjectSerialiser(ApplicationWindow *window);
   explicit ProjectSerialiser(ApplicationWindow *window, Folder *folder);
 
-  bool checkAllWorkspacesInAds(
-      const std::vector<std::string> &expectedWsNames) const;
-
   /// Save the current state of the project to disk
   void save(const QString &projectName, const std::vector<std::string> &wsNames,
             const std::vector<std::string> &windowNames, bool compress = false);

--- a/MantidPlot/src/ProjectSerialiser.h
+++ b/MantidPlot/src/ProjectSerialiser.h
@@ -57,7 +57,8 @@ public:
   explicit ProjectSerialiser(ApplicationWindow *window);
   explicit ProjectSerialiser(ApplicationWindow *window, Folder *folder);
 
-  bool checkAllWorkspacesInAds(const std::vector<std::string> &expectedWsNames) const;
+  bool checkAllWorkspacesInAds(
+      const std::vector<std::string> &expectedWsNames) const;
 
   /// Save the current state of the project to disk
   void save(const QString &projectName, const std::vector<std::string> &wsNames,


### PR DESCRIPTION
**Description of work.**
Adds checks and gracefully stops project loading if a workspace could not be loaded for any reason. 
This will prevent Mantid getting an unhandled exception if the associated `.nxs` file has been deleted/moved.

**To test:**
- Create a sample workspace
- Open a plot
- Save the project file
- Go to project file location, delete the associated .nxs file
- Attempt to load project
- Check it is handled gracefully

Fixes #22540 

Does this update require release notes?
- [ ] Yes
- [x] No

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
