### PR TITLE
Remove specificity from message_box

### DIFF
--- a/scripts/Muon/GUI/Common/message_box.py
+++ b/scripts/Muon/GUI/Common/message_box.py
@@ -4,4 +4,4 @@ import PyQt4.QtGui as QtGui
 def warning(error):
 
     ex = QtGui.QWidget()
-    QtGui.QMessageBox.warning(ex, "Frequency Domain Analysis", str(error))
+    QtGui.QMessageBox.warning(ex, "Error", str(error))


### PR DESCRIPTION
**Description of work.**
`message_box.py` is intended to contain a common class: for this reason, the title should not be specific to Frequency Domain Analysis.

**Report to:** nobody

**To test:**
Open Mantid: Interfaces -> Muon -> Frequency Domain Analysis
The message box should have a title of `Error`

Fixes #23066 

Does this update require release notes?
- [ ] Yes
- [X] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
