### PR TITLE
RROA polarization correction bug.

### DIFF
--- a/Framework/Algorithms/src/PolarizationCorrectionFredrikze.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrectionFredrikze.cpp
@@ -222,16 +222,16 @@ PolarizationCorrectionFredrikze::execPA(WorkspaceGroup_sptr inWS) {
   const auto alpha = this->getEfficiencyWorkspace(cAlphaLabel);
   const auto ap = this->getEfficiencyWorkspace(cApLabel);
 
-  const auto A0 = (Iaa * pp * ap) + (ap * Ipa * rho * pp) +
-                  (ap * Iap * alpha * pp) + (Ipp * ap * alpha * rho * pp);
-  const auto A1 = pp * Iaa;
-  const auto A2 = pp * Iap;
-  const auto A3 = ap * Iaa;
-  const auto A4 = ap * Ipa;
-  const auto A5 = ap * alpha * Ipp;
-  const auto A6 = ap * alpha * Iap;
-  const auto A7 = pp * rho * Ipp;
-  const auto A8 = pp * rho * Ipa;
+  const auto A0 = (Iaa * pp * ap) + (Ipa * ap * rho * pp) +
+                  (Iap * ap * alpha * pp) + (Ipp * ap * alpha * rho * pp);
+  const auto A1 = Iaa * pp;
+  const auto A2 = Iap * pp;
+  const auto A3 = Iaa * ap;
+  const auto A4 = Ipa * ap;
+  const auto A5 = Ipp * ap * alpha;
+  const auto A6 = Iap * ap * alpha;
+  const auto A7 = Ipp * pp * rho;
+  const auto A8 = Ipa * pp * rho;
 
   const auto D = pp * ap * (rho + alpha + 1.0 + (rho * alpha));
 

--- a/Framework/Algorithms/src/ReflectometryReductionOneAuto2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOneAuto2.cpp
@@ -752,7 +752,6 @@ bool ReflectometryReductionOneAuto2::processGroups() {
   alg->setProperty("FirstTransmissionRun", "");
   alg->setProperty("SecondTransmissionRun", "");
   alg->setProperty("CorrectionAlgorithm", "None");
-  alg->setProperty("ThetaIn", Mantid::EMPTY_DBL());
   alg->setProperty("ProcessingInstructions", "0");
   for (size_t i = 0; i < group->size(); ++i) {
     const std::string IvsQName = outputIvsQ + "_" + std::to_string(i + 1);


### PR DESCRIPTION
**Description of work.**

PolarizationCorrectionFredrikze preforms various binary operations on the input workspaces. The Plus and Minus algorithms require the units on the x-axes be the same but Multiply doesn't setting the output's units to those of the first input workspace. If Multiply's inputs have different units the result depends on the multiplication order.

Changed the order in workspace multiplications to make sure that the result workspaces have the same units on the x axes.

**Report to:** Jos Cooper

**To test:**

Follow instructions in the issue description.

Fixes #22997

Does this update require release notes?
- [ ] Yes
- [X] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
