### PR TITLE
Live data monitoring on reflectometry GUI

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/GetLiveInstrumentValue.py
+++ b/Framework/PythonInterface/plugins/algorithms/GetLiveInstrumentValue.py
@@ -38,26 +38,26 @@ class GetLiveInstrumentValue(DataProcessorAlgorithm):
         self._instrument = self.getProperty('Instrument').value
         self._propertyType = self.getProperty('PropertyType').value
         self._propertyName = self.getProperty('PropertyName').value
-        value = self.getLiveValue()
-        self.setOutputValue(value)
+        value = self._get_live_value()
+        self._set_output_value(value)
 
-    def prefix(self):
+    def _prefix(self):
         """Prefix to use at the start of the EPICS string"""
         return 'IN:'
 
-    def namePrefix(self):
+    def _name_prefix(self):
         """Prefix to use in the EPICS string before the property name"""
         if self._propertyType == 'Run':
             return ':DAE:'
         else:
             return ':CS:SB:'
 
-    def getLiveValue(self):
+    def _get_live_value(self):
         from epics import caget
-        epicsName = self.prefix() + self._instrument + self.namePrefix() + self._propertyName
+        epicsName = self._prefix() + self._instrument + self._name_prefix() + self._propertyName
         return caget(epicsName, as_string=True)
 
-    def setOutputValue(self, value):
+    def _set_output_value(self, value):
         if value is not None:
             self.log().notice(self._propertyName + ' = ' + value)
             self.setProperty('Value', str(value))

--- a/Framework/PythonInterface/plugins/algorithms/GetLiveInstrumentValue.py
+++ b/Framework/PythonInterface/plugins/algorithms/GetLiveInstrumentValue.py
@@ -34,10 +34,6 @@ class GetLiveInstrumentValue(DataProcessorAlgorithm):
         self.declareProperty(name='Value', defaultValue='', direction=Direction.Output,
                              doc='The live value from the instrument, or an empty string if not found')
 
-    def validateInputs(self):
-        issues = {}
-        return issues
-
     def PyExec(self):
         self._instrument = self.getProperty('Instrument').value
         self._propertyType = self.getProperty('PropertyType').value

--- a/Framework/PythonInterface/plugins/algorithms/GetLiveInstrumentValue.py
+++ b/Framework/PythonInterface/plugins/algorithms/GetLiveInstrumentValue.py
@@ -53,7 +53,10 @@ class GetLiveInstrumentValue(DataProcessorAlgorithm):
             return ':CS:SB:'
 
     def _get_live_value(self):
-        from epics import caget
+        try:
+            from epics import caget
+        except:
+            raise RuntimeError("PyEpics must be installed to use this algorithm")
         epicsName = self._prefix() + self._instrument + self._name_prefix() + self._propertyName
         return caget(epicsName, as_string=True)
 

--- a/Framework/PythonInterface/plugins/algorithms/GetLiveInstrumentValue.py
+++ b/Framework/PythonInterface/plugins/algorithms/GetLiveInstrumentValue.py
@@ -25,7 +25,7 @@ class GetLiveInstrumentValue(DataProcessorAlgorithm):
 
         self.declareProperty(name='PropertyType', defaultValue='Run', direction=Direction.Input,
                              validator=StringListValidator(['Run', 'Block']),
-                             doc='The type of value to find. For Run this may include title, start time etc. and for Block e.g. theta, slit gaps, etc.')
+                             doc='The type of property to find')
 
         self.declareProperty(name='PropertyName', defaultValue='TITLE', direction=Direction.Input,
                              validator=StringMandatoryValidator(),

--- a/Framework/PythonInterface/plugins/algorithms/GetLiveInstrumentValue.py
+++ b/Framework/PythonInterface/plugins/algorithms/GetLiveInstrumentValue.py
@@ -1,0 +1,49 @@
+from __future__ import (absolute_import, division, print_function)
+
+from mantid.simpleapi import *
+from mantid.kernel import *
+from mantid.api import *
+
+
+class GetLiveInstrumentValue(DataProcessorAlgorithm):
+    def category(self):
+        return 'Utility'
+
+    def summary(self):
+        return 'Get a live data value from and instrument via EPICS'
+
+    def seeAlso(self):
+        return [ "ReflectometryReductionOneLiveData" ]
+
+    def PyInit(self):
+        self.declareProperty(name='Instrument', defaultValue='', direction=Direction.Input,
+                             validator=StringListValidator(['CRISP', 'INTER', 'OFFSPEC', 'POLREF', 'SURF']),
+                             doc='Instrument to find live value for.')
+
+        self.declareProperty(name='LogName', defaultValue='', direction=Direction.Input,
+                             doc='Log name of value to find.')
+
+        self.declareProperty(name='OutputValue', defaultValue=Property.EMPTY_DBL, direction=Direction.Output,
+                             doc='The live value from the instrument, or an empty string if not found')
+
+    def validateInputs(self):
+        issues = {}
+        return issues
+
+    def PyExec(self):
+        instrument = self.getProperty('Instrument').value
+        logName = self.getProperty('LogName').value
+        if logName == '':
+            raise ValueError('LogName was not specified')
+        value = self.getLiveValueFromInstrument(instrument, logName)
+        if value is not None:
+            self.log().notice(logName + ' = ' + value)
+            self.setProperty('OutputValue', value)
+        else:
+            self.log().notice(logName + ' not found')
+
+    def getLiveValueFromInstrument(self, instrument, logName):
+        from epics import caget
+        return caget('IN:' + instrument + ':CS:SB:' + logName, as_string=True)
+
+AlgorithmFactory.subscribe(GetLiveInstrumentValue)

--- a/Framework/PythonInterface/plugins/algorithms/GetLiveInstrumentValue.py
+++ b/Framework/PythonInterface/plugins/algorithms/GetLiveInstrumentValue.py
@@ -55,8 +55,9 @@ class GetLiveInstrumentValue(DataProcessorAlgorithm):
     def _get_live_value(self):
         try:
             from epics import caget
-        except:
-            raise RuntimeError("PyEpics must be installed to use this algorithm")
+        except ImportError:
+            raise RuntimeError("PyEpics must be installed to use this algorithm. "
+                               "For details, see https://www.mantidproject.org/PyEpics_In_Mantid")
         epicsName = self._prefix() + self._instrument + self._name_prefix() + self._propertyName
         return caget(epicsName, as_string=True)
 

--- a/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
+++ b/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
@@ -45,7 +45,6 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
             value = self.getPropertyValue(prop.name)
             alg.setPropertyValue(prop.name, value)
 
-
     def setupSlits(self, ws, liveValues):
         s1 = liveValues['s1vg'].value
         s2 = liveValues['s2vg'].value

--- a/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
+++ b/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
@@ -23,7 +23,7 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
 
     def PyInit(self):
         self.copyProperties('ReflectometryReductionOneAuto',[
-            'InputWorkspace', 'SummationType', 'ReductionType','AnalysisMode',
+            'InputWorkspace', 'SummationType', 'ReductionType','IncludePartialBins', 'AnalysisMode',
             'ProcessingInstructions','ThetaIn', 'ThetaLogName','CorrectDetectors',
             'DetectorCorrectionType','WavelengthMin','WavelengthMax','I0MonitorIndex',
             'MonitorBackgroundWavelengthMin','MonitorBackgroundWavelengthMax',
@@ -32,8 +32,7 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
             'SecondTransmissionRun','Params','StartOverlap','EndOverlap',
             'StrictSpectrumChecking','CorrectionAlgorithm','Polynomial','C0','C1',
             'MomentumTransferMin','MomentumTransferStep','MomentumTransferMax',
-            'PolarizationAnalysis','Pp','Ap','Rho','Alpha','OutputWorkspace','Debug',
-            'IncludePartialBins'])
+            'PolarizationAnalysis','Pp','Ap','Rho','Alpha','Debug','OutputWorkspace'])
 
     def validateInputs(self):
         issues = {}

--- a/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
+++ b/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
@@ -24,7 +24,7 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
     def PyInit(self):
         self.copyProperties('ReflectometryReductionOneAuto',[
             'InputWorkspace', 'SummationType', 'ReductionType','IncludePartialBins', 'AnalysisMode',
-            'ProcessingInstructions','ThetaIn', 'ThetaLogName','CorrectDetectors',
+            'ProcessingInstructions','CorrectDetectors',
             'DetectorCorrectionType','WavelengthMin','WavelengthMax','I0MonitorIndex',
             'MonitorBackgroundWavelengthMin','MonitorBackgroundWavelengthMax',
             'MonitorIntegrationWavelengthMin','MonitorIntegrationWavelengthMax',
@@ -55,7 +55,7 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
         """Set up the reduction algorithm"""
         alg = AlgorithmManager.create("ReflectometryReductionOneAuto")
         alg.initialize()
-        alg.setChild(False)
+        alg.setChild(True)
         self.copyPropertyValuesTo(alg)
         alg.setProperty("InputWorkspace", self.ws_name)
         alg.setProperty("ThetaLogName", "Theta")

--- a/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
+++ b/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
@@ -43,10 +43,6 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
             'PolarizationAnalysis','Pp','Ap','Rho','Alpha','Debug','OutputWorkspace']
         self.copyProperties('ReflectometryReductionOneAuto', self._childProperties)
 
-    def validateInputs(self):
-        issues = {}
-        return issues
-
     def PyExec(self):
         self.setupWorkspaceForReduction()
         alg = self.setupReductionAlgorithm()

--- a/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
+++ b/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
@@ -1,0 +1,148 @@
+from __future__ import (absolute_import, division, print_function)
+
+from mantid.simpleapi import *
+from mantid.kernel import *
+from mantid.api import *
+
+
+class LiveValue():
+    def __init__(self, value, unit):
+        self.value = value
+        self.unit = unit
+
+
+class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
+    def category(self):
+        return 'Reflectometry'
+
+    def summary(self):
+        return 'Run the reflectometry reduction algorithm on live data'
+
+    def seeAlso(self):
+        return [ "ReflectometryReductionOneAuto", "StartLiveData" ]
+
+    def PyInit(self):
+        self.copyProperties('ReflectometryReductionOneAuto',[
+            'InputWorkspace', 'SummationType', 'ReductionType','AnalysisMode',
+            'ProcessingInstructions','ThetaIn', 'ThetaLogName','CorrectDetectors',
+            'DetectorCorrectionType','WavelengthMin','WavelengthMax','I0MonitorIndex',
+            'MonitorBackgroundWavelengthMin','MonitorBackgroundWavelengthMax',
+            'MonitorIntegrationWavelengthMin','MonitorIntegrationWavelengthMax',
+            'NormalizeByIntegratedMonitors','FirstTransmissionRun',
+            'SecondTransmissionRun','Params','StartOverlap','EndOverlap',
+            'StrictSpectrumChecking','CorrectionAlgorithm','Polynomial','C0','C1',
+            'MomentumTransferMin','MomentumTransferStep','MomentumTransferMax',
+            'PolarizationAnalysis','Pp','Ap','Rho','Alpha','OutputWorkspace','Debug',
+            'IncludePartialBins'])
+
+    def validateInputs(self):
+        issues = {}
+        return issues
+
+    def copyPropertyValuesTo(self, alg):
+        props = self.getProperties()
+        for prop in props:
+            value = self.getPropertyValue(prop.name)
+            alg.setPropertyValue(prop.name, value)
+
+    def isGroup(self, ws):
+        try:
+            in_ws.getNumberOfEntries()
+            return True
+        except:
+            return False
+
+    def setupSlitsForSingleWorkspace(self, ws, s1, s2):
+        SetInstrumentParameter(Workspace=ws,
+                               ParameterName='vertical gap',
+                               ParameterType='Number',
+                               ComponentName='slit1',
+                               Value=str(s1))
+        SetInstrumentParameter(Workspace=ws,
+                               ParameterName='vertical gap',
+                               ParameterType='Number',
+                               ComponentName='slit2',
+                               Value=str(s2))
+
+    def setupSlits(self, ws, liveValues):
+        s1 = liveValues['s1vg'].value
+        s2 = liveValues['s2vg'].value
+        # SetIntrumentParameter doesn't work for a group
+        if self.isGroup(ws):
+            print("Setting up slits for all workspaces in group")
+            for ws in in_ws:
+                self.setupSlitsForSingleWorkspace(ws, s1, s2)
+        else:
+            print("Setting up slits")
+            self.setupSlitsForSingleWorkspace(ws, s1, s2)
+
+    def validateLiveValues(self, liveValues):
+        for key in liveValues:
+            if liveValues[key].value is None:
+                raise RuntimeError('Required value ' + key + ' was not found for instrument')
+
+        if float(liveValues['Theta'].value) <= 1e-06:
+            raise RuntimeError('Theta must be greater than zero')
+
+    def getLiveValueFromInstrument(self, logName, instrument):
+        from epics import caget
+        return caget('IN:' + instrument + ':CS:SB:' + logName, as_string=True)
+
+    def getLiveValuesFromInstrument(self, instrument):
+        # set up required values
+        liveValues = {'Theta' : LiveValue(None, 'deg'),
+                      's1vg' : LiveValue(None, 'm'),
+                      's2vg' : LiveValue(None, 'm')}
+        # get values from instrument
+        for key in liveValues:
+            if liveValues[key].value is None:
+                liveValues[key].value = self.getLiveValueFromInstrument(key, instrument)
+        # check we have all we need
+        self.validateLiveValues(liveValues)
+        return liveValues
+
+    def setupInstrument(self):
+        instrument = config.getInstrument().shortName()
+        LoadInstrument(Workspace=self.out_ws_name,RewriteSpectraMap=True,InstrumentName=instrument)
+        return instrument
+
+    def setupSampleLogs(self, liveValues):
+        logNames = [key for key in liveValues]
+        logValues = [liveValues[key].value for key in liveValues]
+        logUnits = [liveValues[key].unit for key in liveValues]
+        AddSampleLogMultiple(Workspace=self.out_ws_name,LogNames=logNames,LogValues=logValues,
+                             LogUnits=logUnits)
+
+    def setupWorkspaceForReduction(self):
+        in_ws_name = self.getProperty("InputWorkspace").value.getName()
+        self.out_ws_name = self.getPropertyValue("OutputWorkspace")
+        CloneWorkspace(InputWorkspace=in_ws_name,OutputWorkspace=self.out_ws_name)
+        # The workspace must have an instrument.
+        instrument = self.setupInstrument()
+        # Set up the sample logs based on live values from the instrument.
+        liveValues = self.getLiveValuesFromInstrument(instrument)
+        self.setupSampleLogs(liveValues)
+        # Set up instrument parameters for the slits
+        self.setupSlits(self.out_ws_name, liveValues)
+
+    def setupReductionAlgorithm(self):
+        alg = AlgorithmManager.create("ReflectometryReductionOneAuto")
+        alg.initialize()
+        alg.setChild(False)
+        self.copyPropertyValuesTo(alg)
+        alg.setProperty("InputWorkspace", self.out_ws_name)
+        alg.setProperty("ThetaLogName", "Theta")
+        alg.setProperty("OutputWorkspaceBinned", self.out_ws_name)
+        return alg
+
+    def runReductionAlgorithm(self, alg):
+        alg.execute()
+        out_ws = alg.getProperty("OutputWorkspaceBinned").value
+        self.setProperty("OutputWorkspace", out_ws)
+
+    def PyExec(self):
+        self.setupWorkspaceForReduction()
+        alg = self.setupReductionAlgorithm()
+        self.runReductionAlgorithm(alg)
+
+AlgorithmFactory.subscribe(ReflectometryReductionOneLiveData)

--- a/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
+++ b/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
@@ -30,7 +30,7 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
         self.declareProperty(name='GetLiveValueAlgorithm', defaultValue='GetLiveInstrumentValue', direction=Direction.Input,
                              doc='The algorithm to use to get live values from the instrument')
 
-        self._childProperties = [
+        self._child_properties = [
             'InputWorkspace', 'SummationType', 'ReductionType','IncludePartialBins', 'AnalysisMode',
             'ProcessingInstructions','CorrectDetectors',
             'DetectorCorrectionType','WavelengthMin','WavelengthMax','I0MonitorIndex',
@@ -41,126 +41,126 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
             'StrictSpectrumChecking','CorrectionAlgorithm','Polynomial','C0','C1',
             'MomentumTransferMin','MomentumTransferStep','MomentumTransferMax',
             'PolarizationAnalysis','Pp','Ap','Rho','Alpha','Debug','OutputWorkspace']
-        self.copyProperties('ReflectometryReductionOneAuto', self._childProperties)
+        self.copyProperties('ReflectometryReductionOneAuto', self._child_properties)
 
     def PyExec(self):
-        self.setupWorkspaceForReduction()
-        alg = self.setupReductionAlgorithm()
-        self.runReductionAlgorithm(alg)
+        self._setup_workspace_for_reduction()
+        alg = self._setup_reduction_algorithm()
+        self._run_reduction_algorithm(alg)
 
-    def setupWorkspaceForReduction(self):
+    def _setup_workspace_for_reduction(self):
         """Set up the workspace ready for the reduction"""
-        self.createWorkspaceForReduction()
-        self.setupInstrument()
-        liveValues = self.getLiveValuesFromInstrument()
-        self.setupSampleLogs(liveValues)
-        self.setupSlits(liveValues)
+        self._create_workspace_for_reduction()
+        self._setup_instrument()
+        liveValues = self._get_live_values_from_instrument()
+        self._setup_sample_logs(liveValues)
+        self._setup_slits(liveValues)
 
-    def setupReductionAlgorithm(self):
+    def _setup_reduction_algorithm(self):
         """Set up the reduction algorithm"""
         alg = AlgorithmManager.create("ReflectometryReductionOneAuto")
         alg.initialize()
         alg.setChild(True)
-        self.copyPropertyValuesTo(alg)
-        alg.setProperty("InputWorkspace", self.ws_name)
+        self._copy_property_values_to(alg)
+        alg.setProperty("InputWorkspace", self._ws_name)
         alg.setProperty("ThetaLogName", "Theta")
-        alg.setProperty("OutputWorkspaceBinned", self.ws_name)
+        alg.setProperty("OutputWorkspaceBinned", self._ws_name)
         return alg
 
-    def runReductionAlgorithm(self, alg):
+    def _run_reduction_algorithm(self, alg):
         """Run the reduction"""
         alg.execute()
         out_ws = alg.getProperty("OutputWorkspaceBinned").value
         self.setProperty("OutputWorkspace", out_ws)
 
-    def createWorkspaceForReduction(self):
+    def _create_workspace_for_reduction(self):
         """Create a workspace for the input/output to the reduction algorithm"""
         in_ws_name = self.getProperty("InputWorkspace").value.getName()
-        self.ws_name = self.getPropertyValue("OutputWorkspace")
-        CloneWorkspace(InputWorkspace=in_ws_name,OutputWorkspace=self.ws_name)
+        self._ws_name = self.getPropertyValue("OutputWorkspace")
+        CloneWorkspace(InputWorkspace=in_ws_name,OutputWorkspace=self._ws_name)
 
-    def setupInstrument(self):
+    def _setup_instrument(self):
         """Sets the instrument name and loads the instrument on the workspace"""
-        self.instrument = self.getProperty('Instrument').value
-        LoadInstrument(Workspace=self.ws_name,RewriteSpectraMap=True,InstrumentName=self.instrument)
+        self._instrument = self.getProperty('Instrument').value
+        LoadInstrument(Workspace=self._ws_name,RewriteSpectraMap=True,InstrumentName=self._instrument)
 
-    def setupSampleLogs(self, liveValues):
+    def _setup_sample_logs(self, liveValues):
         """Set up the sample logs based on live values from the instrument"""
         logNames = [key for key in liveValues]
         logValues = [liveValues[key].value for key in liveValues]
         logUnits = [liveValues[key].unit for key in liveValues]
-        AddSampleLogMultiple(Workspace=self.ws_name,LogNames=logNames,LogValues=logValues,
+        AddSampleLogMultiple(Workspace=self._ws_name,LogNames=logNames,LogValues=logValues,
                              LogUnits=logUnits)
 
-    def setupSlits(self, liveValues):
+    def _setup_slits(self, liveValues):
         """Set up instrument parameters for the slits"""
-        s1 = liveValues[self.s1vgName()].value
-        s2 = liveValues[self.s2vgName()].value
-        SetInstrumentParameter(Workspace=self.ws_name,
+        s1 = liveValues[self._s1vg_name()].value
+        s2 = liveValues[self._s2vg_name()].value
+        SetInstrumentParameter(Workspace=self._ws_name,
                                ParameterName='vertical gap',
                                ParameterType='Number',
                                ComponentName='slit1',
                                Value=str(s1))
-        SetInstrumentParameter(Workspace=self.ws_name,
+        SetInstrumentParameter(Workspace=self._ws_name,
                                ParameterName='vertical gap',
                                ParameterType='Number',
                                ComponentName='slit2',
                                Value=str(s2))
 
-    def copyPropertyValuesTo(self, alg):
-        for prop in self._childProperties:
+    def _copy_property_values_to(self, alg):
+        for prop in self._child_properties:
             value = self.getPropertyValue(prop)
             alg.setPropertyValue(prop, value)
 
-    def getLiveValuesFromInstrument(self):
+    def _get_live_values_from_instrument(self):
         # get values from instrument
-        liveValues = self.liveValueList()
+        liveValues = self._live_value_list()
         for key in liveValues:
             if liveValues[key].value is None:
-                liveValues[key].value = self.getBlockValueFromInstrument(key)
+                liveValues[key].value = self._get_block_value_from_instrument(key)
         # check we have all we need
-        self.validateLiveValues(liveValues)
+        self._validate_live_values(liveValues)
         return liveValues
 
-    def s1vgName(self):
-        if self.instrument == 'INTER' or self.instrument == 'SURF':
+    def _s1vg_name(self):
+        if self._instrument == 'INTER' or self._instrument == 'SURF':
             return 'S1VG'
-        elif self.instrument == 'OFFSPEC':
+        elif self._instrument == 'OFFSPEC':
             return 's1vgap'
         else:
             return 's1vg'
 
-    def s2vgName(self):
-        if self.instrument == 'INTER' or self.instrument == 'SURF':
+    def _s2vg_name(self):
+        if self._instrument == 'INTER' or self._instrument == 'SURF':
             return 'S2VG'
-        elif self.instrument == 'OFFSPEC':
+        elif self._instrument == 'OFFSPEC':
             return 's2vgap'
         else:
             return 's2vg'
 
-    def getDoubleOrNone(self, propertyName):
+    def _get_double_or_none(self, propertyName):
         value = self.getProperty(propertyName)
         if value == Property.EMPTY_DBL:
             return None
         return value.value
 
-    def liveValueList(self):
+    def _live_value_list(self):
         """Get the list of required live value names and their unit type"""
         liveValues =  {'Theta' : LiveValue(None, 'deg'),
-                       self.s1vgName() : LiveValue(None, 'm'),
-                       self.s2vgName() : LiveValue(None, 'm')}
+                       self._s1vg_name() : LiveValue(None, 'm'),
+                       self._s2vg_name() : LiveValue(None, 'm')}
         return liveValues
 
-    def getBlockValueFromInstrument(self, logName):
+    def _get_block_value_from_instrument(self, logName):
         algName = self.getProperty('GetLiveValueAlgorithm').value
         alg = self.createChildAlgorithm(algName)
-        alg.setProperty('Instrument', self.instrument)
+        alg.setProperty('Instrument', self._instrument)
         alg.setProperty('PropertyType', 'Block')
         alg.setProperty('PropertyName', logName)
         alg.execute()
         return alg.getProperty("Value").value
 
-    def validateLiveValues(self, liveValues):
+    def _validate_live_values(self, liveValues):
         for key in liveValues:
             if liveValues[key].value is None:
                 raise RuntimeError('Required value ' + key + ' was not found for instrument')

--- a/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
+++ b/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
@@ -45,14 +45,10 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
             value = self.getPropertyValue(prop.name)
             alg.setPropertyValue(prop.name, value)
 
-    def isGroup(self, ws):
-        try:
-            in_ws.getNumberOfEntries()
-            return True
-        except:
-            return False
 
-    def setupSlitsForSingleWorkspace(self, ws, s1, s2):
+    def setupSlits(self, ws, liveValues):
+        s1 = liveValues['s1vg'].value
+        s2 = liveValues['s2vg'].value
         SetInstrumentParameter(Workspace=ws,
                                ParameterName='vertical gap',
                                ParameterType='Number',
@@ -63,18 +59,6 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
                                ParameterType='Number',
                                ComponentName='slit2',
                                Value=str(s2))
-
-    def setupSlits(self, ws, liveValues):
-        s1 = liveValues['s1vg'].value
-        s2 = liveValues['s2vg'].value
-        # SetIntrumentParameter doesn't work for a group
-        if self.isGroup(ws):
-            print("Setting up slits for all workspaces in group")
-            for ws in in_ws:
-                self.setupSlitsForSingleWorkspace(ws, s1, s2)
-        else:
-            print("Setting up slits")
-            self.setupSlitsForSingleWorkspace(ws, s1, s2)
 
     def validateLiveValues(self, liveValues):
         for key in liveValues:

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
@@ -76,6 +76,7 @@ set ( TEST_PY_FILES
   MuonMaxEntTest.py
   NMoldyn4InterpolationTest.py
   NormaliseSpectraTest.py
+  ReflectometryReductionOneLiveDataTest.py
   RetrieveRunInfoTest.py
   SANSWideAngleCorrectionTest.py
   SaveGEMMAUDParamFileTest.py

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
@@ -7,54 +7,41 @@ from mantid.api import *
 from mantid.simpleapi import (CreateWorkspace, ReflectometryReductionOneLiveData)
 from testhelpers import (assertRaisesNothing, create_algorithm)
 
+
+class GetFakeLiveInstrumentValue(DataProcessorAlgorithm):
+    def PyInit(self):
+        self.declareProperty(name='Instrument', defaultValue='', direction=Direction.Input,
+                             validator=StringListValidator(['CRISP', 'INTER', 'OFFSPEC', 'POLREF', 'SURF']),
+                             doc='Instrument to find live value for.')
+
+        self.declareProperty(name='LogName', defaultValue='', direction=Direction.Input,
+                             doc='Log name of value to find.')
+
+        self.declareProperty(name='OutputValue', defaultValue=Property.EMPTY_DBL, direction=Direction.Output,
+                             doc='The live value from the instrument, or an empty string if not found')
+
+    def PyExec(self):
+        logName = self.getProperty('LogName').value
+        if logName == 'Theta':
+            self.setProperty('OutputValue', 0.5)
+        elif logName == 'S1VG':
+            self.setProperty('OutputValue', 1.001)
+        elif logName == 'S2VG':
+            self.setProperty('OutputValue', 0.5)
+        else:
+            raise RuntimeError('Requested live value for unexpected log name ' + logName)
+
+AlgorithmFactory.subscribe(GetFakeLiveInstrumentValue)
+
+
 class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
     def setUp(self):
-        self._oldFacility = config['default.facility']
-        if self._oldFacility.strip() == '':
-            self._oldFacility = 'TEST_LIVE'
-        config.setFacility('ISIS')
-
-        self._instrument_name = 'INTER'
-        self._oldInstrument = config['default.instrument']
-        config['default.instrument'] = self._instrument_name
-
-        self.__class__._input_ws = self._createTestWorkspace()
-
-        self._defaultArgs = {
-            'InputWorkspace': self.__class__._input_ws,
-            'OutputWorkspace': 'output'
-        }
+        self._setupEnvironment()
+        self._setupWorkspaces()
 
     def tearDown(self):
-        mtd.clear()
-        config.setFacility(self._oldFacility)
-        config['default.instrument'] = self._oldInstrument
-
-    def _createTestWorkspace(self):
-        """Create a test workspace with reflectometry data but no instrument or sample logs"""
-        nSpec = 4
-        x = range(5, 100000, 1000)
-        y = [6,1,0,0,0,3,22,40,59,135,241,406,645,932,1096,1348,1559,1640,1790,1933,2072,2349,2629,2838,2996,3141,3170,3250,3260,3359,3460,3316,3335,3470,3384,3367,3412,3431,3541,3569,3592,3526,3619,3757,3840,4031,4076,4342,4559,4998,5414,6260,8358,11083,11987,10507,9165,8226,6979,6068,5295,4587,4005,3489,3018,2728,2398,2220,1963,1753,1516,1384,1355,1192,1153,1002,944,926,788,778,687,618,586,531,456,305,77,0,0,0,0,0,0,0,0,0,0,0,0]
-        monitor_y = [14,7,583,97285,1474787,3362154,4790669,6768912,9359711,10443338,10478945,9957954,9387695,8660614,8354808,8036977,7649065,7067769,6275327,5558998,4898033,4307711,3776162,3302736,2895372,2539087,2226028,1956162,1721463,1518854,1343139,1193432,1057989,942001,839505,748921,669257,598804,537145,482685,433356,390183,352178,318584,288155,261372,237360,216296,197369,180357,164538,151010,138316,126428,116943,107688,98584,90757,81054,59764,21151,372,18,4,3,1,3,3,0,3,1,0,2,1,1,1,3,1,1,0,1,0,1,1,2,1,0,1,2,2,0,0,0,0,1,0,1,2,0]
-        dataX = list()
-        dataY = list()
-        for i in range(0, nSpec - 1):
-            dataX += x
-            dataY += monitor_y
-        dataX += x
-        dataY += y
-
-        CreateWorkspace(NSpec=nSpec, UnitX='TOF', DataX=dataX, DataY=dataY, OutputWorkspace='input_ws')
-        return mtd['input_ws']
-
-    def _assertDelta(self, value1, value2):
-        self.assertEquals(round(value1, 6), round(value2, 6))
-
-    def _runAlgorithmWithDefaults(self):
-        alg = create_algorithm('ReflectometryReductionOneLiveData', **self._defaultArgs)
-        assertRaisesNothing(self, alg.execute)
-        output_ws = alg.getProperty('OutputWorkspace')
-        return mtd['output']
+        self._resetWorkspaces()
+        self._resetEnvironment()
 
     def test_basic_reduction_works(self):
         workspace = self._runAlgorithmWithDefaults()
@@ -108,6 +95,58 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
         slit2vg = workspace.getInstrument().getComponentByName('slit2').getNumberParameter('vertical gap')
         self.assertEquals(slit1vg[0], 1.001)
         self.assertEquals(slit2vg[0], 0.5)
+
+    def _setupEnvironment(self):
+        self._oldFacility = config['default.facility']
+        if self._oldFacility.strip() == '':
+            self._oldFacility = 'TEST_LIVE'
+        config.setFacility('ISIS')
+
+        self._instrument_name = 'INTER'
+        self._oldInstrument = config['default.instrument']
+        config['default.instrument'] = self._instrument_name
+
+    def _resetEnvironment(self):
+        config.setFacility(self._oldFacility)
+        config['default.instrument'] = self._oldInstrument
+
+    def _setupWorkspaces(self):
+        self.__class__._input_ws = self._createTestWorkspace()
+        self._defaultArgs = {
+            'InputWorkspace': self.__class__._input_ws,
+            'OutputWorkspace': 'output',
+            'Instrument': 'INTER',
+            'GetLiveValueAlgorithm': 'GetFakeLiveInstrumentValue'
+        }
+
+    def _resetWorkspaces(self):
+        mtd.clear()
+
+    def _createTestWorkspace(self):
+        """Create a test workspace with reflectometry data but no instrument or sample logs"""
+        nSpec = 4
+        x = range(5, 100000, 1000)
+        y = [6,1,0,0,0,3,22,40,59,135,241,406,645,932,1096,1348,1559,1640,1790,1933,2072,2349,2629,2838,2996,3141,3170,3250,3260,3359,3460,3316,3335,3470,3384,3367,3412,3431,3541,3569,3592,3526,3619,3757,3840,4031,4076,4342,4559,4998,5414,6260,8358,11083,11987,10507,9165,8226,6979,6068,5295,4587,4005,3489,3018,2728,2398,2220,1963,1753,1516,1384,1355,1192,1153,1002,944,926,788,778,687,618,586,531,456,305,77,0,0,0,0,0,0,0,0,0,0,0,0]
+        monitor_y = [14,7,583,97285,1474787,3362154,4790669,6768912,9359711,10443338,10478945,9957954,9387695,8660614,8354808,8036977,7649065,7067769,6275327,5558998,4898033,4307711,3776162,3302736,2895372,2539087,2226028,1956162,1721463,1518854,1343139,1193432,1057989,942001,839505,748921,669257,598804,537145,482685,433356,390183,352178,318584,288155,261372,237360,216296,197369,180357,164538,151010,138316,126428,116943,107688,98584,90757,81054,59764,21151,372,18,4,3,1,3,3,0,3,1,0,2,1,1,1,3,1,1,0,1,0,1,1,2,1,0,1,2,2,0,0,0,0,1,0,1,2,0]
+        dataX = list()
+        dataY = list()
+        for i in range(0, nSpec - 1):
+            dataX += x
+            dataY += monitor_y
+        dataX += x
+        dataY += y
+
+        CreateWorkspace(NSpec=nSpec, UnitX='TOF', DataX=dataX, DataY=dataY, OutputWorkspace='input_ws')
+        return mtd['input_ws']
+
+    def _runAlgorithmWithDefaults(self):
+        alg = create_algorithm('ReflectometryReductionOneLiveData', **self._defaultArgs)
+        assertRaisesNothing(self, alg.execute)
+        return mtd['output']
+
+    def _assertDelta(self, value1, value2):
+        self.assertEquals(round(value1, 6), round(value2, 6))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
@@ -1,0 +1,113 @@
+from __future__ import (absolute_import, division, print_function)
+
+import unittest
+
+from mantid.kernel import *
+from mantid.api import *
+from mantid.simpleapi import (CreateWorkspace, ReflectometryReductionOneLiveData)
+from testhelpers import (assertRaisesNothing, create_algorithm)
+
+class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
+    def setUp(self):
+        self._oldFacility = config['default.facility']
+        if self._oldFacility.strip() == '':
+            self._oldFacility = 'TEST_LIVE'
+        config.setFacility('ISIS')
+
+        self._instrument_name = 'INTER'
+        self._oldInstrument = config['default.instrument']
+        config['default.instrument'] = self._instrument_name
+
+        self.__class__._input_ws = self._createTestWorkspace()
+
+        self._defaultArgs = {
+            'InputWorkspace': self.__class__._input_ws,
+            'OutputWorkspace': 'output'
+        }
+
+    def tearDown(self):
+        mtd.clear()
+        config.setFacility(self._oldFacility)
+        config['default.instrument'] = self._oldInstrument
+
+    def _createTestWorkspace(self):
+        """Create a test workspace with reflectometry data but no instrument or sample logs"""
+        nSpec = 4
+        x = range(5, 100000, 1000)
+        y = [6,1,0,0,0,3,22,40,59,135,241,406,645,932,1096,1348,1559,1640,1790,1933,2072,2349,2629,2838,2996,3141,3170,3250,3260,3359,3460,3316,3335,3470,3384,3367,3412,3431,3541,3569,3592,3526,3619,3757,3840,4031,4076,4342,4559,4998,5414,6260,8358,11083,11987,10507,9165,8226,6979,6068,5295,4587,4005,3489,3018,2728,2398,2220,1963,1753,1516,1384,1355,1192,1153,1002,944,926,788,778,687,618,586,531,456,305,77,0,0,0,0,0,0,0,0,0,0,0,0]
+        monitor_y = [14,7,583,97285,1474787,3362154,4790669,6768912,9359711,10443338,10478945,9957954,9387695,8660614,8354808,8036977,7649065,7067769,6275327,5558998,4898033,4307711,3776162,3302736,2895372,2539087,2226028,1956162,1721463,1518854,1343139,1193432,1057989,942001,839505,748921,669257,598804,537145,482685,433356,390183,352178,318584,288155,261372,237360,216296,197369,180357,164538,151010,138316,126428,116943,107688,98584,90757,81054,59764,21151,372,18,4,3,1,3,3,0,3,1,0,2,1,1,1,3,1,1,0,1,0,1,1,2,1,0,1,2,2,0,0,0,0,1,0,1,2,0]
+        dataX = list()
+        dataY = list()
+        for i in range(0, nSpec - 1):
+            dataX += x
+            dataY += monitor_y
+        dataX += x
+        dataY += y
+
+        CreateWorkspace(NSpec=nSpec, UnitX='TOF', DataX=dataX, DataY=dataY, OutputWorkspace='input_ws')
+        return mtd['input_ws']
+
+    def _assertDelta(self, value1, value2):
+        self.assertEquals(round(value1, 6), round(value2, 6))
+
+    def _runAlgorithmWithDefaults(self):
+        alg = create_algorithm('ReflectometryReductionOneLiveData', **self._defaultArgs)
+        assertRaisesNothing(self, alg.execute)
+        output_ws = alg.getProperty('OutputWorkspace')
+        return mtd['output']
+
+    def test_basic_reduction_works(self):
+        workspace = self._runAlgorithmWithDefaults()
+        self.assertEquals(workspace.dataX(0).size, 55)
+        self._assertDelta(workspace.dataX(0)[0],  0.006462)
+        self._assertDelta(workspace.dataX(0)[33], 0.027376)
+        self._assertDelta(workspace.dataX(0)[54], 0.066421)
+        self._assertDelta(workspace.dataY(0)[4],  0.043630)
+        self._assertDelta(workspace.dataY(0)[33], 0.000029)
+        self._assertDelta(workspace.dataY(0)[53], 0.0)
+
+    def test_missing_inputs(self):
+        self.assertRaises(RuntimeError,
+                          ReflectometryReductionOneLiveData)
+
+    def test_invalid_input_workspace(self):
+        self.assertRaises(ValueError,
+                          ReflectometryReductionOneLiveData,
+                          InputWorkspace='bad')
+
+    def test_invalid_output_workspace(self):
+        self.assertRaises(RuntimeError,
+                          ReflectometryReductionOneLiveData,
+                          InputWorkspace=self.__class__._input_ws,
+                          OutputWorkspace='')
+
+    def test_instrument_was_set_on_output_workspace(self):
+        workspace = self._runAlgorithmWithDefaults()
+        self.assertEquals(self.__class__._input_ws.getInstrument().getName(), '')
+        self.assertEquals(workspace.getInstrument().getName(), self._instrument_name)
+
+    def test_sample_log_values_were_set_on_output_workspace(self):
+        workspace = self._runAlgorithmWithDefaults()
+
+        names = ['Theta', 'S1VG', 'S2VG']
+        values = [0.5, 1.001, 0.5]
+        units = ['deg', 'm', 'm']
+        logs = workspace.getRun().getProperties()
+        matched_names = list()
+        for log in logs:
+            if log.name in names:
+                matched_names.append(log.name)
+                idx = names.index(log.name)
+                self.assertEquals(log.value, values[idx])
+                self.assertEquals(log.units, units[idx])
+        self.assertEquals(sorted(matched_names), sorted(names))
+
+    def test_slits_gaps_are_set_up_on_output_workspace(self):
+        workspace = self._runAlgorithmWithDefaults()
+        slit1vg = workspace.getInstrument().getComponentByName('slit1').getNumberParameter('vertical gap')
+        slit2vg = workspace.getInstrument().getComponentByName('slit2').getNumberParameter('vertical gap')
+        self.assertEquals(slit1vg[0], 1.001)
+        self.assertEquals(slit2vg[0], 0.5)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
@@ -41,22 +41,22 @@ AlgorithmFactory.subscribe(GetFakeLiveInstrumentValue)
 
 class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
     def setUp(self):
-        self._setupEnvironment()
-        self._setupWorkspaces()
+        self._setup_environment()
+        self._setup_workspaces()
 
     def tearDown(self):
-        self._resetWorkspaces()
-        self._resetEnvironment()
+        self._reset_workspaces()
+        self._reset_environment()
 
     def test_basic_reduction_works(self):
-        workspace = self._runAlgorithmWithDefaults()
+        workspace = self._run_algorithm_with_defaults()
         self.assertEquals(workspace.dataX(0).size, 55)
-        self._assertDelta(workspace.dataX(0)[0],  0.006462)
-        self._assertDelta(workspace.dataX(0)[33], 0.027376)
-        self._assertDelta(workspace.dataX(0)[54], 0.066421)
-        self._assertDelta(workspace.dataY(0)[4],  0.043630)
-        self._assertDelta(workspace.dataY(0)[33], 0.000029)
-        self._assertDelta(workspace.dataY(0)[53], 0.0)
+        self._assert_delta(workspace.dataX(0)[0],  0.006462)
+        self._assert_delta(workspace.dataX(0)[33], 0.027376)
+        self._assert_delta(workspace.dataX(0)[54], 0.066421)
+        self._assert_delta(workspace.dataY(0)[4],  0.043630)
+        self._assert_delta(workspace.dataY(0)[33], 0.000029)
+        self._assert_delta(workspace.dataY(0)[53], 0.0)
 
     def test_missing_inputs(self):
         self.assertRaises(RuntimeError,
@@ -74,12 +74,12 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
                           OutputWorkspace='')
 
     def test_instrument_was_set_on_output_workspace(self):
-        workspace = self._runAlgorithmWithDefaults()
+        workspace = self._run_algorithm_with_defaults()
         self.assertEquals(self.__class__._input_ws.getInstrument().getName(), '')
         self.assertEquals(workspace.getInstrument().getName(), self._instrument_name)
 
     def test_sample_log_values_were_set_on_output_workspace(self):
-        workspace = self._runAlgorithmWithDefaults()
+        workspace = self._run_algorithm_with_defaults()
 
         names = ['Theta', 'S1VG', 'S2VG']
         values = [0.5, 1.001, 0.5]
@@ -95,39 +95,39 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
         self.assertEquals(sorted(matched_names), sorted(names))
 
     def test_slits_gaps_are_set_up_on_output_workspace(self):
-        workspace = self._runAlgorithmWithDefaults()
+        workspace = self._run_algorithm_with_defaults()
         slit1vg = workspace.getInstrument().getComponentByName('slit1').getNumberParameter('vertical gap')
         slit2vg = workspace.getInstrument().getComponentByName('slit2').getNumberParameter('vertical gap')
         self.assertEquals(slit1vg[0], 1.001)
         self.assertEquals(slit2vg[0], 0.5)
 
-    def _setupEnvironment(self):
-        self._oldFacility = config['default.facility']
-        if self._oldFacility.strip() == '':
-            self._oldFacility = 'TEST_LIVE'
+    def _setup_environment(self):
+        self._old_facility = config['default.facility']
+        if self._old_facility.strip() == '':
+            self._old_facility = 'TEST_LIVE'
         config.setFacility('ISIS')
 
         self._instrument_name = 'INTER'
-        self._oldInstrument = config['default.instrument']
+        self._old_instrument = config['default.instrument']
         config['default.instrument'] = self._instrument_name
 
-    def _resetEnvironment(self):
-        config.setFacility(self._oldFacility)
-        config['default.instrument'] = self._oldInstrument
+    def _reset_environment(self):
+        config.setFacility(self._old_facility)
+        config['default.instrument'] = self._old_instrument
 
-    def _setupWorkspaces(self):
-        self.__class__._input_ws = self._createTestWorkspace()
-        self._defaultArgs = {
+    def _setup_workspaces(self):
+        self.__class__._input_ws = self._create_test_workspace()
+        self._default_args = {
             'InputWorkspace': self.__class__._input_ws,
             'OutputWorkspace': 'output',
             'Instrument': 'INTER',
             'GetLiveValueAlgorithm': 'GetFakeLiveInstrumentValue'
         }
 
-    def _resetWorkspaces(self):
+    def _reset_workspaces(self):
         mtd.clear()
 
-    def _createTestWorkspace(self):
+    def _create_test_workspace(self):
         """Create a test workspace with reflectometry data but no instrument or sample logs"""
         nSpec = 4
         x = range(5, 100000, 1000)
@@ -144,12 +144,12 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
         CreateWorkspace(NSpec=nSpec, UnitX='TOF', DataX=dataX, DataY=dataY, OutputWorkspace='input_ws')
         return mtd['input_ws']
 
-    def _runAlgorithmWithDefaults(self):
-        alg = create_algorithm('ReflectometryReductionOneLiveData', **self._defaultArgs)
+    def _run_algorithm_with_defaults(self):
+        alg = create_algorithm('ReflectometryReductionOneLiveData', **self._default_args)
         assertRaisesNothing(self, alg.execute)
         return mtd['output']
 
-    def _assertDelta(self, value1, value2):
+    def _assert_delta(self, value1, value2):
         self.assertEquals(round(value1, 6), round(value2, 6))
 
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
@@ -14,22 +14,27 @@ class GetFakeLiveInstrumentValue(DataProcessorAlgorithm):
                              validator=StringListValidator(['CRISP', 'INTER', 'OFFSPEC', 'POLREF', 'SURF']),
                              doc='Instrument to find live value for.')
 
-        self.declareProperty(name='LogName', defaultValue='', direction=Direction.Input,
-                             doc='Log name of value to find.')
+        self.declareProperty(name='PropertyType', defaultValue='Run', direction=Direction.Input,
+                             validator=StringListValidator(['Run', 'Block']),
+                             doc='The type of property to find')
 
-        self.declareProperty(name='OutputValue', defaultValue=Property.EMPTY_DBL, direction=Direction.Output,
+        self.declareProperty(name='PropertyName', defaultValue='TITLE', direction=Direction.Input,
+                             validator=StringMandatoryValidator(),
+                             doc='Name of value to find.')
+
+        self.declareProperty(name='Value', defaultValue='', direction=Direction.Output,
                              doc='The live value from the instrument, or an empty string if not found')
 
     def PyExec(self):
-        logName = self.getProperty('LogName').value
-        if logName == 'Theta':
-            self.setProperty('OutputValue', 0.5)
-        elif logName == 'S1VG':
-            self.setProperty('OutputValue', 1.001)
-        elif logName == 'S2VG':
-            self.setProperty('OutputValue', 0.5)
+        propertyName = self.getProperty('PropertyName').value
+        if propertyName == 'Theta':
+            self.setProperty('Value', '0.5')
+        elif propertyName == 'S1VG':
+            self.setProperty('Value', '1.001')
+        elif propertyName == 'S2VG':
+            self.setProperty('Value', '0.5')
         else:
-            raise RuntimeError('Requested live value for unexpected log name ' + logName)
+            raise RuntimeError('Requested live value for unexpected property name ' + propertyName)
 
 AlgorithmFactory.subscribe(GetFakeLiveInstrumentValue)
 

--- a/docs/source/algorithms/GetLiveInstrumentValue-v1.rst
+++ b/docs/source/algorithms/GetLiveInstrumentValue-v1.rst
@@ -1,0 +1,29 @@
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+
+GetLiveInstrumentValue
+----------------------
+
+This algorithm gets live values such as run title or theta from an instrument.
+
+Values are accessed via EPICS, so EPICS support must be installed in Mantid for this algorithm to work. This is included by default on Windows but see the instructions `here <http://https://www.mantidproject.org/PyEpics_In_Mantid/>`_ for other platforms.
+
+The instrument must also be on IBEX or have additional processes installed to supply the EPICS values. If it does not, you will get an error that the requested value could not be found.
+
+
+Usage
+-------
+
+    GetLiveInstrumentValue(Instrument='INTER',PropertyType='Block',PropertyName='Theta')
+
+.. seealso :: Algorithm :ref:`algm-ReflectometryReductionOneLiveData`
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/algorithms/GetLiveInstrumentValue-v1.rst
+++ b/docs/source/algorithms/GetLiveInstrumentValue-v1.rst
@@ -12,7 +12,7 @@ GetLiveInstrumentValue
 
 This algorithm gets live values such as run title or theta from an instrument.
 
-Values are accessed via EPICS, so EPICS support must be installed in Mantid for this algorithm to work. This is included by default on Windows but see the instructions `here <http://https://www.mantidproject.org/PyEpics_In_Mantid/>`_ for other platforms.
+Values are accessed via EPICS, so EPICS support must be installed in Mantid for this algorithm to work. This is included by default on Windows but see the instructions `here <https://www.mantidproject.org/PyEpics_In_Mantid>`_ for other platforms.
 
 The instrument must also be on IBEX or have additional processes installed to supply the EPICS values. If it does not, you will get an error that the requested value could not be found.
 

--- a/docs/source/algorithms/ReflectometryReductionOneLiveData-v1.rst
+++ b/docs/source/algorithms/ReflectometryReductionOneLiveData-v1.rst
@@ -1,0 +1,30 @@
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+
+ReflectometryReductionOneAutoLiveData
+-------------------------------------
+
+This algorithm performs a reduction with :ref:`algm-ReflectometryReductionOneAuto` on a live data workspace. It is intended to be run as a post-processing algorithm for :ref:`algm-StartLiveData`, although it can also be called directly on a workspace output from live data monitoring. It is not intended to be run on a workspace for a completed run.
+
+This algorithm does some setting up of the instrument and sample logs, which are not normally present for a live data workspace, so that the reduction can be run. This uses live values for ``theta`` and the slit gaps, which are found from the instrument using :ref:`algm-GetLiveInstrumentValue`. Once the workspace is set up, :ref:`algm-ReflectometryReductionOneAuto` is run, with ``ThetaLogName`` set to the appropriate value to use the value of ``theta`` that was set in the logs.
+
+:ref:`algm-GetLiveInstrumentValue` requires Mantid to have EPICS support installed, and appropriate processes must be running on the instrument to supply the EPICS values. A different algorithm for fetching live values could be specified by overriding the ``GetLiveValueAlgorithm`` property.
+
+Usage
+-------
+
+    StartLiveData(Instrument='INTER',
+        PostProcessingAlgorithm='ReflectometryReductionOneLiveData', PostProcessingProperties='Instrument=INTER',
+        AccumulationMethod='Replace',AccumulationWorkspace='TOF_live',OutputWorkspace='IvsQ_binned_live',)
+
+.. seealso :: Algorithm :ref:`algm-GetLiveInstrumentValue`, :ref:`algm-ReflectometryReductionOneAuto`, :ref:`algm-StartLiveData` and the ``ISIS Reflectometry`` interface.
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/interfaces/ISIS Reflectometry.rst
+++ b/docs/source/interfaces/ISIS Reflectometry.rst
@@ -487,18 +487,19 @@ cancelling the algorithm from the *Algorithm progress* dialog. If you close the
 interface, monitoring will continue running in the backgroud. You can cancel
 the `MonitorLiveData` algorithm from the *Algorithm progress* dialog.
 
-Note that if `MonitorLiveData` stops for any reason other than being terminated
-by the user, it will be automatically re-started by the Interface. Note that if
-anything has changed on the Settings tab then the new values will be used.
+If `MonitorLiveData` stops due to an error, the `Start monitor` button will be
+re-enabled so that it can be re-started from the Interface.
 
 Note that if you close and re-open the Interface, the link to any running
-monitor algorithm will be lost. Stop the algorithm from the *Algorithm process*
-dialog and re-start it from the new instance of the Interface to re-link it.
+monitor algorithm will be lost. You will not be able to start a new version of
+the monitor due to a clash in the output names. Stop the algorithm from the
+*Algorithm process* dialog and re-start it from the new instance of the
+Interface to re-link it.
 
-Live data monitoring has some additional requirements:
+Live data monitoring has the following requirements:
 
 - EPICS support must be installed in Mantid. This is included by default on Windows but see the instructions `here <http://https://www.mantidproject.org/PyEpics_In_Mantid/>`_ for other platforms.
-- The instrument must be on IBEX or have additional processes installed to supply the EPICS values.
+- The instrument must be on IBEX or have additional processes installed to supply the EPICS values. If it does not, you will get an error that live values could not be found for `Theta` and the slits.
 
 
 

--- a/docs/source/interfaces/ISIS Reflectometry.rst
+++ b/docs/source/interfaces/ISIS Reflectometry.rst
@@ -487,18 +487,20 @@ cancelling the algorithm from the *Algorithm progress* dialog. If you close the
 interface, monitoring will continue running in the backgroud. You can cancel
 the `MonitorLiveData` algorithm from the *Algorithm progress* dialog.
 
-Note that the `MonitorLiveData` may stop if it encounters an error, e.g. due to
-a change in the data size, and will need to be manually re-started from the
-GUI.
+Note that if `MonitorLiveData` stops for any reason other than being terminated
+by the user, it will be automatically re-started by the Interface. Note that if
+anything has changed on the Settings tab then the new values will be used.
+
+Note that if you close and re-open the Interface, the link to any running
+monitor algorithm will be lost. Stop the algorithm from the *Algorithm process*
+dialog and re-start it from the new instance of the Interface to re-link it.
 
 Live data monitoring has some additional requirements:
 
-- EPICS support must be installed in Mantid. Tthis is included by default on
-Windows but see the instructions `here<http://https://www.mantidproject.org/PyEpics_In_Mantid/>`_
-for other platforms.
+- EPICS support must be installed in Mantid. This is included by default on Windows but see the instructions `here <http://https://www.mantidproject.org/PyEpics_In_Mantid/>`_ for other platforms.
+- The instrument must be on IBEX or have additional processes installed to supply the EPICS values.
 
-- The instrument must be on IBEX or have additional processes installed to
-  supply the EPICS values.
+
 
 Event Handling tab
 ~~~~~~~~~~~~~~~~~~

--- a/docs/source/interfaces/ISIS Reflectometry.rst
+++ b/docs/source/interfaces/ISIS Reflectometry.rst
@@ -487,8 +487,9 @@ cancelling the algorithm from the *Algorithm progress* dialog. If you close the
 interface, monitoring will continue running in the backgroud. You can cancel
 the `MonitorLiveData` algorithm from the *Algorithm progress* dialog.
 
-If the `MonitorLiveData` algorithm stops for any reason, e.g. due to a change
-in the data size, then it will automatically be re-started.
+Note that the `MonitorLiveData` may stop if it encounters an error, e.g. due to
+a change in the data size, and will need to be manually re-started from the
+GUI.
 
 Live data monitoring has some additional requirements:
 - EPICS support must be installed in Mantid. Tthis is included by default on

--- a/docs/source/interfaces/ISIS Reflectometry.rst
+++ b/docs/source/interfaces/ISIS Reflectometry.rst
@@ -498,7 +498,7 @@ Interface to re-link it.
 
 Live data monitoring has the following requirements:
 
-- EPICS support must be installed in Mantid. This is included by default on Windows but see the instructions `here <http://https://www.mantidproject.org/PyEpics_In_Mantid/>`_ for other platforms.
+- EPICS support must be installed in Mantid. This is included by default on Windows but see the instructions `here <https://www.mantidproject.org/PyEpics_In_Mantid>`_ for other platforms.
 - The instrument must be on IBEX or have additional processes installed to supply the EPICS values. If it does not, you will get an error that live values could not be found for `Theta` and the slits.
 
 

--- a/docs/source/interfaces/ISIS Reflectometry.rst
+++ b/docs/source/interfaces/ISIS Reflectometry.rst
@@ -492,10 +492,11 @@ a change in the data size, and will need to be manually re-started from the
 GUI.
 
 Live data monitoring has some additional requirements:
+
 - EPICS support must be installed in Mantid. Tthis is included by default on
-Windows but see the instructions `here
-<http://https://www.mantidproject.org/PyEpics_In_Mantid/>`_ for other
-platforms.
+Windows but see the instructions `here<http://https://www.mantidproject.org/PyEpics_In_Mantid/>`_
+for other platforms.
+
 - The instrument must be on IBEX or have additional processes installed to
   supply the EPICS values.
 

--- a/docs/source/interfaces/ISIS Reflectometry.rst
+++ b/docs/source/interfaces/ISIS Reflectometry.rst
@@ -466,6 +466,38 @@ then clicking `Autoprocess` will start a new autoprocessing operation, and the
 current contents of the Processing table will be cleared. You will be warned if
 this will cause unsaved changes to be lost.
 
+Live Data Monitoring
+^^^^^^^^^^^^^^^^^^^^
+
+The *Live data* section on the *Runs* tab allows you to start a monitoring
+algorithm that will periodically load live data from the instrument and reduce
+it with :ref:`ReflectometryReductionOneAuto
+<algm-ReflectometryReductionOneAuto>`. It outputs two workspaces, `TOF_live`
+for the original data and `IvsQ_binned_live` for the reduced data.
+
+Live values for `ThetaIn` and the slit gaps are checked and used each time the
+reduction runs. Other algorithm properties are taken from `Group 1` on the
+*Settings* tab. Make any changes you want to the settings and press `Start
+monitor` to begin monitoring. Note that **any changes to the settings will not
+be updated** in the live data reduction unless you stop and re-start
+monitoring.
+
+You can stop monitoring at any time using the `Stop monitor` button or by
+cancelling the algorithm from the *Algorithm progress* dialog. If you close the
+interface, monitoring will continue running in the backgroud. You can cancel
+the `MonitorLiveData` algorithm from the *Algorithm progress* dialog.
+
+If the `MonitorLiveData` algorithm stops for any reason, e.g. due to a change
+in the data size, then it will automatically be re-started.
+
+Live data monitoring has some additional requirements:
+- EPICS support must be installed in Mantid. Tthis is included by default on
+Windows but see the instructions `here
+<http://https://www.mantidproject.org/PyEpics_In_Mantid/>`_ for other
+platforms.
+- The instrument must be on IBEX or have additional processes installed to
+  supply the EPICS values.
+
 Event Handling tab
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/release/v3.13.0/reflectometry.rst
+++ b/docs/source/release/v3.13.0/reflectometry.rst
@@ -15,6 +15,7 @@ New
 ###
 
 - Fully-automatic processing has been added to the interface. Click ``Autoprocess`` to process all of the runs for an investigation and to start polling for new runs. Whenever new runs are found, they will automatically be added to the table and processed.
+- Live data monitoring has been added to the interface. This will periodically load live data from the instrument and reduce it with ``ReflectometryReductionOneAuto`` using live values for ``Theta`` and the slit gaps. Other algorithm properties are taken from ``Group 1`` of the Settings tab. Note that changes to the Settings tab will **not** be updated in the monitor algorithm unless you stop and re-start monitoring.
 - A new option has been added to the Settings tab to control whether partial bins should be included when summing in Q.
 - ``ReflectometryReductionOneAuto`` takes the polarization correction properties from the instrument parameter file when ``PolarizationAnalysis`` is set to ``ParameterFile``. The instrument parameter file can store the efficiencies as vectors of doubles.
 

--- a/qt/scientific_interfaces/ISISReflectometry/IReflRunsTabPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/IReflRunsTabPresenter.h
@@ -49,7 +49,9 @@ public:
     ICATSearchCompleteFlag,
     TransferFlag,
     InstrumentChangedFlag,
-    GroupChangedFlag
+    GroupChangedFlag,
+    StartMonitorFlag,
+    StartMonitorCompleteFlag
   };
 
   // Tell the presenter something happened

--- a/qt/scientific_interfaces/ISISReflectometry/IReflRunsTabPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/IReflRunsTabPresenter.h
@@ -51,6 +51,7 @@ public:
     InstrumentChangedFlag,
     GroupChangedFlag,
     StartMonitorFlag,
+    StopMonitorFlag,
     StartMonitorCompleteFlag
   };
 

--- a/qt/scientific_interfaces/ISISReflectometry/IReflRunsTabView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/IReflRunsTabView.h
@@ -87,6 +87,8 @@ public:
   virtual IReflRunsTabPresenter *getPresenter() const = 0;
   virtual boost::shared_ptr<MantidQt::API::AlgorithmRunner>
   getAlgorithmRunner() const = 0;
+  virtual boost::shared_ptr<MantidQt::API::AlgorithmRunner>
+  getMonitorAlgorithmRunner() const = 0;
 
   // Timer methods
   virtual void startTimer(const int millisecs) = 0;
@@ -94,6 +96,9 @@ public:
 
   // Start an ICAT search
   virtual void startIcatSearch() = 0;
+
+  // Start live data monitoring
+  virtual void startMonitor() = 0;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/IReflRunsTabView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/IReflRunsTabView.h
@@ -99,6 +99,8 @@ public:
 
   // Start live data monitoring
   virtual void startMonitor() = 0;
+  virtual void updateMonitorRunning() = 0;
+  virtual void updateMonitorStopped() = 0;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/IReflRunsTabView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/IReflRunsTabView.h
@@ -75,6 +75,8 @@ public:
   virtual void setTransferMethodComboEnabled(bool enabled) = 0;
   virtual void setSearchTextEntryEnabled(bool enabled) = 0;
   virtual void setSearchButtonEnabled(bool enabled) = 0;
+  virtual void setStartMonitorButtonEnabled(bool enabled) = 0;
+  virtual void setStopMonitorButtonEnabled(bool enabled) = 0;
 
   // Accessor methods
   virtual std::set<int> getSelectedSearchRows() const = 0;
@@ -99,8 +101,7 @@ public:
 
   // Start live data monitoring
   virtual void startMonitor() = 0;
-  virtual void updateMonitorRunning() = 0;
-  virtual void updateMonitorStopped() = 0;
+  virtual void stopMonitor() = 0;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/QtReflRunsTabView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/QtReflRunsTabView.cpp
@@ -253,9 +253,9 @@ void QtReflRunsTabView::setStartMonitorButtonEnabled(bool enabled) {
 }
 
 /**
-* Sets the stop-monitor enabled or disabled
-* @param enabled : Whether to enable or disable the button
-*/
+ * Sets the stop-monitor enabled or disabled
+ * @param enabled : Whether to enable or disable the button
+ */
 void QtReflRunsTabView::setStopMonitorButtonEnabled(bool enabled) {
 
   ui.buttonStopMonitor->setEnabled(enabled);

--- a/qt/scientific_interfaces/ISISReflectometry/QtReflRunsTabView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/QtReflRunsTabView.cpp
@@ -514,5 +514,14 @@ void QtReflRunsTabView::startMonitorComplete() {
   m_presenter->notify(IReflRunsTabPresenter::StartMonitorCompleteFlag);
 }
 
+// TODO Add a busy indicator and update it when monitoring starts/stops
+/** Update the view state to indicate the monitor is running
+ */
+void QtReflRunsTabView::updateMonitorRunning() {}
+
+/** Update the view state to indicate the monitor is stopped
+ */
+void QtReflRunsTabView::updateMonitorStopped() {}
+
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/QtReflRunsTabView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/QtReflRunsTabView.cpp
@@ -80,6 +80,8 @@ void QtReflRunsTabView::initLayout() {
       ,
       processingWidgets /* The data processor presenters */);
   m_algoRunner = boost::make_shared<MantidQt::API::AlgorithmRunner>(this);
+  m_monitorAlgoRunner =
+      boost::make_shared<MantidQt::API::AlgorithmRunner>(this);
 
   // Custom context menu for table
   connect(ui.tableSearchResults,
@@ -458,6 +460,11 @@ QtReflRunsTabView::getAlgorithmRunner() const {
   return m_algoRunner;
 }
 
+boost::shared_ptr<MantidQt::API::AlgorithmRunner>
+QtReflRunsTabView::getMonitorAlgorithmRunner() const {
+  return m_monitorAlgoRunner;
+}
+
 /**
 Get the string the user wants to search for.
 @returns The search string
@@ -485,6 +492,26 @@ int QtReflRunsTabView::getSelectedGroup() const {
  */
 void QtReflRunsTabView::groupChanged() {
   m_presenter->notify(IReflRunsTabPresenter::GroupChangedFlag);
+}
+
+void MantidQt::CustomInterfaces::QtReflRunsTabView::on_buttonMonitor_clicked() {
+  startMonitor();
+}
+
+/** Start live data monitoring
+ */
+void QtReflRunsTabView::startMonitor() {
+  m_monitorAlgoRunner.get()->disconnect(); // disconnect any other connections
+  m_presenter->notify(IReflRunsTabPresenter::StartMonitorFlag);
+  connect(m_monitorAlgoRunner.get(), SIGNAL(algorithmComplete(bool)), this,
+          SLOT(startMonitorComplete()), Qt::UniqueConnection);
+}
+
+/**
+This slot notifies the presenter that the monitoring algorithm finished
+*/
+void QtReflRunsTabView::startMonitorComplete() {
+  m_presenter->notify(IReflRunsTabPresenter::StartMonitorCompleteFlag);
 }
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/QtReflRunsTabView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/QtReflRunsTabView.cpp
@@ -244,6 +244,24 @@ void QtReflRunsTabView::setSearchButtonEnabled(bool enabled) {
 }
 
 /**
+ * Sets the start-monitor button enabled or disabled
+ * @param enabled : Whether to enable or disable the button
+ */
+void QtReflRunsTabView::setStartMonitorButtonEnabled(bool enabled) {
+
+  ui.buttonMonitor->setEnabled(enabled);
+}
+
+/**
+* Sets the stop-monitor enabled or disabled
+* @param enabled : Whether to enable or disable the button
+*/
+void QtReflRunsTabView::setStopMonitorButtonEnabled(bool enabled) {
+
+  ui.buttonStopMonitor->setEnabled(enabled);
+}
+
+/**
  * Set all possible tranfer methods
  * @param methods : All possible transfer methods.
  */
@@ -498,6 +516,11 @@ void MantidQt::CustomInterfaces::QtReflRunsTabView::on_buttonMonitor_clicked() {
   startMonitor();
 }
 
+void MantidQt::CustomInterfaces::QtReflRunsTabView::
+    on_buttonStopMonitor_clicked() {
+  stopMonitor();
+}
+
 /** Start live data monitoring
  */
 void QtReflRunsTabView::startMonitor() {
@@ -514,14 +537,11 @@ void QtReflRunsTabView::startMonitorComplete() {
   m_presenter->notify(IReflRunsTabPresenter::StartMonitorCompleteFlag);
 }
 
-// TODO Add a busy indicator and update it when monitoring starts/stops
-/** Update the view state to indicate the monitor is running
+/** Stop live data monitoring
  */
-void QtReflRunsTabView::updateMonitorRunning() {}
-
-/** Update the view state to indicate the monitor is stopped
- */
-void QtReflRunsTabView::updateMonitorStopped() {}
+void QtReflRunsTabView::stopMonitor() {
+  m_presenter->notify(IReflRunsTabPresenter::StopMonitorFlag);
+}
 
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/QtReflRunsTabView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/QtReflRunsTabView.h
@@ -88,6 +88,8 @@ public:
   void setTransferMethodComboEnabled(bool enabled) override;
   void setSearchTextEntryEnabled(bool enabled) override;
   void setSearchButtonEnabled(bool enabled) override;
+  void setStartMonitorButtonEnabled(bool enabled) override;
+  void setStopMonitorButtonEnabled(bool enabled) override;
 
   // Set the status of the progress bar
   void setProgressRange(int min, int max) override;
@@ -117,8 +119,7 @@ public:
 
   // Live data monitor
   void startMonitor() override;
-  void updateMonitorRunning() override;
-  void updateMonitorStopped() override;
+  void stopMonitor() override;
 
 private:
   /// initialise the interface
@@ -156,6 +157,7 @@ private slots:
   void groupChanged();
   void showSearchContextMenu(const QPoint &pos);
   void on_buttonMonitor_clicked();
+  void on_buttonStopMonitor_clicked();
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/QtReflRunsTabView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/QtReflRunsTabView.h
@@ -117,6 +117,8 @@ public:
 
   // Live data monitor
   void startMonitor() override;
+  void updateMonitorRunning() override;
+  void updateMonitorStopped() override;
 
 private:
   /// initialise the interface

--- a/qt/scientific_interfaces/ISISReflectometry/QtReflRunsTabView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/QtReflRunsTabView.h
@@ -105,6 +105,8 @@ public:
   IReflRunsTabPresenter *getPresenter() const override;
   boost::shared_ptr<MantidQt::API::AlgorithmRunner>
   getAlgorithmRunner() const override;
+  boost::shared_ptr<MantidQt::API::AlgorithmRunner>
+  getMonitorAlgorithmRunner() const override;
 
   // Timer methods
   void startTimer(const int millisecs) override;
@@ -112,6 +114,9 @@ public:
 
   // Start an ICAT search
   void startIcatSearch() override;
+
+  // Live data monitor
+  void startMonitor() override;
 
 private:
   /// initialise the interface
@@ -122,6 +127,7 @@ private:
   void timerEvent(QTimerEvent *event) override;
 
   boost::shared_ptr<MantidQt::API::AlgorithmRunner> m_algoRunner;
+  boost::shared_ptr<MantidQt::API::AlgorithmRunner> m_monitorAlgoRunner;
 
   // the presenter
   std::shared_ptr<IReflRunsTabPresenter> m_presenter;
@@ -143,9 +149,11 @@ private slots:
   void on_actionTransfer_triggered();
   void slitCalculatorTriggered();
   void icatSearchComplete();
+  void startMonitorComplete();
   void instrumentChanged(int index);
   void groupChanged();
   void showSearchContextMenu(const QPoint &pos);
+  void on_buttonMonitor_clicked();
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
@@ -918,11 +918,8 @@ std::string ReflRunsTabPresenter::setupMonitorPostProcessingScript() {
   std::vector<std::string> logNames = {"Theta", "s1vg", "s2vg"};
   std::vector<std::string> logUnits = {"deg", "m", "m"};
 
-  // for (auto &logName : logNames)
-  //  pythonSrcLiveDataVariable(script, instrument, logName);
-  script << "  Theta = '0.5'\n"; // TODO temp test to always supply valid theta
-  script << "  s1vg='3.25'\n";   // TODO temp test to always supply valid theta
-  script << "  s2vg='0.288'\n";  // TODO temp test to always supply valid theta
+  for (auto &logName : logNames)
+    pythonSrcLiveDataVariable(script, instrument, logName);
   pythonSrcThetaValidation(script);
 
   pythonSrcAddSampleLog(script, logNames, logUnits);

--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
@@ -913,17 +913,6 @@ void ReflRunsTabPresenter::stopMonitor() {
   updateViewWhenMonitorStopped();
 }
 
-void ReflRunsTabPresenter::restartMonitorAfterError(const std::string &what) {
-  if (!userTerminatedError(what))
-    startMonitor();
-}
-
-bool ReflRunsTabPresenter::userTerminatedError(const std::string &what) {
-  if (what == "Algorithm terminated")
-    return true;
-  return false;
-}
-
 /** Handler called when the monitor algorithm finishes
  */
 void ReflRunsTabPresenter::finishHandle(const IAlgorithm *alg) {
@@ -938,10 +927,10 @@ void ReflRunsTabPresenter::finishHandle(const IAlgorithm *alg) {
 void ReflRunsTabPresenter::errorHandle(const IAlgorithm *alg,
                                        const std::string &what) {
   UNUSED_ARG(alg);
+  UNUSED_ARG(what);
   stopObserving(m_monitorAlg);
   m_monitorAlg.reset();
   updateViewWhenMonitorStopped();
-  restartMonitorAfterError(what);
 }
 
 const std::string ReflRunsTabPresenter::MeasureTransferMethod = "Measurement";

--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
@@ -137,7 +137,16 @@ void pythonSrcAddSampleLog(std::ostringstream &result,
 void pythonSrcInstrumentParameter(std::ostringstream &result,
                                   const std::string &variable,
                                   const std::string &component) {
-  result << "  SetInstrumentParameter(Workspace=output"
+  result << ""
+         << "  try:\n"
+         << "    SetInstrumentParameter(Workspace=output"
+         << ",ParameterName='vertical gap'"
+         << ",ParameterType='Number'"
+         << ",ComponentName='" << component << "'"
+         << ",Value=" << variable << ")\n"
+         << "  except:\n"
+         << "    for ws in mtd[output]:\n"
+         << "      SetInstrumentParameter(Workspace=ws"
          << ",ParameterName='vertical gap'"
          << ",ParameterType='Number'"
          << ",ComponentName='" << component << "'"

--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
@@ -81,9 +81,7 @@ std::string getRunErrorMessage(
 
 // This namespace contains functions that return python source code
 namespace PythonSrc {
-void increaseIndent(std::string &indent) {
-  indent += "  ";
-}
+void increaseIndent(std::string &indent) { indent += "  "; }
 
 void decreaseIndent(std::string &indent) {
   if (indent.length() >= 2)
@@ -118,19 +116,21 @@ void closeTryWithExceptThatRaisesError(std::ostringstream &result,
 }
 
 void cloneWorkspace(std::ostringstream &result, const std::string &indent) {
-  result << indent << "CloneWorkspace(InputWorkspace=input,OutputWorkspace=output)\n";
+  result << indent
+         << "CloneWorkspace(InputWorkspace=input,OutputWorkspace=output)\n";
 }
 
 void loadInstrument(std::ostringstream &result, const std::string &indent,
                     const std::string &instrument) {
-  result << indent << "LoadInstrument(Workspace=output,RewriteSpectraMap=True,"
-            "InstrumentName='" << instrument << "')\n";
+  result << indent
+         << "LoadInstrument(Workspace=output,RewriteSpectraMap=True,"
+            "InstrumentName='"
+         << instrument << "')\n";
 }
 
 // Get a block variable from epics. The block name is the same as the sample
 // log name
-void getLiveDataVariable(std::ostringstream &result,
-                         const std::string &indent,
+void getLiveDataVariable(std::ostringstream &result, const std::string &indent,
                          const std::string &instrument,
                          const std::string &logName) {
   result << indent << logName << " = caget('IN:" << instrument
@@ -148,15 +148,15 @@ void validateLiveDataVariables(std::ostringstream &result,
 }
 
 void addSampleLog(std::ostringstream &result, const std::string &indent,
-                  const std::string &logNames,
-                  const std::string &variableNames,
+                  const std::string &logNames, const std::string &variableNames,
                   const std::string &logUnits) {
-  result << indent << "AddSampleLogMultiple(Workspace=output,LogNames="
-         << logNames << ",LogValues=" << variableNames << ",LogUnits="
-         << logUnits << ")\n";
+  result << indent
+         << "AddSampleLogMultiple(Workspace=output,LogNames=" << logNames
+         << ",LogValues=" << variableNames << ",LogUnits=" << logUnits << ")\n";
 }
 
-void setInstrumentParameter(std::ostringstream &result, const std::string &indent,
+void setInstrumentParameter(std::ostringstream &result,
+                            const std::string &indent,
                             const std::string &variable,
                             const std::string &component) {
   result << indent << "try:\n"
@@ -182,9 +182,10 @@ void postProcessingAlgorithm(std::ostringstream &result,
   result << indent
          << "ReflectometryReductionOneAuto(InputWorkspace=output,"
             "OutputWorkspaceBinned=output,ThetaLogName='"
-            "Theta'," << optionsString << ")\n";
+            "Theta',"
+         << optionsString << ")\n";
 }
-} //namespace PythonSrc
+} // namespace PythonSrc
 
 /** Constructor
  * @param mainView :: [input] The view we're managing
@@ -945,7 +946,8 @@ std::string ReflRunsTabPresenter::setupMonitorPostProcessingScript() {
   PythonSrc::openTryStatement(script, indent);
   PythonSrc::setInstrumentParameter(script, indent, "s1vg", "slit1");
   PythonSrc::setInstrumentParameter(script, indent, "s2vg", "slit2");
-  PythonSrc::closeTryWithExceptThatPrintsError(script, indent, "Live data error");
+  PythonSrc::closeTryWithExceptThatPrintsError(script, indent,
+                                               "Live data error");
   // Set up the reduction algorithm, getting the properties from the settings
   // tab. It's not ideal but we don't have a group associated with live data so
   // just use the first group.

--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
@@ -846,7 +846,7 @@ IAlgorithm_sptr ReflRunsTabPresenter::setupLiveDataMonitorAlgorithm() {
   alg->setProperty("OutputWorkspace", "IvsQ_binned_live");
   alg->setProperty("AccumulationWorkspace", "TOF_live");
   alg->setProperty("AccumulationMethod", "Replace");
-  alg->setProperty("UpdateEvery", "10");
+  alg->setProperty("UpdateEvery", "60");
   alg->setProperty("PostProcessingAlgorithm", liveDataReductionAlgorithm());
   alg->setProperty("PostProcessingProperties",
                    liveDataReductionOptions(instrument));

--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
@@ -78,13 +78,6 @@ std::string getRunErrorMessage(
   return std::string();
 }
 
-/** Utility to set an option in a map of QStrings from std::strings
- */
-void setOption(OptionsMap &options, const std::string &key,
-               const std::string &value) {
-  options[QString::fromStdString(key)] = QString::fromStdString(value);
-}
-
 void pythonSrcEpicsImport(std::ostringstream &result) {
   result << "try:\n"
          << "  from epics import caget\n"

--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
@@ -820,12 +820,17 @@ std::string ReflRunsTabPresenter::liveDataReductionAlgorithm() {
   return "ReflectometryReductionOneLiveData";
 }
 
-std::string ReflRunsTabPresenter::liveDataReductionOptions() {
+std::string
+ReflRunsTabPresenter::liveDataReductionOptions(const std::string &instrument) {
   // Get the properties for the reduction algorithm from the settings tab. We
   // don't have a group associated with live data. This is not ideal but for
   // now just use the first group.
   int const group = 0;
   auto options = convertOptionsFromQMap(getProcessingOptions(group));
+  // Add other required input properties to the live data reduction algorithnm
+  options["Instrument"] = QString::fromStdString(instrument);
+  options["GetLiveValueAlgorithm"] = "GetLiveInstrumentValue";
+  // Convert the properties to a string to pass to the algorithm
   auto const optionsString =
       convertMapToString(options, ';', false).toStdString();
   return optionsString;
@@ -843,7 +848,8 @@ IAlgorithm_sptr ReflRunsTabPresenter::setupLiveDataMonitorAlgorithm() {
   alg->setProperty("AccumulationMethod", "Replace");
   alg->setProperty("UpdateEvery", "10");
   alg->setProperty("PostProcessingAlgorithm", liveDataReductionAlgorithm());
-  alg->setProperty("PostProcessingProperties", liveDataReductionOptions());
+  alg->setProperty("PostProcessingProperties",
+                   liveDataReductionOptions(instrument));
   alg->setProperty("RunTransitionBehavior", "Restart");
   auto errorMap = alg->validateInputs();
   if (!errorMap.empty()) {

--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
@@ -100,8 +100,7 @@ void pythonSrcCloneWorkspace(std::ostringstream &result) {
 void pythonSrcLoadInstrument(std::ostringstream &result,
                              const std::string &instrument) {
   result << "  LoadInstrument(Workspace=output,RewriteSpectraMap=True,"
-            "InstrumentName='"
-         << instrument << "')\n";
+            "InstrumentName='" << instrument << "')\n";
 }
 
 void pythonSrcLiveDataVariable(std::ostringstream &result,
@@ -895,8 +894,7 @@ void ReflRunsTabPresenter::pythonSrcPostProcessingAlgorithm(
   result << "  "
             "ReflectometryReductionOneAuto(InputWorkspace=output,"
             "OutputWorkspaceBinned=output,ThetaLogName='"
-            "Theta',"
-         << optionsString << ")\n";
+            "Theta'," << optionsString << ")\n";
 }
 
 std::string ReflRunsTabPresenter::setupMonitorPostProcessingScript() {

--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
@@ -79,114 +79,6 @@ std::string getRunErrorMessage(
 }
 } // unnamed namespace
 
-// This namespace contains functions that return python source code
-namespace PythonSrc {
-void increaseIndent(std::string &indent) { indent += "  "; }
-
-void decreaseIndent(std::string &indent) {
-  if (indent.length() >= 2)
-    indent = indent.substr(2);
-}
-
-// Import modules required for lie data
-void importLiveDataDependencies(std::ostringstream &result,
-                                const std::string &indent) {
-  result << indent << "from epics import caget\n";
-}
-
-void openTryStatement(std::ostringstream &result, std::string &indent) {
-  result << indent << "try:\n";
-  increaseIndent(indent);
-}
-
-void closeTryWithExceptThatPrintsError(std::ostringstream &result,
-                                       std::string &indent,
-                                       const std::string &message) {
-  decreaseIndent(indent);
-  result << "except Exception, e:\n"
-         << "  print('" << message << ": ' + str(e))\n";
-}
-
-void closeTryWithExceptThatRaisesError(std::ostringstream &result,
-                                       std::string &indent,
-                                       const std::string &message) {
-  decreaseIndent(indent);
-  result << indent << "except:\n"
-         << indent << "  raise RuntimeError('" << message << "')\n";
-}
-
-void cloneWorkspace(std::ostringstream &result, const std::string &indent) {
-  result << indent
-         << "CloneWorkspace(InputWorkspace=input,OutputWorkspace=output)\n";
-}
-
-void loadInstrument(std::ostringstream &result, const std::string &indent,
-                    const std::string &instrument) {
-  result << indent
-         << "LoadInstrument(Workspace=output,RewriteSpectraMap=True,"
-            "InstrumentName='"
-         << instrument << "')\n";
-}
-
-// Get a block variable from epics. The block name is the same as the sample
-// log name
-void getLiveDataVariable(std::ostringstream &result, const std::string &indent,
-                         const std::string &instrument,
-                         const std::string &logName) {
-  result << indent << logName << " = caget('IN:" << instrument
-         << ":CS:SB:" << logName << "',as_string=True)\n";
-}
-
-void validateLiveDataVariables(std::ostringstream &result,
-                               const std::string &indent,
-                               const std::string &variableNames) {
-  result << indent << "for value in " << variableNames << ":\n"
-         << "  if value == None:\n"
-         << "    raise RuntimeError(value + 'was not found')\n"
-         << indent << "if float(Theta) <= " << Tolerance << ":\n"
-         << "  raise RuntimeError('Theta must be greater than zero')\n";
-}
-
-void addSampleLog(std::ostringstream &result, const std::string &indent,
-                  const std::string &logNames, const std::string &variableNames,
-                  const std::string &logUnits) {
-  result << indent
-         << "AddSampleLogMultiple(Workspace=output,LogNames=" << logNames
-         << ",LogValues=" << variableNames << ",LogUnits=" << logUnits << ")\n";
-}
-
-void setInstrumentParameter(std::ostringstream &result,
-                            const std::string &indent,
-                            const std::string &variable,
-                            const std::string &component) {
-  result << indent << "try:\n"
-         << indent << "  SetInstrumentParameter(Workspace=output"
-         << ",ParameterName='vertical gap'"
-         << ",ParameterType='Number'"
-         << ",ComponentName='" << component << "'"
-         << ",Value=" << variable << ")\n"
-         << indent << "except:\n"
-         << indent << "  for ws in mtd[output]:\n"
-         << indent << "    SetInstrumentParameter(Workspace=ws"
-         << ",ParameterName='vertical gap'"
-         << ",ParameterType='Number'"
-         << ",ComponentName='" << component << "'"
-         << ",Value=" << variable << ")\n";
-}
-
-void postProcessingAlgorithm(std::ostringstream &result,
-                             const std::string &indent, OptionsMap &options) {
-
-  // Append the algorithm name and properties string to the result
-  auto const optionsString = convertMapToString(options).toStdString();
-  result << indent
-         << "ReflectometryReductionOneAuto(InputWorkspace=output,"
-            "OutputWorkspaceBinned=output,ThetaLogName='"
-            "Theta',"
-         << optionsString << ")\n";
-}
-} // namespace PythonSrc
-
 /** Constructor
  * @param mainView :: [input] The view we're managing
  * @param progressableView :: [input] The view reporting progress
@@ -923,43 +815,22 @@ void ReflRunsTabPresenter::handleError(const std::string &message) {
   m_mainPresenter->giveUserCritical(message, "Error");
 }
 
-std::string ReflRunsTabPresenter::setupMonitorPostProcessingScript() {
-  std::ostringstream script;
-  auto instrument = m_view->getSearchInstrument();
-  std::string indent;
-
-  PythonSrc::importLiveDataDependencies(script, indent);
-  // Set up the instrument
-  PythonSrc::cloneWorkspace(script, indent);
-  PythonSrc::loadInstrument(script, indent, instrument);
-  // Set up sample logs
-  std::vector<std::string> logNameList = {"Theta", "s1vg", "s2vg"};
-  std::string logNames = "['Theta', 's1vg', 's2vg']";
-  std::string variableNames = "[Theta, s1vg, s2vg]";
-  std::string logUnits = "['deg', 'm', 'm']";
-  for (auto &logName : logNameList)
-    PythonSrc::getLiveDataVariable(script, indent, instrument, logName);
-  PythonSrc::validateLiveDataVariables(script, indent, variableNames);
-  PythonSrc::addSampleLog(script, indent, logNames, variableNames, logUnits);
-  // Link slits to vertical gap params. Don't throw if there's an error because
-  // slits are not mandatory
-  PythonSrc::openTryStatement(script, indent);
-  PythonSrc::setInstrumentParameter(script, indent, "s1vg", "slit1");
-  PythonSrc::setInstrumentParameter(script, indent, "s2vg", "slit2");
-  PythonSrc::closeTryWithExceptThatPrintsError(script, indent,
-                                               "Live data error");
-  // Set up the reduction algorithm, getting the properties from the settings
-  // tab. It's not ideal but we don't have a group associated with live data so
-  // just use the first group.
-  int const group = 0;
-  auto options = convertOptionsFromQMap(getProcessingOptions(group));
-  PythonSrc::postProcessingAlgorithm(script, indent, options);
-
-  return script.str();
+std::string ReflRunsTabPresenter::liveDataReductionAlgorithm() {
+  return "ReflectometryReductionOneLiveData";
 }
 
-IAlgorithm_sptr ReflRunsTabPresenter::setupMonitorAlgorithm(
-    const std::string &postProcessingScript) {
+std::string ReflRunsTabPresenter::liveDataReductionOptions() {
+  // Get the properties for the reduction algorithm from the settings tab. We
+  // don't have a group associated with live data. This is not ideal but for
+  // now just use the first group.
+  int const group = 0;
+  auto options = convertOptionsFromQMap(getProcessingOptions(group));
+  auto const optionsString =
+      convertMapToString(options, ';', false).toStdString();
+  return optionsString;
+}
+
+IAlgorithm_sptr ReflRunsTabPresenter::setupLiveDataMonitorAlgorithm() {
   auto alg = AlgorithmManager::Instance().create("StartLiveData");
   alg->initialize();
   alg->setChild(true);
@@ -967,10 +838,11 @@ IAlgorithm_sptr ReflRunsTabPresenter::setupMonitorAlgorithm(
   auto instrument = m_view->getSearchInstrument();
   alg->setProperty("Instrument", instrument);
   alg->setProperty("OutputWorkspace", "IvsQ_binned_live");
-  alg->setProperty("AccumulationMethod", "Replace");
   alg->setProperty("AccumulationWorkspace", "TOF_live");
+  alg->setProperty("AccumulationMethod", "Replace");
   alg->setProperty("UpdateEvery", "10");
-  alg->setProperty("PostProcessingScript", postProcessingScript);
+  alg->setProperty("PostProcessingAlgorithm", liveDataReductionAlgorithm());
+  alg->setProperty("PostProcessingProperties", liveDataReductionOptions());
   alg->setProperty("RunTransitionBehavior", "Restart");
   auto errorMap = alg->validateInputs();
   if (!errorMap.empty()) {
@@ -1002,8 +874,7 @@ void ReflRunsTabPresenter::updateViewWhenMonitorStopped() {
  */
 void ReflRunsTabPresenter::startMonitor() {
   try {
-    auto script = setupMonitorPostProcessingScript();
-    auto alg = setupMonitorAlgorithm(script);
+    auto alg = setupLiveDataMonitorAlgorithm();
     if (!alg)
       return;
     auto algRunner = m_view->getMonitorAlgorithmRunner();

--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
@@ -912,6 +912,17 @@ void ReflRunsTabPresenter::stopMonitor() {
   updateViewWhenMonitorStopped();
 }
 
+void ReflRunsTabPresenter::restartMonitorAfterError(const std::string &what) {
+  if (!userTerminatedError(what))
+    startMonitor();
+}
+
+bool ReflRunsTabPresenter::userTerminatedError(const std::string &what) {
+  if (what == "Algorithm terminated")
+    return true;
+  return false;
+}
+
 /** Handler called when the monitor algorithm finishes
  */
 void ReflRunsTabPresenter::finishHandle(const IAlgorithm *alg) {
@@ -926,10 +937,10 @@ void ReflRunsTabPresenter::finishHandle(const IAlgorithm *alg) {
 void ReflRunsTabPresenter::errorHandle(const IAlgorithm *alg,
                                        const std::string &what) {
   UNUSED_ARG(alg);
-  UNUSED_ARG(what);
   stopObserving(m_monitorAlg);
   m_monitorAlg.reset();
   updateViewWhenMonitorStopped();
+  restartMonitorAfterError(what);
 }
 
 const std::string ReflRunsTabPresenter::MeasureTransferMethod = "Measurement";

--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
@@ -1036,9 +1036,6 @@ void ReflRunsTabPresenter::errorHandle(const IAlgorithm *alg,
   stopObserving(m_monitorAlg);
   m_monitorAlg.reset();
   updateViewWhenMonitorStopped();
-  // Restart monitoring, unless the user terminated the algorithm
-  if (what != "Algorithm terminated")
-    startMonitor();
 }
 
 const std::string ReflRunsTabPresenter::MeasureTransferMethod = "Measurement";

--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
@@ -8,7 +8,6 @@
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/FacilityInfo.h"
 #include "MantidKernel/StringTokenizer.h"
-#include "MantidKernel/Tolerance.h"
 #include "MantidKernel/UserCatalogInfo.h"
 #include "MantidQtWidgets/Common/AlgorithmRunner.h"
 #include "MantidQtWidgets/Common/DataProcessorUI/Command.h"
@@ -130,6 +129,8 @@ ReflRunsTabPresenter::ReflRunsTabPresenter(
     for (const auto &presenter : m_tablePresenters)
       presenter->setInstrumentList(fromStdStringVector(instruments), "INTER");
   }
+
+  updateViewWhenMonitorStopped();
 }
 
 ReflRunsTabPresenter::~ReflRunsTabPresenter() {

--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.h
@@ -182,8 +182,6 @@ private:
   void handleError(const std::string &message, const std::exception &e);
   void handleError(const std::string &message);
 
-  void pythonSrcPostProcessingAlgorithm(std::ostringstream &result) const;
-
   void finishHandle(const Mantid::API::IAlgorithm *alg) override;
   void errorHandle(const Mantid::API::IAlgorithm *alg,
                    const std::string &what) override;

--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.h
@@ -175,6 +175,7 @@ private:
   std::string searchModelData(const int row, const int column);
   /// Start the live data monitor
   void startMonitor();
+  void stopMonitor();
   void startMonitorComplete();
   std::string setupMonitorPostProcessingScript();
   Mantid::API::IAlgorithm_sptr
@@ -188,6 +189,9 @@ private:
   void finishHandle(const Mantid::API::IAlgorithm *alg) override;
   void errorHandle(const Mantid::API::IAlgorithm *alg,
                    const std::string &what) override;
+  void updateViewWhenMonitorStarting();
+  void updateViewWhenMonitorStarted();
+  void updateViewWhenMonitorStopped();
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.h
@@ -175,6 +175,8 @@ private:
   void startMonitor();
   void stopMonitor();
   void startMonitorComplete();
+  void restartMonitorAfterError(const std::string &what);
+  bool userTerminatedError(const std::string &what);
   std::string liveDataReductionAlgorithm();
   std::string liveDataReductionOptions();
   Mantid::API::IAlgorithm_sptr setupLiveDataMonitorAlgorithm();

--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.h
@@ -176,7 +176,7 @@ private:
   void stopMonitor();
   void startMonitorComplete();
   std::string liveDataReductionAlgorithm();
-  std::string liveDataReductionOptions();
+  std::string liveDataReductionOptions(const std::string &instrument);
   Mantid::API::IAlgorithm_sptr setupLiveDataMonitorAlgorithm();
 
   void handleError(const std::string &message, const std::exception &e);

--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.h
@@ -129,8 +129,6 @@ private:
   /// Whether the instrument has been changed before a search was made with it
   bool m_instrumentChanged;
   /// The name to use for the live data workspace
-  std::string m_liveDataWorkspace;
-  std::string m_liveDataAccWorkspace;
   Mantid::API::IAlgorithm_sptr m_monitorAlg;
 
   /// searching

--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.h
@@ -3,6 +3,7 @@
 
 #include "DllConfig.h"
 #include "IReflRunsTabPresenter.h"
+#include "MantidAPI/AlgorithmObserver.h"
 #include "MantidAPI/IAlgorithm.h"
 #include "MantidQtWidgets/Common/DataProcessorUI/DataProcessorMainPresenter.h"
 #include "MantidQtWidgets/Common/DataProcessorUI/TreeData.h"
@@ -62,7 +63,8 @@ Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
 class MANTIDQT_ISISREFLECTOMETRY_DLL ReflRunsTabPresenter
     : public IReflRunsTabPresenter,
-      public MantidWidgets::DataProcessor::DataProcessorMainPresenter {
+      public MantidWidgets::DataProcessor::DataProcessorMainPresenter,
+      public Mantid::API::AlgorithmObserver {
 public:
   ReflRunsTabPresenter(IReflRunsTabView *mainView,
                        ProgressableView *progressView,
@@ -129,6 +131,7 @@ private:
   /// The name to use for the live data workspace
   std::string m_liveDataWorkspace;
   std::string m_liveDataAccWorkspace;
+  Mantid::API::IAlgorithm_sptr m_monitorAlg;
 
   /// searching
   bool search();
@@ -176,12 +179,15 @@ private:
   std::string setupMonitorPostProcessingScript();
   Mantid::API::IAlgorithm_sptr
   setupMonitorAlgorithm(const std::string &postProcessingScript);
-  void runMonitorAlgorithm(Mantid::API::IAlgorithm_sptr alg);
 
   void handleError(const std::string &message, const std::exception &e);
   void handleError(const std::string &message);
 
   void pythonSrcPostProcessingAlgorithm(std::ostringstream &result) const;
+
+  void finishHandle(const Mantid::API::IAlgorithm *alg) override;
+  void errorHandle(const Mantid::API::IAlgorithm *alg,
+                   const std::string &what) override;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.h
@@ -175,9 +175,9 @@ private:
   void startMonitor();
   void stopMonitor();
   void startMonitorComplete();
-  std::string setupMonitorPostProcessingScript();
-  Mantid::API::IAlgorithm_sptr
-  setupMonitorAlgorithm(const std::string &postProcessingScript);
+  std::string liveDataReductionAlgorithm();
+  std::string liveDataReductionOptions();
+  Mantid::API::IAlgorithm_sptr setupLiveDataMonitorAlgorithm();
 
   void handleError(const std::string &message, const std::exception &e);
   void handleError(const std::string &message);

--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.h
@@ -126,6 +126,9 @@ private:
   static const std::string MeasureTransferMethod;
   /// Whether the instrument has been changed before a search was made with it
   bool m_instrumentChanged;
+  /// The name to use for the live data workspace
+  std::string m_liveDataWorkspace;
+  std::string m_liveDataAccWorkspace;
 
   /// searching
   bool search();
@@ -167,6 +170,18 @@ private:
       const std::vector<TransferResults::COLUMN_MAP_TYPE> &invalidRuns);
   /// Get the data for a cell in the search results table as a string
   std::string searchModelData(const int row, const int column);
+  /// Start the live data monitor
+  void startMonitor();
+  void startMonitorComplete();
+  std::string setupMonitorPostProcessingScript();
+  Mantid::API::IAlgorithm_sptr
+  setupMonitorAlgorithm(const std::string &postProcessingScript);
+  void runMonitorAlgorithm(Mantid::API::IAlgorithm_sptr alg);
+
+  void handleError(const std::string &message, const std::exception &e);
+  void handleError(const std::string &message);
+
+  void pythonSrcPostProcessingAlgorithm(std::ostringstream &result) const;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.h
@@ -175,8 +175,6 @@ private:
   void startMonitor();
   void stopMonitor();
   void startMonitorComplete();
-  void restartMonitorAfterError(const std::string &what);
-  bool userTerminatedError(const std::string &what);
   std::string liveDataReductionAlgorithm();
   std::string liveDataReductionOptions();
   Mantid::API::IAlgorithm_sptr setupLiveDataMonitorAlgorithm();

--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>959</width>
-    <height>346</height>
+    <width>958</width>
+    <height>409</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -342,6 +342,22 @@
        </item>
       </layout>
      </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="buttonMonitor">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string>Start a background process to monitor live data for this instrument</string>
+     </property>
+     <property name="text">
+      <string>Monitor Live Data</string>
+     </property>
     </widget>
    </item>
   </layout>

--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabWidget.ui
@@ -307,6 +307,74 @@
          </item>
         </layout>
        </item>
+       <item>
+        <widget class="QGroupBox" name="groupLiveData">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>45</height>
+          </size>
+         </property>
+         <property name="title">
+          <string>Live data</string>
+         </property>
+         <widget class="QPushButton" name="buttonMonitor">
+          <property name="geometry">
+           <rect>
+            <x>1</x>
+            <y>20</y>
+            <width>114</width>
+            <height>25</height>
+           </rect>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Start a background process to monitor live data for this instrument</string>
+          </property>
+          <property name="text">
+           <string>Start monitor</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../../MantidPlot/icons/icons.qrc">
+            <normaloff>:/play2.png</normaloff>:/play2.png</iconset>
+          </property>
+         </widget>
+         <widget class="QPushButton" name="buttonStopMonitor">
+          <property name="geometry">
+           <rect>
+            <x>121</x>
+            <y>20</y>
+            <width>114</width>
+            <height>25</height>
+           </rect>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Stop monitor</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../../MantidPlot/icons/icons.qrc">
+            <normaloff>:/pause.png</normaloff>:/pause.png</iconset>
+          </property>
+         </widget>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QGroupBox" name="groupProcessPane">
@@ -342,22 +410,6 @@
        </item>
       </layout>
      </widget>
-    </widget>
-   </item>
-   <item>
-    <widget class="QPushButton" name="buttonMonitor">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="toolTip">
-      <string>Start a background process to monitor live data for this instrument</string>
-     </property>
-     <property name="text">
-      <string>Monitor Live Data</string>
-     </property>
     </widget>
    </item>
   </layout>

--- a/qt/scientific_interfaces/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/test/ReflMockObjects.h
@@ -98,6 +98,8 @@ public:
   MOCK_METHOD0(stopTimer, void());
   MOCK_METHOD0(startIcatSearch, void());
   MOCK_METHOD0(startMonitor, void());
+  MOCK_METHOD0(updateMonitorRunning, void());
+  MOCK_METHOD0(updateMonitorStopped, void());
 
   // Calls we don't care about
   void showSearch(ReflSearchModel_sptr) override{};

--- a/qt/scientific_interfaces/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/test/ReflMockObjects.h
@@ -94,10 +94,13 @@ public:
   MOCK_METHOD1(setTransferMethodComboEnabled, void(bool));
   MOCK_METHOD1(setSearchTextEntryEnabled, void(bool));
   MOCK_METHOD1(setSearchButtonEnabled, void(bool));
+  MOCK_METHOD1(setStartMonitorButtonEnabled, void(bool));
+  MOCK_METHOD1(setStopMonitorButtonEnabled, void(bool));
   MOCK_METHOD1(startTimer, void(const int));
   MOCK_METHOD0(stopTimer, void());
   MOCK_METHOD0(startIcatSearch, void());
   MOCK_METHOD0(startMonitor, void());
+  MOCK_METHOD0(stopMonitor, void());
   MOCK_METHOD0(updateMonitorRunning, void());
   MOCK_METHOD0(updateMonitorStopped, void());
 

--- a/qt/scientific_interfaces/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/test/ReflMockObjects.h
@@ -77,6 +77,8 @@ public:
   MOCK_CONST_METHOD0(getTransferMethod, std::string());
   MOCK_CONST_METHOD0(getAlgorithmRunner,
                      boost::shared_ptr<MantidQt::API::AlgorithmRunner>());
+  MOCK_CONST_METHOD0(getMonitorAlgorithmRunner,
+                     boost::shared_ptr<MantidQt::API::AlgorithmRunner>());
   MOCK_CONST_METHOD0(getSelectedGroup, int());
   MOCK_METHOD1(setTransferMethods, void(const std::set<std::string> &));
   MOCK_METHOD0(setTableCommandsProxy, void());
@@ -95,6 +97,7 @@ public:
   MOCK_METHOD1(startTimer, void(const int));
   MOCK_METHOD0(stopTimer, void());
   MOCK_METHOD0(startIcatSearch, void());
+  MOCK_METHOD0(startMonitor, void());
 
   // Calls we don't care about
   void showSearch(ReflSearchModel_sptr) override{};

--- a/qt/scientific_interfaces/test/ReflRunsTabPresenterTest.h
+++ b/qt/scientific_interfaces/test/ReflRunsTabPresenterTest.h
@@ -415,6 +415,52 @@ public:
     verifyAndClearExpectations();
   }
 
+  void test_startMonitor() {
+    auto presenter = createMocksAndPresenter(2);
+
+    // Should get settings from default group even if another is selected
+    auto DEFAULT_GROUP = 0;
+    EXPECT_CALL(*m_mockRunsTabView, getSelectedGroup()).Times(0);
+    EXPECT_CALL(*m_mockMainPresenter, getReductionOptions(DEFAULT_GROUP))
+        .Times(1)
+        .WillOnce(Return(OptionsQMap()));
+    EXPECT_CALL(*m_mockRunsTabView, getMonitorAlgorithmRunner())
+        .Times(Exactly(1));
+    EXPECT_CALL(*m_mockRunsTabView, setStartMonitorButtonEnabled(false))
+        .Times(Exactly(1));
+    EXPECT_CALL(*m_mockRunsTabView, setStopMonitorButtonEnabled(false))
+        .Times(Exactly(1));
+
+    presenter.notify(IReflRunsTabPresenter::StartMonitorFlag);
+    verifyAndClearExpectations();
+  }
+
+  void test_startMonitorComplete() {
+    auto presenter = createMocksAndPresenter(2);
+
+    EXPECT_CALL(*m_mockRunsTabView, getMonitorAlgorithmRunner())
+        .Times(Exactly(1));
+    EXPECT_CALL(*m_mockRunsTabView, setStartMonitorButtonEnabled(false))
+        .Times(Exactly(1));
+    EXPECT_CALL(*m_mockRunsTabView, setStopMonitorButtonEnabled(true))
+        .Times(Exactly(1));
+
+    presenter.notify(IReflRunsTabPresenter::StartMonitorFlag);
+    verifyAndClearExpectations();
+  }
+
+  void test_stopMonitor() {
+    auto presenter = createMocksAndPresenter(2);
+
+    EXPECT_CALL(*m_mockRunsTabView, setStartMonitorButtonEnabled(true))
+        .Times(Exactly(1));
+    EXPECT_CALL(*m_mockRunsTabView, setStopMonitorButtonEnabled(false))
+        .Times(Exactly(1));
+
+    presenter.notify(IReflRunsTabPresenter::StartMonitorFlag);
+    verifyAndClearExpectations();
+  }
+
 private:
   class ReflRunsTabPresenterFriend : public ReflRunsTabPresenter {
     friend class ReflRunsTabPresenterTest;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ParseKeyValueString.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ParseKeyValueString.h
@@ -49,7 +49,8 @@ void trimWhitespaceAndQuotes(const QString &valueIn);
 void trimWhitespaceQuotesAndEmptyValues(QStringList &values);
 /// Convert an options map to a string
 QString EXPORT_OPT_MANTIDQT_COMMON
-convertMapToString(const std::map<QString, QString> &optionsMap);
+convertMapToString(const std::map<QString, QString> &optionsMap,
+                   const char separator = ',', const bool quoteValues = true);
 std::string EXPORT_OPT_MANTIDQT_COMMON
 optionsToString(std::map<std::string, std::string> const &options);
 } // namespace MantidWidgets

--- a/qt/widgets/common/src/ParseKeyValueString.cpp
+++ b/qt/widgets/common/src/ParseKeyValueString.cpp
@@ -166,7 +166,8 @@ std::map<QString, QString> parseKeyValueQString(const QString &qstr) {
 
 /** Convert an options map to a comma-separated list of key=value pairs
  */
-QString convertMapToString(const std::map<QString, QString> &optionsMap) {
+QString convertMapToString(const std::map<QString, QString> &optionsMap,
+                           const char separator, const bool quoteValues) {
   QString result;
   bool first = true;
 
@@ -175,15 +176,15 @@ QString convertMapToString(const std::map<QString, QString> &optionsMap) {
       continue;
 
     if (!first)
-      result += ", ";
+      result += separator;
     else
       first = false;
 
     const auto key = kvp.first;
     auto value = kvp.second;
 
-    // Put quotes around the value
-    value = "'" + value + "'";
+    if (quoteValues)
+      value = "'" + value + "'";
 
     result += key + "=" + value;
   }


### PR DESCRIPTION
This PR adds a button to start live data monitoring on the `ISIS Reflectometry` GUI. 

**Report to:** Max at ISIS

## To test:
### Algorithms
Run this script. 
```
Load(Filename='INTER13460', OutputWorkspace='input')
ReflectometryReductionOneLiveData(Instrument='INTER', InputWorkspace='input', OutputWorkspace='live_output')
theta = GetLiveInstrumentValue(Instrument='INTER', PropertyType='Block',PropertyName='Theta')
ReflectometryReductionOneAuto(InputWorkspace='input', ThetaIn=theta)
```
- The theta value printed in the log should be the same as that shown on the [dashboard](http://dataweb.isis.rl.ac.uk/SeciWeb/DefaultImplement.aspx?Instrument=inter)
- Note that if the live theta value is zero the reduction should fail (if so, check it gives a sensible error).
- Ohterwise, the `live_output` workspace should contain a single spectrum similar to the `IvsQ_binned_13460` output from `ReflectometryReductionOneAuto` with the same `ThetaIn` (although note that the binning is different because it does not use the live slits)

![live_vs_rroa](https://user-images.githubusercontent.com/12895056/45542883-08683c00-b80b-11e8-9b30-75a776291d80.png)

### GUI
These instructions assume that Theta is non-zero for INTER on the above dashboard. If it's not you could try one of the other instruments.

- Open the `ISIS Reflectometry` GUI
- Select `INTER` and click `Start monitor`
- Note that the `Start monitor` and `Stop monitor` buttons will be greyed out while live data is starting.
- If there is any error (e.g. theta is zero or not found) then it will be displayed at this point and live data will not run. `Start monitor` will be re-enabled.
- Otherwise, once live data is running, `Stop monitor` will be re-enabled.
- Open the Algorithm progress dialog (from the `Running...` button) and you should see that `StartLiveData` is running (if you open it quick enough) and then this should change to `MonitorLiveData`
- There should be two output workspaces, `TOF_live` and `IvsQ_binned_live`. The latter should have been reduced to a single spectrum.
- You should be able to stop the monitor from the GUI or the algorithms dialog. 

### Errors
- If the reduction fails due to invalid settings it should give a sensible error in the log but MonitorLiveData will continue trying to run it (so you will see the same error over and over again). A way to test this for OFFSPEC is to set the AnalysisMode to PointDetectorAnalysis and clear the ProcessingInstructions. There will be two output workspaces `TOF_live` and `IvsQ_binned_live`. They will both be the same because the reduction failed.
- We might encounter other errors due to the instrument setup. Sme errors (such as a `DAE` error or unfound EPICS values) can take a long time to produce if they have a long timeout. The monitor buttons on the GUI should remain greyed out until the error if this happens during startup. If it happens while the monitor is running, the monitor will stop. You can get a DAE error if you make the network connection very slow as described in PR #23443, and then wait till it times out.

Fixes #18828 

Does this update require release notes?
- [x] Yes
- [ ] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
