### PR TITLE
Prevent infinite loops whilst rebinning to a workspace

### DIFF
--- a/Framework/Kernel/src/VectorHelper.cpp
+++ b/Framework/Kernel/src/VectorHelper.cpp
@@ -78,7 +78,10 @@ createAxisFromRebinParams(const std::vector<double> &params,
       // Someone gave a 0-sized step! What a dope.
       throw std::runtime_error(
           "Invalid binning step provided! Can't creating binning axis.");
-    }
+	}
+	else if (!std::isfinite(xs)) {
+		throw std::runtime_error("An infinite or NaN value was found in the binning parameters.");
+	}
 
     if ((xcurr + xs * (1.0 + lastBinCoef)) <= fullParams[ibound]) {
       // If we can still fit current bin _plus_ specified portion of a last bin,

--- a/Framework/Kernel/src/VectorHelper.cpp
+++ b/Framework/Kernel/src/VectorHelper.cpp
@@ -66,7 +66,7 @@ createAxisFromRebinParams(const std::vector<double> &params,
 
   xnew.clear();
   if (resize_xnew)
-	  xnew.push_back(xcurr);
+    xnew.push_back(xcurr);
 
   while ((ibound <= ibounds) && (istep <= isteps)) {
     // if step is negative then it is logarithmic step
@@ -79,10 +79,10 @@ createAxisFromRebinParams(const std::vector<double> &params,
       // Someone gave a 0-sized step! What a dope.
       throw std::runtime_error(
           "Invalid binning step provided! Can't creating binning axis.");
-	}
-	else if (!std::isfinite(xs)) {
-		throw std::runtime_error("An infinite or NaN value was found in the binning parameters.");
-	}
+    } else if (!std::isfinite(xs)) {
+      throw std::runtime_error(
+          "An infinite or NaN value was found in the binning parameters.");
+    }
 
     if ((xcurr + xs * (1.0 + lastBinCoef)) <= fullParams[ibound]) {
       // If we can still fit current bin _plus_ specified portion of a last bin,

--- a/Framework/Kernel/src/VectorHelper.cpp
+++ b/Framework/Kernel/src/VectorHelper.cpp
@@ -45,12 +45,10 @@ createAxisFromRebinParams(const std::vector<double> &params,
         }
         return params;
       }();
-  double xs;
   int ibound(2), istep(1), inew(1);
   // highest index in params array containing a bin boundary
   int ibounds = static_cast<int>(fullParams.size());
   int isteps = ibounds - 1; // highest index in params array containing a step
-  xnew.clear();
 
   // This coefficitent represents the maximum difference between the size of the
   // last bin and all
@@ -63,9 +61,12 @@ createAxisFromRebinParams(const std::vector<double> &params,
     lastBinCoef = 1.0;
   }
 
+  double xs = 0;
   double xcurr = fullParams[0];
+
+  xnew.clear();
   if (resize_xnew)
-    xnew.push_back(xcurr);
+	  xnew.push_back(xcurr);
 
   while ((ibound <= ibounds) && (istep <= isteps)) {
     // if step is negative then it is logarithmic step

--- a/Framework/Kernel/test/VectorHelperTest.h
+++ b/Framework/Kernel/test/VectorHelperTest.h
@@ -167,6 +167,18 @@ public:
                      const std::runtime_error)
   }
 
+  void test_createAxisFromRebinParams_throwsOnInfiniteVal() {
+	  const std::vector<double> params = { 1.0, INFINITY };
+	  std::vector<double> axis;
+	  TS_ASSERT_THROWS(VectorHelper::createAxisFromRebinParams(params, axis), const std::runtime_error);
+  }
+
+  void test_createAxisFromRebinParams_throwsOnNaNVal() {
+	  const std::vector<double> params = { 1.0, NAN };
+	  std::vector<double> axis;
+	  TS_ASSERT_THROWS(VectorHelper::createAxisFromRebinParams(params, axis), const std::runtime_error);
+  }
+
   void test_CreateAxisFromRebinParams_xMinXMaxHints() {
     const std::vector<double> rbParams = {1.0};
     std::vector<double> axis;

--- a/Framework/Kernel/test/VectorHelperTest.h
+++ b/Framework/Kernel/test/VectorHelperTest.h
@@ -168,15 +168,17 @@ public:
   }
 
   void test_createAxisFromRebinParams_throwsOnInfiniteVal() {
-	  const std::vector<double> params = { 1.0, INFINITY };
-	  std::vector<double> axis;
-	  TS_ASSERT_THROWS(VectorHelper::createAxisFromRebinParams(params, axis), const std::runtime_error);
+    const std::vector<double> params = {1.0, INFINITY};
+    std::vector<double> axis;
+    TS_ASSERT_THROWS(VectorHelper::createAxisFromRebinParams(params, axis),
+                     const std::runtime_error);
   }
 
   void test_createAxisFromRebinParams_throwsOnNaNVal() {
-	  const std::vector<double> params = { 1.0, NAN };
-	  std::vector<double> axis;
-	  TS_ASSERT_THROWS(VectorHelper::createAxisFromRebinParams(params, axis), const std::runtime_error);
+    const std::vector<double> params = {1.0, NAN};
+    std::vector<double> axis;
+    TS_ASSERT_THROWS(VectorHelper::createAxisFromRebinParams(params, axis),
+                     const std::runtime_error);
   }
 
   void test_CreateAxisFromRebinParams_xMinXMaxHints() {


### PR DESCRIPTION
**Description of work.**
If a user manages to create x bins with the value of `NaN` or `infinity` the rebin algorithm will enter an infinite loop in `VectorHelper::createAxisFromRebinParams`.

This is because the current x value turns into an invalid number, which fails all comparisons. Therefore the while loop will not terminate.

**To test:**
Run the following script:
```
CreateSampleWorkspace(OutputWorkspace='ws', WorkspaceType='Histogram', BankPixelWidth=3, PixelSpacing=0.1, NumBanks=1, Random=True, XMin=0, XMax=20, BinWidth=2, XUnit="Wavelength")
MoveInstrumentComponent(Workspace='ws', ComponentName='bank1', Y=0.026181)
ConvertUnits(InputWorkspace='ws',OutputWorkspace='ws_Q', Target='MomentumTransfer')
RebinToWorkspace(WorkspaceToRebin='ws_Q',WorkspaceToMatch='ws_Q', OutputWorkspace='ws_Q_rebinned')
```

It should not run infinitely and instead emit an error message and stop.

Fixes #21741 

Does this update require release notes?
- [ ] Yes
- [x] No

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
