### PR TITLE
Fix segfault when calibrating CORELLI with C60

### DIFF
--- a/Framework/Algorithms/src/PDCalibration.cpp
+++ b/Framework/Algorithms/src/PDCalibration.cpp
@@ -87,7 +87,7 @@ public:
       }
     }
 
-    // determin tof max supported by the workspace
+    // determine tof max supported by the workspace
     size_t maxIndex = Y.size() - 1;
     for (; maxIndex > minIndex; --maxIndex) {
       if (isNonZero(Y[maxIndex])) {
@@ -100,36 +100,17 @@ public:
   void setPositions(const std::vector<double> &peaksInD,
                     const std::vector<double> &peaksInDWindows,
                     std::function<double(double)> toTof) {
+    // clear out old values
+    inDPos.clear();
+    inTofPos.clear();
+    inTofWindows.clear();
 
-    const std::size_t numOrig = peaksInD.size();
-    for (std::size_t i = 0; i < numOrig; ++i) {
-      const double centre = toTof(peaksInD[i]);
-      if (centre < tofMax && centre > tofMin) {
-        inDPos.push_back(peaksInD[i]);
-        inTofPos.push_back(peaksInD[i]);
-        inTofWindows.push_back(peaksInDWindows[2 * i]);
-        inTofWindows.push_back(peaksInDWindows[2 * i + 1]);
-      }
-    }
-    std::transform(inTofPos.begin(), inTofPos.end(), inTofPos.begin(), toTof);
-    std::transform(inTofWindows.begin(), inTofWindows.end(),
-                   inTofWindows.begin(), toTof);
-  }
+    // assign things
+    inDPos.assign(peaksInD.begin(), peaksInD.end());
+    inTofPos.assign(peaksInD.begin(), peaksInD.end());
+    inTofWindows.assign(peaksInDWindows.begin(), peaksInDWindows.end());
 
-  // (NEW) Pete: I don't need to get rid of peaks out of TOF range because
-  // FitPeaks checks whether a given peak is in range or not.  I'd rather
-  // to have some peaks out of range than a ragged workspace
-  void calculatePositionWindowInTOF(const std::vector<double> &peaksInD,
-                                    const std::vector<double> &peaksInDWindows,
-                                    std::function<double(double)> toTof) {
-    const std::size_t numOrig = peaksInD.size();
-    for (std::size_t i = 0; i < numOrig; ++i) {
-      // const double centre = toTof(peaksInD[i]);
-      inDPos.push_back(peaksInD[i]);
-      inTofPos.push_back(peaksInD[i]);
-      inTofWindows.push_back(peaksInDWindows[2 * i]);
-      inTofWindows.push_back(peaksInDWindows[2 * i + 1]);
-    }
+    // convert the bits that matter to TOF
     std::transform(inTofPos.begin(), inTofPos.end(), inTofPos.begin(), toTof);
     std::transform(inTofWindows.begin(), inTofWindows.end(),
                    inTofWindows.begin(), toTof);
@@ -486,7 +467,7 @@ void PDCalibration::exec() {
 
   // run and get the result
   algFitPeaks->executeAsChildAlg();
-  g_log.information("finished `FitPeaks");
+  g_log.information("finished FitPeaks");
 
   // get the fit result
   API::ITableWorkspace_sptr fittedTable =
@@ -1226,8 +1207,7 @@ PDCalibration::createTOFPeakCenterFitWindowWorkspaces(
     // calculatePositionWindowInTOF
     PDCalibration::FittedPeaks peaks(dataws, static_cast<size_t>(iws));
     auto toTof = getDSpacingToTof(peaks.detid);
-    peaks.calculatePositionWindowInTOF(m_peaksInDspacing, windowsInDSpacing,
-                                       toTof);
+    peaks.setPositions(m_peaksInDspacing, windowsInDSpacing, toTof);
     peak_pos_ws->setPoints(iws, peaks.inTofPos);
     peak_window_ws->setPoints(iws, peaks.inTofWindows);
     prog.report();


### PR DESCRIPTION
Part of the code was checking if peaks were in range while another part
assumed that all were listed and would clear out the ones that aren't.
There was also (mostly) duplicated code which was removed.

**To test:**

The calibration files to start from are in Ross's home directory. The segfault should no longer happen with his script.

Fixes #22603.

*Report to:* @rosswhitfield 

*Does not need to be in the release notes* because it is already covered in this release.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
