### PR TITLE
Minor change: Fixed TofTof GUI is leaking temporary workspaces

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/TOFTOFCropWorkspace.py
+++ b/Framework/PythonInterface/plugins/algorithms/TOFTOFCropWorkspace.py
@@ -71,7 +71,7 @@ class TOFTOFCropWorkspace(PythonAlgorithm):
         full_channels = float(run.getLogData('full_channels').value)
         tof1 = float(run.getLogData('TOF1').value)
 
-        outputws = api.CropWorkspace(inputws, XMin=0., XMax=full_channels*channel_width + tof1, OutputWorkspace=outputws)
+        outputws = api.CropWorkspace(inputws, XMin=0., XMax=full_channels*channel_width + tof1, StoreInADS=False)
         self.setProperty("OutputWorkspace", outputws)
 
 

--- a/Framework/PythonInterface/plugins/algorithms/TOFTOFCropWorkspace.py
+++ b/Framework/PythonInterface/plugins/algorithms/TOFTOFCropWorkspace.py
@@ -64,7 +64,6 @@ class TOFTOFCropWorkspace(PythonAlgorithm):
         """ Main execution body
         """
         inputws = self.getProperty("InputWorkspace").value
-        outputws = self.getProperty("OutputWorkspace").value
 
         run = inputws.getRun()
         channel_width = float(run.getLogData('channel_width').value)


### PR DESCRIPTION
**Description of work.**

Reported by @soininen (PR #22589)

**To test:**
Start the TOFTOF data reduction GUI: Interfaces->Direct->DGS Reduction. Choose facility MLZ and instrument TOFTOF.

Get the test data
[testdata.zip](https://github.com/mantidproject/mantid/files/1356265/testdata.zip)

and perform the reduction twice(!). There should be no temporary workspaces left.

Fixes #22596. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

Does this update require release notes?
- [ ] Yes
- [ ] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
