### PR TITLE
Changed save extension to .h5 

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
@@ -127,7 +127,7 @@ class SANSSave(DataProcessorAlgorithm):
 
         # SaveNXcanSAS clashes with SaveNexusProcessed
         self.add_file_format_with_appended_name_requirement(file_formats, SaveType.NXcanSAS, file_types,
-                                                            [SaveType.Nexus])
+                                                            [])
 
         # SaveNISTDAT clashes with SaveRKH, both can save to .dat
         self.add_file_format_with_appended_name_requirement(file_formats, SaveType.NistQxy, file_types, [SaveType.RKH])

--- a/Testing/SystemTests/tests/analysis/SANSSaveTest.py
+++ b/Testing/SystemTests/tests/analysis/SANSSaveTest.py
@@ -80,7 +80,7 @@ class SANSSaveTest(unittest.TestCase):
 
         # Assert
         expected_files = ["sample_sans_save_file.xml", "sample_sans_save_file.txt", "sample_sans_save_file_nistqxy.dat",
-                          "sample_sans_save_file_nxcansas.nxs", "sample_sans_save_file.nxs",
+                          "sample_sans_save_file.h5", "sample_sans_save_file.nxs",
                           "sample_sans_save_file.csv"]
         expected_full_file_names = [os.path.join(mantid.config.getString('defaultsave.directory'), elem)
                                     for elem in expected_files]

--- a/docs/source/release/v3.13.0/sans.rst
+++ b/docs/source/release/v3.13.0/sans.rst
@@ -27,6 +27,7 @@ Improvements
 * Improved error messages in the new GUI to be more obvious and clearer.
 * Updated the naming of workspace groups in a sliced reduction.
 * Updated old backend to mask by detector ID rather than spectrum number, improving reliability.
+* NXcanSAS is now saved out with a .h5 extension so it can be read into SASView.
 
 Bugfixes
 ########

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
@@ -291,7 +291,7 @@ QGroupBox::title {
                         <string>Memor&amp;y</string>
                        </property>
                        <property name="checked">
-                        <bool>true</bool>
+                        <bool>false</bool>
                        </property>
                       </widget>
                      </item>
@@ -312,6 +312,9 @@ QGroupBox::title {
                        </property>
                        <property name="text">
                         <string>Both</string>
+                       </property>
+                       <property name="checked">
+                        <bool>true</bool>
                        </property>
                       </widget>
                      </item>

--- a/scripts/SANS/sans/algorithm_detail/save_workspace.py
+++ b/scripts/SANS/sans/algorithm_detail/save_workspace.py
@@ -43,7 +43,7 @@ def get_save_strategy(file_format_bundle, file_name, save_options):
         file_name = get_file_name(file_format_bundle, file_name, "", ".xml")
         save_name = "SaveCanSAS1D"
     elif file_format is SaveType.NXcanSAS:
-        file_name = get_file_name(file_format_bundle, file_name, "_nxcansas", ".nxs")
+        file_name = get_file_name(file_format_bundle, file_name, "_nxcansas", ".h5")
         save_name = "SaveNXcanSAS"
     elif file_format is SaveType.NistQxy:
         file_name = get_file_name(file_format_bundle, file_name, "_nistqxy", ".dat")


### PR DESCRIPTION
**Description of work.**
This PR changes the extension used to save out NXcanSAS file from .nxs to .h5 so they can be read in by SASView
**Report to:** steve <!--If the original issue was raised by a user they should be named here.-->

**To test:**

Run a reduction in the new sans GUI. Data can be found here #22949
* Check that the save option both is selected by default.
* Check that NxCanSAS is checked
* Check that an appropriately names .h5 file appears in the output directory. 

<!-- Instructions for testing. -->

Fixes #22954 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

Does this update require release notes?
- [x] Yes
- [ ] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
