### PR TITLE
Fix ReflectometryILLSumForeground unit tests

### DIFF
--- a/Framework/Algorithms/src/ReflectometrySumInQ.cpp
+++ b/Framework/Algorithms/src/ReflectometrySumInQ.cpp
@@ -489,7 +489,7 @@ ReflectometrySumInQ::referenceAngles(const API::SpectrumInfo &spectrumInfo) {
   Angles a;
   const int beamCentre = getProperty(Prop::BEAM_CENTRE);
   const double centreTwoTheta =
-      spectrumInfo.signedTwoTheta(static_cast<size_t>(beamCentre));
+      spectrumInfo.twoTheta(static_cast<size_t>(beamCentre));
   const bool isFlat = getProperty(Prop::IS_FLAT_SAMPLE);
   if (isFlat) {
     a.horizon = centreTwoTheta / 2.;


### PR DESCRIPTION
**Description of work.**

This PR fixes a broken unit test of `ReflectometryILLSumForeground`. The issue was due to `ReflectometrySumInQ` using a signed 2theta instead of unsigned.

**Report to:** nobody.

**To test:**

Check that the unit tests pass.

No associated issue

Does this update require release notes?
- [ ] Yes
- [x] No


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
