### PR TITLE
Remove newline chars in the script builder when writing history

### DIFF
--- a/Framework/API/src/ScriptBuilder.cpp
+++ b/Framework/API/src/ScriptBuilder.cpp
@@ -222,8 +222,8 @@ ScriptBuilder::buildAlgorithmString(const AlgorithmHistory &algHistory) {
   }
 
   std::string historyEntry = name + "(" + propStr + ")";
-  historyEntry.erase(
-	  boost::remove_if(historyEntry, boost::is_any_of("\n\r")), historyEntry.end());
+  historyEntry.erase(boost::remove_if(historyEntry, boost::is_any_of("\n\r")),
+                     historyEntry.end());
   return historyEntry;
 }
 

--- a/Framework/API/src/ScriptBuilder.cpp
+++ b/Framework/API/src/ScriptBuilder.cpp
@@ -12,6 +12,8 @@
 #include "MantidKernel/Property.h"
 #include "MantidKernel/PropertyHistory.h"
 
+#include <boost/range/algorithm/remove_if.hpp>
+#include <boost/algorithm/string/classification.hpp>
 #include <boost/utility.hpp>
 #include <set>
 
@@ -219,7 +221,10 @@ ScriptBuilder::buildAlgorithmString(const AlgorithmHistory &algHistory) {
     propStr.erase(propStr.size() - 1);
   }
 
-  return name + "(" + propStr + ")";
+  std::string historyEntry = name + "(" + propStr + ")";
+  historyEntry.erase(
+	  boost::remove_if(historyEntry, boost::is_any_of("\n\r")), historyEntry.end());
+  return historyEntry;
 }
 
 /**

--- a/Framework/API/test/ScriptBuilderTest.h
+++ b/Framework/API/test/ScriptBuilderTest.h
@@ -85,37 +85,36 @@ class ScriptBuilderTest : public CxxTest::TestSuite {
     }
   };
 
-
   class NewlineAlgorithm : public Algorithm {
   public:
-	  NewlineAlgorithm() : Algorithm() {}
-	  ~NewlineAlgorithm() override {}
-	  const std::string name() const override { return "Foo\n\rBar"; }
-	  const std::string summary() const override { return "Test"; }
-	  int version() const override { return 1; }
-	  const std::string category() const override { return "Cat;Leopard;Mink"; }
-	  
-	  void afterPropertySet(const std::string &name) override {
-		  if (name == "InputWorkspace")
-			  declareProperty("DynamicInputProperty", "");
-	  }
+    NewlineAlgorithm() : Algorithm() {}
+    ~NewlineAlgorithm() override {}
+    const std::string name() const override { return "Foo\n\rBar"; }
+    const std::string summary() const override { return "Test"; }
+    int version() const override { return 1; }
+    const std::string category() const override { return "Cat;Leopard;Mink"; }
 
-	  void init() override {
-		  declareProperty(make_unique<WorkspaceProperty<MatrixWorkspace>>(
-			  "InputWorkspace", "", Direction::Input));
-		  declareProperty(make_unique<WorkspaceProperty<MatrixWorkspace>>(
-			  "OutputWorkspace", "", Direction::Output));
-		  declareProperty("PropertyA", "Hello");
-		  declareProperty("PropertyB", "World");
-	  }
-	  void exec() override {
-		  declareProperty("DynamicProperty1", "value", Direction::Output);
-		  setPropertyValue("DynamicProperty1", "outputValue");
+    void afterPropertySet(const std::string &name) override {
+      if (name == "InputWorkspace")
+        declareProperty("DynamicInputProperty", "");
+    }
 
-		  boost::shared_ptr<MatrixWorkspace> output =
-			  boost::make_shared<WorkspaceTester>();
-		  setProperty("OutputWorkspace", output);
-	  }
+    void init() override {
+      declareProperty(make_unique<WorkspaceProperty<MatrixWorkspace>>(
+          "InputWorkspace", "", Direction::Input));
+      declareProperty(make_unique<WorkspaceProperty<MatrixWorkspace>>(
+          "OutputWorkspace", "", Direction::Output));
+      declareProperty("PropertyA", "Hello");
+      declareProperty("PropertyB", "World");
+    }
+    void exec() override {
+      declareProperty("DynamicProperty1", "value", Direction::Output);
+      setPropertyValue("DynamicProperty1", "outputValue");
+
+      boost::shared_ptr<MatrixWorkspace> output =
+          boost::make_shared<WorkspaceTester>();
+      setProperty("OutputWorkspace", output);
+    }
   };
 
   // middle layer algorithm executed by a top level algorithm
@@ -238,7 +237,7 @@ public:
     Mantid::API::AlgorithmFactory::Instance().subscribe<NestedAlgorithm>();
     Mantid::API::AlgorithmFactory::Instance().subscribe<BasicAlgorithm>();
     Mantid::API::AlgorithmFactory::Instance().subscribe<SubAlgorithm>();
-	Mantid::API::AlgorithmFactory::Instance().subscribe<NewlineAlgorithm>();
+    Mantid::API::AlgorithmFactory::Instance().subscribe<NewlineAlgorithm>();
     Mantid::API::AlgorithmFactory::Instance()
         .subscribe<AlgorithmWithDynamicProperty>();
   }
@@ -251,7 +250,7 @@ public:
     Mantid::API::AlgorithmFactory::Instance().unsubscribe("SubAlgorithm", 1);
     Mantid::API::AlgorithmFactory::Instance().unsubscribe(
         "AlgorithmWithDynamicProperty", 1);
-	Mantid::API::AlgorithmFactory::Instance().unsubscribe("Foo\n\rBar", 1 );
+    Mantid::API::AlgorithmFactory::Instance().unsubscribe("Foo\n\rBar", 1);
   }
 
   void test_Build_Simple() {
@@ -290,38 +289,39 @@ public:
   }
 
   void test_newline_chars_removed() {
-	  // Check that any newline chars are removed
-	  std::string result[] = {"FooBar(InputWorkspace='test_input_workspace',"
-							  " OutputWorkspace='test_output_workspace')", ""};
+    // Check that any newline chars are removed
+    std::string result[] = {"FooBar(InputWorkspace='test_input_workspace',"
+                            " OutputWorkspace='test_output_workspace')",
+                            ""};
 
-	  boost::shared_ptr<WorkspaceTester> input =
-		  boost::make_shared<WorkspaceTester>();
-	  AnalysisDataService::Instance().addOrReplace("test_input_workspace", input);
+    boost::shared_ptr<WorkspaceTester> input =
+        boost::make_shared<WorkspaceTester>();
+    AnalysisDataService::Instance().addOrReplace("test_input_workspace", input);
 
-	  auto alg = AlgorithmFactory::Instance().create("Foo\n\rBar", 1);
-	  alg->initialize();
-	  alg->setRethrows(true);
-	  alg->setProperty("InputWorkspace", input);
-	  alg->setPropertyValue("OutputWorkspace", "test_output_workspace");
-	  alg->execute();
+    auto alg = AlgorithmFactory::Instance().create("Foo\n\rBar", 1);
+    alg->initialize();
+    alg->setRethrows(true);
+    alg->setProperty("InputWorkspace", input);
+    alg->setPropertyValue("OutputWorkspace", "test_output_workspace");
+    alg->execute();
 
-	  auto ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
-		  "test_output_workspace");
-	  auto wsHist = ws->getHistory();
+    auto ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+        "test_output_workspace");
+    auto wsHist = ws->getHistory();
 
-	  ScriptBuilder builder(wsHist.createView());
-	  std::string scriptText = builder.build();
+    ScriptBuilder builder(wsHist.createView());
+    std::string scriptText = builder.build();
 
-	  std::vector<std::string> scriptLines;
-	  boost::split(scriptLines, scriptText, boost::is_any_of("\n"));
+    std::vector<std::string> scriptLines;
+    boost::split(scriptLines, scriptText, boost::is_any_of("\n"));
 
-	  int i = 0;
-	  for (auto it = scriptLines.begin(); it != scriptLines.end(); ++it, ++i) {
-		  TS_ASSERT_EQUALS(*it, result[i])
-	  }
+    int i = 0;
+    for (auto it = scriptLines.begin(); it != scriptLines.end(); ++it, ++i) {
+      TS_ASSERT_EQUALS(*it, result[i])
+    }
 
-	  AnalysisDataService::Instance().remove("test_output_workspace");
-	  AnalysisDataService::Instance().remove("test_input_workspace");
+    AnalysisDataService::Instance().remove("test_output_workspace");
+    AnalysisDataService::Instance().remove("test_input_workspace");
   }
 
   void test_Build_Simple_Timestamped() {


### PR DESCRIPTION
**Description of work.**
Removes newline characters in the script builder if they exist, for example in a shape geometry. 

**To test:**
- Run the unit tests
- Run the following script which will create a log entry for `SetSample` that has newline chars
```
from isis_powder import Polaris

config_file_path = r"/Users/keithbutler/Mantid/RecoveryMode/TestScripts/Polaris/polaris_config_example.yaml"
polaris_example = Polaris(config_file=config_file_path,
                          user_name="Mantid")                         
polaris_example.create_vanadium( mode="Rietveld", do_absorb_corrections=True, 
                                first_cycle_run_no=98531, multiple_scattering=False)
```

- Crash Mantid and check that the SetSample entry does not split across multiple lines. 
- Note: SetSample will not work due to serialising a Python dictionary incorrectly

Fixes #22898

Does this update require release notes?
- [ ] Yes
- [x] No

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
