### PR TITLE
Fix warnings with GCC 7

### DIFF
--- a/Framework/HistogramData/test/HistogramIteratorTest.h
+++ b/Framework/HistogramData/test/HistogramIteratorTest.h
@@ -301,9 +301,10 @@ public:
 
   void test_convert_counts_to_frequency_for_each_item_sparse() {
     double total = 0;
+    double floor = static_cast<double>(histSize) - 5.0;
     for (size_t i = 0; i < nHists; i++) {
       for (auto &item : m_hist) {
-        if (item.counts() > histSize - 5)
+        if (item.counts() > floor)
           total += item.frequency();
       }
     }
@@ -311,11 +312,12 @@ public:
 
   void test_convert_counts_to_frequency_once_per_histogram_sparse() {
     double total = 0;
+    double floor = static_cast<double>(histSize) - 5.0;
     for (size_t i = 0; i < nHists; i++) {
       const auto &counts = m_hist.counts();
       const auto &frequencies = m_hist.frequencies();
       for (size_t j = 0; j < histSize; ++j)
-        if (counts[j] > histSize - 5)
+        if (counts[j] > floor)
           total += frequencies[j];
     }
   }

--- a/buildconfig/CMake/GoogleTest.in
+++ b/buildconfig/CMake/GoogleTest.in
@@ -16,6 +16,7 @@ ExternalProject_Add(googletest
             COMMAND "@GIT_EXECUTABLE@" apply --whitespace fix "@CMAKE_SOURCE_DIR@/buildconfig/CMake/googletest_override.patch"
             COMMAND "@GIT_EXECUTABLE@" apply --whitespace fix "@CMAKE_SOURCE_DIR@/buildconfig/CMake/googletest_static.patch"
             COMMAND "@GIT_EXECUTABLE@" apply --whitespace fix "@CMAKE_SOURCE_DIR@/buildconfig/CMake/googletest_msvc_cpp11.patch"
+            COMMAND "@GIT_EXECUTABLE@" apply --whitespace fix "@CMAKE_SOURCE_DIR@/buildconfig/CMake/googletest_wconversion.patch"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
   INSTALL_COMMAND   ""

--- a/buildconfig/CMake/googletest_wconversion.patch
+++ b/buildconfig/CMake/googletest_wconversion.patch
@@ -1,0 +1,19 @@
+diff --git a/googlemock/include/gmock/gmock-matchers.h b/googlemock/include/gmock/gmock-matchers.h
+index 33b37a7..fbb5734 100644
+--- a/googlemock/include/gmock/gmock-matchers.h
++++ b/googlemock/include/gmock/gmock-matchers.h
+@@ -1620,8 +1620,13 @@ class VariadicMatcher {
+   }
+ 
+  private:
++#if defined(__GNUC__) && !defined(__clang__)
++#pragma GCC diagnostic ignored "-Wconversion"
++#endif
+   typedef MatcherList<sizeof...(Args), Args...> MatcherListType;
+-
++#if defined(__GNUC__) && !defined(__clang__)
++#pragma GCC diagnostic warning "-Wconversion"
++#endif
+   const typename MatcherListType::ListType matchers_;
+ 
+   GTEST_DISALLOW_ASSIGN_(VariadicMatcher);

--- a/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflDataProcessorPresenter.cpp
@@ -697,7 +697,8 @@ bool ReflDataProcessorPresenter::parseUniform(TimeSlicingInfo &slicing,
   if (mws != nullptr) {
     const auto run = mws->run();
     const auto totalDuration = run.endTime() - run.startTime();
-    double totalDurationSec = totalDuration.total_seconds();
+    double totalDurationSec =
+        static_cast<double>(totalDuration.total_seconds());
     double sliceDuration = .0;
     size_t numSlices = 0;
 

--- a/qt/scientific_interfaces/ISISReflectometry/ReflSettingsWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflSettingsWidget.ui
@@ -440,7 +440,7 @@
          </widget>
         </item>
         <item row="0" column="2">
-         <widget class="QLabel" name="label">
+         <widget class="QLabel" name="label1">
           <property name="text">
            <string>Debug</string>
           </property>

--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -148,7 +148,6 @@ set ( MOC_FILES
     DensityOfStates.h
     Elwin.h
     ILLEnergyTransfer.h
-    IAddWorkspaceDialog.h
     IndirectAddWorkspaceDialog.h
     IndirectBayes.h
     IndirectBayesTab.h


### PR DESCRIPTION
**Description of work.**

This addresses several warnings present with GCC 7.

**To test:**

Build mantid and AllTests on a machine with GCC 7. Verify that no compiler warnings are issued.

<!-- Instructions for testing. -->

There is no GitHub issue associated with this pull request.

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
