### PR TITLE
Fix Sphinx warning in IntegratePeaksProfileFitting

### DIFF
--- a/docs/source/algorithms/IntegratePeaksProfileFitting-v1.rst
+++ b/docs/source/algorithms/IntegratePeaksProfileFitting-v1.rst
@@ -90,6 +90,7 @@ The peak intensity :math:`I`, is given by summing :math:`Y_{model}(\vec{q})` ove
 
 .. math::
     \sigma(I) = \sqrt{\Sigma N_{obs} + \Sigma N_{BG} + \frac{\Sigma N_{obs}(N_{obs}-N_{model})^2}{\Sigma N_{obs}}}
+
 where the first two terms come from Poissionian statistics and the final term is the variance of the fit. Those sums are over the same voxels used to calculate intensity.
 
  


### PR DESCRIPTION
A recent change to the docs for IntegratePeaksProfileFitting introduced a warning in Sphinx which went under the radar, and is now causing problems in other PRs (such as [this](http://builds.mantidproject.org/job/pull_requests-ubuntu/21837/warnings2Result/source.-168175573424561733/#83)). This PR introduces a blank line which gets rid of the warning

**To test:**

Make sure build servers pass

No issue associated with this warning

Does this update require release notes?
- [ ] Yes
- [x] No

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
