### PR TITLE
SANS GUI: Save group workspaces correctly

### DIFF
--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -930,32 +930,18 @@ def get_all_names_to_save(reduction_packages):
     """
     names_to_save = []
     for reduction_package in reduction_packages:
-        is_part_of_multi_period_reduction = reduction_package.is_part_of_multi_period_reduction
-        is_part_of_event_slice_reduction = reduction_package.is_part_of_event_slice_reduction
-        is_group = is_part_of_multi_period_reduction or is_part_of_event_slice_reduction
-
         reduced_lab = reduction_package.reduced_lab
         reduced_hab = reduction_package.reduced_hab
         reduced_merged = reduction_package.reduced_merged
 
         # If we have merged reduction then store the
         if reduced_merged:
-            if is_group:
-                names_to_save.append(reduction_package.reduced_merged_base_name)
-            else:
-                names_to_save.append(reduced_merged.name())
+            names_to_save.append(reduced_merged.name())
         else:
             if reduced_lab:
-                if is_group:
-                    names_to_save.append(reduction_package.reduced_lab_base_name)
-                else:
-                    names_to_save.append(reduced_lab.name())
-
+                names_to_save.append(reduced_lab.name())
             if reduced_hab:
-                if is_group:
-                    names_to_save.append(reduction_package.reduced_hab_base_name)
-                else:
-                    names_to_save.append(reduced_hab.name())
+                names_to_save.append(reduced_hab.name())
 
     # We might have some workspaces as duplicates (the group workspaces), so make them unique
     return set(names_to_save)

--- a/scripts/test/SANS/algorithm_detail/CMakeLists.txt
+++ b/scripts/test/SANS/algorithm_detail/CMakeLists.txt
@@ -10,6 +10,7 @@ set ( TEST_PY_FILES
   scale_helper_test.py
   strip_end_nans_test.py
   centre_finder_new_test.py
+  batch_execution_test.py
 )
 
 check_tests_valid ( ${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES} )

--- a/scripts/test/SANS/algorithm_detail/batch_execution_test.py
+++ b/scripts/test/SANS/algorithm_detail/batch_execution_test.py
@@ -1,0 +1,50 @@
+from __future__ import (absolute_import, division, print_function)
+import unittest
+import sys
+from sans.algorithm_detail.batch_execution import get_all_names_to_save, ReductionPackage
+from mantid.simpleapi import CreateSampleWorkspace
+if sys.version_info.major > 2:
+    from unittest import mock
+else:
+    import mock
+
+class GetAllNamesToSaveTest(unittest.TestCase):
+    def test_returns_merged_name_if_present(self):
+        state = mock.MagicMock()
+        workspaces = ['Sample', 'Transmission', 'Direct']
+        monitors = ['monitor1']
+        reduction_package = ReductionPackage(state, workspaces, monitors)
+        merged_workspace = CreateSampleWorkspace(Function='Flat background', NumBanks=1, BankPixelWidth=1, NumEvents=1,
+                                   XMin=1, XMax=14, BinWidth=2)
+        lab_workspace = CreateSampleWorkspace(Function='Flat background', NumBanks=1, BankPixelWidth=1, NumEvents=1,
+                                   XMin=1, XMax=14, BinWidth=2)
+        hab_workspace = CreateSampleWorkspace(Function='Flat background', NumBanks=1, BankPixelWidth=1, NumEvents=1,
+                                   XMin=1, XMax=14, BinWidth=2)
+        reduction_package.reduced_merged = merged_workspace
+        reduction_package.reduced_lab = lab_workspace
+        reduction_package.reduced_hab = hab_workspace
+        reduction_packages = [reduction_package]
+
+        names_to_save = get_all_names_to_save(reduction_packages)
+
+        self.assertEqual(names_to_save, set(['merged_workspace']))
+
+    def test_hab_and_lab_workspaces_returned_if_merged_workspace_not_present(self):
+        state = mock.MagicMock()
+        workspaces = ['Sample', 'Transmission', 'Direct']
+        monitors = ['monitor1']
+        reduction_package = ReductionPackage(state, workspaces, monitors)
+        lab_workspace = CreateSampleWorkspace(Function='Flat background', NumBanks=1, BankPixelWidth=1, NumEvents=1,
+                                              XMin=1, XMax=14, BinWidth=2)
+        hab_workspace = CreateSampleWorkspace(Function='Flat background', NumBanks=1, BankPixelWidth=1, NumEvents=1,
+                                              XMin=1, XMax=14, BinWidth=2)
+        reduction_package.reduced_lab = lab_workspace
+        reduction_package.reduced_hab = hab_workspace
+        reduction_packages = [reduction_package]
+
+        names_to_save = get_all_names_to_save(reduction_packages)
+
+        self.assertEqual(names_to_save, set(['lab_workspace', 'hab_workspace']))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Description of work.**
When the new sans GUI did a multi period or event sliced reduction the results are stored in a group workspace in the ADS. When saving to file only one of the group workspaces was saved. This PR corrects this. 
**Report to:** robert.dalgliesh@stfc.ac.uk <!--If the original issue was raised by a user they should be named here.-->

**To test:**
* Get this data
[loqdemo.zip](https://github.com/mantidproject/mantid/files/2118722/loqdemo.zip)
* In new gui load the userfile the *.txt file
* load the batch file, the *.csv file
* go to settings->general enter 1:1:3 in the event slice box
* Select Both as the save type from the box below the table
* Check that all of the workspaces in the ADS have been saved out to the correct file location

<!-- Instructions for testing. -->

Fixes #22634 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

Does this update require release notes?
Release notes are updated here #22628 
- [ ] Yes
- [ ] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [x] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
