### PR TITLE
Refs #22681 : This fixes the gcc7 compilation error

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/ReflectometrySumInQ.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ReflectometrySumInQ.h
@@ -3,6 +3,7 @@
 
 #include "MantidAlgorithms/DllConfig.h"
 #include "MantidAPI/Algorithm.h"
+#include <cmath>
 
 namespace Mantid {
 namespace API {


### PR DESCRIPTION
Build was failing with ‘nan’ is not a member of ‘std’ on Ubuntu 18.04.

**Description of work.**

Added `#include <cmath>` in file `ReflectometrySumInQ.h`

**To test:**

Build Mantid with gcc7.

Fixes #22681 

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
