### PR TITLE
Double click table column heading for column options

### DIFF
--- a/MantidPlot/src/Table.cpp
+++ b/MantidPlot/src/Table.cpp
@@ -128,9 +128,13 @@ Table::Table(ScriptingEnv *env, int rows, int cols, const QString &label,
           SLOT(cellEdited(int, int)));
   connect(d_table, SIGNAL(itemSelectionChanged()), this,
           SLOT(recordSelection()));
+  connect(d_table->horizontalHeader(), SIGNAL(sectionDoubleClicked(int)), this,
+          SLOT(onColumnHeaderDoubleClick()));
 
   setAutoUpdateValues(applicationWindow()->autoUpdateTableValues());
 }
+
+void Table::onColumnHeaderDoubleClick() { emit optionsDialog(); }
 
 void Table::setAutoUpdateValues(bool on) {
   if (on) {

--- a/MantidPlot/src/Table.h
+++ b/MantidPlot/src/Table.h
@@ -173,6 +173,7 @@ public slots:
   void moveCurrentCell();
   bool isEmptyRow(int row);
   bool isEmptyColumn(int col);
+  void onColumnHeaderDoubleClick();
 
   void print() override;
   void print(const QString &fileName);


### PR DESCRIPTION
**Description of work.**
The changes made allow you to access the column options of a table by double clicking a column heading.

**To test:**
1. Run MantidPlot
2. File ->New->New Table
3. Double click column heading
4. The column options should appear

Fixes #16440 

Does this update require release notes?
- [ ] Yes
- [X] No

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
