### PR TITLE
Fix issues with numpy datetime64

### DIFF
--- a/scripts/FilterEvents/eventFilterGUI.py
+++ b/scripts/FilterEvents/eventFilterGUI.py
@@ -717,7 +717,7 @@ class MainWindow(QtGui.QMainWindow):
 
         # Set to plot
         xlim = [vecreltimes.min(), vecreltimes.max()]
-        ylim = [vecvalue.min(), vecvalue.min()]
+        ylim = [vecvalue.min(), vecvalue.max()]
         self.ui.mainplot.set_xlim(xlim[0], xlim[1])
         self.ui.mainplot.set_ylim(ylim[0], ylim[1])
 

--- a/scripts/FilterEvents/eventFilterGUI.py
+++ b/scripts/FilterEvents/eventFilterGUI.py
@@ -710,10 +710,10 @@ class MainWindow(QtGui.QMainWindow):
 
         # append 1 more log if original log only has 1 value
         tf = self._dataWS.getRun().getProperty("proton_charge").times[-1]
-        vectimes.append(tf)
+        vectimes = numpy.append(vectimes,tf)
         vecvalue = numpy.append(vecvalue, vecvalue[-1])
 
-        vecreltimes = [float(t - t0) / numpy.timedelta64(1, 's') for t in vectimes]
+        vecreltimes = [(t - t0) / numpy.timedelta64(1, 's') for t in vectimes]
 
         # Set to plot
         xlim = [min(vecreltimes), max(vecreltimes)]

--- a/scripts/FilterEvents/eventFilterGUI.py
+++ b/scripts/FilterEvents/eventFilterGUI.py
@@ -713,11 +713,11 @@ class MainWindow(QtGui.QMainWindow):
         vectimes = numpy.append(vectimes,tf)
         vecvalue = numpy.append(vecvalue, vecvalue[-1])
 
-        vecreltimes = [(t - t0) / numpy.timedelta64(1, 's') for t in vectimes]
+        vecreltimes = (t - t0) / numpy.timedelta64(1, 's')
 
         # Set to plot
-        xlim = [min(vecreltimes), max(vecreltimes)]
-        ylim = [min(vecvalue), max(vecvalue)]
+        xlim = [vecreltimes.min(), vecreltimes.max()]
+        ylim = [vecvalue.min(), vecvalue.min()]
         self.ui.mainplot.set_xlim(xlim[0], xlim[1])
         self.ui.mainplot.set_ylim(ylim[0], ylim[1])
 


### PR DESCRIPTION
When testing the FilterEvents GUI, I've found that one cannot plot the log values anymore. 
**To test:**
Load the `HYS_13657_event.nxs` from systemtests. Plot the `s1` value
Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
