### PR TITLE
Project Recovery: Remove excessive logging on project recovery saving

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadRawHelper.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadRawHelper.h
@@ -2,12 +2,12 @@
 #define MANTID_DATAHANDLING_LOADRAWHELPER_H_
 
 #include "MantidAPI/IFileLoader.h"
-#include "MantidDataObjects/Workspace2D.h"
-#include "MantidDataHandling/ISISRunLogs.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/WorkspaceGroup_fwd.h"
-#include <boost/scoped_ptr.hpp>
+#include "MantidDataHandling/ISISRunLogs.h"
+#include "MantidDataObjects/Workspace2D.h"
 #include <climits>
+#include <memory>
 
 class ISISRAW;
 class ISISRAW2;
@@ -52,6 +52,9 @@ class DLLExport LoadRawHelper
 public:
   /// Default constructor
   LoadRawHelper();
+  // Define destructor in .cpp as we have unique_ptr to forward declared
+  // ISISRAW2
+  ~LoadRawHelper();
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "LoadRawHelper"; }
   /// Algorithm's version for identification overriding a virtual method
@@ -116,10 +119,10 @@ public:
                                    API::Algorithm *const pAlg);
 
   /// Extract the start time from a raw file
-  static Types::Core::DateAndTime extractStartTime(ISISRAW *isisRaw);
+  static Types::Core::DateAndTime extractStartTime(ISISRAW &isisRaw);
 
   /// Extract the end time from a raw file
-  static Types::Core::DateAndTime extractEndTime(ISISRAW *isisRaw);
+  static Types::Core::DateAndTime extractEndTime(ISISRAW &isisRaw);
 
 protected:
   /// Overwrites Algorithm method.
@@ -175,10 +178,6 @@ protected:
       int64_t wsIndex, specnum_t nspecNum, int64_t noTimeRegimes,
       int64_t lengthIn, int64_t binStart);
 
-  /// ISISRAW class instance which does raw file reading. Shared pointer to
-  /// prevent memory leak when an exception is thrown.
-  boost::shared_ptr<ISISRAW2> isisRaw;
-
   /// get proton charge from raw file
   float getProtonCharge() const;
   /// set proton charge
@@ -188,6 +187,8 @@ protected:
 
   /// number of time regimes
   int getNumberofTimeRegimes();
+  /// return an reference to the ISISRAW2 reader
+  ISISRAW2 &isisRaw() const;
   /// resets the isisraw shared pointer
   void reset();
 
@@ -226,6 +227,8 @@ private:
   /// convert month label to int string
   static std::string convertMonthLabelToIntStr(std::string month);
 
+  /// ISISRAW class instance which does raw file reading.
+  mutable std::unique_ptr<ISISRAW2> m_isis_raw;
   /// Allowed values for the cache property
   std::vector<std::string> m_cache_options;
   /// A map for storing the time regime for each spectrum
@@ -246,7 +249,7 @@ private:
   specnum_t m_total_specs;
 
   /// A ptr to the log creator
-  boost::scoped_ptr<ISISRunLogs> m_logCreator;
+  std::unique_ptr<ISISRunLogs> m_logCreator;
 
   /// Search for the log files in the workspace, and output their names as a
   /// set.

--- a/Framework/DataHandling/src/CreateSimulationWorkspace.cpp
+++ b/Framework/DataHandling/src/CreateSimulationWorkspace.cpp
@@ -43,9 +43,9 @@ StartAndEndTime getStartAndEndTimesFromRawFile(std::string filename) {
 
   StartAndEndTime startAndEndTime;
   startAndEndTime.startTime =
-      Mantid::DataHandling::LoadRawHelper::extractStartTime(&isisRaw);
+      Mantid::DataHandling::LoadRawHelper::extractStartTime(isisRaw);
   startAndEndTime.endTime =
-      Mantid::DataHandling::LoadRawHelper::extractEndTime(&isisRaw);
+      Mantid::DataHandling::LoadRawHelper::extractEndTime(isisRaw);
 
   fclose(rawFile);
   return startAndEndTime;
@@ -290,7 +290,7 @@ void CreateSimulationWorkspace::loadMappingFromISISNXS(
     throw std::runtime_error(
         "Cannot find path to isis_vms_compat. Is the file an ISIS NeXus file?");
   }
-  using NXIntArray = boost::scoped_ptr<std::vector<int32_t>>;
+  using NXIntArray = std::unique_ptr<std::vector<int32_t>>;
 
   nxsFile.openData("NDET");
   NXIntArray ndets(nxsFile.getData<int32_t>());

--- a/Framework/DataHandling/src/LoadRaw/isisraw2.cpp
+++ b/Framework/DataHandling/src/LoadRaw/isisraw2.cpp
@@ -17,7 +17,7 @@ Mantid::Kernel::Logger g_log("ISISRAW2");
 ISISRAW2::ISISRAW2()
     : ISISRAW(nullptr, false), ndes(0), outbuff(nullptr), m_bufferSize(0) {
   // Determine the size of the output buffer to create from the config service.
-  g_log.debug() << "Determining ioRaw buffer size\n";
+  g_log.debug("Determining ioRaw buffer size\n");
   if (Mantid::Kernel::ConfigService::Instance().getValue(
           "loadraw.readbuffer.size", m_bufferSize) == 0) {
     m_bufferSize = 200000;

--- a/Framework/DataHandling/src/LoadRaw3.cpp
+++ b/Framework/DataHandling/src/LoadRaw3.cpp
@@ -122,8 +122,8 @@ void LoadRaw3::exec() {
 
   // Only run the Child Algorithms once
   loadRunParameters(localWorkspace);
-  const SpectrumDetectorMapping detectorMapping(isisRaw->spec, isisRaw->udet,
-                                                isisRaw->i_det);
+  const SpectrumDetectorMapping detectorMapping(isisRaw().spec, isisRaw().udet,
+                                                isisRaw().i_det);
   localWorkspace->updateSpectraUsing(detectorMapping);
 
   runLoadInstrument(m_filename, localWorkspace, 0.0, 0.4);

--- a/Framework/DataHandling/src/LoadRawHelper.cpp
+++ b/Framework/DataHandling/src/LoadRawHelper.cpp
@@ -142,7 +142,7 @@ int LoadRawHelper::getNumberofTimeRegimes() {
  */
 ISISRAW2 &LoadRawHelper::isisRaw() const {
   if (!m_isis_raw) {
-    m_isis_raw.reset(new ISISRAW2);
+    m_isis_raw = Kernel::make_unique<ISISRAW2>();
   }
 
   return *m_isis_raw;


### PR DESCRIPTION
**Description of work.**

Moves the instantiation of the internal `ISISRAW` pointer in `LoadRaw` so that it is created on first use.

**To test:**

* start MantidPlot
* set the log level to debug
* start the MuonAnalysis interface
* load the `MUSR00015189` file in the DocTest
* watch the debug log until project saving starts
* there should be very little output from the recovery and no trace of
```
Determining ioRaw buffer size
Unable to find loadraw.readbuffer.size in the properties file
loadraw.readbuffer.size not found, setting to 200000
```

Fixes #22733

Does this update require release notes?
- [ ] Yes
- [X] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
