### PR TITLE
Fix an integer overflow issue in LoadBankFromDiskTask

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadBankFromDiskTask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadBankFromDiskTask.h
@@ -55,8 +55,8 @@ public:
 private:
   void loadPulseTimes(::NeXus::File &file);
   void loadEventIndex(::NeXus::File &file, std::vector<uint64_t> &event_index);
-  void prepareEventId(::NeXus::File &file, size_t &start_event,
-                      size_t &stop_event, std::vector<uint64_t> &event_index);
+  void prepareEventId(::NeXus::File &file, int64_t &start_event,
+                      int64_t &stop_event, std::vector<uint64_t> &event_index);
   void loadEventId(::NeXus::File &file);
   void loadTof(::NeXus::File &file);
   void loadEventWeights(::NeXus::File &file);
@@ -79,9 +79,9 @@ private:
   /// Old names in the file?
   bool m_oldNexusFileNames;
   /// Index to load start at in the file
-  std::vector<int> m_loadStart;
+  std::vector<int64_t> m_loadStart;
   /// How much to load in the file
-  std::vector<int> m_loadSize;
+  std::vector<int64_t> m_loadSize;
   /// Event pixel ID data
   uint32_t *m_event_id;
   /// Minimum pixel ID in this data


### PR DESCRIPTION
There is an integer overflow issue in LoadBankFromDiskTask.  This causes a negative number of events to stop the loading process.  Changing the data type to int64_t shall resolve the issue.

It is same as PR #22890, which was based on master.

**Report to:** Yan Chen of SNS

**To test:**

Load /SNS/VULCAN/IPTS-21357/nexus/VULCAN_163113.nxs.h5.  Check number of events in the high angle bank (from spectrum 6469). 

Fixes #22889. 

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
