### PR TITLE
Added save_type to row state generation for row user file

### DIFF
--- a/Testing/Data/UnitTest/MaskLOQData.txt.md5
+++ b/Testing/Data/UnitTest/MaskLOQData.txt.md5
@@ -1,0 +1,1 @@
+c1ff7d0082fa8166d86de2cff6bbbea0

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -1742,7 +1742,7 @@ class SANSDataProcessorGui(QtGui.QMainWindow, ui_sans_data_processor_window.Ui_S
         self.q_xy_step_line_edit.setText("")
         self.q_xy_step_type_combo_box.setCurrentIndex(0)
 
-        self.gravity_group_box.setChecked(True)
+        self.gravity_group_box.setChecked(False)
         self.gravity_extra_length_line_edit.setText("")
 
         self.q_resolution_group_box.setChecked(False)

--- a/scripts/SANS/sans/gui_logic/models/create_state.py
+++ b/scripts/SANS/sans/gui_logic/models/create_state.py
@@ -32,7 +32,7 @@ def create_states(state_model, table_model, instrument, facility, row_index=None
         if not __is_empty_row(row, table_model):
             row_user_file = table_model.get_row_user_file(row)
             if row_user_file:
-                row_state_model = create_gui_state_from_userfile(row_user_file)
+                row_state_model = create_gui_state_from_userfile(row_user_file, state_model)
                 row_gui_state_director = GuiStateDirector(table_model, row_state_model, facility)
                 state = __create_row_state(row_gui_state_director, row, instrument, file_lookup=file_lookup)
                 states.update({row: state})
@@ -56,7 +56,7 @@ def __is_empty_row(row, table):
     return True
 
 
-def create_gui_state_from_userfile(row_user_file):
+def create_gui_state_from_userfile(row_user_file, state_model):
     user_file_path = FileFinder.getFullPath(row_user_file)
     if not os.path.exists(user_file_path):
         raise RuntimeError("The user path {} does not exist. Make sure a valid user file path"
@@ -64,5 +64,6 @@ def create_gui_state_from_userfile(row_user_file):
 
     user_file_reader = UserFileReader(user_file_path)
     user_file_items = user_file_reader.read_user_file()
-
-    return StateGuiModel(user_file_items)
+    state_gui_model = StateGuiModel(user_file_items)
+    state_gui_model.save_types = state_model.save_types
+    return state_gui_model

--- a/scripts/test/SANS/gui_logic/create_state_test.py
+++ b/scripts/test/SANS/gui_logic/create_state_test.py
@@ -4,8 +4,8 @@ import unittest
 import sys
 import mantid
 
-from sans.gui_logic.models.create_state import (create_states)
-from sans.common.enums import (SANSInstrument, ISISReductionMode, SANSFacility)
+from sans.gui_logic.models.create_state import (create_states, create_gui_state_from_userfile)
+from sans.common.enums import (SANSInstrument, ISISReductionMode, SANSFacility, SaveType)
 from sans.gui_logic.models.state_gui_model import StateGuiModel
 from sans.gui_logic.models.table_model import TableModel, TableIndexModel
 
@@ -60,8 +60,15 @@ class GuiCommonTest(unittest.TestCase):
         states = create_states(self.state_gui_model, table_model, SANSInstrument.LOQ, SANSFacility.ISIS)
 
         self.assertEqual(len(states), 1)
-        create_gui_state_mock.assert_called_once_with('MaskLOQData.txt')
+        create_gui_state_mock.assert_called_once_with('MaskLOQData.txt', self.state_gui_model)
 
+    def test_create_gui_state_from_userfile_adds_save_format_from_gui(self):
+        gui_state = StateGuiModel({})
+        gui_state.save_types = [SaveType.NXcanSAS]
+
+        row_state = create_gui_state_from_userfile('MaskLOQData.txt', gui_state)
+
+        self.assertEqual(gui_state.save_types, row_state.save_types)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**
When a row userfile is specified the state generated does not contain a save_format which leads to errors when attempting to save out data.
**Report to:** <!--If the original issue was raised by a user they should be named here.-->

**To test:**
Follow the steps in #22637 and confirm the error does not reoccur. 
<!-- Instructions for testing. -->

Fixes #22661 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

Does this update require release notes?
Updated release notes here #22628 
- [ ] Yes
- [ ] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [x] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
