### PR TITLE
Export Sample::getShape()

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
@@ -69,8 +69,6 @@ void export_Sample() {
       .def("getShape", &Sample::getShape, arg("self"),
            "Returns a shape of a Sample object.",
            return_value_policy<reference_existing_object>())
-      //.def("getShapeXML", &CSGObject::getShapeXML, arg("self"),
-      //     "Returns a shape XML of a Sample object.")
       // -------------------------Operators
       // -------------------------------------
       .def("__len__", &Sample::size, arg("self"),

--- a/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
@@ -10,7 +10,6 @@
 #include <boost/python/register_ptr_to_python.hpp>
 
 using Mantid::API::Sample;
-using Mantid::Geometry::CSGObject;
 using Mantid::Geometry::OrientedLattice;
 using Mantid::Kernel::Material; // NOLINT
 using namespace boost::python;

--- a/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
@@ -27,8 +27,9 @@ void export_Sample() {
       .def("getName", &Sample::getName,
            return_value_policy<copy_const_reference>(), arg("self"),
            "Returns the string name of the sample")
-      .def("getOrientedLattice", (const OrientedLattice &(Sample::*)() const) &
-                                     Sample::getOrientedLattice,
+      .def("getOrientedLattice",
+           (const OrientedLattice &(Sample::*)() const) &
+               Sample::getOrientedLattice,
            arg("self"), return_value_policy<reference_existing_object>(),
            "Get the oriented lattice for this sample")
       .def("hasOrientedLattice", &Sample::hasOrientedLattice, arg("self"),
@@ -73,6 +74,6 @@ void export_Sample() {
       // -------------------------------------
       .def("__len__", &Sample::size, arg("self"),
            "Gets the number of samples in this collection")
-      .def("__getitem__", &Sample::operator[], (arg("self"), arg("index")),
+      .def("__getitem__", &Sample::operator[],(arg("self"), arg("index")),
            return_internal_reference<>());
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
@@ -1,4 +1,5 @@
 #include "MantidAPI/Sample.h"
+
 #include "MantidGeometry/Crystal/CrystalStructure.h"
 #include "MantidGeometry/Crystal/OrientedLattice.h"
 #include "MantidKernel/Material.h"
@@ -9,6 +10,7 @@
 #include <boost/python/register_ptr_to_python.hpp>
 
 using Mantid::API::Sample;
+using Mantid::Geometry::CSGObject;
 using Mantid::Geometry::OrientedLattice;
 using Mantid::Kernel::Material; // NOLINT
 using namespace boost::python;
@@ -65,6 +67,11 @@ void export_Sample() {
            "Set the height in mm.")
       .def("setWidth", &Sample::setWidth, (arg("self"), arg("width")),
            "Set the width in mm.")
+      .def("getShape", &Sample::getShape, arg("self"),
+           "Returns a shape of a Sample object.",
+           return_value_policy<reference_existing_object>())
+      //.def("getShapeXML", &CSGObject::getShapeXML, arg("self"),
+      //     "Returns a shape XML of a Sample object.")
       // -------------------------Operators
       // -------------------------------------
       .def("__len__", &Sample::size, arg("self"),

--- a/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
@@ -27,9 +27,8 @@ void export_Sample() {
       .def("getName", &Sample::getName,
            return_value_policy<copy_const_reference>(), arg("self"),
            "Returns the string name of the sample")
-      .def("getOrientedLattice",
-           (const OrientedLattice &(Sample::*)() const) &
-               Sample::getOrientedLattice,
+      .def("getOrientedLattice", (const OrientedLattice &(Sample::*)() const) &
+                                     Sample::getOrientedLattice,
            arg("self"), return_value_policy<reference_existing_object>(),
            "Get the oriented lattice for this sample")
       .def("hasOrientedLattice", &Sample::hasOrientedLattice, arg("self"),
@@ -76,6 +75,6 @@ void export_Sample() {
       // -------------------------------------
       .def("__len__", &Sample::size, arg("self"),
            "Gets the number of samples in this collection")
-      .def("__getitem__", &Sample::operator[],(arg("self"), arg("index")),
+      .def("__getitem__", &Sample::operator[], (arg("self"), arg("index")),
            return_internal_reference<>());
 }

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/IObject.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/IObject.cpp
@@ -4,6 +4,7 @@
 #include <boost/python/class.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
 
+using Mantid::Geometry::CSGObject;
 using Mantid::Geometry::IObject;
 using namespace boost::python;
 

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/IObject.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/IObject.cpp
@@ -4,7 +4,6 @@
 #include <boost/python/class.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
 
-using Mantid::Geometry::CSGObject;
 using Mantid::Geometry::IObject;
 using namespace boost::python;
 

--- a/Framework/PythonInterface/test/python/mantid/api/SampleTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/SampleTest.py
@@ -5,6 +5,7 @@ from mantid.api import Sample
 from mantid.simpleapi import CreateWorkspace
 from mantid.simpleapi import SetSampleMaterial
 from mantid.geometry import CrystalStructure
+from mantid.geometry import CSGObject
 
 class SampleTest(unittest.TestCase):
 
@@ -66,6 +67,15 @@ class SampleTest(unittest.TestCase):
         xs1 = atoms[1].neutron()
         xs = ( xs0['coh_scatt_xs']*2 + xs1['coh_scatt_xs']*3 ) / 5
         self.assertAlmostEquals(material.cohScatterXSection(), xs, places=4)
+
+    def test_get_shape(self):
+        sample = self._ws.sample()
+        self.assertEquals(type(sample.getShape()), CSGObject)
+
+    #def test_get_shape_xml(self):
+    #    sample = self._ws.sample()
+    #    self.assertEquals(type(sample.getShapeXML()), str)
+
 
 
 

--- a/Framework/PythonInterface/test/python/mantid/api/SampleTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/SampleTest.py
@@ -72,9 +72,11 @@ class SampleTest(unittest.TestCase):
         sample = self._ws.sample()
         self.assertEquals(type(sample.getShape()), CSGObject)
 
-    #def test_get_shape_xml(self):
-    #    sample = self._ws.sample()
-    #    self.assertEquals(type(sample.getShapeXML()), str)
+    def test_get_shape_xml(self):
+        sample = self._ws.sample()
+        shape = sample.getShape()
+        xml = shape.getShapeXML()
+        self.assertEquals(type(xml), str)
 
 
 


### PR DESCRIPTION
**Description of work.**
Makes it possible to access the shape of a Sample object via the Python interface.

**To test**
Run the following script in the python interface:

```
ws = CreateWorkspace(DataX=[1,2,3,4,5], DataY=[1,2,3,4,5], OutputWorkspace="dummy")

sample = ws.sample()
shape = sample.getShape()
xml = shape.getShapeXML()
```

This should run without any errors as access to a shape of a sample object should be allowed.

Fixes #21465 

Does this update require release notes?
- [ ] Yes
- [X] No

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
