### PR TITLE
Rectangular Detector Fix for ypixels=1

### DIFF
--- a/qt/widgets/instrumentview/src/BankRenderingHelpers.cpp
+++ b/qt/widgets/instrumentview/src/BankRenderingHelpers.cpp
@@ -97,10 +97,10 @@ void renderRectangularBank(const Mantid::Geometry::ComponentInfo &compInfo,
 
   auto c = findCorners(compInfo, index);
   auto bank = compInfo.quadrilateralComponent(index);
-  auto xstep =
-      (c.bottomRight.X() - c.bottomLeft.X()) / static_cast<double>(bank.nX);
-  auto ystep =
-      (c.topRight.Y() - c.bottomLeft.Y()) / static_cast<double>(bank.nY);
+  const auto &detShape = compInfo.shape(bank.bottomLeft);
+  const auto &shapeInfo = detShape.getGeometryHandler()->shapeInfo();
+  auto xstep = shapeInfo.points()[0].X() - shapeInfo.points()[1].X();
+  auto ystep = shapeInfo.points()[1].Y() - shapeInfo.points()[2].Y();
   auto name = compInfo.name(index);
   // Because texture colours are combined with the geometry colour
   // make sure the current colour is white


### PR DESCRIPTION
**Description of work.**

Previously, the x and y steps for the rectangular detector were not calculated using detector shape. This has been corrected.

**To test:**

See issue for testing instructions.

Fixes #22660 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
