### PR TITLE
Fix FIGARO detector angle calculation in LoadILLReflectometry

### DIFF
--- a/Framework/DataHandling/src/LoadILLReflectometry.cpp
+++ b/Framework/DataHandling/src/LoadILLReflectometry.cpp
@@ -710,7 +710,6 @@ double LoadILLReflectometry::detectorRotation() {
   const double peakCentre = reflectometryPeak();
   g_log.debug() << "Using detector angle (degrees): " << m_detectorAngle
                 << '\n';
-  const double deflection = collimationAngle();
   if (!isDefault("OutputBeamPosition")) {
     PeakInfo p;
     p.detectorAngle = m_detectorAngle;
@@ -730,6 +729,7 @@ double LoadILLReflectometry::detectorRotation() {
     return 2 * userAngle - offset;
   }
   if (!posTable) {
+    const double deflection = collimationAngle();
     if (deflection != 0) {
       g_log.debug() << "Using incident deflection angle (degrees): "
                     << deflection << '\n';
@@ -841,12 +841,9 @@ void LoadILLReflectometry::placeSource() {
 
 /// Return the incident neutron deflection angle.
 double LoadILLReflectometry::collimationAngle() const {
-  if (m_instrument != Supported::FIGARO) {
-    return 0;
-  }
-  const auto collimationAngle = doubleFromRun("CollAngle.actual_coll_angle");
-  const auto sampleAngle = doubleFromRun("Theta.actual_theta");
-  return collimationAngle + sampleAngle;
+  return m_instrument == Supported::FIGARO
+             ? doubleFromRun("CollAngle.actual_coll_angle")
+             : 0.;
 }
 
 /// Return the detector center angle.

--- a/Framework/DataHandling/test/LoadILLReflectometryTest.h
+++ b/Framework/DataHandling/test/LoadILLReflectometryTest.h
@@ -345,8 +345,6 @@ public:
         180. * M_PI;
     const auto detDist = std::hypot(beamY - sht1, beamZ) -
                          sampleZOffset / std::cos(collimationAngle);
-    const auto sampleAngle =
-        run.getPropertyValueAsType<double>("Theta.actual_theta") / 180. * M_PI;
     for (size_t i = 0; i < spectrumInfo.size(); ++i) {
       if (spectrumInfo.isMonitor(i)) {
         continue;
@@ -354,8 +352,8 @@ public:
       const auto p = spectrumInfo.position(i);
       TS_ASSERT_EQUALS(p.X(), 0.)
       const auto pixOffset = (static_cast<double>(i) - 127.5) * pixWidth;
-      const auto pixAngle = detAngle + collimationAngle + sampleAngle +
-                            std::atan2(pixOffset, detDist);
+      const auto pixAngle =
+          detAngle + collimationAngle + std::atan2(pixOffset, detDist);
       const auto pixDist = std::hypot(pixOffset, detDist);
       const auto idealY = pixDist * std::sin(pixAngle);
       const auto idealZ = pixDist * std::cos(pixAngle);

--- a/docs/source/release/v3.13.0/reflectometry.rst
+++ b/docs/source/release/v3.13.0/reflectometry.rst
@@ -45,7 +45,7 @@ New
   - ``CreatePolarizationEfficiencies`` creates efficiencies from polynomial coefficients
   - ``JoinISISPolarizationEfficiencies`` joins individual efficiencies into one matrix workspace
   - ``LoadISISPolarizationEfficiencies`` loads efficiencies form files
-* The ILL reflectometry loader ``LoadILLReflectometry`` implements the NeXus file changes of January 2018 and can load again all valid Nexus files for D17 and FIGARO which are available since 2013 and 2017, respectively.
+* The ILL reflectometry loader :ref:`algm-LoadILLReflectometry` implements the NeXus file changes of January 2018 and can load again all valid Nexus files for D17 and FIGARO which are available since 2013 and 2017, respectively.
 * Algorithms for reflectometry reduction at ILL have been added. These handle the basic polarized/unpolarized reduction in SumInLambda or SumInQ modes. Included algorithms:
     - :ref:`algm-ReflectometryILLPreprocess`
     - :ref:`algm-ReflectometryILLSumForeground`
@@ -63,6 +63,7 @@ Bugfixes
 ########
 
 * Correct the angle to the value of ``ThetaIn`` property if summing in lambda in ``ReflectometryReductionOne-v2``.
+* Fixed an incorrectly calculated detector angle when loading FIGARO files using :ref:`algm-LoadILLReflectometry`.
 
 Liquids Reflectometer
 ---------------------


### PR DESCRIPTION
**Description of work**

This PR fixes a problem when loading FIGARO files without explicitly giving a detector angle or using a direct beam reference: in this case the sample angle from `Theta.actual_angle` sample log entry was  incorrectly added to the deflection angle.

**Report to:** [nobody].

**To test:**

Load `ILL/Figaro/000002.nxs` from Mantid's unit test data directory. Don't set the *BeamCentre*, *DirectBeamPosition* or *BraggAngle* properties. Check from the detector table that the two theta value  1.626 degrees, or twice the `Theta.actual_theta` sample log, falls between workspace indices 127 and 128. The indices correspond to the maximum of the specular line on the detector.

Fixes #22794.

Does this update require release notes?
- [x] Yes
- [ ] No


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
