### PR TITLE
Use system eigen and xmlrunner on Windows

### DIFF
--- a/buildconfig/CMake/Bootstrap.cmake
+++ b/buildconfig/CMake/Bootstrap.cmake
@@ -10,7 +10,7 @@ if( MSVC )
   include ( ExternalProject )
   set( EXTERNAL_ROOT ${PROJECT_SOURCE_DIR}/external CACHE PATH "Location to clone third party dependencies to" )
   set( THIRD_PARTY_GIT_URL "https://github.com/mantidproject/thirdparty-msvc2015.git" )
-  set ( THIRD_PARTY_GIT_SHA1 318c5b501ca298d1130d9c67b2feeae0181cf31c )
+  set ( THIRD_PARTY_GIT_SHA1 c8d06145b5520ea9e00d6d48e593ef56ad9a6896 )
   set ( THIRD_PARTY_DIR ${EXTERNAL_ROOT}/src/ThirdParty )
   # Generates a script to do the clone/update in tmp
   set ( _project_name ThirdParty )

--- a/buildconfig/CMake/Eigen.cmake
+++ b/buildconfig/CMake/Eigen.cmake
@@ -1,10 +1,11 @@
 include(ExternalProject)
 
-# Use version 3.2.10 of Eigen
-# A newer version existed at the time of choosing this version (3.3.2), but this had warnings when building
-set(eigen_version "3.2.10")
-
 option(USE_SYSTEM_EIGEN "Use the system installed Eigen - v${eigen_version}?" OFF)
+
+if ( WIN32 )
+  # Installed by 3rd party dependencies bundle
+  set ( USE_SYSTEM_EIGEN ON )
+endif ()
 
 if(USE_SYSTEM_EIGEN)
   message(STATUS "Using system Eigen")

--- a/buildconfig/CMake/Python-xmlrunner.cmake
+++ b/buildconfig/CMake/Python-xmlrunner.cmake
@@ -4,8 +4,13 @@ set(xmlrunner_version "2.1.0")
 
 option(USE_SYSTEM_XMLRUNNER "Use the system installed unittest-xmlrunner?" OFF)
 
+if ( WIN32 )
+  # Installed by 3rd party dependencies bundle
+  set ( USE_SYSTEM_XMLRUNNER ON )
+endif ()
+
 if(USE_SYSTEM_XMLRUNNER)
-  # Currrently assumes item is importable
+  # Currently assumes item is importable
   message(STATUS "Using system unittest-xml-runner")
 else()
   message(STATUS "Using unittest-xml-runner from ExternalProject")


### PR DESCRIPTION
**Description of work.**

Eigen and xmlrunner have been put into the 3rdparty repo for Windows. This avoids long cmake configure times, especially with Eigen.

Please merge mantidproject/thirdparty-msvc2015#36 when this is merged.

**To test:**

Remove the `extern-eigen` and `python-xmlrunner-src` directories and build Mantid.

*No associated GitHub issue*

Does this update require release notes?
- [ ] Yes
- [X] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
