### PR TITLE
Check for whitespace only strings

### DIFF
--- a/qt/scientific_interfaces/General/UserInputValidator.cpp
+++ b/qt/scientific_interfaces/General/UserInputValidator.cpp
@@ -38,7 +38,7 @@ UserInputValidator::UserInputValidator() : m_errorMessages() {}
 bool UserInputValidator::checkFieldIsNotEmpty(const QString &name,
                                               QLineEdit *field,
                                               QLabel *errorLabel) {
-  if (Mantid::Kernel::Strings::isEmpty(field->text().toStdString())) {
+  if (field->text().trimmed().isEmpty()) {
     setErrorLabel(errorLabel, false);
     m_errorMessages.append(name + " has been left blank.");
     return false;

--- a/qt/scientific_interfaces/General/UserInputValidator.cpp
+++ b/qt/scientific_interfaces/General/UserInputValidator.cpp
@@ -1,16 +1,14 @@
 #include "UserInputValidator.h"
-#include "MantidKernel/Strings.h"
-
-#include <QValidator>
-#include <QLineEdit>
 #include <QLabel>
+#include <QLineEdit>
 #include <QString>
+#include <QValidator>
 #include <cmath>
 
 using namespace MantidQt::MantidWidgets;
 
 namespace // anonymous
-    {
+{
 template <typename T> void sortPair(std::pair<T, T> &pair) {
   if (pair.first > pair.second) {
     T temp = pair.first;
@@ -324,5 +322,5 @@ void UserInputValidator::setErrorLabel(QLabel *errorLabel, bool valid) {
   // Only show the label if input is invalid
   errorLabel->setVisible(!valid);
 }
-}
-}
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/General/UserInputValidator.cpp
+++ b/qt/scientific_interfaces/General/UserInputValidator.cpp
@@ -1,10 +1,10 @@
 #include "UserInputValidator.h"
+#include "MantidKernel/Strings.h"
 
 #include <QValidator>
 #include <QLineEdit>
 #include <QLabel>
 #include <QString>
-
 #include <cmath>
 
 using namespace MantidQt::MantidWidgets;
@@ -38,7 +38,7 @@ UserInputValidator::UserInputValidator() : m_errorMessages() {}
 bool UserInputValidator::checkFieldIsNotEmpty(const QString &name,
                                               QLineEdit *field,
                                               QLabel *errorLabel) {
-  if (field->text() == "") {
+  if (Mantid::Kernel::Strings::isEmpty(field->text().toStdString())) {
     setErrorLabel(errorLabel, false);
     m_errorMessages.append(name + " has been left blank.");
     return false;

--- a/qt/scientific_interfaces/General/UserInputValidator.cpp
+++ b/qt/scientific_interfaces/General/UserInputValidator.cpp
@@ -8,7 +8,7 @@
 using namespace MantidQt::MantidWidgets;
 
 namespace // anonymous
-{
+    {
 template <typename T> void sortPair(std::pair<T, T> &pair) {
   if (pair.first > pair.second) {
     T temp = pair.first;


### PR DESCRIPTION
**Description of work.**
Modified check field is not empty in UserInputValidator

**Report to:** nobody  <!--If the original issue was raised by a user they should be named here.-->

**To test:** 

<!-- Instructions for testing. -->

1. Open the Sample Transmission Calculator `Interfaces > General > Sample Transmission Calculator`
2. Set the Low, Width and High parameters to sensible values e.g. 0.2, 0.1, 0.5.
3. Set the chemical formula to one or more spaces. e.g `  `
4. Press calculate.
5. Ensure you get the appropriate error message and not: `Unexpected exception: Invalid value for property ChemicalFormula (string) "  ": A value must be entered for this parameter.`
6. Repeat with a sensible formula e.g. `C1`

Fixes #22002  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
