### PR TITLE
Add option to ADS to return hidden workspaces in getObjects()

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/DataService.h
+++ b/Framework/Kernel/inc/MantidKernel/DataService.h
@@ -486,10 +486,6 @@ public:
   getObjects(DataServiceHidden includeHidden = DataServiceHidden::Auto) const {
     std::lock_guard<std::recursive_mutex> _lock(m_mutex);
 
-    if (includeHidden == DataServiceHidden::Include) {
-      // Return all elements including hidden ones
-    }
-
     const bool alwaysIncludeHidden =
         includeHidden == DataServiceHidden::Include;
     const bool usingAuto =

--- a/Framework/Kernel/inc/MantidKernel/DataService.h
+++ b/Framework/Kernel/inc/MantidKernel/DataService.h
@@ -482,17 +482,20 @@ public:
   }
 
   /// Get a vector of the pointers to the data objects stored by the service
-  std::vector<boost::shared_ptr<T>> getObjects(DataServiceHidden includeHidden = DataServiceHidden::Auto) const {
+  std::vector<boost::shared_ptr<T>>
+  getObjects(DataServiceHidden includeHidden = DataServiceHidden::Auto) const {
     std::lock_guard<std::recursive_mutex> _lock(m_mutex);
 
-	if (includeHidden == DataServiceHidden::Include) {
-		// Return all elements including hidden ones
-	}
+    if (includeHidden == DataServiceHidden::Include) {
+      // Return all elements including hidden ones
+    }
 
-	const bool alwaysIncludeHidden = includeHidden == DataServiceHidden::Include;
-    const bool usingAuto =  includeHidden == DataServiceHidden::Auto && showingHiddenObjects();
-	
-	const bool showingHidden = alwaysIncludeHidden || usingAuto;
+    const bool alwaysIncludeHidden =
+        includeHidden == DataServiceHidden::Include;
+    const bool usingAuto =
+        includeHidden == DataServiceHidden::Auto && showingHiddenObjects();
+
+    const bool showingHidden = alwaysIncludeHidden || usingAuto;
 
     std::vector<boost::shared_ptr<T>> objects;
     objects.reserve(datamap.size());

--- a/Framework/Kernel/inc/MantidKernel/DataService.h
+++ b/Framework/Kernel/inc/MantidKernel/DataService.h
@@ -482,15 +482,23 @@ public:
   }
 
   /// Get a vector of the pointers to the data objects stored by the service
-  std::vector<boost::shared_ptr<T>> getObjects() const {
+  std::vector<boost::shared_ptr<T>> getObjects(DataServiceHidden includeHidden = DataServiceHidden::Auto) const {
     std::lock_guard<std::recursive_mutex> _lock(m_mutex);
 
-    const bool showingHidden = showingHiddenObjects();
+	if (includeHidden == DataServiceHidden::Include) {
+		// Return all elements including hidden ones
+	}
+
+	const bool alwaysIncludeHidden = includeHidden == DataServiceHidden::Include;
+    const bool usingAuto =  includeHidden == DataServiceHidden::Auto && showingHiddenObjects();
+	
+	const bool showingHidden = alwaysIncludeHidden || usingAuto;
+
     std::vector<boost::shared_ptr<T>> objects;
     objects.reserve(datamap.size());
-    for (auto it = datamap.begin(); it != datamap.end(); ++it) {
-      if (showingHidden || !isHiddenDataServiceObject(it->first)) {
-        objects.push_back(it->second);
+    for (const auto &it : datamap) {
+      if (showingHidden || !isHiddenDataServiceObject(it.first)) {
+        objects.push_back(it.second);
       }
     }
     return objects;

--- a/Framework/Kernel/test/DataServiceTest.h
+++ b/Framework/Kernel/test/DataServiceTest.h
@@ -7,7 +7,6 @@
 #include <Poco/NObserver.h>
 #include <boost/make_shared.hpp>
 
-#include <iostream>
 #include <sstream>
 #include <mutex>
 

--- a/Framework/Kernel/test/DataServiceTest.h
+++ b/Framework/Kernel/test/DataServiceTest.h
@@ -331,81 +331,86 @@ public:
   }
 
   void test_getObjectsReturnsConfigOption() {
-	  svc.clear();
+    svc.clear();
 
-	  ConfigService::Instance().setString("MantidOptions.InvisibleWorkspaces",
-		  "0");
-	  auto one = boost::make_shared<int>(1);
-	  auto two = boost::make_shared<int>(2);
-	  auto three = boost::make_shared<int>(3);
-	  svc.add("One", one);
-	  svc.add("Two", two);
-	  svc.add("TwoAgain",
-		  two); // Same pointer again - should appear twice in getObjects()
-	  svc.add("__Three", three);
+    ConfigService::Instance().setString("MantidOptions.InvisibleWorkspaces",
+                                        "0");
+    auto one = boost::make_shared<int>(1);
+    auto two = boost::make_shared<int>(2);
+    auto three = boost::make_shared<int>(3);
+    svc.add("One", one);
+    svc.add("Two", two);
+    svc.add("TwoAgain",
+            two); // Same pointer again - should appear twice in getObjects()
+    svc.add("__Three", three);
 
-	  auto objects = svc.getObjects(DataServiceHidden::Auto);
-	  auto objectsDefaultCall = svc.getObjects();
+    auto objects = svc.getObjects(DataServiceHidden::Auto);
+    auto objectsDefaultCall = svc.getObjects();
 
-	  TSM_ASSERT_EQUALS("Default parameter is not set to auto", objects, objectsDefaultCall);
+    TSM_ASSERT_EQUALS("Default parameter is not set to auto", objects,
+                      objectsDefaultCall);
 
-	  TSM_ASSERT_EQUALS("Hidden entries should not be returned", objects.size(),
-		  3);
-	  // Check the hidden ws isn't present
-	  TS_ASSERT_EQUALS(objects.at(0), one);
-	  TS_ASSERT_EQUALS(objects.at(1), two);
-	  TS_ASSERT_EQUALS(objects.at(2), two);
-	  TSM_ASSERT_EQUALS("Hidden entries should not be returned", std::find(objects.cbegin(), objects.cend(), three),
-		  objects.end());
+    TSM_ASSERT_EQUALS("Hidden entries should not be returned", objects.size(),
+                      3);
+    // Check the hidden ws isn't present
+    TS_ASSERT_EQUALS(objects.at(0), one);
+    TS_ASSERT_EQUALS(objects.at(1), two);
+    TS_ASSERT_EQUALS(objects.at(2), two);
+    TSM_ASSERT_EQUALS("Hidden entries should not be returned",
+                      std::find(objects.cbegin(), objects.cend(), three),
+                      objects.end());
 
-	  ConfigService::Instance().setString("MantidOptions.InvisibleWorkspaces",
-		  "1");
-	  objects = svc.getObjects();
-	  TS_ASSERT_EQUALS(objects.size(), 4);
+    ConfigService::Instance().setString("MantidOptions.InvisibleWorkspaces",
+                                        "1");
+    objects = svc.getObjects();
+    TS_ASSERT_EQUALS(objects.size(), 4);
   }
 
   void test_getObjectsReturnsNoHiddenOption() {
-	  svc.clear();
+    svc.clear();
 
-	  ConfigService::Instance().setString("MantidOptions.InvisibleWorkspaces",
-		  "1");
-	  auto one = boost::make_shared<int>(1);
-	  auto two = boost::make_shared<int>(2);
-	  auto three = boost::make_shared<int>(3);
-	  svc.add("One", one);
-	  svc.add("Two", two);
-	  svc.add("__Three", three);
+    ConfigService::Instance().setString("MantidOptions.InvisibleWorkspaces",
+                                        "1");
+    auto one = boost::make_shared<int>(1);
+    auto two = boost::make_shared<int>(2);
+    auto three = boost::make_shared<int>(3);
+    svc.add("One", one);
+    svc.add("Two", two);
+    svc.add("__Three", three);
 
-	  auto objects = svc.getObjects(DataServiceHidden::Exclude);
-	  TSM_ASSERT_EQUALS("Hidden entries should not be returned", objects.size(),
-		  2);
-	  // Check the hidden ws isn't present
-	  TS_ASSERT_EQUALS(objects.at(0), one);
-	  TS_ASSERT_EQUALS(objects.at(1), two);
-	  TSM_ASSERT_EQUALS("Hidden entries should not be returned", std::find(objects.cbegin(), objects.cend(), three),
-		  objects.end());
+    auto objects = svc.getObjects(DataServiceHidden::Exclude);
+    TSM_ASSERT_EQUALS("Hidden entries should not be returned", objects.size(),
+                      2);
+    // Check the hidden ws isn't present
+    TS_ASSERT_EQUALS(objects.at(0), one);
+    TS_ASSERT_EQUALS(objects.at(1), two);
+    TSM_ASSERT_EQUALS("Hidden entries should not be returned",
+                      std::find(objects.cbegin(), objects.cend(), three),
+                      objects.end());
   }
 
   void test_getObjectsReturnsHiddenOption() {
-	  svc.clear();
+    svc.clear();
 
-	  ConfigService::Instance().setString("MantidOptions.InvisibleWorkspaces",
-		  "0");
-	  auto one = boost::make_shared<int>(1);
-	  auto two = boost::make_shared<int>(2);
-	  auto three = boost::make_shared<int>(3);
-	  svc.add("One", one);
-	  svc.add("Two", two);
-	  svc.add("__Three", three);
+    ConfigService::Instance().setString("MantidOptions.InvisibleWorkspaces",
+                                        "0");
+    auto one = boost::make_shared<int>(1);
+    auto two = boost::make_shared<int>(2);
+    auto three = boost::make_shared<int>(3);
+    svc.add("One", one);
+    svc.add("Two", two);
+    svc.add("__Three", three);
 
-	  auto objects = svc.getObjects(DataServiceHidden::Include);
-	  TSM_ASSERT_EQUALS("Hidden entries should be returned", objects.size(),
-		  3);
-	  // Check the hidden ws isn't present
-	  TS_ASSERT_DIFFERS(std::find(objects.begin(), objects.end(), one), objects.end());
-	  TS_ASSERT_DIFFERS(std::find(objects.begin(), objects.end(), two), objects.end());
-	  TSM_ASSERT_DIFFERS("Hidden entries should be returned", std::find(objects.cbegin(), objects.cend(), three),
-		  objects.end());
+    auto objects = svc.getObjects(DataServiceHidden::Include);
+    TSM_ASSERT_EQUALS("Hidden entries should be returned", objects.size(), 3);
+    // Check the hidden ws isn't present
+    TS_ASSERT_DIFFERS(std::find(objects.begin(), objects.end(), one),
+                      objects.end());
+    TS_ASSERT_DIFFERS(std::find(objects.begin(), objects.end(), two),
+                      objects.end());
+    TSM_ASSERT_DIFFERS("Hidden entries should be returned",
+                       std::find(objects.cbegin(), objects.cend(), three),
+                       objects.end());
   }
 
   void test_sortedAndHiddenGetNames() {

--- a/MantidPlot/src/ProjectRecovery.cpp
+++ b/MantidPlot/src/ProjectRecovery.cpp
@@ -430,7 +430,7 @@ void ProjectRecovery::saveWsHistories(const Poco::Path &historyDestFolder) {
   const auto &ads = Mantid::API::AnalysisDataService::Instance();
 
   // Hold a copy to the shared pointers so they do not get deleted under us
-  const auto wsHandles = ads.getObjects();
+  const auto wsHandles = ads.getObjects(Mantid::Kernel::DataServiceHidden::Include);
 
   if (wsHandles.empty()) {
     return;

--- a/MantidPlot/src/ProjectRecovery.cpp
+++ b/MantidPlot/src/ProjectRecovery.cpp
@@ -430,7 +430,8 @@ void ProjectRecovery::saveWsHistories(const Poco::Path &historyDestFolder) {
   const auto &ads = Mantid::API::AnalysisDataService::Instance();
 
   // Hold a copy to the shared pointers so they do not get deleted under us
-  const auto wsHandles = ads.getObjects(Mantid::Kernel::DataServiceHidden::Include);
+  const auto wsHandles =
+      ads.getObjects(Mantid::Kernel::DataServiceHidden::Include);
 
   if (wsHandles.empty()) {
     return;


### PR DESCRIPTION
**Description of work.**
Adds a parameter to the ADS `getObjects` method similar to that found in `getObjectNames`. 

This allows users to specify whether to include hidden workspaces or retain the default behaviour of using the config option.

**To test:**
- Check unit tests pass
- Create a sample workspace with a hidden name (for example `__foo`)
- Ensure a project recovery checkpoint contains this after saving

Fixes #22901. 

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
