### PR TITLE
Fix segfault in project saving when VSI is hidden

### DIFF
--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/src/MdViewerWidget.cpp
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/src/MdViewerWidget.cpp
@@ -1054,6 +1054,10 @@ void MdViewerWidget::setActiveObjects(pqView *view, pqPipelineSource *source) {
  */
 std::string MdViewerWidget::saveToProject(ApplicationWindow *app) {
   UNUSED_ARG(app);
+  // Early exit if there are no sources
+  auto &activeObjects = pqActiveObjects::instance();
+  if (!activeObjects.activeSource())
+    return "";
   TSVSerialiser tsv, contents;
 
   // save window position & size
@@ -1064,7 +1068,7 @@ std::string MdViewerWidget::saveToProject(ApplicationWindow *app) {
   auto fileName = workingDir.toStdString() + "/VSI.xml";
 
   // Dump the state of VSI to a XML file
-  auto session = pqActiveObjects::instance().activeServer()->proxyManager();
+  auto session = activeObjects.activeServer()->proxyManager();
   session->SaveXMLState(fileName.c_str());
   contents.writeLine("FileName") << fileName;
 
@@ -1072,7 +1076,6 @@ std::string MdViewerWidget::saveToProject(ApplicationWindow *app) {
   auto vtype = currentView->getViewType();
   contents.writeLine("ViewType") << static_cast<int>(vtype);
 
-  auto &activeObjects = pqActiveObjects::instance();
   auto proxyManager = activeObjects.activeServer()->proxyManager();
   auto view = activeObjects.activeView()->getProxy();
   auto source = activeObjects.activeSource()->getProxy();


### PR DESCRIPTION
**Description of work.**

Checks for active sources in the ParaView pipeline before attempting to save the VSI state into a MantidPlot project. 

**To test:**

* Before opening Mantid, set `projectRecovery.secondsBetween = 10` in `Mantid.properties`
* run this in the script window: 
```
CreateMDWorkspace(Dimensions=3, Extents='-10,10,-10,10,-10,10', Names='A,B,C', Units='U,U,U', OutputWorkspace='ws')
BinMD(InputWorkspace='ws', AlignedDim0='A,-10,10,10', AlignedDim1='B,-10,10,10', AlignedDim2='C,-10,10,10', OutputWorkspace='to_display')
```
* open the workspace `to_display` in the vsi
* close the vsi
* wait for next time project recovery kicks in... and no crash should happen. 

Also test:

* close MantidPlot
* set `projectRecovery.enabled = false`
* repeat the above steps to show the VSI
* close the VSI
* save a project manually -> no crash

Fixes #22914.

Does this update require release notes?
- [ ] Yes
- [X] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
