### PR TITLE
Allow loading of logs after duplicate detected

### DIFF
--- a/Framework/DataHandling/src/LoadLog.cpp
+++ b/Framework/DataHandling/src/LoadLog.cpp
@@ -39,6 +39,24 @@ using API::WorkspaceProperty;
 using DataObjects::Workspace2D_sptr;
 using Types::Core::DateAndTime;
 
+namespace {
+
+template <class MapClass, class LoggerType>
+void addLogDataToRun(Mantid::API::Run &run, MapClass &aMap,
+                     LoggerType &logger) {
+  for (auto &itr : aMap) {
+    try {
+      run.addLogData(itr.second.release());
+    } catch (std::invalid_argument &e) {
+      logger.warning() << e.what() << '\n';
+    } catch (Exception::ExistsError &e) {
+      logger.warning() << e.what() << '\n';
+    }
+  }
+}
+
+} // namespace
+
 /// Empty default constructor
 LoadLog::LoadLog() {}
 
@@ -288,18 +306,8 @@ void LoadLog::loadThreeColumnLogFile(std::ifstream &logFileStream,
       }
     }
   }
-  try {
-    for (auto &itr : dMap) {
-      run.addLogData(itr.second.release());
-    }
-    for (auto &sitr : sMap) {
-      run.addLogData(sitr.second.release());
-    }
-  } catch (std::invalid_argument &e) {
-    g_log.warning() << e.what();
-  } catch (Exception::ExistsError &e) {
-    g_log.warning() << e.what();
-  }
+  addLogDataToRun(run, dMap, g_log);
+  addLogDataToRun(run, sMap, g_log);
 }
 
 /**


### PR DESCRIPTION
**Report to:** Freddie Akeroyd

**Description of work.**

Move the exception handling to inside the loops so that log
loading continues after e.g. a duplicate is detected. An issue
was spotted on OFFSPEC where a block called NSPECTRA had been
created and this conflicted with a sample log created by the
LoadRaw routine itself.

**To test:**

Load raw file for OFFSPEC run 42712 which will call LoadLogs but you will not see sample logs such as 
s1hc and s1vc which are visible in the corresponding nxs file. After merging PR you should see s1hc and s1vc in sample logs by both routes (raw and nxs) 

Fixes #22963 

Does this update require release notes?
- [ ] Yes
- [X] No

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [x] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
