### PR TITLE
Rounding sample thickness display value

### DIFF
--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -969,7 +969,7 @@ class RunTabPresenter(object):
             row_entry = "SampleScatter:{},ssp:{},SampleTrans:{},stp:{},SampleDirect:{},sdp:{}," \
                         "CanScatter:{},csp:{},CanTrans:{},ctp:{}," \
                         "CanDirect:{},cdp:{},OutputName:{},User File:{}," \
-                        "Sample Thickness:{}".format(sample_scatter,
+                        "Sample Thickness:{:.2f}".format(sample_scatter,
                                                      get_string_period(sample_scatter_period),
                                                      sample_transmission,
                                                      get_string_period(sample_transmission_period),
@@ -985,7 +985,7 @@ class RunTabPresenter(object):
         else:
             row_entry = "SampleScatter:{},SampleTrans:{},SampleDirect:{}," \
                         "CanScatter:{},CanTrans:{}," \
-                        "CanDirect:{},OutputName:{},User File:{},Sample Thickness:{}".format(sample_scatter,
+                        "CanDirect:{},OutputName:{},User File:{},Sample Thickness:{:.2f}".format(sample_scatter,
                                                                                              sample_transmission,
                                                                                              sample_direct,
                                                                                              can_scatter,

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -970,28 +970,28 @@ class RunTabPresenter(object):
                         "CanScatter:{},csp:{},CanTrans:{},ctp:{}," \
                         "CanDirect:{},cdp:{},OutputName:{},User File:{}," \
                         "Sample Thickness:{:.2f}".format(sample_scatter,
-                                                     get_string_period(sample_scatter_period),
-                                                     sample_transmission,
-                                                     get_string_period(sample_transmission_period),
-                                                     sample_direct,
-                                                     get_string_period(sample_direct_period),
-                                                     can_scatter,
-                                                     get_string_period(can_scatter_period),
-                                                     can_transmission,
-                                                     get_string_period(can_transmission_period),
-                                                     can_direct,
-                                                     get_string_period(can_direct_period),
-                                                     output_name, user_file, sample_thickness)
+                                                         get_string_period(sample_scatter_period),
+                                                         sample_transmission,
+                                                         get_string_period(sample_transmission_period),
+                                                         sample_direct,
+                                                         get_string_period(sample_direct_period),
+                                                         can_scatter,
+                                                         get_string_period(can_scatter_period),
+                                                         can_transmission,
+                                                         get_string_period(can_transmission_period),
+                                                         can_direct,
+                                                         get_string_period(can_direct_period),
+                                                         output_name, user_file, sample_thickness)
         else:
             row_entry = "SampleScatter:{},SampleTrans:{},SampleDirect:{}," \
                         "CanScatter:{},CanTrans:{}," \
                         "CanDirect:{},OutputName:{},User File:{},Sample Thickness:{:.2f}".format(sample_scatter,
-                                                                                             sample_transmission,
-                                                                                             sample_direct,
-                                                                                             can_scatter,
-                                                                                             can_transmission,
-                                                                                             can_direct,
-                                                                                             output_name, user_file,sample_thickness)
+                                                                                                 sample_transmission,
+                                                                                                 sample_direct,
+                                                                                                 can_scatter,
+                                                                                                 can_transmission,
+                                                                                                 can_direct,
+                                                                                                 output_name, user_file,sample_thickness)
 
         self._view.add_row(row_entry)
 

--- a/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
@@ -171,14 +171,15 @@ class RunTabPresenterTest(unittest.TestCase):
         self.assertEqual(view.add_row.call_count, 2)
         if use_multi_period:
             expected_first_row = "SampleScatter:SANS2D00022024,ssp:,SampleTrans:SANS2D00022048,stp:,SampleDirect:SANS2D00022048,sdp:," \
-                                 "CanScatter:,csp:,CanTrans:,ctp:,CanDirect:,cdp:,OutputName:test_file,User File:user_test_file,Sample Thickness:1.0"
+                                 "CanScatter:,csp:,CanTrans:,ctp:,CanDirect:,cdp:,OutputName:test_file," \
+                                 "User File:user_test_file,Sample Thickness:1.00"
             expected_second_row = "SampleScatter:SANS2D00022024,ssp:,SampleTrans:,stp:,SampleDirect:,sdp:," \
-                                  "CanScatter:,csp:,CanTrans:,ctp:,CanDirect:,cdp:,OutputName:test_file2,User File:,Sample Thickness:1.0"
+                                  "CanScatter:,csp:,CanTrans:,ctp:,CanDirect:,cdp:,OutputName:test_file2,User File:,Sample Thickness:1.00"
         else:
             expected_first_row = "SampleScatter:SANS2D00022024,SampleTrans:SANS2D00022048,SampleDirect:SANS2D00022048," \
-                                 "CanScatter:,CanTrans:,CanDirect:,OutputName:test_file,User File:user_test_file,Sample Thickness:1.0"
+                                 "CanScatter:,CanTrans:,CanDirect:,OutputName:test_file,User File:user_test_file,Sample Thickness:1.00"
             expected_second_row = "SampleScatter:SANS2D00022024,SampleTrans:,SampleDirect:," \
-                                  "CanScatter:,CanTrans:,CanDirect:,OutputName:test_file2,User File:,Sample Thickness:1.0"
+                                  "CanScatter:,CanTrans:,CanDirect:,OutputName:test_file2,User File:,Sample Thickness:1.00"
 
         calls = [mock.call(expected_first_row), mock.call(expected_second_row)]
         view.add_row.assert_has_calls(calls)
@@ -212,7 +213,7 @@ class RunTabPresenterTest(unittest.TestCase):
         self.assertEqual(view.set_multi_period_view_mode.call_count, 1)
 
         expected_row = "SampleScatter:SANS2D00022024,ssp:3,SampleTrans:,stp:,SampleDirect:,sdp:," \
-                       "CanScatter:,csp:,CanTrans:,ctp:,CanDirect:,cdp:,OutputName:test_file,User File:,Sample Thickness:1.0"
+                       "CanScatter:,csp:,CanTrans:,ctp:,CanDirect:,cdp:,OutputName:test_file,User File:,Sample Thickness:1.00"
 
         calls = [mock.call(expected_row)]
         view.add_row.assert_has_calls(calls)


### PR DESCRIPTION
**Description of work.**
This rounds the sample thickness to 2 decimal places before displaying it.
**Report to:** steve <!--If the original issue was raised by a user they should be named here.-->

**To test:**
* Get the data from #22949
* In the ISIS SANS GUI load USER_LOQ_181R_M3_Eastoe_8mm_Changer_MAIN.txt as the userfile
Load 

* Load batch_mode_reduction.csv as the batch file

Check that the sample thickness displays as 1.10
<!-- Instructions for testing. -->

Fixes #22969. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

Does this update require release notes?
- [ ] Yes
- [x] No
This is fixing an issue with a feature added this release.
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
