### PR TITLE
Algorithm history includes dynamic input properties.

### DIFF
--- a/Framework/API/src/ScriptBuilder.cpp
+++ b/Framework/API/src/ScriptBuilder.cpp
@@ -169,10 +169,11 @@ ScriptBuilder::buildAlgorithmString(AlgorithmHistory_const_sptr algHistory) {
       freshPropNames.insert(propFresh->name());
     }
 
-    // remove properties that are not present on a fresh algorithm
+    // remove output properties that are not present on a fresh algorithm
     // i.e. remove dynamically added properties
     for (auto prop_iter = props.begin(); prop_iter != props.end();) {
-      if (freshPropNames.find((*prop_iter)->name()) == freshPropNames.end()) {
+      if (freshPropNames.find((*prop_iter)->name()) == freshPropNames.end() &&
+          (*prop_iter)->direction() == Kernel::Direction::Output) {
         prop_iter = props.erase(prop_iter);
       } else {
         ++prop_iter;

--- a/Framework/API/test/ScriptBuilderTest.h
+++ b/Framework/API/test/ScriptBuilderTest.h
@@ -175,6 +175,10 @@ class ScriptBuilderTest : public CxxTest::TestSuite {
     const std::string summary() const override {
       return "AlgorithmWithDynamicProperty";
     }
+    void afterPropertySet(const std::string &name) override {
+      if (name == "InputWorkspace")
+        declareProperty("DynamicInputProperty", "");
+    }
 
     void init() override {
       declareProperty(make_unique<WorkspaceProperty<MatrixWorkspace>>(
@@ -435,7 +439,7 @@ public:
     std::string result =
         "AlgorithmWithDynamicProperty(InputWorkspace='test_input_workspace', "
         "OutputWorkspace='test_output_workspace', PropertyA='A', "
-        "PropertyB='B')\n";
+        "PropertyB='B', DynamicInputProperty='C')\n";
     boost::shared_ptr<WorkspaceTester> input =
         boost::make_shared<WorkspaceTester>();
     AnalysisDataService::Instance().addOrReplace("test_input_workspace", input);
@@ -447,6 +451,7 @@ public:
     alg->setProperty("InputWorkspace", input);
     alg->setProperty("PropertyA", "A");
     alg->setProperty("PropertyB", "B");
+    alg->setProperty("DynamicInputProperty", "C");
     alg->setPropertyValue("OutputWorkspace", "test_output_workspace");
     alg->execute();
 


### PR DESCRIPTION
**Description of work.**

When the script is generated all dynamically added properties are excluded. This change makes `ScriptBuilder` exclude only output properties keeping all input ones.

**To test:**

See the issue description.

Fixes #22625.

Does this update require release notes?
- [ ] Yes
- [X] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
