### PR TITLE
Ignore divide by zero warning in ConvertWANDSCDtoQ

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
+++ b/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
@@ -290,7 +290,9 @@ class ConvertWANDSCDtoQ(PythonAlgorithm):
             createWS_alg.execute()
             mtd.addOrReplace(self.getPropertyValue("OutputWorkspace")+'_normalization', createWS_alg.getProperty("OutputWorkspace").value)
 
-        output /= output_norm
+        old_settings = np.seterr(divide='ignore', invalid='ignore') # Ignore RuntimeWarning: invalid value encountered in true_divide
+        output /= output_norm # We often divide by zero here and we get NaN's, this is desired behaviour
+        np.seterr(**old_settings)
 
         progress.report('Creating MDHistoWorkspace')
         createWS_alg = self.createChildAlgorithm("CreateMDHistoWorkspace", enableLogging=False)


### PR DESCRIPTION
A user discovered that `ConvertWANDSCDtoQ` produces a warning when run in python but not observed in MantidPlot. This ignores the warning. As this algorithm was only added this release and the fix is easy it should be fixed before the release goes out.

The warning:
```
ConvertWANDSCDtoQ-[Notice] ConvertWANDSCDtoQ started
/home/rwp/mantid/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py:294: RuntimeWarning: invalid value encountered in true_divide
  output /= output_norm
ConvertWANDSCDtoQ-[Notice] ConvertWANDSCDtoQ successful, Duration 22.56 seconds
```

**To test:**
Run in mantidpython to see that the warning no longer exits

Load `HB2C_WANDSCD_data.nxs` from system test data and run `ConvertWANDSCDtoQ`
```
from mantid.simpleapi import *
data=LoadMD('HB2C_WANDSCD_data.nxs')
out=ConvertWANDSCDtoQ(InputWorkspace='data')
```


Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
