### PR TITLE
Parallelize creation of NumPy array.

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/CloneMatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/CloneMatrixWorkspace.cpp
@@ -3,6 +3,7 @@
 //-----------------------------------------------------------------------------
 #include "MantidPythonInterface/api/CloneMatrixWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidKernel/MultiThreaded.h"
 
 #include <boost/python/extract.hpp>
 
@@ -33,8 +34,8 @@ enum DataField { XValues = 0, YValues = 1, EValues = 2, DxValues = 3 };
  */
 PyArrayObject *cloneArray(MatrixWorkspace &workspace, DataField field,
                           const size_t start, const size_t endp1) {
-  const size_t numHist = endp1 - start;
-  npy_intp stride(0);
+  const npy_intp numHist(endp1 - start);
+  npy_intp stride{0};
 
   // Find out which function we need to call to access the data
   using ArrayAccessFn =
@@ -57,7 +58,7 @@ PyArrayObject *cloneArray(MatrixWorkspace &workspace, DataField field,
     else
       dataAccesor = &MatrixWorkspace::readE;
   }
-  npy_intp arrayDims[2] = {static_cast<npy_intp>(numHist), stride};
+  npy_intp arrayDims[2] = {numHist, stride};
   PyArrayObject *nparray = reinterpret_cast<PyArrayObject *>(
       PyArray_NewFromDescr(&PyArray_Type, PyArray_DescrFromType(NPY_DOUBLE),
                            2,         // rank 2
@@ -65,10 +66,11 @@ PyArrayObject *cloneArray(MatrixWorkspace &workspace, DataField field,
                            nullptr, nullptr, 0, nullptr));
   double *dest = reinterpret_cast<double *>(
       PyArray_DATA(nparray)); // HEAD of the contiguous numpy data array
-  for (size_t i = start; i < endp1; ++i) {
-    const MantidVec &src = (workspace.*(dataAccesor))(i);
-    std::copy(src.begin(), src.end(), dest);
-    dest += stride; // Move the ptr to the start of the next 1D array
+
+  PARALLEL_FOR_IF(threadSafe(workspace))
+  for (npy_intp i = 0; i < numHist; ++i) {
+    const MantidVec &src = (workspace.*(dataAccesor))(start + i);
+    std::copy(src.begin(), src.end(), std::next(dest, i * stride));
   }
   return nparray;
 }

--- a/Framework/PythonInterface/mantid/plots/helperfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/helperfunctions.py
@@ -275,7 +275,7 @@ def get_matrix_2d_data(workspace, distribution, histogram2D=False):
 
     if workspace.isHistogramData():
         if not distribution:
-            z = z / (x[:, 1:] - x[:, 0:-1])
+            z /= x[:, 1:] - x[:, 0:-1]
         if histogram2D:
             if len(y) == z.shape[0]:
                 y = boundaries_from_points(y)


### PR DESCRIPTION
**Description of work.**

This parallelizing the creation of a NumPy array from a MatrixWorkspace or derived type. This is especially beneficial for EventWorkspaces where the creation of a histogram is done lazily.

On my 18.04 desktop ( 2 x Xeon E5-2630v4 )
Unsorted:
  before: 26.5s
  after: 6.4s

Sorted:
  before: 8.6s
  after: 5.0s

**To test:**

<!-- Instructions for testing. -->

```
from mantid.simpleapi import *

LoadEventNexus(Filename="PG3_37861",OutputWorkspace="meow")
ConvertUnits(InputWorkspace="meow",OutputWorkspace="meow2",target="dSpacing")
Rebin(InputWorkspace="meow2",OutputWorkspace="meow3",Params=".2,-0.0005,2.5")

from mantid import plots
import time
start = time.time()
x,y,z = plots.helperfunctions.get_matrix_2d_data(mtd['meow3'],False,False)
end = time.time()
print(end-start)

start = time.time()
x,y,z = plots.helperfunctions.get_matrix_2d_data(mtd['meow3'],False,False)
end = time.time()
print(end-start)
```

Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

Does this update require release notes?
- [ ] Yes
- [ ] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
