### PR TITLE
Add dummy monitors to reflectometers

### DIFF
--- a/instrument/REF_L_Definition.xml
+++ b/instrument/REF_L_Definition.xml
@@ -74,5 +74,27 @@
   </cuboid>
   <algebra val="pixel-shape"/>
 </type>
- 
+
+<!--MONITORS-->
+<component idlist="monitors" type="monitors">
+  <location/>
+</component>
+<type name="monitors">
+  <component type="monitor">
+    <location name="monitor1" z="-0.23368"/>
+  </component>
+</type>
+<type is="monitor" name="monitor">
+  <cylinder id="cyl-approx">
+    <centre-of-bottom-base x="0.0" y="0.0" z="0.0"/>
+    <axis x="0.0" y="0.0" z="1.0"/>
+    <radius val="0.01"/>
+    <height val="0.03"/>
+  </cylinder>
+  <algebra val="cyl-approx"/>
+</type>
+<idlist idname="monitors">
+  <id val="-1"/>
+</idlist>
+
 </instrument>

--- a/instrument/REF_M_Definition.xml
+++ b/instrument/REF_M_Definition.xml
@@ -74,6 +74,26 @@
   </cuboid>
   <algebra val="pixel-shape"/>
 </type>
-  
- 
+	
+<!--MONITORS-->
+<component idlist="monitors" type="monitors">
+  <location/>
+</component>
+<type name="monitors">
+  <component type="monitor">
+    <location name="monitor1" z="-0.23368"/>
+  </component>
+</type>
+<type is="monitor" name="monitor">
+  <cylinder id="cyl-approx">
+    <centre-of-bottom-base x="0.0" y="0.0" z="0.0"/>
+    <axis x="0.0" y="0.0" z="1.0"/>
+    <radius val="0.01"/>
+    <height val="0.03"/>
+  </cylinder>
+  <algebra val="cyl-approx"/>
+</type>
+<idlist idname="monitors">
+  <id val="-1"/>
+</idlist>
 </instrument>


### PR DESCRIPTION
The SNS live data listener expects at least a dummy monitor in the IDF. Update the LR and MR IDFs with at least one monitor. The MR is expected to get a beam monitor soon, at which point we will update the IDF again with the actual location.

**To test:**
- Start the live data listener and make sure it can read MR or LR data.

Does this update require release notes?
- [ ] Yes
- [x] No


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
