### PR TITLE
(Topic Branches) Recovery background thread

### DIFF
--- a/Framework/API/inc/MantidAPI/FileProperty.h
+++ b/Framework/API/inc/MantidAPI/FileProperty.h
@@ -86,6 +86,9 @@ public:
   /// Returns the main file extension that's used
   std::string getDefaultExt() const { return m_defaultExt; }
 
+  /// Returns the path to the users home directory
+  static std::string FileProperty::getHomePath();
+
   // Unhide the PropertyWithValue assignment operator
   using Kernel::PropertyWithValue<std::string>::operator=;
 

--- a/Framework/API/inc/MantidAPI/FileProperty.h
+++ b/Framework/API/inc/MantidAPI/FileProperty.h
@@ -86,9 +86,6 @@ public:
   /// Returns the main file extension that's used
   std::string getDefaultExt() const { return m_defaultExt; }
 
-  /// Returns the path to the users home directory
-  static std::string FileProperty::getHomePath();
-
   // Unhide the PropertyWithValue assignment operator
   using Kernel::PropertyWithValue<std::string>::operator=;
 

--- a/Framework/API/src/FileProperty.cpp
+++ b/Framework/API/src/FileProperty.cpp
@@ -56,6 +56,32 @@ void addExtension(const std::string &extension,
     extensions.push_back(extension);
 }
 
+/**
+ * Get the path to the user's home directory (associated with ~) if it is set
+ * as an environment variable, and cache it
+ * @return The user's home path
+ */
+const std::string &getHomePath() {
+  static std::string homePath;
+  static bool initialised(false);
+
+  if (initialised) {
+    return homePath;
+  }
+  initialised = true;
+
+  char *home = std::getenv("HOME"); // Usually set on Windows and UNIX
+  if (home) {
+    homePath = std::string(home);
+    return homePath;
+  }
+
+  char *userProfile = std::getenv("USERPROFILE"); // Not usually set on UNIX
+  // Return even if it's an empty string, as we can do no better
+  homePath = userProfile ? std::string(userProfile) : "";
+  return homePath;
+}
+
 /** Expand user variables in file path.
  *  On Windows and UNIX, ~ is replaced by the user's home directory, if found.
  *  If the path contains no user variables, or expansion fails, the path is
@@ -82,7 +108,7 @@ std::string expandUser(const std::string &filepath) {
   if (std::distance(start, nextSlash) != 1)
     return filepath;
 
-  return FileProperty::getHomePath() + std::string(nextSlash, end);
+  return getHomePath() + std::string(nextSlash, end);
 }
 
 /**
@@ -262,33 +288,6 @@ std::string FileProperty::isValid() const {
     return PropertyWithValue<std::string>::isValid();
   }
 }
-
-/**
-* Get the path to the user's home directory (associated with ~) if it is set
-* as an environment variable, and cache it
-* @return The user's home path
-*/
-std::string FileProperty::getHomePath() {
-	static std::string homePath;
-	static bool initialised(false);
-
-	if (initialised) {
-		return homePath;
-	}
-	initialised = true;
-
-	char *home = std::getenv("HOME"); // Usually set on Windows and UNIX
-	if (home) {
-		homePath = std::string(home);
-		return homePath;
-	}
-
-	char *userProfile = std::getenv("USERPROFILE"); // Not usually set on UNIX
-													// Return even if it's an empty string, as we can do no better
-	homePath = userProfile ? std::string(userProfile) : "";
-	return homePath;
-}
-
 
 /**
  * @returns a string depending on whether an empty value is valid

--- a/Framework/API/src/FileProperty.cpp
+++ b/Framework/API/src/FileProperty.cpp
@@ -56,32 +56,6 @@ void addExtension(const std::string &extension,
     extensions.push_back(extension);
 }
 
-/**
- * Get the path to the user's home directory (associated with ~) if it is set
- * as an environment variable, and cache it
- * @return The user's home path
- */
-const std::string &getHomePath() {
-  static std::string homePath;
-  static bool initialised(false);
-
-  if (initialised) {
-    return homePath;
-  }
-  initialised = true;
-
-  char *home = std::getenv("HOME"); // Usually set on Windows and UNIX
-  if (home) {
-    homePath = std::string(home);
-    return homePath;
-  }
-
-  char *userProfile = std::getenv("USERPROFILE"); // Not usually set on UNIX
-  // Return even if it's an empty string, as we can do no better
-  homePath = userProfile ? std::string(userProfile) : "";
-  return homePath;
-}
-
 /** Expand user variables in file path.
  *  On Windows and UNIX, ~ is replaced by the user's home directory, if found.
  *  If the path contains no user variables, or expansion fails, the path is
@@ -108,7 +82,7 @@ std::string expandUser(const std::string &filepath) {
   if (std::distance(start, nextSlash) != 1)
     return filepath;
 
-  return getHomePath() + std::string(nextSlash, end);
+  return FileProperty::getHomePath() + std::string(nextSlash, end);
 }
 
 /**
@@ -288,6 +262,33 @@ std::string FileProperty::isValid() const {
     return PropertyWithValue<std::string>::isValid();
   }
 }
+
+/**
+* Get the path to the user's home directory (associated with ~) if it is set
+* as an environment variable, and cache it
+* @return The user's home path
+*/
+std::string FileProperty::getHomePath() {
+	static std::string homePath;
+	static bool initialised(false);
+
+	if (initialised) {
+		return homePath;
+	}
+	initialised = true;
+
+	char *home = std::getenv("HOME"); // Usually set on Windows and UNIX
+	if (home) {
+		homePath = std::string(home);
+		return homePath;
+	}
+
+	char *userProfile = std::getenv("USERPROFILE"); // Not usually set on UNIX
+													// Return even if it's an empty string, as we can do no better
+	homePath = userProfile ? std::string(userProfile) : "";
+	return homePath;
+}
+
 
 /**
  * @returns a string depending on whether an empty value is valid

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -1408,6 +1408,22 @@ def _attach_algorithm_func_as_method(method_name, algorithm_wrapper, algm_object
 
 # -------------------------------------------------------------------------------------------------------------
 
+
+def write_all_workspaces_histories(folder):
+    logger.debug("Project Recovery: Started workspace history saving")
+    folder = os.path.normpath(folder)
+    if not os.path.exists(folder):
+        logger.information("Creating path")
+        os.makedirs(folder)
+
+    for ws in mtd.getObjectNames():
+        ws_obj = mtd[ws]
+        name = ws_obj.name()
+        filename = os.path.join(folder, name + '.py')
+        write_workspace_history(ws_obj, filename)
+    logger.debug("Project Recovery: Saved workspace histories")
+
+
 def write_workspace_history(ws, filename=None):
     """
        Writes the history of the workspace to a .py file that can be used to re-load the state
@@ -1433,18 +1449,7 @@ def write_workspace_history(ws, filename=None):
         prop_val_string.append([ ''.join((i[0], '=\'', i[1], '\', ')) for i in pv])
     pv_string = [''.join(i[:])[:-2] for i in prop_val_string]
 # Convert list of strings to a single string, removing trailin comma
+    logger.debug("Project Recovery: Saving to {0}".format(filename))
     with open(filename, 'w') as f:
         for i in range(len(hist.getAlgorithmHistories())):
             f.write('%s(%s) # %s \n' % (names[i], pv_string[i], dates[i]))
-
-# Save out a project file - 
-# TODO: this assumes that MantidPlot is open, we need to add a check later
-    # Swap .py extension for .project
-    project_filename = filename.strip(".py")
-    project_filename += ".project"
-
-    # TODO: Remove this terrible workaround. It must NOT be merged into master
-    from pymantidplot import get_project_recovery_handle
-
-    project_writer = get_project_recovery_handle()
-    project_writer.saveOpenWindows(project_filename)

--- a/MantidPlot/CMakeLists.txt
+++ b/MantidPlot/CMakeLists.txt
@@ -91,7 +91,7 @@ set ( QTIPLOT_SRCS src/ApplicationWindow.cpp
                    src/PluginFit.cpp
                    src/PolynomFitDialog.cpp
                    src/PolynomialFit.cpp
-                   src/ProjectRecoveryAdaptor.cpp
+                   src/ProjectRecoveryThread.cpp
                    src/ProjectSaveView.cpp
                    src/ProjectSerialiser.cpp
                    src/PythonScript.cpp
@@ -291,7 +291,7 @@ set ( QTIPLOT_HDRS src/ApplicationWindow.h
                    src/PluginFit.h
                    src/PolynomFitDialog.h
                    src/PolynomialFit.h
-                   src/ProjectRecoveryAdaptor.h
+                   src/ProjectRecoveryThread.h
                    src/ProjectSerialiser.h
                    src/ProjectSaveView.h
                    src/PythonScript.h

--- a/MantidPlot/pymantidplot/__init__.py
+++ b/MantidPlot/pymantidplot/__init__.py
@@ -69,14 +69,6 @@ def runPythonScript(code, async=False, quiet=False, redirect=True):
         async = False
     threadsafe_call(_qti.app.runPythonScript, code, async, quiet, redirect)
 
-def get_project_recovery_handle():
-    """Returns a pointer which can be used to save and load MantidPlot
-    windows as part of project recovery
-
-    Returns:
-        A handle to a ProjectRecoveryAdaptor
-    """
-    return new_proxy(proxies.MDIWindow, _qti.app.getRecoveryHandle)
 
 # Overload for consistency with qtiplot table(..) & matrix(..) commands
 def workspace(name):

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -247,31 +247,21 @@ void file_uncompress(const char *file);
 }
 
 ApplicationWindow::ApplicationWindow(bool factorySettings)
-    : QMainWindow(), Scripted(ScriptingLangManager::newEnv(this)),
-      blockWindowActivation(false), m_enableQtiPlotFitting(false),
-      m_exitCode(0),
-#ifdef Q_OS_MAC // Mac
-      settings(QSettings::IniFormat, QSettings::UserScope, "Mantid",
-               "MantidPlot")
-#else
-      settings("Mantid", "MantidPlot")
-#endif
-{
-  QStringList empty;
-  init(factorySettings, empty);
-}
+// Delegate with an empty string list for the arguments
+	: ApplicationWindow(factorySettings, QStringList{}) {}
 
 ApplicationWindow::ApplicationWindow(bool factorySettings,
-                                     const QStringList &args)
-    : QMainWindow(), Scripted(ScriptingLangManager::newEnv(this)),
-      blockWindowActivation(false), m_enableQtiPlotFitting(false),
-      m_exitCode(0),
+	const QStringList &args)
+	: QMainWindow(), Scripted(ScriptingLangManager::newEnv(this)),
+	blockWindowActivation(false), m_enableQtiPlotFitting(false),
+	m_exitCode(0), 
 #ifdef Q_OS_MAC // Mac
       settings(QSettings::IniFormat, QSettings::UserScope, "Mantid",
-               "MantidPlot")
+               "MantidPlot"),
 #else
-      settings("Mantid", "MantidPlot")
+      settings("Mantid", "MantidPlot"),
 #endif
+	m_projectRecoveryThread(this)
 {
   init(factorySettings, args);
 }
@@ -279,7 +269,7 @@ ApplicationWindow::ApplicationWindow(bool factorySettings,
 /**
  * This function is responsible for copying the old configuration
  * information from the ISIS\MantidPlot area to the new Mantid\MantidPlot
- * area. The old area is deleted once the trnasfer is complete. On subsequent
+ * area. The old area is deleted once the transfer is complete. On subsequent
  * runs, if the old configuration area is missing or empty, the copying
  * is ignored.
  */
@@ -11691,11 +11681,6 @@ void ApplicationWindow::createActions() {
   connect(actionNewTiledWindow, SIGNAL(triggered()), this,
           SLOT(newTiledWindow()));
 
-  actionGetRecoveryHandle = new MantidQt::MantidWidgets::TrackedAction(
-      tr("Get recovery handle"), this);
-  connect(actionGetRecoveryHandle, SIGNAL(triggered()), this,
-          SLOT(getRecoveryHandle()));
-
   actionNewMatrix = new MantidQt::MantidWidgets::TrackedAction(
       QIcon(getQPixmap("new_matrix_xpm")), tr("New &Matrix"), this);
   actionNewMatrix->setShortcut(tr("Ctrl+M"));
@@ -16732,10 +16717,4 @@ void ApplicationWindow::dropInTiledWindow(MdiSubWindow *w, QPoint pos) {
 bool ApplicationWindow::isOfType(const QObject *obj,
                                  const char *toCompare) const {
   return strcmp(obj->metaObject()->className(), toCompare) == 0;
-}
-
-ProjectRecoveryAdaptor *ApplicationWindow::getRecoveryHandle() {
-  auto adaptorHandle =
-      Mantid::Kernel::make_unique<MantidQt::API::ProjectRecoveryAdaptor>(this);
-  return adaptorHandle.release();
 }

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -247,22 +247,21 @@ void file_uncompress(const char *file);
 }
 
 ApplicationWindow::ApplicationWindow(bool factorySettings)
-// Delegate with an empty string list for the arguments
-	: ApplicationWindow(factorySettings, QStringList{}) {}
+    // Delegate with an empty string list for the arguments
+    : ApplicationWindow(factorySettings, QStringList{}) {}
 
 ApplicationWindow::ApplicationWindow(bool factorySettings,
-	const QStringList &args)
-	: QMainWindow(), Scripted(ScriptingLangManager::newEnv(this)),
-	blockWindowActivation(false), m_enableQtiPlotFitting(false),
-	m_exitCode(0), 
+                                     const QStringList &args)
+    : QMainWindow(), Scripted(ScriptingLangManager::newEnv(this)),
+      blockWindowActivation(false), m_enableQtiPlotFitting(false),
+      m_exitCode(0),
 #ifdef Q_OS_MAC // Mac
       settings(QSettings::IniFormat, QSettings::UserScope, "Mantid",
                "MantidPlot"),
 #else
       settings("Mantid", "MantidPlot"),
 #endif
-	m_projectRecoveryThread(this)
-{
+      m_projectRecoveryThread(this) {
   init(factorySettings, args);
 }
 
@@ -12771,7 +12770,6 @@ void ApplicationWindow::createActions() {
       QIcon(":/waterfall_plot.png"), tr("&Waterfall Plot"), this);
   connect(actionWaterfallPlot, SIGNAL(triggered()), this,
           SLOT(waterfallPlot()));
-
 }
 
 void ApplicationWindow::translateActionsStrings() {
@@ -16723,7 +16721,7 @@ bool ApplicationWindow::isOfType(const QObject *obj,
 }
 
 void ApplicationWindow::saveProjectRecovery(const std::string destination) {
-	const bool isRecovery = true;
-	ProjectSerialiser projectWriter(this, isRecovery);
-	projectWriter.save(QString::fromStdString(destination));
+  const bool isRecovery = true;
+  ProjectSerialiser projectWriter(this, isRecovery);
+  projectWriter.save(QString::fromStdString(destination));
 }

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -9770,6 +9770,8 @@ void ApplicationWindow::closeEvent(QCloseEvent *ce) {
   // cleaned up meaning we cannot rely on the deleteLater functionality to
   // work correctly as this will happen in the next iteration of the event loop,
   // i.e after the python shutdown code has been run below.
+  m_shuttingDown = true;
+
   MDIWindowList windows = getAllWindows();
   for (auto &win : windows) {
     win->confirmClose(false);
@@ -12769,6 +12771,7 @@ void ApplicationWindow::createActions() {
       QIcon(":/waterfall_plot.png"), tr("&Waterfall Plot"), this);
   connect(actionWaterfallPlot, SIGNAL(triggered()), this,
           SLOT(waterfallPlot()));
+
 }
 
 void ApplicationWindow::translateActionsStrings() {
@@ -15063,7 +15066,7 @@ void ApplicationWindow::onScriptExecuteError(const QString &message,
  */
 bool ApplicationWindow::runPythonScript(const QString &code, bool async,
                                         bool quiet, bool redirect) {
-  if (code.isEmpty())
+  if (code.isEmpty() || m_shuttingDown)
     return false;
   if (!m_iface_script) {
     if (setScriptingLanguage("Python")) {
@@ -16717,4 +16720,10 @@ void ApplicationWindow::dropInTiledWindow(MdiSubWindow *w, QPoint pos) {
 bool ApplicationWindow::isOfType(const QObject *obj,
                                  const char *toCompare) const {
   return strcmp(obj->metaObject()->className(), toCompare) == 0;
+}
+
+void ApplicationWindow::saveProjectRecovery(const std::string destination) {
+	const bool isRecovery = true;
+	ProjectSerialiser projectWriter(this, isRecovery);
+	projectWriter.save(QString::fromStdString(destination));
 }

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -16720,7 +16720,7 @@ bool ApplicationWindow::isOfType(const QObject *obj,
   return strcmp(obj->metaObject()->className(), toCompare) == 0;
 }
 
-void ApplicationWindow::saveProjectRecovery(const std::string destination) {
+void ApplicationWindow::saveProjectRecovery(std::string destination) {
   const bool isRecovery = true;
   ProjectSerialiser projectWriter(this, isRecovery);
   projectWriter.save(QString::fromStdString(destination));

--- a/MantidPlot/src/ApplicationWindow.h
+++ b/MantidPlot/src/ApplicationWindow.h
@@ -1123,7 +1123,9 @@ public slots:
 
   bool isOfType(const QObject *obj, const char *toCompare) const;
 
-  void saveProjectRecovery(const std::string destination);
+  // Note: The string must be copied from the other thread in saveProjectRecovery
+  /// Saves the current project as part of recovery auto saving
+  void saveProjectRecovery(std::string destination); 
 
 signals:
   void modified();

--- a/MantidPlot/src/ApplicationWindow.h
+++ b/MantidPlot/src/ApplicationWindow.h
@@ -45,7 +45,7 @@ Description          : QtiPlot's main window
 #include "MantidQtWidgets/Common/HelpWindow.h"
 #include "MantidQtWidgets/Common/IProjectSerialisable.h"
 
-#include "ProjectRecoveryAdaptor.h"
+#include "ProjectRecoveryThread.h"
 #include "ProjectSaveView.h"
 #include "Script.h"
 #include "Scripted.h"
@@ -1123,8 +1123,6 @@ public slots:
 
   bool isOfType(const QObject *obj, const char *toCompare) const;
 
-  MantidQt::API::ProjectRecoveryAdaptor *getRecoveryHandle();
-
 signals:
   void modified();
   void shutting_down();
@@ -1604,7 +1602,6 @@ private:
   QAction *actionPanPlot;
   QAction *actionWaterfallPlot;
   QAction *actionNewTiledWindow;
-  QAction *actionGetRecoveryHandle;
 
   QList<QAction *> d_user_actions;
   QList<QMenu *> d_user_menus; // Mantid
@@ -1630,6 +1627,10 @@ private:
   bool blockWindowActivation;
   ///
   bool m_enableQtiPlotFitting;
+
+  /// Owns a thread which automatically triggers project recovery for the GUI
+  MantidQt::API::ProjectRecoveryThread m_projectRecoveryThread;
+
 
 #ifdef SHARED_MENUBAR
   QMenuBar *m_sharedMenuBar; ///< Pointer to the shared menubar

--- a/MantidPlot/src/ApplicationWindow.h
+++ b/MantidPlot/src/ApplicationWindow.h
@@ -1123,6 +1123,8 @@ public slots:
 
   bool isOfType(const QObject *obj, const char *toCompare) const;
 
+  void saveProjectRecovery(const std::string destination);
+
 signals:
   void modified();
   void shutting_down();
@@ -1628,8 +1630,12 @@ private:
   ///
   bool m_enableQtiPlotFitting;
 
+  /// Set to true when the main window is shutting down
+  bool m_shuttingDown{ false };
+
   /// Owns a thread which automatically triggers project recovery for the GUI
   MantidQt::API::ProjectRecoveryThread m_projectRecoveryThread;
+
 
 
 #ifdef SHARED_MENUBAR

--- a/MantidPlot/src/ApplicationWindow.h
+++ b/MantidPlot/src/ApplicationWindow.h
@@ -1631,12 +1631,10 @@ private:
   bool m_enableQtiPlotFitting;
 
   /// Set to true when the main window is shutting down
-  bool m_shuttingDown{ false };
+  bool m_shuttingDown{false};
 
   /// Owns a thread which automatically triggers project recovery for the GUI
   MantidQt::API::ProjectRecoveryThread m_projectRecoveryThread;
-
-
 
 #ifdef SHARED_MENUBAR
   QMenuBar *m_sharedMenuBar; ///< Pointer to the shared menubar

--- a/MantidPlot/src/ProjectRecoveryThread.cpp
+++ b/MantidPlot/src/ProjectRecoveryThread.cpp
@@ -1,23 +1,88 @@
-#include <string>
-
-#include "qstring.h"
+#include "ProjectRecoveryThread.h"
 
 #include "ApplicationWindow.h"
 #include "globals.h"
 #include "Folder.h"
-#include "ProjectRecoveryThread.h"
 #include "ProjectSerialiser.h"
+
+#include "MantidAPI/FileProperty.h"
+
+#include <chrono>
+#include <string>
+#include <thread>
+
+namespace {
+	const std::chrono::seconds TIME_BETWEEN_SAVING = std::chrono::seconds(30);
+
+	std::string getOutputPath() {
+		std::string homePath = Mantid::API::FileProperty::getHomePath();
+		std::string filename = "test";
+		std::string fullBasePath = homePath + '/' + homePath;
+		return fullBasePath;
+	}
+}
 
 namespace MantidQt {
 namespace API {
 
 ProjectRecoveryThread::ProjectRecoveryThread(ApplicationWindow *windowHandle)
-    : m_windowPtr(windowHandle) {}
+    : m_windowPtr(windowHandle), m_backgroundSavingThread(), m_runProjectSaving(true) {
+	startProjectSaving();
+}
+
+ProjectRecoveryThread::~ProjectRecoveryThread() {
+	stopProjectSaving();
+}
+
+std::thread ProjectRecoveryThread::createBackgroundThread() {
+	return std::thread([this] {projectSavingThread(m_runProjectSaving); });
+}
+
+void ProjectRecoveryThread::startProjectSaving() {
+	m_runProjectSaving = true;
+
+	// Close the existing thread first
+	if (m_backgroundSavingThread.joinable()) {
+		m_backgroundSavingThread.join();
+	}
+
+	// Attempt to spin up a new thread
+	m_backgroundSavingThread = createBackgroundThread();
+}
+
+void ProjectRecoveryThread::stopProjectSaving() {
+	m_runProjectSaving = false;
+
+	if (m_backgroundSavingThread.joinable()) {
+		m_backgroundSavingThread.join();
+	}
+}
+
+
+
+void ProjectRecoveryThread::projectSavingThread(bool &runThread) {
+	while (runThread) {
+		// Generate output paths
+		const auto basePath = getOutputPath();
+		const std::string historyDest = basePath + ".history";
+		const std::string projectDest = basePath + ".project";
+
+		// Trigger main saving routines for the ADS and GUI
+		saveWsHistories(historyDest);
+		//saveOpenWindows(projectDest);
+		std::this_thread::sleep_for(TIME_BETWEEN_SAVING);
+	}
+}
 
 void ProjectRecoveryThread::saveOpenWindows(std::string projectFilepath) {
   const bool isRecovery = true;
   ProjectSerialiser projectWriter(m_windowPtr, isRecovery);
   projectWriter.save(QString::fromStdString(projectFilepath));
+}
+
+void ProjectRecoveryThread::saveWsHistories(std::string historyFilePath) {
+	// TODO
+	int foo = 2;
 }
 
 void ProjectRecoveryThread::loadOpenWindows(std::string projectFilePath) {

--- a/MantidPlot/src/ProjectRecoveryThread.cpp
+++ b/MantidPlot/src/ProjectRecoveryThread.cpp
@@ -5,22 +5,22 @@
 #include "ApplicationWindow.h"
 #include "globals.h"
 #include "Folder.h"
-#include "ProjectRecoveryAdaptor.h"
+#include "ProjectRecoveryThread.h"
 #include "ProjectSerialiser.h"
 
 namespace MantidQt {
 namespace API {
 
-ProjectRecoveryAdaptor::ProjectRecoveryAdaptor(ApplicationWindow *windowHandle)
+ProjectRecoveryThread::ProjectRecoveryThread(ApplicationWindow *windowHandle)
     : m_windowPtr(windowHandle) {}
 
-void ProjectRecoveryAdaptor::saveOpenWindows(std::string projectFilepath) {
+void ProjectRecoveryThread::saveOpenWindows(std::string projectFilepath) {
   const bool isRecovery = true;
   ProjectSerialiser projectWriter(m_windowPtr, isRecovery);
   projectWriter.save(QString::fromStdString(projectFilepath));
 }
 
-void ProjectRecoveryAdaptor::loadOpenWindows(std::string projectFilePath) {
+void ProjectRecoveryThread::loadOpenWindows(std::string projectFilePath) {
   const bool isRecovery = true;
   ProjectSerialiser projectWriter(m_windowPtr, isRecovery);
 

--- a/MantidPlot/src/ProjectRecoveryThread.cpp
+++ b/MantidPlot/src/ProjectRecoveryThread.cpp
@@ -98,8 +98,8 @@ void ProjectRecoveryThread::projectSavingThread() {
     const auto basePath = getOutputPath();
     auto projectFile = Poco::Path(basePath).append(getOutputProjectName());
 
-	// Python's OS module cannot handle Poco's parsed paths
-	// so use std::string instead and let OS parse the '/' char on Win
+    // Python's OS module cannot handle Poco's parsed paths
+    // so use std::string instead and let OS parse the '/' char on Win
     saveWsHistories(basePath);
     saveOpenWindows(projectFile.toString());
     g_log.information("Project Recovery: Saving finished");

--- a/MantidPlot/src/ProjectRecoveryThread.h
+++ b/MantidPlot/src/ProjectRecoveryThread.h
@@ -41,7 +41,7 @@ namespace MantidQt {
 namespace API {
 class ProjectRecoveryThread {
 public:
-	/// Constructor
+  /// Constructor
   explicit ProjectRecoveryThread(ApplicationWindow *windowHandle);
   /// Destructor the ensures background thread stops
   ~ProjectRecoveryThread();
@@ -52,9 +52,9 @@ public:
   void stopProjectSaving();
 
 private:
-	/// Captures the current object in the background thread
+  /// Captures the current object in the background thread
   std::thread createBackgroundThread();
-  
+
   /// Loads a project recovery file back into Mantid
   void loadOpenWindows(const std::string &projectFolder);
   /// Saves a project recovery file in Mantid
@@ -63,7 +63,7 @@ private:
   void saveWsHistories(const std::string &projectDestFile);
   /// Main body of saving thread
   void projectSavingThread();
-	
+
   /// Background thread which runs the saving body
   std::thread m_backgroundSavingThread;
 
@@ -74,7 +74,7 @@ private:
   /// Atomic to detect when the thread should fire or exit
   std::condition_variable m_threadNotifier;
 
-  /// Pointer to main GUI window 
+  /// Pointer to main GUI window
   ApplicationWindow *m_windowPtr;
 };
 

--- a/MantidPlot/src/ProjectRecoveryThread.h
+++ b/MantidPlot/src/ProjectRecoveryThread.h
@@ -1,5 +1,5 @@
-#ifndef PROJECT_RECOVERY_ADAPTOR_H_
-#define PROJECT_RECOVERY_ADAPTOR_H_
+#ifndef PROJECT_RECOVERY_THREAD_H_
+#define PROJECT_RECOVERY_THREAD_H_
 
 #include <string>
 
@@ -35,21 +35,18 @@ File change history is stored at: <https://github.com/mantidproject/mantid>
 
 namespace MantidQt {
 namespace API {
-class ProjectRecoveryAdaptor : public QObject {
+class ProjectRecoveryThread {
 public:
-  explicit ProjectRecoveryAdaptor(ApplicationWindow *windowHandle);
+  explicit ProjectRecoveryThread(ApplicationWindow *windowHandle);
 
   void saveOpenWindows(std::string projectFilepath);
   void loadOpenWindows(std::string projectFilePath);
 
 private:
-  // Constructor deleted, this allows SIP bindings to find the deleted
-  // definition
-  ProjectRecoveryAdaptor() = delete;
   ApplicationWindow *m_windowPtr;
 };
 
 } // namespace API
 } // namespace MantidQt
 
-#endif // PROJECT_RECOVERY_ADAPTOR_H_
+#endif // PROJECT_RECOVERY_THREAD_H_

--- a/MantidPlot/src/ProjectRecoveryThread.h
+++ b/MantidPlot/src/ProjectRecoveryThread.h
@@ -1,6 +1,8 @@
 #ifndef PROJECT_RECOVERY_THREAD_H_
 #define PROJECT_RECOVERY_THREAD_H_
 
+#include <chrono>
+#include <thread>
 #include <string>
 
 // Forward declarations
@@ -38,11 +40,24 @@ namespace API {
 class ProjectRecoveryThread {
 public:
   explicit ProjectRecoveryThread(ApplicationWindow *windowHandle);
+  ~ProjectRecoveryThread();
 
-  void saveOpenWindows(std::string projectFilepath);
-  void loadOpenWindows(std::string projectFilePath);
+  void startProjectSaving();
+  void stopProjectSaving();
+
 
 private:
+	std::thread createBackgroundThread();
+	void projectSavingThread(bool &runThread);
+	void saveOpenWindows(std::string projectFilepath);
+	void saveWsHistories(std::string historyFilePath);
+	void loadOpenWindows(std::string projectFilePath);
+
+  /// Flag to toggle the threads operation.
+  bool m_runProjectSaving; // Does not need to be atomic, as we only read in worker
+
+  std::thread m_backgroundSavingThread;
+
   ApplicationWindow *m_windowPtr;
 };
 

--- a/MantidPlot/src/qti.sip
+++ b/MantidPlot/src/qti.sip
@@ -1128,7 +1128,6 @@ public:
   Matrix* newMatrix(const QString&, int=32, int=32);
 
   TiledWindow *newTiledWindow();
-  ProjectRecoveryAdaptor* getRecoveryHandle();
 
   MultiLayer *plot(const QString&) /PyName=graph/;
 %MethodCode
@@ -1512,19 +1511,4 @@ public:
    MantidQt::MantidWidgets::FitPropertyBrowser* fitFunctionBrowser();
 private:
   MantidUI(const MantidUI &);
-};
-
-class ProjectRecoveryAdaptor : public QObject {
-
-%TypeHeaderCode
-#include "src/ProjectRecoveryAdaptor.h"
-using namespace MantidQt::API;
-%End
-
-public:
-    void saveOpenWindows(std::string);
-    void loadOpenWindows(std::string);
-
-private:
-    ProjectRecoveryAdaptor();
 };


### PR DESCRIPTION
**Note this is a merge between topic branches, not into master**

**Description of work.**
Adds a saving loop into a background thread for project recovery. The details of this are below.

Still pending:
- Error handling (stopping the mechanism if something goes wrong...etc.)
- Configuration Options
- Filename generation
- Loading

*Details:* 
- We use a `std::thread` and a  `std::conditional_variable` with a timeout to implement the background thread without polling. If the mutex protected changes (when the flag to indicate thread exit) the thread will be woken. Similarly if the timeout occurs the exit flag is checked and if false, we trigger saving.

To save the Qt side of things we must emit a signal to the event queue in the main thread, this is later processed by ApplicationWindow to trigger project saving. One caveat is if multiple actions are queued (for example 100 window loads) we must wait for them to parse first. In other ways there is no to pre-empt a large number of tasks for the GUI side of things

**To test:**
- Open Mantid
- Set the logger to information, so you can see each time it triggers 
- Debug logging will show details from the Python script too if required
- Go to %appdata%/recovery for saved files

Does this update require release notes?
- [ ] Yes
- [x] No

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
