### PR TITLE
Fix ILL's reflectometry reduction for FIGARO instrument

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILL_common.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILL_common.py
@@ -16,8 +16,8 @@ def chopperOpeningAngle(sampleLogs, instrumentName):
         openoffset = sampleLogs.getProperty('VirtualChopper.open_offset').value
         return 45. - (chopper2Phase - chopper1Phase) - openoffset
     else:
-        firstChopper = sampleLogs.getProperty('ChopperSettings.firstChopper').value
-        secondChopper = sampleLogs.getProperty('ChopperSettings.secondChopper').value
+        firstChopper = int(sampleLogs.getProperty('ChopperSetting.firstChopper').value)
+        secondChopper = int(sampleLogs.getProperty('ChopperSetting.secondChopper').value)
         phase1Entry = 'CH{}.phase'.format(firstChopper)
         phase2Entry = 'CH{}.phase'.format(secondChopper)
         chopper1Phase = sampleLogs.getProperty(phase1Entry).value
@@ -31,7 +31,7 @@ def chopperPairDistance(sampleLogs, instrumentName):
     if instrumentName == 'D17':
         return sampleLogs.getProperty('Distance.ChopperGap').value * 1e-2
     else:
-        return sampleLogs.getProperty('ChopperSettings.distSeparationChopperPair').value * 1e-2
+        return sampleLogs.getProperty('ChopperSetting.distSeparationChopperPair').value * 1e-2
 
 
 def chopperSpeed(sampleLogs, instrumentName):
@@ -39,7 +39,7 @@ def chopperSpeed(sampleLogs, instrumentName):
     if instrumentName == 'D17':
         return sampleLogs.getProperty('VirtualChopper.chopper1_speed_average').value
     else:
-        firstChopper = sampleLogs.getProperty('ChopperSettings.firstChopper').value
+        firstChopper = int(sampleLogs.getProperty('ChopperSetting.firstChopper').value)
         speedEntry = 'CH{}.rotation_speed'.format(firstChopper)
         return sampleLogs.getProperty(speedEntry).value
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLSumForegroundTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLSumForegroundTest.py
@@ -25,6 +25,7 @@ class ReflectometryILLSumForegroundTest(unittest.TestCase):
         }
         alg = create_algorithm('ReflectometryILLSumForeground', **args)
         assertRaisesNothing(self, alg.execute)
+        self.assertTrue(alg.isExecuted())
 
     def testReflectedBeamSumInLambdaExecutes(self):
         dirWS = illhelpers.create_poor_mans_d17_workspace()
@@ -39,6 +40,7 @@ class ReflectometryILLSumForegroundTest(unittest.TestCase):
         }
         alg = create_algorithm('ReflectometryILLSumForeground', **args)
         assertRaisesNothing(self, alg.execute)
+        self.assertTrue(alg.isExecuted())
         dirForeground = alg.getProperty('OutputWorkspace').value
         reflWS = illhelpers.create_poor_mans_d17_workspace()
         illhelpers.refl_rotate_detector(reflWS, 1.2)
@@ -55,6 +57,7 @@ class ReflectometryILLSumForegroundTest(unittest.TestCase):
         }
         alg = create_algorithm('ReflectometryILLSumForeground', **args)
         assertRaisesNothing(self, alg.execute)
+        self.assertTrue(alg.isExecuted())
 
     def testReflectedBeamSumInQExecutes(self):
         dirWS = illhelpers.create_poor_mans_d17_workspace()
@@ -69,6 +72,7 @@ class ReflectometryILLSumForegroundTest(unittest.TestCase):
         }
         alg = create_algorithm('ReflectometryILLSumForeground', **args)
         assertRaisesNothing(self, alg.execute)
+        self.assertTrue(alg.isExecuted())
         dirForeground = alg.getProperty('OutputWorkspace').value
         reflWS = illhelpers.create_poor_mans_d17_workspace()
         illhelpers.refl_rotate_detector(reflWS, 1.2)
@@ -85,6 +89,42 @@ class ReflectometryILLSumForegroundTest(unittest.TestCase):
         }
         alg = create_algorithm('ReflectometryILLSumForeground', **args)
         assertRaisesNothing(self, alg.execute)
+        self.assertTrue(alg.isExecuted())
+
+    def testFigaroSumInLambdaExecutes(self):
+        args = {
+            'Run': 'ILL/Figaro/000002.nxs',
+            'OutputWorkspace': 'direct',
+            'ForegroundHalfWidth': [6, 6],
+            'FlatBackground': 'Background OFF',
+        }
+        alg = create_algorithm('ReflectometryILLPreprocess', **args)
+        assertRaisesNothing(self, alg.execute)
+        self.assertTrue(alg.isExecuted())
+        args = {
+            'InputWorkspace': 'direct',
+            'OutputWorkspace': 'direct-fgd'
+        }
+        alg = create_algorithm('ReflectometryILLSumForeground', **args)
+        assertRaisesNothing(self, alg.execute)
+        self.assertTrue(alg.isExecuted())
+        args = {
+            'Run': 'ILL/Figaro/000002.nxs',
+            'OutputWorkspace': 'reflected',
+            'ForegroundHalfWidth': [6, 6],
+            'FlatBackground': 'Background OFF',
+        }
+        alg = create_algorithm('ReflectometryILLPreprocess', **args)
+        assertRaisesNothing(self, alg.execute)
+        self.assertTrue(alg.isExecuted())
+        args = {
+            'InputWorkspace': 'reflected',
+            'OutputWorkspace': 'reflected-fgd',
+            'DirectForegroundWorkspace': 'direct-fgd'
+        }
+        alg = create_algorithm('ReflectometryILLSumForeground', **args)
+        assertRaisesNothing(self, alg.execute)
+        self.assertTrue(alg.isExecuted())
 
     def testWavelengthRange(self):
         ws = illhelpers.create_poor_mans_d17_workspace()


### PR DESCRIPTION
**Description of work.**

This PR fixes the ILL's reflectometry reduction workflow for the FIGARO instrument. The algorithms were trying to access sample log entries under wrong names.

**Report to:** [nobody].

**To test:**

The following script which uses some data files from the unit test data directory should run without issues after these changes are applied:
```python
ReflectometryILLPreprocess(
    Run='ILL/Figaro/000002.nxs',
    OutputWorkspace='direct',
    ForegroundHalfWidth=[6, 6],
    FlatBackground='Background OFF',
)

ReflectometryILLSumForeground(
    InputWorkspace='direct',
    OutputWorkspace='direct-fgd',
)

ReflectometryILLPreprocess(
    Run='ILL/Figaro/000002.nxs',
    OutputWorkspace='reflected',
    ForegroundHalfWidth=[6, 6],
    FlatBackground='Background OFF',
)

ReflectometryILLSumForeground(
    InputWorkspace='reflected',
    OutputWorkspace='reflected-fgd',
    DirectForegroundWorkspace='direct-fgd'
)
```

Fixes #22799.

Does this update require release notes?
- [ ] Yes
- [x] No

The reduction workflow algorithms which this fixes are being added to the current release.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
