### PR TITLE
Numpy dtype exports to property with value

### DIFF
--- a/Framework/Kernel/CMakeLists.txt
+++ b/Framework/Kernel/CMakeLists.txt
@@ -316,7 +316,6 @@ set ( INC_FILES
 	inc/MantidKernel/cow_ptr.h
 	inc/MantidKernel/make_cow.h
 	inc/MantidKernel/make_unique.h
-	inc/MantidKernel/ContainerDType.h
 )
 
 set ( TEST_FILES

--- a/Framework/Kernel/CMakeLists.txt
+++ b/Framework/Kernel/CMakeLists.txt
@@ -166,7 +166,7 @@ set ( INC_FILES
 	inc/MantidKernel/ConfigService.h
 	inc/MantidKernel/ConfigObserver.h
 	inc/MantidKernel/ConfigPropertyObserver.h
-  inc/MantidKernel/DateAndTime.h
+        inc/MantidKernel/DateAndTime.h
 	inc/MantidKernel/DataItem.h
 	inc/MantidKernel/DataService.h
 	inc/MantidKernel/DateAndTimeHelpers.h
@@ -247,7 +247,7 @@ set ( INC_FILES
 	inc/MantidKernel/NetworkProxy.h
 	inc/MantidKernel/NeutronAtom.h
 	inc/MantidKernel/NexusDescriptor.h
-  inc/MantidKernel/normal_distribution.h
+        inc/MantidKernel/normal_distribution.h
 	inc/MantidKernel/NullValidator.h
 	inc/MantidKernel/OptionalBool.h
 	inc/MantidKernel/ParaViewVersion.h
@@ -316,6 +316,7 @@ set ( INC_FILES
 	inc/MantidKernel/cow_ptr.h
 	inc/MantidKernel/make_cow.h
 	inc/MantidKernel/make_unique.h
+	inc/MantidKernel/ContainerDType.h
 )
 
 set ( TEST_FILES

--- a/Framework/Kernel/inc/MantidKernel/ContainerDtype.h
+++ b/Framework/Kernel/inc/MantidKernel/ContainerDtype.h
@@ -49,9 +49,9 @@ namespace dtypeHelper {
 template <template <class> class Container, typename HeldType>
 std::string dtype(const Container<HeldType>) {
   if (std::is_same<HeldType, bool>::value) {
-    return "boolean";
+    return "bool_";
   } else if (std::is_same<HeldType, short>::value) {
-    return "short";
+    return "int16";
   } else if (std::is_same<HeldType, std::int8_t>::value) {
     return "int8";
   } else if (std::is_same<HeldType, std::int16_t>::value) {
@@ -61,17 +61,17 @@ std::string dtype(const Container<HeldType>) {
   } else if (std::is_same<HeldType, std::int64_t>::value) {
     return "int64";
   } else if (std::is_same<HeldType, long>::value) {
-    return "long";
+    return "int_";
   } else if (std::is_same<HeldType, long long>::value) {
-    return "longlong";
+    return "int64";
   } else if (std::is_same<HeldType, std::float_t>::value) {
-    return "float";
+    return "float32";
   } else if (std::is_same<HeldType, std::double_t>::value) {
-    return "double";
+    return "float64";
   } else if (std::is_same<HeldType, std::string>::value) {
-    return "string";
+    return "string_";
   } else {
-    return "obj";
+    return "object_";
   }
 }
 

--- a/Framework/Kernel/inc/MantidKernel/ContainerDtype.h
+++ b/Framework/Kernel/inc/MantidKernel/ContainerDtype.h
@@ -49,15 +49,27 @@ namespace dtypeHelper {
 template <template <class> class Container, typename HeldType>
 std::string dtype(const Container<HeldType>) {
   if (std::is_same<HeldType, bool>::value) {
-    return "b";
-  } else if (std::is_integral<HeldType>::value) {
-    return "i";
+    return "boolean";
+  } else if (std::is_same<HeldType, short>::value) {
+    return "short";
+  } else if (std::is_same<HeldType, std::int8_t>::value) {
+    return "int8";
+  } else if (std::is_same<HeldType, std::int16_t>::value) {
+    return "int16";
+  } else if (std::is_same<HeldType, std::int32_t>::value) {
+    return "int32";
+  } else if (std::is_same<HeldType, std::int64_t>::value) {
+    return "int64";
+  } else if (std::is_same<HeldType, long>::value) {
+    return "long";
+  } else if (std::is_same<HeldType, long long>::value) {
+    return "longlong";
   } else if (std::is_same<HeldType, std::float_t>::value) {
-    return "f";
+    return "float";
   } else if (std::is_same<HeldType, std::double_t>::value) {
-    return "d";
+    return "double";
   } else if (std::is_same<HeldType, std::string>::value) {
-    return "s";
+    return "string";
   } else {
     return "obj";
   }

--- a/Framework/Kernel/inc/MantidKernel/ContainerDtype.h
+++ b/Framework/Kernel/inc/MantidKernel/ContainerDtype.h
@@ -47,13 +47,9 @@ namespace dtypeHelper {
 
 // Free function to determine data type being stored in container
 template <template <class> class Container, typename HeldType>
-std::string dtype(Container<HeldType>) {
+std::string dtype(const Container<HeldType>) {
   if (std::is_same<HeldType, bool>::value) {
     return "b";
-  } else if (std::is_same<HeldType, std::int32_t>::value) {
-    return "int32";
-  } else if (std::is_same<HeldType, std::int64_t>::value) {
-    return "int64";
   } else if (std::is_integral<HeldType>::value) {
     return "i";
   } else if (std::is_same<HeldType, std::float_t>::value) {

--- a/Framework/Kernel/inc/MantidKernel/ContainerDtype.h
+++ b/Framework/Kernel/inc/MantidKernel/ContainerDtype.h
@@ -1,0 +1,68 @@
+#ifndef MANTID_KERNEL_CONTAINERDTYPE_H_
+#define MANTID_KERNEL_CONTAINERDTYPE_H_
+
+#include <string>
+#include <vector>
+#include <type_traits>
+
+#include <boost/python/class.hpp>
+#include <boost/python/implicit.hpp>
+#include <boost/python/init.hpp>
+#include <boost/python/make_function.hpp>
+#include <boost/python/register_ptr_to_python.hpp>
+#include <boost/python/return_value_policy.hpp>
+
+/**
+    ContainerDtype Header File
+
+    A helper free function to allow identification of data type being used by providing a
+    numpy friendly string.
+
+    @author Lamar Moore STFC, Bhuvan Bezawada STFC
+    @date 21/06/2018
+
+    Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory, NScD Oak
+    Ridge National Laboratory & European Spallation Source
+
+    This file is part of Mantid.
+
+    Mantid is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    Mantid is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+    File change history is stored at: <https://github.com/mantidproject/mantid>.
+    Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+namespace dtypeHelper {
+
+template <template<class> typename Container, typename HeldType>
+std::string dtype(Container<HeldType> &self) {
+  if (std::is_same<HeldType, bool>::value) {
+    return "b";
+  }
+  else if (std::is_integral<HeldType>::value) {
+    return "i";
+  }
+  else if (std::is_floating_point<HeldType>::value) {
+    return "d";
+  }
+  else if (std::is_same<HeldType, std::string>::value) {
+    return "s";
+  }
+  else {
+    return "obj";
+  }
+}
+
+}
+
+#endif /*MANTID_KERNEL_CONTAINERDTYPE_H_*/

--- a/Framework/Kernel/inc/MantidKernel/ContainerDtype.h
+++ b/Framework/Kernel/inc/MantidKernel/ContainerDtype.h
@@ -2,8 +2,8 @@
 #define MANTID_KERNEL_CONTAINERDTYPE_H_
 
 #include <string>
-#include <vector>
 #include <type_traits>
+#include <vector>
 
 #include <boost/python/class.hpp>
 #include <boost/python/implicit.hpp>
@@ -15,8 +15,8 @@
 /**
     ContainerDtype Header File
 
-    A helper free function to allow identification of data type being used by providing a
-    numpy friendly string.
+    A helper free function to allow identification of data type being used by
+   providing a numpy friendly string.
 
     @author Lamar Moore STFC, Bhuvan Bezawada STFC
     @date 21/06/2018
@@ -42,27 +42,31 @@
     File change history is stored at: <https://github.com/mantidproject/mantid>.
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
+
 namespace dtypeHelper {
 
-template <template<class> typename Container, typename HeldType>
+// Free function to determine data type being stored in container
+template <template <class> typename Container, typename HeldType>
 std::string dtype(Container<HeldType> &self) {
   if (std::is_same<HeldType, bool>::value) {
     return "b";
-  }
-  else if (std::is_integral<HeldType>::value) {
+  } else if (std::is_same<HeldType, std::int32_t>::value) {
+    return "int32";
+  } else if (std::is_same<HeldType, std::int64_t>::value) {
+    return "int64";
+  } else if (std::is_integral<HeldType>::value) {
     return "i";
-  }
-  else if (std::is_floating_point<HeldType>::value) {
+  } else if (std::is_same<HeldType, std::float_t>::value) {
+    return "f";
+  } else if (std::is_same<HeldType, std::double_t>::value) {
     return "d";
-  }
-  else if (std::is_same<HeldType, std::string>::value) {
+  } else if (std::is_same<HeldType, std::string>::value) {
     return "s";
-  }
-  else {
+  } else {
     return "obj";
   }
 }
 
-}
+} // namespace dtypeHelper
 
 #endif /*MANTID_KERNEL_CONTAINERDTYPE_H_*/

--- a/Framework/Kernel/inc/MantidKernel/ContainerDtype.h
+++ b/Framework/Kernel/inc/MantidKernel/ContainerDtype.h
@@ -46,8 +46,8 @@
 namespace dtypeHelper {
 
 // Free function to determine data type being stored in container
-template <template <class> typename Container, typename HeldType>
-std::string dtype(Container<HeldType> &self) {
+template <template <class> class Container, typename HeldType>
+std::string dtype(Container<HeldType>) {
   if (std::is_same<HeldType, bool>::value) {
     return "b";
   } else if (std::is_same<HeldType, std::int32_t>::value) {

--- a/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
@@ -121,8 +121,6 @@ public:
   /// Constructor
   explicit TimeSeriesProperty(const std::string &name);
 
-  TimeSeriesProperty(const std::string &name, TimeSeriesProperty<TYPE> &type);
-
   /// Virtual destructor
   ~TimeSeriesProperty() override;
   /// "Virtual" copy constructor

--- a/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
@@ -120,6 +120,9 @@ class DLLExport TimeSeriesProperty : public Property,
 public:
   /// Constructor
   explicit TimeSeriesProperty(const std::string &name);
+
+  TimeSeriesProperty(const std::string &name, TimeSeriesProperty<TYPE> &type);
+
   /// Virtual destructor
   ~TimeSeriesProperty() override;
   /// "Virtual" copy constructor

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/ContainerDtype.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/ContainerDtype.h
@@ -1,22 +1,11 @@
-#ifndef MANTID_KERNEL_CONTAINERDTYPE_H_
-#define MANTID_KERNEL_CONTAINERDTYPE_H_
-
-#include <string>
-#include <type_traits>
-#include <vector>
-
-#include <boost/python/class.hpp>
-#include <boost/python/implicit.hpp>
-#include <boost/python/init.hpp>
-#include <boost/python/make_function.hpp>
-#include <boost/python/register_ptr_to_python.hpp>
-#include <boost/python/return_value_policy.hpp>
+#ifndef MANTID_PYTHONINTERFACE_CONVERTERS_CONTAINERDTYPE_H_
+#define MANTID_PYTHONINTERFACE_CONVERTERS_CONTAINERDTYPE_H_
 
 /**
     ContainerDtype Header File
 
     A helper free function to allow identification of data type being used by
-   providing a numpy friendly string.
+    providing a numpy friendly string.
 
     @author Lamar Moore STFC, Bhuvan Bezawada STFC
     @date 21/06/2018
@@ -43,11 +32,13 @@
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
 
-namespace dtypeHelper {
+namespace Mantid {
+namespace PythonInterface {
+namespace Converters {
 
 // Free function to determine data type being stored in container
 template <template <class> class Container, typename HeldType>
-std::string dtype(const Container<HeldType>) {
+std::string dtype(const Container<HeldType> &) {
   if (std::is_same<HeldType, bool>::value) {
     return "bool_";
   } else if (std::is_same<HeldType, short>::value) {
@@ -75,6 +66,8 @@ std::string dtype(const Container<HeldType>) {
   }
 }
 
-} // namespace dtypeHelper
+} // namespace Converters
+} // namespace PythonInterface
+} // namespace Mantid
 
-#endif /*MANTID_KERNEL_CONTAINERDTYPE_H_*/
+#endif /*MANTID_PYTHONINTERFACE_CONVERTERS_CONTAINERDTYPE_H_*/

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/ContainerDtype.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/ContainerDtype.h
@@ -58,9 +58,9 @@ std::string dtype(const Container<HeldType> &) {
     return "int_";
   } else if (std::is_same<HeldType, long long>::value) {
     return "int64";
-  } else if (std::is_same<HeldType, std::float_t>::value) {
+  } else if (std::is_same<HeldType, float>::value) {
     return "float32";
-  } else if (std::is_same<HeldType, std::double_t>::value) {
+  } else if (std::is_same<HeldType, double>::value) {
     return "float64";
   } else if (std::is_same<HeldType, std::string>::value) {
     return "string_";

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/ContainerDtype.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/ContainerDtype.h
@@ -1,6 +1,9 @@
 #ifndef MANTID_PYTHONINTERFACE_CONVERTERS_CONTAINERDTYPE_H_
 #define MANTID_PYTHONINTERFACE_CONVERTERS_CONTAINERDTYPE_H_
 
+#include <string>
+#include <type_traits>
+
 /**
     ContainerDtype Header File
 

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/PropertyWithValueExporter.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/PropertyWithValueExporter.h
@@ -25,7 +25,7 @@
 */
 
 #include "MantidKernel/PropertyWithValue.h"
-#include "MantidKernel/ContainerDtype.h"
+#include "MantidPythonInterface/kernel/Converters/ContainerDtype.h"
 
 #ifndef Q_MOC_RUN
 #include <boost/python/class.hpp>
@@ -37,7 +37,7 @@
 // Call the dtype helper function
 template <typename HeldType>
 std::string dtype(Mantid::Kernel::PropertyWithValue<HeldType> &self) {
-  return dtypeHelper::dtype(self);
+  return Mantid::PythonInterface::Converters::dtype(self);
 }
 
 namespace Mantid {
@@ -58,7 +58,7 @@ struct PropertyWithValueExporter {
         .add_property("value",
                       make_function(&PropertyWithValue<HeldType>::operator(),
                                     return_value_policy<ValueReturnPolicy>()))
-        .def("dtype", &dtype<HeldType>, arg("self"), "returns :`std::string`");
+        .def("dtype", &dtype<HeldType>, arg("self"));
   }
 };
 }

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/PropertyWithValueExporter.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/PropertyWithValueExporter.h
@@ -25,6 +25,7 @@
 */
 
 #include "MantidKernel/PropertyWithValue.h"
+#include "MantidKernel/ContainerDtype.h"
 
 #ifndef Q_MOC_RUN
 #include <boost/python/class.hpp>
@@ -33,8 +34,15 @@
 #include <boost/python/return_by_value.hpp>
 #endif
 
+// Call the dtype helper function
+template <typename HeldType>
+std::string dtype(Mantid::Kernel::PropertyWithValue<HeldType> &self) {
+  return dtypeHelper::dtype(self);
+}
+
 namespace Mantid {
 namespace PythonInterface {
+
 /**
  * A helper struct to export PropertyWithValue<> types to Python.
  */
@@ -49,9 +57,11 @@ struct PropertyWithValueExporter {
         pythonClassName, no_init)
         .add_property("value",
                       make_function(&PropertyWithValue<HeldType>::operator(),
-                                    return_value_policy<ValueReturnPolicy>()));
+                                    return_value_policy<ValueReturnPolicy>()))
+        .def("dtype", &dtype<HeldType>, arg("self"), "returns :`std::string`");
   }
 };
+
 }
 }
 

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/PropertyWithValueExporter.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/PropertyWithValueExporter.h
@@ -61,7 +61,6 @@ struct PropertyWithValueExporter {
         .def("dtype", &dtype<HeldType>, arg("self"), "returns :`std::string`");
   }
 };
-
 }
 }
 

--- a/Framework/PythonInterface/mantid/kernel/CMakeLists.txt
+++ b/Framework/PythonInterface/mantid/kernel/CMakeLists.txt
@@ -95,6 +95,7 @@ set ( INC_FILES
   ${HEADER_DIR}/kernel/NdArray.h
   ${HEADER_DIR}/kernel/Converters/CArrayToNDArray.h
   ${HEADER_DIR}/kernel/Converters/CloneToNumpy.h
+  ${HEADER_DIR}/kernel/Converters/ContainerDtype.h
   ${HEADER_DIR}/kernel/Converters/DateAndTime.h
   ${HEADER_DIR}/kernel/Converters/MapToPyDictionary.h
   ${HEADER_DIR}/kernel/Converters/MatrixToNDArray.h

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayProperty.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayProperty.cpp
@@ -30,7 +30,7 @@ using return_cloned_numpy =
 
 // Call the dtype helper function
 template <typename type> std::string dtype(ArrayProperty<type> &self) {
-  return Mantid::PythonInterface::Converters::dtype(self);
+  return Converters::dtype(self);
 }
 
 #define EXPORT_ARRAY_PROP(type, prefix)                                        \

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayProperty.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayProperty.cpp
@@ -1,5 +1,6 @@
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/NullValidator.h"
+#include "MantidKernel/ContainerDtype.h"
 
 #include "MantidPythonInterface/kernel/Converters/NDArrayToVector.h"
 #include "MantidPythonInterface/kernel/Converters/PySequenceToVector.h"
@@ -24,31 +25,14 @@ using namespace boost::python;
 
 namespace {
 /// return_value_policy for cloned numpy array
-using return_cloned_numpy =
+  using return_cloned_numpy =
     return_value_policy<Policies::VectorRefToNumpy<Converters::Clone>>;
 
-// Default return if no matches occur
-template <typename type> std::string dtype(ArrayProperty<type> &self) {
-  return "obj";
+// Call the dtype helper function
+template <typename type>
+std::string dtype(ArrayProperty<type> &self) {
+  return dtypeHelper::dtype(self);
 }
-
-// String return
-template <> std::string dtype(ArrayProperty<std::string> &self) { return "s"; }
-
-// Integer (32-bit) return
-template <> std::string dtype(ArrayProperty<int32_t> &self) { return "i"; }
-
-// Integer (64-bit) return
-template <> std::string dtype(ArrayProperty<int64_t> &self) { return "i"; }
-
-// Long return
-template <> std::string dtype(ArrayProperty<long> &self) { return "i"; }
-
-// Boolean return
-template <> std::string dtype(ArrayProperty<bool> &self) { return "b"; }
-
-// Double return
-template <> std::string dtype(ArrayProperty<double> &self) { return "d"; }
 
 #define EXPORT_ARRAY_PROP(type, prefix)                                        \
   class_<ArrayProperty<type>, bases<PropertyWithValue<std::vector<type>>>,     \
@@ -123,7 +107,7 @@ ArrayProperty<T> *createArrayPropertyFromNDArray(const std::string &name,
 
 void export_ArrayProperty() {
   // Match the python names to their C types
-  EXPORT_ARRAY_PROP(double, Float);
+  EXPORT_ARRAY_PROP(double, Float); 
   EXPORT_ARRAY_PROP(long, Int);
   EXPORT_ARRAY_PROP(std::string, String);
 

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayProperty.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayProperty.cpp
@@ -25,12 +25,11 @@ using namespace boost::python;
 
 namespace {
 /// return_value_policy for cloned numpy array
-  using return_cloned_numpy =
+using return_cloned_numpy =
     return_value_policy<Policies::VectorRefToNumpy<Converters::Clone>>;
 
 // Call the dtype helper function
-template <typename type>
-std::string dtype(ArrayProperty<type> &self) {
+template <typename type> std::string dtype(ArrayProperty<type> &self) {
   return dtypeHelper::dtype(self);
 }
 
@@ -107,7 +106,7 @@ ArrayProperty<T> *createArrayPropertyFromNDArray(const std::string &name,
 
 void export_ArrayProperty() {
   // Match the python names to their C types
-  EXPORT_ARRAY_PROP(double, Float); 
+  EXPORT_ARRAY_PROP(double, Float);
   EXPORT_ARRAY_PROP(long, Int);
   EXPORT_ARRAY_PROP(std::string, String);
 

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayProperty.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayProperty.cpp
@@ -1,22 +1,22 @@
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/NullValidator.h"
 
-#include "MantidPythonInterface/kernel/NdArray.h"
-#include "MantidPythonInterface/kernel/Policies/VectorToNumpy.h"
 #include "MantidPythonInterface/kernel/Converters/NDArrayToVector.h"
 #include "MantidPythonInterface/kernel/Converters/PySequenceToVector.h"
+#include "MantidPythonInterface/kernel/NdArray.h"
+#include "MantidPythonInterface/kernel/Policies/VectorToNumpy.h"
 
 #include <boost/python/class.hpp>
 #include <boost/python/list.hpp>
 
-#include <boost/python/make_constructor.hpp>
 #include <boost/python/default_call_policies.hpp>
+#include <boost/python/make_constructor.hpp>
 
 using Mantid::Kernel::ArrayProperty;
-using Mantid::Kernel::PropertyWithValue;
 using Mantid::Kernel::Direction;
 using Mantid::Kernel::IValidator_sptr;
 using Mantid::Kernel::NullValidator;
+using Mantid::Kernel::PropertyWithValue;
 namespace Converters = Mantid::PythonInterface::Converters;
 namespace NumPy = Mantid::PythonInterface::NumPy;
 namespace Policies = Mantid::PythonInterface::Policies;
@@ -26,6 +26,29 @@ namespace {
 /// return_value_policy for cloned numpy array
 using return_cloned_numpy =
     return_value_policy<Policies::VectorRefToNumpy<Converters::Clone>>;
+
+// Default return if no matches occur
+template <typename type> std::string dtype(ArrayProperty<type> &self) {
+  return "obj";
+}
+
+// String return
+template <> std::string dtype(ArrayProperty<std::string> &self) { return "s"; }
+
+// Integer (32-bit) return
+template <> std::string dtype(ArrayProperty<int32_t> &self) { return "i"; }
+
+// Integer (64-bit) return
+template <> std::string dtype(ArrayProperty<int64_t> &self) { return "i"; }
+
+// Long return
+template <> std::string dtype(ArrayProperty<long> &self) { return "i"; }
+
+// Boolean return
+template <> std::string dtype(ArrayProperty<bool> &self) { return "b"; }
+
+// Double return
+template <> std::string dtype(ArrayProperty<double> &self) { return "d"; }
 
 #define EXPORT_ARRAY_PROP(type, prefix)                                        \
   class_<ArrayProperty<type>, bases<PropertyWithValue<std::vector<type>>>,     \
@@ -58,6 +81,7 @@ using return_cloned_numpy =
                (arg("name"), arg("values"),                                    \
                 arg("validator") = IValidator_sptr(new NullValidator),         \
                 arg("direction") = Direction::Input)))                         \
+      .def("dtype", &dtype<type>, arg("self"), "returns :`std::string`")       \
       .add_property("value", make_function(&ArrayProperty<type>::operator(),   \
                                            return_cloned_numpy()));
 
@@ -79,14 +103,14 @@ ArrayProperty<T> *createArrayPropertyFromList(const std::string &name,
 }
 
 /**
-  * Factory function to allow the initial values to be specified as a numpy
+ * Factory function to allow the initial values to be specified as a numpy
  * array
-  * @param name :: The name of the property
-  * @param vec :: A boost python array of initial values
-  * @param validator :: A validator object
-  * @param direction :: A direction
-  * @return
-  */
+ * @param name :: The name of the property
+ * @param vec :: A boost python array of initial values
+ * @param validator :: A validator object
+ * @param direction :: A direction
+ * @return
+ */
 template <typename T>
 ArrayProperty<T> *createArrayPropertyFromNDArray(const std::string &name,
                                                  const NumPy::NdArray &values,
@@ -95,7 +119,7 @@ ArrayProperty<T> *createArrayPropertyFromNDArray(const std::string &name,
   return new ArrayProperty<T>(name, Converters::NDArrayToVector<T>(values)(),
                               validator, direction);
 }
-}
+} // namespace
 
 void export_ArrayProperty() {
   // Match the python names to their C types

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayProperty.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayProperty.cpp
@@ -1,9 +1,9 @@
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/NullValidator.h"
-#include "MantidKernel/ContainerDtype.h"
 
 #include "MantidPythonInterface/kernel/Converters/NDArrayToVector.h"
 #include "MantidPythonInterface/kernel/Converters/PySequenceToVector.h"
+#include "MantidPythonInterface/kernel/Converters/ContainerDtype.h"
 #include "MantidPythonInterface/kernel/NdArray.h"
 #include "MantidPythonInterface/kernel/Policies/VectorToNumpy.h"
 
@@ -30,7 +30,7 @@ using return_cloned_numpy =
 
 // Call the dtype helper function
 template <typename type> std::string dtype(ArrayProperty<type> &self) {
-  return dtypeHelper::dtype(self);
+  return Mantid::PythonInterface::Converters::dtype(self);
 }
 
 #define EXPORT_ARRAY_PROP(type, prefix)                                        \
@@ -64,7 +64,7 @@ template <typename type> std::string dtype(ArrayProperty<type> &self) {
                (arg("name"), arg("values"),                                    \
                 arg("validator") = IValidator_sptr(new NullValidator),         \
                 arg("direction") = Direction::Input)))                         \
-      .def("dtype", &dtype<type>, arg("self"), "returns :`std::string`")       \
+      .def("dtype", &dtype<type>, arg("self"))                                 \
       .add_property("value", make_function(&ArrayProperty<type>::operator(),   \
                                            return_cloned_numpy()));
 

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
@@ -37,8 +37,7 @@ void addPyTimeValue(TimeSeriesProperty<TYPE> &self,
 }
 
 // Call the dtype helper function
-template <typename TYPE>
-std::string dtype(TimeSeriesProperty<TYPE> &self) {
+template <typename TYPE> std::string dtype(TimeSeriesProperty<TYPE> &self) {
   return dtypeHelper::dtype(self);
 }
 
@@ -50,24 +49,22 @@ std::string dtype(TimeSeriesProperty<TYPE> &self) {
       #Prefix "TimeSeriesProperty",                                            \
       init<const std::string &>((arg("self"), arg("value"))))                  \
       .add_property(                                                           \
-          "value",                                                             \
-          make_function(                                                       \
-              &Mantid::Kernel::TimeSeriesProperty<TYPE>::valuesAsVector,       \
-              return_value_policy<VectorToNumpy>()))                           \
+           "value",                                                            \
+           make_function(                                                      \
+               &Mantid::Kernel::TimeSeriesProperty<TYPE>::valuesAsVector,      \
+               return_value_policy<VectorToNumpy>()))                          \
       .add_property(                                                           \
-          "times",                                                             \
-          make_function(                                                       \
-              &Mantid::Kernel::TimeSeriesProperty<TYPE>::timesAsVector,        \
-              return_value_policy<VectorToNumpy>()))                           \
-      .def("addValue",                                                         \
-           (void (TimeSeriesProperty<TYPE>::*)(const DateAndTime &,            \
-                                               const TYPE)) &                  \
-               TimeSeriesProperty<TYPE>::addValue,                             \
+           "times",                                                            \
+           make_function(                                                      \
+               &Mantid::Kernel::TimeSeriesProperty<TYPE>::timesAsVector,       \
+               return_value_policy<VectorToNumpy>()))                          \
+      .def("addValue", (void (TimeSeriesProperty<TYPE>::*)(                    \
+                           const DateAndTime &, const TYPE)) &                 \
+                           TimeSeriesProperty<TYPE>::addValue,                 \
            (arg("self"), arg("time"), arg("value")))                           \
-      .def("addValue",                                                         \
-           (void (TimeSeriesProperty<TYPE>::*)(const std::string &,            \
-                                               const TYPE)) &                  \
-               TimeSeriesProperty<TYPE>::addValue,                             \
+      .def("addValue", (void (TimeSeriesProperty<TYPE>::*)(                    \
+                           const std::string &, const TYPE)) &                 \
+                           TimeSeriesProperty<TYPE>::addValue,                 \
            (arg("self"), arg("time"), arg("value")))                           \
       .def("addValue", &addPyTimeValue<TYPE>,                                  \
            (arg("self"), arg("time"), arg("value")))                           \
@@ -93,7 +90,6 @@ std::string dtype(TimeSeriesProperty<TYPE> &self) {
       .def("dtype", &dtype<TYPE>, arg("self"), "returns :`std::string`");
 
 } // namespace
-
 
 void export_TimeSeriesProperty_Double() {
   EXPORT_TIMESERIES_PROP(double, Float);
@@ -124,8 +120,8 @@ void export_TimeSeriesPropertyStatistics() {
       .add_property("median",
                     &Mantid::Kernel::TimeSeriesPropertyStatistics::median)
       .add_property(
-          "standard_deviation",
-          &Mantid::Kernel::TimeSeriesPropertyStatistics::standard_deviation)
+           "standard_deviation",
+           &Mantid::Kernel::TimeSeriesPropertyStatistics::standard_deviation)
       .add_property("duration",
                     &Mantid::Kernel::TimeSeriesPropertyStatistics::duration);
 }

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
@@ -35,6 +35,11 @@ void addPyTimeValue(TimeSeriesProperty<TYPE> &self,
   self.addValue(*dateandtime, value);
 }
 
+// Function to return numpy friendly string format for dtype
+template <typename TYPE>
+void dtype(TimeSeriesProperty<TYPE> &self) {
+}
+
 // Macro to reduce copy-and-paste
 #define EXPORT_TIMESERIES_PROP(TYPE, Prefix)                                   \
   register_ptr_to_python<TimeSeriesProperty<TYPE> *>();                        \
@@ -80,7 +85,8 @@ void addPyTimeValue(TimeSeriesProperty<TYPE> &self,
            arg("self"),                                                        \
            "returns :class:`mantid.kernel.TimeSeriesPropertyStatistics`")      \
       .def("timeAverageValue", &TimeSeriesProperty<TYPE>::timeAverageValue,    \
-           arg("self"));
+           arg("self"))                                                       \
+      .def("dtype", &dtype<TYPE>, arg("self"), "returns :numpy_array");        \
 }
 
 void export_TimeSeriesProperty_Double() {

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
@@ -35,19 +35,36 @@ void addPyTimeValue(TimeSeriesProperty<TYPE> &self,
   self.addValue(*dateandtime, value);
 }
 
+// Template
 template <typename TYPE>
-void dtype(TimeSeriesProperty<TYPE> &self) {
-    if (self.m_propSortedFlag == TimeSeriesProperty<std::string>) {
-      self.type = "s";
-    } else if (self.m_propSortedFlag == TimeSeriesProperty<int32_t>) {
-      self.type = "i";
-    } else if (self.m_propSortedFlag == TimeSeriesProperty<int64_t>) {
-      self.type = "i";
-    } else if (self.m_propSortedFlag == TimeSeriesProperty<bool>) {
-      self.type = "b";
-    } else if (self.m_propSortedFlag == TimeSeriesProperty<double>) {
-      self.type = "d";
-    }
+// Default return if no matches occur
+std::string dtype(TimeSeriesProperty<TYPE> &self) {
+  return "obj";
+}
+
+// String return
+std::string dtype(TimeSeriesProperty<std::string> &self) {
+  return "s";
+}
+
+// Integer (32-bit) return
+std::string dtype(TimeSeriesProperty<int32_t> &self) {
+  return "i";
+}
+
+// Integer (64-bit) return
+std::string dtype(TimeSeriesProperty<int64_t> &self) {
+  return "i";
+}
+
+// Boolean return
+std::string dtype(TimeSeriesProperty<bool> &self) {
+  return "b";
+}
+
+// Double return
+std::string dtype(TimeSeriesProperty<double> &self) {
+  return "d";
 }
 
 // Macro to reduce copy-and-paste

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
@@ -1,8 +1,8 @@
 #include "MantidKernel/TimeSeriesProperty.h"
 #include "MantidPythonInterface/kernel/Converters/DateAndTime.h"
+#include "MantidPythonInterface/kernel/Converters/ContainerDtype.h"
 #include "MantidPythonInterface/kernel/GetPointer.h"
 #include "MantidPythonInterface/kernel/Policies/VectorToNumpy.h"
-#include "MantidKernel/ContainerDtype.h"
 
 #include <boost/python/class.hpp>
 #include <boost/python/implicit.hpp>
@@ -38,7 +38,7 @@ void addPyTimeValue(TimeSeriesProperty<TYPE> &self,
 
 // Call the dtype helper function
 template <typename TYPE> std::string dtype(TimeSeriesProperty<TYPE> &self) {
-  return dtypeHelper::dtype(self);
+  return Mantid::PythonInterface::Converters::dtype(self);
 }
 
 // Macro to reduce copy-and-paste
@@ -87,7 +87,7 @@ template <typename TYPE> std::string dtype(TimeSeriesProperty<TYPE> &self) {
            "returns :class:`mantid.kernel.TimeSeriesPropertyStatistics`")      \
       .def("timeAverageValue", &TimeSeriesProperty<TYPE>::timeAverageValue,    \
            arg("self"))                                                        \
-      .def("dtype", &dtype<TYPE>, arg("self"), "returns :`std::string`");
+      .def("dtype", &dtype<TYPE>, arg("self"));
 
 } // namespace
 

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
@@ -35,6 +35,7 @@ void addPyTimeValue(TimeSeriesProperty<TYPE> &self,
   self.addValue(*dateandtime, value);
 }
 
+
 // Template
 template <typename TYPE>
 // Default return if no matches occur
@@ -43,25 +44,30 @@ std::string dtype(TimeSeriesProperty<TYPE> &self) {
 }
 
 // String return
+template <> 
 std::string dtype(TimeSeriesProperty<std::string> &self) {
   return "s";
 }
 
+template <>
 // Integer (32-bit) return
 std::string dtype(TimeSeriesProperty<int32_t> &self) {
   return "i";
 }
 
+template <>
 // Integer (64-bit) return
 std::string dtype(TimeSeriesProperty<int64_t> &self) {
   return "i";
 }
 
+template <>
 // Boolean return
 std::string dtype(TimeSeriesProperty<bool> &self) {
   return "b";
 }
 
+template <>
 // Double return
 std::string dtype(TimeSeriesProperty<double> &self) {
   return "d";
@@ -113,7 +119,7 @@ std::string dtype(TimeSeriesProperty<double> &self) {
            "returns :class:`mantid.kernel.TimeSeriesPropertyStatistics`")      \
       .def("timeAverageValue", &TimeSeriesProperty<TYPE>::timeAverageValue,    \
            arg("self"))                                                        \
-      .def("dtype", &dtype<TYPE>, arg("self"));                                \
+      .def("dtype", &dtype<TYPE>, arg("self"), "returns :`std::string`");      \
 
 }
 

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
@@ -2,6 +2,7 @@
 #include "MantidPythonInterface/kernel/Converters/DateAndTime.h"
 #include "MantidPythonInterface/kernel/GetPointer.h"
 #include "MantidPythonInterface/kernel/Policies/VectorToNumpy.h"
+#include "MantidKernel/ContainerDtype.h"
 
 #include <boost/python/class.hpp>
 #include <boost/python/implicit.hpp>
@@ -35,27 +36,11 @@ void addPyTimeValue(TimeSeriesProperty<TYPE> &self,
   self.addValue(*dateandtime, value);
 }
 
-// Default return if no matches occur
-template <typename TYPE> std::string dtype(TimeSeriesProperty<TYPE> &self) {
-  return "obj";
+// Call the dtype helper function
+template <typename TYPE>
+std::string dtype(TimeSeriesProperty<TYPE> &self) {
+  return dtypeHelper::dtype(self);
 }
-
-// String return
-template <> std::string dtype(TimeSeriesProperty<std::string> &self) {
-  return "s";
-}
-
-// Integer (32-bit) return
-template <> std::string dtype(TimeSeriesProperty<int32_t> &self) { return "i"; }
-
-// Integer (64-bit) return
-template <> std::string dtype(TimeSeriesProperty<int64_t> &self) { return "i"; }
-
-// Boolean return
-template <> std::string dtype(TimeSeriesProperty<bool> &self) { return "b"; }
-
-// Double return
-template <> std::string dtype(TimeSeriesProperty<double> &self) { return "d"; }
 
 // Macro to reduce copy-and-paste
 #define EXPORT_TIMESERIES_PROP(TYPE, Prefix)                                   \
@@ -108,6 +93,7 @@ template <> std::string dtype(TimeSeriesProperty<double> &self) { return "d"; }
       .def("dtype", &dtype<TYPE>, arg("self"), "returns :`std::string`");
 
 } // namespace
+
 
 void export_TimeSeriesProperty_Double() {
   EXPORT_TIMESERIES_PROP(double, Float);

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
@@ -7,12 +7,12 @@
 #include <boost/python/implicit.hpp>
 #include <boost/python/init.hpp>
 #include <boost/python/make_function.hpp>
-#include <boost/python/return_value_policy.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
+#include <boost/python/return_value_policy.hpp>
 
-using Mantid::Types::Core::DateAndTime;
-using Mantid::Kernel::TimeSeriesProperty;
 using Mantid::Kernel::Property;
+using Mantid::Kernel::TimeSeriesProperty;
+using Mantid::Types::Core::DateAndTime;
 using namespace boost::python;
 using boost::python::arg;
 
@@ -35,43 +35,27 @@ void addPyTimeValue(TimeSeriesProperty<TYPE> &self,
   self.addValue(*dateandtime, value);
 }
 
-
-// Template
-template <typename TYPE>
 // Default return if no matches occur
-std::string dtype(TimeSeriesProperty<TYPE> &self) {
+template <typename TYPE> std::string dtype(TimeSeriesProperty<TYPE> &self) {
   return "obj";
 }
 
 // String return
-template <> 
-std::string dtype(TimeSeriesProperty<std::string> &self) {
+template <> std::string dtype(TimeSeriesProperty<std::string> &self) {
   return "s";
 }
 
-template <>
 // Integer (32-bit) return
-std::string dtype(TimeSeriesProperty<int32_t> &self) {
-  return "i";
-}
+template <> std::string dtype(TimeSeriesProperty<int32_t> &self) { return "i"; }
 
-template <>
 // Integer (64-bit) return
-std::string dtype(TimeSeriesProperty<int64_t> &self) {
-  return "i";
-}
+template <> std::string dtype(TimeSeriesProperty<int64_t> &self) { return "i"; }
 
-template <>
 // Boolean return
-std::string dtype(TimeSeriesProperty<bool> &self) {
-  return "b";
-}
+template <> std::string dtype(TimeSeriesProperty<bool> &self) { return "b"; }
 
-template <>
 // Double return
-std::string dtype(TimeSeriesProperty<double> &self) {
-  return "d";
-}
+template <> std::string dtype(TimeSeriesProperty<double> &self) { return "d"; }
 
 // Macro to reduce copy-and-paste
 #define EXPORT_TIMESERIES_PROP(TYPE, Prefix)                                   \
@@ -81,22 +65,24 @@ std::string dtype(TimeSeriesProperty<double> &self) {
       #Prefix "TimeSeriesProperty",                                            \
       init<const std::string &>((arg("self"), arg("value"))))                  \
       .add_property(                                                           \
-           "value",                                                            \
-           make_function(                                                      \
-               &Mantid::Kernel::TimeSeriesProperty<TYPE>::valuesAsVector,      \
-               return_value_policy<VectorToNumpy>()))                          \
+          "value",                                                             \
+          make_function(                                                       \
+              &Mantid::Kernel::TimeSeriesProperty<TYPE>::valuesAsVector,       \
+              return_value_policy<VectorToNumpy>()))                           \
       .add_property(                                                           \
-           "times",                                                            \
-           make_function(                                                      \
-               &Mantid::Kernel::TimeSeriesProperty<TYPE>::timesAsVector,       \
-               return_value_policy<VectorToNumpy>()))                          \
-      .def("addValue", (void (TimeSeriesProperty<TYPE>::*)(                    \
-                           const DateAndTime &, const TYPE)) &                 \
-                           TimeSeriesProperty<TYPE>::addValue,                 \
+          "times",                                                             \
+          make_function(                                                       \
+              &Mantid::Kernel::TimeSeriesProperty<TYPE>::timesAsVector,        \
+              return_value_policy<VectorToNumpy>()))                           \
+      .def("addValue",                                                         \
+           (void (TimeSeriesProperty<TYPE>::*)(const DateAndTime &,            \
+                                               const TYPE)) &                  \
+               TimeSeriesProperty<TYPE>::addValue,                             \
            (arg("self"), arg("time"), arg("value")))                           \
-      .def("addValue", (void (TimeSeriesProperty<TYPE>::*)(                    \
-                           const std::string &, const TYPE)) &                 \
-                           TimeSeriesProperty<TYPE>::addValue,                 \
+      .def("addValue",                                                         \
+           (void (TimeSeriesProperty<TYPE>::*)(const std::string &,            \
+                                               const TYPE)) &                  \
+               TimeSeriesProperty<TYPE>::addValue,                             \
            (arg("self"), arg("time"), arg("value")))                           \
       .def("addValue", &addPyTimeValue<TYPE>,                                  \
            (arg("self"), arg("time"), arg("value")))                           \
@@ -119,9 +105,9 @@ std::string dtype(TimeSeriesProperty<double> &self) {
            "returns :class:`mantid.kernel.TimeSeriesPropertyStatistics`")      \
       .def("timeAverageValue", &TimeSeriesProperty<TYPE>::timeAverageValue,    \
            arg("self"))                                                        \
-      .def("dtype", &dtype<TYPE>, arg("self"), "returns :`std::string`");      \
+      .def("dtype", &dtype<TYPE>, arg("self"), "returns :`std::string`");
 
-}
+} // namespace
 
 void export_TimeSeriesProperty_Double() {
   EXPORT_TIMESERIES_PROP(double, Float);
@@ -152,8 +138,8 @@ void export_TimeSeriesPropertyStatistics() {
       .add_property("median",
                     &Mantid::Kernel::TimeSeriesPropertyStatistics::median)
       .add_property(
-           "standard_deviation",
-           &Mantid::Kernel::TimeSeriesPropertyStatistics::standard_deviation)
+          "standard_deviation",
+          &Mantid::Kernel::TimeSeriesPropertyStatistics::standard_deviation)
       .add_property("duration",
                     &Mantid::Kernel::TimeSeriesPropertyStatistics::duration);
 }

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
@@ -35,9 +35,19 @@ void addPyTimeValue(TimeSeriesProperty<TYPE> &self,
   self.addValue(*dateandtime, value);
 }
 
-// Function to return numpy friendly string format for dtype
 template <typename TYPE>
 void dtype(TimeSeriesProperty<TYPE> &self) {
+    if (self.m_propSortedFlag == TimeSeriesProperty<std::string>) {
+      self.type = "s";
+    } else if (self.m_propSortedFlag == TimeSeriesProperty<int32_t>) {
+      self.type = "i";
+    } else if (self.m_propSortedFlag == TimeSeriesProperty<int64_t>) {
+      self.type = "i";
+    } else if (self.m_propSortedFlag == TimeSeriesProperty<bool>) {
+      self.type = "b";
+    } else if (self.m_propSortedFlag == TimeSeriesProperty<double>) {
+      self.type = "d";
+    }
 }
 
 // Macro to reduce copy-and-paste
@@ -85,8 +95,9 @@ void dtype(TimeSeriesProperty<TYPE> &self) {
            arg("self"),                                                        \
            "returns :class:`mantid.kernel.TimeSeriesPropertyStatistics`")      \
       .def("timeAverageValue", &TimeSeriesProperty<TYPE>::timeAverageValue,    \
-           arg("self"))                                                       \
-      .def("dtype", &dtype<TYPE>, arg("self"), "returns :numpy_array");        \
+           arg("self"))                                                        \
+      .def("dtype", &dtype<TYPE>, arg("self"));                                \
+
 }
 
 void export_TimeSeriesProperty_Double() {

--- a/Framework/PythonInterface/test/python/mantid/kernel/ArrayPropertyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/ArrayPropertyTest.py
@@ -154,9 +154,9 @@ class ArrayPropertyTest(unittest.TestCase):
         str_arr = StringArrayProperty("letters", str_input_values, validator, direc)
 
         # Test
-        self.assertEquals(float_arr.dtype(), "d")
-        self.assertEquals(int_arr.dtype(), "i")
-        self.assertEquals(str_arr.dtype(), "s")
+        self.assertEquals(float_arr.dtype(), "double")
+        self.assertEquals(int_arr.dtype(), "long")
+        self.assertEquals(str_arr.dtype(), "string")
 
 
     def test_PythonAlgorithm_setProperty_With_Ranges_String(self):

--- a/Framework/PythonInterface/test/python/mantid/kernel/ArrayPropertyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/ArrayPropertyTest.py
@@ -129,7 +129,7 @@ class ArrayPropertyTest(unittest.TestCase):
                     FloatArrayProperty("Input", Direction.Input), "Float array")
             def PyExec(self):
                 self._input_values = self.getProperty("Input").value
-    
+
         input_values = range(1, 5)
         self._do_algorithm_test(AlgWithFloatArrayProperty, input_values)
 
@@ -144,7 +144,7 @@ class ArrayPropertyTest(unittest.TestCase):
         # Create float array
         float_input_values = [1.1, 2.5, 5.6, 4.6, 9.0, 6.0]
         float_arr = FloatArrayProperty("floats", float_input_values, validator, direc)
-         
+
         # Create int array
         int_input_values = [1, 2, 5, 4, 9, 6]
         int_arr = IntArrayProperty("integers", int_input_values, validator, direc)
@@ -152,7 +152,7 @@ class ArrayPropertyTest(unittest.TestCase):
         # Create string array
         str_input_values =["a", "b", "c", "d", "e"]
         str_arr = StringArrayProperty("letters", str_input_values, validator, direc)
-       
+
         # Test
         self.assertEquals(float_arr.dtype(), "d")
         self.assertEquals(int_arr.dtype(), "i")

--- a/Framework/PythonInterface/test/python/mantid/kernel/ArrayPropertyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/ArrayPropertyTest.py
@@ -155,8 +155,17 @@ class ArrayPropertyTest(unittest.TestCase):
 
         # Test
         self.assertEquals(float_arr.dtype(), "double")
-        self.assertEquals(int_arr.dtype(), "long")
         self.assertEquals(str_arr.dtype(), "string")
+        
+        # Implementation of IntArrayProperty is based on long 
+        # (which is itself implementation defined, so a special case is needed here)
+        import os
+        if os.name == 'nt':
+          # Windows should return "long"
+          self.assertEquals(int_arr.dtype(), "long")
+        else:
+          # Unix based systems should return "int64"
+          self.assertEquals(int_arr.dtype(), "int64")
 
 
     def test_PythonAlgorithm_setProperty_With_Ranges_String(self):

--- a/Framework/PythonInterface/test/python/mantid/kernel/ArrayPropertyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/ArrayPropertyTest.py
@@ -159,12 +159,11 @@ class ArrayPropertyTest(unittest.TestCase):
         
         # Implementation of IntArrayProperty is based on long 
         # (which is itself implementation defined, so a special case is needed here)
-        import os
-        if os.name == 'nt':
-          # Windows should return "long"
+        if sys.platform == 'win32' or sys.platform == 'darwin':
+          # Windows and macOS should return "long"
           self.assertEquals(int_arr.dtype(), "long")
         else:
-          # Unix based systems should return "int64"
+          # Linux based systems should return "int64"
           self.assertEquals(int_arr.dtype(), "int64")
 
 

--- a/Framework/PythonInterface/test/python/mantid/kernel/ArrayPropertyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/ArrayPropertyTest.py
@@ -150,22 +150,64 @@ class ArrayPropertyTest(unittest.TestCase):
         int_arr = IntArrayProperty("integers", int_input_values, validator, direc)
 
         # Create string array
-        str_input_values =["a", "b", "c", "d", "e"]
+        str_input_values = ["a", "b", "c", "d", "e"]
         str_arr = StringArrayProperty("letters", str_input_values, validator, direc)
 
         # Test
-        self.assertEquals(float_arr.dtype(), "double")
-        self.assertEquals(str_arr.dtype(), "string")
+        self.assertEquals(float_arr.dtype(), "float64")
+        self.assertEquals(str_arr.dtype(), "string_")
         
         # Implementation of IntArrayProperty is based on long 
         # (which is itself implementation defined, so a special case is needed here)
         if sys.platform == 'win32' or sys.platform == 'darwin':
-          # Windows and macOS should return "long"
-          self.assertEquals(int_arr.dtype(), "long")
+          # Windows and macOS should return "int_"
+          self.assertEquals(int_arr.dtype(), "int_")
         else:
           # Linux based systems should return "int64"
           self.assertEquals(int_arr.dtype(), "int64")
 
+    def test_construct_numpy_array_with_given_dtype_float(self):
+        # Set up
+        direc = Direction.Output
+        validator = NullValidator()
+
+        # Create float array
+        float_input_values = [1.1, 2.5, 5.6, 4.6, 9.0, 6.0]
+        float_arr = FloatArrayProperty("floats", float_input_values, validator, direc)
+        
+        # Use the returned dtype() to check it works with numpy arrays
+        x = np.arange(1, 10, dtype=float_arr.dtype())
+        self.assertIsInstance(x, np.ndarray)
+        self.assertEquals(x.dtype, float_arr.dtype()) 
+
+    def test_construct_numpy_array_with_given_dtype_int(self):
+        # Set up
+        direc = Direction.Output
+        validator = NullValidator()
+
+        # Create int array
+        int_input_values = [1, 2, 5, 4, 9, 6]
+        int_arr = IntArrayProperty("integers", int_input_values, validator, direc)
+        
+        # Use the returned dtype() to check it works with numpy arrays
+        x = np.arange(1, 10, dtype=int_arr.dtype())
+        self.assertIsInstance(x, np.ndarray)
+        self.assertEquals(x.dtype, int_arr.dtype())
+
+    def test_construct_numpy_array_with_given_dtype_string(self):
+        # Set up
+        direc = Direction.Output
+        validator = NullValidator()
+
+        # Create string array
+        str_input_values = ["hello", "testing", "word", "another word", "word"]
+        str_arr = StringArrayProperty("letters", str_input_values, validator, direc)
+        
+        # Use the returned dtype() to check it works with numpy arrays
+        x = np.array(str_input_values, dtype=str_arr.dtype())
+        self.assertIsInstance(x, np.ndarray)
+        # Expect longest string to be returned
+        self.assertEquals(x.dtype, "S12")     
 
     def test_PythonAlgorithm_setProperty_With_Ranges_String(self):
         """

--- a/Framework/PythonInterface/test/python/mantid/kernel/ArrayPropertyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/ArrayPropertyTest.py
@@ -133,6 +133,32 @@ class ArrayPropertyTest(unittest.TestCase):
         input_values = range(1, 5)
         self._do_algorithm_test(AlgWithFloatArrayProperty, input_values)
 
+    def test_dtype_function_calls(self):
+        """
+        Tests the dtype() function call for the data types stored in the array.
+        """
+        # Set up
+        direc = Direction.Output
+        validator = NullValidator()
+
+        # Create float array
+        float_input_values = [1.1, 2.5, 5.6, 4.6, 9.0, 6.0]
+        float_arr = FloatArrayProperty("floats", float_input_values, validator, direc)
+         
+        # Create int array
+        int_input_values = [1, 2, 5, 4, 9, 6]
+        int_arr = IntArrayProperty("integers", int_input_values, validator, direc)
+
+        # Create string array
+        str_input_values =["a", "b", "c", "d", "e"]
+        str_arr = StringArrayProperty("letters", str_input_values, validator, direc)
+       
+        # Test
+        self.assertEquals(float_arr.dtype(), "d")
+        self.assertEquals(int_arr.dtype(), "i")
+        self.assertEquals(str_arr.dtype(), "s")
+
+
     def test_PythonAlgorithm_setProperty_With_Ranges_String(self):
         """
             Test ArrayProperty within a python algorithm can

--- a/Framework/PythonInterface/test/python/mantid/kernel/PropertyWithValueTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/PropertyWithValueTest.py
@@ -128,7 +128,7 @@ class PropertyWithValueTest(unittest.TestCase):
         self.assertEquals(result.endswith("98,99"), True)
 
         # Check the dtype return value
-        self.assertEquals(det_list_prop.dtype(), "i")
+        self.assertEquals(det_list_prop.dtype(), "int32")
 
     def _do_vector_double_numpy_test(self, int_type=False):
         create_ws = AlgorithmManager.createUnmanaged('CreateWorkspace')

--- a/Framework/PythonInterface/test/python/mantid/kernel/PropertyWithValueTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/PropertyWithValueTest.py
@@ -126,6 +126,9 @@ class PropertyWithValueTest(unittest.TestCase):
         result = det_list_prop.valueAsPrettyStr(40,False)
         self.assertEquals(result.startswith("1,2,3,"), True)
         self.assertEquals(result.endswith("98,99"), True)
+        
+        # Check the dtype return value
+        self.assertEquals(det_list_prop.dtype(), "int32")
 
     def _do_vector_double_numpy_test(self, int_type=False):
         create_ws = AlgorithmManager.createUnmanaged('CreateWorkspace')

--- a/Framework/PythonInterface/test/python/mantid/kernel/PropertyWithValueTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/PropertyWithValueTest.py
@@ -126,9 +126,9 @@ class PropertyWithValueTest(unittest.TestCase):
         result = det_list_prop.valueAsPrettyStr(40,False)
         self.assertEquals(result.startswith("1,2,3,"), True)
         self.assertEquals(result.endswith("98,99"), True)
-        
+
         # Check the dtype return value
-        self.assertEquals(det_list_prop.dtype(), "int32")
+        self.assertEquals(det_list_prop.dtype(), "i")
 
     def _do_vector_double_numpy_test(self, int_type=False):
         create_ws = AlgorithmManager.createUnmanaged('CreateWorkspace')

--- a/Framework/PythonInterface/test/python/mantid/kernel/TimeSeriesPropertyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/TimeSeriesPropertyTest.py
@@ -69,7 +69,7 @@ class TimeSeriesPropertyTest(unittest.TestCase):
         self.assertEquals(log_series.size(), self._nframes)
         self.assertEquals(log_series.nthValue(1), 1436)
         # Check the dtype return value
-        self.assertEquals(log_series.dtype(), "int64")
+        self.assertEquals(log_series.dtype(), "i")
 
     def test_time_series_string_can_be_extracted(self):
         log_series = self._test_ws.getRun()["icp_event"]

--- a/Framework/PythonInterface/test/python/mantid/kernel/TimeSeriesPropertyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/TimeSeriesPropertyTest.py
@@ -69,7 +69,7 @@ class TimeSeriesPropertyTest(unittest.TestCase):
         self.assertEquals(log_series.size(), self._nframes)
         self.assertEquals(log_series.nthValue(1), 1436)
         # Check the dtype return value
-        self.assertEquals(log_series.dtype(), "i")
+        self.assertEquals(log_series.dtype(), "int64")
 
     def test_time_series_string_can_be_extracted(self):
         log_series = self._test_ws.getRun()["icp_event"]

--- a/Framework/PythonInterface/test/python/mantid/kernel/TimeSeriesPropertyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/TimeSeriesPropertyTest.py
@@ -61,7 +61,7 @@ class TimeSeriesPropertyTest(unittest.TestCase):
         self.assertEquals(log_series.size(), self._ntemp)
         self.assertAlmostEqual(log_series.nthValue(0), -0.00161)
         # Check the dtype return value
-        self.assertEquals(log_series.dtype(), "d")
+        self.assertEquals(log_series.dtype(), "double")
 
     def test_time_series_int_can_be_extracted(self):
         log_series = self._test_ws.getRun()["raw_frames"]
@@ -69,7 +69,7 @@ class TimeSeriesPropertyTest(unittest.TestCase):
         self.assertEquals(log_series.size(), self._nframes)
         self.assertEquals(log_series.nthValue(1), 1436)
         # Check the dtype return value
-        self.assertEquals(log_series.dtype(), "i")
+        self.assertEquals(log_series.dtype(), "int64")
 
     def test_time_series_string_can_be_extracted(self):
         log_series = self._test_ws.getRun()["icp_event"]
@@ -77,14 +77,14 @@ class TimeSeriesPropertyTest(unittest.TestCase):
         self.assertEquals(log_series.size(), 4)
         self.assertEquals(log_series.nthValue(0).strip(), 'CHANGE_PERIOD 1')
         # Check the dtype return value
-        self.assertEquals(log_series.dtype(), "s")
+        self.assertEquals(log_series.dtype(), "string")
 
     def test_time_series_bool_can_be_extracted(self):
         log_series = self._test_ws.getRun()["period 1"]
         self._check_has_time_series_attributes(log_series)
         self.assertEquals(log_series.size(), 1)
         # Check the dtype return value
-        self.assertEquals(log_series.dtype(), "b")
+        self.assertEquals(log_series.dtype(), "boolean")
 
     def _check_has_time_series_attributes(self, log, values_type=np.ndarray):
         self.assertTrue(hasattr(log, "value"))

--- a/Framework/PythonInterface/test/python/mantid/kernel/TimeSeriesPropertyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/TimeSeriesPropertyTest.py
@@ -61,7 +61,7 @@ class TimeSeriesPropertyTest(unittest.TestCase):
         self.assertEquals(log_series.size(), self._ntemp)
         self.assertAlmostEqual(log_series.nthValue(0), -0.00161)
         # Check the dtype return value
-        self.assertEquals(log_series.dtype(), "double")
+        self.assertEquals(log_series.dtype(), "float64")
 
     def test_time_series_int_can_be_extracted(self):
         log_series = self._test_ws.getRun()["raw_frames"]
@@ -77,14 +77,14 @@ class TimeSeriesPropertyTest(unittest.TestCase):
         self.assertEquals(log_series.size(), 4)
         self.assertEquals(log_series.nthValue(0).strip(), 'CHANGE_PERIOD 1')
         # Check the dtype return value
-        self.assertEquals(log_series.dtype(), "string")
+        self.assertEquals(log_series.dtype(), "string_")
 
     def test_time_series_bool_can_be_extracted(self):
         log_series = self._test_ws.getRun()["period 1"]
         self._check_has_time_series_attributes(log_series)
         self.assertEquals(log_series.size(), 1)
         # Check the dtype return value
-        self.assertEquals(log_series.dtype(), "boolean")
+        self.assertEquals(log_series.dtype(), "bool_")
 
     def _check_has_time_series_attributes(self, log, values_type=np.ndarray):
         self.assertTrue(hasattr(log, "value"))

--- a/Framework/PythonInterface/test/python/mantid/kernel/TimeSeriesPropertyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/TimeSeriesPropertyTest.py
@@ -60,23 +60,31 @@ class TimeSeriesPropertyTest(unittest.TestCase):
         self._check_has_time_series_attributes(log_series)
         self.assertEquals(log_series.size(), self._ntemp)
         self.assertAlmostEqual(log_series.nthValue(0), -0.00161)
+        # Check the dtype return value
+        self.assertEquals(log_series.dtype(), "d")
 
     def test_time_series_int_can_be_extracted(self):
         log_series = self._test_ws.getRun()["raw_frames"]
         self._check_has_time_series_attributes(log_series)
         self.assertEquals(log_series.size(), self._nframes)
         self.assertEquals(log_series.nthValue(1), 1436)
+        # Check the dtype return value
+        self.assertEquals(log_series.dtype(), "i")
 
     def test_time_series_string_can_be_extracted(self):
         log_series = self._test_ws.getRun()["icp_event"]
         self._check_has_time_series_attributes(log_series, list)
         self.assertEquals(log_series.size(), 4)
         self.assertEquals(log_series.nthValue(0).strip(), 'CHANGE_PERIOD 1')
+        # Check the dtype return value
+        self.assertEquals(log_series.dtype(), "s")
 
     def test_time_series_bool_can_be_extracted(self):
         log_series = self._test_ws.getRun()["period 1"]
         self._check_has_time_series_attributes(log_series)
         self.assertEquals(log_series.size(), 1)
+        # Check the dtype return value
+        self.assertEquals(log_series.dtype(), "b")
 
     def _check_has_time_series_attributes(self, log, values_type=np.ndarray):
         self.assertTrue(hasattr(log, "value"))
@@ -86,7 +94,6 @@ class TimeSeriesPropertyTest(unittest.TestCase):
         values = log.value
         self.assertTrue(isinstance(values, values_type))
         self.assertEquals(log.size(), len(values))
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description of work.**
Implemented a new function called `dtype()` which is exposed to the Python side that returns a numpy friendly string format for the `dtype`.

Documentation of the `numpy` function:
https://docs.scipy.org/doc/numpy-1.14.0/reference/generated/numpy.dtype.html

**Report to:** @samueljackson92  <!--If the original issue was raised by a user they should be named here.-->

**To test:**
Not much to test specifically - just run the Python unit tests.

<!-- Instructions for testing. -->
`ctest -C Debug -R TimeSeriesProperty`

Fixes #22553. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
