### PR TITLE
Fix ISISReflectometryAutoreductionTest for python 3

### DIFF
--- a/Testing/SystemTests/tests/analysis/ISISReflectometryAutoreductionTest.py
+++ b/Testing/SystemTests/tests/analysis/ISISReflectometryAutoreductionTest.py
@@ -3,7 +3,6 @@ System Test for ISIS Reflectometry autoreduction
 Adapted from scripts provided by Max Skoda.
 """
 import re
-import string
 import itertools
 import math
 import stresstesting
@@ -270,7 +269,7 @@ def AutoReduce(transRun=[], runRange=[], oldList=[]):
         for item in sample:
             runno = item[0]
             angle = item[1]
-            runnos = string.split(runno, '+')
+            runnos = runno.split('+')
             # check if runs have been added together
             runnos = [int(i) for i in runnos]
 
@@ -330,11 +329,9 @@ def AutoReduce(transRun=[], runRange=[], oldList=[]):
             # print(Qmin, Qmax, dqq)
             # print(overlapHigh)
             if len(wq_list) > 1:
-                outputwksp = string.split(wq_list[0], sep='_')[
-                    0] + '_' + string.split(wq_list[-1], sep='_')[0][3:]
+                outputwksp = wq_list[0].split('_')[0] + '_' + wq_list[-1].split('_')[0][3:]
             else:
-                outputwksp = string.split(
-                    wq_list[0], sep='_')[0] + '_IvsQ_binned'
+                outputwksp = wq_list[0].split('_')[0] + '_IvsQ_binned'
 
             if not mtd.doesExist(outputwksp):
                 combineDataMulti(


### PR DESCRIPTION
[Failing test here](http://builds.mantidproject.org/job/master_systemtests-ubuntu-16.04-python3/490/testReport/SystemTests/ISISReflectometryAutoreductionTest/ISISReflectometryAutoreductionTest/)

`string.split` doesn't exist in python 3, change to `str.split`

**To test:**
With python3 `./systemtest -R ISISReflectometryAutoreductionTest`


Does this update require release notes?
- [ ] Yes
- [x] No

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
