### PR TITLE
Short sleep after each file of doctests

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -96,8 +96,11 @@ except TypeError:
 
 # Run this after each test group has executed
 doctest_global_cleanup = """
+import time
 from mantid.api import FrameworkManager
 FrameworkManager.Instance().clear()
+# sleep for short period to allow memory to be freed
+time.sleep(2)
 """
 
 # -- Options for pngmath --------------------------------------------------


### PR DESCRIPTION
**Description of work.**

Despite the doctests global cleanup clearing the framework it was observed that the memory was not freed back to the OS. This introduces a small wait between each file of tests.

**To test:**

Doctests should pass

*No associated issue*

Does this update require release notes?
- [ ] Yes
- [X] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
