### PR TITLE
Fix constant Q line profiles in directtools

### DIFF
--- a/scripts/directtools/__init__.py
+++ b/scripts/directtools/__init__.py
@@ -442,7 +442,7 @@ def plotcuts(direction, workspaces, cuts, widths, quantity, unit, style='l', kee
                 if 'm' in style:
                     markerStyle, markerIndex = _chooseMarker(markers, markerIndex)
                 label = _label(ws, cut, width, len(workspaces) == 1, len(cuts) == 1, len(widths) == 1, quantity, unit)
-                axes.errorbar(line, specNum=0, linestyle=lineStyle, marker=markerStyle, label=label)
+                axes.errorbar(line, specNum=0, linestyle=lineStyle, marker=markerStyle, label=label, distribution=True)
     axes.set_xscale(xscale)
     axes.set_yscale(yscale)
     _profileytitle(workspaces[0], axes)
@@ -482,7 +482,7 @@ def plotprofiles(workspaces, labels=None, style='l', xscale='linear', yscale='li
     for ws, label in zip(workspaces, labels):
         if 'm' in style:
             markerStyle, markerIndex = _chooseMarker(markers, markerIndex)
-        axes.errorbar(ws, specNum=0, linestyle=lineStyle, marker=markerStyle, label=label)
+        axes.errorbar(ws, specNum=0, linestyle=lineStyle, marker=markerStyle, label=label, distribution=True)
     axes.set_xscale(xscale)
     axes.set_yscale(yscale)
     _profileytitle(workspaces[0], axes)

--- a/scripts/directtools/__init__.py
+++ b/scripts/directtools/__init__.py
@@ -39,6 +39,16 @@ def _configurematplotlib(params):
     matplotlib.rcParams.update(params)
 
 
+def _denormalizeLine(line):
+    """Multiplies line workspace by the line width."""
+    axis = line.getAxis(1)
+    height = axis.getMax() - axis.getMin()
+    Ys = line.dataY(0)
+    Ys *= height
+    Es = line.dataE(0)
+    Es *= height
+
+
 def _finalizeprofileE(axes):
     """Set axes for const E axes."""
     axes.set_xlim(xmin=0.)
@@ -427,10 +437,12 @@ def plotcuts(direction, workspaces, cuts, widths, quantity, unit, style='l', kee
                     cutWSList.append(wsName)
                 line = LineProfile(ws, cut, width, Direction=direction,
                                    OutputWorkspace=wsName, StoreInADS=keepCutWorkspaces, EnableLogging=False)
+                if ws.isDistribution() and direction == 'Vertical':
+                    _denormalizeLine(line)
                 if 'm' in style:
                     markerStyle, markerIndex = _chooseMarker(markers, markerIndex)
                 label = _label(ws, cut, width, len(workspaces) == 1, len(cuts) == 1, len(widths) == 1, quantity, unit)
-                axes.errorbar(line, specNum=0, linestyle=lineStyle, marker=markerStyle, label=label, distribution=True)
+                axes.errorbar(line, specNum=0, linestyle=lineStyle, marker=markerStyle, label=label)
     axes.set_xscale(xscale)
     axes.set_yscale(yscale)
     _profileytitle(workspaces[0], axes)
@@ -470,7 +482,7 @@ def plotprofiles(workspaces, labels=None, style='l', xscale='linear', yscale='li
     for ws, label in zip(workspaces, labels):
         if 'm' in style:
             markerStyle, markerIndex = _chooseMarker(markers, markerIndex)
-        axes.errorbar(ws, specNum=0, linestyle=lineStyle, marker=markerStyle, label=label, distribution=True)
+        axes.errorbar(ws, specNum=0, linestyle=lineStyle, marker=markerStyle, label=label)
     axes.set_xscale(xscale)
     axes.set_yscale(yscale)
     _profileytitle(workspaces[0], axes)

--- a/scripts/test/directtools/DirectToolsTest.py
+++ b/scripts/test/directtools/DirectToolsTest.py
@@ -250,7 +250,7 @@ class DirectTest(unittest.TestCase):
 
     def test_plotconstE_and_plotconstQ_plot_equal_value_at_crossing(self):
         DirectILLCollectData(
-            Run='ILL/IN4/084447',
+            Run='ILL/IN4/084447.nxs',
             OutputWorkspace='sample',
             IncidentEnergyCalibration='Energy Calibration OFF',
             FlatBkg='Flat Bkg OFF',

--- a/scripts/test/directtools/DirectToolsTest.py
+++ b/scripts/test/directtools/DirectToolsTest.py
@@ -7,7 +7,8 @@ matplotlib.use('AGG')
 
 import directtools
 from mantid.api import mtd
-from mantid.simpleapi import LoadILLTOF, CreateSampleWorkspace, CreateWorkspace
+from mantid.simpleapi import (CreateSampleWorkspace, CreateWorkspace, DirectILLCollectData, DirectILLReduction,
+                              LoadILLTOF)
 import numpy
 import numpy.testing
 import testhelpers
@@ -246,6 +247,27 @@ class DirectTest(unittest.TestCase):
         figure, axes, cuts = testhelpers.assertRaisesNothing(self, directtools.plotconstQ, **kwargs)
         self.assertEquals(axes.get_xscale(), 'log')
         self.assertEquals(axes.get_yscale(), 'log')
+
+    def test_plotconstE_and_plotconstQ_plot_equal_value_at_crossing(self):
+        DirectILLCollectData(
+            Run='ILL/IN4/084447',
+            OutputWorkspace='sample',
+            IncidentEnergyCalibration='Energy Calibration OFF',
+            FlatBkg='Flat Bkg OFF',
+        )
+        DirectILLReduction(
+            InputWorkspace='sample',
+            OutputWorkspace='reduced'
+        )
+        Q = 2.5
+        figure, axes, cuts = directtools.plotconstQ('reduced', Q, 0.01)
+        lineDataQ = axes.get_lines()[0].get_data()
+        E = 2.2
+        figure, axes, cuts = directtools.plotconstE('reduced', E, 0.01)
+        lineDataE = axes.get_lines()[0].get_data()
+        indexE = numpy.argmin(numpy.abs(lineDataQ[0] - E))
+        indexQ = numpy.argmin(numpy.abs(lineDataE[0] - Q))
+        self.assertEquals(lineDataQ[1][indexE], lineDataE[1][indexQ])
 
     def test_plotcuts_keepCutWorkspaces(self):
         ws = LoadILLTOF('ILL/IN4/084446.nxs', StoreInADS=False)


### PR DESCRIPTION
PR  #22407 defined more clearly how the `LineProfile` algorithm handles distributions. This broke some plotting functionality in the `directtools` Python module which this PR fixes. This is a low-risk change.

**Report to:** Björn Fåk, ILL.

**To test:**

You'll need to have the unit test data directory in Mantid's data search directories, and facility set to ILL.

The intensity of vertical line profiles should be roughly independent of line width if the data is relatively flat in the horizontal direction. Therefore, the plot generated by the script below should contain three lines with similar intensities. For comparison, you can try this out on master to see how the plots look like when the lines are wrongly normalized by the cut width.

```python
import directtools as dt

DirectILLCollectData('ILL/IN4/084447', OutputWorkspace='ws')
DirectILLReduction('ws', OutputWorkspace='sqw')

Q = 1.75
dQ = [0.1, 0.5, 1.0]
fig, axes, cuts = dt.plotconstQ('sqw', Q,dQ)
axes.set_xlim(xmin=-1., xmax=8.)
axes.set_ylim(ymin=0., ymax=0.15)
fig.show()
```

Fixes #22718.

Does this update require release notes?
- [ ] Yes
- [x] No

The issue never existed in any release builds.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
