### PR TITLE
Stop calibration from running in separate thread in EnggDiffractionPresenter unit test

### DIFF
--- a/qt/scientific_interfaces/test/EnggDiffractionPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffractionPresenterTest.h
@@ -229,7 +229,7 @@ public:
 
   void test_calcCalibFailsWhenNoCalibDirectory() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
-    MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
+    EnggDiffPresenterNoThread pres(&mockView);
 
     EnggDiffCalibSettings calibSettings;
     calibSettings.m_inputDirCalib = "";


### PR DESCRIPTION
The failing unit test in #22685 was found to be failing occasionally on the build servers. It turns out this was due to a threading issue, which was resolved by using the existing helper class which stops the presenter from spinning up new threads

**To test:**

The test only failed very occasionally, so to satisfy yourself that it did indeed fail, do the following on `master`:
```
for run in {1..100}; do ctest -j 8 -R EnggDiff; done > /dev/null
```
You should see 2 or 3 failures (you'll see `Errors while running CTest` for each failure). Now do the same on the branch, and you should see no errors

Fixes #22685 

Does this update require release notes?
- [ ] Yes
- [x] No, internal change

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
