### PR TITLE
Parameter specializations for double and V3D.

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Instrument/Parameter.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/Parameter.h
@@ -5,11 +5,12 @@
 #ifndef Q_MOC_RUN
 #include <boost/shared_ptr.hpp>
 #endif
+#include <iomanip>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <typeinfo>
 #include <vector>
-#include <stdexcept>
 
 namespace Mantid {
 
@@ -178,16 +179,6 @@ template <class T> void Parameter::set(const T &t) {
 //--------------------------------------------------------------------------
 // Template definitions - ParameterType class
 //--------------------------------------------------------------------------
-
-/** Return the value of the parameter as a string
- * @tparam T The type of the parameter
- * @returns A string representation of the parameter
- */
-template <class Type> std::string ParameterType<Type>::asString() const {
-  std::ostringstream str;
-  str << m_value;
-  return str.str();
-}
 
 /**
  * Set the value of the parameter from a string

--- a/Framework/Geometry/src/Instrument/Parameter.cpp
+++ b/Framework/Geometry/src/Instrument/Parameter.cpp
@@ -20,6 +20,32 @@
 namespace Mantid {
 namespace Geometry {
 
+/** Return the value of the parameter as a string
+ * @tparam T The type of the parameter
+ * @returns A string representation of the parameter
+ */
+template <class Type> std::string ParameterType<Type>::asString() const {
+  std::ostringstream str;
+  str << m_value;
+  return str.str();
+}
+
+/// Specialization for doubles
+template <> std::string ParameterType<double>::asString() const {
+  std::ostringstream str;
+  str << std::setprecision(std::numeric_limits<double>::digits10);
+  str << m_value;
+  return str.str();
+}
+
+/// Specialization for V3D
+template <> std::string ParameterType<Kernel::V3D>::asString() const {
+  std::ostringstream str;
+  str << std::setprecision(std::numeric_limits<double>::digits10);
+  str << m_value;
+  return str.str();
+}
+
 // Initialize the static map
 ParameterFactory::FactoryMap ParameterFactory::s_map;
 

--- a/Framework/Geometry/test/ParameterMapTest.h
+++ b/Framework/Geometry/test/ParameterMapTest.h
@@ -632,6 +632,18 @@ public:
     TS_ASSERT_EQUALS(oldA->value<bool>(), false);
   }
 
+  void test_asString_for_doubles() {
+    ParameterMap pmap;
+    auto comp = m_testInstrument.get();
+    pmap.addDouble(comp, "d", 0.123456789012345);
+    pmap.addV3D(comp, "v",
+                Mantid::Kernel::V3D(0.123456789012345, 0.123456789012345,
+                                    0.123456789012345));
+    TS_ASSERT_EQUALS(pmap.get(comp, "d")->asString(), "0.123456789012345");
+    TS_ASSERT_EQUALS(pmap.get(comp, "v")->asString(),
+                     "[0.123456789012345,0.123456789012345,0.123456789012345]");
+  }
+
 private:
   template <typename ValueType>
   void doCopyAndUpdateTestUsingGenericAdd(const std::string &type,


### PR DESCRIPTION
**Description of work.**

Added specializations for the `asString` method of the `ParameterType` template for types of `double` and `V3D`.

**To test:**

Run the script from the issue description.

Fixes #22571

Does this update require release notes?
- [ ] Yes
- [X] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
