### PR TITLE
Fix finding range of runs

### DIFF
--- a/scripts/Interface/reduction_gui/reduction/diffraction/diffraction_reduction_script.py
+++ b/scripts/Interface/reduction_gui/reduction/diffraction/diffraction_reduction_script.py
@@ -251,7 +251,7 @@ class DiffractionReductionScripter(BaseReductionScripter):
         runnumbers_str = str(runsetupdict["RunNumber"])
         if runnumbers_str.count(':') > 0:
             runnumbers_str = runnumbers_str.replace(':', '-')
-        runnumbers_str = FileFinder.findRuns('{}_{}'.format(self.instrument_name, runnumbers_str))
+        runnumbers_str = FileFinder.findRuns('{}{}'.format(self.instrument_name, runnumbers_str))
         runnumbers_str = [os.path.split(filename)[-1] for filename in runnumbers_str]
 
         # create an integer version


### PR DESCRIPTION
There is/was a bug in `Interfaces` -> `Diffraction` -> `Powder Diffraction Reduction` that was introduced in #22693 where ranges of runs do not get found.

**Report to:** POWGEN team

**To test:**

Start the interface looking for a single run or a range of runs. The bug demonstrates that `FileFinder.findRuns` wants strings where there is no delimiter between the instrument name and the run number when supplying range/multiple runs.

*There is no associated issue.*

*Does not need to be in the release notes* because it is already covered by an existing one.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
