### PR TITLE
Fix conflict in qt libraries for error reporter on OSX

### DIFF
--- a/buildconfig/CMake/Packaging/osx/Mantid_osx_launcher
+++ b/buildconfig/CMake/Packaging/osx/Mantid_osx_launcher
@@ -2,4 +2,4 @@
 
 INSTALLDIR=$(cd "$(dirname "$0")"; pwd)
 cd $INSTALLDIR
-./MantidPlot || /usr/bin/python ../../scripts/ErrorReporter/error_dialog_app.py --exitcode=$1 --directory=$INSTALLDIR
+./MantidPlot || /usr/bin/python ../../scripts/ErrorReporter/error_dialog_app.py --exitcode=$1 --directory=$INSTALLDIR --qtdir=$INSTALLDIR/../PlugIns

--- a/scripts/ErrorReporter/error_dialog_app.py
+++ b/scripts/ErrorReporter/error_dialog_app.py
@@ -18,11 +18,12 @@ from mantid.kernel import UsageService # noqa
 from ErrorReporter.error_report_presenter import ErrorReporterPresenter # noqa
 from ErrorReporter.errorreport import CrashReportPage # noqa
 # Set path to look for package qt libraries
-if command_line_args.qtdir != None:
+if command_line_args.qtdir is not None:
     from PyQt4.QtCore import QCoreApplication
     QCoreApplication.addLibraryPath(
         command_line_args.qtdir
     )
+
 
 def main():
     if not UsageService.isEnabled():

--- a/scripts/ErrorReporter/error_dialog_app.py
+++ b/scripts/ErrorReporter/error_dialog_app.py
@@ -4,6 +4,8 @@ import argparse
 parser = argparse.ArgumentParser(description='Pass in exit_code')
 parser.add_argument('--exitcode', dest='exit_code')
 parser.add_argument('--directory', dest='directory')
+parser.add_argument('--qtdir', dest='qtdir')
+
 command_line_args = parser.parse_args()
 
 sys.path.insert(0, command_line_args.directory)
@@ -15,7 +17,11 @@ from ErrorReporter import resources # noqa
 from mantid.kernel import UsageService # noqa
 from ErrorReporter.error_report_presenter import ErrorReporterPresenter # noqa
 from ErrorReporter.errorreport import CrashReportPage # noqa
-
+# Set path to look for package qt libraries
+from PyQt4.QtCore import QCoreApplication
+QCoreApplication.addLibraryPath(
+    command_line_args.qtdir
+)
 
 def main():
     if not UsageService.isEnabled():

--- a/scripts/ErrorReporter/error_dialog_app.py
+++ b/scripts/ErrorReporter/error_dialog_app.py
@@ -18,10 +18,11 @@ from mantid.kernel import UsageService # noqa
 from ErrorReporter.error_report_presenter import ErrorReporterPresenter # noqa
 from ErrorReporter.errorreport import CrashReportPage # noqa
 # Set path to look for package qt libraries
-from PyQt4.QtCore import QCoreApplication
-QCoreApplication.addLibraryPath(
-    command_line_args.qtdir
-)
+if command_line_args.qtdir != None:
+    from PyQt4.QtCore import QCoreApplication
+    QCoreApplication.addLibraryPath(
+        command_line_args.qtdir
+    )
 
 def main():
     if not UsageService.isEnabled():


### PR DESCRIPTION
**Description of work.**

The error reporter dialog on OSX was crashing immediately upon user interaction. The reason for this was a conflict between the system installed qt libraries (from `cartr/qt4`) and the qt libraries that ship with the package. 

The path to the qt libraries is now set explicitly in the `error_dialog_app.py` file to avoid this conflict.

**Report to:** n/a

**To test:**

On a Mac with `qt@4` installed from `cartr/qt4`
Take the build from the server - 
Run `Segfault` algorithm to crash Mantid
Check that the error reporter dialog does not crash when interacting with it

Fixes: there is no issue associated with this PR.

Does this update require release notes?
- [ ] Yes
- [X] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
