### PR TITLE
Add missing libpoco debug packages to Mantid developer .deb

### DIFF
--- a/buildconfig/dev-packages/deb/mantid-developer/ns-control
+++ b/buildconfig/dev-packages/deb/mantid-developer/ns-control
@@ -3,7 +3,7 @@ Priority: optional
 Standards-Version: 3.9.2
 
 Package: mantid-developer
-Version: 1.3.5
+Version: 1.3.6
 Maintainer: Mantid Project <mantid-tech@mantidproject.org>
 Priority: optional
 Architecture: all
@@ -15,7 +15,14 @@ Depends: git,
   libtbb-dev,
   libgoogle-perftools-dev,
   libboost-all-dev,
+
   libpoco-dev(>=1.4.6),
+  libpocofoundation31-dbg,
+  libpocoutil31-dbg,
+  libpoconet31-dbg,
+  libpococrypto31-dbg,
+  libpoconetssl31-dbg,
+
   libnexus0-dev,
   libhdf5-dev,
   libhdf4-dev,


### PR DESCRIPTION
**Description of work.**
Adds missing libpoco debug packages to the Mantid developer meta package. 
This was preventing debug builds from completing unless the user manually installed libpoco*-dbg

**To test:**
- *Note: You need to be on a Debian based machine*
- cd to `/buildconfig/dev-packages/deb/mantid-developer
- Ensure  `equivs` is installed
- Run `equivs-build ns-control`
- Run `sudo gdebi mantid-developer_3.1.6.deb`
- Ensure the libpoco packages are updated

Does this update require release notes?
- [ ] Yes
- [x] No

*Note: The resulting deb package must be created and uploaded to Sourceforge after this PR is accepted*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
