### PR TITLE
Fix making a package using homebrew LLVM

### DIFF
--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -108,6 +108,10 @@ if(poco_version[0] > 1 || (poco_version[0] == 1 && poco_version[1] >= 6))
 end
 
 if("@OPENMP_FOUND@" == "TRUE")
+  if not File.file?("/usr/lib/libomp.dylib")
+      # assume we're using system llvm
+      library_filenames << "libc++.dylib"
+  end
   library_filenames << "libomp.dylib"
 end
 
@@ -119,6 +123,14 @@ library_filenames.each do |filename|
     copyFile(openssl_dir+filename)
   elsif  filename.include? "libcrypto.dylib"
     copyFile(openssl_dir+filename)
+  elsif filename.include? "libomp.dylib" or filename.include? "libc++.dylib"
+      if File.file?(lib_dir+"libomp.dylib")
+        # using system llvm
+        copyFile(lib_dir+filename)
+      elsif
+        # using homebrew llvm
+        copyFile("/usr/local/opt/llvm/lib/"+filename)
+      end
   else
     copyFile(lib_dir+filename)
   end


### PR DESCRIPTION


**Description of work.**
Previously if using the homebrew LLVM the correct paths were not found
for openMP and the std C++ library.

**To test:**

Needs to be compiled on OSX with someone NOT using homebrew's custom LLVM.

_No associated issue_

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
