### PR TITLE
Make sure cache does not exist before EnggVanadiumCorrectionsModel unit test

### DIFF
--- a/qt/scientific_interfaces/test/EnggVanadiumCorrectionsModelTest.h
+++ b/qt/scientific_interfaces/test/EnggVanadiumCorrectionsModelTest.h
@@ -100,6 +100,12 @@ public:
     calibSettings.m_inputDirCalib = m_inputDir.path();
     calibSettings.m_forceRecalcOverwrite = false;
 
+    if (m_inputDir.exists()) {
+      // Make sure that m_inputDir doesn't exist, as if a previous test exited
+      // abnormally tearDown() may not have been called
+      m_inputDir.remove(true);
+    }
+
     TestEnggVanadiumCorrectionsModel model(calibSettings, CURRENT_INSTRUMENT);
     std::pair<Mantid::API::ITableWorkspace_sptr,
               Mantid::API::MatrixWorkspace_sptr> correctionWorkspaces;


### PR DESCRIPTION
EnggVanadiumCorrectionsModel is responsible for creation of two workspaces. Once generated, it caches them, and when they are requested it checks the cache first to avoid generating them again.

In the unit test for the model, there is a test to make sure that, if the cache does not exist, the workspaces are generated. If EnggVanadiumCorrectionsModelTest exits abnormally, there is a chance that `tearDown`, which removes the cache, won't get called, so the next time this test is run it will fail, as the model will find the cache and hence not bother generating it.

This PR makes sure that the cache doesn't exist before running the test in question

**To test:**

It's a right pain to test, as you just have to run the test and cancel it at random until you see a failure

You can do this if you *really* want: `for i in {1..20}; do ctest -R EnggVanadiumCorrectionsModelTest; done > /dev/null` and `ctrl-c` while it's still running - the loop is there to give you a chance of getting there in time. Errors will manifest as the message `Errors while running CTest`

Do this on `master` to convince yourself that it fails, and then checkout the branch and do it twice as many times as it took you to get the failure on the master, making sure no errors come up this time

Fixes #22687 

Does this update require release notes?
- [ ] Yes
- [x] No, internal change

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
