### PR TITLE
Switch ConfigManager::getValue() to use boost optional return

### DIFF
--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -1624,7 +1624,7 @@ void Algorithm::setLoggingOffset(const int value) {
   if (m_communicator->rank() == 0)
     g_log.setLevelOffset(value);
   else {
-	auto offset = ConfigService::Instance().getValue<int>("mpi.loggingOffset");
+    auto offset = ConfigService::Instance().getValue<int>("mpi.loggingOffset");
     g_log.setLevelOffset(value + offset.get_value_or(1));
   }
 }

--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -1624,9 +1624,8 @@ void Algorithm::setLoggingOffset(const int value) {
   if (m_communicator->rank() == 0)
     g_log.setLevelOffset(value);
   else {
-    int offset{1};
-    ConfigService::Instance().getValue("mpi.loggingOffset", offset);
-    g_log.setLevelOffset(value + offset);
+	auto offset = ConfigService::Instance().getValue<int>("mpi.loggingOffset");
+    g_log.setLevelOffset(value + offset.get_value_or(1));
   }
 }
 

--- a/Framework/API/src/AlgorithmManager.cpp
+++ b/Framework/API/src/AlgorithmManager.cpp
@@ -16,7 +16,8 @@ Kernel::Logger g_log("AlgorithmManager");
 
 /// Private Constructor for singleton class
 AlgorithmManagerImpl::AlgorithmManagerImpl() : m_managed_algs() {
-	auto max_no_algs = Kernel::ConfigService::Instance().getValue<int>("algorithms.retained");
+  auto max_no_algs =
+      Kernel::ConfigService::Instance().getValue<int>("algorithms.retained");
 
   if (max_no_algs.get_value_or(0) < 1) {
     m_max_no_algs = 100; // Default to keeping 100 algorithms if not specified

--- a/Framework/API/src/AlgorithmManager.cpp
+++ b/Framework/API/src/AlgorithmManager.cpp
@@ -16,9 +16,9 @@ Kernel::Logger g_log("AlgorithmManager");
 
 /// Private Constructor for singleton class
 AlgorithmManagerImpl::AlgorithmManagerImpl() : m_managed_algs() {
-  if (!Kernel::ConfigService::Instance().getValue("algorithms.retained",
-                                                  m_max_no_algs) ||
-      m_max_no_algs < 1) {
+	auto max_no_algs = Kernel::ConfigService::Instance().getValue<int>("algorithms.retained");
+
+  if (max_no_algs.get_value_or(0) < 1) {
     m_max_no_algs = 100; // Default to keeping 100 algorithms if not specified
   }
 

--- a/Framework/API/src/AlgorithmManager.cpp
+++ b/Framework/API/src/AlgorithmManager.cpp
@@ -19,7 +19,9 @@ AlgorithmManagerImpl::AlgorithmManagerImpl() : m_managed_algs() {
   auto max_no_algs =
       Kernel::ConfigService::Instance().getValue<int>("algorithms.retained");
 
-  if (max_no_algs.get_value_or(0) < 1) {
+  m_max_no_algs = max_no_algs.get_value_or(0);
+
+  if (m_max_no_algs < 1) {
     m_max_no_algs = 100; // Default to keeping 100 algorithms if not specified
   }
 

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -64,7 +64,7 @@ FileFinderImpl::FileFinderImpl() {
 #else
   m_globOption = Mantid::Kernel::ConfigService::Instance()
                      .getValue<bool>("filefinder.casesensitive")
-                     .get_value_or_default(false);
+                     .get_value_or(false);
 #endif
 }
 

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -62,9 +62,9 @@ FileFinderImpl::FileFinderImpl() {
 #ifdef _WIN32
   m_globOption = Poco::Glob::GLOB_DEFAULT;
 #else
-  m_globOption = Mantid::Kernel::ConfigService::Instance()
-                     .getValue<bool>("filefinder.casesensitive")
-                     .get_value_or(false);
+  setCaseSensitive(Kernel::ConfigService::Instance()
+                       .getValue<bool>("filefinder.casesensitive")
+                       .get_value_or(false));
 #endif
 }
 

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -62,13 +62,9 @@ FileFinderImpl::FileFinderImpl() {
 #ifdef _WIN32
   m_globOption = Poco::Glob::GLOB_DEFAULT;
 #else
-  std::string casesensitive =
-      Mantid::Kernel::ConfigService::Instance().getString(
-          "filefinder.casesensitive");
-  if (boost::iequals("Off", casesensitive))
-    m_globOption = Poco::Glob::GLOB_CASELESS;
-  else
-    m_globOption = Poco::Glob::GLOB_DEFAULT;
+  m_globOption =
+	  Mantid::Kernel::ConfigService::Instance().getValue<bool>(
+		  "filefinder.casesensitive").get_value_or_default(false);
 #endif
 }
 

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -62,9 +62,9 @@ FileFinderImpl::FileFinderImpl() {
 #ifdef _WIN32
   m_globOption = Poco::Glob::GLOB_DEFAULT;
 #else
-  m_globOption =
-	  Mantid::Kernel::ConfigService::Instance().getValue<bool>(
-		  "filefinder.casesensitive").get_value_or_default(false);
+  m_globOption = Mantid::Kernel::ConfigService::Instance()
+                     .getValue<bool>("filefinder.casesensitive")
+                     .get_value_or_default(false);
 #endif
 }
 

--- a/Framework/API/src/FrameworkManager.cpp
+++ b/Framework/API/src/FrameworkManager.cpp
@@ -161,11 +161,9 @@ void FrameworkManagerImpl::loadPlugins() {
  */
 void FrameworkManagerImpl::setNumOMPThreadsToConfigValue() {
   // Set the number of threads to use for this process
-  int maxCores(0);
-  int retVal = Kernel::ConfigService::Instance().getValue(
-      "MultiThreaded.MaxCores", maxCores);
-  if (retVal > 0 && maxCores > 0) {
-    setNumOMPThreads(maxCores);
+	auto maxCores = Kernel::ConfigService::Instance().getValue<int>("MultiThreaded.MaxCores");
+  if (maxCores.get_value_or(0) > 0) {
+    setNumOMPThreads(maxCores.get());
   }
 }
 
@@ -438,20 +436,18 @@ void FrameworkManagerImpl::disableNexusOutput() {
 
 /// Starts asynchronous tasks that are done as part of Start-up.
 void FrameworkManagerImpl::asynchronousStartupTasks() {
-  int instrumentUpdates(0);
-  int retVal = Kernel::ConfigService::Instance().getValue(
-      "UpdateInstrumentDefinitions.OnStartup", instrumentUpdates);
-  if ((retVal == 1) && (instrumentUpdates == 1)) {
+	auto instrumentUpdates = Kernel::ConfigService::Instance().getValue<bool>(
+		"UpdateInstrumentDefinitions.OnStartup");
+
+  if (instrumentUpdates.get_value_or(false)) {
     updateInstrumentDefinitions();
   } else {
     g_log.information() << "Instrument updates disabled - cannot update "
                            "instrument definitions.\n";
   }
 
-  int newVersionCheck(0);
-  int retValVersionCheck = Kernel::ConfigService::Instance().getValue(
-      "CheckMantidVersion.OnStartup", newVersionCheck);
-  if ((retValVersionCheck == 1) && (newVersionCheck == 1)) {
+  auto newVersionCheck = Kernel::ConfigService::Instance().getValue<bool>("CheckMantidVersion.OnStartup");
+  if (newVersionCheck.get_value_or(false)) {
     checkIfNewerVersionIsAvailable();
   } else {
     g_log.information() << "Version check disabled.\n";
@@ -461,16 +457,14 @@ void FrameworkManagerImpl::asynchronousStartupTasks() {
 }
 
 void FrameworkManagerImpl::setupUsageReporting() {
-  int enabled = 0;
-  int interval = 0;
   auto &configSvc = ConfigService::Instance();
-  int retVal = configSvc.getValue("Usage.BufferCheckInterval", interval);
+  auto interval =  configSvc.getValue<int>("Usage.BufferCheckInterval");
   auto &usageSvc = UsageService::Instance();
-  if ((retVal == 1) && (interval > 0)) {
-    usageSvc.setInterval(interval);
+  if (interval.get_value_or(0) > 0) {
+    usageSvc.setInterval(interval.get());
   }
-  retVal = configSvc.getValue("usagereports.enabled", enabled);
-  usageSvc.setEnabled((retVal == 1) && (enabled > 0));
+  auto enabled = configSvc.getValue<bool>("usagereports.enabled");
+  usageSvc.setEnabled(enabled.get_value_or(false));
   usageSvc.registerStartup();
 }
 

--- a/Framework/API/src/FrameworkManager.cpp
+++ b/Framework/API/src/FrameworkManager.cpp
@@ -161,7 +161,8 @@ void FrameworkManagerImpl::loadPlugins() {
  */
 void FrameworkManagerImpl::setNumOMPThreadsToConfigValue() {
   // Set the number of threads to use for this process
-	auto maxCores = Kernel::ConfigService::Instance().getValue<int>("MultiThreaded.MaxCores");
+  auto maxCores =
+      Kernel::ConfigService::Instance().getValue<int>("MultiThreaded.MaxCores");
   if (maxCores.get_value_or(0) > 0) {
     setNumOMPThreads(maxCores.get());
   }
@@ -436,8 +437,8 @@ void FrameworkManagerImpl::disableNexusOutput() {
 
 /// Starts asynchronous tasks that are done as part of Start-up.
 void FrameworkManagerImpl::asynchronousStartupTasks() {
-	auto instrumentUpdates = Kernel::ConfigService::Instance().getValue<bool>(
-		"UpdateInstrumentDefinitions.OnStartup");
+  auto instrumentUpdates = Kernel::ConfigService::Instance().getValue<bool>(
+      "UpdateInstrumentDefinitions.OnStartup");
 
   if (instrumentUpdates.get_value_or(false)) {
     updateInstrumentDefinitions();
@@ -446,7 +447,8 @@ void FrameworkManagerImpl::asynchronousStartupTasks() {
                            "instrument definitions.\n";
   }
 
-  auto newVersionCheck = Kernel::ConfigService::Instance().getValue<bool>("CheckMantidVersion.OnStartup");
+  auto newVersionCheck = Kernel::ConfigService::Instance().getValue<bool>(
+      "CheckMantidVersion.OnStartup");
   if (newVersionCheck.get_value_or(false)) {
     checkIfNewerVersionIsAvailable();
   } else {
@@ -458,7 +460,7 @@ void FrameworkManagerImpl::asynchronousStartupTasks() {
 
 void FrameworkManagerImpl::setupUsageReporting() {
   auto &configSvc = ConfigService::Instance();
-  auto interval =  configSvc.getValue<int>("Usage.BufferCheckInterval");
+  auto interval = configSvc.getValue<int>("Usage.BufferCheckInterval");
   auto &usageSvc = UsageService::Instance();
   if (interval.get_value_or(0) > 0) {
     usageSvc.setInterval(interval.get());

--- a/Framework/API/src/IPowderDiffPeakFunction.cpp
+++ b/Framework/API/src/IPowderDiffPeakFunction.cpp
@@ -26,10 +26,11 @@ IPowderDiffPeakFunction::IPowderDiffPeakFunction()
       m_unitCell(), m_unitCellSize(0.), m_parameterValid(false), mH(0), mK(0),
       mL(0), mHKLSet(false), LATTICEINDEX(9999), HEIGHTINDEX(9999) {
   // Set peak's radius from configuration
-	auto peakRadius = Kernel::ConfigService::Instance().getValue<int>("curvefitting.peakRadius");
-    if (peakRadius.is_initialized() && peakRadius.get() != s_peakRadius) {
-      setPeakRadius(peakRadius.get());
-    }
+  auto peakRadius = Kernel::ConfigService::Instance().getValue<int>(
+      "curvefitting.peakRadius");
+  if (peakRadius.is_initialized() && peakRadius.get() != s_peakRadius) {
+    setPeakRadius(peakRadius.get());
+  }
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/API/src/IPowderDiffPeakFunction.cpp
+++ b/Framework/API/src/IPowderDiffPeakFunction.cpp
@@ -26,13 +26,10 @@ IPowderDiffPeakFunction::IPowderDiffPeakFunction()
       m_unitCell(), m_unitCellSize(0.), m_parameterValid(false), mH(0), mK(0),
       mL(0), mHKLSet(false), LATTICEINDEX(9999), HEIGHTINDEX(9999) {
   // Set peak's radius from configuration
-  int peakRadius;
-  if (Kernel::ConfigService::Instance().getValue("curvefitting.peakRadius",
-                                                 peakRadius)) {
-    if (peakRadius != s_peakRadius) {
-      setPeakRadius(peakRadius);
+	auto peakRadius = Kernel::ConfigService::Instance().getValue<int>("curvefitting.peakRadius");
+    if (peakRadius.is_initialized() && peakRadius.get() != s_peakRadius) {
+      setPeakRadius(peakRadius.get());
     }
-  }
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/API/src/MultipleFileProperty.cpp
+++ b/Framework/API/src/MultipleFileProperty.cpp
@@ -80,8 +80,9 @@ MultipleFileProperty::MultipleFileProperty(const std::string &name,
     m_action = action;
   }
 
-  m_multiFileLoadingEnabled =
-      Kernel::ConfigService::Instance().getValue<bool>("loading.multifile").get_value_or(false);
+  m_multiFileLoadingEnabled = Kernel::ConfigService::Instance()
+                                  .getValue<bool>("loading.multifile")
+                                  .get_value_or(false);
 
   for (const auto &ext : exts)
     if (doesNotContainWildCard(ext))

--- a/Framework/API/src/MultipleFileProperty.cpp
+++ b/Framework/API/src/MultipleFileProperty.cpp
@@ -79,10 +79,9 @@ MultipleFileProperty::MultipleFileProperty(const std::string &name,
   } else {
     m_action = action;
   }
-  std::string allowMultiFileLoading =
-      Kernel::ConfigService::Instance().getString("loading.multifile");
 
-  m_multiFileLoadingEnabled = boost::iequals(allowMultiFileLoading, "On");
+  m_multiFileLoadingEnabled =
+      Kernel::ConfigService::Instance().getValue<bool>("loading.multifile").get_value_or(false);
 
   for (const auto &ext : exts)
     if (doesNotContainWildCard(ext))

--- a/Framework/Algorithms/src/CreateUserDefinedBackground.cpp
+++ b/Framework/Algorithms/src/CreateUserDefinedBackground.cpp
@@ -171,7 +171,9 @@ CreateUserDefinedBackground::createBackgroundWorkspace(
     histogram.setFrequencyStandardDeviations(eBackground);
   } else {
     if (data->isHistogramData() &&
-            Kernel::ConfigService::Instance().getValue<bool>(AUTODISTRIBUTIONKEY).get_value_or(false)) {
+        Kernel::ConfigService::Instance()
+            .getValue<bool>(AUTODISTRIBUTIONKEY)
+            .get_value_or(false)) {
       // Background data is actually frequencies, we put it into temporary to
       // benefit from automatic conversion in setCounts(), etc.
       histogram.setCounts(Frequencies(yBackground), xBinEdges);

--- a/Framework/Algorithms/src/CreateUserDefinedBackground.cpp
+++ b/Framework/Algorithms/src/CreateUserDefinedBackground.cpp
@@ -171,8 +171,7 @@ CreateUserDefinedBackground::createBackgroundWorkspace(
     histogram.setFrequencyStandardDeviations(eBackground);
   } else {
     if (data->isHistogramData() &&
-        "On" ==
-            Kernel::ConfigService::Instance().getString(AUTODISTRIBUTIONKEY)) {
+            Kernel::ConfigService::Instance().getValue<bool>(AUTODISTRIBUTIONKEY).get_value_or(false)) {
       // Background data is actually frequencies, we put it into temporary to
       // benefit from automatic conversion in setCounts(), etc.
       histogram.setCounts(Frequencies(yBackground), xBinEdges);

--- a/Framework/CurveFitting/src/Functions/PawleyFunction.cpp
+++ b/Framework/CurveFitting/src/Functions/PawleyFunction.cpp
@@ -317,11 +317,8 @@ PawleyFunction::PawleyFunction()
     : IPawleyFunction(), m_compositeFunction(), m_pawleyParameterFunction(),
       m_peakProfileComposite(), m_hkls(), m_dUnit(), m_wsUnit(),
       m_peakRadius(5) {
-  int peakRadius;
-  if (Kernel::ConfigService::Instance().getValue("curvefitting.peakRadius",
-                                                 peakRadius)) {
-    m_peakRadius = peakRadius;
-  }
+	auto peakRadius = Kernel::ConfigService::Instance().getValue<int>("curvefitting.peakRadius");
+	m_peakRadius = peakRadius.get_value_or(5);
 }
 
 void PawleyFunction::setMatrixWorkspace(

--- a/Framework/CurveFitting/src/Functions/PawleyFunction.cpp
+++ b/Framework/CurveFitting/src/Functions/PawleyFunction.cpp
@@ -317,8 +317,9 @@ PawleyFunction::PawleyFunction()
     : IPawleyFunction(), m_compositeFunction(), m_pawleyParameterFunction(),
       m_peakProfileComposite(), m_hkls(), m_dUnit(), m_wsUnit(),
       m_peakRadius(5) {
-	auto peakRadius = Kernel::ConfigService::Instance().getValue<int>("curvefitting.peakRadius");
-	m_peakRadius = peakRadius.get_value_or(5);
+  auto peakRadius = Kernel::ConfigService::Instance().getValue<int>(
+      "curvefitting.peakRadius");
+  m_peakRadius = peakRadius.get_value_or(5);
 }
 
 void PawleyFunction::setMatrixWorkspace(

--- a/Framework/DataHandling/src/LoadInstrumentFromNexus.cpp
+++ b/Framework/DataHandling/src/LoadInstrumentFromNexus.cpp
@@ -75,7 +75,8 @@ void LoadInstrumentFromNexus::exec() {
   instrument->add(source);
   instrument->markAsSource(source);
   // If user has provided an L1, use that
-  auto l1ConfigVal = Kernel::ConfigService::Instance().getValue<double>("instrument.L1");
+  auto l1ConfigVal =
+      Kernel::ConfigService::Instance().getValue<double>("instrument.L1");
   // Otherwise try and get it from the nexus file - but not there at present!
   // l1 = nxload.ivpb.i_l1;
   // Default to 10 if the file doesn't have it set

--- a/Framework/DataHandling/src/LoadInstrumentFromNexus.cpp
+++ b/Framework/DataHandling/src/LoadInstrumentFromNexus.cpp
@@ -74,15 +74,13 @@ void LoadInstrumentFromNexus::exec() {
       new Geometry::ObjComponent("Unknown", instrument.get());
   instrument->add(source);
   instrument->markAsSource(source);
-  double l1 = 0.0;
   // If user has provided an L1, use that
-  if (!Kernel::ConfigService::Instance().getValue("instrument.L1", l1)) {
-    // Otherwise try and get it from the nexus file - but not there at present!
-    // l1 = nxload.ivpb.i_l1;
-    // Default to 10 if the file doesn't have it set
-    if (l1 == 0)
-      l1 = 10.0;
-  }
+  auto l1ConfigVal = Kernel::ConfigService::Instance().getValue<double>("instrument.L1");
+  // Otherwise try and get it from the nexus file - but not there at present!
+  // l1 = nxload.ivpb.i_l1;
+  // Default to 10 if the file doesn't have it set
+  double l1 = l1ConfigVal.get_value_or(10.0);
+
   source->setPos(0.0, -1.0 * l1, 0.0);
   localWorkspace->setInstrument(instrument);
   progress(1.0);

--- a/Framework/DataHandling/src/LoadInstrumentFromRaw.cpp
+++ b/Framework/DataHandling/src/LoadInstrumentFromRaw.cpp
@@ -84,14 +84,15 @@ void LoadInstrumentFromRaw::exec() {
   instrument->markAsSource(source);
 
   progress(0.5);
-	  // If user has provided an L1, use that
-  auto l1ConfigValue = Kernel::ConfigService::Instance().getValue<double>("instrument.L1");
-    // Otherwise try and get it from the raw file
-    double l1 = l1ConfigValue.get_value_or(iraw.ivpb.i_l1);
-    // Default to 10 if the raw file doesn't have it set
-    if (l1 == 0)
-      l1 = 10.0;
-  
+  // If user has provided an L1, use that
+  auto l1ConfigValue =
+      Kernel::ConfigService::Instance().getValue<double>("instrument.L1");
+  // Otherwise try and get it from the raw file
+  double l1 = l1ConfigValue.get_value_or(iraw.ivpb.i_l1);
+  // Default to 10 if the raw file doesn't have it set
+  if (l1 == 0)
+    l1 = 10.0;
+
   source->setPos(0.0, 0.0, -1.0 * l1);
 
   // add detectors

--- a/Framework/DataHandling/src/LoadInstrumentFromRaw.cpp
+++ b/Framework/DataHandling/src/LoadInstrumentFromRaw.cpp
@@ -84,15 +84,14 @@ void LoadInstrumentFromRaw::exec() {
   instrument->markAsSource(source);
 
   progress(0.5);
-  double l1;
-  // If user has provided an L1, use that
-  if (!Kernel::ConfigService::Instance().getValue("instrument.L1", l1)) {
+	  // If user has provided an L1, use that
+  auto l1ConfigValue = Kernel::ConfigService::Instance().getValue<double>("instrument.L1");
     // Otherwise try and get it from the raw file
-    l1 = iraw.ivpb.i_l1;
+    double l1 = l1ConfigValue.get_value_or(iraw.ivpb.i_l1);
     // Default to 10 if the raw file doesn't have it set
     if (l1 == 0)
       l1 = 10.0;
-  }
+  
   source->setPos(0.0, 0.0, -1.0 * l1);
 
   // add detectors

--- a/Framework/DataHandling/src/LoadRaw/isisraw2.cpp
+++ b/Framework/DataHandling/src/LoadRaw/isisraw2.cpp
@@ -18,14 +18,16 @@ ISISRAW2::ISISRAW2()
     : ISISRAW(nullptr, false), ndes(0), outbuff(nullptr), m_bufferSize(0) {
   // Determine the size of the output buffer to create from the config service.
   g_log.debug("Determining ioRaw buffer size\n");
-  auto bufferSizeConfigVal = Mantid::Kernel::ConfigService::Instance().getValue<int>("loadraw.readbuffer.size");
+  auto bufferSizeConfigVal =
+      Mantid::Kernel::ConfigService::Instance().getValue<int>(
+          "loadraw.readbuffer.size");
 
-if (!bufferSizeConfigVal.is_initialized()){
+  if (!bufferSizeConfigVal.is_initialized()) {
     m_bufferSize = 200000;
     g_log.debug() << "loadraw.readbuffer.size not found, setting to "
                   << m_bufferSize << "\n";
   } else {
-	m_bufferSize = bufferSizeConfigVal.get();
+    m_bufferSize = bufferSizeConfigVal.get();
     g_log.debug() << "loadraw.readbuffer.size set to " << m_bufferSize << "\n";
   }
 }

--- a/Framework/DataHandling/src/LoadRaw/isisraw2.cpp
+++ b/Framework/DataHandling/src/LoadRaw/isisraw2.cpp
@@ -18,12 +18,14 @@ ISISRAW2::ISISRAW2()
     : ISISRAW(nullptr, false), ndes(0), outbuff(nullptr), m_bufferSize(0) {
   // Determine the size of the output buffer to create from the config service.
   g_log.debug("Determining ioRaw buffer size\n");
-  if (Mantid::Kernel::ConfigService::Instance().getValue(
-          "loadraw.readbuffer.size", m_bufferSize) == 0) {
+  auto bufferSizeConfigVal = Mantid::Kernel::ConfigService::Instance().getValue<int>("loadraw.readbuffer.size");
+
+if (!bufferSizeConfigVal.is_initialized()){
     m_bufferSize = 200000;
     g_log.debug() << "loadraw.readbuffer.size not found, setting to "
                   << m_bufferSize << "\n";
   } else {
+	m_bufferSize = bufferSizeConfigVal.get();
     g_log.debug() << "loadraw.readbuffer.size set to " << m_bufferSize << "\n";
   }
 }

--- a/Framework/DataObjects/src/PeakColumn.cpp
+++ b/Framework/DataObjects/src/PeakColumn.cpp
@@ -84,10 +84,10 @@ PeakColumn::PeakColumn(std::vector<Peak> &peaks, const std::string &name)
   auto hklPrec = ConfigService::Instance().getValue<int>(key);
   this->m_hklPrec = hklPrec.get_value_or(2);
   if (!hklPrec.is_initialized()) {
-	  g_log.information()
-		  << "In PeakColumn constructor, did not find any value for '" << key
-		  << "' from the Config Service. Using default: " << this->m_hklPrec
-		  << "\n";
+    g_log.information()
+        << "In PeakColumn constructor, did not find any value for '" << key
+        << "' from the Config Service. Using default: " << this->m_hklPrec
+        << "\n";
   }
 }
 

--- a/Framework/DataObjects/src/PeakColumn.cpp
+++ b/Framework/DataObjects/src/PeakColumn.cpp
@@ -80,14 +80,15 @@ PeakColumn::PeakColumn(std::vector<Peak> &peaks, const std::string &name)
     : m_peaks(peaks), m_oldRows() {
   this->m_name = name;
   this->m_type = typeFromName(name); // Throws if the name is unknown
-  this->m_hklPrec = 2;
   const std::string key = "PeakColumn.hklPrec";
-  int gotit = ConfigService::Instance().getValue(key, this->m_hklPrec);
-  if (!gotit)
-    g_log.information()
-        << "In PeakColumn constructor, did not find any value for '" << key
-        << "' from the Config Service. Using default: " << this->m_hklPrec
-        << "\n";
+  auto hklPrec = ConfigService::Instance().getValue<int>(key);
+  this->m_hklPrec = hklPrec.get_value_or(2);
+  if (!hklPrec.is_initialized()) {
+	  g_log.information()
+		  << "In PeakColumn constructor, did not find any value for '" << key
+		  << "' from the Config Service. Using default: " << this->m_hklPrec
+		  << "\n";
+  }
 }
 
 /// Returns typeid for the data in the column

--- a/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -7,13 +7,16 @@
 #include "MantidKernel/DllConfig.h"
 #include "MantidKernel/SingletonHolder.h"
 #include "MantidKernel/ProxyInfo.h"
+
+#include <Poco/Notification.h>
+#include <Poco/NotificationCenter.h>
+
+#include <boost/optional/optional.hpp>
+
 #include <map>
 #include <set>
 #include <string>
 #include <vector>
-
-#include <Poco/Notification.h>
-#include <Poco/NotificationCenter.h>
 
 //----------------------------------------------------------------------
 // Forward declarations
@@ -150,7 +153,7 @@ public:
   /// Sets a configuration property
   void setString(const std::string &key, const std::string &value);
   // Searches for a configuration property and returns its value
-  template <typename T> int getValue(const std::string &keyName, T &out);
+  template <typename T> boost::optional<T> getValue(const std::string &keyName);
   /// Return the local properties filename.
   std::string getLocalFilename() const;
   /// Return the user properties filename

--- a/Framework/Kernel/inc/MantidKernel/DataService.h
+++ b/Framework/Kernel/inc/MantidKernel/DataService.h
@@ -503,14 +503,8 @@ public:
   }
 
   static bool showingHiddenObjects() {
-    int showingHiddenFlag;
-    const int success = ConfigService::Instance().getValue(
-        "MantidOptions.InvisibleWorkspaces", showingHiddenFlag);
-    if (success == 1 && showingHiddenFlag == 1) {
-      return true;
-    } else {
-      return false;
-    }
+    auto showingHiddenFlag = ConfigService::Instance().getValue<bool>("MantidOptions.InvisibleWorkspaces");
+	return showingHiddenFlag.get_value_or(false);
   }
 
   /// Sends notifications to observers. Observers can subscribe to

--- a/Framework/Kernel/inc/MantidKernel/DataService.h
+++ b/Framework/Kernel/inc/MantidKernel/DataService.h
@@ -503,8 +503,9 @@ public:
   }
 
   static bool showingHiddenObjects() {
-    auto showingHiddenFlag = ConfigService::Instance().getValue<bool>("MantidOptions.InvisibleWorkspaces");
-	return showingHiddenFlag.get_value_or(false);
+    auto showingHiddenFlag = ConfigService::Instance().getValue<bool>(
+        "MantidOptions.InvisibleWorkspaces");
+    return showingHiddenFlag.get_value_or(false);
   }
 
   /// Sends notifications to observers. Observers can subscribe to

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -938,15 +938,13 @@ std::string ConfigServiceImpl::getString(const std::string &keyName,
       return (*mitr).second;
     }
   }
-  std::string retVal;
-  try {
-    retVal = m_pConf->getString(keyName);
-  } catch (Poco::NotFoundException &) {
-    g_log.debug() << "Unable to find " << keyName << " in the properties file"
-                  << '\n';
-    retVal = "";
+  if (m_pConf->hasProperty(keyName)) {
+	  return m_pConf->getString(keyName);
   }
-  return retVal;
+
+  g_log.debug() << "Unable to find " << keyName << " in the properties file"
+				<< '\n';
+  return;
 }
 
 /** Searches for keys within the currently loaded configuaration values and

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -42,6 +42,7 @@
 #include <Poco/PipeStream.h>
 #include <Poco/StreamCopier.h>
 
+#include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/regex.hpp>
 #include <boost/optional/optional.hpp>
@@ -1139,12 +1140,16 @@ boost::optional<bool> ConfigServiceImpl::getValue(const std::string &keyName) {
     return boost::none;
   }
 
-  std::transform(returnedValue->begin(), returnedValue->end(),
-                 returnedValue->begin(), ::tolower);
+  auto &configVal = returnedValue.get();
 
-  bool trueString = returnedValue->find("true") != std::string::npos;
-  bool valueOne = returnedValue->find("1") != std::string::npos;
-  bool onOffString = returnedValue->find("on") != std::string::npos;
+  std::transform(configVal.begin(), configVal.end(),
+				 configVal.begin(), ::tolower);
+
+  boost::trim(configVal);
+
+  bool trueString = configVal == "true";
+  bool valueOne = configVal == "1";
+  bool onOffString = configVal == "on";
 
   // A string of 1 or true both count
   return trueString || valueOne || onOffString;

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1119,9 +1119,9 @@ boost::optional<T> ConfigServiceImpl::getValue(const std::string &keyName) {
   int result = Mantid::Kernel::Strings::convert(strValue, output);
 
   if (result != 1) {
-	  return boost::none;
+    return boost::none;
   }
-  
+
   return boost::optional<T>(output);
 }
 
@@ -1134,19 +1134,20 @@ boost::optional<T> ConfigServiceImpl::getValue(const std::string &keyName) {
 */
 template <>
 boost::optional<bool> ConfigServiceImpl::getValue(const std::string &keyName) {
-	auto returnedValue = getValue<std::string>(keyName);
-	if (!returnedValue.is_initialized()) {
-		return boost::none;
-	}
+  auto returnedValue = getValue<std::string>(keyName);
+  if (!returnedValue.is_initialized()) {
+    return boost::none;
+  }
 
-  std::transform(returnedValue->begin(), returnedValue->end(), returnedValue->begin(), ::tolower);
+  std::transform(returnedValue->begin(), returnedValue->end(),
+                 returnedValue->begin(), ::tolower);
 
-	bool trueString = returnedValue->find("true") != std::string::npos;
-	bool valueOne = returnedValue->find("1") != std::string::npos;
+  bool trueString = returnedValue->find("true") != std::string::npos;
+  bool valueOne = returnedValue->find("1") != std::string::npos;
   bool onOffString = returnedValue->find("on") != std::string::npos;
 
-	// A string of 1 or true both count
-	return trueString || valueOne || onOffString;
+  // A string of 1 or true both count
+  return trueString || valueOne || onOffString;
 }
 
 /**
@@ -2020,12 +2021,10 @@ Kernel::ProxyInfo &ConfigServiceImpl::getProxy(const std::string &url) {
   if (!m_isProxySet) {
     // set the proxy
     // first check if the proxy is defined in the properties file
-	  auto proxyHost = getValue<std::string>("proxy.host");
-	  auto proxyPort = getValue<int>("proxy.port");
+    auto proxyHost = getValue<std::string>("proxy.host");
+    auto proxyPort = getValue<int>("proxy.port");
 
-
-
-    if ( proxyHost.is_initialized() && proxyPort.is_initialized()) {
+    if (proxyHost.is_initialized() && proxyPort.is_initialized()) {
       // set it from the config values
       m_proxyInfo = ProxyInfo(proxyHost.get(), proxyPort.get(), true);
     } else {
@@ -2116,11 +2115,16 @@ int ConfigServiceImpl::FindLowestFilterLevel() const {
 }
 
 /// \cond TEMPLATE
-template DLLExport boost::optional<double> ConfigServiceImpl::getValue(const std::string &);
-template DLLExport boost::optional<std::string> ConfigServiceImpl::getValue(const std::string &);
-template DLLExport boost::optional<int> ConfigServiceImpl::getValue(const std::string &);
-template DLLExport boost::optional<size_t> ConfigServiceImpl::getValue(const std::string &);
-template DLLExport boost::optional<bool> ConfigServiceImpl::getValue(const std::string &);
+template DLLExport boost::optional<double>
+ConfigServiceImpl::getValue(const std::string &);
+template DLLExport boost::optional<std::string>
+ConfigServiceImpl::getValue(const std::string &);
+template DLLExport boost::optional<int>
+ConfigServiceImpl::getValue(const std::string &);
+template DLLExport boost::optional<size_t>
+ConfigServiceImpl::getValue(const std::string &);
+template DLLExport boost::optional<bool>
+ConfigServiceImpl::getValue(const std::string &);
 /// \endcond TEMPLATE
 
 } // namespace Kernel

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1142,8 +1142,8 @@ boost::optional<bool> ConfigServiceImpl::getValue(const std::string &keyName) {
 
   auto &configVal = returnedValue.get();
 
-  std::transform(configVal.begin(), configVal.end(),
-				 configVal.begin(), ::tolower);
+  std::transform(configVal.begin(), configVal.end(), configVal.begin(),
+                 ::tolower);
 
   boost::trim(configVal);
 

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -939,11 +939,11 @@ std::string ConfigServiceImpl::getString(const std::string &keyName,
     }
   }
   if (m_pConf->hasProperty(keyName)) {
-	  return m_pConf->getString(keyName);
+    return m_pConf->getString(keyName);
   }
 
   g_log.debug() << "Unable to find " << keyName << " in the properties file"
-				<< '\n';
+                << '\n';
   return;
 }
 

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -944,7 +944,7 @@ std::string ConfigServiceImpl::getString(const std::string &keyName,
 
   g_log.debug() << "Unable to find " << keyName << " in the properties file"
                 << '\n';
-  return;
+  return {};
 }
 
 /** Searches for keys within the currently loaded configuaration values and

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1139,11 +1139,14 @@ boost::optional<bool> ConfigServiceImpl::getValue(const std::string &keyName) {
 		return boost::none;
 	}
 
+  std::transform(returnedValue->begin(), returnedValue->end(), returnedValue->begin(), ::tolower);
+
 	bool trueString = returnedValue->find("true") != std::string::npos;
 	bool valueOne = returnedValue->find("1") != std::string::npos;
+  bool onOffString = returnedValue->find("on") != std::string::npos;
 
 	// A string of 1 or true both count
-	return trueString || valueOne;
+	return trueString || valueOne || onOffString;
 }
 
 /**

--- a/Framework/Kernel/src/ErrorReporter.cpp
+++ b/Framework/Kernel/src/ErrorReporter.cpp
@@ -38,12 +38,12 @@ ErrorReporter::ErrorReporter(std::string application,
                              std::string email)
     : m_application(application), m_exitCode(exitCode), m_upTime(upTime),
       m_share(share), m_name(name), m_email(email) {
-	auto url = Mantid::Kernel::ConfigService::Instance().getValue<std::string>("errorreports.rooturl");
+  auto url = Mantid::Kernel::ConfigService::Instance().getValue<std::string>(
+      "errorreports.rooturl");
   if (!url.is_initialized()) {
     g_log.debug() << "Failed to load error report url\n";
-  }
-  else {
-	m_url = url.get();
+  } else {
+    m_url = url.get();
   }
 }
 

--- a/Framework/Kernel/src/ErrorReporter.cpp
+++ b/Framework/Kernel/src/ErrorReporter.cpp
@@ -38,10 +38,12 @@ ErrorReporter::ErrorReporter(std::string application,
                              std::string email)
     : m_application(application), m_exitCode(exitCode), m_upTime(upTime),
       m_share(share), m_name(name), m_email(email) {
-  int retval = Mantid::Kernel::ConfigService::Instance().getValue(
-      "errorreports.rooturl", m_url);
-  if (retval == 0) {
+	auto url = Mantid::Kernel::ConfigService::Instance().getValue<std::string>("errorreports.rooturl");
+  if (!url.is_initialized()) {
     g_log.debug() << "Failed to load error report url\n";
+  }
+  else {
+	m_url = url.get();
   }
 }
 

--- a/Framework/Kernel/src/InternetHelper.cpp
+++ b/Framework/Kernel/src/InternetHelper.cpp
@@ -477,8 +477,8 @@ void InternetHelper::throwNotConnected(const std::string &url,
 **/
 int InternetHelper::getTimeout() {
   if (!m_isTimeoutSet) {
-    if (!ConfigService::Instance().getValue("network.default.timeout",
-                                            m_timeout)) {
+	  auto m_timeout = ConfigService::Instance().getValue<int>("network.default.timeout");
+	  if (!m_timeout.is_initialized()) {
       m_timeout = 30; // the default value if the key is not found
     }
   }

--- a/Framework/Kernel/src/InternetHelper.cpp
+++ b/Framework/Kernel/src/InternetHelper.cpp
@@ -477,8 +477,9 @@ void InternetHelper::throwNotConnected(const std::string &url,
 **/
 int InternetHelper::getTimeout() {
   if (!m_isTimeoutSet) {
-	  auto m_timeout = ConfigService::Instance().getValue<int>("network.default.timeout");
-	  if (!m_timeout.is_initialized()) {
+    auto m_timeout =
+        ConfigService::Instance().getValue<int>("network.default.timeout");
+    if (!m_timeout.is_initialized()) {
       m_timeout = 30; // the default value if the key is not found
     }
   }

--- a/Framework/Kernel/src/MultiFileNameParser.cpp
+++ b/Framework/Kernel/src/MultiFileNameParser.cpp
@@ -549,9 +549,8 @@ generateRange(unsigned int const from, unsigned int const to,
         "Unable to generate a range with a step size of zero.");
 
   size_t limit;
-  std::string limitStr;
-  ConfigService::Instance().getValue("loading.multifilelimit", limitStr);
-  if (!Strings::convert(limitStr, limit)) {
+  auto limitStr = ConfigService::Instance().getValue<std::string>("loading.multifilelimit");
+  if (!limitStr.is_initialized() || !Strings::convert(limitStr.get(), limit)) {
     limit = ConfigService::Instance().getFacility().multiFileLimit();
   }
 

--- a/Framework/Kernel/src/MultiFileNameParser.cpp
+++ b/Framework/Kernel/src/MultiFileNameParser.cpp
@@ -549,7 +549,8 @@ generateRange(unsigned int const from, unsigned int const to,
         "Unable to generate a range with a step size of zero.");
 
   size_t limit;
-  auto limitStr = ConfigService::Instance().getValue<std::string>("loading.multifilelimit");
+  auto limitStr =
+      ConfigService::Instance().getValue<std::string>("loading.multifilelimit");
   if (!limitStr.is_initialized() || !Strings::convert(limitStr.get(), limit)) {
     limit = ConfigService::Instance().getFacility().multiFileLimit();
   }

--- a/Framework/Kernel/src/ThreadPool.cpp
+++ b/Framework/Kernel/src/ThreadPool.cpp
@@ -73,7 +73,8 @@ size_t ThreadPool::getNumPhysicalCores() {
   int physicalCores = PARALLEL_GET_MAX_THREADS;
 #endif
 
-  auto maxCores = Kernel::ConfigService::Instance().getValue<int>("MultiThreaded.MaxCores");
+  auto maxCores =
+      Kernel::ConfigService::Instance().getValue<int>("MultiThreaded.MaxCores");
 
   if (!maxCores.is_initialized())
     return std::min(maxCores.get_value_or(0), physicalCores);

--- a/Framework/Kernel/src/ThreadPool.cpp
+++ b/Framework/Kernel/src/ThreadPool.cpp
@@ -73,11 +73,10 @@ size_t ThreadPool::getNumPhysicalCores() {
   int physicalCores = PARALLEL_GET_MAX_THREADS;
 #endif
 
-  int maxCores(0);
-  int retVal = Kernel::ConfigService::Instance().getValue(
-      "MultiThreaded.MaxCores", maxCores);
-  if (retVal > 0 && maxCores > 0)
-    return std::min(maxCores, physicalCores);
+  auto maxCores = Kernel::ConfigService::Instance().getValue<int>("MultiThreaded.MaxCores");
+
+  if (!maxCores.is_initialized())
+    return std::min(maxCores.get_value_or(0), physicalCores);
   else
     return physicalCores;
 }

--- a/Framework/Kernel/src/UsageService.cpp
+++ b/Framework/Kernel/src/UsageService.cpp
@@ -65,11 +65,12 @@ UsageServiceImpl::UsageServiceImpl()
       m_startupActiveMethod(this, &UsageServiceImpl::sendStartupAsyncImpl),
       m_featureActiveMethod(this, &UsageServiceImpl::sendFeatureAsyncImpl) {
   setInterval(60);
-  auto url = Mantid::Kernel::ConfigService::Instance().getValue<std::string>("usagereports.rooturl");
+  auto url = Mantid::Kernel::ConfigService::Instance().getValue<std::string>(
+      "usagereports.rooturl");
   if (!url.is_initialized()) {
     g_log.debug() << "Failed to load usage report url\n";
   } else {
-	m_url = url.get();
+    m_url = url.get();
     g_log.debug() << "Root usage reporting url is " << m_url << "\n";
   }
   m_startTime = Types::Core::DateAndTime::getCurrentTime();

--- a/Framework/Kernel/src/UsageService.cpp
+++ b/Framework/Kernel/src/UsageService.cpp
@@ -65,11 +65,11 @@ UsageServiceImpl::UsageServiceImpl()
       m_startupActiveMethod(this, &UsageServiceImpl::sendStartupAsyncImpl),
       m_featureActiveMethod(this, &UsageServiceImpl::sendFeatureAsyncImpl) {
   setInterval(60);
-  int retval = Mantid::Kernel::ConfigService::Instance().getValue(
-      "usagereports.rooturl", m_url);
-  if (retval == 0) {
+  auto url = Mantid::Kernel::ConfigService::Instance().getValue<std::string>("usagereports.rooturl");
+  if (!url.is_initialized()) {
     g_log.debug() << "Failed to load usage report url\n";
   } else {
+	m_url = url.get();
     g_log.debug() << "Root usage reporting url is " << m_url << "\n";
   }
   m_startTime = Types::Core::DateAndTime::getCurrentTime();

--- a/Framework/Kernel/test/ConfigServiceTest.h
+++ b/Framework/Kernel/test/ConfigServiceTest.h
@@ -386,10 +386,8 @@ public:
 
   void TestCustomPropertyAsValue() {
     // Mantid.legs is defined in the properties script as 6
-    int value = 0;
-    ConfigService::Instance().getValue("algorithms.retained", value);
-    double dblValue = 0;
-    ConfigService::Instance().getValue("algorithms.retained", dblValue);
+    int value = ConfigService::Instance().getValue<int>("algorithms.retained").get_value_or(0);
+    double dblValue = ConfigService::Instance().getValue<double>("algorithms.retained").get_value_or(0);
 
     TS_ASSERT_EQUALS(value, 50);
     TS_ASSERT_EQUALS(dblValue, 50.0);

--- a/Framework/Kernel/test/ConfigServiceTest.h
+++ b/Framework/Kernel/test/ConfigServiceTest.h
@@ -386,8 +386,12 @@ public:
 
   void TestCustomPropertyAsValue() {
     // Mantid.legs is defined in the properties script as 6
-    int value = ConfigService::Instance().getValue<int>("algorithms.retained").get_value_or(0);
-    double dblValue = ConfigService::Instance().getValue<double>("algorithms.retained").get_value_or(0);
+    int value = ConfigService::Instance()
+                    .getValue<int>("algorithms.retained")
+                    .get_value_or(0);
+    double dblValue = ConfigService::Instance()
+                          .getValue<double>("algorithms.retained")
+                          .get_value_or(0);
 
     TS_ASSERT_EQUALS(value, 50);
     TS_ASSERT_EQUALS(dblValue, 50.0);

--- a/Framework/LiveData/src/FakeEventDataListener.cpp
+++ b/Framework/LiveData/src/FakeEventDataListener.cpp
@@ -20,17 +20,16 @@ DECLARE_LISTENER(FakeEventDataListener)
 FakeEventDataListener::FakeEventDataListener()
     : LiveListener(), m_buffer(), m_rand(new Kernel::MersenneTwister(5489)),
       m_timer(), m_callbackloop(1), m_numExtractDataCalls(0), m_runNumber(1) {
-  if (!ConfigService::Instance().getValue("fakeeventdatalistener.datarate",
-                                          m_datarate))
-    m_datarate = 200; // Default data rate. Low so that our lowest-powered
+	
+	auto datarateConfigVal = ConfigService::Instance().getValue<int>("fakeeventdatalistener.datarate");
+    m_datarate = datarateConfigVal.get_value_or(200); // Default data rate. Low so that our lowest-powered
                       // buildserver can cope.
   // For auto-ending and restarting runs
-  if (!ConfigService::Instance().getValue("fakeeventdatalistener.endrunevery",
-                                          m_endRunEvery))
-    m_endRunEvery = 0;
-  if (!ConfigService::Instance().getValue("fakeeventdatalistener.notyettimes",
-                                          m_notyettimes))
-    m_notyettimes = 0;
+	auto endRunEveryConfigVal = ConfigService::Instance().getValue<int>("fakeeventdatalistener.endrunevery");
+    m_endRunEvery = endRunEveryConfigVal.get_value_or(0);
+
+	auto notyettimesConfigVal = ConfigService::Instance().getValue<int>("fakeeventdatalistener.notyettimes");
+    m_notyettimes = notyettimesConfigVal.get_value_or(0);
 }
 
 /// Destructor

--- a/Framework/LiveData/src/FakeEventDataListener.cpp
+++ b/Framework/LiveData/src/FakeEventDataListener.cpp
@@ -20,16 +20,20 @@ DECLARE_LISTENER(FakeEventDataListener)
 FakeEventDataListener::FakeEventDataListener()
     : LiveListener(), m_buffer(), m_rand(new Kernel::MersenneTwister(5489)),
       m_timer(), m_callbackloop(1), m_numExtractDataCalls(0), m_runNumber(1) {
-	
-	auto datarateConfigVal = ConfigService::Instance().getValue<int>("fakeeventdatalistener.datarate");
-    m_datarate = datarateConfigVal.get_value_or(200); // Default data rate. Low so that our lowest-powered
-                      // buildserver can cope.
-  // For auto-ending and restarting runs
-	auto endRunEveryConfigVal = ConfigService::Instance().getValue<int>("fakeeventdatalistener.endrunevery");
-    m_endRunEvery = endRunEveryConfigVal.get_value_or(0);
 
-	auto notyettimesConfigVal = ConfigService::Instance().getValue<int>("fakeeventdatalistener.notyettimes");
-    m_notyettimes = notyettimesConfigVal.get_value_or(0);
+  auto datarateConfigVal =
+      ConfigService::Instance().getValue<int>("fakeeventdatalistener.datarate");
+  m_datarate = datarateConfigVal.get_value_or(
+      200); // Default data rate. Low so that our lowest-powered
+            // buildserver can cope.
+            // For auto-ending and restarting runs
+  auto endRunEveryConfigVal = ConfigService::Instance().getValue<int>(
+      "fakeeventdatalistener.endrunevery");
+  m_endRunEvery = endRunEveryConfigVal.get_value_or(0);
+
+  auto notyettimesConfigVal = ConfigService::Instance().getValue<int>(
+      "fakeeventdatalistener.notyettimes");
+  m_notyettimes = notyettimesConfigVal.get_value_or(0);
 }
 
 /// Destructor

--- a/Framework/LiveData/src/FileEventDataListener.cpp
+++ b/Framework/LiveData/src/FileEventDataListener.cpp
@@ -53,11 +53,11 @@ FileEventDataListener::FileEventDataListener()
     }
   }
 
-  if (!ConfigService::Instance().getValue("fileeventdatalistener.chunks",
-                                          m_numChunks)) {
+  auto numChunks = ConfigService::Instance().getValue<int>("fileeventdatalistener.chunks");
+  m_numChunks = numChunks.get_value_or(0);
+  if (!numChunks.is_initialized()) {
     g_log.error("Configuration property fileeventdatalistener.chunks not "
                 "found. The algorithm will fail!");
-    m_numChunks = 0; // Set it to 0 so the algorithm just fails
   }
 
   // Add an integer, incremented for each listener instance, to the temporary

--- a/Framework/LiveData/src/FileEventDataListener.cpp
+++ b/Framework/LiveData/src/FileEventDataListener.cpp
@@ -53,7 +53,8 @@ FileEventDataListener::FileEventDataListener()
     }
   }
 
-  auto numChunks = ConfigService::Instance().getValue<int>("fileeventdatalistener.chunks");
+  auto numChunks =
+      ConfigService::Instance().getValue<int>("fileeventdatalistener.chunks");
   m_numChunks = numChunks.get_value_or(0);
   if (!numChunks.is_initialized()) {
     g_log.error("Configuration property fileeventdatalistener.chunks not "

--- a/Framework/LiveData/src/ISIS/DAE/isisds_command.cpp
+++ b/Framework/LiveData/src/ISIS/DAE/isisds_command.cpp
@@ -161,12 +161,9 @@ SOCKET isisds_send_open(const char *host, ISISDSAccessMode access_type,
     return INVALID_SOCKET;
   }
 
-  int timeoutinSec = 120;
-  if (!Mantid::Kernel::ConfigService::Instance().getValue("ISISDAE.Timeout",
-                                                          timeoutinSec) ||
-      timeoutinSec < 1) {
-    timeoutinSec = 120; // Default to  120 seconds if not specified
-  }
+  auto timeoutInSecConfigVal = Mantid::Kernel::ConfigService::Instance().getValue<int>("ISISDAE.Timeout");
+  int timeoutinSec = timeoutInSecConfigVal.get_value_or(120); // Default to  120 seconds if not specified
+
 #ifdef WIN32
   // WINDOWS
   DWORD timeout = timeoutinSec * 1000;

--- a/Framework/LiveData/src/ISIS/DAE/isisds_command.cpp
+++ b/Framework/LiveData/src/ISIS/DAE/isisds_command.cpp
@@ -161,8 +161,11 @@ SOCKET isisds_send_open(const char *host, ISISDSAccessMode access_type,
     return INVALID_SOCKET;
   }
 
-  auto timeoutInSecConfigVal = Mantid::Kernel::ConfigService::Instance().getValue<int>("ISISDAE.Timeout");
-  int timeoutinSec = timeoutInSecConfigVal.get_value_or(120); // Default to  120 seconds if not specified
+  auto timeoutInSecConfigVal =
+      Mantid::Kernel::ConfigService::Instance().getValue<int>(
+          "ISISDAE.Timeout");
+  int timeoutinSec = timeoutInSecConfigVal.get_value_or(
+      120); // Default to  120 seconds if not specified
 
 #ifdef WIN32
   // WINDOWS

--- a/Framework/LiveData/src/SNSLiveEventDataListener.cpp
+++ b/Framework/LiveData/src/SNSLiveEventDataListener.cpp
@@ -90,14 +90,10 @@ SNSLiveEventDataListener::SNSLiveEventDataListener()
   // Initialize m_keepPausedEvents from the config file.
   // NOTE: To the best of my knowledge, the existence of this property is not
   // documented anywhere and this lack of documentation is deliberate.
-  int keepPausedEvents;
-  if (ConfigService::Instance().getValue("livelistener.keeppausedevents",
-                                         keepPausedEvents)) {
-    m_keepPausedEvents = (keepPausedEvents != 0);
-  } else {
-    // If the property hasn't been set, assume false
-    m_keepPausedEvents = false;
-  }
+  auto keepPausedEvents = ConfigService::Instance().getValue<bool>("livelistener.keeppausedevents");
+
+  // If the property hasn't been set, assume false
+  m_keepPausedEvents = keepPausedEvents.get_value_or(false);
 }
 
 /// Destructor

--- a/Framework/LiveData/src/SNSLiveEventDataListener.cpp
+++ b/Framework/LiveData/src/SNSLiveEventDataListener.cpp
@@ -90,7 +90,8 @@ SNSLiveEventDataListener::SNSLiveEventDataListener()
   // Initialize m_keepPausedEvents from the config file.
   // NOTE: To the best of my knowledge, the existence of this property is not
   // documented anywhere and this lack of documentation is deliberate.
-  auto keepPausedEvents = ConfigService::Instance().getValue<bool>("livelistener.keeppausedevents");
+  auto keepPausedEvents =
+      ConfigService::Instance().getValue<bool>("livelistener.keeppausedevents");
 
   // If the property hasn't been set, assume false
   m_keepPausedEvents = keepPausedEvents.get_value_or(false);

--- a/Framework/LiveData/test/TestDataListener.cpp
+++ b/Framework/LiveData/test/TestDataListener.cpp
@@ -30,23 +30,23 @@ TestDataListener::TestDataListener()
 
   m_dataReset = false;
   m_timesCalled = 0;
-  if (!ConfigService::Instance().getValue("testdatalistener.reset_after",
-                                          m_resetAfter))
-    m_resetAfter = 0;
-  if (!ConfigService::Instance().getValue(
-          "testdatalistener.m_changeStatusAfter", m_changeStatusAfter))
-    m_changeStatusAfter = 0;
-  int temp = 0;
-  if (!ConfigService::Instance().getValue("testdatalistener.m_newStatus",
-                                          temp)) {
-    if (temp == 0)
-      m_newStatus = ILiveListener::NoRun;
-    if (temp == 1)
-      m_newStatus = ILiveListener::BeginRun;
-    if (temp == 2)
-      m_newStatus = ILiveListener::Running;
-    if (temp == 4)
-      m_newStatus = ILiveListener::EndRun;
+  m_resetAfter = ConfigService::Instance().getValue<int>("testdatalistener.reset_after").get_value_or(0);
+  m_changeStatusAfter = ConfigService::Instance().getValue<int>("testdatalistener.m_changeStatusAfter").get_value_or(0);
+  int temp = ConfigService::Instance().getValue<int>("testdatalistener.m_newStatus").get_value_or(0);
+  
+  switch (temp) {
+  case 0:
+	  m_newStatus = ILiveListener::NoRun;
+	  break;
+  case 1:
+	  m_newStatus = ILiveListener::BeginRun;
+	  break;
+  case 2:
+	  m_newStatus = ILiveListener::Running;
+	  break;
+  case 4:
+	  m_newStatus = ILiveListener::EndRun;
+	  break;
   }
 }
 

--- a/Framework/LiveData/test/TestDataListener.cpp
+++ b/Framework/LiveData/test/TestDataListener.cpp
@@ -30,23 +30,30 @@ TestDataListener::TestDataListener()
 
   m_dataReset = false;
   m_timesCalled = 0;
-  m_resetAfter = ConfigService::Instance().getValue<int>("testdatalistener.reset_after").get_value_or(0);
-  m_changeStatusAfter = ConfigService::Instance().getValue<int>("testdatalistener.m_changeStatusAfter").get_value_or(0);
-  int temp = ConfigService::Instance().getValue<int>("testdatalistener.m_newStatus").get_value_or(0);
-  
+  m_resetAfter = ConfigService::Instance()
+                     .getValue<int>("testdatalistener.reset_after")
+                     .get_value_or(0);
+  m_changeStatusAfter =
+      ConfigService::Instance()
+          .getValue<int>("testdatalistener.m_changeStatusAfter")
+          .get_value_or(0);
+  int temp = ConfigService::Instance()
+                 .getValue<int>("testdatalistener.m_newStatus")
+                 .get_value_or(0);
+
   switch (temp) {
   case 0:
-	  m_newStatus = ILiveListener::NoRun;
-	  break;
+    m_newStatus = ILiveListener::NoRun;
+    break;
   case 1:
-	  m_newStatus = ILiveListener::BeginRun;
-	  break;
+    m_newStatus = ILiveListener::BeginRun;
+    break;
   case 2:
-	  m_newStatus = ILiveListener::Running;
-	  break;
+    m_newStatus = ILiveListener::Running;
+    break;
   case 4:
-	  m_newStatus = ILiveListener::EndRun;
-	  break;
+    m_newStatus = ILiveListener::EndRun;
+    break;
   }
 }
 

--- a/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
+++ b/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
@@ -1384,11 +1384,8 @@ void ScriptRepositoryImpl::doDownloadFile(const std::string &url_file,
   // Configure Poco HTTP Client Session
   try {
     Kernel::InternetHelper inetHelper;
-    int timeout;
-    if (!ConfigService::Instance().getValue("network.scriptrepo.timeout",
-                                            timeout)) {
-      timeout = DEFAULT_TIMEOUT_SEC;
-    }
+	auto timeoutConfigVal = ConfigService::Instance().getValue<int>("network.scriptrepo.timeout");
+    int timeout = timeoutConfigVal.get_value_or(DEFAULT_TIMEOUT_SEC);
     inetHelper.setTimeout(timeout);
 
     // std::stringstream ss;

--- a/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
+++ b/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
@@ -1384,7 +1384,8 @@ void ScriptRepositoryImpl::doDownloadFile(const std::string &url_file,
   // Configure Poco HTTP Client Session
   try {
     Kernel::InternetHelper inetHelper;
-	auto timeoutConfigVal = ConfigService::Instance().getValue<int>("network.scriptrepo.timeout");
+    auto timeoutConfigVal =
+        ConfigService::Instance().getValue<int>("network.scriptrepo.timeout");
     int timeout = timeoutConfigVal.get_value_or(DEFAULT_TIMEOUT_SEC);
     inetHelper.setTimeout(timeout);
 

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -5014,7 +5014,8 @@ void ApplicationWindow::readSettings() {
     settings.remove("/AutoDistribution1D");
   }
   // Pull default from config service
-  const bool autoDistribution1D = cfgSvc.getValue<bool>("graph1d.autodistribution").get_value_or(false);
+  const bool autoDistribution1D =
+      cfgSvc.getValue<bool>("graph1d.autodistribution").get_value_or(false);
 
   canvasFrameWidth = settings.value("/CanvasFrameWidth", 0).toInt();
   defaultPlotMargin = settings.value("/Margin", 0).toInt();

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -5014,7 +5014,7 @@ void ApplicationWindow::readSettings() {
     settings.remove("/AutoDistribution1D");
   }
   // Pull default from config service
-  const bool autoDistribution1D =
+  autoDistribution1D =
       cfgSvc.getValue<bool>("graph1d.autodistribution").get_value_or(false);
 
   canvasFrameWidth = settings.value("/CanvasFrameWidth", 0).toInt();

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -5014,8 +5014,7 @@ void ApplicationWindow::readSettings() {
     settings.remove("/AutoDistribution1D");
   }
   // Pull default from config service
-  const std::string propStr = cfgSvc.getString("graph1d.autodistribution");
-  autoDistribution1D = (propStr == "On");
+  const bool autoDistribution1D = cfgSvc.getValue<bool>("graph1d.autodistribution").get_value_or(false);
 
   canvasFrameWidth = settings.value("/CanvasFrameWidth", 0).toInt();
   defaultPlotMargin = settings.value("/Margin", 0).toInt();

--- a/MantidPlot/src/ConfigDialog.cpp
+++ b/MantidPlot/src/ConfigDialog.cpp
@@ -961,14 +961,11 @@ void ConfigDialog::initMantidOptionsTab() {
       new QCheckBox("Re-use plot instances for different types of plots");
   m_reusePlotInstances->setChecked(false);
   grid->addWidget(m_reusePlotInstances, 0, 0);
-  QString setting = QString::fromStdString(
-      Mantid::Kernel::ConfigService::Instance().getString(
-          "MantidOptions.ReusePlotInstances"));
-  if (!setting.compare("On")) {
-    m_reusePlotInstances->setChecked(true);
-  } else if (!setting.compare("Off")) {
-    m_reusePlotInstances->setChecked(false);
-  }
+
+  bool setting = Mantid::Kernel::ConfigService::Instance().getValue<bool>(
+	  "MantidOptions.ReusePlotInstances").get_value_or(false);
+
+  m_reusePlotInstance->setChecked(setting);
   m_reusePlotInstances->setToolTip("If on, the same plot instance will be "
                                    "re-used for every of the different plots "
                                    "available in the workspaces window "
@@ -979,14 +976,11 @@ void ConfigDialog::initMantidOptionsTab() {
   m_invisibleWorkspaces->setChecked(false);
   grid->addWidget(m_invisibleWorkspaces, 1, 0);
 
-  setting = QString::fromStdString(
-      Mantid::Kernel::ConfigService::Instance().getString(
-          "MantidOptions.InvisibleWorkspaces"));
-  if (!setting.compare("1")) {
-    m_invisibleWorkspaces->setChecked(true);
-  } else if (!setting.compare("0")) {
-    m_invisibleWorkspaces->setChecked(false);
-  }
+  bool invisibleWsSetting =
+      Mantid::Kernel::ConfigService::Instance().getValue<bool>(
+          "MantidOptions.InvisibleWorkspaces").get_value_or(false);
+  
+  m_invisibleWorkspaces->setChecked(invisibleWsSetting);
 
   // categories tree widget
   treeCategories = new QTreeWidget(frame);
@@ -1004,14 +998,10 @@ void ConfigDialog::initMantidOptionsTab() {
   m_useOpenGL->setChecked(true);
   grid->addWidget(m_useOpenGL, 4, 0);
 
-  setting = QString::fromStdString(
-                Mantid::Kernel::ConfigService::Instance().getString(
-                    "MantidOptions.InstrumentView.UseOpenGL")).toUpper();
-  if (setting == "ON") {
-    m_useOpenGL->setChecked(true);
-  } else {
-    m_useOpenGL->setChecked(false);
-  }
+  bool openglSetting = Mantid::Kernel::ConfigService::Instance().getValue<bool>(
+                    "MantidOptions.InstrumentView.UseOpenGL").get_value_or(false);
+  
+  m_useOpenGL->setChecked(openglSetting);
 }
 
 void ConfigDialog::initSendToProgramTab() {

--- a/MantidPlot/src/ConfigDialog.cpp
+++ b/MantidPlot/src/ConfigDialog.cpp
@@ -966,7 +966,7 @@ void ConfigDialog::initMantidOptionsTab() {
                      .getValue<bool>("MantidOptions.ReusePlotInstances")
                      .get_value_or(false);
 
-  m_reusePlotInstance->setChecked(setting);
+  m_reusePlotInstances->setChecked(setting);
   m_reusePlotInstances->setToolTip("If on, the same plot instance will be "
                                    "re-used for every of the different plots "
                                    "available in the workspaces window "

--- a/MantidPlot/src/ConfigDialog.cpp
+++ b/MantidPlot/src/ConfigDialog.cpp
@@ -962,8 +962,9 @@ void ConfigDialog::initMantidOptionsTab() {
   m_reusePlotInstances->setChecked(false);
   grid->addWidget(m_reusePlotInstances, 0, 0);
 
-  bool setting = Mantid::Kernel::ConfigService::Instance().getValue<bool>(
-	  "MantidOptions.ReusePlotInstances").get_value_or(false);
+  bool setting = Mantid::Kernel::ConfigService::Instance()
+                     .getValue<bool>("MantidOptions.ReusePlotInstances")
+                     .get_value_or(false);
 
   m_reusePlotInstance->setChecked(setting);
   m_reusePlotInstances->setToolTip("If on, the same plot instance will be "
@@ -977,9 +978,10 @@ void ConfigDialog::initMantidOptionsTab() {
   grid->addWidget(m_invisibleWorkspaces, 1, 0);
 
   bool invisibleWsSetting =
-      Mantid::Kernel::ConfigService::Instance().getValue<bool>(
-          "MantidOptions.InvisibleWorkspaces").get_value_or(false);
-  
+      Mantid::Kernel::ConfigService::Instance()
+          .getValue<bool>("MantidOptions.InvisibleWorkspaces")
+          .get_value_or(false);
+
   m_invisibleWorkspaces->setChecked(invisibleWsSetting);
 
   // categories tree widget
@@ -998,9 +1000,11 @@ void ConfigDialog::initMantidOptionsTab() {
   m_useOpenGL->setChecked(true);
   grid->addWidget(m_useOpenGL, 4, 0);
 
-  bool openglSetting = Mantid::Kernel::ConfigService::Instance().getValue<bool>(
-                    "MantidOptions.InstrumentView.UseOpenGL").get_value_or(false);
-  
+  bool openglSetting =
+      Mantid::Kernel::ConfigService::Instance()
+          .getValue<bool>("MantidOptions.InstrumentView.UseOpenGL")
+          .get_value_or(false);
+
   m_useOpenGL->setChecked(openglSetting);
 }
 

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -3822,9 +3822,8 @@ void MantidUI::loadWSFromFile(const std::string &wsName,
 }
 
 bool MantidUI::workspacesDockPlot1To1() {
-  return "On" ==
-         Mantid::Kernel::ConfigService::Instance().getString(
-             "MantidOptions.ReusePlotInstances");
+  return Mantid::Kernel::ConfigService::Instance().getValue<bool>(
+             "MantidOptions.ReusePlotInstances").get_value_or(false);
 }
 
 /**

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -3822,8 +3822,9 @@ void MantidUI::loadWSFromFile(const std::string &wsName,
 }
 
 bool MantidUI::workspacesDockPlot1To1() {
-  return Mantid::Kernel::ConfigService::Instance().getValue<bool>(
-             "MantidOptions.ReusePlotInstances").get_value_or(false);
+  return Mantid::Kernel::ConfigService::Instance()
+      .getValue<bool>("MantidOptions.ReusePlotInstances")
+      .get_value_or(false);
 }
 
 /**

--- a/MantidPlot/src/ProjectRecovery.cpp
+++ b/MantidPlot/src/ProjectRecovery.cpp
@@ -39,25 +39,11 @@ Mantid::Kernel::Logger g_log("ProjectRecovery");
 // Config helper methods
 template <typename T>
 boost::optional<T> getConfigValue(const std::string &key) {
-  T returnedValue;
-
-  int valueIsGood =
-      Mantid::Kernel::ConfigService::Instance().getValue<T>(key, returnedValue);
-
-  if (valueIsGood != 1) {
-    return boost::optional<T>{};
-  }
-
-  return boost::optional<T>{returnedValue};
+  return Mantid::Kernel::ConfigService::Instance().getValue<T>(key);
 }
 
 boost::optional<bool> getConfigBool(const std::string &key) {
-  auto returnedValue = getConfigValue<std::string>(key);
-  if (!returnedValue.is_initialized()) {
-    return boost::optional<bool>{};
-  }
-
-  return returnedValue->find("true") != std::string::npos;
+	return Mantid::Kernel::ConfigService::Instance().getValue<bool>(key);
 }
 
 /// Returns a string to the current top level recovery folder

--- a/MantidPlot/src/ProjectRecovery.cpp
+++ b/MantidPlot/src/ProjectRecovery.cpp
@@ -43,7 +43,7 @@ boost::optional<T> getConfigValue(const std::string &key) {
 }
 
 boost::optional<bool> getConfigBool(const std::string &key) {
-	return Mantid::Kernel::ConfigService::Instance().getValue<bool>(key);
+  return Mantid::Kernel::ConfigService::Instance().getValue<bool>(key);
 }
 
 /// Returns a string to the current top level recovery folder

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -264,8 +264,9 @@ void InstrumentWidget::init(bool resetGeometry, bool autoscaling,
       QString defaultView =
           QString::fromStdString(m_instrumentActor->getDefaultView());
       if (defaultView == "3D" &&
-          Mantid::Kernel::ConfigService::Instance().getValue<bool>(
-              "MantidOptions.InstrumentView.UseOpenGL").get_value_or(false)) {
+          Mantid::Kernel::ConfigService::Instance()
+              .getValue<bool>("MantidOptions.InstrumentView.UseOpenGL")
+              .get_value_or(false)) {
         // if OpenGL is switched off don't open the 3D view at start up
         defaultView = "CYLINDRICAL_Y";
       }

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -264,8 +264,8 @@ void InstrumentWidget::init(bool resetGeometry, bool autoscaling,
       QString defaultView =
           QString::fromStdString(m_instrumentActor->getDefaultView());
       if (defaultView == "3D" &&
-          Mantid::Kernel::ConfigService::Instance().getString(
-              "MantidOptions.InstrumentView.UseOpenGL") != "On") {
+          Mantid::Kernel::ConfigService::Instance().getValue<bool>(
+              "MantidOptions.InstrumentView.UseOpenGL").get_value_or(false)) {
         // if OpenGL is switched off don't open the 3D view at start up
         defaultView = "CYLINDRICAL_Y";
       }

--- a/qt/widgets/sliceviewer/src/QPeaksTableModel.cpp
+++ b/qt/widgets/sliceviewer/src/QPeaksTableModel.cpp
@@ -35,8 +35,10 @@ static QString v3dAsString(const Mantid::Kernel::V3D &v3d) {
  * @returns :: number of decimals to round displayed HKL values to.
  */
 static int getHKLPrecision() {
-	auto hklPrecConfigVal = Mantid::Kernel::ConfigService::Instance().getValue<int>("PeakColumn.hklPrec");
-    int hklPrec = hklPrecConfigVal.get_value_or(2);
+  auto hklPrecConfigVal =
+      Mantid::Kernel::ConfigService::Instance().getValue<int>(
+          "PeakColumn.hklPrec");
+  int hklPrec = hklPrecConfigVal.get_value_or(2);
   return hklPrec;
 }
 

--- a/qt/widgets/sliceviewer/src/QPeaksTableModel.cpp
+++ b/qt/widgets/sliceviewer/src/QPeaksTableModel.cpp
@@ -35,10 +35,8 @@ static QString v3dAsString(const Mantid::Kernel::V3D &v3d) {
  * @returns :: number of decimals to round displayed HKL values to.
  */
 static int getHKLPrecision() {
-  int hklPrec = 0;
-  if (!Mantid::Kernel::ConfigService::Instance().getValue("PeakColumn.hklPrec",
-                                                          hklPrec))
-    hklPrec = 2;
+	auto hklPrecConfigVal = Mantid::Kernel::ConfigService::Instance().getValue<int>("PeakColumn.hklPrec");
+    int hklPrec = hklPrecConfigVal.get_value_or(2);
   return hklPrec;
 }
 

--- a/qt/widgets/sliceviewer/src/SliceViewer.cpp
+++ b/qt/widgets/sliceviewer/src/SliceViewer.cpp
@@ -101,11 +101,8 @@ SliceViewer::SliceViewer(QWidget *parent)
 
   ui.setupUi(this);
   std::string enableNonOrthogonal;
-  Kernel::ConfigService::Instance().getValue("sliceviewer.nonorthogonal",
-                                             enableNonOrthogonal);
-  if (enableNonOrthogonal == "true") {
-    m_nonOrthogonalDefault = true;
-  }
+  auto nonOrthogonalDefaultValue = Kernel::ConfigService::Instance().getValue<bool>("sliceviewer.nonorthogonal");
+  m_nonOrthogonalDefault = nonOrthogonalDefaultValue.get_value_or(false);
 
   m_inf = std::numeric_limits<double>::infinity();
 

--- a/qt/widgets/sliceviewer/src/SliceViewer.cpp
+++ b/qt/widgets/sliceviewer/src/SliceViewer.cpp
@@ -100,7 +100,6 @@ SliceViewer::SliceViewer(QWidget *parent)
       m_holdDisplayUpdates(false) {
 
   ui.setupUi(this);
-  std::string enableNonOrthogonal;
   auto nonOrthogonalDefaultValue =
       Kernel::ConfigService::Instance().getValue<bool>(
           "sliceviewer.nonorthogonal");

--- a/qt/widgets/sliceviewer/src/SliceViewer.cpp
+++ b/qt/widgets/sliceviewer/src/SliceViewer.cpp
@@ -101,7 +101,9 @@ SliceViewer::SliceViewer(QWidget *parent)
 
   ui.setupUi(this);
   std::string enableNonOrthogonal;
-  auto nonOrthogonalDefaultValue = Kernel::ConfigService::Instance().getValue<bool>("sliceviewer.nonorthogonal");
+  auto nonOrthogonalDefaultValue =
+      Kernel::ConfigService::Instance().getValue<bool>(
+          "sliceviewer.nonorthogonal");
   m_nonOrthogonalDefault = nonOrthogonalDefaultValue.get_value_or(false);
 
   m_inf = std::numeric_limits<double>::infinity();


### PR DESCRIPTION
**Description of work.**
Switch ConfigManager::getValue to use boost optional return instead of using `0/1` return value to indicate success.

This also allows us to use get value or default, tidying up a lot of callers

Additionally a specialisation was added for `bool` which can either accept `true`/`on` or `1` (the former being upper or lower case)

**To test:**

Ensure unit tests pass
Code review

Fixes #22647

Does this update require release notes?
- [ ] Yes
- [x] No

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
