### PR TITLE
FacilityInfo timezone support

### DIFF
--- a/Framework/CurveFitting/src/Algorithms/ConvolutionFit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/ConvolutionFit.cpp
@@ -255,7 +255,7 @@ ConvolutionFit<QENSFitSequential>::seeAlso() const {
 template <>
 const std::vector<std::string>
 ConvolutionFit<QENSFitSimultaneous>::seeAlso() const {
-  return {"QENSSimultaneousFit"};
+  return {"QENSFitSimultaneous"};
 }
 
 template <typename Base>

--- a/Framework/Kernel/inc/MantidKernel/FacilityInfo.h
+++ b/Framework/Kernel/inc/MantidKernel/FacilityInfo.h
@@ -67,6 +67,9 @@ public:
   /// Returns the preferred file extension
   const std::string &preferredExtension() const { return m_extensions.front(); }
 
+  /// Returns the time zone designation compatible with pytz
+  const std::string &timezone() const { return m_timezone; }
+
   /// Return the archive search interface names
   const std::vector<std::string> &archiveSearch() const {
     return m_archiveSearch;
@@ -104,6 +107,7 @@ private:
   void fillDelimiter(const Poco::XML::Element *elem);
   void fillExtensions(const Poco::XML::Element *elem);
   void fillArchiveNames(const Poco::XML::Element *elem);
+  void fillTimezone(const Poco::XML::Element *elem);
   void fillInstruments(const Poco::XML::Element *elem);
   void fillHTTPProxy(const Poco::XML::Element *elem);
   void fillComputeResources(const Poco::XML::Element *elem);
@@ -115,6 +119,7 @@ private:
 
   CatalogInfo m_catalogs;   ///< Gain access to the catalogInfo class.
   const std::string m_name; ///< facility name
+  std::string m_timezone;   ///< Timezone designation in pytz
   int m_zeroPadding;        ///< default zero padding for this facility
   std::string
       m_delimiter; ///< default delimiter between instrument name and run number

--- a/Framework/Kernel/src/FacilityInfo.cpp
+++ b/Framework/Kernel/src/FacilityInfo.cpp
@@ -14,6 +14,7 @@
 
 #include <Poco/DOM/Element.h>
 #include <Poco/DOM/NodeList.h>
+#include <Poco/DOM/Text.h>
 #include <MantidKernel/StringTokenizer.h>
 
 using Poco::XML::Element;
@@ -31,9 +32,10 @@ Logger g_log("FacilityInfo");
   * @throw std::runtime_error if name or file extensions are not defined
   */
 FacilityInfo::FacilityInfo(const Poco::XML::Element *elem)
-    : m_catalogs(elem), m_name(elem->getAttribute("name")), m_zeroPadding(0),
-      m_delimiter(), m_extensions(), m_archiveSearch(), m_instruments(),
-      m_noFilePrefix(), m_multiFileLimit(100), m_computeResources() {
+    : m_catalogs(elem), m_name(elem->getAttribute("name")), m_timezone(),
+      m_zeroPadding(0), m_delimiter(), m_extensions(), m_archiveSearch(),
+      m_instruments(), m_noFilePrefix(), m_multiFileLimit(100),
+      m_computeResources() {
   if (m_name.empty()) {
     g_log.error("Facility name is not defined");
     throw std::runtime_error("Facility name is not defined");
@@ -44,6 +46,7 @@ FacilityInfo::FacilityInfo(const Poco::XML::Element *elem)
   fillDelimiter(elem);
   fillExtensions(elem);
   fillArchiveNames(elem);
+  fillTimezone(elem);
   fillComputeResources(elem);
   fillNoFilePrefix(elem);
   fillMultiFileLimit(elem);
@@ -126,6 +129,25 @@ void FacilityInfo::fillArchiveNames(const Poco::XML::Element *elem) {
         m_archiveSearch.push_back(plugin);
       }
     }
+  }
+}
+
+void FacilityInfo::fillTimezone(const Poco::XML::Element *elem) {
+  Poco::AutoPtr<Poco::XML::NodeList> pNL_timezones =
+      elem->getElementsByTagName("timezone");
+  if (pNL_timezones->length() == 0) {
+    g_log.notice() << "No timezone specified for " << m_name
+                   << " in Facilities.xml\n";
+  } else if (pNL_timezones->length() == 1) {
+    pNL_timezones = pNL_timezones->item(0)->childNodes();
+    if (pNL_timezones->length() > 0) {
+      Poco::XML::Text *txt =
+          dynamic_cast<Poco::XML::Text *>(pNL_timezones->item(0));
+      m_timezone = txt->getData();
+    }
+  } else {
+    throw std::runtime_error("Facility " + m_name +
+                             " has more than one timezone specified");
   }
 }
 

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/FacilityInfo.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/FacilityInfo.cpp
@@ -12,55 +12,48 @@ void export_FacilityInfo() {
   register_ptr_to_python<FacilityInfo *>();
 
   class_<FacilityInfo>("FacilityInfo", no_init)
-
       .def("name", &FacilityInfo::name, arg("self"),
            return_value_policy<copy_const_reference>(),
            "Returns name of the facility as definined in the Facilities.xml "
            "file")
-
       .def("__str__", &FacilityInfo::name, arg("self"),
            return_value_policy<copy_const_reference>(),
            "Returns name of the facility as definined in the Facilities.xml "
            "file")
-
       .def("zeroPadding", &FacilityInfo::zeroPadding, arg("self"),
            "Returns default zero padding for this facility")
-
       .def("delimiter", &FacilityInfo::delimiter, arg("self"),
            return_value_policy<copy_const_reference>(),
            "Returns the delimiter between the instrument name and the run "
            "number.")
-
       .def("extensions", &FacilityInfo::extensions, arg("self"),
            "Returns the list of file extensions that are considered as "
            "instrument data files.")
-
       .def("preferredExtension", &FacilityInfo::preferredExtension, arg("self"),
            return_value_policy<copy_const_reference>(),
            "Returns the extension that is preferred for this facility")
-
+      .def("timezone", &FacilityInfo::timezone, arg("self"),
+           return_value_policy<copy_const_reference>(),
+           "Returns the timezone appropriate for the facility. If there is not "
+           "a timezone specified this returns an empty string.")
       .def("archiveSearch", &FacilityInfo::archiveSearch, arg("self"),
            return_value_policy<copy_const_reference>(),
            "Return the archive search interface names")
-
       .def("instruments",
            (const std::vector<InstrumentInfo> &(FacilityInfo::*)() const) &
                FacilityInfo::instruments,
            arg("self"), return_value_policy<copy_const_reference>(),
            "Returns a list of instruments of this facility as defined in the "
            "Facilities.xml file")
-
       .def("instruments", (std::vector<InstrumentInfo>(
                               FacilityInfo::*)(const std::string &) const) &
                               FacilityInfo::instruments,
            (arg("self"), arg("technique")),
            "Returns a list of instruments of given technique")
-
       .def("instrument", &FacilityInfo::instrument,
            (arg("self"), arg("instrumentName")),
            return_value_policy<copy_const_reference>(),
            "Returns the instrument with the given name")
-
       .def("computeResources", &FacilityInfo::computeResources, arg("self"),
            "Returns a vector of the available compute resources");
 }

--- a/Framework/PythonInterface/test/python/mantid/kernel/FacilityInfoTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/FacilityInfoTest.py
@@ -2,7 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import unittest
 from mantid.kernel import FacilityInfo, InstrumentInfo, ConfigService
-
+import pytz
 
 class FacilityInfoTest(unittest.TestCase):
 
@@ -24,8 +24,14 @@ class FacilityInfoTest(unittest.TestCase):
         self.assertTrue(len(test_facility.instruments()) > 30)
         self.assertTrue(len(test_facility.instruments("Neutron Diffraction"))> 10)
         self.assertTrue(isinstance(test_facility.instrument("WISH"), InstrumentInfo))
+        self.assertEquals(test_facility.timezone(), "Europe/London")
 
+    def test_timezones(self):
+        # verify that all of the timezones can get converted by pytz
+        for facility in ConfigService.getFacilities():
+            tz = pytz.timezone(facility.timezone())
+            print(facility.name(), tz)
+            self.assertEquals(str(tz), facility.timezone())
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/Framework/PythonInterface/test/python/mantid/kernel/FacilityInfoTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/FacilityInfoTest.py
@@ -29,6 +29,8 @@ class FacilityInfoTest(unittest.TestCase):
     def test_timezones(self):
         # verify that all of the timezones can get converted by pytz
         for facility in ConfigService.getFacilities():
+            if len(facility.timezone()) == 0:
+                continue # don't test empty strings
             tz = pytz.timezone(facility.timezone())
             print(facility.name(), tz)
             self.assertEquals(str(tz), facility.timezone())

--- a/docs/source/api/python/mantid/kernel/DateAndTime.rst
+++ b/docs/source/api/python/mantid/kernel/DateAndTime.rst
@@ -25,7 +25,7 @@ With :class:`numpy.datetime64`, finding the number of seconds between two times 
 
    diff = (timeArray[-1]-timeArray[0]) / np.timedelta64(1, 's')
 
-For converting :class:`numpy.datetime64` data to a string for the default facilty, use :ref:`numpy.datetime_as_string` explicitly (assuming the times are a variable named ``times``)
+For converting :class:`numpy.datetime64` data to a string for the default facilty, use :func:`numpy.datetime_as_string` explicitly (assuming the times are a variable named ``times``)
 
 .. code-block:: python
 

--- a/docs/source/api/python/mantid/kernel/DateAndTime.rst
+++ b/docs/source/api/python/mantid/kernel/DateAndTime.rst
@@ -25,6 +25,16 @@ With :class:`numpy.datetime64`, finding the number of seconds between two times 
 
    diff = (timeArray[-1]-timeArray[0]) / np.timedelta64(1, 's')
 
+For converting :class:`numpy.datetime64` data to a string for the default facilty, use :ref:`numpy.datetime_as_string` explicitly (assuming the times are a variable named ``times``)
+
+.. code-block:: python
+
+   import pytz
+   tz = pytz.timezone(ConfigService.getFacility().timezone())
+   times = numpy.datetime_as_string(times, timezone=tz)
+
+This is how numpy internally converts :class:`numpy.datetime64` to strings for printing, but the selection of timezone is explicit (using `pytz <https://pythonhosted.org/pytz/>`_) to allow for matching where the data was recorded rather than the system's timezone.
+
 .. module:`mantid.kernel`
 
 .. autoclass:: mantid.kernel.DateAndTime

--- a/docs/source/concepts/FacilitiesFile.rst
+++ b/docs/source/concepts/FacilitiesFile.rst
@@ -24,13 +24,12 @@ component of a facility. A simple facility definition would be
 
     <?xml version="1.0" encoding="UTF-8"?>
     <facilities>
-
      <facility name="BrandNew" delimiter="_" zeropadding="8" FileExtensions=".nxs,.n*">
+      <timezone>UTC</timezone>
 
       <instrument name="ABCDEF"/>
 
      </facility>
-
     </facilities>
 
 which would define a facility called *BrandNew* with an instrument
@@ -42,6 +41,9 @@ called *ABCDEF*. The facilities attributes have the following meanings:
    padded to when constructing a file name;
 -  ``FileExtensions`` should list the extensions of the data files for
    the facility. The first is taken as the preferred extension.
+- ``timezone`` specifies what timezone the facility is in for use with
+  `pytz <https://pythonhosted.org/pytz/>`_. Valid timezones can be found
+  in python by looking at the list in ``pytz.all_timezones``
 
 An instrument can have further attributes which define properties of the
 that instrument rather than the facility as a whole, e.g.

--- a/docs/source/release/v3.13.0/framework.rst
+++ b/docs/source/release/v3.13.0/framework.rst
@@ -72,7 +72,7 @@ Improvements
 - :ref:`Stitch1D <algm-Stitch1D>` can treat point data.
 - The algorithm :ref:`SortXAxis <algm-SortXAxis>` has a new input option that allows ascending (default) and descending sorting. The documentation needed to be corrected in general.
 - :ref:`LoadNexusMonitors <algm-LoadNexusMonitors>` has changed its properties for clarification. This has also propagated to :ref:`LoadEventNexus <algm-LoadEventNexus>` and :ref:`LoadEventAndCompress <algm-LoadEventAndCompress>`
-- :ref:`FacilityInfo` has an additional field with the timezone for use in converting ``numpy.datetime64`` values to strings
+- :class:`mantid.kernel.FacilityInfo` has an additional field with the timezone for use in converting ``numpy.datetime64`` values to strings
 
 Bugfixes
 ########

--- a/docs/source/release/v3.13.0/framework.rst
+++ b/docs/source/release/v3.13.0/framework.rst
@@ -18,7 +18,7 @@ Instrument Definition Updates
 Stability
 ---------
 
-- Mantid now handles poor network stability  better when reading live data from the ISIS DAE.  Mantid will now timeout after a couple of minutes of loss of network connectivity and remains responsive during this time.  You can alter the duration of this timeout by adding a line to the mantid.user.properties file like: 
+- Mantid now handles poor network stability  better when reading live data from the ISIS DAE.  Mantid will now timeout after a couple of minutes of loss of network connectivity and remains responsive during this time.  You can alter the duration of this timeout by adding a line to the mantid.user.properties file like:
 
 ```
 ISISDAE.Timeout = 100 #seconds
@@ -72,6 +72,7 @@ Improvements
 - :ref:`Stitch1D <algm-Stitch1D>` can treat point data.
 - The algorithm :ref:`SortXAxis <algm-SortXAxis>` has a new input option that allows ascending (default) and descending sorting. The documentation needed to be corrected in general.
 - :ref:`LoadNexusMonitors <algm-LoadNexusMonitors>` has changed its properties for clarification. This has also propagated to :ref:`LoadEventNexus <algm-LoadEventNexus>` and :ref:`LoadEventAndCompress <algm-LoadEventAndCompress>`
+- :ref:`FacilityInfo` has an additional field with the timezone for use in converting ``numpy.datetime64`` values to strings
 
 Bugfixes
 ########

--- a/instrument/Facilities.xml
+++ b/instrument/Facilities.xml
@@ -22,6 +22,8 @@
     </filelocation>
   </catalog>
 
+   <timezone>Europe/London</timezone>
+
   <instrument name="ALF">
     <technique>Single Crystal Diffraction</technique>
     <livedata>
@@ -376,6 +378,8 @@
 
 <facility name="HFIR" FileExtensions=".nxs,.dat,.xml">
 
+   <timezone>US/Eastern</timezone>
+
    <instrument name="HB1">
       <technique>Triple Axis Spectroscopy</technique>
    </instrument>
@@ -452,6 +456,8 @@
        <mac replacement=""></mac>
      </filelocation>
    </catalog>
+
+   <timezone>US/Eastern</timezone>
 
    <instrument name="DAS">
       <technique>technique</technique>
@@ -602,12 +608,16 @@
 </facility>
 
 <facility name="NCNR" FileExtensions=".dat,.xml">
+   <timezone>US/Eastern</timezone>
+
    <instrument name="NGSANS">
       <technique>Small Angle Scattering</technique>
    </instrument>
 </facility>
 
 <facility name="LENS" FileExtensions=".nxs,.dat,.xml">
+   <timezone>US/Eastern</timezone>
+
    <instrument name="SANS">
       <technique>Small Angle Scattering</technique>
    </instrument>
@@ -615,6 +625,7 @@
 </facility>
 
 <facility name="ILL" zeropadding="6" FileExtensions=".nxs,.hdf,.inx,.asc" nofileprefix="True" multifilelimit="1000">
+  <timezone>Europe/Paris</timezone>
 
   <instrument name="IN4">
     <technique>Neutron Spectroscopy</technique>
@@ -693,6 +704,7 @@
 </facility>
 
 <facility name="SINQ" FileExtensions=".hdf">
+  <timezone>Europe/Zurich</timezone>
 
   <instrument name="HRPT">
     <technique>Neutron Diffraction</technique>
@@ -767,6 +779,7 @@
 </facility>
 
 <facility name="SmuS" FileExtensions=".nxs,.xml">
+  <timezone>Europe/Zurich</timezone>
 
   <instrument name="GPD">
     <zeropadding size="3"/>
@@ -782,6 +795,8 @@
 
 <!--  Reactor Orphee (France) -->
 <facility name="LLB" FileExtensions=".nxs,.hdf">
+  <timezone>Europe/Paris</timezone>
+
   <instrument name="MIBEMOL">
     <technique>Neutron Spectroscopy</technique>
     <technique>Reactor Direct Geometry Spectroscopy</technique>
@@ -790,6 +805,8 @@
 
 <!--  Facility MLZ (FRMII) (Germany) -->
 <facility name="MLZ" FileExtensions=".nxs,.d_dat,.001,.mtxt,.mdat">
+ <timezone>Europe/Berlin</timezone>
+
   <instrument name="DNS">
     <technique>Neutron Spectroscopy</technique>
     <technique>Reactor Direct Geometry Spectroscopy</technique>
@@ -816,6 +833,8 @@
 
 <!-- ANSTO -->
 <facility name="ANSTO" FileExtensions=".nxs,.tar">
+  <timezone>Australia/Sydney</timezone>
+
   <instrument name="Bilby">
     <technique>Small Angle Scattering</technique>
   </instrument>
@@ -823,6 +842,8 @@
 
 <!-- HZB -->
 <facility name="HZB" FileExtensions=".nxs">
+   <timezone>Europe/Berlin</timezone>
+
   <instrument name="EXED">
     <technique>TOF Direct Geometry Spectroscopy</technique>
     <technique>Single Crystal Diffraction</technique>
@@ -840,6 +861,8 @@
 
 <!--  Test Facility to allow example usage of Live listeners against "Fake" instrument sources -->
 <facility name="TEST_LIVE" FileExtensions=".nxs,.raw">
+  <timezone>UTC</timezone>
+
   <instrument name="ISIS_Histogram">
     <technique>Test Listener</technique>
     <livedata>

--- a/instrument/Schema/Facilities/1.0/FacilitiesSchema.xsd
+++ b/instrument/Schema/Facilities/1.0/FacilitiesSchema.xsd
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" attributeFormDefault="unqualified" elementFormDefault="qualified" 
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" attributeFormDefault="unqualified" elementFormDefault="qualified"
            xmlns:xs="http://www.w3.org/2001/XMLSchema" version="1.0">
   <xs:element name="facilities">
     <xs:complexType>
@@ -68,7 +68,8 @@
                   </xs:element>
                   <xs:attribute name="name" type="xs:string"/>
                 </xs:complexType>
-              </xs:element> 
+              </xs:element>
+              <xs:element name="timezone" type="xs:string" minOccurs="0" maxOccurs="1"/>
               <xs:element name="instrument" maxOccurs="unbounded">
                 <xs:complexType>
                   <xs:choice maxOccurs="unbounded">


### PR DESCRIPTION
Add a new field on `FacilityInfo` which gives the timezone that the facility is in and update the documentation in `DateAndTime` to help users take advantage of this.

**To test:**

See what can be done based off of the new example in `DateAndTime`. `np.datetime64` can be printed with the timezone of where they were measured rather than system timezone.

Fixes #22739.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [x] Are the unit tests small and test the class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] Do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
