### PR TITLE
TOFTOF GUI: add temperature fields

### DIFF
--- a/docs/source/release/v3.13.0/direct_inelastic.rst
+++ b/docs/source/release/v3.13.0/direct_inelastic.rst
@@ -9,6 +9,15 @@ Direct Inelastic Changes
     putting new features at the top of the section, followed by
     improvements, followed by bug fixes.
 
+Interfaces
+----------
+
+
+New features
+############
+
+- Added the ability to manually specify a temperature for a set of runs in the TOFTOF reduction dialog.
+
 Algorithms
 ----------
 

--- a/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
+++ b/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
@@ -17,6 +17,7 @@ from reduction_gui.reduction.scripter import BaseScriptElement, BaseReductionScr
 
 # -------------------------------------------------------------------------------
 
+
 class OptionalFloat():
     """value can be either a float or None. if value is None, str(self) == '' """
     def __init__(self, value=None):
@@ -30,6 +31,7 @@ class OptionalFloat():
 
     def __format__(self, format_spec):
         return self._bind(lambda v: v.__format__(format_spec), default = '')
+
 
 class TOFTOFScriptElement(BaseScriptElement):
 

--- a/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
+++ b/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
@@ -76,6 +76,7 @@ class TOFTOFScriptElement(BaseScriptElement):
 
         # empty can runs, comment, and factor
         self.ecRuns   = ''
+        self.ecTemp   = ''
         self.ecFactor = self.DEF_ecFactor
 
         # data runs: [(runs,comment, temperature), ...]
@@ -124,6 +125,7 @@ class TOFTOFScriptElement(BaseScriptElement):
         put('van_temperature', self.vanTemp)
 
         put('ec_runs',     self.ecRuns)
+        put('ec_temp',     self.ecTemp)
         put('ec_factor',   self.ecFactor)
 
         for (runs, cmnt, temp) in self.dataRuns:
@@ -194,6 +196,7 @@ class TOFTOFScriptElement(BaseScriptElement):
             self.vanTemp  = get_str('van_temperature')
 
             self.ecRuns   = get_str('ec_runs')
+            self.ecTemp   = get_str('ec_temp')
             self.ecFactor = get_flt('ec_factor', self.DEF_ecFactor)
 
             dataRuns = get_strlst('data_runs')
@@ -310,7 +313,7 @@ class TOFTOFScriptElement(BaseScriptElement):
             wsEC    = self.prefix + 'EC'
 
             self.l("# empty can runs")
-            self.merge_runs(wsRawEC, self.ecRuns, wsEC, 'EC')
+            self.merge_runs(wsRawEC, self.ecRuns, wsEC, 'EC', self.ecTemp)
             allGroup.append(wsEC)
 
         # data runs

--- a/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
+++ b/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
@@ -72,6 +72,7 @@ class TOFTOFScriptElement(BaseScriptElement):
         # vanadium runs & comment
         self.vanRuns  = ''
         self.vanCmnt  = ''
+        self.vanTemp  = ''
 
         # empty can runs, comment, and factor
         self.ecRuns   = ''
@@ -118,8 +119,9 @@ class TOFTOFScriptElement(BaseScriptElement):
         put('prefix',      self.prefix)
         put('data_dir',    self.dataDir)
 
-        put('van_runs',    self.vanRuns)
-        put('van_comment', self.vanCmnt)
+        put('van_runs',        self.vanRuns)
+        put('van_comment',     self.vanCmnt)
+        put('van_temperature', self.vanTemp)
 
         put('ec_runs',     self.ecRuns)
         put('ec_factor',   self.ecFactor)
@@ -189,6 +191,7 @@ class TOFTOFScriptElement(BaseScriptElement):
 
             self.vanRuns  = get_str('van_runs')
             self.vanCmnt  = get_str('van_comment')
+            self.vanTemp  = get_str('van_temperature')
 
             self.ecRuns   = get_str('ec_runs')
             self.ecFactor = get_flt('ec_factor', self.DEF_ecFactor)
@@ -298,7 +301,7 @@ class TOFTOFScriptElement(BaseScriptElement):
             wsVan    = self.prefix + 'Van'
 
             self.l("# vanadium runs")
-            self.merge_runs(wsRawVan, self.vanRuns, wsVan, self.vanCmnt)
+            self.merge_runs(wsRawVan, self.vanRuns, wsVan, self.vanCmnt, self.vanTemp)
             allGroup.append(wsVan)
 
         # empty can runs

--- a/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
+++ b/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
@@ -231,7 +231,7 @@ class TOFTOFScriptElement(BaseScriptElement):
             else:
                 # no temperatures in xml file, so generate empty OptionalFloats:
                 dataTemps = (OptionalFloat() for _ in repeat(''))
-                
+
             for dataRun in zip(dataRuns, dataCmts, dataTemps):
                 self.dataRuns.append(list(dataRun))
 

--- a/scripts/Interface/reduction_gui/widgets/data_table_view.py
+++ b/scripts/Interface/reduction_gui/widgets/data_table_view.py
@@ -42,7 +42,7 @@ class DataTableModel(QtCore.QAbstractTableModel):
         :param row: int of the row to get
         :return: data of the row
         """
-        return self.tableData[row] if row < self._numRows() else [""] * self.columnCount()
+        return self.tableData[row] if row < self._numRows() else self._createEmptyRow()
 
     def _isRowEmpty(self, row):
         """
@@ -51,6 +51,9 @@ class DataTableModel(QtCore.QAbstractTableModel):
         :return: true if row is empty
         """
         return all((v is None or not str(v).strip()) for v in self._getRow(row))
+
+    def _createEmptyRow(self):
+        return [self._textToData(self._numRows(), i, '') for i in range(self.columnCount())]
 
     def _removeTrailingEmptyRows(self):
         """
@@ -76,7 +79,7 @@ class DataTableModel(QtCore.QAbstractTableModel):
         :param numRows:  number of rows that should exist
         """
         while self._numRows() < numRows:
-            self.tableData.append([""] * self.columnCount())
+            self.tableData.append(self._createEmptyRow())
 
     def _dataToText(self, row, col, value):
         """

--- a/scripts/Interface/reduction_gui/widgets/data_table_view.py
+++ b/scripts/Interface/reduction_gui/widgets/data_table_view.py
@@ -49,7 +49,7 @@ class DataTableModel(QtCore.QAbstractTableModel):
 		:param row: int of the row to check
 		:return: true if row is empty
 		"""
-		return all(not str(v).strip() for v in self._getRow(row))
+		return all((v is None or not str(v).strip()) for v in self._getRow(row))
 
 	def _removeTrailingEmptyRows(self):
 		"""

--- a/scripts/Interface/reduction_gui/widgets/data_table_view.py
+++ b/scripts/Interface/reduction_gui/widgets/data_table_view.py
@@ -3,244 +3,245 @@ DataTable Widget for data runs.
 """
 from __future__ import (absolute_import, division, print_function)
 try:
-	from PyQt5.QtCore import QObject
-	from PyQt5 import QtCore, QtGui, QtWidgets
+    from PyQt5.QtCore import QObject
+    from PyQt5 import QtCore, QtWidgets
 except:
-	from PyQt4 import QtCore
-	from PyQt4 import QtGui as QtWidgets
+    from PyQt4 import QtCore
+    from PyQt4 import QtGui as QtWidgets
 Qt = QtCore.Qt
 
+
 class DataTableModel(QtCore.QAbstractTableModel):
-	"""
-	DataTable Model for the DataTableView widget.
-	"""
-	def __init__(self, parent, headers = ()):
-		QtCore.QAbstractTableModel.__init__(self, parent)
-		self._tableData = []
-		self.headers = headers
+    """
+    DataTable Model for the DataTableView widget.
+    """
+    def __init__(self, parent, headers = ()):
+        QtCore.QAbstractTableModel.__init__(self, parent)
+        self._tableData = []
+        self.headers = headers
 
-	@property
-	def tableData(self):
-		return self._tableData
-	
-	@tableData.setter
-	def tableData(self, data):
-		def checkAndConvertRow(row):
-			assert(len(row) == self.columnCount())
-			return list(row)
-		self._tableData = map(checkAndConvertRow, data)
+    @property
+    def tableData(self):
+        return self._tableData
 
-	def _numRows(self):
-		"""
-		:return: number of rows with data
-		"""
-		return len(self.tableData)
+    @tableData.setter
+    def tableData(self, data):
+        def checkAndConvertRow(row):
+            assert(len(row) == self.columnCount())
+            return list(row)
+        self._tableData = map(checkAndConvertRow, data)
 
-	def _getRow(self, row):
-		"""
-		:param row: int of the row to get 
-		:return: data of the row
-		"""
-		return self.tableData[row] if row < self._numRows() else [""] * self.columnCount()
+    def _numRows(self):
+        """
+        :return: number of rows with data
+        """
+        return len(self.tableData)
 
-	def _isRowEmpty(self, row):
-		"""
-		checks if the row is empty
-		:param row: int of the row to check
-		:return: true if row is empty
-		"""
-		return all((v is None or not str(v).strip()) for v in self._getRow(row))
+    def _getRow(self, row):
+        """
+        :param row: int of the row to get
+        :return: data of the row
+        """
+        return self.tableData[row] if row < self._numRows() else [""] * self.columnCount()
 
-	def _removeTrailingEmptyRows(self):
-		"""
-		remove all rows at the end of the table that are empty
-		"""
-		for row in reversed(range(self._numRows())):
-			if self._isRowEmpty(row):
-				del self.tableData[row]
-			else:
-				break
+    def _isRowEmpty(self, row):
+        """
+        checks if the row is empty
+        :param row: int of the row to check
+        :return: true if row is empty
+        """
+        return all((v is None or not str(v).strip()) for v in self._getRow(row))
 
-	def _removeEmptyRows(self):
-		"""
-		remove all empty rows 
-		"""
-		for row in reversed(range(self._numRows())):
-			if self._isRowEmpty(row):
-				del self.tableData[row]
+    def _removeTrailingEmptyRows(self):
+        """
+        remove all rows at the end of the table that are empty
+        """
+        for row in reversed(range(self._numRows())):
+            if self._isRowEmpty(row):
+                del self.tableData[row]
+            else:
+                break
 
-	def _ensureHasRows(self, numRows):
-		"""
-		ensure the table has numRows
-		:param numRows:  number of rows that should exist
-		"""
-		while self._numRows() < numRows:
-			self.tableData.append([""] * self.columnCount())
+    def _removeEmptyRows(self):
+        """
+        remove all empty rows
+        """
+        for row in reversed(range(self._numRows())):
+            if self._isRowEmpty(row):
+                del self.tableData[row]
 
-	def _dataToText(self, row, col, value):
-		"""
-		converts the stored data to a displayable text.
-		Override this function if you need data types other than str in your table. 
-		"""
-		return str(value)
+    def _ensureHasRows(self, numRows):
+        """
+        ensure the table has numRows
+        :param numRows:  number of rows that should exist
+        """
+        while self._numRows() < numRows:
+            self.tableData.append([""] * self.columnCount())
 
-	def _textToData(self, row, col, text):
-		"""
-		converts a displayable text back to stored data.
-		Override this function if you need data types other than str in your table. 
-		"""
-		return text # just return the value, it is already str.
+    def _dataToText(self, row, col, value):
+        """
+        converts the stored data to a displayable text.
+        Override this function if you need data types other than str in your table.
+        """
+        return str(value)
 
-	def _setCellText(self, row, col, text):
-		"""
-		set the text of a cell
-		:param row: row of the cell
-		:param col: column of the cell
-		:param text: text for the cell
-		"""
-		self._ensureHasRows(row + 1)
-		self.tableData[row][col] = self._textToData(row, col, str(text).strip())
+    def _textToData(self, row, col, text):
+        """
+        converts a displayable text back to stored data.
+        Override this function if you need data types other than str in your table.
+        """
+        return text # just return the value, it is already str.
 
-	def _getCellText(self, row, col):
-		"""
-		get the text of a cell
-		:param row: row of the cell
-		:param col: column of the cell
-		:return: text of the cell
-		"""
-		rowData = self._getRow(row)
-		return self._dataToText(row, col, rowData[col]).strip() \
-			   if len(rowData) > col else None
+    def _setCellText(self, row, col, text):
+        """
+        set the text of a cell
+        :param row: row of the cell
+        :param col: column of the cell
+        :param text: text for the cell
+        """
+        self._ensureHasRows(row + 1)
+        self.tableData[row][col] = self._textToData(row, col, str(text).strip())
 
-	# reimplemented QAbstractTableModel methods
+    def _getCellText(self, row, col):
+        """
+        get the text of a cell
+        :param row: row of the cell
+        :param col: column of the cell
+        :return: text of the cell
+        """
+        rowData = self._getRow(row)
+        return self._dataToText(row, col, rowData[col]).strip() \
+        	if len(rowData) > col else None
 
-	selectCell = QtCore.pyqtSignal(QtCore.QModelIndex)
+    # reimplemented QAbstractTableModel methods
 
-	def emptyCells(self, indexes):
-		"""
-		empty the cells with the indexes
-		:param indexes: indexes of the cells to be emptied
-		"""
-		for index in indexes:
-			row = index.row()
-			col = index.column()
+    selectCell = QtCore.pyqtSignal(QtCore.QModelIndex)
 
-			self._setCellText(row, col, "")
+    def emptyCells(self, indexes):
+        """
+        empty the cells with the indexes
+        :param indexes: indexes of the cells to be emptied
+        """
+        for index in indexes:
+            row = index.row()
+            col = index.column()
 
-		self._removeEmptyRows()
-		self.beginResetModel()
-		self.endResetModel()
-		# indexes is never empty
-		self.selectCell.emit(indexes[0])
+            self._setCellText(row, col, "")
 
-	def rowCount(self, _=QtCore.QModelIndex()):
-		"""
-		number of rows
-		:return: returns the number of rows
-		"""
-		# one additional row for new data
-		return self._numRows() + 1
+        self._removeEmptyRows()
+        self.beginResetModel()
+        self.endResetModel()
+        # indexes is never empty
+        self.selectCell.emit(indexes[0])
 
-	def columnCount(self, _=QtCore.QModelIndex()):
-		"""
-		number of columns
-		:return: number of columns
-		"""
-		return len(self.headers)
+    def rowCount(self, _=QtCore.QModelIndex()):
+        """
+        number of rows
+        :return: returns the number of rows
+        """
+        # one additional row for new data
+        return self._numRows() + 1
 
-	def headerData(self, selection, orientation, role):
-		"""
-		header of the selection
-		:param selection: selected cells
-		:param orientation: orientation of selection
-		:param role: role of the selection
-		:return: header of the selection
-		"""
-		if Qt.Horizontal == orientation and Qt.DisplayRole == role:
-			return self.headers[selection]
-		return None
+    def columnCount(self, _=QtCore.QModelIndex()):
+        """
+        number of columns
+        :return: number of columns
+        """
+        return len(self.headers)
 
-	def data(self, index, role):
-		"""
-		data of the cell
-		:param index: index of the cell
-		:param role: role of the cell
-		:return: data of the cell
-		"""
-		if Qt.DisplayRole == role or Qt.EditRole == role:
-			return self._getCellText(index.row(), index.column())
-		return None
+    def headerData(self, selection, orientation, role):
+        """
+        header of the selection
+        :param selection: selected cells
+        :param orientation: orientation of selection
+        :param role: role of the selection
+        :return: header of the selection
+        """
+        if Qt.Horizontal == orientation and Qt.DisplayRole == role:
+            return self.headers[selection]
+        return None
 
-	def setData(self, index, text, _):
-		"""
-		set text in the cell
-		:param index: index of the cell
-		:param text: text for the cell
-		:return: true if data is set
-		"""
-		row = index.row()
-		col = index.column()
+    def data(self, index, role):
+        """
+        data of the cell
+        :param index: index of the cell
+        :param role: role of the cell
+        :return: data of the cell
+        """
+        if Qt.DisplayRole == role or Qt.EditRole == role:
+            return self._getCellText(index.row(), index.column())
+        return None
 
-		self._setCellText(row, col, text)
-		self._removeTrailingEmptyRows()
+    def setData(self, index, text, _):
+        """
+        set text in the cell
+        :param index: index of the cell
+        :param text: text for the cell
+        :return: true if data is set
+        """
+        row = index.row()
+        col = index.column()
 
-		self.beginResetModel()
-		self.endResetModel()
+        self._setCellText(row, col, text)
+        self._removeTrailingEmptyRows()
 
-		# move selection to the next column or row
-		col = col + 1
+        self.beginResetModel()
+        self.endResetModel()
 
-		if col >= self.columnCount:
-			row = row + 1
-			col = 0
+        # move selection to the next column or row
+        col = col + 1
 
-		row = min(row, self.rowCount() - 1)
-		self.selectCell.emit(self.index(row, col))
+        if col >= self.columnCount:
+            row = row + 1
+            col = 0
 
-		return True
+        row = min(row, self.rowCount() - 1)
+        self.selectCell.emit(self.index(row, col))
 
-	def flags(self, _):
-		"""
-		flags for the table
-		:return: flags
-		"""
-		return Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsEditable
-		
+        return True
+
+    def flags(self, _):
+        """
+        flags for the table
+        :return: flags
+        """
+        return Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsEditable
+
+
 class DataTableView(QtWidgets.QTableView):
-	"""
-	DataTable Widget for data runs.
-	"""
-	def __init__(self, parent, headers, model_cls=None):
-		"""
-		:param headers: tuple of strings of the column headers
-		:param model: a DataTableModel if an external model should be used. if not specified a new DataTableModel is created
-		:return: a brand new DataTableView
-		"""
-		super(DataTableView, self).__init__(parent)
-		if model_cls is None:
-			model_cls = DataTableModel
-		model = model_cls(self, headers)
+    """
+    DataTable Widget for data runs.
+    """
+    def __init__(self, parent, headers, model_cls=None):
+        """
+        :param headers: tuple of strings of the column headers
+        :param model: a DataTableModel if an external model should be used. if not specified a new DataTableModel is created
+        :return: a brand new DataTableView
+        """
+        super(DataTableView, self).__init__(parent)
+        if model_cls is None:
+            model_cls = DataTableModel
+        model = model_cls(self, headers)
 
-		self.setModel(model)
-		self.verticalHeader().setVisible(False);
-		self.horizontalHeader().setStretchLastSection(True)
-		self.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+        self.setModel(model)
+        self.verticalHeader().setVisible(False)
+        self.horizontalHeader().setStretchLastSection(True)
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
 
-	def keyPressEvent(self, QKeyEvent):
-		"""
-		reimplemented keyPressEvent for deleting cells and arrows in editing cells 
-		:param QKeyEvent: 
-		:return: 
-		"""
-		if self.state() == QtWidgets.QAbstractItemView.EditingState:
-			index = self.currentIndex()
-			if QKeyEvent.key() in [Qt.Key_Down, Qt.Key_Up]:
-				self.setFocus()
-				self.setCurrentIndex(self.model().index(index.row(), index.column()))
-			else:
-				QtWidgets.QTableView.keyPressEvent(self, QKeyEvent)
-		if QKeyEvent.key() in [Qt.Key_Delete, Qt.Key_Backspace]:
-			self.model().emptyCells(self.selectedIndexes())
-		else:
-			QtWidgets.QTableView.keyPressEvent(self, QKeyEvent)
-	
+    def keyPressEvent(self, QKeyEvent):
+        """
+        reimplemented keyPressEvent for deleting cells and arrows in editing cells
+        :param QKeyEvent:
+        :return:
+        """
+        if self.state() == QtWidgets.QAbstractItemView.EditingState:
+            index = self.currentIndex()
+            if QKeyEvent.key() in [Qt.Key_Down, Qt.Key_Up]:
+                self.setFocus()
+                self.setCurrentIndex(self.model().index(index.row(), index.column()))
+            else:
+                QtWidgets.QTableView.keyPressEvent(self, QKeyEvent)
+        if QKeyEvent.key() in [Qt.Key_Delete, Qt.Key_Backspace]:
+            self.model().emptyCells(self.selectedIndexes())
+        else:
+            QtWidgets.QTableView.keyPressEvent(self, QKeyEvent)

--- a/scripts/Interface/reduction_gui/widgets/data_table_view.py
+++ b/scripts/Interface/reduction_gui/widgets/data_table_view.py
@@ -109,8 +109,7 @@ class DataTableModel(QtCore.QAbstractTableModel):
         :return: text of the cell
         """
         rowData = self._getRow(row)
-        return self._dataToText(row, col, rowData[col]).strip() \
-               if len(rowData) > col else None
+        return self._dataToText(row, col, rowData[col]).strip() if len(rowData) > col else None
 
     # reimplemented QAbstractTableModel methods
 

--- a/scripts/Interface/reduction_gui/widgets/data_table_view.py
+++ b/scripts/Interface/reduction_gui/widgets/data_table_view.py
@@ -1,0 +1,229 @@
+"""
+DataTable Widget for data runs.
+"""
+from __future__ import (absolute_import, division, print_function)
+try:
+	from PyQt5.QtCore import QObject
+	from PyQt5 import QtCore, QtGui, QtWidgets
+except:
+	from PyQt4 import QtCore
+	from PyQt4 import QtGui as QtWidgets
+Qt = QtCore.Qt
+
+class DataTableModel(QtCore.QAbstractTableModel):
+	"""
+	DataTable Model for the DataTableView widget.
+	"""
+	def __init__(self, parent, headers = ()):
+		QtCore.QAbstractTableModel.__init__(self, parent)
+		self._tableData = []
+		self.headers = headers
+
+	@property
+	def tableData(self):
+		return self._tableData
+	
+	@tableData.setter
+	def tableData(self, data):
+		def checkAndConvertRow(row):
+			assert(len(row) == self.columnCount())
+			return list(row)
+		self._tableData = map(checkAndConvertRow, data)
+
+	def _numRows(self):
+		"""
+		:return: number of rows with data
+		"""
+		return len(self.tableData)
+
+	def _getRow(self, row):
+		"""
+		:param row: int of the row to get 
+		:return: data of the row
+		"""
+		return self.tableData[row] if row < self._numRows() else [""] * self.columnCount()
+
+	def _isRowEmpty(self, row):
+		"""
+		checks if the row is empty
+		:param row: int of the row to check
+		:return: true if row is empty
+		"""
+		return all(not str(v).strip() for v in self._getRow(row))
+
+	def _removeTrailingEmptyRows(self):
+		"""
+		remove all rows at the end of the table that are empty
+		"""
+		for row in reversed(range(self._numRows())):
+			if self._isRowEmpty(row):
+				del self.tableData[row]
+			else:
+				break
+
+	def _removeEmptyRows(self):
+		"""
+		remove all empty rows 
+		"""
+		for row in reversed(range(self._numRows())):
+			if self._isRowEmpty(row):
+				del self.tableData[row]
+
+	def _ensureHasRows(self, numRows):
+		"""
+		ensure the table has numRows
+		:param numRows:  number of rows that should exist
+		"""
+		while self._numRows() < numRows:
+			self.tableData.append([""] * self.columnCount())
+
+	def _setCellText(self, row, col, text):
+		"""
+		set the text of a cell
+		:param row: row of the cell
+		:param col: column of the cell
+		:param text: text for the cell
+		"""
+		self._ensureHasRows(row + 1)
+		self.tableData[row][col] = str(text).strip()
+
+	def _getCellText(self, row, col):
+		"""
+		get the text of a cell
+		:param row: row of the cell
+		:param col: column of the cell
+		:return: text of the cell
+		"""
+		rowData = self._getRow(row)
+		return str(rowData[col]).strip() if len(rowData) > col else None
+
+	# reimplemented QAbstractTableModel methods
+
+	selectCell = QtCore.pyqtSignal(QtCore.QModelIndex)
+
+	def emptyCells(self, indexes):
+		"""
+		empty the cells with the indexes
+		:param indexes: indexes of the cells to be emptied
+		"""
+		for index in indexes:
+			row = index.row()
+			col = index.column()
+
+			self._setCellText(row, col, "")
+
+		self._removeEmptyRows()
+		self.beginResetModel()
+		self.endResetModel()
+		# indexes is never empty
+		self.selectCell.emit(indexes[0])
+
+	def rowCount(self, _=QtCore.QModelIndex()):
+		"""
+		number of rows
+		:return: returns the number of rows
+		"""
+		# one additional row for new data
+		return self._numRows() + 1
+
+	def columnCount(self, _=QtCore.QModelIndex()):
+		"""
+		number of columns
+		:return: number of columns
+		"""
+		return len(self.headers)
+
+	def headerData(self, selection, orientation, role):
+		"""
+		header of the selection
+		:param selection: selected cells
+		:param orientation: orientation of selection
+		:param role: role of the selection
+		:return: header of the selection
+		"""
+		if Qt.Horizontal == orientation and Qt.DisplayRole == role:
+			return self.headers[selection]
+		return None
+
+	def data(self, index, role):
+		"""
+		data of the cell
+		:param index: index of the cell
+		:param role: role of the cell
+		:return: data of the cell
+		"""
+		if Qt.DisplayRole == role or Qt.EditRole == role:
+			return self._getCellText(index.row(), index.column())
+		return None
+
+	def setData(self, index, text, _):
+		"""
+		set text in the cell
+		:param index: index of the cell
+		:param text: text for the cell
+		:return: true if data is set
+		"""
+		row = index.row()
+		col = index.column()
+
+		self._setCellText(row, col, text)
+		self._removeTrailingEmptyRows()
+
+		self.beginResetModel()
+		self.endResetModel()
+
+		# move selection to the next column or row
+		col = col + 1
+
+		if col >= self.columnCount:
+			row = row + 1
+			col = 0
+
+		row = min(row, self.rowCount() - 1)
+		self.selectCell.emit(self.index(row, col))
+
+		return True
+
+	def flags(self, _):
+		"""
+		flags for the table
+		:return: flags
+		"""
+		return Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsEditable
+		
+class DataTableView(QtWidgets.QTableView):
+	"""
+	DataTable Widget for data runs.
+	"""
+	def __init__(self, parent, headers, model=None):
+		"""
+		:param headers: tuple of strings of the column headers
+		:param model: a DataTableModel if an external model should be used. if not specified a new DataTableModel is created
+		:return: a brand new DataTableView
+		"""
+		super(DataTableView, self).__init__(parent)
+		if model is None:
+			model = DataTableModel(self, headers)
+		self.setModel(model)
+		self.verticalHeader().setVisible(False);
+		self.horizontalHeader().setStretchLastSection(True)
+		self.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+
+	def keyPressEvent(self, QKeyEvent):
+		"""
+		reimplemented keyPressEvent for deleting cells and arrows in editing cells 
+		:param QKeyEvent: 
+		:return: 
+		"""
+		if self.state() == QtWidgets.QAbstractItemView.EditingState:
+			index = self.currentIndex()
+			if QKeyEvent.key() in [Qt.Key_Down, Qt.Key_Up]:
+				self.setFocus()
+				self.setCurrentIndex(self.model().index(index.row(), index.column()))
+			else:
+				QtWidgets.QTableView.keyPressEvent(self, QKeyEvent)
+		if QKeyEvent.key() in [Qt.Key_Delete, Qt.Key_Backspace]:
+			self.model().emptyCells(self.selectedIndexes())
+		else:
+			QtWidgets.QTableView.keyPressEvent(self, QKeyEvent)
+	

--- a/scripts/Interface/reduction_gui/widgets/data_table_view.py
+++ b/scripts/Interface/reduction_gui/widgets/data_table_view.py
@@ -7,6 +7,7 @@ try:
 except:
     from PyQt4 import QtCore
     from PyQt4 import QtGui as QtWidgets
+    QtCore.Signal = QtCore.pyqtSignal
 Qt = QtCore.Qt
 
 
@@ -113,7 +114,7 @@ class DataTableModel(QtCore.QAbstractTableModel):
 
     # reimplemented QAbstractTableModel methods
 
-    selectCell = QtCore.pyqtSignal(QtCore.QModelIndex)
+    selectCell = QtCore.Signal(QtCore.QModelIndex)
 
     def emptyCells(self, indexes):
         """

--- a/scripts/Interface/reduction_gui/widgets/data_table_view.py
+++ b/scripts/Interface/reduction_gui/widgets/data_table_view.py
@@ -3,8 +3,7 @@ DataTable Widget for data runs.
 """
 from __future__ import (absolute_import, division, print_function)
 try:
-    from PyQt5.QtCore import QObject
-    from PyQt5 import QtCore, QtWidgets
+    from qtpy import QtCore, QtWidgets
 except:
     from PyQt4 import QtCore
     from PyQt4 import QtGui as QtWidgets
@@ -111,7 +110,7 @@ class DataTableModel(QtCore.QAbstractTableModel):
         """
         rowData = self._getRow(row)
         return self._dataToText(row, col, rowData[col]).strip() \
-        	if len(rowData) > col else None
+               if len(rowData) > col else None
 
     # reimplemented QAbstractTableModel methods
 

--- a/scripts/Interface/reduction_gui/widgets/data_table_view.py
+++ b/scripts/Interface/reduction_gui/widgets/data_table_view.py
@@ -77,6 +77,20 @@ class DataTableModel(QtCore.QAbstractTableModel):
 		while self._numRows() < numRows:
 			self.tableData.append([""] * self.columnCount())
 
+	def _dataToText(self, row, col, value):
+		"""
+		converts the stored data to a displayable text.
+		Override this function if you need data types other than str in your table. 
+		"""
+		return str(value)
+
+	def _textToData(self, row, col, text):
+		"""
+		converts a displayable text back to stored data.
+		Override this function if you need data types other than str in your table. 
+		"""
+		return text # just return the value, it is already str.
+
 	def _setCellText(self, row, col, text):
 		"""
 		set the text of a cell
@@ -85,7 +99,7 @@ class DataTableModel(QtCore.QAbstractTableModel):
 		:param text: text for the cell
 		"""
 		self._ensureHasRows(row + 1)
-		self.tableData[row][col] = str(text).strip()
+		self.tableData[row][col] = self._textToData(row, col, str(text).strip())
 
 	def _getCellText(self, row, col):
 		"""
@@ -95,7 +109,8 @@ class DataTableModel(QtCore.QAbstractTableModel):
 		:return: text of the cell
 		"""
 		rowData = self._getRow(row)
-		return str(rowData[col]).strip() if len(rowData) > col else None
+		return self._dataToText(row, col, rowData[col]).strip() \
+			   if len(rowData) > col else None
 
 	# reimplemented QAbstractTableModel methods
 
@@ -195,15 +210,17 @@ class DataTableView(QtWidgets.QTableView):
 	"""
 	DataTable Widget for data runs.
 	"""
-	def __init__(self, parent, headers, model=None):
+	def __init__(self, parent, headers, model_cls=None):
 		"""
 		:param headers: tuple of strings of the column headers
 		:param model: a DataTableModel if an external model should be used. if not specified a new DataTableModel is created
 		:return: a brand new DataTableView
 		"""
 		super(DataTableView, self).__init__(parent)
-		if model is None:
-			model = DataTableModel(self, headers)
+		if model_cls is None:
+			model_cls = DataTableModel
+		model = model_cls(self, headers)
+
 		self.setModel(model)
 		self.verticalHeader().setVisible(False);
 		self.horizontalHeader().setStretchLastSection(True)

--- a/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
@@ -155,7 +155,7 @@ class TOFTOFSetupWidget(BaseWidget):
 
         self.maskDetectors = tip(QLineEdit(), self.TIP_maskDetectors)
 
-        headers = ('Data runs', 'Comment', 'Temperature [K]')
+        headers = ('Data runs', 'Comment', 'T (K)')
         self.dataRunsView = tip(DataTableView(self, headers, TOFTOFSetupWidget.TofTofDataTableModel), self.TIP_dataRunsView)
         self.dataRunsView.horizontalHeader().setStretchLastSection(True)
         self.dataRunsView.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
@@ -256,11 +256,11 @@ class TOFTOFSetupWidget(BaseWidget):
         grid.addWidget(self.vanRuns,            0, 1, 1, 3)
         grid.addWidget(QLabel('Van. comment'),  1, 0)
         grid.addWidget(self.vanCmnt,            1, 1, 1, 2)
-        grid.addLayout(hbox(QLabel('Temp.'), self.vanTemp),         1, 3)
+        grid.addLayout(hbox(QLabel('T (K)'), self.vanTemp),         1, 3)
         grid.addWidget(QLabel('Empty can runs'),2, 0)
         grid.addWidget(self.ecRuns,             2, 1, 1, 1)
         grid.addLayout(hbox(QLabel('EC factor'), self.ecFactor), 2, 2, 1, 1)
-        grid.addLayout(hbox(QLabel('Temp.'), self.ecTemp),         2, 3)
+        grid.addLayout(hbox(QLabel('T (K)'), self.ecTemp),         2, 3)
         grid.addWidget(QLabel('Mask detectors'),3, 0)
         grid.addWidget(self.maskDetectors,      3, 1, 1, 3)
 

--- a/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
@@ -27,6 +27,7 @@ class TOFTOFSetupWidget(BaseWidget):
 
     TIP_vanRuns = ''
     TIP_vanCmnt = ''
+    TIP_vanTemp = 'Temperature in [K]. only required if none in data given'
 
     TIP_ecRuns = ''
     TIP_ecFactor = ''
@@ -94,6 +95,7 @@ class TOFTOFSetupWidget(BaseWidget):
 
         self.vanRuns   = tip(QLineEdit(), self.TIP_vanRuns)
         self.vanCmnt   = tip(QLineEdit(), self.TIP_vanCmnt)
+        self.vanTemp   = tip(QLineEdit(), self.TIP_vanTemp)
 
         self.ecRuns    = tip(QLineEdit(), self.TIP_ecRuns)
         self.ecFactor  = tip(QDoubleSpinBox(), self.TIP_ecFactor)
@@ -222,7 +224,9 @@ class TOFTOFSetupWidget(BaseWidget):
         grid.addWidget(QLabel('Vanadium runs'), 0, 0)
         grid.addWidget(self.vanRuns,            0, 1, 1, 3)
         grid.addWidget(QLabel('Van. comment'),  1, 0)
-        grid.addWidget(self.vanCmnt,            1, 1, 1, 3)
+        grid.addWidget(self.vanCmnt,            1, 1, 1, 1)
+        grid.addWidget(QLabel('Van. Temp.'),    1, 2)
+        grid.addWidget(self.vanTemp,            1, 3, 1, 1)
         grid.addWidget(QLabel('Empty can runs'),2, 0)
         grid.addWidget(self.ecRuns,             2, 1)
         grid.addWidget(QLabel('EC factor'),     2, 2)
@@ -320,6 +324,7 @@ class TOFTOFSetupWidget(BaseWidget):
 
         elem.vanRuns       = line_text(self.vanRuns)
         elem.vanCmnt       = line_text(self.vanCmnt)
+        elem.vanTemp       = line_text(self.vanTemp)
 
         elem.ecRuns        = line_text(self.ecRuns)
         elem.ecFactor      = self.ecFactor.value()
@@ -368,6 +373,7 @@ class TOFTOFSetupWidget(BaseWidget):
 
         self.vanRuns.setText(elem.vanRuns)
         self.vanCmnt.setText(elem.vanCmnt)
+        self.vanTemp.setText(elem.vanTemp)
 
         self.ecRuns.setText(elem.ecRuns)
         self.ecFactor.setValue(elem.ecFactor)

--- a/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
@@ -120,7 +120,7 @@ class TOFTOFSetupWidget(BaseWidget):
 
         self.maskDetectors = tip(QLineEdit(), self.TIP_maskDetectors)
 
-        headers = ('Data runs', 'Comment')
+        headers = ('Data runs', 'Comment', "Temperature [K]")
         self.dataRunsView  = tip(DataTableView(self, headers), self.TIP_dataRunsView)
         self.dataRunsView.horizontalHeader().setStretchLastSection(True)
         self.dataRunsView.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)

--- a/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
@@ -347,7 +347,7 @@ class TOFTOFSetupWidget(BaseWidget):
             return lineEdit.text().strip()
 
         def float_or_none(string):
-            float(string) if string else None
+            return float(string) if string else None
 
         elem.facility_name   = self._settings.facility_name
         elem.instrument_name = self._settings.instrument_name

--- a/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
@@ -189,8 +189,7 @@ class TOFTOFSetupWidget(BaseWidget):
         box = QVBoxLayout()
         self._layout.addLayout(box)
 
-        box.addLayout(hbox(gbDataDir, gbPrefix))
-        box.addLayout(hbox(vbox(gbInputs, gbBinning, gbOptions, 1), vbox(gbData, gbSave)))
+        box.addLayout(hbox(vbox(gbDataDir, gbInputs, gbBinning, gbOptions, 1), vbox(gbPrefix, gbData, gbSave)))
 
         gbDataDir.setLayout(hbox(self.dataDir, self.btnDataDir))
         gbPrefix.setLayout(hbox(self.prefix,))

--- a/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
@@ -13,8 +13,9 @@ from reduction_gui.widgets.data_table_view import DataTableView, DataTableModel
 
 #-------------------------------------------------------------------------------
 
+
 class SmallQLineEdit(QLineEdit):
-    '''just a smaller QLineEdit'''  
+    '''just a smaller QLineEdit'''
     def sizeHint(self):
         '''overriding the sizeHint() function to get a smaller lineEdit'''
         sh = super(SmallQLineEdit, self).sizeHint()
@@ -32,7 +33,7 @@ class TOFTOFSetupWidget(BaseWidget):
         def _dataToText(self, row, col, value):
             """
             converts the stored data to a displayable text.
-            Override this function if you need data types other than str in your table. 
+            Override this function if you need data types other than str in your table.
             """
             if col == 2:
                 return str(value) if value is not None else ''
@@ -42,7 +43,7 @@ class TOFTOFSetupWidget(BaseWidget):
         def _textToData(self, row, col, text):
             """
             converts a displayable text back to stored data.
-            Override this function if you need data types other than str in your table. 
+            Override this function if you need data types other than str in your table.
             """
             if col == 2:
                 return float(text) if text else None

--- a/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
@@ -17,7 +17,10 @@ class SmallQLineEdit(QLineEdit):
     '''just a smaller QLineEdit'''  
     def sizeHint(self):
         '''overriding the sizeHint() function to get a smaller lineEdit'''
-        return super(SmallQLineEdit, self).sizeHint() // 2
+        sh = super(SmallQLineEdit, self).sizeHint()
+        sh.setWidth(sh.width() // 2)
+        sh.setHeight(sh.height() // 2)
+        return sh
 
 
 class TOFTOFSetupWidget(BaseWidget):

--- a/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
@@ -120,6 +120,11 @@ class TOFTOFSetupWidget(BaseWidget):
                 widget.setToolTip(text)
             return widget
 
+        def DoubleEdit():
+            edit = SmallQLineEdit()
+            edit.setValidator(QDoubleValidator())
+            return edit
+
         # ui data elements
         self.prefix    = tip(QLineEdit(), self.TIP_prefix)
         self.dataDir   = tip(QLineEdit(), self.TIP_dataDir)
@@ -127,10 +132,10 @@ class TOFTOFSetupWidget(BaseWidget):
 
         self.vanRuns   = tip(QLineEdit(), self.TIP_vanRuns)
         self.vanCmnt   = tip(QLineEdit(), self.TIP_vanCmnt)
-        self.vanTemp   = tip(SmallQLineEdit(), self.TIP_vanTemp)
+        self.vanTemp   = tip(DoubleEdit(), self.TIP_vanTemp)
 
         self.ecRuns    = tip(SmallQLineEdit(), self.TIP_ecRuns)
-        self.ecTemp    = tip(SmallQLineEdit(), self.TIP_ecTemp)
+        self.ecTemp    = tip(DoubleEdit(), self.TIP_ecTemp)
         self.ecFactor  = tip(QDoubleSpinBox(), self.TIP_ecFactor)
 
         set_spin(self.ecFactor, 0, 1)

--- a/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
@@ -27,10 +27,10 @@ class TOFTOFSetupWidget(BaseWidget):
 
     TIP_vanRuns = ''
     TIP_vanCmnt = ''
-    TIP_vanTemp = 'Temperature in [K]. only required if none is in data given'
+    TIP_vanTemp = 'Temperature in [K]. only required if none is given in data'
 
     TIP_ecRuns = ''
-    TIP_ecTemp = 'Temperature in [K]. only required if none is in data given'
+    TIP_ecTemp = 'Temperature in [K]. only required if none is given in data'
     TIP_ecFactor = ''
 
     TIP_binEon = ''
@@ -227,11 +227,11 @@ class TOFTOFSetupWidget(BaseWidget):
         grid.addWidget(self.vanRuns,            0, 1, 1, 3)
         grid.addWidget(QLabel('Van. comment'),  1, 0)
         grid.addWidget(self.vanCmnt,            1, 1, 1, 1)
-        grid.addWidget(QLabel('Van. Temp.'),    1, 2)
+        grid.addWidget(QLabel('Temp.'),         1, 2)
         grid.addWidget(self.vanTemp,            1, 3, 1, 1)
         grid.addWidget(QLabel('Empty can runs'),2, 0)
         grid.addLayout(hbox(self.ecRuns, QLabel('EC factor'), self.ecFactor), 2, 1, 1, 1)
-        grid.addWidget(QLabel('EC Temp.'),      2, 2)
+        grid.addWidget(QLabel('Temp.'),         2, 2)
         grid.addWidget(self.ecTemp,             2, 3)
         grid.addWidget(QLabel('Mask detectors'),3, 0)
         grid.addWidget(self.maskDetectors,      3, 1, 1, 3)

--- a/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
@@ -8,7 +8,7 @@ from PyQt4.QtCore import *
 from PyQt4.QtGui  import *
 
 from reduction_gui.widgets.base_widget import BaseWidget
-from reduction_gui.reduction.toftof.toftof_reduction import TOFTOFScriptElement
+from reduction_gui.reduction.toftof.toftof_reduction import TOFTOFScriptElement, OptionalFloat
 from reduction_gui.widgets.data_table_view import DataTableView, DataTableModel
 
 #-------------------------------------------------------------------------------
@@ -29,24 +29,12 @@ class TOFTOFSetupWidget(BaseWidget):
     name = 'TOFTOF Reduction'
 
     class TofTofDataTableModel(DataTableModel):
-
-        def _dataToText(self, row, col, value):
-            """
-            converts the stored data to a displayable text.
-            Override this function if you need data types other than str in your table.
-            """
-            if col == 2:
-                return str(value) if value is not None else ''
-            else:
-                return str(value) # just return the value, it is already str.
-
         def _textToData(self, row, col, text):
             """
             converts a displayable text back to stored data.
-            Override this function if you need data types other than str in your table.
             """
             if col == 2:
-                return float(text) if text else None
+                return OptionalFloat(text)
             else:
                 return text # just return the value, it is already str.
 
@@ -352,9 +340,6 @@ class TOFTOFSetupWidget(BaseWidget):
         def line_text(lineEdit):
             return lineEdit.text().strip()
 
-        def float_or_none(string):
-            return float(string) if string else None
-
         elem.facility_name   = self._settings.facility_name
         elem.instrument_name = self._settings.instrument_name
 
@@ -363,10 +348,10 @@ class TOFTOFSetupWidget(BaseWidget):
 
         elem.vanRuns       = line_text(self.vanRuns)
         elem.vanCmnt       = line_text(self.vanCmnt)
-        elem.vanTemp       = float_or_none(line_text(self.vanTemp))
+        elem.vanTemp       = OptionalFloat(line_text(self.vanTemp))
 
         elem.ecRuns        = line_text(self.ecRuns)
-        elem.ecTemp        = float_or_none(line_text(self.ecTemp))
+        elem.ecTemp        = OptionalFloat(line_text(self.ecTemp))
         elem.ecFactor      = self.ecFactor.value()
 
         elem.dataRuns      = self.runDataModel.tableData
@@ -413,10 +398,10 @@ class TOFTOFSetupWidget(BaseWidget):
 
         self.vanRuns.setText(elem.vanRuns)
         self.vanCmnt.setText(elem.vanCmnt)
-        self.vanTemp.setText(str(elem.vanTemp) if elem.vanTemp is not None else '')
+        self.vanTemp.setText(str(elem.vanTemp))
 
         self.ecRuns.setText(elem.ecRuns)
-        self.ecTemp.setText(str(elem.ecTemp) if elem.ecTemp is not None else '')
+        self.ecTemp.setText(str(elem.ecTemp))
         self.ecFactor.setValue(elem.ecFactor)
 
         self.runDataModel.tableData = elem.dataRuns

--- a/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
@@ -13,6 +13,12 @@ from reduction_gui.widgets.data_table_view import DataTableView
 
 #-------------------------------------------------------------------------------
 
+class SmallQLineEdit(QLineEdit):
+    '''just a smaller QLineEdit'''  
+    def sizeHint(self):
+        '''overriding the sizeHint() function to get a smaller lineEdit'''
+        return super(SmallQLineEdit, self).sizeHint() // 2
+
 
 class TOFTOFSetupWidget(BaseWidget):
     ''' The one and only tab page. '''
@@ -96,10 +102,10 @@ class TOFTOFSetupWidget(BaseWidget):
 
         self.vanRuns   = tip(QLineEdit(), self.TIP_vanRuns)
         self.vanCmnt   = tip(QLineEdit(), self.TIP_vanCmnt)
-        self.vanTemp   = tip(QLineEdit(), self.TIP_vanTemp)
+        self.vanTemp   = tip(SmallQLineEdit(), self.TIP_vanTemp)
 
-        self.ecRuns    = tip(QLineEdit(), self.TIP_ecRuns)
-        self.ecTemp    = tip(QLineEdit(), self.TIP_ecTemp)
+        self.ecRuns    = tip(SmallQLineEdit(), self.TIP_ecRuns)
+        self.ecTemp    = tip(SmallQLineEdit(), self.TIP_ecTemp)
         self.ecFactor  = tip(QDoubleSpinBox(), self.TIP_ecFactor)
 
         set_spin(self.ecFactor, 0, 1)
@@ -225,13 +231,12 @@ class TOFTOFSetupWidget(BaseWidget):
         grid.addWidget(QLabel('Vanadium runs'), 0, 0)
         grid.addWidget(self.vanRuns,            0, 1, 1, 3)
         grid.addWidget(QLabel('Van. comment'),  1, 0)
-        grid.addWidget(self.vanCmnt,            1, 1, 1, 1)
-        grid.addWidget(QLabel('Temp.'),         1, 2)
-        grid.addWidget(self.vanTemp,            1, 3, 1, 1)
+        grid.addWidget(self.vanCmnt,            1, 1, 1, 2)
+        grid.addLayout(hbox(QLabel('Temp.'), self.vanTemp),         1, 3)
         grid.addWidget(QLabel('Empty can runs'),2, 0)
-        grid.addLayout(hbox(self.ecRuns, QLabel('EC factor'), self.ecFactor), 2, 1, 1, 1)
-        grid.addWidget(QLabel('Temp.'),         2, 2)
-        grid.addWidget(self.ecTemp,             2, 3)
+        grid.addWidget(self.ecRuns,             2, 1, 1, 1)
+        grid.addLayout(hbox(QLabel('EC factor'), self.ecFactor), 2, 2, 1, 1)
+        grid.addLayout(hbox(QLabel('Temp.'), self.ecTemp),         2, 3)
         grid.addWidget(QLabel('Mask detectors'),3, 0)
         grid.addWidget(self.maskDetectors,      3, 1, 1, 3)
 

--- a/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
@@ -27,9 +27,10 @@ class TOFTOFSetupWidget(BaseWidget):
 
     TIP_vanRuns = ''
     TIP_vanCmnt = ''
-    TIP_vanTemp = 'Temperature in [K]. only required if none in data given'
+    TIP_vanTemp = 'Temperature in [K]. only required if none is in data given'
 
     TIP_ecRuns = ''
+    TIP_ecTemp = 'Temperature in [K]. only required if none is in data given'
     TIP_ecFactor = ''
 
     TIP_binEon = ''
@@ -98,6 +99,7 @@ class TOFTOFSetupWidget(BaseWidget):
         self.vanTemp   = tip(QLineEdit(), self.TIP_vanTemp)
 
         self.ecRuns    = tip(QLineEdit(), self.TIP_ecRuns)
+        self.ecTemp    = tip(QLineEdit(), self.TIP_ecTemp)
         self.ecFactor  = tip(QDoubleSpinBox(), self.TIP_ecFactor)
 
         set_spin(self.ecFactor, 0, 1)
@@ -164,10 +166,10 @@ class TOFTOFSetupWidget(BaseWidget):
                     box.addStretch(wgt)
             return box
 
-        def hbox(widgets):
+        def hbox(*widgets):
             return _box(QHBoxLayout, widgets)
 
-        def vbox(widgets):
+        def vbox(*widgets):
             return _box(QVBoxLayout, widgets)
 
         def label(text, tip):
@@ -187,11 +189,11 @@ class TOFTOFSetupWidget(BaseWidget):
         box = QVBoxLayout()
         self._layout.addLayout(box)
 
-        box.addLayout(hbox((gbDataDir, gbPrefix)))
-        box.addLayout(hbox((vbox((gbInputs, gbBinning, gbOptions, 1)), vbox((gbData, gbSave)))))
+        box.addLayout(hbox(gbDataDir, gbPrefix))
+        box.addLayout(hbox(vbox(gbInputs, gbBinning, gbOptions, 1), vbox(gbData, gbSave)))
 
-        gbDataDir.setLayout(hbox((self.dataDir, self.btnDataDir)))
-        gbPrefix.setLayout(hbox((self.prefix,)))
+        gbDataDir.setLayout(hbox(self.dataDir, self.btnDataDir))
+        gbPrefix.setLayout(hbox(self.prefix,))
 
         grid = QGridLayout()
         grid.addWidget(self.chkSubtractECVan,   0, 0, 1, 4)
@@ -228,9 +230,9 @@ class TOFTOFSetupWidget(BaseWidget):
         grid.addWidget(QLabel('Van. Temp.'),    1, 2)
         grid.addWidget(self.vanTemp,            1, 3, 1, 1)
         grid.addWidget(QLabel('Empty can runs'),2, 0)
-        grid.addWidget(self.ecRuns,             2, 1)
-        grid.addWidget(QLabel('EC factor'),     2, 2)
-        grid.addWidget(self.ecFactor,           2, 3)
+        grid.addLayout(hbox(self.ecRuns, QLabel('EC factor'), self.ecFactor), 2, 1, 1, 1)
+        grid.addWidget(QLabel('EC Temp.'),      2, 2)
+        grid.addWidget(self.ecTemp,             2, 3)
         grid.addWidget(QLabel('Mask detectors'),3, 0)
         grid.addWidget(self.maskDetectors,      3, 1, 1, 3)
 
@@ -259,7 +261,7 @@ class TOFTOFSetupWidget(BaseWidget):
 
         gbBinning.setLayout(grid)
 
-        gbData.setLayout(hbox((self.dataRunsView,)))
+        gbData.setLayout(hbox(self.dataRunsView))
 
         grid = QGridLayout()
         grid.addWidget(QLabel('Workspaces'),  0, 0)
@@ -274,7 +276,7 @@ class TOFTOFSetupWidget(BaseWidget):
         # disable save Ascii, it is not available for the moment
         self.chkAscii.setEnabled(False)
 
-        gbSave.setLayout(vbox((label('Directory',''), hbox((self.saveDir, self.btnSaveDir)), grid)))
+        gbSave.setLayout(vbox(label('Directory',''), hbox(self.saveDir, self.btnSaveDir), grid))
 
         # handle signals
         self.btnDataDir.clicked.connect(self._onDataDir)
@@ -327,6 +329,7 @@ class TOFTOFSetupWidget(BaseWidget):
         elem.vanTemp       = line_text(self.vanTemp)
 
         elem.ecRuns        = line_text(self.ecRuns)
+        elem.ecTemp        = line_text(self.ecTemp)
         elem.ecFactor      = self.ecFactor.value()
 
         elem.dataRuns      = self.runDataModel.tableData
@@ -376,6 +379,7 @@ class TOFTOFSetupWidget(BaseWidget):
         self.vanTemp.setText(elem.vanTemp)
 
         self.ecRuns.setText(elem.ecRuns)
+        self.ecTemp.setText(elem.ecTemp)
         self.ecFactor.setValue(elem.ecFactor)
 
         self.runDataModel.tableData = elem.dataRuns

--- a/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
@@ -130,7 +130,7 @@ class TOFTOFSetupWidget(BaseWidget):
 
         self.maskDetectors = tip(QLineEdit(), self.TIP_maskDetectors)
 
-        headers = ('Data runs', 'Comment', "Temperature [K]")
+        headers = ('Data runs', 'Comment', 'Temperature [K]')
         self.dataRunsView  = tip(DataTableView(self, headers), self.TIP_dataRunsView)
         self.dataRunsView.horizontalHeader().setStretchLastSection(True)
         self.dataRunsView.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)


### PR DESCRIPTION
**Description of work.**
added: 
 - temperature input fields for Vanadium runs and empty-can runs (optional)
 - a temperature input column to the data-runs table (optional)

changed:
 - moved `DataTableModel` and `DataTableView` classes from `TOFTOFSetupWidget` class to their own file.
 - Script generator sets `temperature` to ca constant value if the temperature for a run is set, otherwise it calculates it from the run log data

**To test:**
Start the TOFTOF data reduction GUI: Interfaces->Direct->DGS Reduction. Choose facility MLZ and instrument TOFTOF.

Get the test data
[testdata.zip](https://github.com/mantidproject/mantid/files/1356265/testdata.zip)

and make sure that the sample-log for 'temperature' is added to the Vanadium runs workspace is set to a the value set in the `T (K)`field, if (and only if) the field is not empty. Otherwise it should get the temperature from the runs own LogData.
For empty-can runs (EC-Runs) and each row of data-runs it should behave accordingly.

Fixes #22588. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

Does this update require release notes?
- [ ] Yes
- [ ] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
