### PR TITLE
Fix bug in not specifying time-of-flight range

### DIFF
--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -256,26 +256,35 @@ void AlignAndFocusPowder::exec() {
       dspace = false;
   }
   if (dspace) {
-    if (m_params.size() == 1 && dmax > 0) {
-      double step = m_params[0];
-      m_params.clear();
-      if (step > 0 || dmin > 0) {
+    if (m_params.size() == 1 && (!isEmpty(dmin)) && (!isEmpty(dmax))) {
+      if (dmin > 0. && dmax > dmin) {
+        double step = m_params[0];
+        m_params.clear();
         m_params.push_back(dmin);
         m_params.push_back(step);
         m_params.push_back(dmax);
-        g_log.information() << "d-Spacing Binning: " << m_params[0] << "  "
-                            << m_params[1] << "  " << m_params[2] << "\n";
+        g_log.information() << "d-Spacing binning updated: " << m_params[0]
+                            << "  " << m_params[1] << "  " << m_params[2]
+                            << "\n";
+      } else {
+        g_log.warning() << "something is wrong with dmin (" << dmin
+                        << ") and dmax (" << dmax
+                        << "). They are being ignored.\n";
       }
     }
   } else {
-    if (m_params.size() == 1 && tmax > 0) {
-      double step = m_params[0];
-      if (step > 0 || tmin > 0) {
+    if (m_params.size() == 1 && (!isEmpty(tmin)) && (!isEmpty(tmax))) {
+      if (tmin > 0. && tmax > tmin) {
+        double step = m_params[0];
         m_params[0] = tmin;
         m_params.push_back(step);
         m_params.push_back(tmax);
-        g_log.information() << "TOF Binning: " << m_params[0] << "  "
+        g_log.information() << "TOF binning updated: " << m_params[0] << "  "
                             << m_params[1] << "  " << m_params[2] << "\n";
+      } else {
+        g_log.warning() << "something is wrong with tmin (" << tmin
+                        << ") and tmax (" << tmax
+                        << "). They are being ignored.\n";
       }
     }
   }
@@ -776,6 +785,10 @@ AlignAndFocusPowder::rebin(API::MatrixWorkspace_sptr matrixws) {
       g_log.information() << param << " ";
     g_log.information() << ") started at "
                         << Types::Core::DateAndTime::getCurrentTime() << "\n";
+    for (double param : m_params)
+      if (isEmpty(param))
+        g_log.warning("encountered empty binning parameter");
+
     API::IAlgorithm_sptr rebin3Alg = createChildAlgorithm("Rebin");
     rebin3Alg->setProperty("InputWorkspace", matrixws);
     rebin3Alg->setProperty("OutputWorkspace", matrixws);

--- a/docs/source/release/v3.13.0/diffraction.rst
+++ b/docs/source/release/v3.13.0/diffraction.rst
@@ -40,6 +40,7 @@ Improvements
   - The ``.maud`` calibration file format, for conversion to d-spacing (uses a new algorithm
     :ref:`SaveGEMMAUDParamFile <algm-SaveGEMMAUDParamFile>`
 - :ref:`PDCalibration <algm-PDCalibration>` has major upgrades including making use of :ref:`FitPeaks <algm-FitPeaks>` for the individual peak fitting
+- :ref:`AlignAndFocusPowder <algm-AlignAndFocusPowder>` had a bug when binning in time-of-flight without using a property manager to specify the time-of-flight range. In other words: characterization files are no longer necessary.
 
 Engineering Diffraction
 -----------------------


### PR DESCRIPTION
Allow everything to use the workspace ranges as any other algorithm would do.

**Report to:** Nobody noticed the issue so it is a good time to fix it.

**To test:**
```python
LoadEventAndCompress(Filename='/SNS/PG3/IPTS-2767/nexus/PG3_40507.nxs.h5', OutputWorkspace='PG3_40507', FilterBadPulses=10)
NormaliseByCurrent(InputWorkspace='PG3_40507', OutputWorkspace='PG3_40507')
LoadEventAndCompress(Filename='/SNS/PG3/IPTS-2767/nexus/PG3_40503.nxs.h5', OutputWorkspace='PG3_40503', FilterBadPulses=10)
NormaliseByCurrent(InputWorkspace='PG3_40503', OutputWorkspace='PG3_40503')
Minus(LHSWorkspace='PG3_40507', RHSWorkspace='PG3_40503', OutputWorkspace='PG3_40507', ClearRHSWorkspace=True)
CompressEvents(InputWorkspace='PG3_40507', OutputWorkspace='PG3_40507', Tolerance=0.01)
ConvertUnits(InputWorkspace='PG3_40507', OutputWorkspace='PG3_40507', Target='Wavelength')
SetSampleMaterial(InputWorkspace='PG3_40507', ChemicalFormula='V', SampleNumberDensity=0.0721)
CarpenterSampleCorrection(InputWorkspace='PG3_40507', OutputWorkspace='PG3_40507')
ConvertUnits(InputWorkspace='PG3_40507', OutputWorkspace='PG3_40507', Target='TOF')
AlignAndFocusPowder(InputWorkspace='PG3_40507', OutputWorkspace='PG3_40507',
                    CalFileName='/SNS/PG3/shared/CALIBRATION/2018_2_11A_CAL/PG3_PAC_d40481_2018_06_13.h5',
                    Params='-0.0008', RemovePromptPulseWidth=50, PrimaryFlightPath=60, SpectrumIDs='1',
                    L2='3.18', Polar='90', Azimuthal='0')
```
<!-- Instructions for testing. -->

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
