### PR TITLE
Refs #20443 : Threading of Strings::join()

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/Strings.h
+++ b/Framework/Kernel/inc/MantidKernel/Strings.h
@@ -5,10 +5,11 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidKernel/DllConfig.h"
+#include "MantidKernel/MultiThreaded.h"
 #include "MantidKernel/System.h"
 
-#include <map>
 #include <iosfwd>
+#include <map>
 #include <set>
 #include <sstream>
 #include <string>
@@ -52,14 +53,20 @@ namespace Strings {
  * For example, join a vector of strings with commas with:
  *  out = join(v.begin(), v.end(), ", ");
  *
+ * This version is used for random access iterators (e.g. map, set).
+ *
  * @param begin :: iterator at the start
  * @param end :: iterator at the end
  * @param separator :: string to append.
  * @return
  */
 template <typename ITERATOR_TYPE>
-DLLExport std::string join(ITERATOR_TYPE begin, ITERATOR_TYPE end,
-                           const std::string &separator) {
+DLLExport std::string
+join(ITERATOR_TYPE begin, ITERATOR_TYPE end, const std::string &separator,
+     typename std::enable_if<
+         !(std::is_same<
+             typename std::iterator_traits<ITERATOR_TYPE>::iterator_category,
+             std::random_access_iterator_tag>::value)>::type * = nullptr) {
   std::ostringstream output;
   ITERATOR_TYPE it;
   for (it = begin; it != end;) {
@@ -73,21 +80,79 @@ DLLExport std::string join(ITERATOR_TYPE begin, ITERATOR_TYPE end,
 
 //------------------------------------------------------------------------------------------------
 /** Join a set or vector of (something that turns into a string) together
-* into one string, separated by a separator,
-* adjacent items that are precisely 1 away from each other
-* will be compressed into a list syntax e.g. 1-5.
-* Returns an empty string if the range is null.
-* Does not add the separator after the LAST item.
-*
-* For example, join a vector of strings with commas with:
-*  out = join(v.begin(), v.end(), ", ");
-*
-* @param begin :: iterator at the start
-* @param end :: iterator at the end
-* @param separator :: string to append between items.
-* @param listSeparator :: string to append between list items.
-* @return A string with contiguous values compressed using the list syntax
-*/
+ * into one string, separated by a string.
+ * Returns an empty string if the range is null.
+ * Does not add the separator after the LAST item.
+ *
+ * For example, join a vector of strings with commas with:
+ *  out = join(v.begin(), v.end(), ", ");
+ *
+ * This is a faster threaded version of the join() function above.
+ * It is used only if the iterators are not random access (e.g. vector), as it
+ * needs to be able to determine the distance between begin and end.
+ *
+ * @param begin :: iterator at the start
+ * @param end :: iterator at the end
+ * @param separator :: string to append.
+ * @return
+ */
+template <typename ITERATOR_TYPE>
+DLLExport std::string
+join(ITERATOR_TYPE begin, ITERATOR_TYPE end, const std::string &separator,
+     typename std::enable_if<
+         (std::is_same<
+             typename std::iterator_traits<ITERATOR_TYPE>::iterator_category,
+             std::random_access_iterator_tag>::value)>::type * = nullptr) {
+
+  // Get the distance between begining and end
+  long int dist = std::distance(begin, end);
+
+  // Get max number of threads and allocate vector speace
+  int nmax_threads = PARALLEL_GET_MAX_THREADS;
+  std::vector<std::ostringstream> output(nmax_threads);
+
+  // Actual number of threads in the current region
+  int nThreads = 1;
+#pragma omp parallel
+  {
+    nThreads = PARALLEL_NUMBER_OF_THREADS;
+    int idThread = PARALLEL_THREAD_NUMBER;
+    ITERATOR_TYPE it;
+
+#pragma omp for
+    for (int i = 0; i < dist; i++) {
+      // Write to stringstream
+      output[idThread] << separator << *(begin + i);
+    }
+  }
+
+  // Flush all buffers into the first one
+  for (int i = 1; i < nThreads; i++) {
+    output[0] << output[i].str();
+  }
+
+  // Return the stringstream converted to a string, minus the separator at
+  // the start of the string.
+  return output[0].str().erase(0, separator.length());
+}
+
+//------------------------------------------------------------------------------------------------
+/** Join a set or vector of (something that turns into a string) together
+ * into one string, separated by a separator,
+ * adjacent items that are precisely 1 away from each other
+ * will be compressed into a list syntax e.g. 1-5.
+ * Returns an empty string if the range is null.
+ * Does not add the separator after the LAST item.
+ *
+ * For example, join a vector of strings with commas with:
+ *  out = join(v.begin(), v.end(), ", ");
+ *
+ * @param begin :: iterator at the start
+ * @param end :: iterator at the end
+ * @param separator :: string to append between items.
+ * @param listSeparator :: string to append between list items.
+ * @return A string with contiguous values compressed using the list syntax
+ */
 template <typename ITERATOR_TYPE>
 DLLExport std::string joinCompress(ITERATOR_TYPE begin, ITERATOR_TYPE end,
                                    const std::string &separator = ",",
@@ -238,8 +303,8 @@ MANTID_KERNEL_DLL void readToEndOfLine(std::istream &in, bool ConsumeEOL);
 MANTID_KERNEL_DLL std::string getWord(std::istream &in, bool consumeEOL);
 ///  function parses a path, found in input string "path" and returns vector of
 ///  the folders contributed into the path */
-MANTID_KERNEL_DLL size_t
-split_path(const std::string &path, std::vector<std::string> &path_components);
+MANTID_KERNEL_DLL size_t split_path(const std::string &path,
+                                    std::vector<std::string> &path_components);
 
 /// Loads the entire contents of a text file into a string
 MANTID_KERNEL_DLL std::string loadFile(const std::string &filename);

--- a/Framework/Kernel/test/StringsTest.h
+++ b/Framework/Kernel/test/StringsTest.h
@@ -267,6 +267,25 @@ public:
     TS_ASSERT_EQUALS(out, "Help,Me,I'm,Stuck,Inside,A,Test");
   }
 
+  void test_joinSet() {
+    std::set<std::string> v;
+    std::string out;
+
+    out = join(v.begin(), v.end(), ",");
+    TS_ASSERT_EQUALS(out, "");
+
+    v.insert("Help");
+    v.insert("Me");
+    v.insert("I'm");
+    v.insert("Stuck");
+    v.insert("Inside");
+    v.insert("A");
+    v.insert("Test");
+
+    out = join(v.begin(), v.end(), ",");
+    TS_ASSERT_EQUALS(out, "A,Help,I'm,Inside,Me,Stuck,Test");
+  }
+
   void test_joinCompress() {
 
     std::vector<std::vector<int>> inputList{


### PR DESCRIPTION
This uses openmp threads to speed up the `Strings::join()` function which was causing `CreateWorkspace` to be excessively slow when writing to the algorithm history.

**Description of work.**

A new version of the `join()` function was added to `Strings.h`, and is used when the iterators passed as arguments are not random access in nature. If this is the case, then the original function is used.

The speedup is not fantastic as it still takes about 8s to create a 1000x10000 workspace (using 8 threads), but it is an improvement on the 60s yielded by the original function.

A test was added to `StringsTest.h` to make sure both `join()` functions are being tested.

**To test:**

<!-- Instructions for testing. -->

I don't know if this can be considered a full fix to #20443. `CreateWorkspace` is still much slower than `WorkspaceFactory`, but this preserves the full history at least. A more drastic change using incomplete algorithm history or compression of the string in the history (searching for contiguous numbers and changing them to a range, e.g. 1,2,3,4,5 -> 1-5) may be needed to come close to `WorkspaceFactory`.

Does this update require release notes?
- [ ] Yes
- [x] No

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
