### PR TITLE
Fix validateInputs crash on WorkspaceGroup

### DIFF
--- a/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp
@@ -485,8 +485,6 @@ PolarizationCorrectionWildes::validateInputs() {
                                      " is missing from the workspace.";
       }
     }
-  } else {
-    issues[Prop::EFFICIENCIES] = "The input is not a MatrixWorkspace";
   }
   const std::vector<std::string> inputs = getProperty(Prop::INPUT_WS);
   const std::string flipperProperty = getProperty(Prop::FLIPPERS);

--- a/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp
@@ -460,29 +460,33 @@ std::map<std::string, std::string>
 PolarizationCorrectionWildes::validateInputs() {
   std::map<std::string, std::string> issues;
   API::MatrixWorkspace_const_sptr factorWS = getProperty(Prop::EFFICIENCIES);
-  const auto &factorAxis = factorWS->getAxis(1);
-  if (!factorAxis) {
-    issues[Prop::EFFICIENCIES] = "The workspace is missing a vertical axis.";
-  } else if (!factorAxis->isText()) {
-    issues[Prop::EFFICIENCIES] =
-        "The vertical axis in the workspace is not text axis.";
-  } else if (factorWS->getNumberHistograms() < 4) {
-    issues[Prop::EFFICIENCIES] =
-        "The workspace should contain at least 4 histograms.";
-  } else {
-    std::vector<std::string> tags{{"P1", "P2", "F1", "F2"}};
-    for (size_t i = 0; i != factorAxis->length(); ++i) {
-      const auto label = factorAxis->label(i);
-      auto found = std::find(tags.begin(), tags.end(), label);
-      if (found != tags.cend()) {
-        std::swap(tags.back(), *found);
-        tags.pop_back();
+  if (factorWS) {
+    const auto &factorAxis = factorWS->getAxis(1);
+    if (!factorAxis) {
+      issues[Prop::EFFICIENCIES] = "The workspace is missing a vertical axis.";
+    } else if (!factorAxis->isText()) {
+      issues[Prop::EFFICIENCIES] =
+          "The vertical axis in the workspace is not text axis.";
+    } else if (factorWS->getNumberHistograms() < 4) {
+      issues[Prop::EFFICIENCIES] =
+          "The workspace should contain at least 4 histograms.";
+    } else {
+      std::vector<std::string> tags{{"P1", "P2", "F1", "F2"}};
+      for (size_t i = 0; i != factorAxis->length(); ++i) {
+        const auto label = factorAxis->label(i);
+        auto found = std::find(tags.begin(), tags.end(), label);
+        if (found != tags.cend()) {
+          std::swap(tags.back(), *found);
+          tags.pop_back();
+        }
+      }
+      if (!tags.empty()) {
+        issues[Prop::EFFICIENCIES] = "A histogram labeled " + tags.front() +
+                                     " is missing from the workspace.";
       }
     }
-    if (!tags.empty()) {
-      issues[Prop::EFFICIENCIES] = "A histogram labeled " + tags.front() +
-                                   " is missing from the workspace.";
-    }
+  } else {
+    issues[Prop::EFFICIENCIES] = "The input is not a MatrixWorkspace";
   }
   const std::vector<std::string> inputs = getProperty(Prop::INPUT_WS);
   const std::string flipperProperty = getProperty(Prop::FLIPPERS);


### PR DESCRIPTION
**Description of work.**
This fix adds a guard against workspace groups in the PolarizationCorrectionWildes algorithm's validateInputs for the Efficiencies workspace. The algorithm dialog lets you select a workspace group if all of its members are valid matrix workspaces; however, a group is not valid input for this property. Ideally validation would fail for workspace groups, but for now to keep behaviour the same as when running from a script (where validateInputs is not called on the group workspace) we just skip validation of the efficiencies workspace if it is a group.

**To test:**

- Replace POLREF_Parameters.xml in your instrument directory with this version and then start mantid: 
[POLREF_Parameters.zip](https://github.com/mantidproject/mantid/files/2220088/POLREF_Parameters.zip)
- Run this script (it results in an error from `PolarizationCorrectionWildes` but that's not relevant for this PR):
```
ws=Load("POLREF14891")
efficiencies=ExtractPolarizationEfficiencies(InputWorkspace=ws)
result=PolarizationCorrectionWildes(InputWorkspaces='ws_1,ws_2',Efficiencies=mtd['efficiencies'],Flippers='00, 11')
```
- Now run the `PolarizationCorrectionWildes` from the algorithm dialog rather than the script with the same inputs. Mantid should not crash. You should see the same output/error as when running `PolarizationCorrectionWildes` from the script.


Fixes #23061 

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
