### PR TITLE
Project Recovery: Remove checkpoints on close and catch if recovery dir does not exist

### DIFF
--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -9774,6 +9774,7 @@ void ApplicationWindow::closeEvent(QCloseEvent *ce) {
   // Stop background saving thread, so it doesn't try to use a destroyed
   // resource
   m_projectRecovery.stopProjectSaving();
+  m_projectRecovery.clearAllCheckpoints();
 
   // Close the remaining MDI windows. The Python API is required to be active
   // when the MDI window destructor is called so that those references can be

--- a/MantidPlot/src/ProjectRecovery.cpp
+++ b/MantidPlot/src/ProjectRecovery.cpp
@@ -100,8 +100,8 @@ std::vector<Poco::Path>
 getRecoveryFolderCheckpoints(const std::string &recoveryFolderPath) {
   Poco::Path recoveryPath;
 
-  if (!recoveryPath.tryParse(recoveryFolderPath) || 
-	  !Poco::File(recoveryPath).exists()) {
+  if (!recoveryPath.tryParse(recoveryFolderPath) ||
+      !Poco::File(recoveryPath).exists()) {
     // Folder may not exist yet
     g_log.debug("Project Saving: Failed to get working folder whilst deleting "
                 "checkpoints");
@@ -197,27 +197,27 @@ bool ProjectRecovery::attemptRecovery() {
 }
 
 bool ProjectRecovery::checkForRecovery() const noexcept {
-	try {
-		const auto checkpointPaths =
-			getRecoveryFolderCheckpoints(getRecoveryFolder());
-		return checkpointPaths.size() != 0; // Non zero indicates recovery is pending
-	}
-	catch (...) {
-		g_log.warning("Project Recovery: Caught exception whilst attempting to check for existing recovery");
-		return false;
-	}
+  try {
+    const auto checkpointPaths =
+        getRecoveryFolderCheckpoints(getRecoveryFolder());
+    return checkpointPaths.size() !=
+           0; // Non zero indicates recovery is pending
+  } catch (...) {
+    g_log.warning("Project Recovery: Caught exception whilst attempting to "
+                  "check for existing recovery");
+    return false;
+  }
 }
 
-bool ProjectRecovery::clearAllCheckpoints() const noexcept
-{
-	try {
-		deleteExistingCheckpoints(0);
-		return true;
-	}
-	catch (...) {
-		g_log.warning("Project Recovery: Caught exception whilst attempting to clear existing checkpoints.");
-		return false;
-	}
+bool ProjectRecovery::clearAllCheckpoints() const noexcept {
+  try {
+    deleteExistingCheckpoints(0);
+    return true;
+  } catch (...) {
+    g_log.warning("Project Recovery: Caught exception whilst attempting to "
+                  "clear existing checkpoints.");
+    return false;
+  }
 }
 
 /// Returns a background thread with the current object captured inside it

--- a/MantidPlot/src/ProjectRecovery.cpp
+++ b/MantidPlot/src/ProjectRecovery.cpp
@@ -99,7 +99,9 @@ Poco::Path getOutputPath() {
 std::vector<Poco::Path>
 getRecoveryFolderCheckpoints(const std::string &recoveryFolderPath) {
   Poco::Path recoveryPath;
-  if (!recoveryPath.tryParse(recoveryFolderPath)) {
+
+  if (!recoveryPath.tryParse(recoveryFolderPath) || 
+	  !Poco::File(recoveryPath).exists()) {
     // Folder may not exist yet
     g_log.debug("Project Saving: Failed to get working folder whilst deleting "
                 "checkpoints");
@@ -194,10 +196,28 @@ bool ProjectRecovery::attemptRecovery() {
   }
 }
 
-bool ProjectRecovery::checkForRecovery() const {
-  const auto checkpointPaths =
-      getRecoveryFolderCheckpoints(getRecoveryFolder());
-  return checkpointPaths.size() != 0; // Non zero indicates recovery is pending
+bool ProjectRecovery::checkForRecovery() const noexcept {
+	try {
+		const auto checkpointPaths =
+			getRecoveryFolderCheckpoints(getRecoveryFolder());
+		return checkpointPaths.size() != 0; // Non zero indicates recovery is pending
+	}
+	catch (...) {
+		g_log.warning("Project Recovery: Caught exception whilst attempting to check for existing recovery");
+		return false;
+	}
+}
+
+bool ProjectRecovery::clearAllCheckpoints() const noexcept
+{
+	try {
+		deleteExistingCheckpoints(0);
+		return true;
+	}
+	catch (...) {
+		g_log.warning("Project Recovery: Caught exception whilst attempting to clear existing checkpoints.");
+		return false;
+	}
 }
 
 /// Returns a background thread with the current object captured inside it

--- a/MantidPlot/src/ProjectRecovery.h
+++ b/MantidPlot/src/ProjectRecovery.h
@@ -57,10 +57,10 @@ public:
   /// Attempts recovery of the most recent checkpoint
   bool attemptRecovery();
   /// Checks if recovery is required
-  bool checkForRecovery() const;
+  bool checkForRecovery() const noexcept;
 
   /// Clears all checkpoints in the existing folder
-  void clearAllCheckpoints() const { deleteExistingCheckpoints(0); };
+  bool clearAllCheckpoints() const noexcept;
 
   /// Starts the background thread
   void startProjectSaving();


### PR DESCRIPTION
**Description of work.**
- Clears checkpoints when Mantid closes, not just when the user says no to recovery
- Checks if the recovery directory exists before attempting to iterate it.
- Marks various methods ApplicationWindow calls noexcept

**To test:**
- Delete the recovery folder completely from the `.mantidproject` folder or `%appdata%/mantid`.
- Open Mantid
- Ensure no exception is thrown / nothing is logged

----------------------
- Ensure the recovery folder is still deleted
- In `ProjectSerialiser` comment out the following code
``` c++
  if (!recoveryPath.tryParse(recoveryFolderPath) || 
	  !Poco::File(recoveryPath).exists()) {
    // Folder may not exist yet
    g_log.debug("Project Saving: Failed to get working folder whilst deleting "
                "checkpoints");
    return {};
  }
```
- Attempt to load Mantid, a warning should be logged about an exception, instead of a unhandled exception being thrown
----------------------
- Open Mantid and create sample workspaces
- Ensure project recovery has saved these whilst Mantid is running
- Close Mantid normally
- Ensure the checkpoints are removed

- Create some more sample workspace
- Ensure project recovery has saved these
- Close Mantid forcefully e.g. segfault alg
- Ensure checkpoints are still present
- Ensure clicking no to the recovery dialog still removes the existing ones

--------------

Fixes #22729 

Does this update require release notes?
- [ ] Yes
- [x] No

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
