### PR TITLE
WorkspaceGroup->getMemorySize() now returns actual size instead of 0

### DIFF
--- a/Framework/API/inc/MantidAPI/WorkspaceGroup.h
+++ b/Framework/API/inc/MantidAPI/WorkspaceGroup.h
@@ -63,7 +63,7 @@ public:
   const std::string toString() const override;
 
   /// The collection itself is considered to take up no space
-  size_t getMemorySize() const override { return 0; }
+  size_t getMemorySize() const override;
   /// Sort the internal data structure according to member name
   void sortMembersByName();
   /// Adds a workspace to the group.

--- a/Framework/API/inc/MantidAPI/WorkspaceGroup.h
+++ b/Framework/API/inc/MantidAPI/WorkspaceGroup.h
@@ -62,7 +62,7 @@ public:
   /// Returns a formatted string detailing the contents of the group
   const std::string toString() const override;
 
-  /// The collection itself is considered to take up no space
+  /// Return the memory size of all workspaces in this group and subgroups
   size_t getMemorySize() const override;
   /// Sort the internal data structure according to member name
   void sortMembersByName();

--- a/Framework/API/src/WorkspaceGroup.cpp
+++ b/Framework/API/src/WorkspaceGroup.cpp
@@ -463,21 +463,19 @@ bool WorkspaceGroup::isInGroup(const Workspace &workspaceToCheck,
   return false;
 }
 
-size_t WorkspaceGroup::getMemorySize(){
+size_t WorkspaceGroup::getMemorySize() const {
   auto total = std::size_t(0);
   // Go through each workspace
-  for (auto workspace : workspaces) {
+  for (auto workspace : m_workspaces) {
     // If the workspace is a group
     if (workspace->getMemorySize() == 0) {
       total =
-          total + getGroupMemorySize(
-                      boost::dynamic_pointer_cast<WorkspaceGroup>(workspace));
+          total + boost::dynamic_pointer_cast<WorkspaceGroup>(workspace)->getMemorySize();
       continue;
     }
     total = total + workspace->getMemorySize();
   }
   return total;
-}
 }
 
 } // namespace API

--- a/Framework/API/src/WorkspaceGroup.cpp
+++ b/Framework/API/src/WorkspaceGroup.cpp
@@ -469,8 +469,9 @@ size_t WorkspaceGroup::getMemorySize() const {
   for (auto workspace : m_workspaces) {
     // If the workspace is a group
     if (workspace->getMemorySize() == 0) {
-      total =
-          total + boost::dynamic_pointer_cast<WorkspaceGroup>(workspace)->getMemorySize();
+      total = total +
+              boost::dynamic_pointer_cast<WorkspaceGroup>(workspace)
+                  ->getMemorySize();
       continue;
     }
     total = total + workspace->getMemorySize();

--- a/Framework/API/src/WorkspaceGroup.cpp
+++ b/Framework/API/src/WorkspaceGroup.cpp
@@ -463,6 +463,23 @@ bool WorkspaceGroup::isInGroup(const Workspace &workspaceToCheck,
   return false;
 }
 
+size_t WorkspaceGroup::getMemorySize(){
+  auto total = std::size_t(0);
+  // Go through each workspace
+  for (auto workspace : workspaces) {
+    // If the workspace is a group
+    if (workspace->getMemorySize() == 0) {
+      total =
+          total + getGroupMemorySize(
+                      boost::dynamic_pointer_cast<WorkspaceGroup>(workspace));
+      continue;
+    }
+    total = total + workspace->getMemorySize();
+  }
+  return total;
+}
+}
+
 } // namespace API
 } // namespace Mantid
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MantidTreeWidgetItem.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MantidTreeWidgetItem.h
@@ -28,7 +28,6 @@ private:
   static Mantid::Types::Core::DateAndTime
   getLastModified(const QTreeWidgetItem *);
   std::size_t getMemorySize() const;
-  std::size_t getGroupMemorySize(Mantid::API::WorkspaceGroup_sptr group) const;
   int m_sortPos;
 };
 }

--- a/qt/widgets/common/src/MantidTreeWidgetItem.cpp
+++ b/qt/widgets/common/src/MantidTreeWidgetItem.cpp
@@ -65,35 +65,6 @@ bool MantidTreeWidgetItem::operator<(const QTreeWidgetItem &other) const {
   }
   // If both should be sorted and the scheme is set to ByMemorySize ...
   else if (m_parent->getSortScheme() == MantidItemSortScheme::ByMemorySize) {
-    auto thisGroupSize = std::size_t(0);
-    auto otherGroupSize = std::size_t(0);
-    // If workspace parent is a group since groups return 0:
-    if (this->getMemorySize() == 0) {
-      auto theWorkspace = this->data(0, Qt::UserRole).value<Workspace_sptr>();
-      thisGroupSize = getGroupMemorySize(
-          boost::dynamic_pointer_cast<WorkspaceGroup>(theWorkspace));
-    }
-    // If workspace other is a group since groups return 0:
-    if (mantidOther->getMemorySize() == 0) {
-      auto theWorkspace =
-          mantidOther->data(0, Qt::UserRole).value<Workspace_sptr>();
-      otherGroupSize = getGroupMemorySize(
-          boost::dynamic_pointer_cast<WorkspaceGroup>(theWorkspace));
-    }
-    // If either are groups:
-    if (thisGroupSize > 0 || otherGroupSize > 0) {
-      // If this is group and other is not
-      if (thisGroupSize > 0 && otherGroupSize == 0) {
-        return thisGroupSize < mantidOther->getMemorySize();
-      }
-      // If other is group and this iss not
-      if (otherGroupSize > 0 && thisGroupSize == 0) {
-        return this->getMemorySize() < otherGroupSize;
-      }
-      // Both are groups
-      return thisGroupSize < otherGroupSize;
-    }
-    // else return normally:
     return this->getMemorySize() < mantidOther->getMemorySize();
   }
   // ... else both should be sorted and the scheme is set to ByLastModified.
@@ -136,23 +107,6 @@ DateAndTime MantidTreeWidgetItem::getLastModified(const QTreeWidgetItem *item) {
 }
 std::size_t MantidTreeWidgetItem::getMemorySize() const {
   return this->data(0, Qt::UserRole).value<Workspace_sptr>()->getMemorySize();
-}
-std::size_t
-MantidTreeWidgetItem::getGroupMemorySize(WorkspaceGroup_sptr group) const {
-  std::vector<Workspace_sptr> workspaces = group->getAllItems();
-  auto total = std::size_t(0);
-  // Go through each workspace
-  for (auto workspace : workspaces) {
-    // If the workspace is a group
-    if (workspace->getMemorySize() == 0) {
-      total =
-          total + getGroupMemorySize(
-                      boost::dynamic_pointer_cast<WorkspaceGroup>(workspace));
-      continue;
-    }
-    total = total + workspace->getMemorySize();
-  }
-  return total;
 }
 }
 }


### PR DESCRIPTION
**Description of work.**
Cleaned up a previous issue where a nasty hack was used to get a feature into the code in time for release, it's now been cleaned up and getMemorySize works for WorkspaceGroup instead of just returning 0.

**Report to:** nobody. <!--If the original issue was raised by a user they should be named here.-->

**To test:**
This is a code clean up but to make sure the previously fixed issue still works:

- Load multiple workspaces of differing sizes that are plainly obvious
- In the workspace widget Sort->Size
- It should sort by the size now for both groups and normal Workspaces alike

Resolves #22913 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
