### PR TITLE
EventList: Use standard library functions and inline function comparators.

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -403,10 +403,6 @@ private:
 
   template <class T>
   static typename std::vector<T>::const_iterator
-  findFirstEvent(const std::vector<T> &events, const double seek_tof);
-
-  template <class T>
-  static typename std::vector<T>::const_iterator
   findFirstPulseEvent(const std::vector<T> &events,
                       const double seek_pulsetime);
 
@@ -415,10 +411,6 @@ private:
   findFirstTimeAtSampleEvent(const std::vector<T> &events,
                              const double seek_time, const double &tofFactor,
                              const double &tofOffset) const;
-
-  template <class T>
-  static typename std::vector<T>::iterator
-  findFirstEvent(std::vector<T> &events, const double seek_tof);
 
   void generateCountsHistogram(const MantidVec &X, MantidVec &Y) const;
 

--- a/Framework/DataObjects/inc/MantidDataObjects/Events.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Events.h
@@ -131,8 +131,21 @@ public:
   WeightedEventNoTime();
 
   bool operator==(const WeightedEventNoTime &rhs) const;
-  bool operator<(const WeightedEventNoTime &rhs) const;
-  bool operator<(const double rhs_tof) const;
+
+  /** < comparison operator, using the TOF to do the comparison.
+   * @param rhs: the other WeightedEventNoTime to compare.
+   * @return true if this->m_tof < rhs.m_tof
+   */
+  bool operator<(const WeightedEventNoTime &rhs) const {
+    return (this->m_tof < rhs.m_tof);
+  }
+
+  /** < comparison operator, using the TOF to do the comparison.
+   * @param rhs_tof: the other time of flight to compare.
+   * @return true if this->m_tof < rhs.m_tof
+   */
+  bool operator<(const double rhs_tof) const { return (this->m_tof < rhs_tof); }
+
   bool equals(const WeightedEventNoTime &rhs, const double tolTof,
               const double tolWeight) const;
 

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -90,14 +90,6 @@ public:
 /// --------------------- TofEvent Comparators
 /// ----------------------------------
 //==========================================================================
-/** Compare two events' TOF, return true if e1 should be before e2.
- * @param e1 :: first event
- * @param e2 :: second event
- *  */
-template <typename T> bool compareEventTof(const T &e1, const T &e2) {
-  return (e1.tof() < e2.tof());
-}
-
 /** Compare two events' FRAME id, return true if e1 should be before e2.
  * @param e1 :: first event
  * @param e2 :: second event

--- a/Framework/DataObjects/src/Events.cpp
+++ b/Framework/DataObjects/src/Events.cpp
@@ -222,20 +222,6 @@ bool WeightedEventNoTime::operator==(const WeightedEventNoTime &rhs) const {
          (this->m_errorSquared == rhs.m_errorSquared);
 }
 
-/** < comparison operator, using the TOF to do the comparison.
- * @param rhs: the other WeightedEventNoTime to compare.
- * @return true if this->m_tof < rhs.m_tof*/
-bool WeightedEventNoTime::operator<(const WeightedEventNoTime &rhs) const {
-  return (this->m_tof < rhs.m_tof);
-}
-
-/** < comparison operator, using the TOF to do the comparison.
- * @param rhs_tof: the other time of flight to compare.
- * @return true if this->m_tof < rhs.m_tof*/
-bool WeightedEventNoTime::operator<(const double rhs_tof) const {
-  return (this->m_tof < rhs_tof);
-}
-
 /**
  * Compare two events within the specified tolerance
  *

--- a/Framework/Types/inc/MantidTypes/Event/TofEvent.h
+++ b/Framework/Types/inc/MantidTypes/Event/TofEvent.h
@@ -63,8 +63,18 @@ public:
   TofEvent();
 
   bool operator==(const TofEvent &rhs) const;
-  bool operator<(const TofEvent &rhs) const;
-  bool operator<(const double rhs_tof) const;
+  /** < comparison operator, using the TOF to do the comparison.
+   * @param rhs: the other TofEvent to compare.
+   * @return true if this->m_tof < rhs.m_tof
+   */
+  bool operator<(const TofEvent &rhs) const {
+    return (this->m_tof < rhs.m_tof);
+  }
+  /** < comparison operator, using the TOF to do the comparison.
+   * @param rhs_tof: the other time of flight to compare.
+   * @return true if this->m_tof < rhs.m_tof
+   */
+  bool operator<(const double rhs_tof) const { return (this->m_tof < rhs_tof); }
   bool operator>(const TofEvent &rhs) const;
   bool equals(const TofEvent &rhs, const double tolTof,
               const int64_t tolPulse) const;

--- a/Framework/Types/src/Event/TofEvent.cpp
+++ b/Framework/Types/src/Event/TofEvent.cpp
@@ -15,22 +15,8 @@ bool TofEvent::operator==(const TofEvent &rhs) const {
 /** < comparison operator, using the TOF to do the comparison.
  * @param rhs: the other TofEvent to compare.
  * @return true if this->m_tof < rhs.m_tof*/
-bool TofEvent::operator<(const TofEvent &rhs) const {
-  return (this->m_tof < rhs.m_tof);
-}
-
-/** < comparison operator, using the TOF to do the comparison.
- * @param rhs: the other TofEvent to compare.
- * @return true if this->m_tof < rhs.m_tof*/
 bool TofEvent::operator>(const TofEvent &rhs) const {
   return (this->m_tof > rhs.m_tof);
-}
-
-/** < comparison operator, using the TOF to do the comparison.
- * @param rhs_tof: the other time of flight to compare.
- * @return true if this->m_tof < rhs.m_tof*/
-bool TofEvent::operator<(const double rhs_tof) const {
-  return (this->m_tof < rhs_tof);
 }
 
 /**


### PR DESCRIPTION
**Description of work.**

Using `std::find` and Inlining comparison functions gave a significant performance improvement. These changes reduced the time reported by the script below from 35 sec to 31 sec. I tried `std::lower_bound` but found it added about 0.5s to the execution time.

**To test:**

<!-- Instructions for testing. -->

* Code Review
* Try executing the following script with this branch and `master`.
```
LoadEventNexus(Filename="PG3_37861", OutputWorkspace="meow")
ConvertUnits(InputWorkspace="meow", OutputWorkspace="meow2", target="dSpacing")
Rebin(InputWorkspace="meow2", OutputWorkspace="meow3", Params=".2,-0.0005,2.5")

import matplotlib.pyplot as plt
from mantid import plots
from matplotlib.colors import LogNorm
import time

start = time.time()
x,y,z = plots.helperfunctions.get_matrix_2d_data(mtd['meow3'],False,False)
end = time.time()
print(end - start)
```
There is no GitHub issue associated with this pull request.

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
