### PR TITLE
Fix x bounds for fit property browser

### DIFF
--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1361,6 +1361,7 @@ void FitPropertyBrowser::doubleChanged(QtProperty *prop) {
   if (prop == m_startX) {
     // call setWorkspace to change maxX in functions
     setWorkspace(m_compositeFunction);
+    m_doubleManager->setMinimum(m_endX, value);
     getHandler()->setAttribute("StartX", value);
     emit startXChanged(startX());
     emit xRangeChanged(startX(), endX());
@@ -1368,6 +1369,7 @@ void FitPropertyBrowser::doubleChanged(QtProperty *prop) {
   } else if (prop == m_endX) {
     // call setWorkspace to change minX in functions
     setWorkspace(m_compositeFunction);
+    m_doubleManager->setMaximum(m_startX, value);
     getHandler()->setAttribute("EndX", value);
     emit endXChanged(endX());
     emit xRangeChanged(startX(), endX());


### PR DESCRIPTION
**Description of work.**

Limit the x bounds for the user so they cannot set the upper bound higher than the lower bound or visa versa.

**To test:**

 - See issue for testing instructions.
 - I believe this is a regression during this release so no need for release notes.

Fixes #22879 

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
