### PR TITLE
Fix unhandled exception in validateInputs in RSIQ

### DIFF
--- a/Framework/Algorithms/src/ReflectometrySumInQ.cpp
+++ b/Framework/Algorithms/src/ReflectometrySumInQ.cpp
@@ -269,8 +269,18 @@ std::map<std::string, std::string> ReflectometrySumInQ::validateInputs() {
   std::map<std::string, std::string> issues;
   API::MatrixWorkspace_sptr inWS;
   Indexing::SpectrumIndexSet indices;
-  std::tie(inWS, indices) =
-      getWorkspaceAndIndices<API::MatrixWorkspace>(Prop::INPUT_WS);
+
+  // validateInputs is called on the individual workspaces when the algorithm
+  // is executed, it but may get called on a group from AlgorithmDialog. This
+  // isn't handled in getWorkspaceAndIndices. We should fix this properly but
+  // for now skip validation for groups to avoid an exception. See #22933
+  try {
+    std::tie(inWS, indices) =
+        getWorkspaceAndIndices<API::MatrixWorkspace>(Prop::INPUT_WS);
+  } catch (...) {
+    return issues;
+  }
+
   const auto &spectrumInfo = inWS->spectrumInfo();
   const int beamCentre = getProperty(Prop::BEAM_CENTRE);
   bool beamCentreFound{false};

--- a/Framework/Algorithms/src/ReflectometrySumInQ.cpp
+++ b/Framework/Algorithms/src/ReflectometrySumInQ.cpp
@@ -277,7 +277,7 @@ std::map<std::string, std::string> ReflectometrySumInQ::validateInputs() {
   try {
     std::tie(inWS, indices) =
         getWorkspaceAndIndices<API::MatrixWorkspace>(Prop::INPUT_WS);
-  } catch (...) {
+  } catch (std::runtime_error &) {
     return issues;
   }
 


### PR DESCRIPTION
**Description of work.**

This PR adds a temporary fix for an unhandled exception in `ReflectometrySumInQ::validateInputs`. The exception occurs when opening AlgorithmDialog on a group workspace. This first calls validateInputs on the group workspace for the dialog validation, before calling it on the individual workspaces when executing the algorithm. Workspace groups are not currently handled. Adding full validation for groups is beyond this PR so this fix just skips validation to avoid the error.

Fixes #22933

**To test:**

- Follow the instructions in the linked issue and check you no longer get an unhandled exception.
- Check the algorithm runs ok for valid inputs for both group and non-group workspaces.
- Try entering some invalid values, e.g. set WorkspaceIndexSet=`4-8` and BeamCentre=`3`. For a non-group workspace this gives a validation error on the dialog. For a group workspace the validation is skipped so the algorithm runs and shows an error in the log.

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
