### PR TITLE
Fix unused-variable warning in MuonFitDataSelector

### DIFF
--- a/qt/widgets/common/src/MuonFitDataSelector.cpp
+++ b/qt/widgets/common/src/MuonFitDataSelector.cpp
@@ -193,7 +193,6 @@ void MuonFitDataSelector::setWorkspaceDetails(
  * Defaults copy those previously used in muon fit property browser
  */
 void MuonFitDataSelector::setDefaultValues() {
-  const QChar muMicro{0x03BC}; // mu in Unicode
   this->setStartTime(0.0);
   this->setEndTime(0.0);
   m_ui.txtSimFitLabel->setText("0");


### PR DESCRIPTION
**Description of work.**
Spotted this warning while building master.

**To test:**
 - Code review
 - Compile & check warning is gone.

_No associated issue_

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
