### PR TITLE
Switch to pure C implementation for other instance checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,7 +301,7 @@ if ( ENABLE_CPACK )
       set( CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES},OCE-draw,OCE-foundation,OCE-modeling,OCE-ocaf,OCE-visualization")
       set ( CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES},poco-crypto,poco-data,poco-mysql,poco-sqlite,poco-odbc,poco-util,poco-xml,poco-zip,poco-net,poco-netssl,poco-foundation,PyQt4" )
       set ( CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES},sip >= 4.18" )
-      set ( CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES},python-six,python-ipython >= 1.1.0,python-ipython-notebook,PyYAML,python2-psutil" )
+      set ( CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES},python-six,python-ipython >= 1.1.0,python-ipython-notebook,PyYAML" )
       # scipy
       set ( CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES},scipy" )
       set ( CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES},mxml,hdf,hdf5,jsoncpp >= 0.7.0" )
@@ -361,8 +361,7 @@ if ( ENABLE_CPACK )
                            "libhdf5-cpp-11,"
                            "python-pycifrw (>= 4.2.1),"
                            "python-yaml,"
-                           "python-qtawesome,"
-                           "python-psutil")
+                           "python-qtawesome")
         set ( PERFTOOLS_DEB_PACKAGE "libgoogle-perftools4 (>= 1.7)" )
         if( "${UNIX_CODENAME}" STREQUAL "bionic")
             list ( APPEND DEPENDS_LIST ",libgsl23,liboce-foundation11,liboce-modeling11,libqscintilla2-qt4-13,jupyter-notebook,libhdf5-cpp-100")

--- a/MantidPlot/CMakeLists.txt
+++ b/MantidPlot/CMakeLists.txt
@@ -814,6 +814,10 @@ target_link_libraries ( MantidPlot LINK_PRIVATE
   ${OPENGL_glu_LIBRARY}
   ${OPENGL_gl_LIBRARY}
 )
+if (WIN32)
+  set_target_properties ( MantidPlot PROPERTIES COMPILE_DEFINITIONS "PSAPI_VERSION=1" )
+  target_link_libraries ( MantidPlot PRIVATE Psapi.lib )
+endif ()
 
 if(MAKE_VATES)
   target_include_directories( MantidPlot SYSTEM PRIVATE ${PARAVIEW_INCLUDE_DIRS} )

--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -325,7 +325,7 @@ end
 #currently missing epics
 path = "/Library/Python/2.7/site-packages"
 directories = ["sphinx","sphinx_bootstrap_theme","IPython","zmq","pygments","backports", "qtawesome", "qtpy",
-               "certifi","tornado","markupsafe","jinja2","psutil","jsonschema","functools32","ptyprocess","CifFile","yaml"]
+               "certifi","tornado","markupsafe","jinja2","jsonschema","functools32","ptyprocess","CifFile","yaml"]
 directories.each do |directory|
   addPythonLibrary("#{path}/#{directory}","Contents/MacOS/")
 end

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -16644,6 +16644,7 @@ void ApplicationWindow::onAboutToStart() {
   // instance currently running
   try {
     if (!Process::isAnotherInstanceRunning()) {
+      g_log.debug("Starting project autosaving.");
       checkForProjectRecovery();
     } else {
       g_log.debug("Another MantidPlot process is running. Project recovery is "

--- a/MantidPlot/src/Process.cpp
+++ b/MantidPlot/src/Process.cpp
@@ -1,85 +1,35 @@
-// clang-format off
-#include "MantidQtWidgets/Common/PythonThreading.h"
-// clang-format on
-
 #include "Process.h"
 
-#include <iostream>
-#include <stdexcept>
 #include <QCoreApplication>
+#include <QFileInfo>
+
+#if defined(Q_OS_LINUX)
+#include <QDir>
+#include <QFile>
+#elif defined(Q_OS_WIN)
+#define WIN32_LEAN_AND_MEAN
+#include <Psapi.h>
+#include "MantidQtWidgets/Common/QStringUtils.h"
+#elif defined(Q_OS_MAC)
+#include <libproc.h>
+#include <sys/sysctl.h>
+#endif
 
 namespace {
 
-class PyObjectNewReference {
-public:
-  explicit PyObjectNewReference(PyObject *object) : m_object(object) {}
-  ~PyObjectNewReference() { Py_XDECREF(m_object); }
+bool isOtherInstance(int64_t otherPID, QString otherExeName) {
+  static const int64_t ourPID(QCoreApplication::applicationPid());
+  if (otherPID == ourPID)
+    return false;
 
-  PyObjectNewReference(const PyObjectNewReference &) = delete;
-  PyObjectNewReference &operator=(const PyObjectNewReference &) = delete;
-
-  PyObjectNewReference(PyObjectNewReference &&o) { *this = std::move(o); }
-
-  PyObjectNewReference &operator=(PyObjectNewReference &&other) {
-    this->m_object = other.m_object;
-    other.m_object = nullptr;
-    return *this;
-  }
-
-  inline PyObject *ptr() const { return m_object; }
-
-private:
-  PyObject *m_object;
-};
-
-/**
- * @brief Retrieve a named attribute
- * @param source The source object
- * @param name The name of the attribute
- * @return The attribute
- * @throws std::runtime_error if an error occurs retrieving the attribute
- */
-PyObjectNewReference attr(PyObject *source, const char *name) {
-  PyObjectNewReference attr(PyObject_GetAttrString(source, name));
-  if (attr.ptr()) {
-    return attr;
-  } else {
-    PyErr_Print();
-    throw std::runtime_error(std::string("Process: No attribute ") + name +
-                             " found");
-  }
+  static const QString ourExeName(
+      QFileInfo(QCoreApplication::applicationFilePath()).fileName());
+  if (ourExeName == otherExeName)
+    return true;
+  else
+    return false;
 }
 
-/**
- * @brief Call a named function with an check for errors
- * @param source The source object
- * @param name The name of the attribute to call
- * @return The return value of the function
- * @throws std::runtime_error if an error occurs retrieving the attribute
- */
-PyObjectNewReference call(PyObject *source, const char *name) {
-  auto returnedAttr = attr(source, name);
-  auto result = PyObject_CallFunction(returnedAttr.ptr(), nullptr);
-  if (result)
-    return PyObjectNewReference(result);
-  else {
-    PyErr_Print();
-    throw std::runtime_error(std::string("Process: Error calling function ") +
-                             name);
-  }
-}
-
-/**
- * @return Return a pointer to the psutil module. A new reference is returned.
- */
-PyObjectNewReference psutil() {
-  if (auto process = PyImport_ImportModule("psutil")) {
-    return PyObjectNewReference(process);
-  } else {
-    PyErr_Clear();
-    throw std::runtime_error("Python module psutil cannot be imported.");
-  }
-}
 } // namespace
 
 namespace Process {
@@ -88,38 +38,147 @@ namespace Process {
   * Returns true is another instance of Mantid is running
   * on this machine
   * @return True if another instance is running
-  * @throws std::runtime_error if the PID list cannot be determined
+  * @throws std::runtime_error if this cannot be determined
   */
-bool isAnotherInstanceRunning() { return !otherInstancePIDs().empty(); }
+#ifdef Q_OS_LINUX
+bool isAnotherInstanceRunning() {
+  // Inspired by psutil._pslinux.Process.exe:
+  // https://github.com/giampaolo/psutil/blob/master/psutil/_pslinux.py
+  QDir procfs{"/proc"};
 
-/**
- * @brief Return a list of process IDs for other instances of this process.
- * @return A list of other processes running. The PID for this process is
- * removed from the list. An empty list is returned
- * if no other processes are running.
- * @throws std::runtime_error if the PID list cannot be determined
- */
-std::vector<int64_t> otherInstancePIDs() {
-  ScopedPythonGIL lock;
-  const int64_t ourPID(QCoreApplication::applicationPid());
-  const PyObjectNewReference ourName(
-      FROM_CSTRING(QCoreApplication::applicationName().toLatin1().data()));
-  auto psutilModule(psutil());
-  auto processIter(call(psutilModule.ptr(), "process_iter"));
+  bool otherIsRunning(false);
+  auto entries{procfs.entryList(QDir::Dirs)};
+  for (const auto &pidStr : entries) {
+    bool isDigit(false);
+    auto pid{pidStr.toLongLong(&isDigit)};
+    if (!isDigit)
+      continue;
 
-  std::vector<int64_t> otherPIDs;
-  PyObject *item(nullptr);
-  while ((item = PyIter_Next(processIter.ptr()))) {
-    auto name = call(item, "name");
-    if (PyObject_RichCompareBool(name.ptr(), ourName.ptr(), Py_EQ)) {
-      auto pid = PyLong_AsLong(attr(item, "pid").ptr());
-      if (pid != ourPID) {
-        otherPIDs.emplace_back(pid);
-      }
+    // /proc/pid/exe should point to executable
+    QFileInfo exe{"/proc/" + pidStr + "/exe"};
+    if (!exe.exists() || !exe.isSymLink())
+      continue;
+
+    if (isOtherInstance(pid, QFileInfo(exe.symLinkTarget()).fileName())) {
+      otherIsRunning = true;
+      break;
     }
-    Py_DECREF(item);
   }
-  return otherPIDs;
+  return otherIsRunning;
 }
+#elif defined(Q_OS_WIN)
+bool isAnotherInstanceRunning() {
+  using MantidQt::API::toQStringInternal;
+  // Inspired by psutil.psutil_get_pids at
+  // https://github.com/giampaolo/psutil/blob/master/psutil/arch/windows/process_info.c
+
+  // EnumProcesses in Win32 SDK says the only way to know if our process array
+  // wasn't large enough is to check the returned size and make
+  // sure that it doesn't match the size of the array.
+  // If it does we allocate a larger array and try again
+
+  std::vector<DWORD> processes;
+  // Stores the byte size of the returned array from EnumProcesses
+  DWORD enumReturnSz{0};
+  do {
+    processes.resize(processes.size() + 1024);
+    const DWORD procArrayByteSz =
+        static_cast<DWORD>(processes.size()) * sizeof(DWORD);
+    if (!EnumProcesses(processes.data(), procArrayByteSz, &enumReturnSz)) {
+      throw std::runtime_error("Unable to determine running process list");
+    }
+  } while (enumReturnSz == processes.size());
+  // Set the vector back to the appropriate size
+  processes.resize(enumReturnSz / sizeof(DWORD));
+
+  bool otherIsRunning(false);
+  wchar_t exe[MAX_PATH];
+  for (const auto pid : processes) {
+    // system-idle process
+    if (pid == 0)
+      continue;
+    auto procHandle = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, pid);
+    if (!procHandle)
+      continue;
+    DWORD exeSz = GetProcessImageFileNameW(procHandle, exe, MAX_PATH);
+    CloseHandle(procHandle);
+    if (exeSz > 0 &&
+        isOtherInstance(pid, QFileInfo(toQStringInternal(exe)).fileName())) {
+      otherIsRunning = true;
+      break;
+    }
+  }
+  return otherIsRunning;
+}
+
+#elif defined(Q_OS_MAC)
+bool isAnotherInstanceRunning() {
+  kinfo_proc *processes[] = {nullptr};
+  size_t processesLength(0);
+  const int sysctlQuery[3] = {CTL_KERN, KERN_PROC, KERN_PROC_ALL};
+  /*
+   * We start by calling sysctl with ptr == NULL and size == 0.
+   * That will succeed, and set size to the appropriate length.
+   * We then allocate a buffer of at least that size and call
+   * sysctl with that buffer.  If that succeeds, we're done.
+   * If that call fails with ENOMEM, we throw the buffer away
+   * and try again.
+   * Note that the loop calls sysctl with NULL again.  This is
+   * is necessary because the ENOMEM failure case sets size to
+   * the amount of data returned, not the amount of data that
+   * could have been returned.
+   */
+  int attempts = 8; // An arbitrary number of attempts to try
+  void *memory{nullptr};
+  while (attempts-- > 0) {
+    size_t size = 0;
+    if (sysctl((int *)sysctlQuery, 3, NULL, &size, NULL, 0) == -1) {
+      throw std::runtime_error("Unable to retrieve process list");
+    }
+    const size_t size2 =
+        size + (size >> 3); // add some to cover more popping in
+    if (size2 > size) {
+      memory = malloc(size2);
+      if (memory == nullptr)
+        memory = malloc(size);
+      else
+        size = size2;
+    } else {
+      memory = malloc(size);
+    }
+    if (memory == nullptr)
+      throw std::runtime_error(
+          "Unable to allocate memory to retrieve process list");
+    if (sysctl((int *)sysctlQuery, 3, memory, &size, NULL, 0) == -1) {
+      free(memory);
+      throw std::runtime_error("Unable to retrieve process list");
+    } else {
+      *processes = (kinfo_proc *)memory;
+      processesLength = size / sizeof(kinfo_proc);
+      break;
+    }
+  }
+
+  kinfo_proc *processListBegin = processes[0];
+  kinfo_proc *processIter = processListBegin;
+  char exePath[PATH_MAX];
+  for (size_t i = 0; i < processesLength; ++i) {
+    const auto pid = processIter->kp_proc.p_pid;
+    if (proc_pidpath(pid, exePath, PATH_MAX) > 0) {
+      // assume process is dead...
+      continue;
+    }
+    if (isOtherInstance(pid,
+                        QFileInfo(toQStringInternal(exePath)).fileName())) {
+      otherIsRunning = true;
+      break;
+    }
+    processIter++;
+  }
+  free(processListBegin);
+
+  return otherIsRunning;
+}
+#endif
 
 } // namespace Process

--- a/MantidPlot/src/Process.cpp
+++ b/MantidPlot/src/Process.cpp
@@ -47,10 +47,10 @@ bool isAnotherInstanceRunning() {
   QDir procfs{"/proc"};
 
   bool otherIsRunning(false);
-  auto entries{procfs.entryList(QDir::Dirs)};
+  const QStringList entries{procfs.entryList(QDir::Dirs)};
   for (const auto &pidStr : entries) {
     bool isDigit(false);
-    auto pid{pidStr.toLongLong(&isDigit)};
+    const long long pid{pidStr.toLongLong(&isDigit)};
     if (!isDigit)
       continue;
 

--- a/MantidPlot/src/Process.cpp
+++ b/MantidPlot/src/Process.cpp
@@ -115,7 +115,7 @@ bool isAnotherInstanceRunning() {
 bool isAnotherInstanceRunning() {
   kinfo_proc *processes[] = {nullptr};
   size_t processesLength(0);
-  const int sysctlQuery[3] = {CTL_KERN, KERN_PROC, KERN_PROC_ALL};
+  int sysctlQuery[3] = {CTL_KERN, KERN_PROC, KERN_PROC_ALL};
   /*
    * We start by calling sysctl with ptr == NULL and size == 0.
    * That will succeed, and set size to the appropriate length.
@@ -162,14 +162,15 @@ bool isAnotherInstanceRunning() {
   kinfo_proc *processListBegin = processes[0];
   kinfo_proc *processIter = processListBegin;
   char exePath[PATH_MAX];
+  auto otherIsRunning = false;
   for (size_t i = 0; i < processesLength; ++i) {
     const auto pid = processIter->kp_proc.p_pid;
-    if (proc_pidpath(pid, exePath, PATH_MAX) > 0) {
+    if (proc_pidpath(pid, exePath, PATH_MAX) <= 0) {
       // assume process is dead...
       continue;
     }
     if (isOtherInstance(pid,
-                        QFileInfo(toQStringInternal(exePath)).fileName())) {
+                        QFileInfo(QString::fromAscii(exePath)).fileName())) {
       otherIsRunning = true;
       break;
     }

--- a/MantidPlot/src/Process.h
+++ b/MantidPlot/src/Process.h
@@ -22,18 +22,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 File change history is stored at: <https://github.com/mantidproject/mantid>
 Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-#include <cstdint>
-#include <vector>
 
 /*
- * A minimal wrapper around Python's psutil package to gather information
- * about processes
+ * Access information about the process and others
  */
 
 namespace Process {
 
 bool isAnotherInstanceRunning();
-
-std::vector<int64_t> otherInstancePIDs();
 }
 #endif // PROCESS_H_


### PR DESCRIPTION
**Description of work.**

Replaces the check for other instances with pure C++ code rather than using `psutil`. Distributing `psutil` on macOS whas causing issues and the calling code from C++->Python is not the easiest to understand.

**To test:**

Must be tested on all 3 OSs.

Check that project recovery is disabled for other instances of MantidPlot that are started. Crashing one instance then requires shutting down all instances to be able to recover.

*No associated issue*

Does this update require release notes?
- [ ] Yes
- [X] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
