### PR TITLE
MWRunFiles : launch file finding also with empty string

### DIFF
--- a/qt/widgets/common/src/MWRunFiles.cpp
+++ b/qt/widgets/common/src/MWRunFiles.cpp
@@ -586,13 +586,11 @@ const QString MWRunFiles::findFilesGetSearchText(QString &searchText) {
 * @param searchText :: text to create search parameters from
 */
 void MWRunFiles::runFindFiles(const QString &searchText) {
-  if (!searchText.isEmpty()) {
-    emit findingFiles();
+  emit findingFiles();
 
-    const auto parameters =
-        createFindFilesSearchParameters(searchText.toStdString());
-    m_pool.createWorker(this, parameters);
-  }
+  const auto parameters =
+      createFindFilesSearchParameters(searchText.toStdString());
+  m_pool.createWorker(this, parameters);
 }
 
 /** Calls cancel on a running instance of MonitorLiveData.


### PR DESCRIPTION
**Description of work.**

The `MWRunFiles` widget does not currently start file finding if the input is manually cleared. This causes odd behaviour as explained in the issue. This PR cures the issue by removing an extraneous check.

**To test:**
1. Open the LoadDialog and load any file.
2. Open it again, manually clear the file input, tab out.
3. Click run again, it should complain that the input is not valid.

<!-- Instructions for testing. -->

Fixes #22873 #22857 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
