### PR TITLE
Fix MantidPlot ctest PYTHONPATH for Windows

### DIFF
--- a/MantidPlot/CMakeLists.txt
+++ b/MantidPlot/CMakeLists.txt
@@ -910,7 +910,16 @@ else ()
 endif ()
 
 # Add an environment property MANTID_SOURCE so that the script can find the source of xmlrunner
-set (TEST_ENVIRONMENT "MANTID_SOURCE=${CMAKE_SOURCE_DIR};PYTHONPATH=$ENV{PYTHONPATH}:${PYTHON_XMLRUNNER_DIR};MANTID_SCREENSHOT_REPORT=${SCREENSHOTS_DIR}" )
+if ( ${CMAKE_SYSTEM_NAME} STREQUAL "Windows" )
+  set ( _python_path $ENV{PYTHONPATH};${PYTHON_XMLRUNNER_DIR} )
+  # cmake list separator and Windows environment seprator are the same so escape the cmake one
+  string ( REPLACE ";" "\\;" _python_path "${_python_path}" )
+else()
+  set ( _python_path $ENV{PYTHONPATH}:${PYTHON_XMLRUNNER_DIR} )
+endif ()
+list ( APPEND _test_environment "PYTHONPATH=${_python_path}" )
+list ( APPEND _test_environment "MANTID_SOURCE=${CMAKE_SOURCE_DIR}" )
+list ( APPEND _test_environment "MANTID_SCREENSHOT_REPORT=${SCREENSHOTS_DIR}" )
 # Make a ctest target for each file
 foreach  ( PYFILE ${MANTIDPLOT_TEST_PY_FILES} )
   # Add the test. Name of test = name of the file
@@ -918,7 +927,7 @@ foreach  ( PYFILE ${MANTIDPLOT_TEST_PY_FILES} )
   # Set the previously-built environment
   set_tests_properties ( ${PYFILE} PROPERTIES
     RUN_SERIAL 1
-    ENVIRONMENT "${TEST_ENVIRONMENT}"
+    ENVIRONMENT "${_test_environment}"
     TIMEOUT ${TESTING_TIMEOUT} )
 endforeach ()
 


### PR DESCRIPTION
**Description of work.**

The most recent [clean Windows build](http://builds.mantidproject.org/view/Master%20Pipeline/job/master_clean-win7/756/console) failed due to not being able to find the xmlrunner tool

This change escapes the semi-colon separator for the MantidPlot unit tests on Windows.

**To test:**

Code review and tests should pass

*No associated issue*

Does this update require release notes?
- [ ] Yes
- [X] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
