### PR TITLE
Remove unused variable in TOFExtinction to fix warning for OSX

### DIFF
--- a/Framework/Crystal/src/TOFExtinction.cpp
+++ b/Framework/Crystal/src/TOFExtinction.cpp
@@ -32,13 +32,6 @@ const double pc[4][19] = {
      -0.0993, -0.1176, -0.1153, -0.1125, -0.1073, -0.1016, -0.0962, -0.0922,
      -0.0898, -0.0892}};
 
-const double MAX_WAVELENGTH = 50.0; // max in lamda_weight table
-
-const double STEPS_PER_ANGSTROM = 100; // resolution of lamda table
-
-const int NUM_WAVELENGTHS =
-    static_cast<int>(std::ceil(MAX_WAVELENGTH * STEPS_PER_ANGSTROM));
-
 const double radtodeg_half = 180.0 / M_PI / 2.;
 }
 


### PR DESCRIPTION
**Description of work.**
There's an unused variable warning in the release branch that is causing OSX to fail. This fixes it.

**To test:**
 - Mantid compiles
 - Code review

_No associated issue_

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
