### PR TITLE
Add fully automated project recovery

### DIFF
--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -16748,12 +16748,11 @@ bool ApplicationWindow::isOfType(const QObject *obj,
   * @param sourceFile The full path to the .project file
   * @return True is loading was successful, false otherwise
   */
-bool ApplicationWindow::loadProjectRecovery(std::string sourceFile)
-{
-	const bool isRecovery = true;
-	ProjectSerialiser projectWriter(this, isRecovery);
-	// File version is not applicable to project recovery - so set to 0
-	return projectWriter.load(sourceFile, 0);
+bool ApplicationWindow::loadProjectRecovery(std::string sourceFile) {
+  const bool isRecovery = true;
+  ProjectSerialiser projectWriter(this, isRecovery);
+  // File version is not applicable to project recovery - so set to 0
+  return projectWriter.load(sourceFile, 0);
 }
 
 /**

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -16743,6 +16743,20 @@ bool ApplicationWindow::isOfType(const QObject *obj,
 }
 
 /**
+  * Loads a project file as part of project recovery
+  *
+  * @param sourceFile The full path to the .project file
+  * @return True is loading was successful, false otherwise
+  */
+bool ApplicationWindow::loadProjectRecovery(std::string sourceFile)
+{
+	const bool isRecovery = true;
+	ProjectSerialiser projectWriter(this, isRecovery);
+	// File version is not applicable to project recovery - so set to 0
+	return projectWriter.load(sourceFile, 0);
+}
+
+/**
  * Triggers saving project recovery on behalf of an external thread
  * or caller, such as project recovery.
  *
@@ -16762,9 +16776,5 @@ void ApplicationWindow::checkForProjectRecovery() {
   }
 
   // Recovery file present
-  if (m_projectRecovery.attemptRecovery()) {
-    // If it worked correctly reset project recovery and start saving
-    m_projectRecovery.clearAllCheckpoints();
-    m_projectRecovery.startProjectSaving();
-  }
+  m_projectRecovery.attemptRecovery();
 }

--- a/MantidPlot/src/ApplicationWindow.h
+++ b/MantidPlot/src/ApplicationWindow.h
@@ -1123,6 +1123,8 @@ public slots:
 
   bool isOfType(const QObject *obj, const char *toCompare) const;
 
+  bool loadProjectRecovery(std::string sourceFile);
+
   // The string must be copied from the other thread in saveProjectRecovery
   /// Saves the current project as part of recovery auto saving
   bool saveProjectRecovery(std::string destination);

--- a/MantidPlot/src/ProjectRecovery.cpp
+++ b/MantidPlot/src/ProjectRecovery.cpp
@@ -343,37 +343,36 @@ void ProjectRecovery::stopProjectSaving() {
   * @param recoveryFolder : The checkpoint folder
   * @throws : If Qt binding fails to main GUI thread
   */
-void ProjectRecovery::loadRecoveryCheckpoint(const Poco::Path &recoveryFolder) {	
-	ScriptingWindow *scriptWindow = m_windowPtr->getScriptWindowHandle();
-	if (!scriptWindow) {
-		throw std::runtime_error("Could not get handle to scripting window");
-	}
+void ProjectRecovery::loadRecoveryCheckpoint(const Poco::Path &recoveryFolder) {
+  ScriptingWindow *scriptWindow = m_windowPtr->getScriptWindowHandle();
+  if (!scriptWindow) {
+    throw std::runtime_error("Could not get handle to scripting window");
+  }
 
-	// Ensure the window repaints so it doesn't appear frozen before exec
-	scriptWindow->executeCurrentTab(Script::ExecutionMode::Serialised);
-	g_log.notice("Re-opening GUIs");
+  // Ensure the window repaints so it doesn't appear frozen before exec
+  scriptWindow->executeCurrentTab(Script::ExecutionMode::Serialised);
+  g_log.notice("Re-opening GUIs");
 
-	
-	auto projectFile = Poco::Path(recoveryFolder).append(OUTPUT_PROJ_NAME);
+  auto projectFile = Poco::Path(recoveryFolder).append(OUTPUT_PROJ_NAME);
 
-	bool loadCompleted = false;
-	if (!QMetaObject::invokeMethod(m_windowPtr, "loadProjectRecovery",
-		Qt::BlockingQueuedConnection,
-		Q_RETURN_ARG(bool, loadCompleted),
-		Q_ARG(const std::string, projectFile.toString()))) {
-		throw std::runtime_error(
-			"Project Recovery: Failed to load project windows - Qt binding failed");
-	}
+  bool loadCompleted = false;
+  if (!QMetaObject::invokeMethod(
+          m_windowPtr, "loadProjectRecovery", Qt::BlockingQueuedConnection,
+          Q_RETURN_ARG(bool, loadCompleted),
+          Q_ARG(const std::string, projectFile.toString()))) {
+    throw std::runtime_error(
+        "Project Recovery: Failed to load project windows - Qt binding failed");
+  }
 
-	if (!loadCompleted) {
-		g_log.warning("Loading failed to recovery everything completely");
-		return;
-	}
-	g_log.notice("Project Recovery finished");
+  if (!loadCompleted) {
+    g_log.warning("Loading failed to recovery everything completely");
+    return;
+  }
+  g_log.notice("Project Recovery finished");
 
-	// Restart project recovery when the async part finishes 
-	clearAllCheckpoints();
-	startProjectSaving();
+  // Restart project recovery when the async part finishes
+  clearAllCheckpoints();
+  startProjectSaving();
 }
 
 /**
@@ -384,7 +383,8 @@ void ProjectRecovery::loadRecoveryCheckpoint(const Poco::Path &recoveryFolder) {
   * @param historyDest : Where to save the ordered history
   * @throws If a handle to the scripting window cannot be obtained
   */
-void ProjectRecovery::openInEditor(const Poco::Path &inputFolder, const Poco::Path &historyDest) {
+void ProjectRecovery::openInEditor(const Poco::Path &inputFolder,
+                                   const Poco::Path &historyDest) {
   compileRecoveryScript(inputFolder, historyDest);
 
   // Force application window to create the script window first

--- a/MantidPlot/src/ProjectRecovery.cpp
+++ b/MantidPlot/src/ProjectRecovery.cpp
@@ -206,7 +206,7 @@ void ProjectRecovery::attemptRecovery() {
     // we exec
     openInEditor(mostRecentCheckpoint, destFilename);
     std::thread recoveryThread(
-        [=] { loadRecoveryCheckpoint(mostRecentCheckpoint, destFilename); });
+        [=] { loadRecoveryCheckpoint(mostRecentCheckpoint); });
     recoveryThread.detach();
   } else if (userChoice == 2) {
     openInEditor(mostRecentCheckpoint, destFilename);
@@ -333,43 +333,6 @@ void ProjectRecovery::stopProjectSaving() {
   }
 }
 
-<<<<<<< HEAD
-void ProjectRecovery::loadRecoveryCheckpoint(const Poco::Path &recoveryFolder,
-                                             const Poco::Path &historyDest) {
-  ScriptingWindow *scriptWindow = m_windowPtr->getScriptWindowHandle();
-  if (!scriptWindow) {
-    throw std::runtime_error("Could not get handle to scripting window");
-  }
-
-  // Ensure the window repaints so it doesn't appear frozen before exec
-  scriptWindow->executeCurrentTab(Script::ExecutionMode::Serialised);
-  g_log.notice("Re-opening GUIs");
-
-  auto projectFile = Poco::Path(recoveryFolder).append(OUTPUT_PROJ_NAME);
-
-  bool loadCompleted = false;
-  if (!QMetaObject::invokeMethod(
-          m_windowPtr, "loadProjectRecovery", Qt::BlockingQueuedConnection,
-          Q_RETURN_ARG(bool, loadCompleted),
-          Q_ARG(const std::string, projectFile.toString()))) {
-    throw std::runtime_error(
-        "Project Recovery: Failed to load project windows - Qt binding failed");
-  }
-
-  if (!loadCompleted) {
-    g_log.warning("Loading failed to recovery everything completely");
-    return;
-  }
-  g_log.notice("Project Recovery finished");
-
-  // Restart project recovery when the async part finishes
-  clearAllCheckpoints();
-  startProjectSaving();
-}
-
-void ProjectRecovery::openInEditor(const Poco::Path &inputFolder,
-                                   const Poco::Path &historyDest) {
-=======
 /**
   * Asynchronously loads a recovery checkpoint by opening
   * a scripting window to the ordered workspace
@@ -422,7 +385,6 @@ void ProjectRecovery::loadRecoveryCheckpoint(const Poco::Path &recoveryFolder) {
   * @throws If a handle to the scripting window cannot be obtained
   */
 void ProjectRecovery::openInEditor(const Poco::Path &inputFolder, const Poco::Path &historyDest) {
->>>>>>> Re #22878 Remove unused param and add doxygen
   compileRecoveryScript(inputFolder, historyDest);
 
   // Force application window to create the script window first

--- a/MantidPlot/src/ProjectRecovery.h
+++ b/MantidPlot/src/ProjectRecovery.h
@@ -82,10 +82,12 @@ private:
   void deleteExistingCheckpoints(size_t checkpointsToKeep) const;
 
   /// Loads a recovery checkpoint in the given folder - TODO in future PR
-  void loadRecoveryCheckpoint(const Poco::Path &path, const Poco::Path &historyDest);
+  void loadRecoveryCheckpoint(const Poco::Path &path,
+                              const Poco::Path &historyDest);
 
   /// Open a recovery checkpoint in the scripting window
-  void openInEditor(const Poco::Path &inputFolder, const Poco::Path &historyDest);
+  void openInEditor(const Poco::Path &inputFolder,
+                    const Poco::Path &historyDest);
 
   /// Wraps the thread in a try catch to log any failures
   void projectSavingThreadWrapper();

--- a/MantidPlot/src/ProjectRecovery.h
+++ b/MantidPlot/src/ProjectRecovery.h
@@ -55,7 +55,7 @@ public:
   ~ProjectRecovery();
 
   /// Attempts recovery of the most recent checkpoint
-  bool attemptRecovery();
+  void attemptRecovery();
   /// Checks if recovery is required
   bool checkForRecovery() const noexcept;
 
@@ -82,10 +82,10 @@ private:
   void deleteExistingCheckpoints(size_t checkpointsToKeep) const;
 
   /// Loads a recovery checkpoint in the given folder - TODO in future PR
-  // bool loadRecoveryCheckpoint(const Poco::Path &path);
+  void loadRecoveryCheckpoint(const Poco::Path &path, const Poco::Path &historyDest);
 
   /// Open a recovery checkpoint in the scripting window
-  bool openInEditor(const Poco::Path &inputFolder);
+  void openInEditor(const Poco::Path &inputFolder, const Poco::Path &historyDest);
 
   /// Wraps the thread in a try catch to log any failures
   void projectSavingThreadWrapper();

--- a/MantidPlot/src/ProjectRecovery.h
+++ b/MantidPlot/src/ProjectRecovery.h
@@ -81,7 +81,7 @@ private:
   /// Deletes oldest checkpoints beyond the maximum number to keep
   void deleteExistingCheckpoints(size_t checkpointsToKeep) const;
 
-  /// Loads a recovery checkpoint in the given folder 
+  /// Loads a recovery checkpoint in the given folder
   void loadRecoveryCheckpoint(const Poco::Path &path);
 
   /// Open a recovery checkpoint in the scripting window

--- a/MantidPlot/src/ProjectRecovery.h
+++ b/MantidPlot/src/ProjectRecovery.h
@@ -81,9 +81,8 @@ private:
   /// Deletes oldest checkpoints beyond the maximum number to keep
   void deleteExistingCheckpoints(size_t checkpointsToKeep) const;
 
-  /// Loads a recovery checkpoint in the given folder - TODO in future PR
-  void loadRecoveryCheckpoint(const Poco::Path &path,
-                              const Poco::Path &historyDest);
+  /// Loads a recovery checkpoint in the given folder 
+  void loadRecoveryCheckpoint(const Poco::Path &path);
 
   /// Open a recovery checkpoint in the scripting window
   void openInEditor(const Poco::Path &inputFolder,

--- a/MantidPlot/src/ProjectSerialiser.cpp
+++ b/MantidPlot/src/ProjectSerialiser.cpp
@@ -281,11 +281,11 @@ void ProjectSerialiser::loadWorkspaces(const TSVSerialiser &tsv) {
     std::unordered_set<std::string> allWsNames(parsedNames.at(ALL_WS).begin(),
                                                parsedNames.at(ALL_WS).end());
 
-	if (parsedNames.find(ALL_GROUP_NAMES) != parsedNames.cend()) {
-		// Add group names to the list of accepted names
-		allWsNames.insert(parsedNames.at(ALL_GROUP_NAMES).begin(),
-						  parsedNames.at(ALL_GROUP_NAMES).end());
-	}
+    if (parsedNames.find(ALL_GROUP_NAMES) != parsedNames.cend()) {
+      // Add group names to the list of accepted names
+      allWsNames.insert(parsedNames.at(ALL_GROUP_NAMES).begin(),
+                        parsedNames.at(ALL_GROUP_NAMES).end());
+    }
 
     const auto loadedWs = adsInstance.getObjectNames();
     for (const std::string &adsWsName : loadedWs) {

--- a/MantidPlot/src/ProjectSerialiser.cpp
+++ b/MantidPlot/src/ProjectSerialiser.cpp
@@ -132,8 +132,9 @@ bool ProjectSerialiser::save(const QString &projectName, bool compress,
  * @param fileVersion :: project file version used
  * @param isTopLevel :: whether this function is being called on a top level
  * 		folder. (Default True)
+ * @return True is loading was successful, otherwise false
  */
-void ProjectSerialiser::load(std::string filepath, const int fileVersion,
+bool ProjectSerialiser::load(std::string filepath, const int fileVersion,
                              const bool isTopLevel) {
   // We have to accept std::string to maintain Python compatibility
   auto qfilePath = QString::fromStdString(filepath);
@@ -204,6 +205,8 @@ void ProjectSerialiser::load(std::string filepath, const int fileVersion,
 
   g_log.notice() << "Finished Loading Project: "
                  << window->projectname.toStdString() << "\n";
+
+  return true;
 }
 
 /**
@@ -225,7 +228,7 @@ void ProjectSerialiser::loadProjectSections(const std::string &lines,
   // If this is the top level folder of the project, we'll need to load the
   // workspaces before anything else.
   // If were recovering projects the workspaces should already be loaded
-  if (isTopLevel && !m_projectRecovery) {
+  if (isTopLevel) {
     loadWorkspaces(tsv);
   }
 
@@ -278,8 +281,11 @@ void ProjectSerialiser::loadWorkspaces(const TSVSerialiser &tsv) {
     std::unordered_set<std::string> allWsNames(parsedNames.at(ALL_WS).begin(),
                                                parsedNames.at(ALL_WS).end());
 
-    allWsNames.insert(parsedNames.at(ALL_GROUP_NAMES).begin(),
-                      parsedNames.at(ALL_GROUP_NAMES).end());
+	if (parsedNames.find(ALL_GROUP_NAMES) != parsedNames.cend()) {
+		// Add group names to the list of accepted names
+		allWsNames.insert(parsedNames.at(ALL_GROUP_NAMES).begin(),
+						  parsedNames.at(ALL_GROUP_NAMES).end());
+	}
 
     const auto loadedWs = adsInstance.getObjectNames();
     for (const std::string &adsWsName : loadedWs) {
@@ -302,7 +308,7 @@ void ProjectSerialiser::loadWorkspaces(const TSVSerialiser &tsv) {
 void ProjectSerialiser::loadWindows(const TSVSerialiser &tsv,
                                     const int fileVersion) {
   auto keys = WindowFactory::Instance().getKeys();
-  // Work around for graph-table dependance. Graph3D's currently rely on
+  // Work around for graph-table dependence. Graph3D's currently rely on
   // looking up tables. These must be loaded before the graphs, so work around
   // by loading in reverse alphabetical order.
   std::reverse(keys.begin(), keys.end());
@@ -932,8 +938,8 @@ MantidQt::API::ProjectSerialiser::parseWsNames(const std::string &wsNames) {
   // The first element is removed since it says "WorkspaceNames"
   unparsedWorkspaces.erase(unparsedWorkspaces.begin());
 
+  const char groupWorkspaceChar = ',';
   for (const auto &workspaceName : unparsedWorkspaces) {
-    const char groupWorkspaceChar = ',';
 
     if (workspaceName.find(groupWorkspaceChar) == std::string::npos) {
       // Normal workspace

--- a/MantidPlot/src/ProjectSerialiser.h
+++ b/MantidPlot/src/ProjectSerialiser.h
@@ -71,7 +71,7 @@ public:
   bool save(const QString &projectName, bool compress = false,
             bool saveAll = true);
   /// Load a project file from disk
-  void load(std::string filepath, const int fileVersion,
+  bool load(std::string filepath, const int fileVersion,
             const bool isTopLevel = true);
   /// Open the script window and load scripts from string
   void openScriptWindow(const QStringList &files);


### PR DESCRIPTION
**Description of work.**
Adds fully automated project recovery. This opens the ordered workspace history file in a script editor and executes it first. 

We must run the python script using a separate thread, else the GUI will block as Qt cannot run it's main event loop. Because of this the cleanup and recovery stages have been moved out of application window back into Project Recovery

**To test:**

- Run any workflow and some GUI windows
- Segfault / Stop Mantid
- Ensure the dialog box appears when you restart Mantid
- Select yes to recovery
- Ensure the script runs and the GUI windows restore back to where they were
- Ensure any extra workspaces from the script are removed

Fixes #22878 

Does this update require release notes?
- [ ] Yes
- [x] No

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
