### PR TITLE
Minor change: TOFTOF GUI: replace NaN erros with 1

### DIFF
--- a/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
+++ b/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
@@ -615,8 +615,10 @@ class TOFTOFScriptElement(BaseScriptElement):
             self.l("# calculate momentum transfer Q for sample data")
             self.l("rebinQ = '{:.3f}, {:.3f}, {:.3f}'"
                    .format(self.binQstart, self.binQstep, self.binQend))
-            self.l("{} = SofQW3({}, QAxisBinning=rebinQ, EMode='Direct', EFixed=Ei, ReplaceNaNs={})"
-                   .format(gDataBinQ, gLast, self.replaceNaNs))
+            self.l("{} = SofQW3({}, QAxisBinning=rebinQ, EMode='Direct', EFixed=Ei, ReplaceNaNs=False)"
+                   .format(gDataBinQ, gLast))
+            if self.replaceNaNs:
+                self.l("%s = ReplaceSpecialValues(%s, NaNValue=0, NaNError=1)" % (gDataBinQ, gDataBinQ))
             self.l()
             if self.saveSofQW:
                 self.save_wsgroup(gDataBinQ, "'_SQW'")

--- a/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
+++ b/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
@@ -618,7 +618,7 @@ class TOFTOFScriptElement(BaseScriptElement):
             self.l("{} = SofQW3({}, QAxisBinning=rebinQ, EMode='Direct', EFixed=Ei, ReplaceNaNs=False)"
                    .format(gDataBinQ, gLast))
             if self.replaceNaNs:
-                self.l("%s = ReplaceSpecialValues(%s, NaNValue=0, NaNError=1)" % (gDataBinQ, gDataBinQ))
+                self.l("{} = ReplaceSpecialValues({}, NaNValue=0, NaNError=1)".format(gDataBinQ, gDataBinQ))
             self.l()
             if self.saveSofQW:
                 self.save_wsgroup(gDataBinQ, "'_SQW'")


### PR DESCRIPTION
**Description of work.**
added: Script generator adds `ReplaceSpecialValues` algorithm to script, if `Replace special values in S(Q,W) with 0` option is checked

**To test:**
Start the TOFTOF data reduciton GUI: Interfaces->Direct->DGS Reduction. Choose facility MLZ and instrument TOFTOF.

Get the test data
[testdata.zip](https://github.com/mantidproject/mantid/files/1356265/testdata.zip)

and make sure that for the workspaces in `gwsDataSQW` all NaNs are replaced with 0 for values and 1 for errors if (and only if) the `Replace special values in S(Q,W) with 0` option is checked.

Fixes #22586. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
