### PR TITLE
Fix child algorithms EnableLogging setting

### DIFF
--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -983,7 +983,10 @@ def _set_logging_option(algm_obj, kwargs):
         :param algm_obj: An initialised algorithm object
         :param **kwargs: A dictionary of the keyword arguments passed to the simple function call
     """
-    algm_obj.setLogging(kwargs.pop(__LOGGING_KEYWORD__, True))
+    import inspect
+    parent = _find_parent_pythonalgorithm(inspect.currentframe())
+    logging_default = parent.isLogging() if parent is not None else True
+    algm_obj.setLogging(kwargs.pop(__LOGGING_KEYWORD__, logging_default))
 
 
 def _set_store_ads(algm_obj, kwargs):
@@ -1119,7 +1122,6 @@ def _create_algorithm_object(name, version=-1, startProgress=None, endProgress=N
             kwargs['startProgress'] = float(startProgress)
             kwargs['endProgress'] = float(endProgress)
         alg = parent.createChildAlgorithm(name, **kwargs)
-        alg.setLogging(parent.isLogging())  # default is to log if parent is logging
     else:
         # managed algorithm so that progress reporting
         # can be more easily wired up automatically

--- a/Framework/PythonInterface/plugins/algorithms/LoadAndMerge.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadAndMerge.py
@@ -77,6 +77,7 @@ class LoadAndMerge(PythonAlgorithm):
         # MergeRuns, which does not work outside ADS (because of WorkspaceGroup input)
         alg = self.createChildAlgorithm(self._loader, self._version)
         alg.setAlwaysStoreInADS(True)
+        alg.setLogging(self.isLogging())
         alg.initialize()
         for key in self._loader_options.keys():
             alg.setPropertyValue(key, self._loader_options.getPropertyValue(key))

--- a/docs/source/release/v3.13.0/framework.rst
+++ b/docs/source/release/v3.13.0/framework.rst
@@ -93,5 +93,6 @@ Bugfixes
 - Checks on the structure of Python fit function classes have been improved to avoid scenarios, such as writing ``function1d`` rather than ``function1D``, which
   would previously have resulted in a hard crash.
 - Fit functions defined in a python script can be used with the new fit function API right after sibscription.
+- Child algorithms now respect their parent algorithm's ``EnableLogging`` setting when invoked using the function-style calling. Previously, some messages could appear in the log even though ``EnableLogging`` was set to ``False``.
 
 :ref:`Release 3.13.0 <v3.13.0>`


### PR DESCRIPTION
`simpleapi` used to default to `EnableLogging=True` even for child algorithms when they were called using the function style call in Python algorithms. This PR fixes the issue by correctly propagating the logging setting from the parent to the child algorithms.

**Report to:** nobody

**To test:**

You should be able to try this with any Python algorithm calling other algorithms using function-style calls. One example is `LoadAndMerge`. The following line should produce a single warning to Mantid's logs when logging level is set to *notice*:
```python
ws = LoadAndMerge('ILL/D17/317369,317369', EnableLogging=False)
```

Note that the default facility should be set to ILL and the unit test data directory has to be in the data search path.

Changing `EnableLogging=True` above should produce output from the child algorithms called from `LoadAndMerge`.

Fixes #22403.

Does this update require release notes?
- [x] Yes
- [ ] No

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
