### PR TITLE
Fix warning from duplicate QLabel name

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/ReflSettingsWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflSettingsWidget.ui
@@ -440,7 +440,7 @@
          </widget>
         </item>
         <item row="0" column="2">
-         <widget class="QLabel" name="label">
+         <widget class="QLabel" name="label1">
           <property name="text">
            <string>Debug</string>
           </property>


### PR DESCRIPTION
**Description of work.**
Rename this QLabel to remove a warning during building Mantid.

**To test:**
 - The following warning does not appear while building:

```
/qt/scientific_interfaces/ISISReflectometry/ReflSettingsWidget.ui: Warning: The name 'label' (QLabel) is already in use, defaulting to 'label1'.
```

_No associated issue_

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
