### PR TITLE
MuonAnalysis crops at start of data

### DIFF
--- a/Framework/WorkflowAlgorithms/src/MuonProcess.cpp
+++ b/Framework/WorkflowAlgorithms/src/MuonProcess.cpp
@@ -118,7 +118,7 @@ void MuonProcess::init() {
 
   declareProperty("CropWorkspace", true, "Determines if the input workspace "
                                          "should be cropped at Xmax, Xmin is "
-                                         "still apllied.");
+                                         "still aplied.");
 
   declareProperty("WorkspaceName", "", "The name of the input workspace");
 }

--- a/Framework/WorkflowAlgorithms/src/MuonProcess.cpp
+++ b/Framework/WorkflowAlgorithms/src/MuonProcess.cpp
@@ -117,7 +117,7 @@ void MuonProcess::init() {
                   "An output workspace.");
 
   declareProperty("CropWorkspace", true,
-                  "Determines if the input workspace should be cropped");
+                  "Determines if the input workspace should be cropped at Xmax, Xmin is still apllied.");
 
   declareProperty("WorkspaceName", "", "The name of the input workspace");
 }
@@ -300,8 +300,6 @@ MatrixWorkspace_sptr MuonProcess::correctWorkspace(MatrixWorkspace_sptr ws,
 
     ws = changeOffset->getProperty("OutputWorkspace");
   }
-  bool toCrop = getProperty("CropWorkspace");
-  if (toCrop) {
     // Crop workspace, if need to
     double Xmin = getProperty("Xmin");
     double Xmax = getProperty("Xmax");
@@ -311,14 +309,14 @@ MatrixWorkspace_sptr MuonProcess::correctWorkspace(MatrixWorkspace_sptr ws,
 
       if (Xmin != EMPTY_DBL())
         crop->setProperty("Xmin", Xmin);
-
-      if (Xmax != EMPTY_DBL())
-        crop->setProperty("Xmax", Xmax);
-
+	  bool toCrop = getProperty("CropWorkspace");
+	  if (toCrop) {
+		  if (Xmax != EMPTY_DBL())
+			  crop->setProperty("Xmax", Xmax);
+	  }
       crop->execute();
 
       ws = crop->getProperty("OutputWorkspace");
-    }
   }
 
   // Rebin workspace if need to

--- a/Framework/WorkflowAlgorithms/src/MuonProcess.cpp
+++ b/Framework/WorkflowAlgorithms/src/MuonProcess.cpp
@@ -116,8 +116,9 @@ void MuonProcess::init() {
                       "OutputWorkspace", "", Direction::Output),
                   "An output workspace.");
 
-  declareProperty("CropWorkspace", true,
-                  "Determines if the input workspace should be cropped at Xmax, Xmin is still apllied.");
+  declareProperty("CropWorkspace", true, "Determines if the input workspace "
+                                         "should be cropped at Xmax, Xmin is "
+                                         "still apllied.");
 
   declareProperty("WorkspaceName", "", "The name of the input workspace");
 }
@@ -300,23 +301,23 @@ MatrixWorkspace_sptr MuonProcess::correctWorkspace(MatrixWorkspace_sptr ws,
 
     ws = changeOffset->getProperty("OutputWorkspace");
   }
-    // Crop workspace, if need to
-    double Xmin = getProperty("Xmin");
-    double Xmax = getProperty("Xmax");
-    if (Xmin != EMPTY_DBL() || Xmax != EMPTY_DBL()) {
-      IAlgorithm_sptr crop = createChildAlgorithm("CropWorkspace");
-      crop->setProperty("InputWorkspace", ws);
+  // Crop workspace, if need to
+  double Xmin = getProperty("Xmin");
+  double Xmax = getProperty("Xmax");
+  if (Xmin != EMPTY_DBL() || Xmax != EMPTY_DBL()) {
+    IAlgorithm_sptr crop = createChildAlgorithm("CropWorkspace");
+    crop->setProperty("InputWorkspace", ws);
 
-      if (Xmin != EMPTY_DBL())
-        crop->setProperty("Xmin", Xmin);
-	  bool toCrop = getProperty("CropWorkspace");
-	  if (toCrop) {
-		  if (Xmax != EMPTY_DBL())
-			  crop->setProperty("Xmax", Xmax);
-	  }
-      crop->execute();
+    if (Xmin != EMPTY_DBL())
+      crop->setProperty("Xmin", Xmin);
+    bool toCrop = getProperty("CropWorkspace");
+    if (toCrop) {
+      if (Xmax != EMPTY_DBL())
+        crop->setProperty("Xmax", Xmax);
+    }
+    crop->execute();
 
-      ws = crop->getProperty("OutputWorkspace");
+    ws = crop->getProperty("OutputWorkspace");
   }
 
   // Rebin workspace if need to

--- a/Framework/WorkflowAlgorithms/test/MuonProcessTest.h
+++ b/Framework/WorkflowAlgorithms/test/MuonProcessTest.h
@@ -191,9 +191,9 @@ public:
     if (ws) {
       TS_ASSERT_EQUALS(ws->getNumberHistograms(), 1);
 
-      TS_ASSERT_DELTA(ws->readX(0)[0], -0.254, 0.001);
-      TS_ASSERT_DELTA(ws->readX(0)[1000], 15.746, 0.001);
-      TS_ASSERT_DELTA(ws->readX(0)[1752], 27.778, 0.001);
+      TS_ASSERT_DELTA(ws->readX(0)[0], 3.010, 0.001);
+      TS_ASSERT_DELTA(ws->readX(0)[1000], 19.010, 0.001);
+      TS_ASSERT_DELTA(ws->readX(0)[1752], 31.042, 0.001);
     }
   }
 

--- a/docs/source/algorithms/ApplyMuonDetectorGroupPairing-v1.rst
+++ b/docs/source/algorithms/ApplyMuonDetectorGroupPairing-v1.rst
@@ -114,7 +114,7 @@ Output:
 
 .. testoutput:: ExMUSRPairAsymmetry
 
-   -0.0176193517359
+   -0.0141980129084
 
 .. categories::
 

--- a/docs/source/algorithms/ApplyMuonDetectorGrouping-v1.rst
+++ b/docs/source/algorithms/ApplyMuonDetectorGrouping-v1.rst
@@ -101,12 +101,12 @@ Output:
 
 .. testoutput:: ExCountsOffsetAndRebin
 
-   Total counts (rebinned) : 84438
-   Total counts (no rebin) : 84438
+   Total counts (rebinned) : 79970
+   Total counts (no rebin) : 79970
 
    Time range (original) : -0.550 - 31.450 mus
-   Time range (no rebin) : -0.550 - 31.450 mus
-   Time range (rebinned) : -0.550 - 31.450 mus
+   Time range (no rebin) : 0.106 - 31.450 mus
+   Time range (rebinned) : 0.106 - 31.306 mus
 
    Time step (original)  : 0.016 mus
    Time step (no rebin)  : 0.016 mus

--- a/docs/source/release/v3.13.0/muon.rst
+++ b/docs/source/release/v3.13.0/muon.rst
@@ -39,5 +39,6 @@ Bug fixes
 - :ref:`MuonMaxent <algm-MuonMaxent>` and :ref:`PhaseQuad <algm-PhaseQuad>`  no longer include dead detectors (zero counts) when calculating the frequency spectrum.
 - :ref:`RemoveExpDecay <algm-RemoveExpDecay>` will not alter data from a dead detectors (zero counts).
 - :ref:`CalMuonDetectorPhases <algm-CalMuonDetectorPhases>` will give an error code for dead detectors (zero counts) in the phase table.
+- :ref:`MuonProcess <algm-MuonProcess>` always crops the data from `Xmin`.
 
 :ref:`Release 3.13.0 <v3.13.0>`

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -55,6 +55,11 @@
 
 #include <fstream>
 
+/*
+Looks like first good data is not causing the ws to update
+*/
+
+
 // Add this class to the list of specialised dialogs in this namespace
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -591,7 +596,7 @@ Workspace_sptr MuonAnalysis::createAnalysisWorkspace(ItemType itemType,
   options.subtractedPeriods = getSubtractedPeriods();
   options.timeZero = timeZero();           // user input
   options.loadedTimeZero = m_dataTimeZero; // from file
-  options.timeLimits.first = startTime();
+  options.timeLimits.first = firstGoodBin();
   options.timeLimits.second = finishTime();
   options.rebinArgs = isRaw ? "" : rebinParams(loadedWS);
   options.plotType = plotType;
@@ -3098,7 +3103,8 @@ MuonAnalysis::groupWorkspace(const std::string &wsName,
         m_dataTimeZero); // won't be used, but property is mandatory
     groupAlg->setPropertyValue("DetectorGroupingTable", groupingName);
     groupAlg->setPropertyValue("OutputWorkspace", outputEntry.name());
-    groupAlg->setProperty("xmin", m_dataSelector->getStartTime());
+	// want to remove data before first good data
+    groupAlg->setProperty("xmin", firstGoodBin());
     groupAlg->setProperty("xmax", m_dataSelector->getEndTime());
     groupAlg->execute();
 

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -55,11 +55,6 @@
 
 #include <fstream>
 
-/*
-Looks like first good data is not causing the ws to update
-*/
-
-
 // Add this class to the list of specialised dialogs in this namespace
 namespace MantidQt {
 namespace CustomInterfaces {

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -3098,7 +3098,7 @@ MuonAnalysis::groupWorkspace(const std::string &wsName,
         m_dataTimeZero); // won't be used, but property is mandatory
     groupAlg->setPropertyValue("DetectorGroupingTable", groupingName);
     groupAlg->setPropertyValue("OutputWorkspace", outputEntry.name());
-	// want to remove data before first good data
+    // want to remove data before first good data
     groupAlg->setProperty("xmin", firstGoodBin());
     groupAlg->setProperty("xmax", m_dataSelector->getEndTime());
     groupAlg->execute();

--- a/qt/scientific_interfaces/test/MuonAnalysisDataLoaderTest.h
+++ b/qt/scientific_interfaces/test/MuonAnalysisDataLoaderTest.h
@@ -258,13 +258,13 @@ public:
         analysed = loader.createAnalysisWorkspace(corrected, options));
     // test the output
     Mantid::MantidVec expectedOutput = {
-        -0.000584754, -0.037308, -0.0183329, 0.0250825, -0.0154756,
-        0.018308,     0.0116216, -0.019053,  0.0100087, -0.0393029};
+        -0.037308, -0.0183329, 0.0250825, -0.0154756,
+        0.018308,     0.0116216, -0.019053,  0.0100087, -0.0393029, -0.001696};
     const auto outputWS =
         boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(analysed);
     TS_ASSERT(outputWS);
     const auto &data = outputWS->y(0);
-    TS_ASSERT_EQUALS(data.size(), 2000);
+    TS_ASSERT_EQUALS(data.size(), 1958);
     auto xData = outputWS->x(0);
     auto offset = std::distance(xData.begin(),
                                 std::lower_bound(xData.begin(), xData.end(),

--- a/qt/scientific_interfaces/test/MuonAnalysisDataLoaderTest.h
+++ b/qt/scientific_interfaces/test/MuonAnalysisDataLoaderTest.h
@@ -258,8 +258,8 @@ public:
         analysed = loader.createAnalysisWorkspace(corrected, options));
     // test the output
     Mantid::MantidVec expectedOutput = {
-        -0.037308, -0.0183329, 0.0250825, -0.0154756,
-        0.018308,     0.0116216, -0.019053,  0.0100087, -0.0393029, -0.001696};
+        -0.037308, -0.0183329, 0.0250825, -0.0154756, 0.018308,
+        0.0116216, -0.019053,  0.0100087, -0.0393029, -0.001696};
     const auto outputWS =
         boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(analysed);
     TS_ASSERT(outputWS);


### PR DESCRIPTION
Muon analysis was not cropping the start of the data. This fixes the issue.

**Report to:** Steve - already done

**To test:**
Open muon analysis
Go to the settings tab and set `start` to 1 and `finish` to 5
Go back to the home tab
Set `First good data` to 2
Load some data

The plot should start at 1, but the data will start at 2. 
<!-- Instructions for testing. -->

Fixes #22745 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

Does this update require release notes?
- [X] Yes
- [ ] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
