### PR TITLE
Fix custom user docs stylesheet for Sphinx > 1.6

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -49,4 +49,7 @@
 {%- endblock %}
 
 {# Custom CSS overrides #}
+<!-- Overriding style sheets changed in Sphinx >=1.6.1: https://github.com/ryan-roemer/sphinx-bootstrap-theme/blob/master/README.rst#adding-custom-css
+     Later versions of sphinx-theme-bootstrap-theme ignore this value but we keep it so that old versions still work
+ -->
 {% set bootswatch_css_custom = ['_static/custom.css'] %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,6 +5,7 @@
 
 import sys
 import os
+from sphinx import __version__ as sphinx_version
 import sphinx_bootstrap_theme # checked at cmake time
 import mantid
 from mantid import ConfigService
@@ -15,6 +16,13 @@ from mantid import ConfigService
 sys.path.insert(0, os.path.abspath(os.path.join('..', 'sphinxext')))
 
 # -- General configuration ------------------------------------------------
+
+if sphinx_version > "1.6":
+    def setup(app):
+        """Called automatically by Sphinx when starting the build process
+        """
+        app.add_stylesheet("custom.css")
+
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -139,9 +147,12 @@ html_static_path = ['_static']
 # directly to the root of the documentation.
 #html_extra_path = []
 
-# If true, SmartyPants will be used to convert quotes and dashes to
+# If true, Smart Quotes will be used to convert quotes and dashes to
 # typographically correct entities.
-html_use_smartypants = True
+if sphinx_version < "1.7":
+    html_use_smartypants = True
+else:
+    smartquotes = True
 
 # Hide the Sphinx usage as we reference it on github instead.
 html_show_sphinx = False


### PR DESCRIPTION
**Description of work.**

Sphinx & sphinx-bootstrap-theme have changed the way custom css is included in [later versions](https://github.com/ryan-roemer/sphinx-bootstrap-theme#adding-custom-css). This change should allow us to build with both older and later versions.

**To test:**

* The docs build should succeed without warnings.

*No associated issue*

Does this update require release notes?
- [ ] Yes
- [X] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
