### PR TITLE
Indirect Data reduction use the same syntax as GroupDetector algorithm

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
@@ -360,9 +360,6 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
 
         self._output_ws = self.getPropertyValue('OutputWorkspace')
 
-        if self._grouping_string is not None:
-            self._grouping_string = self._grouping_string.replace('-', ':')
-
         # Disable sum files if there is only one file
         if len(self._data_files) == 1:
             if self._sum_files:

--- a/docs/source/interfaces/Indirect Data Reduction.rst
+++ b/docs/source/interfaces/Indirect Data Reduction.rst
@@ -136,7 +136,11 @@ Grouping
 The following options are available for grouping output data:
 
 Custom
-  A comma separated list can be entered to specify the groups, e.g. 1, 3-5, 6-8, 10.
+  Follows the same grouping patterns used in the :ref:`GroupDetectors <algm-GroupDetectors>` algorithm.
+  An example of the syntax is 1,2+3,4-6,7-10
+
+  This would produce spectra for: spectra 1, the sum of spectra 2 and 3, the sum of spectra 4-6 (4+5+6)
+  and individual spectra from 7 to 10 (7,8,9,10)
 
 Individual
   All detectors will remain on individual spectra.

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -48,7 +48,7 @@ ISISEnergyTransfer::ISISEnergyTransfer(IndirectDataReduction *idrUI,
   mappingOptionSelected(m_uiForm.cbGroupingOptions->currentText());
 
   // Add validation to custom detector grouping
-  QRegExp re("([0-9]+[-]?[0-9]*,[ ]?)*[0-9]+[-]?[0-9]*");
+  QRegExp re("([0-9]+[-:+]?[0-9]*,[ ]?)*[0-9]+[-:+]?[0-9]*");
   m_uiForm.leCustomGroups->setValidator(new QRegExpValidator(re, this));
 
   // Validate to remove invalid markers

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.ui
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.ui
@@ -313,6 +313,13 @@
             <property name="enabled">
              <bool>true</bool>
             </property>
+            <property name="toolTip">
+              <string>, allows you to specify additional indices. 1,2,4 will keep indices 1, 2 and 4 only.
+: indicates a continuous range of indices. For example, 1:5 is the same as 1,2,3,4,5.
++ sums two spectra together. 7+9 will produce a single spectra listing the sum of 7 and 9, ignoring any others.
+- sums a range of spectra together. For example, 3-8 is the same as 3+4+5+6+7+8.
+              </string>
+            </property>
             <property name="maximumSize">
              <size>
               <width>16777215</width>


### PR DESCRIPTION
**Description of work.**

This is an additional part of the fix for #22858. The original PR stopped the crash behaviour however, without this PR, the custom grouping option in the interface does not perform any of the grouping operations as expected. This is a small change that will allow users to use the same syntax for the group detectors algorithm in the custom grouping field.


**To test:**

* Open mantid plot
* Open the Indirect data reduction interface (Interfaces > Indirect > Data Reduction)
* Enter the run number 21360 (this can be found in the unit test data) into the Run Files field
* Change the Detector Grouping mode to Custom.
* Leave the field empty and click Run
* See that a dialog box with an appropriate error message is produced.
* Try out different [custom grouping patterns](http://docs.mantidproject.org/nightly/algorithms/GroupDetectors-v2.html#groupingpattern) and ensure that you get the number of spectra in the output workspace that you would expect

Fixes #22858

*No release notes required*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
