### PR TITLE
Use fixed line-width printing of numpy array

### DIFF
--- a/docs/source/algorithms/RotateInstrumentComponent-v1.rst
+++ b/docs/source/algorithms/RotateInstrumentComponent-v1.rst
@@ -177,7 +177,11 @@ Example 3: Rotating a single detector
 
   # Take element by element difference of the solid angles
   diff = sa2 - sa1
+  # control linewidth of printed array to ensure it matches on different versions
+  pp_opts_orig = np.get_printoptions()
+  np.set_printoptions(linewidth=64)
   print(diff)
+  np.set_printoptions(**pp_opts_orig)
   print('The non-zero difference {:.13f} is due to detector {}'.format(diff[32], ws.getDetector(32).getID()))
 
 Output
@@ -187,16 +191,17 @@ Output
 
   [0.0888151,-0.108221,-0.145]
   [0.0888151,-0.108221,-0.145]
-  [ 0.          0.          0.          0.          0.          0.          0.
-    0.          0.          0.          0.          0.          0.          0.
-    0.          0.          0.          0.          0.          0.          0.
-    0.          0.          0.          0.          0.          0.          0.
-    0.          0.          0.          0.         -0.04645313  0.          0.
-    0.          0.          0.          0.          0.          0.          0.
-    0.          0.          0.          0.          0.          0.          0.
-    0.          0.          0.          0.          0.          0.          0.
-    0.          0.          0.          0.          0.          0.          0.
-    0.        ]
+  [ 0.          0.          0.          0.          0.          0.
+    0.          0.          0.          0.          0.          0.
+    0.          0.          0.          0.          0.          0.
+    0.          0.          0.          0.          0.          0.
+    0.          0.          0.          0.          0.          0.
+    0.          0.         -0.04645313  0.          0.          0.
+    0.          0.          0.          0.          0.          0.
+    0.          0.          0.          0.          0.          0.
+    0.          0.          0.          0.          0.          0.
+    0.          0.          0.          0.          0.          0.
+    0.          0.          0.          0.        ]
   The non-zero difference -0.0464531276188 is due to detector 33
 
 .. categories::


### PR DESCRIPTION
**Description of work.**

Fixes the line width of a numpy array in a doctest to avoid differences across versions.

A recent doc test build [failed](http://builds.mantidproject.org/view/Release%20Pipeline/job/release_clean-ubuntu-16.04/76/consoleText) due to different line lengths used to format a numpy array. The output of the test is reproduced here for clarity:

```
Document: algorithms/RotateInstrumentComponent-v1
-------------------------------------------------
**********************************************************************
File "algorithms/RotateInstrumentComponent-v1.rst", line 295, in ExDet
Failed example:
    import numpy as np

    # Load a MUSR file
    musr = Load('MUSR00015189')
    # and use the first workspace in the workspace group
    ws = mtd['musr_1']

    # Rotating a detector doesn't change its position, just its orientation

    # Original position of detector 33
    print(ws.getInstrument().getDetector(33).getPos())

    # Caclulate the solid angles for all detectors in the instrument
    # The result is a single-bin workspace with solid angles for all spectra in ws
    saws = SolidAngle( ws )
    # Collect the solid angles from the first bin in saws and save them in numpy array.
    # Numpy module makes it easy to manipulate arrays
    sa1 = np.array( [ saws.readY(i)[0] for i in range(saws.getNumberHistograms()) ] )

    # Rotate detector 33 around the Z axis by 90 degrees.
    RotateInstrumentComponent( ws, DetectorID=33, X=0,Y=0,Z=1, Angle=90 )

    # Check the position of detector 33 stays unchanged
    print(ws.getInstrument().getDetector(33).getPos())

    # Calculate the solid angles after rotation
    saws = SolidAngle( ws )
    sa2 = np.array( [ saws.readY(i)[0] for i in range(saws.getNumberHistograms()) ] )

    # Take element by element difference of the solid angles
    diff = sa2 - sa1
    print(diff)
    print('The non-zero difference {:.13f} is due to detector {}'.format(diff[32], ws.getDetector(32).getID()))
Expected:
    [0.0888151,-0.108221,-0.145]
    [0.0888151,-0.108221,-0.145]
    [ 0.          0.          0.          0.          0.          0.          0.
      0.          0.          0.          0.          0.          0.          0.
      0.          0.          0.          0.          0.          0.          0.
      0.          0.          0.          0.          0.          0.          0.
      0.          0.          0.          0.         -0.04645313  0.          0.
      0.          0.          0.          0.          0.          0.          0.
      0.          0.          0.          0.          0.          0.          0.
      0.          0.          0.          0.          0.          0.          0.
      0.          0.          0.          0.          0.          0.          0.
      0.        ]
    The non-zero difference -0.0464531276188 is due to detector 33
Got:
    [0.0888151,-0.108221,-0.145]
    [0.0888151,-0.108221,-0.145]
    [ 0.          0.          0.          0.          0.          0.
      0.          0.          0.          0.          0.          0.
      0.          0.          0.          0.          0.          0.
      0.          0.          0.          0.          0.          0.
      0.          0.          0.          0.          0.          0.
      0.          0.         -0.04645313  0.          0.          0.
      0.          0.          0.          0.          0.          0.
      0.          0.          0.          0.          0.          0.
      0.          0.          0.          0.          0.          0.
      0.          0.          0.          0.          0.          0.
      0.          0.          0.          0.        ]
    The non-zero difference -0.0464531276188 is due to detector 33
2 items passed all tests:
   1 tests in ExBank
   1 tests in ExBank2
**********************************************************************
```

This change forces a fixed width when the array is printed.

**To test:**

* Review and check the doc tests pass.

*No associated issue*

Does this update require release notes?
- [ ] Yes
- [X] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
