### PR TITLE
Event filter array property fix

### DIFF
--- a/scripts/FilterEvents/eventFilterGUI.py
+++ b/scripts/FilterEvents/eventFilterGUI.py
@@ -806,11 +806,14 @@ class MainWindow(QtGui.QMainWindow):
         run = dataws.getRun()
         plist = run.getProperties()
         for p in plist:
-            pv = p.value
-            if isinstance(pv, numpy.ndarray):
+            for p in plist:
+            try:
                 times = p.times
                 if len(times) > 1:
                     self._sampleLogNames.append(p.name)
+            # This is here for FloatArrayProperty. If a log value was of this type it does not have times
+            except AttributeError:
+                pass
         # ENDFOR(p)
 
         # Set up sample log

--- a/scripts/FilterEvents/eventFilterGUI.py
+++ b/scripts/FilterEvents/eventFilterGUI.py
@@ -806,12 +806,11 @@ class MainWindow(QtGui.QMainWindow):
         run = dataws.getRun()
         plist = run.getProperties()
         for p in plist:
-            for p in plist:
             try:
                 times = p.times
                 if len(times) > 1:
                     self._sampleLogNames.append(p.name)
-            # This is here for FloatArrayProperty. If a log value was of this type it does not have times
+            # This is here for FloatArrayProperty. If a log value is of this type it does not have times
             except AttributeError:
                 pass
         # ENDFOR(p)


### PR DESCRIPTION
**Description of work.**
The FilterEvents GUI was failing to load files which contained a property which was of type FloatArrayProperty. This adds a try catch block to prevent this error.

**To test:**
To test try loading the file SANS2D00022048.nxs. This can be found in the ExternalData/Testing/Data/SystemTest/SANS2D . This file should now load properly and the GUI should be able to slice it. 
<!-- Instructions for testing. -->

Fixes #22862 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

Does this update require release notes?
- [ ] Yes
- [ ] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
