### PR TITLE
Fix unhandled exception SliceViewer in Non-orthogonal mode.

### DIFF
--- a/qt/widgets/sliceviewer/src/ConcretePeaksPresenter.cpp
+++ b/qt/widgets/sliceviewer/src/ConcretePeaksPresenter.cpp
@@ -554,7 +554,11 @@ bool ConcretePeaksPresenter::addPeakAt(double plotCoordsPointX,
       boost::const_pointer_cast<Mantid::API::IPeaksWorkspace>(this->m_peaksWS);
 
   const auto frame = m_transform->getCoordinateSystem();
-  peaksWS->addPeak(position, frame);
+  try {
+    peaksWS->addPeak(position, frame);
+  } catch (const std::invalid_argument &e) {
+    g_log.warning(e.what());
+  }
 
   // Reproduce the views. Proxy representations recreated for all peaks.
   this->produceViews();


### PR DESCRIPTION
**Description of work.**

If I try and add a peak in HKL in non-orthogonal mode I get an unhandled exception and the error reporting kicks in. This catches it an prints a message warning about the issue.

**To test:**

Here's a script that will generate some data you can use to reproduce. Input files & script can be found on `Scratch/SXD/NaCl/`:

```python
Load(Filename='/Users/samueljackson/data/SXD/NaCl/SXD30895.raw', OutputWorkspace='SXD30895')
Load(Filename='/Users/samueljackson/data/SXD/NaCl/peaks.nxs', OutputWorkspace='peaks')
CopySample(InputWorkspace='peaks', OutputWorkspace='SXD30895', CopyName=False, CopyMaterial=False, CopyEnvironment=False, CopyShape=False)
ConvertToDiffractionMDWorkspace(InputWorkspace='SXD30895', OutputWorkspace='md', OneEventPerBin=False, OutputDimensions='HKL', LorentzCorrection=True)
```

Once that has loaded do the following:
 - Open Slice Viewer on `md`
 - Overlay the peaks workspace.
 - Switch to non-orthogonal view
 - Click add peak
 - Click somewhere non-physical. e.g. H=30, K=10, L=0

_No associated issue_

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
