### PR TITLE
Project Recovery - Catch top level exceptions

### DIFF
--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -16748,12 +16748,11 @@ bool ApplicationWindow::isOfType(const QObject *obj,
   * @param sourceFile The full path to the .project file
   * @return True is loading was successful, false otherwise
   */
-bool ApplicationWindow::loadProjectRecovery(std::string sourceFile)
-{
-	const bool isRecovery = true;
-	ProjectSerialiser projectWriter(this, isRecovery);
-	// File version is not applicable to project recovery - so set to 0
-	return projectWriter.load(sourceFile, 0);
+bool ApplicationWindow::loadProjectRecovery(std::string sourceFile) {
+  const bool isRecovery = true;
+  ProjectSerialiser projectWriter(this, isRecovery);
+  // File version is not applicable to project recovery - so set to 0
+  return projectWriter.load(sourceFile, 0);
 }
 
 /**

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -16769,24 +16769,26 @@ bool ApplicationWindow::saveProjectRecovery(std::string destination) {
 }
 
 void ApplicationWindow::checkForProjectRecovery() {
-	if (!m_projectRecovery.checkForRecovery()) {
-		m_projectRecovery.startProjectSaving();
-		return;
-	}
+  if (!m_projectRecovery.checkForRecovery()) {
+    m_projectRecovery.startProjectSaving();
+    return;
+  }
 
-	// Recovery file present
-	try {
-		m_projectRecovery.attemptRecovery();
-	}
-	catch (std::exception &e) {
-		std::string err{ "Project Recovery failed to recover this checkpoint. Details: " };
-		err.append(e.what());
-	  g_log.error(err);
-	  QMessageBox::information(this, "Could Not Recover",
-		  "We could not fully recover your work.\nMantid will continue to run normally now.", "OK");
+  // Recovery file present
+  try {
+    m_projectRecovery.attemptRecovery();
+  } catch (std::exception &e) {
+    std::string err{
+        "Project Recovery failed to recover this checkpoint. Details: "};
+    err.append(e.what());
+    g_log.error(err);
+    QMessageBox::information(this, "Could Not Recover",
+                             "We could not fully recover your work.\nMantid "
+                             "will continue to run normally now.",
+                             "OK");
 
-	  // Restart project recovery manually
-	  m_projectRecovery.clearAllCheckpoints();
-	  m_projectRecovery.startProjectSaving();
+    // Restart project recovery manually
+    m_projectRecovery.clearAllCheckpoints();
+    m_projectRecovery.startProjectSaving();
   }
 }

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -16769,11 +16769,24 @@ bool ApplicationWindow::saveProjectRecovery(std::string destination) {
 }
 
 void ApplicationWindow::checkForProjectRecovery() {
-  if (!m_projectRecovery.checkForRecovery()) {
-    m_projectRecovery.startProjectSaving();
-    return;
-  }
+	if (!m_projectRecovery.checkForRecovery()) {
+		m_projectRecovery.startProjectSaving();
+		return;
+	}
 
-  // Recovery file present
-  m_projectRecovery.attemptRecovery();
+	// Recovery file present
+	try {
+		m_projectRecovery.attemptRecovery();
+	}
+	catch (std::exception &e) {
+		std::string err{ "Project Recovery failed to recover this checkpoint. Details: " };
+		err.append(e.what());
+	  g_log.error(err);
+	  QMessageBox::information(this, "Could Not Recover",
+		  "We could not fully recover your work.\nMantid will continue to run normally now.", "OK");
+
+	  // Restart project recovery manually
+	  m_projectRecovery.clearAllCheckpoints();
+	  m_projectRecovery.startProjectSaving();
+  }
 }

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -16743,6 +16743,20 @@ bool ApplicationWindow::isOfType(const QObject *obj,
 }
 
 /**
+  * Loads a project file as part of project recovery
+  *
+  * @param sourceFile The full path to the .project file
+  * @return True is loading was successful, false otherwise
+  */
+bool ApplicationWindow::loadProjectRecovery(std::string sourceFile)
+{
+	const bool isRecovery = true;
+	ProjectSerialiser projectWriter(this, isRecovery);
+	// File version is not applicable to project recovery - so set to 0
+	return projectWriter.load(sourceFile, 0);
+}
+
+/**
  * Triggers saving project recovery on behalf of an external thread
  * or caller, such as project recovery.
  *
@@ -16762,9 +16776,5 @@ void ApplicationWindow::checkForProjectRecovery() {
   }
 
   // Recovery file present
-  if (m_projectRecovery.attemptRecovery()) {
-    // If it worked correctly reset project recovery and start saving
-    m_projectRecovery.clearAllCheckpoints();
-    m_projectRecovery.startProjectSaving();
-  }
+  m_projectRecovery.attemptRecovery();
 }

--- a/MantidPlot/src/ApplicationWindow.h
+++ b/MantidPlot/src/ApplicationWindow.h
@@ -1123,6 +1123,8 @@ public slots:
 
   bool isOfType(const QObject *obj, const char *toCompare) const;
 
+  bool loadProjectRecovery(std::string sourceFile);
+
   // The string must be copied from the other thread in saveProjectRecovery
   /// Saves the current project as part of recovery auto saving
   bool saveProjectRecovery(std::string destination);

--- a/MantidPlot/src/MultiTabScriptInterpreter.cpp
+++ b/MantidPlot/src/MultiTabScriptInterpreter.cpp
@@ -272,8 +272,8 @@ void MultiTabScriptInterpreter::uncomment() { m_current->uncomment(); }
  * Execute the highlighted code from the current tab
  * *@param mode :: The mode used to execute
  */
-void MultiTabScriptInterpreter::executeAll(const Script::ExecutionMode mode) {
-  m_current->executeAll(mode);
+bool MultiTabScriptInterpreter::executeAll(const Script::ExecutionMode mode) {
+  return m_current->executeAll(mode);
 }
 
 /** Execute the highlighted code from the current tab using the

--- a/MantidPlot/src/MultiTabScriptInterpreter.h
+++ b/MantidPlot/src/MultiTabScriptInterpreter.h
@@ -149,7 +149,7 @@ public slots:
   /** @name Execute members.*/
   //@{
   /// Execute all using the given mode
-  void executeAll(const Script::ExecutionMode mode);
+  bool executeAll(const Script::ExecutionMode mode);
   /// Execute selection using the given mode
   void executeSelection(const Script::ExecutionMode mode);
   /// Abort the current script

--- a/MantidPlot/src/ProjectRecovery.cpp
+++ b/MantidPlot/src/ProjectRecovery.cpp
@@ -343,37 +343,36 @@ void ProjectRecovery::stopProjectSaving() {
   * @param recoveryFolder : The checkpoint folder
   * @throws : If Qt binding fails to main GUI thread
   */
-void ProjectRecovery::loadRecoveryCheckpoint(const Poco::Path &recoveryFolder) {	
-	ScriptingWindow *scriptWindow = m_windowPtr->getScriptWindowHandle();
-	if (!scriptWindow) {
-		throw std::runtime_error("Could not get handle to scripting window");
-	}
+void ProjectRecovery::loadRecoveryCheckpoint(const Poco::Path &recoveryFolder) {
+  ScriptingWindow *scriptWindow = m_windowPtr->getScriptWindowHandle();
+  if (!scriptWindow) {
+    throw std::runtime_error("Could not get handle to scripting window");
+  }
 
-	// Ensure the window repaints so it doesn't appear frozen before exec
-	scriptWindow->executeCurrentTab(Script::ExecutionMode::Serialised);
-	g_log.notice("Re-opening GUIs");
+  // Ensure the window repaints so it doesn't appear frozen before exec
+  scriptWindow->executeCurrentTab(Script::ExecutionMode::Serialised);
+  g_log.notice("Re-opening GUIs");
 
-	
-	auto projectFile = Poco::Path(recoveryFolder).append(OUTPUT_PROJ_NAME);
+  auto projectFile = Poco::Path(recoveryFolder).append(OUTPUT_PROJ_NAME);
 
-	bool loadCompleted = false;
-	if (!QMetaObject::invokeMethod(m_windowPtr, "loadProjectRecovery",
-		Qt::BlockingQueuedConnection,
-		Q_RETURN_ARG(bool, loadCompleted),
-		Q_ARG(const std::string, projectFile.toString()))) {
-		throw std::runtime_error(
-			"Project Recovery: Failed to load project windows - Qt binding failed");
-	}
+  bool loadCompleted = false;
+  if (!QMetaObject::invokeMethod(
+          m_windowPtr, "loadProjectRecovery", Qt::BlockingQueuedConnection,
+          Q_RETURN_ARG(bool, loadCompleted),
+          Q_ARG(const std::string, projectFile.toString()))) {
+    throw std::runtime_error(
+        "Project Recovery: Failed to load project windows - Qt binding failed");
+  }
 
-	if (!loadCompleted) {
-		g_log.warning("Loading failed to recovery everything completely");
-		return;
-	}
-	g_log.notice("Project Recovery finished");
+  if (!loadCompleted) {
+    g_log.warning("Loading failed to recovery everything completely");
+    return;
+  }
+  g_log.notice("Project Recovery finished");
 
-	// Restart project recovery when the async part finishes 
-	clearAllCheckpoints();
-	startProjectSaving();
+  // Restart project recovery when the async part finishes
+  clearAllCheckpoints();
+  startProjectSaving();
 }
 
 /**
@@ -384,7 +383,8 @@ void ProjectRecovery::loadRecoveryCheckpoint(const Poco::Path &recoveryFolder) {
   * @param historyDest : Where to save the ordered history
   * @throws If a handle to the scripting window cannot be obtained
   */
-void ProjectRecovery::openInEditor(const Poco::Path &inputFolder, const Poco::Path &historyDest) {
+void ProjectRecovery::openInEditor(const Poco::Path &inputFolder,
+                                   const Poco::Path &historyDest) {
   compileRecoveryScript(inputFolder, historyDest);
 
   // Force application window to create the script window first

--- a/MantidPlot/src/ProjectRecovery.cpp
+++ b/MantidPlot/src/ProjectRecovery.cpp
@@ -355,6 +355,8 @@ void ProjectRecovery::loadRecoveryCheckpoint(const Poco::Path &recoveryFolder) {
 	  // Note: We must NOT throw from the method for excepted failures, 
 	  // since doing so will cause the application to terminate from a uncaught exception
 	  g_log.error("Project recovery script did not finish. Your work has been partially recovered.");
+    this->clearAllCheckpoints();
+    this->startProjectSaving();
 	  return;
   }
   g_log.notice("Re-opening GUIs");

--- a/MantidPlot/src/ProjectRecovery.cpp
+++ b/MantidPlot/src/ProjectRecovery.cpp
@@ -345,19 +345,21 @@ void ProjectRecovery::stopProjectSaving() {
 void ProjectRecovery::loadRecoveryCheckpoint(const Poco::Path &recoveryFolder) {
   ScriptingWindow *scriptWindow = m_windowPtr->getScriptWindowHandle();
   if (!scriptWindow) {
-	  throw std::runtime_error("Could not get handle to scripting window");
+    throw std::runtime_error("Could not get handle to scripting window");
   }
 
   // Ensure the window repaints so it doesn't appear frozen before exec
   scriptWindow->executeCurrentTab(Script::ExecutionMode::Serialised);
   if (scriptWindow->getSynchronousErrorFlag()) {
-	  // We failed to run the whole script
-	  // Note: We must NOT throw from the method for excepted failures, 
-	  // since doing so will cause the application to terminate from a uncaught exception
-	  g_log.error("Project recovery script did not finish. Your work has been partially recovered.");
+    // We failed to run the whole script
+    // Note: We must NOT throw from the method for excepted failures,
+    // since doing so will cause the application to terminate from a uncaught
+    // exception
+    g_log.error("Project recovery script did not finish. Your work has been "
+                "partially recovered.");
     this->clearAllCheckpoints();
     this->startProjectSaving();
-	  return;
+    return;
   }
   g_log.notice("Re-opening GUIs");
 

--- a/MantidPlot/src/ProjectRecovery.cpp
+++ b/MantidPlot/src/ProjectRecovery.cpp
@@ -206,7 +206,7 @@ void ProjectRecovery::attemptRecovery() {
     // we exec
     openInEditor(mostRecentCheckpoint, destFilename);
     std::thread recoveryThread(
-        [=] { loadRecoveryCheckpoint(mostRecentCheckpoint, destFilename); });
+        [=] { loadRecoveryCheckpoint(mostRecentCheckpoint); });
     recoveryThread.detach();
   } else if (userChoice == 2) {
     openInEditor(mostRecentCheckpoint, destFilename);
@@ -333,43 +333,6 @@ void ProjectRecovery::stopProjectSaving() {
   }
 }
 
-<<<<<<< HEAD
-void ProjectRecovery::loadRecoveryCheckpoint(const Poco::Path &recoveryFolder,
-                                             const Poco::Path &historyDest) {
-  ScriptingWindow *scriptWindow = m_windowPtr->getScriptWindowHandle();
-  if (!scriptWindow) {
-    throw std::runtime_error("Could not get handle to scripting window");
-  }
-
-  // Ensure the window repaints so it doesn't appear frozen before exec
-  scriptWindow->executeCurrentTab(Script::ExecutionMode::Serialised);
-  g_log.notice("Re-opening GUIs");
-
-  auto projectFile = Poco::Path(recoveryFolder).append(OUTPUT_PROJ_NAME);
-
-  bool loadCompleted = false;
-  if (!QMetaObject::invokeMethod(
-          m_windowPtr, "loadProjectRecovery", Qt::BlockingQueuedConnection,
-          Q_RETURN_ARG(bool, loadCompleted),
-          Q_ARG(const std::string, projectFile.toString()))) {
-    throw std::runtime_error(
-        "Project Recovery: Failed to load project windows - Qt binding failed");
-  }
-
-  if (!loadCompleted) {
-    g_log.warning("Loading failed to recovery everything completely");
-    return;
-  }
-  g_log.notice("Project Recovery finished");
-
-  // Restart project recovery when the async part finishes
-  clearAllCheckpoints();
-  startProjectSaving();
-}
-
-void ProjectRecovery::openInEditor(const Poco::Path &inputFolder,
-                                   const Poco::Path &historyDest) {
-=======
 /**
   * Asynchronously loads a recovery checkpoint by opening
   * a scripting window to the ordered workspace
@@ -422,7 +385,6 @@ void ProjectRecovery::loadRecoveryCheckpoint(const Poco::Path &recoveryFolder) {
   * @throws If a handle to the scripting window cannot be obtained
   */
 void ProjectRecovery::openInEditor(const Poco::Path &inputFolder, const Poco::Path &historyDest) {
->>>>>>> Re #22878 Remove unused param and add doxygen
   compileRecoveryScript(inputFolder, historyDest);
 
   // Force application window to create the script window first

--- a/MantidPlot/src/ProjectRecovery.h
+++ b/MantidPlot/src/ProjectRecovery.h
@@ -82,10 +82,12 @@ private:
   void deleteExistingCheckpoints(size_t checkpointsToKeep) const;
 
   /// Loads a recovery checkpoint in the given folder - TODO in future PR
-  void loadRecoveryCheckpoint(const Poco::Path &path, const Poco::Path &historyDest);
+  void loadRecoveryCheckpoint(const Poco::Path &path,
+                              const Poco::Path &historyDest);
 
   /// Open a recovery checkpoint in the scripting window
-  void openInEditor(const Poco::Path &inputFolder, const Poco::Path &historyDest);
+  void openInEditor(const Poco::Path &inputFolder,
+                    const Poco::Path &historyDest);
 
   /// Wraps the thread in a try catch to log any failures
   void projectSavingThreadWrapper();

--- a/MantidPlot/src/ProjectRecovery.h
+++ b/MantidPlot/src/ProjectRecovery.h
@@ -55,7 +55,7 @@ public:
   ~ProjectRecovery();
 
   /// Attempts recovery of the most recent checkpoint
-  bool attemptRecovery();
+  void attemptRecovery();
   /// Checks if recovery is required
   bool checkForRecovery() const noexcept;
 
@@ -82,10 +82,10 @@ private:
   void deleteExistingCheckpoints(size_t checkpointsToKeep) const;
 
   /// Loads a recovery checkpoint in the given folder - TODO in future PR
-  // bool loadRecoveryCheckpoint(const Poco::Path &path);
+  void loadRecoveryCheckpoint(const Poco::Path &path, const Poco::Path &historyDest);
 
   /// Open a recovery checkpoint in the scripting window
-  bool openInEditor(const Poco::Path &inputFolder);
+  void openInEditor(const Poco::Path &inputFolder, const Poco::Path &historyDest);
 
   /// Wraps the thread in a try catch to log any failures
   void projectSavingThreadWrapper();

--- a/MantidPlot/src/ProjectRecovery.h
+++ b/MantidPlot/src/ProjectRecovery.h
@@ -81,7 +81,7 @@ private:
   /// Deletes oldest checkpoints beyond the maximum number to keep
   void deleteExistingCheckpoints(size_t checkpointsToKeep) const;
 
-  /// Loads a recovery checkpoint in the given folder 
+  /// Loads a recovery checkpoint in the given folder
   void loadRecoveryCheckpoint(const Poco::Path &path);
 
   /// Open a recovery checkpoint in the scripting window

--- a/MantidPlot/src/ProjectRecovery.h
+++ b/MantidPlot/src/ProjectRecovery.h
@@ -81,9 +81,8 @@ private:
   /// Deletes oldest checkpoints beyond the maximum number to keep
   void deleteExistingCheckpoints(size_t checkpointsToKeep) const;
 
-  /// Loads a recovery checkpoint in the given folder - TODO in future PR
-  void loadRecoveryCheckpoint(const Poco::Path &path,
-                              const Poco::Path &historyDest);
+  /// Loads a recovery checkpoint in the given folder 
+  void loadRecoveryCheckpoint(const Poco::Path &path);
 
   /// Open a recovery checkpoint in the scripting window
   void openInEditor(const Poco::Path &inputFolder,

--- a/MantidPlot/src/ProjectSerialiser.cpp
+++ b/MantidPlot/src/ProjectSerialiser.cpp
@@ -281,11 +281,11 @@ void ProjectSerialiser::loadWorkspaces(const TSVSerialiser &tsv) {
     std::unordered_set<std::string> allWsNames(parsedNames.at(ALL_WS).begin(),
                                                parsedNames.at(ALL_WS).end());
 
-	if (parsedNames.find(ALL_GROUP_NAMES) != parsedNames.cend()) {
-		// Add group names to the list of accepted names
-		allWsNames.insert(parsedNames.at(ALL_GROUP_NAMES).begin(),
-						  parsedNames.at(ALL_GROUP_NAMES).end());
-	}
+    if (parsedNames.find(ALL_GROUP_NAMES) != parsedNames.cend()) {
+      // Add group names to the list of accepted names
+      allWsNames.insert(parsedNames.at(ALL_GROUP_NAMES).begin(),
+                        parsedNames.at(ALL_GROUP_NAMES).end());
+    }
 
     const auto loadedWs = adsInstance.getObjectNames();
     for (const std::string &adsWsName : loadedWs) {

--- a/MantidPlot/src/ProjectSerialiser.cpp
+++ b/MantidPlot/src/ProjectSerialiser.cpp
@@ -132,8 +132,9 @@ bool ProjectSerialiser::save(const QString &projectName, bool compress,
  * @param fileVersion :: project file version used
  * @param isTopLevel :: whether this function is being called on a top level
  * 		folder. (Default True)
+ * @return True is loading was successful, otherwise false
  */
-void ProjectSerialiser::load(std::string filepath, const int fileVersion,
+bool ProjectSerialiser::load(std::string filepath, const int fileVersion,
                              const bool isTopLevel) {
   // We have to accept std::string to maintain Python compatibility
   auto qfilePath = QString::fromStdString(filepath);
@@ -204,6 +205,8 @@ void ProjectSerialiser::load(std::string filepath, const int fileVersion,
 
   g_log.notice() << "Finished Loading Project: "
                  << window->projectname.toStdString() << "\n";
+
+  return true;
 }
 
 /**
@@ -225,7 +228,7 @@ void ProjectSerialiser::loadProjectSections(const std::string &lines,
   // If this is the top level folder of the project, we'll need to load the
   // workspaces before anything else.
   // If were recovering projects the workspaces should already be loaded
-  if (isTopLevel && !m_projectRecovery) {
+  if (isTopLevel) {
     loadWorkspaces(tsv);
   }
 
@@ -278,8 +281,11 @@ void ProjectSerialiser::loadWorkspaces(const TSVSerialiser &tsv) {
     std::unordered_set<std::string> allWsNames(parsedNames.at(ALL_WS).begin(),
                                                parsedNames.at(ALL_WS).end());
 
-    allWsNames.insert(parsedNames.at(ALL_GROUP_NAMES).begin(),
-                      parsedNames.at(ALL_GROUP_NAMES).end());
+	if (parsedNames.find(ALL_GROUP_NAMES) != parsedNames.cend()) {
+		// Add group names to the list of accepted names
+		allWsNames.insert(parsedNames.at(ALL_GROUP_NAMES).begin(),
+						  parsedNames.at(ALL_GROUP_NAMES).end());
+	}
 
     const auto loadedWs = adsInstance.getObjectNames();
     for (const std::string &adsWsName : loadedWs) {
@@ -302,7 +308,7 @@ void ProjectSerialiser::loadWorkspaces(const TSVSerialiser &tsv) {
 void ProjectSerialiser::loadWindows(const TSVSerialiser &tsv,
                                     const int fileVersion) {
   auto keys = WindowFactory::Instance().getKeys();
-  // Work around for graph-table dependance. Graph3D's currently rely on
+  // Work around for graph-table dependence. Graph3D's currently rely on
   // looking up tables. These must be loaded before the graphs, so work around
   // by loading in reverse alphabetical order.
   std::reverse(keys.begin(), keys.end());
@@ -932,8 +938,8 @@ MantidQt::API::ProjectSerialiser::parseWsNames(const std::string &wsNames) {
   // The first element is removed since it says "WorkspaceNames"
   unparsedWorkspaces.erase(unparsedWorkspaces.begin());
 
+  const char groupWorkspaceChar = ',';
   for (const auto &workspaceName : unparsedWorkspaces) {
-    const char groupWorkspaceChar = ',';
 
     if (workspaceName.find(groupWorkspaceChar) == std::string::npos) {
       // Normal workspace

--- a/MantidPlot/src/ProjectSerialiser.h
+++ b/MantidPlot/src/ProjectSerialiser.h
@@ -71,7 +71,7 @@ public:
   bool save(const QString &projectName, bool compress = false,
             bool saveAll = true);
   /// Load a project file from disk
-  void load(std::string filepath, const int fileVersion,
+  bool load(std::string filepath, const int fileVersion,
             const bool isTopLevel = true);
   /// Open the script window and load scripts from string
   void openScriptWindow(const QStringList &files);

--- a/MantidPlot/src/ScriptFileInterpreter.cpp
+++ b/MantidPlot/src/ScriptFileInterpreter.cpp
@@ -515,21 +515,21 @@ bool ScriptFileInterpreter::executeCode(const ScriptCode &code,
                                         const Script::ExecutionMode mode) {
   if (code.isEmpty())
     // This cannot fail
-	return true;
+    return true;
   if (mode == Script::Asynchronous) {
     try {
       m_runner->executeAsync(code);
-	  // Best attempt at returning a status
-	  return true;
+      // Best attempt at returning a status
+      return true;
     } catch (std::runtime_error &exc) {
       QMessageBox::critical(this, "MantidPlot", exc.what());
-	  return false; // To silence the compiler despite being useless
+      return false; // To silence the compiler despite being useless
     }
   } else if (mode == Script::Serialised) {
     return m_runner->execute(code);
   } else {
     QMessageBox::warning(this, "MantidPlot", "Unknown script execution mode");
-	return false;
+    return false;
   }
 }
 

--- a/MantidPlot/src/ScriptFileInterpreter.cpp
+++ b/MantidPlot/src/ScriptFileInterpreter.cpp
@@ -350,9 +350,9 @@ void ScriptFileInterpreter::showFindReplaceDialog() {
  * Execute the whole script in the editor. Always clears the contents of the
  * local variable dictionary first.
  */
-void ScriptFileInterpreter::executeAll(const Script::ExecutionMode mode) {
+bool ScriptFileInterpreter::executeAll(const Script::ExecutionMode mode) {
   m_runner->clearLocals();
-  executeCode(ScriptCode(m_editor->text()), mode);
+  return executeCode(ScriptCode(m_editor->text()), mode);
 }
 
 /**
@@ -511,20 +511,25 @@ bool ScriptFileInterpreter::readFileIntoEditor(const QString &filename) {
  * Use the current Script object to execute the code asynchronously
  * @param code :: The code string to run
  */
-void ScriptFileInterpreter::executeCode(const ScriptCode &code,
+bool ScriptFileInterpreter::executeCode(const ScriptCode &code,
                                         const Script::ExecutionMode mode) {
   if (code.isEmpty())
-    return;
+    // This cannot fail
+	return true;
   if (mode == Script::Asynchronous) {
     try {
       m_runner->executeAsync(code);
+	  // Best attempt at returning a status
+	  return true;
     } catch (std::runtime_error &exc) {
       QMessageBox::critical(this, "MantidPlot", exc.what());
+	  return false; // To silence the compiler despite being useless
     }
   } else if (mode == Script::Serialised) {
-    m_runner->execute(code);
+    return m_runner->execute(code);
   } else {
     QMessageBox::warning(this, "MantidPlot", "Unknown script execution mode");
+	return false;
   }
 }
 

--- a/MantidPlot/src/ScriptFileInterpreter.h
+++ b/MantidPlot/src/ScriptFileInterpreter.h
@@ -87,7 +87,7 @@ public slots:
   virtual void spacesToTabs();
 
   /// Execute the whole script.
-  virtual void
+  virtual bool
   executeAll(const Script::ExecutionMode mode = Script::Asynchronous);
   /// Execute the current selection
   virtual void
@@ -152,7 +152,7 @@ private:
   void setupScriptRunner(const ScriptingEnv &env, const QString &identifier);
 
   bool readFileIntoEditor(const QString &filename);
-  void executeCode(const ScriptCode &code, const Script::ExecutionMode mode);
+  bool executeCode(const ScriptCode &code, const Script::ExecutionMode mode);
 
   void toggleComment(bool addComment);
 
@@ -200,7 +200,7 @@ private slots:
   void showFindReplaceDialog() override {}
 
   /// Does nothing
-  void executeAll(const Script::ExecutionMode) override {}
+  bool executeAll(const Script::ExecutionMode) override { return true; }
   /// Does nothing
   void executeSelection(const Script::ExecutionMode) override {}
   /// Does nothing

--- a/MantidPlot/src/ScriptingWindow.cpp
+++ b/MantidPlot/src/ScriptingWindow.cpp
@@ -199,7 +199,8 @@ void ScriptingWindow::open(const QString &filename, bool newtab) {
  * @param mode :: The execution type
  * */
 void ScriptingWindow::executeCurrentTab(const Script::ExecutionMode mode) {
-  m_manager->executeAll(mode);
+  // Async will always return true before executing
+  m_failureFlag = !m_manager->executeAll(mode);
 }
 
 //-------------------------------------------

--- a/MantidPlot/src/ScriptingWindow.h
+++ b/MantidPlot/src/ScriptingWindow.h
@@ -10,7 +10,6 @@
 #include <boost/optional.hpp>
 #include <QMainWindow>
 
-
 //----------------------------------------------------------
 // Forward declarations
 //---------------------------------------------------------
@@ -69,7 +68,7 @@ public:
 
   /// Sets a flag which is set to true if synchronous execution fails
   // We set a flag on failure to avoid problems with Async not returning success
-  bool getSynchronousErrorFlag() { return m_failureFlag;  }
+  bool getSynchronousErrorFlag() { return m_failureFlag; }
 
 signals:
   /// Show the scripting language dialog
@@ -193,7 +192,7 @@ private:
   /// Flag to define whether we should accept a close event
   bool m_acceptClose;
 
-  bool m_failureFlag{ false };
+  bool m_failureFlag{false};
 };
 
 #endif // SCRIPTINGWINDOW_H_

--- a/MantidPlot/src/ScriptingWindow.h
+++ b/MantidPlot/src/ScriptingWindow.h
@@ -6,7 +6,10 @@
 //----------------------------------
 #include "MantidQtWidgets/Common/IProjectSerialisable.h"
 #include "Script.h"
+
+#include <boost/optional.hpp>
 #include <QMainWindow>
+
 
 //----------------------------------------------------------
 // Forward declarations
@@ -63,6 +66,11 @@ public:
                        const int fileVersion);
   // Loads the scripts from a list of filenames
   void loadFromFileList(const QStringList &files);
+
+  /// Sets a flag which is set to true if synchronous execution fails
+  // We set a flag on failure to avoid problems with Async not returning success
+  bool getSynchronousErrorFlag() { return m_failureFlag;  }
+
 signals:
   /// Show the scripting language dialog
   void chooseScriptingLanguage();
@@ -184,6 +192,8 @@ private:
   QAction *m_scripting_lang;
   /// Flag to define whether we should accept a close event
   bool m_acceptClose;
+
+  bool m_failureFlag{ false };
 };
 
 #endif // SCRIPTINGWINDOW_H_


### PR DESCRIPTION
**Cannot be merged before #22887**

**Description of work.**
Adds a top level try / catch around the recovery attempt. This will open a dialog box informing the user a full recovery could not be completed and that Mantid will continue running correctly.

**To test:**
- Open Mantid
- Create a sample workspace
- Ensure a checkpoint is saved
- Crash Mantid
- On the most recent checkpoint, open a .py file
- Remove the timestamp (everything after the # char)
- Restart and attempt recovery

Partly deals with #22901.

Does this update require release notes?
- [ ] Yes
- [x] No

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
