### PR TITLE
Crash doing Show Detectors on a workspace without an instrument

### DIFF
--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -1270,6 +1270,11 @@ Table *MantidUI::createDetectorTable(
     const std::vector<int> &indices, bool include_data) {
   using namespace Mantid::Geometry;
 
+  IComponent_const_sptr sample = ws->getInstrument()->getSample();
+  if (!sample) {
+    return nullptr;
+  }
+
   // check if efixed value is available
   bool calcQ(true);
 
@@ -1330,7 +1335,6 @@ Table *MantidUI::createDetectorTable(
   t->setTextFormat(ncols - 1);
 
   // Cache some frequently used values
-  IComponent_const_sptr sample = ws->getInstrument()->getSample();
   const auto beamAxisIndex =
       ws->getInstrument()->getReferenceFrame()->pointingAlongBeam();
   const auto sampleDist = sample->getPos()[beamAxisIndex];

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
@@ -1600,9 +1600,14 @@ void WorkspaceTreeWidget::onClickShowDetectorTable() {
 
 void WorkspaceTreeWidget::showDetectorsTable() {
   // get selected workspace
-  auto ws = getSelectedWorkspaceNames()[0];
-  m_mantidDisplayModel->createDetectorTable(QString::fromStdString(ws),
-                                            std::vector<int>(), false);
+  auto ws = QString::fromStdString(getSelectedWorkspaceNames()[0]);
+  auto table =
+      m_mantidDisplayModel->createDetectorTable(ws, std::vector<int>(), false);
+  if (!table) {
+    QMessageBox::information(
+        this, "Error",
+        QString("Cannot create detectors tables for workspace ") + ws);
+  }
 }
 
 void WorkspaceTreeWidget::onClickShowBoxData() {


### PR DESCRIPTION
**Description of work.**
Check if the instrument has the sample. If it doesn't do not attempt to create the table. Show a warning.

**To test:**
* Create a workspace
```
ws = CreateWorkspace([0, 1], [1, 1])
```
* Try to open the detector table.


Fixes #23018

Does this update require release notes?
- [ ] Yes
- [X] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
