### PR TITLE
Fix clang warnings

### DIFF
--- a/Framework/API/test/ExperimentInfoTest.h
+++ b/Framework/API/test/ExperimentInfoTest.h
@@ -156,14 +156,12 @@ public:
 
   void test_GetSetSample() {
     ExperimentInfo ws;
-    TS_ASSERT(&ws.sample());
     ws.mutableSample().setName("test");
     TS_ASSERT_EQUALS(ws.sample().getName(), "test");
   }
 
   void test_GetSetRun() {
     ExperimentInfo ws;
-    TS_ASSERT(&ws.run());
     ws.mutableRun().setProtonCharge(1.234);
     TS_ASSERT_DELTA(ws.run().getProtonCharge(), 1.234, 0.001);
   }

--- a/Framework/API/test/FunctionParameterDecoratorTest.h
+++ b/Framework/API/test/FunctionParameterDecoratorTest.h
@@ -443,9 +443,9 @@ private:
   class MockTestableFunctionParameterDecorator
       : public TestableFunctionParameterDecorator {
   public:
-    GCC_DIAG_OFF_SUGGEST_OVERRIDE
+    DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_METHOD1(beforeDecoratedFunctionSet, void(const IFunction_sptr &));
-    GCC_DIAG_ON_SUGGEST_OVERRIDE
+    DIAG_ON_SUGGEST_OVERRIDE
   };
 };
 

--- a/Framework/API/test/FunctionParameterDecoratorTest.h
+++ b/Framework/API/test/FunctionParameterDecoratorTest.h
@@ -443,9 +443,9 @@ private:
   class MockTestableFunctionParameterDecorator
       : public TestableFunctionParameterDecorator {
   public:
-    DIAG_OFF_SUGGEST_OVERRIDE
+    GNU_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_METHOD1(beforeDecoratedFunctionSet, void(const IFunction_sptr &));
-    DIAG_ON_SUGGEST_OVERRIDE
+    GNU_DIAG_ON_SUGGEST_OVERRIDE
   };
 };
 

--- a/Framework/API/test/ILatticeFunctionTest.h
+++ b/Framework/API/test/ILatticeFunctionTest.h
@@ -73,7 +73,7 @@ public:
 
 private:
   std::vector<V3D> getTestHKLs() { return {{1, 1, 0}}; }
-  DIAG_OFF_SUGGEST_OVERRIDE
+  GNU_DIAG_OFF_SUGGEST_OVERRIDE
   // Mock function to check whether the correct methods are called
   class MockLatticeFunction : public ILatticeFunction {
   public:
@@ -104,6 +104,6 @@ private:
   };
 };
 
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 #endif /* MANTID_API_ILATTICEFUNCTIONTEST_H_ */

--- a/Framework/API/test/ILatticeFunctionTest.h
+++ b/Framework/API/test/ILatticeFunctionTest.h
@@ -73,7 +73,7 @@ public:
 
 private:
   std::vector<V3D> getTestHKLs() { return {{1, 1, 0}}; }
-  GCC_DIAG_OFF_SUGGEST_OVERRIDE
+  DIAG_OFF_SUGGEST_OVERRIDE
   // Mock function to check whether the correct methods are called
   class MockLatticeFunction : public ILatticeFunction {
   public:
@@ -104,6 +104,6 @@ private:
   };
 };
 
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 
 #endif /* MANTID_API_ILATTICEFUNCTIONTEST_H_ */

--- a/Framework/API/test/ImplicitFunctionFactoryTest.h
+++ b/Framework/API/test/ImplicitFunctionFactoryTest.h
@@ -16,7 +16,7 @@
 #include <memory>
 #include <vector>
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 class ImplicitFunctionFactoryTest : public CxxTest::TestSuite {
 private:
@@ -107,7 +107,7 @@ private:
     MOCK_METHOD1(setSuccessorParser,
                  void(Mantid::API::ImplicitFunctionParameterParser *successor));
   };
-  GCC_DIAG_ON_SUGGEST_OVERRIDE
+  DIAG_ON_SUGGEST_OVERRIDE
 
   class MockImplicitFunctionBuilderA
       : public Mantid::API::ImplicitFunctionBuilder {

--- a/Framework/API/test/ImplicitFunctionFactoryTest.h
+++ b/Framework/API/test/ImplicitFunctionFactoryTest.h
@@ -16,7 +16,7 @@
 #include <memory>
 #include <vector>
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 class ImplicitFunctionFactoryTest : public CxxTest::TestSuite {
 private:
@@ -107,7 +107,7 @@ private:
     MOCK_METHOD1(setSuccessorParser,
                  void(Mantid::API::ImplicitFunctionParameterParser *successor));
   };
-  DIAG_ON_SUGGEST_OVERRIDE
+  GNU_DIAG_ON_SUGGEST_OVERRIDE
 
   class MockImplicitFunctionBuilderA
       : public Mantid::API::ImplicitFunctionBuilder {

--- a/Framework/API/test/ImplicitFunctionParameterParserFactoryTest.h
+++ b/Framework/API/test/ImplicitFunctionParameterParserFactoryTest.h
@@ -17,11 +17,11 @@ private:
   class MockImplicitFunctionParameter
       : public Mantid::API::ImplicitFunctionParameter {
   public:
-    DIAG_OFF_SUGGEST_OVERRIDE
+    GNU_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(getName, std::string());
     MOCK_CONST_METHOD0(isValid, bool());
     MOCK_CONST_METHOD0(toXMLString, std::string());
-    DIAG_ON_SUGGEST_OVERRIDE
+    GNU_DIAG_ON_SUGGEST_OVERRIDE
   protected:
     ImplicitFunctionParameter *clone() const override {
       return new MockImplicitFunctionParameter;

--- a/Framework/API/test/ImplicitFunctionParameterParserFactoryTest.h
+++ b/Framework/API/test/ImplicitFunctionParameterParserFactoryTest.h
@@ -17,11 +17,11 @@ private:
   class MockImplicitFunctionParameter
       : public Mantid::API::ImplicitFunctionParameter {
   public:
-    GCC_DIAG_OFF_SUGGEST_OVERRIDE
+    DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(getName, std::string());
     MOCK_CONST_METHOD0(isValid, bool());
     MOCK_CONST_METHOD0(toXMLString, std::string());
-    GCC_DIAG_ON_SUGGEST_OVERRIDE
+    DIAG_ON_SUGGEST_OVERRIDE
   protected:
     ImplicitFunctionParameter *clone() const override {
       return new MockImplicitFunctionParameter;

--- a/Framework/API/test/LiveListenerTest.h
+++ b/Framework/API/test/LiveListenerTest.h
@@ -14,7 +14,7 @@ public:
     // Set this flag to true for testing
     m_dataReset = true;
   }
-  DIAG_OFF_SUGGEST_OVERRIDE
+  GNU_DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_CONST_METHOD0(name, std::string());
   MOCK_CONST_METHOD0(supportsHistory, bool());
   MOCK_CONST_METHOD0(buffersEvents, bool());
@@ -25,7 +25,7 @@ public:
   MOCK_METHOD0(runStatus, RunStatus());
   MOCK_CONST_METHOD0(runNumber, int());
   MOCK_METHOD1(setAlgorithm, void(const Mantid::API::IAlgorithm &));
-  DIAG_ON_SUGGEST_OVERRIDE
+  GNU_DIAG_ON_SUGGEST_OVERRIDE
 };
 
 class LiveListenerTest : public CxxTest::TestSuite {

--- a/Framework/API/test/LiveListenerTest.h
+++ b/Framework/API/test/LiveListenerTest.h
@@ -14,7 +14,7 @@ public:
     // Set this flag to true for testing
     m_dataReset = true;
   }
-  GCC_DIAG_OFF_SUGGEST_OVERRIDE
+  DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_CONST_METHOD0(name, std::string());
   MOCK_CONST_METHOD0(supportsHistory, bool());
   MOCK_CONST_METHOD0(buffersEvents, bool());
@@ -25,7 +25,7 @@ public:
   MOCK_METHOD0(runStatus, RunStatus());
   MOCK_CONST_METHOD0(runNumber, int());
   MOCK_METHOD1(setAlgorithm, void(const Mantid::API::IAlgorithm &));
-  GCC_DIAG_ON_SUGGEST_OVERRIDE
+  DIAG_ON_SUGGEST_OVERRIDE
 };
 
 class LiveListenerTest : public CxxTest::TestSuite {

--- a/Framework/API/test/ModeratorModelTest.h
+++ b/Framework/API/test/ModeratorModelTest.h
@@ -13,13 +13,13 @@ public:
   boost::shared_ptr<ModeratorModel> clone() const override {
     return boost::shared_ptr<MockModerator>();
   }
-  GCC_DIAG_OFF_SUGGEST_OVERRIDE
+  DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_CONST_METHOD0(emissionTimeMean, double());
   MOCK_CONST_METHOD0(emissionTimeVariance, double());
   MOCK_CONST_METHOD1(sampleTimeDistribution, double(const double));
   MOCK_METHOD2(setParameterValue,
                void(const std::string &, const std::string &));
-  GCC_DIAG_ON_SUGGEST_OVERRIDE
+  DIAG_ON_SUGGEST_OVERRIDE
 };
 
 class ModeratorModelTest : public CxxTest::TestSuite {

--- a/Framework/API/test/ModeratorModelTest.h
+++ b/Framework/API/test/ModeratorModelTest.h
@@ -13,13 +13,13 @@ public:
   boost::shared_ptr<ModeratorModel> clone() const override {
     return boost::shared_ptr<MockModerator>();
   }
-  DIAG_OFF_SUGGEST_OVERRIDE
+  GNU_DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_CONST_METHOD0(emissionTimeMean, double());
   MOCK_CONST_METHOD0(emissionTimeVariance, double());
   MOCK_CONST_METHOD1(sampleTimeDistribution, double(const double));
   MOCK_METHOD2(setParameterValue,
                void(const std::string &, const std::string &));
-  DIAG_ON_SUGGEST_OVERRIDE
+  GNU_DIAG_ON_SUGGEST_OVERRIDE
 };
 
 class ModeratorModelTest : public CxxTest::TestSuite {

--- a/Framework/API/test/WorkspaceFactoryTest.h
+++ b/Framework/API/test/WorkspaceFactoryTest.h
@@ -9,6 +9,7 @@
 #include "MantidAPI/Sample.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidKernel/ConfigService.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidTestHelpers/FakeObjects.h"
 
 using Mantid::MantidVec;
@@ -55,15 +56,13 @@ public:
     MatrixWorkspace_sptr space;
     TS_ASSERT_THROWS_NOTHING(
         space = WorkspaceFactory::Instance().create("work", 1, 1, 1));
-// AppleClang gives warning if the result is unused.
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-value"
-#endif
+    // clang-format off
+    DIAG_OFF(unused-value)
+    // clang-format on
     TS_ASSERT_THROWS_NOTHING(dynamic_cast<WorkspaceTester *>(space.get()));
-#if __clang__
-#pragma clang diagnostic pop
-#endif
+    // clang-format off
+    DIAG_ON(unused-value)
+    // clang-format on
   }
 
   /** Make a parent, have the child be created with the same sizes */

--- a/Framework/API/test/WorkspaceFactoryTest.h
+++ b/Framework/API/test/WorkspaceFactoryTest.h
@@ -56,13 +56,9 @@ public:
     MatrixWorkspace_sptr space;
     TS_ASSERT_THROWS_NOTHING(
         space = WorkspaceFactory::Instance().create("work", 1, 1, 1));
-    // clang-format off
-    DIAG_OFF(unused-value)
-    // clang-format on
+    DIAG_OFF("unused-value")
     TS_ASSERT_THROWS_NOTHING(dynamic_cast<WorkspaceTester *>(space.get()));
-    // clang-format off
-    DIAG_ON(unused-value)
-    // clang-format on
+    DIAG_ON("unused-value")
   }
 
   /** Make a parent, have the child be created with the same sizes */

--- a/Framework/API/test/WorkspaceFactoryTest.h
+++ b/Framework/API/test/WorkspaceFactoryTest.h
@@ -56,9 +56,9 @@ public:
     MatrixWorkspace_sptr space;
     TS_ASSERT_THROWS_NOTHING(
         space = WorkspaceFactory::Instance().create("work", 1, 1, 1));
-    DIAG_OFF("unused-value")
+    GNU_DIAG_OFF("unused-value")
     TS_ASSERT_THROWS_NOTHING(dynamic_cast<WorkspaceTester *>(space.get()));
-    DIAG_ON("unused-value")
+    GNU_DIAG_ON("unused-value")
   }
 
   /** Make a parent, have the child be created with the same sizes */

--- a/Framework/API/test/WorkspaceGroupTest.h
+++ b/Framework/API/test/WorkspaceGroupTest.h
@@ -58,13 +58,13 @@ private:
 
   // Helper type, representing some concrete workspace type.
   class MockWorkspace : public Mantid::API::Workspace {
-    GCC_DIAG_OFF_SUGGEST_OVERRIDE
+    DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(id, const std::string());
     MOCK_CONST_METHOD0(name, const std::string());
     MOCK_CONST_METHOD0(threadSafe, bool());
     MOCK_CONST_METHOD0(toString, const std::string());
     MOCK_CONST_METHOD0(getMemorySize, size_t());
-    GCC_DIAG_ON_SUGGEST_OVERRIDE
+    DIAG_ON_SUGGEST_OVERRIDE
   private:
     MockWorkspace *doClone() const override {
       throw std::runtime_error("Cloning of MockWorkspace is not implemented.");

--- a/Framework/API/test/WorkspaceGroupTest.h
+++ b/Framework/API/test/WorkspaceGroupTest.h
@@ -58,13 +58,13 @@ private:
 
   // Helper type, representing some concrete workspace type.
   class MockWorkspace : public Mantid::API::Workspace {
-    DIAG_OFF_SUGGEST_OVERRIDE
+    GNU_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(id, const std::string());
     MOCK_CONST_METHOD0(name, const std::string());
     MOCK_CONST_METHOD0(threadSafe, bool());
     MOCK_CONST_METHOD0(toString, const std::string());
     MOCK_CONST_METHOD0(getMemorySize, size_t());
-    DIAG_ON_SUGGEST_OVERRIDE
+    GNU_DIAG_ON_SUGGEST_OVERRIDE
   private:
     MockWorkspace *doClone() const override {
       throw std::runtime_error("Cloning of MockWorkspace is not implemented.");

--- a/Framework/Algorithms/test/MCAbsorptionStrategyTest.h
+++ b/Framework/Algorithms/test/MCAbsorptionStrategyTest.h
@@ -87,7 +87,7 @@ private:
   class MockBeamProfile final : public Mantid::Algorithms::IBeamProfile {
   public:
     using Mantid::Algorithms::IBeamProfile::Ray;
-    GCC_DIAG_OFF_SUGGEST_OVERRIDE
+    DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD1(generatePoint,
                        Ray(Mantid::Kernel::PseudoRandomNumberGenerator &));
     MOCK_CONST_METHOD2(generatePoint,
@@ -95,7 +95,7 @@ private:
                            const Mantid::Geometry::BoundingBox &));
     MOCK_CONST_METHOD1(defineActiveRegion, Mantid::Geometry::BoundingBox(
                                                const Mantid::API::Sample &));
-    GCC_DIAG_ON_SUGGEST_OVERRIDE
+    DIAG_ON_SUGGEST_OVERRIDE
   };
 };
 

--- a/Framework/Algorithms/test/MCAbsorptionStrategyTest.h
+++ b/Framework/Algorithms/test/MCAbsorptionStrategyTest.h
@@ -87,7 +87,7 @@ private:
   class MockBeamProfile final : public Mantid::Algorithms::IBeamProfile {
   public:
     using Mantid::Algorithms::IBeamProfile::Ray;
-    DIAG_OFF_SUGGEST_OVERRIDE
+    GNU_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD1(generatePoint,
                        Ray(Mantid::Kernel::PseudoRandomNumberGenerator &));
     MOCK_CONST_METHOD2(generatePoint,
@@ -95,7 +95,7 @@ private:
                            const Mantid::Geometry::BoundingBox &));
     MOCK_CONST_METHOD1(defineActiveRegion, Mantid::Geometry::BoundingBox(
                                                const Mantid::API::Sample &));
-    DIAG_ON_SUGGEST_OVERRIDE
+    GNU_DIAG_ON_SUGGEST_OVERRIDE
   };
 };
 

--- a/Framework/Algorithms/test/MaxEnt/MaxentCalculatorTest.h
+++ b/Framework/Algorithms/test/MaxEnt/MaxentCalculatorTest.h
@@ -13,7 +13,7 @@ using namespace Mantid::Algorithms;
 using namespace testing;
 
 class MockEntropy : public MaxentEntropy {
-  GCC_DIAG_OFF_SUGGEST_OVERRIDE
+  DIAG_OFF_SUGGEST_OVERRIDE
 public:
   MOCK_METHOD2(derivative,
                std::vector<double>(const std::vector<double> &, double));
@@ -29,7 +29,7 @@ public:
   MOCK_METHOD1(imageToData, std::vector<double>(const std::vector<double> &));
   MOCK_METHOD1(dataToImage, std::vector<double>(const std::vector<double> &));
 };
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 using MockEntropy_sptr = std::shared_ptr<MockEntropy>;
 
 class MaxentCalculatorTest : public CxxTest::TestSuite {

--- a/Framework/Algorithms/test/MaxEnt/MaxentCalculatorTest.h
+++ b/Framework/Algorithms/test/MaxEnt/MaxentCalculatorTest.h
@@ -13,7 +13,7 @@ using namespace Mantid::Algorithms;
 using namespace testing;
 
 class MockEntropy : public MaxentEntropy {
-  DIAG_OFF_SUGGEST_OVERRIDE
+  GNU_DIAG_OFF_SUGGEST_OVERRIDE
 public:
   MOCK_METHOD2(derivative,
                std::vector<double>(const std::vector<double> &, double));
@@ -29,7 +29,7 @@ public:
   MOCK_METHOD1(imageToData, std::vector<double>(const std::vector<double> &));
   MOCK_METHOD1(dataToImage, std::vector<double>(const std::vector<double> &));
 };
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 using MockEntropy_sptr = std::shared_ptr<MockEntropy>;
 
 class MaxentCalculatorTest : public CxxTest::TestSuite {

--- a/Framework/Algorithms/test/MonteCarloTesting.h
+++ b/Framework/Algorithms/test/MonteCarloTesting.h
@@ -25,7 +25,7 @@ namespace MonteCarloTesting {
 // -----------------------------------------------------------------------------
 class MockRNG final : public Mantid::Kernel::PseudoRandomNumberGenerator {
 public:
-  DIAG_OFF_SUGGEST_OVERRIDE
+  GNU_DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD0(nextValue, double());
   MOCK_METHOD2(nextValue, double(double, double));
   MOCK_METHOD2(nextInt, int(int, int));
@@ -36,7 +36,7 @@ public:
   MOCK_METHOD2(setRange, void(const double, const double));
   MOCK_CONST_METHOD0(min, double());
   MOCK_CONST_METHOD0(max, double());
-  DIAG_ON_SUGGEST_OVERRIDE
+  GNU_DIAG_ON_SUGGEST_OVERRIDE
 };
 
 // -----------------------------------------------------------------------------

--- a/Framework/Algorithms/test/MonteCarloTesting.h
+++ b/Framework/Algorithms/test/MonteCarloTesting.h
@@ -25,7 +25,7 @@ namespace MonteCarloTesting {
 // -----------------------------------------------------------------------------
 class MockRNG final : public Mantid::Kernel::PseudoRandomNumberGenerator {
 public:
-  GCC_DIAG_OFF_SUGGEST_OVERRIDE
+  DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD0(nextValue, double());
   MOCK_METHOD2(nextValue, double(double, double));
   MOCK_METHOD2(nextInt, int(int, int));
@@ -36,7 +36,7 @@ public:
   MOCK_METHOD2(setRange, void(const double, const double));
   MOCK_CONST_METHOD0(min, double());
   MOCK_CONST_METHOD0(max, double());
-  GCC_DIAG_ON_SUGGEST_OVERRIDE
+  DIAG_ON_SUGGEST_OVERRIDE
 };
 
 // -----------------------------------------------------------------------------

--- a/Framework/Algorithms/test/RebinByTimeBaseTest.h
+++ b/Framework/Algorithms/test/RebinByTimeBaseTest.h
@@ -72,7 +72,7 @@ createEventWorkspace(const int numberspectra, const int nDistrubutedEvents,
   return retVal;
 }
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 /*
  This type is an IEventWorkspace, but not an EventWorkspace.
@@ -115,7 +115,7 @@ private:
 };
 }
 
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 //=====================================================================================
 // Functional Tests

--- a/Framework/Algorithms/test/RebinByTimeBaseTest.h
+++ b/Framework/Algorithms/test/RebinByTimeBaseTest.h
@@ -72,7 +72,7 @@ createEventWorkspace(const int numberspectra, const int nDistrubutedEvents,
   return retVal;
 }
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 /*
  This type is an IEventWorkspace, but not an EventWorkspace.
@@ -115,7 +115,7 @@ private:
 };
 }
 
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 
 //=====================================================================================
 // Functional Tests

--- a/Framework/Crystal/test/FindSXPeaksHelperTest.h
+++ b/Framework/Crystal/test/FindSXPeaksHelperTest.h
@@ -16,14 +16,14 @@ using namespace testing;
 
 namespace {
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockProgressBase : public Mantid::Kernel::ProgressBase {
 public:
   MOCK_METHOD1(doReport, void(const std::string &));
 };
 
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 }
 
 class FindSXPeaksHelperTest : public CxxTest::TestSuite {

--- a/Framework/Crystal/test/FindSXPeaksHelperTest.h
+++ b/Framework/Crystal/test/FindSXPeaksHelperTest.h
@@ -16,14 +16,14 @@ using namespace testing;
 
 namespace {
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockProgressBase : public Mantid::Kernel::ProgressBase {
 public:
   MOCK_METHOD1(doReport, void(const std::string &));
 };
 
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 }
 
 class FindSXPeaksHelperTest : public CxxTest::TestSuite {

--- a/Framework/Crystal/test/MockObjects.h
+++ b/Framework/Crystal/test/MockObjects.h
@@ -17,7 +17,7 @@
 namespace Mantid {
 namespace Crystal {
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 // Mock Background strategy
 class MockBackgroundStrategy : public BackgroundStrategy {
@@ -49,7 +49,7 @@ public:
   }
 };
 
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 }
 }
 

--- a/Framework/Crystal/test/MockObjects.h
+++ b/Framework/Crystal/test/MockObjects.h
@@ -17,7 +17,7 @@
 namespace Mantid {
 namespace Crystal {
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 // Mock Background strategy
 class MockBackgroundStrategy : public BackgroundStrategy {
@@ -49,7 +49,7 @@ public:
   }
 };
 
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 }
 }
 

--- a/Framework/Crystal/test/PeakBackgroundTest.h
+++ b/Framework/Crystal/test/PeakBackgroundTest.h
@@ -33,7 +33,7 @@ IPeaksWorkspace_sptr make_peaks_workspace(const V3D &hklPeak) {
   return peakWS;
 }
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 // Mock Background strategy
 class MockIMDIterator : public IMDIterator {
@@ -68,7 +68,7 @@ public:
   MOCK_CONST_METHOD1(isWithinBounds, bool(size_t));
 };
 }
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 class PeakBackgroundTest : public CxxTest::TestSuite {
 public:

--- a/Framework/Crystal/test/PeakBackgroundTest.h
+++ b/Framework/Crystal/test/PeakBackgroundTest.h
@@ -33,7 +33,7 @@ IPeaksWorkspace_sptr make_peaks_workspace(const V3D &hklPeak) {
   return peakWS;
 }
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 // Mock Background strategy
 class MockIMDIterator : public IMDIterator {
@@ -68,7 +68,7 @@ public:
   MOCK_CONST_METHOD1(isWithinBounds, bool(size_t));
 };
 }
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 
 class PeakBackgroundTest : public CxxTest::TestSuite {
 public:

--- a/Framework/CurveFitting/src/Functions/CrystalElectricField.cpp
+++ b/Framework/CurveFitting/src/Functions/CrystalElectricField.cpp
@@ -2,6 +2,7 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidCurveFitting/Functions/CrystalElectricField.h"
+#include "MantidKernel/WarningSuppressions.h"
 
 #include <algorithm>
 #include <array>
@@ -14,12 +15,11 @@ namespace Functions {
 
 namespace {
 
-#ifdef __clang__
 // The missing braces warning is a false positive -
 // https://llvm.org/bugs/show_bug.cgi?id=21629
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wmissing-braces"
-#endif
+// clang-format off
+DIAG_OFF(missing-braces)
+// clang-format on
 
 // Get a complex conjugate of the value returned by
 // ComplexMatrix::operator(i,j)
@@ -636,9 +636,9 @@ void diagonalise(const ComplexFortranMatrix &hamiltonian,
   eigenvalues += -eshift;
 }
 
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+// clang-format off
+DIAG_OFF(missing-braces)
+// clang-format on
 
 } // anonymous namespace
 

--- a/Framework/CurveFitting/src/Functions/CrystalElectricField.cpp
+++ b/Framework/CurveFitting/src/Functions/CrystalElectricField.cpp
@@ -17,7 +17,7 @@ namespace {
 
 // The missing braces warning is a false positive -
 // https://llvm.org/bugs/show_bug.cgi?id=21629
-DIAG_OFF("missing-braces")
+GNU_DIAG_OFF("missing-braces")
 
 // Get a complex conjugate of the value returned by
 // ComplexMatrix::operator(i,j)
@@ -634,7 +634,7 @@ void diagonalise(const ComplexFortranMatrix &hamiltonian,
   eigenvalues += -eshift;
 }
 
-DIAG_OFF("missing-braces")
+GNU_DIAG_OFF("missing-braces")
 
 } // anonymous namespace
 

--- a/Framework/CurveFitting/src/Functions/CrystalElectricField.cpp
+++ b/Framework/CurveFitting/src/Functions/CrystalElectricField.cpp
@@ -17,9 +17,7 @@ namespace {
 
 // The missing braces warning is a false positive -
 // https://llvm.org/bugs/show_bug.cgi?id=21629
-// clang-format off
-DIAG_OFF(missing-braces)
-// clang-format on
+DIAG_OFF("missing-braces")
 
 // Get a complex conjugate of the value returned by
 // ComplexMatrix::operator(i,j)
@@ -636,9 +634,7 @@ void diagonalise(const ComplexFortranMatrix &hamiltonian,
   eigenvalues += -eshift;
 }
 
-// clang-format off
-DIAG_OFF(missing-braces)
-// clang-format on
+DIAG_OFF("missing-braces")
 
 } // anonymous namespace
 

--- a/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.tcc
@@ -1286,9 +1286,7 @@ TMDE(void MDGridBox)::centroidSphere(API::CoordTransform &radiusTransform,
   } // (for each box)
 }
 //-----------------------------------------------------------------------------------------------
-// clang-format off
-DIAG_OFF(array-bounds)
-// clang-format on
+DIAG_OFF("array-bounds")
 /** Integrate the signal within a sphere; for example, to perform single-crystal
  * peak integration.
  * The CoordTransform object could be used for more complex shapes, e.g.
@@ -1492,9 +1490,7 @@ TMDE(void MDGridBox)::integrateCylinder(
   delete[] verticesContained;
   delete[] boxMightTouch;
 }
-// clang-format off
-DIAG_ON(array-bounds)
-// clang-format on
+DIAG_ON("array-bounds")
 
 /**
 Getter for the masking status of the gridded box.

--- a/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.tcc
@@ -1287,7 +1287,7 @@ TMDE(void MDGridBox)::centroidSphere(API::CoordTransform &radiusTransform,
 }
 //-----------------------------------------------------------------------------------------------
 // clang-format off
-GCC_DIAG_OFF(array-bounds)
+DIAG_OFF(array-bounds)
 // clang-format on
 /** Integrate the signal within a sphere; for example, to perform single-crystal
  * peak integration.
@@ -1493,7 +1493,7 @@ TMDE(void MDGridBox)::integrateCylinder(
   delete[] boxMightTouch;
 }
 // clang-format off
-GCC_DIAG_ON(array-bounds)
+DIAG_ON(array-bounds)
 // clang-format on
 
 /**

--- a/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.tcc
@@ -1286,7 +1286,7 @@ TMDE(void MDGridBox)::centroidSphere(API::CoordTransform &radiusTransform,
   } // (for each box)
 }
 //-----------------------------------------------------------------------------------------------
-DIAG_OFF("array-bounds")
+GNU_DIAG_OFF("array-bounds")
 /** Integrate the signal within a sphere; for example, to perform single-crystal
  * peak integration.
  * The CoordTransform object could be used for more complex shapes, e.g.
@@ -1490,7 +1490,7 @@ TMDE(void MDGridBox)::integrateCylinder(
   delete[] verticesContained;
   delete[] boxMightTouch;
 }
-DIAG_ON("array-bounds")
+GNU_DIAG_ON("array-bounds")
 
 /**
 Getter for the masking status of the gridded box.

--- a/Framework/DataObjects/src/MDHistoWorkspace.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspace.cpp
@@ -1347,7 +1347,7 @@ uint64_t MDHistoWorkspace::sumNContribEvents() const {
  * Get the Q frame system (if any) to use.
 */
 // clang-format off
-GCC_DIAG_OFF(strict-aliasing)
+DIAG_OFF(strict-aliasing)
 // clang-format on
 Kernel::SpecialCoordinateSystem
 MDHistoWorkspace::getSpecialCoordinateSystem() const {

--- a/Framework/DataObjects/src/MDHistoWorkspace.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspace.cpp
@@ -1346,7 +1346,7 @@ uint64_t MDHistoWorkspace::sumNContribEvents() const {
 /**
  * Get the Q frame system (if any) to use.
 */
-DIAG_OFF("strict-aliasing")
+GNU_DIAG_OFF("strict-aliasing")
 Kernel::SpecialCoordinateSystem
 MDHistoWorkspace::getSpecialCoordinateSystem() const {
   MDFramesToSpecialCoordinateSystem converter;

--- a/Framework/DataObjects/src/MDHistoWorkspace.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspace.cpp
@@ -1346,9 +1346,7 @@ uint64_t MDHistoWorkspace::sumNContribEvents() const {
 /**
  * Get the Q frame system (if any) to use.
 */
-// clang-format off
-DIAG_OFF(strict-aliasing)
-// clang-format on
+DIAG_OFF("strict-aliasing")
 Kernel::SpecialCoordinateSystem
 MDHistoWorkspace::getSpecialCoordinateSystem() const {
   MDFramesToSpecialCoordinateSystem converter;

--- a/Framework/DataObjects/test/AffineMatrixParameterParserTest.h
+++ b/Framework/DataObjects/test/AffineMatrixParameterParserTest.h
@@ -28,12 +28,12 @@ public:
     AffineMatrixType product = parameter->getAffineMatrix();
 
     // Check that matrix is recovered.
-    TSM_ASSERT(1, product[0][0]);
-    TSM_ASSERT(2, product[0][1]);
-    TSM_ASSERT(3, product[1][0]);
-    TSM_ASSERT(4, product[1][1]);
-    TSM_ASSERT(5, product[2][0]);
-    TSM_ASSERT(6, product[2][1]);
+    TS_ASSERT_EQUALS(1, product[0][0]);
+    TS_ASSERT_EQUALS(2, product[0][1]);
+    TS_ASSERT_EQUALS(3, product[1][0]);
+    TS_ASSERT_EQUALS(4, product[1][1]);
+    TS_ASSERT_EQUALS(5, product[2][0]);
+    TS_ASSERT_EQUALS(6, product[2][1]);
 
     delete parameter;
   }
@@ -53,15 +53,15 @@ public:
     AffineMatrixType product = parameter->getAffineMatrix();
 
     // Check that matrix is recovered.
-    TSM_ASSERT(1, product[0][0]);
-    TSM_ASSERT(2, product[0][1]);
-    TSM_ASSERT(3, product[0][2]);
-    TSM_ASSERT(4, product[1][0]);
-    TSM_ASSERT(5, product[1][1]);
-    TSM_ASSERT(6, product[1][2]);
-    TSM_ASSERT(7, product[2][0]);
-    TSM_ASSERT(8, product[2][1]);
-    TSM_ASSERT(9, product[2][2]);
+    TS_ASSERT_EQUALS(1, product[0][0]);
+    TS_ASSERT_EQUALS(2, product[0][1]);
+    TS_ASSERT_EQUALS(3, product[0][2]);
+    TS_ASSERT_EQUALS(4, product[1][0]);
+    TS_ASSERT_EQUALS(5, product[1][1]);
+    TS_ASSERT_EQUALS(6, product[1][2]);
+    TS_ASSERT_EQUALS(7, product[2][0]);
+    TS_ASSERT_EQUALS(8, product[2][1]);
+    TS_ASSERT_EQUALS(9, product[2][2]);
 
     delete parameter;
   }
@@ -81,18 +81,18 @@ public:
     AffineMatrixType product = parameter->getAffineMatrix();
 
     // Check that matrix is recovered.
-    TSM_ASSERT(1, product[0][0]);
-    TSM_ASSERT(2, product[0][1]);
-    TSM_ASSERT(3, product[0][2]);
-    TSM_ASSERT(4, product[0][3]);
-    TSM_ASSERT(5, product[1][0]);
-    TSM_ASSERT(6, product[1][1]);
-    TSM_ASSERT(7, product[1][2]);
-    TSM_ASSERT(8, product[1][3]);
-    TSM_ASSERT(9, product[2][0]);
-    TSM_ASSERT(10, product[2][1]);
-    TSM_ASSERT(11, product[2][2]);
-    TSM_ASSERT(12, product[2][3]);
+    TS_ASSERT_EQUALS(1, product[0][0]);
+    TS_ASSERT_EQUALS(2, product[0][1]);
+    TS_ASSERT_EQUALS(3, product[0][2]);
+    TS_ASSERT_EQUALS(4, product[0][3]);
+    TS_ASSERT_EQUALS(5, product[1][0]);
+    TS_ASSERT_EQUALS(6, product[1][1]);
+    TS_ASSERT_EQUALS(7, product[1][2]);
+    TS_ASSERT_EQUALS(8, product[1][3]);
+    TS_ASSERT_EQUALS(9, product[2][0]);
+    TS_ASSERT_EQUALS(10, product[2][1]);
+    TS_ASSERT_EQUALS(11, product[2][2]);
+    TS_ASSERT_EQUALS(12, product[2][3]);
 
     delete parameter;
   }

--- a/Framework/DataObjects/test/MDBoxIteratorTest.h
+++ b/Framework/DataObjects/test/MDBoxIteratorTest.h
@@ -492,9 +492,9 @@ public:
             pBC(MDBox<MDLeanEvent<2>, 2>::getBoxController())
 
       {}
-      GCC_DIAG_OFF_SUGGEST_OVERRIDE
+      DIAG_OFF_SUGGEST_OVERRIDE
       MOCK_CONST_METHOD0(getIsMasked, bool());
-      GCC_DIAG_ON_SUGGEST_OVERRIDE
+      DIAG_ON_SUGGEST_OVERRIDE
       ~MockMDBox() override { delete pBC; }
     };
 
@@ -570,10 +570,10 @@ public:
     /// Mock Skipping Policy Type to inject.
     class MockSkippingPolicy : public SkippingPolicy {
     public:
-      GCC_DIAG_OFF_SUGGEST_OVERRIDE
+      DIAG_OFF_SUGGEST_OVERRIDE
       MOCK_CONST_METHOD0(keepGoing, bool());
       MOCK_METHOD0(Die, void());
-      GCC_DIAG_ON_SUGGEST_OVERRIDE
+      DIAG_ON_SUGGEST_OVERRIDE
       ~MockSkippingPolicy() override { Die(); }
     };
 

--- a/Framework/DataObjects/test/MDBoxIteratorTest.h
+++ b/Framework/DataObjects/test/MDBoxIteratorTest.h
@@ -492,9 +492,9 @@ public:
             pBC(MDBox<MDLeanEvent<2>, 2>::getBoxController())
 
       {}
-      DIAG_OFF_SUGGEST_OVERRIDE
+      GNU_DIAG_OFF_SUGGEST_OVERRIDE
       MOCK_CONST_METHOD0(getIsMasked, bool());
-      DIAG_ON_SUGGEST_OVERRIDE
+      GNU_DIAG_ON_SUGGEST_OVERRIDE
       ~MockMDBox() override { delete pBC; }
     };
 
@@ -570,10 +570,10 @@ public:
     /// Mock Skipping Policy Type to inject.
     class MockSkippingPolicy : public SkippingPolicy {
     public:
-      DIAG_OFF_SUGGEST_OVERRIDE
+      GNU_DIAG_OFF_SUGGEST_OVERRIDE
       MOCK_CONST_METHOD0(keepGoing, bool());
       MOCK_METHOD0(Die, void());
-      DIAG_ON_SUGGEST_OVERRIDE
+      GNU_DIAG_ON_SUGGEST_OVERRIDE
       ~MockSkippingPolicy() override { Die(); }
     };
 

--- a/Framework/DataObjects/test/MDGridBoxTest.h
+++ b/Framework/DataObjects/test/MDGridBoxTest.h
@@ -47,12 +47,12 @@ private:
     MockMDBox()
         : MDBox<MDLeanEvent<1>, 1>(new API::BoxController(1)),
           pBC(MDBox<MDLeanEvent<1>, 1>::getBoxController()) {}
-    GCC_DIAG_OFF_SUGGEST_OVERRIDE
+    DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(getIsMasked, bool());
     MOCK_METHOD0(mask, void());
     MOCK_METHOD0(unmask, void());
     ~MockMDBox() override { delete pBC; }
-    GCC_DIAG_ON_SUGGEST_OVERRIDE
+    DIAG_ON_SUGGEST_OVERRIDE
   };
 
   // the sp to a box controller used as general reference to all tested

--- a/Framework/DataObjects/test/MDGridBoxTest.h
+++ b/Framework/DataObjects/test/MDGridBoxTest.h
@@ -47,12 +47,12 @@ private:
     MockMDBox()
         : MDBox<MDLeanEvent<1>, 1>(new API::BoxController(1)),
           pBC(MDBox<MDLeanEvent<1>, 1>::getBoxController()) {}
-    DIAG_OFF_SUGGEST_OVERRIDE
+    GNU_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(getIsMasked, bool());
     MOCK_METHOD0(mask, void());
     MOCK_METHOD0(unmask, void());
     ~MockMDBox() override { delete pBC; }
-    DIAG_ON_SUGGEST_OVERRIDE
+    GNU_DIAG_ON_SUGGEST_OVERRIDE
   };
 
   // the sp to a box controller used as general reference to all tested

--- a/Framework/DataObjects/test/MockObjects.h
+++ b/Framework/DataObjects/test/MockObjects.h
@@ -10,7 +10,7 @@
 namespace Mantid {
 namespace DataObjects {
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockPeakShapeFactory : public PeakShapeFactory {
 public:
@@ -37,6 +37,6 @@ public:
 }
 }
 
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 #endif /* MOCKOBJECTS_H_ */

--- a/Framework/DataObjects/test/MockObjects.h
+++ b/Framework/DataObjects/test/MockObjects.h
@@ -10,7 +10,7 @@
 namespace Mantid {
 namespace DataObjects {
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockPeakShapeFactory : public PeakShapeFactory {
 public:
@@ -37,6 +37,6 @@ public:
 }
 }
 
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 
 #endif /* MOCKOBJECTS_H_ */

--- a/Framework/Geometry/src/Objects/RuleItems.cpp
+++ b/Framework/Geometry/src/Objects/RuleItems.cpp
@@ -34,18 +34,14 @@
 #endif
 
 #include "MantidKernel/WarningSuppressions.h"
-// clang-format off
-DIAG_OFF(conversion)
-DIAG_OFF(cast-qual)
-// clang-format on
+DIAG_OFF("conversion")
+DIAG_OFF("cast-qual")
 #include <TopoDS_Shape.hxx>
 #include <BRepAlgoAPI_Common.hxx>
 #include <BRepAlgoAPI_Fuse.hxx>
 #include <BRepPrimAPI_MakeBox.hxx>
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(cast-qual)
-// clang-format on
+DIAG_ON("conversion")
+DIAG_ON("cast-qual")
 #endif
 
 namespace Mantid {

--- a/Framework/Geometry/src/Objects/RuleItems.cpp
+++ b/Framework/Geometry/src/Objects/RuleItems.cpp
@@ -34,14 +34,14 @@
 #endif
 
 #include "MantidKernel/WarningSuppressions.h"
-DIAG_OFF("conversion")
-DIAG_OFF("cast-qual")
+GNU_DIAG_OFF("conversion")
+GNU_DIAG_OFF("cast-qual")
 #include <TopoDS_Shape.hxx>
 #include <BRepAlgoAPI_Common.hxx>
 #include <BRepAlgoAPI_Fuse.hxx>
 #include <BRepPrimAPI_MakeBox.hxx>
-DIAG_ON("conversion")
-DIAG_ON("cast-qual")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("cast-qual")
 #endif
 
 namespace Mantid {

--- a/Framework/Geometry/src/Objects/RuleItems.cpp
+++ b/Framework/Geometry/src/Objects/RuleItems.cpp
@@ -34,17 +34,17 @@
 #endif
 
 #include "MantidKernel/WarningSuppressions.h"
-GCC_DIAG_OFF(conversion)
 // clang-format off
-GCC_DIAG_OFF(cast-qual)
+DIAG_OFF(conversion)
+DIAG_OFF(cast-qual)
 // clang-format on
 #include <TopoDS_Shape.hxx>
 #include <BRepAlgoAPI_Common.hxx>
 #include <BRepAlgoAPI_Fuse.hxx>
 #include <BRepPrimAPI_MakeBox.hxx>
-GCC_DIAG_ON(conversion)
 // clang-format off
-GCC_DIAG_ON(cast-qual)
+DIAG_ON(conversion)
+DIAG_ON(cast-qual)
 // clang-format on
 #endif
 

--- a/Framework/Geometry/src/Rendering/GeometryTriangulator.cpp
+++ b/Framework/Geometry/src/Rendering/GeometryTriangulator.cpp
@@ -23,10 +23,9 @@
 #endif
 #endif
 
-// clang-format off
-DIAG_OFF(conversion)
-DIAG_OFF(cast-qual)
-// clang-format on
+DIAG_OFF("conversion")
+DIAG_OFF("cast-qual")
+
 #include <gp_Trsf.hxx>
 #include <gp_Pnt.hxx>
 #include <gp_Pln.hxx>
@@ -39,10 +38,8 @@ DIAG_OFF(cast-qual)
 #include <BRepBuilderAPI_Transform.hxx>
 #include <BRep_Tool.hxx>
 #include <Poly_Triangulation.hxx>
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(cast-qual)
-// clang-format on
+DIAG_ON("conversion")
+DIAG_ON("cast-qual")
 
 #ifdef __INTEL_COMPILER
 #pragma warning enable 191

--- a/Framework/Geometry/src/Rendering/GeometryTriangulator.cpp
+++ b/Framework/Geometry/src/Rendering/GeometryTriangulator.cpp
@@ -23,8 +23,8 @@
 #endif
 #endif
 
-DIAG_OFF("conversion")
-DIAG_OFF("cast-qual")
+GNU_DIAG_OFF("conversion")
+GNU_DIAG_OFF("cast-qual")
 
 #include <gp_Trsf.hxx>
 #include <gp_Pnt.hxx>
@@ -38,8 +38,8 @@ DIAG_OFF("cast-qual")
 #include <BRepBuilderAPI_Transform.hxx>
 #include <BRep_Tool.hxx>
 #include <Poly_Triangulation.hxx>
-DIAG_ON("conversion")
-DIAG_ON("cast-qual")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("cast-qual")
 
 #ifdef __INTEL_COMPILER
 #pragma warning enable 191

--- a/Framework/Geometry/src/Rendering/GeometryTriangulator.cpp
+++ b/Framework/Geometry/src/Rendering/GeometryTriangulator.cpp
@@ -23,9 +23,9 @@
 #endif
 #endif
 
-GCC_DIAG_OFF(conversion)
 // clang-format off
-GCC_DIAG_OFF(cast-qual)
+DIAG_OFF(conversion)
+DIAG_OFF(cast-qual)
 // clang-format on
 #include <gp_Trsf.hxx>
 #include <gp_Pnt.hxx>
@@ -39,9 +39,9 @@ GCC_DIAG_OFF(cast-qual)
 #include <BRepBuilderAPI_Transform.hxx>
 #include <BRep_Tool.hxx>
 #include <Poly_Triangulation.hxx>
-GCC_DIAG_ON(conversion)
 // clang-format off
-GCC_DIAG_ON(cast-qual)
+DIAG_ON(conversion)
+DIAG_ON(cast-qual)
 // clang-format on
 
 #ifdef __INTEL_COMPILER

--- a/Framework/Geometry/src/Rendering/RenderingHelpers.cpp
+++ b/Framework/Geometry/src/Rendering/RenderingHelpers.cpp
@@ -28,9 +28,9 @@
 #endif
 #endif
 
-GCC_DIAG_OFF(conversion)
 // clang-format off
-GCC_DIAG_OFF(cast-qual)
+DIAG_OFF(conversion)
+DIAG_OFF(cast-qual)
 // clang-format on
 #include <gp_Pnt.hxx>
 #include <TopoDS.hxx>
@@ -41,9 +41,9 @@ GCC_DIAG_OFF(cast-qual)
 #include <Poly_Array1OfTriangle.hxx>
 #include <TColgp_Array1OfPnt.hxx>
 #include <Poly_Triangulation.hxx>
-GCC_DIAG_ON(conversion)
 // clang-format off
-GCC_DIAG_ON(cast-qual)
+DIAG_ON(conversion)
+DIAG_ON(cast-qual)
 // clang-format on
 
 #ifdef __INTEL_COMPILER

--- a/Framework/Geometry/src/Rendering/RenderingHelpers.cpp
+++ b/Framework/Geometry/src/Rendering/RenderingHelpers.cpp
@@ -28,10 +28,9 @@
 #endif
 #endif
 
-// clang-format off
-DIAG_OFF(conversion)
-DIAG_OFF(cast-qual)
-// clang-format on
+DIAG_OFF("conversion")
+DIAG_OFF("cast-qual")
+
 #include <gp_Pnt.hxx>
 #include <TopoDS.hxx>
 #include <TopoDS_Shape.hxx>
@@ -41,10 +40,8 @@ DIAG_OFF(cast-qual)
 #include <Poly_Array1OfTriangle.hxx>
 #include <TColgp_Array1OfPnt.hxx>
 #include <Poly_Triangulation.hxx>
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(cast-qual)
-// clang-format on
+DIAG_ON("conversion")
+DIAG_ON("cast-qual")
 
 #ifdef __INTEL_COMPILER
 #pragma warning enable 191

--- a/Framework/Geometry/src/Rendering/RenderingHelpers.cpp
+++ b/Framework/Geometry/src/Rendering/RenderingHelpers.cpp
@@ -28,8 +28,8 @@
 #endif
 #endif
 
-DIAG_OFF("conversion")
-DIAG_OFF("cast-qual")
+GNU_DIAG_OFF("conversion")
+GNU_DIAG_OFF("cast-qual")
 
 #include <gp_Pnt.hxx>
 #include <TopoDS.hxx>
@@ -40,8 +40,8 @@ DIAG_OFF("cast-qual")
 #include <Poly_Array1OfTriangle.hxx>
 #include <TColgp_Array1OfPnt.hxx>
 #include <Poly_Triangulation.hxx>
-DIAG_ON("conversion")
-DIAG_ON("cast-qual")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("cast-qual")
 
 #ifdef __INTEL_COMPILER
 #pragma warning enable 191

--- a/Framework/Geometry/src/Surfaces/Cone.cpp
+++ b/Framework/Geometry/src/Surfaces/Cone.cpp
@@ -30,15 +30,11 @@
 #endif
 
 #include "MantidKernel/WarningSuppressions.h"
-// clang-format off
-DIAG_OFF(conversion)
-DIAG_OFF(cast-qual)
-// clang-format on
+DIAG_OFF("conversion")
+DIAG_OFF("cast-qual")
 #include <BRepPrimAPI_MakeCone.hxx>
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(cast-qual)
-// clang-format on
+DIAG_ON("conversion")
+DIAG_ON("cast-qual")
 #endif
 
 namespace Mantid {

--- a/Framework/Geometry/src/Surfaces/Cone.cpp
+++ b/Framework/Geometry/src/Surfaces/Cone.cpp
@@ -30,14 +30,14 @@
 #endif
 
 #include "MantidKernel/WarningSuppressions.h"
-GCC_DIAG_OFF(conversion)
 // clang-format off
-GCC_DIAG_OFF(cast-qual)
+DIAG_OFF(conversion)
+DIAG_OFF(cast-qual)
 // clang-format on
 #include <BRepPrimAPI_MakeCone.hxx>
-GCC_DIAG_ON(conversion)
 // clang-format off
-GCC_DIAG_ON(cast-qual)
+DIAG_ON(conversion)
+DIAG_ON(cast-qual)
 // clang-format on
 #endif
 

--- a/Framework/Geometry/src/Surfaces/Cone.cpp
+++ b/Framework/Geometry/src/Surfaces/Cone.cpp
@@ -30,11 +30,11 @@
 #endif
 
 #include "MantidKernel/WarningSuppressions.h"
-DIAG_OFF("conversion")
-DIAG_OFF("cast-qual")
+GNU_DIAG_OFF("conversion")
+GNU_DIAG_OFF("cast-qual")
 #include <BRepPrimAPI_MakeCone.hxx>
-DIAG_ON("conversion")
-DIAG_ON("cast-qual")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("cast-qual")
 #endif
 
 namespace Mantid {

--- a/Framework/Geometry/src/Surfaces/Cylinder.cpp
+++ b/Framework/Geometry/src/Surfaces/Cylinder.cpp
@@ -16,14 +16,14 @@
 #endif
 
 #include "MantidKernel/WarningSuppressions.h"
-GCC_DIAG_OFF(conversion)
 // clang-format off
-GCC_DIAG_OFF(cast-qual)
+DIAG_OFF(conversion)
+DIAG_OFF(cast-qual)
 // clang-format on
 #include <BRepPrimAPI_MakeCylinder.hxx>
-GCC_DIAG_ON(conversion)
 // clang-format off
-GCC_DIAG_ON(cast-qual)
+DIAG_ON(conversion)
+DIAG_ON(cast-qual)
 // clang-format on
 #endif
 

--- a/Framework/Geometry/src/Surfaces/Cylinder.cpp
+++ b/Framework/Geometry/src/Surfaces/Cylinder.cpp
@@ -16,15 +16,11 @@
 #endif
 
 #include "MantidKernel/WarningSuppressions.h"
-// clang-format off
-DIAG_OFF(conversion)
-DIAG_OFF(cast-qual)
-// clang-format on
+DIAG_OFF("conversion")
+DIAG_OFF("cast-qual")
 #include <BRepPrimAPI_MakeCylinder.hxx>
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(cast-qual)
-// clang-format on
+DIAG_ON("conversion")
+DIAG_ON("cast-qual")
 #endif
 
 namespace Mantid {

--- a/Framework/Geometry/src/Surfaces/Cylinder.cpp
+++ b/Framework/Geometry/src/Surfaces/Cylinder.cpp
@@ -16,11 +16,11 @@
 #endif
 
 #include "MantidKernel/WarningSuppressions.h"
-DIAG_OFF("conversion")
-DIAG_OFF("cast-qual")
+GNU_DIAG_OFF("conversion")
+GNU_DIAG_OFF("cast-qual")
 #include <BRepPrimAPI_MakeCylinder.hxx>
-DIAG_ON("conversion")
-DIAG_ON("cast-qual")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("cast-qual")
 #endif
 
 namespace Mantid {

--- a/Framework/Geometry/src/Surfaces/Plane.cpp
+++ b/Framework/Geometry/src/Surfaces/Plane.cpp
@@ -17,15 +17,15 @@
 #endif
 
 #include "MantidKernel/WarningSuppressions.h"
-DIAG_OFF("conversion")
-DIAG_OFF("cast-qual")
+GNU_DIAG_OFF("conversion")
+GNU_DIAG_OFF("cast-qual")
 #include <BRepPrimAPI_MakeBox.hxx>
 #include <BRepBuilderAPI_MakeFace.hxx>
 #include <BRepPrimAPI_MakeHalfSpace.hxx>
 #include <BRepAlgoAPI_Common.hxx>
 #include <gp_Pln.hxx>
-DIAG_ON("conversion")
-DIAG_ON("cast-qual")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("cast-qual")
 #endif
 
 namespace Mantid {

--- a/Framework/Geometry/src/Surfaces/Plane.cpp
+++ b/Framework/Geometry/src/Surfaces/Plane.cpp
@@ -17,19 +17,15 @@
 #endif
 
 #include "MantidKernel/WarningSuppressions.h"
-// clang-format off
-DIAG_OFF(conversion)
-DIAG_OFF(cast-qual)
-// clang-format on
+DIAG_OFF("conversion")
+DIAG_OFF("cast-qual")
 #include <BRepPrimAPI_MakeBox.hxx>
 #include <BRepBuilderAPI_MakeFace.hxx>
 #include <BRepPrimAPI_MakeHalfSpace.hxx>
 #include <BRepAlgoAPI_Common.hxx>
 #include <gp_Pln.hxx>
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(cast-qual)
-// clang-format on
+DIAG_ON("conversion")
+DIAG_ON("cast-qual")
 #endif
 
 namespace Mantid {

--- a/Framework/Geometry/src/Surfaces/Plane.cpp
+++ b/Framework/Geometry/src/Surfaces/Plane.cpp
@@ -17,18 +17,18 @@
 #endif
 
 #include "MantidKernel/WarningSuppressions.h"
-GCC_DIAG_OFF(conversion)
 // clang-format off
-GCC_DIAG_OFF(cast-qual)
+DIAG_OFF(conversion)
+DIAG_OFF(cast-qual)
 // clang-format on
 #include <BRepPrimAPI_MakeBox.hxx>
 #include <BRepBuilderAPI_MakeFace.hxx>
 #include <BRepPrimAPI_MakeHalfSpace.hxx>
 #include <BRepAlgoAPI_Common.hxx>
 #include <gp_Pln.hxx>
-GCC_DIAG_ON(conversion)
 // clang-format off
-GCC_DIAG_ON(cast-qual)
+DIAG_ON(conversion)
+DIAG_ON(cast-qual)
 // clang-format on
 #endif
 

--- a/Framework/Geometry/src/Surfaces/Sphere.cpp
+++ b/Framework/Geometry/src/Surfaces/Sphere.cpp
@@ -14,14 +14,14 @@
 #endif
 
 #include "MantidKernel/WarningSuppressions.h"
-GCC_DIAG_OFF(conversion)
 // clang-format off
-GCC_DIAG_OFF(cast-qual)
+DIAG_OFF(conversion)
+DIAG_OFF(cast-qual)
 // clang-format on
 #include <BRepPrimAPI_MakeSphere.hxx>
-GCC_DIAG_ON(conversion)
 // clang-format off
-GCC_DIAG_ON(cast-qual)
+DIAG_ON(conversion)
+DIAG_ON(cast-qual)
 // clang-format on
 #endif
 

--- a/Framework/Geometry/src/Surfaces/Sphere.cpp
+++ b/Framework/Geometry/src/Surfaces/Sphere.cpp
@@ -14,15 +14,11 @@
 #endif
 
 #include "MantidKernel/WarningSuppressions.h"
-// clang-format off
-DIAG_OFF(conversion)
-DIAG_OFF(cast-qual)
-// clang-format on
+DIAG_OFF("conversion")
+DIAG_OFF("cast-qual")
 #include <BRepPrimAPI_MakeSphere.hxx>
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(cast-qual)
-// clang-format on
+DIAG_ON("conversion")
+DIAG_ON("cast-qual")
 #endif
 
 namespace Mantid {

--- a/Framework/Geometry/src/Surfaces/Sphere.cpp
+++ b/Framework/Geometry/src/Surfaces/Sphere.cpp
@@ -14,11 +14,11 @@
 #endif
 
 #include "MantidKernel/WarningSuppressions.h"
-DIAG_OFF("conversion")
-DIAG_OFF("cast-qual")
+GNU_DIAG_OFF("conversion")
+GNU_DIAG_OFF("cast-qual")
 #include <BRepPrimAPI_MakeSphere.hxx>
-DIAG_ON("conversion")
-DIAG_ON("cast-qual")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("cast-qual")
 #endif
 
 namespace Mantid {

--- a/Framework/Geometry/src/Surfaces/Surface.cpp
+++ b/Framework/Geometry/src/Surfaces/Surface.cpp
@@ -29,14 +29,14 @@
 #endif
 
 #include "MantidKernel/WarningSuppressions.h"
-GCC_DIAG_OFF(conversion)
 // clang-format off
-GCC_DIAG_OFF(cast-qual)
+DIAG_OFF(conversion)
+DIAG_OFF(cast-qual)
 // clang-format on
 #include <TopoDS_Shape.hxx>
-GCC_DIAG_ON(conversion)
 // clang-format off
-GCC_DIAG_ON(cast-qual)
+DIAG_ON(conversion)
+DIAG_ON(cast-qual)
 // clang-format on
 #endif
 

--- a/Framework/Geometry/src/Surfaces/Surface.cpp
+++ b/Framework/Geometry/src/Surfaces/Surface.cpp
@@ -29,11 +29,11 @@
 #endif
 
 #include "MantidKernel/WarningSuppressions.h"
-DIAG_OFF("conversion")
-DIAG_OFF("cast-qual")
+GNU_DIAG_OFF("conversion")
+GNU_DIAG_OFF("cast-qual")
 #include <TopoDS_Shape.hxx>
-DIAG_ON("conversion")
-DIAG_ON("cast-qual")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("cast-qual")
 #endif
 
 namespace Mantid {

--- a/Framework/Geometry/src/Surfaces/Surface.cpp
+++ b/Framework/Geometry/src/Surfaces/Surface.cpp
@@ -29,15 +29,11 @@
 #endif
 
 #include "MantidKernel/WarningSuppressions.h"
-// clang-format off
-DIAG_OFF(conversion)
-DIAG_OFF(cast-qual)
-// clang-format on
+DIAG_OFF("conversion")
+DIAG_OFF("cast-qual")
 #include <TopoDS_Shape.hxx>
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(cast-qual)
-// clang-format on
+DIAG_ON("conversion")
+DIAG_ON("cast-qual")
 #endif
 
 namespace Mantid {

--- a/Framework/Geometry/src/Surfaces/Torus.cpp
+++ b/Framework/Geometry/src/Surfaces/Torus.cpp
@@ -29,14 +29,14 @@
 #endif
 
 #include "MantidKernel/WarningSuppressions.h"
-GCC_DIAG_OFF(conversion)
 // clang-format off
-GCC_DIAG_OFF(cast-qual)
+DIAG_OFF(conversion)
+DIAG_OFF(cast-qual)
 // clang-format on
 #include <TopoDS_Shape.hxx>
-GCC_DIAG_ON(conversion)
 // clang-format off
-GCC_DIAG_ON(cast-qual)
+DIAG_ON(conversion)
+DIAG_ON(cast-qual)
 // clang-format on
 #endif
 

--- a/Framework/Geometry/src/Surfaces/Torus.cpp
+++ b/Framework/Geometry/src/Surfaces/Torus.cpp
@@ -29,11 +29,11 @@
 #endif
 
 #include "MantidKernel/WarningSuppressions.h"
-DIAG_OFF("conversion")
-DIAG_OFF("cast-qual")
+GNU_DIAG_OFF("conversion")
+GNU_DIAG_OFF("cast-qual")
 #include <TopoDS_Shape.hxx>
-DIAG_ON("conversion")
-DIAG_ON("cast-qual")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("cast-qual")
 #endif
 
 namespace Mantid {

--- a/Framework/Geometry/src/Surfaces/Torus.cpp
+++ b/Framework/Geometry/src/Surfaces/Torus.cpp
@@ -29,15 +29,11 @@
 #endif
 
 #include "MantidKernel/WarningSuppressions.h"
-// clang-format off
-DIAG_OFF(conversion)
-DIAG_OFF(cast-qual)
-// clang-format on
+DIAG_OFF("conversion")
+DIAG_OFF("cast-qual")
 #include <TopoDS_Shape.hxx>
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(cast-qual)
-// clang-format on
+DIAG_ON("conversion")
+DIAG_ON("cast-qual")
 #endif
 
 namespace Mantid {

--- a/Framework/Geometry/test/BasicHKLFiltersTest.h
+++ b/Framework/Geometry/test/BasicHKLFiltersTest.h
@@ -136,7 +136,7 @@ public:
 
     TS_ASSERT(Mock::VerifyAndClearExpectations(mock.get()))
   }
-  DIAG_OFF_SUGGEST_OVERRIDE
+  GNU_DIAG_OFF_SUGGEST_OVERRIDE
 private:
   class MockStructureFactorCalculator : public StructureFactorCalculator {
   public:
@@ -144,5 +144,5 @@ private:
     MOCK_CONST_METHOD1(getFSquared, double(const V3D &));
   };
 };
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 #endif /* MANTID_GEOMETRY_BASICHKLFILTERSTEST_H_ */

--- a/Framework/Geometry/test/BasicHKLFiltersTest.h
+++ b/Framework/Geometry/test/BasicHKLFiltersTest.h
@@ -136,7 +136,7 @@ public:
 
     TS_ASSERT(Mock::VerifyAndClearExpectations(mock.get()))
   }
-  GCC_DIAG_OFF_SUGGEST_OVERRIDE
+  DIAG_OFF_SUGGEST_OVERRIDE
 private:
   class MockStructureFactorCalculator : public StructureFactorCalculator {
   public:
@@ -144,5 +144,5 @@ private:
     MOCK_CONST_METHOD1(getFSquared, double(const V3D &));
   };
 };
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 #endif /* MANTID_GEOMETRY_BASICHKLFILTERSTEST_H_ */

--- a/Framework/Geometry/test/BraggScattererFactoryTest.h
+++ b/Framework/Geometry/test/BraggScattererFactoryTest.h
@@ -56,10 +56,10 @@ private:
     ~MockScatterer() override {}
 
     std::string name() const override { return "MockScatterer"; }
-    GCC_DIAG_OFF_SUGGEST_OVERRIDE
+    DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(clone, BraggScatterer_sptr());
     MOCK_CONST_METHOD1(calculateStructureFactor, StructureFactor(const V3D &));
-    GCC_DIAG_ON_SUGGEST_OVERRIDE
+    DIAG_ON_SUGGEST_OVERRIDE
   };
 };
 

--- a/Framework/Geometry/test/BraggScattererFactoryTest.h
+++ b/Framework/Geometry/test/BraggScattererFactoryTest.h
@@ -56,10 +56,10 @@ private:
     ~MockScatterer() override {}
 
     std::string name() const override { return "MockScatterer"; }
-    DIAG_OFF_SUGGEST_OVERRIDE
+    GNU_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(clone, BraggScatterer_sptr());
     MOCK_CONST_METHOD1(calculateStructureFactor, StructureFactor(const V3D &));
-    DIAG_ON_SUGGEST_OVERRIDE
+    GNU_DIAG_ON_SUGGEST_OVERRIDE
   };
 };
 

--- a/Framework/Geometry/test/BraggScattererInCrystalStructureTest.h
+++ b/Framework/Geometry/test/BraggScattererInCrystalStructureTest.h
@@ -112,12 +112,12 @@ private:
   public:
     MockBraggScatterer() : BraggScattererInCrystalStructure() {}
     ~MockBraggScatterer() override {}
-    DIAG_OFF_SUGGEST_OVERRIDE
+    GNU_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(name, std::string());
     MOCK_CONST_METHOD0(clone, BraggScatterer_sptr());
     MOCK_CONST_METHOD1(calculateStructureFactor, StructureFactor(const V3D &));
     MOCK_METHOD1(afterScattererPropertySet, void(const std::string &));
-    DIAG_ON_SUGGEST_OVERRIDE
+    GNU_DIAG_ON_SUGGEST_OVERRIDE
   };
 };
 

--- a/Framework/Geometry/test/BraggScattererInCrystalStructureTest.h
+++ b/Framework/Geometry/test/BraggScattererInCrystalStructureTest.h
@@ -112,12 +112,12 @@ private:
   public:
     MockBraggScatterer() : BraggScattererInCrystalStructure() {}
     ~MockBraggScatterer() override {}
-    GCC_DIAG_OFF_SUGGEST_OVERRIDE
+    DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(name, std::string());
     MOCK_CONST_METHOD0(clone, BraggScatterer_sptr());
     MOCK_CONST_METHOD1(calculateStructureFactor, StructureFactor(const V3D &));
     MOCK_METHOD1(afterScattererPropertySet, void(const std::string &));
-    GCC_DIAG_ON_SUGGEST_OVERRIDE
+    DIAG_ON_SUGGEST_OVERRIDE
   };
 };
 

--- a/Framework/Geometry/test/BraggScattererTest.h
+++ b/Framework/Geometry/test/BraggScattererTest.h
@@ -43,12 +43,12 @@ private:
 
   class MockBraggScatterer : public BraggScatterer {
   public:
-    GCC_DIAG_OFF_SUGGEST_OVERRIDE
+    DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(name, std::string());
     MOCK_CONST_METHOD0(clone, BraggScatterer_sptr());
     MOCK_CONST_METHOD1(calculateStructureFactor, StructureFactor(const V3D &));
     MOCK_METHOD1(afterScattererPropertySet, void(const std::string &));
-    GCC_DIAG_ON_SUGGEST_OVERRIDE
+    DIAG_ON_SUGGEST_OVERRIDE
   };
 };
 

--- a/Framework/Geometry/test/BraggScattererTest.h
+++ b/Framework/Geometry/test/BraggScattererTest.h
@@ -43,12 +43,12 @@ private:
 
   class MockBraggScatterer : public BraggScatterer {
   public:
-    DIAG_OFF_SUGGEST_OVERRIDE
+    GNU_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(name, std::string());
     MOCK_CONST_METHOD0(clone, BraggScatterer_sptr());
     MOCK_CONST_METHOD1(calculateStructureFactor, StructureFactor(const V3D &));
     MOCK_METHOD1(afterScattererPropertySet, void(const std::string &));
-    DIAG_ON_SUGGEST_OVERRIDE
+    GNU_DIAG_ON_SUGGEST_OVERRIDE
   };
 };
 

--- a/Framework/Geometry/test/CSGObjectTest.h
+++ b/Framework/Geometry/test/CSGObjectTest.h
@@ -45,7 +45,7 @@ namespace {
 // -----------------------------------------------------------------------------
 class MockRNG final : public Mantid::Kernel::PseudoRandomNumberGenerator {
 public:
-  DIAG_OFF_SUGGEST_OVERRIDE
+  GNU_DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD0(nextValue, double());
   MOCK_METHOD2(nextValue, double(double, double));
   MOCK_METHOD2(nextInt, int(int, int));
@@ -56,7 +56,7 @@ public:
   MOCK_METHOD2(setRange, void(const double, const double));
   MOCK_CONST_METHOD0(min, double());
   MOCK_CONST_METHOD0(max, double());
-  DIAG_ON_SUGGEST_OVERRIDE
+  GNU_DIAG_ON_SUGGEST_OVERRIDE
 };
 }
 

--- a/Framework/Geometry/test/CSGObjectTest.h
+++ b/Framework/Geometry/test/CSGObjectTest.h
@@ -45,7 +45,7 @@ namespace {
 // -----------------------------------------------------------------------------
 class MockRNG final : public Mantid::Kernel::PseudoRandomNumberGenerator {
 public:
-  GCC_DIAG_OFF_SUGGEST_OVERRIDE
+  DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD0(nextValue, double());
   MOCK_METHOD2(nextValue, double(double, double));
   MOCK_METHOD2(nextInt, int(int, int));
@@ -56,7 +56,7 @@ public:
   MOCK_METHOD2(setRange, void(const double, const double));
   MOCK_CONST_METHOD0(min, double());
   MOCK_CONST_METHOD0(max, double());
-  GCC_DIAG_ON_SUGGEST_OVERRIDE
+  DIAG_ON_SUGGEST_OVERRIDE
 };
 }
 

--- a/Framework/Geometry/test/CompositeImplicitFunctionTest.h
+++ b/Framework/Geometry/test/CompositeImplicitFunctionTest.h
@@ -18,11 +18,11 @@ private:
   // composite.
   class MockImplicitFunction : public Mantid::Geometry::MDImplicitFunction {
   public:
-    DIAG_OFF_SUGGEST_OVERRIDE
+    GNU_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(toXMLString, std::string());
     MOCK_CONST_METHOD0(getName, std::string());
     MOCK_METHOD1(isPointContained, bool(const Mantid::coord_t *coords));
-    DIAG_ON_SUGGEST_OVERRIDE
+    GNU_DIAG_ON_SUGGEST_OVERRIDE
     bool isPointContained(const std::vector<Mantid::coord_t> &) override {
       return true;
     }

--- a/Framework/Geometry/test/CompositeImplicitFunctionTest.h
+++ b/Framework/Geometry/test/CompositeImplicitFunctionTest.h
@@ -18,11 +18,11 @@ private:
   // composite.
   class MockImplicitFunction : public Mantid::Geometry::MDImplicitFunction {
   public:
-    GCC_DIAG_OFF_SUGGEST_OVERRIDE
+    DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(toXMLString, std::string());
     MOCK_CONST_METHOD0(getName, std::string());
     MOCK_METHOD1(isPointContained, bool(const Mantid::coord_t *coords));
-    GCC_DIAG_ON_SUGGEST_OVERRIDE
+    DIAG_ON_SUGGEST_OVERRIDE
     bool isPointContained(const std::vector<Mantid::coord_t> &) override {
       return true;
     }

--- a/Framework/Geometry/test/GroupTest.h
+++ b/Framework/Geometry/test/GroupTest.h
@@ -3,10 +3,11 @@
 
 #include <cxxtest/TestSuite.h>
 
-#include "MantidKernel/V3D.h"
 #include "MantidGeometry/Crystal/Group.h"
 #include "MantidGeometry/Crystal/SymmetryOperationFactory.h"
 #include "MantidGeometry/Crystal/UnitCell.h"
+#include "MantidKernel/V3D.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include <boost/make_shared.hpp>
 
 using namespace Mantid::Geometry;
@@ -367,16 +368,15 @@ public:
     Group_const_sptr null;
 
     TS_ASSERT_THROWS(null * null, std::invalid_argument);
-// AppleClang gives a warning if we don't use the result
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-comparison"
-#endif
+    // clang gives a warning if we don't use the result
+    // clang-format off
+    DIAG_OFF(unused-comparison)
+    // clang-format on
     TS_ASSERT_THROWS(null == null, std::invalid_argument);
     TS_ASSERT_THROWS(null != null, std::invalid_argument);
-#if __clang__
-#pragma clang diagnostic pop
-#endif
+    // clang-format off
+    DIAG_ON(unused-comparison)
+    // clang-format on
     TS_ASSERT_THROWS(three * null, std::invalid_argument);
     TS_ASSERT_THROWS(null * three, std::invalid_argument);
 

--- a/Framework/Geometry/test/GroupTest.h
+++ b/Framework/Geometry/test/GroupTest.h
@@ -369,10 +369,10 @@ public:
 
     TS_ASSERT_THROWS(null * null, std::invalid_argument);
     // clang gives a warning if we don't use the result
-    DIAG_OFF("unused-comparison")
+    GNU_DIAG_OFF("unused-comparison")
     TS_ASSERT_THROWS(null == null, std::invalid_argument);
     TS_ASSERT_THROWS(null != null, std::invalid_argument);
-    DIAG_ON("unused-comparison")
+    GNU_DIAG_ON("unused-comparison")
     TS_ASSERT_THROWS(three * null, std::invalid_argument);
     TS_ASSERT_THROWS(null * three, std::invalid_argument);
 

--- a/Framework/Geometry/test/GroupTest.h
+++ b/Framework/Geometry/test/GroupTest.h
@@ -369,14 +369,10 @@ public:
 
     TS_ASSERT_THROWS(null * null, std::invalid_argument);
     // clang gives a warning if we don't use the result
-    // clang-format off
-    DIAG_OFF(unused-comparison)
-    // clang-format on
+    DIAG_OFF("unused-comparison")
     TS_ASSERT_THROWS(null == null, std::invalid_argument);
     TS_ASSERT_THROWS(null != null, std::invalid_argument);
-    // clang-format off
-    DIAG_ON(unused-comparison)
-    // clang-format on
+    DIAG_ON("unused-comparison")
     TS_ASSERT_THROWS(three * null, std::invalid_argument);
     TS_ASSERT_THROWS(null * three, std::invalid_argument);
 

--- a/Framework/Geometry/test/HKLFilterTest.h
+++ b/Framework/Geometry/test/HKLFilterTest.h
@@ -184,7 +184,7 @@ public:
     TS_ASSERT_EQUALS(orFilterCasted->getLHS(), lhs);
     TS_ASSERT_EQUALS(orFilterCasted->getRHS(), rhs);
   }
-  DIAG_OFF_SUGGEST_OVERRIDE
+  GNU_DIAG_OFF_SUGGEST_OVERRIDE
 private:
   class MockHKLFilter : public HKLFilter {
   public:
@@ -212,5 +212,5 @@ private:
     MOCK_CONST_METHOD1(isAllowed, bool(const V3D &));
   };
 };
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 #endif /* MANTID_GEOMETRY_HKLFILTERTEST_H_ */

--- a/Framework/Geometry/test/HKLFilterTest.h
+++ b/Framework/Geometry/test/HKLFilterTest.h
@@ -184,7 +184,7 @@ public:
     TS_ASSERT_EQUALS(orFilterCasted->getLHS(), lhs);
     TS_ASSERT_EQUALS(orFilterCasted->getRHS(), rhs);
   }
-  GCC_DIAG_OFF_SUGGEST_OVERRIDE
+  DIAG_OFF_SUGGEST_OVERRIDE
 private:
   class MockHKLFilter : public HKLFilter {
   public:
@@ -212,5 +212,5 @@ private:
     MOCK_CONST_METHOD1(isAllowed, bool(const V3D &));
   };
 };
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 #endif /* MANTID_GEOMETRY_HKLFILTERTEST_H_ */

--- a/Framework/Geometry/test/InstrumentDefinitionParserTest.h
+++ b/Framework/Geometry/test/InstrumentDefinitionParserTest.h
@@ -22,7 +22,7 @@ using namespace testing;
 using ScopedFileHelper::ScopedFile;
 
 class InstrumentDefinitionParserTest : public CxxTest::TestSuite {
-  GCC_DIAG_OFF_SUGGEST_OVERRIDE
+  DIAG_OFF_SUGGEST_OVERRIDE
 private:
   /// Mock Type to act as IDF files.
   class MockIDFObject : public Mantid::Geometry::IDFObject {
@@ -40,7 +40,7 @@ private:
     MOCK_CONST_METHOD0(exists, bool());
     MOCK_CONST_METHOD0(getParentDirectory, const Poco::Path());
   };
-  GCC_DIAG_ON_SUGGEST_OVERRIDE
+  DIAG_ON_SUGGEST_OVERRIDE
   /**
   Helper type to pass around related IDF environment information in a
   collection.

--- a/Framework/Geometry/test/InstrumentDefinitionParserTest.h
+++ b/Framework/Geometry/test/InstrumentDefinitionParserTest.h
@@ -22,7 +22,7 @@ using namespace testing;
 using ScopedFileHelper::ScopedFile;
 
 class InstrumentDefinitionParserTest : public CxxTest::TestSuite {
-  DIAG_OFF_SUGGEST_OVERRIDE
+  GNU_DIAG_OFF_SUGGEST_OVERRIDE
 private:
   /// Mock Type to act as IDF files.
   class MockIDFObject : public Mantid::Geometry::IDFObject {
@@ -40,7 +40,7 @@ private:
     MOCK_CONST_METHOD0(exists, bool());
     MOCK_CONST_METHOD0(getParentDirectory, const Poco::Path());
   };
-  DIAG_ON_SUGGEST_OVERRIDE
+  GNU_DIAG_ON_SUGGEST_OVERRIDE
   /**
   Helper type to pass around related IDF environment information in a
   collection.

--- a/Framework/Geometry/test/MDGeometryXMLBuilderTest.h
+++ b/Framework/Geometry/test/MDGeometryXMLBuilderTest.h
@@ -34,7 +34,7 @@ private:
   /// dependency.
   class MockIMDDimension : public Mantid::Geometry::IMDDimension {
   public:
-    GCC_DIAG_OFF_SUGGEST_OVERRIDE
+    DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(getName, std::string());
     MOCK_CONST_METHOD0(getUnits, const Mantid::Kernel::UnitLabel());
     MOCK_CONST_METHOD0(getDimensionId, const std::string &());
@@ -48,7 +48,7 @@ private:
     MOCK_METHOD3(setRange, void(size_t nBins, coord_t min, coord_t max));
     MOCK_CONST_METHOD0(getMDUnits, const Kernel::MDUnit &());
     MOCK_CONST_METHOD0(getMDFrame, const Geometry::MDFrame &());
-    GCC_DIAG_ON_SUGGEST_OVERRIDE
+    DIAG_ON_SUGGEST_OVERRIDE
   };
 
   static std::string createDimensionXMLString(unsigned int nbins, int min,

--- a/Framework/Geometry/test/MDGeometryXMLBuilderTest.h
+++ b/Framework/Geometry/test/MDGeometryXMLBuilderTest.h
@@ -34,7 +34,7 @@ private:
   /// dependency.
   class MockIMDDimension : public Mantid::Geometry::IMDDimension {
   public:
-    DIAG_OFF_SUGGEST_OVERRIDE
+    GNU_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(getName, std::string());
     MOCK_CONST_METHOD0(getUnits, const Mantid::Kernel::UnitLabel());
     MOCK_CONST_METHOD0(getDimensionId, const std::string &());
@@ -48,7 +48,7 @@ private:
     MOCK_METHOD3(setRange, void(size_t nBins, coord_t min, coord_t max));
     MOCK_CONST_METHOD0(getMDUnits, const Kernel::MDUnit &());
     MOCK_CONST_METHOD0(getMDFrame, const Geometry::MDFrame &());
-    DIAG_ON_SUGGEST_OVERRIDE
+    GNU_DIAG_ON_SUGGEST_OVERRIDE
   };
 
   static std::string createDimensionXMLString(unsigned int nbins, int min,

--- a/Framework/Geometry/test/MeshObjectTest.h
+++ b/Framework/Geometry/test/MeshObjectTest.h
@@ -37,7 +37,7 @@ namespace {
 // -----------------------------------------------------------------------------
 class MockRNG final : public Mantid::Kernel::PseudoRandomNumberGenerator {
 public:
-  DIAG_OFF_SUGGEST_OVERRIDE
+  GNU_DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD0(nextValue, double());
   MOCK_METHOD2(nextValue, double(double, double));
   MOCK_METHOD2(nextInt, int(int, int));
@@ -48,7 +48,7 @@ public:
   MOCK_METHOD2(setRange, void(const double, const double));
   MOCK_CONST_METHOD0(min, double());
   MOCK_CONST_METHOD0(max, double());
-  DIAG_ON_SUGGEST_OVERRIDE
+  GNU_DIAG_ON_SUGGEST_OVERRIDE
 };
 
 std::unique_ptr<MeshObject> createCube(const double size, const V3D &centre) {

--- a/Framework/Geometry/test/MeshObjectTest.h
+++ b/Framework/Geometry/test/MeshObjectTest.h
@@ -37,7 +37,7 @@ namespace {
 // -----------------------------------------------------------------------------
 class MockRNG final : public Mantid::Kernel::PseudoRandomNumberGenerator {
 public:
-  GCC_DIAG_OFF_SUGGEST_OVERRIDE
+  DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD0(nextValue, double());
   MOCK_METHOD2(nextValue, double(double, double));
   MOCK_METHOD2(nextInt, int(int, int));
@@ -48,7 +48,7 @@ public:
   MOCK_METHOD2(setRange, void(const double, const double));
   MOCK_CONST_METHOD0(min, double());
   MOCK_CONST_METHOD0(max, double());
-  GCC_DIAG_ON_SUGGEST_OVERRIDE
+  DIAG_ON_SUGGEST_OVERRIDE
 };
 
 std::unique_ptr<MeshObject> createCube(const double size, const V3D &centre) {

--- a/Framework/Geometry/test/MockObjects.h
+++ b/Framework/Geometry/test/MockObjects.h
@@ -23,7 +23,7 @@ using boost::regex;
 
 namespace {
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 /*------------------------------------------------------------
  Mock Peak Transform
@@ -121,5 +121,5 @@ public:
   MOCK_CONST_METHOD0(getPeakShape, const Mantid::Geometry::PeakShape &());
 };
 }
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 #endif /* MANTIDGEOMETRYTEST_MOCKOBJECTS_H_ */

--- a/Framework/Geometry/test/MockObjects.h
+++ b/Framework/Geometry/test/MockObjects.h
@@ -23,7 +23,7 @@ using boost::regex;
 
 namespace {
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 /*------------------------------------------------------------
  Mock Peak Transform
@@ -121,5 +121,5 @@ public:
   MOCK_CONST_METHOD0(getPeakShape, const Mantid::Geometry::PeakShape &());
 };
 }
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 #endif /* MANTIDGEOMETRYTEST_MOCKOBJECTS_H_ */

--- a/Framework/Geometry/test/PeakTransformSelectorTest.h
+++ b/Framework/Geometry/test/PeakTransformSelectorTest.h
@@ -23,12 +23,12 @@ private:
     enum { value = I };
 
   public:
-    GCC_DIAG_OFF_SUGGEST_OVERRIDE
+    DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(createDefaultTransform, PeakTransform_sptr());
     MOCK_CONST_METHOD2(createTransform,
                        PeakTransform_sptr(const std::string &,
                                           const std::string &));
-    GCC_DIAG_ON_SUGGEST_OVERRIDE
+    DIAG_ON_SUGGEST_OVERRIDE
   };
 
   using MockPeakTransformFactory = MockPeakTransformFactoryType<0>;

--- a/Framework/Geometry/test/PeakTransformSelectorTest.h
+++ b/Framework/Geometry/test/PeakTransformSelectorTest.h
@@ -23,12 +23,12 @@ private:
     enum { value = I };
 
   public:
-    DIAG_OFF_SUGGEST_OVERRIDE
+    GNU_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(createDefaultTransform, PeakTransform_sptr());
     MOCK_CONST_METHOD2(createTransform,
                        PeakTransform_sptr(const std::string &,
                                           const std::string &));
-    DIAG_ON_SUGGEST_OVERRIDE
+    GNU_DIAG_ON_SUGGEST_OVERRIDE
   };
 
   using MockPeakTransformFactory = MockPeakTransformFactoryType<0>;

--- a/Framework/Geometry/test/SampleEnvironmentTest.h
+++ b/Framework/Geometry/test/SampleEnvironmentTest.h
@@ -21,7 +21,7 @@ namespace {
 // -----------------------------------------------------------------------------
 class MockRNG final : public Mantid::Kernel::PseudoRandomNumberGenerator {
 public:
-  DIAG_OFF_SUGGEST_OVERRIDE
+  GNU_DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD0(nextValue, double());
   MOCK_METHOD2(nextValue, double(double, double));
   MOCK_METHOD2(nextInt, int(int, int));
@@ -32,7 +32,7 @@ public:
   MOCK_METHOD2(setRange, void(const double, const double));
   MOCK_CONST_METHOD0(min, double());
   MOCK_CONST_METHOD0(max, double());
-  DIAG_ON_SUGGEST_OVERRIDE
+  GNU_DIAG_ON_SUGGEST_OVERRIDE
 };
 }
 

--- a/Framework/Geometry/test/SampleEnvironmentTest.h
+++ b/Framework/Geometry/test/SampleEnvironmentTest.h
@@ -21,7 +21,7 @@ namespace {
 // -----------------------------------------------------------------------------
 class MockRNG final : public Mantid::Kernel::PseudoRandomNumberGenerator {
 public:
-  GCC_DIAG_OFF_SUGGEST_OVERRIDE
+  DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD0(nextValue, double());
   MOCK_METHOD2(nextValue, double(double, double));
   MOCK_METHOD2(nextInt, int(int, int));
@@ -32,7 +32,7 @@ public:
   MOCK_METHOD2(setRange, void(const double, const double));
   MOCK_CONST_METHOD0(min, double());
   MOCK_CONST_METHOD0(max, double());
-  GCC_DIAG_ON_SUGGEST_OVERRIDE
+  DIAG_ON_SUGGEST_OVERRIDE
 };
 }
 

--- a/Framework/Geometry/test/SpaceGroupFactoryTest.h
+++ b/Framework/Geometry/test/SpaceGroupFactoryTest.h
@@ -398,9 +398,9 @@ private:
     MockSpaceGroupGenerator(size_t number, const std::string &hmSymbol,
                             const std::string &generatorInformation)
         : AbstractSpaceGroupGenerator(number, hmSymbol, generatorInformation) {}
-    DIAG_OFF_SUGGEST_OVERRIDE
+    GNU_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(generateGroup, Group_const_sptr());
-    DIAG_ON_SUGGEST_OVERRIDE
+    GNU_DIAG_ON_SUGGEST_OVERRIDE
   };
 
   /* Testing TransformationSpaceGroupGenerator is a bit hard in the sense that

--- a/Framework/Geometry/test/SpaceGroupFactoryTest.h
+++ b/Framework/Geometry/test/SpaceGroupFactoryTest.h
@@ -398,9 +398,9 @@ private:
     MockSpaceGroupGenerator(size_t number, const std::string &hmSymbol,
                             const std::string &generatorInformation)
         : AbstractSpaceGroupGenerator(number, hmSymbol, generatorInformation) {}
-    GCC_DIAG_OFF_SUGGEST_OVERRIDE
+    DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(generateGroup, Group_const_sptr());
-    GCC_DIAG_ON_SUGGEST_OVERRIDE
+    DIAG_ON_SUGGEST_OVERRIDE
   };
 
   /* Testing TransformationSpaceGroupGenerator is a bit hard in the sense that

--- a/Framework/Geometry/test/StructureFactorCalculatorTest.h
+++ b/Framework/Geometry/test/StructureFactorCalculatorTest.h
@@ -99,11 +99,11 @@ private:
    */
   class MockStructureFactorCalculator : public StructureFactorCalculator {
   public:
-    GCC_DIAG_OFF_SUGGEST_OVERRIDE
+    DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD1(getF, StructureFactor(const V3D &hkl));
     MOCK_METHOD1(crystalStructureSetHook,
                  void(const CrystalStructure &crystalStructure));
-    GCC_DIAG_ON_SUGGEST_OVERRIDE
+    DIAG_ON_SUGGEST_OVERRIDE
   };
 };
 

--- a/Framework/Geometry/test/StructureFactorCalculatorTest.h
+++ b/Framework/Geometry/test/StructureFactorCalculatorTest.h
@@ -99,11 +99,11 @@ private:
    */
   class MockStructureFactorCalculator : public StructureFactorCalculator {
   public:
-    DIAG_OFF_SUGGEST_OVERRIDE
+    GNU_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD1(getF, StructureFactor(const V3D &hkl));
     MOCK_METHOD1(crystalStructureSetHook,
                  void(const CrystalStructure &crystalStructure));
-    DIAG_ON_SUGGEST_OVERRIDE
+    GNU_DIAG_ON_SUGGEST_OVERRIDE
   };
 };
 

--- a/Framework/Geometry/test/SymmetryElementFactoryTest.h
+++ b/Framework/Geometry/test/SymmetryElementFactoryTest.h
@@ -396,12 +396,12 @@ private:
   class TestableSymmetryElementWithAxisGenerator
       : public SymmetryElementWithAxisGenerator {
     friend class SymmetryElementFactoryTest;
-    GCC_DIAG_OFF_SUGGEST_OVERRIDE
+    DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD1(generateElement,
                        SymmetryElement_sptr(const SymmetryOperation &));
     MOCK_CONST_METHOD1(canProcess, bool(const SymmetryOperation &));
     MOCK_CONST_METHOD1(determineSymbol, std::string(const SymmetryOperation &));
-    GCC_DIAG_ON_SUGGEST_OVERRIDE
+    DIAG_ON_SUGGEST_OVERRIDE
   };
 
   class TestableSymmetryElementRotationGenerator

--- a/Framework/Geometry/test/SymmetryElementFactoryTest.h
+++ b/Framework/Geometry/test/SymmetryElementFactoryTest.h
@@ -396,12 +396,12 @@ private:
   class TestableSymmetryElementWithAxisGenerator
       : public SymmetryElementWithAxisGenerator {
     friend class SymmetryElementFactoryTest;
-    DIAG_OFF_SUGGEST_OVERRIDE
+    GNU_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD1(generateElement,
                        SymmetryElement_sptr(const SymmetryOperation &));
     MOCK_CONST_METHOD1(canProcess, bool(const SymmetryOperation &));
     MOCK_CONST_METHOD1(determineSymbol, std::string(const SymmetryOperation &));
-    DIAG_ON_SUGGEST_OVERRIDE
+    GNU_DIAG_ON_SUGGEST_OVERRIDE
   };
 
   class TestableSymmetryElementRotationGenerator

--- a/Framework/Geometry/test/SymmetryElementTest.h
+++ b/Framework/Geometry/test/SymmetryElementTest.h
@@ -159,7 +159,7 @@ public:
 private:
   class MockSymmetryElement : public SymmetryElement {
     friend class SymmetryElementTest;
-    DIAG_OFF_SUGGEST_OVERRIDE
+    GNU_DIAG_OFF_SUGGEST_OVERRIDE
   public:
     MockSymmetryElement(const std::string &hmSymbol)
         : SymmetryElement(hmSymbol) {}
@@ -175,7 +175,7 @@ private:
         : SymmetryElementWithAxis(symbol, axis, translation) {}
     MOCK_CONST_METHOD0(clone, SymmetryElement_sptr());
   };
-  DIAG_ON_SUGGEST_OVERRIDE
+  GNU_DIAG_ON_SUGGEST_OVERRIDE
 };
 
 #endif /* MANTID_GEOMETRY_SYMMETRYELEMENTTEST_H_ */

--- a/Framework/Geometry/test/SymmetryElementTest.h
+++ b/Framework/Geometry/test/SymmetryElementTest.h
@@ -159,7 +159,7 @@ public:
 private:
   class MockSymmetryElement : public SymmetryElement {
     friend class SymmetryElementTest;
-    GCC_DIAG_OFF_SUGGEST_OVERRIDE
+    DIAG_OFF_SUGGEST_OVERRIDE
   public:
     MockSymmetryElement(const std::string &hmSymbol)
         : SymmetryElement(hmSymbol) {}
@@ -175,7 +175,7 @@ private:
         : SymmetryElementWithAxis(symbol, axis, translation) {}
     MOCK_CONST_METHOD0(clone, SymmetryElement_sptr());
   };
-  GCC_DIAG_ON_SUGGEST_OVERRIDE
+  DIAG_ON_SUGGEST_OVERRIDE
 };
 
 #endif /* MANTID_GEOMETRY_SYMMETRYELEMENTTEST_H_ */

--- a/Framework/ICat/src/CatalogSearch.cpp
+++ b/Framework/ICat/src/CatalogSearch.cpp
@@ -1,9 +1,9 @@
 #if GCC_VERSION >= 40800 // 4.8.0
-DIAG_OFF("literal-suffix")
+GNU_DIAG_OFF("literal-suffix")
 #endif
 #include "MantidICat/CatalogSearch.h"
 #if GCC_VERSION >= 40800 // 4.8.0
-DIAG_ON("literal-suffix")
+GNU_DIAG_ON("literal-suffix")
 #endif
 
 #include "MantidAPI/CatalogManager.h"

--- a/Framework/ICat/src/CatalogSearch.cpp
+++ b/Framework/ICat/src/CatalogSearch.cpp
@@ -1,12 +1,12 @@
 #if GCC_VERSION >= 40800 // 4.8.0
 // clang-format off
-GCC_DIAG_OFF(literal-suffix)
+DIAG_OFF(literal-suffix)
 // clang-format on
 #endif
 #include "MantidICat/CatalogSearch.h"
 #if GCC_VERSION >= 40800 // 4.8.0
 // clang-format off
-GCC_DIAG_ON(literal-suffix)
+DIAG_ON(literal-suffix)
 // clang-format on
 #endif
 

--- a/Framework/ICat/src/CatalogSearch.cpp
+++ b/Framework/ICat/src/CatalogSearch.cpp
@@ -1,13 +1,9 @@
 #if GCC_VERSION >= 40800 // 4.8.0
-// clang-format off
-DIAG_OFF(literal-suffix)
-// clang-format on
+DIAG_OFF("literal-suffix")
 #endif
 #include "MantidICat/CatalogSearch.h"
 #if GCC_VERSION >= 40800 // 4.8.0
-// clang-format off
-DIAG_ON(literal-suffix)
-// clang-format on
+DIAG_ON("literal-suffix")
 #endif
 
 #include "MantidAPI/CatalogManager.h"

--- a/Framework/ICat/src/GSoap.cpp
+++ b/Framework/ICat/src/GSoap.cpp
@@ -5,16 +5,16 @@
 // it is automatically generated code
 //------------------------------------------------------------------------------
 // clang-format off
-GCC_DIAG_OFF(cast-qual)
-GCC_DIAG_OFF(conversion)
-GCC_DIAG_OFF(unused-parameter)
-GCC_DIAG_OFF(strict-aliasing)
+DIAG_OFF(cast-qual)
+DIAG_OFF(conversion)
+DIAG_OFF(unused-parameter)
+DIAG_OFF(strict-aliasing)
+DIAG_OFF(format)
+DIAG_OFF(vla)
 // clang-format on
-GCC_DIAG_OFF(format)
-GCC_DIAG_OFF(vla)
 #if GCC_VERSION >= 40800 // 4.8.0
 // clang-format off
-GCC_DIAG_OFF(literal-suffix)
+DIAG_OFF(literal-suffix)
 // clang-format on
 #endif
 #ifdef _WIN32

--- a/Framework/ICat/src/GSoap.cpp
+++ b/Framework/ICat/src/GSoap.cpp
@@ -4,18 +4,14 @@
 // disable some warnings that we understand but do not want to touch as
 // it is automatically generated code
 //------------------------------------------------------------------------------
-// clang-format off
-DIAG_OFF(cast-qual)
-DIAG_OFF(conversion)
-DIAG_OFF(unused-parameter)
-DIAG_OFF(strict-aliasing)
-DIAG_OFF(format)
-DIAG_OFF(vla)
-// clang-format on
+DIAG_OFF("cast-qual")
+DIAG_OFF("conversion")
+DIAG_OFF("unused-parameter")
+DIAG_OFF("strict-aliasing")
+DIAG_OFF("format")
+DIAG_OFF("vla")
 #if GCC_VERSION >= 40800 // 4.8.0
-// clang-format off
-DIAG_OFF(literal-suffix)
-// clang-format on
+DIAG_OFF("literal-suffix")
 #endif
 #ifdef _WIN32
 #pragma warning(disable : 4100)

--- a/Framework/ICat/src/GSoap.cpp
+++ b/Framework/ICat/src/GSoap.cpp
@@ -4,14 +4,14 @@
 // disable some warnings that we understand but do not want to touch as
 // it is automatically generated code
 //------------------------------------------------------------------------------
-DIAG_OFF("cast-qual")
-DIAG_OFF("conversion")
-DIAG_OFF("unused-parameter")
-DIAG_OFF("strict-aliasing")
-DIAG_OFF("format")
-DIAG_OFF("vla")
+GNU_DIAG_OFF("cast-qual")
+GNU_DIAG_OFF("conversion")
+GNU_DIAG_OFF("unused-parameter")
+GNU_DIAG_OFF("strict-aliasing")
+GNU_DIAG_OFF("format")
+GNU_DIAG_OFF("vla")
 #if GCC_VERSION >= 40800 // 4.8.0
-DIAG_OFF("literal-suffix")
+GNU_DIAG_OFF("literal-suffix")
 #endif
 #ifdef _WIN32
 #pragma warning(disable : 4100)

--- a/Framework/ICat/src/GSoap/stdsoap2.cpp
+++ b/Framework/ICat/src/GSoap/stdsoap2.cpp
@@ -1,19 +1,14 @@
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wcast-align"
-#endif
 
 #include "MantidKernel/WarningSuppressions.h"
 // ignore warnings in gSOAP
 // Long-term solution is to use gSOAP as an external library or external
 // project. see issue #19433
 // clang-format off
-#if defined(__GNUC__) && __GNUC__ >= 7
-GCC_DIAG_OFF(deprecated-declarations)
-GCC_DIAG_OFF(format-overflow)
-GCC_DIAG_OFF(format-truncation)
-GCC_DIAG_OFF(implicit-fallthrough)
-#endif
+DIAG_OFF(deprecated-declarations)
+DIAG_OFF(format-overflow)
+DIAG_OFF(format-truncation)
+DIAG_OFF(implicit-fallthrough)
+DIAG_OFF(cast-align)
 // clang-format on
 
 /*
@@ -17022,14 +17017,9 @@ soap::~soap() {
 /******************************************************************************/
 
 // clang-format off
-#if defined(__GNUC__) && __GNUC__ >= 7
-GCC_DIAG_ON(deprecated-declarations)
-GCC_DIAG_ON(format-overflow)
-GCC_DIAG_ON(format-truncation)
-GCC_DIAG_ON(implicit-fallthrough)
-#endif
+DIAG_ON(deprecated-declarations)
+DIAG_ON(format-overflow)
+DIAG_ON(format-truncation)
+DIAG_ON(implicit-fallthrough)
+DIAG_ON(cast-align)
 // clang-format on
-
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif

--- a/Framework/ICat/src/GSoap/stdsoap2.cpp
+++ b/Framework/ICat/src/GSoap/stdsoap2.cpp
@@ -3,11 +3,11 @@
 // ignore warnings in gSOAP
 // Long-term solution is to use gSOAP as an external library or external
 // project. see issue #19433
-DIAG_OFF("deprecated-declarations")
-DIAG_OFF("format-overflow")
-DIAG_OFF("format-truncation")
-DIAG_OFF("implicit-fallthrough")
-DIAG_OFF("cast-align")
+GNU_DIAG_OFF("deprecated-declarations")
+GNU_DIAG_OFF("format-overflow")
+GNU_DIAG_OFF("format-truncation")
+GNU_DIAG_OFF("implicit-fallthrough")
+GNU_DIAG_OFF("cast-align")
 
 /*
   stdsoap2.c[pp] 2.8.15
@@ -17014,8 +17014,8 @@ soap::~soap() {
 
 /******************************************************************************/
 
-DIAG_ON("deprecated-declarations")
-DIAG_ON("format-overflow")
-DIAG_ON("format-truncation")
-DIAG_ON("implicit-fallthrough")
-DIAG_ON("cast-align")
+GNU_DIAG_ON("deprecated-declarations")
+GNU_DIAG_ON("format-overflow")
+GNU_DIAG_ON("format-truncation")
+GNU_DIAG_ON("implicit-fallthrough")
+GNU_DIAG_ON("cast-align")

--- a/Framework/ICat/src/GSoap/stdsoap2.cpp
+++ b/Framework/ICat/src/GSoap/stdsoap2.cpp
@@ -3,13 +3,11 @@
 // ignore warnings in gSOAP
 // Long-term solution is to use gSOAP as an external library or external
 // project. see issue #19433
-// clang-format off
-DIAG_OFF(deprecated-declarations)
-DIAG_OFF(format-overflow)
-DIAG_OFF(format-truncation)
-DIAG_OFF(implicit-fallthrough)
-DIAG_OFF(cast-align)
-// clang-format on
+DIAG_OFF("deprecated-declarations")
+DIAG_OFF("format-overflow")
+DIAG_OFF("format-truncation")
+DIAG_OFF("implicit-fallthrough")
+DIAG_OFF("cast-align")
 
 /*
   stdsoap2.c[pp] 2.8.15
@@ -17016,10 +17014,8 @@ soap::~soap() {
 
 /******************************************************************************/
 
-// clang-format off
-DIAG_ON(deprecated-declarations)
-DIAG_ON(format-overflow)
-DIAG_ON(format-truncation)
-DIAG_ON(implicit-fallthrough)
-DIAG_ON(cast-align)
-// clang-format on
+DIAG_ON("deprecated-declarations")
+DIAG_ON("format-overflow")
+DIAG_ON("format-truncation")
+DIAG_ON("implicit-fallthrough")
+DIAG_ON("cast-align")

--- a/Framework/ICat/src/ICat3/ICat3GSoapGenerated.cpp
+++ b/Framework/ICat/src/ICat3/ICat3GSoapGenerated.cpp
@@ -5,16 +5,16 @@
 // it is automatically generated code
 //------------------------------------------------------------------------------
 // clang-format off
-GCC_DIAG_OFF(cast-qual)
-GCC_DIAG_OFF(conversion)
-GCC_DIAG_OFF(unused-parameter)
-GCC_DIAG_OFF(strict-aliasing)
+DIAG_OFF(cast-qual)
+DIAG_OFF(conversion)
+DIAG_OFF(unused-parameter)
+DIAG_OFF(strict-aliasing)
+DIAG_OFF(format)
+DIAG_OFF(vla)
 // clang-format on
-GCC_DIAG_OFF(format)
-GCC_DIAG_OFF(vla)
 #if GCC_VERSION >= 40800 // 4.8.0
 // clang-format off
-GCC_DIAG_OFF(literal-suffix)
+DIAG_OFF(literal-suffix)
 // clang-format on
 #endif
 #ifdef _WIN32

--- a/Framework/ICat/src/ICat3/ICat3GSoapGenerated.cpp
+++ b/Framework/ICat/src/ICat3/ICat3GSoapGenerated.cpp
@@ -4,18 +4,14 @@
 // disable some warnings that we understand but do not want to touch as
 // it is automatically generated code
 //------------------------------------------------------------------------------
-// clang-format off
-DIAG_OFF(cast-qual)
-DIAG_OFF(conversion)
-DIAG_OFF(unused-parameter)
-DIAG_OFF(strict-aliasing)
-DIAG_OFF(format)
-DIAG_OFF(vla)
-// clang-format on
+DIAG_OFF("cast-qual")
+DIAG_OFF("conversion")
+DIAG_OFF("unused-parameter")
+DIAG_OFF("strict-aliasing")
+DIAG_OFF("format")
+DIAG_OFF("vla")
 #if GCC_VERSION >= 40800 // 4.8.0
-// clang-format off
-DIAG_OFF(literal-suffix)
-// clang-format on
+DIAG_OFF("literal-suffix")
 #endif
 #ifdef _WIN32
 #pragma warning(disable : 4100)

--- a/Framework/ICat/src/ICat3/ICat3GSoapGenerated.cpp
+++ b/Framework/ICat/src/ICat3/ICat3GSoapGenerated.cpp
@@ -4,14 +4,14 @@
 // disable some warnings that we understand but do not want to touch as
 // it is automatically generated code
 //------------------------------------------------------------------------------
-DIAG_OFF("cast-qual")
-DIAG_OFF("conversion")
-DIAG_OFF("unused-parameter")
-DIAG_OFF("strict-aliasing")
-DIAG_OFF("format")
-DIAG_OFF("vla")
+GNU_DIAG_OFF("cast-qual")
+GNU_DIAG_OFF("conversion")
+GNU_DIAG_OFF("unused-parameter")
+GNU_DIAG_OFF("strict-aliasing")
+GNU_DIAG_OFF("format")
+GNU_DIAG_OFF("vla")
 #if GCC_VERSION >= 40800 // 4.8.0
-DIAG_OFF("literal-suffix")
+GNU_DIAG_OFF("literal-suffix")
 #endif
 #ifdef _WIN32
 #pragma warning(disable : 4100)

--- a/Framework/ICat/src/ICat3/ICat3Helper.cpp
+++ b/Framework/ICat/src/ICat3/ICat3Helper.cpp
@@ -2,7 +2,7 @@
 // Poco-related compilation error on Windows
 #include "MantidAPI/WorkspaceFactory.h"
 #if GCC_VERSION >= 40800 // 4.8.0
-DIAG_OFF("literal-suffix")
+GNU_DIAG_OFF("literal-suffix")
 #endif
 #include "MantidICat/ICat3/ICat3Helper.h"
 #include "MantidICat/ICat3/ICat3ErrorHandling.h"

--- a/Framework/ICat/src/ICat3/ICat3Helper.cpp
+++ b/Framework/ICat/src/ICat3/ICat3Helper.cpp
@@ -3,7 +3,7 @@
 #include "MantidAPI/WorkspaceFactory.h"
 #if GCC_VERSION >= 40800 // 4.8.0
 // clang-format off
-GCC_DIAG_OFF(literal-suffix)
+DIAG_OFF(literal-suffix)
 // clang-format on
 #endif
 #include "MantidICat/ICat3/ICat3Helper.h"

--- a/Framework/ICat/src/ICat3/ICat3Helper.cpp
+++ b/Framework/ICat/src/ICat3/ICat3Helper.cpp
@@ -2,9 +2,7 @@
 // Poco-related compilation error on Windows
 #include "MantidAPI/WorkspaceFactory.h"
 #if GCC_VERSION >= 40800 // 4.8.0
-// clang-format off
-DIAG_OFF(literal-suffix)
-// clang-format on
+DIAG_OFF("literal-suffix")
 #endif
 #include "MantidICat/ICat3/ICat3Helper.h"
 #include "MantidICat/ICat3/ICat3ErrorHandling.h"

--- a/Framework/ICat/src/ICat4/ICat4GSoapGenerated.cpp
+++ b/Framework/ICat/src/ICat4/ICat4GSoapGenerated.cpp
@@ -5,16 +5,16 @@
 // it is automatically generated code
 //------------------------------------------------------------------------------
 // clang-format off
-GCC_DIAG_OFF(cast-qual)
-GCC_DIAG_OFF(conversion)
-GCC_DIAG_OFF(unused-parameter)
-GCC_DIAG_OFF(strict-aliasing)
+DIAG_OFF(cast-qual)
+DIAG_OFF(conversion)
+DIAG_OFF(unused-parameter)
+DIAG_OFF(strict-aliasing)
+DIAG_OFF(format)
+DIAG_OFF(vla)
 // clang-format on
-GCC_DIAG_OFF(format)
-GCC_DIAG_OFF(vla)
 #if GCC_VERSION >= 40800 // 4.8.0
 // clang-format off
-GCC_DIAG_OFF(literal-suffix)
+DIAG_OFF(literal-suffix)
 // clang-format on
 #endif
 #ifdef _WIN32

--- a/Framework/ICat/src/ICat4/ICat4GSoapGenerated.cpp
+++ b/Framework/ICat/src/ICat4/ICat4GSoapGenerated.cpp
@@ -4,18 +4,14 @@
 // disable some warnings that we understand but do not want to touch as
 // it is automatically generated code
 //------------------------------------------------------------------------------
-// clang-format off
-DIAG_OFF(cast-qual)
-DIAG_OFF(conversion)
-DIAG_OFF(unused-parameter)
-DIAG_OFF(strict-aliasing)
-DIAG_OFF(format)
-DIAG_OFF(vla)
-// clang-format on
+DIAG_OFF("cast-qual")
+DIAG_OFF("conversion")
+DIAG_OFF("unused-parameter")
+DIAG_OFF("strict-aliasing")
+DIAG_OFF("format")
+DIAG_OFF("vla")
 #if GCC_VERSION >= 40800 // 4.8.0
-// clang-format off
-DIAG_OFF(literal-suffix)
-// clang-format on
+DIAG_OFF("literal-suffix")
 #endif
 #ifdef _WIN32
 #pragma warning(disable : 4100)

--- a/Framework/ICat/src/ICat4/ICat4GSoapGenerated.cpp
+++ b/Framework/ICat/src/ICat4/ICat4GSoapGenerated.cpp
@@ -4,14 +4,14 @@
 // disable some warnings that we understand but do not want to touch as
 // it is automatically generated code
 //------------------------------------------------------------------------------
-DIAG_OFF("cast-qual")
-DIAG_OFF("conversion")
-DIAG_OFF("unused-parameter")
-DIAG_OFF("strict-aliasing")
-DIAG_OFF("format")
-DIAG_OFF("vla")
+GNU_DIAG_OFF("cast-qual")
+GNU_DIAG_OFF("conversion")
+GNU_DIAG_OFF("unused-parameter")
+GNU_DIAG_OFF("strict-aliasing")
+GNU_DIAG_OFF("format")
+GNU_DIAG_OFF("vla")
 #if GCC_VERSION >= 40800 // 4.8.0
-DIAG_OFF("literal-suffix")
+GNU_DIAG_OFF("literal-suffix")
 #endif
 #ifdef _WIN32
 #pragma warning(disable : 4100)

--- a/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
@@ -124,11 +124,14 @@ std::string toPrettyString(
   }
   return Strings::shorten(retVal, maxLength);
 }
+
 GNU_DIAG_OFF("unused-function")
+
 /** Explicit specialization for a property of type std::vector<bool>.
 *   This will catch Vectors of char, double, float etc.
 *   This simply concatenates the values using a delimiter
 */
+
 template <>
 std::string toPrettyString(
     const std::vector<bool> &value, size_t maxLength, bool collapseLists,
@@ -139,6 +142,7 @@ std::string toPrettyString(
   return Strings::shorten(Strings::join(value.begin(), value.end(), delimiter),
                           maxLength);
 }
+
 GNU_DIAG_ON("unused-function")
 
 /// Specialization for a property of type std::vector<std::vector>.

--- a/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
@@ -124,9 +124,7 @@ std::string toPrettyString(
   }
   return Strings::shorten(retVal, maxLength);
 }
-// clang-format off
-DIAG_OFF(unused-function)
-// clang-format on
+DIAG_OFF("unused-function")
 /** Explicit specialization for a property of type std::vector<bool>.
 *   This will catch Vectors of char, double, float etc.
 *   This simply concatenates the values using a delimiter
@@ -141,9 +139,7 @@ std::string toPrettyString(
   return Strings::shorten(Strings::join(value.begin(), value.end(), delimiter),
                           maxLength);
 }
-// clang-format off
-DIAG_ON(unused-function)
-// clang-format on
+DIAG_ON("unused-function")
 
 /// Specialization for a property of type std::vector<std::vector>.
 template <typename T>

--- a/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
@@ -124,14 +124,8 @@ std::string toPrettyString(
   }
   return Strings::shorten(retVal, maxLength);
 }
-
-// AppleClang gives warning if the result is unused.
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
-#endif
 // clang-format off
-GCC_DIAG_OFF(unused-function)
+DIAG_OFF(unused-function)
 // clang-format on
 /** Explicit specialization for a property of type std::vector<bool>.
 *   This will catch Vectors of char, double, float etc.
@@ -148,11 +142,8 @@ std::string toPrettyString(
                           maxLength);
 }
 // clang-format off
-GCC_DIAG_ON(unused-function)
+DIAG_ON(unused-function)
 // clang-format on
-#if __clang__
-#pragma clang diagnostic pop
-#endif
 
 /// Specialization for a property of type std::vector<std::vector>.
 template <typename T>

--- a/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
@@ -124,7 +124,7 @@ std::string toPrettyString(
   }
   return Strings::shorten(retVal, maxLength);
 }
-DIAG_OFF("unused-function")
+GNU_DIAG_OFF("unused-function")
 /** Explicit specialization for a property of type std::vector<bool>.
 *   This will catch Vectors of char, double, float etc.
 *   This simply concatenates the values using a delimiter
@@ -139,7 +139,7 @@ std::string toPrettyString(
   return Strings::shorten(Strings::join(value.begin(), value.end(), delimiter),
                           maxLength);
 }
-DIAG_ON("unused-function")
+GNU_DIAG_ON("unused-function")
 
 /// Specialization for a property of type std::vector<std::vector>.
 template <typename T>

--- a/Framework/Kernel/inc/MantidKernel/WarningSuppressions.h
+++ b/Framework/Kernel/inc/MantidKernel/WarningSuppressions.h
@@ -44,19 +44,8 @@
 #if defined(GCC_VERSION) || defined(CLANG_VERSION)
 // how to use a pragma in a macro
 #define PRAGMA(x) _Pragma(#x)
-
 // things to make the macros clearer
-#define GNU_DIAG_STR(s) #s
-// undefine definition from Poco 1.6
-#ifdef GNU_DIAG_JOINSTR
-#undef GNU_DIAG_JOINSTR
-#endif
-#define GNU_DIAG_JOINSTR(x, y) GNU_DIAG_STR(x##y)
 #define GNU_DIAG_MAKE_WARNING(x) "-W" x
-// undefine definition from Poco 1.6
-#ifdef GNU_DIAG_DO_PRAGMA
-#undef GNU_DIAG_DO_PRAGMA
-#endif
 #define GNU_DIAG_DO_PRAGMA(x) _Pragma(#x)
 
 #if defined(GCC_VERSION)
@@ -78,20 +67,12 @@
 // note that we turn off unknown warnings here as well so that we can use the
 // same macro for GCC and clang.
 // clang-format off
-#if GCC_VERSION >= 40600 // GCC 4.6.0
 #define GNU_DIAG_OFF(x)                                                          \
   GNU_DIAG_PRAGMA(push)                                                          \
-  GNU_DIAG_PRAGMA(ignored GNU_DIAG_MAKE_WARNING("unknown-warning"))                     \
+  GNU_DIAG_PRAGMA(ignored GNU_DIAG_MAKE_WARNING("pragmas"))                      \
   GNU_DIAG_PRAGMA(ignored GNU_DIAG_MAKE_WARNING(x))
 #define GNU_DIAG_ON(x) GNU_DIAG_PRAGMA(pop)
-#else
-#define GNU_DIAG_OFF(x)                                                          \
-  GNU_DIAG_PRAGMA(ignored GNU_DIAG_MAKE_WARNING("unknown-warning"))                     \
-  GNU_DIAG_PRAGMA(ignored GNU_DIAG_MAKE_WARNING(x))
-#define GNU_DIAG_ON(x)                                                           \
-  GNU_DIAG_PRAGMA(warning GNU_DIAG_MAKE_WARNING("unknown-warning"))                     \
-  GNU_DIAG_PRAGMA(warning GNU_DIAG_MAKE_WARNING(x))
-#endif
+
 // clang-format on
 
 #elif defined(CLANG_VERSION) && CLANG_VERSION >= 306
@@ -101,16 +82,16 @@
 // clang-format off
 #define GNU_DIAG_OFF(x)                                                         \
   GNU_DIAG_PRAGMA(push)                                                         \
-  GNU_DIAG_PRAGMA(ignored GNU_DIAG_MAKE_WARNING("unknown-warning-option"))        \
+  GNU_DIAG_PRAGMA(ignored GNU_DIAG_MAKE_WARNING("unknown-pragmas"))             \
+  GNU_DIAG_PRAGMA(ignored GNU_DIAG_MAKE_WARNING("unknown-warning-option"))      \
   GNU_DIAG_PRAGMA(ignored GNU_DIAG_MAKE_WARNING(x))
 #define GNU_DIAG_ON(x) GNU_DIAG_PRAGMA(pop)
 // clang-format on
+#endif
 #else
 // neither clang or GCC
 #define GNU_DIAG_OFF(x)
 #define GNU_DIAG_ON(x)
-#endif
-
 #endif
 
 // Defining this macro separately since clang-tidy tries to add spaces around

--- a/Framework/Kernel/inc/MantidKernel/WarningSuppressions.h
+++ b/Framework/Kernel/inc/MantidKernel/WarningSuppressions.h
@@ -52,6 +52,7 @@
 #undef DIAG_JOINSTR
 #endif
 #define DIAG_JOINSTR(x, y) DIAG_STR(x##y)
+#define DIAG_MAKE_WARNING(x) "-W" x
 // undefine definition from Poco 1.6
 #ifdef DIAG_DO_PRAGMA
 #undef DIAG_DO_PRAGMA
@@ -80,16 +81,16 @@
 #if GCC_VERSION >= 40600 // GCC 4.6.0
 #define DIAG_OFF(x)                                                          \
   DIAG_PRAGMA(push)                                                          \
-  DIAG_PRAGMA(ignored DIAG_JOINSTR(-W, unknown-warning))                     \
-  DIAG_PRAGMA(ignored DIAG_JOINSTR(-W, x))
+  DIAG_PRAGMA(ignored DIAG_MAKE_WARNING("unknown-warning"))                     \
+  DIAG_PRAGMA(ignored DIAG_MAKE_WARNING(x))
 #define DIAG_ON(x) DIAG_PRAGMA(pop)
 #else
 #define DIAG_OFF(x)                                                          \
-  DIAG_PRAGMA(ignored DIAG_JOINSTR(-W, unknown-warning))                     \
-  DIAG_PRAGMA(ignored DIAG_JOINSTR(-W, x))
+  DIAG_PRAGMA(ignored DIAG_MAKE_WARNING("unknown-warning"))                     \
+  DIAG_PRAGMA(ignored DIAG_MAKE_WARNING(x))
 #define DIAG_ON(x)                                                           \
-  DIAG_PRAGMA(warning DIAG_JOINSTR(-W, unknown-warning))                     \
-  DIAG_PRAGMA(warning DIAG_JOINSTR(-W, x))
+  DIAG_PRAGMA(warning DIAG_MAKE_WARNING("unknown-warning"))                     \
+  DIAG_PRAGMA(warning DIAG_MAKE_WARNING(x))
 #endif
 // clang-format on
 
@@ -100,8 +101,8 @@
 // clang-format off
 #define DIAG_OFF(x)                                                         \
   DIAG_PRAGMA(push)                                                         \
-  DIAG_PRAGMA(ignored DIAG_JOINSTR(-W, unknown-warning-option))             \
-  DIAG_PRAGMA(ignored DIAG_JOINSTR(-W, x))
+  DIAG_PRAGMA(ignored DIAG_MAKE_WARNING("unknown-warning-option"))        \
+  DIAG_PRAGMA(ignored DIAG_MAKE_WARNING(x))
 #define DIAG_ON(x) DIAG_PRAGMA(pop)
 // clang-format on
 #else
@@ -116,11 +117,11 @@
 // the hyphen and we use it in a lot of test files.
 // clang-format off
 #if defined(__cplusplus) && defined(GCC_VERSION) && GCC_VERSION >= 50000
-#define DIAG_OFF_SUGGEST_OVERRIDE DIAG_OFF(suggest-override)
-#define DIAG_ON_SUGGEST_OVERRIDE DIAG_ON(suggest-override)
+#define DIAG_OFF_SUGGEST_OVERRIDE DIAG_OFF("suggest-override")
+#define DIAG_ON_SUGGEST_OVERRIDE DIAG_ON("suggest-override")
 #elif defined(__cplusplus) && defined(CLANG_VERSION) && CLANG_VERSION >= 306
-#define DIAG_OFF_SUGGEST_OVERRIDE DIAG_OFF(inconsistent-missing-override)
-#define DIAG_ON_SUGGEST_OVERRIDE DIAG_ON(inconsistent-missing-override)
+#define DIAG_OFF_SUGGEST_OVERRIDE DIAG_OFF("inconsistent-missing-override")
+#define DIAG_ON_SUGGEST_OVERRIDE DIAG_ON("inconsistent-missing-override")
 #else
 #define DIAG_OFF_SUGGEST_OVERRIDE
 #define DIAG_ON_SUGGEST_OVERRIDE

--- a/Framework/Kernel/inc/MantidKernel/WarningSuppressions.h
+++ b/Framework/Kernel/inc/MantidKernel/WarningSuppressions.h
@@ -46,31 +46,31 @@
 #define PRAGMA(x) _Pragma(#x)
 
 // things to make the macros clearer
-#define DIAG_STR(s) #s
+#define GNU_DIAG_STR(s) #s
 // undefine definition from Poco 1.6
-#ifdef DIAG_JOINSTR
-#undef DIAG_JOINSTR
+#ifdef GNU_DIAG_JOINSTR
+#undef GNU_DIAG_JOINSTR
 #endif
-#define DIAG_JOINSTR(x, y) DIAG_STR(x##y)
-#define DIAG_MAKE_WARNING(x) "-W" x
+#define GNU_DIAG_JOINSTR(x, y) GNU_DIAG_STR(x##y)
+#define GNU_DIAG_MAKE_WARNING(x) "-W" x
 // undefine definition from Poco 1.6
-#ifdef DIAG_DO_PRAGMA
-#undef DIAG_DO_PRAGMA
+#ifdef GNU_DIAG_DO_PRAGMA
+#undef GNU_DIAG_DO_PRAGMA
 #endif
-#define DIAG_DO_PRAGMA(x) _Pragma(#x)
+#define GNU_DIAG_DO_PRAGMA(x) _Pragma(#x)
 
 #if defined(GCC_VERSION)
-#define DIAG_PRAGMA(x) DIAG_DO_PRAGMA(GCC diagnostic x)
+#define GNU_DIAG_PRAGMA(x) GNU_DIAG_DO_PRAGMA(GCC diagnostic x)
 #else
-#define DIAG_PRAGMA(x) DIAG_DO_PRAGMA(clang diagnostic x)
+#define GNU_DIAG_PRAGMA(x) GNU_DIAG_DO_PRAGMA(clang diagnostic x)
 #endif
 
 // the following were previously defined in Poco/Platform_POSIX.h
-#ifdef DIAG_ON
-#undef DIAG_ON
+#ifdef GNU_DIAG_ON
+#undef GNU_DIAG_ON
 #endif
-#ifdef DIAG_OFF
-#undef DIAG_OFF
+#ifdef GNU_DIAG_OFF
+#undef GNU_DIAG_OFF
 #endif
 
 #if defined(GCC_VERSION)
@@ -79,18 +79,18 @@
 // same macro for GCC and clang.
 // clang-format off
 #if GCC_VERSION >= 40600 // GCC 4.6.0
-#define DIAG_OFF(x)                                                          \
-  DIAG_PRAGMA(push)                                                          \
-  DIAG_PRAGMA(ignored DIAG_MAKE_WARNING("unknown-warning"))                     \
-  DIAG_PRAGMA(ignored DIAG_MAKE_WARNING(x))
-#define DIAG_ON(x) DIAG_PRAGMA(pop)
+#define GNU_DIAG_OFF(x)                                                          \
+  GNU_DIAG_PRAGMA(push)                                                          \
+  GNU_DIAG_PRAGMA(ignored GNU_DIAG_MAKE_WARNING("unknown-warning"))                     \
+  GNU_DIAG_PRAGMA(ignored GNU_DIAG_MAKE_WARNING(x))
+#define GNU_DIAG_ON(x) GNU_DIAG_PRAGMA(pop)
 #else
-#define DIAG_OFF(x)                                                          \
-  DIAG_PRAGMA(ignored DIAG_MAKE_WARNING("unknown-warning"))                     \
-  DIAG_PRAGMA(ignored DIAG_MAKE_WARNING(x))
-#define DIAG_ON(x)                                                           \
-  DIAG_PRAGMA(warning DIAG_MAKE_WARNING("unknown-warning"))                     \
-  DIAG_PRAGMA(warning DIAG_MAKE_WARNING(x))
+#define GNU_DIAG_OFF(x)                                                          \
+  GNU_DIAG_PRAGMA(ignored GNU_DIAG_MAKE_WARNING("unknown-warning"))                     \
+  GNU_DIAG_PRAGMA(ignored GNU_DIAG_MAKE_WARNING(x))
+#define GNU_DIAG_ON(x)                                                           \
+  GNU_DIAG_PRAGMA(warning GNU_DIAG_MAKE_WARNING("unknown-warning"))                     \
+  GNU_DIAG_PRAGMA(warning GNU_DIAG_MAKE_WARNING(x))
 #endif
 // clang-format on
 
@@ -99,16 +99,16 @@
 // note that we turn off unknown warnings here as well so that we can use the
 // same macro for GCC and clang.
 // clang-format off
-#define DIAG_OFF(x)                                                         \
-  DIAG_PRAGMA(push)                                                         \
-  DIAG_PRAGMA(ignored DIAG_MAKE_WARNING("unknown-warning-option"))        \
-  DIAG_PRAGMA(ignored DIAG_MAKE_WARNING(x))
-#define DIAG_ON(x) DIAG_PRAGMA(pop)
+#define GNU_DIAG_OFF(x)                                                         \
+  GNU_DIAG_PRAGMA(push)                                                         \
+  GNU_DIAG_PRAGMA(ignored GNU_DIAG_MAKE_WARNING("unknown-warning-option"))        \
+  GNU_DIAG_PRAGMA(ignored GNU_DIAG_MAKE_WARNING(x))
+#define GNU_DIAG_ON(x) GNU_DIAG_PRAGMA(pop)
 // clang-format on
 #else
 // neither clang or GCC
-#define DIAG_OFF(x)
-#define DIAG_ON(x)
+#define GNU_DIAG_OFF(x)
+#define GNU_DIAG_ON(x)
 #endif
 
 #endif
@@ -117,21 +117,21 @@
 // the hyphen and we use it in a lot of test files.
 // clang-format off
 #if defined(__cplusplus) && defined(GCC_VERSION) && GCC_VERSION >= 50000
-#define DIAG_OFF_SUGGEST_OVERRIDE DIAG_OFF("suggest-override")
-#define DIAG_ON_SUGGEST_OVERRIDE DIAG_ON("suggest-override")
+#define GNU_DIAG_OFF_SUGGEST_OVERRIDE GNU_DIAG_OFF("suggest-override")
+#define GNU_DIAG_ON_SUGGEST_OVERRIDE GNU_DIAG_ON("suggest-override")
 #elif defined(__cplusplus) && defined(CLANG_VERSION) && CLANG_VERSION >= 306
-#define DIAG_OFF_SUGGEST_OVERRIDE DIAG_OFF("inconsistent-missing-override")
-#define DIAG_ON_SUGGEST_OVERRIDE DIAG_ON("inconsistent-missing-override")
+#define GNU_DIAG_OFF_SUGGEST_OVERRIDE GNU_DIAG_OFF("inconsistent-missing-override")
+#define GNU_DIAG_ON_SUGGEST_OVERRIDE GNU_DIAG_ON("inconsistent-missing-override")
 #else
-#define DIAG_OFF_SUGGEST_OVERRIDE
-#define DIAG_ON_SUGGEST_OVERRIDE
+#define GNU_DIAG_OFF_SUGGEST_OVERRIDE
+#define GNU_DIAG_ON_SUGGEST_OVERRIDE
 #endif
 // clang-format on
 
 #if defined(GCC_VERSION) || defined(CLANG_VERSION)
-#define UNUSED_FUNCTION __attribute__((unused))
+#define GNU_UNUSED_FUNCTION __attribute__((unused))
 #else
-#define UNUSED_FUNCTION
+#define GNU_UNUSED_FUNCTION
 #endif
 
 #endif /*MANTID_KERNEL_WARNINGSUPPRESSIONS_H_*/

--- a/Framework/Kernel/inc/MantidKernel/WarningSuppressions.h
+++ b/Framework/Kernel/inc/MantidKernel/WarningSuppressions.h
@@ -40,10 +40,7 @@
   (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #endif
 
-// Currently this is only defined for gcc
 #if defined(GCC_VERSION) || defined(CLANG_VERSION)
-// how to use a pragma in a macro
-#define PRAGMA(x) _Pragma(#x)
 // things to make the macros clearer
 #define GNU_DIAG_MAKE_WARNING(x) "-W" x
 #define GNU_DIAG_DO_PRAGMA(x) _Pragma(#x)

--- a/Framework/Kernel/inc/MantidKernel/WarningSuppressions.h
+++ b/Framework/Kernel/inc/MantidKernel/WarningSuppressions.h
@@ -76,30 +76,34 @@
 // define macros for turning the warning suppression on/off for GCC
 // note that we turn off unknown warnings here as well so that we can use the
 // same macro for GCC and clang.
+// clang-format off
 #if GCC_VERSION >= 40600 // GCC 4.6.0
-#define DIAG_OFF(x)                                                         \
-  DIAG_PRAGMA(push)                                                             \
-  DIAG_PRAGMA(ignored DIAG_JOINSTR(-W, unknown-warning))                        \
+#define DIAG_OFF(x)                                                          \
+  DIAG_PRAGMA(push)                                                          \
+  DIAG_PRAGMA(ignored DIAG_JOINSTR(-W, unknown-warning))                     \
   DIAG_PRAGMA(ignored DIAG_JOINSTR(-W, x))
 #define DIAG_ON(x) DIAG_PRAGMA(pop)
 #else
-#define DIAG_OFF(x)                                                         \
-  DIAG_PRAGMA(ignored DIAG_JOINSTR(-W, unknown-warning))                        \
+#define DIAG_OFF(x)                                                          \
+  DIAG_PRAGMA(ignored DIAG_JOINSTR(-W, unknown-warning))                     \
   DIAG_PRAGMA(ignored DIAG_JOINSTR(-W, x))
-#define DIAG_ON(x)                                                          \
-  DIAG_PRAGMA(warning DIAG_JOINSTR(-W, unknown-warning))                        \
-  DIAG_PRAGMA(warning DIAG_JOINSTR(-W, x))                                      
+#define DIAG_ON(x)                                                           \
+  DIAG_PRAGMA(warning DIAG_JOINSTR(-W, unknown-warning))                     \
+  DIAG_PRAGMA(warning DIAG_JOINSTR(-W, x))
 #endif
+// clang-format on
 
 #elif defined(CLANG_VERSION) && CLANG_VERSION >= 306
 // define macros for turning the warning suppression on/off for clang
 // note that we turn off unknown warnings here as well so that we can use the
 // same macro for GCC and clang.
-#define DIAG_OFF(x)                                                        \
-  DIAG_PRAGMA(push)                                                            \
-  DIAG_PRAGMA(ignored DIAG_JOINSTR(-W, unknown-warning-option))                \
-  DIAG_PRAGMA(ignored DIAG_JOINSTR(-W, x))                                       
+// clang-format off
+#define DIAG_OFF(x)                                                         \
+  DIAG_PRAGMA(push)                                                         \
+  DIAG_PRAGMA(ignored DIAG_JOINSTR(-W, unknown-warning-option))             \
+  DIAG_PRAGMA(ignored DIAG_JOINSTR(-W, x))
 #define DIAG_ON(x) DIAG_PRAGMA(pop)
+// clang-format on
 #else
 // neither clang or GCC
 #define DIAG_OFF(x)
@@ -107,7 +111,6 @@
 #endif
 
 #endif
-
 
 // Defining this macro separately since clang-tidy tries to add spaces around
 // the hyphen and we use it in a lot of test files.
@@ -124,10 +127,10 @@
 #endif
 // clang-format on
 
-#ifdef GCC_VERSION
-#define GCC_UNUSED_FUNCTION __attribute__((unused))
+#if defined(GCC_VERSION) || defined(CLANG_VERSION)
+#define UNUSED_FUNCTION __attribute__((unused))
 #else
-#define GCC_UNUSED_FUNCTION
+#define UNUSED_FUNCTION
 #endif
 
 #endif /*MANTID_KERNEL_WARNINGSUPPRESSIONS_H_*/

--- a/Framework/Kernel/inc/MantidKernel/normal_distribution.h
+++ b/Framework/Kernel/inc/MantidKernel/normal_distribution.h
@@ -170,7 +170,7 @@ public:
              normal_distribution<_RT> &__x);
 };
 
-DIAG_OFF("maybe-uninitialized")
+GNU_DIAG_OFF("maybe-uninitialized")
 template <class _RealType>
 template <class _URNG>
 _RealType normal_distribution<_RealType>::operator()(_URNG &__g,
@@ -196,7 +196,7 @@ _RealType normal_distribution<_RealType>::operator()(_URNG &__g,
   }
   return _Up * __p.stddev() + __p.mean();
 }
-DIAG_ON("maybe-uninitialized")
+GNU_DIAG_ON("maybe-uninitialized")
 
 template <class _CharT, class _Traits, class _RT>
 std::basic_ostream<_CharT, _Traits> &

--- a/Framework/Kernel/inc/MantidKernel/normal_distribution.h
+++ b/Framework/Kernel/inc/MantidKernel/normal_distribution.h
@@ -170,9 +170,7 @@ public:
              normal_distribution<_RT> &__x);
 };
 
-// clang-format off
-DIAG_OFF(maybe-uninitialized)
-// clang-format on
+DIAG_OFF("maybe-uninitialized")
 template <class _RealType>
 template <class _URNG>
 _RealType normal_distribution<_RealType>::operator()(_URNG &__g,
@@ -198,9 +196,7 @@ _RealType normal_distribution<_RealType>::operator()(_URNG &__g,
   }
   return _Up * __p.stddev() + __p.mean();
 }
-// clang-format off
-DIAG_ON(maybe-uninitialized)
-// clang-format on
+DIAG_ON("maybe-uninitialized")
 
 template <class _CharT, class _Traits, class _RT>
 std::basic_ostream<_CharT, _Traits> &

--- a/Framework/Kernel/inc/MantidKernel/normal_distribution.h
+++ b/Framework/Kernel/inc/MantidKernel/normal_distribution.h
@@ -171,9 +171,7 @@ public:
 };
 
 // clang-format off
-#if !defined(__clang__)
-GCC_DIAG_OFF(maybe-uninitialized)
-#endif
+DIAG_OFF(maybe-uninitialized)
 // clang-format on
 template <class _RealType>
 template <class _URNG>
@@ -201,9 +199,7 @@ _RealType normal_distribution<_RealType>::operator()(_URNG &__g,
   return _Up * __p.stddev() + __p.mean();
 }
 // clang-format off
-#if !defined(__clang__)
-GCC_DIAG_ON(maybe-uninitialized)
-#endif
+DIAG_ON(maybe-uninitialized)
 // clang-format on
 
 template <class _CharT, class _Traits, class _RT>

--- a/Framework/Kernel/test/MDUnitFactoryTest.h
+++ b/Framework/Kernel/test/MDUnitFactoryTest.h
@@ -14,7 +14,7 @@ using namespace testing;
 /**
  * Helper Mock MDUnit
  */
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 class MockMDUnit : public MDUnit {
 public:
   MOCK_CONST_METHOD0(getUnitLabel, UnitLabel());
@@ -31,7 +31,7 @@ public:
   MOCK_CONST_METHOD1(createRaw, MDUnit *(const std::string &));
   MOCK_CONST_METHOD1(canInterpret, bool(const std::string &));
 };
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 class MDUnitFactoryTest : public CxxTest::TestSuite {
 public:
   // This pair of boilerplate methods prevent the suite being created statically

--- a/Framework/Kernel/test/MDUnitFactoryTest.h
+++ b/Framework/Kernel/test/MDUnitFactoryTest.h
@@ -14,7 +14,7 @@ using namespace testing;
 /**
  * Helper Mock MDUnit
  */
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 class MockMDUnit : public MDUnit {
 public:
   MOCK_CONST_METHOD0(getUnitLabel, UnitLabel());
@@ -31,7 +31,7 @@ public:
   MOCK_CONST_METHOD1(createRaw, MDUnit *(const std::string &));
   MOCK_CONST_METHOD1(canInterpret, bool(const std::string &));
 };
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 class MDUnitFactoryTest : public CxxTest::TestSuite {
 public:
   // This pair of boilerplate methods prevent the suite being created statically

--- a/Framework/Kernel/test/NDRandomNumberGeneratorTest.h
+++ b/Framework/Kernel/test/NDRandomNumberGeneratorTest.h
@@ -17,12 +17,12 @@ private:
   public:
     Mock3DRandomNumberGenerator()
         : Mantid::Kernel::NDRandomNumberGenerator(3) {}
-    GCC_DIAG_OFF_SUGGEST_OVERRIDE
+    DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_METHOD0(generateNextPoint, void());
     MOCK_METHOD0(restart, void());
     MOCK_METHOD0(save, void());
     MOCK_METHOD0(restore, void());
-    GCC_DIAG_ON_SUGGEST_OVERRIDE
+    DIAG_ON_SUGGEST_OVERRIDE
   };
 
 public:

--- a/Framework/Kernel/test/NDRandomNumberGeneratorTest.h
+++ b/Framework/Kernel/test/NDRandomNumberGeneratorTest.h
@@ -17,12 +17,12 @@ private:
   public:
     Mock3DRandomNumberGenerator()
         : Mantid::Kernel::NDRandomNumberGenerator(3) {}
-    DIAG_OFF_SUGGEST_OVERRIDE
+    GNU_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_METHOD0(generateNextPoint, void());
     MOCK_METHOD0(restart, void());
     MOCK_METHOD0(save, void());
     MOCK_METHOD0(restore, void());
-    DIAG_ON_SUGGEST_OVERRIDE
+    GNU_DIAG_ON_SUGGEST_OVERRIDE
   };
 
 public:

--- a/Framework/Kernel/test/UserCatalogInfoTest.h
+++ b/Framework/Kernel/test/UserCatalogInfoTest.h
@@ -19,7 +19,7 @@ operator<<(std::basic_ostream<CharType, CharTrait> &out,
   return out;
 }
 }
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 using namespace Mantid::Kernel;
 class MockCatalogConfigService : public CatalogConfigService {
 public:
@@ -37,7 +37,7 @@ public:
   MOCK_CONST_METHOD0(linuxPrefix, const std::string());
   MOCK_CONST_METHOD0(clone, ICatalogInfo *());
 };
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 // Adaptee
 struct UserType {
   std::string getString(const std::string &) const { return "my_value"; }

--- a/Framework/Kernel/test/UserCatalogInfoTest.h
+++ b/Framework/Kernel/test/UserCatalogInfoTest.h
@@ -19,7 +19,7 @@ operator<<(std::basic_ostream<CharType, CharTrait> &out,
   return out;
 }
 }
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 using namespace Mantid::Kernel;
 class MockCatalogConfigService : public CatalogConfigService {
 public:
@@ -37,7 +37,7 @@ public:
   MOCK_CONST_METHOD0(linuxPrefix, const std::string());
   MOCK_CONST_METHOD0(clone, ICatalogInfo *());
 };
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 // Adaptee
 struct UserType {
   std::string getString(const std::string &) const { return "my_value"; }

--- a/Framework/LiveData/inc/MantidLiveData/ISIS/TCPEventStreamDefs.h
+++ b/Framework/LiveData/inc/MantidLiveData/ISIS/TCPEventStreamDefs.h
@@ -9,7 +9,7 @@
 #include <vector>
 
 // to ignore warnings when comparing header versions
-DIAG_OFF("type-limits")
+GNU_DIAG_OFF("type-limits")
 #if defined(_WIN32)
 #pragma warning(disable : 4296)
 #endif
@@ -51,7 +51,7 @@ struct TCPStreamEventHeader {
       : marker1(marker), marker2(marker), version(current_version),
         length(sizeof(TCPStreamEventHeader)), type(type_) {}
 
-  DIAG_OFF("tautological-compare")
+  GNU_DIAG_OFF("tautological-compare")
   bool isValid() const {
     return marker1 == marker && marker2 == marker &&
            length >= sizeof(TCPStreamEventHeader) &&
@@ -59,7 +59,7 @@ struct TCPStreamEventHeader {
            minorVersion() >= TCPStreamEventHeader::minor_version &&
            type != InvalidStream;
   }
-  DIAG_ON("tautological-compare")
+  GNU_DIAG_ON("tautological-compare")
 
   static const uint32_t major_version =
       1; ///< starts at 1, then incremented whenever layout of this or further
@@ -189,5 +189,5 @@ struct TCPStreamEventDataSE {
 }
 }
 
-DIAG_ON("type-limits")
+GNU_DIAG_ON("type-limits")
 #endif /* TCP_EVENT_STREAM_DEFS_H */

--- a/Framework/LiveData/inc/MantidLiveData/ISIS/TCPEventStreamDefs.h
+++ b/Framework/LiveData/inc/MantidLiveData/ISIS/TCPEventStreamDefs.h
@@ -9,9 +9,7 @@
 #include <vector>
 
 // to ignore warnings when comparing header versions
-// clang-format off
-DIAG_OFF(type-limits)
-// clang-format on
+DIAG_OFF("type-limits")
 #if defined(_WIN32)
 #pragma warning(disable : 4296)
 #endif
@@ -53,9 +51,7 @@ struct TCPStreamEventHeader {
       : marker1(marker), marker2(marker), version(current_version),
         length(sizeof(TCPStreamEventHeader)), type(type_) {}
 
-  // clang-format off
-  DIAG_OFF(autological-compare)
-  // clang-format on
+  DIAG_OFF("tautological-compare")
   bool isValid() const {
     return marker1 == marker && marker2 == marker &&
            length >= sizeof(TCPStreamEventHeader) &&
@@ -63,9 +59,7 @@ struct TCPStreamEventHeader {
            minorVersion() >= TCPStreamEventHeader::minor_version &&
            type != InvalidStream;
   }
-  // clang-format off
-  DIAG_ON(autological-compare)
-  // clang-format on
+  DIAG_ON("tautological-compare")
 
   static const uint32_t major_version =
       1; ///< starts at 1, then incremented whenever layout of this or further
@@ -195,7 +189,5 @@ struct TCPStreamEventDataSE {
 }
 }
 
-// clang-format off
-DIAG_ON(type-limits)
-// clang-format on
+DIAG_ON("type-limits")
 #endif /* TCP_EVENT_STREAM_DEFS_H */

--- a/Framework/LiveData/inc/MantidLiveData/ISIS/TCPEventStreamDefs.h
+++ b/Framework/LiveData/inc/MantidLiveData/ISIS/TCPEventStreamDefs.h
@@ -1,15 +1,18 @@
 #ifndef TCP_EVENT_STREAM_DEFS_H
 #define TCP_EVENT_STREAM_DEFS_H
 
+#include "MantidKernel/WarningSuppressions.h"
+
 #include <cstdint>
 #include <cstring>
 #include <ctime>
 #include <vector>
 
 // to ignore warnings when comparing header versions
-#if defined(__GNUC__) && !(defined(__INTEL_COMPILER))
-#pragma GCC diagnostic ignored "-Wtype-limits"
-#elif defined(_WIN32)
+// clang-format off
+DIAG_OFF(type-limits)
+// clang-format on
+#if defined(_WIN32)
 #pragma warning(disable : 4296)
 #endif
 
@@ -49,10 +52,10 @@ struct TCPStreamEventHeader {
   TCPStreamEventHeader(uint32_t type_)
       : marker1(marker), marker2(marker), version(current_version),
         length(sizeof(TCPStreamEventHeader)), type(type_) {}
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wtautological-compare"
-#endif
+
+  // clang-format off
+  DIAG_OFF(autological-compare)
+  // clang-format on
   bool isValid() const {
     return marker1 == marker && marker2 == marker &&
            length >= sizeof(TCPStreamEventHeader) &&
@@ -60,9 +63,10 @@ struct TCPStreamEventHeader {
            minorVersion() >= TCPStreamEventHeader::minor_version &&
            type != InvalidStream;
   }
-#if __clang__
-#pragma clang diagnostic pop
-#endif
+  // clang-format off
+  DIAG_ON(autological-compare)
+  // clang-format on
+
   static const uint32_t major_version =
       1; ///< starts at 1, then incremented whenever layout of this or further
   /// packets changes in a non backward compatible way
@@ -190,4 +194,8 @@ struct TCPStreamEventDataSE {
 };
 }
 }
+
+// clang-format off
+DIAG_ON(type-limits)
+// clang-format on
 #endif /* TCP_EVENT_STREAM_DEFS_H */

--- a/Framework/LiveData/src/ISIS/ISISHistoDataListener.cpp
+++ b/Framework/LiveData/src/ISIS/ISISHistoDataListener.cpp
@@ -21,7 +21,7 @@
 #ifdef GCC_VERSION
 // Avoid compiler warnings on gcc from unused static constants in
 // isisds_command.h
-DIAG_OFF("unused-variable")
+GNU_DIAG_OFF("unused-variable")
 #endif
 #include "DAE/idc.h"
 

--- a/Framework/LiveData/src/ISIS/ISISHistoDataListener.cpp
+++ b/Framework/LiveData/src/ISIS/ISISHistoDataListener.cpp
@@ -21,9 +21,7 @@
 #ifdef GCC_VERSION
 // Avoid compiler warnings on gcc from unused static constants in
 // isisds_command.h
-// clang-format off
-DIAG_OFF(unused-variable)
-// clang-format on
+DIAG_OFF("unused-variable")
 #endif
 #include "DAE/idc.h"
 

--- a/Framework/LiveData/src/ISIS/ISISHistoDataListener.cpp
+++ b/Framework/LiveData/src/ISIS/ISISHistoDataListener.cpp
@@ -22,7 +22,7 @@
 // Avoid compiler warnings on gcc from unused static constants in
 // isisds_command.h
 // clang-format off
-GCC_DIAG_OFF(unused-variable)
+DIAG_OFF(unused-variable)
 // clang-format on
 #endif
 #include "DAE/idc.h"

--- a/Framework/LiveData/src/ISIS/ISISLiveEventDataListener.cpp
+++ b/Framework/LiveData/src/ISIS/ISISLiveEventDataListener.cpp
@@ -19,9 +19,7 @@
 #ifdef GCC_VERSION
 // Avoid compiler warnings on gcc from unused static constants in
 // isisds_command.h
-// clang-format off
-DIAG_OFF(unused-variable)
-// clang-format on
+DIAG_OFF("unused-variable")
 #endif
 #include "DAE/idc.h"
 

--- a/Framework/LiveData/src/ISIS/ISISLiveEventDataListener.cpp
+++ b/Framework/LiveData/src/ISIS/ISISLiveEventDataListener.cpp
@@ -20,7 +20,7 @@
 // Avoid compiler warnings on gcc from unused static constants in
 // isisds_command.h
 // clang-format off
-GCC_DIAG_OFF(unused-variable)
+DIAG_OFF(unused-variable)
 // clang-format on
 #endif
 #include "DAE/idc.h"

--- a/Framework/LiveData/src/ISIS/ISISLiveEventDataListener.cpp
+++ b/Framework/LiveData/src/ISIS/ISISLiveEventDataListener.cpp
@@ -19,7 +19,7 @@
 #ifdef GCC_VERSION
 // Avoid compiler warnings on gcc from unused static constants in
 // isisds_command.h
-DIAG_OFF("unused-variable")
+GNU_DIAG_OFF("unused-variable")
 #endif
 #include "DAE/idc.h"
 

--- a/Framework/LiveData/src/Kafka/KafkaEventStreamDecoder.cpp
+++ b/Framework/LiveData/src/Kafka/KafkaEventStreamDecoder.cpp
@@ -14,13 +14,17 @@
 #include "MantidLiveData/Exception.h"
 #include "MantidLiveData/Kafka/KafkaTopicSubscriber.h"
 
-GCC_DIAG_OFF(conversion)
+// clang-format off
+DIAG_OFF(conversion)
+// clang-format on
 #include "private/Schema/ba57_run_info_generated.h"
 #include "private/Schema/df12_det_spec_map_generated.h"
 #include "private/Schema/ev42_events_generated.h"
 #include "private/Schema/f142_logdata_generated.h"
 #include "private/Schema/is84_isis_events_generated.h"
-GCC_DIAG_ON(conversion)
+// clang-format off
+DIAG_ON(conversion)
+// clang-format on
 
 using namespace Mantid::Types;
 

--- a/Framework/LiveData/src/Kafka/KafkaEventStreamDecoder.cpp
+++ b/Framework/LiveData/src/Kafka/KafkaEventStreamDecoder.cpp
@@ -14,17 +14,13 @@
 #include "MantidLiveData/Exception.h"
 #include "MantidLiveData/Kafka/KafkaTopicSubscriber.h"
 
-// clang-format off
-DIAG_OFF(conversion)
-// clang-format on
+DIAG_OFF("conversion")
 #include "private/Schema/ba57_run_info_generated.h"
 #include "private/Schema/df12_det_spec_map_generated.h"
 #include "private/Schema/ev42_events_generated.h"
 #include "private/Schema/f142_logdata_generated.h"
 #include "private/Schema/is84_isis_events_generated.h"
-// clang-format off
-DIAG_ON(conversion)
-// clang-format on
+DIAG_ON("conversion")
 
 using namespace Mantid::Types;
 

--- a/Framework/LiveData/src/Kafka/KafkaEventStreamDecoder.cpp
+++ b/Framework/LiveData/src/Kafka/KafkaEventStreamDecoder.cpp
@@ -14,13 +14,13 @@
 #include "MantidLiveData/Exception.h"
 #include "MantidLiveData/Kafka/KafkaTopicSubscriber.h"
 
-DIAG_OFF("conversion")
+GNU_DIAG_OFF("conversion")
 #include "private/Schema/ba57_run_info_generated.h"
 #include "private/Schema/df12_det_spec_map_generated.h"
 #include "private/Schema/ev42_events_generated.h"
 #include "private/Schema/f142_logdata_generated.h"
 #include "private/Schema/is84_isis_events_generated.h"
-DIAG_ON("conversion")
+GNU_DIAG_ON("conversion")
 
 using namespace Mantid::Types;
 

--- a/Framework/LiveData/test/KafkaTesting.h
+++ b/Framework/LiveData/test/KafkaTesting.h
@@ -8,13 +8,17 @@
 #include "MantidTypes/Core/DateAndTime.h"
 #include <gmock/gmock.h>
 
-GCC_DIAG_OFF(conversion)
+// clang-format off
+DIAG_OFF(conversion)
+// clang-format on
 #include "Kafka/private/Schema/ba57_run_info_generated.h"
 #include "Kafka/private/Schema/df12_det_spec_map_generated.h"
 #include "Kafka/private/Schema/ev42_events_generated.h"
 #include "Kafka/private/Schema/f142_logdata_generated.h"
 #include "Kafka/private/Schema/is84_isis_events_generated.h"
-GCC_DIAG_ON(conversion)
+// clang-format off
+DIAG_ON(conversion)
+// clang-format on
 
 #include <ctime>
 
@@ -29,7 +33,7 @@ public:
       std::unique_ptr<Mantid::LiveData::IKafkaStreamSubscriber>;
   using IKafkaStreamSubscriber_ptr = Mantid::LiveData::IKafkaStreamSubscriber *;
 
-  GCC_DIAG_OFF_SUGGEST_OVERRIDE
+  DIAG_OFF_SUGGEST_OVERRIDE
   // GMock cannot mock non-copyable return types so we resort to a small
   // adapter method. Users have to use EXPECT_CALL(subscribe_) instead
   MOCK_CONST_METHOD2(subscribe_, IKafkaStreamSubscriber_ptr(
@@ -50,7 +54,7 @@ public:
     return std::unique_ptr<Mantid::LiveData::IKafkaStreamSubscriber>(
         this->subscribe_(s, offset, option));
   }
-  GCC_DIAG_ON_SUGGEST_OVERRIDE
+  DIAG_ON_SUGGEST_OVERRIDE
 };
 
 // -----------------------------------------------------------------------------

--- a/Framework/LiveData/test/KafkaTesting.h
+++ b/Framework/LiveData/test/KafkaTesting.h
@@ -8,17 +8,13 @@
 #include "MantidTypes/Core/DateAndTime.h"
 #include <gmock/gmock.h>
 
-// clang-format off
-DIAG_OFF(conversion)
-// clang-format on
+DIAG_OFF("conversion")
 #include "Kafka/private/Schema/ba57_run_info_generated.h"
 #include "Kafka/private/Schema/df12_det_spec_map_generated.h"
 #include "Kafka/private/Schema/ev42_events_generated.h"
 #include "Kafka/private/Schema/f142_logdata_generated.h"
 #include "Kafka/private/Schema/is84_isis_events_generated.h"
-// clang-format off
-DIAG_ON(conversion)
-// clang-format on
+DIAG_ON("conversion")
 
 #include <ctime>
 

--- a/Framework/LiveData/test/KafkaTesting.h
+++ b/Framework/LiveData/test/KafkaTesting.h
@@ -8,13 +8,13 @@
 #include "MantidTypes/Core/DateAndTime.h"
 #include <gmock/gmock.h>
 
-DIAG_OFF("conversion")
+GNU_DIAG_OFF("conversion")
 #include "Kafka/private/Schema/ba57_run_info_generated.h"
 #include "Kafka/private/Schema/df12_det_spec_map_generated.h"
 #include "Kafka/private/Schema/ev42_events_generated.h"
 #include "Kafka/private/Schema/f142_logdata_generated.h"
 #include "Kafka/private/Schema/is84_isis_events_generated.h"
-DIAG_ON("conversion")
+GNU_DIAG_ON("conversion")
 
 #include <ctime>
 
@@ -29,7 +29,7 @@ public:
       std::unique_ptr<Mantid::LiveData::IKafkaStreamSubscriber>;
   using IKafkaStreamSubscriber_ptr = Mantid::LiveData::IKafkaStreamSubscriber *;
 
-  DIAG_OFF_SUGGEST_OVERRIDE
+  GNU_DIAG_OFF_SUGGEST_OVERRIDE
   // GMock cannot mock non-copyable return types so we resort to a small
   // adapter method. Users have to use EXPECT_CALL(subscribe_) instead
   MOCK_CONST_METHOD2(subscribe_, IKafkaStreamSubscriber_ptr(
@@ -50,7 +50,7 @@ public:
     return std::unique_ptr<Mantid::LiveData::IKafkaStreamSubscriber>(
         this->subscribe_(s, offset, option));
   }
-  DIAG_ON_SUGGEST_OVERRIDE
+  GNU_DIAG_ON_SUGGEST_OVERRIDE
 };
 
 // -----------------------------------------------------------------------------

--- a/Framework/MDAlgorithms/src/LoadSQW2.cpp
+++ b/Framework/MDAlgorithms/src/LoadSQW2.cpp
@@ -485,7 +485,7 @@ std::vector<float> LoadSQW2::calculateDimLimitsFromData() {
 
 // The missing braces warning is a false positive -
 // https://llvm.org/bugs/show_bug.cgi?id=21629
-DIAG_OFF("missing-braces")
+GNU_DIAG_OFF("missing-braces")
 /**
  * Create the Q MDHistoDimension for the output frame and given information
  * from the file
@@ -539,7 +539,7 @@ LoadSQW2::createQDimension(size_t index, float dimMin, float dimMax,
   return builder.create();
 }
 
-DIAG_ON("missing-braces")
+GNU_DIAG_ON("missing-braces")
 
 /**
  * Create an energy dimension

--- a/Framework/MDAlgorithms/src/LoadSQW2.cpp
+++ b/Framework/MDAlgorithms/src/LoadSQW2.cpp
@@ -12,12 +12,13 @@
 #include "MantidGeometry/MDGeometry/MDHistoDimension.h"
 #include "MantidGeometry/MDGeometry/MDHistoDimensionBuilder.h"
 #include "MantidKernel/ListValidator.h"
-#include "MantidKernel/make_unique.h"
 #include "MantidKernel/Matrix.h"
 #include "MantidKernel/Memory.h"
 #include "MantidKernel/ThreadScheduler.h"
 #include "MantidKernel/Timer.h"
 #include "MantidKernel/V3D.h"
+#include "MantidKernel/WarningSuppressions.h"
+#include "MantidKernel/make_unique.h"
 
 namespace Mantid {
 namespace MDAlgorithms {
@@ -482,12 +483,11 @@ std::vector<float> LoadSQW2::calculateDimLimitsFromData() {
   return dimLimits;
 }
 
-#ifdef __clang__
 // The missing braces warning is a false positive -
 // https://llvm.org/bugs/show_bug.cgi?id=21629
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wmissing-braces"
-#endif
+// clang-format off
+DIAG_OFF(missing-braces)
+// clang-format on
 /**
  * Create the Q MDHistoDimension for the output frame and given information
  * from the file
@@ -540,9 +540,10 @@ LoadSQW2::createQDimension(size_t index, float dimMin, float dimMax,
 
   return builder.create();
 }
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+
+// clang-format off
+DIAG_ON(missing-braces)
+// clang-format on
 
 /**
  * Create an energy dimension

--- a/Framework/MDAlgorithms/src/LoadSQW2.cpp
+++ b/Framework/MDAlgorithms/src/LoadSQW2.cpp
@@ -485,9 +485,7 @@ std::vector<float> LoadSQW2::calculateDimLimitsFromData() {
 
 // The missing braces warning is a false positive -
 // https://llvm.org/bugs/show_bug.cgi?id=21629
-// clang-format off
-DIAG_OFF(missing-braces)
-// clang-format on
+DIAG_OFF("missing-braces")
 /**
  * Create the Q MDHistoDimension for the output frame and given information
  * from the file
@@ -541,9 +539,7 @@ LoadSQW2::createQDimension(size_t index, float dimMin, float dimMax,
   return builder.create();
 }
 
-// clang-format off
-DIAG_ON(missing-braces)
-// clang-format on
+DIAG_ON("missing-braces")
 
 /**
  * Create an energy dimension

--- a/Framework/MDAlgorithms/test/BinMDTest.h
+++ b/Framework/MDAlgorithms/test/BinMDTest.h
@@ -34,7 +34,7 @@ using namespace Mantid::MDAlgorithms;
 using Mantid::coord_t;
 
 class BinMDTest : public CxxTest::TestSuite {
-  GCC_DIAG_OFF_SUGGEST_OVERRIDE
+  DIAG_OFF_SUGGEST_OVERRIDE
 private:
   // Helper class. Mock Implicit function.
   class MockImplicitFunction : public Mantid::Geometry::MDImplicitFunction {
@@ -45,7 +45,7 @@ private:
     std::string getName() const override { return "MockImplicitFunction"; }
     MOCK_CONST_METHOD0(toXMLString, std::string());
   };
-  GCC_DIAG_ON_SUGGEST_OVERRIDE
+  DIAG_ON_SUGGEST_OVERRIDE
   // Helper class. Builds mock implicit functions.
   class MockImplicitFunctionBuilder
       : public Mantid::API::ImplicitFunctionBuilder {

--- a/Framework/MDAlgorithms/test/BinMDTest.h
+++ b/Framework/MDAlgorithms/test/BinMDTest.h
@@ -34,7 +34,7 @@ using namespace Mantid::MDAlgorithms;
 using Mantid::coord_t;
 
 class BinMDTest : public CxxTest::TestSuite {
-  DIAG_OFF_SUGGEST_OVERRIDE
+  GNU_DIAG_OFF_SUGGEST_OVERRIDE
 private:
   // Helper class. Mock Implicit function.
   class MockImplicitFunction : public Mantid::Geometry::MDImplicitFunction {
@@ -45,7 +45,7 @@ private:
     std::string getName() const override { return "MockImplicitFunction"; }
     MOCK_CONST_METHOD0(toXMLString, std::string());
   };
-  DIAG_ON_SUGGEST_OVERRIDE
+  GNU_DIAG_ON_SUGGEST_OVERRIDE
   // Helper class. Builds mock implicit functions.
   class MockImplicitFunctionBuilder
       : public Mantid::API::ImplicitFunctionBuilder {

--- a/Framework/MDAlgorithms/test/BinaryOperationMDTest.h
+++ b/Framework/MDAlgorithms/test/BinaryOperationMDTest.h
@@ -19,7 +19,7 @@ using namespace Mantid::DataObjects;
 using namespace Mantid::MDAlgorithms;
 using namespace testing;
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockBinaryOperationMD : public BinaryOperationMD {
 public:
@@ -35,7 +35,7 @@ public:
            Mantid::DataObjects::WorkspaceSingleValue_const_sptr scalar));
   void exec() override { BinaryOperationMD::exec(); }
 };
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 class BinaryOperationMDTest : public CxxTest::TestSuite {
 public:
   // This pair of boilerplate methods prevent the suite being created statically

--- a/Framework/MDAlgorithms/test/BinaryOperationMDTest.h
+++ b/Framework/MDAlgorithms/test/BinaryOperationMDTest.h
@@ -19,7 +19,7 @@ using namespace Mantid::DataObjects;
 using namespace Mantid::MDAlgorithms;
 using namespace testing;
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockBinaryOperationMD : public BinaryOperationMD {
 public:
@@ -35,7 +35,7 @@ public:
            Mantid::DataObjects::WorkspaceSingleValue_const_sptr scalar));
   void exec() override { BinaryOperationMD::exec(); }
 };
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 class BinaryOperationMDTest : public CxxTest::TestSuite {
 public:
   // This pair of boilerplate methods prevent the suite being created statically

--- a/Framework/MDAlgorithms/test/BooleanBinaryOperationMDTest.h
+++ b/Framework/MDAlgorithms/test/BooleanBinaryOperationMDTest.h
@@ -9,7 +9,7 @@
 
 using namespace Mantid::MDAlgorithms;
 using namespace testing;
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 class MockBooleanBinaryOperationMD : public BooleanBinaryOperationMD {
 public:
   MOCK_METHOD0(initExtraProperties, void());
@@ -17,7 +17,7 @@ public:
                void(Mantid::DataObjects::MDHistoWorkspace_sptr,
                     Mantid::DataObjects::MDHistoWorkspace_const_sptr));
 };
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 class BooleanBinaryOperationMDTest : public CxxTest::TestSuite {
 public:
   void test_basics() {

--- a/Framework/MDAlgorithms/test/BooleanBinaryOperationMDTest.h
+++ b/Framework/MDAlgorithms/test/BooleanBinaryOperationMDTest.h
@@ -9,7 +9,7 @@
 
 using namespace Mantid::MDAlgorithms;
 using namespace testing;
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 class MockBooleanBinaryOperationMD : public BooleanBinaryOperationMD {
 public:
   MOCK_METHOD0(initExtraProperties, void());
@@ -17,7 +17,7 @@ public:
                void(Mantid::DataObjects::MDHistoWorkspace_sptr,
                     Mantid::DataObjects::MDHistoWorkspace_const_sptr));
 };
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 class BooleanBinaryOperationMDTest : public CxxTest::TestSuite {
 public:
   void test_basics() {

--- a/Framework/MDAlgorithms/test/LoadSQW2Test.h
+++ b/Framework/MDAlgorithms/test/LoadSQW2Test.h
@@ -190,7 +190,7 @@ private:
     }
   }
 
-  DIAG_OFF("missing-braces")
+  GNU_DIAG_OFF("missing-braces")
   DimensionProperties getExpectedDimProperties(std::string outputFrame,
                                                DataType dtype) {
     DimensionProperties expected;
@@ -231,7 +231,7 @@ private:
     return expected;
   }
 
-  DIAG_ON("missing-braces")
+  GNU_DIAG_ON("missing-braces")
 
   void checkExperimentInfoAsExpected(const IMDEventWorkspace &outputWS) {
     TS_ASSERT_EQUALS(2, outputWS.getNumExperimentInfo());

--- a/Framework/MDAlgorithms/test/LoadSQW2Test.h
+++ b/Framework/MDAlgorithms/test/LoadSQW2Test.h
@@ -8,8 +8,9 @@
 #include "MantidAPI/Run.h"
 #include "MantidAPI/Sample.h"
 #include "MantidGeometry/Crystal/OrientedLattice.h"
-#include "MantidMDAlgorithms/LoadSQW2.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidKernel/make_unique.h"
+#include "MantidMDAlgorithms/LoadSQW2.h"
 
 #include <Poco/TemporaryFile.h>
 
@@ -189,12 +190,9 @@ private:
     }
   }
 
-#ifdef __clang__
-// The missing braces warning is a false positive -
-// https://llvm.org/bugs/show_bug.cgi?id=21629
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wmissing-braces"
-#endif
+  // clang-format off
+  DIAG_OFF(missing-braces)
+  // clang-format on
   DimensionProperties getExpectedDimProperties(std::string outputFrame,
                                                DataType dtype) {
     DimensionProperties expected;
@@ -235,9 +233,9 @@ private:
     return expected;
   }
 
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+  // clang-format off
+  DIAG_ON(missing-braces)
+  // clang-format on
 
   void checkExperimentInfoAsExpected(const IMDEventWorkspace &outputWS) {
     TS_ASSERT_EQUALS(2, outputWS.getNumExperimentInfo());

--- a/Framework/MDAlgorithms/test/LoadSQW2Test.h
+++ b/Framework/MDAlgorithms/test/LoadSQW2Test.h
@@ -190,9 +190,7 @@ private:
     }
   }
 
-  // clang-format off
-  DIAG_OFF(missing-braces)
-  // clang-format on
+  DIAG_OFF("missing-braces")
   DimensionProperties getExpectedDimProperties(std::string outputFrame,
                                                DataType dtype) {
     DimensionProperties expected;
@@ -233,9 +231,7 @@ private:
     return expected;
   }
 
-  // clang-format off
-  DIAG_ON(missing-braces)
-  // clang-format on
+  DIAG_ON("missing-braces")
 
   void checkExperimentInfoAsExpected(const IMDEventWorkspace &outputWS) {
     TS_ASSERT_EQUALS(2, outputWS.getNumExperimentInfo());

--- a/Framework/MDAlgorithms/test/PreprocessDetectorsToMDTest.h
+++ b/Framework/MDAlgorithms/test/PreprocessDetectorsToMDTest.h
@@ -101,7 +101,6 @@ public:
     auto &Azimuthal = tws->getColVector<double>("Azimuthal");
     auto &detDir = tws->getColVector<Kernel::V3D>("DetDirections");
 
-    TS_ASSERT(&detDir[0]);
     TS_ASSERT_EQUALS(nVal, detDir.size());
 
     for (size_t i = 0; i < nVal; i++) {

--- a/Framework/MDAlgorithms/test/UnaryOperationMDTest.h
+++ b/Framework/MDAlgorithms/test/UnaryOperationMDTest.h
@@ -23,11 +23,11 @@ using namespace testing;
 
 class MockUnaryOperationMD : public UnaryOperationMD {
 public:
-  DIAG_OFF_SUGGEST_OVERRIDE
+  GNU_DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD1(execEvent, void(Mantid::API::IMDEventWorkspace_sptr));
   MOCK_METHOD0(checkInputs, void());
   MOCK_METHOD1(execHisto, void(Mantid::DataObjects::MDHistoWorkspace_sptr));
-  DIAG_ON_SUGGEST_OVERRIDE
+  GNU_DIAG_ON_SUGGEST_OVERRIDE
   void exec() override { UnaryOperationMD::exec(); }
 };
 

--- a/Framework/MDAlgorithms/test/UnaryOperationMDTest.h
+++ b/Framework/MDAlgorithms/test/UnaryOperationMDTest.h
@@ -23,11 +23,11 @@ using namespace testing;
 
 class MockUnaryOperationMD : public UnaryOperationMD {
 public:
-  GCC_DIAG_OFF_SUGGEST_OVERRIDE
+  DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD1(execEvent, void(Mantid::API::IMDEventWorkspace_sptr));
   MOCK_METHOD0(checkInputs, void());
   MOCK_METHOD1(execHisto, void(Mantid::DataObjects::MDHistoWorkspace_sptr));
-  GCC_DIAG_ON_SUGGEST_OVERRIDE
+  DIAG_ON_SUGGEST_OVERRIDE
   void exec() override { UnaryOperationMD::exec(); }
 };
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
@@ -58,11 +58,11 @@ using declarePropertyType3 = void (*)(boost::python::object &,
 using declarePropertyType4 = void (*)(boost::python::object &,
                                       const std::string &,
                                       const boost::python::object &, const int);
-DIAG_OFF("unknown-pragmas")
-DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unknown-pragmas")
+GNU_DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF("conversion")
+GNU_DIAG_OFF("conversion")
 // Overload types
 BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType1_Overload,
                                 PythonAlgorithm::declarePyAlgProperty, 2, 3)
@@ -70,9 +70,9 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType2_Overload,
                                 PythonAlgorithm::declarePyAlgProperty, 3, 6)
 BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType3_Overload,
                                 PythonAlgorithm::declarePyAlgProperty, 4, 5)
-DIAG_ON("conversion")
-DIAG_ON("unknown-pragmas")
-DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("unknown-pragmas")
+GNU_DIAG_ON("unused-local-typdef")
 
 /**
  * Map a CancelException to a Python KeyboardInterupt

--- a/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
@@ -58,14 +58,13 @@ using declarePropertyType3 = void (*)(boost::python::object &,
 using declarePropertyType4 = void (*)(boost::python::object &,
                                       const std::string &,
                                       const boost::python::object &, const int);
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic ignored "-Wunused-local-typedef"
-#endif
+// clang-format off
+DIAG_OFF(unknown-pragmas)
+DIAG_OFF(unused-local-typdef)
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-GCC_DIAG_OFF(conversion)
+DIAG_OFF(conversion)
+// clang-format on
 // Overload types
 BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType1_Overload,
                                 PythonAlgorithm::declarePyAlgProperty, 2, 3)
@@ -73,10 +72,11 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType2_Overload,
                                 PythonAlgorithm::declarePyAlgProperty, 3, 6)
 BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType3_Overload,
                                 PythonAlgorithm::declarePyAlgProperty, 4, 5)
-GCC_DIAG_ON(conversion)
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+// clang-format off
+DIAG_ON(conversion)
+DIAG_ON(unknown-pragmas)
+DIAG_ON(unused-local-typdef)
+// clang-format on
 /**
  * Map a CancelException to a Python KeyboardInterupt
  * @param exc A cancel exception to translate. Unused here as the message is

--- a/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
@@ -59,7 +59,7 @@ using declarePropertyType4 = void (*)(boost::python::object &,
                                       const std::string &,
                                       const boost::python::object &, const int);
 GNU_DIAG_OFF("unknown-pragmas")
-GNU_DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
 GNU_DIAG_OFF("conversion")
@@ -72,7 +72,7 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType3_Overload,
                                 PythonAlgorithm::declarePyAlgProperty, 4, 5)
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unknown-pragmas")
-GNU_DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("unused-local-typedef")
 
 /**
  * Map a CancelException to a Python KeyboardInterupt

--- a/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
@@ -58,7 +58,6 @@ using declarePropertyType3 = void (*)(boost::python::object &,
 using declarePropertyType4 = void (*)(boost::python::object &,
                                       const std::string &,
                                       const boost::python::object &, const int);
-GNU_DIAG_OFF("unknown-pragmas")
 GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
@@ -71,7 +70,6 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType2_Overload,
 BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType3_Overload,
                                 PythonAlgorithm::declarePyAlgProperty, 4, 5)
 GNU_DIAG_ON("conversion")
-GNU_DIAG_ON("unknown-pragmas")
 GNU_DIAG_ON("unused-local-typedef")
 
 /**

--- a/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
@@ -58,13 +58,11 @@ using declarePropertyType3 = void (*)(boost::python::object &,
 using declarePropertyType4 = void (*)(boost::python::object &,
                                       const std::string &,
                                       const boost::python::object &, const int);
-// clang-format off
-DIAG_OFF(unknown-pragmas)
-DIAG_OFF(unused-local-typdef)
+DIAG_OFF("unknown-pragmas")
+DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF(conversion)
-// clang-format on
+DIAG_OFF("conversion")
 // Overload types
 BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType1_Overload,
                                 PythonAlgorithm::declarePyAlgProperty, 2, 3)
@@ -72,11 +70,10 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType2_Overload,
                                 PythonAlgorithm::declarePyAlgProperty, 3, 6)
 BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType3_Overload,
                                 PythonAlgorithm::declarePyAlgProperty, 4, 5)
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(unknown-pragmas)
-DIAG_ON(unused-local-typdef)
-// clang-format on
+DIAG_ON("conversion")
+DIAG_ON("unknown-pragmas")
+DIAG_ON("unused-local-typdef")
+
 /**
  * Map a CancelException to a Python KeyboardInterupt
  * @param exc A cancel exception to translate. Unused here as the message is

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
@@ -82,7 +82,7 @@ list getDescriptors(AlgorithmFactoryImpl &self, bool includeHidden) {
 std::recursive_mutex PYALG_REGISTER_MUTEX;
 
 // clang-format off
-GCC_DIAG_OFF(cast-qual)
+DIAG_OFF(cast-qual)
 // clang-format on
 
 /**
@@ -118,24 +118,25 @@ void subscribe(AlgorithmFactoryImpl &self, const boost::python::object &obj) {
   // from the FileLoaderRegistry
   FileLoaderRegistry::Instance().unsubscribe(descr.first, descr.second);
 }
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic ignored "-Wunused-local-typedef"
-#endif
+
+// clang-format off
+DIAG_OFF(unknown-pragmas)
+DIAG_OFF(unused-local-typdef)
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-GCC_DIAG_OFF(conversion)
+DIAG_OFF(conversion)
+// clang-format on
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(existsOverloader, exists, 1, 2)
-GCC_DIAG_ON(conversion)
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+// clang-format off
+DIAG_ON(conversion)
+DIAG_ON(unknown-pragmas)
+DIAG_ON(unused-local-typdef)
+// clang-format on
 
 ///@endcond
 }
 // clang-format off
-GCC_DIAG_ON(cast-qual)
+DIAG_ON(cast-qual)
 // clang-format on
 
 void export_AlgorithmFactory() {

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
@@ -117,7 +117,6 @@ void subscribe(AlgorithmFactoryImpl &self, const boost::python::object &obj) {
   FileLoaderRegistry::Instance().unsubscribe(descr.first, descr.second);
 }
 
-GNU_DIAG_OFF("unknown-pragmas")
 GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
@@ -126,7 +125,6 @@ GNU_DIAG_OFF("conversion")
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(existsOverloader, exists, 1, 2)
 
 GNU_DIAG_ON("conversion")
-GNU_DIAG_ON("unknown-pragmas")
 GNU_DIAG_ON("unused-local-typedef")
 
 ///@endcond

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
@@ -81,9 +81,7 @@ list getDescriptors(AlgorithmFactoryImpl &self, bool includeHidden) {
 // Python algorithm registration mutex in anonymous namespace (aka static)
 std::recursive_mutex PYALG_REGISTER_MUTEX;
 
-// clang-format off
-DIAG_OFF(cast-qual)
-// clang-format on
+DIAG_OFF("cast-qual")
 
 /**
  * A free function to subscribe a Python algorithm into the factory
@@ -119,25 +117,21 @@ void subscribe(AlgorithmFactoryImpl &self, const boost::python::object &obj) {
   FileLoaderRegistry::Instance().unsubscribe(descr.first, descr.second);
 }
 
-// clang-format off
-DIAG_OFF(unknown-pragmas)
-DIAG_OFF(unused-local-typdef)
+DIAG_OFF("unknown-pragmas")
+DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF(conversion)
-// clang-format on
+DIAG_OFF("conversion")
+
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(existsOverloader, exists, 1, 2)
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(unknown-pragmas)
-DIAG_ON(unused-local-typdef)
-// clang-format on
+
+DIAG_ON("conversion")
+DIAG_ON("unknown-pragmas")
+DIAG_ON("unused-local-typdef")
 
 ///@endcond
 }
-// clang-format off
-DIAG_ON(cast-qual)
-// clang-format on
+DIAG_ON("cast-qual")
 
 void export_AlgorithmFactory() {
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
@@ -81,7 +81,7 @@ list getDescriptors(AlgorithmFactoryImpl &self, bool includeHidden) {
 // Python algorithm registration mutex in anonymous namespace (aka static)
 std::recursive_mutex PYALG_REGISTER_MUTEX;
 
-DIAG_OFF("cast-qual")
+GNU_DIAG_OFF("cast-qual")
 
 /**
  * A free function to subscribe a Python algorithm into the factory
@@ -117,21 +117,21 @@ void subscribe(AlgorithmFactoryImpl &self, const boost::python::object &obj) {
   FileLoaderRegistry::Instance().unsubscribe(descr.first, descr.second);
 }
 
-DIAG_OFF("unknown-pragmas")
-DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unknown-pragmas")
+GNU_DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF("conversion")
+GNU_DIAG_OFF("conversion")
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(existsOverloader, exists, 1, 2)
 
-DIAG_ON("conversion")
-DIAG_ON("unknown-pragmas")
-DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("unknown-pragmas")
+GNU_DIAG_ON("unused-local-typdef")
 
 ///@endcond
 }
-DIAG_ON("cast-qual")
+GNU_DIAG_ON("cast-qual")
 
 void export_AlgorithmFactory() {
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
@@ -118,7 +118,7 @@ void subscribe(AlgorithmFactoryImpl &self, const boost::python::object &obj) {
 }
 
 GNU_DIAG_OFF("unknown-pragmas")
-GNU_DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
 GNU_DIAG_OFF("conversion")
@@ -127,7 +127,7 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(existsOverloader, exists, 1, 2)
 
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unknown-pragmas")
-GNU_DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("unused-local-typedef")
 
 ///@endcond
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
@@ -56,7 +56,6 @@ boost::python::list runningInstancesOf(AlgorithmManagerImpl &self,
 
 ///@cond
 //------------------------------------------------------------------------------------------------------
-GNU_DIAG_OFF("unknown-pragmas")
 GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
@@ -68,7 +67,6 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(createUnmanaged_overloads,
                                        AlgorithmManagerImpl::createUnmanaged, 1,
                                        2)
 GNU_DIAG_ON("conversion")
-GNU_DIAG_ON("unknown-pragmas")
 GNU_DIAG_ON("unused-local-typedef")
 ///@endcond
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
@@ -56,20 +56,20 @@ boost::python::list runningInstancesOf(AlgorithmManagerImpl &self,
 
 ///@cond
 //------------------------------------------------------------------------------------------------------
-DIAG_OFF("unknown-pragmas")
-DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unknown-pragmas")
+GNU_DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF("conversion")
+GNU_DIAG_OFF("conversion")
 /// Define overload generators
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(create_overloads,
                                        AlgorithmManagerImpl::create, 1, 2)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(createUnmanaged_overloads,
                                        AlgorithmManagerImpl::createUnmanaged, 1,
                                        2)
-DIAG_ON("conversion")
-DIAG_ON("unknown-pragmas")
-DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("unknown-pragmas")
+GNU_DIAG_ON("unused-local-typdef")
 ///@endcond
 }
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
@@ -56,24 +56,24 @@ boost::python::list runningInstancesOf(AlgorithmManagerImpl &self,
 
 ///@cond
 //------------------------------------------------------------------------------------------------------
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic ignored "-Wunused-local-typedef"
-#endif
+// clang-format off
+DIAG_OFF(unknown-pragmas)
+DIAG_OFF(unused-local-typdef)
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-GCC_DIAG_OFF(conversion)
+DIAG_OFF(conversion)
+// clang-format on
 /// Define overload generators
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(create_overloads,
                                        AlgorithmManagerImpl::create, 1, 2)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(createUnmanaged_overloads,
                                        AlgorithmManagerImpl::createUnmanaged, 1,
                                        2)
-GCC_DIAG_ON(conversion)
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+// clang-format off
+DIAG_ON(conversion)
+DIAG_ON(unknown-pragmas)
+DIAG_ON(unused-local-typdef)
+// clang-format on
 ///@endcond
 }
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
@@ -56,24 +56,20 @@ boost::python::list runningInstancesOf(AlgorithmManagerImpl &self,
 
 ///@cond
 //------------------------------------------------------------------------------------------------------
-// clang-format off
-DIAG_OFF(unknown-pragmas)
-DIAG_OFF(unused-local-typdef)
+DIAG_OFF("unknown-pragmas")
+DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF(conversion)
-// clang-format on
+DIAG_OFF("conversion")
 /// Define overload generators
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(create_overloads,
                                        AlgorithmManagerImpl::create, 1, 2)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(createUnmanaged_overloads,
                                        AlgorithmManagerImpl::createUnmanaged, 1,
                                        2)
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(unknown-pragmas)
-DIAG_ON(unused-local-typdef)
-// clang-format on
+DIAG_ON("conversion")
+DIAG_ON("unknown-pragmas")
+DIAG_ON("unused-local-typdef")
 ///@endcond
 }
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
@@ -57,7 +57,7 @@ boost::python::list runningInstancesOf(AlgorithmManagerImpl &self,
 ///@cond
 //------------------------------------------------------------------------------------------------------
 GNU_DIAG_OFF("unknown-pragmas")
-GNU_DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
 GNU_DIAG_OFF("conversion")
@@ -69,7 +69,7 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(createUnmanaged_overloads,
                                        2)
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unknown-pragmas")
-GNU_DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("unused-local-typedef")
 ///@endcond
 }
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp
@@ -29,20 +29,18 @@ GET_POINTER_SPECIALIZATION(Axis)
 namespace {
 
 //------------------------------- Overload macros ---------------------------
-// clang-format off
-DIAG_OFF(unknown-pragmas)
-DIAG_OFF(unused-local-typdef)
+DIAG_OFF("unknown-pragmas")
+DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF(conversion)
-// clang-format on
+DIAG_OFF("conversion")
+
 // Overloads for operator() function which has 1 optional argument
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Axis_getValue, Axis::getValue, 1, 2)
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(unknown-pragmas)
-DIAG_ON(unused-local-typdef)
-// clang-format on
+
+DIAG_ON("conversion")
+DIAG_ON("unknown-pragmas")
+DIAG_ON("unused-local-typdef")
 /**
  * Extract the axis values as a sequence. A numpy array is used if the
  * data is numerical or a simple python list is used if the data is a string

--- a/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp
@@ -29,21 +29,20 @@ GET_POINTER_SPECIALIZATION(Axis)
 namespace {
 
 //------------------------------- Overload macros ---------------------------
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic ignored "-Wunused-local-typedef"
-#endif
+// clang-format off
+DIAG_OFF(unknown-pragmas)
+DIAG_OFF(unused-local-typdef)
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-GCC_DIAG_OFF(conversion)
+DIAG_OFF(conversion)
+// clang-format on
 // Overloads for operator() function which has 1 optional argument
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Axis_getValue, Axis::getValue, 1, 2)
-GCC_DIAG_ON(conversion)
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
-
+// clang-format off
+DIAG_ON(conversion)
+DIAG_ON(unknown-pragmas)
+DIAG_ON(unused-local-typdef)
+// clang-format on
 /**
  * Extract the axis values as a sequence. A numpy array is used if the
  * data is numerical or a simple python list is used if the data is a string

--- a/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp
@@ -30,7 +30,7 @@ namespace {
 
 //------------------------------- Overload macros ---------------------------
 GNU_DIAG_OFF("unknown-pragmas")
-GNU_DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
 GNU_DIAG_OFF("conversion")
@@ -40,7 +40,7 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Axis_getValue, Axis::getValue, 1, 2)
 
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unknown-pragmas")
-GNU_DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("unused-local-typedef")
 /**
  * Extract the axis values as a sequence. A numpy array is used if the
  * data is numerical or a simple python list is used if the data is a string

--- a/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp
@@ -29,7 +29,6 @@ GET_POINTER_SPECIALIZATION(Axis)
 namespace {
 
 //------------------------------- Overload macros ---------------------------
-GNU_DIAG_OFF("unknown-pragmas")
 GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
@@ -39,7 +38,6 @@ GNU_DIAG_OFF("conversion")
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Axis_getValue, Axis::getValue, 1, 2)
 
 GNU_DIAG_ON("conversion")
-GNU_DIAG_ON("unknown-pragmas")
 GNU_DIAG_ON("unused-local-typedef")
 /**
  * Extract the axis values as a sequence. A numpy array is used if the

--- a/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp
@@ -29,18 +29,18 @@ GET_POINTER_SPECIALIZATION(Axis)
 namespace {
 
 //------------------------------- Overload macros ---------------------------
-DIAG_OFF("unknown-pragmas")
-DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unknown-pragmas")
+GNU_DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF("conversion")
+GNU_DIAG_OFF("conversion")
 
 // Overloads for operator() function which has 1 optional argument
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Axis_getValue, Axis::getValue, 1, 2)
 
-DIAG_ON("conversion")
-DIAG_ON("unknown-pragmas")
-DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("unknown-pragmas")
+GNU_DIAG_ON("unused-local-typdef")
 /**
  * Extract the axis values as a sequence. A numpy array is used if the
  * data is numerical or a simple python list is used if the data is a string

--- a/Framework/PythonInterface/mantid/api/src/Exports/CompositeFunction.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/CompositeFunction.cpp
@@ -19,14 +19,12 @@ using getParameterType2 =
 
 using setParameterType2 = void (CompositeFunction::*)(const std::string &,
                                                       const double &, bool);
-GNU_DIAG_OFF("unknown-pragmas")
 GNU_DIAG_OFF("unused-local-typedef")
 GNU_DIAG_OFF("conversion")
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(setParameterType2_Overloads,
                                        setParameter, 2, 3)
 GNU_DIAG_ON("conversion")
-GNU_DIAG_ON("unknown-pragmas")
 GNU_DIAG_ON("unused-local-typedef")
 } // namespace
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/CompositeFunction.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/CompositeFunction.cpp
@@ -19,18 +19,18 @@ using getParameterType2 =
 
 using setParameterType2 = void (CompositeFunction::*)(const std::string &,
                                                       const double &, bool);
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic ignored "-Wunused-local-typedef"
-#endif
-GCC_DIAG_OFF(conversion)
+// clang-format off
+DIAG_OFF(unknown-pragmas)
+DIAG_OFF(unused-local-typdef)
+DIAG_OFF(conversion)
+// clang-format on
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(setParameterType2_Overloads,
                                        setParameter, 2, 3)
-GCC_DIAG_ON(conversion)
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+// clang-format off
+DIAG_ON(conversion)
+DIAG_ON(unknown-pragmas)
+DIAG_ON(unused-local-typdef)
+// clang-format on
 } // namespace
 
 void export_CompositeFunction() {

--- a/Framework/PythonInterface/mantid/api/src/Exports/CompositeFunction.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/CompositeFunction.cpp
@@ -19,15 +19,15 @@ using getParameterType2 =
 
 using setParameterType2 = void (CompositeFunction::*)(const std::string &,
                                                       const double &, bool);
-DIAG_OFF("unknown-pragmas")
-DIAG_OFF("unused-local-typdef")
-DIAG_OFF("conversion")
+GNU_DIAG_OFF("unknown-pragmas")
+GNU_DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("conversion")
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(setParameterType2_Overloads,
                                        setParameter, 2, 3)
-DIAG_ON("conversion")
-DIAG_ON("unknown-pragmas")
-DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("unknown-pragmas")
+GNU_DIAG_ON("unused-local-typdef")
 } // namespace
 
 void export_CompositeFunction() {

--- a/Framework/PythonInterface/mantid/api/src/Exports/CompositeFunction.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/CompositeFunction.cpp
@@ -20,14 +20,14 @@ using getParameterType2 =
 using setParameterType2 = void (CompositeFunction::*)(const std::string &,
                                                       const double &, bool);
 GNU_DIAG_OFF("unknown-pragmas")
-GNU_DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unused-local-typedef")
 GNU_DIAG_OFF("conversion")
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(setParameterType2_Overloads,
                                        setParameter, 2, 3)
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unknown-pragmas")
-GNU_DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("unused-local-typedef")
 } // namespace
 
 void export_CompositeFunction() {

--- a/Framework/PythonInterface/mantid/api/src/Exports/CompositeFunction.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/CompositeFunction.cpp
@@ -19,18 +19,15 @@ using getParameterType2 =
 
 using setParameterType2 = void (CompositeFunction::*)(const std::string &,
                                                       const double &, bool);
-// clang-format off
-DIAG_OFF(unknown-pragmas)
-DIAG_OFF(unused-local-typdef)
-DIAG_OFF(conversion)
-// clang-format on
+DIAG_OFF("unknown-pragmas")
+DIAG_OFF("unused-local-typdef")
+DIAG_OFF("conversion")
+
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(setParameterType2_Overloads,
                                        setParameter, 2, 3)
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(unknown-pragmas)
-DIAG_ON(unused-local-typdef)
-// clang-format on
+DIAG_ON("conversion")
+DIAG_ON("unknown-pragmas")
+DIAG_ON("unused-local-typdef")
 } // namespace
 
 void export_CompositeFunction() {

--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -18,17 +18,17 @@ using namespace boost::python;
 
 GET_POINTER_SPECIALIZATION(ExperimentInfo)
 
-DIAG_OFF("unknown-pragmas")
-DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unknown-pragmas")
+GNU_DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF("conversion")
+GNU_DIAG_OFF("conversion")
 /// Overload generator for getInstrumentFilename
 BOOST_PYTHON_FUNCTION_OVERLOADS(getInstrumentFilename_Overload,
                                 ExperimentInfo::getInstrumentFilename, 1, 2)
-DIAG_ON("conversion")
-DIAG_ON("unknown-pragmas")
-DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("unknown-pragmas")
+GNU_DIAG_ON("unused-local-typdef")
 
 void export_ExperimentInfo() {
   register_ptr_to_python<boost::shared_ptr<ExperimentInfo>>();

--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -18,7 +18,6 @@ using namespace boost::python;
 
 GET_POINTER_SPECIALIZATION(ExperimentInfo)
 
-GNU_DIAG_OFF("unknown-pragmas")
 GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
@@ -27,7 +26,6 @@ GNU_DIAG_OFF("conversion")
 BOOST_PYTHON_FUNCTION_OVERLOADS(getInstrumentFilename_Overload,
                                 ExperimentInfo::getInstrumentFilename, 1, 2)
 GNU_DIAG_ON("conversion")
-GNU_DIAG_ON("unknown-pragmas")
 GNU_DIAG_ON("unused-local-typedef")
 
 void export_ExperimentInfo() {

--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -18,21 +18,17 @@ using namespace boost::python;
 
 GET_POINTER_SPECIALIZATION(ExperimentInfo)
 
-// clang-format off
-DIAG_OFF(unknown-pragmas)
-DIAG_OFF(unused-local-typdef)
+DIAG_OFF("unknown-pragmas")
+DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF(conversion)
-// clang-format on
+DIAG_OFF("conversion")
 /// Overload generator for getInstrumentFilename
 BOOST_PYTHON_FUNCTION_OVERLOADS(getInstrumentFilename_Overload,
                                 ExperimentInfo::getInstrumentFilename, 1, 2)
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(unknown-pragmas)
-DIAG_ON(unused-local-typdef)
-// clang-format on
+DIAG_ON("conversion")
+DIAG_ON("unknown-pragmas")
+DIAG_ON("unused-local-typdef")
 
 void export_ExperimentInfo() {
   register_ptr_to_python<boost::shared_ptr<ExperimentInfo>>();

--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -19,7 +19,7 @@ using namespace boost::python;
 GET_POINTER_SPECIALIZATION(ExperimentInfo)
 
 GNU_DIAG_OFF("unknown-pragmas")
-GNU_DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
 GNU_DIAG_OFF("conversion")
@@ -28,7 +28,7 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(getInstrumentFilename_Overload,
                                 ExperimentInfo::getInstrumentFilename, 1, 2)
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unknown-pragmas")
-GNU_DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("unused-local-typedef")
 
 void export_ExperimentInfo() {
   register_ptr_to_python<boost::shared_ptr<ExperimentInfo>>();

--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -18,21 +18,21 @@ using namespace boost::python;
 
 GET_POINTER_SPECIALIZATION(ExperimentInfo)
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic ignored "-Wunused-local-typedef"
-#endif
+// clang-format off
+DIAG_OFF(unknown-pragmas)
+DIAG_OFF(unused-local-typdef)
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-GCC_DIAG_OFF(conversion)
+DIAG_OFF(conversion)
+// clang-format on
 /// Overload generator for getInstrumentFilename
 BOOST_PYTHON_FUNCTION_OVERLOADS(getInstrumentFilename_Overload,
                                 ExperimentInfo::getInstrumentFilename, 1, 2)
-GCC_DIAG_ON(conversion)
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+// clang-format off
+DIAG_ON(conversion)
+DIAG_ON(unknown-pragmas)
+DIAG_ON(unused-local-typdef)
+// clang-format on
 
 void export_ExperimentInfo() {
   register_ptr_to_python<boost::shared_ptr<ExperimentInfo>>();

--- a/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
@@ -9,7 +9,6 @@ using Mantid::API::FileFinderImpl;
 using namespace boost::python;
 
 namespace {
-GNU_DIAG_OFF("unknown-pragmas")
 GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
@@ -18,7 +17,6 @@ GNU_DIAG_OFF("conversion")
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getFullPathOverloader, getFullPath, 1, 2)
 
 GNU_DIAG_ON("conversion")
-GNU_DIAG_ON("unknown-pragmas")
 GNU_DIAG_ON("unused-local-typedef")
 }
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
@@ -9,17 +9,17 @@ using Mantid::API::FileFinderImpl;
 using namespace boost::python;
 
 namespace {
-DIAG_OFF("unknown-pragmas")
-DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unknown-pragmas")
+GNU_DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF("conversion")
+GNU_DIAG_OFF("conversion")
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getFullPathOverloader, getFullPath, 1, 2)
 
-DIAG_ON("conversion")
-DIAG_ON("unknown-pragmas")
-DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("unknown-pragmas")
+GNU_DIAG_ON("unused-local-typdef")
 }
 
 void export_FileFinder() {

--- a/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
@@ -9,19 +9,19 @@ using Mantid::API::FileFinderImpl;
 using namespace boost::python;
 
 namespace {
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic ignored "-Wunused-local-typedef"
-#endif
+// clang-format off
+DIAG_OFF(unknown-pragmas)
+DIAG_OFF(unused-local-typdef)
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-GCC_DIAG_OFF(conversion)
+DIAG_OFF(conversion)
+// clang-format on
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getFullPathOverloader, getFullPath, 1, 2)
-GCC_DIAG_ON(conversion)
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+// clang-format off
+DIAG_ON(conversion)
+DIAG_ON(unknown-pragmas)
+DIAG_ON(unused-local-typdef)
+// clang-format on
 }
 
 void export_FileFinder() {

--- a/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
@@ -9,19 +9,17 @@ using Mantid::API::FileFinderImpl;
 using namespace boost::python;
 
 namespace {
-// clang-format off
-DIAG_OFF(unknown-pragmas)
-DIAG_OFF(unused-local-typdef)
+DIAG_OFF("unknown-pragmas")
+DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF(conversion)
-// clang-format on
+DIAG_OFF("conversion")
+
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getFullPathOverloader, getFullPath, 1, 2)
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(unknown-pragmas)
-DIAG_ON(unused-local-typdef)
-// clang-format on
+
+DIAG_ON("conversion")
+DIAG_ON("unknown-pragmas")
+DIAG_ON("unused-local-typdef")
 }
 
 void export_FileFinder() {

--- a/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
@@ -10,7 +10,7 @@ using namespace boost::python;
 
 namespace {
 GNU_DIAG_OFF("unknown-pragmas")
-GNU_DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
 GNU_DIAG_OFF("conversion")
@@ -19,7 +19,7 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getFullPathOverloader, getFullPath, 1, 2)
 
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unknown-pragmas")
-GNU_DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("unused-local-typedef")
 }
 
 void export_FileFinder() {

--- a/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
@@ -50,11 +50,11 @@ double getError(IFunction &self, std::string const &name) {
 // -- Set property overloads --
 // setProperty(index,value,explicit)
 using setParameterType1 = void (IFunction::*)(size_t, const double &, bool);
-DIAG_OFF("unknown-pragmas")
-DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unknown-pragmas")
+GNU_DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF("conversion")
+GNU_DIAG_OFF("conversion")
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(setParameterType1_Overloads,
                                        setParameter, 2, 3)
@@ -72,9 +72,9 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(fix_Overloads, fix, 1, 2)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(fixAll_Overloads, fixAll, 0, 1)
 using removeTieByName = void (IFunction::*)(const std::string &);
 
-DIAG_ON("conversion")
-DIAG_ON("unknown-pragmas")
-DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("unknown-pragmas")
+GNU_DIAG_ON("unused-local-typdef")
 ///@endcond
 }
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
@@ -50,13 +50,12 @@ double getError(IFunction &self, std::string const &name) {
 // -- Set property overloads --
 // setProperty(index,value,explicit)
 using setParameterType1 = void (IFunction::*)(size_t, const double &, bool);
-// clang-format off
-DIAG_OFF(unknown-pragmas)
-DIAG_OFF(unused-local-typdef)
+DIAG_OFF("unknown-pragmas")
+DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF(conversion)
-// clang-format on
+DIAG_OFF("conversion")
+
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(setParameterType1_Overloads,
                                        setParameter, 2, 3)
 // setProperty(index,value,explicit)
@@ -73,11 +72,9 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(fix_Overloads, fix, 1, 2)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(fixAll_Overloads, fixAll, 0, 1)
 using removeTieByName = void (IFunction::*)(const std::string &);
 
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(unknown-pragmas)
-DIAG_ON(unused-local-typdef)
-// clang-format on
+DIAG_ON("conversion")
+DIAG_ON("unknown-pragmas")
+DIAG_ON("unused-local-typdef")
 ///@endcond
 }
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
@@ -51,7 +51,7 @@ double getError(IFunction &self, std::string const &name) {
 // setProperty(index,value,explicit)
 using setParameterType1 = void (IFunction::*)(size_t, const double &, bool);
 GNU_DIAG_OFF("unknown-pragmas")
-GNU_DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
 GNU_DIAG_OFF("conversion")
@@ -74,7 +74,7 @@ using removeTieByName = void (IFunction::*)(const std::string &);
 
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unknown-pragmas")
-GNU_DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("unused-local-typedef")
 ///@endcond
 }
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
@@ -50,7 +50,6 @@ double getError(IFunction &self, std::string const &name) {
 // -- Set property overloads --
 // setProperty(index,value,explicit)
 using setParameterType1 = void (IFunction::*)(size_t, const double &, bool);
-GNU_DIAG_OFF("unknown-pragmas")
 GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
@@ -73,7 +72,6 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(fixAll_Overloads, fixAll, 0, 1)
 using removeTieByName = void (IFunction::*)(const std::string &);
 
 GNU_DIAG_ON("conversion")
-GNU_DIAG_ON("unknown-pragmas")
 GNU_DIAG_ON("unused-local-typedef")
 ///@endcond
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
@@ -50,14 +50,13 @@ double getError(IFunction &self, std::string const &name) {
 // -- Set property overloads --
 // setProperty(index,value,explicit)
 using setParameterType1 = void (IFunction::*)(size_t, const double &, bool);
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic ignored "-Wunused-local-typedef"
-#endif
+// clang-format off
+DIAG_OFF(unknown-pragmas)
+DIAG_OFF(unused-local-typdef)
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-GCC_DIAG_OFF(conversion)
+DIAG_OFF(conversion)
+// clang-format on
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(setParameterType1_Overloads,
                                        setParameter, 2, 3)
 // setProperty(index,value,explicit)
@@ -74,10 +73,11 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(fix_Overloads, fix, 1, 2)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(fixAll_Overloads, fixAll, 0, 1)
 using removeTieByName = void (IFunction::*)(const std::string &);
 
-GCC_DIAG_ON(conversion)
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+// clang-format off
+DIAG_ON(conversion)
+DIAG_ON(unknown-pragmas)
+DIAG_ON(unused-local-typdef)
+// clang-format on
 ///@endcond
 }
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/IMaskWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IMaskWorkspace.cpp
@@ -6,9 +6,7 @@
 #include <boost/python/extract.hpp>
 #include <boost/python/list.hpp>
 
-// clang-format off
-DIAG_OFF(strict-aliasing)
-// clang-format on
+DIAG_OFF("strict-aliasing")
 
 using Mantid::API::IMaskWorkspace;
 using namespace Mantid::PythonInterface::Registry;

--- a/Framework/PythonInterface/mantid/api/src/Exports/IMaskWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IMaskWorkspace.cpp
@@ -7,7 +7,7 @@
 #include <boost/python/list.hpp>
 
 // clang-format off
-GCC_DIAG_OFF(strict-aliasing)
+DIAG_OFF(strict-aliasing)
 // clang-format on
 
 using Mantid::API::IMaskWorkspace;

--- a/Framework/PythonInterface/mantid/api/src/Exports/IMaskWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IMaskWorkspace.cpp
@@ -6,7 +6,7 @@
 #include <boost/python/extract.hpp>
 #include <boost/python/list.hpp>
 
-DIAG_OFF("strict-aliasing")
+GNU_DIAG_OFF("strict-aliasing")
 
 using Mantid::API::IMaskWorkspace;
 using namespace Mantid::PythonInterface::Registry;

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -49,7 +49,6 @@ using return_readwrite_numpy =
     return_value_policy<VectorRefToNumpy<WrapReadWrite>>;
 
 //------------------------------- Overload macros ---------------------------
-GNU_DIAG_OFF("unknown-pragmas")
 GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
@@ -58,7 +57,6 @@ GNU_DIAG_OFF("conversion")
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(MatrixWorkspace_binIndexOfOverloads,
                                        MatrixWorkspace::binIndexOf, 1, 2)
 GNU_DIAG_ON("conversion")
-GNU_DIAG_ON("unknown-pragmas")
 GNU_DIAG_ON("unused-local-typedef")
 
 /**

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -49,21 +49,21 @@ using return_readwrite_numpy =
     return_value_policy<VectorRefToNumpy<WrapReadWrite>>;
 
 //------------------------------- Overload macros ---------------------------
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic ignored "-Wunused-local-typedef"
-#endif
+// clang-format off
+DIAG_OFF(unknown-pragmas)
+DIAG_OFF(unused-local-typdef)
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-GCC_DIAG_OFF(conversion)
+DIAG_OFF(conversion)
+// clang-format on
 // Overloads for binIndexOf function which has 1 optional argument
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(MatrixWorkspace_binIndexOfOverloads,
                                        MatrixWorkspace::binIndexOf, 1, 2)
-GCC_DIAG_ON(conversion)
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+// clang-format off
+DIAG_ON(conversion)
+DIAG_ON(unknown-pragmas)
+DIAG_ON(unused-local-typdef)
+// clang-format on
 
 /**
  * Set the values from an python array-style object into the given spectrum in

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -50,7 +50,7 @@ using return_readwrite_numpy =
 
 //------------------------------- Overload macros ---------------------------
 GNU_DIAG_OFF("unknown-pragmas")
-GNU_DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
 GNU_DIAG_OFF("conversion")
@@ -59,7 +59,7 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(MatrixWorkspace_binIndexOfOverloads,
                                        MatrixWorkspace::binIndexOf, 1, 2)
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unknown-pragmas")
-GNU_DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("unused-local-typedef")
 
 /**
  * Set the values from an python array-style object into the given spectrum in

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -49,17 +49,17 @@ using return_readwrite_numpy =
     return_value_policy<VectorRefToNumpy<WrapReadWrite>>;
 
 //------------------------------- Overload macros ---------------------------
-DIAG_OFF("unknown-pragmas")
-DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unknown-pragmas")
+GNU_DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF("conversion")
+GNU_DIAG_OFF("conversion")
 // Overloads for binIndexOf function which has 1 optional argument
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(MatrixWorkspace_binIndexOfOverloads,
                                        MatrixWorkspace::binIndexOf, 1, 2)
-DIAG_ON("conversion")
-DIAG_ON("unknown-pragmas")
-DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("unknown-pragmas")
+GNU_DIAG_ON("unused-local-typdef")
 
 /**
  * Set the values from an python array-style object into the given spectrum in

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -49,21 +49,17 @@ using return_readwrite_numpy =
     return_value_policy<VectorRefToNumpy<WrapReadWrite>>;
 
 //------------------------------- Overload macros ---------------------------
-// clang-format off
-DIAG_OFF(unknown-pragmas)
-DIAG_OFF(unused-local-typdef)
+DIAG_OFF("unknown-pragmas")
+DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF(conversion)
-// clang-format on
+DIAG_OFF("conversion")
 // Overloads for binIndexOf function which has 1 optional argument
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(MatrixWorkspace_binIndexOfOverloads,
                                        MatrixWorkspace::binIndexOf, 1, 2)
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(unknown-pragmas)
-DIAG_ON(unused-local-typdef)
-// clang-format on
+DIAG_ON("conversion")
+DIAG_ON("unknown-pragmas")
+DIAG_ON("unused-local-typdef")
 
 /**
  * Set the values from an python array-style object into the given spectrum in

--- a/Framework/PythonInterface/mantid/api/src/Exports/Projection.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Projection.cpp
@@ -15,7 +15,7 @@ using namespace Mantid::API;
 using namespace Mantid::PythonInterface;
 using namespace boost::python;
 
-DIAG_OFF("strict-aliasing")
+GNU_DIAG_OFF("strict-aliasing")
 
 namespace {
 std::string getUnit(Projection &p, size_t nd) {

--- a/Framework/PythonInterface/mantid/api/src/Exports/Projection.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Projection.cpp
@@ -15,7 +15,7 @@ using namespace Mantid::API;
 using namespace Mantid::PythonInterface;
 using namespace boost::python;
 // clang-format off
-GCC_DIAG_OFF(strict-aliasing)
+DIAG_OFF(strict-aliasing)
 // clang-format on
 
 namespace {

--- a/Framework/PythonInterface/mantid/api/src/Exports/Projection.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Projection.cpp
@@ -14,9 +14,8 @@
 using namespace Mantid::API;
 using namespace Mantid::PythonInterface;
 using namespace boost::python;
-// clang-format off
-DIAG_OFF(strict-aliasing)
-// clang-format on
+
+DIAG_OFF("strict-aliasing")
 
 namespace {
 std::string getUnit(Projection &p, size_t nd) {

--- a/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
@@ -115,7 +115,6 @@ bpl::list keys(Run &self) {
   return names;
 }
 }
-GNU_DIAG_OFF("unknown-pragmas")
 GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
@@ -124,7 +123,6 @@ GNU_DIAG_OFF("conversion")
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(integrateProtonCharge_Overload,
                                        integrateProtonCharge, 0, 1)
 GNU_DIAG_ON("conversion")
-GNU_DIAG_ON("unknown-pragmas")
 GNU_DIAG_ON("unused-local-typedef")
 
 void export_Run() {

--- a/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
@@ -115,17 +115,17 @@ bpl::list keys(Run &self) {
   return names;
 }
 }
-DIAG_OFF("unknown-pragmas")
-DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unknown-pragmas")
+GNU_DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF("conversion")
+GNU_DIAG_OFF("conversion")
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(integrateProtonCharge_Overload,
                                        integrateProtonCharge, 0, 1)
-DIAG_ON("conversion")
-DIAG_ON("unknown-pragmas")
-DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("unknown-pragmas")
+GNU_DIAG_ON("unused-local-typdef")
 
 void export_Run() {
   // Pointer

--- a/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
@@ -115,20 +115,20 @@ bpl::list keys(Run &self) {
   return names;
 }
 }
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic ignored "-Wunused-local-typedef"
-#endif
+// clang-format off
+DIAG_OFF(unknown-pragmas)
+DIAG_OFF(unused-local-typdef)
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-GCC_DIAG_OFF(conversion)
+DIAG_OFF(conversion)
+// clang-format on
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(integrateProtonCharge_Overload,
                                        integrateProtonCharge, 0, 1)
-GCC_DIAG_ON(conversion)
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+// clang-format off
+DIAG_ON(conversion)
+DIAG_ON(unknown-pragmas)
+DIAG_ON(unused-local-typdef)
+// clang-format on
 
 void export_Run() {
   // Pointer

--- a/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
@@ -115,20 +115,17 @@ bpl::list keys(Run &self) {
   return names;
 }
 }
-// clang-format off
-DIAG_OFF(unknown-pragmas)
-DIAG_OFF(unused-local-typdef)
+DIAG_OFF("unknown-pragmas")
+DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF(conversion)
-// clang-format on
+DIAG_OFF("conversion")
+
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(integrateProtonCharge_Overload,
                                        integrateProtonCharge, 0, 1)
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(unknown-pragmas)
-DIAG_ON(unused-local-typdef)
-// clang-format on
+DIAG_ON("conversion")
+DIAG_ON("unknown-pragmas")
+DIAG_ON("unused-local-typdef")
 
 void export_Run() {
   // Pointer

--- a/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
@@ -116,7 +116,7 @@ bpl::list keys(Run &self) {
 }
 }
 GNU_DIAG_OFF("unknown-pragmas")
-GNU_DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
 GNU_DIAG_OFF("conversion")
@@ -125,7 +125,7 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(integrateProtonCharge_Overload,
                                        integrateProtonCharge, 0, 1)
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unknown-pragmas")
-GNU_DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("unused-local-typedef")
 
 void export_Run() {
   // Pointer

--- a/Framework/PythonInterface/mantid/api/src/Exports/Workspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Workspace.cpp
@@ -19,16 +19,16 @@ GET_POINTER_SPECIALIZATION(Workspace)
 
 namespace {
 ///@cond
-DIAG_OFF("unknown-pragmas")
-DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unknown-pragmas")
+GNU_DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF("conversion")
+GNU_DIAG_OFF("conversion")
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Workspace_isDirtyOverloads,
                                        Workspace::isDirty, 0, 1)
-DIAG_ON("conversion")
-DIAG_ON("unknown-pragmas")
-DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("unknown-pragmas")
+GNU_DIAG_ON("unused-local-typdef")
 
 ///@endcond
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/Workspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Workspace.cpp
@@ -20,7 +20,7 @@ GET_POINTER_SPECIALIZATION(Workspace)
 namespace {
 ///@cond
 GNU_DIAG_OFF("unknown-pragmas")
-GNU_DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
 GNU_DIAG_OFF("conversion")
@@ -28,7 +28,7 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Workspace_isDirtyOverloads,
                                        Workspace::isDirty, 0, 1)
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unknown-pragmas")
-GNU_DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("unused-local-typedef")
 
 ///@endcond
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/Workspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Workspace.cpp
@@ -19,20 +19,16 @@ GET_POINTER_SPECIALIZATION(Workspace)
 
 namespace {
 ///@cond
-// clang-format off
-DIAG_OFF(unknown-pragmas)
-DIAG_OFF(unused-local-typdef)
+DIAG_OFF("unknown-pragmas")
+DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF(conversion)
-// clang-format on
+DIAG_OFF("conversion")
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Workspace_isDirtyOverloads,
                                        Workspace::isDirty, 0, 1)
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(unknown-pragmas)
-DIAG_ON(unused-local-typdef)
-// clang-format on
+DIAG_ON("conversion")
+DIAG_ON("unknown-pragmas")
+DIAG_ON("unused-local-typdef")
 
 ///@endcond
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/Workspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Workspace.cpp
@@ -19,7 +19,6 @@ GET_POINTER_SPECIALIZATION(Workspace)
 
 namespace {
 ///@cond
-GNU_DIAG_OFF("unknown-pragmas")
 GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
@@ -27,7 +26,6 @@ GNU_DIAG_OFF("conversion")
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Workspace_isDirtyOverloads,
                                        Workspace::isDirty, 0, 1)
 GNU_DIAG_ON("conversion")
-GNU_DIAG_ON("unknown-pragmas")
 GNU_DIAG_ON("unused-local-typedef")
 
 ///@endcond

--- a/Framework/PythonInterface/mantid/api/src/Exports/Workspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Workspace.cpp
@@ -19,20 +19,21 @@ GET_POINTER_SPECIALIZATION(Workspace)
 
 namespace {
 ///@cond
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic ignored "-Wunused-local-typedef"
-#endif
+// clang-format off
+DIAG_OFF(unknown-pragmas)
+DIAG_OFF(unused-local-typdef)
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-GCC_DIAG_OFF(conversion)
+DIAG_OFF(conversion)
+// clang-format on
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Workspace_isDirtyOverloads,
                                        Workspace::isDirty, 0, 1)
-GCC_DIAG_ON(conversion)
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+// clang-format off
+DIAG_ON(conversion)
+DIAG_ON(unknown-pragmas)
+DIAG_ON(unused-local-typdef)
+// clang-format on
+
 ///@endcond
 }
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceFactory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceFactory.cpp
@@ -47,7 +47,7 @@ Workspace_sptr createFromParentPtr(WorkspaceFactoryImpl &self,
 
 /// Overload generator for create
 GNU_DIAG_OFF("unknown-pragmas")
-GNU_DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
 GNU_DIAG_OFF("conversion")
@@ -59,7 +59,7 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(createPeaks_Overload, createPeaks, 0, 1)
 
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unknown-pragmas")
-GNU_DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("unused-local-typedef")
 }
 
 void export_WorkspaceFactory() {

--- a/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceFactory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceFactory.cpp
@@ -46,22 +46,22 @@ Workspace_sptr createFromParentPtr(WorkspaceFactoryImpl &self,
 }
 
 /// Overload generator for create
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic ignored "-Wunused-local-typedef"
-#endif
+// clang-format off
+DIAG_OFF(unknown-pragmas)
+DIAG_OFF(unused-local-typdef)
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-GCC_DIAG_OFF(conversion)
+DIAG_OFF(conversion)
+// clang-format on
 BOOST_PYTHON_FUNCTION_OVERLOADS(createFromParent_Overload, createFromParentPtr,
                                 2, 5)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(createTable_Overload, createTable, 0, 1)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(createPeaks_Overload, createPeaks, 0, 1)
-GCC_DIAG_ON(conversion)
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+// clang-format off
+DIAG_ON(conversion)
+DIAG_ON(unknown-pragmas)
+DIAG_ON(unused-local-typdef)
+// clang-format on
 }
 
 void export_WorkspaceFactory() {

--- a/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceFactory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceFactory.cpp
@@ -46,20 +46,20 @@ Workspace_sptr createFromParentPtr(WorkspaceFactoryImpl &self,
 }
 
 /// Overload generator for create
-DIAG_OFF("unknown-pragmas")
-DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unknown-pragmas")
+GNU_DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF("conversion")
+GNU_DIAG_OFF("conversion")
 
 BOOST_PYTHON_FUNCTION_OVERLOADS(createFromParent_Overload, createFromParentPtr,
                                 2, 5)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(createTable_Overload, createTable, 0, 1)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(createPeaks_Overload, createPeaks, 0, 1)
 
-DIAG_ON("conversion")
-DIAG_ON("unknown-pragmas")
-DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("unknown-pragmas")
+GNU_DIAG_ON("unused-local-typdef")
 }
 
 void export_WorkspaceFactory() {

--- a/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceFactory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceFactory.cpp
@@ -46,7 +46,6 @@ Workspace_sptr createFromParentPtr(WorkspaceFactoryImpl &self,
 }
 
 /// Overload generator for create
-GNU_DIAG_OFF("unknown-pragmas")
 GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
@@ -58,7 +57,6 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(createTable_Overload, createTable, 0, 1)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(createPeaks_Overload, createPeaks, 0, 1)
 
 GNU_DIAG_ON("conversion")
-GNU_DIAG_ON("unknown-pragmas")
 GNU_DIAG_ON("unused-local-typedef")
 }
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceFactory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceFactory.cpp
@@ -46,22 +46,20 @@ Workspace_sptr createFromParentPtr(WorkspaceFactoryImpl &self,
 }
 
 /// Overload generator for create
-// clang-format off
-DIAG_OFF(unknown-pragmas)
-DIAG_OFF(unused-local-typdef)
+DIAG_OFF("unknown-pragmas")
+DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF(conversion)
-// clang-format on
+DIAG_OFF("conversion")
+
 BOOST_PYTHON_FUNCTION_OVERLOADS(createFromParent_Overload, createFromParentPtr,
                                 2, 5)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(createTable_Overload, createTable, 0, 1)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(createPeaks_Overload, createPeaks, 0, 1)
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(unknown-pragmas)
-DIAG_ON(unused-local-typdef)
-// clang-format on
+
+DIAG_ON("conversion")
+DIAG_ON("unknown-pragmas")
+DIAG_ON("unused-local-typdef")
 }
 
 void export_WorkspaceFactory() {

--- a/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
@@ -1,13 +1,14 @@
 #include "MantidPythonInterface/api/PythonAlgorithm/AlgorithmAdapter.h"
-#include "MantidPythonInterface/kernel/Registry/PropertyWithValueFactory.h"
-#include "MantidPythonInterface/kernel/Environment/WrapperHelpers.h"
+#include "MantidAPI/DataProcessorAlgorithm.h"
+#include "MantidAPI/DistributedAlgorithm.h"
+#include "MantidAPI/ParallelAlgorithm.h"
+#include "MantidAPI/SerialAlgorithm.h"
+#include "MantidKernel/WarningSuppressions.h"
+#include "MantidPythonInterface/kernel/Converters/PySequenceToVector.h"
 #include "MantidPythonInterface/kernel/Environment/CallMethod.h"
 #include "MantidPythonInterface/kernel/Environment/GlobalInterpreterLock.h"
-#include "MantidPythonInterface/kernel/Converters/PySequenceToVector.h"
-#include "MantidAPI/DataProcessorAlgorithm.h"
-#include "MantidAPI/SerialAlgorithm.h"
-#include "MantidAPI/ParallelAlgorithm.h"
-#include "MantidAPI/DistributedAlgorithm.h"
+#include "MantidPythonInterface/kernel/Environment/WrapperHelpers.h"
+#include "MantidPythonInterface/kernel/Registry/PropertyWithValueFactory.h"
 
 #include <boost/python/class.hpp>
 #include <boost/python/dict.hpp>
@@ -145,10 +146,10 @@ bool AlgorithmAdapter<BaseAlgorithm>::isRunning() const {
     return SuperClass::isRunning();
   } else {
     Environment::GlobalInterpreterLock gil;
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wparentheses-equality"
-#endif
+
+    // clang-format off
+    DIAG_OFF(parentheses-equality)
+    // clang-format on
     PyObject *result = PyObject_CallObject(m_isRunningObj, nullptr);
     if (PyErr_Occurred())
       throw Environment::PythonException();
@@ -164,9 +165,9 @@ bool AlgorithmAdapter<BaseAlgorithm>::isRunning() const {
       throw std::runtime_error(
           "Algorithm.isRunning - Expected bool return type.");
   }
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+  // clang-format off
+  DIAG_ON(parentheses-equality)
+  // clang-format on
 }
 
 /**

--- a/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
@@ -145,19 +145,28 @@ bool AlgorithmAdapter<BaseAlgorithm>::isRunning() const {
     return SuperClass::isRunning();
   } else {
     Environment::GlobalInterpreterLock gil;
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wparentheses-equality"
+#endif
     PyObject *result = PyObject_CallObject(m_isRunningObj, nullptr);
     if (PyErr_Occurred())
       throw Environment::PythonException();
     if (PyBool_Check(result)) {
+
 #if PY_MAJOR_VERSION >= 3
       return static_cast<bool>(PyLong_AsLong(result));
 #else
       return static_cast<bool>(PyInt_AsLong(result));
 #endif
+
     } else
       throw std::runtime_error(
           "Algorithm.isRunning - Expected bool return type.");
   }
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 }
 
 /**

--- a/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
@@ -147,7 +147,7 @@ bool AlgorithmAdapter<BaseAlgorithm>::isRunning() const {
   } else {
     Environment::GlobalInterpreterLock gil;
 
-    DIAG_OFF("parentheses-equality")
+    GNU_DIAG_OFF("parentheses-equality")
     PyObject *result = PyObject_CallObject(m_isRunningObj, nullptr);
     if (PyErr_Occurred())
       throw Environment::PythonException();
@@ -163,7 +163,7 @@ bool AlgorithmAdapter<BaseAlgorithm>::isRunning() const {
       throw std::runtime_error(
           "Algorithm.isRunning - Expected bool return type.");
   }
-  DIAG_ON("parentheses-equality")
+  GNU_DIAG_ON("parentheses-equality")
 }
 
 /**

--- a/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
@@ -147,9 +147,7 @@ bool AlgorithmAdapter<BaseAlgorithm>::isRunning() const {
   } else {
     Environment::GlobalInterpreterLock gil;
 
-    // clang-format off
-    DIAG_OFF(parentheses-equality)
-    // clang-format on
+    DIAG_OFF("parentheses-equality")
     PyObject *result = PyObject_CallObject(m_isRunningObj, nullptr);
     if (PyErr_Occurred())
       throw Environment::PythonException();
@@ -165,9 +163,7 @@ bool AlgorithmAdapter<BaseAlgorithm>::isRunning() const {
       throw std::runtime_error(
           "Algorithm.isRunning - Expected bool return type.");
   }
-  // clang-format off
-  DIAG_ON(parentheses-equality)
-  // clang-format on
+  DIAG_ON("parentheses-equality")
 }
 
 /**

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
@@ -9,7 +9,7 @@ using namespace boost::python;
 
 namespace {
 GNU_DIAG_OFF("unknown-pragmas")
-GNU_DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
 GNU_DIAG_OFF("conversion")
@@ -45,7 +45,7 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParamDescription,
 
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unknown-pragmas")
-GNU_DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("unused-local-typedef")
 }
 void export_Component() {
   class_<Component, bases<IComponent>, boost::noncopyable>("Component", no_init)

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
@@ -8,11 +8,11 @@ using Mantid::Geometry::IComponent;
 using namespace boost::python;
 
 namespace {
-DIAG_OFF("unknown-pragmas")
-DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unknown-pragmas")
+GNU_DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF("conversion")
+GNU_DIAG_OFF("conversion")
 
 // Default parameter function overloads
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParameterNames,
@@ -43,9 +43,9 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParamShortDescription,
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParamDescription,
                                        Component::getParamDescription, 1, 2)
 
-DIAG_ON("conversion")
-DIAG_ON("unknown-pragmas")
-DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("unknown-pragmas")
+GNU_DIAG_ON("unused-local-typdef")
 }
 void export_Component() {
   class_<Component, bases<IComponent>, boost::noncopyable>("Component", no_init)

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
@@ -8,15 +8,14 @@ using Mantid::Geometry::IComponent;
 using namespace boost::python;
 
 namespace {
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic ignored "-Wunused-local-typedef"
-#endif
+// clang-format off
+DIAG_OFF(unknown-pragmas)
+DIAG_OFF(unused-local-typdef)
 
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-GCC_DIAG_OFF(conversion)
+DIAG_OFF(conversion)
+// clang-format on
 
 // Default parameter function overloads
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParameterNames,
@@ -47,11 +46,11 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParamShortDescription,
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParamDescription,
                                        Component::getParamDescription, 1, 2)
 
-GCC_DIAG_ON(conversion)
-
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+// clang-format off
+DIAG_ON(conversion)
+DIAG_ON(unknown-pragmas)
+DIAG_ON(unused-local-typdef)
+// clang-format on
 }
 void export_Component() {
   class_<Component, bases<IComponent>, boost::noncopyable>("Component", no_init)

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
@@ -8,14 +8,11 @@ using Mantid::Geometry::IComponent;
 using namespace boost::python;
 
 namespace {
-// clang-format off
-DIAG_OFF(unknown-pragmas)
-DIAG_OFF(unused-local-typdef)
-
+DIAG_OFF("unknown-pragmas")
+DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF(conversion)
-// clang-format on
+DIAG_OFF("conversion")
 
 // Default parameter function overloads
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParameterNames,
@@ -46,11 +43,9 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParamShortDescription,
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParamDescription,
                                        Component::getParamDescription, 1, 2)
 
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(unknown-pragmas)
-DIAG_ON(unused-local-typdef)
-// clang-format on
+DIAG_ON("conversion")
+DIAG_ON("unknown-pragmas")
+DIAG_ON("unused-local-typdef")
 }
 void export_Component() {
   class_<Component, bases<IComponent>, boost::noncopyable>("Component", no_init)

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
@@ -8,7 +8,6 @@ using Mantid::Geometry::IComponent;
 using namespace boost::python;
 
 namespace {
-GNU_DIAG_OFF("unknown-pragmas")
 GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
@@ -44,7 +43,6 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParamDescription,
                                        Component::getParamDescription, 1, 2)
 
 GNU_DIAG_ON("conversion")
-GNU_DIAG_ON("unknown-pragmas")
 GNU_DIAG_ON("unused-local-typedef")
 }
 void export_Component() {

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
@@ -16,7 +16,6 @@ using namespace boost::python;
 namespace //<unnamed>
     {
 ///@cond
-GNU_DIAG_OFF("unknown-pragmas")
 GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
@@ -25,7 +24,6 @@ GNU_DIAG_OFF("conversion")
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getEulerAngles_overloads,
                                        Goniometer::getEulerAngles, 0, 1)
 GNU_DIAG_ON("conversion")
-GNU_DIAG_ON("unknown-pragmas")
 GNU_DIAG_ON("unused-local-typedef")
 ///@endcond
 

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
@@ -16,21 +16,21 @@ using namespace boost::python;
 namespace //<unnamed>
     {
 ///@cond
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic ignored "-Wunused-local-typedef"
-#endif
+// clang-format off
+DIAG_OFF(unknown-pragmas)
+DIAG_OFF(unused-local-typdef)
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-GCC_DIAG_OFF(conversion)
+DIAG_OFF(conversion)
+// clang-format on
 // define overloaded functions
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getEulerAngles_overloads,
                                        Goniometer::getEulerAngles, 0, 1)
-GCC_DIAG_ON(conversion)
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+// clang-format off
+DIAG_ON(conversion)
+DIAG_ON(unknown-pragmas)
+DIAG_ON(unused-local-typdef)
+// clang-format on
 ///@endcond
 
 /// Set the U vector via a numpy array

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
@@ -16,21 +16,17 @@ using namespace boost::python;
 namespace //<unnamed>
     {
 ///@cond
-// clang-format off
-DIAG_OFF(unknown-pragmas)
-DIAG_OFF(unused-local-typdef)
+DIAG_OFF("unknown-pragmas")
+DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF(conversion)
-// clang-format on
+DIAG_OFF("conversion")
 // define overloaded functions
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getEulerAngles_overloads,
                                        Goniometer::getEulerAngles, 0, 1)
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(unknown-pragmas)
-DIAG_ON(unused-local-typdef)
-// clang-format on
+DIAG_ON("conversion")
+DIAG_ON("unknown-pragmas")
+DIAG_ON("unused-local-typdef")
 ///@endcond
 
 /// Set the U vector via a numpy array

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
@@ -17,7 +17,7 @@ namespace //<unnamed>
     {
 ///@cond
 GNU_DIAG_OFF("unknown-pragmas")
-GNU_DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
 GNU_DIAG_OFF("conversion")
@@ -26,7 +26,7 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getEulerAngles_overloads,
                                        Goniometer::getEulerAngles, 0, 1)
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unknown-pragmas")
-GNU_DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("unused-local-typedef")
 ///@endcond
 
 /// Set the U vector via a numpy array

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
@@ -16,17 +16,17 @@ using namespace boost::python;
 namespace //<unnamed>
     {
 ///@cond
-DIAG_OFF("unknown-pragmas")
-DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unknown-pragmas")
+GNU_DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF("conversion")
+GNU_DIAG_OFF("conversion")
 // define overloaded functions
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getEulerAngles_overloads,
                                        Goniometer::getEulerAngles, 0, 1)
-DIAG_ON("conversion")
-DIAG_ON("unknown-pragmas")
-DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("unknown-pragmas")
+GNU_DIAG_ON("unused-local-typdef")
 ///@endcond
 
 /// Set the U vector via a numpy array

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/IMDDimension.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/IMDDimension.cpp
@@ -15,9 +15,7 @@ using namespace boost::python;
 
 GET_POINTER_SPECIALIZATION(IMDDimension)
 
-// clang-format off
-DIAG_OFF(strict-aliasing)
-// clang-format on
+DIAG_OFF("strict-aliasing")
 
 namespace {
 /**

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/IMDDimension.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/IMDDimension.cpp
@@ -15,7 +15,7 @@ using namespace boost::python;
 
 GET_POINTER_SPECIALIZATION(IMDDimension)
 
-DIAG_OFF("strict-aliasing")
+GNU_DIAG_OFF("strict-aliasing")
 
 namespace {
 /**

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/IMDDimension.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/IMDDimension.cpp
@@ -16,7 +16,7 @@ using namespace boost::python;
 GET_POINTER_SPECIALIZATION(IMDDimension)
 
 // clang-format off
-GCC_DIAG_OFF(strict-aliasing)
+DIAG_OFF(strict-aliasing)
 // clang-format on
 
 namespace {

--- a/Framework/PythonInterface/mantid/kernel/src/Converters/DateAndTime.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Converters/DateAndTime.cpp
@@ -47,13 +47,9 @@ PyArray_Descr *descr_ns() { return func_PyArray_Descr("M8[ns]"); }
 // internal function that handles raw pointer
 boost::shared_ptr<Types::Core::DateAndTime>
 to_dateandtime(const PyObject *datetime) {
-  // clang-format off
-DIAG_OFF(cast-qual)
-  // clang-format on
+DIAG_OFF("cast-qual")
   if (!PyArray_IsScalar(datetime, Datetime)) {
-    // clang-format off
-DIAG_ON(cast-qual)
-    // clang-format on
+DIAG_ON("cast-qual")
     throw std::runtime_error("Expected datetime64");
   }
 

--- a/Framework/PythonInterface/mantid/kernel/src/Converters/DateAndTime.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Converters/DateAndTime.cpp
@@ -47,9 +47,9 @@ PyArray_Descr *descr_ns() { return func_PyArray_Descr("M8[ns]"); }
 // internal function that handles raw pointer
 boost::shared_ptr<Types::Core::DateAndTime>
 to_dateandtime(const PyObject *datetime) {
-DIAG_OFF("cast-qual")
+  GNU_DIAG_OFF("cast-qual")
   if (!PyArray_IsScalar(datetime, Datetime)) {
-DIAG_ON("cast-qual")
+    GNU_DIAG_ON("cast-qual")
     throw std::runtime_error("Expected datetime64");
   }
 

--- a/Framework/PythonInterface/mantid/kernel/src/Converters/DateAndTime.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Converters/DateAndTime.cpp
@@ -1,4 +1,5 @@
 #include "MantidPythonInterface/kernel/Converters/DateAndTime.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidPythonInterface/kernel/Converters/NumpyFunctions.h"
 #include <boost/make_shared.hpp>
 #include <boost/python.hpp>
@@ -46,14 +47,13 @@ PyArray_Descr *descr_ns() { return func_PyArray_Descr("M8[ns]"); }
 // internal function that handles raw pointer
 boost::shared_ptr<Types::Core::DateAndTime>
 to_dateandtime(const PyObject *datetime) {
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wcast-qual"
-#endif
+  // clang-format off
+DIAG_OFF(cast-qual)
+  // clang-format on
   if (!PyArray_IsScalar(datetime, Datetime)) {
-#if __clang__
-#pragma clang diagnostic pop
-#endif
+    // clang-format off
+DIAG_ON(cast-qual)
+    // clang-format on
     throw std::runtime_error("Expected datetime64");
   }
 

--- a/Framework/PythonInterface/mantid/kernel/src/Converters/PyObjectToVMD.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Converters/PyObjectToVMD.cpp
@@ -15,7 +15,7 @@ using boost::python::extract;
 using boost::python::object;
 using boost::python::len;
 
-DIAG_OFF("strict-aliasing")
+GNU_DIAG_OFF("strict-aliasing")
 
 namespace Mantid {
 namespace PythonInterface {

--- a/Framework/PythonInterface/mantid/kernel/src/Converters/PyObjectToVMD.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Converters/PyObjectToVMD.cpp
@@ -15,9 +15,7 @@ using boost::python::extract;
 using boost::python::object;
 using boost::python::len;
 
-// clang-format off
-DIAG_OFF(strict-aliasing)
-// clang-format on
+DIAG_OFF("strict-aliasing")
 
 namespace Mantid {
 namespace PythonInterface {

--- a/Framework/PythonInterface/mantid/kernel/src/Converters/PyObjectToVMD.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Converters/PyObjectToVMD.cpp
@@ -16,7 +16,7 @@ using boost::python::object;
 using boost::python::len;
 
 // clang-format off
-GCC_DIAG_OFF(strict-aliasing)
+DIAG_OFF(strict-aliasing)
 // clang-format on
 
 namespace Mantid {

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -33,7 +33,7 @@ std::string getStringUsingCache(ConfigServiceImpl &self,
 }
 
 GNU_DIAG_OFF("unknown-pragmas")
-GNU_DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
 GNU_DIAG_OFF("conversion")
@@ -45,7 +45,7 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getString_Overload, getString, 1, 2)
 
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unknown-pragmas")
-GNU_DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("unused-local-typedef")
 }
 
 void export_ConfigService() {

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -32,7 +32,6 @@ std::string getStringUsingCache(ConfigServiceImpl &self,
   return self.getString(key, true);
 }
 
-GNU_DIAG_OFF("unknown-pragmas")
 GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
@@ -44,7 +43,6 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getInstrument_Overload, getInstrument, 0,
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getString_Overload, getString, 1, 2)
 
 GNU_DIAG_ON("conversion")
-GNU_DIAG_ON("unknown-pragmas")
 GNU_DIAG_ON("unused-local-typedef")
 }
 

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -32,23 +32,20 @@ std::string getStringUsingCache(ConfigServiceImpl &self,
   return self.getString(key, true);
 }
 
-// clang-format off
-DIAG_OFF(unknown-pragmas)
-DIAG_OFF(unused-local-typdef)
+DIAG_OFF("unknown-pragmas")
+DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF(conversion)
-// clang-format on
+DIAG_OFF("conversion")
 /// Overload generator for getInstrument
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getInstrument_Overload, getInstrument, 0,
                                        1)
 /// Overload generator for getString
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getString_Overload, getString, 1, 2)
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(unknown-pragmas)
-DIAG_ON(unused-local-typdef)
-// clang-format on
+
+DIAG_ON("conversion")
+DIAG_ON("unknown-pragmas")
+DIAG_ON("unused-local-typdef")
 }
 
 void export_ConfigService() {

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -32,23 +32,23 @@ std::string getStringUsingCache(ConfigServiceImpl &self,
   return self.getString(key, true);
 }
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic ignored "-Wunused-local-typedef"
-#endif
+// clang-format off
+DIAG_OFF(unknown-pragmas)
+DIAG_OFF(unused-local-typdef)
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-GCC_DIAG_OFF(conversion)
+DIAG_OFF(conversion)
+// clang-format on
 /// Overload generator for getInstrument
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getInstrument_Overload, getInstrument, 0,
                                        1)
 /// Overload generator for getString
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getString_Overload, getString, 1, 2)
-GCC_DIAG_ON(conversion)
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+// clang-format off
+DIAG_ON(conversion)
+DIAG_ON(unknown-pragmas)
+DIAG_ON(unused-local-typdef)
+// clang-format on
 }
 
 void export_ConfigService() {

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -32,20 +32,20 @@ std::string getStringUsingCache(ConfigServiceImpl &self,
   return self.getString(key, true);
 }
 
-DIAG_OFF("unknown-pragmas")
-DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unknown-pragmas")
+GNU_DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF("conversion")
+GNU_DIAG_OFF("conversion")
 /// Overload generator for getInstrument
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getInstrument_Overload, getInstrument, 0,
                                        1)
 /// Overload generator for getString
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getString_Overload, getString, 1, 2)
 
-DIAG_ON("conversion")
-DIAG_ON("unknown-pragmas")
-DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("unknown-pragmas")
+GNU_DIAG_ON("unused-local-typdef")
 }
 
 void export_ConfigService() {

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Property.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Property.cpp
@@ -24,18 +24,18 @@ using Mantid::PythonInterface::std_vector_exporter;
 using namespace boost::python;
 
 GET_POINTER_SPECIALIZATION(Property)
-DIAG_OFF("unknown-pragmas")
-DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unknown-pragmas")
+GNU_DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF("conversion")
+GNU_DIAG_OFF("conversion")
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(valueAsPrettyStrOverloader,
 
                                        valueAsPrettyStr, 0, 2)
-DIAG_ON("conversion")
-DIAG_ON("unknown-pragmas")
-DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("unknown-pragmas")
+GNU_DIAG_ON("unused-local-typdef")
 
 void export_Property() {
   register_ptr_to_python<Property *>();

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Property.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Property.cpp
@@ -24,20 +24,18 @@ using Mantid::PythonInterface::std_vector_exporter;
 using namespace boost::python;
 
 GET_POINTER_SPECIALIZATION(Property)
-// clang-format off
-DIAG_OFF(unknown-pragmas)
-DIAG_OFF(unused-local-typdef)
+DIAG_OFF("unknown-pragmas")
+DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF(conversion)
-// clang-format on
+DIAG_OFF("conversion")
+
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(valueAsPrettyStrOverloader,
+
                                        valueAsPrettyStr, 0, 2)
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(unknown-pragmas)
-DIAG_ON(unused-local-typdef)
-// clang-format on
+DIAG_ON("conversion")
+DIAG_ON("unknown-pragmas")
+DIAG_ON("unused-local-typdef")
 
 void export_Property() {
   register_ptr_to_python<Property *>();

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Property.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Property.cpp
@@ -25,7 +25,7 @@ using namespace boost::python;
 
 GET_POINTER_SPECIALIZATION(Property)
 GNU_DIAG_OFF("unknown-pragmas")
-GNU_DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
 GNU_DIAG_OFF("conversion")
@@ -35,7 +35,7 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(valueAsPrettyStrOverloader,
                                        valueAsPrettyStr, 0, 2)
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unknown-pragmas")
-GNU_DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("unused-local-typedef")
 
 void export_Property() {
   register_ptr_to_python<Property *>();

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Property.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Property.cpp
@@ -24,19 +24,20 @@ using Mantid::PythonInterface::std_vector_exporter;
 using namespace boost::python;
 
 GET_POINTER_SPECIALIZATION(Property)
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-local-typedef"
-#endif
+// clang-format off
+DIAG_OFF(unknown-pragmas)
+DIAG_OFF(unused-local-typdef)
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-GCC_DIAG_OFF(conversion)
+DIAG_OFF(conversion)
+// clang-format on
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(valueAsPrettyStrOverloader,
                                        valueAsPrettyStr, 0, 2)
-GCC_DIAG_ON(conversion)
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+// clang-format off
+DIAG_ON(conversion)
+DIAG_ON(unknown-pragmas)
+DIAG_ON(unused-local-typdef)
+// clang-format on
 
 void export_Property() {
   register_ptr_to_python<Property *>();

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Property.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Property.cpp
@@ -24,7 +24,6 @@ using Mantid::PythonInterface::std_vector_exporter;
 using namespace boost::python;
 
 GET_POINTER_SPECIALIZATION(Property)
-GNU_DIAG_OFF("unknown-pragmas")
 GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
@@ -34,7 +33,6 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(valueAsPrettyStrOverloader,
 
                                        valueAsPrettyStr, 0, 2)
 GNU_DIAG_ON("conversion")
-GNU_DIAG_ON("unknown-pragmas")
 GNU_DIAG_ON("unused-local-typedef")
 
 void export_Property() {

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
@@ -97,7 +97,6 @@ Statistics getStatisticsNumpy(const NumPy::NdArray &data,
   }
 }
 
-GNU_DIAG_OFF("unknown-pragmas")
 GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
@@ -107,7 +106,6 @@ GNU_DIAG_OFF("conversion")
 BOOST_PYTHON_FUNCTION_OVERLOADS(getStatisticsOverloads, getStatisticsNumpy, 1,
                                 2)
 GNU_DIAG_ON("conversion")
-GNU_DIAG_ON("unknown-pragmas")
 GNU_DIAG_ON("unused-local-typedef")
 //============================ Z score
 //============================================
@@ -157,7 +155,6 @@ std::vector<double> getModifiedZscoreNumpy(const NumPy::NdArray &data,
   }
 }
 
-GNU_DIAG_OFF("unknown-pragmas")
 GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
@@ -167,7 +164,6 @@ GNU_DIAG_OFF("conversion")
 BOOST_PYTHON_FUNCTION_OVERLOADS(getModifiedZscoreOverloads,
                                 getModifiedZscoreNumpy, 1, 2)
 GNU_DIAG_ON("conversion")
-GNU_DIAG_ON("unknown-pragmas")
 GNU_DIAG_ON("unused-local-typedef")
 
 //============================ getMoments
@@ -219,7 +215,6 @@ std::vector<double> getMomentsAboutOriginNumpy(const NumPy::NdArray &indep,
   return getMomentsNumpyImpl(&getMomentsAboutOrigin, indep, depend, maxMoment);
 }
 
-GNU_DIAG_OFF("unknown-pragmas")
 GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
@@ -228,7 +223,6 @@ GNU_DIAG_OFF("conversion")
 BOOST_PYTHON_FUNCTION_OVERLOADS(getMomentsAboutOriginOverloads,
                                 getMomentsAboutOriginNumpy, 2, 3)
 GNU_DIAG_ON("conversion")
-GNU_DIAG_ON("unknown-pragmas")
 GNU_DIAG_ON("unused-local-typedef")
 /**
  * Proxy for @see Mantid::Kernel::getMomentsAboutMean so that it can accept
@@ -241,7 +235,6 @@ std::vector<double> getMomentsAboutMeanNumpy(const NumPy::NdArray &indep,
   return getMomentsNumpyImpl(&getMomentsAboutMean, indep, depend, maxMoment);
 }
 
-GNU_DIAG_OFF("unknown-pragmas")
 GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
@@ -250,7 +243,6 @@ GNU_DIAG_OFF("conversion")
 BOOST_PYTHON_FUNCTION_OVERLOADS(getMomentsAboutMeanOverloads,
                                 getMomentsAboutMeanNumpy, 2, 3)
 GNU_DIAG_ON("conversion")
-GNU_DIAG_ON("unknown-pragmas")
 GNU_DIAG_ON("unused-local-typedef")
 
 ///@endcond

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
@@ -97,18 +97,18 @@ Statistics getStatisticsNumpy(const NumPy::NdArray &data,
   }
 }
 
-DIAG_OFF("unknown-pragmas")
-DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unknown-pragmas")
+GNU_DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF("conversion")
+GNU_DIAG_OFF("conversion")
 
 // Define an overload to handle the default argument
 BOOST_PYTHON_FUNCTION_OVERLOADS(getStatisticsOverloads, getStatisticsNumpy, 1,
                                 2)
-DIAG_ON("conversion")
-DIAG_ON("unknown-pragmas")
-DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("unknown-pragmas")
+GNU_DIAG_ON("unused-local-typdef")
 //============================ Z score
 //============================================
 
@@ -157,18 +157,18 @@ std::vector<double> getModifiedZscoreNumpy(const NumPy::NdArray &data,
   }
 }
 
-DIAG_OFF("unknown-pragmas")
-DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unknown-pragmas")
+GNU_DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF("conversion")
+GNU_DIAG_OFF("conversion")
 
 // Define an overload to handle the default argument
 BOOST_PYTHON_FUNCTION_OVERLOADS(getModifiedZscoreOverloads,
                                 getModifiedZscoreNumpy, 1, 2)
-DIAG_ON("conversion")
-DIAG_ON("unknown-pragmas")
-DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("unknown-pragmas")
+GNU_DIAG_ON("unused-local-typdef")
 
 //============================ getMoments
 //============================================
@@ -219,17 +219,17 @@ std::vector<double> getMomentsAboutOriginNumpy(const NumPy::NdArray &indep,
   return getMomentsNumpyImpl(&getMomentsAboutOrigin, indep, depend, maxMoment);
 }
 
-DIAG_OFF("unknown-pragmas")
-DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unknown-pragmas")
+GNU_DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF("conversion")
+GNU_DIAG_OFF("conversion")
 // Define an overload to handle the default argument
 BOOST_PYTHON_FUNCTION_OVERLOADS(getMomentsAboutOriginOverloads,
                                 getMomentsAboutOriginNumpy, 2, 3)
-DIAG_ON("conversion")
-DIAG_ON("unknown-pragmas")
-DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("unknown-pragmas")
+GNU_DIAG_ON("unused-local-typdef")
 /**
  * Proxy for @see Mantid::Kernel::getMomentsAboutMean so that it can accept
  * numpy arrays
@@ -241,17 +241,17 @@ std::vector<double> getMomentsAboutMeanNumpy(const NumPy::NdArray &indep,
   return getMomentsNumpyImpl(&getMomentsAboutMean, indep, depend, maxMoment);
 }
 
-DIAG_OFF("unknown-pragmas")
-DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unknown-pragmas")
+GNU_DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF("conversion")
+GNU_DIAG_OFF("conversion")
 // Define an overload to handle the default argument
 BOOST_PYTHON_FUNCTION_OVERLOADS(getMomentsAboutMeanOverloads,
                                 getMomentsAboutMeanNumpy, 2, 3)
-DIAG_ON("conversion")
-DIAG_ON("unknown-pragmas")
-DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("unknown-pragmas")
+GNU_DIAG_ON("unused-local-typdef")
 
 ///@endcond
 }

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
@@ -97,21 +97,18 @@ Statistics getStatisticsNumpy(const NumPy::NdArray &data,
   }
 }
 
-// clang-format off
-DIAG_OFF(unknown-pragmas)
-DIAG_OFF(unused-local-typdef)
+DIAG_OFF("unknown-pragmas")
+DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF(conversion)
-// clang-format on
+DIAG_OFF("conversion")
+
 // Define an overload to handle the default argument
 BOOST_PYTHON_FUNCTION_OVERLOADS(getStatisticsOverloads, getStatisticsNumpy, 1,
                                 2)
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(unknown-pragmas)
-DIAG_ON(unused-local-typdef)
-// clang-format on
+DIAG_ON("conversion")
+DIAG_ON("unknown-pragmas")
+DIAG_ON("unused-local-typdef")
 //============================ Z score
 //============================================
 
@@ -160,21 +157,18 @@ std::vector<double> getModifiedZscoreNumpy(const NumPy::NdArray &data,
   }
 }
 
-// clang-format off
-DIAG_OFF(unknown-pragmas)
-DIAG_OFF(unused-local-typdef)
+DIAG_OFF("unknown-pragmas")
+DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF(conversion)
-// clang-format on
+DIAG_OFF("conversion")
+
 // Define an overload to handle the default argument
 BOOST_PYTHON_FUNCTION_OVERLOADS(getModifiedZscoreOverloads,
                                 getModifiedZscoreNumpy, 1, 2)
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(unknown-pragmas)
-DIAG_ON(unused-local-typdef)
-// clang-format on
+DIAG_ON("conversion")
+DIAG_ON("unknown-pragmas")
+DIAG_ON("unused-local-typdef")
 
 //============================ getMoments
 //============================================
@@ -225,21 +219,17 @@ std::vector<double> getMomentsAboutOriginNumpy(const NumPy::NdArray &indep,
   return getMomentsNumpyImpl(&getMomentsAboutOrigin, indep, depend, maxMoment);
 }
 
-// clang-format off
-DIAG_OFF(unknown-pragmas)
-DIAG_OFF(unused-local-typdef)
+DIAG_OFF("unknown-pragmas")
+DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF(conversion)
-// clang-format on
+DIAG_OFF("conversion")
 // Define an overload to handle the default argument
 BOOST_PYTHON_FUNCTION_OVERLOADS(getMomentsAboutOriginOverloads,
                                 getMomentsAboutOriginNumpy, 2, 3)
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(unknown-pragmas)
-DIAG_ON(unused-local-typdef)
-// clang-format on
+DIAG_ON("conversion")
+DIAG_ON("unknown-pragmas")
+DIAG_ON("unused-local-typdef")
 /**
  * Proxy for @see Mantid::Kernel::getMomentsAboutMean so that it can accept
  * numpy arrays
@@ -251,21 +241,17 @@ std::vector<double> getMomentsAboutMeanNumpy(const NumPy::NdArray &indep,
   return getMomentsNumpyImpl(&getMomentsAboutMean, indep, depend, maxMoment);
 }
 
-// clang-format off
-DIAG_OFF(unknown-pragmas)
-DIAG_OFF(unused-local-typdef)
+DIAG_OFF("unknown-pragmas")
+DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF(conversion)
-// clang-format on
+DIAG_OFF("conversion")
 // Define an overload to handle the default argument
 BOOST_PYTHON_FUNCTION_OVERLOADS(getMomentsAboutMeanOverloads,
                                 getMomentsAboutMeanNumpy, 2, 3)
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(unknown-pragmas)
-DIAG_ON(unused-local-typdef)
-// clang-format on
+DIAG_ON("conversion")
+DIAG_ON("unknown-pragmas")
+DIAG_ON("unused-local-typdef")
 
 ///@endcond
 }

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
@@ -97,21 +97,21 @@ Statistics getStatisticsNumpy(const NumPy::NdArray &data,
   }
 }
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic ignored "-Wunused-local-typedef"
-#endif
+// clang-format off
+DIAG_OFF(unknown-pragmas)
+DIAG_OFF(unused-local-typdef)
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-GCC_DIAG_OFF(conversion)
+DIAG_OFF(conversion)
+// clang-format on
 // Define an overload to handle the default argument
 BOOST_PYTHON_FUNCTION_OVERLOADS(getStatisticsOverloads, getStatisticsNumpy, 1,
                                 2)
-GCC_DIAG_ON(conversion)
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+// clang-format off
+DIAG_ON(conversion)
+DIAG_ON(unknown-pragmas)
+DIAG_ON(unused-local-typdef)
+// clang-format on
 //============================ Z score
 //============================================
 
@@ -160,21 +160,21 @@ std::vector<double> getModifiedZscoreNumpy(const NumPy::NdArray &data,
   }
 }
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic ignored "-Wunused-local-typedef"
-#endif
+// clang-format off
+DIAG_OFF(unknown-pragmas)
+DIAG_OFF(unused-local-typdef)
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-GCC_DIAG_OFF(conversion)
+DIAG_OFF(conversion)
+// clang-format on
 // Define an overload to handle the default argument
 BOOST_PYTHON_FUNCTION_OVERLOADS(getModifiedZscoreOverloads,
                                 getModifiedZscoreNumpy, 1, 2)
-GCC_DIAG_ON(conversion)
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+// clang-format off
+DIAG_ON(conversion)
+DIAG_ON(unknown-pragmas)
+DIAG_ON(unused-local-typdef)
+// clang-format on
 
 //============================ getMoments
 //============================================
@@ -225,21 +225,21 @@ std::vector<double> getMomentsAboutOriginNumpy(const NumPy::NdArray &indep,
   return getMomentsNumpyImpl(&getMomentsAboutOrigin, indep, depend, maxMoment);
 }
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic ignored "-Wunused-local-typedef"
-#endif
+// clang-format off
+DIAG_OFF(unknown-pragmas)
+DIAG_OFF(unused-local-typdef)
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-GCC_DIAG_OFF(conversion)
+DIAG_OFF(conversion)
+// clang-format on
 // Define an overload to handle the default argument
 BOOST_PYTHON_FUNCTION_OVERLOADS(getMomentsAboutOriginOverloads,
                                 getMomentsAboutOriginNumpy, 2, 3)
-GCC_DIAG_ON(conversion)
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+// clang-format off
+DIAG_ON(conversion)
+DIAG_ON(unknown-pragmas)
+DIAG_ON(unused-local-typdef)
+// clang-format on
 /**
  * Proxy for @see Mantid::Kernel::getMomentsAboutMean so that it can accept
  * numpy arrays
@@ -251,21 +251,21 @@ std::vector<double> getMomentsAboutMeanNumpy(const NumPy::NdArray &indep,
   return getMomentsNumpyImpl(&getMomentsAboutMean, indep, depend, maxMoment);
 }
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic ignored "-Wunused-local-typedef"
-#endif
+// clang-format off
+DIAG_OFF(unknown-pragmas)
+DIAG_OFF(unused-local-typdef)
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-GCC_DIAG_OFF(conversion)
+DIAG_OFF(conversion)
+// clang-format on
 // Define an overload to handle the default argument
 BOOST_PYTHON_FUNCTION_OVERLOADS(getMomentsAboutMeanOverloads,
                                 getMomentsAboutMeanNumpy, 2, 3)
-GCC_DIAG_ON(conversion)
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+// clang-format off
+DIAG_ON(conversion)
+DIAG_ON(unknown-pragmas)
+DIAG_ON(unused-local-typdef)
+// clang-format on
 
 ///@endcond
 }

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
@@ -98,7 +98,7 @@ Statistics getStatisticsNumpy(const NumPy::NdArray &data,
 }
 
 GNU_DIAG_OFF("unknown-pragmas")
-GNU_DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
 GNU_DIAG_OFF("conversion")
@@ -108,7 +108,7 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(getStatisticsOverloads, getStatisticsNumpy, 1,
                                 2)
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unknown-pragmas")
-GNU_DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("unused-local-typedef")
 //============================ Z score
 //============================================
 
@@ -158,7 +158,7 @@ std::vector<double> getModifiedZscoreNumpy(const NumPy::NdArray &data,
 }
 
 GNU_DIAG_OFF("unknown-pragmas")
-GNU_DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
 GNU_DIAG_OFF("conversion")
@@ -168,7 +168,7 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(getModifiedZscoreOverloads,
                                 getModifiedZscoreNumpy, 1, 2)
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unknown-pragmas")
-GNU_DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("unused-local-typedef")
 
 //============================ getMoments
 //============================================
@@ -220,7 +220,7 @@ std::vector<double> getMomentsAboutOriginNumpy(const NumPy::NdArray &indep,
 }
 
 GNU_DIAG_OFF("unknown-pragmas")
-GNU_DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
 GNU_DIAG_OFF("conversion")
@@ -229,7 +229,7 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(getMomentsAboutOriginOverloads,
                                 getMomentsAboutOriginNumpy, 2, 3)
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unknown-pragmas")
-GNU_DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("unused-local-typedef")
 /**
  * Proxy for @see Mantid::Kernel::getMomentsAboutMean so that it can accept
  * numpy arrays
@@ -242,7 +242,7 @@ std::vector<double> getMomentsAboutMeanNumpy(const NumPy::NdArray &indep,
 }
 
 GNU_DIAG_OFF("unknown-pragmas")
-GNU_DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
 GNU_DIAG_OFF("conversion")
@@ -251,7 +251,7 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(getMomentsAboutMeanOverloads,
                                 getMomentsAboutMeanNumpy, 2, 3)
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unknown-pragmas")
-GNU_DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("unused-local-typedef")
 
 ///@endcond
 }

--- a/Framework/PythonInterface/mantid/kernel/src/Registry/PropertyWithValueFactory.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Registry/PropertyWithValueFactory.cpp
@@ -187,7 +187,7 @@ const std::string PropertyWithValueFactory::isArray(PyObject *const object) {
 
     PyObject *item = PySequence_Fast_GET_ITEM(object, 0);
     // Boolean can be cast to int, so check first.
-    DIAG_OFF("parentheses-equality")
+    GNU_DIAG_OFF("parentheses-equality")
     if (PyBool_Check(item)) {
       throw std::runtime_error(
           "Unable to support extracting arrays of booleans.");
@@ -195,7 +195,7 @@ const std::string PropertyWithValueFactory::isArray(PyObject *const object) {
     if (PyLong_Check(item)) {
       return std::string("LongIntArray");
     }
-    DIAG_ON("parentheses-equality")
+    GNU_DIAG_ON("parentheses-equality")
 
 #if PY_MAJOR_VERSION < 3
     // In python 2 ints & longs are separate

--- a/Framework/PythonInterface/mantid/kernel/src/Registry/PropertyWithValueFactory.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Registry/PropertyWithValueFactory.cpp
@@ -187,9 +187,7 @@ const std::string PropertyWithValueFactory::isArray(PyObject *const object) {
 
     PyObject *item = PySequence_Fast_GET_ITEM(object, 0);
     // Boolean can be cast to int, so check first.
-    // clang-format off
-    DIAG_OFF(parentheses-equality)
-    // clang-format on
+    DIAG_OFF("parentheses-equality")
     if (PyBool_Check(item)) {
       throw std::runtime_error(
           "Unable to support extracting arrays of booleans.");
@@ -197,9 +195,7 @@ const std::string PropertyWithValueFactory::isArray(PyObject *const object) {
     if (PyLong_Check(item)) {
       return std::string("LongIntArray");
     }
-    // clang-format off
-    DIAG_ON(parentheses-equality)
-// clang-format on
+    DIAG_ON("parentheses-equality")
 
 #if PY_MAJOR_VERSION < 3
     // In python 2 ints & longs are separate

--- a/Framework/PythonInterface/mantid/kernel/src/Registry/PropertyWithValueFactory.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Registry/PropertyWithValueFactory.cpp
@@ -2,10 +2,11 @@
 // Includes
 //-----------------------------------------------------------------------------
 #include "MantidPythonInterface/kernel/Registry/PropertyWithValueFactory.h"
-#include "MantidPythonInterface/kernel/Registry/MappingTypeHandler.h"
-#include "MantidPythonInterface/kernel/Registry/TypedPropertyValueHandler.h"
-#include "MantidPythonInterface/kernel/Registry/SequenceTypeHandler.h"
 #include "MantidKernel/PropertyWithValue.h"
+#include "MantidKernel/WarningSuppressions.h"
+#include "MantidPythonInterface/kernel/Registry/MappingTypeHandler.h"
+#include "MantidPythonInterface/kernel/Registry/SequenceTypeHandler.h"
+#include "MantidPythonInterface/kernel/Registry/TypedPropertyValueHandler.h"
 
 #include <boost/make_shared.hpp>
 
@@ -186,10 +187,9 @@ const std::string PropertyWithValueFactory::isArray(PyObject *const object) {
 
     PyObject *item = PySequence_Fast_GET_ITEM(object, 0);
     // Boolean can be cast to int, so check first.
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wparentheses-equality"
-#endif
+    // clang-format off
+    DIAG_OFF(parentheses-equality)
+    // clang-format on
     if (PyBool_Check(item)) {
       throw std::runtime_error(
           "Unable to support extracting arrays of booleans.");
@@ -197,9 +197,9 @@ const std::string PropertyWithValueFactory::isArray(PyObject *const object) {
     if (PyLong_Check(item)) {
       return std::string("LongIntArray");
     }
-#if __clang__
-#pragma clang diagnostic pop
-#endif
+    // clang-format off
+    DIAG_ON(parentheses-equality)
+// clang-format on
 
 #if PY_MAJOR_VERSION < 3
     // In python 2 ints & longs are separate

--- a/Framework/PythonInterface/mantid/kernel/src/Registry/PropertyWithValueFactory.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Registry/PropertyWithValueFactory.cpp
@@ -186,6 +186,10 @@ const std::string PropertyWithValueFactory::isArray(PyObject *const object) {
 
     PyObject *item = PySequence_Fast_GET_ITEM(object, 0);
     // Boolean can be cast to int, so check first.
+#if __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wparentheses-equality"
+#endif
     if (PyBool_Check(item)) {
       throw std::runtime_error(
           "Unable to support extracting arrays of booleans.");
@@ -193,6 +197,10 @@ const std::string PropertyWithValueFactory::isArray(PyObject *const object) {
     if (PyLong_Check(item)) {
       return std::string("LongIntArray");
     }
+#if __clang__
+#pragma clang diagnostic pop
+#endif
+
 #if PY_MAJOR_VERSION < 3
     // In python 2 ints & longs are separate
     if (PyInt_Check(item)) {

--- a/Framework/PythonInterface/test/testhelpers/WorkspaceCreationHelperModule.cpp
+++ b/Framework/PythonInterface/test/testhelpers/WorkspaceCreationHelperModule.cpp
@@ -22,7 +22,6 @@ using namespace Mantid::DataObjects::MDEventsTestHelper;
 using namespace Mantid::PythonInterface::Policies;
 using namespace WorkspaceCreationHelper;
 
-GNU_DIAG_OFF("unknown-pragmas")
 GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
@@ -37,7 +36,6 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(
     create2DWorkspaceWithRectangularInstrument_overloads,
     create2DWorkspaceWithRectangularInstrument, 3, 3)
 GNU_DIAG_ON("conversion")
-GNU_DIAG_ON("unknown-pragmas")
 GNU_DIAG_ON("unused-local-typedef")
 
 BOOST_PYTHON_MODULE(WorkspaceCreationHelper) {

--- a/Framework/PythonInterface/test/testhelpers/WorkspaceCreationHelperModule.cpp
+++ b/Framework/PythonInterface/test/testhelpers/WorkspaceCreationHelperModule.cpp
@@ -23,7 +23,7 @@ using namespace Mantid::PythonInterface::Policies;
 using namespace WorkspaceCreationHelper;
 
 GNU_DIAG_OFF("unknown-pragmas")
-GNU_DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
 GNU_DIAG_OFF("conversion")
@@ -38,7 +38,7 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(
     create2DWorkspaceWithRectangularInstrument, 3, 3)
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unknown-pragmas")
-GNU_DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("unused-local-typedef")
 
 BOOST_PYTHON_MODULE(WorkspaceCreationHelper) {
   using namespace boost::python;

--- a/Framework/PythonInterface/test/testhelpers/WorkspaceCreationHelperModule.cpp
+++ b/Framework/PythonInterface/test/testhelpers/WorkspaceCreationHelperModule.cpp
@@ -22,14 +22,13 @@ using namespace Mantid::DataObjects::MDEventsTestHelper;
 using namespace Mantid::PythonInterface::Policies;
 using namespace WorkspaceCreationHelper;
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic ignored "-Wunused-local-typedef"
-#endif
+// clang-format off
+DIAG_OFF(unknown-pragmas)
+DIAG_OFF(unused-local-typdef)
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-GCC_DIAG_OFF(conversion)
+DIAG_OFF(conversion)
+// clang-format on
 BOOST_PYTHON_FUNCTION_OVERLOADS(create2DWorkspaceWithFullInstrument_overloads,
                                 create2DWorkspaceWithFullInstrument, 2, 4)
 
@@ -39,10 +38,11 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(makeFakeMDHistoWorkspace_overloads,
 BOOST_PYTHON_FUNCTION_OVERLOADS(
     create2DWorkspaceWithRectangularInstrument_overloads,
     create2DWorkspaceWithRectangularInstrument, 3, 3)
-GCC_DIAG_ON(conversion)
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+// clang-format off
+DIAG_ON(conversion)
+DIAG_ON(unknown-pragmas)
+DIAG_ON(unused-local-typdef)
+// clang-format on
 
 BOOST_PYTHON_MODULE(WorkspaceCreationHelper) {
   using namespace boost::python;

--- a/Framework/PythonInterface/test/testhelpers/WorkspaceCreationHelperModule.cpp
+++ b/Framework/PythonInterface/test/testhelpers/WorkspaceCreationHelperModule.cpp
@@ -22,11 +22,11 @@ using namespace Mantid::DataObjects::MDEventsTestHelper;
 using namespace Mantid::PythonInterface::Policies;
 using namespace WorkspaceCreationHelper;
 
-DIAG_OFF("unknown-pragmas")
-DIAG_OFF("unused-local-typdef")
+GNU_DIAG_OFF("unknown-pragmas")
+GNU_DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF("conversion")
+GNU_DIAG_OFF("conversion")
 BOOST_PYTHON_FUNCTION_OVERLOADS(create2DWorkspaceWithFullInstrument_overloads,
                                 create2DWorkspaceWithFullInstrument, 2, 4)
 
@@ -36,9 +36,9 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(makeFakeMDHistoWorkspace_overloads,
 BOOST_PYTHON_FUNCTION_OVERLOADS(
     create2DWorkspaceWithRectangularInstrument_overloads,
     create2DWorkspaceWithRectangularInstrument, 3, 3)
-DIAG_ON("conversion")
-DIAG_ON("unknown-pragmas")
-DIAG_ON("unused-local-typdef")
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("unknown-pragmas")
+GNU_DIAG_ON("unused-local-typdef")
 
 BOOST_PYTHON_MODULE(WorkspaceCreationHelper) {
   using namespace boost::python;

--- a/Framework/PythonInterface/test/testhelpers/WorkspaceCreationHelperModule.cpp
+++ b/Framework/PythonInterface/test/testhelpers/WorkspaceCreationHelperModule.cpp
@@ -22,13 +22,11 @@ using namespace Mantid::DataObjects::MDEventsTestHelper;
 using namespace Mantid::PythonInterface::Policies;
 using namespace WorkspaceCreationHelper;
 
-// clang-format off
-DIAG_OFF(unknown-pragmas)
-DIAG_OFF(unused-local-typdef)
+DIAG_OFF("unknown-pragmas")
+DIAG_OFF("unused-local-typdef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-DIAG_OFF(conversion)
-// clang-format on
+DIAG_OFF("conversion")
 BOOST_PYTHON_FUNCTION_OVERLOADS(create2DWorkspaceWithFullInstrument_overloads,
                                 create2DWorkspaceWithFullInstrument, 2, 4)
 
@@ -38,11 +36,9 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(makeFakeMDHistoWorkspace_overloads,
 BOOST_PYTHON_FUNCTION_OVERLOADS(
     create2DWorkspaceWithRectangularInstrument_overloads,
     create2DWorkspaceWithRectangularInstrument, 3, 3)
-// clang-format off
-DIAG_ON(conversion)
-DIAG_ON(unknown-pragmas)
-DIAG_ON(unused-local-typdef)
-// clang-format on
+DIAG_ON("conversion")
+DIAG_ON("unknown-pragmas")
+DIAG_ON("unused-local-typdef")
 
 BOOST_PYTHON_MODULE(WorkspaceCreationHelper) {
   using namespace boost::python;

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiMockInstrumentHelpers.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiMockInstrumentHelpers.h
@@ -53,14 +53,14 @@ public:
   void loadConfiguration(Instrument_const_sptr poldiInstrument) override {
     UNUSED_ARG(poldiInstrument);
   }
-  DIAG_OFF_SUGGEST_OVERRIDE
+  GNU_DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD0(efficiency, double());
   MOCK_METHOD1(twoTheta, double(int elementIndex));
   MOCK_METHOD1(distanceFromSample, double(int elementIndex));
   MOCK_METHOD0(elementCount, size_t());
   MOCK_METHOD0(centralElement, size_t());
   MOCK_METHOD2(qLimits, DoublePair(double lambdaMin, double lambdaMax));
-  DIAG_ON_SUGGEST_OVERRIDE
+  GNU_DIAG_ON_SUGGEST_OVERRIDE
 
   const std::vector<int> &availableElements() override {
     return m_availableElements;
@@ -105,14 +105,14 @@ public:
   void loadConfiguration(Instrument_const_sptr poldiInstrument) override {
     UNUSED_ARG(poldiInstrument)
   }
-  DIAG_OFF_SUGGEST_OVERRIDE
+  GNU_DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD0(rotationSpeed, double());
   MOCK_METHOD0(cycleTime, double());
   MOCK_METHOD0(zeroOffset, double());
   MOCK_METHOD0(distanceFromSample, double());
 
   MOCK_METHOD1(setRotationSpeed, void(double rotationSpeed));
-  DIAG_ON_SUGGEST_OVERRIDE
+  GNU_DIAG_ON_SUGGEST_OVERRIDE
 
   const std::vector<double> &slitPositions() override {
     return m_slitPositions;

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiMockInstrumentHelpers.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiMockInstrumentHelpers.h
@@ -53,14 +53,14 @@ public:
   void loadConfiguration(Instrument_const_sptr poldiInstrument) override {
     UNUSED_ARG(poldiInstrument);
   }
-  GCC_DIAG_OFF_SUGGEST_OVERRIDE
+  DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD0(efficiency, double());
   MOCK_METHOD1(twoTheta, double(int elementIndex));
   MOCK_METHOD1(distanceFromSample, double(int elementIndex));
   MOCK_METHOD0(elementCount, size_t());
   MOCK_METHOD0(centralElement, size_t());
   MOCK_METHOD2(qLimits, DoublePair(double lambdaMin, double lambdaMax));
-  GCC_DIAG_ON_SUGGEST_OVERRIDE
+  DIAG_ON_SUGGEST_OVERRIDE
 
   const std::vector<int> &availableElements() override {
     return m_availableElements;
@@ -105,14 +105,14 @@ public:
   void loadConfiguration(Instrument_const_sptr poldiInstrument) override {
     UNUSED_ARG(poldiInstrument)
   }
-  GCC_DIAG_OFF_SUGGEST_OVERRIDE
+  DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD0(rotationSpeed, double());
   MOCK_METHOD0(cycleTime, double());
   MOCK_METHOD0(zeroOffset, double());
   MOCK_METHOD0(distanceFromSample, double());
 
   MOCK_METHOD1(setRotationSpeed, void(double rotationSpeed));
-  GCC_DIAG_ON_SUGGEST_OVERRIDE
+  DIAG_ON_SUGGEST_OVERRIDE
 
   const std::vector<double> &slitPositions() override {
     return m_slitPositions;

--- a/Framework/SINQ/test/PoldiSpectrumPawleyFunctionTest.h
+++ b/Framework/SINQ/test/PoldiSpectrumPawleyFunctionTest.h
@@ -21,7 +21,7 @@ using Mantid::Kernel::V3D;
 using ::testing::_;
 using ::testing::Mock;
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockPawleyFunction : public IPawleyFunction {
 public:
@@ -45,7 +45,7 @@ public:
 
   MOCK_METHOD4(setMatrixWorkspace,
                void(MatrixWorkspace_const_sptr, size_t, double, double));
-  DIAG_ON_SUGGEST_OVERRIDE
+  GNU_DIAG_ON_SUGGEST_OVERRIDE
 protected:
   void init() override { setDecoratedFunction("Gaussian"); }
 };

--- a/Framework/SINQ/test/PoldiSpectrumPawleyFunctionTest.h
+++ b/Framework/SINQ/test/PoldiSpectrumPawleyFunctionTest.h
@@ -21,7 +21,7 @@ using Mantid::Kernel::V3D;
 using ::testing::_;
 using ::testing::Mock;
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockPawleyFunction : public IPawleyFunction {
 public:
@@ -45,7 +45,7 @@ public:
 
   MOCK_METHOD4(setMatrixWorkspace,
                void(MatrixWorkspace_const_sptr, size_t, double, double));
-  GCC_DIAG_ON_SUGGEST_OVERRIDE
+  DIAG_ON_SUGGEST_OVERRIDE
 protected:
   void init() override { setDecoratedFunction("Gaussian"); }
 };

--- a/MantidPlot/src/PythonScript.cpp
+++ b/MantidPlot/src/PythonScript.cpp
@@ -539,7 +539,14 @@ QVariant PythonScript::evaluateImpl() {
     }
   }
   /* bool */
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wparentheses-equality"
+#endif
   else if (PyBool_Check(pyret)) {
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
     qret = QVariant(pyret == Py_True);
   }
   // could handle advanced types (such as PyList->QValueList) here if needed

--- a/MantidPlot/src/PythonScript.cpp
+++ b/MantidPlot/src/PythonScript.cpp
@@ -32,6 +32,7 @@
 #endif
 
 #include "PythonScript.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "PythonScripting.h"
 
 #include "sipAPI_qti.h"
@@ -539,14 +540,13 @@ QVariant PythonScript::evaluateImpl() {
     }
   }
   /* bool */
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wparentheses-equality"
-#endif
+  // clang-format off
+  DIAG_OFF(parentheses-equality)
+  // clang-format on
   else if (PyBool_Check(pyret)) {
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+    // clang-format off
+  DIAG_ON(parentheses-equality)
+    // clang-format on
     qret = QVariant(pyret == Py_True);
   }
   // could handle advanced types (such as PyList->QValueList) here if needed

--- a/MantidPlot/src/PythonScript.cpp
+++ b/MantidPlot/src/PythonScript.cpp
@@ -540,13 +540,9 @@ QVariant PythonScript::evaluateImpl() {
     }
   }
   /* bool */
-  // clang-format off
-  DIAG_OFF(parentheses-equality)
-  // clang-format on
+  DIAG_OFF("parentheses-equality")
   else if (PyBool_Check(pyret)) {
-    // clang-format off
-  DIAG_ON(parentheses-equality)
-    // clang-format on
+  DIAG_ON("parentheses-equality")
     qret = QVariant(pyret == Py_True);
   }
   // could handle advanced types (such as PyList->QValueList) here if needed

--- a/MantidPlot/src/PythonScript.cpp
+++ b/MantidPlot/src/PythonScript.cpp
@@ -540,9 +540,9 @@ QVariant PythonScript::evaluateImpl() {
     }
   }
   /* bool */
-  DIAG_OFF("parentheses-equality")
+  GNU_DIAG_OFF("parentheses-equality")
   else if (PyBool_Check(pyret)) {
-  DIAG_ON("parentheses-equality")
+    GNU_DIAG_ON("parentheses-equality")
     qret = QVariant(pyret == Py_True);
   }
   // could handle advanced types (such as PyList->QValueList) here if needed

--- a/MantidPlot/src/PythonScript.cpp
+++ b/MantidPlot/src/PythonScript.cpp
@@ -538,13 +538,13 @@ QVariant PythonScript::evaluateImpl() {
       qret = QVariant(PyFloat_AS_DOUBLE(number));
       Py_DECREF(number);
     }
+    GNU_DIAG_OFF("parentheses-equality")
   }
   /* bool */
-  GNU_DIAG_OFF("parentheses-equality")
   else if (PyBool_Check(pyret)) {
-    GNU_DIAG_ON("parentheses-equality")
     qret = QVariant(pyret == Py_True);
   }
+  GNU_DIAG_ON("parentheses-equality")
   // could handle advanced types (such as PyList->QValueList) here if needed
   /* fallback: try to convert to (unicode) string */
   if (!qret.isValid()) {

--- a/qt/paraview_ext/PVPlugins/Sources/MDEWSource/vtkMDEWSource.cxx
+++ b/qt/paraview_ext/PVPlugins/Sources/MDEWSource/vtkMDEWSource.cxx
@@ -186,7 +186,7 @@ int vtkMDEWSource::RequestData(vtkInformation *, vtkInformationVector **,
 }
 
 // clang-format off
-GCC_DIAG_OFF(strict-aliasing)
+DIAG_OFF(strict-aliasing)
 // clang-format on
 int vtkMDEWSource::RequestInformation(
     vtkInformation *vtkNotUsed(request),

--- a/qt/paraview_ext/PVPlugins/Sources/MDEWSource/vtkMDEWSource.cxx
+++ b/qt/paraview_ext/PVPlugins/Sources/MDEWSource/vtkMDEWSource.cxx
@@ -185,7 +185,7 @@ int vtkMDEWSource::RequestData(vtkInformation *, vtkInformationVector **,
   return 1;
 }
 
-DIAG_OFF("strict-aliasing")
+GNU_DIAG_OFF("strict-aliasing")
 int vtkMDEWSource::RequestInformation(
     vtkInformation *vtkNotUsed(request),
     vtkInformationVector **vtkNotUsed(inputVector),

--- a/qt/paraview_ext/PVPlugins/Sources/MDEWSource/vtkMDEWSource.cxx
+++ b/qt/paraview_ext/PVPlugins/Sources/MDEWSource/vtkMDEWSource.cxx
@@ -185,9 +185,7 @@ int vtkMDEWSource::RequestData(vtkInformation *, vtkInformationVector **,
   return 1;
 }
 
-// clang-format off
-DIAG_OFF(strict-aliasing)
-// clang-format on
+DIAG_OFF("strict-aliasing")
 int vtkMDEWSource::RequestInformation(
     vtkInformation *vtkNotUsed(request),
     vtkInformationVector **vtkNotUsed(inputVector),

--- a/qt/paraview_ext/VatesAPI/src/vtkDataSetToPeaksFilteredDataSet.cpp
+++ b/qt/paraview_ext/VatesAPI/src/vtkDataSetToPeaksFilteredDataSet.cpp
@@ -176,7 +176,7 @@ vtkDataSetToPeaksFilteredDataSet::getPeaksInfo(
   return peaksInfo;
 }
 
-DIAG_OFF("strict-aliasing")
+GNU_DIAG_OFF("strict-aliasing")
 /**
  * Get the radius from a PeakShape object.
  * @param shape The PeakShape from which the information will be extracted.

--- a/qt/paraview_ext/VatesAPI/src/vtkDataSetToPeaksFilteredDataSet.cpp
+++ b/qt/paraview_ext/VatesAPI/src/vtkDataSetToPeaksFilteredDataSet.cpp
@@ -176,9 +176,7 @@ vtkDataSetToPeaksFilteredDataSet::getPeaksInfo(
   return peaksInfo;
 }
 
-// clang-format off
-DIAG_OFF(strict-aliasing)
-// clang-format on
+DIAG_OFF("strict-aliasing")
 /**
  * Get the radius from a PeakShape object.
  * @param shape The PeakShape from which the information will be extracted.

--- a/qt/paraview_ext/VatesAPI/src/vtkDataSetToPeaksFilteredDataSet.cpp
+++ b/qt/paraview_ext/VatesAPI/src/vtkDataSetToPeaksFilteredDataSet.cpp
@@ -177,7 +177,7 @@ vtkDataSetToPeaksFilteredDataSet::getPeaksInfo(
 }
 
 // clang-format off
-GCC_DIAG_OFF(strict-aliasing)
+DIAG_OFF(strict-aliasing)
 // clang-format on
 /**
  * Get the radius from a PeakShape object.
@@ -225,7 +225,6 @@ Kernel::V3D vtkDataSetToPeaksFilteredDataSet::getPeakPosition(
   return position;
 }
 
-// GCC_DIAG_ON(strict-aliasing)
 /**
  * Get the radius for no shape
  * @returns The shape of the radius.

--- a/qt/paraview_ext/VatesAPI/test/BoxInfoTest.h
+++ b/qt/paraview_ext/VatesAPI/test/BoxInfoTest.h
@@ -55,7 +55,7 @@ public:
   }
 
   // clang-format off
-  GCC_DIAG_OFF(strict-aliasing)
+  DIAG_OFF(strict-aliasing)
   // clang-format on
   void test_initial_recursion_depth_is_1_for_MD_Event_w_split() {
     // Arrange

--- a/qt/paraview_ext/VatesAPI/test/BoxInfoTest.h
+++ b/qt/paraview_ext/VatesAPI/test/BoxInfoTest.h
@@ -54,9 +54,7 @@ public:
     AnalysisDataService::Instance().remove(wsName);
   }
 
-  // clang-format off
-  DIAG_OFF(strict-aliasing)
-  // clang-format on
+  DIAG_OFF("strict-aliasing")
   void test_initial_recursion_depth_is_1_for_MD_Event_w_split() {
     // Arrange
     const std::string wsName = "MD_EVENT_WS_WITH_SPLITTING";

--- a/qt/paraview_ext/VatesAPI/test/BoxInfoTest.h
+++ b/qt/paraview_ext/VatesAPI/test/BoxInfoTest.h
@@ -54,7 +54,7 @@ public:
     AnalysisDataService::Instance().remove(wsName);
   }
 
-  DIAG_OFF("strict-aliasing")
+  GNU_DIAG_OFF("strict-aliasing")
   void test_initial_recursion_depth_is_1_for_MD_Event_w_split() {
     // Arrange
     const std::string wsName = "MD_EVENT_WS_WITH_SPLITTING";

--- a/qt/paraview_ext/VatesAPI/test/ConcretePeaksPresenterVsiTest.h
+++ b/qt/paraview_ext/VatesAPI/test/ConcretePeaksPresenterVsiTest.h
@@ -23,7 +23,7 @@
 
 using namespace ::testing;
 using namespace Mantid::VATES;
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 class MockPeakConcrete : public Mantid::DataObjects::Peak {
 public:
   MOCK_CONST_METHOD0(getHKL, Mantid::Kernel::V3D(void));
@@ -38,7 +38,7 @@ public:
   MOCK_METHOD1(getPeak, Mantid::DataObjects::Peak &(int peakNum));
   MOCK_CONST_METHOD1(getPeak, const Mantid::DataObjects::Peak &(int peakNum));
 };
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 class ConcretePeaksPresenterVsiTest : public CxxTest::TestSuite {
 public:
   void testSetupPresenterCorrectly() {

--- a/qt/paraview_ext/VatesAPI/test/ConcretePeaksPresenterVsiTest.h
+++ b/qt/paraview_ext/VatesAPI/test/ConcretePeaksPresenterVsiTest.h
@@ -23,7 +23,7 @@
 
 using namespace ::testing;
 using namespace Mantid::VATES;
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 class MockPeakConcrete : public Mantid::DataObjects::Peak {
 public:
   MOCK_CONST_METHOD0(getHKL, Mantid::Kernel::V3D(void));
@@ -38,7 +38,7 @@ public:
   MOCK_METHOD1(getPeak, Mantid::DataObjects::Peak &(int peakNum));
   MOCK_CONST_METHOD1(getPeak, const Mantid::DataObjects::Peak &(int peakNum));
 };
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 class ConcretePeaksPresenterVsiTest : public CxxTest::TestSuite {
 public:
   void testSetupPresenterCorrectly() {

--- a/qt/paraview_ext/VatesAPI/test/MDEWInMemoryLoadingPresenterTest.h
+++ b/qt/paraview_ext/VatesAPI/test/MDEWInMemoryLoadingPresenterTest.h
@@ -26,12 +26,12 @@ private:
   // Helper type. Mocks a Workspace Provider.
   class MockWorkspaceProvider : public Mantid::VATES::WorkspaceProvider {
   public:
-    GCC_DIAG_OFF_SUGGEST_OVERRIDE
+    DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD1(canProvideWorkspace, bool(std::string));
     MOCK_CONST_METHOD1(fetchWorkspace,
                        Mantid::API::Workspace_sptr(std::string));
     MOCK_CONST_METHOD1(disposeWorkspace, void(std::string));
-    GCC_DIAG_ON_SUGGEST_OVERRIDE
+    DIAG_ON_SUGGEST_OVERRIDE
   };
 
   // Helper method. Generates and returns a valid IMDEventWorkspace

--- a/qt/paraview_ext/VatesAPI/test/MDEWInMemoryLoadingPresenterTest.h
+++ b/qt/paraview_ext/VatesAPI/test/MDEWInMemoryLoadingPresenterTest.h
@@ -26,12 +26,12 @@ private:
   // Helper type. Mocks a Workspace Provider.
   class MockWorkspaceProvider : public Mantid::VATES::WorkspaceProvider {
   public:
-    DIAG_OFF_SUGGEST_OVERRIDE
+    GNU_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD1(canProvideWorkspace, bool(std::string));
     MOCK_CONST_METHOD1(fetchWorkspace,
                        Mantid::API::Workspace_sptr(std::string));
     MOCK_CONST_METHOD1(disposeWorkspace, void(std::string));
-    DIAG_ON_SUGGEST_OVERRIDE
+    GNU_DIAG_ON_SUGGEST_OVERRIDE
   };
 
   // Helper method. Generates and returns a valid IMDEventWorkspace

--- a/qt/paraview_ext/VatesAPI/test/MDHWInMemoryLoadingPresenterTest.h
+++ b/qt/paraview_ext/VatesAPI/test/MDHWInMemoryLoadingPresenterTest.h
@@ -27,12 +27,12 @@ private:
   // Helper type. Mocks a Workspace Provider.
   class MockWorkspaceProvider : public Mantid::VATES::WorkspaceProvider {
   public:
-    GCC_DIAG_OFF_SUGGEST_OVERRIDE
+    DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD1(canProvideWorkspace, bool(std::string));
     MOCK_CONST_METHOD1(fetchWorkspace,
                        Mantid::API::Workspace_sptr(std::string));
     MOCK_CONST_METHOD1(disposeWorkspace, void(std::string));
-    GCC_DIAG_ON_SUGGEST_OVERRIDE
+    DIAG_ON_SUGGEST_OVERRIDE
   };
 
   // Helper method. Generates and returns a valid IMDHistoWorkspace

--- a/qt/paraview_ext/VatesAPI/test/MDHWInMemoryLoadingPresenterTest.h
+++ b/qt/paraview_ext/VatesAPI/test/MDHWInMemoryLoadingPresenterTest.h
@@ -27,12 +27,12 @@ private:
   // Helper type. Mocks a Workspace Provider.
   class MockWorkspaceProvider : public Mantid::VATES::WorkspaceProvider {
   public:
-    DIAG_OFF_SUGGEST_OVERRIDE
+    GNU_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD1(canProvideWorkspace, bool(std::string));
     MOCK_CONST_METHOD1(fetchWorkspace,
                        Mantid::API::Workspace_sptr(std::string));
     MOCK_CONST_METHOD1(disposeWorkspace, void(std::string));
-    DIAG_ON_SUGGEST_OVERRIDE
+    GNU_DIAG_ON_SUGGEST_OVERRIDE
   };
 
   // Helper method. Generates and returns a valid IMDHistoWorkspace

--- a/qt/paraview_ext/VatesAPI/test/MockObjects.h
+++ b/qt/paraview_ext/VatesAPI/test/MockObjects.h
@@ -69,7 +69,7 @@ public:
   ~FakeIMDDimension() override {}
 };
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 //=================================================================================================
 /// Concrete mocked implementation of IMDWorkspace for testing.
 class MockIMDWorkspace : public Mantid::API::IMDWorkspace {
@@ -178,7 +178,7 @@ public:
   MOCK_METHOD1(eventRaised, void(double));
 };
 
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 class FakeProgressAction : public Mantid::VATES::ProgressAction {
   void eventRaised(double) override {}
@@ -189,7 +189,7 @@ Create a field data entry containing (as contents) the argument text.
 @param testData : Text to enter
 @return new vtkFieldData object containing text.
 */
-UNUSED_FUNCTION vtkFieldData *
+GNU_UNUSED_FUNCTION vtkFieldData *
 createFieldDataWithCharArray(std::string testData) {
   vtkFieldData *fieldData = vtkFieldData::New();
   vtkCharArray *charArray = vtkCharArray::New();
@@ -274,7 +274,7 @@ view.
 view.
 @return full xml as string.
 */
-UNUSED_FUNCTION std::string
+GNU_UNUSED_FUNCTION std::string
 constructXML(const std::string &xDimensionIdMapping,
              const std::string &yDimensionIdMapping,
              const std::string &zDimensionIdMapping,
@@ -372,7 +372,7 @@ view.
 view.
 @return full xml as string.
 */
-UNUSED_FUNCTION std::string
+GNU_UNUSED_FUNCTION std::string
 constructXMLForMDEvHelperData(const std::string &xDimensionIdMapping,
                               const std::string &yDimensionIdMapping,
                               const std::string &zDimensionIdMapping,
@@ -403,7 +403,7 @@ Mantid::API::Workspace_sptr createSimple3DWorkspace() {
   return outWs;
 }
 
-UNUSED_FUNCTION Mantid::API::Workspace_sptr
+GNU_UNUSED_FUNCTION Mantid::API::Workspace_sptr
 get3DWorkspace(bool integratedTDimension, bool sliceMD) {
   using namespace Mantid::API;
   using namespace Mantid::DataObjects;
@@ -442,8 +442,8 @@ get3DWorkspace(bool integratedTDimension, bool sliceMD) {
  * @param fieldName : The requested field data entry
  * @return The value of the requested field data entry
  */
-UNUSED_FUNCTION std::string getStringFieldDataValue(vtkDataSet *ds,
-                                                    std::string fieldName) {
+GNU_UNUSED_FUNCTION std::string getStringFieldDataValue(vtkDataSet *ds,
+                                                        std::string fieldName) {
   vtkAbstractArray *value =
       ds->GetFieldData()->GetAbstractArray(fieldName.c_str());
   vtkStringArray *array = vtkStringArray::SafeDownCast(value);

--- a/qt/paraview_ext/VatesAPI/test/MockObjects.h
+++ b/qt/paraview_ext/VatesAPI/test/MockObjects.h
@@ -69,7 +69,7 @@ public:
   ~FakeIMDDimension() override {}
 };
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 //=================================================================================================
 /// Concrete mocked implementation of IMDWorkspace for testing.
 class MockIMDWorkspace : public Mantid::API::IMDWorkspace {
@@ -178,7 +178,7 @@ public:
   MOCK_METHOD1(eventRaised, void(double));
 };
 
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 
 class FakeProgressAction : public Mantid::VATES::ProgressAction {
   void eventRaised(double) override {}
@@ -189,7 +189,7 @@ Create a field data entry containing (as contents) the argument text.
 @param testData : Text to enter
 @return new vtkFieldData object containing text.
 */
-GCC_UNUSED_FUNCTION vtkFieldData *
+UNUSED_FUNCTION vtkFieldData *
 createFieldDataWithCharArray(std::string testData) {
   vtkFieldData *fieldData = vtkFieldData::New();
   vtkCharArray *charArray = vtkCharArray::New();
@@ -274,7 +274,7 @@ view.
 view.
 @return full xml as string.
 */
-GCC_UNUSED_FUNCTION std::string
+UNUSED_FUNCTION std::string
 constructXML(const std::string &xDimensionIdMapping,
              const std::string &yDimensionIdMapping,
              const std::string &zDimensionIdMapping,
@@ -372,7 +372,7 @@ view.
 view.
 @return full xml as string.
 */
-GCC_UNUSED_FUNCTION std::string
+UNUSED_FUNCTION std::string
 constructXMLForMDEvHelperData(const std::string &xDimensionIdMapping,
                               const std::string &yDimensionIdMapping,
                               const std::string &zDimensionIdMapping,
@@ -403,7 +403,7 @@ Mantid::API::Workspace_sptr createSimple3DWorkspace() {
   return outWs;
 }
 
-GCC_UNUSED_FUNCTION Mantid::API::Workspace_sptr
+UNUSED_FUNCTION Mantid::API::Workspace_sptr
 get3DWorkspace(bool integratedTDimension, bool sliceMD) {
   using namespace Mantid::API;
   using namespace Mantid::DataObjects;
@@ -442,8 +442,8 @@ get3DWorkspace(bool integratedTDimension, bool sliceMD) {
  * @param fieldName : The requested field data entry
  * @return The value of the requested field data entry
  */
-GCC_UNUSED_FUNCTION std::string getStringFieldDataValue(vtkDataSet *ds,
-                                                        std::string fieldName) {
+UNUSED_FUNCTION std::string getStringFieldDataValue(vtkDataSet *ds,
+                                                    std::string fieldName) {
   vtkAbstractArray *value =
       ds->GetFieldData()->GetAbstractArray(fieldName.c_str());
   vtkStringArray *array = vtkStringArray::SafeDownCast(value);

--- a/qt/paraview_ext/VatesAPI/test/VatesKnowledgeSerializerTest.h
+++ b/qt/paraview_ext/VatesAPI/test/VatesKnowledgeSerializerTest.h
@@ -21,13 +21,13 @@ private:
   // Helper class
   class MockImplicitFunction : public Mantid::Geometry::MDImplicitFunction {
   public:
-    DIAG_OFF_SUGGEST_OVERRIDE
+    GNU_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_METHOD1(isPointContained, bool(const Mantid::coord_t *pPoint));
     MOCK_METHOD1(isPointContained, bool(const std::vector<Mantid::coord_t> &));
     MOCK_METHOD1(isPointContained, bool(const Mantid::Kernel::VMD &));
     MOCK_CONST_METHOD0(getName, std::string());
     MOCK_CONST_METHOD0(toXMLString, std::string());
-    DIAG_ON_SUGGEST_OVERRIDE
+    GNU_DIAG_ON_SUGGEST_OVERRIDE
   };
 
   // Test methods

--- a/qt/paraview_ext/VatesAPI/test/VatesKnowledgeSerializerTest.h
+++ b/qt/paraview_ext/VatesAPI/test/VatesKnowledgeSerializerTest.h
@@ -21,13 +21,13 @@ private:
   // Helper class
   class MockImplicitFunction : public Mantid::Geometry::MDImplicitFunction {
   public:
-    GCC_DIAG_OFF_SUGGEST_OVERRIDE
+    DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_METHOD1(isPointContained, bool(const Mantid::coord_t *pPoint));
     MOCK_METHOD1(isPointContained, bool(const std::vector<Mantid::coord_t> &));
     MOCK_METHOD1(isPointContained, bool(const Mantid::Kernel::VMD &));
     MOCK_CONST_METHOD0(getName, std::string());
     MOCK_CONST_METHOD0(toXMLString, std::string());
-    GCC_DIAG_ON_SUGGEST_OVERRIDE
+    DIAG_ON_SUGGEST_OVERRIDE
   };
 
   // Test methods

--- a/qt/paraview_ext/VatesAPI/test/vtkDataSetFactoryTest.h
+++ b/qt/paraview_ext/VatesAPI/test/vtkDataSetFactoryTest.h
@@ -27,14 +27,14 @@ private:
   /// Mocked helper type
   class MockvtkDataSetFactory : public Mantid::VATES::vtkDataSetFactory {
   public:
-    DIAG_OFF_SUGGEST_OVERRIDE
+    GNU_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD1(
         create, vtkSmartPointer<vtkDataSet>(Mantid::VATES::ProgressAction &));
     MOCK_METHOD1(initialize,
                  void(const boost::shared_ptr<Mantid::API::Workspace> &));
     MOCK_CONST_METHOD0(validate, void());
     MOCK_CONST_METHOD0(getFactoryTypeName, std::string());
-    DIAG_ON_SUGGEST_OVERRIDE
+    GNU_DIAG_ON_SUGGEST_OVERRIDE
     void setSuccessorConcrete(std::unique_ptr<vtkDataSetFactory> pSuccessor) {
       vtkDataSetFactory::setSuccessor(pSuccessor);
     }

--- a/qt/paraview_ext/VatesAPI/test/vtkDataSetFactoryTest.h
+++ b/qt/paraview_ext/VatesAPI/test/vtkDataSetFactoryTest.h
@@ -27,14 +27,14 @@ private:
   /// Mocked helper type
   class MockvtkDataSetFactory : public Mantid::VATES::vtkDataSetFactory {
   public:
-    GCC_DIAG_OFF_SUGGEST_OVERRIDE
+    DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD1(
         create, vtkSmartPointer<vtkDataSet>(Mantid::VATES::ProgressAction &));
     MOCK_METHOD1(initialize,
                  void(const boost::shared_ptr<Mantid::API::Workspace> &));
     MOCK_CONST_METHOD0(validate, void());
     MOCK_CONST_METHOD0(getFactoryTypeName, std::string());
-    GCC_DIAG_ON_SUGGEST_OVERRIDE
+    DIAG_ON_SUGGEST_OVERRIDE
     void setSuccessorConcrete(std::unique_ptr<vtkDataSetFactory> pSuccessor) {
       vtkDataSetFactory::setSuccessor(pSuccessor);
     }

--- a/qt/paraview_ext/VatesAPI/test/vtkDataSetToPeaksFilteredDataSetTest.h
+++ b/qt/paraview_ext/VatesAPI/test/vtkDataSetToPeaksFilteredDataSetTest.h
@@ -36,7 +36,7 @@
 using namespace Mantid::DataObjects;
 using namespace Mantid::VATES;
 using namespace ::testing;
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 class MockPeakFilter : public Mantid::DataObjects::Peak {
 public:
   MOCK_CONST_METHOD0(getHKL, Mantid::Kernel::V3D(void));
@@ -50,7 +50,7 @@ public:
   MOCK_METHOD1(getPeak, Mantid::DataObjects::Peak &(int peakNum));
   MOCK_CONST_METHOD1(getPeak, const Mantid::DataObjects::Peak &(int peakNum));
 };
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 struct PeaksFilterDataContainer {
   double radius;
   double radiusFactor;

--- a/qt/paraview_ext/VatesAPI/test/vtkDataSetToPeaksFilteredDataSetTest.h
+++ b/qt/paraview_ext/VatesAPI/test/vtkDataSetToPeaksFilteredDataSetTest.h
@@ -36,7 +36,7 @@
 using namespace Mantid::DataObjects;
 using namespace Mantid::VATES;
 using namespace ::testing;
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 class MockPeakFilter : public Mantid::DataObjects::Peak {
 public:
   MOCK_CONST_METHOD0(getHKL, Mantid::Kernel::V3D(void));
@@ -50,7 +50,7 @@ public:
   MOCK_METHOD1(getPeak, Mantid::DataObjects::Peak &(int peakNum));
   MOCK_CONST_METHOD1(getPeak, const Mantid::DataObjects::Peak &(int peakNum));
 };
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 struct PeaksFilterDataContainer {
   double radius;
   double radiusFactor;

--- a/qt/paraview_ext/VatesAPI/test/vtkPeakMarkerFactoryTest.h
+++ b/qt/paraview_ext/VatesAPI/test/vtkPeakMarkerFactoryTest.h
@@ -25,7 +25,7 @@ using namespace ::testing;
 using namespace Mantid::VATES;
 using Mantid::VATES::vtkPeakMarkerFactory;
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockPeakShape : public Peak {
 public:
@@ -55,7 +55,7 @@ public:
   MOCK_METHOD1(getPeak, Mantid::DataObjects::Peak &(int peakNum));
   MOCK_CONST_METHOD1(getPeak, const Mantid::DataObjects::Peak &(int peakNum));
 };
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 //=====================================================================================
 // Functional Tests

--- a/qt/paraview_ext/VatesAPI/test/vtkPeakMarkerFactoryTest.h
+++ b/qt/paraview_ext/VatesAPI/test/vtkPeakMarkerFactoryTest.h
@@ -25,7 +25,7 @@ using namespace ::testing;
 using namespace Mantid::VATES;
 using Mantid::VATES::vtkPeakMarkerFactory;
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockPeakShape : public Peak {
 public:
@@ -55,7 +55,7 @@ public:
   MOCK_METHOD1(getPeak, Mantid::DataObjects::Peak &(int peakNum));
   MOCK_CONST_METHOD1(getPeak, const Mantid::DataObjects::Peak &(int peakNum));
 };
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 
 //=====================================================================================
 // Functional Tests

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/src/ViewBase.cpp
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/src/ViewBase.cpp
@@ -268,7 +268,7 @@ pqPipelineRepresentation *ViewBase::getPvActiveRep() {
   return qobject_cast<pqPipelineRepresentation *>(drep);
 }
 
-DIAG_OFF("strict-aliasing")
+GNU_DIAG_OFF("strict-aliasing")
 /**
  * This function creates a ParaView source from a given plugin name and
  * workspace name. This is used in the plugin mode of the simple interface.

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/src/ViewBase.cpp
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/src/ViewBase.cpp
@@ -268,9 +268,7 @@ pqPipelineRepresentation *ViewBase::getPvActiveRep() {
   return qobject_cast<pqPipelineRepresentation *>(drep);
 }
 
-// clang-format off
-DIAG_OFF(strict-aliasing)
-// clang-format on
+DIAG_OFF("strict-aliasing")
 /**
  * This function creates a ParaView source from a given plugin name and
  * workspace name. This is used in the plugin mode of the simple interface.

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/src/ViewBase.cpp
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/src/ViewBase.cpp
@@ -269,7 +269,7 @@ pqPipelineRepresentation *ViewBase::getPvActiveRep() {
 }
 
 // clang-format off
-GCC_DIAG_OFF(strict-aliasing)
+DIAG_OFF(strict-aliasing)
 // clang-format on
 /**
  * This function creates a ParaView source from a given plugin name and

--- a/qt/scientific_interfaces/test/ALCBaselineModellingPresenterTest.h
+++ b/qt/scientific_interfaces/test/ALCBaselineModellingPresenterTest.h
@@ -24,7 +24,7 @@ using Mantid::HistogramData::Counts;
 using Mantid::HistogramData::CountStandardDeviations;
 using Mantid::HistogramData::LinearGenerator;
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockALCBaselineModellingView : public IALCBaselineModellingView {
 public:
@@ -91,7 +91,7 @@ MATCHER_P3(QwtDataY, i, value, delta, "") {
 MATCHER_P3(VectorValue, i, value, delta, "") {
   return fabs(arg.at(i) - value) < delta;
 }
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 
 class ALCBaselineModellingPresenterTest : public CxxTest::TestSuite {
   MockALCBaselineModellingView *m_view;

--- a/qt/scientific_interfaces/test/ALCBaselineModellingPresenterTest.h
+++ b/qt/scientific_interfaces/test/ALCBaselineModellingPresenterTest.h
@@ -24,7 +24,7 @@ using Mantid::HistogramData::Counts;
 using Mantid::HistogramData::CountStandardDeviations;
 using Mantid::HistogramData::LinearGenerator;
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockALCBaselineModellingView : public IALCBaselineModellingView {
 public:
@@ -91,7 +91,7 @@ MATCHER_P3(QwtDataY, i, value, delta, "") {
 MATCHER_P3(VectorValue, i, value, delta, "") {
   return fabs(arg.at(i) - value) < delta;
 }
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 class ALCBaselineModellingPresenterTest : public CxxTest::TestSuite {
   MockALCBaselineModellingView *m_view;

--- a/qt/scientific_interfaces/test/ALCDataLoadingPresenterTest.h
+++ b/qt/scientific_interfaces/test/ALCDataLoadingPresenterTest.h
@@ -25,7 +25,7 @@ operator<<(std::basic_ostream<CharType, CharTrait> &out,
 }
 }
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockALCDataLoadingView : public IALCDataLoadingView {
   // XXX: A workaround, needed because of the way the comma is treated in a
@@ -78,7 +78,7 @@ MATCHER_P3(VectorValue, i, value, delta, "") {
   return fabs(arg.at(i) - value) < delta;
 }
 
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 class ALCDataLoadingPresenterTest : public CxxTest::TestSuite {
   MockALCDataLoadingView *m_view;

--- a/qt/scientific_interfaces/test/ALCDataLoadingPresenterTest.h
+++ b/qt/scientific_interfaces/test/ALCDataLoadingPresenterTest.h
@@ -25,7 +25,7 @@ operator<<(std::basic_ostream<CharType, CharTrait> &out,
 }
 }
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockALCDataLoadingView : public IALCDataLoadingView {
   // XXX: A workaround, needed because of the way the comma is treated in a
@@ -78,7 +78,7 @@ MATCHER_P3(VectorValue, i, value, delta, "") {
   return fabs(arg.at(i) - value) < delta;
 }
 
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 
 class ALCDataLoadingPresenterTest : public CxxTest::TestSuite {
   MockALCDataLoadingView *m_view;

--- a/qt/scientific_interfaces/test/ALCPeakFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/ALCPeakFittingPresenterTest.h
@@ -32,7 +32,7 @@ operator<<(std::basic_ostream<CharType, CharTrait> &out,
 }
 }
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockALCPeakFittingView : public IALCPeakFittingView {
 public:
@@ -359,5 +359,5 @@ public:
     m_model->setError("Test error");
   }
 };
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 #endif /* MANTIDQT_CUSTOMINTERFACES_ALCPEAKFITTINGTEST_H_ */

--- a/qt/scientific_interfaces/test/ALCPeakFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/ALCPeakFittingPresenterTest.h
@@ -32,7 +32,7 @@ operator<<(std::basic_ostream<CharType, CharTrait> &out,
 }
 }
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockALCPeakFittingView : public IALCPeakFittingView {
 public:
@@ -359,5 +359,5 @@ public:
     m_model->setError("Test error");
   }
 };
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 #endif /* MANTIDQT_CUSTOMINTERFACES_ALCPEAKFITTINGTEST_H_ */

--- a/qt/scientific_interfaces/test/EnggDiffFittingModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffFittingModelMock.h
@@ -13,7 +13,7 @@
 
 using namespace MantidQt::CustomInterfaces;
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockEnggDiffFittingModel : public IEnggDiffFittingModel {
 
@@ -61,6 +61,6 @@ public:
   MOCK_METHOD1(removeRun, void(const RunLabel &runLabel));
 };
 
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 
 #endif // MANTID_CUSTOM_INTERFACES_ENGGDIFFFITTINGMODELMOCK_H

--- a/qt/scientific_interfaces/test/EnggDiffFittingModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffFittingModelMock.h
@@ -13,7 +13,7 @@
 
 using namespace MantidQt::CustomInterfaces;
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockEnggDiffFittingModel : public IEnggDiffFittingModel {
 
@@ -61,6 +61,6 @@ public:
   MOCK_METHOD1(removeRun, void(const RunLabel &runLabel));
 };
 
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 #endif // MANTID_CUSTOM_INTERFACES_ENGGDIFFFITTINGMODELMOCK_H

--- a/qt/scientific_interfaces/test/EnggDiffFittingViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffFittingViewMock.h
@@ -6,7 +6,7 @@
 
 #include <gmock/gmock.h>
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 // This is a simple mock for the tomo interface view when using SCARF.
 class MockEnggDiffFittingView
@@ -162,6 +162,6 @@ public:
                void(const std::vector<std::string> &rows));
 };
 
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 #endif // MANTID_CUSTOMINTERFACES_ENGGDIFFFITTINGVIEWMOCK_H

--- a/qt/scientific_interfaces/test/EnggDiffFittingViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffFittingViewMock.h
@@ -6,7 +6,7 @@
 
 #include <gmock/gmock.h>
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 // This is a simple mock for the tomo interface view when using SCARF.
 class MockEnggDiffFittingView
@@ -162,6 +162,6 @@ public:
                void(const std::vector<std::string> &rows));
 };
 
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 
 #endif // MANTID_CUSTOMINTERFACES_ENGGDIFFFITTINGVIEWMOCK_H

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
@@ -6,7 +6,7 @@
 
 #include <gmock/gmock.h>
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 using namespace MantidQt::CustomInterfaces;
 
@@ -44,6 +44,6 @@ public:
                void(boost::shared_ptr<IEnggDiffGSASFittingObserver> observer));
 };
 
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 
 #endif // MANTID_CUSTOM_INTERFACES_ENGGDIFFFITTINGMODELMOCK_H_

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
@@ -6,7 +6,7 @@
 
 #include <gmock/gmock.h>
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 using namespace MantidQt::CustomInterfaces;
 
@@ -44,6 +44,6 @@ public:
                void(boost::shared_ptr<IEnggDiffGSASFittingObserver> observer));
 };
 
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 #endif // MANTID_CUSTOM_INTERFACES_ENGGDIFFFITTINGMODELMOCK_H_

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingViewMock.h
@@ -8,7 +8,7 @@
 
 using namespace MantidQt::CustomInterfaces;
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockEnggDiffGSASFittingView : public IEnggDiffGSASFittingView {
 
@@ -72,6 +72,6 @@ public:
                                        const std::string &warningDescription));
 };
 
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 
 #endif // MANTID_CUSTOMINTERFACES_ENGGDIFFGSASFITTINGVIEWMOCK_H_

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingViewMock.h
@@ -8,7 +8,7 @@
 
 using namespace MantidQt::CustomInterfaces;
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockEnggDiffGSASFittingView : public IEnggDiffGSASFittingView {
 
@@ -72,6 +72,6 @@ public:
                                        const std::string &warningDescription));
 };
 
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 #endif // MANTID_CUSTOMINTERFACES_ENGGDIFFGSASFITTINGVIEWMOCK_H_

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelMock.h
@@ -8,7 +8,7 @@
 
 using namespace MantidQt::CustomInterfaces;
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockEnggDiffMultiRunFittingWidgetModel
     : public IEnggDiffMultiRunFittingWidgetModel {
@@ -36,6 +36,6 @@ public:
   MOCK_METHOD1(removeRun, void(const RunLabel &runLabel));
 };
 
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 #endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETMODELMOCK_H_

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelMock.h
@@ -8,7 +8,7 @@
 
 using namespace MantidQt::CustomInterfaces;
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockEnggDiffMultiRunFittingWidgetModel
     : public IEnggDiffMultiRunFittingWidgetModel {
@@ -36,6 +36,6 @@ public:
   MOCK_METHOD1(removeRun, void(const RunLabel &runLabel));
 };
 
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 
 #endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETMODELMOCK_H_

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterMock.h
@@ -9,7 +9,7 @@
 
 using namespace MantidQt::CustomInterfaces;
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockEnggDiffMultiRunFittingWidgetPresenter
     : public IEnggDiffMultiRunFittingWidgetPresenter {
@@ -48,6 +48,6 @@ MockEnggDiffMultiRunFittingWidgetPresenter::getWidgetAdder() const {
   return Mantid::Kernel::make_unique<FakeEnggDiffMultiRunFittingWidgetAdder>();
 }
 
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 #endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETPRESENTERMOCK_H_

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterMock.h
@@ -9,7 +9,7 @@
 
 using namespace MantidQt::CustomInterfaces;
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockEnggDiffMultiRunFittingWidgetPresenter
     : public IEnggDiffMultiRunFittingWidgetPresenter {
@@ -48,6 +48,6 @@ MockEnggDiffMultiRunFittingWidgetPresenter::getWidgetAdder() const {
   return Mantid::Kernel::make_unique<FakeEnggDiffMultiRunFittingWidgetAdder>();
 }
 
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 
 #endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETPRESENTERMOCK_H_

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
@@ -8,7 +8,7 @@
 
 using namespace MantidQt::CustomInterfaces;
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 using namespace MantidQt::CustomInterfaces;
 
@@ -53,6 +53,6 @@ public:
   MOCK_METHOD1(updateRunList, void(const std::vector<RunLabel> &runLabels));
 };
 
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 #endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETVIEWMOCK_H_

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
@@ -8,7 +8,7 @@
 
 using namespace MantidQt::CustomInterfaces;
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 using namespace MantidQt::CustomInterfaces;
 
@@ -53,6 +53,6 @@ public:
   MOCK_METHOD1(updateRunList, void(const std::vector<RunLabel> &runLabels));
 };
 
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 
 #endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETVIEWMOCK_H_

--- a/qt/scientific_interfaces/test/EnggDiffractionParamMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffractionParamMock.h
@@ -6,7 +6,7 @@
 
 #include <gmock/gmock.h>
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 using namespace MantidQt::CustomInterfaces;
 
@@ -20,6 +20,6 @@ public:
                      std::string(const std::vector<RunLabel> &runLabels));
 };
 
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 
 #endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONPARAMMOCK_H_

--- a/qt/scientific_interfaces/test/EnggDiffractionParamMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffractionParamMock.h
@@ -6,7 +6,7 @@
 
 #include <gmock/gmock.h>
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 using namespace MantidQt::CustomInterfaces;
 
@@ -20,6 +20,6 @@ public:
                      std::string(const std::vector<RunLabel> &runLabels));
 };
 
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 #endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONPARAMMOCK_H_

--- a/qt/scientific_interfaces/test/EnggDiffractionViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffractionViewMock.h
@@ -8,7 +8,7 @@
 
 class QwtData;
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 // This is a simple mock for the tomo interface view when using SCARF.
 class MockEnggDiffractionView
@@ -185,6 +185,6 @@ public:
   // virtual void updateTabsInstrument(const std::string & newInstrument) = 0;
   MOCK_METHOD1(updateTabsInstrument, void(const std::string &newInstrument));
 };
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 #endif // MANTID_CUSTOMINTERFACES_ENGGDIFFRACTIONVIEWMOCK_H

--- a/qt/scientific_interfaces/test/EnggDiffractionViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffractionViewMock.h
@@ -8,7 +8,7 @@
 
 class QwtData;
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 // This is a simple mock for the tomo interface view when using SCARF.
 class MockEnggDiffractionView
@@ -185,6 +185,6 @@ public:
   // virtual void updateTabsInstrument(const std::string & newInstrument) = 0;
   MOCK_METHOD1(updateTabsInstrument, void(const std::string &newInstrument));
 };
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 
 #endif // MANTID_CUSTOMINTERFACES_ENGGDIFFRACTIONVIEWMOCK_H

--- a/qt/scientific_interfaces/test/MuonAnalysisFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/test/MuonAnalysisFitDataPresenterTest.h
@@ -51,7 +51,7 @@ operator<<(std::basic_ostream<CharType, CharTrait> &out,
 /// Mock data selector widget
 class MockDataSelector : public IMuonFitDataSelector {
 public:
-  GCC_DIAG_OFF_SUGGEST_OVERRIDE
+  DIAG_OFF_SUGGEST_OVERRIDE
 
   MOCK_CONST_METHOD0(getFilenames, QStringList());
   MOCK_CONST_METHOD0(getStartTime, double());
@@ -75,13 +75,13 @@ public:
   MOCK_METHOD1(setDatasetNames, void(const QStringList &));
   MOCK_CONST_METHOD0(getDatasetName, QString());
   MOCK_METHOD0(askUserWhetherToOverwrite, bool());
-  GCC_DIAG_ON_SUGGEST_OVERRIDE
+  DIAG_ON_SUGGEST_OVERRIDE
 };
 
 /// Mock fit property browser
 class MockFitBrowser : public IWorkspaceFitControl, public IMuonFitDataModel {
 public:
-  GCC_DIAG_OFF_SUGGEST_OVERRIDE
+  DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD1(setWorkspaceName, void(const QString &));
   MOCK_METHOD1(setStartX, void(double));
   MOCK_METHOD1(setEndX, void(double));
@@ -99,7 +99,7 @@ public:
   void preFitChecksRequested(bool sequential) override {
     UNUSED_ARG(sequential);
   }
-  GCC_DIAG_ON_SUGGEST_OVERRIDE
+  DIAG_ON_SUGGEST_OVERRIDE
 };
 
 class MuonAnalysisFitDataPresenterTest : public CxxTest::TestSuite {

--- a/qt/scientific_interfaces/test/MuonAnalysisFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/test/MuonAnalysisFitDataPresenterTest.h
@@ -51,7 +51,7 @@ operator<<(std::basic_ostream<CharType, CharTrait> &out,
 /// Mock data selector widget
 class MockDataSelector : public IMuonFitDataSelector {
 public:
-  DIAG_OFF_SUGGEST_OVERRIDE
+  GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
   MOCK_CONST_METHOD0(getFilenames, QStringList());
   MOCK_CONST_METHOD0(getStartTime, double());
@@ -75,13 +75,13 @@ public:
   MOCK_METHOD1(setDatasetNames, void(const QStringList &));
   MOCK_CONST_METHOD0(getDatasetName, QString());
   MOCK_METHOD0(askUserWhetherToOverwrite, bool());
-  DIAG_ON_SUGGEST_OVERRIDE
+  GNU_DIAG_ON_SUGGEST_OVERRIDE
 };
 
 /// Mock fit property browser
 class MockFitBrowser : public IWorkspaceFitControl, public IMuonFitDataModel {
 public:
-  DIAG_OFF_SUGGEST_OVERRIDE
+  GNU_DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD1(setWorkspaceName, void(const QString &));
   MOCK_METHOD1(setStartX, void(double));
   MOCK_METHOD1(setEndX, void(double));
@@ -99,7 +99,7 @@ public:
   void preFitChecksRequested(bool sequential) override {
     UNUSED_ARG(sequential);
   }
-  DIAG_ON_SUGGEST_OVERRIDE
+  GNU_DIAG_ON_SUGGEST_OVERRIDE
 };
 
 class MuonAnalysisFitDataPresenterTest : public CxxTest::TestSuite {

--- a/qt/scientific_interfaces/test/MuonAnalysisFitFunctionPresenterTest.h
+++ b/qt/scientific_interfaces/test/MuonAnalysisFitFunctionPresenterTest.h
@@ -25,7 +25,7 @@ public:
     m_func =
         Mantid::API::FunctionFactory::Instance().createFunction("Gaussian");
   }
-  DIAG_OFF_SUGGEST_OVERRIDE
+  GNU_DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD0(getFunctionString, QString());
   Mantid::API::IFunction_sptr getGlobalFunction() override { return m_func; }
   MOCK_METHOD0(functionStructureChanged, void());
@@ -46,7 +46,7 @@ public:
   MOCK_METHOD3(setLocalParameterFixed, void(const QString &, int, bool));
   MOCK_METHOD3(setLocalParameterTie, void(const QString &, int, QString));
   MOCK_METHOD1(setCurrentDataset, void(int));
-  DIAG_ON_SUGGEST_OVERRIDE
+  GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 private:
   Mantid::API::IFunction_sptr m_func;
@@ -55,7 +55,7 @@ private:
 // Mock muon fit property browser
 class MockFitFunctionControl : public IMuonFitFunctionModel {
 public:
-  DIAG_OFF_SUGGEST_OVERRIDE
+  GNU_DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD1(setFunction, void(const Mantid::API::IFunction_sptr));
   MOCK_METHOD0(runFit, void());
   MOCK_METHOD0(runSequentialFit, void());
@@ -70,7 +70,7 @@ public:
   MOCK_METHOD0(doRemoveGuess, void());
   MOCK_METHOD0(doPlotGuess, void());
   MOCK_CONST_METHOD0(hasGuess, bool());
-  DIAG_ON_SUGGEST_OVERRIDE
+  GNU_DIAG_ON_SUGGEST_OVERRIDE
 };
 
 class MuonAnalysisFitFunctionPresenterTest : public CxxTest::TestSuite {

--- a/qt/scientific_interfaces/test/MuonAnalysisFitFunctionPresenterTest.h
+++ b/qt/scientific_interfaces/test/MuonAnalysisFitFunctionPresenterTest.h
@@ -25,7 +25,7 @@ public:
     m_func =
         Mantid::API::FunctionFactory::Instance().createFunction("Gaussian");
   }
-  GCC_DIAG_OFF_SUGGEST_OVERRIDE
+  DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD0(getFunctionString, QString());
   Mantid::API::IFunction_sptr getGlobalFunction() override { return m_func; }
   MOCK_METHOD0(functionStructureChanged, void());
@@ -46,7 +46,7 @@ public:
   MOCK_METHOD3(setLocalParameterFixed, void(const QString &, int, bool));
   MOCK_METHOD3(setLocalParameterTie, void(const QString &, int, QString));
   MOCK_METHOD1(setCurrentDataset, void(int));
-  GCC_DIAG_ON_SUGGEST_OVERRIDE
+  DIAG_ON_SUGGEST_OVERRIDE
 
 private:
   Mantid::API::IFunction_sptr m_func;
@@ -55,7 +55,7 @@ private:
 // Mock muon fit property browser
 class MockFitFunctionControl : public IMuonFitFunctionModel {
 public:
-  GCC_DIAG_OFF_SUGGEST_OVERRIDE
+  DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD1(setFunction, void(const Mantid::API::IFunction_sptr));
   MOCK_METHOD0(runFit, void());
   MOCK_METHOD0(runSequentialFit, void());
@@ -70,7 +70,7 @@ public:
   MOCK_METHOD0(doRemoveGuess, void());
   MOCK_METHOD0(doPlotGuess, void());
   MOCK_CONST_METHOD0(hasGuess, bool());
-  GCC_DIAG_ON_SUGGEST_OVERRIDE
+  DIAG_ON_SUGGEST_OVERRIDE
 };
 
 class MuonAnalysisFitFunctionPresenterTest : public CxxTest::TestSuite {

--- a/qt/scientific_interfaces/test/ReflMeasureTransferStrategyTest.h
+++ b/qt/scientific_interfaces/test/ReflMeasureTransferStrategyTest.h
@@ -18,11 +18,11 @@ using namespace MantidQt::CustomInterfaces;
 class MockReflMeasurementItemSource
     : public MantidQt::CustomInterfaces::ReflMeasurementItemSource {
 public:
-  DIAG_OFF_SUGGEST_OVERRIDE
+  GNU_DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_CONST_METHOD2(obtain, MantidQt::CustomInterfaces::MeasurementItem(
                                  const std::string &, const std::string &));
   MOCK_CONST_METHOD0(clone, MockReflMeasurementItemSource *());
-  DIAG_ON_SUGGEST_OVERRIDE
+  GNU_DIAG_ON_SUGGEST_OVERRIDE
 };
 
 class ReflMeasureTransferStrategyTest : public CxxTest::TestSuite {

--- a/qt/scientific_interfaces/test/ReflMeasureTransferStrategyTest.h
+++ b/qt/scientific_interfaces/test/ReflMeasureTransferStrategyTest.h
@@ -18,11 +18,11 @@ using namespace MantidQt::CustomInterfaces;
 class MockReflMeasurementItemSource
     : public MantidQt::CustomInterfaces::ReflMeasurementItemSource {
 public:
-  GCC_DIAG_OFF_SUGGEST_OVERRIDE
+  DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_CONST_METHOD2(obtain, MantidQt::CustomInterfaces::MeasurementItem(
                                  const std::string &, const std::string &));
   MOCK_CONST_METHOD0(clone, MockReflMeasurementItemSource *());
-  GCC_DIAG_ON_SUGGEST_OVERRIDE
+  DIAG_ON_SUGGEST_OVERRIDE
 };
 
 class ReflMeasureTransferStrategyTest : public CxxTest::TestSuite {

--- a/qt/scientific_interfaces/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/test/ReflMockObjects.h
@@ -32,7 +32,7 @@ using namespace MantidQt::CustomInterfaces;
 using namespace Mantid::API;
 using namespace MantidQt::MantidWidgets::DataProcessor;
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 /**** Models ****/
 
@@ -385,6 +385,6 @@ public:
   virtual ~MockReflAsciiSaver() = default;
 };
 
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 #endif /*MANTID_CUSTOMINTERFACES_REFLMOCKOBJECTS_H*/

--- a/qt/scientific_interfaces/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/test/ReflMockObjects.h
@@ -32,7 +32,7 @@ using namespace MantidQt::CustomInterfaces;
 using namespace Mantid::API;
 using namespace MantidQt::MantidWidgets::DataProcessor;
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 /**** Models ****/
 
@@ -385,6 +385,6 @@ public:
   virtual ~MockReflAsciiSaver() = default;
 };
 
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 
 #endif /*MANTID_CUSTOMINTERFACES_REFLMOCKOBJECTS_H*/

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/MockObjects.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/MockObjects.h
@@ -29,7 +29,7 @@ const int ScaleCol = 7;
 const int OptionsCol = 8;
 const int HiddenOptionsCol = 9;
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockDataProcessorView : public DataProcessorView {
 public:
@@ -242,6 +242,6 @@ public:
   };
 };
 
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 #endif /*MANTID_MANTIDWIDGETS_DATAPROCESSORVIEWMOCKOBJECTS_H*/

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/MockObjects.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/MockObjects.h
@@ -29,7 +29,7 @@ const int ScaleCol = 7;
 const int OptionsCol = 8;
 const int HiddenOptionsCol = 9;
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockDataProcessorView : public DataProcessorView {
 public:
@@ -242,6 +242,6 @@ public:
   };
 };
 
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 
 #endif /*MANTID_MANTIDWIDGETS_DATAPROCESSORVIEWMOCKOBJECTS_H*/

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/ProgressableViewMockObject.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/ProgressableViewMockObject.h
@@ -10,11 +10,11 @@ using namespace MantidQt::MantidWidgets::DataProcessor;
 
 class MockProgressableView : public ProgressableView {
 public:
-  GCC_DIAG_OFF_SUGGEST_OVERRIDE
+  DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD1(setProgress, void(int));
   MOCK_METHOD2(setProgressRange, void(int, int));
   MOCK_METHOD0(clearProgress, void());
-  GCC_DIAG_ON_SUGGEST_OVERRIDE
+  DIAG_ON_SUGGEST_OVERRIDE
 };
 
 #endif /* MANTID_MANTIDWIDGETS_PROGRESSABLEVIEWMOCKOBJECT_H */

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/ProgressableViewMockObject.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/ProgressableViewMockObject.h
@@ -10,11 +10,11 @@ using namespace MantidQt::MantidWidgets::DataProcessor;
 
 class MockProgressableView : public ProgressableView {
 public:
-  DIAG_OFF_SUGGEST_OVERRIDE
+  GNU_DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD1(setProgress, void(int));
   MOCK_METHOD2(setProgressRange, void(int, int));
   MOCK_METHOD0(clearProgress, void());
-  DIAG_ON_SUGGEST_OVERRIDE
+  GNU_DIAG_ON_SUGGEST_OVERRIDE
 };
 
 #endif /* MANTID_MANTIDWIDGETS_PROGRESSABLEVIEWMOCKOBJECT_H */

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceDockMockObjects.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceDockMockObjects.h
@@ -12,7 +12,7 @@
 
 using namespace MantidQt::MantidWidgets;
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockMantidDisplayBase;
 
@@ -103,6 +103,6 @@ public:
   MOCK_METHOD1(notifyFromWorkspaceProvider, void(Flag flag));
 };
 
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 #endif // MANTIDQT_MANTIDWIDGETS_WORKSPACEDOCKMOCKOBJECTS_H

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceDockMockObjects.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceDockMockObjects.h
@@ -12,7 +12,7 @@
 
 using namespace MantidQt::MantidWidgets;
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockMantidDisplayBase;
 
@@ -103,6 +103,6 @@ public:
   MOCK_METHOD1(notifyFromWorkspaceProvider, void(Flag flag));
 };
 
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 
 #endif // MANTIDQT_MANTIDWIDGETS_WORKSPACEDOCKMOCKOBJECTS_H

--- a/qt/widgets/common/test/ProjectSaveMockObjects.h
+++ b/qt/widgets/common/test/ProjectSaveMockObjects.h
@@ -10,7 +10,7 @@
 using namespace MantidQt::API;
 using namespace MantidQt::MantidWidgets;
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockProjectSaveView : public IProjectSaveView {
 public:

--- a/qt/widgets/common/test/ProjectSaveMockObjects.h
+++ b/qt/widgets/common/test/ProjectSaveMockObjects.h
@@ -10,7 +10,7 @@
 using namespace MantidQt::API;
 using namespace MantidQt::MantidWidgets;
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockProjectSaveView : public IProjectSaveView {
 public:

--- a/qt/widgets/legacyqwt/test/SignalRangeTest.h
+++ b/qt/widgets/legacyqwt/test/SignalRangeTest.h
@@ -12,7 +12,7 @@
 
 #include "MantidAPI/IMDIterator.h"
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 class SignalRangeTest : public CxxTest::TestSuite {
 private:
@@ -86,7 +86,7 @@ private:
     MOCK_CONST_METHOD0(getLinearIndex, size_t());
     MOCK_CONST_METHOD1(isWithinBounds, bool(size_t));
   };
-  DIAG_ON_SUGGEST_OVERRIDE
+  GNU_DIAG_ON_SUGGEST_OVERRIDE
   class NormalizableMockIterator : public MockMDIterator {
   public:
     Mantid::signal_t getNormalizedSignal() const override {

--- a/qt/widgets/legacyqwt/test/SignalRangeTest.h
+++ b/qt/widgets/legacyqwt/test/SignalRangeTest.h
@@ -12,7 +12,7 @@
 
 #include "MantidAPI/IMDIterator.h"
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 class SignalRangeTest : public CxxTest::TestSuite {
 private:
@@ -86,7 +86,7 @@ private:
     MOCK_CONST_METHOD0(getLinearIndex, size_t());
     MOCK_CONST_METHOD1(isWithinBounds, bool(size_t));
   };
-  GCC_DIAG_ON_SUGGEST_OVERRIDE
+  DIAG_ON_SUGGEST_OVERRIDE
   class NormalizableMockIterator : public MockMDIterator {
   public:
     Mantid::signal_t getNormalizedSignal() const override {

--- a/qt/widgets/sliceviewer/test/MockObjects.h
+++ b/qt/widgets/sliceviewer/test/MockObjects.h
@@ -25,7 +25,7 @@ using namespace Mantid::Geometry;
 using namespace Mantid;
 using boost::regex;
 
-DIAG_OFF_SUGGEST_OVERRIDE
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 namespace {
 /*------------------------------------------------------------
@@ -197,6 +197,6 @@ public:
 };
 }
 
-DIAG_ON_SUGGEST_OVERRIDE
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 #endif

--- a/qt/widgets/sliceviewer/test/MockObjects.h
+++ b/qt/widgets/sliceviewer/test/MockObjects.h
@@ -25,7 +25,7 @@ using namespace Mantid::Geometry;
 using namespace Mantid;
 using boost::regex;
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
+DIAG_OFF_SUGGEST_OVERRIDE
 
 namespace {
 /*------------------------------------------------------------
@@ -197,6 +197,6 @@ public:
 };
 }
 
-GCC_DIAG_ON_SUGGEST_OVERRIDE
+DIAG_ON_SUGGEST_OVERRIDE
 
 #endif

--- a/qt/widgets/sliceviewer/test/PeakRepresentationSphereTest.h
+++ b/qt/widgets/sliceviewer/test/PeakRepresentationSphereTest.h
@@ -34,7 +34,7 @@ public:
                                   outerBackgroundRadius);
 
     // Act + Assert
-    TSM_ASSERT(radius, peak.getEffectiveRadius());
+    TS_ASSERT_EQUALS(radius, peak.getEffectiveRadius());
   }
 
   void test_getRadius_gets_outer_background_radius_if_background_is_shown() {
@@ -49,7 +49,7 @@ public:
     peak.showBackgroundRadius(true);
 
     // Act + Assert
-    TSM_ASSERT(outerBackgroundRadius, peak.getEffectiveRadius());
+    TS_ASSERT_EQUALS(outerBackgroundRadius, peak.getEffectiveRadius());
   }
 
   void test_handle_outer_background_radius_zero() {


### PR DESCRIPTION
**Description of work.**
Fixes clang warnings cropping up in clang `6.0.0` and unifies the warning suppression macros to work for both clang and gcc.

**To test:**

 - Mantid needs to compile without warnings on GCC and Clang builds.

_No associated issue_

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
