### PR TITLE
Fix RPATH issues on Ubuntu 18.04

### DIFF
--- a/buildconfig/CMake/GNUSetup.cmake
+++ b/buildconfig/CMake/GNUSetup.cmake
@@ -47,6 +47,13 @@ add_compile_options ( $<$<COMPILE_LANGUAGE:CXX>:-Woverloaded-virtual>
   $<$<COMPILE_LANGUAGE:CXX>:-fno-operator-names>
 )
 
+#Linking errors on Ubuntu 18.04 with --enable-new-dtags 
+if ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
+  string(APPEND CMAKE_MODULE_LINKER_FLAGS " -Wl,--disable-new-dtags" )
+  string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,--disable-new-dtags" )
+  string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl,--disable-new-dtags" )
+endif ()
+
 # Check if we have a new enough version for these flags
 if ( CMAKE_COMPILER_IS_GNUCXX )
   add_compile_options ( -Wpedantic )

--- a/qt/paraview_ext/VatesSimpleGui/QtWidgets/CMakeLists.txt
+++ b/qt/paraview_ext/VatesSimpleGui/QtWidgets/CMakeLists.txt
@@ -52,7 +52,7 @@ mtd_add_qt_library (TARGET_NAME VatesSimpleGuiQtWidgets
     @loader_path/../../Contents/Libraries
     @loader_path/../../Contents/MacOS
   LINUX_INSTALL_RPATH
-    "\$ORIGIN/../${LIB_DIR}"
+    "\$ORIGIN/../../${LIB_DIR};\$ORIGIN/../../${LIB_DIR}/paraview-${ParaView_VERSION_MAJOR}.${ParaView_VERSION_MINOR}"
 )
 
 # Set the name of the generated library

--- a/qt/paraview_ext/VatesSimpleGui/QtWidgets/CMakeLists.txt
+++ b/qt/paraview_ext/VatesSimpleGui/QtWidgets/CMakeLists.txt
@@ -52,7 +52,7 @@ mtd_add_qt_library (TARGET_NAME VatesSimpleGuiQtWidgets
     @loader_path/../../Contents/Libraries
     @loader_path/../../Contents/MacOS
   LINUX_INSTALL_RPATH
-    "\$ORIGIN/../../${LIB_DIR}"
+    "\$ORIGIN/../${LIB_DIR}"
 )
 
 # Set the name of the generated library

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/CMakeLists.txt
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/CMakeLists.txt
@@ -136,7 +136,7 @@ mtd_add_qt_library (TARGET_NAME VatesSimpleGuiViewWidgets
     @loader_path/../../Contents/MacOS
     @loader_path/../../Contents/Libraries
   LINUX_INSTALL_RPATH
-    "\$ORIGIN/../${LIB_DIR};\$ORIGIN"
+    "\$ORIGIN/../../${LIB_DIR};\$ORIGIN/../../${LIB_DIR}/paraview-${ParaView_VERSION_MAJOR}.${ParaView_VERSION_MINOR};\$ORIGIN"
 )
 
 # Set the name of the generated library

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/CMakeLists.txt
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/CMakeLists.txt
@@ -136,7 +136,7 @@ mtd_add_qt_library (TARGET_NAME VatesSimpleGuiViewWidgets
     @loader_path/../../Contents/MacOS
     @loader_path/../../Contents/Libraries
   LINUX_INSTALL_RPATH
-    "\$ORIGIN/../../${LIB_DIR};\$ORIGIN"
+    "\$ORIGIN/../${LIB_DIR};\$ORIGIN"
 )
 
 # Set the name of the generated library

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -535,7 +535,7 @@ mtd_add_qt_library (TARGET_NAME MantidQtWidgetsCommon
     @loader_path/../MacOS
     @loader_path/../Libraries
   LINUX_INSTALL_RPATH
-    "\$ORIGIN/../../${LIB_DIR}"
+    "\$ORIGIN/../${LIB_DIR}"
 )
 
 ###########################################################################

--- a/qt/widgets/factory/CMakeLists.txt
+++ b/qt/widgets/factory/CMakeLists.txt
@@ -37,6 +37,7 @@ mtd_add_qt_library (TARGET_NAME MantidQtWidgetsFactory
     MantidQtWidgetsCommon
     MantidQtWidgetsLegacyQwt
     MantidQtWidgetsSliceViewer
+  LINUX_INSTALL_RPATH
+    "\$ORIGIN/../${LIB_DIR}"
 )
-
 

--- a/qt/widgets/legacyqwt/CMakeLists.txt
+++ b/qt/widgets/legacyqwt/CMakeLists.txt
@@ -80,7 +80,7 @@ mtd_add_qt_library (TARGET_NAME MantidQtWidgetsLegacyQwt
   OSX_INSTALL_RPATH
     @loader_path/../MacOS
   LINUX_INSTALL_RPATH
-    "\$ORIGIN/../../${LIB_DIR}"
+    "\$ORIGIN/../${LIB_DIR}"
 )
 
 ###########################################################################

--- a/qt/widgets/sliceviewer/CMakeLists.txt
+++ b/qt/widgets/sliceviewer/CMakeLists.txt
@@ -141,7 +141,7 @@ mtd_add_qt_library (TARGET_NAME MantidQtWidgetsSliceViewer
   OSX_INSTALL_RPATH
     loader_path/../MacOS
   LINUX_INSTALL_RPATH
-    "\$ORIGIN/../../${LIB_DIR}"
+    "\$ORIGIN/../${LIB_DIR}"
 )
 
 ###########################################################################


### PR DESCRIPTION
**Description of work.**

This changes the `LINUX_INSTALL_RPATH` to match the library's location. For reasons I don't understand, the location of the executable isn't being used on Ubuntu 18.04.

**Report to:** [user name]/[nobody]. <!--If the original issue was raised by a user they should be named here.-->

**To test:**

<!-- Instructions for testing. -->

1. Build or obtain a .deb package with these changes.
1. Install .deb package on an Ubuntu 18.04 machine
1. Start up MantidPlot and verify there are no warnings about missing libraries
1. Use `ldd` to verify that all shared libraries are found. 

There is no GitHub issue associated with this pull request.

Does this update require release notes?
- [ ] Yes
- [ ] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
