### PR TITLE
Exposed the release number to the configure step

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,7 +293,9 @@ if ( ENABLE_CPACK )
     elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
       include ( CPackLinuxSetup )
       # let people know what is coming out the other end
-      message ( STATUS "CPACK_PACKAGE_FILE_NAME = ${CPACK_PACKAGE_FILE_NAME}" )
+      if (CPACK_GENERATOR STREQUAL "DEB") # rpm filename is not visible?
+        message ( STATUS "CPACK_PACKAGE_FILE_NAME = ${CPACK_PACKAGE_FILE_NAME}" )
+      endif()
 
       # rhel requirements
       set ( CPACK_RPM_PACKAGE_REQUIRES "qt4 >= 4.2,nexus >= 4.3.1,gsl,glibc,qwtplot3d-qt4,muParser,numpy,h5py >= 2.3.1,PyCifRW >= 4.2.1,tbb,librdkafka" )
@@ -306,7 +308,7 @@ if ( ENABLE_CPACK )
       set ( CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES},scipy" )
       set ( CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES},mxml,hdf,hdf5,jsoncpp >= 0.7.0" )
 
-      if( "${UNIX_CODENAME}" MATCHES "Santiago" )
+      if( "${UNIX_CODENAME}" MATCHES "Santiago" ) # RHEL6
         # On RHEL6 we have to use an updated qscintilla to fix an auto complete bug
         set ( CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES} qscintilla >= 2.4.6, boost157,python-matplotlib" )
         # On RHEL6 we are using SCL packages for Qt
@@ -317,7 +319,7 @@ if ( ENABLE_CPACK )
       endif()
 
       # Add software collections for RHEL
-      if ( "${UNIX_CODENAME}" MATCHES "Santiago" )
+      if ( "${UNIX_CODENAME}" MATCHES "Santiago" ) # RHEL6
         set ( CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES} scl-utils" )
       endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,10 +292,6 @@ if ( ENABLE_CPACK )
       include ( WindowsNSIS )
     elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
       include ( CPackLinuxSetup )
-      # let people know what is coming out the other end
-      if (CPACK_GENERATOR STREQUAL "DEB") # rpm filename is not visible?
-        message ( STATUS "CPACK_PACKAGE_FILE_NAME = ${CPACK_PACKAGE_FILE_NAME}" )
-      endif()
 
       # rhel requirements
       set ( CPACK_RPM_PACKAGE_REQUIRES "qt4 >= 4.2,nexus >= 4.3.1,gsl,glibc,qwtplot3d-qt4,muParser,numpy,h5py >= 2.3.1,PyCifRW >= 4.2.1,tbb,librdkafka" )
@@ -388,4 +384,6 @@ if ( ENABLE_CPACK )
     ENDIF ()
     # run cpack configuration
     include ( CPack )
+    # let people know what is coming out the other end - must be after cpack generates value for rpm
+    message ( STATUS "CPACK_PACKAGE_FILE_NAME = ${CPACK_PACKAGE_FILE_NAME}" )
 endif ()

--- a/buildconfig/CMake/CPackLinuxSetup.cmake
+++ b/buildconfig/CMake/CPackLinuxSetup.cmake
@@ -37,34 +37,19 @@ if ( "${UNIX_DIST}" MATCHES "RedHatEnterprise" OR "${UNIX_DIST}" MATCHES "Fedora
   find_program ( RPMBUILD_CMD rpmbuild )
   if ( RPMBUILD_CMD )
     set ( CPACK_GENERATOR "RPM" )
+
     set ( CPACK_RPM_PACKAGE_ARCHITECTURE "${CMAKE_SYSTEM_PROCESSOR}" )
     set ( CPACK_RPM_PACKAGE_URL "http://www.mantidproject.org" )
+    set ( CPACK_RPM_PACKAGE_LICENSE "GPLv3" )
     set ( CPACK_RPM_COMPRESSION_TYPE "xz" )
 
-    # determine the distribution number
-    if(NOT CPACK_RPM_DIST)
-      execute_process(COMMAND ${RPMBUILD_CMD} -E %{?dist}
-                      OUTPUT_VARIABLE CPACK_RPM_DIST
-                      ERROR_QUIET
-                      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    set (CPACK_RPM_PACKAGE_RELEASE 1 CACHE STRING "The release number")
+    if ( CMAKE_VERSION VERSION_GREATER "3.5" )
+      # cmake can set the distribution flag correctly
+      set (CPACK_RPM_PACKAGE_RELEASE_DIST "on")
+    else ()
+      message (FATAL_ERROR "Will not create packages on cmake <3.6")
     endif()
-
-    # release number defaults to 1
-    if(NOT CPACK_RPM_PACKAGE_RELEASE_NUMBER)
-      set(CPACK_RPM_PACKAGE_RELEASE_NUMBER "1")
-    endif()
-
-    # reset the release name
-    set( CPACK_RPM_PACKAGE_RELEASE "${CPACK_RPM_PACKAGE_RELEASE_NUMBER}${CPACK_RPM_DIST}" )
-
-    # If CPACK_SET_DESTDIR is ON then the Prefix doesn't get put in the spec file
-    if( CPACK_SET_DESTDIR )
-      message ( STATUS "Adding \"Prefix:\" line to spec file manually when CPACK_SET_DESTDIR is set")
-      set( CPACK_RPM_SPEC_MORE_DEFINE "Prefix: ${CPACK_PACKAGING_INSTALL_PREFIX}" )
-    endif()
-
-    # according to rpm.org: name-version-release.architecture.rpm
-    set ( CPACK_PACKAGE_FILE_NAME
-      "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_RPM_PACKAGE_RELEASE}.${CPACK_RPM_PACKAGE_ARCHITECTURE}" )
-  endif ( RPMBUILD_CMD)
-endif ()
+    set (CPACK_RPM_FILE_NAME RPM-DEFAULT)
+  endif()
+endif()

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -233,8 +233,16 @@ if [[ ${DO_BUILD_PKG} == true ]]; then
       # everything else uses lower-case values
       PACKAGINGVARS="${PACKAGINGVARS} -DCMAKE_INSTALL_PREFIX=/opt/mantid${PACKAGE_SUFFIX} -DCPACK_PACKAGE_SUFFIX=${PACKAGE_SUFFIX}"
     fi
+
+    if [[ ${ON_RHEL7} == true ]]; then
+      if [[ -n "${RELEASE_NUMBER}" ]]; then
+        RELEASE_NUMBER="1"
+      fi
+      PACKAGINGVARS="${PACKAGINGVARS} -DCPACK_RPM_PACKAGE_RELEASE=${RELEASE_NUMBER}"
+    fi
   fi
 fi
+
 
 ###############################################################################
 # Generator


### PR DESCRIPTION
Also got rid of the brittle inspection of the architecture
and distribution favoring `CPACK_RPM_PACKAGE_RELEASE_DIST`
introduced in cmake 3.6.

https://cmake.org/cmake/help/v3.6/module/CPackRPM.html

This is not required for the release, but it will make it easier to rebuild it at a later date.

**To test:**

Build the package and see what the package name is. Also `cmake -DCPACK_RPM_PACKAGE_RELEASE=2 .`, build the package and see that the release number has increased.

*There is no associated issue.*

*This does not need to be in the release notes* because it only affects building rpms.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
