### PR TITLE
Fix constraint removal in multi-dataset fit interface.

### DIFF
--- a/qt/widgets/common/src/FunctionBrowser.cpp
+++ b/qt/widgets/common/src/FunctionBrowser.cpp
@@ -1857,14 +1857,15 @@ void FunctionBrowser::removeConstraint() {
   QtProperty *prop = item->property();
   if (!isConstraint(prop))
     return;
-  removeProperty(prop);
-  if (isLocalParameterProperty(getParentParameterProperty(prop))) {
-    auto parName = getParameterName(prop);
+  auto paramProp = getParentParameterProperty(prop);
+  if (isLocalParameterProperty(paramProp)) {
+    auto parName = getParameterName(paramProp);
     checkLocalParameter(parName);
     auto &localValue = m_localParameterValues[parName][m_currentDataset];
     localValue.lowerBound = "";
     localValue.upperBound = "";
   }
+  removeProperty(prop);
 }
 
 void FunctionBrowser::updateCurrentFunctionIndex() {


### PR DESCRIPTION
**Description of work.**
Corrected the code that updates the local parameter property after removing a constraint.

**To test:**

Add a constraint to a local parameter then remove it. Try removing it via the context menu of both the parameter property and the constraint bound property.

Fixes #22958.

Does this update require release notes?
- [ ] Yes
- [X] No

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
