### PR TITLE
WorkspaceFactory : Remove from Algorithms/src/A*-P*

### DIFF
--- a/Framework/Algorithms/src/AbsorptionCorrection.cpp
+++ b/Framework/Algorithms/src/AbsorptionCorrection.cpp
@@ -8,8 +8,8 @@
 #include "MantidAPI/InstrumentValidator.h"
 #include "MantidAPI/Sample.h"
 #include "MantidAPI/SpectrumInfo.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/IDetector.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Objects/ShapeFactory.h"
@@ -32,6 +32,7 @@ using namespace Geometry;
 using HistogramData::interpolateLinearInplace;
 using namespace Kernel;
 using namespace Mantid::PhysicalConstants;
+using namespace Mantid::DataObjects;
 
 AbsorptionCorrection::AbsorptionCorrection()
     : API::Algorithm(), m_inputWS(), m_sampleObject(nullptr), m_L1s(),
@@ -109,8 +110,7 @@ void AbsorptionCorrection::exec() {
   retrieveBaseProperties();
 
   // Create the output workspace
-  MatrixWorkspace_sptr correctionFactors =
-      WorkspaceFactory::Instance().create(m_inputWS);
+  MatrixWorkspace_sptr correctionFactors = create<MatrixWorkspace>(*m_inputWS);
   correctionFactors->setDistribution(
       true);                       // The output of this is a distribution
   correctionFactors->setYUnit(""); // Need to explicitly set YUnit to nothing

--- a/Framework/Algorithms/src/ApplyDetailedBalance.cpp
+++ b/Framework/Algorithms/src/ApplyDetailedBalance.cpp
@@ -6,8 +6,8 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidAlgorithms/ApplyDetailedBalance.h"
 #include "MantidAPI/Run.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidKernel/CompositeValidator.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/PhysicalConstants.h"
@@ -20,6 +20,7 @@
 using std::string;
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
+using namespace Mantid::DataObjects;
 
 namespace Mantid {
 namespace Algorithms {
@@ -57,7 +58,7 @@ void ApplyDetailedBalance::exec() {
   // If input and output workspaces are not the same, create a new workspace for
   // the output
   if (outputWS != inputWS) {
-    outputWS = API::WorkspaceFactory::Instance().create(inputWS);
+    outputWS = create<MatrixWorkspace>(*inputWS);
   }
 
   std::string Tstring = getProperty("Temperature");

--- a/Framework/Algorithms/src/ApplyTransmissionCorrection.cpp
+++ b/Framework/Algorithms/src/ApplyTransmissionCorrection.cpp
@@ -7,9 +7,10 @@
 #include "MantidAlgorithms/ApplyTransmissionCorrection.h"
 #include "MantidAPI/HistogramValidator.h"
 #include "MantidAPI/SpectrumInfo.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceOpOverloads.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/IDetector.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/CompositeValidator.h"
@@ -24,6 +25,7 @@ using namespace Kernel;
 using namespace API;
 using namespace Geometry;
 using namespace HistogramData;
+using namespace DataObjects;
 
 void ApplyTransmissionCorrection::init() {
   auto wsValidator = boost::make_shared<CompositeValidator>();
@@ -90,7 +92,7 @@ void ApplyTransmissionCorrection::exec() {
   Progress progress(this, 0.0, 1.0, numHists);
 
   // Create a Workspace2D to match the intput workspace
-  MatrixWorkspace_sptr corrWS = WorkspaceFactory::Instance().create(inputWS);
+  MatrixWorkspace_sptr corrWS = create<HistoWorkspace>(*inputWS);
 
   const auto &spectrumInfo = inputWS->spectrumInfo();
 

--- a/Framework/Algorithms/src/ApplyTransmissionCorrection.cpp
+++ b/Framework/Algorithms/src/ApplyTransmissionCorrection.cpp
@@ -7,9 +7,9 @@
 #include "MantidAlgorithms/ApplyTransmissionCorrection.h"
 #include "MantidAPI/HistogramValidator.h"
 #include "MantidAPI/SpectrumInfo.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceOpOverloads.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/IDetector.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/CompositeValidator.h"
@@ -24,6 +24,7 @@ using namespace Kernel;
 using namespace API;
 using namespace Geometry;
 using namespace HistogramData;
+using namespace Mantid::DataObjects;
 
 void ApplyTransmissionCorrection::init() {
   auto wsValidator = boost::make_shared<CompositeValidator>();
@@ -90,7 +91,7 @@ void ApplyTransmissionCorrection::exec() {
   Progress progress(this, 0.0, 1.0, numHists);
 
   // Create a Workspace2D to match the intput workspace
-  MatrixWorkspace_sptr corrWS = WorkspaceFactory::Instance().create(inputWS);
+  MatrixWorkspace_sptr corrWS = create<MatrixWorkspace>(*inputWS);
 
   const auto &spectrumInfo = inputWS->spectrumInfo();
 

--- a/Framework/Algorithms/src/ApplyTransmissionCorrection.cpp
+++ b/Framework/Algorithms/src/ApplyTransmissionCorrection.cpp
@@ -24,7 +24,7 @@ using namespace Kernel;
 using namespace API;
 using namespace Geometry;
 using namespace HistogramData;
-using namespace Mantid::DataObjects;
+using namespace DataObjects;
 
 void ApplyTransmissionCorrection::init() {
   auto wsValidator = boost::make_shared<CompositeValidator>();

--- a/Framework/Algorithms/src/ApplyTransmissionCorrection.cpp
+++ b/Framework/Algorithms/src/ApplyTransmissionCorrection.cpp
@@ -7,9 +7,9 @@
 #include "MantidAlgorithms/ApplyTransmissionCorrection.h"
 #include "MantidAPI/HistogramValidator.h"
 #include "MantidAPI/SpectrumInfo.h"
+#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceOpOverloads.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
-#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/IDetector.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/CompositeValidator.h"
@@ -24,7 +24,6 @@ using namespace Kernel;
 using namespace API;
 using namespace Geometry;
 using namespace HistogramData;
-using namespace DataObjects;
 
 void ApplyTransmissionCorrection::init() {
   auto wsValidator = boost::make_shared<CompositeValidator>();
@@ -91,7 +90,7 @@ void ApplyTransmissionCorrection::exec() {
   Progress progress(this, 0.0, 1.0, numHists);
 
   // Create a Workspace2D to match the intput workspace
-  MatrixWorkspace_sptr corrWS = create<MatrixWorkspace>(*inputWS);
+  MatrixWorkspace_sptr corrWS = WorkspaceFactory::Instance().create(inputWS);
 
   const auto &spectrumInfo = inputWS->spectrumInfo();
 

--- a/Framework/Algorithms/src/BinaryOperation.cpp
+++ b/Framework/Algorithms/src/BinaryOperation.cpp
@@ -13,17 +13,20 @@
 #include "MantidAPI/WorkspaceProperty.h"
 #include "MantidDataObjects/EventList.h"
 #include "MantidDataObjects/EventWorkspace.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidDataObjects/WorkspaceSingleValue.h"
 #include "MantidGeometry/Instrument/ParameterMap.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/Timer.h"
 #include "MantidKernel/Unit.h"
-
 #include <boost/make_shared.hpp>
 
 using namespace Mantid::Geometry;
 using namespace Mantid::API;
 using namespace Mantid::Kernel;
 using namespace Mantid::DataObjects;
+using namespace Mantid::HistogramData;
 using std::size_t;
 
 namespace Mantid {
@@ -105,7 +108,7 @@ bool BinaryOperation::handleSpecialDivideMinus() {
     } else if (this->name() == "Minus") {
       // x - workspace = x + (workspace * -1)
       MatrixWorkspace_sptr minusOne =
-          WorkspaceFactory::Instance().create("WorkspaceSingleValue", 1, 1, 1);
+          create<WorkspaceSingleValue>(1, Points(1));
       minusOne->dataY(0)[0] = -1.0;
       minusOne->dataE(0)[0] = 0.0;
 
@@ -234,7 +237,7 @@ void BinaryOperation::exec() {
     //   (b) it has been, but it's not the correct dimensions
     if ((m_out != m_lhs && m_out != m_rhs) ||
         (m_out == m_rhs && (m_lhs->size() > m_rhs->size()))) {
-      m_out = WorkspaceFactory::Instance().create(m_lhs);
+      m_out = create<HistoWorkspace>(*m_lhs);
     }
   }
 

--- a/Framework/Algorithms/src/CalculateCarpenterSampleCorrection.cpp
+++ b/Framework/Algorithms/src/CalculateCarpenterSampleCorrection.cpp
@@ -5,13 +5,14 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidAlgorithms/CalculateCarpenterSampleCorrection.h"
+#include "MantidAPI/HistoWorkspace.h"
 #include "MantidAPI/InstrumentValidator.h"
 #include "MantidAPI/Sample.h"
 #include "MantidAPI/SpectrumInfo.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
 #include "MantidDataObjects/EventWorkspace.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/CompositeValidator.h"
 #include "MantidKernel/Material.h"
@@ -23,7 +24,7 @@ namespace Algorithms {
 DECLARE_ALGORITHM(CalculateCarpenterSampleCorrection) // Register the class
                                                       // into the algorithm
                                                       // factory
-
+using namespace DataObjects;
 using namespace Kernel;
 using namespace API;
 using Mantid::DataObjects::EventWorkspace;
@@ -414,8 +415,7 @@ void CalculateCarpenterSampleCorrection::calculate_ms_correction(
 
 MatrixWorkspace_sptr CalculateCarpenterSampleCorrection::createOutputWorkspace(
     const MatrixWorkspace_sptr &inputWksp, const std::string ylabel) const {
-  MatrixWorkspace_sptr outputWS =
-      WorkspaceFactory::Instance().create(inputWksp);
+  MatrixWorkspace_sptr outputWS = create<HistoWorkspace>(*inputWksp);
   // The algorithm computes the signal values at bin centres so they should
   // be treated as a distribution
   outputWS->setDistribution(true);

--- a/Framework/Algorithms/src/CalculateCountRate.cpp
+++ b/Framework/Algorithms/src/CalculateCountRate.cpp
@@ -6,6 +6,13 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidAlgorithms/CalculateCountRate.h"
 
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/Axis.h"
+#include "MantidAPI/NumericAxis.h"
+#include "MantidAPI/Run.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/MandatoryValidator.h"
@@ -15,14 +22,10 @@
 #include "MantidKernel/UnitFactory.h"
 #include "MantidKernel/make_unique.h"
 
-#include "MantidAPI/AlgorithmManager.h"
-#include "MantidAPI/Axis.h"
-#include "MantidAPI/NumericAxis.h"
-#include "MantidAPI/Run.h"
-#include "MantidAPI/WorkspaceFactory.h"
-
-#include "MantidDataObjects/Workspace2D.h"
 #include <numeric>
+
+using namespace Mantid::DataObjects;
+using namespace Mantid::HistogramData;
 
 namespace Mantid {
 namespace Algorithms {
@@ -621,9 +624,7 @@ void CalculateCountRate::checkAndInitVisWorkspace() {
   int numXBins = getProperty("XResolution");
   std::string RangeUnits = getProperty("RangeUnits");
 
-  m_visWs = boost::dynamic_pointer_cast<DataObjects::Workspace2D>(
-      API::WorkspaceFactory::Instance().create("Workspace2D", numTBins,
-                                               numXBins + 1, numXBins));
+  m_visWs = create<Workspace2D>(numTBins, BinEdges(numXBins + 1));
   m_visWs->setTitle(visWSName);
 
   double Xmax = m_XRangeMax;

--- a/Framework/Algorithms/src/CalculateFlatBackground.cpp
+++ b/Framework/Algorithms/src/CalculateFlatBackground.cpp
@@ -9,15 +9,17 @@
 #include "MantidAPI/IFunction.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/SpectrumInfo.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceOpOverloads.h"
 #include "MantidDataObjects/TableWorkspace.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/IDetector.h"
 #include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/EnabledWhenProperty.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/VectorHelper.h"
+
 #include <algorithm>
 #include <boost/lexical_cast.hpp>
 #include <climits>
@@ -31,6 +33,7 @@ DECLARE_ALGORITHM(CalculateFlatBackground)
 
 using namespace Kernel;
 using namespace API;
+using namespace DataObjects;
 
 /// Enumeration for the different operating modes.
 enum class Modes { LINEAR_FIT, MEAN, MOVING_AVERAGE };
@@ -168,7 +171,7 @@ void CalculateFlatBackground::exec() {
   // If input and output workspaces are not the same, create a new workspace for
   // the output
   if (outputWS != inputWS) {
-    outputWS = WorkspaceFactory::Instance().create(inputWS);
+    outputWS = create<MatrixWorkspace>(*inputWS);
   }
 
   // For logging purposes.
@@ -382,8 +385,7 @@ void CalculateFlatBackground::Mean(const HistogramData::Histogram &histogram,
 void CalculateFlatBackground::LinearFit(
     const HistogramData::Histogram &histogram, double &background,
     double &variance, const double startX, const double endX) {
-  MatrixWorkspace_sptr WS = WorkspaceFactory::Instance().create(
-      "Workspace2D", 1, histogram.x().size(), histogram.y().size());
+  MatrixWorkspace_sptr WS = create<Workspace2D>(1, histogram);
   WS->setHistogram(0, histogram);
   IAlgorithm_sptr childAlg = createChildAlgorithm("Fit");
 

--- a/Framework/Algorithms/src/CalculateTransmissionBeamSpreader.cpp
+++ b/Framework/Algorithms/src/CalculateTransmissionBeamSpreader.cpp
@@ -11,10 +11,12 @@
 #include "MantidAPI/CommonBinsValidator.h"
 #include "MantidAPI/HistogramValidator.h"
 #include "MantidAPI/SpectrumInfo.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceOpOverloads.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidDataObjects/WorkspaceSingleValue.h"
 #include "MantidGeometry/Instrument.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/CompositeValidator.h"
 #include "MantidKernel/ListValidator.h"
@@ -27,6 +29,8 @@ DECLARE_ALGORITHM(CalculateTransmissionBeamSpreader)
 
 using namespace Kernel;
 using namespace API;
+using namespace DataObjects;
+using namespace HistogramData;
 using std::size_t;
 
 void CalculateTransmissionBeamSpreader::init() {
@@ -163,7 +167,7 @@ void CalculateTransmissionBeamSpreader::exec() {
 
   // Beam spreader transmission
   MatrixWorkspace_sptr spreader_trans =
-      WorkspaceFactory::Instance().create("WorkspaceSingleValue", 1, 1, 1);
+      create<WorkspaceSingleValue>(1, Points(1));
   spreader_trans->setYUnit("");
   spreader_trans->setDistribution(true);
   spreader_trans->mutableX(0)[0] = 0.0;

--- a/Framework/Algorithms/src/CalculateZscore.cpp
+++ b/Framework/Algorithms/src/CalculateZscore.cpp
@@ -5,11 +5,12 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidAlgorithms/CalculateZscore.h"
-
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceProperty.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidHistogramData/Histogram.h"
+#include "MantidHistogramData/HistogramBuilder.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/Statistics.h"
 
@@ -19,6 +20,7 @@ using namespace Mantid;
 using namespace Mantid::API;
 using namespace Mantid::Kernel;
 using namespace Mantid::DataObjects;
+using namespace Mantid::HistogramData;
 using namespace std;
 
 namespace Mantid {
@@ -66,9 +68,11 @@ void CalculateZscore::exec() {
   size_t sizex = inpWS->x(0).size();
   size_t sizey = inpWS->y(0).size();
 
-  Workspace2D_sptr outWS = boost::dynamic_pointer_cast<Workspace2D>(
-      WorkspaceFactory::Instance().create("Workspace2D", numspec, sizex,
-                                          sizey));
+  HistogramBuilder builder;
+  builder.setX(sizex);
+  builder.setY(sizey);
+  builder.setDistribution(inpWS->isDistribution());
+  Workspace2D_sptr outWS = create<Workspace2D>(numspec, builder.build());
 
   Progress progress(this, 0.0, 1.0, numspec);
 

--- a/Framework/Algorithms/src/ChopData.cpp
+++ b/Framework/Algorithms/src/ChopData.cpp
@@ -6,10 +6,12 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidAlgorithms/ChopData.h"
 #include "MantidAPI/HistogramValidator.h"
+#include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/SpectraAxisValidator.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/CompositeValidator.h"
 #include "MantidKernel/MultiThreaded.h"
 
@@ -18,6 +20,8 @@ namespace Algorithms {
 using namespace Kernel;
 using namespace API;
 using namespace Geometry;
+using namespace DataObjects;
+using namespace HistogramData;
 
 DECLARE_ALGORITHM(ChopData)
 
@@ -42,7 +46,7 @@ void ChopData::init() {
 
 void ChopData::exec() {
   // Get the input workspace
-  MatrixWorkspace_const_sptr inputWS = getProperty("InputWorkspace");
+  MatrixWorkspace_sptr inputWS = getProperty("InputWorkspace");
   const std::string output = getPropertyValue("OutputWorkspace");
   const double step = getProperty("Step");
   const int chops = getProperty("NChops");
@@ -70,9 +74,8 @@ void ChopData::exec() {
     // Select the spectrum that is to be used to compare the sections of the
     // workspace
     // This will generally be the monitor spectrum.
-    MatrixWorkspace_sptr monitorWS;
-    monitorWS = WorkspaceFactory::Instance().create(inputWS, 1);
-    monitorWS->setHistogram(0, inputWS->histogram(monitorWi));
+    MatrixWorkspace_sptr monitorWS =
+        create<MatrixWorkspace>(*inputWS, 1, inputWS->histogram(monitorWi));
 
     int lowest = 0;
 
@@ -132,8 +135,7 @@ void ChopData::exec() {
     size_t nbins = indexHigh - indexLow;
 
     MatrixWorkspace_sptr workspace =
-        Mantid::API::WorkspaceFactory::Instance().create(inputWS, nHist,
-                                                         nbins + 1, nbins);
+        create<MatrixWorkspace>(*inputWS, nHist, BinEdges(nbins + 1));
 
     // Copy over X, Y and E data
     PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *workspace))

--- a/Framework/Algorithms/src/ChopData.cpp
+++ b/Framework/Algorithms/src/ChopData.cpp
@@ -135,7 +135,7 @@ void ChopData::exec() {
     size_t nbins = indexHigh - indexLow;
 
     MatrixWorkspace_sptr workspace =
-        create<MatrixWorkspace>(*inputWS, nHist, BinEdges(nbins + 1));
+        create<MatrixWorkspace>(*inputWS, BinEdges(nbins + 1));
 
     // Copy over X, Y and E data
     PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *workspace))

--- a/Framework/Algorithms/src/CompareWorkspaces.cpp
+++ b/Framework/Algorithms/src/CompareWorkspaces.cpp
@@ -14,7 +14,6 @@
 #include "MantidAPI/Run.h"
 #include "MantidAPI/Sample.h"
 #include "MantidAPI/TableRow.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidDataObjects/PeaksWorkspace.h"
@@ -179,7 +178,7 @@ void CompareWorkspaces::init() {
           "Messages", "compare_msgs", Direction::Output),
       "TableWorkspace containing messages about any mismatches detected");
 
-  m_messages = WorkspaceFactory::Instance().createTable("TableWorkspace");
+  m_messages = boost::make_shared<TableWorkspace>();
   m_messages->addColumn("str", "Message");
   m_messages->addColumn("str", "Workspace 1");
   m_messages->addColumn("str", "Workspace 2");

--- a/Framework/Algorithms/src/ConjoinXRuns.cpp
+++ b/Framework/Algorithms/src/ConjoinXRuns.cpp
@@ -11,12 +11,13 @@
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Run.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidAPI/WorkspaceHistory.h"
 #include "MantidAlgorithms/RunCombinationHelpers/RunCombinationHelper.h"
 #include "MantidAlgorithms/RunCombinationHelpers/SampleLogsBehaviour.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/Instrument.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidHistogramData/HistogramDx.h"
 #include "MantidHistogramData/HistogramE.h"
 #include "MantidHistogramData/HistogramX.h"
@@ -36,6 +37,8 @@ namespace Algorithms {
 using namespace API;
 using namespace Kernel;
 using namespace RunCombinationOptions;
+using namespace DataObjects;
+using namespace HistogramData;
 
 namespace {
 static const std::string INPUT_WORKSPACE_PROPERTY = "InputWorkspaces";
@@ -425,8 +428,7 @@ void ConjoinXRuns::exec() {
   // now get the size of the output
   size_t numSpec = first->getNumberHistograms();
 
-  m_outWS = WorkspaceFactory::Instance().create(first, numSpec, outBlockSize,
-                                                outBlockSize);
+  m_outWS = create<MatrixWorkspace>(*first, numSpec, Points(outBlockSize));
 
   // copy over the merged sample logs from the temp
   m_outWS->mutableRun() = temp->run();

--- a/Framework/Algorithms/src/ConjoinXRuns.cpp
+++ b/Framework/Algorithms/src/ConjoinXRuns.cpp
@@ -428,7 +428,7 @@ void ConjoinXRuns::exec() {
   // now get the size of the output
   size_t numSpec = first->getNumberHistograms();
 
-  m_outWS = create<MatrixWorkspace>(*first, numSpec, Points(outBlockSize));
+  m_outWS = create<MatrixWorkspace>(*first, Points(outBlockSize));
 
   // copy over the merged sample logs from the temp
   m_outWS->mutableRun() = temp->run();

--- a/Framework/Algorithms/src/ConvertAxesToRealSpace.cpp
+++ b/Framework/Algorithms/src/ConvertAxesToRealSpace.cpp
@@ -7,9 +7,10 @@
 #include "MantidAlgorithms/ConvertAxesToRealSpace.h"
 #include "MantidAPI/NumericAxis.h"
 #include "MantidAPI/SpectrumInfo.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/IDetector.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/Unit.h"
 #include "MantidKernel/UnitFactory.h"
@@ -22,6 +23,7 @@ namespace Algorithms {
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
 using namespace Mantid::DataObjects;
+using namespace Mantid::HistogramData;
 
 // Register the algorithm into the AlgorithmFactory
 DECLARE_ALGORITHM(ConvertAxesToRealSpace)
@@ -100,8 +102,8 @@ void ConvertAxesToRealSpace::exec() {
 
   // Create the output workspace. Can't re-use the input one because we'll be
   // re-ordering the spectra.
-  MatrixWorkspace_sptr outputWs = WorkspaceFactory::Instance().create(
-      inputWs, axisVector[1].bins, axisVector[0].bins, axisVector[0].bins);
+  MatrixWorkspace_sptr outputWs = create<MatrixWorkspace>(
+      *inputWs, axisVector[1].bins, Points(axisVector[0].bins));
 
   // first integrate the data
   IAlgorithm_sptr alg = this->createChildAlgorithm("Integration", 0, 0.4);

--- a/Framework/Algorithms/src/ConvertAxesToRealSpace.cpp
+++ b/Framework/Algorithms/src/ConvertAxesToRealSpace.cpp
@@ -7,10 +7,9 @@
 #include "MantidAlgorithms/ConvertAxesToRealSpace.h"
 #include "MantidAPI/NumericAxis.h"
 #include "MantidAPI/SpectrumInfo.h"
+#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidDataObjects/Workspace2D.h"
-#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/IDetector.h"
-#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/Unit.h"
 #include "MantidKernel/UnitFactory.h"
@@ -23,7 +22,6 @@ namespace Algorithms {
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
 using namespace Mantid::DataObjects;
-using namespace Mantid::HistogramData;
 
 // Register the algorithm into the AlgorithmFactory
 DECLARE_ALGORITHM(ConvertAxesToRealSpace)
@@ -102,8 +100,8 @@ void ConvertAxesToRealSpace::exec() {
 
   // Create the output workspace. Can't re-use the input one because we'll be
   // re-ordering the spectra.
-  MatrixWorkspace_sptr outputWs = create<MatrixWorkspace>(
-      *inputWs, axisVector[1].bins, Points(axisVector[0].bins));
+  MatrixWorkspace_sptr outputWs = WorkspaceFactory::Instance().create(
+      inputWs, axisVector[1].bins, axisVector[0].bins, axisVector[0].bins);
 
   // first integrate the data
   IAlgorithm_sptr alg = this->createChildAlgorithm("Integration", 0, 0.4);

--- a/Framework/Algorithms/src/ConvertSpectrumAxis.cpp
+++ b/Framework/Algorithms/src/ConvertSpectrumAxis.cpp
@@ -158,7 +158,8 @@ void ConvertSpectrumAxis::exec() {
   builder.setX(nxBins);
   builder.setY(nBins);
   builder.setDistribution(inputWS->isDistribution());
-  MatrixWorkspace_sptr outputWS = create<MatrixWorkspace>(*inputWS, indexMap.size(), builder.build());
+  MatrixWorkspace_sptr outputWS =
+      create<MatrixWorkspace>(*inputWS, indexMap.size(), builder.build());
   // Now set up a new, numeric axis holding the theta values corresponding to
   // each spectrum
   auto const newAxis = new NumericAxis(indexMap.size());

--- a/Framework/Algorithms/src/ConvertSpectrumAxis.cpp
+++ b/Framework/Algorithms/src/ConvertSpectrumAxis.cpp
@@ -10,8 +10,10 @@
 #include "MantidAPI/Run.h"
 #include "MantidAPI/SpectraAxisValidator.h"
 #include "MantidAPI/SpectrumInfo.h"
-#include "MantidAPI/WorkspaceFactory.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/Instrument.h"
+#include "MantidHistogramData/Histogram.h"
+#include "MantidHistogramData/HistogramBuilder.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/CompositeValidator.h"
 #include "MantidKernel/ListValidator.h"
@@ -30,7 +32,8 @@ DECLARE_ALGORITHM(ConvertSpectrumAxis)
 using namespace Kernel;
 using namespace API;
 using namespace Geometry;
-
+using namespace DataObjects;
+using namespace HistogramData;
 namespace {
 constexpr double rad2deg = 180. / M_PI;
 }
@@ -151,8 +154,11 @@ void ConvertSpectrumAxis::exec() {
   }
   // Create the output workspace. Can't re-use the input one because we'll be
   // re-ordering the spectra.
-  MatrixWorkspace_sptr outputWS = WorkspaceFactory::Instance().create(
-      inputWS, indexMap.size(), nxBins, nBins);
+  HistogramBuilder builder;
+  builder.setX(nxBins);
+  builder.setY(nBins);
+  builder.setDistribution(inputWS->isDistribution());
+  MatrixWorkspace_sptr outputWS = create<MatrixWorkspace>(*inputWS, indexMap.size(), builder.build());
   // Now set up a new, numeric axis holding the theta values corresponding to
   // each spectrum
   auto const newAxis = new NumericAxis(indexMap.size());

--- a/Framework/Algorithms/src/ConvertSpectrumAxis2.cpp
+++ b/Framework/Algorithms/src/ConvertSpectrumAxis2.cpp
@@ -10,9 +10,11 @@
 #include "MantidAPI/Run.h"
 #include "MantidAPI/SpectraAxisValidator.h"
 #include "MantidAPI/SpectrumInfo.h"
-#include "MantidAPI/WorkspaceFactory.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
+#include "MantidHistogramData/Histogram.h"
+#include "MantidHistogramData/HistogramBuilder.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/CompositeValidator.h"
 #include "MantidKernel/ListValidator.h"
@@ -32,6 +34,8 @@ DECLARE_ALGORITHM(ConvertSpectrumAxis2)
 using namespace Kernel;
 using namespace API;
 using namespace Geometry;
+using namespace DataObjects;
+using namespace HistogramData;
 
 void ConvertSpectrumAxis2::init() {
   // Validator for Input Workspace
@@ -225,8 +229,12 @@ MatrixWorkspace_sptr ConvertSpectrumAxis2::createOutputWorkspace(
   NumericAxis *newAxis = nullptr;
   if (m_toOrder) {
     // Can not re-use the input one because the spectra are re-ordered.
-    outputWorkspace = WorkspaceFactory::Instance().create(
-        inputWS, m_indexMap.size(), inputWS->x(0).size(), inputWS->y(0).size());
+    HistogramBuilder builder;
+    builder.setX(inputWS->x(0).size());
+    builder.setY(inputWS->y(0).size());
+    builder.setDistribution(inputWS->isDistribution());
+    outputWorkspace =
+        create<MatrixWorkspace>(*inputWS, m_indexMap.size(), builder.build());
     std::vector<double> axis;
     axis.reserve(m_indexMap.size());
     for (const auto &it : m_indexMap) {

--- a/Framework/Algorithms/src/ConvertTableToMatrixWorkspace.cpp
+++ b/Framework/Algorithms/src/ConvertTableToMatrixWorkspace.cpp
@@ -11,7 +11,8 @@
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidAPI/WorkspaceFactory.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidKernel/MandatoryValidator.h"
 #include "MantidKernel/Unit.h"
 #include "MantidKernel/UnitFactory.h"
@@ -25,6 +26,7 @@ DECLARE_ALGORITHM(ConvertTableToMatrixWorkspace)
 using namespace Kernel;
 using namespace API;
 using namespace HistogramData;
+using namespace DataObjects;
 
 void ConvertTableToMatrixWorkspace::init() {
   declareProperty(make_unique<WorkspaceProperty<API::ITableWorkspace>>(
@@ -58,7 +60,7 @@ void ConvertTableToMatrixWorkspace::exec() {
   auto Y = inputWorkspace->getColumn(columnY)->numeric_fill<>();
 
   MatrixWorkspace_sptr outputWorkspace =
-      WorkspaceFactory::Instance().create("Workspace2D", 1, nrows, nrows);
+      create<Workspace2D>(1, Points(nrows));
 
   outputWorkspace->mutableX(0).assign(X.begin(), X.end());
   outputWorkspace->mutableY(0).assign(Y.begin(), Y.end());

--- a/Framework/Algorithms/src/ConvertTableToMatrixWorkspace.cpp
+++ b/Framework/Algorithms/src/ConvertTableToMatrixWorkspace.cpp
@@ -59,8 +59,7 @@ void ConvertTableToMatrixWorkspace::exec() {
   auto X = inputWorkspace->getColumn(columnX)->numeric_fill<>();
   auto Y = inputWorkspace->getColumn(columnY)->numeric_fill<>();
 
-  MatrixWorkspace_sptr outputWorkspace =
-      create<Workspace2D>(1, Points(nrows));
+  MatrixWorkspace_sptr outputWorkspace = create<Workspace2D>(1, Points(nrows));
 
   outputWorkspace->mutableX(0).assign(X.begin(), X.end());
   outputWorkspace->mutableY(0).assign(Y.begin(), Y.end());

--- a/Framework/Algorithms/src/ConvertToConstantL2.cpp
+++ b/Framework/Algorithms/src/ConvertToConstantL2.cpp
@@ -8,9 +8,9 @@
 #include "MantidAPI/HistogramValidator.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/SpectrumInfo.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidGeometry/Instrument/ParameterMap.h"
 #include "MantidKernel/CompositeValidator.h"
@@ -27,6 +27,7 @@ namespace Algorithms {
 using namespace Kernel;
 using namespace API;
 using namespace Geometry;
+using namespace DataObjects;
 
 // Register the class into the algorithm factory
 DECLARE_ALGORITHM(ConvertToConstantL2)
@@ -63,7 +64,7 @@ void ConvertToConstantL2::initWorkspaces() {
   // If input and output workspaces are not the same, create a new workspace for
   // the output
   if (m_outputWS != this->m_inputWS) {
-    m_outputWS = API::WorkspaceFactory::Instance().create(m_inputWS);
+    m_outputWS = create<MatrixWorkspace>(*m_inputWS);
   }
 
   m_wavelength = getRunProperty("wavelength");

--- a/Framework/Algorithms/src/ConvertToMatrixWorkspace.cpp
+++ b/Framework/Algorithms/src/ConvertToMatrixWorkspace.cpp
@@ -52,7 +52,7 @@ void ConvertToMatrixWorkspace::exec() {
 
     // Create the output workspace. This will copy many aspects fron the input
     // one.
-    outputWorkspace = outputWorkspace = create<Workspace2D>(*inputWorkspace);
+    outputWorkspace = create<Workspace2D>(*inputWorkspace);
 
     // ...but not the data, so do that here.
     PARALLEL_FOR_IF(Kernel::threadSafe(*inputWorkspace, *outputWorkspace))

--- a/Framework/Algorithms/src/ConvertToMatrixWorkspace.cpp
+++ b/Framework/Algorithms/src/ConvertToMatrixWorkspace.cpp
@@ -8,8 +8,9 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidAlgorithms/ConvertToMatrixWorkspace.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidDataObjects/EventWorkspace.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 
 namespace Mantid {
 namespace Algorithms {
@@ -51,7 +52,7 @@ void ConvertToMatrixWorkspace::exec() {
 
     // Create the output workspace. This will copy many aspects fron the input
     // one.
-    outputWorkspace = WorkspaceFactory::Instance().create(inputWorkspace);
+    outputWorkspace = outputWorkspace = create<Workspace2D>(*inputWorkspace);
 
     // ...but not the data, so do that here.
     PARALLEL_FOR_IF(Kernel::threadSafe(*inputWorkspace, *outputWorkspace))

--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -735,7 +735,7 @@ API::MatrixWorkspace_sptr ConvertUnits::removeUnphysicalBins(
     MantidVec::difference_type bins = X0.cend() - start;
     MantidVec::difference_type first = start - X0.cbegin();
 
-    result = create<MatrixWorkspace>(*workspace, numSpec, BinEdges(bins));
+    result = create<MatrixWorkspace>(*workspace, BinEdges(bins));
 
     for (size_t i = 0; i < numSpec; ++i) {
       auto &X = workspace->x(i);

--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -10,11 +10,12 @@
 #include "MantidAPI/CommonBinsValidator.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/SpectrumInfo.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/Instrument.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/CompositeValidator.h"
 #include "MantidKernel/ListValidator.h"
@@ -734,8 +735,7 @@ API::MatrixWorkspace_sptr ConvertUnits::removeUnphysicalBins(
     MantidVec::difference_type bins = X0.cend() - start;
     MantidVec::difference_type first = start - X0.cbegin();
 
-    result =
-        WorkspaceFactory::Instance().create(workspace, numSpec, bins, bins - 1);
+    result = create<MatrixWorkspace>(*workspace, numSpec, BinEdges(bins));
 
     for (size_t i = 0; i < numSpec; ++i) {
       auto &X = workspace->x(i);
@@ -765,8 +765,7 @@ API::MatrixWorkspace_sptr ConvertUnits::removeUnphysicalBins(
     g_log.debug() << maxBins << '\n';
     // Now create an output workspace large enough for the longest 'good'
     // range
-    result = WorkspaceFactory::Instance().create(workspace, numSpec, maxBins,
-                                                 maxBins - 1);
+    result = create<MatrixWorkspace>(*workspace, numSpec, BinEdges(maxBins));
     // Next, loop again copying in the correct range for each spectrum
     for (int64_t j = 0; j < int64_t(numSpec); ++j) {
       auto edges = workspace->binEdges(j);

--- a/Framework/Algorithms/src/CorrectKiKf.cpp
+++ b/Framework/Algorithms/src/CorrectKiKf.cpp
@@ -7,10 +7,10 @@
 #include "MantidAlgorithms/CorrectKiKf.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/SpectrumInfo.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/IDetector.h"
 #include "MantidGeometry/Instrument/ParameterMap.h"
 #include "MantidKernel/BoundedValidator.h"
@@ -69,7 +69,7 @@ void CorrectKiKf::exec() {
   // If input and output workspaces are not the same, create a new workspace for
   // the output
   if (outputWS != inputWS) {
-    outputWS = API::WorkspaceFactory::Instance().create(inputWS);
+    outputWS = create<MatrixWorkspace>(*inputWS);
   }
 
   const size_t size = inputWS->blocksize();

--- a/Framework/Algorithms/src/CorrectToFile.cpp
+++ b/Framework/Algorithms/src/CorrectToFile.cpp
@@ -56,7 +56,7 @@ void CorrectToFile::exec() {
   MatrixWorkspace_sptr rkhInput = loadInFile(getProperty("Filename"));
   // Only create the output workspace if it's not the same as the input one
   MatrixWorkspace_sptr outputWS = getProperty("OutputWorkspace");
-  outputWS = create<Workspace2D>(*toCorrect);
+  outputWS = create<HistoWorkspace>(*toCorrect);
   const std::string operation = getProperty("WorkspaceOperation");
 
   if (getPropertyValue("FirstColumnValue") == "SpectrumNumber") {

--- a/Framework/Algorithms/src/CorrectToFile.cpp
+++ b/Framework/Algorithms/src/CorrectToFile.cpp
@@ -57,7 +57,7 @@ void CorrectToFile::exec() {
   // Only create the output workspace if it's not the same as the input one
   MatrixWorkspace_sptr outputWS = getProperty("OutputWorkspace");
   if (outputWS != toCorrect) {
-        if (toCorrect->id() == "EventWorkspace") {
+    if (toCorrect->id() == "EventWorkspace") {
       outputWS = create<Workspace2D>(*toCorrect);
     } else {
       outputWS = create<HistoWorkspace>(*toCorrect);

--- a/Framework/Algorithms/src/CorrectToFile.cpp
+++ b/Framework/Algorithms/src/CorrectToFile.cpp
@@ -56,13 +56,7 @@ void CorrectToFile::exec() {
   MatrixWorkspace_sptr rkhInput = loadInFile(getProperty("Filename"));
   // Only create the output workspace if it's not the same as the input one
   MatrixWorkspace_sptr outputWS = getProperty("OutputWorkspace");
-  if (outputWS != toCorrect) {
-    if (toCorrect->id() == "EventWorkspace") {
-      outputWS = create<Workspace2D>(*toCorrect);
-    } else {
-      outputWS = create<HistoWorkspace>(*toCorrect);
-    }
-  }
+  outputWS = create<Workspace2D>(*toCorrect);
   const std::string operation = getProperty("WorkspaceOperation");
 
   if (getPropertyValue("FirstColumnValue") == "SpectrumNumber") {

--- a/Framework/Algorithms/src/CorrectToFile.cpp
+++ b/Framework/Algorithms/src/CorrectToFile.cpp
@@ -8,14 +8,16 @@
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/FileProperty.h"
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidAPI/WorkspaceFactory.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/Unit.h"
 #include "MantidKernel/UnitFactory.h"
 
 namespace Mantid {
 namespace Algorithms {
-using namespace Mantid::API;
+using namespace API;
+using namespace DataObjects;
 
 // Register the algorithm into the AlgorithmFactory
 DECLARE_ALGORITHM(CorrectToFile)
@@ -55,7 +57,11 @@ void CorrectToFile::exec() {
   // Only create the output workspace if it's not the same as the input one
   MatrixWorkspace_sptr outputWS = getProperty("OutputWorkspace");
   if (outputWS != toCorrect) {
-    outputWS = WorkspaceFactory::Instance().create(toCorrect);
+        if (toCorrect->id() == "EventWorkspace") {
+      outputWS = create<Workspace2D>(*toCorrect);
+    } else {
+      outputWS = create<HistoWorkspace>(*toCorrect);
+    }
   }
   const std::string operation = getProperty("WorkspaceOperation");
 

--- a/Framework/Algorithms/src/CreateEPP.cpp
+++ b/Framework/Algorithms/src/CreateEPP.cpp
@@ -10,8 +10,8 @@
 #include "MantidAPI/InstrumentValidator.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/SpectrumInfo.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
+#include "MantidDataObjects/TableWorkspace.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/CompositeValidator.h"
 #include "MantidKernel/UnitConversion.h"
@@ -110,7 +110,7 @@ void CreateEPP::exec() {
       getProperty(PropertyNames::INPUT_WORKSPACE);
   const auto &spectrumInfo = inputWS->spectrumInfo();
   API::ITableWorkspace_sptr outputWS =
-      API::WorkspaceFactory::Instance().createTable("TableWorkspace");
+      boost::make_shared<DataObjects::TableWorkspace>();
   addEPPColumns(outputWS);
   const double sigma = getProperty(PropertyNames::SIGMA);
   const size_t spectraCount = spectrumInfo.size();

--- a/Framework/Algorithms/src/CreateLogPropertyTable.cpp
+++ b/Framework/Algorithms/src/CreateLogPropertyTable.cpp
@@ -10,8 +10,8 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/TableRow.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceGroup.h"
+#include "MantidDataObjects/TableWorkspace.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/MandatoryValidator.h"
@@ -113,8 +113,7 @@ void CreateLogPropertyTable::exec() {
   }
 
   // Set up output table.
-  boost::shared_ptr<ITableWorkspace> outputTable =
-      WorkspaceFactory::Instance().createTable();
+  auto outputTable = boost::make_shared<DataObjects::TableWorkspace>();
   // One column for each property.
   for (const auto &propName : propNames)
     outputTable->addColumn("str", propName);

--- a/Framework/Algorithms/src/CrossCorrelate.cpp
+++ b/Framework/Algorithms/src/CrossCorrelate.cpp
@@ -10,12 +10,12 @@
 #include "MantidAlgorithms/CrossCorrelate.h"
 #include "MantidAPI/RawCountValidator.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
+#include "MantidDataObjects/Workspace2D.h"
 #include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/CompositeValidator.h"
 #include "MantidKernel/VectorHelper.h"
-
 #include <boost/iterator/counting_iterator.hpp>
 #include <numeric>
 #include <sstream>
@@ -148,7 +148,7 @@ void CrossCorrelate::exec() {
     throw std::runtime_error("Range is not valid");
 
   MatrixWorkspace_sptr out =
-      create<MatrixWorkspace>(*inputWS, nspecs, Points(npoints));
+      create<HistoWorkspace>(*inputWS, nspecs, Points(npoints));
 
   // Calculate the mean value of the reference spectrum and associated error
   // squared

--- a/Framework/Algorithms/src/CrossCorrelate.cpp
+++ b/Framework/Algorithms/src/CrossCorrelate.cpp
@@ -9,13 +9,14 @@
 //----------------------------------------------------------------------
 #include "MantidAlgorithms/CrossCorrelate.h"
 #include "MantidAPI/RawCountValidator.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/CompositeValidator.h"
 #include "MantidKernel/VectorHelper.h"
-#include <boost/iterator/counting_iterator.hpp>
 
+#include <boost/iterator/counting_iterator.hpp>
 #include <numeric>
 #include <sstream>
 
@@ -27,6 +28,8 @@ DECLARE_ALGORITHM(CrossCorrelate)
 
 using namespace Kernel;
 using namespace API;
+using namespace DataObjects;
+using namespace HistogramData;
 
 /// Initialisation method.
 void CrossCorrelate::init() {
@@ -145,7 +148,7 @@ void CrossCorrelate::exec() {
     throw std::runtime_error("Range is not valid");
 
   MatrixWorkspace_sptr out =
-      WorkspaceFactory::Instance().create(inputWS, nspecs, npoints, npoints);
+      create<MatrixWorkspace>(*inputWS, nspecs, Points(npoints));
 
   // Calculate the mean value of the reference spectrum and associated error
   // squared

--- a/Framework/Algorithms/src/DetectorEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/DetectorEfficiencyCor.cpp
@@ -10,8 +10,8 @@
 #include "MantidAPI/InstrumentValidator.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/SpectrumInfo.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidGeometry/Instrument/ParameterMap.h"
@@ -34,6 +34,7 @@ DECLARE_ALGORITHM(DetectorEfficiencyCor)
 using namespace Kernel;
 using namespace API;
 using namespace Geometry;
+using namespace DataObjects;
 
 namespace {
 
@@ -187,7 +188,7 @@ void DetectorEfficiencyCor::retrieveProperties() {
   // If input and output workspaces are not the same, create a new workspace for
   // the output
   if (m_outputWS != m_inputWS) {
-    m_outputWS = WorkspaceFactory::Instance().create(m_inputWS);
+    m_outputWS = create<MatrixWorkspace>(*m_inputWS);
   }
 }
 

--- a/Framework/Algorithms/src/DiffractionFocussing.cpp
+++ b/Framework/Algorithms/src/DiffractionFocussing.cpp
@@ -8,7 +8,8 @@
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/FileProperty.h"
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidAPI/WorkspaceFactory.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidIndexing/IndexInfo.h"
 #include "MantidKernel/Unit.h"
 
@@ -29,6 +30,8 @@ DiffractionFocussing::DiffractionFocussing()
 }
 
 using namespace Kernel;
+using namespace HistogramData;
+
 using API::FileProperty;
 using API::MatrixWorkspace;
 using API::MatrixWorkspace_sptr;
@@ -134,8 +137,8 @@ void DiffractionFocussing::exec() {
   // Create a new workspace that's the right size for the meaningful spectra and
   // copy them in
   int64_t newSize = tmpW->blocksize();
-  API::MatrixWorkspace_sptr outputW = API::WorkspaceFactory::Instance().create(
-      tmpW, resultIndeces.size(), newSize + 1, newSize);
+  API::MatrixWorkspace_sptr outputW = DataObjects::create<API::MatrixWorkspace>(
+       *tmpW, resultIndeces.size(), BinEdges(newSize + 1));
 
   std::vector<Indexing::SpectrumNumber> specNums;
   const auto &tmpIndices = tmpW->indexInfo();

--- a/Framework/Algorithms/src/DiffractionFocussing.cpp
+++ b/Framework/Algorithms/src/DiffractionFocussing.cpp
@@ -138,7 +138,7 @@ void DiffractionFocussing::exec() {
   // copy them in
   int64_t newSize = tmpW->blocksize();
   API::MatrixWorkspace_sptr outputW = DataObjects::create<API::MatrixWorkspace>(
-       *tmpW, resultIndeces.size(), BinEdges(newSize + 1));
+      *tmpW, resultIndeces.size(), BinEdges(newSize + 1));
 
   std::vector<Indexing::SpectrumNumber> specNums;
   const auto &tmpIndices = tmpW->indexInfo();

--- a/Framework/Algorithms/src/DiffractionFocussing2.cpp
+++ b/Framework/Algorithms/src/DiffractionFocussing2.cpp
@@ -12,11 +12,10 @@
 #include "MantidAPI/RawCountValidator.h"
 #include "MantidAPI/SpectraAxis.h"
 #include "MantidAPI/SpectrumInfo.h"
+#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidDataObjects/GroupingWorkspace.h"
-#include "MantidDataObjects/Workspace2D.h"
 #include "MantidDataObjects/WorkspaceCreation.h"
-#include "MantidHistogramData/Histogram.h"
 #include "MantidHistogramData/LogarithmicGenerator.h"
 #include "MantidIndexing/Group.h"
 #include "MantidIndexing/IndexInfo.h"
@@ -170,8 +169,8 @@ void DiffractionFocussing2::exec() {
   if (nPoints <= 0) {
     throw std::runtime_error("No points found in the data range.");
   }
-  API::MatrixWorkspace_sptr out = DataObjects::create<HistoWorkspace>(
-      *m_matrixInputW, m_validGroups.size(), BinEdges(nPoints + 1));
+  API::MatrixWorkspace_sptr out = API::WorkspaceFactory::Instance().create(
+      m_matrixInputW, m_validGroups.size(), nPoints + 1, nPoints);
   // Caching containers that are either only read from or unused. Initialize
   // them once.
   // Helgrind will show a race-condition but the data is completely unused so it

--- a/Framework/Algorithms/src/DiffractionFocussing2.cpp
+++ b/Framework/Algorithms/src/DiffractionFocussing2.cpp
@@ -12,10 +12,11 @@
 #include "MantidAPI/RawCountValidator.h"
 #include "MantidAPI/SpectraAxis.h"
 #include "MantidAPI/SpectrumInfo.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidDataObjects/GroupingWorkspace.h"
+#include "MantidDataObjects/Workspace2D.h"
 #include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidHistogramData/LogarithmicGenerator.h"
 #include "MantidIndexing/Group.h"
 #include "MantidIndexing/IndexInfo.h"
@@ -169,8 +170,8 @@ void DiffractionFocussing2::exec() {
   if (nPoints <= 0) {
     throw std::runtime_error("No points found in the data range.");
   }
-  API::MatrixWorkspace_sptr out = API::WorkspaceFactory::Instance().create(
-      m_matrixInputW, m_validGroups.size(), nPoints + 1, nPoints);
+  API::MatrixWorkspace_sptr out = DataObjects::create<HistoWorkspace>(
+      *m_matrixInputW, m_validGroups.size(), BinEdges(nPoints + 1));
   // Caching containers that are either only read from or unused. Initialize
   // them once.
   // Helgrind will show a race-condition but the data is completely unused so it

--- a/Framework/Algorithms/src/ExportTimeSeriesLog.cpp
+++ b/Framework/Algorithms/src/ExportTimeSeriesLog.cpp
@@ -9,13 +9,13 @@
 #include "MantidAPI/FileProperty.h"
 #include "MantidAPI/IEventList.h"
 #include "MantidAPI/Run.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceProperty.h"
 #include "MantidDataObjects/EventList.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidDataObjects/Events.h"
 #include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/Instrument.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/System.h"
 #include "MantidKernel/TimeSeriesProperty.h"
@@ -28,6 +28,7 @@ using namespace Mantid;
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
 using namespace Mantid::DataObjects;
+using namespace Mantid::HistogramData;
 using Mantid::Types::Core::DateAndTime;
 
 using namespace std;
@@ -247,12 +248,7 @@ void ExportTimeSeriesLog::setupWorkspace2D(
     outsize = static_cast<size_t>(numentries);
 
   // Create 2D workspace
-  m_outWS = boost::dynamic_pointer_cast<MatrixWorkspace>(
-      WorkspaceFactory::Instance().create("Workspace2D", nspec, outsize,
-                                          outsize));
-  if (!m_outWS)
-    throw runtime_error(
-        "Unable to create a Workspace2D casted to MatrixWorkspace.");
+  m_outWS = create<Workspace2D>(nspec, Points(outsize));
 
   auto &vecX = m_outWS->mutableX(0);
   auto &vecY = m_outWS->mutableY(0);

--- a/Framework/Algorithms/src/ExtractFFTSpectrum.cpp
+++ b/Framework/Algorithms/src/ExtractFFTSpectrum.cpp
@@ -10,7 +10,7 @@
 #include "MantidAlgorithms/ExtractFFTSpectrum.h"
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidAPI/WorkspaceFactory.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/MultiThreaded.h"
 #include "MantidKernel/Unit.h"
@@ -24,6 +24,7 @@ DECLARE_ALGORITHM(ExtractFFTSpectrum)
 
 using namespace Kernel;
 using namespace API;
+using namespace DataObjects;
 
 void ExtractFFTSpectrum::init() {
   declareProperty(
@@ -47,7 +48,7 @@ void ExtractFFTSpectrum::exec() {
   MatrixWorkspace_sptr inputImagWS = getProperty("InputImagWorkspace");
   const int fftPart = getProperty("FFTPart");
   const int numHists = static_cast<int>(inputWS->getNumberHistograms());
-  MatrixWorkspace_sptr outputWS = WorkspaceFactory::Instance().create(inputWS);
+  MatrixWorkspace_sptr outputWS = create<MatrixWorkspace>(*inputWS);
 
   Progress prog(this, 0.0, 1.0, numHists);
 

--- a/Framework/Algorithms/src/FFT.cpp
+++ b/Framework/Algorithms/src/FFT.cpp
@@ -10,7 +10,9 @@
 #include "MantidAlgorithms/FFT.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/TextAxis.h"
-#include "MantidAPI/WorkspaceFactory.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/EnabledWhenProperty.h"
 #include "MantidKernel/EqualBinsChecker.h"
@@ -36,6 +38,8 @@ DECLARE_ALGORITHM(FFT)
 
 using namespace Kernel;
 using namespace API;
+using namespace DataObjects;
+using namespace HistogramData;
 
 /// Initialisation method. Declares properties to be used in algorithm.
 void FFT::init() {
@@ -111,7 +115,11 @@ void FFT::exec() {
     addPositiveOnly = true;
   }
 
-  m_outWS = WorkspaceFactory::Instance().create(m_inWS, nOut, nPoints, nPoints);
+  if (m_inWS->id() == "EventWorkspace") {
+    m_outWS = create<Workspace2D>(*m_inWS, nOut, Points(nPoints));
+  } else {
+    m_outWS = create<HistoWorkspace>(*m_inWS, nOut, Points(nPoints));
+  }
   for (int i = 0; i < nOut; ++i)
     m_outWS->getSpectrum(i).setDetectorID(static_cast<detid_t>(i + 1));
 

--- a/Framework/Algorithms/src/FFT.cpp
+++ b/Framework/Algorithms/src/FFT.cpp
@@ -115,11 +115,8 @@ void FFT::exec() {
     addPositiveOnly = true;
   }
 
-  if (m_inWS->id() == "EventWorkspace") {
-    m_outWS = create<Workspace2D>(*m_inWS, nOut, Points(nPoints));
-  } else {
-    m_outWS = create<HistoWorkspace>(*m_inWS, nOut, Points(nPoints));
-  }
+  m_outWS = create<HistoWorkspace>(*m_inWS, nOut, Points(nPoints));
+
   for (int i = 0; i < nOut; ++i)
     m_outWS->getSpectrum(i).setDetectorID(static_cast<detid_t>(i + 1));
 

--- a/Framework/Algorithms/src/FFTDerivative.cpp
+++ b/Framework/Algorithms/src/FFTDerivative.cpp
@@ -88,7 +88,7 @@ void FFTDerivative::execComplexFFT() {
     fft->setProperty("Imaginary", 4);
     fft->setProperty("Transform", "Backward");
     fft->execute();
-  
+
     transWS = fft->getProperty("OutputWorkspace");
 
     // If the input was histogram data, convert the output to histogram data too

--- a/Framework/Algorithms/src/FFTDerivative.cpp
+++ b/Framework/Algorithms/src/FFTDerivative.cpp
@@ -58,8 +58,8 @@ void FFTDerivative::execComplexFFT() {
   // possible edge effects.
 
   HistogramBuilder builder;
-  builder.setX(std::move(nx + ny));
-  builder.setY(std::move(nx + ny));
+  builder.setX(nx + ny);
+  builder.setY(ny + ny);
   builder.setDistribution(inWS->isDistribution());
   MatrixWorkspace_sptr copyWS =
       create<MatrixWorkspace>(*inWS, 1, builder.build());
@@ -88,7 +88,7 @@ void FFTDerivative::execComplexFFT() {
     fft->setProperty("Imaginary", 4);
     fft->setProperty("Transform", "Backward");
     fft->execute();
-
+  
     transWS = fft->getProperty("OutputWorkspace");
 
     // If the input was histogram data, convert the output to histogram data too

--- a/Framework/Algorithms/src/FFTDerivative.cpp
+++ b/Framework/Algorithms/src/FFTDerivative.cpp
@@ -6,7 +6,9 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidAlgorithms/FFTDerivative.h"
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidAPI/WorkspaceFactory.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidHistogramData/Histogram.h"
+#include "MantidHistogramData/HistogramBuilder.h"
 #include "MantidKernel/BoundedValidator.h"
 
 #include <algorithm>
@@ -23,6 +25,8 @@ DECLARE_ALGORITHM(FFTDerivative)
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
+using namespace Mantid::DataObjects;
+using namespace Mantid::HistogramData;
 
 void FFTDerivative::init() {
   declareProperty(
@@ -52,10 +56,13 @@ void FFTDerivative::execComplexFFT() {
   // Workspace for holding a copy of a spectrum. Each spectrum is symmetrized to
   // minimize
   // possible edge effects.
+
+  HistogramBuilder builder;
+  builder.setX(std::move(nx + ny));
+  builder.setY(std::move(nx + ny));
+  builder.setDistribution(inWS->isDistribution());
   MatrixWorkspace_sptr copyWS =
-      boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(
-          Mantid::API::WorkspaceFactory::Instance().create(inWS, 1, nx + ny,
-                                                           ny + ny));
+      create<MatrixWorkspace>(*inWS, 1, builder.build());
 
   for (size_t spec = 0; spec < n; ++spec) {
     symmetriseSpectrum(inWS->histogram(spec), copyWS->mutableX(0),
@@ -93,8 +100,7 @@ void FFTDerivative::execComplexFFT() {
     }
 
     if (!outWS) {
-      outWS = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(
-          Mantid::API::WorkspaceFactory::Instance().create(inWS));
+      outWS = create<MatrixWorkspace>(*inWS);
     }
 
     // Save the upper half of the inverse transform for output

--- a/Framework/Algorithms/src/FFTSmooth.cpp
+++ b/Framework/Algorithms/src/FFTSmooth.cpp
@@ -64,10 +64,10 @@ void FFTSmooth::exec() {
 
   HistogramBuilder builder;
   builder.setX(m_inWS->x(0).size());
-  builder.setY(m_inWS->y(0).size());
+  builder.setY(m_inWS->y(0).size() + dn);
   builder.setDistribution(m_inWS->isDistribution());
   API::MatrixWorkspace_sptr symmWS =
-      create<MatrixWorkspace>(*m_inWS, 1, builder.build());
+      create<Workspace2D>(*m_inWS, 1, builder.build());
 
   double dx = (m_inWS->x(spec).back() - m_inWS->x(spec).front()) /
               static_cast<double>(m_inWS->x(spec).size() - 1);

--- a/Framework/Algorithms/src/FFTSmooth.cpp
+++ b/Framework/Algorithms/src/FFTSmooth.cpp
@@ -10,10 +10,12 @@
 #include "MantidAlgorithms/FFTSmooth.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/TextAxis.h"
-#include "MantidAPI/WorkspaceFactory.h"
-#include "MantidKernel/Exception.h"
-
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidHistogramData/Histogram.h"
+#include "MantidHistogramData/HistogramBuilder.h"
 #include "MantidKernel/BoundedValidator.h"
+#include "MantidKernel/Exception.h"
 #include "MantidKernel/ListValidator.h"
 
 namespace Mantid {
@@ -24,6 +26,8 @@ DECLARE_ALGORITHM(FFTSmooth)
 
 using namespace Kernel;
 using namespace API;
+using namespace DataObjects;
+using namespace HistogramData;
 
 /// Initialisation method. Declares properties to be used in algorithm.
 void FFTSmooth::init() {
@@ -58,8 +62,12 @@ void FFTSmooth::exec() {
   // Symmetrize the input spectrum
   int dn = static_cast<int>(m_inWS->y(0).size());
 
-  API::MatrixWorkspace_sptr symmWS = API::WorkspaceFactory::Instance().create(
-      "Workspace2D", 1, m_inWS->x(0).size() + dn, m_inWS->y(0).size() + dn);
+  HistogramBuilder builder;
+  builder.setX(m_inWS->x(0).size());
+  builder.setY(m_inWS->y(0).size());
+  builder.setDistribution(m_inWS->isDistribution());
+  API::MatrixWorkspace_sptr symmWS =
+      create<MatrixWorkspace>(*m_inWS, 1, builder.build());
 
   double dx = (m_inWS->x(spec).back() - m_inWS->x(spec).front()) /
               static_cast<double>(m_inWS->x(spec).size() - 1);
@@ -121,8 +129,11 @@ void FFTSmooth::exec() {
   API::MatrixWorkspace_sptr tmpWS = fft->getProperty("OutputWorkspace");
 
   // Create output
-  API::MatrixWorkspace_sptr outWS = API::WorkspaceFactory::Instance().create(
-      m_inWS, 1, m_inWS->x(0).size(), m_inWS->y(0).size());
+  builder.setX(m_inWS->x(0).size());
+  builder.setY(m_inWS->y(0).size());
+  builder.setDistribution(m_inWS->isDistribution());
+  API::MatrixWorkspace_sptr outWS =
+      create<MatrixWorkspace>(*m_inWS, 1, builder.build());
 
   dn = static_cast<int>(tmpWS->blocksize()) / 2;
 
@@ -144,8 +155,11 @@ void FFTSmooth::truncate(int n) {
   if (ny == 0)
     ny = 1;
   int nx = m_unfilteredWS->isHistogramData() ? ny + 1 : ny;
-  m_filteredWS =
-      API::WorkspaceFactory::Instance().create(m_unfilteredWS, 2, nx, ny);
+  HistogramBuilder builder;
+  builder.setX(nx);
+  builder.setY(ny);
+  builder.setDistribution(m_unfilteredWS->isDistribution());
+  m_filteredWS = create<MatrixWorkspace>(*m_unfilteredWS, 2, builder.build());
 
   auto &Yr = m_unfilteredWS->y(0);
   auto &Yi = m_unfilteredWS->y(1);
@@ -178,8 +192,11 @@ void FFTSmooth::zero(int n) {
   if (ny == 0)
     ny = 1;
 
-  m_filteredWS =
-      API::WorkspaceFactory::Instance().create(m_unfilteredWS, 2, mx, my);
+  HistogramBuilder builder;
+  builder.setX(mx);
+  builder.setY(my);
+  builder.setDistribution(m_unfilteredWS->isDistribution());
+  m_filteredWS = create<MatrixWorkspace>(*m_unfilteredWS, 2, builder.build());
 
   m_filteredWS->setSharedX(0, m_unfilteredWS->sharedX(0));
   m_filteredWS->setSharedX(1, m_unfilteredWS->sharedX(0));

--- a/Framework/Algorithms/src/FFTSmooth.cpp
+++ b/Framework/Algorithms/src/FFTSmooth.cpp
@@ -63,7 +63,7 @@ void FFTSmooth::exec() {
   int dn = static_cast<int>(m_inWS->y(0).size());
 
   HistogramBuilder builder;
-  builder.setX(m_inWS->x(0).size());
+  builder.setX(m_inWS->x(0).size() + dn);
   builder.setY(m_inWS->y(0).size() + dn);
   builder.setDistribution(m_inWS->isDistribution());
   API::MatrixWorkspace_sptr symmWS =

--- a/Framework/Algorithms/src/FilterEvents.cpp
+++ b/Framework/Algorithms/src/FilterEvents.cpp
@@ -10,7 +10,6 @@
 #include "MantidAPI/Run.h"
 #include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/TableRow.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidAPI/WorkspaceProperty.h"
 #include "MantidAlgorithms/TimeAtSampleStrategyDirect.h"
@@ -18,8 +17,10 @@
 #include "MantidAlgorithms/TimeAtSampleStrategyIndirect.h"
 #include "MantidDataObjects/SplittersWorkspace.h"
 #include "MantidDataObjects/TableWorkspace.h"
+#include "MantidDataObjects/Workspace2D.h"
 #include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/Instrument/Goniometer.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/ListValidator.h"
@@ -37,6 +38,7 @@ using namespace Mantid;
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
 using namespace Mantid::DataObjects;
+using namespace Mantid::HistogramData;
 using namespace Mantid::Geometry;
 using Types::Core::DateAndTime;
 
@@ -1388,8 +1390,7 @@ void FilterEvents::createOutputWorkspacesTableSplitterCase() {
 void FilterEvents::setupDetectorTOFCalibration() {
   // Set output correction workspace and set to output
   const size_t numhist = m_eventWS->getNumberHistograms();
-  MatrixWorkspace_sptr corrws = boost::dynamic_pointer_cast<MatrixWorkspace>(
-      WorkspaceFactory::Instance().create("Workspace2D", numhist, 2, 2));
+  MatrixWorkspace_sptr corrws = create<Workspace2D>(numhist, Points(2));
   setProperty("OutputTOFCorrectionWorkspace", corrws);
 
   // Set up the size of correction and output correction workspace

--- a/Framework/Algorithms/src/FindCenterOfMassPosition.cpp
+++ b/Framework/Algorithms/src/FindCenterOfMassPosition.cpp
@@ -9,8 +9,8 @@
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/TableRow.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
+#include "MantidDataObjects/TableWorkspace.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/BoundedValidator.h"
@@ -27,6 +27,7 @@ DECLARE_ALGORITHM(FindCenterOfMassPosition)
 using namespace Kernel;
 using namespace API;
 using namespace Geometry;
+using namespace DataObjects;
 
 void FindCenterOfMassPosition::init() {
   auto wsValidator = boost::make_shared<CompositeValidator>();
@@ -215,7 +216,7 @@ void FindCenterOfMassPosition::exec() {
     setPropertyValue("OutputWorkspace", output);
 
     Mantid::API::ITableWorkspace_sptr m_result =
-        Mantid::API::WorkspaceFactory::Instance().createTable("TableWorkspace");
+        boost::make_shared<TableWorkspace>();
     m_result->addColumn("str", "Name");
     m_result->addColumn("double", "Value");
 

--- a/Framework/Algorithms/src/FindCenterOfMassPosition2.cpp
+++ b/Framework/Algorithms/src/FindCenterOfMassPosition2.cpp
@@ -13,12 +13,13 @@
 #include "MantidAPI/WorkspaceUnitValidator.h"
 #include "MantidDataObjects/EventList.h"
 #include "MantidDataObjects/EventWorkspace.h"
+#include "MantidDataObjects/TableWorkspace.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/CompositeValidator.h"
 #include "MantidKernel/PhysicalConstants.h"
-
 namespace Mantid {
 namespace Algorithms {
 
@@ -260,7 +261,7 @@ void FindCenterOfMassPosition2::exec() {
     setPropertyValue("OutputWorkspace", output);
 
     Mantid::API::ITableWorkspace_sptr m_result =
-        Mantid::API::WorkspaceFactory::Instance().createTable("TableWorkspace");
+        boost::make_shared<TableWorkspace>();
     m_result->addColumn("str", "Name");
     m_result->addColumn("double", "Value");
 

--- a/Framework/Algorithms/src/FindEPP.cpp
+++ b/Framework/Algorithms/src/FindEPP.cpp
@@ -6,7 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidAlgorithms/FindEPP.h"
 #include "MantidAPI/TableRow.h"
-#include "MantidAPI/WorkspaceFactory.h"
+#include "MantidDataObjects/TableWorkspace.h"
 #include "MantidKernel/make_unique.h"
 
 #include <cmath>
@@ -17,6 +17,7 @@ namespace Algorithms {
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
+using namespace Mantid::DataObjects;
 
 // Register the algorithm into the AlgorithmFactory
 DECLARE_ALGORITHM(FindEPP)
@@ -189,7 +190,7 @@ void FindEPP::fitGaussian(int64_t index) {
  */
 void FindEPP::initWorkspace() {
 
-  m_outWS = WorkspaceFactory::Instance().createTable("TableWorkspace");
+  m_outWS = boost::make_shared<TableWorkspace>();
 
   const std::vector<std::string> columns = {
       "PeakCentre", "PeakCentreError", "Sigma", "SigmaError",

--- a/Framework/Algorithms/src/FindPeakBackground.cpp
+++ b/Framework/Algorithms/src/FindPeakBackground.cpp
@@ -7,7 +7,6 @@
 #include "MantidAlgorithms/FindPeakBackground.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/TableRow.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceProperty.h"
 #include "MantidAlgorithms/FindPeaks.h"
 #include "MantidDataObjects/TableWorkspace.h"
@@ -375,7 +374,7 @@ void FindPeakBackground::setFitWindow(const std::vector<double> &fitwindow) {
  */
 void FindPeakBackground::createOutputWorkspaces() {
   // Set up output table workspace
-  m_outPeakTableWS = WorkspaceFactory::Instance().createTable("TableWorkspace");
+  m_outPeakTableWS = boost::make_shared<TableWorkspace>();
   m_outPeakTableWS->addColumn("int", "wksp_index");
   m_outPeakTableWS->addColumn("int", "peak_min_index");
   m_outPeakTableWS->addColumn("int", "peak_max_index");

--- a/Framework/Algorithms/src/FindPeaks.cpp
+++ b/Framework/Algorithms/src/FindPeaks.cpp
@@ -11,8 +11,8 @@
 #include "MantidAPI/FuncMinimizerFactory.h"
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/TableRow.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAlgorithms/FitPeak.h"
+#include "MantidDataObjects/TableWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidIndexing/GlobalSpectrumIndex.h"
 #include "MantidIndexing/IndexInfo.h"
@@ -290,7 +290,7 @@ void FindPeaks::processAlgorithmProperties() {
 /** Generate a table workspace for output peak parameters
  */
 void FindPeaks::generateOutputPeakParameterTable() {
-  m_outPeakTableWS = WorkspaceFactory::Instance().createTable("TableWorkspace");
+  m_outPeakTableWS = boost::make_shared<TableWorkspace>();
   m_outPeakTableWS->addColumn("int", "spectrum");
 
   if (m_rawPeaksTable) {

--- a/Framework/Algorithms/src/FitPeak.cpp
+++ b/Framework/Algorithms/src/FitPeak.cpp
@@ -14,17 +14,19 @@
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/FunctionProperty.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/MultiDomainFunction.h"
 #include "MantidAPI/TableRow.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceProperty.h"
 #include "MantidDataObjects/TableWorkspace.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidHistogramData/Histogram.h"
+#include "MantidHistogramData/HistogramBuilder.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/IValidator.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/StartsWithValidator.h"
-
-#include "MantidAPI/MultiDomainFunction.h"
 
 #include "boost/algorithm/string.hpp"
 #include "boost/algorithm/string/trim.hpp"
@@ -32,6 +34,7 @@
 using namespace Mantid;
 using namespace Mantid::API;
 using namespace Mantid::DataObjects;
+using namespace Mantid::HistogramData;
 using namespace Mantid::Kernel;
 using Mantid::HistogramData::HistogramX;
 
@@ -356,8 +359,11 @@ API::MatrixWorkspace_sptr FitOneSinglePeak::genFitWindowWS() {
   size_t ishift = i_maxFitX + 1;
   if (ishift >= vecY.size())
     ysize = vecY.size() - i_minFitX;
-  MatrixWorkspace_sptr purePeakWS =
-      WorkspaceFactory::Instance().create("Workspace2D", 1, size, ysize);
+
+  HistogramBuilder builder;
+  builder.setX(size);
+  builder.setY(ysize);
+  MatrixWorkspace_sptr purePeakWS = create<Workspace2D>(1, builder.build());
 
   auto &vecX = m_dataWS->x(m_wsIndex);
   auto &vecE = m_dataWS->e(m_wsIndex);
@@ -1514,9 +1520,10 @@ void FitPeak::setupOutput(
   size_t sizex = vecoutx.size();
   size_t sizey = vecoutx.size();
 
-  MatrixWorkspace_sptr outws = boost::dynamic_pointer_cast<MatrixWorkspace>(
-      WorkspaceFactory::Instance().create("Workspace2D", nspec, sizex, sizey));
-
+  HistogramBuilder builder;
+  builder.setX(sizex);
+  builder.setY(sizey);
+  MatrixWorkspace_sptr outws = create<Workspace2D>(nspec, builder.build());
   // Calculate again
   FunctionDomain1DVector domain(vecoutx);
   FunctionValues values(domain);

--- a/Framework/Algorithms/src/GenerateEventsFilter.cpp
+++ b/Framework/Algorithms/src/GenerateEventsFilter.cpp
@@ -7,8 +7,11 @@
 #include "MantidAlgorithms/GenerateEventsFilter.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/TableRow.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceProperty.h"
+#include "MantidDataObjects/TableWorkspace.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/VisibleWhenProperty.h"
@@ -18,6 +21,8 @@
 using namespace Mantid;
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
+using namespace Mantid::DataObjects;
+using namespace Mantid::HistogramData;
 using Types::Core::DateAndTime;
 using Types::Core::time_duration;
 
@@ -228,8 +233,7 @@ void GenerateEventsFilter::processInOutWorkspaces() {
     // Using default
     title = "Splitters";
   }
-  m_filterInfoWS =
-      API::WorkspaceFactory::Instance().createTable("TableWorkspace");
+  m_filterInfoWS = m_filterInfoWS = boost::make_shared<TableWorkspace>();
   m_filterInfoWS->setTitle(title);
   m_filterInfoWS->addColumn("int", "workspacegroup");
   m_filterInfoWS->addColumn("str", "title");
@@ -1755,8 +1759,7 @@ void GenerateEventsFilter::generateSplittersInMatrixWorkspace() {
     throw runtime_error("Logic error on splitter vectors' size. ");
   }
 
-  m_filterWS =
-      API::WorkspaceFactory::Instance().create("Workspace2D", 1, sizex, sizey);
+  m_filterWS = create<Workspace2D>(1, BinEdges(sizex));
   auto &dataX = m_filterWS->mutableX(0);
   for (size_t i = 0; i < sizex; ++i) {
     // x is in the unit as second
@@ -1788,10 +1791,8 @@ void GenerateEventsFilter::generateSplittersInMatrixWorkspaceParallel() {
   ++numtimes;
 
   size_t sizex = numtimes;
-  size_t sizey = numtimes - 1;
 
-  m_filterWS =
-      API::WorkspaceFactory::Instance().create("Workspace2D", 1, sizex, sizey);
+  m_filterWS = create<Workspace2D>(1, BinEdges(sizex));
   auto &dataX = m_filterWS->mutableX(0);
   auto &dataY = m_filterWS->mutableY(0);
 

--- a/Framework/Algorithms/src/GeneratePeaks.cpp
+++ b/Framework/Algorithms/src/GeneratePeaks.cpp
@@ -11,9 +11,9 @@
 #include "MantidAPI/FunctionValues.h"
 #include "MantidAPI/IBackgroundFunction.h"
 #include "MantidAPI/SpectraAxis.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceProperty.h"
 #include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidHistogramData/HistogramBuilder.h"
 #include "MantidIndexing/IndexInfo.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/ListValidator.h"
@@ -705,10 +705,13 @@ API::MatrixWorkspace_sptr GeneratePeaks::createOutputWorkspace() {
           << "Both binning parameters and input workspace are given. "
           << "Using input worksapce to generate output workspace!\n";
 
-    outputWS = API::WorkspaceFactory::Instance().create(
-        inputWS, inputWS->getNumberHistograms(), inputWS->x(0).size(),
-        inputWS->y(0).size());
+    HistogramBuilder builder;
+    builder.setX(std::move(inputWS->x(0).size()));
+    builder.setY(std::move(inputWS->y(0).size()));
 
+    builder.setDistribution(inputWS->isDistribution());
+    outputWS = create<MatrixWorkspace>(*inputWS, inputWS->getNumberHistograms(),
+                                       builder.build());
     // Only copy the X-values from spectra with peaks specified in the table
     // workspace.
     for (const auto &iws : m_spectraSet) {

--- a/Framework/Algorithms/src/GeneratePeaks.cpp
+++ b/Framework/Algorithms/src/GeneratePeaks.cpp
@@ -706,12 +706,11 @@ API::MatrixWorkspace_sptr GeneratePeaks::createOutputWorkspace() {
           << "Using input worksapce to generate output workspace!\n";
 
     HistogramBuilder builder;
-    builder.setX(std::move(inputWS->x(0).size()));
-    builder.setY(std::move(inputWS->y(0).size()));
+    builder.setX(inputWS->x(0).size());
+    builder.setY(inputWS->y(0).size());
 
     builder.setDistribution(inputWS->isDistribution());
-    outputWS = create<MatrixWorkspace>(*inputWS, inputWS->getNumberHistograms(),
-                                       builder.build());
+    outputWS = create<MatrixWorkspace>(*inputWS, builder.build());
     // Only copy the X-values from spectra with peaks specified in the table
     // workspace.
     for (const auto &iws : m_spectraSet) {

--- a/Framework/Algorithms/src/GetAllEi.cpp
+++ b/Framework/Algorithms/src/GetAllEi.cpp
@@ -384,7 +384,7 @@ void GetAllEi::exec() {
   std::sort(peaks.begin(), peaks.end());
 
   // finalize output
-  API::MatrixWorkspace_sptr result_ws = create<Workspace2D>(1, Points(nPeaks));
+  auto result_ws = create<Workspace2D>(1, Points(nPeaks));
 
   HistogramX peaks_positions(peaks.size());
   std::transform(peaks.cbegin(), peaks.cend(), peaks_positions.begin(),
@@ -399,7 +399,7 @@ void GetAllEi::exec() {
 
   result_ws->setPoints(0, peaks_positions);
 
-  setProperty("OutputWorkspace", result_ws);
+  setProperty("OutputWorkspace", std::move(result_ws));
 }
 /**Auxiliary method to print guess chopper energies in debug mode
  *

--- a/Framework/Algorithms/src/GetAllEi.cpp
+++ b/Framework/Algorithms/src/GetAllEi.cpp
@@ -9,8 +9,8 @@
 #include "MantidAPI/HistoWorkspace.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/SpectrumInfo.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidDataObjects/TableWorkspace.h"
+#include "MantidDataObjects/Workspace2D.h"
 #include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/IComponent.h"
 #include "MantidGeometry/Instrument.h"
@@ -31,7 +31,8 @@
 namespace Mantid {
 namespace Algorithms {
 
-using namespace HistogramData;
+using namespace Mantid::DataObjects;
+using namespace Mantid::HistogramData;
 DECLARE_ALGORITHM(GetAllEi)
 
 /// Empty default constructor
@@ -383,8 +384,7 @@ void GetAllEi::exec() {
   std::sort(peaks.begin(), peaks.end());
 
   // finalize output
-  auto result_ws = API::WorkspaceFactory::Instance().create("Workspace2D", 1,
-                                                            nPeaks, nPeaks);
+  API::MatrixWorkspace_sptr result_ws = create<Workspace2D>(1, Points(nPeaks));
 
   HistogramX peaks_positions(peaks.size());
   std::transform(peaks.cbegin(), peaks.cend(), peaks_positions.begin(),

--- a/Framework/Algorithms/src/GetDetOffsetsMultiPeaks.cpp
+++ b/Framework/Algorithms/src/GetDetOffsetsMultiPeaks.cpp
@@ -14,11 +14,12 @@
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/TableRow.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidDataObjects/MaskWorkspace.h"
 #include "MantidDataObjects/OffsetsWorkspace.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/StartsWithValidator.h"
@@ -29,6 +30,9 @@
 #include <gsl/gsl_multimin.h>
 
 #include <sstream>
+
+using namespace Mantid::DataObjects;
+using namespace Mantid::HistogramData;
 
 namespace Mantid {
 namespace Algorithms {
@@ -1166,8 +1170,7 @@ void GetDetOffsetsMultiPeaks::createInformationWorkspaces() {
   }
 
   // Create resolution (delta(d)/d) workspace
-  m_resolutionWS = boost::dynamic_pointer_cast<MatrixWorkspace>(
-      WorkspaceFactory::Instance().create("Workspace2D", numspec, 1, 1));
+  m_resolutionWS = create<Workspace2D>(numspec, Points(1));
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/Algorithms/src/GetTimeSeriesLogInformation.cpp
+++ b/Framework/Algorithms/src/GetTimeSeriesLogInformation.cpp
@@ -7,11 +7,12 @@
 #include "MantidAlgorithms/GetTimeSeriesLogInformation.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/TableRow.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceProperty.h"
 #include "MantidDataObjects/EventList.h"
 #include "MantidDataObjects/EventWorkspace.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/Instrument.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 #include <algorithm>
@@ -20,6 +21,7 @@
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
 using namespace Mantid::DataObjects;
+using namespace Mantid::HistogramData;
 using Mantid::Types::Core::DateAndTime;
 
 using namespace std;
@@ -375,9 +377,7 @@ Workspace2D_sptr GetTimeSeriesLogInformation::calDistributions(
   g_log.notice() << "Distribution has " << numbins << " bins.  Delta T = ("
                  << dtmin << ", " << dtmax << ")\n";
 
-  Workspace2D_sptr distws = boost::dynamic_pointer_cast<Workspace2D>(
-      API::WorkspaceFactory::Instance().create("Workspace2D", 1, numbins,
-                                               numbins));
+  Workspace2D_sptr distws = create<Workspace2D>(1, Points(numbins));
   auto &vecDeltaT = distws->mutableX(0);
   auto &vecCount = distws->mutableY(0);
 

--- a/Framework/Algorithms/src/He3TubeEfficiency.cpp
+++ b/Framework/Algorithms/src/He3TubeEfficiency.cpp
@@ -9,10 +9,10 @@
 #include "MantidAPI/HistogramValidator.h"
 #include "MantidAPI/InstrumentValidator.h"
 #include "MantidAPI/SpectrumInfo.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/ParameterMap.h"
 #include "MantidGeometry/Objects/IObject.h"
@@ -36,6 +36,7 @@ const double TOL = 1.0e-8;
 namespace Mantid {
 namespace Algorithms {
 
+using namespace DataObjects;
 using namespace HistogramData;
 // Register the class into the algorithm factory
 DECLARE_ALGORITHM(He3TubeEfficiency)
@@ -100,7 +101,7 @@ void He3TubeEfficiency::exec() {
   m_outputWS = this->getProperty("OutputWorkspace");
 
   if (m_outputWS != m_inputWS) {
-    m_outputWS = API::WorkspaceFactory::Instance().create(m_inputWS);
+    m_outputWS = create<API::MatrixWorkspace>(*m_inputWS);
   }
 
   // Get the detector parameters

--- a/Framework/Algorithms/src/HyspecScharpfCorrection.cpp
+++ b/Framework/Algorithms/src/HyspecScharpfCorrection.cpp
@@ -8,9 +8,9 @@
 #include "MantidAPI/InstrumentValidator.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/SpectrumInfo.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
 #include "MantidDataObjects/EventWorkspace.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/ReferenceFrame.h"
 #include "MantidKernel/BoundedValidator.h"
@@ -21,6 +21,7 @@ namespace Algorithms {
 
 using Mantid::API::WorkspaceProperty;
 using Mantid::Kernel::Direction;
+using namespace DataObjects;
 
 // Register the algorithm into the AlgorithmFactory
 DECLARE_ALGORITHM(HyspecScharpfCorrection)
@@ -105,7 +106,7 @@ void HyspecScharpfCorrection::exec() {
   // If input and output workspaces are not the same, create a new workspace for
   // the output
   if (m_outputWS != m_inputWS) {
-    m_outputWS = API::WorkspaceFactory::Instance().create(m_inputWS);
+    m_outputWS = create<API::MatrixWorkspace>(*m_inputWS);
   }
 
   const auto &spectrumInfo = m_inputWS->spectrumInfo();

--- a/Framework/Algorithms/src/IQTransform.cpp
+++ b/Framework/Algorithms/src/IQTransform.cpp
@@ -12,14 +12,20 @@
 #include "MantidAPI/IncreasingAxisValidator.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/RawCountValidator.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
+#include "MantidDataObjects/TableWorkspace.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/CompositeValidator.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/Unit.h"
 #include "MantidKernel/VectorHelper.h"
+
+using namespace Mantid::DataObjects;
+using namespace Mantid::HistogramData;
 
 namespace Mantid {
 namespace Algorithms {
@@ -118,7 +124,7 @@ void IQTransform::exec() {
   // Create the output workspace
   const size_t length = tmpWS->blocksize();
   MatrixWorkspace_sptr outputWS =
-      WorkspaceFactory::Instance().create(inputWS, 1, length, length);
+      create<MatrixWorkspace>(*inputWS, 1, Points(length));
   m_label->setLabel("");
   outputWS->setYUnit("");
   // Copy the data over. Assume single spectrum input (output will be).

--- a/Framework/Algorithms/src/IdentifyNoisyDetectors.cpp
+++ b/Framework/Algorithms/src/IdentifyNoisyDetectors.cpp
@@ -8,8 +8,9 @@
 #include "MantidAPI/HistogramValidator.h"
 #include "MantidAPI/InstrumentValidator.h"
 #include "MantidAPI/SpectraAxisValidator.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/CompositeValidator.h"
 #include <numeric>
 
@@ -18,6 +19,7 @@ namespace Algorithms {
 using namespace Kernel;
 using namespace API;
 using namespace HistogramData;
+using namespace DataObjects;
 
 DECLARE_ALGORITHM(IdentifyNoisyDetectors)
 
@@ -55,10 +57,10 @@ void IdentifyNoisyDetectors::exec() {
 
   // Create the output workspace a single value for each spectra.
   MatrixWorkspace_sptr outputWs;
-  outputWs = WorkspaceFactory::Instance().create(inputWS, nHist, 1, 1);
+  outputWs = create<MatrixWorkspace>(*inputWS, nHist, Points(1));
 
   MatrixWorkspace_sptr stdDevWs;
-  stdDevWs = WorkspaceFactory::Instance().create(outputWs);
+  stdDevWs = create<MatrixWorkspace>(*outputWs);
 
   progress.report("Integrating...");
 

--- a/Framework/Algorithms/src/IdentifyNoisyDetectors.cpp
+++ b/Framework/Algorithms/src/IdentifyNoisyDetectors.cpp
@@ -57,7 +57,7 @@ void IdentifyNoisyDetectors::exec() {
 
   // Create the output workspace a single value for each spectra.
   MatrixWorkspace_sptr outputWs;
-  outputWs = create<MatrixWorkspace>(*inputWS, nHist, Points(1));
+  outputWs = create<MatrixWorkspace>(*inputWS, Points(1));
 
   MatrixWorkspace_sptr stdDevWs;
   stdDevWs = create<MatrixWorkspace>(*outputWs);

--- a/Framework/Algorithms/src/Integration.cpp
+++ b/Framework/Algorithms/src/Integration.cpp
@@ -160,9 +160,9 @@ void Integration::exec() {
   }
 
   // Create the 2D workspace (with 1 bin) for the output
- 
+
   MatrixWorkspace_sptr outputWorkspace = create<Workspace2D>(
-    *localworkspace, maxWsIndex-minWsIndex+1, BinEdges(2));
+      *localworkspace, maxWsIndex - minWsIndex + 1, BinEdges(2));
   auto rebinned_input =
       boost::dynamic_pointer_cast<const RebinnedOutput>(localworkspace);
   auto rebinned_output =

--- a/Framework/Algorithms/src/Integration.cpp
+++ b/Framework/Algorithms/src/Integration.cpp
@@ -10,9 +10,12 @@
 #include "MantidAlgorithms/Integration.h"
 #include "MantidAPI/NumericAxis.h"
 #include "MantidAPI/TextAxis.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidDataObjects/RebinnedOutput.h"
+#include "MantidDataObjects/TableWorkspace.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/VectorHelper.h"
@@ -29,6 +32,7 @@ DECLARE_ALGORITHM(Integration)
 using namespace Kernel;
 using namespace API;
 using namespace DataObjects;
+using namespace HistogramData;
 
 /** Initialisation method.
  *
@@ -156,9 +160,9 @@ void Integration::exec() {
   }
 
   // Create the 2D workspace (with 1 bin) for the output
-  MatrixWorkspace_sptr outputWorkspace =
-      API::WorkspaceFactory::Instance().create(
-          localworkspace, maxWsIndex - minWsIndex + 1, 2, 1);
+ 
+  MatrixWorkspace_sptr outputWorkspace = create<Workspace2D>(
+    *localworkspace, maxWsIndex-minWsIndex+1, BinEdges(2));
   auto rebinned_input =
       boost::dynamic_pointer_cast<const RebinnedOutput>(localworkspace);
   auto rebinned_output =

--- a/Framework/Algorithms/src/InterpolatingRebin.cpp
+++ b/Framework/Algorithms/src/InterpolatingRebin.cpp
@@ -79,7 +79,7 @@ void InterpolatingRebin::exec() {
   const int nHists = static_cast<int>(inputW->getNumberHistograms());
   // make output Workspace the same type as the input but with the new axes
   MatrixWorkspace_sptr outputW =
-      create<MatrixWorkspace>(*inputW, nHists, BinEdges(ntcnew));
+      create<MatrixWorkspace>(*inputW, BinEdges(ntcnew));
   // Copy over the 'vertical' axis
   if (inputW->axes() > 1)
     outputW->replaceAxis(1, inputW->getAxis(1)->clone(outputW.get()));

--- a/Framework/Algorithms/src/InterpolatingRebin.cpp
+++ b/Framework/Algorithms/src/InterpolatingRebin.cpp
@@ -7,7 +7,10 @@
 #include "MantidAlgorithms/InterpolatingRebin.h"
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidAPI/WorkspaceFactory.h"
+#include "MantidDataObjects/TableWorkspace.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/RebinParamsValidator.h"
 #include "MantidKernel/VectorHelper.h"
@@ -27,6 +30,7 @@ DECLARE_ALGORITHM(InterpolatingRebin)
 using namespace Kernel;
 using namespace API;
 using namespace HistogramData;
+using namespace DataObjects;
 
 /** Only calls its parent's (Rebin) init()
  *
@@ -75,7 +79,7 @@ void InterpolatingRebin::exec() {
   const int nHists = static_cast<int>(inputW->getNumberHistograms());
   // make output Workspace the same type as the input but with the new axes
   MatrixWorkspace_sptr outputW =
-      WorkspaceFactory::Instance().create(inputW, nHists, ntcnew, ntcnew - 1);
+      create<MatrixWorkspace>(*inputW, nHists, BinEdges(ntcnew));
   // Copy over the 'vertical' axis
   if (inputW->axes() > 1)
     outputW->replaceAxis(1, inputW->getAxis(1)->clone(outputW.get()));

--- a/Framework/Algorithms/src/MagFormFactorCorrection.cpp
+++ b/Framework/Algorithms/src/MagFormFactorCorrection.cpp
@@ -8,12 +8,15 @@
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidAPI/WorkspaceFactory.h"
+#include "MantidDataObjects/TableWorkspace.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidHistogramData/Histogram.h"
+#include "MantidHistogramData/HistogramBuilder.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/MagneticIon.h"
 #include "MantidKernel/Unit.h"
 #include "MantidKernel/UnitFactory.h"
-
 using namespace Mantid::PhysicalConstants;
 
 namespace Mantid {
@@ -25,6 +28,8 @@ DECLARE_ALGORITHM(MagFormFactorCorrection)
 using namespace Kernel;
 using namespace API;
 using namespace PhysicalConstants;
+using namespace Mantid::DataObjects;
+using namespace Mantid::HistogramData;
 
 void MagFormFactorCorrection::init() {
   declareProperty(
@@ -94,8 +99,10 @@ void MagFormFactorCorrection::exec() {
     FF.push_back(ion.analyticalFormFactor(Qval * Qval));
   }
   if (!ffwsStr.empty()) {
-    MatrixWorkspace_sptr ffws = API::WorkspaceFactory::Instance().create(
-        "Workspace2D", 1, Qvals.size(), FF.size());
+    HistogramBuilder builder;
+    builder.setX(Qvals.size());
+    builder.setY(FF.size());
+    MatrixWorkspace_sptr ffws = create<Workspace2D>(1, builder.build());
     ffws->mutableX(0).assign(Qvals.begin(), Qvals.end());
     ffws->mutableY(0).assign(FF.begin(), FF.end());
     ffws->getAxis(0)->unit() =

--- a/Framework/Algorithms/src/MaxMin.cpp
+++ b/Framework/Algorithms/src/MaxMin.cpp
@@ -95,13 +95,9 @@ void MaxMin::exec() {
 
   // Create the 1D workspace for the output
   MatrixWorkspace_sptr outputWorkspace;
-  if (localworkspace->id() == "EventWorkspace") {
-    outputWorkspace = create<DataObjects::Workspace2D>(
-        *localworkspace, MaxSpec - MinSpec + 1, BinEdges(2));
-  } else {
-    outputWorkspace = create<HistoWorkspace>(
-        *localworkspace, MaxSpec - MinSpec + 1, BinEdges(2));
-  }
+
+  outputWorkspace = create<HistoWorkspace>(*localworkspace,
+                                           MaxSpec - MinSpec + 1, BinEdges(2));
 
   Progress progress(this, 0.0, 1.0, (MaxSpec - MinSpec + 1));
   PARALLEL_FOR_IF(Kernel::threadSafe(*localworkspace, *outputWorkspace))

--- a/Framework/Algorithms/src/MaxMin.cpp
+++ b/Framework/Algorithms/src/MaxMin.cpp
@@ -9,7 +9,10 @@
 //----------------------------------------------------------------------
 #include "MantidAlgorithms/MaxMin.h"
 #include "MantidAPI/HistogramValidator.h"
-#include "MantidAPI/WorkspaceFactory.h"
+#include "MantidDataObjects/TableWorkspace.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/BoundedValidator.h"
 
 namespace Mantid {
@@ -20,6 +23,8 @@ DECLARE_ALGORITHM(MaxMin)
 
 using namespace Kernel;
 using namespace API;
+using namespace Mantid::DataObjects;
+using namespace Mantid::HistogramData;
 
 /** Initialisation method.
  *
@@ -89,9 +94,14 @@ void MaxMin::exec() {
   }
 
   // Create the 1D workspace for the output
-  MatrixWorkspace_sptr outputWorkspace =
-      API::WorkspaceFactory::Instance().create(localworkspace,
-                                               MaxSpec - MinSpec + 1, 2, 1);
+  MatrixWorkspace_sptr outputWorkspace;
+  if (localworkspace->id() == "EventWorkspace") {
+    outputWorkspace = create<DataObjects::Workspace2D>(
+        *localworkspace, MaxSpec - MinSpec + 1, BinEdges(2));
+  } else {
+    outputWorkspace = create<HistoWorkspace>(
+        *localworkspace, MaxSpec - MinSpec + 1, BinEdges(2));
+  }
 
   Progress progress(this, 0.0, 1.0, (MaxSpec - MinSpec + 1));
   PARALLEL_FOR_IF(Kernel::threadSafe(*localworkspace, *outputWorkspace))

--- a/Framework/Algorithms/src/ModeratorTzero.cpp
+++ b/Framework/Algorithms/src/ModeratorTzero.cpp
@@ -8,12 +8,14 @@
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/SpectrumInfo.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
 #include "MantidDataObjects/EventList.h"
 #include "MantidDataObjects/EventWorkspace.h"
+#include "MantidDataObjects/TableWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/muParser_Silent.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/UnitFactory.h"
 
@@ -29,6 +31,7 @@ using namespace Mantid::Kernel;
 using namespace Mantid::API;
 using namespace Mantid::Geometry;
 using namespace Mantid::DataObjects;
+using namespace Mantid::HistogramData;
 
 ModeratorTzero::ModeratorTzero()
     : Mantid::API::Algorithm(),
@@ -104,7 +107,7 @@ void ModeratorTzero::exec() {
   // Check whether input == output to see whether a new workspace is required.
   if (outputWS != inputWS) {
     // Create new workspace for output from old
-    outputWS = WorkspaceFactory::Instance().create(inputWS);
+    outputWS = create<MatrixWorkspace>(*inputWS);
   }
 
   // calculate tof shift once for all neutrons if emode==Direct

--- a/Framework/Algorithms/src/ModeratorTzeroLinear.cpp
+++ b/Framework/Algorithms/src/ModeratorTzeroLinear.cpp
@@ -8,10 +8,12 @@
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/SpectrumInfo.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
 #include "MantidDataObjects/EventWorkspace.h"
+#include "MantidDataObjects/TableWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/PhysicalConstants.h"
 #include "MantidKernel/UnitFactory.h"
 
@@ -27,6 +29,7 @@ using namespace Mantid::Kernel;
 using namespace Mantid::API;
 using namespace Mantid::Geometry;
 using namespace Mantid::DataObjects;
+using namespace Mantid::HistogramData;
 
 // A reference to the logger is provided by the base class, it is called g_log.
 // It is used to print out information, warning and error messages
@@ -133,7 +136,7 @@ void ModeratorTzeroLinear::exec() {
   // Check whether input = output to see whether a new workspace is required.
   if (outputWS != inputWS) {
     // Create new workspace for output from old
-    outputWS = WorkspaceFactory::Instance().create(inputWS);
+    outputWS = create<MatrixWorkspace>(*inputWS);
   }
 
   // do the shift in X

--- a/Framework/Algorithms/src/MonitorEfficiencyCorUser.cpp
+++ b/Framework/Algorithms/src/MonitorEfficiencyCorUser.cpp
@@ -9,9 +9,12 @@
 #include "MantidAPI/InstrumentValidator.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Run.h"
-#include "MantidAPI/WorkspaceFactory.h"
+#include "MantidDataObjects/TableWorkspace.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/muParser_Silent.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidHistogramData/HistogramMath.h"
 #include "MantidKernel/MultiThreaded.h"
 #include "MantidKernel/Strings.h"
@@ -22,6 +25,8 @@ namespace Algorithms {
 using namespace Kernel;
 using namespace API;
 using namespace Geometry;
+using namespace DataObjects;
+using namespace HistogramData;
 
 // Register the algorithm into the AlgorithmFactory
 DECLARE_ALGORITHM(MonitorEfficiencyCorUser)
@@ -47,7 +52,7 @@ void MonitorEfficiencyCorUser::exec() {
   // If input and output workspaces are not the same, create a new workspace for
   // the output
   if (m_outputWS != this->m_inputWS) {
-    m_outputWS = API::WorkspaceFactory::Instance().create(m_inputWS);
+    m_outputWS = create<MatrixWorkspace>(*m_inputWS);
   }
   m_Ei = m_inputWS->run().getPropertyValueAsType<double>("Ei");
 

--- a/Framework/Algorithms/src/MultiplyRange.cpp
+++ b/Framework/Algorithms/src/MultiplyRange.cpp
@@ -9,7 +9,10 @@
 //----------------------------------------------------------------------
 #include "MantidAlgorithms/MultiplyRange.h"
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidAPI/WorkspaceFactory.h"
+#include "MantidDataObjects/TableWorkspace.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/BoundedValidator.h"
 
 namespace Mantid {
@@ -20,6 +23,8 @@ DECLARE_ALGORITHM(MultiplyRange)
 
 using namespace Kernel;
 using namespace API;
+using namespace DataObjects;
+using namespace HistogramData;
 
 void MultiplyRange::init() {
   // Declare an input workspace property.
@@ -69,7 +74,7 @@ void MultiplyRange::exec() {
   // Only create the output workspace if it's different to the input one
   MatrixWorkspace_sptr outputWS = getProperty("OutputWorkspace");
   if (outputWS != inputWS) {
-    outputWS = WorkspaceFactory::Instance().create(inputWS);
+    outputWS = create<MatrixWorkspace>(*inputWS);
     setProperty("OutputWorkspace", outputWS);
   }
 

--- a/Framework/Algorithms/src/NormaliseToMonitor.cpp
+++ b/Framework/Algorithms/src/NormaliseToMonitor.cpp
@@ -10,12 +10,15 @@
 #include "MantidAPI/SingleCountValidator.h"
 #include "MantidAPI/SpectraAxis.h"
 #include "MantidAPI/SpectrumInfo.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceOpOverloads.h"
 #include "MantidDataObjects/EventWorkspace.h"
+#include "MantidDataObjects/TableWorkspace.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/IDetector.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/CompositeValidator.h"
 #include "MantidKernel/EnabledWhenProperty.h"
@@ -686,7 +689,7 @@ void NormaliseToMonitor::normaliseBinByBin(
     if (inputEvent) {
       outputWorkspace = inputWorkspace->clone();
     } else
-      outputWorkspace = WorkspaceFactory::Instance().create(inputWorkspace);
+      outputWorkspace = create<MatrixWorkspace>(*inputWorkspace);
   }
   auto outputEvent =
       boost::dynamic_pointer_cast<EventWorkspace>(outputWorkspace);

--- a/Framework/Algorithms/src/PDCalibration.cpp
+++ b/Framework/Algorithms/src/PDCalibration.cpp
@@ -11,15 +11,17 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/TableRow.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidDataObjects/MaskWorkspace.h"
 #include "MantidDataObjects/SpecialWorkspace2D.h"
 #include "MantidDataObjects/TableWorkspace.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/IDetector.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/ArrayBoundedValidator.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/BoundedValidator.h"
@@ -40,6 +42,8 @@
 namespace Mantid {
 namespace Algorithms {
 
+using namespace Mantid::DataObjects;
+using namespace Mantid::HistogramData;
 using Mantid::API::FileProperty;
 using Mantid::API::MatrixWorkspace;
 using Mantid::API::MatrixWorkspace_sptr;
@@ -1198,11 +1202,10 @@ PDCalibration::createTOFPeakCenterFitWindowWorkspaces(
   // create workspaces
   size_t numspec = dataws->getNumberHistograms();
   size_t numpeaks = m_peaksInDspacing.size();
-  MatrixWorkspace_sptr peak_pos_ws = API::WorkspaceFactory::Instance().create(
-      "Workspace2D", numspec, numpeaks, numpeaks);
+  MatrixWorkspace_sptr peak_pos_ws =
+      create<Workspace2D>(numspec, Points(numpeaks));
   MatrixWorkspace_sptr peak_window_ws =
-      API::WorkspaceFactory::Instance().create("Workspace2D", numspec,
-                                               numpeaks * 2, numpeaks * 2);
+      create<Workspace2D>(numspec, Points(numpeaks * 2));
 
   const int64_t NUM_HIST = static_cast<int64_t>(dataws->getNumberHistograms());
   API::Progress prog(this, 0., .2, NUM_HIST);

--- a/Framework/Algorithms/src/PDFFourierTransform.cpp
+++ b/Framework/Algorithms/src/PDFFourierTransform.cpp
@@ -8,8 +8,10 @@
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/Sample.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidHistogramData/LinearGenerator.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/ListValidator.h"
@@ -32,6 +34,7 @@ DECLARE_ALGORITHM(PDFFourierTransform)
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
+using namespace DataObjects;
 
 namespace { // anonymous namespace
 /// Crystalline PDF
@@ -329,8 +332,7 @@ void PDFFourierTransform::exec() {
   bool filter = getProperty("Filter");
 
   // create the output workspace
-  API::MatrixWorkspace_sptr outputWS =
-      WorkspaceFactory::Instance().create("Workspace2D", 1, sizer, sizer);
+  API::MatrixWorkspace_sptr outputWS = create<Workspace2D>(1, Points(sizer));
   outputWS->getAxis(0)->unit() = UnitFactory::Instance().create("Label");
   Unit_sptr unit = outputWS->getAxis(0)->unit();
   boost::shared_ptr<Units::Label> label =

--- a/Framework/Algorithms/src/PaddingAndApodization.cpp
+++ b/Framework/Algorithms/src/PaddingAndApodization.cpp
@@ -12,8 +12,11 @@
 
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/Workspace_fwd.h"
+#include "MantidDataObjects/TableWorkspace.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/ListValidator.h"
@@ -27,6 +30,8 @@ namespace Mantid {
 namespace Algorithms {
 
 using namespace Kernel;
+using namespace DataObjects;
+using namespace HistogramData;
 using API::Progress;
 using std::size_t;
 
@@ -72,7 +77,7 @@ void PaddingAndApodization::exec() {
   // Create output workspace with same dimensions as input
   API::MatrixWorkspace_sptr outputWS = getProperty("OutputWorkspace");
   if (inputWS != outputWS) {
-    outputWS = API::WorkspaceFactory::Instance().create(inputWS);
+    outputWS = create<API::MatrixWorkspace>(*inputWS);
   }
 
   // Share the X values

--- a/Framework/Algorithms/src/PointByPointVCorrection.cpp
+++ b/Framework/Algorithms/src/PointByPointVCorrection.cpp
@@ -10,7 +10,7 @@
 #include "MantidAlgorithms/PointByPointVCorrection.h"
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidAPI/WorkspaceFactory.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/VectorHelper.h"
 
@@ -26,6 +26,7 @@ DECLARE_ALGORITHM(PointByPointVCorrection)
 
 using namespace Kernel;
 using namespace API;
+using namespace DataObjects;
 
 /// Default constructor
 PointByPointVCorrection::PointByPointVCorrection() : Algorithm() {}
@@ -183,7 +184,7 @@ void PointByPointVCorrection::check_validity(
   if (out != w1 && out != w2) // Create a new workspace only if it is different
                               // from of the input ones.
   {
-    out = API::WorkspaceFactory::Instance().create(w1);
+    out = create<MatrixWorkspace>(*w1);
     setProperty("OutputWorkspace", out);
   } else if (out == w2) {
     g_log.warning("Any masking in the output workspaces will be taken from the "

--- a/Framework/Muon/inc/MantidMuon/CalMuonDetectorPhases.h
+++ b/Framework/Muon/inc/MantidMuon/CalMuonDetectorPhases.h
@@ -57,13 +57,13 @@ private:
   removeExpDecay(const API::MatrixWorkspace_sptr &wsInput);
   /// Fit the workspace
   void fitWorkspace(const API::MatrixWorkspace_sptr &ws, double freq,
-                    std::string groupName, API::ITableWorkspace_sptr &resTab,
+                    std::string groupName, API::ITableWorkspace_sptr resTab,
                     API::WorkspaceGroup_sptr &resGroup);
   /// Create the fitting function as string
   std::string createFittingFunction(double freq, bool fixFreq);
   /// Extract asymmetry and phase from fitting results
-  void extractDetectorInfo(const API::ITableWorkspace_sptr &paramTab,
-                           const API::ITableWorkspace_sptr &resultsTab,
+  void extractDetectorInfo(API::ITableWorkspace &paramTab,
+                           API::ITableWorkspace &resultsTab,
                            const Indexing::SpectrumNumber spectrumNumber);
   /// Find frequency to use in sequential fit
   double getFrequency(const API::MatrixWorkspace_sptr &ws);

--- a/Framework/Muon/src/CalMuonDeadTime.cpp
+++ b/Framework/Muon/src/CalMuonDeadTime.cpp
@@ -11,7 +11,7 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/TableRow.h"
-#include "MantidAPI/WorkspaceFactory.h"
+#include "MantidDataObjects/TableWorkspace.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/PhysicalConstants.h"
 
@@ -22,6 +22,7 @@ namespace Mantid {
 namespace Algorithms {
 
 using namespace Kernel;
+using namespace DataObjects;
 
 // Register the class into the algorithm factory
 DECLARE_ALGORITHM(CalMuonDeadTime)
@@ -95,8 +96,7 @@ void CalMuonDeadTime::exec() {
 
   // Do the initial setup of the ouput table-workspace
 
-  API::ITableWorkspace_sptr outTable =
-      API::WorkspaceFactory::Instance().createTable("TableWorkspace");
+  API::ITableWorkspace_sptr outTable = boost::make_shared<TableWorkspace>();
   outTable->addColumn("int", "spectrum");
   outTable->addColumn("double", "dead-time");
 

--- a/Framework/Muon/src/CalMuonDetectorPhases.cpp
+++ b/Framework/Muon/src/CalMuonDetectorPhases.cpp
@@ -15,8 +15,8 @@
 #include "MantidAPI/MultiDomainFunction.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/TableRow.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceGroup.h"
+#include "MantidDataObjects/TableWorkspace.h"
 #include "MantidIndexing/IndexInfo.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/PhysicalConstants.h"
@@ -30,6 +30,7 @@ namespace Mantid {
 namespace Algorithms {
 
 using namespace Kernel;
+using namespace DataObjects;
 
 // Register the algorithm into the AlgorithmFactory
 DECLARE_ALGORITHM(CalMuonDetectorPhases)
@@ -127,7 +128,7 @@ void CalMuonDetectorPhases::exec() {
   double freq = getFrequency(tempWS);
 
   // Create the output workspaces
-  auto tab = API::WorkspaceFactory::Instance().createTable("TableWorkspace");
+  TableWorkspace_sptr tab = boost::make_shared<TableWorkspace>();
   auto group = boost::make_shared<API::WorkspaceGroup>();
 
   // Get the name of 'DataFitted'
@@ -152,7 +153,7 @@ void CalMuonDetectorPhases::exec() {
  */
 void CalMuonDetectorPhases::fitWorkspace(const API::MatrixWorkspace_sptr &ws,
                                          double freq, std::string groupName,
-                                         API::ITableWorkspace_sptr &resTab,
+                                         API::ITableWorkspace_sptr resTab,
                                          API::WorkspaceGroup_sptr &resGroup) {
 
   int nhist = static_cast<int>(ws->getNumberHistograms());
@@ -177,8 +178,7 @@ void CalMuonDetectorPhases::fitWorkspace(const API::MatrixWorkspace_sptr &ws,
                                      [](double value) { return value == 0.; });
     if (emptySpectrum) {
       g_log.warning("Spectrum " + std::to_string(wsIndex) + " is empty");
-      auto tab =
-          API::WorkspaceFactory::Instance().createTable("TableWorkspace");
+      TableWorkspace_sptr tab = boost::make_shared<TableWorkspace>();
       tab->addColumn("str", "Name");
       tab->addColumn("double", "Value");
       tab->addColumn("double", "Error");
@@ -191,7 +191,7 @@ void CalMuonDetectorPhases::fitWorkspace(const API::MatrixWorkspace_sptr &ws,
         }
       }
 
-      extractDetectorInfo(tab, resTab, indexInfo.spectrumNumber(wsIndex));
+      extractDetectorInfo(*tab, *resTab, indexInfo.spectrumNumber(wsIndex));
 
     } else {
       auto fit = createChildAlgorithm("Fit");
@@ -217,7 +217,7 @@ void CalMuonDetectorPhases::fitWorkspace(const API::MatrixWorkspace_sptr &ws,
       // Now we have our fitting results stored in tab
       // but we need to extract the relevant information, i.e.
       // the detector phases (parameter 'p') and asymmetries ('A')
-      extractDetectorInfo(tab, resTab, indexInfo.spectrumNumber(wsIndex));
+      extractDetectorInfo(*tab, *resTab, indexInfo.spectrumNumber(wsIndex));
     }
   }
 }
@@ -229,12 +229,11 @@ void CalMuonDetectorPhases::fitWorkspace(const API::MatrixWorkspace_sptr &ws,
  * @param spectrumNumber :: [input] Spectrum number
  */
 void CalMuonDetectorPhases::extractDetectorInfo(
-    const API::ITableWorkspace_sptr &paramTab,
-    const API::ITableWorkspace_sptr &resultsTab,
+    API::ITableWorkspace &paramTab, API::ITableWorkspace &resultsTab,
     const Indexing::SpectrumNumber spectrumNumber) {
 
-  double asym = paramTab->Double(0, 1);
-  double phase = paramTab->Double(2, 1);
+  double asym = paramTab.Double(0, 1);
+  double phase = paramTab.Double(2, 1);
   // If asym<0, take the absolute value and add \pi to phase
   // f(x) = A * cos( w * x - p) = -A * cos( w * x - p - PI)
   if (asym < 0) {
@@ -247,7 +246,7 @@ void CalMuonDetectorPhases::extractDetectorInfo(
     phase = phase - factor * 2. * M_PI;
   }
   // Copy parameters to new row in results table
-  API::TableRow row = resultsTab->appendRow();
+  API::TableRow row = resultsTab.appendRow();
   row << static_cast<int>(spectrumNumber) << asym << phase;
 }
 

--- a/Framework/Muon/src/EstimateMuonAsymmetryFromCounts.cpp
+++ b/Framework/Muon/src/EstimateMuonAsymmetryFromCounts.cpp
@@ -13,8 +13,8 @@
 #include "MantidAPI/IFunction.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Run.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/Workspace_fwd.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/PhysicalConstants.h"
 #include "MantidMuon/MuonAlgorithmHelper.h"
@@ -26,6 +26,7 @@
 namespace Mantid {
 namespace Algorithms {
 
+using namespace Mantid::DataObjects;
 using namespace Kernel;
 using API::Progress;
 using std::size_t;
@@ -121,11 +122,10 @@ void EstimateMuonAsymmetryFromCounts::exec() {
   // Create output workspace with same dimensions as input
   API::MatrixWorkspace_sptr outputWS = getProperty("OutputWorkspace");
   if (inputWS != outputWS) {
-    outputWS = API::WorkspaceFactory::Instance().create(inputWS);
+    outputWS = create<API::MatrixWorkspace>(*inputWS);
   }
   bool extraData = getProperty("OutputUnNormData");
-  API::MatrixWorkspace_sptr unnormWS =
-      API::WorkspaceFactory::Instance().create(outputWS);
+  API::MatrixWorkspace_sptr unnormWS = create<API::MatrixWorkspace>(*outputWS);
   double startX = getProperty("StartX");
   double endX = getProperty("EndX");
   const Mantid::API::Run &run = inputWS->run();

--- a/Framework/Muon/src/PhaseQuadMuon.cpp
+++ b/Framework/Muon/src/PhaseQuadMuon.cpp
@@ -9,9 +9,14 @@
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/MatrixWorkspaceValidator.h"
-#include "MantidAPI/WorkspaceFactory.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/PhysicalConstants.h"
 #include "MantidKernel/Unit.h"
+
+using namespace Mantid::DataObjects;
+using namespace Mantid::HistogramData;
 
 namespace {
 const std::array<std::string, 2> phaseNames = {{"phase", "phi"}};
@@ -291,7 +296,7 @@ PhaseQuadMuon::squash(const API::MatrixWorkspace_sptr &ws,
   const size_t npoints = ws->blocksize();
   // Create and populate output workspace
   API::MatrixWorkspace_sptr ows =
-      API::WorkspaceFactory::Instance().create(ws, 2, npoints + 1, npoints);
+      create<API::MatrixWorkspace>(*ws, 2, BinEdges(npoints + 1));
 
   // X
   ows->setSharedX(0, ws->sharedX(0));


### PR DESCRIPTION
The use of outdated methods to create `Workspace`s via the `WorkspaceFactory` singleton can be replaced using the templated `create` function from `WorkspaceCreation.h`.

This PR (mostly) removes the use of `WorkspaceFactory` from the `Algorithms/src/` folder for algorithms A* to P*. The unit tests and the rest of the algorithms will be an additional PR.

**Report to:** nobody

Fixes #22935 

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
