### PR TITLE
Added the option to load NX 5 extension

### DIFF
--- a/scripts/Interface/reduction_gui/instruments/eqsans_interface_dev.py
+++ b/scripts/Interface/reduction_gui/instruments/eqsans_interface_dev.py
@@ -31,7 +31,7 @@ class EQSANSInterface(InstrumentInterface):
     """
         Defines the widgets for EQSANS reduction
     """
-    data_type = "Data files *.nxs *.dat (*.nxs *.dat)"
+    data_type = "Data files *.nxs *.dat *.h5 (*.nxs *.dat *.h5)"
 
     def __init__(self, name, settings):
         super(EQSANSInterface, self).__init__(name, settings)


### PR DESCRIPTION
**Description of work.**

On the ORNL EQSANS interface added an option to load 

**To test:**

Tests should pass but if you really want to test, run the shell code below.

Note: change `~git/mantid` with the root of your mantid folder.

```
cd ~/git/mantid/scripts/Interface/
export PYTHONPATH=$PYTHONPATH:~/git/mantid/scripts/Interface/:~/git/mantid/Build/bin
python reduction_application.py
```

Pick ORNL and EQSANS.
You should be able to load an` .nxs.h5` file.
E.g.: `/SNS/EQSANS/IPTS-21494/nexus/EQSANS_96412.nxs.h5`.

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
