### PR TITLE
RHEL7 devtoolset-7

### DIFF
--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -242,6 +242,12 @@ if ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
 endif ()
 
 ###########################################################################
+# Set the c++ standard to 14 - cmake should do the right thing with msvc
+###########################################################################
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+###########################################################################
 # Add compiler options if using gcc
 ###########################################################################
 if ( CMAKE_COMPILER_IS_GNUCXX )

--- a/buildconfig/CMake/GNUSetup.cmake
+++ b/buildconfig/CMake/GNUSetup.cmake
@@ -97,7 +97,7 @@ if(WITH_UBSAN)
 endif()
 
 set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # XCode isn't picking up the standard set above.
 if(CMAKE_GENERATOR STREQUAL Xcode)

--- a/buildconfig/CMake/GNUSetup.cmake
+++ b/buildconfig/CMake/GNUSetup.cmake
@@ -96,10 +96,7 @@ if(WITH_UBSAN)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${SAN_FLAGS}" )
 endif()
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-# XCode isn't picking up the standard set above.
+# XCode isn't picking up the c++ standard by CMAKE_CXX_STANDARD
 if(CMAKE_GENERATOR STREQUAL Xcode)
   set ( CMAKE_XCODE_ATTRIBUTE_OTHER_CPLUSPLUSFLAGS "${GNUFLAGS} -Woverloaded-virtual -fno-operator-names")
   set ( CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++14")

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -66,6 +66,13 @@ else
   BUILD_CONFIG="Release"
 fi
 
+# Setup software collections on rhel7 to allow using gcc7
+if [[ $ON_RHEL7 ]]; then
+  SCL_ENABLE="scl enable devtoolset-7"
+else
+  SCL_ENABLE="eval"
+fi
+
 # For pull requests decide on what to build based on changeset and Jenkins
 # parameters.
 DO_BUILD_CODE=true
@@ -270,7 +277,7 @@ rm -f -- *.dmg *.rpm *.deb *.tar.gz *.tar.xz
 ###############################################################################
 # CMake configuration
 ###############################################################################
-${CMAKE_EXE} ${CMAKE_GENERATOR} -DCMAKE_BUILD_TYPE=${BUILD_CONFIG} -DENABLE_CPACK=ON -DMAKE_VATES=ON -DParaView_DIR=${PARAVIEW_DIR} -DMANTID_DATA_STORE=${MANTID_DATA_STORE} -DDOCS_HTML=ON -DENABLE_CONDA=ON -DENABLE_WORKBENCH=ON -DENABLE_FILE_LOGGING=OFF ${DIST_FLAGS} ${PACKAGINGVARS} ${CLANGTIDYVAR} ..
+$SCL_ENABLE "${CMAKE_EXE} ${CMAKE_GENERATOR} -DCMAKE_BUILD_TYPE=${BUILD_CONFIG} -DENABLE_CPACK=ON -DMAKE_VATES=ON -DParaView_DIR=${PARAVIEW_DIR} -DMANTID_DATA_STORE=${MANTID_DATA_STORE} -DDOCS_HTML=ON -DENABLE_CONDA=ON -DENABLE_WORKBENCH=ON -DENABLE_FILE_LOGGING=OFF ${DIST_FLAGS} ${PACKAGINGVARS} ${CLANGTIDYVAR} .."
 
 ###############################################################################
 # Coverity build should exit early

--- a/buildconfig/Jenkins/pylint-buildscript
+++ b/buildconfig/Jenkins/pylint-buildscript
@@ -86,7 +86,17 @@ fi
 # Need this because some strange control sequences when using default TERM=xterm
 export TERM="linux"
 PYLINT_FORMAT="parseable"
-${CMAKE_EXE} ${CMAKE_GENERATOR} -DCMAKE_BUILD_TYPE=${BUILD_CONFIG} -DENABLE_CPACK=OFF -DMAKE_VATES=OFF -DPYLINT_MSG_TEMPLATE=\"${PYLINT_FORMAT}\" -DPYLINT_NTHREADS=${BUILD_THREADS:?} -DPYLINT_OUTPUT_DIR=${PYLINT_OUTPUT_DIR} ..
+
+###############################################################################
+# Configure cmake
+###############################################################################
+# Setup software collections on rhel7 to allow using gcc7
+if [[ ${NODE_LABELS} == *rhel7* ]] || [[ ${NODE_LABELS} == *centos7* ]] || [[ ${NODE_LABELS} == *scilin7* ]]; then
+  SCL_ENABLE="scl enable devtoolset-7"
+else
+  SCL_ENABLE="eval"
+fi
+$SCL_ENABLE "${CMAKE_EXE} ${CMAKE_GENERATOR} -DCMAKE_BUILD_TYPE=${BUILD_CONFIG} -DENABLE_CPACK=OFF -DMAKE_VATES=OFF -DPYLINT_MSG_TEMPLATE=\"${PYLINT_FORMAT}\" -DPYLINT_NTHREADS=${BUILD_THREADS:?} -DPYLINT_OUTPUT_DIR=${PYLINT_OUTPUT_DIR} .."
 
 ###############################################################################
 # Build step (we only need the framework)

--- a/qt/paraview_ext/VatesAPI/src/MDHWInMemoryLoadingPresenter.cpp
+++ b/qt/paraview_ext/VatesAPI/src/MDHWInMemoryLoadingPresenter.cpp
@@ -9,7 +9,6 @@
 #include "MantidVatesAPI/WorkspaceProvider.h"
 #include "MantidVatesAPI/vtkDataSetFactory.h"
 
-#include "tbb/tbb.h"
 #include "vtkStructuredGrid.h"
 #include "vtkUnsignedCharArray.h"
 #include "vtkUnstructuredGrid.h"


### PR DESCRIPTION
Add `devtoolset-7` back to the build scripts. The `scl enable devtoolset-7` wrapper is only required during cmake configure time because cmake stores the full path to the compiler in the generated build scripts for cmake/ninja. Only the main buildscript and pylint buildscript use gcc on rhel7. The other builds are not affected.

**To test:**

The `cmake` change can be tested (on gcc) by configuring a new build and seeing what compiler flags are set. For people on rhel7 using ninja it would be
```shell
scl enable devtoolset-7 "cmake3 -G Ninja"
ninja-build Kernel
```
and look that `-std=c++14` is passed to gcc.

The changes to the buildscript are best reviewed by looking at the code. Unless someone makes a clean build, you will not see the changes on a build server.

*There is no associated issue,* but it is mentioned in the list of [maintenance tasks](https://github.com/mantidproject/documents/blob/7e32df09754505884c949e3b15677fc9523ad5f5/Project-Management/TechnicalSteeringCommittee/reports/MaintenanceTasks.md).

*This has no release notes* because it only affects developers.

**Notes to the person that merges:**

1. People maintaining rhel7 build servers need to have `devtoolset-7` installed before this is merged.
2. Once this is merged all rhel7 builds should have their workspaces deleted so cached cmake configurations are not used.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
