### PR TITLE
Read efficiency errors from parameters file

### DIFF
--- a/Framework/DataHandling/src/ExtractPolarizationEfficiencies.cpp
+++ b/Framework/DataHandling/src/ExtractPolarizationEfficiencies.cpp
@@ -143,7 +143,9 @@ void ExtractPolarizationEfficiencies::exec() {
     }
     auto const errorName = name + "_Errors";
     propValue = instrument->getParameterAsString(errorName);
-    auto const errorProp = propValue.empty() ? std::vector<double>() : parseVector(errorName, propValue);
+    auto const errorProp = propValue.empty()
+                               ? std::vector<double>()
+                               : parseVector(errorName, propValue);
     auto ws = createWorkspace(lambda, prop, errorProp);
     alg->setProperty(name, ws);
   }

--- a/Framework/DataHandling/src/ExtractPolarizationEfficiencies.cpp
+++ b/Framework/DataHandling/src/ExtractPolarizationEfficiencies.cpp
@@ -48,12 +48,14 @@ std::vector<double> parseVector(std::string const &name,
   return result;
 }
 
-MatrixWorkspace_sptr createWorkspace(std::vector<double> const &x,
-                                     std::vector<double> const &y) {
+MatrixWorkspace_sptr
+createWorkspace(std::vector<double> const &x, std::vector<double> const &y,
+                std::vector<double> const &e = std::vector<double>()) {
   Points xVals(x);
   Counts yVals(y);
+  CountVariances eVals(e.empty() ? std::vector<double>(y.size()) : e);
   auto retVal = boost::make_shared<Workspace2D>();
-  retVal->initialize(1, Histogram(xVals, yVals));
+  retVal->initialize(1, Histogram(xVals, yVals, eVals));
   return retVal;
 }
 
@@ -134,7 +136,7 @@ void ExtractPolarizationEfficiencies::exec() {
     auto const prop = parseVector(name, propValue);
     if (lambda.size() != prop.size()) {
       throw std::runtime_error("Instrument vector parameter \"" + name +
-                               "\" is expeced to be the same size as \"" +
+                               "\" is expected to be the same size as \"" +
                                LAMBDA_PARAMETER + "\" but " +
                                std::to_string(prop.size()) + " != " +
                                std::to_string(lambda.size()));

--- a/Framework/DataHandling/test/ExtractPolarizationEfficienciesTest.h
+++ b/Framework/DataHandling/test/ExtractPolarizationEfficienciesTest.h
@@ -548,11 +548,11 @@ private:
       pmap->addString(instrument.get(), "P2", "0.981 0.982 0.983 0.984");
       pmap->addString(instrument.get(), "F1", "0.971 0.972 0.973 0.974");
       pmap->addString(instrument.get(), "F2", "0.961 0.962 0.963 0.964");
-        if (loadErrors) {
-          pmap->addString(instrument.get(), "P2_Errors", "0.11 0.21 0.31 0.41");
-          pmap->addString(instrument.get(), "F1_Errors", "0.12 0.22 0.32 0.42");
-          pmap->addString(instrument.get(), "F2_Errors", "0.13 0.23 0.33 0.43");
-        }
+      if (loadErrors) {
+        pmap->addString(instrument.get(), "P2_Errors", "0.11 0.21 0.31 0.41");
+        pmap->addString(instrument.get(), "F1_Errors", "0.12 0.22 0.32 0.42");
+        pmap->addString(instrument.get(), "F2_Errors", "0.13 0.23 0.33 0.43");
+      }
     }
 
     instrument = boost::make_shared<Instrument>(instrument, pmap);

--- a/Framework/DataHandling/test/ExtractPolarizationEfficienciesTest.h
+++ b/Framework/DataHandling/test/ExtractPolarizationEfficienciesTest.h
@@ -317,6 +317,77 @@ public:
     TS_ASSERT_DELTA(outWS->e(3)[3], 0.0, 1e-14);
   }
 
+  void test_Wildes_errors() {
+    auto workspace = createInputWorkspace("Wildes", "1 2 3 4", false, true);
+
+    ExtractPolarizationEfficiencies alg;
+    alg.initialize();
+    alg.setChild(true);
+    alg.setRethrows(true);
+    alg.setProperty("InputWorkspace", workspace);
+    alg.setProperty("OutputWorkspace", "dummy");
+    alg.execute();
+    MatrixWorkspace_sptr outWS = alg.getProperty("OutputWorkspace");
+
+    TS_ASSERT(outWS);
+    TS_ASSERT_EQUALS(outWS->getNumberHistograms(), 4);
+    TS_ASSERT_EQUALS(outWS->blocksize(), 4);
+    TS_ASSERT_EQUALS(outWS->getAxis(0)->unit()->caption(), "Wavelength");
+
+    auto axis1 = outWS->getAxis(1);
+    TS_ASSERT_EQUALS(axis1->label(0), "P1");
+    TS_ASSERT_EQUALS(axis1->label(1), "P2");
+    TS_ASSERT_EQUALS(axis1->label(2), "F1");
+    TS_ASSERT_EQUALS(axis1->label(3), "F2");
+
+    TS_ASSERT(!outWS->isHistogramData());
+
+    TS_ASSERT_DELTA(outWS->x(0)[0], 1.0, 1e-14);
+    TS_ASSERT_DELTA(outWS->x(0)[1], 2.0, 1e-14);
+    TS_ASSERT_DELTA(outWS->x(0)[2], 3.0, 1e-14);
+    TS_ASSERT_DELTA(outWS->x(0)[3], 4.0, 1e-14);
+
+    TS_ASSERT_DELTA(outWS->y(0)[0], 0.991, 1e-14);
+    TS_ASSERT_DELTA(outWS->y(0)[1], 0.992, 1e-14);
+    TS_ASSERT_DELTA(outWS->y(0)[2], 0.993, 1e-14);
+    TS_ASSERT_DELTA(outWS->y(0)[3], 0.994, 1e-14);
+
+    TS_ASSERT_DELTA(outWS->e(0)[0], 0.1, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(0)[1], 0.2, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(0)[2], 0.3, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(0)[3], 0.4, 1e-14);
+
+    TS_ASSERT_DELTA(outWS->y(1)[0], 0.981, 1e-14);
+    TS_ASSERT_DELTA(outWS->y(1)[1], 0.982, 1e-14);
+    TS_ASSERT_DELTA(outWS->y(1)[2], 0.983, 1e-14);
+    TS_ASSERT_DELTA(outWS->y(1)[3], 0.984, 1e-14);
+
+    TS_ASSERT_DELTA(outWS->e(1)[0], 0.11, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(1)[1], 0.21, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(1)[2], 0.31, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(1)[3], 0.41, 1e-14);
+
+    TS_ASSERT_DELTA(outWS->y(2)[0], 0.971, 1e-14);
+    TS_ASSERT_DELTA(outWS->y(2)[1], 0.972, 1e-14);
+    TS_ASSERT_DELTA(outWS->y(2)[2], 0.973, 1e-14);
+    TS_ASSERT_DELTA(outWS->y(2)[3], 0.974, 1e-14);
+
+    TS_ASSERT_DELTA(outWS->e(2)[0], 0.12, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(2)[1], 0.22, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(2)[2], 0.32, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(2)[3], 0.42, 1e-14);
+
+    TS_ASSERT_DELTA(outWS->y(3)[0], 0.961, 1e-14);
+    TS_ASSERT_DELTA(outWS->y(3)[1], 0.962, 1e-14);
+    TS_ASSERT_DELTA(outWS->y(3)[2], 0.963, 1e-14);
+    TS_ASSERT_DELTA(outWS->y(3)[3], 0.964, 1e-14);
+
+    TS_ASSERT_DELTA(outWS->e(3)[0], 0.13, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(3)[1], 0.23, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(3)[2], 0.33, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(3)[3], 0.43, 1e-14);
+  }
+
   void test_loading_from_file() {
     auto workspace = createPointWS(1, 0, 10);
     LoadInstrument loader;
@@ -450,7 +521,7 @@ private:
   MatrixWorkspace_sptr
   createInputWorkspace(std::string const &method,
                        std::string const &lambda = "1 2 3 4",
-                       bool skipP1 = false) {
+                       bool skipP1 = false, bool loadErrors = false) {
     auto workspace = createPointWS(1, 0, 10);
     auto pmap = boost::make_shared<ParameterMap>();
     auto instrument = boost::make_shared<Instrument>();
@@ -470,10 +541,18 @@ private:
                       "00,01,10,11");
       if (!skipP1) {
         pmap->addString(instrument.get(), "P1", "0.991 0.992 0.993 0.994");
+        if (loadErrors) {
+          pmap->addString(instrument.get(), "P1_Errors", "0.1 0.2 0.3 0.4");
+        }
       }
       pmap->addString(instrument.get(), "P2", "0.981 0.982 0.983 0.984");
       pmap->addString(instrument.get(), "F1", "0.971 0.972 0.973 0.974");
       pmap->addString(instrument.get(), "F2", "0.961 0.962 0.963 0.964");
+        if (loadErrors) {
+          pmap->addString(instrument.get(), "P2_Errors", "0.11 0.21 0.31 0.41");
+          pmap->addString(instrument.get(), "F1_Errors", "0.12 0.22 0.32 0.42");
+          pmap->addString(instrument.get(), "F2_Errors", "0.13 0.23 0.33 0.43");
+        }
     }
 
     instrument = boost::make_shared<Instrument>(instrument, pmap);

--- a/Framework/DataHandling/test/ExtractPolarizationEfficienciesTest.h
+++ b/Framework/DataHandling/test/ExtractPolarizationEfficienciesTest.h
@@ -210,20 +210,40 @@ public:
     TS_ASSERT_DELTA(outWS->y(0)[2], 0.993, 1e-14);
     TS_ASSERT_DELTA(outWS->y(0)[3], 0.994, 1e-14);
 
+    TS_ASSERT_DELTA(outWS->e(0)[0], 0.0, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(0)[1], 0.0, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(0)[2], 0.0, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(0)[3], 0.0, 1e-14);
+
     TS_ASSERT_DELTA(outWS->y(1)[0], 0.981, 1e-14);
     TS_ASSERT_DELTA(outWS->y(1)[1], 0.982, 1e-14);
     TS_ASSERT_DELTA(outWS->y(1)[2], 0.983, 1e-14);
     TS_ASSERT_DELTA(outWS->y(1)[3], 0.984, 1e-14);
+
+    TS_ASSERT_DELTA(outWS->e(1)[0], 0.0, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(1)[1], 0.0, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(1)[2], 0.0, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(1)[3], 0.0, 1e-14);
 
     TS_ASSERT_DELTA(outWS->y(2)[0], 0.971, 1e-14);
     TS_ASSERT_DELTA(outWS->y(2)[1], 0.972, 1e-14);
     TS_ASSERT_DELTA(outWS->y(2)[2], 0.973, 1e-14);
     TS_ASSERT_DELTA(outWS->y(2)[3], 0.974, 1e-14);
 
+    TS_ASSERT_DELTA(outWS->e(2)[0], 0.0, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(2)[1], 0.0, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(2)[2], 0.0, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(2)[3], 0.0, 1e-14);
+
     TS_ASSERT_DELTA(outWS->y(3)[0], 0.961, 1e-14);
     TS_ASSERT_DELTA(outWS->y(3)[1], 0.962, 1e-14);
     TS_ASSERT_DELTA(outWS->y(3)[2], 0.963, 1e-14);
     TS_ASSERT_DELTA(outWS->y(3)[3], 0.964, 1e-14);
+
+    TS_ASSERT_DELTA(outWS->e(3)[0], 0.0, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(3)[1], 0.0, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(3)[2], 0.0, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(3)[3], 0.0, 1e-14);
   }
 
   void test_Wildes() {
@@ -261,20 +281,40 @@ public:
     TS_ASSERT_DELTA(outWS->y(0)[2], 0.993, 1e-14);
     TS_ASSERT_DELTA(outWS->y(0)[3], 0.994, 1e-14);
 
+    TS_ASSERT_DELTA(outWS->e(0)[0], 0.0, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(0)[1], 0.0, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(0)[2], 0.0, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(0)[3], 0.0, 1e-14);
+
     TS_ASSERT_DELTA(outWS->y(1)[0], 0.981, 1e-14);
     TS_ASSERT_DELTA(outWS->y(1)[1], 0.982, 1e-14);
     TS_ASSERT_DELTA(outWS->y(1)[2], 0.983, 1e-14);
     TS_ASSERT_DELTA(outWS->y(1)[3], 0.984, 1e-14);
+
+    TS_ASSERT_DELTA(outWS->e(1)[0], 0.0, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(1)[1], 0.0, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(1)[2], 0.0, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(1)[3], 0.0, 1e-14);
 
     TS_ASSERT_DELTA(outWS->y(2)[0], 0.971, 1e-14);
     TS_ASSERT_DELTA(outWS->y(2)[1], 0.972, 1e-14);
     TS_ASSERT_DELTA(outWS->y(2)[2], 0.973, 1e-14);
     TS_ASSERT_DELTA(outWS->y(2)[3], 0.974, 1e-14);
 
+    TS_ASSERT_DELTA(outWS->e(2)[0], 0.0, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(2)[1], 0.0, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(2)[2], 0.0, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(2)[3], 0.0, 1e-14);
+
     TS_ASSERT_DELTA(outWS->y(3)[0], 0.961, 1e-14);
     TS_ASSERT_DELTA(outWS->y(3)[1], 0.962, 1e-14);
     TS_ASSERT_DELTA(outWS->y(3)[2], 0.963, 1e-14);
     TS_ASSERT_DELTA(outWS->y(3)[3], 0.964, 1e-14);
+
+    TS_ASSERT_DELTA(outWS->e(3)[0], 0.0, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(3)[1], 0.0, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(3)[2], 0.0, 1e-14);
+    TS_ASSERT_DELTA(outWS->e(3)[3], 0.0, 1e-14);
   }
 
   void test_loading_from_file() {
@@ -392,7 +432,7 @@ public:
     alg.setProperty("OutputWorkspace", "dummy");
     TS_ASSERT_THROWS_EQUALS(
         alg.execute(), std::runtime_error & e, std::string(e.what()),
-        "Instrument vector parameter \"P1\" is expeced to be the same size as "
+        "Instrument vector parameter \"P1\" is expected to be the same size as "
         "\"efficiency_lambda\" but 4 != 3");
   }
 


### PR DESCRIPTION
**Description of work.**
Read efficiency errors from the parameters file if they are present. If they are absent set the errors to 0.

**Report to:** Andrew Caruana, Jos Cooper

**To test:**

* Run the steps from #22997
* Plot spectra of the output workspaces with error bars. They must make sense.

Fixes #23000

Does this update require release notes?
- [ ] Yes
- [X] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
