### PR TITLE
Ignore string TSPs in FilterEvents GUI

### DIFF
--- a/scripts/FilterEvents/eventFilterGUI.py
+++ b/scripts/FilterEvents/eventFilterGUI.py
@@ -808,7 +808,7 @@ class MainWindow(QtGui.QMainWindow):
         for p in plist:
             try:
                 times = p.times
-                if len(times) > 1:
+                if len(times) > 1 and numpy.isreal(p.value[0]):
                     self._sampleLogNames.append(p.name)
             # This is here for FloatArrayProperty. If a log value is of this type it does not have times
             except AttributeError:


### PR DESCRIPTION
Fix issue found in testing of FilterEvents GUI. It should not show now string time series.

**To test:**
See https://github.com/mantidproject/mantid/issues/22767

<!-- Instructions for testing. -->

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
