### PR TITLE
Fix binary operators not saving ws history correctly

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/BinaryOperations.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/BinaryOperations.cpp
@@ -176,10 +176,10 @@ ResultType performBinaryOpWithDouble(const LHSType inputWS, const double value,
   if (alg->isExecuted()) {
     singleValue = alg->getProperty("OutputWorkspace");
 
-	// We must store this in the ADS to force the workspace
-	// to have a name, so that the history entry does not
-	// use a temporary name which changes from time to time
-	ads.add(tmp_name, singleValue);
+    // We must store this in the ADS to force the workspace
+    // to have a name, so that the history entry does not
+    // use a temporary name which changes from time to time
+    ads.add(tmp_name, singleValue);
   } else {
     throw std::runtime_error(
         "performBinaryOp: Error in execution of CreateSingleValuedWorkspace");

--- a/Framework/PythonInterface/mantid/api/src/Exports/BinaryOperations.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/BinaryOperations.cpp
@@ -156,39 +156,50 @@ ResultType performBinaryOpWithDouble(const LHSType inputWS, const double value,
                                      const std::string &op,
                                      const std::string &name, bool inplace,
                                      bool reverse) {
-  const std::string &algoName = op;
+  // RAII struct to add/remove workspace from ADS
+  struct ScopedADSEntry {
+    ScopedADSEntry(const std::string &entryName,
+                   const MatrixWorkspace_sptr &value)
+        : name(entryName) {
+      ads.addOrReplace(entryName, value);
+    }
+    ~ScopedADSEntry() { ads.remove(name); }
 
-  // Create the single valued workspace first so that it is run as a top-level
-  // algorithm
-  // such that it's history can be recreated
-  API::Algorithm_sptr alg = API::AlgorithmManager::Instance().createUnmanaged(
+    const std::string &name;
+    API::AnalysisDataServiceImpl &ads = API::AnalysisDataService::Instance();
+  };
+
+  // In order to recreate a history record of the final binary operation
+  // there must be a record of the creation of the single value workspace used
+  // on the RHS here. This is achieved by running CreateSingleValuedWorkspace
+  // algorithm and adding the output workspace to the ADS. Adding the output
+  // to the ADS is critical so that workspace.name() is updated, by the ADS, to
+  // return the same string. WorkspaceProperty<TYPE>::createHistory() then
+  // records the correct workspace name for input into the final binary
+  // operation rather than creating a temporary name.
+  auto alg = API::AlgorithmManager::Instance().createUnmanaged(
       "CreateSingleValuedWorkspace");
   alg->setChild(false);
+  // we manually store the workspace as it's easier to retrieve the correct
+  // type from alg->getProperty rather than calling the ADS again and casting
   alg->setAlwaysStoreInADS(false);
   alg->initialize();
   alg->setProperty<double>("DataValue", value);
-  const std::string tmp_name("__single_value");
-  alg->setPropertyValue("OutputWorkspace", tmp_name);
+  const std::string tmpName("__python_binary_op_single_value");
+  alg->setPropertyValue("OutputWorkspace", tmpName);
   alg->execute();
 
-  auto &ads = Mantid::API::AnalysisDataService::Instance();
   MatrixWorkspace_sptr singleValue;
   if (alg->isExecuted()) {
     singleValue = alg->getProperty("OutputWorkspace");
-
-    // We must store this in the ADS to force the workspace
-    // to have a name, so that the history entry does not
-    // use a temporary name which changes from time to time
-    ads.add(tmp_name, singleValue);
   } else {
-    throw std::runtime_error(
-        "performBinaryOp: Error in execution of CreateSingleValuedWorkspace");
+    throw std::runtime_error("performBinaryOp: Error in execution of "
+                             "CreateSingleValuedWorkspace");
   }
-  // Call the function above with the single-value workspace
+  ScopedADSEntry removeOnExit(tmpName, singleValue);
   ResultType result =
       performBinaryOp<LHSType, MatrixWorkspace_sptr, ResultType>(
-          inputWS, singleValue, algoName, name, inplace, reverse);
-  ads.remove(tmp_name);
+          inputWS, singleValue, op, name, inplace, reverse);
   return result;
 }
 


### PR DESCRIPTION
**Description of work.**
Fixes binary operators not saving ws history correctly. As we create a
workspace and use it's pointer there is no name associated. This means
that the pointer is suffixed onto `__tmp`.

When users go to load the history later the __tmp name doesn't match the
output property name used in CreateSingleValueWorkspace, so this fails.

Instead we register it into the ADS before executing the operator, then
remove it afterwards. This guarentees a name exists on the workspace as
a side effect of using the ADS

**Report to:** [user name]/[nobody]. <!--If the original issue was raised by a user they should be named here.-->

**To test:**
Run the following:
```
ws = CreateSampleWorkspace()
ws *= 5
```

Open the workspace history
Copy it to a clipboard
Re-run that script, check it runs correctly

Fixes #22927 .

Does this update require release notes?
- [ ] Yes
- [x] No

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
