### PR TITLE
Workaround Qt4 moc bug with boost

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/Strings.h
+++ b/Framework/Kernel/inc/MantidKernel/Strings.h
@@ -8,7 +8,9 @@
 #include "MantidKernel/StringTokenizer.h"
 #include "MantidKernel/System.h"
 
+#ifndef Q_MOC_RUN
 #include <boost/lexical_cast.hpp>
+#endif
 #include <iosfwd>
 #include <map>
 #include <set>


### PR DESCRIPTION
**Description of work.**

The most [recent clean build](http://builds.mantidproject.org/view/Master%20Pipeline/job/master_clean-osx/726/console) on OSX failed with errors:

```
FAILED: MantidPlot/src/moc_DataSetDialog.cxx 
cd /Users/builder/Jenkins/workspace/master_clean-osx/build/MantidPlot/src && /usr/local/bin/moc @/Users/builder/Jenkins/workspace/master_clean-osx/build/MantidPlot/src/moc_DataSetDialog.cxx_parameters
usr/local/Cellar/boost/1.61.0/include/boost/type_traits/detail/has_binary_operator.hp:50: Parse error at "BOOST_JOIN"
[3706/4218] Generating src/moc_Differentiation.cxx
FAILED: MantidPlot/src/moc_Differentiation.cxx 
cd /Users/builder/Jenkins/workspace/master_clean-osx/build/MantidPlot/src && /usr/local/bin/moc @/Users/builder/Jenkins/workspace/master_clean-osx/build/MantidPlot/src/moc_Differentiation.cxx_parameters
usr/local/Cellar/boost/1.61.0/include/boost/type_traits/detail/has_binary_operator.hp:50: Parse error at "BOOST_JOIN"
[3707/4218] Generating src/moc_Correlation.cxx
FAILED: MantidPlot/src/moc_Correlation.cxx 
cd /Users/builder/Jenkins/workspace/master_clean-osx/build/MantidPlot/src && /usr/local/bin/moc @/Users/builder/Jenkins/workspace/master_clean-osx/build/MantidPlot/src/moc_Correlation.cxx_parameters
usr/local/Cellar/boost/1.61.0/include/boost/type_traits/detail/has_binary_operator.hp:50: Parse error at "BOOST_JOIN"
[3708/4218] Generating src/moc_ApplicationWindow.cxx
FAILED: MantidPlot/src/moc_ApplicationWindow.cxx 
cd /Users/builder/Jenkins/workspace/master_clean-osx/build/MantidPlot/src && /usr/local/bin/moc @/Users/builder/Jenkins/workspace/master_clean-osx/build/MantidPlot/src/moc_ApplicationWindow.cxx_parameters
usr/local/Cellar/boost/1.61.0/include/boost/type_traits/detail/has_binary_operator.hp:50: Parse error at "BOOST_JOIN"
[3709/4218] Generating src/moc_Convolution.cxx
FAILED: MantidPlot/src/moc_Convolution.cxx 
cd /Users/builder/Jenkins/workspace/master_clean-osx/build/MantidPlot/src && /usr/local/bin/moc @/Users/builder/Jenkins/workspace/master_clean-osx/build/MantidPlot/src/moc_Convolution.cxx_parameters
usr/local/Cellar/boost/1.61.0/include/boost/type_traits/detail/has_binary_operator.hp:50: Parse error at "BOOST_JOIN"
[3710/4218] Generating src/moc_ExponentialFit.cxx
FAILED: MantidPlot/src/moc_ExponentialFit.cxx 
cd /Users/builder/Jenkins/workspace/master_clean-osx/build/MantidPlot/src && /usr/local/bin/moc @/Users/builder/Jenkins/workspace/master_clean-osx/build/MantidPlot/src/moc_ExponentialFit.cxx_parameters
usr/local/Cellar/boost/1.61.0/include/boost/type_traits/detail/has_binary_operator.hp:50: Parse error at "BOOST_JOIN"
[3711/4218] Building CXX object qt/paraview_ext/VatesSimpleGui/ViewWidgets/CMakeFiles/VatesSimpleGuiViewWidgetsQt4.dir/qt4/inc/MantidVatesSimpleGuiViewWidgets/moc_RebinnedSourcesManager.cxx.o
[3712/4218] Building CXX object qt/paraview_ext/VatesSimpleGui/ViewWidgets/CMakeFiles/VatesSimpleGuiViewWidgetsQt4.dir/qt4/inc/MantidVatesSimpleGuiViewWidgets/moc_MdViewerWidget.cxx.o
ninja: build stopped: subcommand failed.
Build step 'Invoke XShell command' marked build as failure
```

This is a [known issue](https://bugreports.qt.io/browse/QTBUG-23947) in Qt 4 and has been fixed in Qt 5. This change adds in the known workaround.


**To test:**

Code review and check OSX build passes.

*No associated issue*

Does this update require release notes?
- [ ] Yes
- [X] No

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
