### PR TITLE
Make BinMD always remember value of basis vector properties

### DIFF
--- a/docs/source/release/v3.13.0/framework.rst
+++ b/docs/source/release/v3.13.0/framework.rst
@@ -64,6 +64,7 @@ Bug fixes
 - The output workspace of :ref:`LineProfile <algm-LineProfile>` now has correct sample logs, instrument and history.
 - TimeSeriesProperty::splitByTimeVector's behavior on a boundary condition is changed.  In the set of splitters toward a same target splitted workspace, if there is a splitter's beginning time is after the last entry of the TimeSeriesProperty to be split, then this last entry shall be included in its output TimeSeriesProperty.
 - Fixed a bug in :ref:`MergeRuns <algm-MergeRuns>` which could cause the runs to be merged in a different sequence than indicated in the *InputWorkspaces* property.
+- Fixed a bug where the values entered for basis vector properties in :ref:`BinMD <algm-BinMD>` were not being remembered.
 
 New
 ###

--- a/qt/widgets/common/src/SlicingAlgorithmDialog.cpp
+++ b/qt/widgets/common/src/SlicingAlgorithmDialog.cpp
@@ -266,7 +266,7 @@ void SlicingAlgorithmDialog::buildDimensionInputs(const bool bForceForget) {
   } else {
     makeDimensionInputs("BasisVector",
                         this->ui.non_axis_aligned_layout->layout(),
-                        formatNonAlignedDimensionInput, useHistory);
+                        formatNonAlignedDimensionInput, Remember);
   }
 }
 


### PR DESCRIPTION
**Description of work.**
Fix BinMD not saving the value of the basis vector properties between runs.

This is very annoying for users. Now the custom dialog will remember the previous value.

**Report to:** Pascal Manuel

**To test:**

Try to use BinMD on an MD workspace an set the basis vector to something, then try to perform another rebin. It should now remember the parameters used.

_No associated issue._

Does this update require release notes?
- [x] Yes
- [ ] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
