### PR TITLE
ISIS Indirect data reduction: Change default grouping option and add validation

### DIFF
--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -194,6 +194,10 @@ QString ISISEnergyTransfer::validateDetectorGrouping() {
     if (!m_uiForm.dsMapFile->isValid())
       return "Mapping file is invalid.";
   }
+  if (m_uiForm.cbGroupingOptions->currentText() == "Custom") {
+    if (m_uiForm.leCustomGroups->text() == "")
+      return "Please supply a custom grouping for detectors.";
+  }
   return "";
 }
 

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.ui
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.ui
@@ -215,12 +215,12 @@
         </property>
         <item>
          <property name="text">
-          <string>Custom</string>
+          <string>Individual</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Individual</string>
+          <string>Custom</string>
          </property>
         </item>
         <item>


### PR DESCRIPTION
**Description of work.**

* Added validation to the Indirect data reduction gui to ensure custom grouping is not empty
* Changed the default grouping to be individual meaning users don't have to input into that field unless they physically change the detector grouping option.

**Report to:** @brandonhewer 

**To test:**

* Open mantid plot
* Open the Indirect data reduction interface (Interfaces > Indirect > Data Reduction)
* Observe that in the `Detector Grouping` section, the mode should default to `Individual`
* Enter the run number `21360` (this can be found in the unit test data) into the `Run Files` box
* Click run and see that a workspace is created with 50 spectra (spectrumNumber 3-53)
* Change the `Detector Grouping` mode to `Custom`.
* Leave the field empty and click `Run` 
* See that a dialog box with an appropriate error message is produced.
* Enter a value into the custom grouping box e.g. `0-10`
* Observe that the workspace that has been produced (it will have overwritten the previous one stored in the ADS) contains 10 spectra.

Fixes #22858

*Does not need to be in the release notes as this was  a bug introduced during this development cycle*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
