### PR TITLE
Fix an apparent bug in FitPeaks.

### DIFF
--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -854,9 +854,7 @@ FitPeaks::fitPeaks() {
 namespace {
 /// Supported peak profiles for observation
 std::vector<std::string> supported_peak_profiles{"Gaussian", "Lorentzian",
-                                                 "962"
-                                                 "Voigt",
-                                                 "Voigt"};
+                                                 "PseudoVoigt", "Voigt"};
 
 double numberCounts(const Histogram &histogram) {
   double total = 0.;

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -854,7 +854,9 @@ FitPeaks::fitPeaks() {
 namespace {
 /// Supported peak profiles for observation
 std::vector<std::string> supported_peak_profiles{"Gaussian", "Lorentzian",
-                                                 "PseudoVoigt", "Voigt"};
+                                                 "962"
+                                                 "Voigt",
+                                                 "Voigt"};
 
 double numberCounts(const Histogram &histogram) {
   double total = 0.;
@@ -959,7 +961,7 @@ void FitPeaks::fitSpectrumPeaks(
       bool observe_peak_width_flag =
           decideToEstimatePeakWidth(!foundAnyPeak, peakfunction);
 
-      if (observe_peak_width &&
+      if (observe_peak_width_flag &&
           m_peakWidthEstimateApproach == EstimatePeakWidth::NoEstimation) {
         g_log.warning(
             "Peak width can be estimated as ZERO.  The result can be wrong");


### PR DESCRIPTION
**Description of work.**

There is an apparent bug in FindPeaks in method isObservablePeakProfile() which checks whether a peak profile is supported to have peak width observed.  

**To test:**

1. Review the change of codes
2. All the unit and system test pass

<!-- Instructions for testing. -->


Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
