### PR TITLE
Prevent crash from removing non-existing layer

### DIFF
--- a/MantidPlot/src/MultiLayer.cpp
+++ b/MantidPlot/src/MultiLayer.cpp
@@ -91,7 +91,7 @@ Mantid::Kernel::Logger g_log("MultiLayer");
 const double MAXIMUM = std::numeric_limits<double>::max();
 const double MINIMUM = std::numeric_limits<double>::min();
 constexpr int AXIS_X(0), AXIS_Y(1);
-}
+} // namespace
 
 LayerButton::LayerButton(const QString &text, QWidget *parent)
     : QPushButton(text, parent) {
@@ -350,6 +350,10 @@ void MultiLayer::confirmRemoveLayer() {
 }
 
 void MultiLayer::removeLayer() {
+  // ignore function if no layers
+  if (active_graph == nullptr)
+    return;
+
   // remove corresponding button
   foreach (LayerButton *btn, buttonsList) {
     if (btn->isChecked()) {
@@ -371,6 +375,7 @@ void MultiLayer::removeLayer() {
   active_graph->setAttribute(Qt::WA_DeleteOnClose, false);
   active_graph->close();
   delete active_graph;
+
   if (index >= graphsList.count())
     index--;
 
@@ -1398,8 +1403,8 @@ void MultiLayer::dropOntoMatrixCurve(Graph *g, MantidMatrixCurve *originalCurve,
 }
 
 /**
-* Mark the layer selector for deletion and set the pointer to NULL
-*/
+ * Mark the layer selector for deletion and set the pointer to NULL
+ */
 void MultiLayer::removeLayerSelectionFrame() {
   d_layers_selector->deleteLater();
   d_layers_selector = nullptr;


### PR DESCRIPTION
**Description of work.**
Adds a check to see if there is an active graph. If there is no active graph (i.e. no layer to remove), return from the removeLayer function having done nothing. This prevents a crash which occurs when removing a layer from an empty plot.

**To test:**
1. Plot a spectrum
2. Click Graph->Remove Layer (in the main menu)
3. Click Graph->Remove Layer again

Expected result: no crash!

Fixes #21912 

Does this update require release notes?
- [ ] Yes
- [X] No

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
