### PR TITLE
Time standard deviation for TimeSeriesProperty

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/ITimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/ITimeSeriesProperty.h
@@ -53,10 +53,16 @@ public:
   /// Calculate the time-weighted average of a property in a filtered range
   virtual double
   averageValueInFilter(const std::vector<SplittingInterval> &filter) const = 0;
+  /// Calculate the time-weighted average and standard deviation of a property
+  /// in a filtered range
+  virtual std::pair<double, double> averageAndStdDevInFilter(
+      const std::vector<SplittingInterval> &filter) const = 0;
   /// Return the time series's times as a vector<DateAndTime>
   virtual std::vector<Types::Core::DateAndTime> timesAsVector() const = 0;
   /// Returns the calculated time weighted average value
   virtual double timeAverageValue() const = 0;
+  /// Returns the calculated time weighted average value and standard deviation
+  virtual std::pair<double, double> timeAverageValueAndStdDev() const = 0;
   /// Returns the real size of the time series property map:
   virtual int realSize() const = 0;
   /// Deletes the series of values in the property

--- a/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
@@ -181,12 +181,12 @@ public:
   /// Calculate the time-weighted average of a property in a filtered range
   double averageValueInFilter(
       const std::vector<SplittingInterval> &filter) const override;
-  /// @copydoc ITimeSeriesPropery::averageAndStdDevInFilter
+  /// @copydoc Mantid::Kernel::ITimeSeriesProperty::averageAndStdDevInFilter()
   std::pair<double, double> averageAndStdDevInFilter(
       const std::vector<SplittingInterval> &filter) const override;
   /// Calculate the time-weighted average of a property
   double timeAverageValue() const override;
-  /// @copydoc ITimeSeriesPropery::timeAverageValueAndStdDev
+  /// @copydoc Mantid::Kernel::ITimeSeriesProperty::timeAverageValueAndStdDev()
   std::pair<double, double> timeAverageValueAndStdDev() const override;
   /// generate constant time-step histogram from the property values
   void histogramData(const Types::Core::DateAndTime &tMin,

--- a/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
@@ -182,9 +182,8 @@ public:
   double averageValueInFilter(
       const std::vector<SplittingInterval> &filter) const override;
   /// @copydoc ITimeSeriesPropery::averageAndStdDevInFilter
-  std::pair<double, double>
-  averageAndStdDevInFilter(const std::vector<SplittingInterval> &filter) const
-      override;
+  std::pair<double, double> averageAndStdDevInFilter(
+      const std::vector<SplittingInterval> &filter) const override;
   /// Calculate the time-weighted average of a property
   double timeAverageValue() const override;
   /// @copydoc ITimeSeriesPropery::timeAverageValueAndStdDev

--- a/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
@@ -181,8 +181,14 @@ public:
   /// Calculate the time-weighted average of a property in a filtered range
   double averageValueInFilter(
       const std::vector<SplittingInterval> &filter) const override;
+  /// @copydoc ITimeSeriesPropery::averageAndStdDevInFilter
+  std::pair<double, double>
+  averageAndStdDevInFilter(const std::vector<SplittingInterval> &filter) const
+      override;
   /// Calculate the time-weighted average of a property
   double timeAverageValue() const override;
+  /// @copydoc ITimeSeriesPropery::timeAverageValueAndStdDev
+  std::pair<double, double> timeAverageValueAndStdDev() const override;
   /// generate constant time-step histogram from the property values
   void histogramData(const Types::Core::DateAndTime &tMin,
                      const Types::Core::DateAndTime &tMax,

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -1024,21 +1024,23 @@ std::pair<double, double> TimeSeriesProperty<TYPE>::averageAndStdDevInFilter(
     // Get the log value and index at the start time of the filter
     int index;
     double value = getSingleValue(time.start(), index);
-    value = (value - mean) * (value - mean);
+    double valuestddev = (value - mean) * (value - mean);
     DateAndTime startTime = time.start();
 
     while (index < realSize() - 1 && m_values[index + 1].time() < time.stop()) {
       ++index;
+
       numerator +=
           DateAndTime::secondsFromDuration(m_values[index].time() - startTime) *
-          value;
+          valuestddev;
       startTime = m_values[index].time();
       value = static_cast<double>(m_values[index].value());
+      valuestddev = (value - mean) * (value - mean);
     }
 
     // Now close off with the end of the current filter range
     numerator +=
-        DateAndTime::secondsFromDuration(time.stop() - startTime) * value;
+        DateAndTime::secondsFromDuration(time.stop() - startTime) * valuestddev;
   }
 
   // Normalise by the total time

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -917,8 +917,7 @@ double TimeSeriesProperty<TYPE>::timeAverageValue() const {
   try {
     const auto &filter = getSplittingIntervals();
     retVal = this->averageValueInFilter(filter);
-  }
-  catch (std::exception &) {
+  } catch (std::exception &) {
     // just return nan
     retVal = std::numeric_limits<double>::quiet_NaN();
   }
@@ -991,7 +990,7 @@ double TimeSeriesProperty<std::string>::averageValueInFilter(
 template <typename TYPE>
 std::pair<double, double>
 TimeSeriesProperty<TYPE>::timeAverageValueAndStdDev() const {
-  std::pair<double, double> retVal{ 0., 0. }; // mean and stddev
+  std::pair<double, double> retVal{0., 0.}; // mean and stddev
   try {
     const auto &filter = getSplittingIntervals();
     retVal = this->averageAndStdDevInFilter(filter);
@@ -1012,9 +1011,8 @@ std::pair<double, double> TimeSeriesProperty<TYPE>::averageAndStdDevInFilter(
   // First of all, if the log or the filter is empty or is a single value,
   // return NaN for the uncertainty
   if (realSize() <= 1 || filter.empty()) {
-    return std::pair<double, double>{
-      mean, std::numeric_limits<double>::quiet_NaN()
-    };
+    return std::pair<double, double>{mean,
+                                     std::numeric_limits<double>::quiet_NaN()};
   }
 
   double numerator(0.0), totalTime(0.0);
@@ -1044,7 +1042,7 @@ std::pair<double, double> TimeSeriesProperty<TYPE>::averageAndStdDevInFilter(
   }
 
   // Normalise by the total time
-  return std::pair<double, double>{ mean, std::sqrt(numerator / totalTime) };
+  return std::pair<double, double>{mean, std::sqrt(numerator / totalTime)};
 }
 
 /** Function specialization for TimeSeriesProperty<std::string>

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -908,6 +908,23 @@ void TimeSeriesProperty<std::string>::expandFilterToRange(
                                        "properties");
 }
 
+/** Calculates the time-weighted average of a property.
+ *  @return The time-weighted average value of the log.
+ */
+template <typename TYPE>
+double TimeSeriesProperty<TYPE>::timeAverageValue() const {
+  double retVal = 0.0;
+  try {
+    const auto &filter = getSplittingIntervals();
+    retVal = this->averageValueInFilter(filter);
+  }
+  catch (std::exception &) {
+    // just return nan
+    retVal = std::numeric_limits<double>::quiet_NaN();
+  }
+  return retVal;
+}
+
 /** Calculates the time-weighted average of a property in a filtered range.
  *  This is written for that case of logs whose values start at the times given.
  *  @param filter The splitter/filter restricting the range of values included
@@ -959,21 +976,6 @@ double TimeSeriesProperty<TYPE>::averageValueInFilter(
   // 'Normalise' by the total time
   return numerator / totalTime;
 }
-/** Calculates the time-weighted average of a property.
- *  @return The time-weighted average value of the log.
- */
-template <typename TYPE>
-double TimeSeriesProperty<TYPE>::timeAverageValue() const {
-  double retVal = 0.0;
-  try {
-    const auto &filter = getSplittingIntervals();
-    retVal = this->averageValueInFilter(filter);
-  } catch (std::exception &) {
-    // just return nan
-    retVal = std::numeric_limits<double>::quiet_NaN();
-  }
-  return retVal;
-}
 
 /** Function specialization for TimeSeriesProperty<std::string>
  *  @throws Kernel::Exception::NotImplementedError always
@@ -983,6 +985,77 @@ double TimeSeriesProperty<std::string>::averageValueInFilter(
     const TimeSplitterType &) const {
   throw Exception::NotImplementedError("TimeSeriesProperty::"
                                        "averageValueInFilter is not "
+                                       "implemented for string properties");
+}
+
+template <typename TYPE>
+std::pair<double, double>
+TimeSeriesProperty<TYPE>::timeAverageValueAndStdDev() const {
+  std::pair<double, double> retVal{ 0., 0. }; // mean and stddev
+  try {
+    const auto &filter = getSplittingIntervals();
+    retVal = this->averageAndStdDevInFilter(filter);
+  } catch (std::exception &) {
+    retVal.first = std::numeric_limits<double>::quiet_NaN();
+    retVal.second = std::numeric_limits<double>::quiet_NaN();
+  }
+  return retVal;
+}
+
+template <typename TYPE>
+std::pair<double, double> TimeSeriesProperty<TYPE>::averageAndStdDevInFilter(
+    const std::vector<SplittingInterval> &filter) const {
+  // the mean to calculate the standard deviation about
+  // this will sort the log as necessary as well
+  const double mean = this->averageValueInFilter(filter);
+
+  // First of all, if the log or the filter is empty or is a single value,
+  // return NaN for the uncertainty
+  if (realSize() <= 1 || filter.empty()) {
+    return std::pair<double, double>{
+      mean, std::numeric_limits<double>::quiet_NaN()
+    };
+  }
+
+  double numerator(0.0), totalTime(0.0);
+  // Loop through the filter ranges
+  for (const auto &time : filter) {
+    // Calculate the total time duration (in seconds) within by the filter
+    totalTime += time.duration();
+
+    // Get the log value and index at the start time of the filter
+    int index;
+    double value = getSingleValue(time.start(), index);
+    value = (value - mean) * (value - mean);
+    DateAndTime startTime = time.start();
+
+    while (index < realSize() - 1 && m_values[index + 1].time() < time.stop()) {
+      ++index;
+      numerator +=
+          DateAndTime::secondsFromDuration(m_values[index].time() - startTime) *
+          value;
+      startTime = m_values[index].time();
+      value = static_cast<double>(m_values[index].value());
+    }
+
+    // Now close off with the end of the current filter range
+    numerator +=
+        DateAndTime::secondsFromDuration(time.stop() - startTime) * value;
+  }
+
+  // Normalise by the total time
+  return std::pair<double, double>{ mean, std::sqrt(numerator / totalTime) };
+}
+
+/** Function specialization for TimeSeriesProperty<std::string>
+ *  @throws Kernel::Exception::NotImplementedError always
+ */
+template <>
+std::pair<double, double>
+TimeSeriesProperty<std::string>::averageAndStdDevInFilter(
+    const TimeSplitterType &) const {
+  throw Exception::NotImplementedError("TimeSeriesProperty::"
+                                       "averageAndStdDevInFilter is not "
                                        "implemented for string properties");
 }
 

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -613,8 +613,19 @@ public:
     auto dblLog = createDoubleTSP();
     auto intLog = createIntegerTSP(5);
 
-    TS_ASSERT_DELTA(dblLog->timeAverageValue(), 7.6966, .0001);
-    TS_ASSERT_DELTA(intLog->timeAverageValue(), 2.5, .0001);
+    // average values
+    const double dblMean = dblLog->timeAverageValue();
+    TS_ASSERT_DELTA(dblMean, 7.6966, .0001);
+    const double intMean = intLog->timeAverageValue();
+    TS_ASSERT_DELTA(intMean, 2.5, .0001);
+
+    // average is unchanged, standard deviation within tolerance
+    const auto dblPair = dblLog->timeAverageValueAndStdDev();
+    TS_ASSERT_EQUALS(dblPair.first, dblMean);
+    TS_ASSERT_DELTA(dblPair.second, 2.4738, .0001);
+    const auto intPair = intLog->timeAverageValueAndStdDev();
+    TS_ASSERT_EQUALS(intPair.first, intMean);
+    TS_ASSERT_DELTA(intPair.second, 1.6771, .0001);
 
     // Clean up
     delete dblLog;
@@ -624,6 +635,8 @@ public:
   void test_averageValueInFilter_throws_for_string_property() {
     TimeSplitterType splitter;
     TS_ASSERT_THROWS(sProp->averageValueInFilter(splitter),
+                     Exception::NotImplementedError);
+    TS_ASSERT_THROWS(sProp->averageAndStdDevInFilter(splitter),
                      Exception::NotImplementedError);
   }
 

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -622,10 +622,10 @@ public:
     // average is unchanged, standard deviation within tolerance
     const auto dblPair = dblLog->timeAverageValueAndStdDev();
     TS_ASSERT_EQUALS(dblPair.first, dblMean);
-    TS_ASSERT_DELTA(dblPair.second, 2.4738, .0001);
+    TS_ASSERT_DELTA(dblPair.second, 1.8156, .0001);
     const auto intPair = intLog->timeAverageValueAndStdDev();
     TS_ASSERT_EQUALS(intPair.first, intMean);
-    TS_ASSERT_DELTA(intPair.second, 1.6771, .0001);
+    TS_ASSERT_DELTA(intPair.second, 1.1180, .0001);
 
     // Clean up
     delete dblLog;

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
@@ -9,6 +9,7 @@
 #include <boost/python/make_function.hpp>
 #include <boost/python/return_value_policy.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
+#include <boost/python/tuple.hpp>
 
 using Mantid::Types::Core::DateAndTime;
 using Mantid::Kernel::TimeSeriesProperty;
@@ -33,6 +34,12 @@ void addPyTimeValue(TimeSeriesProperty<TYPE> &self,
   const auto dateandtime =
       Mantid::PythonInterface::Converters::to_dateandtime(datetime);
   self.addValue(*dateandtime, value);
+}
+
+template <typename TYPE>
+tuple pyTimeAverageValueAndStdDev(const TimeSeriesProperty<TYPE> &self) {
+  const std::pair<double, double> value = self.timeAverageValueAndStdDev();
+  return make_tuple(value.first, value.second);
 }
 
 // Macro to reduce copy-and-paste
@@ -80,7 +87,9 @@ void addPyTimeValue(TimeSeriesProperty<TYPE> &self,
            arg("self"),                                                        \
            "returns :class:`mantid.kernel.TimeSeriesPropertyStatistics`")      \
       .def("timeAverageValue", &TimeSeriesProperty<TYPE>::timeAverageValue,    \
-           arg("self"));
+           arg("self"))                                                        \
+      .def("timeAverageValueAndStdDev", &pyTimeAverageValueAndStdDev<TYPE>,    \
+           arg("self"), "Time average value and standard deviation");
 }
 
 void export_TimeSeriesProperty_Double() {

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
@@ -43,9 +43,9 @@ tuple pyTimeAverageValueAndStdDev(const TimeSeriesProperty<TYPE> &self) {
   return make_tuple(value.first, value.second);
 
   // Call the dtype helper function
-template <typename TYPE> std::string dtype(TimeSeriesProperty<TYPE> &self) {
-  return Mantid::PythonInterface::Converters::dtype(self);
-}
+  template <typename TYPE> std::string dtype(TimeSeriesProperty<TYPE> & self) {
+    return Mantid::PythonInterface::Converters::dtype(self);
+  }
 
 // Macro to reduce copy-and-paste
 #define EXPORT_TIMESERIES_PROP(TYPE, Prefix)                                   \

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
@@ -41,11 +41,12 @@ template <typename TYPE>
 tuple pyTimeAverageValueAndStdDev(const TimeSeriesProperty<TYPE> &self) {
   const std::pair<double, double> value = self.timeAverageValueAndStdDev();
   return make_tuple(value.first, value.second);
+}
 
-  // Call the dtype helper function
-  template <typename TYPE> std::string dtype(TimeSeriesProperty<TYPE> & self) {
-    return Mantid::PythonInterface::Converters::dtype(self);
-  }
+// Call the dtype helper function
+template <typename TYPE> std::string dtype(TimeSeriesProperty<TYPE> &self) {
+  return Mantid::PythonInterface::Converters::dtype(self);
+}
 
 // Macro to reduce copy-and-paste
 #define EXPORT_TIMESERIES_PROP(TYPE, Prefix)                                   \

--- a/MantidPlot/src/Mantid/MantidSampleLogDialog.cpp
+++ b/MantidPlot/src/Mantid/MantidSampleLogDialog.cpp
@@ -65,8 +65,9 @@ MantidSampleLogDialog::MantidSampleLogDialog(const QString &wsname,
   }
 
   // -------------- Statistics on logs ------------------------
-  std::string stats[NUM_STATS] = {
-      "Min:", "Max:", "Mean:", "Time Avg:", "Median:", "Std Dev:", "Duration:"};
+  std::string stats[NUM_STATS] = { "Min:",          "Max:",     "Mean:",
+                                   "Median:",       "Std Dev:", "Time Avg:",
+                                   "Time Std Dev:", "Duration:" };
   QGroupBox *statsBox = new QGroupBox("Log Statistics");
   QFormLayout *statsBoxLayout = new QFormLayout;
   for (size_t i = 0; i < NUM_STATS; i++) {

--- a/MantidPlot/src/Mantid/MantidSampleLogDialog.cpp
+++ b/MantidPlot/src/Mantid/MantidSampleLogDialog.cpp
@@ -65,9 +65,9 @@ MantidSampleLogDialog::MantidSampleLogDialog(const QString &wsname,
   }
 
   // -------------- Statistics on logs ------------------------
-  std::string stats[NUM_STATS] = { "Min:",          "Max:",     "Mean:",
-                                   "Median:",       "Std Dev:", "Time Avg:",
-                                   "Time Std Dev:", "Duration:" };
+  std::string stats[NUM_STATS] = {"Min:",          "Max:",     "Mean:",
+                                  "Median:",       "Std Dev:", "Time Avg:",
+                                  "Time Std Dev:", "Duration:"};
   QGroupBox *statsBox = new QGroupBox("Log Statistics");
   QFormLayout *statsBoxLayout = new QFormLayout;
   for (size_t i = 0; i < NUM_STATS; i++) {

--- a/MantidPlot/src/Mantid/SampleLogDialogBase.cpp
+++ b/MantidPlot/src/Mantid/SampleLogDialogBase.cpp
@@ -138,7 +138,7 @@ void SampleLogDialogBase::showLogStatisticsOfItem(
         dynamic_cast<TimeSeriesProperty<double> *>(logData);
     Mantid::Kernel::TimeSeriesProperty<int> *tspi =
         dynamic_cast<TimeSeriesProperty<int> *>(logData);
-    std::pair<double, double> timeAvgStdDev{ 0., 0. };
+    std::pair<double, double> timeAvgStdDev{0., 0.};
     LogFilterGenerator generator(filter, m_ei->run());
     const auto &logFilter = generator.generateFilter(logName);
     if (tspd) {

--- a/MantidPlot/src/Mantid/SampleLogDialogBase.cpp
+++ b/MantidPlot/src/Mantid/SampleLogDialogBase.cpp
@@ -138,17 +138,17 @@ void SampleLogDialogBase::showLogStatisticsOfItem(
         dynamic_cast<TimeSeriesProperty<double> *>(logData);
     Mantid::Kernel::TimeSeriesProperty<int> *tspi =
         dynamic_cast<TimeSeriesProperty<int> *>(logData);
-    double timeAvg = 0.;
+    std::pair<double, double> timeAvgStdDev{ 0., 0. };
     LogFilterGenerator generator(filter, m_ei->run());
     const auto &logFilter = generator.generateFilter(logName);
     if (tspd) {
       ScopedFilter<double> applyFilter(tspd, std::move(logFilter));
       stats = tspd->getStatistics();
-      timeAvg = tspd->timeAverageValue();
+      timeAvgStdDev = tspd->timeAverageValueAndStdDev();
     } else if (tspi) {
       ScopedFilter<int> applyFilter(tspi, std::move(logFilter));
       stats = tspi->getStatistics();
-      timeAvg = tspi->timeAverageValue();
+      timeAvgStdDev = tspi->timeAverageValueAndStdDev();
     } else
       return;
 
@@ -156,10 +156,11 @@ void SampleLogDialogBase::showLogStatisticsOfItem(
     statValues[0]->setText(QString::number(stats.minimum));
     statValues[1]->setText(QString::number(stats.maximum));
     statValues[2]->setText(QString::number(stats.mean));
-    statValues[3]->setText(QString::number(timeAvg));
-    statValues[4]->setText(QString::number(stats.median));
-    statValues[5]->setText(QString::number(stats.standard_deviation));
-    statValues[6]->setText(QString::number(stats.duration));
+    statValues[3]->setText(QString::number(stats.median));
+    statValues[4]->setText(QString::number(stats.standard_deviation));
+    statValues[5]->setText(QString::number(timeAvgStdDev.first));
+    statValues[6]->setText(QString::number(timeAvgStdDev.second));
+    statValues[7]->setText(QString::number(stats.duration));
     return;
     break;
   }

--- a/MantidPlot/src/Mantid/SampleLogDialogBase.h
+++ b/MantidPlot/src/Mantid/SampleLogDialogBase.h
@@ -133,7 +133,7 @@ protected:
   QPushButton *buttonPlot, *buttonClose;
 
   /// Number of statistic values
-  static const std::size_t NUM_STATS = 7;
+  static const std::size_t NUM_STATS = 8;
 
   /// Testboxes with stats data
   QLineEdit *statValues[NUM_STATS];

--- a/docs/source/release/v3.14.0/ui.rst
+++ b/docs/source/release/v3.14.0/ui.rst
@@ -9,4 +9,6 @@ UI & Usability Changes
     putting new features at the top of the section, followed by
     improvements, followed by bug fixes.
 
+- Added time standard deviation to the sample log dialog
+
 :ref:`Release 3.14.0 <v3.14.0>`


### PR DESCRIPTION
Add a calculation of the time standard deviation (sigma) to `TimeSeriesProperty`, expose it to python, and show it in the sample dialog. Since calculating the standard deviation requires knowing the mean, the decision was made to bundle the two values together.

**To test:**

Check that the new value appears in the sample log dialog box as well as can be returned from python. The big thing is to confirm that the equation is correct and the name of the method makes sense.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
