### PR TITLE
Fix ReflectometrySumInQ for clang 6.0.0

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/ReflectometrySumInQ.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ReflectometrySumInQ.h
@@ -46,7 +46,11 @@ public:
   struct MinMax {
     double min{std::numeric_limits<double>::max()};
     double max{std::numeric_limits<double>::lowest()};
-    MinMax() noexcept = default;
+    // Do not add noexcept to defaulted constructor here as this
+    // causes the constructor to be deleted in clang 6.0.0
+    // For more see:
+    // https://stackoverflow.com/questions/46866686/default-member-initializer-needed-within-definition-of-enclosing-class-outside
+    MinMax() = default;
     MinMax(const double a, const double b) noexcept;
     void testAndSet(const double a) noexcept;
   };


### PR DESCRIPTION
**Description of work.**

This code fails to compile with clang 6.0.0 because of the noexcept on
the defaulted constructor. For more info see this stack overflow isssue:

https://stackoverflow.com/questions/46866686/default-member-initializer-needed-within-definition-of-enclosing-class-outside

**To test:**
 - Code review

_No associated issue_

Does this update require release notes?
- [ ] Yes
- [ ] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
