### PR TITLE
LoadNexusMonitors, load Histogram if both are present by default

### DIFF
--- a/Framework/DataHandling/src/LoadNexusMonitors2.cpp
+++ b/Framework/DataHandling/src/LoadNexusMonitors2.cpp
@@ -137,7 +137,7 @@ void LoadNexusMonitors2::init() {
   declareProperty("LoadOnly", "",
                   boost::make_shared<Kernel::StringListValidator>(options),
                   "If multiple repesentations exist, which one to load. "
-                  "Default is to load the one that is present.");
+                  "Default is to load the one that is present, and Histogram if both are present.");
 }
 
 //------------------------------------------------------------------------------
@@ -621,11 +621,14 @@ bool LoadNexusMonitors2::createOutputWorkspace(
       std::stringstream errmsg;
       errmsg << "There are " << numHistoMon << " histogram monitors and "
              << numEventMon
-             << " event monitors. Need to specify which to load.";
-      throw std::invalid_argument(errmsg.str());
+             << " event monitors. Loading Histogram by default. "
+             << "Use \"LoadOnly\" or \"MonitorLoadOnly\" to specify which to load.";
+      m_log.warning(errmsg.str());
+      useEventMon = false;
+    } else {
+      // more than one event monitor means use that since both can't be nonzero
+      useEventMon = (numEventMon > 0);
     }
-    // more than one event monitor means use that since both can't be nonzero
-    useEventMon = (numEventMon > 0);
   }
 
   // set up the flags to load monitor

--- a/Framework/DataHandling/src/LoadNexusMonitors2.cpp
+++ b/Framework/DataHandling/src/LoadNexusMonitors2.cpp
@@ -137,7 +137,8 @@ void LoadNexusMonitors2::init() {
   declareProperty("LoadOnly", "",
                   boost::make_shared<Kernel::StringListValidator>(options),
                   "If multiple repesentations exist, which one to load. "
-                  "Default is to load the one that is present, and Histogram if both are present.");
+                  "Default is to load the one that is present, and Histogram "
+                  "if both are present.");
 }
 
 //------------------------------------------------------------------------------
@@ -620,9 +621,9 @@ bool LoadNexusMonitors2::createOutputWorkspace(
     if (numEventMon > 0 && numHistoMon > 0) {
       std::stringstream errmsg;
       errmsg << "There are " << numHistoMon << " histogram monitors and "
-             << numEventMon
-             << " event monitors. Loading Histogram by default. "
-             << "Use \"LoadOnly\" or \"MonitorLoadOnly\" to specify which to load.";
+             << numEventMon << " event monitors. Loading Histogram by default. "
+             << "Use \"LoadOnly\" or \"MonitorLoadOnly\" to specify which to "
+                "load.";
       m_log.warning(errmsg.str());
       useEventMon = false;
     } else {

--- a/Framework/DataHandling/test/LoadNexusMonitorsTest.h
+++ b/Framework/DataHandling/test/LoadNexusMonitorsTest.h
@@ -143,14 +143,7 @@ public:
     load.initialize();
     load.setPropertyValue("Filename", filename);
 
-    // first make sure it fails since the file has both event and histograms
-    // user should specify what to do
-    load.setPropertyValue("OutputWorkspace", "testing");
-    load.execute();
-    TS_ASSERT(!load.isExecuted());
-
-    // force loading histograms
-    load.setPropertyValue("LoadOnly", "Histogram");
+    // do not specify LoadOnly - it should load histograms by default
     load.setPropertyValue("OutputWorkspace", histoWSname);
     load.execute();
     TS_ASSERT(load.isExecuted());

--- a/docs/source/algorithms/LoadNexusMonitors-v2.rst
+++ b/docs/source/algorithms/LoadNexusMonitors-v2.rst
@@ -47,8 +47,12 @@ Load NeXus file containing both event monitor and histogram monitor
 For most files, the ``LoadOnly`` option can be set to an empty string
 (the default) and the correct form of the data will be loaded
 (i.e. events for event monitors and histograms for histogram
-monitors. In some NeXus files, both histograms and events are
-provided. For those cases, the user **must** use the ``LoadOnly``
+monitors). In some NeXus files, both histograms and events are
+provided. In this case, if ``LoadOnly`` is not defined, then histogram 
+monitors will be loaded and a warning will be outputted to the Log.
+
+To suppress the warning, or to select which form of logs to load the 
+user **must** use the ``LoadOnly``
 option to specify what is desired.
 
 ISIS event monitor


### PR DESCRIPTION
**Description of work.**

Change the behaviour for LoadNexusMonitors in the case where an input file has both Histogram and Event Monitors included (LET is the example), and the property to select which log to load was left at default (Blank).

The new behaviour should be to output a warning that both logs are present, but load Histogram by default (Load, LoadEventNexus and LoadNexueMonitors).

Previous behaviour (introduced in this release) was to throw and Error until the property was selected. Behaviour before that was ambiguous as LoadNexusMonitors would tend towards histogram and LoadEventNexus(LoadMonitors=True, ...) would tend towards events. 

It should still error out if there aren't monitors and the user tried to load them.

The name of the Property to specify which monitor type to load changes a bit depending on the algorithm.

Load and LoadEventNexus
 - MonitorLoadOnly, and you have to have LoadMonitors selected

LoadNexusMonitors
 - LoadOnly


**To test:**

<!-- Instructions for testing. -->

These tests use an LET file that is in with the system test data

This should work and Load Histogram Montiors, but have a warning that both types of monitors are present
``` python
LoadEventNexus(Filename='LET00006278.nxs', OutputWorkspace='LET00006278', 
LoadMonitors=True)
```
This should work and Load Histogram Montiors, without the warning that both types of monitors are present.
``` python
LoadEventNexus(Filename='LET00006278.nxs', OutputWorkspace='LET00006278', 
LoadMonitors=True, MonitorsLoadOnly="Histogram")
```

This should work and Load Event Montiors, without the warning that both types of monitors are present.
``` python
LoadEventNexus(Filename='LET00006278.nxs', OutputWorkspace='LET00006278', 
LoadMonitors=True, MonitorsLoadOnly="Events")
```
Fixes #22815.

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
