### PR TITLE
Sans renames workspace groups correctly

### DIFF
--- a/Testing/SystemTests/tests/analysis/LOQReductionGUI.py
+++ b/Testing/SystemTests/tests/analysis/LOQReductionGUI.py
@@ -26,4 +26,4 @@ class LOQMinimalBatchReduction(stresstesting.MantidStressTest):
         # when overlaying the two options they overlap very well
         self.tolerance = 1.0e+1
         self.disableChecking.append('Instrument')
-        return 'first_time_merged', 'LOQReductionMergedData.nxs'
+        return 'first_time_merged_1D_2.2_10.0', 'LOQReductionMergedData.nxs'

--- a/Testing/SystemTests/tests/analysis/SANS2DReductionGUI.py
+++ b/Testing/SystemTests/tests/analysis/SANS2DReductionGUI.py
@@ -48,7 +48,7 @@ class SANS2DMinimalBatchReduction(stresstesting.MantidStressTest):
 
     def validate(self):
         self.disableChecking.append('Instrument')
-        return "trans_test_rear","SANSReductionGUI.nxs"
+        return "trans_test_rear_1D_1.5_12.5","SANSReductionGUI.nxs"
 
 
 class SANS2DMinimalSingleReduction(SANS2DMinimalBatchReduction):
@@ -62,7 +62,7 @@ class SANS2DMinimalSingleReduction(SANS2DMinimalBatchReduction):
         i.TransmissionSample('22041','22024')
         i.TransmissionCan('22024', '22024')
         reduced = i.WavRangeReduction()
-        RenameWorkspace(reduced, OutputWorkspace='trans_test_rear')
+        RenameWorkspace(reduced, OutputWorkspace='trans_test_rear_1D_1.5_12.5')
 
 
 class SANS2DGUIBatchReduction(SANS2DMinimalBatchReduction):
@@ -199,7 +199,7 @@ class SANS2DGUIBatchReduction(SANS2DMinimalBatchReduction):
         self.tolerance_is_reller = True
         self.tolerance = 1.0e-2
         self.disableChecking.append('Instrument')
-        return "trans_test_rear","SANSReductionGUI.nxs"
+        return "trans_test_rear_1D_1.5_12.5","SANSReductionGUI.nxs"
 
 
 class SANS2DGUIReduction(SANS2DGUIBatchReduction):
@@ -266,7 +266,7 @@ class SANS2DGUIReduction(SANS2DGUIBatchReduction):
 
         self.checkFittingSettings()
 
-        RenameWorkspace(reduced, OutputWorkspace='trans_test_rear')
+        RenameWorkspace(reduced, OutputWorkspace='trans_test_rear_1D_1.5_12.5')
 
         self.cleanReduction(_user_settings_copy)
 

--- a/Testing/SystemTests/tests/analysis/SANS2DSlicing.py
+++ b/Testing/SystemTests/tests/analysis/SANS2DSlicing.py
@@ -26,7 +26,7 @@ class SANS2DMinimalBatchReductionSliced(stresstesting.MantidStressTest):
         self.tolerance = 0.02
         self.tolerance_is_reller=True
         self.disableChecking.append('Instrument')
-        return str(mtd['trans_test_rear'][0]), 'SANSReductionGUI.nxs'
+        return str(mtd['trans_test_rear_1D_1.5_12.5'][0]), 'SANSReductionGUI.nxs'
 
 
 class SANS2DMinimalSingleReductionSliced(SANS2DMinimalBatchReductionSliced):
@@ -39,7 +39,7 @@ class SANS2DMinimalSingleReductionSliced(SANS2DMinimalBatchReductionSliced):
         i.TransmissionCan('22024', '22024')
         i.SetEventSlices("0.0-450, 5-10")
         reduced = i.WavRangeReduction()
-        RenameWorkspace(reduced, OutputWorkspace='trans_test_rear')
+        RenameWorkspace(reduced, OutputWorkspace='trans_test_rear_1D_1.5_12.5')
 
 
 if __name__ == "__main__":

--- a/scripts/SANS/ISISCommandInterface.py
+++ b/scripts/SANS/ISISCommandInterface.py
@@ -576,6 +576,8 @@ def _merge_workspaces(retWSname_front, retWSname_rear, rAnds):
     retWSname_merged = retWSname_rear
     if retWSname_merged.count('rear') == 1:
         retWSname_merged = retWSname_merged.replace('rear', 'merged')
+    elif retWSname_merged.count('main') == 1:
+        retWSname_merged = retWSname_merged.replace('main', 'merged')
     else:
         retWSname_merged = retWSname_merged + "_merged"
 

--- a/scripts/SANS/SANSBatchMode.py
+++ b/scripts/SANS/SANSBatchMode.py
@@ -340,7 +340,7 @@ def BatchReduce(filename, format, plotresults=False, saveAlgs={'SaveRKH':'txt'},
                 rear_reduced = reduced.replace('merged', 'rear')
                 front_reduced = reduced.replace('merged', 'front')
             else:
-                rear_reduced = reduced.replace('_merged', '')
+                rear_reduced = reduced.replace('merged', 'main')
                 front_reduced = rear_reduced.replace('main', 'HAB')
             new_name_Merged = su.rename_workspace_correctly(ins_name, su.ReducedType.Merged, final_name, reduced)
             new_name_LAB = su.rename_workspace_correctly(ins_name, su.ReducedType.LAB, final_name, rear_reduced)

--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -2060,16 +2060,26 @@ def rename_workspace_correctly(instrument_name, reduced_type, final_name, worksp
         else:
             return ""
 
-    run_number = re.findall(r'\d+', workspace)[0]
     reduced_workspace = mtd[workspace]
-    final_suffix = get_suffix(instrument_name, reduced_type)
     workspaces_to_rename = [workspace]
+
     if isinstance(reduced_workspace, WorkspaceGroup):
         workspaces_to_rename += reduced_workspace.getNames()
-    for workspace_name in workspaces_to_rename:
-        complete_name = workspace_name.replace(run_number, final_name + '_')
-        RenameWorkspace(InputWorkspace=workspace_name, OutputWorkspace=complete_name)
-    return workspace.replace(run_number, final_name + '_')
+
+    run_number = re.findall(r'\d+', workspace)[0] if re.findall(r'\d+', workspace) else None
+
+    if run_number and workspace.startswith(run_number):
+        for workspace_name in workspaces_to_rename:
+            complete_name = workspace_name.replace(run_number, final_name + '_')
+            RenameWorkspace(InputWorkspace=workspace_name, OutputWorkspace=complete_name)
+        return workspace.replace(run_number, final_name + '_')
+    else:
+        final_suffix = get_suffix(instrument_name, reduced_type)
+        for workspace_name in workspaces_to_rename:
+            complete_name = workspace_name.replace(workspace, final_name) + final_suffix
+            RenameWorkspace(InputWorkspace=workspace_name, OutputWorkspace=complete_name)
+        return final_name + final_suffix
+
 
 
 ###############################################################################

--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -2059,10 +2059,15 @@ def rename_workspace_correctly(instrument_name, reduced_type, final_name, worksp
             return suffix
         else:
             return ""
+    reduced_workspace = mtd[workspace]
     final_suffix = get_suffix(instrument_name, reduced_type)
-    complete_name = final_name + final_suffix
-    RenameWorkspace(InputWorkspace=workspace, OutputWorkspace=complete_name)
-    return complete_name
+    workspaces_to_rename = [workspace]
+    if isinstance(reduced_workspace, WorkspaceGroup):
+        workspaces_to_rename += reduced_workspace.getNames()
+    for workspace_name in workspaces_to_rename:
+        complete_name = workspace_name.replace(workspace, final_name) + final_suffix
+        RenameWorkspace(InputWorkspace=workspace_name, OutputWorkspace=complete_name)
+    return final_name + final_suffix
 
 
 ###############################################################################

--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -2081,7 +2081,6 @@ def rename_workspace_correctly(instrument_name, reduced_type, final_name, worksp
         return final_name + final_suffix
 
 
-
 ###############################################################################
 ######################### Start of Deprecated Code ############################
 ###############################################################################

--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -2062,7 +2062,6 @@ def rename_workspace_correctly(instrument_name, reduced_type, final_name, worksp
 
     run_number = re.findall(r'\d+', workspace)[0]
     reduced_workspace = mtd[workspace]
-    final_suffix = get_suffix(instrument_name, reduced_type)
     workspaces_to_rename = [workspace]
     if isinstance(reduced_workspace, WorkspaceGroup):
         workspaces_to_rename += reduced_workspace.getNames()

--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -2059,15 +2059,17 @@ def rename_workspace_correctly(instrument_name, reduced_type, final_name, worksp
             return suffix
         else:
             return ""
+
+    run_number = re.findall(r'\d+', workspace)[0]
     reduced_workspace = mtd[workspace]
     final_suffix = get_suffix(instrument_name, reduced_type)
     workspaces_to_rename = [workspace]
     if isinstance(reduced_workspace, WorkspaceGroup):
         workspaces_to_rename += reduced_workspace.getNames()
     for workspace_name in workspaces_to_rename:
-        complete_name = workspace_name.replace(workspace, final_name) + final_suffix
+        complete_name = workspace_name.replace(run_number, final_name + '_')
         RenameWorkspace(InputWorkspace=workspace_name, OutputWorkspace=complete_name)
-    return final_name + final_suffix
+    return workspace.replace(run_number, final_name + '_')
 
 
 ###############################################################################

--- a/scripts/test/SANSUtilityTest.py
+++ b/scripts/test/SANSUtilityTest.py
@@ -1633,28 +1633,48 @@ class TestRenamingOfBatchModeWorkspaces(unittest.TestCase):
 
     def test_that_SANS2D_workspace_is_renamed_correctly(self):
         workspace = self._create_sample_workspace()
-        out_name = su.rename_workspace_correctly("SANS2D", su.ReducedType.LAB, "test", workspace)
+        workspace_name = workspace.getName()
+        out_name = su.rename_workspace_correctly("SANS2D", su.ReducedType.LAB, "test", workspace_name)
         self.assertTrue(AnalysisDataService.doesExist("test_rear"))
         self.assertTrue(out_name == "test_rear")
-        out_name = su.rename_workspace_correctly("SANS2D", su.ReducedType.HAB, "test", workspace)
+        out_name = su.rename_workspace_correctly("SANS2D", su.ReducedType.HAB, "test", out_name)
         self.assertTrue(AnalysisDataService.doesExist("test_front"))
         self.assertTrue(out_name == "test_front")
-        out_name = su.rename_workspace_correctly("SANS2D", su.ReducedType.Merged, "test", workspace)
+        out_name = su.rename_workspace_correctly("SANS2D", su.ReducedType.Merged, "test", out_name)
         self.assertTrue(AnalysisDataService.doesExist("test_merged"))
         self.assertTrue(out_name == "test_merged")
 
         if AnalysisDataService.doesExist("test_merged"):
             AnalysisDataService.remove("test_merged")
 
+    def test_for_a_group_workspace_renames_entire_group(self):
+        workspace_t0_T1 = CreateSampleWorkspace(Function='Flat background', NumBanks=1, BankPixelWidth=1, NumEvents=1,
+                                   XMin=1, XMax=14, BinWidth=2)
+        workspace_t1_T2 = CreateSampleWorkspace(Function='Flat background', NumBanks=1, BankPixelWidth=1, NumEvents=1,
+                                   XMin=1, XMax=14, BinWidth=2)
+        workspace_name = 'workspace'
+        GroupWorkspaces(InputWorkspaces=['workspace_t0_T1', 'workspace_t1_T2'], OutputWorkspace=workspace_name)
+
+        out_name = su.rename_workspace_correctly("SANS2D", su.ReducedType.LAB, "test", workspace_name)
+        self.assertTrue(AnalysisDataService.doesExist("test_rear"))
+        self.assertTrue(AnalysisDataService.doesExist("test_t0_T1_rear"))
+        self.assertTrue(AnalysisDataService.doesExist("test_t1_T2_rear"))
+        self.assertEqual(out_name, "test_rear")
+
+        AnalysisDataService.remove("test_t1_T2_rear")
+        AnalysisDataService.remove("test_t0_T1_rear")
+        AnalysisDataService.remove("test_rear")
+
     def test_that_LOQ_workspace_is_renamed_correctly(self):
         workspace = self._create_sample_workspace()
-        out_name = su.rename_workspace_correctly("LOQ", su.ReducedType.LAB, "test", workspace)
+        workspace_name = workspace.getName()
+        out_name = su.rename_workspace_correctly("LOQ", su.ReducedType.LAB, "test", workspace_name)
         self.assertTrue(AnalysisDataService.doesExist("test_main"))
         self.assertTrue(out_name == "test_main")
-        out_name = su.rename_workspace_correctly("LOQ", su.ReducedType.HAB, "test", workspace)
+        out_name = su.rename_workspace_correctly("LOQ", su.ReducedType.HAB, "test", out_name)
         self.assertTrue(AnalysisDataService.doesExist("test_hab"))
         self.assertTrue(out_name == "test_hab")
-        out_name = su.rename_workspace_correctly("LOQ", su.ReducedType.Merged, "test", workspace)
+        out_name = su.rename_workspace_correctly("LOQ", su.ReducedType.Merged, "test", out_name)
         self.assertTrue(AnalysisDataService.doesExist("test_merged"))
         self.assertTrue(out_name == "test_merged")
 
@@ -1663,7 +1683,9 @@ class TestRenamingOfBatchModeWorkspaces(unittest.TestCase):
 
     def test_that_LAMROR_workspace_is_not_renamed(self):
         workspace = self._create_sample_workspace()
-        out_name = su.rename_workspace_correctly("LARMOR", su.ReducedType.LAB, "test", workspace)
+        workspace_name = workspace.getName()
+
+        out_name = su.rename_workspace_correctly("LARMOR", su.ReducedType.LAB, "test", workspace_name)
         self.assertTrue(AnalysisDataService.doesExist("test"))
         self.assertTrue(out_name == "test")
 
@@ -1672,8 +1694,11 @@ class TestRenamingOfBatchModeWorkspaces(unittest.TestCase):
 
     def test_that_raies_for_unkown_reduction_type(self):
         workspace = self._create_sample_workspace()
-        args = ["SANS2D", "jsdlkfsldkfj", "test", workspace]
+        workspace_name = workspace.getName()
+        args = ["SANS2D", "jsdlkfsldkfj", "test", workspace_name]
+
         self.assertRaises(RuntimeError, su.rename_workspace_correctly, *args)
+
         AnalysisDataService.remove("ws")
 
 


### PR DESCRIPTION

**Description of work.**

This changes how the workspaces within workspace groups are renamed in the sans reduction. The individual members of the group are now renamed in line with the group itself.

**Report to:** sarah.rogers@stfc.ac.uk <!--If the original issue was raised by a user they should be named here.-->

**To test:**

The test files for this PR are available from //olympic/babylon5/Scratch/Matthew Andrew/SANS2DSAMPLE

* Open the old Isis Sans GUI,
* Select SANS2D as the instrument
* Load the maskfile from the folder (this is the *.txt file)
* Select Batch mode and load a batch file (this is the *.csv file)
* Type 1:1:3 into the event slices box. This is specifying the event slices you want to reduce and in this case between 1 and 3 in steps of 1
*  Click 1D Reduce
* At the end of the reduction confirm that there is a workspace group called line_1_reduction_rear which contains line_1_reduction_t1_T2_rear and line_1_reduction_t2_T3_rear.

<!-- Instructions for testing. -->

Fixes #18933. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

Release notes are here #22628
- [x] Yes
- [ ] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
