### PR TITLE
Fix ctrl+c on show data causes crash

### DIFF
--- a/MantidPlot/src/Mantid/MantidMatrix.cpp
+++ b/MantidPlot/src/Mantid/MantidMatrix.cpp
@@ -417,6 +417,11 @@ void MantidMatrix::copySelection() {
   QString eol = applicationWindow()->endOfLine();
   if (!selModel->hasSelection()) {
     QModelIndex index = selModel->currentIndex();
+	if (!index.isValid()) {
+		// No text boxes were selected. So we cannot copy anything
+		return;
+	}
+
     s = text(index.row(), index.column());
   } else {
     QItemSelection sel = selModel->selection();

--- a/MantidPlot/src/Mantid/MantidMatrix.cpp
+++ b/MantidPlot/src/Mantid/MantidMatrix.cpp
@@ -417,10 +417,10 @@ void MantidMatrix::copySelection() {
   QString eol = applicationWindow()->endOfLine();
   if (!selModel->hasSelection()) {
     QModelIndex index = selModel->currentIndex();
-	if (!index.isValid()) {
-		// No text boxes were selected. So we cannot copy anything
-		return;
-	}
+    if (!index.isValid()) {
+      // No text boxes were selected. So we cannot copy anything
+      return;
+    }
 
     s = text(index.row(), index.column());
   } else {


### PR DESCRIPTION
**Description of work.**
Fixes Qt trying to copy an invalid field to the clipboard. This causes an unsigned underflow which is then used as a workspace index

**To test:**
- Create a sample workspace
- Show data from the workspace
- Without clicking any fields (e.g. click the title bar of the data display) hit Ctrl+C
- On master this will cause an exception
- Nothing will happen on this branch

Fixes #7999

Does this update require release notes?
- [ ] Yes
- [x] No

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
