### PR TITLE
Muon analysis multiple fitting label

### DIFF
--- a/docs/source/release/v3.13.0/muon.rst
+++ b/docs/source/release/v3.13.0/muon.rst
@@ -21,6 +21,7 @@ Bugfixes
 - The run number is now updated before the periods, preventing irrelevant warnings from being produced.
 - In single fit the workspace can be changed.
 - In multiple fitting the function can be replaced without causing a crash.
+- Loading current run in Muon Analysis and going to previous runs no longer creates an error in the simultaneous fit label.
 
 Algorithms
 ----------

--- a/qt/widgets/common/src/MuonFitDataSelector.cpp
+++ b/qt/widgets/common/src/MuonFitDataSelector.cpp
@@ -3,7 +3,7 @@
 
 #include "MantidQtWidgets/Common/QtPropertyBrowser/qttreepropertybrowser.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/qtpropertymanager.h"
-#include <QFileInfo.h>
+#include <QFileInfo>
 
 namespace {
 Mantid::Kernel::Logger g_log("MuonFitDataSelector");

--- a/qt/widgets/common/src/MuonFitDataSelector.cpp
+++ b/qt/widgets/common/src/MuonFitDataSelector.cpp
@@ -3,6 +3,7 @@
 
 #include "MantidQtWidgets/Common/QtPropertyBrowser/qttreepropertybrowser.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/qtpropertymanager.h"
+#include <QFileInfo.h>
 
 namespace {
 Mantid::Kernel::Logger g_log("MuonFitDataSelector");
@@ -357,22 +358,17 @@ QString MuonFitDataSelector::getSimultaneousFitLabel() const {
  */
 void MuonFitDataSelector::setSimultaneousFitLabel(const QString &label) {
   // do some checks that it is valid
-  auto safeLabel = label.toStdString();
-  auto index = safeLabel.find(".nxs");
-  if (index != std::string::npos) {
-    safeLabel = safeLabel.substr(0, index);
-  }
-  index = safeLabel.find_last_of("\\");
-  if (index != std::string::npos) {
-    safeLabel = safeLabel.substr(index + 1, safeLabel.size());
-    // need to remove instrument name and leading zeros
-    index = safeLabel.find_last_of("0");
-    safeLabel = safeLabel.substr(index, safeLabel.size());
-    while (safeLabel.front() == '0') {
-      safeLabel = safeLabel.substr(1, safeLabel.size());
-    }
-  }
-  m_ui.txtSimFitLabel->setText(QString::fromStdString(safeLabel));
+	auto safeLabel = label;
+	if (label.indexOf(".") >= 0) {
+		QFileInfo file(label);
+		safeLabel = file.baseName();
+		// trim instrument name
+		auto index = safeLabel.indexOf("0");
+		safeLabel= safeLabel.mid(index);
+		// trim leading zeros
+		safeLabel= safeLabel.remove(QRegExp("^[0]*"));
+	}
+  m_ui.txtSimFitLabel->setText(safeLabel);
 }
 
 /**

--- a/qt/widgets/common/src/MuonFitDataSelector.cpp
+++ b/qt/widgets/common/src/MuonFitDataSelector.cpp
@@ -356,7 +356,24 @@ QString MuonFitDataSelector::getSimultaneousFitLabel() const {
  * @param label :: [input] Text to set as label
  */
 void MuonFitDataSelector::setSimultaneousFitLabel(const QString &label) {
-  m_ui.txtSimFitLabel->setText(label);
+  //do some checks that it is valid
+  auto safeLabel = label.toStdString();
+  auto index = safeLabel.find(".nxs");
+  if ( index != std::string::npos) {
+	  safeLabel = safeLabel.substr(0, index);
+  }
+  index = safeLabel.find_last_of("\\");
+	  if (index != std::string::npos) {
+		  safeLabel = safeLabel.substr(index+1 ,safeLabel.size());
+		  //need to remove instrument name and leading zeros
+		  index = safeLabel.find_last_of("0");
+		  safeLabel = safeLabel.substr(index, safeLabel.size());
+		  while (safeLabel.front() == '0') {
+			  safeLabel = safeLabel.substr(1, safeLabel.size());
+
+		  }
+	  }
+  m_ui.txtSimFitLabel->setText(QString::fromStdString(safeLabel));
 }
 
 /**

--- a/qt/widgets/common/src/MuonFitDataSelector.cpp
+++ b/qt/widgets/common/src/MuonFitDataSelector.cpp
@@ -356,23 +356,22 @@ QString MuonFitDataSelector::getSimultaneousFitLabel() const {
  * @param label :: [input] Text to set as label
  */
 void MuonFitDataSelector::setSimultaneousFitLabel(const QString &label) {
-  //do some checks that it is valid
+  // do some checks that it is valid
   auto safeLabel = label.toStdString();
   auto index = safeLabel.find(".nxs");
-  if ( index != std::string::npos) {
-	  safeLabel = safeLabel.substr(0, index);
+  if (index != std::string::npos) {
+    safeLabel = safeLabel.substr(0, index);
   }
   index = safeLabel.find_last_of("\\");
-	  if (index != std::string::npos) {
-		  safeLabel = safeLabel.substr(index+1 ,safeLabel.size());
-		  //need to remove instrument name and leading zeros
-		  index = safeLabel.find_last_of("0");
-		  safeLabel = safeLabel.substr(index, safeLabel.size());
-		  while (safeLabel.front() == '0') {
-			  safeLabel = safeLabel.substr(1, safeLabel.size());
-
-		  }
-	  }
+  if (index != std::string::npos) {
+    safeLabel = safeLabel.substr(index + 1, safeLabel.size());
+    // need to remove instrument name and leading zeros
+    index = safeLabel.find_last_of("0");
+    safeLabel = safeLabel.substr(index, safeLabel.size());
+    while (safeLabel.front() == '0') {
+      safeLabel = safeLabel.substr(1, safeLabel.size());
+    }
+  }
   m_ui.txtSimFitLabel->setText(QString::fromStdString(safeLabel));
 }
 

--- a/qt/widgets/common/src/MuonFitDataSelector.cpp
+++ b/qt/widgets/common/src/MuonFitDataSelector.cpp
@@ -358,16 +358,16 @@ QString MuonFitDataSelector::getSimultaneousFitLabel() const {
  */
 void MuonFitDataSelector::setSimultaneousFitLabel(const QString &label) {
   // do some checks that it is valid
-	auto safeLabel = label;
-	if (label.indexOf(".") >= 0) {
-		QFileInfo file(label);
-		safeLabel = file.baseName();
-		// trim instrument name
-		auto index = safeLabel.indexOf("0");
-		safeLabel= safeLabel.mid(index);
-		// trim leading zeros
-		safeLabel= safeLabel.remove(QRegExp("^[0]*"));
-	}
+  auto safeLabel = label;
+  if (label.indexOf(".") >= 0) {
+    QFileInfo file(label);
+    safeLabel = file.baseName();
+    // trim instrument name
+    auto index = safeLabel.indexOf("0");
+    safeLabel = safeLabel.mid(index);
+    // trim leading zeros
+    safeLabel = safeLabel.remove(QRegExp("^[0]*"));
+  }
   m_ui.txtSimFitLabel->setText(safeLabel);
 }
 


### PR DESCRIPTION
In muon analysis the loading the current run would cause problems for the multiple fitting label. 

**Report to:**Adrian. <!--If the original issue was raised by a user they should be named here.-->

**To test:**

<!-- Instructions for testing. -->
Open muon analysis
Go to the settings tab and make sure that the multiple fitting is enabled
On the home tab press `load current run` (set the instrument to HIFI)
Go the the groupings tab and add a second pair by typing a name in to the box below the one which says `long`
Go to the data analysis tab
The label will be the run number (without the leading zeros)
Go to the home tab and press the back arrow (to load previous run)
Go to the data analysis tab and the name should be updated (previously it was the path to the file)
Go to the home tab and press the back arrow (to load previous run)
Go to the data analysis tab and the name should be updated (previously it did not update from the path)

Fixes #22824. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

Does this update require release notes?
- [x ] Yes
- [ ] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] Do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
