### PR TITLE
Use highestVersion instead of getDescriptors for script histories 

### DIFF
--- a/Framework/API/inc/MantidAPI/AlgorithmFactory.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmFactory.h
@@ -133,9 +133,6 @@ public:
   /// Get the algorithm categories
   const std::map<std::string, bool> getCategoriesWithState() const;
 
-  /// Returns a single algorithm descriptor
-  int getAlgLatestVersion(const std::string &algName) const;
-
   /// Returns algorithm descriptors.
   std::vector<AlgorithmDescriptor>
   getDescriptors(bool includeHidden = false) const;

--- a/Framework/API/inc/MantidAPI/AlgorithmFactory.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmFactory.h
@@ -16,11 +16,14 @@ namespace API {
 
 /// Structure uniquely describing an algorithm with its name, category and
 /// version.
-struct AlgorithmDescriptor {
-  std::string name;     ///< name
-  std::string alias;    ///< alias
+struct AlgorithmKey {
+	std::string name;     ///< Algorithm Name
+	int version;          ///< version
+};
+
+struct AlgorithmDescriptor : public AlgorithmKey {
   std::string category; ///< category
-  int version;          ///< version
+  std::string alias;    ///< alias
 };
 
 //----------------------------------------------------------------------
@@ -134,8 +137,7 @@ public:
   const std::map<std::string, bool> getCategoriesWithState() const;
 
   /// Returns a single algorithm descriptor
-  AlgorithmDescriptor getDescriptor(const std::string &algName,
-                                    int version = -1) const;
+  int getAlgLatestVersion(const std::string &algName) const;
 
   /// Returns algorithm descriptors.
   std::vector<AlgorithmDescriptor>

--- a/Framework/API/inc/MantidAPI/AlgorithmFactory.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmFactory.h
@@ -16,12 +16,9 @@ namespace API {
 
 /// Structure uniquely describing an algorithm with its name, category and
 /// version.
-struct AlgorithmKey {
-	std::string name;     ///< Algorithm Name
-	int version;          ///< version
-};
-
-struct AlgorithmDescriptor : public AlgorithmKey {
+struct AlgorithmDescriptor {
+  std::string name;     ///< Algorithm Name
+  int version;          ///< version
   std::string category; ///< category
   std::string alias;    ///< alias
 };

--- a/Framework/API/inc/MantidAPI/AlgorithmFactory.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmFactory.h
@@ -134,7 +134,8 @@ public:
   const std::map<std::string, bool> getCategoriesWithState() const;
 
   /// Returns a single algorithm descriptor
-  AlgorithmDescriptor getDescriptor(const std::string &algName, int version = -1) const;
+  AlgorithmDescriptor getDescriptor(const std::string &algName,
+                                    int version = -1) const;
 
   /// Returns algorithm descriptors.
   std::vector<AlgorithmDescriptor>

--- a/Framework/API/inc/MantidAPI/AlgorithmFactory.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmFactory.h
@@ -133,6 +133,9 @@ public:
   /// Get the algorithm categories
   const std::map<std::string, bool> getCategoriesWithState() const;
 
+  /// Returns a single algorithm descriptor
+  AlgorithmDescriptor getDescriptor(const std::string &algName, int version = -1) const;
+
   /// Returns algorithm descriptors.
   std::vector<AlgorithmDescriptor>
   getDescriptors(bool includeHidden = false) const;

--- a/Framework/API/inc/MantidAPI/ScriptBuilder.h
+++ b/Framework/API/inc/MantidAPI/ScriptBuilder.h
@@ -61,8 +61,7 @@ private:
                      std::vector<HistoryItem>::const_iterator &iter,
                      int depth = 1);
   const std::string buildCommentString(const AlgorithmHistory &algHistory);
-  const std::string
-  buildAlgorithmString(const AlgorithmHistory &algHistory);
+  const std::string buildAlgorithmString(const AlgorithmHistory &algHistory);
   const std::string
   buildPropertyString(const Mantid::Kernel::PropertyHistory &propHistory);
 

--- a/Framework/API/inc/MantidAPI/ScriptBuilder.h
+++ b/Framework/API/inc/MantidAPI/ScriptBuilder.h
@@ -60,11 +60,11 @@ private:
   void buildChildren(std::ostringstream &os,
                      std::vector<HistoryItem>::const_iterator &iter,
                      int depth = 1);
-  const std::string buildCommentString(AlgorithmHistory_const_sptr algHistory);
+  const std::string buildCommentString(const AlgorithmHistory &algHistory);
   const std::string
-  buildAlgorithmString(AlgorithmHistory_const_sptr algHistory);
+  buildAlgorithmString(const AlgorithmHistory &algHistory);
   const std::string
-  buildPropertyString(Mantid::Kernel::PropertyHistory_const_sptr propHistory);
+  buildPropertyString(const Mantid::Kernel::PropertyHistory &propHistory);
 
   const std::vector<HistoryItem> m_historyItems;
   std::string m_output;

--- a/Framework/API/src/AlgorithmFactory.cpp
+++ b/Framework/API/src/AlgorithmFactory.cpp
@@ -35,39 +35,37 @@ AlgorithmFactoryImpl::~AlgorithmFactoryImpl() = default;
 */
 boost::shared_ptr<Algorithm>
 AlgorithmFactoryImpl::create(const std::string &name,
-	const int &version) const {
-	int local_version = version;
-	if (version < 0) {
-		if (version == -1) // get latest version since not supplied
-		{
-			auto it = m_vmap.find(name);
-			if (!name.empty()) {
-				if (it == m_vmap.end())
-					throw std::runtime_error("Algorithm not registered " + name);
-				else
-					local_version = it->second;
-			}
-			else
-				throw std::runtime_error(
-					"Algorithm not registered (empty algorithm name)");
-		}
-	}
-	try {
-		return this->createAlgorithm(name, local_version);
-	}
-	catch (Kernel::Exception::NotFoundError &) {
-		auto it = m_vmap.find(name);
-		if (it == m_vmap.end())
-			throw std::runtime_error("algorithm not registered " + name);
-		else {
-			g_log.error() << "algorithm " << name << " version " << version
-				<< " is not registered \n";
-			g_log.error() << "the latest registered version is " << it->second
-				<< '\n';
-			throw std::runtime_error("algorithm not registered " +
-				createName(name, local_version));
-		}
-	}
+                             const int &version) const {
+  int local_version = version;
+  if (version < 0) {
+    if (version == -1) // get latest version since not supplied
+    {
+      auto it = m_vmap.find(name);
+      if (!name.empty()) {
+        if (it == m_vmap.end())
+          throw std::runtime_error("Algorithm not registered " + name);
+        else
+          local_version = it->second;
+      } else
+        throw std::runtime_error(
+            "Algorithm not registered (empty algorithm name)");
+    }
+  }
+  try {
+    return this->createAlgorithm(name, local_version);
+  } catch (Kernel::Exception::NotFoundError &) {
+    auto it = m_vmap.find(name);
+    if (it == m_vmap.end())
+      throw std::runtime_error("algorithm not registered " + name);
+    else {
+      g_log.error() << "algorithm " << name << " version " << version
+                    << " is not registered \n";
+      g_log.error() << "the latest registered version is " << it->second
+                    << '\n';
+      throw std::runtime_error("algorithm not registered " +
+                               createName(name, local_version));
+    }
+  }
 }
 
 /**
@@ -312,18 +310,20 @@ AlgorithmFactoryImpl::getCategories(bool includeHidden) const {
   * Returns a the latest version number of the given algorithm
   *
   * @param algName The name of the algorithm to get a version for
-  * @param throwIfNotRegistered (Default true) Throw if the algorithm is not registered
+  * @param throwIfNotRegistered (Default true) Throw if the algorithm is not
+  *registered
   * @return Integer of the latest algorithm version or -1 if it does not exist
   * @throws std::runtime_error if algorithm does not exist and throw is true
   */
-int AlgorithmFactoryImpl::getAlgLatestVersion(const std::string &algName) const{
-	  auto it = m_vmap.find(algName);
-	  
-	  if (it == m_vmap.end()) {
-		throw std::runtime_error("Algorithm not registered " + algName);
-	  }
-	  
-	  return it->second;
+int AlgorithmFactoryImpl::getAlgLatestVersion(
+    const std::string &algName) const {
+  auto it = m_vmap.find(algName);
+
+  if (it == m_vmap.end()) {
+    throw std::runtime_error("Algorithm not registered " + algName);
+  }
+
+  return it->second;
 }
 
 /**

--- a/Framework/API/src/AlgorithmFactory.cpp
+++ b/Framework/API/src/AlgorithmFactory.cpp
@@ -307,26 +307,6 @@ AlgorithmFactoryImpl::getCategories(bool includeHidden) const {
 }
 
 /**
-  * Returns a the latest version number of the given algorithm
-  *
-  * @param algName The name of the algorithm to get a version for
-  * @param throwIfNotRegistered (Default true) Throw if the algorithm is not
-  *registered
-  * @return Integer of the latest algorithm version or -1 if it does not exist
-  * @throws std::runtime_error if algorithm does not exist and throw is true
-  */
-int AlgorithmFactoryImpl::getAlgLatestVersion(
-    const std::string &algName) const {
-  auto it = m_vmap.find(algName);
-
-  if (it == m_vmap.end()) {
-    throw std::runtime_error("Algorithm not registered " + algName);
-  }
-
-  return it->second;
-}
-
-/**
 * Get a list of descriptor objects used to order the algorithms in the stored
 * map
 * where an algorithm has multiple categories it will be represented using

--- a/Framework/API/src/AlgorithmFactory.cpp
+++ b/Framework/API/src/AlgorithmFactory.cpp
@@ -280,7 +280,6 @@ AlgorithmFactoryImpl::getCategoriesWithState() const {
   return resultCategories;
 }
 
-
 /**
 * Return the categories of the algorithms. This includes those within the
 * Factory itself and
@@ -315,19 +314,20 @@ AlgorithmFactoryImpl::getCategories(bool includeHidden) const {
   * @return AlgorithmDescriptor object
   * @throws std::runtime_error if algorithm does not exist
   */
-AlgorithmDescriptor AlgorithmFactoryImpl::getDescriptor(const std::string & algName, int version) const
-{
-	AlgorithmDescriptor desc;
-	desc.name = algName;
+AlgorithmDescriptor
+AlgorithmFactoryImpl::getDescriptor(const std::string &algName,
+                                    int version) const {
+  AlgorithmDescriptor desc;
+  desc.name = algName;
 
-	boost::shared_ptr<IAlgorithm> alg = create(algName, version);
-	auto categories = alg->categories();
-	desc.version = alg->version();
-	// Set the category if there are any
-	desc.category = categories.empty() ? "" : categories.back();
-	desc.alias = alg->alias();
+  boost::shared_ptr<IAlgorithm> alg = create(algName, version);
+  auto categories = alg->categories();
+  desc.version = alg->version();
+  // Set the category if there are any
+  desc.category = categories.empty() ? "" : categories.back();
+  desc.alias = alg->alias();
 
-	return desc;
+  return desc;
 }
 
 /**

--- a/Framework/API/src/AlgorithmFactory.cpp
+++ b/Framework/API/src/AlgorithmFactory.cpp
@@ -308,8 +308,13 @@ AlgorithmFactoryImpl::getCategories(bool includeHidden) const {
 }
 
 /**
-
-*/
+  * Returns a single algorithm descriptor for the given algorithm name
+  *
+  * @param algName The name of the algorithm to get a descriptor for
+  * @param version The version of the algorithm (default = latest)
+  * @return AlgorithmDescriptor object
+  * @throws std::runtime_error if algorithm does not exist
+  */
 AlgorithmDescriptor AlgorithmFactoryImpl::getDescriptor(const std::string & algName, int version) const
 {
 	AlgorithmDescriptor desc;

--- a/Framework/API/src/AlgorithmFactory.cpp
+++ b/Framework/API/src/AlgorithmFactory.cpp
@@ -280,6 +280,7 @@ AlgorithmFactoryImpl::getCategoriesWithState() const {
   return resultCategories;
 }
 
+
 /**
 * Return the categories of the algorithms. This includes those within the
 * Factory itself and
@@ -304,6 +305,24 @@ AlgorithmFactoryImpl::getCategories(bool includeHidden) const {
   }
 
   return validCategories;
+}
+
+/**
+
+*/
+AlgorithmDescriptor AlgorithmFactoryImpl::getDescriptor(const std::string & algName, int version) const
+{
+	AlgorithmDescriptor desc;
+	desc.name = algName;
+
+	boost::shared_ptr<IAlgorithm> alg = create(algName, version);
+	auto categories = alg->categories();
+	desc.version = alg->version();
+	// Set the category if there are any
+	desc.category = categories.empty() ? "" : categories.back();
+	desc.alias = alg->alias();
+
+	return desc;
 }
 
 /**

--- a/Framework/API/src/AlgorithmFactory.cpp
+++ b/Framework/API/src/AlgorithmFactory.cpp
@@ -35,37 +35,39 @@ AlgorithmFactoryImpl::~AlgorithmFactoryImpl() = default;
 */
 boost::shared_ptr<Algorithm>
 AlgorithmFactoryImpl::create(const std::string &name,
-                             const int &version) const {
-  int local_version = version;
-  if (version < 0) {
-    if (version == -1) // get latest version since not supplied
-    {
-      auto it = m_vmap.find(name);
-      if (!name.empty()) {
-        if (it == m_vmap.end())
-          throw std::runtime_error("Algorithm not registered " + name);
-        else
-          local_version = it->second;
-      } else
-        throw std::runtime_error(
-            "Algorithm not registered (empty algorithm name)");
-    }
-  }
-  try {
-    return this->createAlgorithm(name, local_version);
-  } catch (Kernel::Exception::NotFoundError &) {
-    auto it = m_vmap.find(name);
-    if (it == m_vmap.end())
-      throw std::runtime_error("algorithm not registered " + name);
-    else {
-      g_log.error() << "algorithm " << name << " version " << version
-                    << " is not registered \n";
-      g_log.error() << "the latest registered version is " << it->second
-                    << '\n';
-      throw std::runtime_error("algorithm not registered " +
-                               createName(name, local_version));
-    }
-  }
+	const int &version) const {
+	int local_version = version;
+	if (version < 0) {
+		if (version == -1) // get latest version since not supplied
+		{
+			auto it = m_vmap.find(name);
+			if (!name.empty()) {
+				if (it == m_vmap.end())
+					throw std::runtime_error("Algorithm not registered " + name);
+				else
+					local_version = it->second;
+			}
+			else
+				throw std::runtime_error(
+					"Algorithm not registered (empty algorithm name)");
+		}
+	}
+	try {
+		return this->createAlgorithm(name, local_version);
+	}
+	catch (Kernel::Exception::NotFoundError &) {
+		auto it = m_vmap.find(name);
+		if (it == m_vmap.end())
+			throw std::runtime_error("algorithm not registered " + name);
+		else {
+			g_log.error() << "algorithm " << name << " version " << version
+				<< " is not registered \n";
+			g_log.error() << "the latest registered version is " << it->second
+				<< '\n';
+			throw std::runtime_error("algorithm not registered " +
+				createName(name, local_version));
+		}
+	}
 }
 
 /**
@@ -307,27 +309,21 @@ AlgorithmFactoryImpl::getCategories(bool includeHidden) const {
 }
 
 /**
-  * Returns a single algorithm descriptor for the given algorithm name
+  * Returns a the latest version number of the given algorithm
   *
-  * @param algName The name of the algorithm to get a descriptor for
-  * @param version The version of the algorithm (default = latest)
-  * @return AlgorithmDescriptor object
-  * @throws std::runtime_error if algorithm does not exist
+  * @param algName The name of the algorithm to get a version for
+  * @param throwIfNotRegistered (Default true) Throw if the algorithm is not registered
+  * @return Integer of the latest algorithm version or -1 if it does not exist
+  * @throws std::runtime_error if algorithm does not exist and throw is true
   */
-AlgorithmDescriptor
-AlgorithmFactoryImpl::getDescriptor(const std::string &algName,
-                                    int version) const {
-  AlgorithmDescriptor desc;
-  desc.name = algName;
-
-  boost::shared_ptr<IAlgorithm> alg = create(algName, version);
-  auto categories = alg->categories();
-  desc.version = alg->version();
-  // Set the category if there are any
-  desc.category = categories.empty() ? "" : categories.back();
-  desc.alias = alg->alias();
-
-  return desc;
+int AlgorithmFactoryImpl::getAlgLatestVersion(const std::string &algName) const{
+	  auto it = m_vmap.find(algName);
+	  
+	  if (it == m_vmap.end()) {
+		throw std::runtime_error("Algorithm not registered " + algName);
+	  }
+	  
+	  return it->second;
 }
 
 /**

--- a/Framework/API/src/NotebookBuilder.cpp
+++ b/Framework/API/src/NotebookBuilder.cpp
@@ -123,8 +123,7 @@ NotebookBuilder::buildAlgorithmString(AlgorithmHistory_const_sptr algHistory) {
   } else if (m_versionSpecificity == "old") {
     //...or only specify algorithm versions when they're not the newest version
     const auto &algName = algHistory->name();
-    int latestVersion =
-        AlgorithmFactory::Instance().highestVersion(algName);
+    int latestVersion = AlgorithmFactory::Instance().highestVersion(algName);
     // If a newer version of this algorithm exists, then this must be an old
     // version.
     if (latestVersion > algHistory->version()) {

--- a/Framework/API/src/NotebookBuilder.cpp
+++ b/Framework/API/src/NotebookBuilder.cpp
@@ -124,7 +124,7 @@ NotebookBuilder::buildAlgorithmString(AlgorithmHistory_const_sptr algHistory) {
     //...or only specify algorithm versions when they're not the newest version
     const auto &algName = algHistory->name();
     int latestVersion =
-        AlgorithmFactory::Instance().getAlgLatestVersion(algName);
+        AlgorithmFactory::Instance().highestVersion(algName);
     // If a newer version of this algorithm exists, then this must be an old
     // version.
     if (latestVersion > algHistory->version()) {

--- a/Framework/API/src/NotebookBuilder.cpp
+++ b/Framework/API/src/NotebookBuilder.cpp
@@ -123,18 +123,16 @@ NotebookBuilder::buildAlgorithmString(AlgorithmHistory_const_sptr algHistory) {
   } else if (m_versionSpecificity == "old") {
     //...or only specify algorithm versions when they're not the newest version
     bool oldVersion = false;
+	const auto &algName = algHistory->name();
 
-    std::vector<AlgorithmDescriptor> descriptors =
-        AlgorithmFactory::Instance().getDescriptors();
-    for (auto &descriptor : descriptors) {
-      // If a newer version of this algorithm exists, then this must be an old
-      // version.
-      if (descriptor.name == algHistory->name() &&
-          descriptor.version > algHistory->version()) {
-        oldVersion = true;
-        break;
-      }
-    }
+	auto descriptor = AlgorithmFactory::Instance().getDescriptor(algName);
+
+	// If a newer version of this algorithm exists, then this must be an old
+	// version.
+	if (descriptor.name == algHistory->name() &&
+		descriptor.version > algHistory->version()) {
+		oldVersion = true;
+	}
 
     if (oldVersion) {
       properties << "Version=" << algHistory->version() << ", ";

--- a/Framework/API/src/NotebookBuilder.cpp
+++ b/Framework/API/src/NotebookBuilder.cpp
@@ -119,16 +119,22 @@ NotebookBuilder::buildAlgorithmString(AlgorithmHistory_const_sptr algHistory) {
 
   // Three cases, we can either specify the version of every algorithm...
   if (m_versionSpecificity == "all") {
-    properties << "Version=" << algHistory->version() << ", ";
-  } else if (m_versionSpecificity == "old") {
-    //...or only specify algorithm versions when they're not the newest version
-    const auto &algName = algHistory->name();
-    int latestVersion = AlgorithmFactory::Instance().highestVersion(algName);
-    // If a newer version of this algorithm exists, then this must be an old
-    // version.
-    if (latestVersion > algHistory->version()) {
-      properties << "Version=" << algHistory->version() << ", ";
-    }
+	  properties << "Version=" << algHistory->version() << ", ";
+  }
+  else if (m_versionSpecificity == "old") {
+	  //...or only specify algorithm versions when they're not the newest version
+	  const auto &algName = algHistory->name();
+	  auto &algFactory = API::AlgorithmFactory::Instance();
+	  int latestVersion = 0;
+
+	  if (algFactory.exists(algName)) { // Check the alg still exists in Mantid
+		  latestVersion = AlgorithmFactory::Instance().highestVersion(algName);
+	  }
+	  // If a newer version of this algorithm exists, then this must be an old
+	  // version.
+	  if (latestVersion > algHistory->version()) {
+		  properties << "Version=" << algHistory->version() << ", ";
+	  }
   }
   // Third case is we never specify the version, so do nothing.
 

--- a/Framework/API/src/NotebookBuilder.cpp
+++ b/Framework/API/src/NotebookBuilder.cpp
@@ -119,22 +119,21 @@ NotebookBuilder::buildAlgorithmString(AlgorithmHistory_const_sptr algHistory) {
 
   // Three cases, we can either specify the version of every algorithm...
   if (m_versionSpecificity == "all") {
-	  properties << "Version=" << algHistory->version() << ", ";
-  }
-  else if (m_versionSpecificity == "old") {
-	  //...or only specify algorithm versions when they're not the newest version
-	  const auto &algName = algHistory->name();
-	  auto &algFactory = API::AlgorithmFactory::Instance();
-	  int latestVersion = 0;
+    properties << "Version=" << algHistory->version() << ", ";
+  } else if (m_versionSpecificity == "old") {
+    //...or only specify algorithm versions when they're not the newest version
+    const auto &algName = algHistory->name();
+    auto &algFactory = API::AlgorithmFactory::Instance();
+    int latestVersion = 0;
 
-	  if (algFactory.exists(algName)) { // Check the alg still exists in Mantid
-		  latestVersion = AlgorithmFactory::Instance().highestVersion(algName);
-	  }
-	  // If a newer version of this algorithm exists, then this must be an old
-	  // version.
-	  if (latestVersion > algHistory->version()) {
-		  properties << "Version=" << algHistory->version() << ", ";
-	  }
+    if (algFactory.exists(algName)) { // Check the alg still exists in Mantid
+      latestVersion = AlgorithmFactory::Instance().highestVersion(algName);
+    }
+    // If a newer version of this algorithm exists, then this must be an old
+    // version.
+    if (latestVersion > algHistory->version()) {
+      properties << "Version=" << algHistory->version() << ", ";
+    }
   }
   // Third case is we never specify the version, so do nothing.
 

--- a/Framework/API/src/NotebookBuilder.cpp
+++ b/Framework/API/src/NotebookBuilder.cpp
@@ -123,16 +123,16 @@ NotebookBuilder::buildAlgorithmString(AlgorithmHistory_const_sptr algHistory) {
   } else if (m_versionSpecificity == "old") {
     //...or only specify algorithm versions when they're not the newest version
     bool oldVersion = false;
-	const auto &algName = algHistory->name();
+    const auto &algName = algHistory->name();
 
-	auto descriptor = AlgorithmFactory::Instance().getDescriptor(algName);
+    auto descriptor = AlgorithmFactory::Instance().getDescriptor(algName);
 
-	// If a newer version of this algorithm exists, then this must be an old
-	// version.
-	if (descriptor.name == algHistory->name() &&
-		descriptor.version > algHistory->version()) {
-		oldVersion = true;
-	}
+    // If a newer version of this algorithm exists, then this must be an old
+    // version.
+    if (descriptor.name == algHistory->name() &&
+        descriptor.version > algHistory->version()) {
+      oldVersion = true;
+    }
 
     if (oldVersion) {
       properties << "Version=" << algHistory->version() << ", ";

--- a/Framework/API/src/NotebookBuilder.cpp
+++ b/Framework/API/src/NotebookBuilder.cpp
@@ -119,24 +119,17 @@ NotebookBuilder::buildAlgorithmString(AlgorithmHistory_const_sptr algHistory) {
 
   // Three cases, we can either specify the version of every algorithm...
   if (m_versionSpecificity == "all") {
-    properties << "Version=" << algHistory->version() << ", ";
-  } else if (m_versionSpecificity == "old") {
-    //...or only specify algorithm versions when they're not the newest version
-    bool oldVersion = false;
-    const auto &algName = algHistory->name();
-
-    auto descriptor = AlgorithmFactory::Instance().getDescriptor(algName);
-
-    // If a newer version of this algorithm exists, then this must be an old
-    // version.
-    if (descriptor.name == algHistory->name() &&
-        descriptor.version > algHistory->version()) {
-      oldVersion = true;
-    }
-
-    if (oldVersion) {
-      properties << "Version=" << algHistory->version() << ", ";
-    }
+	  properties << "Version=" << algHistory->version() << ", ";
+  }
+  else if (m_versionSpecificity == "old") {
+	  //...or only specify algorithm versions when they're not the newest version
+	  const auto &algName = algHistory->name();
+	  int latestVersion = AlgorithmFactory::Instance().getAlgLatestVersion(algName);
+	  // If a newer version of this algorithm exists, then this must be an old
+	  // version.
+	  if (latestVersion > algHistory->version()) {
+		  properties << "Version=" << algHistory->version() << ", ";
+	  }
   }
   // Third case is we never specify the version, so do nothing.
 

--- a/Framework/API/src/NotebookBuilder.cpp
+++ b/Framework/API/src/NotebookBuilder.cpp
@@ -119,17 +119,17 @@ NotebookBuilder::buildAlgorithmString(AlgorithmHistory_const_sptr algHistory) {
 
   // Three cases, we can either specify the version of every algorithm...
   if (m_versionSpecificity == "all") {
-	  properties << "Version=" << algHistory->version() << ", ";
-  }
-  else if (m_versionSpecificity == "old") {
-	  //...or only specify algorithm versions when they're not the newest version
-	  const auto &algName = algHistory->name();
-	  int latestVersion = AlgorithmFactory::Instance().getAlgLatestVersion(algName);
-	  // If a newer version of this algorithm exists, then this must be an old
-	  // version.
-	  if (latestVersion > algHistory->version()) {
-		  properties << "Version=" << algHistory->version() << ", ";
-	  }
+    properties << "Version=" << algHistory->version() << ", ";
+  } else if (m_versionSpecificity == "old") {
+    //...or only specify algorithm versions when they're not the newest version
+    const auto &algName = algHistory->name();
+    int latestVersion =
+        AlgorithmFactory::Instance().getAlgLatestVersion(algName);
+    // If a newer version of this algorithm exists, then this must be an old
+    // version.
+    if (latestVersion > algHistory->version()) {
+      properties << "Version=" << algHistory->version() << ", ";
+    }
   }
   // Third case is we never specify the version, so do nothing.
 

--- a/Framework/API/src/ScriptBuilder.cpp
+++ b/Framework/API/src/ScriptBuilder.cpp
@@ -85,7 +85,7 @@ void ScriptBuilder::writeHistoryToStream(
     }
   } else {
     // create the string for this algorithm
-    os << buildAlgorithmString(algHistory);
+    os << buildAlgorithmString(*algHistory);
     if (m_timestampCommands) {
       os << " # " << algHistory->executionDate().toISO8601String();
     }
@@ -125,11 +125,11 @@ void ScriptBuilder::buildChildren(
  * @returns std::string to run this algorithm
  */
 const std::string
-ScriptBuilder::buildCommentString(AlgorithmHistory_const_sptr algHistory) {
+ScriptBuilder::buildCommentString(const AlgorithmHistory &algHistory) {
   std::ostringstream comment;
-  const std::string name = algHistory->name();
+  const std::string name = algHistory.name();
   if (name == COMMENT_ALG) {
-    auto props = algHistory->getProperties();
+    auto props = algHistory.getProperties();
     for (auto &prop : props) {
       if (prop->name() == "Note") {
         comment << "# " << prop->value();
@@ -146,22 +146,24 @@ ScriptBuilder::buildCommentString(AlgorithmHistory_const_sptr algHistory) {
  * @returns std::string to run this algorithm
  */
 const std::string
-ScriptBuilder::buildAlgorithmString(AlgorithmHistory_const_sptr algHistory) {
+ScriptBuilder::buildAlgorithmString(const AlgorithmHistory &algHistory) {
   std::ostringstream properties;
-  const std::string name = algHistory->name();
+  const std::string name = algHistory.name();
   std::string prop;
 
   if (name == COMMENT_ALG)
     return buildCommentString(algHistory);
 
-  auto props = algHistory->getProperties();
+  auto props = algHistory.getProperties();
+
 
   try {
     // create a fresh version of the algorithm - unmanaged
-    IAlgorithm_sptr algFresh = AlgorithmManager::Instance().createUnmanaged(
-        name, algHistory->version());
+    auto algFresh = AlgorithmManager::Instance().createUnmanaged(
+        name, algHistory.version());
     algFresh->initialize();
 
+  
     const auto &propsFresh = algFresh->getProperties();
     // just get the names out of the fresh alg properties
     std::set<std::string> freshPropNames;
@@ -179,13 +181,16 @@ ScriptBuilder::buildAlgorithmString(AlgorithmHistory_const_sptr algHistory) {
       }
     }
 
-  } catch (std::exception &) {
-    g_log.error() << "Could not create a fresh version of " << name
-                  << " version " << algHistory->version() << "\n";
+  }
+  catch (std::exception &) {
+	  g_log.error() << "Could not create a fresh version of " << name
+		  << " version " << algHistory.version() << "\n";
   }
 
+
+
   for (auto &propIter : props) {
-    prop = buildPropertyString(propIter);
+    prop = buildPropertyString(*propIter);
     if (prop.length() > 0) {
       properties << prop << ", ";
     }
@@ -193,15 +198,20 @@ ScriptBuilder::buildAlgorithmString(AlgorithmHistory_const_sptr algHistory) {
 
   // Three cases, we can either specify the version of every algorithm...
   if (m_versionSpecificity == "all") {
-    properties << "Version=" << algHistory->version() << ", ";
+    properties << "Version=" << algHistory.version() << ", ";
   } else if (m_versionSpecificity == "old") {
     //...or only specify algorithm versions when they're not the newest version
-    const auto &algName = algHistory->name();
-    int latestVersion = AlgorithmFactory::Instance().highestVersion(algName);
+    const auto &algName = algHistory.name();
+	auto &algFactory = API::AlgorithmFactory::Instance();
+	int latestVersion = 0;
+
+	if (algFactory.exists(algName)) { // Check the alg still exists in Mantid
+		latestVersion = AlgorithmFactory::Instance().highestVersion(algName);
+	}
     // If a newer version of this algorithm exists, then this must be an old
     // version.
-    if (latestVersion > algHistory->version()) {
-      properties << "Version=" << algHistory->version() << ", ";
+    if (latestVersion > algHistory.version()) {
+      properties << "Version=" << algHistory.version() << ", ";
     }
   }
   // Third case is we never specify the version, so do nothing.
@@ -223,7 +233,7 @@ ScriptBuilder::buildAlgorithmString(AlgorithmHistory_const_sptr algHistory) {
  * @returns std::string for this property
  */
 const std::string
-ScriptBuilder::buildPropertyString(PropertyHistory_const_sptr propHistory) {
+ScriptBuilder::buildPropertyString(const Mantid::Kernel::PropertyHistory &propHistory) {
   using Mantid::Kernel::Direction;
 
   // Create a vector of all non workspace property type names
@@ -231,28 +241,28 @@ ScriptBuilder::buildPropertyString(PropertyHistory_const_sptr propHistory) {
 
   std::string prop;
   // No need to specify value for default properties
-  if (!propHistory->isDefault()) {
+  if (!propHistory.isDefault()) {
     // Do not give values to output properties other than workspace properties
     if (find(nonWorkspaceTypes.begin(), nonWorkspaceTypes.end(),
-             propHistory->type()) != nonWorkspaceTypes.end() &&
-        propHistory->direction() == Direction::Output) {
-      g_log.debug() << "Ignoring property " << propHistory->name()
-                    << " of type " << propHistory->type() << '\n';
+             propHistory.type()) != nonWorkspaceTypes.end() &&
+        propHistory.direction() == Direction::Output) {
+      g_log.debug() << "Ignoring property " << propHistory.name()
+                    << " of type " << propHistory.type() << '\n';
       // Handle numerical properties
-    } else if (propHistory->type() == "number") {
-      prop = propHistory->name() + "=" + propHistory->value();
+    } else if (propHistory.type() == "number") {
+      prop = propHistory.name() + "=" + propHistory.value();
       // Handle boolean properties
-    } else if (propHistory->type() == "boolean") {
-      std::string value = (propHistory->value() == "1" ? "True" : "False");
-      prop = propHistory->name() + "=" + value;
+    } else if (propHistory.type() == "boolean") {
+      std::string value = (propHistory.value() == "1" ? "True" : "False");
+      prop = propHistory.name() + "=" + value;
       // Handle all other property types
     } else {
       std::string opener = "='";
-      if (propHistory->value().find('\\') != std::string::npos) {
+      if (propHistory.value().find('\\') != std::string::npos) {
         opener = "=r'";
       }
 
-      prop = propHistory->name() + opener + propHistory->value() + "'";
+      prop = propHistory.name() + opener + propHistory.value() + "'";
     }
   }
 

--- a/Framework/API/src/ScriptBuilder.cpp
+++ b/Framework/API/src/ScriptBuilder.cpp
@@ -196,19 +196,11 @@ ScriptBuilder::buildAlgorithmString(AlgorithmHistory_const_sptr algHistory) {
     properties << "Version=" << algHistory->version() << ", ";
   } else if (m_versionSpecificity == "old") {
     //...or only specify algorithm versions when they're not the newest version
-    bool oldVersion = false;
     const auto &algName = algHistory->name();
-
-    auto descriptor = AlgorithmFactory::Instance().getDescriptor(algName);
-
+	int latestVersion = AlgorithmFactory::Instance().getAlgLatestVersion(algName);
     // If a newer version of this algorithm exists, then this must be an old
     // version.
-    if (descriptor.name == algHistory->name() &&
-        descriptor.version > algHistory->version()) {
-      oldVersion = true;
-    }
-
-    if (oldVersion) {
+    if (latestVersion > algHistory->version()) {
       properties << "Version=" << algHistory->version() << ", ";
     }
   }

--- a/Framework/API/src/ScriptBuilder.cpp
+++ b/Framework/API/src/ScriptBuilder.cpp
@@ -197,8 +197,7 @@ ScriptBuilder::buildAlgorithmString(AlgorithmHistory_const_sptr algHistory) {
   } else if (m_versionSpecificity == "old") {
     //...or only specify algorithm versions when they're not the newest version
     const auto &algName = algHistory->name();
-    int latestVersion =
-        AlgorithmFactory::Instance().highestVersion(algName);
+    int latestVersion = AlgorithmFactory::Instance().highestVersion(algName);
     // If a newer version of this algorithm exists, then this must be an old
     // version.
     if (latestVersion > algHistory->version()) {

--- a/Framework/API/src/ScriptBuilder.cpp
+++ b/Framework/API/src/ScriptBuilder.cpp
@@ -198,7 +198,7 @@ ScriptBuilder::buildAlgorithmString(AlgorithmHistory_const_sptr algHistory) {
     //...or only specify algorithm versions when they're not the newest version
     const auto &algName = algHistory->name();
     int latestVersion =
-        AlgorithmFactory::Instance().getAlgLatestVersion(algName);
+        AlgorithmFactory::Instance().highestVersion(algName);
     // If a newer version of this algorithm exists, then this must be an old
     // version.
     if (latestVersion > algHistory->version()) {

--- a/Framework/API/src/ScriptBuilder.cpp
+++ b/Framework/API/src/ScriptBuilder.cpp
@@ -156,14 +156,12 @@ ScriptBuilder::buildAlgorithmString(const AlgorithmHistory &algHistory) {
 
   auto props = algHistory.getProperties();
 
-
   try {
     // create a fresh version of the algorithm - unmanaged
     auto algFresh = AlgorithmManager::Instance().createUnmanaged(
         name, algHistory.version());
     algFresh->initialize();
 
-  
     const auto &propsFresh = algFresh->getProperties();
     // just get the names out of the fresh alg properties
     std::set<std::string> freshPropNames;
@@ -181,13 +179,10 @@ ScriptBuilder::buildAlgorithmString(const AlgorithmHistory &algHistory) {
       }
     }
 
+  } catch (std::exception &) {
+    g_log.error() << "Could not create a fresh version of " << name
+                  << " version " << algHistory.version() << "\n";
   }
-  catch (std::exception &) {
-	  g_log.error() << "Could not create a fresh version of " << name
-		  << " version " << algHistory.version() << "\n";
-  }
-
-
 
   for (auto &propIter : props) {
     prop = buildPropertyString(*propIter);
@@ -202,12 +197,12 @@ ScriptBuilder::buildAlgorithmString(const AlgorithmHistory &algHistory) {
   } else if (m_versionSpecificity == "old") {
     //...or only specify algorithm versions when they're not the newest version
     const auto &algName = algHistory.name();
-	auto &algFactory = API::AlgorithmFactory::Instance();
-	int latestVersion = 0;
+    auto &algFactory = API::AlgorithmFactory::Instance();
+    int latestVersion = 0;
 
-	if (algFactory.exists(algName)) { // Check the alg still exists in Mantid
-		latestVersion = AlgorithmFactory::Instance().highestVersion(algName);
-	}
+    if (algFactory.exists(algName)) { // Check the alg still exists in Mantid
+      latestVersion = AlgorithmFactory::Instance().highestVersion(algName);
+    }
     // If a newer version of this algorithm exists, then this must be an old
     // version.
     if (latestVersion > algHistory.version()) {
@@ -232,8 +227,8 @@ ScriptBuilder::buildAlgorithmString(const AlgorithmHistory &algHistory) {
  * @param propHistory :: reference to a property history object
  * @returns std::string for this property
  */
-const std::string
-ScriptBuilder::buildPropertyString(const Mantid::Kernel::PropertyHistory &propHistory) {
+const std::string ScriptBuilder::buildPropertyString(
+    const Mantid::Kernel::PropertyHistory &propHistory) {
   using Mantid::Kernel::Direction;
 
   // Create a vector of all non workspace property type names
@@ -246,8 +241,8 @@ ScriptBuilder::buildPropertyString(const Mantid::Kernel::PropertyHistory &propHi
     if (find(nonWorkspaceTypes.begin(), nonWorkspaceTypes.end(),
              propHistory.type()) != nonWorkspaceTypes.end() &&
         propHistory.direction() == Direction::Output) {
-      g_log.debug() << "Ignoring property " << propHistory.name()
-                    << " of type " << propHistory.type() << '\n';
+      g_log.debug() << "Ignoring property " << propHistory.name() << " of type "
+                    << propHistory.type() << '\n';
       // Handle numerical properties
     } else if (propHistory.type() == "number") {
       prop = propHistory.name() + "=" + propHistory.value();

--- a/Framework/API/src/ScriptBuilder.cpp
+++ b/Framework/API/src/ScriptBuilder.cpp
@@ -197,19 +197,17 @@ ScriptBuilder::buildAlgorithmString(AlgorithmHistory_const_sptr algHistory) {
   } else if (m_versionSpecificity == "old") {
     //...or only specify algorithm versions when they're not the newest version
     bool oldVersion = false;
+	const auto &algName = algHistory->name();
 
-    std::vector<AlgorithmDescriptor> descriptors =
-        AlgorithmFactory::Instance().getDescriptors();
-    for (auto &descriptor : descriptors) {
-      // If a newer version of this algorithm exists, then this must be an old
-      // version.
-      if (descriptor.name == algHistory->name() &&
-          descriptor.version > algHistory->version()) {
+	auto descriptor = AlgorithmFactory::Instance().getDescriptor(algName);
+
+    // If a newer version of this algorithm exists, then this must be an old
+    // version.
+    if (descriptor.name == algHistory->name() &&
+        descriptor.version > algHistory->version()) {
         oldVersion = true;
-        break;
-      }
     }
-
+  
     if (oldVersion) {
       properties << "Version=" << algHistory->version() << ", ";
     }

--- a/Framework/API/src/ScriptBuilder.cpp
+++ b/Framework/API/src/ScriptBuilder.cpp
@@ -197,17 +197,17 @@ ScriptBuilder::buildAlgorithmString(AlgorithmHistory_const_sptr algHistory) {
   } else if (m_versionSpecificity == "old") {
     //...or only specify algorithm versions when they're not the newest version
     bool oldVersion = false;
-	const auto &algName = algHistory->name();
+    const auto &algName = algHistory->name();
 
-	auto descriptor = AlgorithmFactory::Instance().getDescriptor(algName);
+    auto descriptor = AlgorithmFactory::Instance().getDescriptor(algName);
 
     // If a newer version of this algorithm exists, then this must be an old
     // version.
     if (descriptor.name == algHistory->name() &&
         descriptor.version > algHistory->version()) {
-        oldVersion = true;
+      oldVersion = true;
     }
-  
+
     if (oldVersion) {
       properties << "Version=" << algHistory->version() << ", ";
     }

--- a/Framework/API/src/ScriptBuilder.cpp
+++ b/Framework/API/src/ScriptBuilder.cpp
@@ -197,7 +197,8 @@ ScriptBuilder::buildAlgorithmString(AlgorithmHistory_const_sptr algHistory) {
   } else if (m_versionSpecificity == "old") {
     //...or only specify algorithm versions when they're not the newest version
     const auto &algName = algHistory->name();
-	int latestVersion = AlgorithmFactory::Instance().getAlgLatestVersion(algName);
+    int latestVersion =
+        AlgorithmFactory::Instance().getAlgLatestVersion(algName);
     // If a newer version of this algorithm exists, then this must be an old
     // version.
     if (latestVersion > algHistory->version()) {

--- a/Framework/API/test/AlgorithmFactoryTest.h
+++ b/Framework/API/test/AlgorithmFactoryTest.h
@@ -25,9 +25,9 @@ public:
 
     auto &algFactory = AlgorithmFactory::Instance();
 
-	// Ensure the algorithm factory does not already have this
-	algFactory.unsubscribe("ToyAlgorithm", 1);
-	algFactory.unsubscribe("ToyAlgorithm", 2);
+    // Ensure the algorithm factory does not already have this
+    algFactory.unsubscribe("ToyAlgorithm", 1);
+    algFactory.unsubscribe("ToyAlgorithm", 2);
 
     // get the number of algorithms it already has
     std::vector<std::string> keys = algFactory.getKeys();
@@ -192,17 +192,18 @@ public:
 
     const std::string algName = "ToyAlgorithm";
     algFactory.subscribe<ToyAlgorithm>();
-	algFactory.subscribe<ToyAlgorithmTwo>();
+    algFactory.subscribe<ToyAlgorithmTwo>();
 
-	int version = -1;
+    int version = -1;
     TS_ASSERT_THROWS_NOTHING(version = algFactory.getAlgLatestVersion(algName));
 
     TS_ASSERT_EQUALS(version, 2);
 
     algFactory.unsubscribe(algName, 1);
-	algFactory.unsubscribe(algName, 2);
+    algFactory.unsubscribe(algName, 2);
 
-    TS_ASSERT_THROWS(algFactory.getAlgLatestVersion(algName), std::runtime_error);
+    TS_ASSERT_THROWS(algFactory.getAlgLatestVersion(algName),
+                     std::runtime_error);
   }
 
   void testGetCategories() {

--- a/Framework/API/test/AlgorithmFactoryTest.h
+++ b/Framework/API/test/AlgorithmFactoryTest.h
@@ -23,18 +23,16 @@ public:
     Mantid::Kernel::Instantiator<ToyAlgorithmTwo, Algorithm> *newTwo =
         new Mantid::Kernel::Instantiator<ToyAlgorithmTwo, Algorithm>;
 
-	auto &algFactory = AlgorithmFactory::Instance();
+    auto &algFactory = AlgorithmFactory::Instance();
 
     // get the number of algorithms it already has
     std::vector<std::string> keys = algFactory.getKeys();
     size_t noOfAlgs = keys.size();
 
-    TS_ASSERT_THROWS_NOTHING(
-        algFactory.subscribe<ToyAlgorithm>());
+    TS_ASSERT_THROWS_NOTHING(algFactory.subscribe<ToyAlgorithm>());
     TS_ASSERT_THROWS_NOTHING(algFactory.subscribe(newTwo));
 
-    TS_ASSERT_THROWS_ANYTHING(
-        algFactory.subscribe<ToyAlgorithm>());
+    TS_ASSERT_THROWS_ANYTHING(algFactory.subscribe<ToyAlgorithm>());
 
     // get the number of algorithms it has now
     keys = algFactory.getKeys();
@@ -48,8 +46,8 @@ public:
   void testUnsubscribe() {
     Mantid::Kernel::Instantiator<ToyAlgorithmTwo, Algorithm> *newTwo =
         new Mantid::Kernel::Instantiator<ToyAlgorithmTwo, Algorithm>;
-	  
-	auto &algFactory = AlgorithmFactory::Instance();
+
+    auto &algFactory = AlgorithmFactory::Instance();
 
     // get the nubmer of algorithms it already has
     std::vector<std::string> keys = algFactory.getKeys();
@@ -58,10 +56,8 @@ public:
     algFactory.subscribe<ToyAlgorithm>();
     algFactory.subscribe(newTwo);
 
-    TS_ASSERT_THROWS_NOTHING(
-        algFactory.unsubscribe("ToyAlgorithm", 1));
-    TS_ASSERT_THROWS_NOTHING(
-        algFactory.unsubscribe("ToyAlgorithm", 2));
+    TS_ASSERT_THROWS_NOTHING(algFactory.unsubscribe("ToyAlgorithm", 1));
+    TS_ASSERT_THROWS_NOTHING(algFactory.unsubscribe("ToyAlgorithm", 2));
 
     // get the nubmer of algorithms it has now
     keys = algFactory.getKeys();
@@ -70,10 +66,8 @@ public:
     TS_ASSERT_EQUALS(noOfAlgsAfter, noOfAlgs)
 
     // try unsubscribing them again
-    TS_ASSERT_THROWS_NOTHING(
-        algFactory.unsubscribe("ToyAlgorithm", 1));
-    TS_ASSERT_THROWS_NOTHING(
-        algFactory.unsubscribe("ToyAlgorithm", 2));
+    TS_ASSERT_THROWS_NOTHING(algFactory.unsubscribe("ToyAlgorithm", 1));
+    TS_ASSERT_THROWS_NOTHING(algFactory.unsubscribe("ToyAlgorithm", 2));
 
     // make sure the number hasn't changed
     keys = algFactory.getKeys();
@@ -86,7 +80,7 @@ public:
     Mantid::Kernel::Instantiator<ToyAlgorithmTwo, Algorithm> *newTwo =
         new Mantid::Kernel::Instantiator<ToyAlgorithmTwo, Algorithm>;
 
-	auto &algFactory = AlgorithmFactory::Instance();
+    auto &algFactory = AlgorithmFactory::Instance();
 
     algFactory.subscribe<ToyAlgorithm>();
     algFactory.subscribe(newTwo);
@@ -104,7 +98,7 @@ public:
   void testGetKeys() {
     std::vector<std::string> keys;
 
-	auto &algFactory = AlgorithmFactory::Instance();
+    auto &algFactory = AlgorithmFactory::Instance();
 
     TS_ASSERT_EQUALS(0, keys.size());
     algFactory.subscribe<ToyAlgorithm>();
@@ -119,7 +113,7 @@ public:
   }
 
   void test_HighestVersion() {
-	auto &algFactory = AlgorithmFactory::Instance();
+    auto &algFactory = AlgorithmFactory::Instance();
 
     TS_ASSERT_THROWS(algFactory.highestVersion("ToyAlgorithm"),
                      std::invalid_argument);
@@ -140,44 +134,35 @@ public:
     Mantid::Kernel::Instantiator<ToyAlgorithmTwo, Algorithm> *newTwo =
         new Mantid::Kernel::Instantiator<ToyAlgorithmTwo, Algorithm>;
 
-	auto &algFactory = AlgorithmFactory::Instance();
+    auto &algFactory = AlgorithmFactory::Instance();
 
     algFactory.subscribe<ToyAlgorithm>();
     algFactory.subscribe(newTwo);
 
-    TS_ASSERT_THROWS_NOTHING(
-        algFactory.create("ToyAlgorithm", -1));
-    TS_ASSERT_THROWS_ANYTHING(
-        algFactory.create("AlgorithmDoesntExist", -1));
+    TS_ASSERT_THROWS_NOTHING(algFactory.create("ToyAlgorithm", -1));
+    TS_ASSERT_THROWS_ANYTHING(algFactory.create("AlgorithmDoesntExist", -1));
 
-    TS_ASSERT_THROWS_NOTHING(
-        algFactory.create("ToyAlgorithm", 1));
-    TS_ASSERT_THROWS_NOTHING(
-        algFactory.create("ToyAlgorithm", 2));
-    TS_ASSERT_THROWS_ANYTHING(
-        algFactory.create("AlgorithmDoesntExist", 1));
-    TS_ASSERT_THROWS_ANYTHING(
-        algFactory.create("AlgorithmDoesntExist", 2));
+    TS_ASSERT_THROWS_NOTHING(algFactory.create("ToyAlgorithm", 1));
+    TS_ASSERT_THROWS_NOTHING(algFactory.create("ToyAlgorithm", 2));
+    TS_ASSERT_THROWS_ANYTHING(algFactory.create("AlgorithmDoesntExist", 1));
+    TS_ASSERT_THROWS_ANYTHING(algFactory.create("AlgorithmDoesntExist", 2));
 
     TS_ASSERT_THROWS_ANYTHING(algFactory.create("", 1));
     TS_ASSERT_THROWS_ANYTHING(algFactory.create("", -1));
 
-    TS_ASSERT_THROWS_ANYTHING(
-        algFactory.create("ToyAlgorithm", 3));
-    TS_ASSERT_THROWS_ANYTHING(
-        algFactory.create("ToyAlgorithm", 4));
+    TS_ASSERT_THROWS_ANYTHING(algFactory.create("ToyAlgorithm", 3));
+    TS_ASSERT_THROWS_ANYTHING(algFactory.create("ToyAlgorithm", 4));
 
     algFactory.unsubscribe("ToyAlgorithm", 1);
     algFactory.unsubscribe("ToyAlgorithm", 2);
   }
 
   void testGetDescriptors() {
-	auto &algFactory = AlgorithmFactory::Instance();
+    auto &algFactory = AlgorithmFactory::Instance();
 
     algFactory.subscribe<ToyAlgorithm>();
     std::vector<AlgorithmDescriptor> descriptors;
-    TS_ASSERT_THROWS_NOTHING(
-        descriptors = algFactory.getDescriptors(true));
+    TS_ASSERT_THROWS_NOTHING(descriptors = algFactory.getDescriptors(true));
 
     size_t noOfAlgs = descriptors.size();
     std::vector<AlgorithmDescriptor>::const_iterator descItr =
@@ -193,85 +178,74 @@ public:
 
     algFactory.unsubscribe("ToyAlgorithm", 1);
 
-    TS_ASSERT_THROWS_NOTHING(
-        descriptors = algFactory.getDescriptors(true));
+    TS_ASSERT_THROWS_NOTHING(descriptors = algFactory.getDescriptors(true));
 
     TS_ASSERT_EQUALS(noOfAlgs - 1, descriptors.size());
   }
 
   void testGetDescriptor() {
-	  auto &algFactory = AlgorithmFactory::Instance();
+    auto &algFactory = AlgorithmFactory::Instance();
 
-	  const std::string algName = "ToyAlgorithm";
-	  algFactory.subscribe<ToyAlgorithm>();
-	  AlgorithmDescriptor descriptor;
+    const std::string algName = "ToyAlgorithm";
+    algFactory.subscribe<ToyAlgorithm>();
+    AlgorithmDescriptor descriptor;
 
-	  TS_ASSERT_THROWS_NOTHING(
-		  descriptor = algFactory.getDescriptor(algName));
+    TS_ASSERT_THROWS_NOTHING(descriptor = algFactory.getDescriptor(algName));
 
-	  bool AlgCorrect = ("Cat" == descriptor.category) &&
-						(algName == descriptor.name) &&
-						("Dog" == descriptor.alias) &&
-						(1 == descriptor.version);
+    bool AlgCorrect = ("Cat" == descriptor.category) &&
+                      (algName == descriptor.name) &&
+                      ("Dog" == descriptor.alias) && (1 == descriptor.version);
 
-	  TS_ASSERT(AlgCorrect);
+    TS_ASSERT(AlgCorrect);
 
-	  algFactory.unsubscribe("ToyAlgorithm", 1);
+    algFactory.unsubscribe("ToyAlgorithm", 1);
 
-	  TS_ASSERT_THROWS(algFactory.getDescriptor(algName), std::runtime_error);
+    TS_ASSERT_THROWS(algFactory.getDescriptor(algName), std::runtime_error);
   }
 
-
-
   void testGetCategories() {
-	auto &algFactory = AlgorithmFactory::Instance();
+    auto &algFactory = AlgorithmFactory::Instance();
     algFactory.subscribe<CategoryAlgorithm>();
     std::unordered_set<std::string> validCategories;
-    TS_ASSERT_THROWS_NOTHING(
-        validCategories = algFactory.getCategories(true));
+    TS_ASSERT_THROWS_NOTHING(validCategories = algFactory.getCategories(true));
 
     size_t noOfCats = validCategories.size();
     TS_ASSERT_DIFFERS(validCategories.find("Fake"), validCategories.end());
 
     algFactory.unsubscribe("CategoryAlgorithm", 1);
-    TS_ASSERT_THROWS_NOTHING(
-        validCategories = algFactory.getCategories(true));
+    TS_ASSERT_THROWS_NOTHING(validCategories = algFactory.getCategories(true));
     TS_ASSERT_EQUALS(noOfCats - 1, validCategories.size());
   }
 
   void testGetCategoriesWithState() {
-	auto &algFactory = AlgorithmFactory::Instance();
+    auto &algFactory = AlgorithmFactory::Instance();
     algFactory.subscribe<CategoryAlgorithm>();
 
     std::map<std::string, bool> validCategories;
-    TS_ASSERT_THROWS_NOTHING(
-        validCategories =
-            algFactory.getCategoriesWithState());
+    TS_ASSERT_THROWS_NOTHING(validCategories =
+                                 algFactory.getCategoriesWithState());
     size_t noOfCats = validCategories.size();
     TS_ASSERT_DIFFERS(validCategories.find("Fake"), validCategories.end());
 
     algFactory.unsubscribe("CategoryAlgorithm", 1);
-    TS_ASSERT_THROWS_NOTHING(
-        validCategories =
-            algFactory.getCategoriesWithState());
+    TS_ASSERT_THROWS_NOTHING(validCategories =
+                                 algFactory.getCategoriesWithState());
     TS_ASSERT_EQUALS(noOfCats - 1, validCategories.size());
   }
 
   void testDecodeName() {
-	auto &algFactory = AlgorithmFactory::Instance();
+    auto &algFactory = AlgorithmFactory::Instance();
     std::pair<std::string, int> basePair;
     basePair.first = "Cat";
     basePair.second = 1;
     std::string mangledName = "Cat|1";
     std::pair<std::string, int> outPair;
-    TS_ASSERT_THROWS_NOTHING(
-        outPair = algFactory.decodeName(mangledName));
+    TS_ASSERT_THROWS_NOTHING(outPair = algFactory.decodeName(mangledName));
     TS_ASSERT_EQUALS(basePair.first, outPair.first);
     TS_ASSERT_EQUALS(basePair.second, outPair.second);
 
     mangledName = "Cat 1";
-    TS_ASSERT_THROWS_ANYTHING(
-        outPair = algFactory.decodeName(mangledName));
+    TS_ASSERT_THROWS_ANYTHING(outPair = algFactory.decodeName(mangledName));
   }
 };
 

--- a/Framework/API/test/AlgorithmFactoryTest.h
+++ b/Framework/API/test/AlgorithmFactoryTest.h
@@ -23,56 +23,60 @@ public:
     Mantid::Kernel::Instantiator<ToyAlgorithmTwo, Algorithm> *newTwo =
         new Mantid::Kernel::Instantiator<ToyAlgorithmTwo, Algorithm>;
 
+	auto &algFactory = AlgorithmFactory::Instance();
+
     // get the number of algorithms it already has
-    std::vector<std::string> keys = AlgorithmFactory::Instance().getKeys();
+    std::vector<std::string> keys = algFactory.getKeys();
     size_t noOfAlgs = keys.size();
 
     TS_ASSERT_THROWS_NOTHING(
-        AlgorithmFactory::Instance().subscribe<ToyAlgorithm>());
-    TS_ASSERT_THROWS_NOTHING(AlgorithmFactory::Instance().subscribe(newTwo));
+        algFactory.subscribe<ToyAlgorithm>());
+    TS_ASSERT_THROWS_NOTHING(algFactory.subscribe(newTwo));
 
     TS_ASSERT_THROWS_ANYTHING(
-        AlgorithmFactory::Instance().subscribe<ToyAlgorithm>());
+        algFactory.subscribe<ToyAlgorithm>());
 
     // get the number of algorithms it has now
-    keys = AlgorithmFactory::Instance().getKeys();
+    keys = algFactory.getKeys();
     size_t noOfAlgsAfter = keys.size();
     TS_ASSERT_EQUALS(noOfAlgsAfter, noOfAlgs + 2);
 
-    AlgorithmFactory::Instance().unsubscribe("ToyAlgorithm", 1);
-    AlgorithmFactory::Instance().unsubscribe("ToyAlgorithm", 2);
+    algFactory.unsubscribe("ToyAlgorithm", 1);
+    algFactory.unsubscribe("ToyAlgorithm", 2);
   }
 
   void testUnsubscribe() {
     Mantid::Kernel::Instantiator<ToyAlgorithmTwo, Algorithm> *newTwo =
         new Mantid::Kernel::Instantiator<ToyAlgorithmTwo, Algorithm>;
+	  
+	auto &algFactory = AlgorithmFactory::Instance();
 
     // get the nubmer of algorithms it already has
-    std::vector<std::string> keys = AlgorithmFactory::Instance().getKeys();
+    std::vector<std::string> keys = algFactory.getKeys();
     size_t noOfAlgs = keys.size();
 
-    AlgorithmFactory::Instance().subscribe<ToyAlgorithm>();
-    AlgorithmFactory::Instance().subscribe(newTwo);
+    algFactory.subscribe<ToyAlgorithm>();
+    algFactory.subscribe(newTwo);
 
     TS_ASSERT_THROWS_NOTHING(
-        AlgorithmFactory::Instance().unsubscribe("ToyAlgorithm", 1));
+        algFactory.unsubscribe("ToyAlgorithm", 1));
     TS_ASSERT_THROWS_NOTHING(
-        AlgorithmFactory::Instance().unsubscribe("ToyAlgorithm", 2));
+        algFactory.unsubscribe("ToyAlgorithm", 2));
 
     // get the nubmer of algorithms it has now
-    keys = AlgorithmFactory::Instance().getKeys();
+    keys = algFactory.getKeys();
     size_t noOfAlgsAfter = keys.size();
 
     TS_ASSERT_EQUALS(noOfAlgsAfter, noOfAlgs)
 
     // try unsubscribing them again
     TS_ASSERT_THROWS_NOTHING(
-        AlgorithmFactory::Instance().unsubscribe("ToyAlgorithm", 1));
+        algFactory.unsubscribe("ToyAlgorithm", 1));
     TS_ASSERT_THROWS_NOTHING(
-        AlgorithmFactory::Instance().unsubscribe("ToyAlgorithm", 2));
+        algFactory.unsubscribe("ToyAlgorithm", 2));
 
     // make sure the number hasn't changed
-    keys = AlgorithmFactory::Instance().getKeys();
+    keys = algFactory.getKeys();
     size_t noOfAlgsAgain = keys.size();
 
     TS_ASSERT_EQUALS(noOfAlgsAfter, noOfAlgsAgain);
@@ -82,90 +86,98 @@ public:
     Mantid::Kernel::Instantiator<ToyAlgorithmTwo, Algorithm> *newTwo =
         new Mantid::Kernel::Instantiator<ToyAlgorithmTwo, Algorithm>;
 
-    AlgorithmFactory::Instance().subscribe<ToyAlgorithm>();
-    AlgorithmFactory::Instance().subscribe(newTwo);
+	auto &algFactory = AlgorithmFactory::Instance();
 
-    TS_ASSERT(AlgorithmFactory::Instance().exists("ToyAlgorithm", 1));
-    TS_ASSERT(AlgorithmFactory::Instance().exists("ToyAlgorithm", 2));
-    TS_ASSERT(!AlgorithmFactory::Instance().exists("ToyAlgorithm", 3));
-    TS_ASSERT(!AlgorithmFactory::Instance().exists("ToyAlgorithm", 4));
-    TS_ASSERT(AlgorithmFactory::Instance().exists("ToyAlgorithm", -1));
+    algFactory.subscribe<ToyAlgorithm>();
+    algFactory.subscribe(newTwo);
 
-    AlgorithmFactory::Instance().unsubscribe("ToyAlgorithm", 1);
-    AlgorithmFactory::Instance().unsubscribe("ToyAlgorithm", 2);
+    TS_ASSERT(algFactory.exists("ToyAlgorithm", 1));
+    TS_ASSERT(algFactory.exists("ToyAlgorithm", 2));
+    TS_ASSERT(!algFactory.exists("ToyAlgorithm", 3));
+    TS_ASSERT(!algFactory.exists("ToyAlgorithm", 4));
+    TS_ASSERT(algFactory.exists("ToyAlgorithm", -1));
+
+    algFactory.unsubscribe("ToyAlgorithm", 1);
+    algFactory.unsubscribe("ToyAlgorithm", 2);
   }
 
   void testGetKeys() {
     std::vector<std::string> keys;
 
-    TS_ASSERT_EQUALS(0, keys.size());
-    AlgorithmFactory::Instance().subscribe<ToyAlgorithm>();
+	auto &algFactory = AlgorithmFactory::Instance();
 
-    TS_ASSERT_THROWS_NOTHING(keys = AlgorithmFactory::Instance().getKeys());
+    TS_ASSERT_EQUALS(0, keys.size());
+    algFactory.subscribe<ToyAlgorithm>();
+
+    TS_ASSERT_THROWS_NOTHING(keys = algFactory.getKeys());
     size_t noOfAlgs = keys.size();
 
-    AlgorithmFactory::Instance().unsubscribe("ToyAlgorithm", 1);
+    algFactory.unsubscribe("ToyAlgorithm", 1);
 
-    TS_ASSERT_THROWS_NOTHING(keys = AlgorithmFactory::Instance().getKeys());
+    TS_ASSERT_THROWS_NOTHING(keys = algFactory.getKeys());
     TS_ASSERT_EQUALS(noOfAlgs - 1, keys.size());
   }
 
   void test_HighestVersion() {
-    auto &factory = AlgorithmFactory::Instance();
+	auto &algFactory = AlgorithmFactory::Instance();
 
-    TS_ASSERT_THROWS(factory.highestVersion("ToyAlgorithm"),
+    TS_ASSERT_THROWS(algFactory.highestVersion("ToyAlgorithm"),
                      std::invalid_argument);
 
-    AlgorithmFactory::Instance().subscribe<ToyAlgorithm>();
-    TS_ASSERT_EQUALS(1, factory.highestVersion("ToyAlgorithm"));
+    algFactory.subscribe<ToyAlgorithm>();
+    TS_ASSERT_EQUALS(1, algFactory.highestVersion("ToyAlgorithm"));
 
     Mantid::Kernel::Instantiator<ToyAlgorithmTwo, Algorithm> *newTwo =
         new Mantid::Kernel::Instantiator<ToyAlgorithmTwo, Algorithm>;
-    AlgorithmFactory::Instance().subscribe(newTwo);
-    TS_ASSERT_EQUALS(2, factory.highestVersion("ToyAlgorithm"));
+    algFactory.subscribe(newTwo);
+    TS_ASSERT_EQUALS(2, algFactory.highestVersion("ToyAlgorithm"));
 
-    AlgorithmFactory::Instance().unsubscribe("ToyAlgorithm", 1);
-    AlgorithmFactory::Instance().unsubscribe("ToyAlgorithm", 2);
+    algFactory.unsubscribe("ToyAlgorithm", 1);
+    algFactory.unsubscribe("ToyAlgorithm", 2);
   }
 
   void testCreate() {
     Mantid::Kernel::Instantiator<ToyAlgorithmTwo, Algorithm> *newTwo =
         new Mantid::Kernel::Instantiator<ToyAlgorithmTwo, Algorithm>;
 
-    AlgorithmFactory::Instance().subscribe<ToyAlgorithm>();
-    AlgorithmFactory::Instance().subscribe(newTwo);
+	auto &algFactory = AlgorithmFactory::Instance();
+
+    algFactory.subscribe<ToyAlgorithm>();
+    algFactory.subscribe(newTwo);
 
     TS_ASSERT_THROWS_NOTHING(
-        AlgorithmFactory::Instance().create("ToyAlgorithm", -1));
+        algFactory.create("ToyAlgorithm", -1));
     TS_ASSERT_THROWS_ANYTHING(
-        AlgorithmFactory::Instance().create("AlgorithmDoesntExist", -1));
+        algFactory.create("AlgorithmDoesntExist", -1));
 
     TS_ASSERT_THROWS_NOTHING(
-        AlgorithmFactory::Instance().create("ToyAlgorithm", 1));
+        algFactory.create("ToyAlgorithm", 1));
     TS_ASSERT_THROWS_NOTHING(
-        AlgorithmFactory::Instance().create("ToyAlgorithm", 2));
+        algFactory.create("ToyAlgorithm", 2));
     TS_ASSERT_THROWS_ANYTHING(
-        AlgorithmFactory::Instance().create("AlgorithmDoesntExist", 1));
+        algFactory.create("AlgorithmDoesntExist", 1));
     TS_ASSERT_THROWS_ANYTHING(
-        AlgorithmFactory::Instance().create("AlgorithmDoesntExist", 2));
+        algFactory.create("AlgorithmDoesntExist", 2));
 
-    TS_ASSERT_THROWS_ANYTHING(AlgorithmFactory::Instance().create("", 1));
-    TS_ASSERT_THROWS_ANYTHING(AlgorithmFactory::Instance().create("", -1));
+    TS_ASSERT_THROWS_ANYTHING(algFactory.create("", 1));
+    TS_ASSERT_THROWS_ANYTHING(algFactory.create("", -1));
 
     TS_ASSERT_THROWS_ANYTHING(
-        AlgorithmFactory::Instance().create("ToyAlgorithm", 3));
+        algFactory.create("ToyAlgorithm", 3));
     TS_ASSERT_THROWS_ANYTHING(
-        AlgorithmFactory::Instance().create("ToyAlgorithm", 4));
+        algFactory.create("ToyAlgorithm", 4));
 
-    AlgorithmFactory::Instance().unsubscribe("ToyAlgorithm", 1);
-    AlgorithmFactory::Instance().unsubscribe("ToyAlgorithm", 2);
+    algFactory.unsubscribe("ToyAlgorithm", 1);
+    algFactory.unsubscribe("ToyAlgorithm", 2);
   }
 
   void testGetDescriptors() {
-    AlgorithmFactory::Instance().subscribe<ToyAlgorithm>();
+	auto &algFactory = AlgorithmFactory::Instance();
+
+    algFactory.subscribe<ToyAlgorithm>();
     std::vector<AlgorithmDescriptor> descriptors;
     TS_ASSERT_THROWS_NOTHING(
-        descriptors = AlgorithmFactory::Instance().getDescriptors(true));
+        descriptors = algFactory.getDescriptors(true));
 
     size_t noOfAlgs = descriptors.size();
     std::vector<AlgorithmDescriptor>::const_iterator descItr =
@@ -179,60 +191,87 @@ public:
     }
     TS_ASSERT(foundAlg);
 
-    AlgorithmFactory::Instance().unsubscribe("ToyAlgorithm", 1);
+    algFactory.unsubscribe("ToyAlgorithm", 1);
 
     TS_ASSERT_THROWS_NOTHING(
-        descriptors = AlgorithmFactory::Instance().getDescriptors(true));
+        descriptors = algFactory.getDescriptors(true));
 
     TS_ASSERT_EQUALS(noOfAlgs - 1, descriptors.size());
   }
 
+  void testGetDescriptor() {
+	  auto &algFactory = AlgorithmFactory::Instance();
+
+	  const std::string algName = "ToyAlgorithm";
+	  algFactory.subscribe<ToyAlgorithm>();
+	  AlgorithmDescriptor descriptor;
+
+	  TS_ASSERT_THROWS_NOTHING(
+		  descriptor = algFactory.getDescriptor(algName));
+
+	  bool AlgCorrect = ("Cat" == descriptor.category) &&
+						(algName == descriptor.name) &&
+						("Dog" == descriptor.alias) &&
+						(1 == descriptor.version);
+
+	  TS_ASSERT(AlgCorrect);
+
+	  algFactory.unsubscribe("ToyAlgorithm", 1);
+
+	  TS_ASSERT_THROWS(algFactory.getDescriptor(algName), std::runtime_error);
+  }
+
+
+
   void testGetCategories() {
-    AlgorithmFactory::Instance().subscribe<CategoryAlgorithm>();
+	auto &algFactory = AlgorithmFactory::Instance();
+    algFactory.subscribe<CategoryAlgorithm>();
     std::unordered_set<std::string> validCategories;
     TS_ASSERT_THROWS_NOTHING(
-        validCategories = AlgorithmFactory::Instance().getCategories(true));
+        validCategories = algFactory.getCategories(true));
 
     size_t noOfCats = validCategories.size();
     TS_ASSERT_DIFFERS(validCategories.find("Fake"), validCategories.end());
 
-    AlgorithmFactory::Instance().unsubscribe("CategoryAlgorithm", 1);
+    algFactory.unsubscribe("CategoryAlgorithm", 1);
     TS_ASSERT_THROWS_NOTHING(
-        validCategories = AlgorithmFactory::Instance().getCategories(true));
+        validCategories = algFactory.getCategories(true));
     TS_ASSERT_EQUALS(noOfCats - 1, validCategories.size());
   }
 
   void testGetCategoriesWithState() {
-    AlgorithmFactory::Instance().subscribe<CategoryAlgorithm>();
+	auto &algFactory = AlgorithmFactory::Instance();
+    algFactory.subscribe<CategoryAlgorithm>();
 
     std::map<std::string, bool> validCategories;
     TS_ASSERT_THROWS_NOTHING(
         validCategories =
-            AlgorithmFactory::Instance().getCategoriesWithState());
+            algFactory.getCategoriesWithState());
     size_t noOfCats = validCategories.size();
     TS_ASSERT_DIFFERS(validCategories.find("Fake"), validCategories.end());
 
-    AlgorithmFactory::Instance().unsubscribe("CategoryAlgorithm", 1);
+    algFactory.unsubscribe("CategoryAlgorithm", 1);
     TS_ASSERT_THROWS_NOTHING(
         validCategories =
-            AlgorithmFactory::Instance().getCategoriesWithState());
+            algFactory.getCategoriesWithState());
     TS_ASSERT_EQUALS(noOfCats - 1, validCategories.size());
   }
 
   void testDecodeName() {
+	auto &algFactory = AlgorithmFactory::Instance();
     std::pair<std::string, int> basePair;
     basePair.first = "Cat";
     basePair.second = 1;
     std::string mangledName = "Cat|1";
     std::pair<std::string, int> outPair;
     TS_ASSERT_THROWS_NOTHING(
-        outPair = AlgorithmFactory::Instance().decodeName(mangledName));
+        outPair = algFactory.decodeName(mangledName));
     TS_ASSERT_EQUALS(basePair.first, outPair.first);
     TS_ASSERT_EQUALS(basePair.second, outPair.second);
 
     mangledName = "Cat 1";
     TS_ASSERT_THROWS_ANYTHING(
-        outPair = AlgorithmFactory::Instance().decodeName(mangledName));
+        outPair = algFactory.decodeName(mangledName));
   }
 };
 

--- a/Framework/API/test/AlgorithmFactoryTest.h
+++ b/Framework/API/test/AlgorithmFactoryTest.h
@@ -25,6 +25,10 @@ public:
 
     auto &algFactory = AlgorithmFactory::Instance();
 
+	// Ensure the algorithm factory does not already have this
+	algFactory.unsubscribe("ToyAlgorithm", 1);
+	algFactory.unsubscribe("ToyAlgorithm", 2);
+
     // get the number of algorithms it already has
     std::vector<std::string> keys = algFactory.getKeys();
     size_t noOfAlgs = keys.size();
@@ -183,24 +187,22 @@ public:
     TS_ASSERT_EQUALS(noOfAlgs - 1, descriptors.size());
   }
 
-  void testGetDescriptor() {
+  void testGetLatestVersion() {
     auto &algFactory = AlgorithmFactory::Instance();
 
     const std::string algName = "ToyAlgorithm";
     algFactory.subscribe<ToyAlgorithm>();
-    AlgorithmDescriptor descriptor;
+	algFactory.subscribe<ToyAlgorithmTwo>();
 
-    TS_ASSERT_THROWS_NOTHING(descriptor = algFactory.getDescriptor(algName));
+	int version = -1;
+    TS_ASSERT_THROWS_NOTHING(version = algFactory.getAlgLatestVersion(algName));
 
-    bool AlgCorrect = ("Cat" == descriptor.category) &&
-                      (algName == descriptor.name) &&
-                      ("Dog" == descriptor.alias) && (1 == descriptor.version);
+    TS_ASSERT_EQUALS(version, 2);
 
-    TS_ASSERT(AlgCorrect);
+    algFactory.unsubscribe(algName, 1);
+	algFactory.unsubscribe(algName, 2);
 
-    algFactory.unsubscribe("ToyAlgorithm", 1);
-
-    TS_ASSERT_THROWS(algFactory.getDescriptor(algName), std::runtime_error);
+    TS_ASSERT_THROWS(algFactory.getAlgLatestVersion(algName), std::runtime_error);
   }
 
   void testGetCategories() {

--- a/Framework/API/test/AlgorithmFactoryTest.h
+++ b/Framework/API/test/AlgorithmFactoryTest.h
@@ -187,25 +187,6 @@ public:
     TS_ASSERT_EQUALS(noOfAlgs - 1, descriptors.size());
   }
 
-  void testGetLatestVersion() {
-    auto &algFactory = AlgorithmFactory::Instance();
-
-    const std::string algName = "ToyAlgorithm";
-    algFactory.subscribe<ToyAlgorithm>();
-    algFactory.subscribe<ToyAlgorithmTwo>();
-
-    int version = -1;
-    TS_ASSERT_THROWS_NOTHING(version = algFactory.getAlgLatestVersion(algName));
-
-    TS_ASSERT_EQUALS(version, 2);
-
-    algFactory.unsubscribe(algName, 1);
-    algFactory.unsubscribe(algName, 2);
-
-    TS_ASSERT_THROWS(algFactory.getAlgLatestVersion(algName),
-                     std::runtime_error);
-  }
-
   void testGetCategories() {
     auto &algFactory = AlgorithmFactory::Instance();
     algFactory.subscribe<CategoryAlgorithm>();

--- a/Framework/Algorithms/test/GenerateIPythonNotebookTest.h
+++ b/Framework/Algorithms/test/GenerateIPythonNotebookTest.h
@@ -148,7 +148,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(powerer.execute());
     TS_ASSERT_EQUALS(powerer.isExecuted(), true);
 
-    // set up history for the algorithn which is presumably removed from Mantid
+    // set up history for the algorithm which is presumably removed from Mantid
     auto ws = API::FrameworkManager::Instance().getWorkspace(wsName);
     API::WorkspaceHistory &history = ws->history();
     auto pAlg = Mantid::Kernel::make_unique<NonExistingAlgorithm>();


### PR DESCRIPTION
**Description of work.**
Adds a method get a single descriptor in the Algorithm factory, this avoids us having to get all algorithm descriptors each time we want a descriptor

Previously every algorithm object was allocated (900+) then discarded for each workspace. These changes drop the project saving time from 2+ minutes to ~5 seconds in debug mode for a large case.

**To test:**
- Build master copy of Mantid
- Run the following script
```
for i in range(100):
    ws_name = str(i)
    CreateSampleWorkspace(OutputWorkspace=ws_name)
    for i in range(100):
        AddSampleLog(ws_name,'history_destroyer','blah')
```
- Wait for project recovery to start saving after the script has run (set logger to debug)
- Wait several minutes for it to save

- Build these changes
- Repeat and verify the time taken.

<!-- Instructions for testing. -->

Fixes #22788 . 

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
