### PR TITLE
Fix clang-tidy modernize-use-nullptr warnings

### DIFF
--- a/Framework/ICat/inc/MantidICat/ICat3/GSoapGenerated/ICat3H.h
+++ b/Framework/ICat/inc/MantidICat/ICat3/GSoapGenerated/ICat3H.h
@@ -798,14 +798,14 @@ soap_instantiate_ns1__elementType_(struct soap *, int, const char *,
 
 inline ns1__elementType_ *soap_new_ns1__elementType_(struct soap *soap,
                                                      int n = -1) {
-  return soap_instantiate_ns1__elementType_(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__elementType_(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__elementType_ *
 soap_new_req_ns1__elementType_(struct soap *soap,
                                enum ns1__elementType __item) {
   ns1__elementType_ *_p =
-      soap_instantiate_ns1__elementType_(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__elementType_(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__elementType_::__item = __item;
@@ -817,7 +817,7 @@ inline ns1__elementType_ *
 soap_new_set_ns1__elementType_(struct soap *soap, enum ns1__elementType __item,
                                char *__item1) {
   ns1__elementType_ *_p =
-      soap_instantiate_ns1__elementType_(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__elementType_(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__elementType_::__item = __item;
@@ -873,14 +873,15 @@ soap_instantiate_ns1__parameterType_(struct soap *, int, const char *,
 
 inline ns1__parameterType_ *soap_new_ns1__parameterType_(struct soap *soap,
                                                          int n = -1) {
-  return soap_instantiate_ns1__parameterType_(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__parameterType_(soap, n, nullptr, nullptr,
+                                              nullptr);
 }
 
 inline ns1__parameterType_ *
 soap_new_req_ns1__parameterType_(struct soap *soap,
                                  enum ns1__parameterType __item) {
   ns1__parameterType_ *_p =
-      soap_instantiate_ns1__parameterType_(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__parameterType_(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__parameterType_::__item = __item;
@@ -891,7 +892,7 @@ soap_new_req_ns1__parameterType_(struct soap *soap,
 inline ns1__parameterType_ *soap_new_set_ns1__parameterType_(
     struct soap *soap, enum ns1__parameterType __item, char *__item1) {
   ns1__parameterType_ *_p =
-      soap_instantiate_ns1__parameterType_(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__parameterType_(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__parameterType_::__item = __item;
@@ -946,14 +947,14 @@ soap_instantiate_ns1__keywordType_(struct soap *, int, const char *,
 
 inline ns1__keywordType_ *soap_new_ns1__keywordType_(struct soap *soap,
                                                      int n = -1) {
-  return soap_instantiate_ns1__keywordType_(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__keywordType_(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__keywordType_ *
 soap_new_req_ns1__keywordType_(struct soap *soap,
                                enum ns1__keywordType __item) {
   ns1__keywordType_ *_p =
-      soap_instantiate_ns1__keywordType_(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__keywordType_(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__keywordType_::__item = __item;
@@ -965,7 +966,7 @@ inline ns1__keywordType_ *
 soap_new_set_ns1__keywordType_(struct soap *soap, enum ns1__keywordType __item,
                                char *__item1) {
   ns1__keywordType_ *_p =
-      soap_instantiate_ns1__keywordType_(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__keywordType_(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__keywordType_::__item = __item;
@@ -1022,14 +1023,15 @@ soap_instantiate_ns1__comparisonOperator_(struct soap *, int, const char *,
 
 inline ns1__comparisonOperator_ *
 soap_new_ns1__comparisonOperator_(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__comparisonOperator_(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__comparisonOperator_(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline ns1__comparisonOperator_ *
 soap_new_req_ns1__comparisonOperator_(struct soap *soap,
                                       enum ns1__comparisonOperator __item) {
-  ns1__comparisonOperator_ *_p =
-      soap_instantiate_ns1__comparisonOperator_(soap, -1, NULL, NULL, NULL);
+  ns1__comparisonOperator_ *_p = soap_instantiate_ns1__comparisonOperator_(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__comparisonOperator_::__item = __item;
@@ -1039,8 +1041,8 @@ soap_new_req_ns1__comparisonOperator_(struct soap *soap,
 
 inline ns1__comparisonOperator_ *soap_new_set_ns1__comparisonOperator_(
     struct soap *soap, enum ns1__comparisonOperator __item, char *__item1) {
-  ns1__comparisonOperator_ *_p =
-      soap_instantiate_ns1__comparisonOperator_(soap, -1, NULL, NULL, NULL);
+  ns1__comparisonOperator_ *_p = soap_instantiate_ns1__comparisonOperator_(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__comparisonOperator_::__item = __item;
@@ -1097,14 +1099,15 @@ soap_instantiate_ns1__parameterValueType_(struct soap *, int, const char *,
 
 inline ns1__parameterValueType_ *
 soap_new_ns1__parameterValueType_(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__parameterValueType_(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__parameterValueType_(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline ns1__parameterValueType_ *
 soap_new_req_ns1__parameterValueType_(struct soap *soap,
                                       enum ns1__parameterValueType __item) {
-  ns1__parameterValueType_ *_p =
-      soap_instantiate_ns1__parameterValueType_(soap, -1, NULL, NULL, NULL);
+  ns1__parameterValueType_ *_p = soap_instantiate_ns1__parameterValueType_(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__parameterValueType_::__item = __item;
@@ -1114,8 +1117,8 @@ soap_new_req_ns1__parameterValueType_(struct soap *soap,
 
 inline ns1__parameterValueType_ *soap_new_set_ns1__parameterValueType_(
     struct soap *soap, enum ns1__parameterValueType __item, char *__item1) {
-  ns1__parameterValueType_ *_p =
-      soap_instantiate_ns1__parameterValueType_(soap, -1, NULL, NULL, NULL);
+  ns1__parameterValueType_ *_p = soap_instantiate_ns1__parameterValueType_(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__parameterValueType_::__item = __item;
@@ -1171,14 +1174,15 @@ soap_instantiate_ns1__sampleInclude_(struct soap *, int, const char *,
 
 inline ns1__sampleInclude_ *soap_new_ns1__sampleInclude_(struct soap *soap,
                                                          int n = -1) {
-  return soap_instantiate_ns1__sampleInclude_(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__sampleInclude_(soap, n, nullptr, nullptr,
+                                              nullptr);
 }
 
 inline ns1__sampleInclude_ *
 soap_new_req_ns1__sampleInclude_(struct soap *soap,
                                  enum ns1__sampleInclude __item) {
   ns1__sampleInclude_ *_p =
-      soap_instantiate_ns1__sampleInclude_(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__sampleInclude_(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__sampleInclude_::__item = __item;
@@ -1189,7 +1193,7 @@ soap_new_req_ns1__sampleInclude_(struct soap *soap,
 inline ns1__sampleInclude_ *soap_new_set_ns1__sampleInclude_(
     struct soap *soap, enum ns1__sampleInclude __item, char *__item1) {
   ns1__sampleInclude_ *_p =
-      soap_instantiate_ns1__sampleInclude_(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__sampleInclude_(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__sampleInclude_::__item = __item;
@@ -1248,14 +1252,15 @@ soap_instantiate_ns1__restrictionAttributes_(struct soap *, int, const char *,
 
 inline ns1__restrictionAttributes_ *
 soap_new_ns1__restrictionAttributes_(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__restrictionAttributes_(soap, n, NULL, NULL,
-                                                      NULL);
+  return soap_instantiate_ns1__restrictionAttributes_(soap, n, nullptr, nullptr,
+                                                      nullptr);
 }
 
 inline ns1__restrictionAttributes_ *soap_new_req_ns1__restrictionAttributes_(
     struct soap *soap, enum ns1__restrictionAttributes __item) {
   ns1__restrictionAttributes_ *_p =
-      soap_instantiate_ns1__restrictionAttributes_(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__restrictionAttributes_(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__restrictionAttributes_::__item = __item;
@@ -1266,7 +1271,8 @@ inline ns1__restrictionAttributes_ *soap_new_req_ns1__restrictionAttributes_(
 inline ns1__restrictionAttributes_ *soap_new_set_ns1__restrictionAttributes_(
     struct soap *soap, enum ns1__restrictionAttributes __item, char *__item1) {
   ns1__restrictionAttributes_ *_p =
-      soap_instantiate_ns1__restrictionAttributes_(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__restrictionAttributes_(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__restrictionAttributes_::__item = __item;
@@ -1324,14 +1330,15 @@ soap_instantiate_ns1__investigationInclude_(struct soap *, int, const char *,
 
 inline ns1__investigationInclude_ *
 soap_new_ns1__investigationInclude_(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__investigationInclude_(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__investigationInclude_(soap, n, nullptr, nullptr,
+                                                     nullptr);
 }
 
 inline ns1__investigationInclude_ *
 soap_new_req_ns1__investigationInclude_(struct soap *soap,
                                         enum ns1__investigationInclude __item) {
-  ns1__investigationInclude_ *_p =
-      soap_instantiate_ns1__investigationInclude_(soap, -1, NULL, NULL, NULL);
+  ns1__investigationInclude_ *_p = soap_instantiate_ns1__investigationInclude_(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__investigationInclude_::__item = __item;
@@ -1341,8 +1348,8 @@ soap_new_req_ns1__investigationInclude_(struct soap *soap,
 
 inline ns1__investigationInclude_ *soap_new_set_ns1__investigationInclude_(
     struct soap *soap, enum ns1__investigationInclude __item, char *__item1) {
-  ns1__investigationInclude_ *_p =
-      soap_instantiate_ns1__investigationInclude_(soap, -1, NULL, NULL, NULL);
+  ns1__investigationInclude_ *_p = soap_instantiate_ns1__investigationInclude_(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__investigationInclude_::__item = __item;
@@ -1399,14 +1406,15 @@ soap_instantiate_ns1__datasetInclude_(struct soap *, int, const char *,
 
 inline ns1__datasetInclude_ *soap_new_ns1__datasetInclude_(struct soap *soap,
                                                            int n = -1) {
-  return soap_instantiate_ns1__datasetInclude_(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__datasetInclude_(soap, n, nullptr, nullptr,
+                                               nullptr);
 }
 
 inline ns1__datasetInclude_ *
 soap_new_req_ns1__datasetInclude_(struct soap *soap,
                                   enum ns1__datasetInclude __item) {
-  ns1__datasetInclude_ *_p =
-      soap_instantiate_ns1__datasetInclude_(soap, -1, NULL, NULL, NULL);
+  ns1__datasetInclude_ *_p = soap_instantiate_ns1__datasetInclude_(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__datasetInclude_::__item = __item;
@@ -1416,8 +1424,8 @@ soap_new_req_ns1__datasetInclude_(struct soap *soap,
 
 inline ns1__datasetInclude_ *soap_new_set_ns1__datasetInclude_(
     struct soap *soap, enum ns1__datasetInclude __item, char *__item1) {
-  ns1__datasetInclude_ *_p =
-      soap_instantiate_ns1__datasetInclude_(soap, -1, NULL, NULL, NULL);
+  ns1__datasetInclude_ *_p = soap_instantiate_ns1__datasetInclude_(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__datasetInclude_::__item = __item;
@@ -1473,14 +1481,15 @@ soap_instantiate_ns1__datafileInclude_(struct soap *, int, const char *,
 
 inline ns1__datafileInclude_ *soap_new_ns1__datafileInclude_(struct soap *soap,
                                                              int n = -1) {
-  return soap_instantiate_ns1__datafileInclude_(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__datafileInclude_(soap, n, nullptr, nullptr,
+                                                nullptr);
 }
 
 inline ns1__datafileInclude_ *
 soap_new_req_ns1__datafileInclude_(struct soap *soap,
                                    enum ns1__datafileInclude __item) {
-  ns1__datafileInclude_ *_p =
-      soap_instantiate_ns1__datafileInclude_(soap, -1, NULL, NULL, NULL);
+  ns1__datafileInclude_ *_p = soap_instantiate_ns1__datafileInclude_(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__datafileInclude_::__item = __item;
@@ -1490,8 +1499,8 @@ soap_new_req_ns1__datafileInclude_(struct soap *soap,
 
 inline ns1__datafileInclude_ *soap_new_set_ns1__datafileInclude_(
     struct soap *soap, enum ns1__datafileInclude __item, char *__item1) {
-  ns1__datafileInclude_ *_p =
-      soap_instantiate_ns1__datafileInclude_(soap, -1, NULL, NULL, NULL);
+  ns1__datafileInclude_ *_p = soap_instantiate_ns1__datafileInclude_(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__datafileInclude_::__item = __item;
@@ -1547,14 +1556,15 @@ soap_instantiate_ns1__logicalOperator_(struct soap *, int, const char *,
 
 inline ns1__logicalOperator_ *soap_new_ns1__logicalOperator_(struct soap *soap,
                                                              int n = -1) {
-  return soap_instantiate_ns1__logicalOperator_(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__logicalOperator_(soap, n, nullptr, nullptr,
+                                                nullptr);
 }
 
 inline ns1__logicalOperator_ *
 soap_new_req_ns1__logicalOperator_(struct soap *soap,
                                    enum ns1__logicalOperator __item) {
-  ns1__logicalOperator_ *_p =
-      soap_instantiate_ns1__logicalOperator_(soap, -1, NULL, NULL, NULL);
+  ns1__logicalOperator_ *_p = soap_instantiate_ns1__logicalOperator_(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__logicalOperator_::__item = __item;
@@ -1564,8 +1574,8 @@ soap_new_req_ns1__logicalOperator_(struct soap *soap,
 
 inline ns1__logicalOperator_ *soap_new_set_ns1__logicalOperator_(
     struct soap *soap, enum ns1__logicalOperator __item, char *__item1) {
-  ns1__logicalOperator_ *_p =
-      soap_instantiate_ns1__logicalOperator_(soap, -1, NULL, NULL, NULL);
+  ns1__logicalOperator_ *_p = soap_instantiate_ns1__logicalOperator_(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__logicalOperator_::__item = __item;
@@ -1622,13 +1632,14 @@ soap_instantiate_ns3__NoSuchUserException(struct soap *, int, const char *,
 
 inline ns3__NoSuchUserException *
 soap_new_ns3__NoSuchUserException(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns3__NoSuchUserException(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns3__NoSuchUserException(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline ns3__NoSuchUserException *
 soap_new_req_ns3__NoSuchUserException(struct soap *soap) {
-  ns3__NoSuchUserException *_p =
-      soap_instantiate_ns3__NoSuchUserException(soap, -1, NULL, NULL, NULL);
+  ns3__NoSuchUserException *_p = soap_instantiate_ns3__NoSuchUserException(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -1639,8 +1650,8 @@ inline ns3__NoSuchUserException *
 soap_new_set_ns3__NoSuchUserException(struct soap *soap, std::string *message,
                                       std::string *stackTraceAsString,
                                       std::string *uniqueId, char *__item1) {
-  ns3__NoSuchUserException *_p =
-      soap_instantiate_ns3__NoSuchUserException(soap, -1, NULL, NULL, NULL);
+  ns3__NoSuchUserException *_p = soap_instantiate_ns3__NoSuchUserException(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns3__NoSuchUserException::message = message;
@@ -1701,14 +1712,15 @@ soap_instantiate_ns3__getUserDetailsResponse(struct soap *, int, const char *,
 
 inline ns3__getUserDetailsResponse *
 soap_new_ns3__getUserDetailsResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns3__getUserDetailsResponse(soap, n, NULL, NULL,
-                                                      NULL);
+  return soap_instantiate_ns3__getUserDetailsResponse(soap, n, nullptr, nullptr,
+                                                      nullptr);
 }
 
 inline ns3__getUserDetailsResponse *
 soap_new_req_ns3__getUserDetailsResponse(struct soap *soap) {
   ns3__getUserDetailsResponse *_p =
-      soap_instantiate_ns3__getUserDetailsResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns3__getUserDetailsResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -1718,7 +1730,8 @@ soap_new_req_ns3__getUserDetailsResponse(struct soap *soap) {
 inline ns3__getUserDetailsResponse *soap_new_set_ns3__getUserDetailsResponse(
     struct soap *soap, ns1__userDetails *return_, char *__item1) {
   ns3__getUserDetailsResponse *_p =
-      soap_instantiate_ns3__getUserDetailsResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns3__getUserDetailsResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns3__getUserDetailsResponse::return_ = return_;
@@ -1775,13 +1788,14 @@ soap_instantiate_ns3__getUserDetails(struct soap *, int, const char *,
 
 inline ns3__getUserDetails *soap_new_ns3__getUserDetails(struct soap *soap,
                                                          int n = -1) {
-  return soap_instantiate_ns3__getUserDetails(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns3__getUserDetails(soap, n, nullptr, nullptr,
+                                              nullptr);
 }
 
 inline ns3__getUserDetails *
 soap_new_req_ns3__getUserDetails(struct soap *soap) {
   ns3__getUserDetails *_p =
-      soap_instantiate_ns3__getUserDetails(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns3__getUserDetails(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -1792,7 +1806,7 @@ inline ns3__getUserDetails *
 soap_new_set_ns3__getUserDetails(struct soap *soap, std::string *sessionId,
                                  std::string *usersName, char *__item1) {
   ns3__getUserDetails *_p =
-      soap_instantiate_ns3__getUserDetails(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns3__getUserDetails(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns3__getUserDetails::sessionId = sessionId;
@@ -1850,13 +1864,14 @@ soap_instantiate_ns3__ValidationException(struct soap *, int, const char *,
 
 inline ns3__ValidationException *
 soap_new_ns3__ValidationException(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns3__ValidationException(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns3__ValidationException(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline ns3__ValidationException *
 soap_new_req_ns3__ValidationException(struct soap *soap) {
-  ns3__ValidationException *_p =
-      soap_instantiate_ns3__ValidationException(soap, -1, NULL, NULL, NULL);
+  ns3__ValidationException *_p = soap_instantiate_ns3__ValidationException(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -1867,8 +1882,8 @@ inline ns3__ValidationException *
 soap_new_set_ns3__ValidationException(struct soap *soap, std::string *message,
                                       std::string *stackTraceAsString,
                                       std::string *uniqueId, char *__item1) {
-  ns3__ValidationException *_p =
-      soap_instantiate_ns3__ValidationException(soap, -1, NULL, NULL, NULL);
+  ns3__ValidationException *_p = soap_instantiate_ns3__ValidationException(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns3__ValidationException::message = message;
@@ -1930,15 +1945,15 @@ soap_instantiate_ns3__NoSuchObjectFoundException(struct soap *, int,
 
 inline ns3__NoSuchObjectFoundException *
 soap_new_ns3__NoSuchObjectFoundException(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns3__NoSuchObjectFoundException(soap, n, NULL, NULL,
-                                                          NULL);
+  return soap_instantiate_ns3__NoSuchObjectFoundException(soap, n, nullptr,
+                                                          nullptr, nullptr);
 }
 
 inline ns3__NoSuchObjectFoundException *
 soap_new_req_ns3__NoSuchObjectFoundException(struct soap *soap) {
   ns3__NoSuchObjectFoundException *_p =
-      soap_instantiate_ns3__NoSuchObjectFoundException(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate_ns3__NoSuchObjectFoundException(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -1952,8 +1967,8 @@ soap_new_set_ns3__NoSuchObjectFoundException(struct soap *soap,
                                              std::string *uniqueId,
                                              char *__item1) {
   ns3__NoSuchObjectFoundException *_p =
-      soap_instantiate_ns3__NoSuchObjectFoundException(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate_ns3__NoSuchObjectFoundException(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns3__NoSuchObjectFoundException::message = message;
@@ -2012,13 +2027,14 @@ soap_instantiate_ns3__SessionException(struct soap *, int, const char *,
 
 inline ns3__SessionException *soap_new_ns3__SessionException(struct soap *soap,
                                                              int n = -1) {
-  return soap_instantiate_ns3__SessionException(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns3__SessionException(soap, n, nullptr, nullptr,
+                                                nullptr);
 }
 
 inline ns3__SessionException *
 soap_new_req_ns3__SessionException(struct soap *soap) {
-  ns3__SessionException *_p =
-      soap_instantiate_ns3__SessionException(soap, -1, NULL, NULL, NULL);
+  ns3__SessionException *_p = soap_instantiate_ns3__SessionException(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -2029,8 +2045,8 @@ inline ns3__SessionException *
 soap_new_set_ns3__SessionException(struct soap *soap, std::string *message,
                                    std::string *stackTraceAsString,
                                    std::string *uniqueId, char *__item1) {
-  ns3__SessionException *_p =
-      soap_instantiate_ns3__SessionException(soap, -1, NULL, NULL, NULL);
+  ns3__SessionException *_p = soap_instantiate_ns3__SessionException(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns3__SessionException::message = message;
@@ -2101,7 +2117,7 @@ inline ns1__searchInvestigationByRestrictionComparasionResponse *
 soap_new_ns1__searchInvestigationByRestrictionComparasionResponse(
     struct soap *soap, int n = -1) {
   return soap_instantiate_ns1__searchInvestigationByRestrictionComparasionResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchInvestigationByRestrictionComparasionResponse *
@@ -2109,7 +2125,7 @@ soap_new_req_ns1__searchInvestigationByRestrictionComparasionResponse(
     struct soap *soap) {
   ns1__searchInvestigationByRestrictionComparasionResponse *_p =
       soap_instantiate_ns1__searchInvestigationByRestrictionComparasionResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -2121,7 +2137,7 @@ soap_new_set_ns1__searchInvestigationByRestrictionComparasionResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchInvestigationByRestrictionComparasionResponse *_p =
       soap_instantiate_ns1__searchInvestigationByRestrictionComparasionResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchInvestigationByRestrictionComparasionResponse::return_ =
@@ -2188,7 +2204,7 @@ inline ns1__searchInvestigationByRestrictionComparasion *
 soap_new_ns1__searchInvestigationByRestrictionComparasion(struct soap *soap,
                                                           int n = -1) {
   return soap_instantiate_ns1__searchInvestigationByRestrictionComparasion(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchInvestigationByRestrictionComparasion *
@@ -2196,7 +2212,7 @@ soap_new_req_ns1__searchInvestigationByRestrictionComparasion(
     struct soap *soap) {
   ns1__searchInvestigationByRestrictionComparasion *_p =
       soap_instantiate_ns1__searchInvestigationByRestrictionComparasion(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -2210,7 +2226,7 @@ soap_new_set_ns1__searchInvestigationByRestrictionComparasion(
     char *__item1) {
   ns1__searchInvestigationByRestrictionComparasion *_p =
       soap_instantiate_ns1__searchInvestigationByRestrictionComparasion(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchInvestigationByRestrictionComparasion::sessionId = sessionId;
@@ -2271,13 +2287,14 @@ soap_instantiate_ns1__getDatasetsResponse(struct soap *, int, const char *,
 
 inline ns1__getDatasetsResponse *
 soap_new_ns1__getDatasetsResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getDatasetsResponse(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__getDatasetsResponse(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline ns1__getDatasetsResponse *
 soap_new_req_ns1__getDatasetsResponse(struct soap *soap) {
-  ns1__getDatasetsResponse *_p =
-      soap_instantiate_ns1__getDatasetsResponse(soap, -1, NULL, NULL, NULL);
+  ns1__getDatasetsResponse *_p = soap_instantiate_ns1__getDatasetsResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -2286,8 +2303,8 @@ soap_new_req_ns1__getDatasetsResponse(struct soap *soap) {
 
 inline ns1__getDatasetsResponse *soap_new_set_ns1__getDatasetsResponse(
     struct soap *soap, std::vector<ns1__dataset *> &return_, char *__item1) {
-  ns1__getDatasetsResponse *_p =
-      soap_instantiate_ns1__getDatasetsResponse(soap, -1, NULL, NULL, NULL);
+  ns1__getDatasetsResponse *_p = soap_instantiate_ns1__getDatasetsResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getDatasetsResponse::return_ = return_;
@@ -2342,12 +2359,12 @@ soap_instantiate_ns1__getDatasets(struct soap *, int, const char *,
 
 inline ns1__getDatasets *soap_new_ns1__getDatasets(struct soap *soap,
                                                    int n = -1) {
-  return soap_instantiate_ns1__getDatasets(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__getDatasets(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__getDatasets *soap_new_req_ns1__getDatasets(struct soap *soap) {
   ns1__getDatasets *_p =
-      soap_instantiate_ns1__getDatasets(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__getDatasets(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -2358,7 +2375,7 @@ inline ns1__getDatasets *
 soap_new_set_ns1__getDatasets(struct soap *soap, std::string *sessionId,
                               std::vector<LONG64> &datasetIds, char *__item1) {
   ns1__getDatasets *_p =
-      soap_instantiate_ns1__getDatasets(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__getDatasets(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getDatasets::sessionId = sessionId;
@@ -2419,15 +2436,15 @@ soap_instantiate_ns1__modifyDataFileParameterResponse(struct soap *, int,
 
 inline ns1__modifyDataFileParameterResponse *
 soap_new_ns1__modifyDataFileParameterResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__modifyDataFileParameterResponse(soap, n, NULL,
-                                                               NULL, NULL);
+  return soap_instantiate_ns1__modifyDataFileParameterResponse(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__modifyDataFileParameterResponse *
 soap_new_req_ns1__modifyDataFileParameterResponse(struct soap *soap) {
   ns1__modifyDataFileParameterResponse *_p =
-      soap_instantiate_ns1__modifyDataFileParameterResponse(soap, -1, NULL,
-                                                            NULL, NULL);
+      soap_instantiate_ns1__modifyDataFileParameterResponse(soap, -1, nullptr,
+                                                            nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -2438,8 +2455,8 @@ inline ns1__modifyDataFileParameterResponse *
 soap_new_set_ns1__modifyDataFileParameterResponse(struct soap *soap,
                                                   char *__item1) {
   ns1__modifyDataFileParameterResponse *_p =
-      soap_instantiate_ns1__modifyDataFileParameterResponse(soap, -1, NULL,
-                                                            NULL, NULL);
+      soap_instantiate_ns1__modifyDataFileParameterResponse(soap, -1, nullptr,
+                                                            nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -2498,14 +2515,15 @@ soap_instantiate_ns1__modifyDataFileParameter(struct soap *, int, const char *,
 
 inline ns1__modifyDataFileParameter *
 soap_new_ns1__modifyDataFileParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__modifyDataFileParameter(soap, n, NULL, NULL,
-                                                       NULL);
+  return soap_instantiate_ns1__modifyDataFileParameter(soap, n, nullptr,
+                                                       nullptr, nullptr);
 }
 
 inline ns1__modifyDataFileParameter *
 soap_new_req_ns1__modifyDataFileParameter(struct soap *soap) {
   ns1__modifyDataFileParameter *_p =
-      soap_instantiate_ns1__modifyDataFileParameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__modifyDataFileParameter(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -2516,7 +2534,8 @@ inline ns1__modifyDataFileParameter *soap_new_set_ns1__modifyDataFileParameter(
     struct soap *soap, std::string *sessionId,
     ns1__datafileParameter *dataFileParameter, char *__item1) {
   ns1__modifyDataFileParameter *_p =
-      soap_instantiate_ns1__modifyDataFileParameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__modifyDataFileParameter(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__modifyDataFileParameter::sessionId = sessionId;
@@ -2577,14 +2596,15 @@ soap_instantiate_ns1__listParametersResponse(struct soap *, int, const char *,
 
 inline ns1__listParametersResponse *
 soap_new_ns1__listParametersResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__listParametersResponse(soap, n, NULL, NULL,
-                                                      NULL);
+  return soap_instantiate_ns1__listParametersResponse(soap, n, nullptr, nullptr,
+                                                      nullptr);
 }
 
 inline ns1__listParametersResponse *
 soap_new_req_ns1__listParametersResponse(struct soap *soap) {
   ns1__listParametersResponse *_p =
-      soap_instantiate_ns1__listParametersResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__listParametersResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -2594,7 +2614,8 @@ soap_new_req_ns1__listParametersResponse(struct soap *soap) {
 inline ns1__listParametersResponse *soap_new_set_ns1__listParametersResponse(
     struct soap *soap, std::vector<ns1__parameter *> &return_, char *__item1) {
   ns1__listParametersResponse *_p =
-      soap_instantiate_ns1__listParametersResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__listParametersResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__listParametersResponse::return_ = return_;
@@ -2651,13 +2672,14 @@ soap_instantiate_ns1__listParameters(struct soap *, int, const char *,
 
 inline ns1__listParameters *soap_new_ns1__listParameters(struct soap *soap,
                                                          int n = -1) {
-  return soap_instantiate_ns1__listParameters(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__listParameters(soap, n, nullptr, nullptr,
+                                              nullptr);
 }
 
 inline ns1__listParameters *
 soap_new_req_ns1__listParameters(struct soap *soap) {
   ns1__listParameters *_p =
-      soap_instantiate_ns1__listParameters(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__listParameters(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -2668,7 +2690,7 @@ inline ns1__listParameters *
 soap_new_set_ns1__listParameters(struct soap *soap, std::string *sessionId,
                                  char *__item1) {
   ns1__listParameters *_p =
-      soap_instantiate_ns1__listParameters(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__listParameters(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__listParameters::sessionId = sessionId;
@@ -2731,14 +2753,14 @@ inline ns1__searchSampleByParameterComparisonResponse *
 soap_new_ns1__searchSampleByParameterComparisonResponse(struct soap *soap,
                                                         int n = -1) {
   return soap_instantiate_ns1__searchSampleByParameterComparisonResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchSampleByParameterComparisonResponse *
 soap_new_req_ns1__searchSampleByParameterComparisonResponse(struct soap *soap) {
   ns1__searchSampleByParameterComparisonResponse *_p =
       soap_instantiate_ns1__searchSampleByParameterComparisonResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -2750,7 +2772,7 @@ soap_new_set_ns1__searchSampleByParameterComparisonResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchSampleByParameterComparisonResponse *_p =
       soap_instantiate_ns1__searchSampleByParameterComparisonResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchSampleByParameterComparisonResponse::return_ = return_;
@@ -2812,15 +2834,15 @@ soap_instantiate_ns1__searchSampleByParameterComparison(struct soap *, int,
 
 inline ns1__searchSampleByParameterComparison *
 soap_new_ns1__searchSampleByParameterComparison(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchSampleByParameterComparison(soap, n, NULL,
-                                                                 NULL, NULL);
+  return soap_instantiate_ns1__searchSampleByParameterComparison(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchSampleByParameterComparison *
 soap_new_req_ns1__searchSampleByParameterComparison(struct soap *soap) {
   ns1__searchSampleByParameterComparison *_p =
-      soap_instantiate_ns1__searchSampleByParameterComparison(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate_ns1__searchSampleByParameterComparison(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -2833,8 +2855,8 @@ soap_new_set_ns1__searchSampleByParameterComparison(
     std::vector<ns1__parameterComparisonCondition *> &comparison,
     char *__item1) {
   ns1__searchSampleByParameterComparison *_p =
-      soap_instantiate_ns1__searchSampleByParameterComparison(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate_ns1__searchSampleByParameterComparison(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchSampleByParameterComparison::sessionId = sessionId;
@@ -2896,15 +2918,15 @@ soap_instantiate_ns1__deleteSampleParameterResponse(struct soap *, int,
 
 inline ns1__deleteSampleParameterResponse *
 soap_new_ns1__deleteSampleParameterResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__deleteSampleParameterResponse(soap, n, NULL,
-                                                             NULL, NULL);
+  return soap_instantiate_ns1__deleteSampleParameterResponse(soap, n, nullptr,
+                                                             nullptr, nullptr);
 }
 
 inline ns1__deleteSampleParameterResponse *
 soap_new_req_ns1__deleteSampleParameterResponse(struct soap *soap) {
   ns1__deleteSampleParameterResponse *_p =
-      soap_instantiate_ns1__deleteSampleParameterResponse(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate_ns1__deleteSampleParameterResponse(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -2915,8 +2937,8 @@ inline ns1__deleteSampleParameterResponse *
 soap_new_set_ns1__deleteSampleParameterResponse(struct soap *soap,
                                                 char *__item1) {
   ns1__deleteSampleParameterResponse *_p =
-      soap_instantiate_ns1__deleteSampleParameterResponse(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate_ns1__deleteSampleParameterResponse(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -2972,13 +2994,14 @@ soap_instantiate_ns1__deleteSampleParameter(struct soap *, int, const char *,
 
 inline ns1__deleteSampleParameter *
 soap_new_ns1__deleteSampleParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__deleteSampleParameter(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__deleteSampleParameter(soap, n, nullptr, nullptr,
+                                                     nullptr);
 }
 
 inline ns1__deleteSampleParameter *
 soap_new_req_ns1__deleteSampleParameter(struct soap *soap) {
-  ns1__deleteSampleParameter *_p =
-      soap_instantiate_ns1__deleteSampleParameter(soap, -1, NULL, NULL, NULL);
+  ns1__deleteSampleParameter *_p = soap_instantiate_ns1__deleteSampleParameter(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -2988,8 +3011,8 @@ soap_new_req_ns1__deleteSampleParameter(struct soap *soap) {
 inline ns1__deleteSampleParameter *soap_new_set_ns1__deleteSampleParameter(
     struct soap *soap, std::string *sessionId,
     ns1__sampleParameterPK *sampleParameterPK, char *__item1) {
-  ns1__deleteSampleParameter *_p =
-      soap_instantiate_ns1__deleteSampleParameter(soap, -1, NULL, NULL, NULL);
+  ns1__deleteSampleParameter *_p = soap_instantiate_ns1__deleteSampleParameter(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__deleteSampleParameter::sessionId = sessionId;
@@ -3054,14 +3077,14 @@ inline ns1__searchSampleByRestrictionLogicalResponse *
 soap_new_ns1__searchSampleByRestrictionLogicalResponse(struct soap *soap,
                                                        int n = -1) {
   return soap_instantiate_ns1__searchSampleByRestrictionLogicalResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchSampleByRestrictionLogicalResponse *
 soap_new_req_ns1__searchSampleByRestrictionLogicalResponse(struct soap *soap) {
   ns1__searchSampleByRestrictionLogicalResponse *_p =
       soap_instantiate_ns1__searchSampleByRestrictionLogicalResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -3073,7 +3096,7 @@ soap_new_set_ns1__searchSampleByRestrictionLogicalResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchSampleByRestrictionLogicalResponse *_p =
       soap_instantiate_ns1__searchSampleByRestrictionLogicalResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchSampleByRestrictionLogicalResponse::return_ = return_;
@@ -3134,15 +3157,15 @@ soap_instantiate_ns1__searchSampleByRestrictionLogical(struct soap *, int,
 
 inline ns1__searchSampleByRestrictionLogical *
 soap_new_ns1__searchSampleByRestrictionLogical(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchSampleByRestrictionLogical(soap, n, NULL,
-                                                                NULL, NULL);
+  return soap_instantiate_ns1__searchSampleByRestrictionLogical(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchSampleByRestrictionLogical *
 soap_new_req_ns1__searchSampleByRestrictionLogical(struct soap *soap) {
   ns1__searchSampleByRestrictionLogical *_p =
-      soap_instantiate_ns1__searchSampleByRestrictionLogical(soap, -1, NULL,
-                                                             NULL, NULL);
+      soap_instantiate_ns1__searchSampleByRestrictionLogical(soap, -1, nullptr,
+                                                             nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -3154,8 +3177,8 @@ soap_new_set_ns1__searchSampleByRestrictionLogical(
     struct soap *soap, std::string *sessionId,
     ns1__restrictionLogicalCondition *restriction, char *__item1) {
   ns1__searchSampleByRestrictionLogical *_p =
-      soap_instantiate_ns1__searchSampleByRestrictionLogical(soap, -1, NULL,
-                                                             NULL, NULL);
+      soap_instantiate_ns1__searchSampleByRestrictionLogical(soap, -1, nullptr,
+                                                             nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchSampleByRestrictionLogical::sessionId = sessionId;
@@ -3216,15 +3239,15 @@ soap_instantiate_ns1__addDataFileParameterResponse(struct soap *, int,
 
 inline ns1__addDataFileParameterResponse *
 soap_new_ns1__addDataFileParameterResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__addDataFileParameterResponse(soap, n, NULL, NULL,
-                                                            NULL);
+  return soap_instantiate_ns1__addDataFileParameterResponse(soap, n, nullptr,
+                                                            nullptr, nullptr);
 }
 
 inline ns1__addDataFileParameterResponse *
 soap_new_req_ns1__addDataFileParameterResponse(struct soap *soap) {
   ns1__addDataFileParameterResponse *_p =
-      soap_instantiate_ns1__addDataFileParameterResponse(soap, -1, NULL, NULL,
-                                                         NULL);
+      soap_instantiate_ns1__addDataFileParameterResponse(soap, -1, nullptr,
+                                                         nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -3236,8 +3259,8 @@ soap_new_set_ns1__addDataFileParameterResponse(struct soap *soap,
                                                ns1__datafileParameter *return_,
                                                char *__item1) {
   ns1__addDataFileParameterResponse *_p =
-      soap_instantiate_ns1__addDataFileParameterResponse(soap, -1, NULL, NULL,
-                                                         NULL);
+      soap_instantiate_ns1__addDataFileParameterResponse(soap, -1, nullptr,
+                                                         nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__addDataFileParameterResponse::return_ = return_;
@@ -3294,13 +3317,14 @@ soap_instantiate_ns1__addDataFileParameter(struct soap *, int, const char *,
 
 inline ns1__addDataFileParameter *
 soap_new_ns1__addDataFileParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__addDataFileParameter(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__addDataFileParameter(soap, n, nullptr, nullptr,
+                                                    nullptr);
 }
 
 inline ns1__addDataFileParameter *
 soap_new_req_ns1__addDataFileParameter(struct soap *soap) {
-  ns1__addDataFileParameter *_p =
-      soap_instantiate_ns1__addDataFileParameter(soap, -1, NULL, NULL, NULL);
+  ns1__addDataFileParameter *_p = soap_instantiate_ns1__addDataFileParameter(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -3311,8 +3335,8 @@ inline ns1__addDataFileParameter *soap_new_set_ns1__addDataFileParameter(
     struct soap *soap, std::string *sessionId,
     ns1__datafileParameter *dataFileParameter, LONG64 *datafileId,
     char *__item1) {
-  ns1__addDataFileParameter *_p =
-      soap_instantiate_ns1__addDataFileParameter(soap, -1, NULL, NULL, NULL);
+  ns1__addDataFileParameter *_p = soap_instantiate_ns1__addDataFileParameter(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__addDataFileParameter::sessionId = sessionId;
@@ -3375,15 +3399,15 @@ soap_instantiate_ns1__searchDatasetsBySampleResponse(struct soap *, int,
 
 inline ns1__searchDatasetsBySampleResponse *
 soap_new_ns1__searchDatasetsBySampleResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchDatasetsBySampleResponse(soap, n, NULL,
-                                                              NULL, NULL);
+  return soap_instantiate_ns1__searchDatasetsBySampleResponse(soap, n, nullptr,
+                                                              nullptr, nullptr);
 }
 
 inline ns1__searchDatasetsBySampleResponse *
 soap_new_req_ns1__searchDatasetsBySampleResponse(struct soap *soap) {
   ns1__searchDatasetsBySampleResponse *_p =
-      soap_instantiate_ns1__searchDatasetsBySampleResponse(soap, -1, NULL, NULL,
-                                                           NULL);
+      soap_instantiate_ns1__searchDatasetsBySampleResponse(soap, -1, nullptr,
+                                                           nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -3394,8 +3418,8 @@ inline ns1__searchDatasetsBySampleResponse *
 soap_new_set_ns1__searchDatasetsBySampleResponse(
     struct soap *soap, std::vector<ns1__dataset *> &return_, char *__item1) {
   ns1__searchDatasetsBySampleResponse *_p =
-      soap_instantiate_ns1__searchDatasetsBySampleResponse(soap, -1, NULL, NULL,
-                                                           NULL);
+      soap_instantiate_ns1__searchDatasetsBySampleResponse(soap, -1, nullptr,
+                                                           nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatasetsBySampleResponse::return_ = return_;
@@ -3454,14 +3478,15 @@ soap_instantiate_ns1__searchDatasetsBySample(struct soap *, int, const char *,
 
 inline ns1__searchDatasetsBySample *
 soap_new_ns1__searchDatasetsBySample(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchDatasetsBySample(soap, n, NULL, NULL,
-                                                      NULL);
+  return soap_instantiate_ns1__searchDatasetsBySample(soap, n, nullptr, nullptr,
+                                                      nullptr);
 }
 
 inline ns1__searchDatasetsBySample *
 soap_new_req_ns1__searchDatasetsBySample(struct soap *soap) {
   ns1__searchDatasetsBySample *_p =
-      soap_instantiate_ns1__searchDatasetsBySample(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__searchDatasetsBySample(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -3473,7 +3498,8 @@ soap_new_set_ns1__searchDatasetsBySample(struct soap *soap,
                                          std::string *sessionId,
                                          ns1__sample *sample, char *__item1) {
   ns1__searchDatasetsBySample *_p =
-      soap_instantiate_ns1__searchDatasetsBySample(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__searchDatasetsBySample(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatasetsBySample::sessionId = sessionId;
@@ -3535,15 +3561,15 @@ soap_instantiate_ns1__createInvestigationResponse(struct soap *, int,
 
 inline ns1__createInvestigationResponse *
 soap_new_ns1__createInvestigationResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__createInvestigationResponse(soap, n, NULL, NULL,
-                                                           NULL);
+  return soap_instantiate_ns1__createInvestigationResponse(soap, n, nullptr,
+                                                           nullptr, nullptr);
 }
 
 inline ns1__createInvestigationResponse *
 soap_new_req_ns1__createInvestigationResponse(struct soap *soap) {
   ns1__createInvestigationResponse *_p =
-      soap_instantiate_ns1__createInvestigationResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__createInvestigationResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -3555,8 +3581,8 @@ soap_new_set_ns1__createInvestigationResponse(struct soap *soap,
                                               ns1__investigation *return_,
                                               char *__item1) {
   ns1__createInvestigationResponse *_p =
-      soap_instantiate_ns1__createInvestigationResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__createInvestigationResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__createInvestigationResponse::return_ = return_;
@@ -3613,13 +3639,14 @@ soap_instantiate_ns1__createInvestigation(struct soap *, int, const char *,
 
 inline ns1__createInvestigation *
 soap_new_ns1__createInvestigation(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__createInvestigation(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__createInvestigation(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline ns1__createInvestigation *
 soap_new_req_ns1__createInvestigation(struct soap *soap) {
-  ns1__createInvestigation *_p =
-      soap_instantiate_ns1__createInvestigation(soap, -1, NULL, NULL, NULL);
+  ns1__createInvestigation *_p = soap_instantiate_ns1__createInvestigation(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -3630,8 +3657,8 @@ inline ns1__createInvestigation *
 soap_new_set_ns1__createInvestigation(struct soap *soap, std::string *sessionId,
                                       ns1__investigation *ns1__investigation_,
                                       char *__item1) {
-  ns1__createInvestigation *_p =
-      soap_instantiate_ns1__createInvestigation(soap, -1, NULL, NULL, NULL);
+  ns1__createInvestigation *_p = soap_instantiate_ns1__createInvestigation(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__createInvestigation::sessionId = sessionId;
@@ -3691,14 +3718,15 @@ soap_instantiate_ns1__addPublicationResponse(struct soap *, int, const char *,
 
 inline ns1__addPublicationResponse *
 soap_new_ns1__addPublicationResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__addPublicationResponse(soap, n, NULL, NULL,
-                                                      NULL);
+  return soap_instantiate_ns1__addPublicationResponse(soap, n, nullptr, nullptr,
+                                                      nullptr);
 }
 
 inline ns1__addPublicationResponse *
 soap_new_req_ns1__addPublicationResponse(struct soap *soap) {
   ns1__addPublicationResponse *_p =
-      soap_instantiate_ns1__addPublicationResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__addPublicationResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -3708,7 +3736,8 @@ soap_new_req_ns1__addPublicationResponse(struct soap *soap) {
 inline ns1__addPublicationResponse *soap_new_set_ns1__addPublicationResponse(
     struct soap *soap, ns1__publication *return_, char *__item1) {
   ns1__addPublicationResponse *_p =
-      soap_instantiate_ns1__addPublicationResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__addPublicationResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__addPublicationResponse::return_ = return_;
@@ -3765,13 +3794,14 @@ soap_instantiate_ns1__addPublication(struct soap *, int, const char *,
 
 inline ns1__addPublication *soap_new_ns1__addPublication(struct soap *soap,
                                                          int n = -1) {
-  return soap_instantiate_ns1__addPublication(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__addPublication(soap, n, nullptr, nullptr,
+                                              nullptr);
 }
 
 inline ns1__addPublication *
 soap_new_req_ns1__addPublication(struct soap *soap) {
   ns1__addPublication *_p =
-      soap_instantiate_ns1__addPublication(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__addPublication(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -3783,7 +3813,7 @@ soap_new_set_ns1__addPublication(struct soap *soap, std::string *sessionId,
                                  ns1__publication *publication,
                                  LONG64 *investigationId, char *__item1) {
   ns1__addPublication *_p =
-      soap_instantiate_ns1__addPublication(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__addPublication(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__addPublication::sessionId = sessionId;
@@ -3845,15 +3875,15 @@ soap_instantiate_ns1__deleteDataFileParameterResponse(struct soap *, int,
 
 inline ns1__deleteDataFileParameterResponse *
 soap_new_ns1__deleteDataFileParameterResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__deleteDataFileParameterResponse(soap, n, NULL,
-                                                               NULL, NULL);
+  return soap_instantiate_ns1__deleteDataFileParameterResponse(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__deleteDataFileParameterResponse *
 soap_new_req_ns1__deleteDataFileParameterResponse(struct soap *soap) {
   ns1__deleteDataFileParameterResponse *_p =
-      soap_instantiate_ns1__deleteDataFileParameterResponse(soap, -1, NULL,
-                                                            NULL, NULL);
+      soap_instantiate_ns1__deleteDataFileParameterResponse(soap, -1, nullptr,
+                                                            nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -3864,8 +3894,8 @@ inline ns1__deleteDataFileParameterResponse *
 soap_new_set_ns1__deleteDataFileParameterResponse(struct soap *soap,
                                                   char *__item1) {
   ns1__deleteDataFileParameterResponse *_p =
-      soap_instantiate_ns1__deleteDataFileParameterResponse(soap, -1, NULL,
-                                                            NULL, NULL);
+      soap_instantiate_ns1__deleteDataFileParameterResponse(soap, -1, nullptr,
+                                                            nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -3924,14 +3954,15 @@ soap_instantiate_ns1__deleteDataFileParameter(struct soap *, int, const char *,
 
 inline ns1__deleteDataFileParameter *
 soap_new_ns1__deleteDataFileParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__deleteDataFileParameter(soap, n, NULL, NULL,
-                                                       NULL);
+  return soap_instantiate_ns1__deleteDataFileParameter(soap, n, nullptr,
+                                                       nullptr, nullptr);
 }
 
 inline ns1__deleteDataFileParameter *
 soap_new_req_ns1__deleteDataFileParameter(struct soap *soap) {
   ns1__deleteDataFileParameter *_p =
-      soap_instantiate_ns1__deleteDataFileParameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__deleteDataFileParameter(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -3942,7 +3973,8 @@ inline ns1__deleteDataFileParameter *soap_new_set_ns1__deleteDataFileParameter(
     struct soap *soap, std::string *sessionId,
     ns1__datafileParameterPK *datafileParameterPK, char *__item1) {
   ns1__deleteDataFileParameter *_p =
-      soap_instantiate_ns1__deleteDataFileParameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__deleteDataFileParameter(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__deleteDataFileParameter::sessionId = sessionId;
@@ -4004,15 +4036,15 @@ soap_instantiate_ns1__getInvestigationResponse(struct soap *, int, const char *,
 
 inline ns1__getInvestigationResponse *
 soap_new_ns1__getInvestigationResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getInvestigationResponse(soap, n, NULL, NULL,
-                                                        NULL);
+  return soap_instantiate_ns1__getInvestigationResponse(soap, n, nullptr,
+                                                        nullptr, nullptr);
 }
 
 inline ns1__getInvestigationResponse *
 soap_new_req_ns1__getInvestigationResponse(struct soap *soap) {
   ns1__getInvestigationResponse *_p =
-      soap_instantiate_ns1__getInvestigationResponse(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate_ns1__getInvestigationResponse(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -4024,8 +4056,8 @@ soap_new_set_ns1__getInvestigationResponse(struct soap *soap,
                                            ns1__investigation *return_,
                                            char *__item1) {
   ns1__getInvestigationResponse *_p =
-      soap_instantiate_ns1__getInvestigationResponse(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate_ns1__getInvestigationResponse(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getInvestigationResponse::return_ = return_;
@@ -4082,13 +4114,14 @@ soap_instantiate_ns1__getInvestigation(struct soap *, int, const char *,
 
 inline ns1__getInvestigation *soap_new_ns1__getInvestigation(struct soap *soap,
                                                              int n = -1) {
-  return soap_instantiate_ns1__getInvestigation(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__getInvestigation(soap, n, nullptr, nullptr,
+                                                nullptr);
 }
 
 inline ns1__getInvestigation *
 soap_new_req_ns1__getInvestigation(struct soap *soap) {
-  ns1__getInvestigation *_p =
-      soap_instantiate_ns1__getInvestigation(soap, -1, NULL, NULL, NULL);
+  ns1__getInvestigation *_p = soap_instantiate_ns1__getInvestigation(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -4098,8 +4131,8 @@ soap_new_req_ns1__getInvestigation(struct soap *soap) {
 inline ns1__getInvestigation *
 soap_new_set_ns1__getInvestigation(struct soap *soap, std::string *sessionId,
                                    LONG64 *investigationId, char *__item1) {
-  ns1__getInvestigation *_p =
-      soap_instantiate_ns1__getInvestigation(soap, -1, NULL, NULL, NULL);
+  ns1__getInvestigation *_p = soap_instantiate_ns1__getInvestigation(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getInvestigation::sessionId = sessionId;
@@ -4160,15 +4193,15 @@ soap_instantiate_ns1__getInvestigationIncludesResponse(struct soap *, int,
 
 inline ns1__getInvestigationIncludesResponse *
 soap_new_ns1__getInvestigationIncludesResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getInvestigationIncludesResponse(soap, n, NULL,
-                                                                NULL, NULL);
+  return soap_instantiate_ns1__getInvestigationIncludesResponse(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__getInvestigationIncludesResponse *
 soap_new_req_ns1__getInvestigationIncludesResponse(struct soap *soap) {
   ns1__getInvestigationIncludesResponse *_p =
-      soap_instantiate_ns1__getInvestigationIncludesResponse(soap, -1, NULL,
-                                                             NULL, NULL);
+      soap_instantiate_ns1__getInvestigationIncludesResponse(soap, -1, nullptr,
+                                                             nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -4180,8 +4213,8 @@ soap_new_set_ns1__getInvestigationIncludesResponse(struct soap *soap,
                                                    ns1__investigation *return_,
                                                    char *__item1) {
   ns1__getInvestigationIncludesResponse *_p =
-      soap_instantiate_ns1__getInvestigationIncludesResponse(soap, -1, NULL,
-                                                             NULL, NULL);
+      soap_instantiate_ns1__getInvestigationIncludesResponse(soap, -1, nullptr,
+                                                             nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getInvestigationIncludesResponse::return_ = return_;
@@ -4241,15 +4274,15 @@ soap_instantiate_ns1__getInvestigationIncludes(struct soap *, int, const char *,
 
 inline ns1__getInvestigationIncludes *
 soap_new_ns1__getInvestigationIncludes(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getInvestigationIncludes(soap, n, NULL, NULL,
-                                                        NULL);
+  return soap_instantiate_ns1__getInvestigationIncludes(soap, n, nullptr,
+                                                        nullptr, nullptr);
 }
 
 inline ns1__getInvestigationIncludes *
 soap_new_req_ns1__getInvestigationIncludes(struct soap *soap) {
   ns1__getInvestigationIncludes *_p =
-      soap_instantiate_ns1__getInvestigationIncludes(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate_ns1__getInvestigationIncludes(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -4261,8 +4294,8 @@ soap_new_set_ns1__getInvestigationIncludes(
     struct soap *soap, std::string *sessionId, LONG64 *investigationId,
     enum ns1__investigationInclude *investigationInclude, char *__item1) {
   ns1__getInvestigationIncludes *_p =
-      soap_instantiate_ns1__getInvestigationIncludes(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate_ns1__getInvestigationIncludes(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getInvestigationIncludes::sessionId = sessionId;
@@ -4325,14 +4358,15 @@ soap_instantiate_ns1__modifyDataFileResponse(struct soap *, int, const char *,
 
 inline ns1__modifyDataFileResponse *
 soap_new_ns1__modifyDataFileResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__modifyDataFileResponse(soap, n, NULL, NULL,
-                                                      NULL);
+  return soap_instantiate_ns1__modifyDataFileResponse(soap, n, nullptr, nullptr,
+                                                      nullptr);
 }
 
 inline ns1__modifyDataFileResponse *
 soap_new_req_ns1__modifyDataFileResponse(struct soap *soap) {
   ns1__modifyDataFileResponse *_p =
-      soap_instantiate_ns1__modifyDataFileResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__modifyDataFileResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -4342,7 +4376,8 @@ soap_new_req_ns1__modifyDataFileResponse(struct soap *soap) {
 inline ns1__modifyDataFileResponse *
 soap_new_set_ns1__modifyDataFileResponse(struct soap *soap, char *__item1) {
   ns1__modifyDataFileResponse *_p =
-      soap_instantiate_ns1__modifyDataFileResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__modifyDataFileResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -4398,13 +4433,14 @@ soap_instantiate_ns1__modifyDataFile(struct soap *, int, const char *,
 
 inline ns1__modifyDataFile *soap_new_ns1__modifyDataFile(struct soap *soap,
                                                          int n = -1) {
-  return soap_instantiate_ns1__modifyDataFile(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__modifyDataFile(soap, n, nullptr, nullptr,
+                                              nullptr);
 }
 
 inline ns1__modifyDataFile *
 soap_new_req_ns1__modifyDataFile(struct soap *soap) {
   ns1__modifyDataFile *_p =
-      soap_instantiate_ns1__modifyDataFile(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__modifyDataFile(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -4415,7 +4451,7 @@ inline ns1__modifyDataFile *
 soap_new_set_ns1__modifyDataFile(struct soap *soap, std::string *sessionId,
                                  ns1__datafile *dataFile, char *__item1) {
   ns1__modifyDataFile *_p =
-      soap_instantiate_ns1__modifyDataFile(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__modifyDataFile(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__modifyDataFile::sessionId = sessionId;
@@ -4473,13 +4509,14 @@ soap_instantiate_ns1__getDatafileResponse(struct soap *, int, const char *,
 
 inline ns1__getDatafileResponse *
 soap_new_ns1__getDatafileResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getDatafileResponse(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__getDatafileResponse(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline ns1__getDatafileResponse *
 soap_new_req_ns1__getDatafileResponse(struct soap *soap) {
-  ns1__getDatafileResponse *_p =
-      soap_instantiate_ns1__getDatafileResponse(soap, -1, NULL, NULL, NULL);
+  ns1__getDatafileResponse *_p = soap_instantiate_ns1__getDatafileResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -4489,8 +4526,8 @@ soap_new_req_ns1__getDatafileResponse(struct soap *soap) {
 inline ns1__getDatafileResponse *
 soap_new_set_ns1__getDatafileResponse(struct soap *soap, ns1__datafile *return_,
                                       char *__item1) {
-  ns1__getDatafileResponse *_p =
-      soap_instantiate_ns1__getDatafileResponse(soap, -1, NULL, NULL, NULL);
+  ns1__getDatafileResponse *_p = soap_instantiate_ns1__getDatafileResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getDatafileResponse::return_ = return_;
@@ -4545,12 +4582,12 @@ soap_instantiate_ns1__getDatafile(struct soap *, int, const char *,
 
 inline ns1__getDatafile *soap_new_ns1__getDatafile(struct soap *soap,
                                                    int n = -1) {
-  return soap_instantiate_ns1__getDatafile(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__getDatafile(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__getDatafile *soap_new_req_ns1__getDatafile(struct soap *soap) {
   ns1__getDatafile *_p =
-      soap_instantiate_ns1__getDatafile(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__getDatafile(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -4562,7 +4599,7 @@ inline ns1__getDatafile *soap_new_set_ns1__getDatafile(struct soap *soap,
                                                        LONG64 *datafileId,
                                                        char *__item1) {
   ns1__getDatafile *_p =
-      soap_instantiate_ns1__getDatafile(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__getDatafile(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getDatafile::sessionId = sessionId;
@@ -4619,13 +4656,14 @@ soap_instantiate_ns1__ICATAPIException(struct soap *, int, const char *,
 
 inline ns1__ICATAPIException *soap_new_ns1__ICATAPIException(struct soap *soap,
                                                              int n = -1) {
-  return soap_instantiate_ns1__ICATAPIException(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__ICATAPIException(soap, n, nullptr, nullptr,
+                                                nullptr);
 }
 
 inline ns1__ICATAPIException *
 soap_new_req_ns1__ICATAPIException(struct soap *soap) {
-  ns1__ICATAPIException *_p =
-      soap_instantiate_ns1__ICATAPIException(soap, -1, NULL, NULL, NULL);
+  ns1__ICATAPIException *_p = soap_instantiate_ns1__ICATAPIException(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -4636,8 +4674,8 @@ inline ns1__ICATAPIException *
 soap_new_set_ns1__ICATAPIException(struct soap *soap, std::string *message,
                                    std::string *stackTraceAsString,
                                    std::string *uniqueId, char *__item1) {
-  ns1__ICATAPIException *_p =
-      soap_instantiate_ns1__ICATAPIException(soap, -1, NULL, NULL, NULL);
+  ns1__ICATAPIException *_p = soap_instantiate_ns1__ICATAPIException(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__ICATAPIException::message = message;
@@ -4698,14 +4736,15 @@ soap_instantiate_ns1__ingestMetadataResponse(struct soap *, int, const char *,
 
 inline ns1__ingestMetadataResponse *
 soap_new_ns1__ingestMetadataResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__ingestMetadataResponse(soap, n, NULL, NULL,
-                                                      NULL);
+  return soap_instantiate_ns1__ingestMetadataResponse(soap, n, nullptr, nullptr,
+                                                      nullptr);
 }
 
 inline ns1__ingestMetadataResponse *
 soap_new_req_ns1__ingestMetadataResponse(struct soap *soap) {
   ns1__ingestMetadataResponse *_p =
-      soap_instantiate_ns1__ingestMetadataResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__ingestMetadataResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -4715,7 +4754,8 @@ soap_new_req_ns1__ingestMetadataResponse(struct soap *soap) {
 inline ns1__ingestMetadataResponse *soap_new_set_ns1__ingestMetadataResponse(
     struct soap *soap, std::vector<LONG64> &return_, char *__item1) {
   ns1__ingestMetadataResponse *_p =
-      soap_instantiate_ns1__ingestMetadataResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__ingestMetadataResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__ingestMetadataResponse::return_ = return_;
@@ -4772,13 +4812,14 @@ soap_instantiate_ns1__ingestMetadata(struct soap *, int, const char *,
 
 inline ns1__ingestMetadata *soap_new_ns1__ingestMetadata(struct soap *soap,
                                                          int n = -1) {
-  return soap_instantiate_ns1__ingestMetadata(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__ingestMetadata(soap, n, nullptr, nullptr,
+                                              nullptr);
 }
 
 inline ns1__ingestMetadata *
 soap_new_req_ns1__ingestMetadata(struct soap *soap) {
   ns1__ingestMetadata *_p =
-      soap_instantiate_ns1__ingestMetadata(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__ingestMetadata(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -4789,7 +4830,7 @@ inline ns1__ingestMetadata *
 soap_new_set_ns1__ingestMetadata(struct soap *soap, std::string *sessionId,
                                  std::string *xml, char *__item1) {
   ns1__ingestMetadata *_p =
-      soap_instantiate_ns1__ingestMetadata(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__ingestMetadata(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__ingestMetadata::sessionId = sessionId;
@@ -4853,15 +4894,15 @@ soap_instantiate_ns1__searchDatasetByRestrictionResponse(struct soap *, int,
 inline ns1__searchDatasetByRestrictionResponse *
 soap_new_ns1__searchDatasetByRestrictionResponse(struct soap *soap,
                                                  int n = -1) {
-  return soap_instantiate_ns1__searchDatasetByRestrictionResponse(soap, n, NULL,
-                                                                  NULL, NULL);
+  return soap_instantiate_ns1__searchDatasetByRestrictionResponse(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatasetByRestrictionResponse *
 soap_new_req_ns1__searchDatasetByRestrictionResponse(struct soap *soap) {
   ns1__searchDatasetByRestrictionResponse *_p =
-      soap_instantiate_ns1__searchDatasetByRestrictionResponse(soap, -1, NULL,
-                                                               NULL, NULL);
+      soap_instantiate_ns1__searchDatasetByRestrictionResponse(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -4872,8 +4913,8 @@ inline ns1__searchDatasetByRestrictionResponse *
 soap_new_set_ns1__searchDatasetByRestrictionResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchDatasetByRestrictionResponse *_p =
-      soap_instantiate_ns1__searchDatasetByRestrictionResponse(soap, -1, NULL,
-                                                               NULL, NULL);
+      soap_instantiate_ns1__searchDatasetByRestrictionResponse(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatasetByRestrictionResponse::return_ = return_;
@@ -4934,15 +4975,15 @@ soap_instantiate_ns1__searchDatasetByRestriction(struct soap *, int,
 
 inline ns1__searchDatasetByRestriction *
 soap_new_ns1__searchDatasetByRestriction(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchDatasetByRestriction(soap, n, NULL, NULL,
-                                                          NULL);
+  return soap_instantiate_ns1__searchDatasetByRestriction(soap, n, nullptr,
+                                                          nullptr, nullptr);
 }
 
 inline ns1__searchDatasetByRestriction *
 soap_new_req_ns1__searchDatasetByRestriction(struct soap *soap) {
   ns1__searchDatasetByRestriction *_p =
-      soap_instantiate_ns1__searchDatasetByRestriction(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate_ns1__searchDatasetByRestriction(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -4954,8 +4995,8 @@ soap_new_set_ns1__searchDatasetByRestriction(
     struct soap *soap, std::string *sessionId,
     ns1__restrictionCondition *restriction, char *__item1) {
   ns1__searchDatasetByRestriction *_p =
-      soap_instantiate_ns1__searchDatasetByRestriction(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate_ns1__searchDatasetByRestriction(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatasetByRestriction::sessionId = sessionId;
@@ -5012,13 +5053,14 @@ soap_instantiate_ns1__listRolesResponse(struct soap *, int, const char *,
 
 inline ns1__listRolesResponse *
 soap_new_ns1__listRolesResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__listRolesResponse(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__listRolesResponse(soap, n, nullptr, nullptr,
+                                                 nullptr);
 }
 
 inline ns1__listRolesResponse *
 soap_new_req_ns1__listRolesResponse(struct soap *soap) {
-  ns1__listRolesResponse *_p =
-      soap_instantiate_ns1__listRolesResponse(soap, -1, NULL, NULL, NULL);
+  ns1__listRolesResponse *_p = soap_instantiate_ns1__listRolesResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -5027,8 +5069,8 @@ soap_new_req_ns1__listRolesResponse(struct soap *soap) {
 
 inline ns1__listRolesResponse *soap_new_set_ns1__listRolesResponse(
     struct soap *soap, std::vector<ns1__icatRole *> &return_, char *__item1) {
-  ns1__listRolesResponse *_p =
-      soap_instantiate_ns1__listRolesResponse(soap, -1, NULL, NULL, NULL);
+  ns1__listRolesResponse *_p = soap_instantiate_ns1__listRolesResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__listRolesResponse::return_ = return_;
@@ -5082,12 +5124,12 @@ soap_instantiate_ns1__listRoles(struct soap *, int, const char *, const char *,
                                 size_t *);
 
 inline ns1__listRoles *soap_new_ns1__listRoles(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__listRoles(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__listRoles(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__listRoles *soap_new_req_ns1__listRoles(struct soap *soap) {
   ns1__listRoles *_p =
-      soap_instantiate_ns1__listRoles(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__listRoles(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -5098,7 +5140,7 @@ inline ns1__listRoles *soap_new_set_ns1__listRoles(struct soap *soap,
                                                    std::string *sessionId,
                                                    char *__item1) {
   ns1__listRoles *_p =
-      soap_instantiate_ns1__listRoles(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__listRoles(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__listRoles::sessionId = sessionId;
@@ -5157,15 +5199,15 @@ soap_instantiate_ns1__updateAuthorisationResponse(struct soap *, int,
 
 inline ns1__updateAuthorisationResponse *
 soap_new_ns1__updateAuthorisationResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__updateAuthorisationResponse(soap, n, NULL, NULL,
-                                                           NULL);
+  return soap_instantiate_ns1__updateAuthorisationResponse(soap, n, nullptr,
+                                                           nullptr, nullptr);
 }
 
 inline ns1__updateAuthorisationResponse *
 soap_new_req_ns1__updateAuthorisationResponse(struct soap *soap) {
   ns1__updateAuthorisationResponse *_p =
-      soap_instantiate_ns1__updateAuthorisationResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__updateAuthorisationResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -5176,8 +5218,8 @@ inline ns1__updateAuthorisationResponse *
 soap_new_set_ns1__updateAuthorisationResponse(struct soap *soap,
                                               char *__item1) {
   ns1__updateAuthorisationResponse *_p =
-      soap_instantiate_ns1__updateAuthorisationResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__updateAuthorisationResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -5233,13 +5275,14 @@ soap_instantiate_ns1__updateAuthorisation(struct soap *, int, const char *,
 
 inline ns1__updateAuthorisation *
 soap_new_ns1__updateAuthorisation(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__updateAuthorisation(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__updateAuthorisation(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline ns1__updateAuthorisation *
 soap_new_req_ns1__updateAuthorisation(struct soap *soap) {
-  ns1__updateAuthorisation *_p =
-      soap_instantiate_ns1__updateAuthorisation(soap, -1, NULL, NULL, NULL);
+  ns1__updateAuthorisation *_p = soap_instantiate_ns1__updateAuthorisation(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -5250,8 +5293,8 @@ inline ns1__updateAuthorisation *
 soap_new_set_ns1__updateAuthorisation(struct soap *soap, std::string *sessionId,
                                       std::string *toChangetoRole,
                                       LONG64 *authorisationId, char *__item1) {
-  ns1__updateAuthorisation *_p =
-      soap_instantiate_ns1__updateAuthorisation(soap, -1, NULL, NULL, NULL);
+  ns1__updateAuthorisation *_p = soap_instantiate_ns1__updateAuthorisation(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__updateAuthorisation::sessionId = sessionId;
@@ -5313,15 +5356,15 @@ soap_instantiate_ns1__getDatasetIncludesResponse(struct soap *, int,
 
 inline ns1__getDatasetIncludesResponse *
 soap_new_ns1__getDatasetIncludesResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getDatasetIncludesResponse(soap, n, NULL, NULL,
-                                                          NULL);
+  return soap_instantiate_ns1__getDatasetIncludesResponse(soap, n, nullptr,
+                                                          nullptr, nullptr);
 }
 
 inline ns1__getDatasetIncludesResponse *
 soap_new_req_ns1__getDatasetIncludesResponse(struct soap *soap) {
   ns1__getDatasetIncludesResponse *_p =
-      soap_instantiate_ns1__getDatasetIncludesResponse(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate_ns1__getDatasetIncludesResponse(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -5333,8 +5376,8 @@ soap_new_set_ns1__getDatasetIncludesResponse(struct soap *soap,
                                              ns1__dataset *return_,
                                              char *__item1) {
   ns1__getDatasetIncludesResponse *_p =
-      soap_instantiate_ns1__getDatasetIncludesResponse(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate_ns1__getDatasetIncludesResponse(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getDatasetIncludesResponse::return_ = return_;
@@ -5390,13 +5433,14 @@ soap_instantiate_ns1__getDatasetIncludes(struct soap *, int, const char *,
 
 inline ns1__getDatasetIncludes *
 soap_new_ns1__getDatasetIncludes(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getDatasetIncludes(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__getDatasetIncludes(soap, n, nullptr, nullptr,
+                                                  nullptr);
 }
 
 inline ns1__getDatasetIncludes *
 soap_new_req_ns1__getDatasetIncludes(struct soap *soap) {
-  ns1__getDatasetIncludes *_p =
-      soap_instantiate_ns1__getDatasetIncludes(soap, -1, NULL, NULL, NULL);
+  ns1__getDatasetIncludes *_p = soap_instantiate_ns1__getDatasetIncludes(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -5406,8 +5450,8 @@ soap_new_req_ns1__getDatasetIncludes(struct soap *soap) {
 inline ns1__getDatasetIncludes *soap_new_set_ns1__getDatasetIncludes(
     struct soap *soap, std::string *sessionId, LONG64 *datasetId,
     enum ns1__datasetInclude *datasetInclude, char *__item1) {
-  ns1__getDatasetIncludes *_p =
-      soap_instantiate_ns1__getDatasetIncludes(soap, -1, NULL, NULL, NULL);
+  ns1__getDatasetIncludes *_p = soap_instantiate_ns1__getDatasetIncludes(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getDatasetIncludes::sessionId = sessionId;
@@ -5465,13 +5509,14 @@ soap_instantiate_ns1__getDatasetResponse(struct soap *, int, const char *,
 
 inline ns1__getDatasetResponse *
 soap_new_ns1__getDatasetResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getDatasetResponse(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__getDatasetResponse(soap, n, nullptr, nullptr,
+                                                  nullptr);
 }
 
 inline ns1__getDatasetResponse *
 soap_new_req_ns1__getDatasetResponse(struct soap *soap) {
-  ns1__getDatasetResponse *_p =
-      soap_instantiate_ns1__getDatasetResponse(soap, -1, NULL, NULL, NULL);
+  ns1__getDatasetResponse *_p = soap_instantiate_ns1__getDatasetResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -5481,8 +5526,8 @@ soap_new_req_ns1__getDatasetResponse(struct soap *soap) {
 inline ns1__getDatasetResponse *
 soap_new_set_ns1__getDatasetResponse(struct soap *soap, ns1__dataset *return_,
                                      char *__item1) {
-  ns1__getDatasetResponse *_p =
-      soap_instantiate_ns1__getDatasetResponse(soap, -1, NULL, NULL, NULL);
+  ns1__getDatasetResponse *_p = soap_instantiate_ns1__getDatasetResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getDatasetResponse::return_ = return_;
@@ -5537,12 +5582,12 @@ soap_instantiate_ns1__getDataset(struct soap *, int, const char *, const char *,
 
 inline ns1__getDataset *soap_new_ns1__getDataset(struct soap *soap,
                                                  int n = -1) {
-  return soap_instantiate_ns1__getDataset(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__getDataset(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__getDataset *soap_new_req_ns1__getDataset(struct soap *soap) {
   ns1__getDataset *_p =
-      soap_instantiate_ns1__getDataset(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__getDataset(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -5554,7 +5599,7 @@ inline ns1__getDataset *soap_new_set_ns1__getDataset(struct soap *soap,
                                                      LONG64 *datasetId,
                                                      char *__item1) {
   ns1__getDataset *_p =
-      soap_instantiate_ns1__getDataset(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__getDataset(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getDataset::sessionId = sessionId;
@@ -5614,15 +5659,15 @@ soap_instantiate_ns1__deleteAuthorisationResponse(struct soap *, int,
 
 inline ns1__deleteAuthorisationResponse *
 soap_new_ns1__deleteAuthorisationResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__deleteAuthorisationResponse(soap, n, NULL, NULL,
-                                                           NULL);
+  return soap_instantiate_ns1__deleteAuthorisationResponse(soap, n, nullptr,
+                                                           nullptr, nullptr);
 }
 
 inline ns1__deleteAuthorisationResponse *
 soap_new_req_ns1__deleteAuthorisationResponse(struct soap *soap) {
   ns1__deleteAuthorisationResponse *_p =
-      soap_instantiate_ns1__deleteAuthorisationResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__deleteAuthorisationResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -5633,8 +5678,8 @@ inline ns1__deleteAuthorisationResponse *
 soap_new_set_ns1__deleteAuthorisationResponse(struct soap *soap,
                                               char *__item1) {
   ns1__deleteAuthorisationResponse *_p =
-      soap_instantiate_ns1__deleteAuthorisationResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__deleteAuthorisationResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -5690,13 +5735,14 @@ soap_instantiate_ns1__deleteAuthorisation(struct soap *, int, const char *,
 
 inline ns1__deleteAuthorisation *
 soap_new_ns1__deleteAuthorisation(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__deleteAuthorisation(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__deleteAuthorisation(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline ns1__deleteAuthorisation *
 soap_new_req_ns1__deleteAuthorisation(struct soap *soap) {
-  ns1__deleteAuthorisation *_p =
-      soap_instantiate_ns1__deleteAuthorisation(soap, -1, NULL, NULL, NULL);
+  ns1__deleteAuthorisation *_p = soap_instantiate_ns1__deleteAuthorisation(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -5706,8 +5752,8 @@ soap_new_req_ns1__deleteAuthorisation(struct soap *soap) {
 inline ns1__deleteAuthorisation *
 soap_new_set_ns1__deleteAuthorisation(struct soap *soap, std::string *sessionId,
                                       LONG64 *authorisationId, char *__item1) {
-  ns1__deleteAuthorisation *_p =
-      soap_instantiate_ns1__deleteAuthorisation(soap, -1, NULL, NULL, NULL);
+  ns1__deleteAuthorisation *_p = soap_instantiate_ns1__deleteAuthorisation(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__deleteAuthorisation::sessionId = sessionId;
@@ -5769,15 +5815,15 @@ soap_instantiate_ns1__deletePublicationResponse(struct soap *, int,
 
 inline ns1__deletePublicationResponse *
 soap_new_ns1__deletePublicationResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__deletePublicationResponse(soap, n, NULL, NULL,
-                                                         NULL);
+  return soap_instantiate_ns1__deletePublicationResponse(soap, n, nullptr,
+                                                         nullptr, nullptr);
 }
 
 inline ns1__deletePublicationResponse *
 soap_new_req_ns1__deletePublicationResponse(struct soap *soap) {
   ns1__deletePublicationResponse *_p =
-      soap_instantiate_ns1__deletePublicationResponse(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__deletePublicationResponse(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -5787,8 +5833,8 @@ soap_new_req_ns1__deletePublicationResponse(struct soap *soap) {
 inline ns1__deletePublicationResponse *
 soap_new_set_ns1__deletePublicationResponse(struct soap *soap, char *__item1) {
   ns1__deletePublicationResponse *_p =
-      soap_instantiate_ns1__deletePublicationResponse(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__deletePublicationResponse(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -5844,13 +5890,14 @@ soap_instantiate_ns1__deletePublication(struct soap *, int, const char *,
 
 inline ns1__deletePublication *
 soap_new_ns1__deletePublication(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__deletePublication(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__deletePublication(soap, n, nullptr, nullptr,
+                                                 nullptr);
 }
 
 inline ns1__deletePublication *
 soap_new_req_ns1__deletePublication(struct soap *soap) {
-  ns1__deletePublication *_p =
-      soap_instantiate_ns1__deletePublication(soap, -1, NULL, NULL, NULL);
+  ns1__deletePublication *_p = soap_instantiate_ns1__deletePublication(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -5860,8 +5907,8 @@ soap_new_req_ns1__deletePublication(struct soap *soap) {
 inline ns1__deletePublication *
 soap_new_set_ns1__deletePublication(struct soap *soap, std::string *sessionId,
                                     LONG64 *publicationId, char *__item1) {
-  ns1__deletePublication *_p =
-      soap_instantiate_ns1__deletePublication(soap, -1, NULL, NULL, NULL);
+  ns1__deletePublication *_p = soap_instantiate_ns1__deletePublication(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__deletePublication::sessionId = sessionId;
@@ -5918,12 +5965,13 @@ soap_instantiate_ns1__loginResponse(struct soap *, int, const char *,
 
 inline ns1__loginResponse *soap_new_ns1__loginResponse(struct soap *soap,
                                                        int n = -1) {
-  return soap_instantiate_ns1__loginResponse(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__loginResponse(soap, n, nullptr, nullptr,
+                                             nullptr);
 }
 
 inline ns1__loginResponse *soap_new_req_ns1__loginResponse(struct soap *soap) {
   ns1__loginResponse *_p =
-      soap_instantiate_ns1__loginResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__loginResponse(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -5934,7 +5982,7 @@ inline ns1__loginResponse *soap_new_set_ns1__loginResponse(struct soap *soap,
                                                            std::string *return_,
                                                            char *__item1) {
   ns1__loginResponse *_p =
-      soap_instantiate_ns1__loginResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__loginResponse(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__loginResponse::return_ = return_;
@@ -5985,11 +6033,12 @@ soap_instantiate_ns1__login(struct soap *, int, const char *, const char *,
                             size_t *);
 
 inline ns1__login *soap_new_ns1__login(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__login(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__login(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__login *soap_new_req_ns1__login(struct soap *soap) {
-  ns1__login *_p = soap_instantiate_ns1__login(soap, -1, NULL, NULL, NULL);
+  ns1__login *_p =
+      soap_instantiate_ns1__login(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -6000,7 +6049,8 @@ inline ns1__login *soap_new_set_ns1__login(struct soap *soap,
                                            std::string *username,
                                            std::string *password,
                                            char *__item1) {
-  ns1__login *_p = soap_instantiate_ns1__login(soap, -1, NULL, NULL, NULL);
+  ns1__login *_p =
+      soap_instantiate_ns1__login(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__login::username = username;
@@ -6056,13 +6106,14 @@ soap_instantiate_ns1__loginLifetimeResponse(struct soap *, int, const char *,
 
 inline ns1__loginLifetimeResponse *
 soap_new_ns1__loginLifetimeResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__loginLifetimeResponse(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__loginLifetimeResponse(soap, n, nullptr, nullptr,
+                                                     nullptr);
 }
 
 inline ns1__loginLifetimeResponse *
 soap_new_req_ns1__loginLifetimeResponse(struct soap *soap) {
-  ns1__loginLifetimeResponse *_p =
-      soap_instantiate_ns1__loginLifetimeResponse(soap, -1, NULL, NULL, NULL);
+  ns1__loginLifetimeResponse *_p = soap_instantiate_ns1__loginLifetimeResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -6072,8 +6123,8 @@ soap_new_req_ns1__loginLifetimeResponse(struct soap *soap) {
 inline ns1__loginLifetimeResponse *
 soap_new_set_ns1__loginLifetimeResponse(struct soap *soap, std::string *return_,
                                         char *__item1) {
-  ns1__loginLifetimeResponse *_p =
-      soap_instantiate_ns1__loginLifetimeResponse(soap, -1, NULL, NULL, NULL);
+  ns1__loginLifetimeResponse *_p = soap_instantiate_ns1__loginLifetimeResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__loginLifetimeResponse::return_ = return_;
@@ -6130,13 +6181,14 @@ soap_instantiate_ns1__loginLifetime(struct soap *, int, const char *,
 
 inline ns1__loginLifetime *soap_new_ns1__loginLifetime(struct soap *soap,
                                                        int n = -1) {
-  return soap_instantiate_ns1__loginLifetime(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__loginLifetime(soap, n, nullptr, nullptr,
+                                             nullptr);
 }
 
 inline ns1__loginLifetime *soap_new_req_ns1__loginLifetime(struct soap *soap,
                                                            int lifetime) {
   ns1__loginLifetime *_p =
-      soap_instantiate_ns1__loginLifetime(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__loginLifetime(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__loginLifetime::lifetime = lifetime;
@@ -6149,7 +6201,7 @@ soap_new_set_ns1__loginLifetime(struct soap *soap, std::string *username,
                                 std::string *password, int lifetime,
                                 char *__item1) {
   ns1__loginLifetime *_p =
-      soap_instantiate_ns1__loginLifetime(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__loginLifetime(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__loginLifetime::username = username;
@@ -6211,15 +6263,15 @@ soap_instantiate_ns1__getParameterByUnitsResponse(struct soap *, int,
 
 inline ns1__getParameterByUnitsResponse *
 soap_new_ns1__getParameterByUnitsResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getParameterByUnitsResponse(soap, n, NULL, NULL,
-                                                           NULL);
+  return soap_instantiate_ns1__getParameterByUnitsResponse(soap, n, nullptr,
+                                                           nullptr, nullptr);
 }
 
 inline ns1__getParameterByUnitsResponse *
 soap_new_req_ns1__getParameterByUnitsResponse(struct soap *soap) {
   ns1__getParameterByUnitsResponse *_p =
-      soap_instantiate_ns1__getParameterByUnitsResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__getParameterByUnitsResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -6230,8 +6282,8 @@ inline ns1__getParameterByUnitsResponse *
 soap_new_set_ns1__getParameterByUnitsResponse(
     struct soap *soap, std::vector<ns1__parameter *> &return_, char *__item1) {
   ns1__getParameterByUnitsResponse *_p =
-      soap_instantiate_ns1__getParameterByUnitsResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__getParameterByUnitsResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getParameterByUnitsResponse::return_ = return_;
@@ -6288,13 +6340,14 @@ soap_instantiate_ns1__getParameterByUnits(struct soap *, int, const char *,
 
 inline ns1__getParameterByUnits *
 soap_new_ns1__getParameterByUnits(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getParameterByUnits(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__getParameterByUnits(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline ns1__getParameterByUnits *
 soap_new_req_ns1__getParameterByUnits(struct soap *soap) {
-  ns1__getParameterByUnits *_p =
-      soap_instantiate_ns1__getParameterByUnits(soap, -1, NULL, NULL, NULL);
+  ns1__getParameterByUnits *_p = soap_instantiate_ns1__getParameterByUnits(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -6304,8 +6357,8 @@ soap_new_req_ns1__getParameterByUnits(struct soap *soap) {
 inline ns1__getParameterByUnits *
 soap_new_set_ns1__getParameterByUnits(struct soap *soap, std::string *sessionId,
                                       std::string *units, char *__item1) {
-  ns1__getParameterByUnits *_p =
-      soap_instantiate_ns1__getParameterByUnits(soap, -1, NULL, NULL, NULL);
+  ns1__getParameterByUnits *_p = soap_instantiate_ns1__getParameterByUnits(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getParameterByUnits::sessionId = sessionId;
@@ -6362,13 +6415,14 @@ soap_instantiate_ns1__addSampleResponse(struct soap *, int, const char *,
 
 inline ns1__addSampleResponse *
 soap_new_ns1__addSampleResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__addSampleResponse(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__addSampleResponse(soap, n, nullptr, nullptr,
+                                                 nullptr);
 }
 
 inline ns1__addSampleResponse *
 soap_new_req_ns1__addSampleResponse(struct soap *soap) {
-  ns1__addSampleResponse *_p =
-      soap_instantiate_ns1__addSampleResponse(soap, -1, NULL, NULL, NULL);
+  ns1__addSampleResponse *_p = soap_instantiate_ns1__addSampleResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -6378,8 +6432,8 @@ soap_new_req_ns1__addSampleResponse(struct soap *soap) {
 inline ns1__addSampleResponse *
 soap_new_set_ns1__addSampleResponse(struct soap *soap, ns1__sample *return_,
                                     char *__item1) {
-  ns1__addSampleResponse *_p =
-      soap_instantiate_ns1__addSampleResponse(soap, -1, NULL, NULL, NULL);
+  ns1__addSampleResponse *_p = soap_instantiate_ns1__addSampleResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__addSampleResponse::return_ = return_;
@@ -6433,12 +6487,12 @@ soap_instantiate_ns1__addSample(struct soap *, int, const char *, const char *,
                                 size_t *);
 
 inline ns1__addSample *soap_new_ns1__addSample(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__addSample(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__addSample(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__addSample *soap_new_req_ns1__addSample(struct soap *soap) {
   ns1__addSample *_p =
-      soap_instantiate_ns1__addSample(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__addSample(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -6451,7 +6505,7 @@ inline ns1__addSample *soap_new_set_ns1__addSample(struct soap *soap,
                                                    LONG64 *investigationId,
                                                    char *__item1) {
   ns1__addSample *_p =
-      soap_instantiate_ns1__addSample(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__addSample(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__addSample::sessionId = sessionId;
@@ -6512,15 +6566,15 @@ soap_instantiate_ns1__addAuthorisationResponse(struct soap *, int, const char *,
 
 inline ns1__addAuthorisationResponse *
 soap_new_ns1__addAuthorisationResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__addAuthorisationResponse(soap, n, NULL, NULL,
-                                                        NULL);
+  return soap_instantiate_ns1__addAuthorisationResponse(soap, n, nullptr,
+                                                        nullptr, nullptr);
 }
 
 inline ns1__addAuthorisationResponse *
 soap_new_req_ns1__addAuthorisationResponse(struct soap *soap) {
   ns1__addAuthorisationResponse *_p =
-      soap_instantiate_ns1__addAuthorisationResponse(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate_ns1__addAuthorisationResponse(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -6532,8 +6586,8 @@ soap_new_set_ns1__addAuthorisationResponse(struct soap *soap,
                                            ns1__icatAuthorisation *return_,
                                            char *__item1) {
   ns1__addAuthorisationResponse *_p =
-      soap_instantiate_ns1__addAuthorisationResponse(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate_ns1__addAuthorisationResponse(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__addAuthorisationResponse::return_ = return_;
@@ -6590,13 +6644,14 @@ soap_instantiate_ns1__addAuthorisation(struct soap *, int, const char *,
 
 inline ns1__addAuthorisation *soap_new_ns1__addAuthorisation(struct soap *soap,
                                                              int n = -1) {
-  return soap_instantiate_ns1__addAuthorisation(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__addAuthorisation(soap, n, nullptr, nullptr,
+                                                nullptr);
 }
 
 inline ns1__addAuthorisation *
 soap_new_req_ns1__addAuthorisation(struct soap *soap) {
-  ns1__addAuthorisation *_p =
-      soap_instantiate_ns1__addAuthorisation(soap, -1, NULL, NULL, NULL);
+  ns1__addAuthorisation *_p = soap_instantiate_ns1__addAuthorisation(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -6607,8 +6662,8 @@ inline ns1__addAuthorisation *soap_new_set_ns1__addAuthorisation(
     struct soap *soap, std::string *sessionId, std::string *toAddFedId,
     std::string *toAddRole, LONG64 *elementId,
     enum ns1__elementType *elementType, char *__item1) {
-  ns1__addAuthorisation *_p =
-      soap_instantiate_ns1__addAuthorisation(soap, -1, NULL, NULL, NULL);
+  ns1__addAuthorisation *_p = soap_instantiate_ns1__addAuthorisation(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__addAuthorisation::sessionId = sessionId;
@@ -6672,14 +6727,15 @@ soap_instantiate_ns1__createDataFilesResponse(struct soap *, int, const char *,
 
 inline ns1__createDataFilesResponse *
 soap_new_ns1__createDataFilesResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__createDataFilesResponse(soap, n, NULL, NULL,
-                                                       NULL);
+  return soap_instantiate_ns1__createDataFilesResponse(soap, n, nullptr,
+                                                       nullptr, nullptr);
 }
 
 inline ns1__createDataFilesResponse *
 soap_new_req_ns1__createDataFilesResponse(struct soap *soap) {
   ns1__createDataFilesResponse *_p =
-      soap_instantiate_ns1__createDataFilesResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__createDataFilesResponse(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -6689,7 +6745,8 @@ soap_new_req_ns1__createDataFilesResponse(struct soap *soap) {
 inline ns1__createDataFilesResponse *soap_new_set_ns1__createDataFilesResponse(
     struct soap *soap, std::vector<ns1__datafile *> &return_, char *__item1) {
   ns1__createDataFilesResponse *_p =
-      soap_instantiate_ns1__createDataFilesResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__createDataFilesResponse(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__createDataFilesResponse::return_ = return_;
@@ -6746,13 +6803,14 @@ soap_instantiate_ns1__createDataFiles(struct soap *, int, const char *,
 
 inline ns1__createDataFiles *soap_new_ns1__createDataFiles(struct soap *soap,
                                                            int n = -1) {
-  return soap_instantiate_ns1__createDataFiles(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__createDataFiles(soap, n, nullptr, nullptr,
+                                               nullptr);
 }
 
 inline ns1__createDataFiles *
 soap_new_req_ns1__createDataFiles(struct soap *soap) {
-  ns1__createDataFiles *_p =
-      soap_instantiate_ns1__createDataFiles(soap, -1, NULL, NULL, NULL);
+  ns1__createDataFiles *_p = soap_instantiate_ns1__createDataFiles(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -6763,8 +6821,8 @@ inline ns1__createDataFiles *
 soap_new_set_ns1__createDataFiles(struct soap *soap, std::string *sessionId,
                                   std::vector<ns1__datafile *> &dataFiles,
                                   LONG64 *datasetId, char *__item1) {
-  ns1__createDataFiles *_p =
-      soap_instantiate_ns1__createDataFiles(soap, -1, NULL, NULL, NULL);
+  ns1__createDataFiles *_p = soap_instantiate_ns1__createDataFiles(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__createDataFiles::sessionId = sessionId;
@@ -6826,15 +6884,15 @@ soap_instantiate_ns1__addDataSetParameterResponse(struct soap *, int,
 
 inline ns1__addDataSetParameterResponse *
 soap_new_ns1__addDataSetParameterResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__addDataSetParameterResponse(soap, n, NULL, NULL,
-                                                           NULL);
+  return soap_instantiate_ns1__addDataSetParameterResponse(soap, n, nullptr,
+                                                           nullptr, nullptr);
 }
 
 inline ns1__addDataSetParameterResponse *
 soap_new_req_ns1__addDataSetParameterResponse(struct soap *soap) {
   ns1__addDataSetParameterResponse *_p =
-      soap_instantiate_ns1__addDataSetParameterResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__addDataSetParameterResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -6846,8 +6904,8 @@ soap_new_set_ns1__addDataSetParameterResponse(struct soap *soap,
                                               ns1__datasetParameter *return_,
                                               char *__item1) {
   ns1__addDataSetParameterResponse *_p =
-      soap_instantiate_ns1__addDataSetParameterResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__addDataSetParameterResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__addDataSetParameterResponse::return_ = return_;
@@ -6904,13 +6962,14 @@ soap_instantiate_ns1__addDataSetParameter(struct soap *, int, const char *,
 
 inline ns1__addDataSetParameter *
 soap_new_ns1__addDataSetParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__addDataSetParameter(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__addDataSetParameter(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline ns1__addDataSetParameter *
 soap_new_req_ns1__addDataSetParameter(struct soap *soap) {
-  ns1__addDataSetParameter *_p =
-      soap_instantiate_ns1__addDataSetParameter(soap, -1, NULL, NULL, NULL);
+  ns1__addDataSetParameter *_p = soap_instantiate_ns1__addDataSetParameter(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -6921,8 +6980,8 @@ inline ns1__addDataSetParameter *
 soap_new_set_ns1__addDataSetParameter(struct soap *soap, std::string *sessionId,
                                       ns1__datasetParameter *dataSetParameter,
                                       LONG64 *datasetId, char *__item1) {
-  ns1__addDataSetParameter *_p =
-      soap_instantiate_ns1__addDataSetParameter(soap, -1, NULL, NULL, NULL);
+  ns1__addDataSetParameter *_p = soap_instantiate_ns1__addDataSetParameter(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__addDataSetParameter::sessionId = sessionId;
@@ -6984,15 +7043,15 @@ soap_instantiate_ns1__modifyInvestigatorResponse(struct soap *, int,
 
 inline ns1__modifyInvestigatorResponse *
 soap_new_ns1__modifyInvestigatorResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__modifyInvestigatorResponse(soap, n, NULL, NULL,
-                                                          NULL);
+  return soap_instantiate_ns1__modifyInvestigatorResponse(soap, n, nullptr,
+                                                          nullptr, nullptr);
 }
 
 inline ns1__modifyInvestigatorResponse *
 soap_new_req_ns1__modifyInvestigatorResponse(struct soap *soap) {
   ns1__modifyInvestigatorResponse *_p =
-      soap_instantiate_ns1__modifyInvestigatorResponse(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate_ns1__modifyInvestigatorResponse(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -7002,8 +7061,8 @@ soap_new_req_ns1__modifyInvestigatorResponse(struct soap *soap) {
 inline ns1__modifyInvestigatorResponse *
 soap_new_set_ns1__modifyInvestigatorResponse(struct soap *soap, char *__item1) {
   ns1__modifyInvestigatorResponse *_p =
-      soap_instantiate_ns1__modifyInvestigatorResponse(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate_ns1__modifyInvestigatorResponse(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -7058,13 +7117,14 @@ soap_instantiate_ns1__modifyInvestigator(struct soap *, int, const char *,
 
 inline ns1__modifyInvestigator *
 soap_new_ns1__modifyInvestigator(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__modifyInvestigator(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__modifyInvestigator(soap, n, nullptr, nullptr,
+                                                  nullptr);
 }
 
 inline ns1__modifyInvestigator *
 soap_new_req_ns1__modifyInvestigator(struct soap *soap) {
-  ns1__modifyInvestigator *_p =
-      soap_instantiate_ns1__modifyInvestigator(soap, -1, NULL, NULL, NULL);
+  ns1__modifyInvestigator *_p = soap_instantiate_ns1__modifyInvestigator(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -7075,8 +7135,8 @@ inline ns1__modifyInvestigator *
 soap_new_set_ns1__modifyInvestigator(struct soap *soap, std::string *sessionId,
                                      ns1__investigator *ns1__investigator_,
                                      char *__item1) {
-  ns1__modifyInvestigator *_p =
-      soap_instantiate_ns1__modifyInvestigator(soap, -1, NULL, NULL, NULL);
+  ns1__modifyInvestigator *_p = soap_instantiate_ns1__modifyInvestigator(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__modifyInvestigator::sessionId = sessionId;
@@ -7137,15 +7197,15 @@ soap_instantiate_ns1__modifySampleParameterResponse(struct soap *, int,
 
 inline ns1__modifySampleParameterResponse *
 soap_new_ns1__modifySampleParameterResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__modifySampleParameterResponse(soap, n, NULL,
-                                                             NULL, NULL);
+  return soap_instantiate_ns1__modifySampleParameterResponse(soap, n, nullptr,
+                                                             nullptr, nullptr);
 }
 
 inline ns1__modifySampleParameterResponse *
 soap_new_req_ns1__modifySampleParameterResponse(struct soap *soap) {
   ns1__modifySampleParameterResponse *_p =
-      soap_instantiate_ns1__modifySampleParameterResponse(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate_ns1__modifySampleParameterResponse(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -7156,8 +7216,8 @@ inline ns1__modifySampleParameterResponse *
 soap_new_set_ns1__modifySampleParameterResponse(struct soap *soap,
                                                 char *__item1) {
   ns1__modifySampleParameterResponse *_p =
-      soap_instantiate_ns1__modifySampleParameterResponse(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate_ns1__modifySampleParameterResponse(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -7213,13 +7273,14 @@ soap_instantiate_ns1__modifySampleParameter(struct soap *, int, const char *,
 
 inline ns1__modifySampleParameter *
 soap_new_ns1__modifySampleParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__modifySampleParameter(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__modifySampleParameter(soap, n, nullptr, nullptr,
+                                                     nullptr);
 }
 
 inline ns1__modifySampleParameter *
 soap_new_req_ns1__modifySampleParameter(struct soap *soap) {
-  ns1__modifySampleParameter *_p =
-      soap_instantiate_ns1__modifySampleParameter(soap, -1, NULL, NULL, NULL);
+  ns1__modifySampleParameter *_p = soap_instantiate_ns1__modifySampleParameter(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -7229,8 +7290,8 @@ soap_new_req_ns1__modifySampleParameter(struct soap *soap) {
 inline ns1__modifySampleParameter *soap_new_set_ns1__modifySampleParameter(
     struct soap *soap, std::string *sessionId,
     ns1__sampleParameter *sampleParameter, char *__item1) {
-  ns1__modifySampleParameter *_p =
-      soap_instantiate_ns1__modifySampleParameter(soap, -1, NULL, NULL, NULL);
+  ns1__modifySampleParameter *_p = soap_instantiate_ns1__modifySampleParameter(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__modifySampleParameter::sessionId = sessionId;
@@ -7292,15 +7353,15 @@ soap_instantiate_ns1__listDatafileFormatsResponse(struct soap *, int,
 
 inline ns1__listDatafileFormatsResponse *
 soap_new_ns1__listDatafileFormatsResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__listDatafileFormatsResponse(soap, n, NULL, NULL,
-                                                           NULL);
+  return soap_instantiate_ns1__listDatafileFormatsResponse(soap, n, nullptr,
+                                                           nullptr, nullptr);
 }
 
 inline ns1__listDatafileFormatsResponse *
 soap_new_req_ns1__listDatafileFormatsResponse(struct soap *soap) {
   ns1__listDatafileFormatsResponse *_p =
-      soap_instantiate_ns1__listDatafileFormatsResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__listDatafileFormatsResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -7312,8 +7373,8 @@ soap_new_set_ns1__listDatafileFormatsResponse(
     struct soap *soap, std::vector<ns1__datafileFormat *> &return_,
     char *__item1) {
   ns1__listDatafileFormatsResponse *_p =
-      soap_instantiate_ns1__listDatafileFormatsResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__listDatafileFormatsResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__listDatafileFormatsResponse::return_ = return_;
@@ -7370,13 +7431,14 @@ soap_instantiate_ns1__listDatafileFormats(struct soap *, int, const char *,
 
 inline ns1__listDatafileFormats *
 soap_new_ns1__listDatafileFormats(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__listDatafileFormats(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__listDatafileFormats(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline ns1__listDatafileFormats *
 soap_new_req_ns1__listDatafileFormats(struct soap *soap) {
-  ns1__listDatafileFormats *_p =
-      soap_instantiate_ns1__listDatafileFormats(soap, -1, NULL, NULL, NULL);
+  ns1__listDatafileFormats *_p = soap_instantiate_ns1__listDatafileFormats(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -7386,8 +7448,8 @@ soap_new_req_ns1__listDatafileFormats(struct soap *soap) {
 inline ns1__listDatafileFormats *
 soap_new_set_ns1__listDatafileFormats(struct soap *soap, std::string *sessionId,
                                       char *__item1) {
-  ns1__listDatafileFormats *_p =
-      soap_instantiate_ns1__listDatafileFormats(soap, -1, NULL, NULL, NULL);
+  ns1__listDatafileFormats *_p = soap_instantiate_ns1__listDatafileFormats(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__listDatafileFormats::sessionId = sessionId;
@@ -7451,14 +7513,14 @@ inline ns1__searchInvestigationByParameterResponse *
 soap_new_ns1__searchInvestigationByParameterResponse(struct soap *soap,
                                                      int n = -1) {
   return soap_instantiate_ns1__searchInvestigationByParameterResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchInvestigationByParameterResponse *
 soap_new_req_ns1__searchInvestigationByParameterResponse(struct soap *soap) {
   ns1__searchInvestigationByParameterResponse *_p =
       soap_instantiate_ns1__searchInvestigationByParameterResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -7470,7 +7532,7 @@ soap_new_set_ns1__searchInvestigationByParameterResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchInvestigationByParameterResponse *_p =
       soap_instantiate_ns1__searchInvestigationByParameterResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchInvestigationByParameterResponse::return_ = return_;
@@ -7531,15 +7593,15 @@ soap_instantiate_ns1__searchInvestigationByParameter(struct soap *, int,
 
 inline ns1__searchInvestigationByParameter *
 soap_new_ns1__searchInvestigationByParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchInvestigationByParameter(soap, n, NULL,
-                                                              NULL, NULL);
+  return soap_instantiate_ns1__searchInvestigationByParameter(soap, n, nullptr,
+                                                              nullptr, nullptr);
 }
 
 inline ns1__searchInvestigationByParameter *
 soap_new_req_ns1__searchInvestigationByParameter(struct soap *soap) {
   ns1__searchInvestigationByParameter *_p =
-      soap_instantiate_ns1__searchInvestigationByParameter(soap, -1, NULL, NULL,
-                                                           NULL);
+      soap_instantiate_ns1__searchInvestigationByParameter(soap, -1, nullptr,
+                                                           nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -7551,8 +7613,8 @@ soap_new_set_ns1__searchInvestigationByParameter(
     struct soap *soap, std::string *sessionId,
     std::vector<ns1__parameterSearch *> &parameters, char *__item1) {
   ns1__searchInvestigationByParameter *_p =
-      soap_instantiate_ns1__searchInvestigationByParameter(soap, -1, NULL, NULL,
-                                                           NULL);
+      soap_instantiate_ns1__searchInvestigationByParameter(soap, -1, nullptr,
+                                                           nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchInvestigationByParameter::sessionId = sessionId;
@@ -7613,15 +7675,15 @@ soap_instantiate_ns1__searchByAdvancedResponse(struct soap *, int, const char *,
 
 inline ns1__searchByAdvancedResponse *
 soap_new_ns1__searchByAdvancedResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchByAdvancedResponse(soap, n, NULL, NULL,
-                                                        NULL);
+  return soap_instantiate_ns1__searchByAdvancedResponse(soap, n, nullptr,
+                                                        nullptr, nullptr);
 }
 
 inline ns1__searchByAdvancedResponse *
 soap_new_req_ns1__searchByAdvancedResponse(struct soap *soap) {
   ns1__searchByAdvancedResponse *_p =
-      soap_instantiate_ns1__searchByAdvancedResponse(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate_ns1__searchByAdvancedResponse(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -7633,8 +7695,8 @@ soap_new_set_ns1__searchByAdvancedResponse(
     struct soap *soap, std::vector<ns1__investigation *> &return_,
     char *__item1) {
   ns1__searchByAdvancedResponse *_p =
-      soap_instantiate_ns1__searchByAdvancedResponse(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate_ns1__searchByAdvancedResponse(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchByAdvancedResponse::return_ = return_;
@@ -7691,13 +7753,14 @@ soap_instantiate_ns1__searchByAdvanced(struct soap *, int, const char *,
 
 inline ns1__searchByAdvanced *soap_new_ns1__searchByAdvanced(struct soap *soap,
                                                              int n = -1) {
-  return soap_instantiate_ns1__searchByAdvanced(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__searchByAdvanced(soap, n, nullptr, nullptr,
+                                                nullptr);
 }
 
 inline ns1__searchByAdvanced *
 soap_new_req_ns1__searchByAdvanced(struct soap *soap) {
-  ns1__searchByAdvanced *_p =
-      soap_instantiate_ns1__searchByAdvanced(soap, -1, NULL, NULL, NULL);
+  ns1__searchByAdvanced *_p = soap_instantiate_ns1__searchByAdvanced(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -7707,8 +7770,8 @@ soap_new_req_ns1__searchByAdvanced(struct soap *soap) {
 inline ns1__searchByAdvanced *soap_new_set_ns1__searchByAdvanced(
     struct soap *soap, std::string *sessionId,
     ns1__advancedSearchDetails *advancedSearchDetails, char *__item1) {
-  ns1__searchByAdvanced *_p =
-      soap_instantiate_ns1__searchByAdvanced(soap, -1, NULL, NULL, NULL);
+  ns1__searchByAdvanced *_p = soap_instantiate_ns1__searchByAdvanced(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchByAdvanced::sessionId = sessionId;
@@ -7772,15 +7835,15 @@ soap_instantiate_ns1__searchByAdvancedPaginationResponse(struct soap *, int,
 inline ns1__searchByAdvancedPaginationResponse *
 soap_new_ns1__searchByAdvancedPaginationResponse(struct soap *soap,
                                                  int n = -1) {
-  return soap_instantiate_ns1__searchByAdvancedPaginationResponse(soap, n, NULL,
-                                                                  NULL, NULL);
+  return soap_instantiate_ns1__searchByAdvancedPaginationResponse(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchByAdvancedPaginationResponse *
 soap_new_req_ns1__searchByAdvancedPaginationResponse(struct soap *soap) {
   ns1__searchByAdvancedPaginationResponse *_p =
-      soap_instantiate_ns1__searchByAdvancedPaginationResponse(soap, -1, NULL,
-                                                               NULL, NULL);
+      soap_instantiate_ns1__searchByAdvancedPaginationResponse(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -7792,8 +7855,8 @@ soap_new_set_ns1__searchByAdvancedPaginationResponse(
     struct soap *soap, std::vector<ns1__investigation *> &return_,
     char *__item1) {
   ns1__searchByAdvancedPaginationResponse *_p =
-      soap_instantiate_ns1__searchByAdvancedPaginationResponse(soap, -1, NULL,
-                                                               NULL, NULL);
+      soap_instantiate_ns1__searchByAdvancedPaginationResponse(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchByAdvancedPaginationResponse::return_ = return_;
@@ -7851,13 +7914,14 @@ soap_instantiate_ns1__advancedSearchDetails(struct soap *, int, const char *,
 
 inline ns1__advancedSearchDetails *
 soap_new_ns1__advancedSearchDetails(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__advancedSearchDetails(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__advancedSearchDetails(soap, n, nullptr, nullptr,
+                                                     nullptr);
 }
 
 inline ns1__advancedSearchDetails *
 soap_new_req_ns1__advancedSearchDetails(struct soap *soap, bool caseSensitive) {
-  ns1__advancedSearchDetails *_p =
-      soap_instantiate_ns1__advancedSearchDetails(soap, -1, NULL, NULL, NULL);
+  ns1__advancedSearchDetails *_p = soap_instantiate_ns1__advancedSearchDetails(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__advancedSearchDetails::caseSensitive = caseSensitive;
@@ -7875,8 +7939,8 @@ inline ns1__advancedSearchDetails *soap_new_set_ns1__advancedSearchDetails(
     std::vector<std::string> &investigators, std::vector<std::string> &keywords,
     double *runEnd, double *runStart, std::string *sampleName,
     std::string *visitId, char *__item1) {
-  ns1__advancedSearchDetails *_p =
-      soap_instantiate_ns1__advancedSearchDetails(soap, -1, NULL, NULL, NULL);
+  ns1__advancedSearchDetails *_p = soap_instantiate_ns1__advancedSearchDetails(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__advancedSearchDetails::backCatalogueInvestigatorString =
@@ -7956,16 +8020,16 @@ soap_instantiate_ns1__searchByAdvancedPagination(struct soap *, int,
 
 inline ns1__searchByAdvancedPagination *
 soap_new_ns1__searchByAdvancedPagination(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchByAdvancedPagination(soap, n, NULL, NULL,
-                                                          NULL);
+  return soap_instantiate_ns1__searchByAdvancedPagination(soap, n, nullptr,
+                                                          nullptr, nullptr);
 }
 
 inline ns1__searchByAdvancedPagination *
 soap_new_req_ns1__searchByAdvancedPagination(struct soap *soap, int startIndex,
                                              int numberOfResults) {
   ns1__searchByAdvancedPagination *_p =
-      soap_instantiate_ns1__searchByAdvancedPagination(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate_ns1__searchByAdvancedPagination(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchByAdvancedPagination::startIndex = startIndex;
@@ -7980,8 +8044,8 @@ soap_new_set_ns1__searchByAdvancedPagination(
     ns1__advancedSearchDetails *advancedSearchDetails, int startIndex,
     int numberOfResults, char *__item1) {
   ns1__searchByAdvancedPagination *_p =
-      soap_instantiate_ns1__searchByAdvancedPagination(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate_ns1__searchByAdvancedPagination(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchByAdvancedPagination::sessionId = sessionId;
@@ -8049,7 +8113,7 @@ inline ns1__searchDatafileByParameterComparisonResponse *
 soap_new_ns1__searchDatafileByParameterComparisonResponse(struct soap *soap,
                                                           int n = -1) {
   return soap_instantiate_ns1__searchDatafileByParameterComparisonResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatafileByParameterComparisonResponse *
@@ -8057,7 +8121,7 @@ soap_new_req_ns1__searchDatafileByParameterComparisonResponse(
     struct soap *soap) {
   ns1__searchDatafileByParameterComparisonResponse *_p =
       soap_instantiate_ns1__searchDatafileByParameterComparisonResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -8069,7 +8133,7 @@ soap_new_set_ns1__searchDatafileByParameterComparisonResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchDatafileByParameterComparisonResponse *_p =
       soap_instantiate_ns1__searchDatafileByParameterComparisonResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatafileByParameterComparisonResponse::return_ = return_;
@@ -8135,14 +8199,14 @@ inline ns1__searchDatafileByParameterComparison *
 soap_new_ns1__searchDatafileByParameterComparison(struct soap *soap,
                                                   int n = -1) {
   return soap_instantiate_ns1__searchDatafileByParameterComparison(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatafileByParameterComparison *
 soap_new_req_ns1__searchDatafileByParameterComparison(struct soap *soap) {
   ns1__searchDatafileByParameterComparison *_p =
-      soap_instantiate_ns1__searchDatafileByParameterComparison(soap, -1, NULL,
-                                                                NULL, NULL);
+      soap_instantiate_ns1__searchDatafileByParameterComparison(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -8155,8 +8219,8 @@ soap_new_set_ns1__searchDatafileByParameterComparison(
     std::vector<ns1__parameterComparisonCondition *> &comparison,
     char *__item1) {
   ns1__searchDatafileByParameterComparison *_p =
-      soap_instantiate_ns1__searchDatafileByParameterComparison(soap, -1, NULL,
-                                                                NULL, NULL);
+      soap_instantiate_ns1__searchDatafileByParameterComparison(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatafileByParameterComparison::sessionId = sessionId;
@@ -8219,15 +8283,15 @@ soap_instantiate_ns1__searchByRunNumberResponse(struct soap *, int,
 
 inline ns1__searchByRunNumberResponse *
 soap_new_ns1__searchByRunNumberResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchByRunNumberResponse(soap, n, NULL, NULL,
-                                                         NULL);
+  return soap_instantiate_ns1__searchByRunNumberResponse(soap, n, nullptr,
+                                                         nullptr, nullptr);
 }
 
 inline ns1__searchByRunNumberResponse *
 soap_new_req_ns1__searchByRunNumberResponse(struct soap *soap) {
   ns1__searchByRunNumberResponse *_p =
-      soap_instantiate_ns1__searchByRunNumberResponse(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__searchByRunNumberResponse(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -8238,8 +8302,8 @@ inline ns1__searchByRunNumberResponse *
 soap_new_set_ns1__searchByRunNumberResponse(
     struct soap *soap, std::vector<ns1__datafile *> &return_, char *__item1) {
   ns1__searchByRunNumberResponse *_p =
-      soap_instantiate_ns1__searchByRunNumberResponse(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__searchByRunNumberResponse(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchByRunNumberResponse::return_ = return_;
@@ -8296,14 +8360,15 @@ soap_instantiate_ns1__searchByRunNumber(struct soap *, int, const char *,
 
 inline ns1__searchByRunNumber *
 soap_new_ns1__searchByRunNumber(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchByRunNumber(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__searchByRunNumber(soap, n, nullptr, nullptr,
+                                                 nullptr);
 }
 
 inline ns1__searchByRunNumber *
 soap_new_req_ns1__searchByRunNumber(struct soap *soap, float startRun,
                                     float endRun) {
-  ns1__searchByRunNumber *_p =
-      soap_instantiate_ns1__searchByRunNumber(soap, -1, NULL, NULL, NULL);
+  ns1__searchByRunNumber *_p = soap_instantiate_ns1__searchByRunNumber(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchByRunNumber::startRun = startRun;
@@ -8317,8 +8382,8 @@ soap_new_set_ns1__searchByRunNumber(struct soap *soap, std::string *sessionId,
                                     std::vector<std::string> &instruments,
                                     float startRun, float endRun,
                                     char *__item1) {
-  ns1__searchByRunNumber *_p =
-      soap_instantiate_ns1__searchByRunNumber(soap, -1, NULL, NULL, NULL);
+  ns1__searchByRunNumber *_p = soap_instantiate_ns1__searchByRunNumber(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchByRunNumber::sessionId = sessionId;
@@ -8385,14 +8450,14 @@ inline ns1__searchByRunNumberPaginationResponse *
 soap_new_ns1__searchByRunNumberPaginationResponse(struct soap *soap,
                                                   int n = -1) {
   return soap_instantiate_ns1__searchByRunNumberPaginationResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchByRunNumberPaginationResponse *
 soap_new_req_ns1__searchByRunNumberPaginationResponse(struct soap *soap) {
   ns1__searchByRunNumberPaginationResponse *_p =
-      soap_instantiate_ns1__searchByRunNumberPaginationResponse(soap, -1, NULL,
-                                                                NULL, NULL);
+      soap_instantiate_ns1__searchByRunNumberPaginationResponse(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -8403,8 +8468,8 @@ inline ns1__searchByRunNumberPaginationResponse *
 soap_new_set_ns1__searchByRunNumberPaginationResponse(
     struct soap *soap, std::vector<ns1__datafile *> &return_, char *__item1) {
   ns1__searchByRunNumberPaginationResponse *_p =
-      soap_instantiate_ns1__searchByRunNumberPaginationResponse(soap, -1, NULL,
-                                                                NULL, NULL);
+      soap_instantiate_ns1__searchByRunNumberPaginationResponse(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchByRunNumberPaginationResponse::return_ = return_;
@@ -8465,8 +8530,8 @@ soap_instantiate_ns1__searchByRunNumberPagination(struct soap *, int,
 
 inline ns1__searchByRunNumberPagination *
 soap_new_ns1__searchByRunNumberPagination(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchByRunNumberPagination(soap, n, NULL, NULL,
-                                                           NULL);
+  return soap_instantiate_ns1__searchByRunNumberPagination(soap, n, nullptr,
+                                                           nullptr, nullptr);
 }
 
 inline ns1__searchByRunNumberPagination *
@@ -8474,8 +8539,8 @@ soap_new_req_ns1__searchByRunNumberPagination(struct soap *soap, float startRun,
                                               float endRun, int startIndex,
                                               int numberOfResults) {
   ns1__searchByRunNumberPagination *_p =
-      soap_instantiate_ns1__searchByRunNumberPagination(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__searchByRunNumberPagination(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchByRunNumberPagination::startRun = startRun;
@@ -8492,8 +8557,8 @@ soap_new_set_ns1__searchByRunNumberPagination(
     std::vector<std::string> &instruments, float startRun, float endRun,
     int startIndex, int numberOfResults, char *__item1) {
   ns1__searchByRunNumberPagination *_p =
-      soap_instantiate_ns1__searchByRunNumberPagination(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__searchByRunNumberPagination(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchByRunNumberPagination::sessionId = sessionId;
@@ -8558,15 +8623,15 @@ soap_instantiate_ns1__addDataSetParametersResponse(struct soap *, int,
 
 inline ns1__addDataSetParametersResponse *
 soap_new_ns1__addDataSetParametersResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__addDataSetParametersResponse(soap, n, NULL, NULL,
-                                                            NULL);
+  return soap_instantiate_ns1__addDataSetParametersResponse(soap, n, nullptr,
+                                                            nullptr, nullptr);
 }
 
 inline ns1__addDataSetParametersResponse *
 soap_new_req_ns1__addDataSetParametersResponse(struct soap *soap) {
   ns1__addDataSetParametersResponse *_p =
-      soap_instantiate_ns1__addDataSetParametersResponse(soap, -1, NULL, NULL,
-                                                         NULL);
+      soap_instantiate_ns1__addDataSetParametersResponse(soap, -1, nullptr,
+                                                         nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -8578,8 +8643,8 @@ soap_new_set_ns1__addDataSetParametersResponse(
     struct soap *soap, std::vector<ns1__datasetParameter *> &return_,
     char *__item1) {
   ns1__addDataSetParametersResponse *_p =
-      soap_instantiate_ns1__addDataSetParametersResponse(soap, -1, NULL, NULL,
-                                                         NULL);
+      soap_instantiate_ns1__addDataSetParametersResponse(soap, -1, nullptr,
+                                                         nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__addDataSetParametersResponse::return_ = return_;
@@ -8636,13 +8701,14 @@ soap_instantiate_ns1__addDataSetParameters(struct soap *, int, const char *,
 
 inline ns1__addDataSetParameters *
 soap_new_ns1__addDataSetParameters(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__addDataSetParameters(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__addDataSetParameters(soap, n, nullptr, nullptr,
+                                                    nullptr);
 }
 
 inline ns1__addDataSetParameters *
 soap_new_req_ns1__addDataSetParameters(struct soap *soap) {
-  ns1__addDataSetParameters *_p =
-      soap_instantiate_ns1__addDataSetParameters(soap, -1, NULL, NULL, NULL);
+  ns1__addDataSetParameters *_p = soap_instantiate_ns1__addDataSetParameters(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -8653,8 +8719,8 @@ inline ns1__addDataSetParameters *soap_new_set_ns1__addDataSetParameters(
     struct soap *soap, std::string *sessionId,
     std::vector<ns1__datasetParameter *> &dataSetParameters, LONG64 *datasetId,
     char *__item1) {
-  ns1__addDataSetParameters *_p =
-      soap_instantiate_ns1__addDataSetParameters(soap, -1, NULL, NULL, NULL);
+  ns1__addDataSetParameters *_p = soap_instantiate_ns1__addDataSetParameters(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__addDataSetParameters::sessionId = sessionId;
@@ -8714,13 +8780,14 @@ soap_instantiate_ns1__deleteKeywordResponse(struct soap *, int, const char *,
 
 inline ns1__deleteKeywordResponse *
 soap_new_ns1__deleteKeywordResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__deleteKeywordResponse(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__deleteKeywordResponse(soap, n, nullptr, nullptr,
+                                                     nullptr);
 }
 
 inline ns1__deleteKeywordResponse *
 soap_new_req_ns1__deleteKeywordResponse(struct soap *soap) {
-  ns1__deleteKeywordResponse *_p =
-      soap_instantiate_ns1__deleteKeywordResponse(soap, -1, NULL, NULL, NULL);
+  ns1__deleteKeywordResponse *_p = soap_instantiate_ns1__deleteKeywordResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -8729,8 +8796,8 @@ soap_new_req_ns1__deleteKeywordResponse(struct soap *soap) {
 
 inline ns1__deleteKeywordResponse *
 soap_new_set_ns1__deleteKeywordResponse(struct soap *soap, char *__item1) {
-  ns1__deleteKeywordResponse *_p =
-      soap_instantiate_ns1__deleteKeywordResponse(soap, -1, NULL, NULL, NULL);
+  ns1__deleteKeywordResponse *_p = soap_instantiate_ns1__deleteKeywordResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -8786,12 +8853,13 @@ soap_instantiate_ns1__deleteKeyword(struct soap *, int, const char *,
 
 inline ns1__deleteKeyword *soap_new_ns1__deleteKeyword(struct soap *soap,
                                                        int n = -1) {
-  return soap_instantiate_ns1__deleteKeyword(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__deleteKeyword(soap, n, nullptr, nullptr,
+                                             nullptr);
 }
 
 inline ns1__deleteKeyword *soap_new_req_ns1__deleteKeyword(struct soap *soap) {
   ns1__deleteKeyword *_p =
-      soap_instantiate_ns1__deleteKeyword(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__deleteKeyword(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -8802,7 +8870,7 @@ inline ns1__deleteKeyword *
 soap_new_set_ns1__deleteKeyword(struct soap *soap, std::string *sessionId,
                                 ns1__keywordPK *keywordPK, char *__item1) {
   ns1__deleteKeyword *_p =
-      soap_instantiate_ns1__deleteKeyword(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__deleteKeyword(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__deleteKeyword::sessionId = sessionId;
@@ -8863,15 +8931,15 @@ soap_instantiate_ns1__searchDatasetByParameterResponse(struct soap *, int,
 
 inline ns1__searchDatasetByParameterResponse *
 soap_new_ns1__searchDatasetByParameterResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchDatasetByParameterResponse(soap, n, NULL,
-                                                                NULL, NULL);
+  return soap_instantiate_ns1__searchDatasetByParameterResponse(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatasetByParameterResponse *
 soap_new_req_ns1__searchDatasetByParameterResponse(struct soap *soap) {
   ns1__searchDatasetByParameterResponse *_p =
-      soap_instantiate_ns1__searchDatasetByParameterResponse(soap, -1, NULL,
-                                                             NULL, NULL);
+      soap_instantiate_ns1__searchDatasetByParameterResponse(soap, -1, nullptr,
+                                                             nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -8882,8 +8950,8 @@ inline ns1__searchDatasetByParameterResponse *
 soap_new_set_ns1__searchDatasetByParameterResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchDatasetByParameterResponse *_p =
-      soap_instantiate_ns1__searchDatasetByParameterResponse(soap, -1, NULL,
-                                                             NULL, NULL);
+      soap_instantiate_ns1__searchDatasetByParameterResponse(soap, -1, nullptr,
+                                                             nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatasetByParameterResponse::return_ = return_;
@@ -8943,15 +9011,15 @@ soap_instantiate_ns1__searchDatasetByParameter(struct soap *, int, const char *,
 
 inline ns1__searchDatasetByParameter *
 soap_new_ns1__searchDatasetByParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchDatasetByParameter(soap, n, NULL, NULL,
-                                                        NULL);
+  return soap_instantiate_ns1__searchDatasetByParameter(soap, n, nullptr,
+                                                        nullptr, nullptr);
 }
 
 inline ns1__searchDatasetByParameter *
 soap_new_req_ns1__searchDatasetByParameter(struct soap *soap) {
   ns1__searchDatasetByParameter *_p =
-      soap_instantiate_ns1__searchDatasetByParameter(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate_ns1__searchDatasetByParameter(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -8963,8 +9031,8 @@ soap_new_set_ns1__searchDatasetByParameter(
     struct soap *soap, std::string *sessionId,
     std::vector<ns1__parameterSearch *> &parameters, char *__item1) {
   ns1__searchDatasetByParameter *_p =
-      soap_instantiate_ns1__searchDatasetByParameter(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate_ns1__searchDatasetByParameter(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatasetByParameter::sessionId = sessionId;
@@ -9023,13 +9091,14 @@ soap_instantiate_ns1__deleteSampleResponse(struct soap *, int, const char *,
 
 inline ns1__deleteSampleResponse *
 soap_new_ns1__deleteSampleResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__deleteSampleResponse(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__deleteSampleResponse(soap, n, nullptr, nullptr,
+                                                    nullptr);
 }
 
 inline ns1__deleteSampleResponse *
 soap_new_req_ns1__deleteSampleResponse(struct soap *soap) {
-  ns1__deleteSampleResponse *_p =
-      soap_instantiate_ns1__deleteSampleResponse(soap, -1, NULL, NULL, NULL);
+  ns1__deleteSampleResponse *_p = soap_instantiate_ns1__deleteSampleResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -9038,8 +9107,8 @@ soap_new_req_ns1__deleteSampleResponse(struct soap *soap) {
 
 inline ns1__deleteSampleResponse *
 soap_new_set_ns1__deleteSampleResponse(struct soap *soap, char *__item1) {
-  ns1__deleteSampleResponse *_p =
-      soap_instantiate_ns1__deleteSampleResponse(soap, -1, NULL, NULL, NULL);
+  ns1__deleteSampleResponse *_p = soap_instantiate_ns1__deleteSampleResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -9095,12 +9164,12 @@ soap_instantiate_ns1__deleteSample(struct soap *, int, const char *,
 
 inline ns1__deleteSample *soap_new_ns1__deleteSample(struct soap *soap,
                                                      int n = -1) {
-  return soap_instantiate_ns1__deleteSample(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__deleteSample(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__deleteSample *soap_new_req_ns1__deleteSample(struct soap *soap) {
   ns1__deleteSample *_p =
-      soap_instantiate_ns1__deleteSample(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__deleteSample(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -9112,7 +9181,7 @@ inline ns1__deleteSample *soap_new_set_ns1__deleteSample(struct soap *soap,
                                                          LONG64 *sampleId,
                                                          char *__item1) {
   ns1__deleteSample *_p =
-      soap_instantiate_ns1__deleteSample(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__deleteSample(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__deleteSample::sessionId = sessionId;
@@ -9174,15 +9243,15 @@ soap_instantiate_ns1__listDatasetStatusResponse(struct soap *, int,
 
 inline ns1__listDatasetStatusResponse *
 soap_new_ns1__listDatasetStatusResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__listDatasetStatusResponse(soap, n, NULL, NULL,
-                                                         NULL);
+  return soap_instantiate_ns1__listDatasetStatusResponse(soap, n, nullptr,
+                                                         nullptr, nullptr);
 }
 
 inline ns1__listDatasetStatusResponse *
 soap_new_req_ns1__listDatasetStatusResponse(struct soap *soap) {
   ns1__listDatasetStatusResponse *_p =
-      soap_instantiate_ns1__listDatasetStatusResponse(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__listDatasetStatusResponse(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -9194,8 +9263,8 @@ soap_new_set_ns1__listDatasetStatusResponse(struct soap *soap,
                                             std::vector<std::string> &return_,
                                             char *__item1) {
   ns1__listDatasetStatusResponse *_p =
-      soap_instantiate_ns1__listDatasetStatusResponse(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__listDatasetStatusResponse(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__listDatasetStatusResponse::return_ = return_;
@@ -9252,13 +9321,14 @@ soap_instantiate_ns1__listDatasetStatus(struct soap *, int, const char *,
 
 inline ns1__listDatasetStatus *
 soap_new_ns1__listDatasetStatus(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__listDatasetStatus(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__listDatasetStatus(soap, n, nullptr, nullptr,
+                                                 nullptr);
 }
 
 inline ns1__listDatasetStatus *
 soap_new_req_ns1__listDatasetStatus(struct soap *soap) {
-  ns1__listDatasetStatus *_p =
-      soap_instantiate_ns1__listDatasetStatus(soap, -1, NULL, NULL, NULL);
+  ns1__listDatasetStatus *_p = soap_instantiate_ns1__listDatasetStatus(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -9268,8 +9338,8 @@ soap_new_req_ns1__listDatasetStatus(struct soap *soap) {
 inline ns1__listDatasetStatus *
 soap_new_set_ns1__listDatasetStatus(struct soap *soap, std::string *sessionId,
                                     char *__item1) {
-  ns1__listDatasetStatus *_p =
-      soap_instantiate_ns1__listDatasetStatus(soap, -1, NULL, NULL, NULL);
+  ns1__listDatasetStatus *_p = soap_instantiate_ns1__listDatasetStatus(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__listDatasetStatus::sessionId = sessionId;
@@ -9329,15 +9399,15 @@ soap_instantiate_ns1__modifyInvestigationResponse(struct soap *, int,
 
 inline ns1__modifyInvestigationResponse *
 soap_new_ns1__modifyInvestigationResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__modifyInvestigationResponse(soap, n, NULL, NULL,
-                                                           NULL);
+  return soap_instantiate_ns1__modifyInvestigationResponse(soap, n, nullptr,
+                                                           nullptr, nullptr);
 }
 
 inline ns1__modifyInvestigationResponse *
 soap_new_req_ns1__modifyInvestigationResponse(struct soap *soap) {
   ns1__modifyInvestigationResponse *_p =
-      soap_instantiate_ns1__modifyInvestigationResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__modifyInvestigationResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -9348,8 +9418,8 @@ inline ns1__modifyInvestigationResponse *
 soap_new_set_ns1__modifyInvestigationResponse(struct soap *soap,
                                               char *__item1) {
   ns1__modifyInvestigationResponse *_p =
-      soap_instantiate_ns1__modifyInvestigationResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__modifyInvestigationResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -9405,13 +9475,14 @@ soap_instantiate_ns1__modifyInvestigation(struct soap *, int, const char *,
 
 inline ns1__modifyInvestigation *
 soap_new_ns1__modifyInvestigation(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__modifyInvestigation(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__modifyInvestigation(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline ns1__modifyInvestigation *
 soap_new_req_ns1__modifyInvestigation(struct soap *soap) {
-  ns1__modifyInvestigation *_p =
-      soap_instantiate_ns1__modifyInvestigation(soap, -1, NULL, NULL, NULL);
+  ns1__modifyInvestigation *_p = soap_instantiate_ns1__modifyInvestigation(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -9422,8 +9493,8 @@ inline ns1__modifyInvestigation *
 soap_new_set_ns1__modifyInvestigation(struct soap *soap, std::string *sessionId,
                                       ns1__investigation *investigaion,
                                       char *__item1) {
-  ns1__modifyInvestigation *_p =
-      soap_instantiate_ns1__modifyInvestigation(soap, -1, NULL, NULL, NULL);
+  ns1__modifyInvestigation *_p = soap_instantiate_ns1__modifyInvestigation(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__modifyInvestigation::sessionId = sessionId;
@@ -9480,13 +9551,14 @@ soap_instantiate_ns1__icatAuthorisation(struct soap *, int, const char *,
 
 inline ns1__icatAuthorisation *
 soap_new_ns1__icatAuthorisation(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__icatAuthorisation(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__icatAuthorisation(soap, n, nullptr, nullptr,
+                                                 nullptr);
 }
 
 inline ns1__icatAuthorisation *soap_new_req_ns1__icatAuthorisation(
     struct soap *soap, bool facilityAcquiredData1, bool selected1) {
-  ns1__icatAuthorisation *_p =
-      soap_instantiate_ns1__icatAuthorisation(soap, -1, NULL, NULL, NULL);
+  ns1__icatAuthorisation *_p = soap_instantiate_ns1__icatAuthorisation(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__entityBaseBean::facilityAcquiredData = facilityAcquiredData1;
@@ -9500,8 +9572,8 @@ inline ns1__icatAuthorisation *soap_new_set_ns1__icatAuthorisation(
     LONG64 *id, ns1__icatRole *role, LONG64 *userChildRecord,
     std::string *userId, bool facilityAcquiredData1, ns1__icatRole *icatRole1,
     bool selected1, std::string *uniqueId1, char *__item2) {
-  ns1__icatAuthorisation *_p =
-      soap_instantiate_ns1__icatAuthorisation(soap, -1, NULL, NULL, NULL);
+  ns1__icatAuthorisation *_p = soap_instantiate_ns1__icatAuthorisation(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__icatAuthorisation::elementId = elementId;
@@ -9571,15 +9643,15 @@ soap_instantiate_ns1__getAuthorisationsResponse(struct soap *, int,
 
 inline ns1__getAuthorisationsResponse *
 soap_new_ns1__getAuthorisationsResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getAuthorisationsResponse(soap, n, NULL, NULL,
-                                                         NULL);
+  return soap_instantiate_ns1__getAuthorisationsResponse(soap, n, nullptr,
+                                                         nullptr, nullptr);
 }
 
 inline ns1__getAuthorisationsResponse *
 soap_new_req_ns1__getAuthorisationsResponse(struct soap *soap) {
   ns1__getAuthorisationsResponse *_p =
-      soap_instantiate_ns1__getAuthorisationsResponse(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__getAuthorisationsResponse(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -9591,8 +9663,8 @@ soap_new_set_ns1__getAuthorisationsResponse(
     struct soap *soap, std::vector<ns1__icatAuthorisation *> &return_,
     char *__item1) {
   ns1__getAuthorisationsResponse *_p =
-      soap_instantiate_ns1__getAuthorisationsResponse(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__getAuthorisationsResponse(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getAuthorisationsResponse::return_ = return_;
@@ -9649,13 +9721,14 @@ soap_instantiate_ns1__getAuthorisations(struct soap *, int, const char *,
 
 inline ns1__getAuthorisations *
 soap_new_ns1__getAuthorisations(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getAuthorisations(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__getAuthorisations(soap, n, nullptr, nullptr,
+                                                 nullptr);
 }
 
 inline ns1__getAuthorisations *
 soap_new_req_ns1__getAuthorisations(struct soap *soap) {
-  ns1__getAuthorisations *_p =
-      soap_instantiate_ns1__getAuthorisations(soap, -1, NULL, NULL, NULL);
+  ns1__getAuthorisations *_p = soap_instantiate_ns1__getAuthorisations(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -9665,8 +9738,8 @@ soap_new_req_ns1__getAuthorisations(struct soap *soap) {
 inline ns1__getAuthorisations *soap_new_set_ns1__getAuthorisations(
     struct soap *soap, std::string *sessionId, LONG64 *elementId,
     enum ns1__elementType *elementType, char *__item1) {
-  ns1__getAuthorisations *_p =
-      soap_instantiate_ns1__getAuthorisations(soap, -1, NULL, NULL, NULL);
+  ns1__getAuthorisations *_p = soap_instantiate_ns1__getAuthorisations(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getAuthorisations::sessionId = sessionId;
@@ -9724,13 +9797,14 @@ soap_instantiate_ns1__addKeywordResponse(struct soap *, int, const char *,
 
 inline ns1__addKeywordResponse *
 soap_new_ns1__addKeywordResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__addKeywordResponse(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__addKeywordResponse(soap, n, nullptr, nullptr,
+                                                  nullptr);
 }
 
 inline ns1__addKeywordResponse *
 soap_new_req_ns1__addKeywordResponse(struct soap *soap) {
-  ns1__addKeywordResponse *_p =
-      soap_instantiate_ns1__addKeywordResponse(soap, -1, NULL, NULL, NULL);
+  ns1__addKeywordResponse *_p = soap_instantiate_ns1__addKeywordResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -9740,8 +9814,8 @@ soap_new_req_ns1__addKeywordResponse(struct soap *soap) {
 inline ns1__addKeywordResponse *
 soap_new_set_ns1__addKeywordResponse(struct soap *soap, ns1__keyword *return_,
                                      char *__item1) {
-  ns1__addKeywordResponse *_p =
-      soap_instantiate_ns1__addKeywordResponse(soap, -1, NULL, NULL, NULL);
+  ns1__addKeywordResponse *_p = soap_instantiate_ns1__addKeywordResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__addKeywordResponse::return_ = return_;
@@ -9796,12 +9870,12 @@ soap_instantiate_ns1__addKeyword(struct soap *, int, const char *, const char *,
 
 inline ns1__addKeyword *soap_new_ns1__addKeyword(struct soap *soap,
                                                  int n = -1) {
-  return soap_instantiate_ns1__addKeyword(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__addKeyword(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__addKeyword *soap_new_req_ns1__addKeyword(struct soap *soap) {
   ns1__addKeyword *_p =
-      soap_instantiate_ns1__addKeyword(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__addKeyword(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -9814,7 +9888,7 @@ inline ns1__addKeyword *soap_new_set_ns1__addKeyword(struct soap *soap,
                                                      LONG64 *investigationId,
                                                      char *__item1) {
   ns1__addKeyword *_p =
-      soap_instantiate_ns1__addKeyword(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__addKeyword(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__addKeyword::sessionId = sessionId;
@@ -9880,7 +9954,7 @@ inline ns1__searchDatasetByRestrictionComparisonResponse *
 soap_new_ns1__searchDatasetByRestrictionComparisonResponse(struct soap *soap,
                                                            int n = -1) {
   return soap_instantiate_ns1__searchDatasetByRestrictionComparisonResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatasetByRestrictionComparisonResponse *
@@ -9888,7 +9962,7 @@ soap_new_req_ns1__searchDatasetByRestrictionComparisonResponse(
     struct soap *soap) {
   ns1__searchDatasetByRestrictionComparisonResponse *_p =
       soap_instantiate_ns1__searchDatasetByRestrictionComparisonResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -9900,7 +9974,7 @@ soap_new_set_ns1__searchDatasetByRestrictionComparisonResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchDatasetByRestrictionComparisonResponse *_p =
       soap_instantiate_ns1__searchDatasetByRestrictionComparisonResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatasetByRestrictionComparisonResponse::return_ = return_;
@@ -9966,14 +10040,14 @@ inline ns1__searchDatasetByRestrictionComparison *
 soap_new_ns1__searchDatasetByRestrictionComparison(struct soap *soap,
                                                    int n = -1) {
   return soap_instantiate_ns1__searchDatasetByRestrictionComparison(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatasetByRestrictionComparison *
 soap_new_req_ns1__searchDatasetByRestrictionComparison(struct soap *soap) {
   ns1__searchDatasetByRestrictionComparison *_p =
-      soap_instantiate_ns1__searchDatasetByRestrictionComparison(soap, -1, NULL,
-                                                                 NULL, NULL);
+      soap_instantiate_ns1__searchDatasetByRestrictionComparison(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -9986,8 +10060,8 @@ soap_new_set_ns1__searchDatasetByRestrictionComparison(
     std::vector<ns1__restrictionComparisonCondition *> &restriction,
     char *__item1) {
   ns1__searchDatasetByRestrictionComparison *_p =
-      soap_instantiate_ns1__searchDatasetByRestrictionComparison(soap, -1, NULL,
-                                                                 NULL, NULL);
+      soap_instantiate_ns1__searchDatasetByRestrictionComparison(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatasetByRestrictionComparison::sessionId = sessionId;
@@ -10053,14 +10127,14 @@ inline ns1__searchSampleByParameterLogicalResponse *
 soap_new_ns1__searchSampleByParameterLogicalResponse(struct soap *soap,
                                                      int n = -1) {
   return soap_instantiate_ns1__searchSampleByParameterLogicalResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchSampleByParameterLogicalResponse *
 soap_new_req_ns1__searchSampleByParameterLogicalResponse(struct soap *soap) {
   ns1__searchSampleByParameterLogicalResponse *_p =
       soap_instantiate_ns1__searchSampleByParameterLogicalResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -10072,7 +10146,7 @@ soap_new_set_ns1__searchSampleByParameterLogicalResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchSampleByParameterLogicalResponse *_p =
       soap_instantiate_ns1__searchSampleByParameterLogicalResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchSampleByParameterLogicalResponse::return_ = return_;
@@ -10133,15 +10207,15 @@ soap_instantiate_ns1__searchSampleByParameterLogical(struct soap *, int,
 
 inline ns1__searchSampleByParameterLogical *
 soap_new_ns1__searchSampleByParameterLogical(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchSampleByParameterLogical(soap, n, NULL,
-                                                              NULL, NULL);
+  return soap_instantiate_ns1__searchSampleByParameterLogical(soap, n, nullptr,
+                                                              nullptr, nullptr);
 }
 
 inline ns1__searchSampleByParameterLogical *
 soap_new_req_ns1__searchSampleByParameterLogical(struct soap *soap) {
   ns1__searchSampleByParameterLogical *_p =
-      soap_instantiate_ns1__searchSampleByParameterLogical(soap, -1, NULL, NULL,
-                                                           NULL);
+      soap_instantiate_ns1__searchSampleByParameterLogical(soap, -1, nullptr,
+                                                           nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -10153,8 +10227,8 @@ soap_new_set_ns1__searchSampleByParameterLogical(
     struct soap *soap, std::string *sessionId,
     ns1__parameterLogicalCondition *logicalCondition, char *__item1) {
   ns1__searchSampleByParameterLogical *_p =
-      soap_instantiate_ns1__searchSampleByParameterLogical(soap, -1, NULL, NULL,
-                                                           NULL);
+      soap_instantiate_ns1__searchSampleByParameterLogical(soap, -1, nullptr,
+                                                           nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchSampleByParameterLogical::sessionId = sessionId;
@@ -10213,13 +10287,14 @@ soap_instantiate_ns1__removeDataSetResponse(struct soap *, int, const char *,
 
 inline ns1__removeDataSetResponse *
 soap_new_ns1__removeDataSetResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__removeDataSetResponse(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__removeDataSetResponse(soap, n, nullptr, nullptr,
+                                                     nullptr);
 }
 
 inline ns1__removeDataSetResponse *
 soap_new_req_ns1__removeDataSetResponse(struct soap *soap) {
-  ns1__removeDataSetResponse *_p =
-      soap_instantiate_ns1__removeDataSetResponse(soap, -1, NULL, NULL, NULL);
+  ns1__removeDataSetResponse *_p = soap_instantiate_ns1__removeDataSetResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -10228,8 +10303,8 @@ soap_new_req_ns1__removeDataSetResponse(struct soap *soap) {
 
 inline ns1__removeDataSetResponse *
 soap_new_set_ns1__removeDataSetResponse(struct soap *soap, char *__item1) {
-  ns1__removeDataSetResponse *_p =
-      soap_instantiate_ns1__removeDataSetResponse(soap, -1, NULL, NULL, NULL);
+  ns1__removeDataSetResponse *_p = soap_instantiate_ns1__removeDataSetResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -10285,12 +10360,13 @@ soap_instantiate_ns1__removeDataSet(struct soap *, int, const char *,
 
 inline ns1__removeDataSet *soap_new_ns1__removeDataSet(struct soap *soap,
                                                        int n = -1) {
-  return soap_instantiate_ns1__removeDataSet(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__removeDataSet(soap, n, nullptr, nullptr,
+                                             nullptr);
 }
 
 inline ns1__removeDataSet *soap_new_req_ns1__removeDataSet(struct soap *soap) {
   ns1__removeDataSet *_p =
-      soap_instantiate_ns1__removeDataSet(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__removeDataSet(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -10301,7 +10377,7 @@ inline ns1__removeDataSet *
 soap_new_set_ns1__removeDataSet(struct soap *soap, std::string *sessionId,
                                 LONG64 *dataSetId, char *__item1) {
   ns1__removeDataSet *_p =
-      soap_instantiate_ns1__removeDataSet(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__removeDataSet(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__removeDataSet::sessionId = sessionId;
@@ -10362,15 +10438,15 @@ soap_instantiate_ns1__modifyDataSetParameterResponse(struct soap *, int,
 
 inline ns1__modifyDataSetParameterResponse *
 soap_new_ns1__modifyDataSetParameterResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__modifyDataSetParameterResponse(soap, n, NULL,
-                                                              NULL, NULL);
+  return soap_instantiate_ns1__modifyDataSetParameterResponse(soap, n, nullptr,
+                                                              nullptr, nullptr);
 }
 
 inline ns1__modifyDataSetParameterResponse *
 soap_new_req_ns1__modifyDataSetParameterResponse(struct soap *soap) {
   ns1__modifyDataSetParameterResponse *_p =
-      soap_instantiate_ns1__modifyDataSetParameterResponse(soap, -1, NULL, NULL,
-                                                           NULL);
+      soap_instantiate_ns1__modifyDataSetParameterResponse(soap, -1, nullptr,
+                                                           nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -10381,8 +10457,8 @@ inline ns1__modifyDataSetParameterResponse *
 soap_new_set_ns1__modifyDataSetParameterResponse(struct soap *soap,
                                                  char *__item1) {
   ns1__modifyDataSetParameterResponse *_p =
-      soap_instantiate_ns1__modifyDataSetParameterResponse(soap, -1, NULL, NULL,
-                                                           NULL);
+      soap_instantiate_ns1__modifyDataSetParameterResponse(soap, -1, nullptr,
+                                                           nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -10440,14 +10516,15 @@ soap_instantiate_ns1__modifyDataSetParameter(struct soap *, int, const char *,
 
 inline ns1__modifyDataSetParameter *
 soap_new_ns1__modifyDataSetParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__modifyDataSetParameter(soap, n, NULL, NULL,
-                                                      NULL);
+  return soap_instantiate_ns1__modifyDataSetParameter(soap, n, nullptr, nullptr,
+                                                      nullptr);
 }
 
 inline ns1__modifyDataSetParameter *
 soap_new_req_ns1__modifyDataSetParameter(struct soap *soap) {
   ns1__modifyDataSetParameter *_p =
-      soap_instantiate_ns1__modifyDataSetParameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__modifyDataSetParameter(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -10458,7 +10535,8 @@ inline ns1__modifyDataSetParameter *soap_new_set_ns1__modifyDataSetParameter(
     struct soap *soap, std::string *sessionId,
     ns1__datasetParameter *dataSetParameter, char *__item1) {
   ns1__modifyDataSetParameter *_p =
-      soap_instantiate_ns1__modifyDataSetParameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__modifyDataSetParameter(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__modifyDataSetParameter::sessionId = sessionId;
@@ -10520,15 +10598,15 @@ soap_instantiate_ns1__listInvestigationTypesResponse(struct soap *, int,
 
 inline ns1__listInvestigationTypesResponse *
 soap_new_ns1__listInvestigationTypesResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__listInvestigationTypesResponse(soap, n, NULL,
-                                                              NULL, NULL);
+  return soap_instantiate_ns1__listInvestigationTypesResponse(soap, n, nullptr,
+                                                              nullptr, nullptr);
 }
 
 inline ns1__listInvestigationTypesResponse *
 soap_new_req_ns1__listInvestigationTypesResponse(struct soap *soap) {
   ns1__listInvestigationTypesResponse *_p =
-      soap_instantiate_ns1__listInvestigationTypesResponse(soap, -1, NULL, NULL,
-                                                           NULL);
+      soap_instantiate_ns1__listInvestigationTypesResponse(soap, -1, nullptr,
+                                                           nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -10539,8 +10617,8 @@ inline ns1__listInvestigationTypesResponse *
 soap_new_set_ns1__listInvestigationTypesResponse(
     struct soap *soap, std::vector<std::string> &return_, char *__item1) {
   ns1__listInvestigationTypesResponse *_p =
-      soap_instantiate_ns1__listInvestigationTypesResponse(soap, -1, NULL, NULL,
-                                                           NULL);
+      soap_instantiate_ns1__listInvestigationTypesResponse(soap, -1, nullptr,
+                                                           nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__listInvestigationTypesResponse::return_ = return_;
@@ -10599,14 +10677,15 @@ soap_instantiate_ns1__listInvestigationTypes(struct soap *, int, const char *,
 
 inline ns1__listInvestigationTypes *
 soap_new_ns1__listInvestigationTypes(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__listInvestigationTypes(soap, n, NULL, NULL,
-                                                      NULL);
+  return soap_instantiate_ns1__listInvestigationTypes(soap, n, nullptr, nullptr,
+                                                      nullptr);
 }
 
 inline ns1__listInvestigationTypes *
 soap_new_req_ns1__listInvestigationTypes(struct soap *soap) {
   ns1__listInvestigationTypes *_p =
-      soap_instantiate_ns1__listInvestigationTypes(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__listInvestigationTypes(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -10616,7 +10695,8 @@ soap_new_req_ns1__listInvestigationTypes(struct soap *soap) {
 inline ns1__listInvestigationTypes *soap_new_set_ns1__listInvestigationTypes(
     struct soap *soap, std::string *sessionId, char *__item1) {
   ns1__listInvestigationTypes *_p =
-      soap_instantiate_ns1__listInvestigationTypes(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__listInvestigationTypes(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__listInvestigationTypes::sessionId = sessionId;
@@ -10677,15 +10757,15 @@ soap_instantiate_ns1__getKeywordsForUserResponse(struct soap *, int,
 
 inline ns1__getKeywordsForUserResponse *
 soap_new_ns1__getKeywordsForUserResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getKeywordsForUserResponse(soap, n, NULL, NULL,
-                                                          NULL);
+  return soap_instantiate_ns1__getKeywordsForUserResponse(soap, n, nullptr,
+                                                          nullptr, nullptr);
 }
 
 inline ns1__getKeywordsForUserResponse *
 soap_new_req_ns1__getKeywordsForUserResponse(struct soap *soap) {
   ns1__getKeywordsForUserResponse *_p =
-      soap_instantiate_ns1__getKeywordsForUserResponse(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate_ns1__getKeywordsForUserResponse(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -10697,8 +10777,8 @@ soap_new_set_ns1__getKeywordsForUserResponse(struct soap *soap,
                                              std::vector<std::string> &return_,
                                              char *__item1) {
   ns1__getKeywordsForUserResponse *_p =
-      soap_instantiate_ns1__getKeywordsForUserResponse(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate_ns1__getKeywordsForUserResponse(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getKeywordsForUserResponse::return_ = return_;
@@ -10754,13 +10834,14 @@ soap_instantiate_ns1__getKeywordsForUser(struct soap *, int, const char *,
 
 inline ns1__getKeywordsForUser *
 soap_new_ns1__getKeywordsForUser(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getKeywordsForUser(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__getKeywordsForUser(soap, n, nullptr, nullptr,
+                                                  nullptr);
 }
 
 inline ns1__getKeywordsForUser *
 soap_new_req_ns1__getKeywordsForUser(struct soap *soap) {
-  ns1__getKeywordsForUser *_p =
-      soap_instantiate_ns1__getKeywordsForUser(soap, -1, NULL, NULL, NULL);
+  ns1__getKeywordsForUser *_p = soap_instantiate_ns1__getKeywordsForUser(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -10770,8 +10851,8 @@ soap_new_req_ns1__getKeywordsForUser(struct soap *soap) {
 inline ns1__getKeywordsForUser *
 soap_new_set_ns1__getKeywordsForUser(struct soap *soap, std::string *sessionId,
                                      char *__item1) {
-  ns1__getKeywordsForUser *_p =
-      soap_instantiate_ns1__getKeywordsForUser(soap, -1, NULL, NULL, NULL);
+  ns1__getKeywordsForUser *_p = soap_instantiate_ns1__getKeywordsForUser(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getKeywordsForUser::sessionId = sessionId;
@@ -10835,14 +10916,14 @@ inline ns1__getKeywordsForUserStartWithMaxResponse *
 soap_new_ns1__getKeywordsForUserStartWithMaxResponse(struct soap *soap,
                                                      int n = -1) {
   return soap_instantiate_ns1__getKeywordsForUserStartWithMaxResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__getKeywordsForUserStartWithMaxResponse *
 soap_new_req_ns1__getKeywordsForUserStartWithMaxResponse(struct soap *soap) {
   ns1__getKeywordsForUserStartWithMaxResponse *_p =
       soap_instantiate_ns1__getKeywordsForUserStartWithMaxResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -10854,7 +10935,7 @@ soap_new_set_ns1__getKeywordsForUserStartWithMaxResponse(
     struct soap *soap, std::vector<std::string> &return_, char *__item1) {
   ns1__getKeywordsForUserStartWithMaxResponse *_p =
       soap_instantiate_ns1__getKeywordsForUserStartWithMaxResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getKeywordsForUserStartWithMaxResponse::return_ = return_;
@@ -10915,16 +10996,16 @@ soap_instantiate_ns1__getKeywordsForUserStartWithMax(struct soap *, int,
 
 inline ns1__getKeywordsForUserStartWithMax *
 soap_new_ns1__getKeywordsForUserStartWithMax(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getKeywordsForUserStartWithMax(soap, n, NULL,
-                                                              NULL, NULL);
+  return soap_instantiate_ns1__getKeywordsForUserStartWithMax(soap, n, nullptr,
+                                                              nullptr, nullptr);
 }
 
 inline ns1__getKeywordsForUserStartWithMax *
 soap_new_req_ns1__getKeywordsForUserStartWithMax(struct soap *soap,
                                                  int numberReturned) {
   ns1__getKeywordsForUserStartWithMax *_p =
-      soap_instantiate_ns1__getKeywordsForUserStartWithMax(soap, -1, NULL, NULL,
-                                                           NULL);
+      soap_instantiate_ns1__getKeywordsForUserStartWithMax(soap, -1, nullptr,
+                                                           nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getKeywordsForUserStartWithMax::numberReturned = numberReturned;
@@ -10939,8 +11020,8 @@ soap_new_set_ns1__getKeywordsForUserStartWithMax(struct soap *soap,
                                                  int numberReturned,
                                                  char *__item1) {
   ns1__getKeywordsForUserStartWithMax *_p =
-      soap_instantiate_ns1__getKeywordsForUserStartWithMax(soap, -1, NULL, NULL,
-                                                           NULL);
+      soap_instantiate_ns1__getKeywordsForUserStartWithMax(soap, -1, nullptr,
+                                                           nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getKeywordsForUserStartWithMax::sessionId = sessionId;
@@ -11002,15 +11083,15 @@ soap_instantiate_ns1__getKeywordsForUserMaxResponse(struct soap *, int,
 
 inline ns1__getKeywordsForUserMaxResponse *
 soap_new_ns1__getKeywordsForUserMaxResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getKeywordsForUserMaxResponse(soap, n, NULL,
-                                                             NULL, NULL);
+  return soap_instantiate_ns1__getKeywordsForUserMaxResponse(soap, n, nullptr,
+                                                             nullptr, nullptr);
 }
 
 inline ns1__getKeywordsForUserMaxResponse *
 soap_new_req_ns1__getKeywordsForUserMaxResponse(struct soap *soap) {
   ns1__getKeywordsForUserMaxResponse *_p =
-      soap_instantiate_ns1__getKeywordsForUserMaxResponse(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate_ns1__getKeywordsForUserMaxResponse(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -11021,8 +11102,8 @@ inline ns1__getKeywordsForUserMaxResponse *
 soap_new_set_ns1__getKeywordsForUserMaxResponse(
     struct soap *soap, std::vector<std::string> &return_, char *__item1) {
   ns1__getKeywordsForUserMaxResponse *_p =
-      soap_instantiate_ns1__getKeywordsForUserMaxResponse(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate_ns1__getKeywordsForUserMaxResponse(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getKeywordsForUserMaxResponse::return_ = return_;
@@ -11079,13 +11160,14 @@ soap_instantiate_ns1__getKeywordsForUserMax(struct soap *, int, const char *,
 
 inline ns1__getKeywordsForUserMax *
 soap_new_ns1__getKeywordsForUserMax(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getKeywordsForUserMax(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__getKeywordsForUserMax(soap, n, nullptr, nullptr,
+                                                     nullptr);
 }
 
 inline ns1__getKeywordsForUserMax *
 soap_new_req_ns1__getKeywordsForUserMax(struct soap *soap, int numberReturned) {
-  ns1__getKeywordsForUserMax *_p =
-      soap_instantiate_ns1__getKeywordsForUserMax(soap, -1, NULL, NULL, NULL);
+  ns1__getKeywordsForUserMax *_p = soap_instantiate_ns1__getKeywordsForUserMax(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getKeywordsForUserMax::numberReturned = numberReturned;
@@ -11097,8 +11179,8 @@ inline ns1__getKeywordsForUserMax *
 soap_new_set_ns1__getKeywordsForUserMax(struct soap *soap,
                                         std::string *sessionId,
                                         int numberReturned, char *__item1) {
-  ns1__getKeywordsForUserMax *_p =
-      soap_instantiate_ns1__getKeywordsForUserMax(soap, -1, NULL, NULL, NULL);
+  ns1__getKeywordsForUserMax *_p = soap_instantiate_ns1__getKeywordsForUserMax(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getKeywordsForUserMax::sessionId = sessionId;
@@ -11160,15 +11242,15 @@ soap_instantiate_ns1__getKeywordsForUserTypeResponse(struct soap *, int,
 
 inline ns1__getKeywordsForUserTypeResponse *
 soap_new_ns1__getKeywordsForUserTypeResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getKeywordsForUserTypeResponse(soap, n, NULL,
-                                                              NULL, NULL);
+  return soap_instantiate_ns1__getKeywordsForUserTypeResponse(soap, n, nullptr,
+                                                              nullptr, nullptr);
 }
 
 inline ns1__getKeywordsForUserTypeResponse *
 soap_new_req_ns1__getKeywordsForUserTypeResponse(struct soap *soap) {
   ns1__getKeywordsForUserTypeResponse *_p =
-      soap_instantiate_ns1__getKeywordsForUserTypeResponse(soap, -1, NULL, NULL,
-                                                           NULL);
+      soap_instantiate_ns1__getKeywordsForUserTypeResponse(soap, -1, nullptr,
+                                                           nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -11179,8 +11261,8 @@ inline ns1__getKeywordsForUserTypeResponse *
 soap_new_set_ns1__getKeywordsForUserTypeResponse(
     struct soap *soap, std::vector<std::string> &return_, char *__item1) {
   ns1__getKeywordsForUserTypeResponse *_p =
-      soap_instantiate_ns1__getKeywordsForUserTypeResponse(soap, -1, NULL, NULL,
-                                                           NULL);
+      soap_instantiate_ns1__getKeywordsForUserTypeResponse(soap, -1, nullptr,
+                                                           nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getKeywordsForUserTypeResponse::return_ = return_;
@@ -11239,14 +11321,15 @@ soap_instantiate_ns1__getKeywordsForUserType(struct soap *, int, const char *,
 
 inline ns1__getKeywordsForUserType *
 soap_new_ns1__getKeywordsForUserType(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getKeywordsForUserType(soap, n, NULL, NULL,
-                                                      NULL);
+  return soap_instantiate_ns1__getKeywordsForUserType(soap, n, nullptr, nullptr,
+                                                      nullptr);
 }
 
 inline ns1__getKeywordsForUserType *
 soap_new_req_ns1__getKeywordsForUserType(struct soap *soap) {
   ns1__getKeywordsForUserType *_p =
-      soap_instantiate_ns1__getKeywordsForUserType(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__getKeywordsForUserType(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -11257,7 +11340,8 @@ inline ns1__getKeywordsForUserType *soap_new_set_ns1__getKeywordsForUserType(
     struct soap *soap, std::string *sessionId,
     enum ns1__keywordType *keywordType, char *__item1) {
   ns1__getKeywordsForUserType *_p =
-      soap_instantiate_ns1__getKeywordsForUserType(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__getKeywordsForUserType(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getKeywordsForUserType::sessionId = sessionId;
@@ -11319,15 +11403,15 @@ soap_instantiate_ns1__getParameterByNameResponse(struct soap *, int,
 
 inline ns1__getParameterByNameResponse *
 soap_new_ns1__getParameterByNameResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getParameterByNameResponse(soap, n, NULL, NULL,
-                                                          NULL);
+  return soap_instantiate_ns1__getParameterByNameResponse(soap, n, nullptr,
+                                                          nullptr, nullptr);
 }
 
 inline ns1__getParameterByNameResponse *
 soap_new_req_ns1__getParameterByNameResponse(struct soap *soap) {
   ns1__getParameterByNameResponse *_p =
-      soap_instantiate_ns1__getParameterByNameResponse(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate_ns1__getParameterByNameResponse(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -11338,8 +11422,8 @@ inline ns1__getParameterByNameResponse *
 soap_new_set_ns1__getParameterByNameResponse(
     struct soap *soap, std::vector<ns1__parameter *> &return_, char *__item1) {
   ns1__getParameterByNameResponse *_p =
-      soap_instantiate_ns1__getParameterByNameResponse(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate_ns1__getParameterByNameResponse(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getParameterByNameResponse::return_ = return_;
@@ -11395,13 +11479,14 @@ soap_instantiate_ns1__getParameterByName(struct soap *, int, const char *,
 
 inline ns1__getParameterByName *
 soap_new_ns1__getParameterByName(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getParameterByName(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__getParameterByName(soap, n, nullptr, nullptr,
+                                                  nullptr);
 }
 
 inline ns1__getParameterByName *
 soap_new_req_ns1__getParameterByName(struct soap *soap) {
-  ns1__getParameterByName *_p =
-      soap_instantiate_ns1__getParameterByName(soap, -1, NULL, NULL, NULL);
+  ns1__getParameterByName *_p = soap_instantiate_ns1__getParameterByName(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -11411,8 +11496,8 @@ soap_new_req_ns1__getParameterByName(struct soap *soap) {
 inline ns1__getParameterByName *
 soap_new_set_ns1__getParameterByName(struct soap *soap, std::string *sessionId,
                                      std::string *name, char *__item1) {
-  ns1__getParameterByName *_p =
-      soap_instantiate_ns1__getParameterByName(soap, -1, NULL, NULL, NULL);
+  ns1__getParameterByName *_p = soap_instantiate_ns1__getParameterByName(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getParameterByName::sessionId = sessionId;
@@ -11473,15 +11558,15 @@ soap_instantiate_ns1__downloadDatafileResponse(struct soap *, int, const char *,
 
 inline ns1__downloadDatafileResponse *
 soap_new_ns1__downloadDatafileResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__downloadDatafileResponse(soap, n, NULL, NULL,
-                                                        NULL);
+  return soap_instantiate_ns1__downloadDatafileResponse(soap, n, nullptr,
+                                                        nullptr, nullptr);
 }
 
 inline ns1__downloadDatafileResponse *
 soap_new_req_ns1__downloadDatafileResponse(struct soap *soap) {
   ns1__downloadDatafileResponse *_p =
-      soap_instantiate_ns1__downloadDatafileResponse(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate_ns1__downloadDatafileResponse(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -11492,8 +11577,8 @@ inline ns1__downloadDatafileResponse *
 soap_new_set_ns1__downloadDatafileResponse(struct soap *soap, std::string *URL,
                                            char *__item1) {
   ns1__downloadDatafileResponse *_p =
-      soap_instantiate_ns1__downloadDatafileResponse(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate_ns1__downloadDatafileResponse(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__downloadDatafileResponse::URL = URL;
@@ -11550,13 +11635,14 @@ soap_instantiate_ns1__downloadDatafile(struct soap *, int, const char *,
 
 inline ns1__downloadDatafile *soap_new_ns1__downloadDatafile(struct soap *soap,
                                                              int n = -1) {
-  return soap_instantiate_ns1__downloadDatafile(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__downloadDatafile(soap, n, nullptr, nullptr,
+                                                nullptr);
 }
 
 inline ns1__downloadDatafile *
 soap_new_req_ns1__downloadDatafile(struct soap *soap) {
-  ns1__downloadDatafile *_p =
-      soap_instantiate_ns1__downloadDatafile(soap, -1, NULL, NULL, NULL);
+  ns1__downloadDatafile *_p = soap_instantiate_ns1__downloadDatafile(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -11566,8 +11652,8 @@ soap_new_req_ns1__downloadDatafile(struct soap *soap) {
 inline ns1__downloadDatafile *
 soap_new_set_ns1__downloadDatafile(struct soap *soap, std::string *sessionId,
                                    LONG64 *datafileId, char *__item1) {
-  ns1__downloadDatafile *_p =
-      soap_instantiate_ns1__downloadDatafile(soap, -1, NULL, NULL, NULL);
+  ns1__downloadDatafile *_p = soap_instantiate_ns1__downloadDatafile(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__downloadDatafile::sessionId = sessionId;
@@ -11628,15 +11714,15 @@ soap_instantiate_ns1__setDataSetSampleResponse(struct soap *, int, const char *,
 
 inline ns1__setDataSetSampleResponse *
 soap_new_ns1__setDataSetSampleResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__setDataSetSampleResponse(soap, n, NULL, NULL,
-                                                        NULL);
+  return soap_instantiate_ns1__setDataSetSampleResponse(soap, n, nullptr,
+                                                        nullptr, nullptr);
 }
 
 inline ns1__setDataSetSampleResponse *
 soap_new_req_ns1__setDataSetSampleResponse(struct soap *soap) {
   ns1__setDataSetSampleResponse *_p =
-      soap_instantiate_ns1__setDataSetSampleResponse(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate_ns1__setDataSetSampleResponse(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -11646,8 +11732,8 @@ soap_new_req_ns1__setDataSetSampleResponse(struct soap *soap) {
 inline ns1__setDataSetSampleResponse *
 soap_new_set_ns1__setDataSetSampleResponse(struct soap *soap, char *__item1) {
   ns1__setDataSetSampleResponse *_p =
-      soap_instantiate_ns1__setDataSetSampleResponse(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate_ns1__setDataSetSampleResponse(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -11703,13 +11789,14 @@ soap_instantiate_ns1__setDataSetSample(struct soap *, int, const char *,
 
 inline ns1__setDataSetSample *soap_new_ns1__setDataSetSample(struct soap *soap,
                                                              int n = -1) {
-  return soap_instantiate_ns1__setDataSetSample(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__setDataSetSample(soap, n, nullptr, nullptr,
+                                                nullptr);
 }
 
 inline ns1__setDataSetSample *
 soap_new_req_ns1__setDataSetSample(struct soap *soap) {
-  ns1__setDataSetSample *_p =
-      soap_instantiate_ns1__setDataSetSample(soap, -1, NULL, NULL, NULL);
+  ns1__setDataSetSample *_p = soap_instantiate_ns1__setDataSetSample(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -11720,8 +11807,8 @@ inline ns1__setDataSetSample *
 soap_new_set_ns1__setDataSetSample(struct soap *soap, std::string *sessionId,
                                    LONG64 *sampleId, LONG64 *datafileId,
                                    char *__item1) {
-  ns1__setDataSetSample *_p =
-      soap_instantiate_ns1__setDataSetSample(soap, -1, NULL, NULL, NULL);
+  ns1__setDataSetSample *_p = soap_instantiate_ns1__setDataSetSample(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__setDataSetSample::sessionId = sessionId;
@@ -11783,15 +11870,15 @@ soap_instantiate_ns1__deleteDataSetParameterResponse(struct soap *, int,
 
 inline ns1__deleteDataSetParameterResponse *
 soap_new_ns1__deleteDataSetParameterResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__deleteDataSetParameterResponse(soap, n, NULL,
-                                                              NULL, NULL);
+  return soap_instantiate_ns1__deleteDataSetParameterResponse(soap, n, nullptr,
+                                                              nullptr, nullptr);
 }
 
 inline ns1__deleteDataSetParameterResponse *
 soap_new_req_ns1__deleteDataSetParameterResponse(struct soap *soap) {
   ns1__deleteDataSetParameterResponse *_p =
-      soap_instantiate_ns1__deleteDataSetParameterResponse(soap, -1, NULL, NULL,
-                                                           NULL);
+      soap_instantiate_ns1__deleteDataSetParameterResponse(soap, -1, nullptr,
+                                                           nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -11802,8 +11889,8 @@ inline ns1__deleteDataSetParameterResponse *
 soap_new_set_ns1__deleteDataSetParameterResponse(struct soap *soap,
                                                  char *__item1) {
   ns1__deleteDataSetParameterResponse *_p =
-      soap_instantiate_ns1__deleteDataSetParameterResponse(soap, -1, NULL, NULL,
-                                                           NULL);
+      soap_instantiate_ns1__deleteDataSetParameterResponse(soap, -1, nullptr,
+                                                           nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -11861,14 +11948,15 @@ soap_instantiate_ns1__deleteDataSetParameter(struct soap *, int, const char *,
 
 inline ns1__deleteDataSetParameter *
 soap_new_ns1__deleteDataSetParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__deleteDataSetParameter(soap, n, NULL, NULL,
-                                                      NULL);
+  return soap_instantiate_ns1__deleteDataSetParameter(soap, n, nullptr, nullptr,
+                                                      nullptr);
 }
 
 inline ns1__deleteDataSetParameter *
 soap_new_req_ns1__deleteDataSetParameter(struct soap *soap) {
   ns1__deleteDataSetParameter *_p =
-      soap_instantiate_ns1__deleteDataSetParameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__deleteDataSetParameter(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -11879,7 +11967,8 @@ inline ns1__deleteDataSetParameter *soap_new_set_ns1__deleteDataSetParameter(
     struct soap *soap, std::string *sessionId,
     ns1__datasetParameterPK *datasetParameterPK, char *__item1) {
   ns1__deleteDataSetParameter *_p =
-      soap_instantiate_ns1__deleteDataSetParameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__deleteDataSetParameter(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__deleteDataSetParameter::sessionId = sessionId;
@@ -11941,15 +12030,15 @@ soap_instantiate_ns1__removeSampleParameterResponse(struct soap *, int,
 
 inline ns1__removeSampleParameterResponse *
 soap_new_ns1__removeSampleParameterResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__removeSampleParameterResponse(soap, n, NULL,
-                                                             NULL, NULL);
+  return soap_instantiate_ns1__removeSampleParameterResponse(soap, n, nullptr,
+                                                             nullptr, nullptr);
 }
 
 inline ns1__removeSampleParameterResponse *
 soap_new_req_ns1__removeSampleParameterResponse(struct soap *soap) {
   ns1__removeSampleParameterResponse *_p =
-      soap_instantiate_ns1__removeSampleParameterResponse(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate_ns1__removeSampleParameterResponse(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -11960,8 +12049,8 @@ inline ns1__removeSampleParameterResponse *
 soap_new_set_ns1__removeSampleParameterResponse(struct soap *soap,
                                                 char *__item1) {
   ns1__removeSampleParameterResponse *_p =
-      soap_instantiate_ns1__removeSampleParameterResponse(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate_ns1__removeSampleParameterResponse(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -12017,13 +12106,14 @@ soap_instantiate_ns1__removeSampleParameter(struct soap *, int, const char *,
 
 inline ns1__removeSampleParameter *
 soap_new_ns1__removeSampleParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__removeSampleParameter(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__removeSampleParameter(soap, n, nullptr, nullptr,
+                                                     nullptr);
 }
 
 inline ns1__removeSampleParameter *
 soap_new_req_ns1__removeSampleParameter(struct soap *soap) {
-  ns1__removeSampleParameter *_p =
-      soap_instantiate_ns1__removeSampleParameter(soap, -1, NULL, NULL, NULL);
+  ns1__removeSampleParameter *_p = soap_instantiate_ns1__removeSampleParameter(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -12033,8 +12123,8 @@ soap_new_req_ns1__removeSampleParameter(struct soap *soap) {
 inline ns1__removeSampleParameter *soap_new_set_ns1__removeSampleParameter(
     struct soap *soap, std::string *sessionId,
     ns1__sampleParameterPK *sampleParameterPK, char *__item1) {
-  ns1__removeSampleParameter *_p =
-      soap_instantiate_ns1__removeSampleParameter(soap, -1, NULL, NULL, NULL);
+  ns1__removeSampleParameter *_p = soap_instantiate_ns1__removeSampleParameter(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__removeSampleParameter::sessionId = sessionId;
@@ -12103,7 +12193,7 @@ inline ns1__searchInvestigationByRestrictionLogicalResponse *
 soap_new_ns1__searchInvestigationByRestrictionLogicalResponse(struct soap *soap,
                                                               int n = -1) {
   return soap_instantiate_ns1__searchInvestigationByRestrictionLogicalResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchInvestigationByRestrictionLogicalResponse *
@@ -12111,7 +12201,7 @@ soap_new_req_ns1__searchInvestigationByRestrictionLogicalResponse(
     struct soap *soap) {
   ns1__searchInvestigationByRestrictionLogicalResponse *_p =
       soap_instantiate_ns1__searchInvestigationByRestrictionLogicalResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -12123,7 +12213,7 @@ soap_new_set_ns1__searchInvestigationByRestrictionLogicalResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchInvestigationByRestrictionLogicalResponse *_p =
       soap_instantiate_ns1__searchInvestigationByRestrictionLogicalResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchInvestigationByRestrictionLogicalResponse::return_ = return_;
@@ -12188,14 +12278,14 @@ inline ns1__searchInvestigationByRestrictionLogical *
 soap_new_ns1__searchInvestigationByRestrictionLogical(struct soap *soap,
                                                       int n = -1) {
   return soap_instantiate_ns1__searchInvestigationByRestrictionLogical(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchInvestigationByRestrictionLogical *
 soap_new_req_ns1__searchInvestigationByRestrictionLogical(struct soap *soap) {
   ns1__searchInvestigationByRestrictionLogical *_p =
       soap_instantiate_ns1__searchInvestigationByRestrictionLogical(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -12208,7 +12298,7 @@ soap_new_set_ns1__searchInvestigationByRestrictionLogical(
     ns1__restrictionLogicalCondition *restriction, char *__item1) {
   ns1__searchInvestigationByRestrictionLogical *_p =
       soap_instantiate_ns1__searchInvestigationByRestrictionLogical(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchInvestigationByRestrictionLogical::sessionId = sessionId;
@@ -12275,7 +12365,7 @@ inline ns1__searchDatafileByParameterRestrictionResponse *
 soap_new_ns1__searchDatafileByParameterRestrictionResponse(struct soap *soap,
                                                            int n = -1) {
   return soap_instantiate_ns1__searchDatafileByParameterRestrictionResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatafileByParameterRestrictionResponse *
@@ -12283,7 +12373,7 @@ soap_new_req_ns1__searchDatafileByParameterRestrictionResponse(
     struct soap *soap) {
   ns1__searchDatafileByParameterRestrictionResponse *_p =
       soap_instantiate_ns1__searchDatafileByParameterRestrictionResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -12295,7 +12385,7 @@ soap_new_set_ns1__searchDatafileByParameterRestrictionResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchDatafileByParameterRestrictionResponse *_p =
       soap_instantiate_ns1__searchDatafileByParameterRestrictionResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatafileByParameterRestrictionResponse::return_ = return_;
@@ -12361,14 +12451,14 @@ inline ns1__searchDatafileByParameterRestriction *
 soap_new_ns1__searchDatafileByParameterRestriction(struct soap *soap,
                                                    int n = -1) {
   return soap_instantiate_ns1__searchDatafileByParameterRestriction(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatafileByParameterRestriction *
 soap_new_req_ns1__searchDatafileByParameterRestriction(struct soap *soap) {
   ns1__searchDatafileByParameterRestriction *_p =
-      soap_instantiate_ns1__searchDatafileByParameterRestriction(soap, -1, NULL,
-                                                                 NULL, NULL);
+      soap_instantiate_ns1__searchDatafileByParameterRestriction(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -12381,8 +12471,8 @@ soap_new_set_ns1__searchDatafileByParameterRestriction(
     ns1__parameterCondition *parameterCondition,
     ns1__restrictionCondition *restrictions, char *__item1) {
   ns1__searchDatafileByParameterRestriction *_p =
-      soap_instantiate_ns1__searchDatafileByParameterRestriction(soap, -1, NULL,
-                                                                 NULL, NULL);
+      soap_instantiate_ns1__searchDatafileByParameterRestriction(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatafileByParameterRestriction::sessionId = sessionId;
@@ -12443,13 +12533,14 @@ soap_instantiate_ns1__createDataSetResponse(struct soap *, int, const char *,
 
 inline ns1__createDataSetResponse *
 soap_new_ns1__createDataSetResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__createDataSetResponse(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__createDataSetResponse(soap, n, nullptr, nullptr,
+                                                     nullptr);
 }
 
 inline ns1__createDataSetResponse *
 soap_new_req_ns1__createDataSetResponse(struct soap *soap) {
-  ns1__createDataSetResponse *_p =
-      soap_instantiate_ns1__createDataSetResponse(soap, -1, NULL, NULL, NULL);
+  ns1__createDataSetResponse *_p = soap_instantiate_ns1__createDataSetResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -12459,8 +12550,8 @@ soap_new_req_ns1__createDataSetResponse(struct soap *soap) {
 inline ns1__createDataSetResponse *
 soap_new_set_ns1__createDataSetResponse(struct soap *soap,
                                         ns1__dataset *return_, char *__item1) {
-  ns1__createDataSetResponse *_p =
-      soap_instantiate_ns1__createDataSetResponse(soap, -1, NULL, NULL, NULL);
+  ns1__createDataSetResponse *_p = soap_instantiate_ns1__createDataSetResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__createDataSetResponse::return_ = return_;
@@ -12517,12 +12608,13 @@ soap_instantiate_ns1__createDataSet(struct soap *, int, const char *,
 
 inline ns1__createDataSet *soap_new_ns1__createDataSet(struct soap *soap,
                                                        int n = -1) {
-  return soap_instantiate_ns1__createDataSet(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__createDataSet(soap, n, nullptr, nullptr,
+                                             nullptr);
 }
 
 inline ns1__createDataSet *soap_new_req_ns1__createDataSet(struct soap *soap) {
   ns1__createDataSet *_p =
-      soap_instantiate_ns1__createDataSet(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__createDataSet(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -12534,7 +12626,7 @@ soap_new_set_ns1__createDataSet(struct soap *soap, std::string *sessionId,
                                 ns1__dataset *dataSet, LONG64 *investigationId,
                                 char *__item1) {
   ns1__createDataSet *_p =
-      soap_instantiate_ns1__createDataSet(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__createDataSet(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__createDataSet::sessionId = sessionId;
@@ -12599,14 +12691,14 @@ inline ns1__searchDatafileByParameterLogicalResponse *
 soap_new_ns1__searchDatafileByParameterLogicalResponse(struct soap *soap,
                                                        int n = -1) {
   return soap_instantiate_ns1__searchDatafileByParameterLogicalResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatafileByParameterLogicalResponse *
 soap_new_req_ns1__searchDatafileByParameterLogicalResponse(struct soap *soap) {
   ns1__searchDatafileByParameterLogicalResponse *_p =
       soap_instantiate_ns1__searchDatafileByParameterLogicalResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -12618,7 +12710,7 @@ soap_new_set_ns1__searchDatafileByParameterLogicalResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchDatafileByParameterLogicalResponse *_p =
       soap_instantiate_ns1__searchDatafileByParameterLogicalResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatafileByParameterLogicalResponse::return_ = return_;
@@ -12679,15 +12771,15 @@ soap_instantiate_ns1__searchDatafileByParameterLogical(struct soap *, int,
 
 inline ns1__searchDatafileByParameterLogical *
 soap_new_ns1__searchDatafileByParameterLogical(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchDatafileByParameterLogical(soap, n, NULL,
-                                                                NULL, NULL);
+  return soap_instantiate_ns1__searchDatafileByParameterLogical(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatafileByParameterLogical *
 soap_new_req_ns1__searchDatafileByParameterLogical(struct soap *soap) {
   ns1__searchDatafileByParameterLogical *_p =
-      soap_instantiate_ns1__searchDatafileByParameterLogical(soap, -1, NULL,
-                                                             NULL, NULL);
+      soap_instantiate_ns1__searchDatafileByParameterLogical(soap, -1, nullptr,
+                                                             nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -12699,8 +12791,8 @@ soap_new_set_ns1__searchDatafileByParameterLogical(
     struct soap *soap, std::string *sessionId,
     ns1__parameterLogicalCondition *logicalCondition, char *__item1) {
   ns1__searchDatafileByParameterLogical *_p =
-      soap_instantiate_ns1__searchDatafileByParameterLogical(soap, -1, NULL,
-                                                             NULL, NULL);
+      soap_instantiate_ns1__searchDatafileByParameterLogical(soap, -1, nullptr,
+                                                             nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatafileByParameterLogical::sessionId = sessionId;
@@ -12762,14 +12854,15 @@ soap_instantiate_ns1__addInvestigatorResponse(struct soap *, int, const char *,
 
 inline ns1__addInvestigatorResponse *
 soap_new_ns1__addInvestigatorResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__addInvestigatorResponse(soap, n, NULL, NULL,
-                                                       NULL);
+  return soap_instantiate_ns1__addInvestigatorResponse(soap, n, nullptr,
+                                                       nullptr, nullptr);
 }
 
 inline ns1__addInvestigatorResponse *
 soap_new_req_ns1__addInvestigatorResponse(struct soap *soap) {
   ns1__addInvestigatorResponse *_p =
-      soap_instantiate_ns1__addInvestigatorResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__addInvestigatorResponse(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -12779,7 +12872,8 @@ soap_new_req_ns1__addInvestigatorResponse(struct soap *soap) {
 inline ns1__addInvestigatorResponse *soap_new_set_ns1__addInvestigatorResponse(
     struct soap *soap, ns1__investigator *return_, char *__item1) {
   ns1__addInvestigatorResponse *_p =
-      soap_instantiate_ns1__addInvestigatorResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__addInvestigatorResponse(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__addInvestigatorResponse::return_ = return_;
@@ -12836,13 +12930,14 @@ soap_instantiate_ns1__addInvestigator(struct soap *, int, const char *,
 
 inline ns1__addInvestigator *soap_new_ns1__addInvestigator(struct soap *soap,
                                                            int n = -1) {
-  return soap_instantiate_ns1__addInvestigator(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__addInvestigator(soap, n, nullptr, nullptr,
+                                               nullptr);
 }
 
 inline ns1__addInvestigator *
 soap_new_req_ns1__addInvestigator(struct soap *soap) {
-  ns1__addInvestigator *_p =
-      soap_instantiate_ns1__addInvestigator(soap, -1, NULL, NULL, NULL);
+  ns1__addInvestigator *_p = soap_instantiate_ns1__addInvestigator(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -12853,8 +12948,8 @@ inline ns1__addInvestigator *
 soap_new_set_ns1__addInvestigator(struct soap *soap, std::string *sessionId,
                                   ns1__investigator *ns1__investigator_,
                                   LONG64 *investigationId, char *__item1) {
-  ns1__addInvestigator *_p =
-      soap_instantiate_ns1__addInvestigator(soap, -1, NULL, NULL, NULL);
+  ns1__addInvestigator *_p = soap_instantiate_ns1__addInvestigator(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__addInvestigator::sessionId = sessionId;
@@ -12916,15 +13011,15 @@ soap_instantiate_ns1__deleteInvestigatorResponse(struct soap *, int,
 
 inline ns1__deleteInvestigatorResponse *
 soap_new_ns1__deleteInvestigatorResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__deleteInvestigatorResponse(soap, n, NULL, NULL,
-                                                          NULL);
+  return soap_instantiate_ns1__deleteInvestigatorResponse(soap, n, nullptr,
+                                                          nullptr, nullptr);
 }
 
 inline ns1__deleteInvestigatorResponse *
 soap_new_req_ns1__deleteInvestigatorResponse(struct soap *soap) {
   ns1__deleteInvestigatorResponse *_p =
-      soap_instantiate_ns1__deleteInvestigatorResponse(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate_ns1__deleteInvestigatorResponse(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -12934,8 +13029,8 @@ soap_new_req_ns1__deleteInvestigatorResponse(struct soap *soap) {
 inline ns1__deleteInvestigatorResponse *
 soap_new_set_ns1__deleteInvestigatorResponse(struct soap *soap, char *__item1) {
   ns1__deleteInvestigatorResponse *_p =
-      soap_instantiate_ns1__deleteInvestigatorResponse(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate_ns1__deleteInvestigatorResponse(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -12990,13 +13085,14 @@ soap_instantiate_ns1__deleteInvestigator(struct soap *, int, const char *,
 
 inline ns1__deleteInvestigator *
 soap_new_ns1__deleteInvestigator(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__deleteInvestigator(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__deleteInvestigator(soap, n, nullptr, nullptr,
+                                                  nullptr);
 }
 
 inline ns1__deleteInvestigator *
 soap_new_req_ns1__deleteInvestigator(struct soap *soap) {
-  ns1__deleteInvestigator *_p =
-      soap_instantiate_ns1__deleteInvestigator(soap, -1, NULL, NULL, NULL);
+  ns1__deleteInvestigator *_p = soap_instantiate_ns1__deleteInvestigator(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -13007,8 +13103,8 @@ inline ns1__deleteInvestigator *
 soap_new_set_ns1__deleteInvestigator(struct soap *soap, std::string *sessionId,
                                      ns1__investigatorPK *investigatorPK,
                                      char *__item1) {
-  ns1__deleteInvestigator *_p =
-      soap_instantiate_ns1__deleteInvestigator(soap, -1, NULL, NULL, NULL);
+  ns1__deleteInvestigator *_p = soap_instantiate_ns1__deleteInvestigator(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__deleteInvestigator::sessionId = sessionId;
@@ -13072,14 +13168,14 @@ inline ns1__searchInvestigationByRestrictionResponse *
 soap_new_ns1__searchInvestigationByRestrictionResponse(struct soap *soap,
                                                        int n = -1) {
   return soap_instantiate_ns1__searchInvestigationByRestrictionResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchInvestigationByRestrictionResponse *
 soap_new_req_ns1__searchInvestigationByRestrictionResponse(struct soap *soap) {
   ns1__searchInvestigationByRestrictionResponse *_p =
       soap_instantiate_ns1__searchInvestigationByRestrictionResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -13091,7 +13187,7 @@ soap_new_set_ns1__searchInvestigationByRestrictionResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchInvestigationByRestrictionResponse *_p =
       soap_instantiate_ns1__searchInvestigationByRestrictionResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchInvestigationByRestrictionResponse::return_ = return_;
@@ -13152,15 +13248,15 @@ soap_instantiate_ns1__searchInvestigationByRestriction(struct soap *, int,
 
 inline ns1__searchInvestigationByRestriction *
 soap_new_ns1__searchInvestigationByRestriction(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchInvestigationByRestriction(soap, n, NULL,
-                                                                NULL, NULL);
+  return soap_instantiate_ns1__searchInvestigationByRestriction(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchInvestigationByRestriction *
 soap_new_req_ns1__searchInvestigationByRestriction(struct soap *soap) {
   ns1__searchInvestigationByRestriction *_p =
-      soap_instantiate_ns1__searchInvestigationByRestriction(soap, -1, NULL,
-                                                             NULL, NULL);
+      soap_instantiate_ns1__searchInvestigationByRestriction(soap, -1, nullptr,
+                                                             nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -13172,8 +13268,8 @@ soap_new_set_ns1__searchInvestigationByRestriction(
     struct soap *soap, std::string *sessionId,
     ns1__restrictionCondition *restriction, char *__item1) {
   ns1__searchInvestigationByRestriction *_p =
-      soap_instantiate_ns1__searchInvestigationByRestriction(soap, -1, NULL,
-                                                             NULL, NULL);
+      soap_instantiate_ns1__searchInvestigationByRestriction(soap, -1, nullptr,
+                                                             nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchInvestigationByRestriction::sessionId = sessionId;
@@ -13235,15 +13331,15 @@ soap_instantiate_ns1__getICATAPIVersionResponse(struct soap *, int,
 
 inline ns1__getICATAPIVersionResponse *
 soap_new_ns1__getICATAPIVersionResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getICATAPIVersionResponse(soap, n, NULL, NULL,
-                                                         NULL);
+  return soap_instantiate_ns1__getICATAPIVersionResponse(soap, n, nullptr,
+                                                         nullptr, nullptr);
 }
 
 inline ns1__getICATAPIVersionResponse *
 soap_new_req_ns1__getICATAPIVersionResponse(struct soap *soap) {
   ns1__getICATAPIVersionResponse *_p =
-      soap_instantiate_ns1__getICATAPIVersionResponse(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__getICATAPIVersionResponse(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -13255,8 +13351,8 @@ soap_new_set_ns1__getICATAPIVersionResponse(struct soap *soap,
                                             std::string *return_,
                                             char *__item1) {
   ns1__getICATAPIVersionResponse *_p =
-      soap_instantiate_ns1__getICATAPIVersionResponse(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__getICATAPIVersionResponse(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getICATAPIVersionResponse::return_ = return_;
@@ -13313,13 +13409,14 @@ soap_instantiate_ns1__getICATAPIVersion(struct soap *, int, const char *,
 
 inline ns1__getICATAPIVersion *
 soap_new_ns1__getICATAPIVersion(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getICATAPIVersion(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__getICATAPIVersion(soap, n, nullptr, nullptr,
+                                                 nullptr);
 }
 
 inline ns1__getICATAPIVersion *
 soap_new_req_ns1__getICATAPIVersion(struct soap *soap) {
-  ns1__getICATAPIVersion *_p =
-      soap_instantiate_ns1__getICATAPIVersion(soap, -1, NULL, NULL, NULL);
+  ns1__getICATAPIVersion *_p = soap_instantiate_ns1__getICATAPIVersion(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -13329,8 +13426,8 @@ soap_new_req_ns1__getICATAPIVersion(struct soap *soap) {
 inline ns1__getICATAPIVersion *
 soap_new_set_ns1__getICATAPIVersion(struct soap *soap, std::string *sessionId,
                                     char *__item1) {
-  ns1__getICATAPIVersion *_p =
-      soap_instantiate_ns1__getICATAPIVersion(soap, -1, NULL, NULL, NULL);
+  ns1__getICATAPIVersion *_p = soap_instantiate_ns1__getICATAPIVersion(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getICATAPIVersion::sessionId = sessionId;
@@ -13387,13 +13484,14 @@ soap_instantiate_ns1__getDatafilesResponse(struct soap *, int, const char *,
 
 inline ns1__getDatafilesResponse *
 soap_new_ns1__getDatafilesResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getDatafilesResponse(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__getDatafilesResponse(soap, n, nullptr, nullptr,
+                                                    nullptr);
 }
 
 inline ns1__getDatafilesResponse *
 soap_new_req_ns1__getDatafilesResponse(struct soap *soap) {
-  ns1__getDatafilesResponse *_p =
-      soap_instantiate_ns1__getDatafilesResponse(soap, -1, NULL, NULL, NULL);
+  ns1__getDatafilesResponse *_p = soap_instantiate_ns1__getDatafilesResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -13402,8 +13500,8 @@ soap_new_req_ns1__getDatafilesResponse(struct soap *soap) {
 
 inline ns1__getDatafilesResponse *soap_new_set_ns1__getDatafilesResponse(
     struct soap *soap, std::vector<ns1__datafile *> &return_, char *__item1) {
-  ns1__getDatafilesResponse *_p =
-      soap_instantiate_ns1__getDatafilesResponse(soap, -1, NULL, NULL, NULL);
+  ns1__getDatafilesResponse *_p = soap_instantiate_ns1__getDatafilesResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getDatafilesResponse::return_ = return_;
@@ -13460,12 +13558,12 @@ soap_instantiate_ns1__getDatafiles(struct soap *, int, const char *,
 
 inline ns1__getDatafiles *soap_new_ns1__getDatafiles(struct soap *soap,
                                                      int n = -1) {
-  return soap_instantiate_ns1__getDatafiles(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__getDatafiles(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__getDatafiles *soap_new_req_ns1__getDatafiles(struct soap *soap) {
   ns1__getDatafiles *_p =
-      soap_instantiate_ns1__getDatafiles(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__getDatafiles(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -13477,7 +13575,7 @@ soap_new_set_ns1__getDatafiles(struct soap *soap, std::string *sessionId,
                                std::vector<LONG64> &datafileIds,
                                char *__item1) {
   ns1__getDatafiles *_p =
-      soap_instantiate_ns1__getDatafiles(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__getDatafiles(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getDatafiles::sessionId = sessionId;
@@ -13537,14 +13635,15 @@ soap_instantiate_ns1__isSessionValidResponse(struct soap *, int, const char *,
 
 inline ns1__isSessionValidResponse *
 soap_new_ns1__isSessionValidResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__isSessionValidResponse(soap, n, NULL, NULL,
-                                                      NULL);
+  return soap_instantiate_ns1__isSessionValidResponse(soap, n, nullptr, nullptr,
+                                                      nullptr);
 }
 
 inline ns1__isSessionValidResponse *
 soap_new_req_ns1__isSessionValidResponse(struct soap *soap, bool return_) {
   ns1__isSessionValidResponse *_p =
-      soap_instantiate_ns1__isSessionValidResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__isSessionValidResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__isSessionValidResponse::return_ = return_;
@@ -13556,7 +13655,8 @@ inline ns1__isSessionValidResponse *
 soap_new_set_ns1__isSessionValidResponse(struct soap *soap, bool return_,
                                          char *__item1) {
   ns1__isSessionValidResponse *_p =
-      soap_instantiate_ns1__isSessionValidResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__isSessionValidResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__isSessionValidResponse::return_ = return_;
@@ -13613,13 +13713,14 @@ soap_instantiate_ns1__isSessionValid(struct soap *, int, const char *,
 
 inline ns1__isSessionValid *soap_new_ns1__isSessionValid(struct soap *soap,
                                                          int n = -1) {
-  return soap_instantiate_ns1__isSessionValid(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__isSessionValid(soap, n, nullptr, nullptr,
+                                              nullptr);
 }
 
 inline ns1__isSessionValid *
 soap_new_req_ns1__isSessionValid(struct soap *soap) {
   ns1__isSessionValid *_p =
-      soap_instantiate_ns1__isSessionValid(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__isSessionValid(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -13630,7 +13731,7 @@ inline ns1__isSessionValid *
 soap_new_set_ns1__isSessionValid(struct soap *soap, std::string *sessionId,
                                  char *__item1) {
   ns1__isSessionValid *_p =
-      soap_instantiate_ns1__isSessionValid(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__isSessionValid(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__isSessionValid::sessionId = sessionId;
@@ -13698,7 +13799,7 @@ inline ns1__searchInvestigationByParameterComparisonResponse *
 soap_new_ns1__searchInvestigationByParameterComparisonResponse(
     struct soap *soap, int n = -1) {
   return soap_instantiate_ns1__searchInvestigationByParameterComparisonResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchInvestigationByParameterComparisonResponse *
@@ -13706,7 +13807,7 @@ soap_new_req_ns1__searchInvestigationByParameterComparisonResponse(
     struct soap *soap) {
   ns1__searchInvestigationByParameterComparisonResponse *_p =
       soap_instantiate_ns1__searchInvestigationByParameterComparisonResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -13718,7 +13819,7 @@ soap_new_set_ns1__searchInvestigationByParameterComparisonResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchInvestigationByParameterComparisonResponse *_p =
       soap_instantiate_ns1__searchInvestigationByParameterComparisonResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchInvestigationByParameterComparisonResponse::return_ =
@@ -13783,14 +13884,14 @@ inline ns1__searchInvestigationByParameterComparison *
 soap_new_ns1__searchInvestigationByParameterComparison(struct soap *soap,
                                                        int n = -1) {
   return soap_instantiate_ns1__searchInvestigationByParameterComparison(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchInvestigationByParameterComparison *
 soap_new_req_ns1__searchInvestigationByParameterComparison(struct soap *soap) {
   ns1__searchInvestigationByParameterComparison *_p =
       soap_instantiate_ns1__searchInvestigationByParameterComparison(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -13804,7 +13905,7 @@ soap_new_set_ns1__searchInvestigationByParameterComparison(
     char *__item1) {
   ns1__searchInvestigationByParameterComparison *_p =
       soap_instantiate_ns1__searchInvestigationByParameterComparison(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchInvestigationByParameterComparison::sessionId = sessionId;
@@ -13864,13 +13965,14 @@ soap_instantiate_ns1__deleteDataSetResponse(struct soap *, int, const char *,
 
 inline ns1__deleteDataSetResponse *
 soap_new_ns1__deleteDataSetResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__deleteDataSetResponse(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__deleteDataSetResponse(soap, n, nullptr, nullptr,
+                                                     nullptr);
 }
 
 inline ns1__deleteDataSetResponse *
 soap_new_req_ns1__deleteDataSetResponse(struct soap *soap) {
-  ns1__deleteDataSetResponse *_p =
-      soap_instantiate_ns1__deleteDataSetResponse(soap, -1, NULL, NULL, NULL);
+  ns1__deleteDataSetResponse *_p = soap_instantiate_ns1__deleteDataSetResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -13879,8 +13981,8 @@ soap_new_req_ns1__deleteDataSetResponse(struct soap *soap) {
 
 inline ns1__deleteDataSetResponse *
 soap_new_set_ns1__deleteDataSetResponse(struct soap *soap, char *__item1) {
-  ns1__deleteDataSetResponse *_p =
-      soap_instantiate_ns1__deleteDataSetResponse(soap, -1, NULL, NULL, NULL);
+  ns1__deleteDataSetResponse *_p = soap_instantiate_ns1__deleteDataSetResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -13936,12 +14038,13 @@ soap_instantiate_ns1__deleteDataSet(struct soap *, int, const char *,
 
 inline ns1__deleteDataSet *soap_new_ns1__deleteDataSet(struct soap *soap,
                                                        int n = -1) {
-  return soap_instantiate_ns1__deleteDataSet(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__deleteDataSet(soap, n, nullptr, nullptr,
+                                             nullptr);
 }
 
 inline ns1__deleteDataSet *soap_new_req_ns1__deleteDataSet(struct soap *soap) {
   ns1__deleteDataSet *_p =
-      soap_instantiate_ns1__deleteDataSet(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__deleteDataSet(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -13952,7 +14055,7 @@ inline ns1__deleteDataSet *
 soap_new_set_ns1__deleteDataSet(struct soap *soap, std::string *sessionId,
                                 LONG64 *dataSetId, char *__item1) {
   ns1__deleteDataSet *_p =
-      soap_instantiate_ns1__deleteDataSet(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__deleteDataSet(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__deleteDataSet::sessionId = sessionId;
@@ -14014,15 +14117,15 @@ soap_instantiate_ns1__getInvestigationsResponse(struct soap *, int,
 
 inline ns1__getInvestigationsResponse *
 soap_new_ns1__getInvestigationsResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getInvestigationsResponse(soap, n, NULL, NULL,
-                                                         NULL);
+  return soap_instantiate_ns1__getInvestigationsResponse(soap, n, nullptr,
+                                                         nullptr, nullptr);
 }
 
 inline ns1__getInvestigationsResponse *
 soap_new_req_ns1__getInvestigationsResponse(struct soap *soap) {
   ns1__getInvestigationsResponse *_p =
-      soap_instantiate_ns1__getInvestigationsResponse(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__getInvestigationsResponse(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -14034,8 +14137,8 @@ soap_new_set_ns1__getInvestigationsResponse(
     struct soap *soap, std::vector<ns1__investigation *> &return_,
     char *__item1) {
   ns1__getInvestigationsResponse *_p =
-      soap_instantiate_ns1__getInvestigationsResponse(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__getInvestigationsResponse(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getInvestigationsResponse::return_ = return_;
@@ -14092,13 +14195,14 @@ soap_instantiate_ns1__getInvestigations(struct soap *, int, const char *,
 
 inline ns1__getInvestigations *
 soap_new_ns1__getInvestigations(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getInvestigations(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__getInvestigations(soap, n, nullptr, nullptr,
+                                                 nullptr);
 }
 
 inline ns1__getInvestigations *
 soap_new_req_ns1__getInvestigations(struct soap *soap) {
-  ns1__getInvestigations *_p =
-      soap_instantiate_ns1__getInvestigations(soap, -1, NULL, NULL, NULL);
+  ns1__getInvestigations *_p = soap_instantiate_ns1__getInvestigations(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -14109,8 +14213,8 @@ inline ns1__getInvestigations *
 soap_new_set_ns1__getInvestigations(struct soap *soap, std::string *userId,
                                     std::vector<LONG64> &investigationIds,
                                     char *__item1) {
-  ns1__getInvestigations *_p =
-      soap_instantiate_ns1__getInvestigations(soap, -1, NULL, NULL, NULL);
+  ns1__getInvestigations *_p = soap_instantiate_ns1__getInvestigations(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getInvestigations::userId = userId;
@@ -14172,15 +14276,15 @@ soap_instantiate_ns1__getInvestigationsIncludesResponse(struct soap *, int,
 
 inline ns1__getInvestigationsIncludesResponse *
 soap_new_ns1__getInvestigationsIncludesResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getInvestigationsIncludesResponse(soap, n, NULL,
-                                                                 NULL, NULL);
+  return soap_instantiate_ns1__getInvestigationsIncludesResponse(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__getInvestigationsIncludesResponse *
 soap_new_req_ns1__getInvestigationsIncludesResponse(struct soap *soap) {
   ns1__getInvestigationsIncludesResponse *_p =
-      soap_instantiate_ns1__getInvestigationsIncludesResponse(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate_ns1__getInvestigationsIncludesResponse(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -14192,8 +14296,8 @@ soap_new_set_ns1__getInvestigationsIncludesResponse(
     struct soap *soap, std::vector<ns1__investigation *> &return_,
     char *__item1) {
   ns1__getInvestigationsIncludesResponse *_p =
-      soap_instantiate_ns1__getInvestigationsIncludesResponse(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate_ns1__getInvestigationsIncludesResponse(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getInvestigationsIncludesResponse::return_ = return_;
@@ -14255,15 +14359,15 @@ soap_instantiate_ns1__getInvestigationsIncludes(struct soap *, int,
 
 inline ns1__getInvestigationsIncludes *
 soap_new_ns1__getInvestigationsIncludes(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getInvestigationsIncludes(soap, n, NULL, NULL,
-                                                         NULL);
+  return soap_instantiate_ns1__getInvestigationsIncludes(soap, n, nullptr,
+                                                         nullptr, nullptr);
 }
 
 inline ns1__getInvestigationsIncludes *
 soap_new_req_ns1__getInvestigationsIncludes(struct soap *soap) {
   ns1__getInvestigationsIncludes *_p =
-      soap_instantiate_ns1__getInvestigationsIncludes(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__getInvestigationsIncludes(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -14276,8 +14380,8 @@ soap_new_set_ns1__getInvestigationsIncludes(
     std::vector<LONG64> &investigationIds,
     enum ns1__investigationInclude *investigationInclude, char *__item1) {
   ns1__getInvestigationsIncludes *_p =
-      soap_instantiate_ns1__getInvestigationsIncludes(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__getInvestigationsIncludes(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getInvestigationsIncludes::userId = userId;
@@ -14341,15 +14445,15 @@ soap_instantiate_ns1__searchSampleByParameterResponse(struct soap *, int,
 
 inline ns1__searchSampleByParameterResponse *
 soap_new_ns1__searchSampleByParameterResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchSampleByParameterResponse(soap, n, NULL,
-                                                               NULL, NULL);
+  return soap_instantiate_ns1__searchSampleByParameterResponse(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchSampleByParameterResponse *
 soap_new_req_ns1__searchSampleByParameterResponse(struct soap *soap) {
   ns1__searchSampleByParameterResponse *_p =
-      soap_instantiate_ns1__searchSampleByParameterResponse(soap, -1, NULL,
-                                                            NULL, NULL);
+      soap_instantiate_ns1__searchSampleByParameterResponse(soap, -1, nullptr,
+                                                            nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -14360,8 +14464,8 @@ inline ns1__searchSampleByParameterResponse *
 soap_new_set_ns1__searchSampleByParameterResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchSampleByParameterResponse *_p =
-      soap_instantiate_ns1__searchSampleByParameterResponse(soap, -1, NULL,
-                                                            NULL, NULL);
+      soap_instantiate_ns1__searchSampleByParameterResponse(soap, -1, nullptr,
+                                                            nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchSampleByParameterResponse::return_ = return_;
@@ -14421,14 +14525,15 @@ soap_instantiate_ns1__searchSampleByParameter(struct soap *, int, const char *,
 
 inline ns1__searchSampleByParameter *
 soap_new_ns1__searchSampleByParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchSampleByParameter(soap, n, NULL, NULL,
-                                                       NULL);
+  return soap_instantiate_ns1__searchSampleByParameter(soap, n, nullptr,
+                                                       nullptr, nullptr);
 }
 
 inline ns1__searchSampleByParameter *
 soap_new_req_ns1__searchSampleByParameter(struct soap *soap) {
   ns1__searchSampleByParameter *_p =
-      soap_instantiate_ns1__searchSampleByParameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__searchSampleByParameter(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -14439,7 +14544,8 @@ inline ns1__searchSampleByParameter *soap_new_set_ns1__searchSampleByParameter(
     struct soap *soap, std::string *sessionId,
     std::vector<ns1__parameterSearch *> &parameters, char *__item1) {
   ns1__searchSampleByParameter *_p =
-      soap_instantiate_ns1__searchSampleByParameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__searchSampleByParameter(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchSampleByParameter::sessionId = sessionId;
@@ -14504,14 +14610,14 @@ inline ns1__searchDatasetByParameterConditionResponse *
 soap_new_ns1__searchDatasetByParameterConditionResponse(struct soap *soap,
                                                         int n = -1) {
   return soap_instantiate_ns1__searchDatasetByParameterConditionResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatasetByParameterConditionResponse *
 soap_new_req_ns1__searchDatasetByParameterConditionResponse(struct soap *soap) {
   ns1__searchDatasetByParameterConditionResponse *_p =
       soap_instantiate_ns1__searchDatasetByParameterConditionResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -14523,7 +14629,7 @@ soap_new_set_ns1__searchDatasetByParameterConditionResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchDatasetByParameterConditionResponse *_p =
       soap_instantiate_ns1__searchDatasetByParameterConditionResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatasetByParameterConditionResponse::return_ = return_;
@@ -14585,15 +14691,15 @@ soap_instantiate_ns1__searchDatasetByParameterCondition(struct soap *, int,
 
 inline ns1__searchDatasetByParameterCondition *
 soap_new_ns1__searchDatasetByParameterCondition(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchDatasetByParameterCondition(soap, n, NULL,
-                                                                 NULL, NULL);
+  return soap_instantiate_ns1__searchDatasetByParameterCondition(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatasetByParameterCondition *
 soap_new_req_ns1__searchDatasetByParameterCondition(struct soap *soap) {
   ns1__searchDatasetByParameterCondition *_p =
-      soap_instantiate_ns1__searchDatasetByParameterCondition(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate_ns1__searchDatasetByParameterCondition(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -14605,8 +14711,8 @@ soap_new_set_ns1__searchDatasetByParameterCondition(
     struct soap *soap, std::string *sessionId,
     ns1__parameterCondition *logicalCondition, char *__item1) {
   ns1__searchDatasetByParameterCondition *_p =
-      soap_instantiate_ns1__searchDatasetByParameterCondition(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate_ns1__searchDatasetByParameterCondition(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatasetByParameterCondition::sessionId = sessionId;
@@ -14669,15 +14775,15 @@ soap_instantiate_ns1__removeDataFileParameterResponse(struct soap *, int,
 
 inline ns1__removeDataFileParameterResponse *
 soap_new_ns1__removeDataFileParameterResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__removeDataFileParameterResponse(soap, n, NULL,
-                                                               NULL, NULL);
+  return soap_instantiate_ns1__removeDataFileParameterResponse(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__removeDataFileParameterResponse *
 soap_new_req_ns1__removeDataFileParameterResponse(struct soap *soap) {
   ns1__removeDataFileParameterResponse *_p =
-      soap_instantiate_ns1__removeDataFileParameterResponse(soap, -1, NULL,
-                                                            NULL, NULL);
+      soap_instantiate_ns1__removeDataFileParameterResponse(soap, -1, nullptr,
+                                                            nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -14688,8 +14794,8 @@ inline ns1__removeDataFileParameterResponse *
 soap_new_set_ns1__removeDataFileParameterResponse(struct soap *soap,
                                                   char *__item1) {
   ns1__removeDataFileParameterResponse *_p =
-      soap_instantiate_ns1__removeDataFileParameterResponse(soap, -1, NULL,
-                                                            NULL, NULL);
+      soap_instantiate_ns1__removeDataFileParameterResponse(soap, -1, nullptr,
+                                                            nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -14748,14 +14854,15 @@ soap_instantiate_ns1__removeDataFileParameter(struct soap *, int, const char *,
 
 inline ns1__removeDataFileParameter *
 soap_new_ns1__removeDataFileParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__removeDataFileParameter(soap, n, NULL, NULL,
-                                                       NULL);
+  return soap_instantiate_ns1__removeDataFileParameter(soap, n, nullptr,
+                                                       nullptr, nullptr);
 }
 
 inline ns1__removeDataFileParameter *
 soap_new_req_ns1__removeDataFileParameter(struct soap *soap) {
   ns1__removeDataFileParameter *_p =
-      soap_instantiate_ns1__removeDataFileParameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__removeDataFileParameter(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -14766,7 +14873,8 @@ inline ns1__removeDataFileParameter *soap_new_set_ns1__removeDataFileParameter(
     struct soap *soap, std::string *sessionId,
     ns1__datafileParameterPK *datafileParameterPK, char *__item1) {
   ns1__removeDataFileParameter *_p =
-      soap_instantiate_ns1__removeDataFileParameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__removeDataFileParameter(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__removeDataFileParameter::sessionId = sessionId;
@@ -14832,14 +14940,14 @@ inline ns1__searchDatasetByParameterLogicalResponse *
 soap_new_ns1__searchDatasetByParameterLogicalResponse(struct soap *soap,
                                                       int n = -1) {
   return soap_instantiate_ns1__searchDatasetByParameterLogicalResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatasetByParameterLogicalResponse *
 soap_new_req_ns1__searchDatasetByParameterLogicalResponse(struct soap *soap) {
   ns1__searchDatasetByParameterLogicalResponse *_p =
       soap_instantiate_ns1__searchDatasetByParameterLogicalResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -14851,7 +14959,7 @@ soap_new_set_ns1__searchDatasetByParameterLogicalResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchDatasetByParameterLogicalResponse *_p =
       soap_instantiate_ns1__searchDatasetByParameterLogicalResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatasetByParameterLogicalResponse::return_ = return_;
@@ -14912,15 +15020,15 @@ soap_instantiate_ns1__searchDatasetByParameterLogical(struct soap *, int,
 
 inline ns1__searchDatasetByParameterLogical *
 soap_new_ns1__searchDatasetByParameterLogical(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchDatasetByParameterLogical(soap, n, NULL,
-                                                               NULL, NULL);
+  return soap_instantiate_ns1__searchDatasetByParameterLogical(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatasetByParameterLogical *
 soap_new_req_ns1__searchDatasetByParameterLogical(struct soap *soap) {
   ns1__searchDatasetByParameterLogical *_p =
-      soap_instantiate_ns1__searchDatasetByParameterLogical(soap, -1, NULL,
-                                                            NULL, NULL);
+      soap_instantiate_ns1__searchDatasetByParameterLogical(soap, -1, nullptr,
+                                                            nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -14932,8 +15040,8 @@ soap_new_set_ns1__searchDatasetByParameterLogical(
     struct soap *soap, std::string *sessionId,
     ns1__parameterLogicalCondition *logicalCondition, char *__item1) {
   ns1__searchDatasetByParameterLogical *_p =
-      soap_instantiate_ns1__searchDatasetByParameterLogical(soap, -1, NULL,
-                                                            NULL, NULL);
+      soap_instantiate_ns1__searchDatasetByParameterLogical(soap, -1, nullptr,
+                                                            nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatasetByParameterLogical::sessionId = sessionId;
@@ -14995,15 +15103,15 @@ soap_instantiate_ns1__searchByUserIDPaginationResponse(struct soap *, int,
 
 inline ns1__searchByUserIDPaginationResponse *
 soap_new_ns1__searchByUserIDPaginationResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchByUserIDPaginationResponse(soap, n, NULL,
-                                                                NULL, NULL);
+  return soap_instantiate_ns1__searchByUserIDPaginationResponse(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchByUserIDPaginationResponse *
 soap_new_req_ns1__searchByUserIDPaginationResponse(struct soap *soap) {
   ns1__searchByUserIDPaginationResponse *_p =
-      soap_instantiate_ns1__searchByUserIDPaginationResponse(soap, -1, NULL,
-                                                             NULL, NULL);
+      soap_instantiate_ns1__searchByUserIDPaginationResponse(soap, -1, nullptr,
+                                                             nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -15015,8 +15123,8 @@ soap_new_set_ns1__searchByUserIDPaginationResponse(
     struct soap *soap, std::vector<ns1__investigation *> &return_,
     char *__item1) {
   ns1__searchByUserIDPaginationResponse *_p =
-      soap_instantiate_ns1__searchByUserIDPaginationResponse(soap, -1, NULL,
-                                                             NULL, NULL);
+      soap_instantiate_ns1__searchByUserIDPaginationResponse(soap, -1, nullptr,
+                                                             nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchByUserIDPaginationResponse::return_ = return_;
@@ -15076,16 +15184,16 @@ soap_instantiate_ns1__searchByUserIDPagination(struct soap *, int, const char *,
 
 inline ns1__searchByUserIDPagination *
 soap_new_ns1__searchByUserIDPagination(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchByUserIDPagination(soap, n, NULL, NULL,
-                                                        NULL);
+  return soap_instantiate_ns1__searchByUserIDPagination(soap, n, nullptr,
+                                                        nullptr, nullptr);
 }
 
 inline ns1__searchByUserIDPagination *
 soap_new_req_ns1__searchByUserIDPagination(struct soap *soap, int startIndex,
                                            int numberOfResults) {
   ns1__searchByUserIDPagination *_p =
-      soap_instantiate_ns1__searchByUserIDPagination(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate_ns1__searchByUserIDPagination(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchByUserIDPagination::startIndex = startIndex;
@@ -15101,8 +15209,8 @@ soap_new_set_ns1__searchByUserIDPagination(struct soap *soap,
                                            int startIndex, int numberOfResults,
                                            char *__item1) {
   ns1__searchByUserIDPagination *_p =
-      soap_instantiate_ns1__searchByUserIDPagination(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate_ns1__searchByUserIDPagination(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchByUserIDPagination::sessionId = sessionId;
@@ -15165,14 +15273,15 @@ soap_instantiate_ns1__searchByUserIDResponse(struct soap *, int, const char *,
 
 inline ns1__searchByUserIDResponse *
 soap_new_ns1__searchByUserIDResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchByUserIDResponse(soap, n, NULL, NULL,
-                                                      NULL);
+  return soap_instantiate_ns1__searchByUserIDResponse(soap, n, nullptr, nullptr,
+                                                      nullptr);
 }
 
 inline ns1__searchByUserIDResponse *
 soap_new_req_ns1__searchByUserIDResponse(struct soap *soap) {
   ns1__searchByUserIDResponse *_p =
-      soap_instantiate_ns1__searchByUserIDResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__searchByUserIDResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -15183,7 +15292,8 @@ inline ns1__searchByUserIDResponse *soap_new_set_ns1__searchByUserIDResponse(
     struct soap *soap, std::vector<ns1__investigation *> &return_,
     char *__item1) {
   ns1__searchByUserIDResponse *_p =
-      soap_instantiate_ns1__searchByUserIDResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__searchByUserIDResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchByUserIDResponse::return_ = return_;
@@ -15240,13 +15350,14 @@ soap_instantiate_ns1__searchByUserID(struct soap *, int, const char *,
 
 inline ns1__searchByUserID *soap_new_ns1__searchByUserID(struct soap *soap,
                                                          int n = -1) {
-  return soap_instantiate_ns1__searchByUserID(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__searchByUserID(soap, n, nullptr, nullptr,
+                                              nullptr);
 }
 
 inline ns1__searchByUserID *
 soap_new_req_ns1__searchByUserID(struct soap *soap) {
   ns1__searchByUserID *_p =
-      soap_instantiate_ns1__searchByUserID(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__searchByUserID(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -15257,7 +15368,7 @@ inline ns1__searchByUserID *
 soap_new_set_ns1__searchByUserID(struct soap *soap, std::string *sessionId,
                                  std::string *userSearch, char *__item1) {
   ns1__searchByUserID *_p =
-      soap_instantiate_ns1__searchByUserID(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__searchByUserID(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchByUserID::sessionId = sessionId;
@@ -15319,15 +15430,15 @@ soap_instantiate_ns1__modifyPublicationResponse(struct soap *, int,
 
 inline ns1__modifyPublicationResponse *
 soap_new_ns1__modifyPublicationResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__modifyPublicationResponse(soap, n, NULL, NULL,
-                                                         NULL);
+  return soap_instantiate_ns1__modifyPublicationResponse(soap, n, nullptr,
+                                                         nullptr, nullptr);
 }
 
 inline ns1__modifyPublicationResponse *
 soap_new_req_ns1__modifyPublicationResponse(struct soap *soap) {
   ns1__modifyPublicationResponse *_p =
-      soap_instantiate_ns1__modifyPublicationResponse(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__modifyPublicationResponse(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -15337,8 +15448,8 @@ soap_new_req_ns1__modifyPublicationResponse(struct soap *soap) {
 inline ns1__modifyPublicationResponse *
 soap_new_set_ns1__modifyPublicationResponse(struct soap *soap, char *__item1) {
   ns1__modifyPublicationResponse *_p =
-      soap_instantiate_ns1__modifyPublicationResponse(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__modifyPublicationResponse(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -15394,13 +15505,14 @@ soap_instantiate_ns1__modifyPublication(struct soap *, int, const char *,
 
 inline ns1__modifyPublication *
 soap_new_ns1__modifyPublication(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__modifyPublication(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__modifyPublication(soap, n, nullptr, nullptr,
+                                                 nullptr);
 }
 
 inline ns1__modifyPublication *
 soap_new_req_ns1__modifyPublication(struct soap *soap) {
-  ns1__modifyPublication *_p =
-      soap_instantiate_ns1__modifyPublication(soap, -1, NULL, NULL, NULL);
+  ns1__modifyPublication *_p = soap_instantiate_ns1__modifyPublication(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -15411,8 +15523,8 @@ inline ns1__modifyPublication *
 soap_new_set_ns1__modifyPublication(struct soap *soap, std::string *sessionId,
                                     ns1__publication *publication,
                                     char *__item1) {
-  ns1__modifyPublication *_p =
-      soap_instantiate_ns1__modifyPublication(soap, -1, NULL, NULL, NULL);
+  ns1__modifyPublication *_p = soap_instantiate_ns1__modifyPublication(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__modifyPublication::sessionId = sessionId;
@@ -15482,7 +15594,7 @@ inline ns1__searchInvestigationByParameterRestrictionResponse *
 soap_new_ns1__searchInvestigationByParameterRestrictionResponse(
     struct soap *soap, int n = -1) {
   return soap_instantiate_ns1__searchInvestigationByParameterRestrictionResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchInvestigationByParameterRestrictionResponse *
@@ -15490,7 +15602,7 @@ soap_new_req_ns1__searchInvestigationByParameterRestrictionResponse(
     struct soap *soap) {
   ns1__searchInvestigationByParameterRestrictionResponse *_p =
       soap_instantiate_ns1__searchInvestigationByParameterRestrictionResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -15502,7 +15614,7 @@ soap_new_set_ns1__searchInvestigationByParameterRestrictionResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchInvestigationByParameterRestrictionResponse *_p =
       soap_instantiate_ns1__searchInvestigationByParameterRestrictionResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchInvestigationByParameterRestrictionResponse::return_ =
@@ -15567,14 +15679,14 @@ inline ns1__searchInvestigationByParameterRestriction *
 soap_new_ns1__searchInvestigationByParameterRestriction(struct soap *soap,
                                                         int n = -1) {
   return soap_instantiate_ns1__searchInvestigationByParameterRestriction(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchInvestigationByParameterRestriction *
 soap_new_req_ns1__searchInvestigationByParameterRestriction(struct soap *soap) {
   ns1__searchInvestigationByParameterRestriction *_p =
       soap_instantiate_ns1__searchInvestigationByParameterRestriction(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -15588,7 +15700,7 @@ soap_new_set_ns1__searchInvestigationByParameterRestriction(
     ns1__restrictionCondition *restriction, char *__item1) {
   ns1__searchInvestigationByParameterRestriction *_p =
       soap_instantiate_ns1__searchInvestigationByParameterRestriction(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchInvestigationByParameterRestriction::sessionId = sessionId;
@@ -15656,14 +15768,14 @@ inline ns1__searchSampleByParameterConditionResponse *
 soap_new_ns1__searchSampleByParameterConditionResponse(struct soap *soap,
                                                        int n = -1) {
   return soap_instantiate_ns1__searchSampleByParameterConditionResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchSampleByParameterConditionResponse *
 soap_new_req_ns1__searchSampleByParameterConditionResponse(struct soap *soap) {
   ns1__searchSampleByParameterConditionResponse *_p =
       soap_instantiate_ns1__searchSampleByParameterConditionResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -15675,7 +15787,7 @@ soap_new_set_ns1__searchSampleByParameterConditionResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchSampleByParameterConditionResponse *_p =
       soap_instantiate_ns1__searchSampleByParameterConditionResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchSampleByParameterConditionResponse::return_ = return_;
@@ -15736,15 +15848,15 @@ soap_instantiate_ns1__searchSampleByParameterCondition(struct soap *, int,
 
 inline ns1__searchSampleByParameterCondition *
 soap_new_ns1__searchSampleByParameterCondition(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchSampleByParameterCondition(soap, n, NULL,
-                                                                NULL, NULL);
+  return soap_instantiate_ns1__searchSampleByParameterCondition(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchSampleByParameterCondition *
 soap_new_req_ns1__searchSampleByParameterCondition(struct soap *soap) {
   ns1__searchSampleByParameterCondition *_p =
-      soap_instantiate_ns1__searchSampleByParameterCondition(soap, -1, NULL,
-                                                             NULL, NULL);
+      soap_instantiate_ns1__searchSampleByParameterCondition(soap, -1, nullptr,
+                                                             nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -15756,8 +15868,8 @@ soap_new_set_ns1__searchSampleByParameterCondition(
     struct soap *soap, std::string *sessionId,
     ns1__parameterCondition *logicalCondition, char *__item1) {
   ns1__searchSampleByParameterCondition *_p =
-      soap_instantiate_ns1__searchSampleByParameterCondition(soap, -1, NULL,
-                                                             NULL, NULL);
+      soap_instantiate_ns1__searchSampleByParameterCondition(soap, -1, nullptr,
+                                                             nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchSampleByParameterCondition::sessionId = sessionId;
@@ -15819,15 +15931,15 @@ soap_instantiate_ns1__removeDataSetParameterResponse(struct soap *, int,
 
 inline ns1__removeDataSetParameterResponse *
 soap_new_ns1__removeDataSetParameterResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__removeDataSetParameterResponse(soap, n, NULL,
-                                                              NULL, NULL);
+  return soap_instantiate_ns1__removeDataSetParameterResponse(soap, n, nullptr,
+                                                              nullptr, nullptr);
 }
 
 inline ns1__removeDataSetParameterResponse *
 soap_new_req_ns1__removeDataSetParameterResponse(struct soap *soap) {
   ns1__removeDataSetParameterResponse *_p =
-      soap_instantiate_ns1__removeDataSetParameterResponse(soap, -1, NULL, NULL,
-                                                           NULL);
+      soap_instantiate_ns1__removeDataSetParameterResponse(soap, -1, nullptr,
+                                                           nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -15838,8 +15950,8 @@ inline ns1__removeDataSetParameterResponse *
 soap_new_set_ns1__removeDataSetParameterResponse(struct soap *soap,
                                                  char *__item1) {
   ns1__removeDataSetParameterResponse *_p =
-      soap_instantiate_ns1__removeDataSetParameterResponse(soap, -1, NULL, NULL,
-                                                           NULL);
+      soap_instantiate_ns1__removeDataSetParameterResponse(soap, -1, nullptr,
+                                                           nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -15897,14 +16009,15 @@ soap_instantiate_ns1__removeDataSetParameter(struct soap *, int, const char *,
 
 inline ns1__removeDataSetParameter *
 soap_new_ns1__removeDataSetParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__removeDataSetParameter(soap, n, NULL, NULL,
-                                                      NULL);
+  return soap_instantiate_ns1__removeDataSetParameter(soap, n, nullptr, nullptr,
+                                                      nullptr);
 }
 
 inline ns1__removeDataSetParameter *
 soap_new_req_ns1__removeDataSetParameter(struct soap *soap) {
   ns1__removeDataSetParameter *_p =
-      soap_instantiate_ns1__removeDataSetParameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__removeDataSetParameter(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -15915,7 +16028,8 @@ inline ns1__removeDataSetParameter *soap_new_set_ns1__removeDataSetParameter(
     struct soap *soap, std::string *sessionId,
     ns1__datasetParameterPK *datasetParameterPK, char *__item1) {
   ns1__removeDataSetParameter *_p =
-      soap_instantiate_ns1__removeDataSetParameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__removeDataSetParameter(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__removeDataSetParameter::sessionId = sessionId;
@@ -15980,7 +16094,7 @@ inline ns1__searchSampleByParameterRestrictionResponse *
 soap_new_ns1__searchSampleByParameterRestrictionResponse(struct soap *soap,
                                                          int n = -1) {
   return soap_instantiate_ns1__searchSampleByParameterRestrictionResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchSampleByParameterRestrictionResponse *
@@ -15988,7 +16102,7 @@ soap_new_req_ns1__searchSampleByParameterRestrictionResponse(
     struct soap *soap) {
   ns1__searchSampleByParameterRestrictionResponse *_p =
       soap_instantiate_ns1__searchSampleByParameterRestrictionResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -16000,7 +16114,7 @@ soap_new_set_ns1__searchSampleByParameterRestrictionResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchSampleByParameterRestrictionResponse *_p =
       soap_instantiate_ns1__searchSampleByParameterRestrictionResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchSampleByParameterRestrictionResponse::return_ = return_;
@@ -16064,15 +16178,15 @@ soap_instantiate_ns1__searchSampleByParameterRestriction(struct soap *, int,
 inline ns1__searchSampleByParameterRestriction *
 soap_new_ns1__searchSampleByParameterRestriction(struct soap *soap,
                                                  int n = -1) {
-  return soap_instantiate_ns1__searchSampleByParameterRestriction(soap, n, NULL,
-                                                                  NULL, NULL);
+  return soap_instantiate_ns1__searchSampleByParameterRestriction(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchSampleByParameterRestriction *
 soap_new_req_ns1__searchSampleByParameterRestriction(struct soap *soap) {
   ns1__searchSampleByParameterRestriction *_p =
-      soap_instantiate_ns1__searchSampleByParameterRestriction(soap, -1, NULL,
-                                                               NULL, NULL);
+      soap_instantiate_ns1__searchSampleByParameterRestriction(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -16085,8 +16199,8 @@ soap_new_set_ns1__searchSampleByParameterRestriction(
     ns1__parameterCondition *parameterCondition,
     ns1__restrictionCondition *restrictions, char *__item1) {
   ns1__searchSampleByParameterRestriction *_p =
-      soap_instantiate_ns1__searchSampleByParameterRestriction(soap, -1, NULL,
-                                                               NULL, NULL);
+      soap_instantiate_ns1__searchSampleByParameterRestriction(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchSampleByParameterRestriction::sessionId = sessionId;
@@ -16155,7 +16269,7 @@ inline ns1__getMyInvestigationsIncludesPaginationResponse *
 soap_new_ns1__getMyInvestigationsIncludesPaginationResponse(struct soap *soap,
                                                             int n = -1) {
   return soap_instantiate_ns1__getMyInvestigationsIncludesPaginationResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__getMyInvestigationsIncludesPaginationResponse *
@@ -16163,7 +16277,7 @@ soap_new_req_ns1__getMyInvestigationsIncludesPaginationResponse(
     struct soap *soap) {
   ns1__getMyInvestigationsIncludesPaginationResponse *_p =
       soap_instantiate_ns1__getMyInvestigationsIncludesPaginationResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -16176,7 +16290,7 @@ soap_new_set_ns1__getMyInvestigationsIncludesPaginationResponse(
     char *__item1) {
   ns1__getMyInvestigationsIncludesPaginationResponse *_p =
       soap_instantiate_ns1__getMyInvestigationsIncludesPaginationResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getMyInvestigationsIncludesPaginationResponse::return_ = return_;
@@ -16240,7 +16354,7 @@ inline ns1__getMyInvestigationsIncludesPagination *
 soap_new_ns1__getMyInvestigationsIncludesPagination(struct soap *soap,
                                                     int n = -1) {
   return soap_instantiate_ns1__getMyInvestigationsIncludesPagination(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__getMyInvestigationsIncludesPagination *
@@ -16249,7 +16363,7 @@ soap_new_req_ns1__getMyInvestigationsIncludesPagination(struct soap *soap,
                                                         int numberOfResults) {
   ns1__getMyInvestigationsIncludesPagination *_p =
       soap_instantiate_ns1__getMyInvestigationsIncludesPagination(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getMyInvestigationsIncludesPagination::startIndex = startIndex;
@@ -16266,7 +16380,7 @@ soap_new_set_ns1__getMyInvestigationsIncludesPagination(
     int numberOfResults, char *__item1) {
   ns1__getMyInvestigationsIncludesPagination *_p =
       soap_instantiate_ns1__getMyInvestigationsIncludesPagination(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getMyInvestigationsIncludesPagination::sessionId = sessionId;
@@ -16336,14 +16450,14 @@ inline ns1__getMyInvestigationsIncludesResponse *
 soap_new_ns1__getMyInvestigationsIncludesResponse(struct soap *soap,
                                                   int n = -1) {
   return soap_instantiate_ns1__getMyInvestigationsIncludesResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__getMyInvestigationsIncludesResponse *
 soap_new_req_ns1__getMyInvestigationsIncludesResponse(struct soap *soap) {
   ns1__getMyInvestigationsIncludesResponse *_p =
-      soap_instantiate_ns1__getMyInvestigationsIncludesResponse(soap, -1, NULL,
-                                                                NULL, NULL);
+      soap_instantiate_ns1__getMyInvestigationsIncludesResponse(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -16355,8 +16469,8 @@ soap_new_set_ns1__getMyInvestigationsIncludesResponse(
     struct soap *soap, std::vector<ns1__investigation *> &return_,
     char *__item1) {
   ns1__getMyInvestigationsIncludesResponse *_p =
-      soap_instantiate_ns1__getMyInvestigationsIncludesResponse(soap, -1, NULL,
-                                                                NULL, NULL);
+      soap_instantiate_ns1__getMyInvestigationsIncludesResponse(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getMyInvestigationsIncludesResponse::return_ = return_;
@@ -16417,15 +16531,15 @@ soap_instantiate_ns1__getMyInvestigationsIncludes(struct soap *, int,
 
 inline ns1__getMyInvestigationsIncludes *
 soap_new_ns1__getMyInvestigationsIncludes(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getMyInvestigationsIncludes(soap, n, NULL, NULL,
-                                                           NULL);
+  return soap_instantiate_ns1__getMyInvestigationsIncludes(soap, n, nullptr,
+                                                           nullptr, nullptr);
 }
 
 inline ns1__getMyInvestigationsIncludes *
 soap_new_req_ns1__getMyInvestigationsIncludes(struct soap *soap) {
   ns1__getMyInvestigationsIncludes *_p =
-      soap_instantiate_ns1__getMyInvestigationsIncludes(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__getMyInvestigationsIncludes(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -16437,8 +16551,8 @@ soap_new_set_ns1__getMyInvestigationsIncludes(
     struct soap *soap, std::string *sessionId,
     enum ns1__investigationInclude *investigationInclude, char *__item1) {
   ns1__getMyInvestigationsIncludes *_p =
-      soap_instantiate_ns1__getMyInvestigationsIncludes(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__getMyInvestigationsIncludes(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getMyInvestigationsIncludes::sessionId = sessionId;
@@ -16500,15 +16614,15 @@ soap_instantiate_ns1__getMyInvestigationsResponse(struct soap *, int,
 
 inline ns1__getMyInvestigationsResponse *
 soap_new_ns1__getMyInvestigationsResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getMyInvestigationsResponse(soap, n, NULL, NULL,
-                                                           NULL);
+  return soap_instantiate_ns1__getMyInvestigationsResponse(soap, n, nullptr,
+                                                           nullptr, nullptr);
 }
 
 inline ns1__getMyInvestigationsResponse *
 soap_new_req_ns1__getMyInvestigationsResponse(struct soap *soap) {
   ns1__getMyInvestigationsResponse *_p =
-      soap_instantiate_ns1__getMyInvestigationsResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__getMyInvestigationsResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -16520,8 +16634,8 @@ soap_new_set_ns1__getMyInvestigationsResponse(
     struct soap *soap, std::vector<ns1__investigation *> &return_,
     char *__item1) {
   ns1__getMyInvestigationsResponse *_p =
-      soap_instantiate_ns1__getMyInvestigationsResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__getMyInvestigationsResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getMyInvestigationsResponse::return_ = return_;
@@ -16578,13 +16692,14 @@ soap_instantiate_ns1__getMyInvestigations(struct soap *, int, const char *,
 
 inline ns1__getMyInvestigations *
 soap_new_ns1__getMyInvestigations(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getMyInvestigations(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__getMyInvestigations(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline ns1__getMyInvestigations *
 soap_new_req_ns1__getMyInvestigations(struct soap *soap) {
-  ns1__getMyInvestigations *_p =
-      soap_instantiate_ns1__getMyInvestigations(soap, -1, NULL, NULL, NULL);
+  ns1__getMyInvestigations *_p = soap_instantiate_ns1__getMyInvestigations(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -16594,8 +16709,8 @@ soap_new_req_ns1__getMyInvestigations(struct soap *soap) {
 inline ns1__getMyInvestigations *
 soap_new_set_ns1__getMyInvestigations(struct soap *soap, std::string *sessionId,
                                       char *__item1) {
-  ns1__getMyInvestigations *_p =
-      soap_instantiate_ns1__getMyInvestigations(soap, -1, NULL, NULL, NULL);
+  ns1__getMyInvestigations *_p = soap_instantiate_ns1__getMyInvestigations(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getMyInvestigations::sessionId = sessionId;
@@ -16658,7 +16773,7 @@ inline ns1__searchDatafileByRestrictionLogicalResponse *
 soap_new_ns1__searchDatafileByRestrictionLogicalResponse(struct soap *soap,
                                                          int n = -1) {
   return soap_instantiate_ns1__searchDatafileByRestrictionLogicalResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatafileByRestrictionLogicalResponse *
@@ -16666,7 +16781,7 @@ soap_new_req_ns1__searchDatafileByRestrictionLogicalResponse(
     struct soap *soap) {
   ns1__searchDatafileByRestrictionLogicalResponse *_p =
       soap_instantiate_ns1__searchDatafileByRestrictionLogicalResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -16678,7 +16793,7 @@ soap_new_set_ns1__searchDatafileByRestrictionLogicalResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchDatafileByRestrictionLogicalResponse *_p =
       soap_instantiate_ns1__searchDatafileByRestrictionLogicalResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatafileByRestrictionLogicalResponse::return_ = return_;
@@ -16742,15 +16857,15 @@ soap_instantiate_ns1__searchDatafileByRestrictionLogical(struct soap *, int,
 inline ns1__searchDatafileByRestrictionLogical *
 soap_new_ns1__searchDatafileByRestrictionLogical(struct soap *soap,
                                                  int n = -1) {
-  return soap_instantiate_ns1__searchDatafileByRestrictionLogical(soap, n, NULL,
-                                                                  NULL, NULL);
+  return soap_instantiate_ns1__searchDatafileByRestrictionLogical(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatafileByRestrictionLogical *
 soap_new_req_ns1__searchDatafileByRestrictionLogical(struct soap *soap) {
   ns1__searchDatafileByRestrictionLogical *_p =
-      soap_instantiate_ns1__searchDatafileByRestrictionLogical(soap, -1, NULL,
-                                                               NULL, NULL);
+      soap_instantiate_ns1__searchDatafileByRestrictionLogical(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -16762,8 +16877,8 @@ soap_new_set_ns1__searchDatafileByRestrictionLogical(
     struct soap *soap, std::string *sessionId,
     ns1__restrictionLogicalCondition *restriction, char *__item1) {
   ns1__searchDatafileByRestrictionLogical *_p =
-      soap_instantiate_ns1__searchDatafileByRestrictionLogical(soap, -1, NULL,
-                                                               NULL, NULL);
+      soap_instantiate_ns1__searchDatafileByRestrictionLogical(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatafileByRestrictionLogical::sessionId = sessionId;
@@ -16826,15 +16941,15 @@ soap_instantiate_ns1__getAllInstrumentsResponse(struct soap *, int,
 
 inline ns1__getAllInstrumentsResponse *
 soap_new_ns1__getAllInstrumentsResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getAllInstrumentsResponse(soap, n, NULL, NULL,
-                                                         NULL);
+  return soap_instantiate_ns1__getAllInstrumentsResponse(soap, n, nullptr,
+                                                         nullptr, nullptr);
 }
 
 inline ns1__getAllInstrumentsResponse *
 soap_new_req_ns1__getAllInstrumentsResponse(struct soap *soap) {
   ns1__getAllInstrumentsResponse *_p =
-      soap_instantiate_ns1__getAllInstrumentsResponse(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__getAllInstrumentsResponse(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -16845,8 +16960,8 @@ inline ns1__getAllInstrumentsResponse *
 soap_new_set_ns1__getAllInstrumentsResponse(
     struct soap *soap, std::vector<ns1__instrument *> &return_, char *__item1) {
   ns1__getAllInstrumentsResponse *_p =
-      soap_instantiate_ns1__getAllInstrumentsResponse(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__getAllInstrumentsResponse(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getAllInstrumentsResponse::return_ = return_;
@@ -16903,13 +17018,14 @@ soap_instantiate_ns1__getAllInstruments(struct soap *, int, const char *,
 
 inline ns1__getAllInstruments *
 soap_new_ns1__getAllInstruments(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getAllInstruments(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__getAllInstruments(soap, n, nullptr, nullptr,
+                                                 nullptr);
 }
 
 inline ns1__getAllInstruments *
 soap_new_req_ns1__getAllInstruments(struct soap *soap) {
-  ns1__getAllInstruments *_p =
-      soap_instantiate_ns1__getAllInstruments(soap, -1, NULL, NULL, NULL);
+  ns1__getAllInstruments *_p = soap_instantiate_ns1__getAllInstruments(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -16919,8 +17035,8 @@ soap_new_req_ns1__getAllInstruments(struct soap *soap) {
 inline ns1__getAllInstruments *
 soap_new_set_ns1__getAllInstruments(struct soap *soap, std::string *sessionId,
                                     char *__item1) {
-  ns1__getAllInstruments *_p =
-      soap_instantiate_ns1__getAllInstruments(soap, -1, NULL, NULL, NULL);
+  ns1__getAllInstruments *_p = soap_instantiate_ns1__getAllInstruments(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getAllInstruments::sessionId = sessionId;
@@ -16980,15 +17096,15 @@ soap_instantiate_ns1__searchByKeywordsAllResponse(struct soap *, int,
 
 inline ns1__searchByKeywordsAllResponse *
 soap_new_ns1__searchByKeywordsAllResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchByKeywordsAllResponse(soap, n, NULL, NULL,
-                                                           NULL);
+  return soap_instantiate_ns1__searchByKeywordsAllResponse(soap, n, nullptr,
+                                                           nullptr, nullptr);
 }
 
 inline ns1__searchByKeywordsAllResponse *
 soap_new_req_ns1__searchByKeywordsAllResponse(struct soap *soap) {
   ns1__searchByKeywordsAllResponse *_p =
-      soap_instantiate_ns1__searchByKeywordsAllResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__searchByKeywordsAllResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -17000,8 +17116,8 @@ soap_new_set_ns1__searchByKeywordsAllResponse(
     struct soap *soap, std::vector<ns1__investigation *> &return_,
     char *__item1) {
   ns1__searchByKeywordsAllResponse *_p =
-      soap_instantiate_ns1__searchByKeywordsAllResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__searchByKeywordsAllResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchByKeywordsAllResponse::return_ = return_;
@@ -17057,13 +17173,14 @@ soap_instantiate_ns1__keywordDetails(struct soap *, int, const char *,
 
 inline ns1__keywordDetails *soap_new_ns1__keywordDetails(struct soap *soap,
                                                          int n = -1) {
-  return soap_instantiate_ns1__keywordDetails(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__keywordDetails(soap, n, nullptr, nullptr,
+                                              nullptr);
 }
 
 inline ns1__keywordDetails *
 soap_new_req_ns1__keywordDetails(struct soap *soap, bool caseSensitive) {
   ns1__keywordDetails *_p =
-      soap_instantiate_ns1__keywordDetails(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__keywordDetails(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__keywordDetails::caseSensitive = caseSensitive;
@@ -17076,7 +17193,7 @@ inline ns1__keywordDetails *soap_new_set_ns1__keywordDetails(
     enum ns1__investigationInclude *investigationInclude,
     std::vector<std::string> &keywords, char *__item1) {
   ns1__keywordDetails *_p =
-      soap_instantiate_ns1__keywordDetails(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__keywordDetails(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__keywordDetails::caseSensitive = caseSensitive;
@@ -17135,14 +17252,15 @@ soap_instantiate_ns1__searchByKeywordsAll(struct soap *, int, const char *,
 
 inline ns1__searchByKeywordsAll *
 soap_new_ns1__searchByKeywordsAll(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchByKeywordsAll(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__searchByKeywordsAll(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline ns1__searchByKeywordsAll *
 soap_new_req_ns1__searchByKeywordsAll(struct soap *soap, int startIndex,
                                       int numberOfResults) {
-  ns1__searchByKeywordsAll *_p =
-      soap_instantiate_ns1__searchByKeywordsAll(soap, -1, NULL, NULL, NULL);
+  ns1__searchByKeywordsAll *_p = soap_instantiate_ns1__searchByKeywordsAll(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchByKeywordsAll::startIndex = startIndex;
@@ -17156,8 +17274,8 @@ soap_new_set_ns1__searchByKeywordsAll(struct soap *soap, std::string *sessionId,
                                       ns1__keywordDetails *keywordDetails,
                                       int startIndex, int numberOfResults,
                                       char *__item1) {
-  ns1__searchByKeywordsAll *_p =
-      soap_instantiate_ns1__searchByKeywordsAll(soap, -1, NULL, NULL, NULL);
+  ns1__searchByKeywordsAll *_p = soap_instantiate_ns1__searchByKeywordsAll(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchByKeywordsAll::sessionId = sessionId;
@@ -17220,15 +17338,15 @@ soap_instantiate_ns1__searchByKeywordsResponse(struct soap *, int, const char *,
 
 inline ns1__searchByKeywordsResponse *
 soap_new_ns1__searchByKeywordsResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchByKeywordsResponse(soap, n, NULL, NULL,
-                                                        NULL);
+  return soap_instantiate_ns1__searchByKeywordsResponse(soap, n, nullptr,
+                                                        nullptr, nullptr);
 }
 
 inline ns1__searchByKeywordsResponse *
 soap_new_req_ns1__searchByKeywordsResponse(struct soap *soap) {
   ns1__searchByKeywordsResponse *_p =
-      soap_instantiate_ns1__searchByKeywordsResponse(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate_ns1__searchByKeywordsResponse(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -17240,8 +17358,8 @@ soap_new_set_ns1__searchByKeywordsResponse(
     struct soap *soap, std::vector<ns1__investigation *> &return_,
     char *__item1) {
   ns1__searchByKeywordsResponse *_p =
-      soap_instantiate_ns1__searchByKeywordsResponse(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate_ns1__searchByKeywordsResponse(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchByKeywordsResponse::return_ = return_;
@@ -17298,13 +17416,14 @@ soap_instantiate_ns1__searchByKeywords(struct soap *, int, const char *,
 
 inline ns1__searchByKeywords *soap_new_ns1__searchByKeywords(struct soap *soap,
                                                              int n = -1) {
-  return soap_instantiate_ns1__searchByKeywords(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__searchByKeywords(soap, n, nullptr, nullptr,
+                                                nullptr);
 }
 
 inline ns1__searchByKeywords *
 soap_new_req_ns1__searchByKeywords(struct soap *soap) {
-  ns1__searchByKeywords *_p =
-      soap_instantiate_ns1__searchByKeywords(soap, -1, NULL, NULL, NULL);
+  ns1__searchByKeywords *_p = soap_instantiate_ns1__searchByKeywords(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -17315,8 +17434,8 @@ inline ns1__searchByKeywords *
 soap_new_set_ns1__searchByKeywords(struct soap *soap, std::string *sessionId,
                                    std::vector<std::string> &keywords,
                                    char *__item1) {
-  ns1__searchByKeywords *_p =
-      soap_instantiate_ns1__searchByKeywords(soap, -1, NULL, NULL, NULL);
+  ns1__searchByKeywords *_p = soap_instantiate_ns1__searchByKeywords(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchByKeywords::sessionId = sessionId;
@@ -17380,15 +17499,15 @@ soap_instantiate_ns1__checkDatasetDownloadAccessResponse(struct soap *, int,
 inline ns1__checkDatasetDownloadAccessResponse *
 soap_new_ns1__checkDatasetDownloadAccessResponse(struct soap *soap,
                                                  int n = -1) {
-  return soap_instantiate_ns1__checkDatasetDownloadAccessResponse(soap, n, NULL,
-                                                                  NULL, NULL);
+  return soap_instantiate_ns1__checkDatasetDownloadAccessResponse(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__checkDatasetDownloadAccessResponse *
 soap_new_req_ns1__checkDatasetDownloadAccessResponse(struct soap *soap) {
   ns1__checkDatasetDownloadAccessResponse *_p =
-      soap_instantiate_ns1__checkDatasetDownloadAccessResponse(soap, -1, NULL,
-                                                               NULL, NULL);
+      soap_instantiate_ns1__checkDatasetDownloadAccessResponse(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -17399,8 +17518,8 @@ inline ns1__checkDatasetDownloadAccessResponse *
 soap_new_set_ns1__checkDatasetDownloadAccessResponse(
     struct soap *soap, ns1__downloadInfo *downloadInfo, char *__item1) {
   ns1__checkDatasetDownloadAccessResponse *_p =
-      soap_instantiate_ns1__checkDatasetDownloadAccessResponse(soap, -1, NULL,
-                                                               NULL, NULL);
+      soap_instantiate_ns1__checkDatasetDownloadAccessResponse(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__checkDatasetDownloadAccessResponse::downloadInfo = downloadInfo;
@@ -17461,15 +17580,15 @@ soap_instantiate_ns1__checkDatasetDownloadAccess(struct soap *, int,
 
 inline ns1__checkDatasetDownloadAccess *
 soap_new_ns1__checkDatasetDownloadAccess(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__checkDatasetDownloadAccess(soap, n, NULL, NULL,
-                                                          NULL);
+  return soap_instantiate_ns1__checkDatasetDownloadAccess(soap, n, nullptr,
+                                                          nullptr, nullptr);
 }
 
 inline ns1__checkDatasetDownloadAccess *
 soap_new_req_ns1__checkDatasetDownloadAccess(struct soap *soap) {
   ns1__checkDatasetDownloadAccess *_p =
-      soap_instantiate_ns1__checkDatasetDownloadAccess(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate_ns1__checkDatasetDownloadAccess(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -17481,8 +17600,8 @@ soap_new_set_ns1__checkDatasetDownloadAccess(struct soap *soap,
                                              std::string *sessionId,
                                              LONG64 *datasetId, char *__item1) {
   ns1__checkDatasetDownloadAccess *_p =
-      soap_instantiate_ns1__checkDatasetDownloadAccess(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate_ns1__checkDatasetDownloadAccess(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__checkDatasetDownloadAccess::sessionId = sessionId;
@@ -17546,7 +17665,7 @@ inline ns1__searchDatafileByParameterConditionResponse *
 soap_new_ns1__searchDatafileByParameterConditionResponse(struct soap *soap,
                                                          int n = -1) {
   return soap_instantiate_ns1__searchDatafileByParameterConditionResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatafileByParameterConditionResponse *
@@ -17554,7 +17673,7 @@ soap_new_req_ns1__searchDatafileByParameterConditionResponse(
     struct soap *soap) {
   ns1__searchDatafileByParameterConditionResponse *_p =
       soap_instantiate_ns1__searchDatafileByParameterConditionResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -17566,7 +17685,7 @@ soap_new_set_ns1__searchDatafileByParameterConditionResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchDatafileByParameterConditionResponse *_p =
       soap_instantiate_ns1__searchDatafileByParameterConditionResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatafileByParameterConditionResponse::return_ = return_;
@@ -17630,15 +17749,15 @@ soap_instantiate_ns1__searchDatafileByParameterCondition(struct soap *, int,
 inline ns1__searchDatafileByParameterCondition *
 soap_new_ns1__searchDatafileByParameterCondition(struct soap *soap,
                                                  int n = -1) {
-  return soap_instantiate_ns1__searchDatafileByParameterCondition(soap, n, NULL,
-                                                                  NULL, NULL);
+  return soap_instantiate_ns1__searchDatafileByParameterCondition(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatafileByParameterCondition *
 soap_new_req_ns1__searchDatafileByParameterCondition(struct soap *soap) {
   ns1__searchDatafileByParameterCondition *_p =
-      soap_instantiate_ns1__searchDatafileByParameterCondition(soap, -1, NULL,
-                                                               NULL, NULL);
+      soap_instantiate_ns1__searchDatafileByParameterCondition(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -17650,8 +17769,8 @@ soap_new_set_ns1__searchDatafileByParameterCondition(
     struct soap *soap, std::string *sessionId,
     ns1__parameterCondition *logicalCondition, char *__item1) {
   ns1__searchDatafileByParameterCondition *_p =
-      soap_instantiate_ns1__searchDatafileByParameterCondition(soap, -1, NULL,
-                                                               NULL, NULL);
+      soap_instantiate_ns1__searchDatafileByParameterCondition(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatafileByParameterCondition::sessionId = sessionId;
@@ -17718,14 +17837,14 @@ inline ns1__searchByUserSurnamePaginationResponse *
 soap_new_ns1__searchByUserSurnamePaginationResponse(struct soap *soap,
                                                     int n = -1) {
   return soap_instantiate_ns1__searchByUserSurnamePaginationResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchByUserSurnamePaginationResponse *
 soap_new_req_ns1__searchByUserSurnamePaginationResponse(struct soap *soap) {
   ns1__searchByUserSurnamePaginationResponse *_p =
       soap_instantiate_ns1__searchByUserSurnamePaginationResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -17738,7 +17857,7 @@ soap_new_set_ns1__searchByUserSurnamePaginationResponse(
     char *__item1) {
   ns1__searchByUserSurnamePaginationResponse *_p =
       soap_instantiate_ns1__searchByUserSurnamePaginationResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchByUserSurnamePaginationResponse::return_ = return_;
@@ -17799,8 +17918,8 @@ soap_instantiate_ns1__searchByUserSurnamePagination(struct soap *, int,
 
 inline ns1__searchByUserSurnamePagination *
 soap_new_ns1__searchByUserSurnamePagination(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchByUserSurnamePagination(soap, n, NULL,
-                                                             NULL, NULL);
+  return soap_instantiate_ns1__searchByUserSurnamePagination(soap, n, nullptr,
+                                                             nullptr, nullptr);
 }
 
 inline ns1__searchByUserSurnamePagination *
@@ -17808,8 +17927,8 @@ soap_new_req_ns1__searchByUserSurnamePagination(struct soap *soap,
                                                 int startIndex,
                                                 int numberOfResults) {
   ns1__searchByUserSurnamePagination *_p =
-      soap_instantiate_ns1__searchByUserSurnamePagination(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate_ns1__searchByUserSurnamePagination(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchByUserSurnamePagination::startIndex = startIndex;
@@ -17823,8 +17942,8 @@ soap_new_set_ns1__searchByUserSurnamePagination(
     struct soap *soap, std::string *sessionId, std::string *surname,
     int startIndex, int numberOfResults, char *__item1) {
   ns1__searchByUserSurnamePagination *_p =
-      soap_instantiate_ns1__searchByUserSurnamePagination(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate_ns1__searchByUserSurnamePagination(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchByUserSurnamePagination::sessionId = sessionId;
@@ -17880,11 +17999,12 @@ soap_instantiate_ns1__shiftPK(struct soap *, int, const char *, const char *,
                               size_t *);
 
 inline ns1__shiftPK *soap_new_ns1__shiftPK(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__shiftPK(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__shiftPK(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__shiftPK *soap_new_req_ns1__shiftPK(struct soap *soap) {
-  ns1__shiftPK *_p = soap_instantiate_ns1__shiftPK(soap, -1, NULL, NULL, NULL);
+  ns1__shiftPK *_p =
+      soap_instantiate_ns1__shiftPK(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -17896,7 +18016,8 @@ inline ns1__shiftPK *soap_new_set_ns1__shiftPK(struct soap *soap,
                                                LONG64 *investigationId,
                                                time_t *startDate,
                                                char *__item2) {
-  ns1__shiftPK *_p = soap_instantiate_ns1__shiftPK(soap, -1, NULL, NULL, NULL);
+  ns1__shiftPK *_p =
+      soap_instantiate_ns1__shiftPK(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__shiftPK::endDate = endDate;
@@ -17948,13 +18069,14 @@ soap_instantiate_ns1__shift(struct soap *, int, const char *, const char *,
                             size_t *);
 
 inline ns1__shift *soap_new_ns1__shift(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__shift(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__shift(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__shift *soap_new_req_ns1__shift(struct soap *soap,
                                            bool facilityAcquiredData1,
                                            bool selected1) {
-  ns1__shift *_p = soap_instantiate_ns1__shift(soap, -1, NULL, NULL, NULL);
+  ns1__shift *_p =
+      soap_instantiate_ns1__shift(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__entityBaseBean::facilityAcquiredData = facilityAcquiredData1;
@@ -17968,7 +18090,8 @@ soap_new_set_ns1__shift(struct soap *soap, std::string *shiftComment,
                         ns1__shiftPK *shiftPK, bool facilityAcquiredData1,
                         ns1__icatRole *icatRole1, bool selected1,
                         std::string *uniqueId1, char *__item2) {
-  ns1__shift *_p = soap_instantiate_ns1__shift(soap, -1, NULL, NULL, NULL);
+  ns1__shift *_p =
+      soap_instantiate_ns1__shift(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__shift::shiftComment = shiftComment;
@@ -18026,14 +18149,14 @@ soap_instantiate_ns1__publication(struct soap *, int, const char *,
 
 inline ns1__publication *soap_new_ns1__publication(struct soap *soap,
                                                    int n = -1) {
-  return soap_instantiate_ns1__publication(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__publication(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__publication *
 soap_new_req_ns1__publication(struct soap *soap, bool facilityAcquiredData1,
                               bool selected1) {
   ns1__publication *_p =
-      soap_instantiate_ns1__publication(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__publication(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__entityBaseBean::facilityAcquiredData = facilityAcquiredData1;
@@ -18048,7 +18171,7 @@ inline ns1__publication *soap_new_set_ns1__publication(
     bool facilityAcquiredData1, ns1__icatRole *icatRole1, bool selected1,
     std::string *uniqueId1, char *__item2) {
   ns1__publication *_p =
-      soap_instantiate_ns1__publication(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__publication(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__publication::fullReference = fullReference;
@@ -18109,13 +18232,14 @@ soap_instantiate_ns1__keyword(struct soap *, int, const char *, const char *,
                               size_t *);
 
 inline ns1__keyword *soap_new_ns1__keyword(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__keyword(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__keyword(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__keyword *soap_new_req_ns1__keyword(struct soap *soap,
                                                bool facilityAcquiredData1,
                                                bool selected1) {
-  ns1__keyword *_p = soap_instantiate_ns1__keyword(soap, -1, NULL, NULL, NULL);
+  ns1__keyword *_p =
+      soap_instantiate_ns1__keyword(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__entityBaseBean::facilityAcquiredData = facilityAcquiredData1;
@@ -18129,7 +18253,8 @@ soap_new_set_ns1__keyword(struct soap *soap, ns1__keywordPK *keywordPK,
                           bool facilityAcquiredData1, ns1__icatRole *icatRole1,
                           bool selected1, std::string *uniqueId1,
                           char *__item2) {
-  ns1__keyword *_p = soap_instantiate_ns1__keyword(soap, -1, NULL, NULL, NULL);
+  ns1__keyword *_p =
+      soap_instantiate_ns1__keyword(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__keyword::keywordPK = keywordPK;
@@ -18188,14 +18313,14 @@ soap_instantiate_ns1__investigator(struct soap *, int, const char *,
 
 inline ns1__investigator *soap_new_ns1__investigator(struct soap *soap,
                                                      int n = -1) {
-  return soap_instantiate_ns1__investigator(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__investigator(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__investigator *
 soap_new_req_ns1__investigator(struct soap *soap, bool facilityAcquiredData1,
                                bool selected1) {
   ns1__investigator *_p =
-      soap_instantiate_ns1__investigator(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__investigator(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__entityBaseBean::facilityAcquiredData = facilityAcquiredData1;
@@ -18210,7 +18335,7 @@ inline ns1__investigator *soap_new_set_ns1__investigator(
     bool facilityAcquiredData1, ns1__icatRole *icatRole1, bool selected1,
     std::string *uniqueId1, char *__item2) {
   ns1__investigator *_p =
-      soap_instantiate_ns1__investigator(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__investigator(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__investigator::ns1__facilityUser_ = ns1__facilityUser_;
@@ -18272,14 +18397,15 @@ soap_instantiate_ns1__investigation(struct soap *, int, const char *,
 
 inline ns1__investigation *soap_new_ns1__investigation(struct soap *soap,
                                                        int n = -1) {
-  return soap_instantiate_ns1__investigation(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__investigation(soap, n, nullptr, nullptr,
+                                             nullptr);
 }
 
 inline ns1__investigation *
 soap_new_req_ns1__investigation(struct soap *soap, bool facilityAcquiredData1,
                                 bool selected1) {
   ns1__investigation *_p =
-      soap_instantiate_ns1__investigation(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__investigation(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__entityBaseBean::facilityAcquiredData = facilityAcquiredData1;
@@ -18303,7 +18429,7 @@ inline ns1__investigation *soap_new_set_ns1__investigation(
     std::string *visitId, bool facilityAcquiredData1, ns1__icatRole *icatRole1,
     bool selected1, std::string *uniqueId1, char *__item2) {
   ns1__investigation *_p =
-      soap_instantiate_ns1__investigation(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__investigation(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__investigation::bcatInvStr = bcatInvStr;
@@ -18389,15 +18515,15 @@ soap_instantiate_ns1__searchByUserSurnameResponse(struct soap *, int,
 
 inline ns1__searchByUserSurnameResponse *
 soap_new_ns1__searchByUserSurnameResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchByUserSurnameResponse(soap, n, NULL, NULL,
-                                                           NULL);
+  return soap_instantiate_ns1__searchByUserSurnameResponse(soap, n, nullptr,
+                                                           nullptr, nullptr);
 }
 
 inline ns1__searchByUserSurnameResponse *
 soap_new_req_ns1__searchByUserSurnameResponse(struct soap *soap) {
   ns1__searchByUserSurnameResponse *_p =
-      soap_instantiate_ns1__searchByUserSurnameResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__searchByUserSurnameResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -18409,8 +18535,8 @@ soap_new_set_ns1__searchByUserSurnameResponse(
     struct soap *soap, std::vector<ns1__investigation *> &return_,
     char *__item1) {
   ns1__searchByUserSurnameResponse *_p =
-      soap_instantiate_ns1__searchByUserSurnameResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__searchByUserSurnameResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchByUserSurnameResponse::return_ = return_;
@@ -18467,13 +18593,14 @@ soap_instantiate_ns1__searchByUserSurname(struct soap *, int, const char *,
 
 inline ns1__searchByUserSurname *
 soap_new_ns1__searchByUserSurname(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchByUserSurname(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__searchByUserSurname(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline ns1__searchByUserSurname *
 soap_new_req_ns1__searchByUserSurname(struct soap *soap) {
-  ns1__searchByUserSurname *_p =
-      soap_instantiate_ns1__searchByUserSurname(soap, -1, NULL, NULL, NULL);
+  ns1__searchByUserSurname *_p = soap_instantiate_ns1__searchByUserSurname(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -18483,8 +18610,8 @@ soap_new_req_ns1__searchByUserSurname(struct soap *soap) {
 inline ns1__searchByUserSurname *
 soap_new_set_ns1__searchByUserSurname(struct soap *soap, std::string *sessionId,
                                       std::string *surname, char *__item1) {
-  ns1__searchByUserSurname *_p =
-      soap_instantiate_ns1__searchByUserSurname(soap, -1, NULL, NULL, NULL);
+  ns1__searchByUserSurname *_p = soap_instantiate_ns1__searchByUserSurname(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchByUserSurname::sessionId = sessionId;
@@ -18544,14 +18671,15 @@ soap_instantiate_ns1__deleteDataFileResponse(struct soap *, int, const char *,
 
 inline ns1__deleteDataFileResponse *
 soap_new_ns1__deleteDataFileResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__deleteDataFileResponse(soap, n, NULL, NULL,
-                                                      NULL);
+  return soap_instantiate_ns1__deleteDataFileResponse(soap, n, nullptr, nullptr,
+                                                      nullptr);
 }
 
 inline ns1__deleteDataFileResponse *
 soap_new_req_ns1__deleteDataFileResponse(struct soap *soap) {
   ns1__deleteDataFileResponse *_p =
-      soap_instantiate_ns1__deleteDataFileResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__deleteDataFileResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -18561,7 +18689,8 @@ soap_new_req_ns1__deleteDataFileResponse(struct soap *soap) {
 inline ns1__deleteDataFileResponse *
 soap_new_set_ns1__deleteDataFileResponse(struct soap *soap, char *__item1) {
   ns1__deleteDataFileResponse *_p =
-      soap_instantiate_ns1__deleteDataFileResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__deleteDataFileResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -18617,13 +18746,14 @@ soap_instantiate_ns1__deleteDataFile(struct soap *, int, const char *,
 
 inline ns1__deleteDataFile *soap_new_ns1__deleteDataFile(struct soap *soap,
                                                          int n = -1) {
-  return soap_instantiate_ns1__deleteDataFile(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__deleteDataFile(soap, n, nullptr, nullptr,
+                                              nullptr);
 }
 
 inline ns1__deleteDataFile *
 soap_new_req_ns1__deleteDataFile(struct soap *soap) {
   ns1__deleteDataFile *_p =
-      soap_instantiate_ns1__deleteDataFile(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__deleteDataFile(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -18634,7 +18764,7 @@ inline ns1__deleteDataFile *
 soap_new_set_ns1__deleteDataFile(struct soap *soap, std::string *sessionId,
                                  LONG64 *datafileId, char *__item1) {
   ns1__deleteDataFile *_p =
-      soap_instantiate_ns1__deleteDataFile(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__deleteDataFile(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__deleteDataFile::sessionId = sessionId;
@@ -18691,12 +18821,12 @@ soap_instantiate_ns1__downloadInfo(struct soap *, int, const char *,
 
 inline ns1__downloadInfo *soap_new_ns1__downloadInfo(struct soap *soap,
                                                      int n = -1) {
-  return soap_instantiate_ns1__downloadInfo(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__downloadInfo(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__downloadInfo *soap_new_req_ns1__downloadInfo(struct soap *soap) {
   ns1__downloadInfo *_p =
-      soap_instantiate_ns1__downloadInfo(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__downloadInfo(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -18709,7 +18839,7 @@ soap_new_set_ns1__downloadInfo(struct soap *soap, std::string *credential,
                                std::vector<xsd__anyType *> &datafileNames,
                                std::string *userId, char *__item1) {
   ns1__downloadInfo *_p =
-      soap_instantiate_ns1__downloadInfo(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__downloadInfo(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__downloadInfo::credential = credential;
@@ -18776,14 +18906,14 @@ inline ns1__checkDatafileDownloadAccessResponse *
 soap_new_ns1__checkDatafileDownloadAccessResponse(struct soap *soap,
                                                   int n = -1) {
   return soap_instantiate_ns1__checkDatafileDownloadAccessResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__checkDatafileDownloadAccessResponse *
 soap_new_req_ns1__checkDatafileDownloadAccessResponse(struct soap *soap) {
   ns1__checkDatafileDownloadAccessResponse *_p =
-      soap_instantiate_ns1__checkDatafileDownloadAccessResponse(soap, -1, NULL,
-                                                                NULL, NULL);
+      soap_instantiate_ns1__checkDatafileDownloadAccessResponse(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -18794,8 +18924,8 @@ inline ns1__checkDatafileDownloadAccessResponse *
 soap_new_set_ns1__checkDatafileDownloadAccessResponse(
     struct soap *soap, ns1__downloadInfo *downloadInfo, char *__item1) {
   ns1__checkDatafileDownloadAccessResponse *_p =
-      soap_instantiate_ns1__checkDatafileDownloadAccessResponse(soap, -1, NULL,
-                                                                NULL, NULL);
+      soap_instantiate_ns1__checkDatafileDownloadAccessResponse(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__checkDatafileDownloadAccessResponse::downloadInfo = downloadInfo;
@@ -18856,15 +18986,15 @@ soap_instantiate_ns1__checkDatafileDownloadAccess(struct soap *, int,
 
 inline ns1__checkDatafileDownloadAccess *
 soap_new_ns1__checkDatafileDownloadAccess(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__checkDatafileDownloadAccess(soap, n, NULL, NULL,
-                                                           NULL);
+  return soap_instantiate_ns1__checkDatafileDownloadAccess(soap, n, nullptr,
+                                                           nullptr, nullptr);
 }
 
 inline ns1__checkDatafileDownloadAccess *
 soap_new_req_ns1__checkDatafileDownloadAccess(struct soap *soap) {
   ns1__checkDatafileDownloadAccess *_p =
-      soap_instantiate_ns1__checkDatafileDownloadAccess(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__checkDatafileDownloadAccess(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -18877,8 +19007,8 @@ soap_new_set_ns1__checkDatafileDownloadAccess(struct soap *soap,
                                               std::vector<LONG64> &datafileIds,
                                               char *__item1) {
   ns1__checkDatafileDownloadAccess *_p =
-      soap_instantiate_ns1__checkDatafileDownloadAccess(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__checkDatafileDownloadAccess(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__checkDatafileDownloadAccess::sessionId = sessionId;
@@ -18943,14 +19073,14 @@ inline ns1__getFacilityUserByFacilityUserIdResponse *
 soap_new_ns1__getFacilityUserByFacilityUserIdResponse(struct soap *soap,
                                                       int n = -1) {
   return soap_instantiate_ns1__getFacilityUserByFacilityUserIdResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__getFacilityUserByFacilityUserIdResponse *
 soap_new_req_ns1__getFacilityUserByFacilityUserIdResponse(struct soap *soap) {
   ns1__getFacilityUserByFacilityUserIdResponse *_p =
       soap_instantiate_ns1__getFacilityUserByFacilityUserIdResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -18962,7 +19092,7 @@ soap_new_set_ns1__getFacilityUserByFacilityUserIdResponse(
     struct soap *soap, ns1__facilityUser *return_, char *__item1) {
   ns1__getFacilityUserByFacilityUserIdResponse *_p =
       soap_instantiate_ns1__getFacilityUserByFacilityUserIdResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getFacilityUserByFacilityUserIdResponse::return_ = return_;
@@ -19023,15 +19153,15 @@ soap_instantiate_ns1__getFacilityUserByFacilityUserId(struct soap *, int,
 
 inline ns1__getFacilityUserByFacilityUserId *
 soap_new_ns1__getFacilityUserByFacilityUserId(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getFacilityUserByFacilityUserId(soap, n, NULL,
-                                                               NULL, NULL);
+  return soap_instantiate_ns1__getFacilityUserByFacilityUserId(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__getFacilityUserByFacilityUserId *
 soap_new_req_ns1__getFacilityUserByFacilityUserId(struct soap *soap) {
   ns1__getFacilityUserByFacilityUserId *_p =
-      soap_instantiate_ns1__getFacilityUserByFacilityUserId(soap, -1, NULL,
-                                                            NULL, NULL);
+      soap_instantiate_ns1__getFacilityUserByFacilityUserId(soap, -1, nullptr,
+                                                            nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -19044,8 +19174,8 @@ soap_new_set_ns1__getFacilityUserByFacilityUserId(struct soap *soap,
                                                   std::string *facilityUserId,
                                                   char *__item1) {
   ns1__getFacilityUserByFacilityUserId *_p =
-      soap_instantiate_ns1__getFacilityUserByFacilityUserId(soap, -1, NULL,
-                                                            NULL, NULL);
+      soap_instantiate_ns1__getFacilityUserByFacilityUserId(soap, -1, nullptr,
+                                                            nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getFacilityUserByFacilityUserId::sessionId = sessionId;
@@ -19113,7 +19243,7 @@ inline ns1__getFacilityCyclesWithDataForInstrumentResponse *
 soap_new_ns1__getFacilityCyclesWithDataForInstrumentResponse(struct soap *soap,
                                                              int n = -1) {
   return soap_instantiate_ns1__getFacilityCyclesWithDataForInstrumentResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__getFacilityCyclesWithDataForInstrumentResponse *
@@ -19121,7 +19251,7 @@ soap_new_req_ns1__getFacilityCyclesWithDataForInstrumentResponse(
     struct soap *soap) {
   ns1__getFacilityCyclesWithDataForInstrumentResponse *_p =
       soap_instantiate_ns1__getFacilityCyclesWithDataForInstrumentResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -19134,7 +19264,7 @@ soap_new_set_ns1__getFacilityCyclesWithDataForInstrumentResponse(
     char *__item1) {
   ns1__getFacilityCyclesWithDataForInstrumentResponse *_p =
       soap_instantiate_ns1__getFacilityCyclesWithDataForInstrumentResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getFacilityCyclesWithDataForInstrumentResponse::return_ = return_;
@@ -19198,14 +19328,14 @@ inline ns1__getFacilityCyclesWithDataForInstrument *
 soap_new_ns1__getFacilityCyclesWithDataForInstrument(struct soap *soap,
                                                      int n = -1) {
   return soap_instantiate_ns1__getFacilityCyclesWithDataForInstrument(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__getFacilityCyclesWithDataForInstrument *
 soap_new_req_ns1__getFacilityCyclesWithDataForInstrument(struct soap *soap) {
   ns1__getFacilityCyclesWithDataForInstrument *_p =
       soap_instantiate_ns1__getFacilityCyclesWithDataForInstrument(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -19218,7 +19348,7 @@ soap_new_set_ns1__getFacilityCyclesWithDataForInstrument(
     char *__item1) {
   ns1__getFacilityCyclesWithDataForInstrument *_p =
       soap_instantiate_ns1__getFacilityCyclesWithDataForInstrument(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getFacilityCyclesWithDataForInstrument::sessionId = sessionId;
@@ -19280,15 +19410,15 @@ soap_instantiate_ns1__addSampleParameterResponse(struct soap *, int,
 
 inline ns1__addSampleParameterResponse *
 soap_new_ns1__addSampleParameterResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__addSampleParameterResponse(soap, n, NULL, NULL,
-                                                          NULL);
+  return soap_instantiate_ns1__addSampleParameterResponse(soap, n, nullptr,
+                                                          nullptr, nullptr);
 }
 
 inline ns1__addSampleParameterResponse *
 soap_new_req_ns1__addSampleParameterResponse(struct soap *soap) {
   ns1__addSampleParameterResponse *_p =
-      soap_instantiate_ns1__addSampleParameterResponse(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate_ns1__addSampleParameterResponse(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -19300,8 +19430,8 @@ soap_new_set_ns1__addSampleParameterResponse(struct soap *soap,
                                              ns1__sampleParameter *return_,
                                              char *__item1) {
   ns1__addSampleParameterResponse *_p =
-      soap_instantiate_ns1__addSampleParameterResponse(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate_ns1__addSampleParameterResponse(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__addSampleParameterResponse::return_ = return_;
@@ -19357,13 +19487,14 @@ soap_instantiate_ns1__addSampleParameter(struct soap *, int, const char *,
 
 inline ns1__addSampleParameter *
 soap_new_ns1__addSampleParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__addSampleParameter(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__addSampleParameter(soap, n, nullptr, nullptr,
+                                                  nullptr);
 }
 
 inline ns1__addSampleParameter *
 soap_new_req_ns1__addSampleParameter(struct soap *soap) {
-  ns1__addSampleParameter *_p =
-      soap_instantiate_ns1__addSampleParameter(soap, -1, NULL, NULL, NULL);
+  ns1__addSampleParameter *_p = soap_instantiate_ns1__addSampleParameter(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -19374,8 +19505,8 @@ inline ns1__addSampleParameter *
 soap_new_set_ns1__addSampleParameter(struct soap *soap, std::string *sessionId,
                                      ns1__sampleParameter *sampleParameter,
                                      LONG64 *investigationId, char *__item1) {
-  ns1__addSampleParameter *_p =
-      soap_instantiate_ns1__addSampleParameter(soap, -1, NULL, NULL, NULL);
+  ns1__addSampleParameter *_p = soap_instantiate_ns1__addSampleParameter(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__addSampleParameter::sessionId = sessionId;
@@ -19434,13 +19565,14 @@ soap_instantiate_ns1__modifyDataSetResponse(struct soap *, int, const char *,
 
 inline ns1__modifyDataSetResponse *
 soap_new_ns1__modifyDataSetResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__modifyDataSetResponse(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__modifyDataSetResponse(soap, n, nullptr, nullptr,
+                                                     nullptr);
 }
 
 inline ns1__modifyDataSetResponse *
 soap_new_req_ns1__modifyDataSetResponse(struct soap *soap) {
-  ns1__modifyDataSetResponse *_p =
-      soap_instantiate_ns1__modifyDataSetResponse(soap, -1, NULL, NULL, NULL);
+  ns1__modifyDataSetResponse *_p = soap_instantiate_ns1__modifyDataSetResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -19449,8 +19581,8 @@ soap_new_req_ns1__modifyDataSetResponse(struct soap *soap) {
 
 inline ns1__modifyDataSetResponse *
 soap_new_set_ns1__modifyDataSetResponse(struct soap *soap, char *__item1) {
-  ns1__modifyDataSetResponse *_p =
-      soap_instantiate_ns1__modifyDataSetResponse(soap, -1, NULL, NULL, NULL);
+  ns1__modifyDataSetResponse *_p = soap_instantiate_ns1__modifyDataSetResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -19506,12 +19638,13 @@ soap_instantiate_ns1__modifyDataSet(struct soap *, int, const char *,
 
 inline ns1__modifyDataSet *soap_new_ns1__modifyDataSet(struct soap *soap,
                                                        int n = -1) {
-  return soap_instantiate_ns1__modifyDataSet(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__modifyDataSet(soap, n, nullptr, nullptr,
+                                             nullptr);
 }
 
 inline ns1__modifyDataSet *soap_new_req_ns1__modifyDataSet(struct soap *soap) {
   ns1__modifyDataSet *_p =
-      soap_instantiate_ns1__modifyDataSet(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__modifyDataSet(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -19522,7 +19655,7 @@ inline ns1__modifyDataSet *
 soap_new_set_ns1__modifyDataSet(struct soap *soap, std::string *sessionId,
                                 ns1__dataset *dataSet, char *__item1) {
   ns1__modifyDataSet *_p =
-      soap_instantiate_ns1__modifyDataSet(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__modifyDataSet(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__modifyDataSet::sessionId = sessionId;
@@ -19586,7 +19719,7 @@ inline ns1__searchDatasetByParameterComparisonResponse *
 soap_new_ns1__searchDatasetByParameterComparisonResponse(struct soap *soap,
                                                          int n = -1) {
   return soap_instantiate_ns1__searchDatasetByParameterComparisonResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatasetByParameterComparisonResponse *
@@ -19594,7 +19727,7 @@ soap_new_req_ns1__searchDatasetByParameterComparisonResponse(
     struct soap *soap) {
   ns1__searchDatasetByParameterComparisonResponse *_p =
       soap_instantiate_ns1__searchDatasetByParameterComparisonResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -19606,7 +19739,7 @@ soap_new_set_ns1__searchDatasetByParameterComparisonResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchDatasetByParameterComparisonResponse *_p =
       soap_instantiate_ns1__searchDatasetByParameterComparisonResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatasetByParameterComparisonResponse::return_ = return_;
@@ -19667,16 +19800,16 @@ soap_instantiate_ns1__parameterComparisonCondition(struct soap *, int,
 
 inline ns1__parameterComparisonCondition *
 soap_new_ns1__parameterComparisonCondition(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__parameterComparisonCondition(soap, n, NULL, NULL,
-                                                            NULL);
+  return soap_instantiate_ns1__parameterComparisonCondition(soap, n, nullptr,
+                                                            nullptr, nullptr);
 }
 
 inline ns1__parameterComparisonCondition *
 soap_new_req_ns1__parameterComparisonCondition(struct soap *soap, bool negate2,
                                                bool sensitive2) {
   ns1__parameterComparisonCondition *_p =
-      soap_instantiate_ns1__parameterComparisonCondition(soap, -1, NULL, NULL,
-                                                         NULL);
+      soap_instantiate_ns1__parameterComparisonCondition(soap, -1, nullptr,
+                                                         nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__condition::negate = negate2;
@@ -19691,8 +19824,8 @@ soap_new_set_ns1__parameterComparisonCondition(
     ns1__parameterSearch *parameterSearch, xsd__anyType *value,
     xsd__anyType *valueRight, bool negate2, bool sensitive2, char *__item3) {
   ns1__parameterComparisonCondition *_p =
-      soap_instantiate_ns1__parameterComparisonCondition(soap, -1, NULL, NULL,
-                                                         NULL);
+      soap_instantiate_ns1__parameterComparisonCondition(soap, -1, nullptr,
+                                                         nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__parameterComparisonCondition::comparator = comparator;
@@ -19760,15 +19893,15 @@ soap_instantiate_ns1__searchDatasetByParameterComparison(struct soap *, int,
 inline ns1__searchDatasetByParameterComparison *
 soap_new_ns1__searchDatasetByParameterComparison(struct soap *soap,
                                                  int n = -1) {
-  return soap_instantiate_ns1__searchDatasetByParameterComparison(soap, n, NULL,
-                                                                  NULL, NULL);
+  return soap_instantiate_ns1__searchDatasetByParameterComparison(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatasetByParameterComparison *
 soap_new_req_ns1__searchDatasetByParameterComparison(struct soap *soap) {
   ns1__searchDatasetByParameterComparison *_p =
-      soap_instantiate_ns1__searchDatasetByParameterComparison(soap, -1, NULL,
-                                                               NULL, NULL);
+      soap_instantiate_ns1__searchDatasetByParameterComparison(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -19781,8 +19914,8 @@ soap_new_set_ns1__searchDatasetByParameterComparison(
     std::vector<ns1__parameterComparisonCondition *> &comparison,
     char *__item1) {
   ns1__searchDatasetByParameterComparison *_p =
-      soap_instantiate_ns1__searchDatasetByParameterComparison(soap, -1, NULL,
-                                                               NULL, NULL);
+      soap_instantiate_ns1__searchDatasetByParameterComparison(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatasetByParameterComparison::sessionId = sessionId;
@@ -19845,15 +19978,15 @@ soap_instantiate_ns1__searchSampleByRestrictionResponse(struct soap *, int,
 
 inline ns1__searchSampleByRestrictionResponse *
 soap_new_ns1__searchSampleByRestrictionResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchSampleByRestrictionResponse(soap, n, NULL,
-                                                                 NULL, NULL);
+  return soap_instantiate_ns1__searchSampleByRestrictionResponse(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchSampleByRestrictionResponse *
 soap_new_req_ns1__searchSampleByRestrictionResponse(struct soap *soap) {
   ns1__searchSampleByRestrictionResponse *_p =
-      soap_instantiate_ns1__searchSampleByRestrictionResponse(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate_ns1__searchSampleByRestrictionResponse(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -19864,8 +19997,8 @@ inline ns1__searchSampleByRestrictionResponse *
 soap_new_set_ns1__searchSampleByRestrictionResponse(
     struct soap *soap, std::vector<ns1__sample *> &return_, char *__item1) {
   ns1__searchSampleByRestrictionResponse *_p =
-      soap_instantiate_ns1__searchSampleByRestrictionResponse(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate_ns1__searchSampleByRestrictionResponse(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchSampleByRestrictionResponse::return_ = return_;
@@ -19927,15 +20060,15 @@ soap_instantiate_ns1__searchSampleByRestriction(struct soap *, int,
 
 inline ns1__searchSampleByRestriction *
 soap_new_ns1__searchSampleByRestriction(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchSampleByRestriction(soap, n, NULL, NULL,
-                                                         NULL);
+  return soap_instantiate_ns1__searchSampleByRestriction(soap, n, nullptr,
+                                                         nullptr, nullptr);
 }
 
 inline ns1__searchSampleByRestriction *
 soap_new_req_ns1__searchSampleByRestriction(struct soap *soap) {
   ns1__searchSampleByRestriction *_p =
-      soap_instantiate_ns1__searchSampleByRestriction(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__searchSampleByRestriction(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -19947,8 +20080,8 @@ soap_new_set_ns1__searchSampleByRestriction(
     struct soap *soap, std::string *sessionId,
     ns1__restrictionCondition *restriction, char *__item1) {
   ns1__searchSampleByRestriction *_p =
-      soap_instantiate_ns1__searchSampleByRestriction(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__searchSampleByRestriction(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchSampleByRestriction::sessionId = sessionId;
@@ -20011,15 +20144,15 @@ soap_instantiate_ns1__downloadDatafilesResponse(struct soap *, int,
 
 inline ns1__downloadDatafilesResponse *
 soap_new_ns1__downloadDatafilesResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__downloadDatafilesResponse(soap, n, NULL, NULL,
-                                                         NULL);
+  return soap_instantiate_ns1__downloadDatafilesResponse(soap, n, nullptr,
+                                                         nullptr, nullptr);
 }
 
 inline ns1__downloadDatafilesResponse *
 soap_new_req_ns1__downloadDatafilesResponse(struct soap *soap) {
   ns1__downloadDatafilesResponse *_p =
-      soap_instantiate_ns1__downloadDatafilesResponse(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__downloadDatafilesResponse(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -20030,8 +20163,8 @@ inline ns1__downloadDatafilesResponse *
 soap_new_set_ns1__downloadDatafilesResponse(struct soap *soap, std::string *URL,
                                             char *__item1) {
   ns1__downloadDatafilesResponse *_p =
-      soap_instantiate_ns1__downloadDatafilesResponse(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__downloadDatafilesResponse(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__downloadDatafilesResponse::URL = URL;
@@ -20088,13 +20221,14 @@ soap_instantiate_ns1__downloadDatafiles(struct soap *, int, const char *,
 
 inline ns1__downloadDatafiles *
 soap_new_ns1__downloadDatafiles(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__downloadDatafiles(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__downloadDatafiles(soap, n, nullptr, nullptr,
+                                                 nullptr);
 }
 
 inline ns1__downloadDatafiles *
 soap_new_req_ns1__downloadDatafiles(struct soap *soap) {
-  ns1__downloadDatafiles *_p =
-      soap_instantiate_ns1__downloadDatafiles(soap, -1, NULL, NULL, NULL);
+  ns1__downloadDatafiles *_p = soap_instantiate_ns1__downloadDatafiles(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -20105,8 +20239,8 @@ inline ns1__downloadDatafiles *
 soap_new_set_ns1__downloadDatafiles(struct soap *soap, std::string *sessionId,
                                     std::vector<LONG64> &datafileIds,
                                     char *__item1) {
-  ns1__downloadDatafiles *_p =
-      soap_instantiate_ns1__downloadDatafiles(soap, -1, NULL, NULL, NULL);
+  ns1__downloadDatafiles *_p = soap_instantiate_ns1__downloadDatafiles(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__downloadDatafiles::sessionId = sessionId;
@@ -20174,7 +20308,7 @@ inline ns1__searchInvestigationByParameterConditionResponse *
 soap_new_ns1__searchInvestigationByParameterConditionResponse(struct soap *soap,
                                                               int n = -1) {
   return soap_instantiate_ns1__searchInvestigationByParameterConditionResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchInvestigationByParameterConditionResponse *
@@ -20182,7 +20316,7 @@ soap_new_req_ns1__searchInvestigationByParameterConditionResponse(
     struct soap *soap) {
   ns1__searchInvestigationByParameterConditionResponse *_p =
       soap_instantiate_ns1__searchInvestigationByParameterConditionResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -20194,7 +20328,7 @@ soap_new_set_ns1__searchInvestigationByParameterConditionResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchInvestigationByParameterConditionResponse *_p =
       soap_instantiate_ns1__searchInvestigationByParameterConditionResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchInvestigationByParameterConditionResponse::return_ = return_;
@@ -20259,14 +20393,14 @@ inline ns1__searchInvestigationByParameterCondition *
 soap_new_ns1__searchInvestigationByParameterCondition(struct soap *soap,
                                                       int n = -1) {
   return soap_instantiate_ns1__searchInvestigationByParameterCondition(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchInvestigationByParameterCondition *
 soap_new_req_ns1__searchInvestigationByParameterCondition(struct soap *soap) {
   ns1__searchInvestigationByParameterCondition *_p =
       soap_instantiate_ns1__searchInvestigationByParameterCondition(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -20279,7 +20413,7 @@ soap_new_set_ns1__searchInvestigationByParameterCondition(
     ns1__parameterCondition *logicalCondition, char *__item1) {
   ns1__searchInvestigationByParameterCondition *_p =
       soap_instantiate_ns1__searchInvestigationByParameterCondition(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchInvestigationByParameterCondition::sessionId = sessionId;
@@ -20343,15 +20477,15 @@ soap_instantiate_ns1__searchDatafileByParameterResponse(struct soap *, int,
 
 inline ns1__searchDatafileByParameterResponse *
 soap_new_ns1__searchDatafileByParameterResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchDatafileByParameterResponse(soap, n, NULL,
-                                                                 NULL, NULL);
+  return soap_instantiate_ns1__searchDatafileByParameterResponse(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatafileByParameterResponse *
 soap_new_req_ns1__searchDatafileByParameterResponse(struct soap *soap) {
   ns1__searchDatafileByParameterResponse *_p =
-      soap_instantiate_ns1__searchDatafileByParameterResponse(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate_ns1__searchDatafileByParameterResponse(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -20362,8 +20496,8 @@ inline ns1__searchDatafileByParameterResponse *
 soap_new_set_ns1__searchDatafileByParameterResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchDatafileByParameterResponse *_p =
-      soap_instantiate_ns1__searchDatafileByParameterResponse(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate_ns1__searchDatafileByParameterResponse(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatafileByParameterResponse::return_ = return_;
@@ -20420,14 +20554,15 @@ soap_instantiate_ns1__parameterSearch(struct soap *, int, const char *,
 
 inline ns1__parameterSearch *soap_new_ns1__parameterSearch(struct soap *soap,
                                                            int n = -1) {
-  return soap_instantiate_ns1__parameterSearch(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__parameterSearch(soap, n, nullptr, nullptr,
+                                               nullptr);
 }
 
 inline ns1__parameterSearch *
 soap_new_req_ns1__parameterSearch(struct soap *soap, bool negate2,
                                   bool sensitive2) {
-  ns1__parameterSearch *_p =
-      soap_instantiate_ns1__parameterSearch(soap, -1, NULL, NULL, NULL);
+  ns1__parameterSearch *_p = soap_instantiate_ns1__parameterSearch(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__condition::negate = negate2;
@@ -20440,8 +20575,8 @@ inline ns1__parameterSearch *
 soap_new_set_ns1__parameterSearch(struct soap *soap, ns1__parameter *param,
                                   enum ns1__parameterType *type, bool negate2,
                                   bool sensitive2, char *__item3) {
-  ns1__parameterSearch *_p =
-      soap_instantiate_ns1__parameterSearch(soap, -1, NULL, NULL, NULL);
+  ns1__parameterSearch *_p = soap_instantiate_ns1__parameterSearch(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__parameterSearch::param = param;
@@ -20505,15 +20640,15 @@ soap_instantiate_ns1__searchDatafileByParameter(struct soap *, int,
 
 inline ns1__searchDatafileByParameter *
 soap_new_ns1__searchDatafileByParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchDatafileByParameter(soap, n, NULL, NULL,
-                                                         NULL);
+  return soap_instantiate_ns1__searchDatafileByParameter(soap, n, nullptr,
+                                                         nullptr, nullptr);
 }
 
 inline ns1__searchDatafileByParameter *
 soap_new_req_ns1__searchDatafileByParameter(struct soap *soap) {
   ns1__searchDatafileByParameter *_p =
-      soap_instantiate_ns1__searchDatafileByParameter(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__searchDatafileByParameter(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -20525,8 +20660,8 @@ soap_new_set_ns1__searchDatafileByParameter(
     struct soap *soap, std::string *sessionId,
     std::vector<ns1__parameterSearch *> &parameters, char *__item1) {
   ns1__searchDatafileByParameter *_p =
-      soap_instantiate_ns1__searchDatafileByParameter(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__searchDatafileByParameter(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatafileByParameter::sessionId = sessionId;
@@ -20583,12 +20718,12 @@ soap_instantiate_ns1__userDetails(struct soap *, int, const char *,
 
 inline ns1__userDetails *soap_new_ns1__userDetails(struct soap *soap,
                                                    int n = -1) {
-  return soap_instantiate_ns1__userDetails(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__userDetails(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__userDetails *soap_new_req_ns1__userDetails(struct soap *soap) {
   ns1__userDetails *_p =
-      soap_instantiate_ns1__userDetails(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__userDetails(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -20601,7 +20736,7 @@ inline ns1__userDetails *soap_new_set_ns1__userDetails(
     std::string *initial, std::string *institution, std::string *lastName,
     std::string *title, char *__item1) {
   ns1__userDetails *_p =
-      soap_instantiate_ns1__userDetails(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__userDetails(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__userDetails::credential = credential;
@@ -20674,7 +20809,7 @@ inline ns1__searchDatafileByRestrictionComparisonResponse *
 soap_new_ns1__searchDatafileByRestrictionComparisonResponse(struct soap *soap,
                                                             int n = -1) {
   return soap_instantiate_ns1__searchDatafileByRestrictionComparisonResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatafileByRestrictionComparisonResponse *
@@ -20682,7 +20817,7 @@ soap_new_req_ns1__searchDatafileByRestrictionComparisonResponse(
     struct soap *soap) {
   ns1__searchDatafileByRestrictionComparisonResponse *_p =
       soap_instantiate_ns1__searchDatafileByRestrictionComparisonResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -20694,7 +20829,7 @@ soap_new_set_ns1__searchDatafileByRestrictionComparisonResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchDatafileByRestrictionComparisonResponse *_p =
       soap_instantiate_ns1__searchDatafileByRestrictionComparisonResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatafileByRestrictionComparisonResponse::return_ = return_;
@@ -20758,14 +20893,14 @@ inline ns1__searchDatafileByRestrictionComparison *
 soap_new_ns1__searchDatafileByRestrictionComparison(struct soap *soap,
                                                     int n = -1) {
   return soap_instantiate_ns1__searchDatafileByRestrictionComparison(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatafileByRestrictionComparison *
 soap_new_req_ns1__searchDatafileByRestrictionComparison(struct soap *soap) {
   ns1__searchDatafileByRestrictionComparison *_p =
       soap_instantiate_ns1__searchDatafileByRestrictionComparison(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -20779,7 +20914,7 @@ soap_new_set_ns1__searchDatafileByRestrictionComparison(
     char *__item1) {
   ns1__searchDatafileByRestrictionComparison *_p =
       soap_instantiate_ns1__searchDatafileByRestrictionComparison(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatafileByRestrictionComparison::sessionId = sessionId;
@@ -20840,14 +20975,15 @@ soap_instantiate_ns1__getAllKeywordsResponse(struct soap *, int, const char *,
 
 inline ns1__getAllKeywordsResponse *
 soap_new_ns1__getAllKeywordsResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getAllKeywordsResponse(soap, n, NULL, NULL,
-                                                      NULL);
+  return soap_instantiate_ns1__getAllKeywordsResponse(soap, n, nullptr, nullptr,
+                                                      nullptr);
 }
 
 inline ns1__getAllKeywordsResponse *
 soap_new_req_ns1__getAllKeywordsResponse(struct soap *soap) {
   ns1__getAllKeywordsResponse *_p =
-      soap_instantiate_ns1__getAllKeywordsResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__getAllKeywordsResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -20857,7 +20993,8 @@ soap_new_req_ns1__getAllKeywordsResponse(struct soap *soap) {
 inline ns1__getAllKeywordsResponse *soap_new_set_ns1__getAllKeywordsResponse(
     struct soap *soap, std::vector<std::string> &return_, char *__item1) {
   ns1__getAllKeywordsResponse *_p =
-      soap_instantiate_ns1__getAllKeywordsResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__getAllKeywordsResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getAllKeywordsResponse::return_ = return_;
@@ -20914,13 +21051,14 @@ soap_instantiate_ns1__getAllKeywords(struct soap *, int, const char *,
 
 inline ns1__getAllKeywords *soap_new_ns1__getAllKeywords(struct soap *soap,
                                                          int n = -1) {
-  return soap_instantiate_ns1__getAllKeywords(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__getAllKeywords(soap, n, nullptr, nullptr,
+                                              nullptr);
 }
 
 inline ns1__getAllKeywords *
 soap_new_req_ns1__getAllKeywords(struct soap *soap) {
   ns1__getAllKeywords *_p =
-      soap_instantiate_ns1__getAllKeywords(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__getAllKeywords(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -20931,7 +21069,7 @@ inline ns1__getAllKeywords *
 soap_new_set_ns1__getAllKeywords(struct soap *soap, std::string *sessionId,
                                  enum ns1__keywordType *type, char *__item1) {
   ns1__getAllKeywords *_p =
-      soap_instantiate_ns1__getAllKeywords(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__getAllKeywords(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getAllKeywords::sessionId = sessionId;
@@ -20993,15 +21131,15 @@ soap_instantiate_ns1__removePublicationResponse(struct soap *, int,
 
 inline ns1__removePublicationResponse *
 soap_new_ns1__removePublicationResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__removePublicationResponse(soap, n, NULL, NULL,
-                                                         NULL);
+  return soap_instantiate_ns1__removePublicationResponse(soap, n, nullptr,
+                                                         nullptr, nullptr);
 }
 
 inline ns1__removePublicationResponse *
 soap_new_req_ns1__removePublicationResponse(struct soap *soap) {
   ns1__removePublicationResponse *_p =
-      soap_instantiate_ns1__removePublicationResponse(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__removePublicationResponse(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -21011,8 +21149,8 @@ soap_new_req_ns1__removePublicationResponse(struct soap *soap) {
 inline ns1__removePublicationResponse *
 soap_new_set_ns1__removePublicationResponse(struct soap *soap, char *__item1) {
   ns1__removePublicationResponse *_p =
-      soap_instantiate_ns1__removePublicationResponse(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__removePublicationResponse(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -21068,13 +21206,14 @@ soap_instantiate_ns1__removePublication(struct soap *, int, const char *,
 
 inline ns1__removePublication *
 soap_new_ns1__removePublication(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__removePublication(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__removePublication(soap, n, nullptr, nullptr,
+                                                 nullptr);
 }
 
 inline ns1__removePublication *
 soap_new_req_ns1__removePublication(struct soap *soap) {
-  ns1__removePublication *_p =
-      soap_instantiate_ns1__removePublication(soap, -1, NULL, NULL, NULL);
+  ns1__removePublication *_p = soap_instantiate_ns1__removePublication(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -21084,8 +21223,8 @@ soap_new_req_ns1__removePublication(struct soap *soap) {
 inline ns1__removePublication *
 soap_new_set_ns1__removePublication(struct soap *soap, std::string *sessionId,
                                     LONG64 *publicationId, char *__item1) {
-  ns1__removePublication *_p =
-      soap_instantiate_ns1__removePublication(soap, -1, NULL, NULL, NULL);
+  ns1__removePublication *_p = soap_instantiate_ns1__removePublication(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__removePublication::sessionId = sessionId;
@@ -21145,14 +21284,15 @@ soap_instantiate_ns1__createDataSetsResponse(struct soap *, int, const char *,
 
 inline ns1__createDataSetsResponse *
 soap_new_ns1__createDataSetsResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__createDataSetsResponse(soap, n, NULL, NULL,
-                                                      NULL);
+  return soap_instantiate_ns1__createDataSetsResponse(soap, n, nullptr, nullptr,
+                                                      nullptr);
 }
 
 inline ns1__createDataSetsResponse *
 soap_new_req_ns1__createDataSetsResponse(struct soap *soap) {
   ns1__createDataSetsResponse *_p =
-      soap_instantiate_ns1__createDataSetsResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__createDataSetsResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -21162,7 +21302,8 @@ soap_new_req_ns1__createDataSetsResponse(struct soap *soap) {
 inline ns1__createDataSetsResponse *soap_new_set_ns1__createDataSetsResponse(
     struct soap *soap, std::vector<ns1__dataset *> &return_, char *__item1) {
   ns1__createDataSetsResponse *_p =
-      soap_instantiate_ns1__createDataSetsResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__createDataSetsResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__createDataSetsResponse::return_ = return_;
@@ -21219,13 +21360,14 @@ soap_instantiate_ns1__datasetParameterPK(struct soap *, int, const char *,
 
 inline ns1__datasetParameterPK *
 soap_new_ns1__datasetParameterPK(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__datasetParameterPK(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__datasetParameterPK(soap, n, nullptr, nullptr,
+                                                  nullptr);
 }
 
 inline ns1__datasetParameterPK *
 soap_new_req_ns1__datasetParameterPK(struct soap *soap) {
-  ns1__datasetParameterPK *_p =
-      soap_instantiate_ns1__datasetParameterPK(soap, -1, NULL, NULL, NULL);
+  ns1__datasetParameterPK *_p = soap_instantiate_ns1__datasetParameterPK(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -21236,8 +21378,8 @@ inline ns1__datasetParameterPK *
 soap_new_set_ns1__datasetParameterPK(struct soap *soap, LONG64 *datasetId,
                                      std::string *name, std::string *units,
                                      char *__item2) {
-  ns1__datasetParameterPK *_p =
-      soap_instantiate_ns1__datasetParameterPK(soap, -1, NULL, NULL, NULL);
+  ns1__datasetParameterPK *_p = soap_instantiate_ns1__datasetParameterPK(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__datasetParameterPK::datasetId = datasetId;
@@ -21295,14 +21437,15 @@ soap_instantiate_ns1__datasetParameter(struct soap *, int, const char *,
 
 inline ns1__datasetParameter *soap_new_ns1__datasetParameter(struct soap *soap,
                                                              int n = -1) {
-  return soap_instantiate_ns1__datasetParameter(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__datasetParameter(soap, n, nullptr, nullptr,
+                                                nullptr);
 }
 
 inline ns1__datasetParameter *
 soap_new_req_ns1__datasetParameter(struct soap *soap,
                                    bool facilityAcquiredData1, bool selected1) {
-  ns1__datasetParameter *_p =
-      soap_instantiate_ns1__datasetParameter(soap, -1, NULL, NULL, NULL);
+  ns1__datasetParameter *_p = soap_instantiate_ns1__datasetParameter(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__entityBaseBean::facilityAcquiredData = facilityAcquiredData1;
@@ -21319,8 +21462,8 @@ inline ns1__datasetParameter *soap_new_set_ns1__datasetParameter(
     enum ns1__parameterValueType *valueType, bool facilityAcquiredData1,
     ns1__icatRole *icatRole1, bool selected1, std::string *uniqueId1,
     char *__item2) {
-  ns1__datasetParameter *_p =
-      soap_instantiate_ns1__datasetParameter(soap, -1, NULL, NULL, NULL);
+  ns1__datasetParameter *_p = soap_instantiate_ns1__datasetParameter(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__datasetParameter::datasetParameterPK = datasetParameterPK;
@@ -21386,13 +21529,14 @@ soap_instantiate_ns1__dataset(struct soap *, int, const char *, const char *,
                               size_t *);
 
 inline ns1__dataset *soap_new_ns1__dataset(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__dataset(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__dataset(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__dataset *soap_new_req_ns1__dataset(struct soap *soap,
                                                bool facilityAcquiredData1,
                                                bool selected1) {
-  ns1__dataset *_p = soap_instantiate_ns1__dataset(soap, -1, NULL, NULL, NULL);
+  ns1__dataset *_p =
+      soap_instantiate_ns1__dataset(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__entityBaseBean::facilityAcquiredData = facilityAcquiredData1;
@@ -21409,7 +21553,8 @@ inline ns1__dataset *soap_new_set_ns1__dataset(
     std::string *location, std::string *name, LONG64 *sampleId,
     bool facilityAcquiredData1, ns1__icatRole *icatRole1, bool selected1,
     std::string *uniqueId1, char *__item2) {
-  ns1__dataset *_p = soap_instantiate_ns1__dataset(soap, -1, NULL, NULL, NULL);
+  ns1__dataset *_p =
+      soap_instantiate_ns1__dataset(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__dataset::datafileCollection = datafileCollection;
@@ -21477,13 +21622,14 @@ soap_instantiate_ns1__createDataSets(struct soap *, int, const char *,
 
 inline ns1__createDataSets *soap_new_ns1__createDataSets(struct soap *soap,
                                                          int n = -1) {
-  return soap_instantiate_ns1__createDataSets(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__createDataSets(soap, n, nullptr, nullptr,
+                                              nullptr);
 }
 
 inline ns1__createDataSets *
 soap_new_req_ns1__createDataSets(struct soap *soap) {
   ns1__createDataSets *_p =
-      soap_instantiate_ns1__createDataSets(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__createDataSets(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -21495,7 +21641,7 @@ soap_new_set_ns1__createDataSets(struct soap *soap, std::string *sessionId,
                                  std::vector<ns1__dataset *> &dataSets,
                                  LONG64 *investigationId, char *__item1) {
   ns1__createDataSets *_p =
-      soap_instantiate_ns1__createDataSets(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__createDataSets(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__createDataSets::sessionId = sessionId;
@@ -21557,15 +21703,15 @@ soap_instantiate_ns1__deleteInvestigationResponse(struct soap *, int,
 
 inline ns1__deleteInvestigationResponse *
 soap_new_ns1__deleteInvestigationResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__deleteInvestigationResponse(soap, n, NULL, NULL,
-                                                           NULL);
+  return soap_instantiate_ns1__deleteInvestigationResponse(soap, n, nullptr,
+                                                           nullptr, nullptr);
 }
 
 inline ns1__deleteInvestigationResponse *
 soap_new_req_ns1__deleteInvestigationResponse(struct soap *soap) {
   ns1__deleteInvestigationResponse *_p =
-      soap_instantiate_ns1__deleteInvestigationResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__deleteInvestigationResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -21576,8 +21722,8 @@ inline ns1__deleteInvestigationResponse *
 soap_new_set_ns1__deleteInvestigationResponse(struct soap *soap,
                                               char *__item1) {
   ns1__deleteInvestigationResponse *_p =
-      soap_instantiate_ns1__deleteInvestigationResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__deleteInvestigationResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -21633,13 +21779,14 @@ soap_instantiate_ns1__deleteInvestigation(struct soap *, int, const char *,
 
 inline ns1__deleteInvestigation *
 soap_new_ns1__deleteInvestigation(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__deleteInvestigation(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__deleteInvestigation(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline ns1__deleteInvestigation *
 soap_new_req_ns1__deleteInvestigation(struct soap *soap) {
-  ns1__deleteInvestigation *_p =
-      soap_instantiate_ns1__deleteInvestigation(soap, -1, NULL, NULL, NULL);
+  ns1__deleteInvestigation *_p = soap_instantiate_ns1__deleteInvestigation(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -21649,8 +21796,8 @@ soap_new_req_ns1__deleteInvestigation(struct soap *soap) {
 inline ns1__deleteInvestigation *
 soap_new_set_ns1__deleteInvestigation(struct soap *soap, std::string *sessionId,
                                       LONG64 *investigationId, char *__item1) {
-  ns1__deleteInvestigation *_p =
-      soap_instantiate_ns1__deleteInvestigation(soap, -1, NULL, NULL, NULL);
+  ns1__deleteInvestigation *_p = soap_instantiate_ns1__deleteInvestigation(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__deleteInvestigation::sessionId = sessionId;
@@ -21708,13 +21855,14 @@ soap_instantiate_ns1__removeKeywordResponse(struct soap *, int, const char *,
 
 inline ns1__removeKeywordResponse *
 soap_new_ns1__removeKeywordResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__removeKeywordResponse(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__removeKeywordResponse(soap, n, nullptr, nullptr,
+                                                     nullptr);
 }
 
 inline ns1__removeKeywordResponse *
 soap_new_req_ns1__removeKeywordResponse(struct soap *soap) {
-  ns1__removeKeywordResponse *_p =
-      soap_instantiate_ns1__removeKeywordResponse(soap, -1, NULL, NULL, NULL);
+  ns1__removeKeywordResponse *_p = soap_instantiate_ns1__removeKeywordResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -21723,8 +21871,8 @@ soap_new_req_ns1__removeKeywordResponse(struct soap *soap) {
 
 inline ns1__removeKeywordResponse *
 soap_new_set_ns1__removeKeywordResponse(struct soap *soap, char *__item1) {
-  ns1__removeKeywordResponse *_p =
-      soap_instantiate_ns1__removeKeywordResponse(soap, -1, NULL, NULL, NULL);
+  ns1__removeKeywordResponse *_p = soap_instantiate_ns1__removeKeywordResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -21778,12 +21926,12 @@ soap_instantiate_ns1__keywordPK(struct soap *, int, const char *, const char *,
                                 size_t *);
 
 inline ns1__keywordPK *soap_new_ns1__keywordPK(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__keywordPK(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__keywordPK(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__keywordPK *soap_new_req_ns1__keywordPK(struct soap *soap) {
   ns1__keywordPK *_p =
-      soap_instantiate_ns1__keywordPK(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__keywordPK(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -21795,7 +21943,7 @@ inline ns1__keywordPK *soap_new_set_ns1__keywordPK(struct soap *soap,
                                                    std::string *name,
                                                    char *__item2) {
   ns1__keywordPK *_p =
-      soap_instantiate_ns1__keywordPK(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__keywordPK(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__keywordPK::investigationId = investigationId;
@@ -21851,12 +21999,13 @@ soap_instantiate_ns1__removeKeyword(struct soap *, int, const char *,
 
 inline ns1__removeKeyword *soap_new_ns1__removeKeyword(struct soap *soap,
                                                        int n = -1) {
-  return soap_instantiate_ns1__removeKeyword(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__removeKeyword(soap, n, nullptr, nullptr,
+                                             nullptr);
 }
 
 inline ns1__removeKeyword *soap_new_req_ns1__removeKeyword(struct soap *soap) {
   ns1__removeKeyword *_p =
-      soap_instantiate_ns1__removeKeyword(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__removeKeyword(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -21867,7 +22016,7 @@ inline ns1__removeKeyword *
 soap_new_set_ns1__removeKeyword(struct soap *soap, std::string *sessionId,
                                 ns1__keywordPK *keywordPK, char *__item1) {
   ns1__removeKeyword *_p =
-      soap_instantiate_ns1__removeKeyword(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__removeKeyword(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__removeKeyword::sessionId = sessionId;
@@ -21929,15 +22078,15 @@ soap_instantiate_ns1__getParameterByRestrictionResponse(struct soap *, int,
 
 inline ns1__getParameterByRestrictionResponse *
 soap_new_ns1__getParameterByRestrictionResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getParameterByRestrictionResponse(soap, n, NULL,
-                                                                 NULL, NULL);
+  return soap_instantiate_ns1__getParameterByRestrictionResponse(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__getParameterByRestrictionResponse *
 soap_new_req_ns1__getParameterByRestrictionResponse(struct soap *soap) {
   ns1__getParameterByRestrictionResponse *_p =
-      soap_instantiate_ns1__getParameterByRestrictionResponse(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate_ns1__getParameterByRestrictionResponse(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -21948,8 +22097,8 @@ inline ns1__getParameterByRestrictionResponse *
 soap_new_set_ns1__getParameterByRestrictionResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__getParameterByRestrictionResponse *_p =
-      soap_instantiate_ns1__getParameterByRestrictionResponse(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate_ns1__getParameterByRestrictionResponse(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getParameterByRestrictionResponse::return_ = return_;
@@ -22011,15 +22160,15 @@ soap_instantiate_ns1__getParameterByRestriction(struct soap *, int,
 
 inline ns1__getParameterByRestriction *
 soap_new_ns1__getParameterByRestriction(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getParameterByRestriction(soap, n, NULL, NULL,
-                                                         NULL);
+  return soap_instantiate_ns1__getParameterByRestriction(soap, n, nullptr,
+                                                         nullptr, nullptr);
 }
 
 inline ns1__getParameterByRestriction *
 soap_new_req_ns1__getParameterByRestriction(struct soap *soap) {
   ns1__getParameterByRestriction *_p =
-      soap_instantiate_ns1__getParameterByRestriction(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__getParameterByRestriction(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -22031,8 +22180,8 @@ soap_new_set_ns1__getParameterByRestriction(
     struct soap *soap, std::string *sessionId,
     ns1__restrictionCondition *condition, char *__item1) {
   ns1__getParameterByRestriction *_p =
-      soap_instantiate_ns1__getParameterByRestriction(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__getParameterByRestriction(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getParameterByRestriction::sessionId = sessionId;
@@ -22094,15 +22243,15 @@ soap_instantiate_ns1__removeInvestigatorResponse(struct soap *, int,
 
 inline ns1__removeInvestigatorResponse *
 soap_new_ns1__removeInvestigatorResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__removeInvestigatorResponse(soap, n, NULL, NULL,
-                                                          NULL);
+  return soap_instantiate_ns1__removeInvestigatorResponse(soap, n, nullptr,
+                                                          nullptr, nullptr);
 }
 
 inline ns1__removeInvestigatorResponse *
 soap_new_req_ns1__removeInvestigatorResponse(struct soap *soap) {
   ns1__removeInvestigatorResponse *_p =
-      soap_instantiate_ns1__removeInvestigatorResponse(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate_ns1__removeInvestigatorResponse(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -22112,8 +22261,8 @@ soap_new_req_ns1__removeInvestigatorResponse(struct soap *soap) {
 inline ns1__removeInvestigatorResponse *
 soap_new_set_ns1__removeInvestigatorResponse(struct soap *soap, char *__item1) {
   ns1__removeInvestigatorResponse *_p =
-      soap_instantiate_ns1__removeInvestigatorResponse(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate_ns1__removeInvestigatorResponse(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -22168,13 +22317,14 @@ soap_instantiate_ns1__investigatorPK(struct soap *, int, const char *,
 
 inline ns1__investigatorPK *soap_new_ns1__investigatorPK(struct soap *soap,
                                                          int n = -1) {
-  return soap_instantiate_ns1__investigatorPK(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__investigatorPK(soap, n, nullptr, nullptr,
+                                              nullptr);
 }
 
 inline ns1__investigatorPK *
 soap_new_req_ns1__investigatorPK(struct soap *soap) {
   ns1__investigatorPK *_p =
-      soap_instantiate_ns1__investigatorPK(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__investigatorPK(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -22185,7 +22335,7 @@ inline ns1__investigatorPK *
 soap_new_set_ns1__investigatorPK(struct soap *soap, std::string *facilityUserId,
                                  LONG64 *investigationId, char *__item2) {
   ns1__investigatorPK *_p =
-      soap_instantiate_ns1__investigatorPK(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__investigatorPK(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__investigatorPK::facilityUserId = facilityUserId;
@@ -22242,13 +22392,14 @@ soap_instantiate_ns1__removeInvestigator(struct soap *, int, const char *,
 
 inline ns1__removeInvestigator *
 soap_new_ns1__removeInvestigator(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__removeInvestigator(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__removeInvestigator(soap, n, nullptr, nullptr,
+                                                  nullptr);
 }
 
 inline ns1__removeInvestigator *
 soap_new_req_ns1__removeInvestigator(struct soap *soap) {
-  ns1__removeInvestigator *_p =
-      soap_instantiate_ns1__removeInvestigator(soap, -1, NULL, NULL, NULL);
+  ns1__removeInvestigator *_p = soap_instantiate_ns1__removeInvestigator(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -22259,8 +22410,8 @@ inline ns1__removeInvestigator *
 soap_new_set_ns1__removeInvestigator(struct soap *soap, std::string *sessionId,
                                      ns1__investigatorPK *investigatorPK,
                                      char *__item1) {
-  ns1__removeInvestigator *_p =
-      soap_instantiate_ns1__removeInvestigator(soap, -1, NULL, NULL, NULL);
+  ns1__removeInvestigator *_p = soap_instantiate_ns1__removeInvestigator(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__removeInvestigator::sessionId = sessionId;
@@ -22321,15 +22472,15 @@ soap_instantiate_ns1__removeInvestigationResponse(struct soap *, int,
 
 inline ns1__removeInvestigationResponse *
 soap_new_ns1__removeInvestigationResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__removeInvestigationResponse(soap, n, NULL, NULL,
-                                                           NULL);
+  return soap_instantiate_ns1__removeInvestigationResponse(soap, n, nullptr,
+                                                           nullptr, nullptr);
 }
 
 inline ns1__removeInvestigationResponse *
 soap_new_req_ns1__removeInvestigationResponse(struct soap *soap) {
   ns1__removeInvestigationResponse *_p =
-      soap_instantiate_ns1__removeInvestigationResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__removeInvestigationResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -22340,8 +22491,8 @@ inline ns1__removeInvestigationResponse *
 soap_new_set_ns1__removeInvestigationResponse(struct soap *soap,
                                               char *__item1) {
   ns1__removeInvestigationResponse *_p =
-      soap_instantiate_ns1__removeInvestigationResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__removeInvestigationResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -22397,13 +22548,14 @@ soap_instantiate_ns1__removeInvestigation(struct soap *, int, const char *,
 
 inline ns1__removeInvestigation *
 soap_new_ns1__removeInvestigation(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__removeInvestigation(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__removeInvestigation(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline ns1__removeInvestigation *
 soap_new_req_ns1__removeInvestigation(struct soap *soap) {
-  ns1__removeInvestigation *_p =
-      soap_instantiate_ns1__removeInvestigation(soap, -1, NULL, NULL, NULL);
+  ns1__removeInvestigation *_p = soap_instantiate_ns1__removeInvestigation(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -22413,8 +22565,8 @@ soap_new_req_ns1__removeInvestigation(struct soap *soap) {
 inline ns1__removeInvestigation *
 soap_new_set_ns1__removeInvestigation(struct soap *soap, std::string *sessionId,
                                       LONG64 *investigationId, char *__item1) {
-  ns1__removeInvestigation *_p =
-      soap_instantiate_ns1__removeInvestigation(soap, -1, NULL, NULL, NULL);
+  ns1__removeInvestigation *_p = soap_instantiate_ns1__removeInvestigation(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__removeInvestigation::sessionId = sessionId;
@@ -22478,15 +22630,15 @@ soap_instantiate_ns1__getFacilityUserByFederalIdResponse(struct soap *, int,
 inline ns1__getFacilityUserByFederalIdResponse *
 soap_new_ns1__getFacilityUserByFederalIdResponse(struct soap *soap,
                                                  int n = -1) {
-  return soap_instantiate_ns1__getFacilityUserByFederalIdResponse(soap, n, NULL,
-                                                                  NULL, NULL);
+  return soap_instantiate_ns1__getFacilityUserByFederalIdResponse(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__getFacilityUserByFederalIdResponse *
 soap_new_req_ns1__getFacilityUserByFederalIdResponse(struct soap *soap) {
   ns1__getFacilityUserByFederalIdResponse *_p =
-      soap_instantiate_ns1__getFacilityUserByFederalIdResponse(soap, -1, NULL,
-                                                               NULL, NULL);
+      soap_instantiate_ns1__getFacilityUserByFederalIdResponse(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -22498,8 +22650,8 @@ soap_new_set_ns1__getFacilityUserByFederalIdResponse(struct soap *soap,
                                                      ns1__facilityUser *return_,
                                                      char *__item1) {
   ns1__getFacilityUserByFederalIdResponse *_p =
-      soap_instantiate_ns1__getFacilityUserByFederalIdResponse(soap, -1, NULL,
-                                                               NULL, NULL);
+      soap_instantiate_ns1__getFacilityUserByFederalIdResponse(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getFacilityUserByFederalIdResponse::return_ = return_;
@@ -22560,15 +22712,15 @@ soap_instantiate_ns1__getFacilityUserByFederalId(struct soap *, int,
 
 inline ns1__getFacilityUserByFederalId *
 soap_new_ns1__getFacilityUserByFederalId(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getFacilityUserByFederalId(soap, n, NULL, NULL,
-                                                          NULL);
+  return soap_instantiate_ns1__getFacilityUserByFederalId(soap, n, nullptr,
+                                                          nullptr, nullptr);
 }
 
 inline ns1__getFacilityUserByFederalId *
 soap_new_req_ns1__getFacilityUserByFederalId(struct soap *soap) {
   ns1__getFacilityUserByFederalId *_p =
-      soap_instantiate_ns1__getFacilityUserByFederalId(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate_ns1__getFacilityUserByFederalId(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -22581,8 +22733,8 @@ soap_new_set_ns1__getFacilityUserByFederalId(struct soap *soap,
                                              std::string *federalId,
                                              char *__item1) {
   ns1__getFacilityUserByFederalId *_p =
-      soap_instantiate_ns1__getFacilityUserByFederalId(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate_ns1__getFacilityUserByFederalId(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getFacilityUserByFederalId::sessionId = sessionId;
@@ -22643,14 +22795,15 @@ soap_instantiate_ns1__downloadDatasetResponse(struct soap *, int, const char *,
 
 inline ns1__downloadDatasetResponse *
 soap_new_ns1__downloadDatasetResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__downloadDatasetResponse(soap, n, NULL, NULL,
-                                                       NULL);
+  return soap_instantiate_ns1__downloadDatasetResponse(soap, n, nullptr,
+                                                       nullptr, nullptr);
 }
 
 inline ns1__downloadDatasetResponse *
 soap_new_req_ns1__downloadDatasetResponse(struct soap *soap) {
   ns1__downloadDatasetResponse *_p =
-      soap_instantiate_ns1__downloadDatasetResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__downloadDatasetResponse(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -22661,7 +22814,8 @@ inline ns1__downloadDatasetResponse *
 soap_new_set_ns1__downloadDatasetResponse(struct soap *soap, std::string *URL,
                                           char *__item1) {
   ns1__downloadDatasetResponse *_p =
-      soap_instantiate_ns1__downloadDatasetResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__downloadDatasetResponse(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__downloadDatasetResponse::URL = URL;
@@ -22718,13 +22872,14 @@ soap_instantiate_ns1__downloadDataset(struct soap *, int, const char *,
 
 inline ns1__downloadDataset *soap_new_ns1__downloadDataset(struct soap *soap,
                                                            int n = -1) {
-  return soap_instantiate_ns1__downloadDataset(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__downloadDataset(soap, n, nullptr, nullptr,
+                                               nullptr);
 }
 
 inline ns1__downloadDataset *
 soap_new_req_ns1__downloadDataset(struct soap *soap) {
-  ns1__downloadDataset *_p =
-      soap_instantiate_ns1__downloadDataset(soap, -1, NULL, NULL, NULL);
+  ns1__downloadDataset *_p = soap_instantiate_ns1__downloadDataset(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -22734,8 +22889,8 @@ soap_new_req_ns1__downloadDataset(struct soap *soap) {
 inline ns1__downloadDataset *
 soap_new_set_ns1__downloadDataset(struct soap *soap, std::string *sessionId,
                                   LONG64 *datasetId, char *__item1) {
-  ns1__downloadDataset *_p =
-      soap_instantiate_ns1__downloadDataset(soap, -1, NULL, NULL, NULL);
+  ns1__downloadDataset *_p = soap_instantiate_ns1__downloadDataset(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__downloadDataset::sessionId = sessionId;
@@ -22791,14 +22946,14 @@ soap_instantiate_ns1__instrument(struct soap *, int, const char *, const char *,
 
 inline ns1__instrument *soap_new_ns1__instrument(struct soap *soap,
                                                  int n = -1) {
-  return soap_instantiate_ns1__instrument(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__instrument(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__instrument *soap_new_req_ns1__instrument(struct soap *soap,
                                                      bool facilityAcquiredData1,
                                                      bool selected1) {
   ns1__instrument *_p =
-      soap_instantiate_ns1__instrument(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__instrument(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__entityBaseBean::facilityAcquiredData = facilityAcquiredData1;
@@ -22814,7 +22969,7 @@ soap_new_set_ns1__instrument(struct soap *soap, std::string *description,
                              ns1__icatRole *icatRole1, bool selected1,
                              std::string *uniqueId1, char *__item2) {
   ns1__instrument *_p =
-      soap_instantiate_ns1__instrument(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__instrument(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__instrument::description = description;
@@ -22880,15 +23035,15 @@ soap_instantiate_ns1__getInstrumentsWithDataResponse(struct soap *, int,
 
 inline ns1__getInstrumentsWithDataResponse *
 soap_new_ns1__getInstrumentsWithDataResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getInstrumentsWithDataResponse(soap, n, NULL,
-                                                              NULL, NULL);
+  return soap_instantiate_ns1__getInstrumentsWithDataResponse(soap, n, nullptr,
+                                                              nullptr, nullptr);
 }
 
 inline ns1__getInstrumentsWithDataResponse *
 soap_new_req_ns1__getInstrumentsWithDataResponse(struct soap *soap) {
   ns1__getInstrumentsWithDataResponse *_p =
-      soap_instantiate_ns1__getInstrumentsWithDataResponse(soap, -1, NULL, NULL,
-                                                           NULL);
+      soap_instantiate_ns1__getInstrumentsWithDataResponse(soap, -1, nullptr,
+                                                           nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -22899,8 +23054,8 @@ inline ns1__getInstrumentsWithDataResponse *
 soap_new_set_ns1__getInstrumentsWithDataResponse(
     struct soap *soap, std::vector<ns1__instrument *> &return_, char *__item1) {
   ns1__getInstrumentsWithDataResponse *_p =
-      soap_instantiate_ns1__getInstrumentsWithDataResponse(soap, -1, NULL, NULL,
-                                                           NULL);
+      soap_instantiate_ns1__getInstrumentsWithDataResponse(soap, -1, nullptr,
+                                                           nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getInstrumentsWithDataResponse::return_ = return_;
@@ -22959,14 +23114,15 @@ soap_instantiate_ns1__getInstrumentsWithData(struct soap *, int, const char *,
 
 inline ns1__getInstrumentsWithData *
 soap_new_ns1__getInstrumentsWithData(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getInstrumentsWithData(soap, n, NULL, NULL,
-                                                      NULL);
+  return soap_instantiate_ns1__getInstrumentsWithData(soap, n, nullptr, nullptr,
+                                                      nullptr);
 }
 
 inline ns1__getInstrumentsWithData *
 soap_new_req_ns1__getInstrumentsWithData(struct soap *soap) {
   ns1__getInstrumentsWithData *_p =
-      soap_instantiate_ns1__getInstrumentsWithData(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__getInstrumentsWithData(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -22976,7 +23132,8 @@ soap_new_req_ns1__getInstrumentsWithData(struct soap *soap) {
 inline ns1__getInstrumentsWithData *soap_new_set_ns1__getInstrumentsWithData(
     struct soap *soap, std::string *sessionId, char *__item1) {
   ns1__getInstrumentsWithData *_p =
-      soap_instantiate_ns1__getInstrumentsWithData(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__getInstrumentsWithData(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getInstrumentsWithData::sessionId = sessionId;
@@ -23033,13 +23190,14 @@ soap_instantiate_ns1__logoutResponse(struct soap *, int, const char *,
 
 inline ns1__logoutResponse *soap_new_ns1__logoutResponse(struct soap *soap,
                                                          int n = -1) {
-  return soap_instantiate_ns1__logoutResponse(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__logoutResponse(soap, n, nullptr, nullptr,
+                                              nullptr);
 }
 
 inline ns1__logoutResponse *soap_new_req_ns1__logoutResponse(struct soap *soap,
                                                              bool return_) {
   ns1__logoutResponse *_p =
-      soap_instantiate_ns1__logoutResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__logoutResponse(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__logoutResponse::return_ = return_;
@@ -23051,7 +23209,7 @@ inline ns1__logoutResponse *soap_new_set_ns1__logoutResponse(struct soap *soap,
                                                              bool return_,
                                                              char *__item1) {
   ns1__logoutResponse *_p =
-      soap_instantiate_ns1__logoutResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__logoutResponse(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__logoutResponse::return_ = return_;
@@ -23103,11 +23261,12 @@ soap_instantiate_ns1__logout(struct soap *, int, const char *, const char *,
                              size_t *);
 
 inline ns1__logout *soap_new_ns1__logout(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__logout(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__logout(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__logout *soap_new_req_ns1__logout(struct soap *soap) {
-  ns1__logout *_p = soap_instantiate_ns1__logout(soap, -1, NULL, NULL, NULL);
+  ns1__logout *_p =
+      soap_instantiate_ns1__logout(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -23117,7 +23276,8 @@ inline ns1__logout *soap_new_req_ns1__logout(struct soap *soap) {
 inline ns1__logout *soap_new_set_ns1__logout(struct soap *soap,
                                              std::string *sessionId,
                                              char *__item1) {
-  ns1__logout *_p = soap_instantiate_ns1__logout(soap, -1, NULL, NULL, NULL);
+  ns1__logout *_p =
+      soap_instantiate_ns1__logout(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__logout::sessionId = sessionId;
@@ -23176,15 +23336,15 @@ soap_instantiate_ns1__addDataFileParametersResponse(struct soap *, int,
 
 inline ns1__addDataFileParametersResponse *
 soap_new_ns1__addDataFileParametersResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__addDataFileParametersResponse(soap, n, NULL,
-                                                             NULL, NULL);
+  return soap_instantiate_ns1__addDataFileParametersResponse(soap, n, nullptr,
+                                                             nullptr, nullptr);
 }
 
 inline ns1__addDataFileParametersResponse *
 soap_new_req_ns1__addDataFileParametersResponse(struct soap *soap) {
   ns1__addDataFileParametersResponse *_p =
-      soap_instantiate_ns1__addDataFileParametersResponse(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate_ns1__addDataFileParametersResponse(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -23196,8 +23356,8 @@ soap_new_set_ns1__addDataFileParametersResponse(
     struct soap *soap, std::vector<ns1__datafileParameter *> &return_,
     char *__item1) {
   ns1__addDataFileParametersResponse *_p =
-      soap_instantiate_ns1__addDataFileParametersResponse(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate_ns1__addDataFileParametersResponse(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__addDataFileParametersResponse::return_ = return_;
@@ -23254,13 +23414,14 @@ soap_instantiate_ns1__addDataFileParameters(struct soap *, int, const char *,
 
 inline ns1__addDataFileParameters *
 soap_new_ns1__addDataFileParameters(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__addDataFileParameters(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__addDataFileParameters(soap, n, nullptr, nullptr,
+                                                     nullptr);
 }
 
 inline ns1__addDataFileParameters *
 soap_new_req_ns1__addDataFileParameters(struct soap *soap) {
-  ns1__addDataFileParameters *_p =
-      soap_instantiate_ns1__addDataFileParameters(soap, -1, NULL, NULL, NULL);
+  ns1__addDataFileParameters *_p = soap_instantiate_ns1__addDataFileParameters(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -23271,8 +23432,8 @@ inline ns1__addDataFileParameters *soap_new_set_ns1__addDataFileParameters(
     struct soap *soap, std::string *sessionId,
     std::vector<ns1__datafileParameter *> &dataFileParameters,
     LONG64 *datafileId, char *__item1) {
-  ns1__addDataFileParameters *_p =
-      soap_instantiate_ns1__addDataFileParameters(soap, -1, NULL, NULL, NULL);
+  ns1__addDataFileParameters *_p = soap_instantiate_ns1__addDataFileParameters(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__addDataFileParameters::sessionId = sessionId;
@@ -23331,14 +23492,15 @@ soap_instantiate_ns1__facilityCycle(struct soap *, int, const char *,
 
 inline ns1__facilityCycle *soap_new_ns1__facilityCycle(struct soap *soap,
                                                        int n = -1) {
-  return soap_instantiate_ns1__facilityCycle(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__facilityCycle(soap, n, nullptr, nullptr,
+                                             nullptr);
 }
 
 inline ns1__facilityCycle *
 soap_new_req_ns1__facilityCycle(struct soap *soap, bool facilityAcquiredData1,
                                 bool selected1) {
   ns1__facilityCycle *_p =
-      soap_instantiate_ns1__facilityCycle(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__facilityCycle(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__entityBaseBean::facilityAcquiredData = facilityAcquiredData1;
@@ -23354,7 +23516,7 @@ soap_new_set_ns1__facilityCycle(struct soap *soap, std::string *description,
                                 ns1__icatRole *icatRole1, bool selected1,
                                 std::string *uniqueId1, char *__item2) {
   ns1__facilityCycle *_p =
-      soap_instantiate_ns1__facilityCycle(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__facilityCycle(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__facilityCycle::description = description;
@@ -23421,15 +23583,15 @@ soap_instantiate_ns1__listFacilityCyclesResponse(struct soap *, int,
 
 inline ns1__listFacilityCyclesResponse *
 soap_new_ns1__listFacilityCyclesResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__listFacilityCyclesResponse(soap, n, NULL, NULL,
-                                                          NULL);
+  return soap_instantiate_ns1__listFacilityCyclesResponse(soap, n, nullptr,
+                                                          nullptr, nullptr);
 }
 
 inline ns1__listFacilityCyclesResponse *
 soap_new_req_ns1__listFacilityCyclesResponse(struct soap *soap) {
   ns1__listFacilityCyclesResponse *_p =
-      soap_instantiate_ns1__listFacilityCyclesResponse(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate_ns1__listFacilityCyclesResponse(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -23441,8 +23603,8 @@ soap_new_set_ns1__listFacilityCyclesResponse(
     struct soap *soap, std::vector<ns1__facilityCycle *> &return_,
     char *__item1) {
   ns1__listFacilityCyclesResponse *_p =
-      soap_instantiate_ns1__listFacilityCyclesResponse(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate_ns1__listFacilityCyclesResponse(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__listFacilityCyclesResponse::return_ = return_;
@@ -23498,13 +23660,14 @@ soap_instantiate_ns1__listFacilityCycles(struct soap *, int, const char *,
 
 inline ns1__listFacilityCycles *
 soap_new_ns1__listFacilityCycles(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__listFacilityCycles(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__listFacilityCycles(soap, n, nullptr, nullptr,
+                                                  nullptr);
 }
 
 inline ns1__listFacilityCycles *
 soap_new_req_ns1__listFacilityCycles(struct soap *soap) {
-  ns1__listFacilityCycles *_p =
-      soap_instantiate_ns1__listFacilityCycles(soap, -1, NULL, NULL, NULL);
+  ns1__listFacilityCycles *_p = soap_instantiate_ns1__listFacilityCycles(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -23514,8 +23677,8 @@ soap_new_req_ns1__listFacilityCycles(struct soap *soap) {
 inline ns1__listFacilityCycles *
 soap_new_set_ns1__listFacilityCycles(struct soap *soap, std::string *sessionId,
                                      char *__item1) {
-  ns1__listFacilityCycles *_p =
-      soap_instantiate_ns1__listFacilityCycles(soap, -1, NULL, NULL, NULL);
+  ns1__listFacilityCycles *_p = soap_instantiate_ns1__listFacilityCycles(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__listFacilityCycles::sessionId = sessionId;
@@ -23575,15 +23738,15 @@ soap_instantiate_ns1__removeAuthorisationResponse(struct soap *, int,
 
 inline ns1__removeAuthorisationResponse *
 soap_new_ns1__removeAuthorisationResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__removeAuthorisationResponse(soap, n, NULL, NULL,
-                                                           NULL);
+  return soap_instantiate_ns1__removeAuthorisationResponse(soap, n, nullptr,
+                                                           nullptr, nullptr);
 }
 
 inline ns1__removeAuthorisationResponse *
 soap_new_req_ns1__removeAuthorisationResponse(struct soap *soap) {
   ns1__removeAuthorisationResponse *_p =
-      soap_instantiate_ns1__removeAuthorisationResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__removeAuthorisationResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -23594,8 +23757,8 @@ inline ns1__removeAuthorisationResponse *
 soap_new_set_ns1__removeAuthorisationResponse(struct soap *soap,
                                               char *__item1) {
   ns1__removeAuthorisationResponse *_p =
-      soap_instantiate_ns1__removeAuthorisationResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__removeAuthorisationResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -23651,13 +23814,14 @@ soap_instantiate_ns1__removeAuthorisation(struct soap *, int, const char *,
 
 inline ns1__removeAuthorisation *
 soap_new_ns1__removeAuthorisation(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__removeAuthorisation(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__removeAuthorisation(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline ns1__removeAuthorisation *
 soap_new_req_ns1__removeAuthorisation(struct soap *soap) {
-  ns1__removeAuthorisation *_p =
-      soap_instantiate_ns1__removeAuthorisation(soap, -1, NULL, NULL, NULL);
+  ns1__removeAuthorisation *_p = soap_instantiate_ns1__removeAuthorisation(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -23667,8 +23831,8 @@ soap_new_req_ns1__removeAuthorisation(struct soap *soap) {
 inline ns1__removeAuthorisation *
 soap_new_set_ns1__removeAuthorisation(struct soap *soap, std::string *sessionId,
                                       LONG64 *authorisationId, char *__item1) {
-  ns1__removeAuthorisation *_p =
-      soap_instantiate_ns1__removeAuthorisation(soap, -1, NULL, NULL, NULL);
+  ns1__removeAuthorisation *_p = soap_instantiate_ns1__removeAuthorisation(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__removeAuthorisation::sessionId = sessionId;
@@ -23728,14 +23892,15 @@ soap_instantiate_ns1__removeDataFileResponse(struct soap *, int, const char *,
 
 inline ns1__removeDataFileResponse *
 soap_new_ns1__removeDataFileResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__removeDataFileResponse(soap, n, NULL, NULL,
-                                                      NULL);
+  return soap_instantiate_ns1__removeDataFileResponse(soap, n, nullptr, nullptr,
+                                                      nullptr);
 }
 
 inline ns1__removeDataFileResponse *
 soap_new_req_ns1__removeDataFileResponse(struct soap *soap) {
   ns1__removeDataFileResponse *_p =
-      soap_instantiate_ns1__removeDataFileResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__removeDataFileResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -23745,7 +23910,8 @@ soap_new_req_ns1__removeDataFileResponse(struct soap *soap) {
 inline ns1__removeDataFileResponse *
 soap_new_set_ns1__removeDataFileResponse(struct soap *soap, char *__item1) {
   ns1__removeDataFileResponse *_p =
-      soap_instantiate_ns1__removeDataFileResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__removeDataFileResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -23801,13 +23967,14 @@ soap_instantiate_ns1__removeDataFile(struct soap *, int, const char *,
 
 inline ns1__removeDataFile *soap_new_ns1__removeDataFile(struct soap *soap,
                                                          int n = -1) {
-  return soap_instantiate_ns1__removeDataFile(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__removeDataFile(soap, n, nullptr, nullptr,
+                                              nullptr);
 }
 
 inline ns1__removeDataFile *
 soap_new_req_ns1__removeDataFile(struct soap *soap) {
   ns1__removeDataFile *_p =
-      soap_instantiate_ns1__removeDataFile(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__removeDataFile(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -23818,7 +23985,7 @@ inline ns1__removeDataFile *
 soap_new_set_ns1__removeDataFile(struct soap *soap, std::string *sessionId,
                                  LONG64 *datafileId, char *__item1) {
   ns1__removeDataFile *_p =
-      soap_instantiate_ns1__removeDataFile(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__removeDataFile(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__removeDataFile::sessionId = sessionId;
@@ -23874,12 +24041,12 @@ soap_instantiate_ns1__parameterPK(struct soap *, int, const char *,
 
 inline ns1__parameterPK *soap_new_ns1__parameterPK(struct soap *soap,
                                                    int n = -1) {
-  return soap_instantiate_ns1__parameterPK(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__parameterPK(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__parameterPK *soap_new_req_ns1__parameterPK(struct soap *soap) {
   ns1__parameterPK *_p =
-      soap_instantiate_ns1__parameterPK(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__parameterPK(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -23891,7 +24058,7 @@ inline ns1__parameterPK *soap_new_set_ns1__parameterPK(struct soap *soap,
                                                        std::string *units,
                                                        char *__item2) {
   ns1__parameterPK *_p =
-      soap_instantiate_ns1__parameterPK(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__parameterPK(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__parameterPK::name = name;
@@ -23946,7 +24113,7 @@ soap_instantiate_ns1__parameter(struct soap *, int, const char *, const char *,
                                 size_t *);
 
 inline ns1__parameter *soap_new_ns1__parameter(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__parameter(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__parameter(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__parameter *
@@ -23955,7 +24122,7 @@ soap_new_req_ns1__parameter(struct soap *soap, bool datafileParameter,
                             bool verified, bool facilityAcquiredData1,
                             bool selected1) {
   ns1__parameter *_p =
-      soap_instantiate_ns1__parameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__parameter(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__parameter::datafileParameter = datafileParameter;
@@ -23977,7 +24144,7 @@ inline ns1__parameter *soap_new_set_ns1__parameter(
     bool facilityAcquiredData1, ns1__icatRole *icatRole1, bool selected1,
     std::string *uniqueId1, char *__item2) {
   ns1__parameter *_p =
-      soap_instantiate_ns1__parameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__parameter(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__parameter::datafileParameter = datafileParameter;
@@ -24049,15 +24216,15 @@ soap_instantiate_ns1__getParameterByNameUnitsResponse(struct soap *, int,
 
 inline ns1__getParameterByNameUnitsResponse *
 soap_new_ns1__getParameterByNameUnitsResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getParameterByNameUnitsResponse(soap, n, NULL,
-                                                               NULL, NULL);
+  return soap_instantiate_ns1__getParameterByNameUnitsResponse(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__getParameterByNameUnitsResponse *
 soap_new_req_ns1__getParameterByNameUnitsResponse(struct soap *soap) {
   ns1__getParameterByNameUnitsResponse *_p =
-      soap_instantiate_ns1__getParameterByNameUnitsResponse(soap, -1, NULL,
-                                                            NULL, NULL);
+      soap_instantiate_ns1__getParameterByNameUnitsResponse(soap, -1, nullptr,
+                                                            nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -24068,8 +24235,8 @@ inline ns1__getParameterByNameUnitsResponse *
 soap_new_set_ns1__getParameterByNameUnitsResponse(
     struct soap *soap, std::vector<ns1__parameter *> &return_, char *__item1) {
   ns1__getParameterByNameUnitsResponse *_p =
-      soap_instantiate_ns1__getParameterByNameUnitsResponse(soap, -1, NULL,
-                                                            NULL, NULL);
+      soap_instantiate_ns1__getParameterByNameUnitsResponse(soap, -1, nullptr,
+                                                            nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getParameterByNameUnitsResponse::return_ = return_;
@@ -24129,14 +24296,15 @@ soap_instantiate_ns1__getParameterByNameUnits(struct soap *, int, const char *,
 
 inline ns1__getParameterByNameUnits *
 soap_new_ns1__getParameterByNameUnits(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__getParameterByNameUnits(soap, n, NULL, NULL,
-                                                       NULL);
+  return soap_instantiate_ns1__getParameterByNameUnits(soap, n, nullptr,
+                                                       nullptr, nullptr);
 }
 
 inline ns1__getParameterByNameUnits *
 soap_new_req_ns1__getParameterByNameUnits(struct soap *soap) {
   ns1__getParameterByNameUnits *_p =
-      soap_instantiate_ns1__getParameterByNameUnits(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__getParameterByNameUnits(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -24147,7 +24315,8 @@ inline ns1__getParameterByNameUnits *soap_new_set_ns1__getParameterByNameUnits(
     struct soap *soap, std::string *sesssionId, std::string *name,
     std::string *units, char *__item1) {
   ns1__getParameterByNameUnits *_p =
-      soap_instantiate_ns1__getParameterByNameUnits(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__getParameterByNameUnits(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__getParameterByNameUnits::sesssionId = sesssionId;
@@ -24215,7 +24384,7 @@ inline ns1__searchInvestigationByParameterLogicalResponse *
 soap_new_ns1__searchInvestigationByParameterLogicalResponse(struct soap *soap,
                                                             int n = -1) {
   return soap_instantiate_ns1__searchInvestigationByParameterLogicalResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchInvestigationByParameterLogicalResponse *
@@ -24223,7 +24392,7 @@ soap_new_req_ns1__searchInvestigationByParameterLogicalResponse(
     struct soap *soap) {
   ns1__searchInvestigationByParameterLogicalResponse *_p =
       soap_instantiate_ns1__searchInvestigationByParameterLogicalResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -24235,7 +24404,7 @@ soap_new_set_ns1__searchInvestigationByParameterLogicalResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchInvestigationByParameterLogicalResponse *_p =
       soap_instantiate_ns1__searchInvestigationByParameterLogicalResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchInvestigationByParameterLogicalResponse::return_ = return_;
@@ -24296,16 +24465,16 @@ soap_instantiate_ns1__parameterLogicalCondition(struct soap *, int,
 
 inline ns1__parameterLogicalCondition *
 soap_new_ns1__parameterLogicalCondition(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__parameterLogicalCondition(soap, n, NULL, NULL,
-                                                         NULL);
+  return soap_instantiate_ns1__parameterLogicalCondition(soap, n, nullptr,
+                                                         nullptr, nullptr);
 }
 
 inline ns1__parameterLogicalCondition *
 soap_new_req_ns1__parameterLogicalCondition(struct soap *soap, bool negate2,
                                             bool sensitive2) {
   ns1__parameterLogicalCondition *_p =
-      soap_instantiate_ns1__parameterLogicalCondition(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__parameterLogicalCondition(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__condition::negate = negate2;
@@ -24320,8 +24489,8 @@ soap_new_set_ns1__parameterLogicalCondition(
     enum ns1__logicalOperator *operator_, bool negate2, bool sensitive2,
     char *__item3) {
   ns1__parameterLogicalCondition *_p =
-      soap_instantiate_ns1__parameterLogicalCondition(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__parameterLogicalCondition(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__parameterLogicalCondition::listComparable = listComparable;
@@ -24389,14 +24558,14 @@ inline ns1__searchInvestigationByParameterLogical *
 soap_new_ns1__searchInvestigationByParameterLogical(struct soap *soap,
                                                     int n = -1) {
   return soap_instantiate_ns1__searchInvestigationByParameterLogical(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchInvestigationByParameterLogical *
 soap_new_req_ns1__searchInvestigationByParameterLogical(struct soap *soap) {
   ns1__searchInvestigationByParameterLogical *_p =
       soap_instantiate_ns1__searchInvestigationByParameterLogical(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -24409,7 +24578,7 @@ soap_new_set_ns1__searchInvestigationByParameterLogical(
     ns1__parameterLogicalCondition *logicalCondition, char *__item1) {
   ns1__searchInvestigationByParameterLogical *_p =
       soap_instantiate_ns1__searchInvestigationByParameterLogical(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchInvestigationByParameterLogical::sessionId = sessionId;
@@ -24469,13 +24638,14 @@ soap_instantiate_ns1__modifySampleResponse(struct soap *, int, const char *,
 
 inline ns1__modifySampleResponse *
 soap_new_ns1__modifySampleResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__modifySampleResponse(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__modifySampleResponse(soap, n, nullptr, nullptr,
+                                                    nullptr);
 }
 
 inline ns1__modifySampleResponse *
 soap_new_req_ns1__modifySampleResponse(struct soap *soap) {
-  ns1__modifySampleResponse *_p =
-      soap_instantiate_ns1__modifySampleResponse(soap, -1, NULL, NULL, NULL);
+  ns1__modifySampleResponse *_p = soap_instantiate_ns1__modifySampleResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -24484,8 +24654,8 @@ soap_new_req_ns1__modifySampleResponse(struct soap *soap) {
 
 inline ns1__modifySampleResponse *
 soap_new_set_ns1__modifySampleResponse(struct soap *soap, char *__item1) {
-  ns1__modifySampleResponse *_p =
-      soap_instantiate_ns1__modifySampleResponse(soap, -1, NULL, NULL, NULL);
+  ns1__modifySampleResponse *_p = soap_instantiate_ns1__modifySampleResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -24541,12 +24711,12 @@ soap_instantiate_ns1__modifySample(struct soap *, int, const char *,
 
 inline ns1__modifySample *soap_new_ns1__modifySample(struct soap *soap,
                                                      int n = -1) {
-  return soap_instantiate_ns1__modifySample(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__modifySample(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__modifySample *soap_new_req_ns1__modifySample(struct soap *soap) {
   ns1__modifySample *_p =
-      soap_instantiate_ns1__modifySample(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__modifySample(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -24558,7 +24728,7 @@ inline ns1__modifySample *soap_new_set_ns1__modifySample(struct soap *soap,
                                                          ns1__sample *sample,
                                                          char *__item1) {
   ns1__modifySample *_p =
-      soap_instantiate_ns1__modifySample(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__modifySample(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__modifySample::sessionId = sessionId;
@@ -24618,14 +24788,15 @@ soap_instantiate_ns1__createDataFileResponse(struct soap *, int, const char *,
 
 inline ns1__createDataFileResponse *
 soap_new_ns1__createDataFileResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__createDataFileResponse(soap, n, NULL, NULL,
-                                                      NULL);
+  return soap_instantiate_ns1__createDataFileResponse(soap, n, nullptr, nullptr,
+                                                      nullptr);
 }
 
 inline ns1__createDataFileResponse *
 soap_new_req_ns1__createDataFileResponse(struct soap *soap) {
   ns1__createDataFileResponse *_p =
-      soap_instantiate_ns1__createDataFileResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__createDataFileResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -24635,7 +24806,8 @@ soap_new_req_ns1__createDataFileResponse(struct soap *soap) {
 inline ns1__createDataFileResponse *soap_new_set_ns1__createDataFileResponse(
     struct soap *soap, ns1__datafile *return_, char *__item1) {
   ns1__createDataFileResponse *_p =
-      soap_instantiate_ns1__createDataFileResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__createDataFileResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__createDataFileResponse::return_ = return_;
@@ -24692,13 +24864,14 @@ soap_instantiate_ns1__relatedDatafilesPK(struct soap *, int, const char *,
 
 inline ns1__relatedDatafilesPK *
 soap_new_ns1__relatedDatafilesPK(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__relatedDatafilesPK(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__relatedDatafilesPK(soap, n, nullptr, nullptr,
+                                                  nullptr);
 }
 
 inline ns1__relatedDatafilesPK *
 soap_new_req_ns1__relatedDatafilesPK(struct soap *soap) {
-  ns1__relatedDatafilesPK *_p =
-      soap_instantiate_ns1__relatedDatafilesPK(soap, -1, NULL, NULL, NULL);
+  ns1__relatedDatafilesPK *_p = soap_instantiate_ns1__relatedDatafilesPK(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -24708,8 +24881,8 @@ soap_new_req_ns1__relatedDatafilesPK(struct soap *soap) {
 inline ns1__relatedDatafilesPK *
 soap_new_set_ns1__relatedDatafilesPK(struct soap *soap, LONG64 *destDatafileId,
                                      LONG64 *sourceDatafileId, char *__item2) {
-  ns1__relatedDatafilesPK *_p =
-      soap_instantiate_ns1__relatedDatafilesPK(soap, -1, NULL, NULL, NULL);
+  ns1__relatedDatafilesPK *_p = soap_instantiate_ns1__relatedDatafilesPK(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__relatedDatafilesPK::destDatafileId = destDatafileId;
@@ -24766,14 +24939,15 @@ soap_instantiate_ns1__relatedDatafiles(struct soap *, int, const char *,
 
 inline ns1__relatedDatafiles *soap_new_ns1__relatedDatafiles(struct soap *soap,
                                                              int n = -1) {
-  return soap_instantiate_ns1__relatedDatafiles(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__relatedDatafiles(soap, n, nullptr, nullptr,
+                                                nullptr);
 }
 
 inline ns1__relatedDatafiles *
 soap_new_req_ns1__relatedDatafiles(struct soap *soap,
                                    bool facilityAcquiredData1, bool selected1) {
-  ns1__relatedDatafiles *_p =
-      soap_instantiate_ns1__relatedDatafiles(soap, -1, NULL, NULL, NULL);
+  ns1__relatedDatafiles *_p = soap_instantiate_ns1__relatedDatafiles(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__entityBaseBean::facilityAcquiredData = facilityAcquiredData1;
@@ -24786,8 +24960,8 @@ inline ns1__relatedDatafiles *soap_new_set_ns1__relatedDatafiles(
     struct soap *soap, ns1__relatedDatafilesPK *relatedDatafilesPK,
     std::string *relation, bool facilityAcquiredData1, ns1__icatRole *icatRole1,
     bool selected1, std::string *uniqueId1, char *__item2) {
-  ns1__relatedDatafiles *_p =
-      soap_instantiate_ns1__relatedDatafiles(soap, -1, NULL, NULL, NULL);
+  ns1__relatedDatafiles *_p = soap_instantiate_ns1__relatedDatafiles(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__relatedDatafiles::relatedDatafilesPK = relatedDatafilesPK;
@@ -24849,13 +25023,14 @@ soap_instantiate_ns1__datafileParameterPK(struct soap *, int, const char *,
 
 inline ns1__datafileParameterPK *
 soap_new_ns1__datafileParameterPK(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__datafileParameterPK(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__datafileParameterPK(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline ns1__datafileParameterPK *
 soap_new_req_ns1__datafileParameterPK(struct soap *soap) {
-  ns1__datafileParameterPK *_p =
-      soap_instantiate_ns1__datafileParameterPK(soap, -1, NULL, NULL, NULL);
+  ns1__datafileParameterPK *_p = soap_instantiate_ns1__datafileParameterPK(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -24866,8 +25041,8 @@ inline ns1__datafileParameterPK *
 soap_new_set_ns1__datafileParameterPK(struct soap *soap, LONG64 *datafileId,
                                       std::string *name, std::string *units,
                                       char *__item2) {
-  ns1__datafileParameterPK *_p =
-      soap_instantiate_ns1__datafileParameterPK(soap, -1, NULL, NULL, NULL);
+  ns1__datafileParameterPK *_p = soap_instantiate_ns1__datafileParameterPK(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__datafileParameterPK::datafileId = datafileId;
@@ -24925,13 +25100,14 @@ soap_instantiate_ns1__datafileParameter(struct soap *, int, const char *,
 
 inline ns1__datafileParameter *
 soap_new_ns1__datafileParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__datafileParameter(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__datafileParameter(soap, n, nullptr, nullptr,
+                                                 nullptr);
 }
 
 inline ns1__datafileParameter *soap_new_req_ns1__datafileParameter(
     struct soap *soap, bool facilityAcquiredData1, bool selected1) {
-  ns1__datafileParameter *_p =
-      soap_instantiate_ns1__datafileParameter(soap, -1, NULL, NULL, NULL);
+  ns1__datafileParameter *_p = soap_instantiate_ns1__datafileParameter(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__entityBaseBean::facilityAcquiredData = facilityAcquiredData1;
@@ -24947,8 +25123,8 @@ inline ns1__datafileParameter *soap_new_set_ns1__datafileParameter(
     std::string *stringValue, enum ns1__parameterValueType *valueType,
     bool facilityAcquiredData1, ns1__icatRole *icatRole1, bool selected1,
     std::string *uniqueId1, char *__item2) {
-  ns1__datafileParameter *_p =
-      soap_instantiate_ns1__datafileParameter(soap, -1, NULL, NULL, NULL);
+  ns1__datafileParameter *_p = soap_instantiate_ns1__datafileParameter(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__datafileParameter::datafileParameterPK = datafileParameterPK;
@@ -25016,13 +25192,14 @@ soap_instantiate_ns1__datafileFormatPK(struct soap *, int, const char *,
 
 inline ns1__datafileFormatPK *soap_new_ns1__datafileFormatPK(struct soap *soap,
                                                              int n = -1) {
-  return soap_instantiate_ns1__datafileFormatPK(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__datafileFormatPK(soap, n, nullptr, nullptr,
+                                                nullptr);
 }
 
 inline ns1__datafileFormatPK *
 soap_new_req_ns1__datafileFormatPK(struct soap *soap) {
-  ns1__datafileFormatPK *_p =
-      soap_instantiate_ns1__datafileFormatPK(soap, -1, NULL, NULL, NULL);
+  ns1__datafileFormatPK *_p = soap_instantiate_ns1__datafileFormatPK(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -25032,8 +25209,8 @@ soap_new_req_ns1__datafileFormatPK(struct soap *soap) {
 inline ns1__datafileFormatPK *
 soap_new_set_ns1__datafileFormatPK(struct soap *soap, std::string *name,
                                    std::string *version, char *__item2) {
-  ns1__datafileFormatPK *_p =
-      soap_instantiate_ns1__datafileFormatPK(soap, -1, NULL, NULL, NULL);
+  ns1__datafileFormatPK *_p = soap_instantiate_ns1__datafileFormatPK(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__datafileFormatPK::name = name;
@@ -25090,14 +25267,15 @@ soap_instantiate_ns1__datafileFormat(struct soap *, int, const char *,
 
 inline ns1__datafileFormat *soap_new_ns1__datafileFormat(struct soap *soap,
                                                          int n = -1) {
-  return soap_instantiate_ns1__datafileFormat(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__datafileFormat(soap, n, nullptr, nullptr,
+                                              nullptr);
 }
 
 inline ns1__datafileFormat *
 soap_new_req_ns1__datafileFormat(struct soap *soap, bool facilityAcquiredData1,
                                  bool selected1) {
   ns1__datafileFormat *_p =
-      soap_instantiate_ns1__datafileFormat(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__datafileFormat(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__entityBaseBean::facilityAcquiredData = facilityAcquiredData1;
@@ -25112,7 +25290,7 @@ inline ns1__datafileFormat *soap_new_set_ns1__datafileFormat(
     bool facilityAcquiredData1, ns1__icatRole *icatRole1, bool selected1,
     std::string *uniqueId1, char *__item2) {
   ns1__datafileFormat *_p =
-      soap_instantiate_ns1__datafileFormat(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__datafileFormat(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__datafileFormat::datafileFormatPK = datafileFormatPK;
@@ -25172,14 +25350,14 @@ soap_instantiate_ns1__datafile(struct soap *, int, const char *, const char *,
                                size_t *);
 
 inline ns1__datafile *soap_new_ns1__datafile(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__datafile(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__datafile(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__datafile *soap_new_req_ns1__datafile(struct soap *soap,
                                                  bool facilityAcquiredData1,
                                                  bool selected1) {
   ns1__datafile *_p =
-      soap_instantiate_ns1__datafile(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__datafile(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__entityBaseBean::facilityAcquiredData = facilityAcquiredData1;
@@ -25202,7 +25380,7 @@ inline ns1__datafile *soap_new_set_ns1__datafile(
     ns1__icatRole *icatRole1, bool selected1, std::string *uniqueId1,
     char *__item2) {
   ns1__datafile *_p =
-      soap_instantiate_ns1__datafile(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__datafile(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__datafile::checksum = checksum;
@@ -25280,13 +25458,14 @@ soap_instantiate_ns1__createDataFile(struct soap *, int, const char *,
 
 inline ns1__createDataFile *soap_new_ns1__createDataFile(struct soap *soap,
                                                          int n = -1) {
-  return soap_instantiate_ns1__createDataFile(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__createDataFile(soap, n, nullptr, nullptr,
+                                              nullptr);
 }
 
 inline ns1__createDataFile *
 soap_new_req_ns1__createDataFile(struct soap *soap) {
   ns1__createDataFile *_p =
-      soap_instantiate_ns1__createDataFile(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__createDataFile(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -25298,7 +25477,7 @@ soap_new_set_ns1__createDataFile(struct soap *soap, std::string *sessionId,
                                  ns1__datafile *dataFile, LONG64 *datasetId,
                                  char *__item1) {
   ns1__createDataFile *_p =
-      soap_instantiate_ns1__createDataFile(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__createDataFile(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__createDataFile::sessionId = sessionId;
@@ -25360,15 +25539,15 @@ soap_instantiate_ns1__InsufficientPrivilegesException(struct soap *, int,
 
 inline ns1__InsufficientPrivilegesException *
 soap_new_ns1__InsufficientPrivilegesException(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__InsufficientPrivilegesException(soap, n, NULL,
-                                                               NULL, NULL);
+  return soap_instantiate_ns1__InsufficientPrivilegesException(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__InsufficientPrivilegesException *
 soap_new_req_ns1__InsufficientPrivilegesException(struct soap *soap) {
   ns1__InsufficientPrivilegesException *_p =
-      soap_instantiate_ns1__InsufficientPrivilegesException(soap, -1, NULL,
-                                                            NULL, NULL);
+      soap_instantiate_ns1__InsufficientPrivilegesException(soap, -1, nullptr,
+                                                            nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -25380,8 +25559,8 @@ soap_new_set_ns1__InsufficientPrivilegesException(
     struct soap *soap, std::string *message, std::string *stackTraceAsString,
     std::string *uniqueId, char *__item1) {
   ns1__InsufficientPrivilegesException *_p =
-      soap_instantiate_ns1__InsufficientPrivilegesException(soap, -1, NULL,
-                                                            NULL, NULL);
+      soap_instantiate_ns1__InsufficientPrivilegesException(soap, -1, nullptr,
+                                                            nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__InsufficientPrivilegesException::message = message;
@@ -25441,13 +25620,14 @@ soap_instantiate_ns1__removeSampleResponse(struct soap *, int, const char *,
 
 inline ns1__removeSampleResponse *
 soap_new_ns1__removeSampleResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__removeSampleResponse(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__removeSampleResponse(soap, n, nullptr, nullptr,
+                                                    nullptr);
 }
 
 inline ns1__removeSampleResponse *
 soap_new_req_ns1__removeSampleResponse(struct soap *soap) {
-  ns1__removeSampleResponse *_p =
-      soap_instantiate_ns1__removeSampleResponse(soap, -1, NULL, NULL, NULL);
+  ns1__removeSampleResponse *_p = soap_instantiate_ns1__removeSampleResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -25456,8 +25636,8 @@ soap_new_req_ns1__removeSampleResponse(struct soap *soap) {
 
 inline ns1__removeSampleResponse *
 soap_new_set_ns1__removeSampleResponse(struct soap *soap, char *__item1) {
-  ns1__removeSampleResponse *_p =
-      soap_instantiate_ns1__removeSampleResponse(soap, -1, NULL, NULL, NULL);
+  ns1__removeSampleResponse *_p = soap_instantiate_ns1__removeSampleResponse(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -25513,12 +25693,12 @@ soap_instantiate_ns1__removeSample(struct soap *, int, const char *,
 
 inline ns1__removeSample *soap_new_ns1__removeSample(struct soap *soap,
                                                      int n = -1) {
-  return soap_instantiate_ns1__removeSample(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__removeSample(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__removeSample *soap_new_req_ns1__removeSample(struct soap *soap) {
   ns1__removeSample *_p =
-      soap_instantiate_ns1__removeSample(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__removeSample(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -25530,7 +25710,7 @@ inline ns1__removeSample *soap_new_set_ns1__removeSample(struct soap *soap,
                                                          LONG64 *sampleId,
                                                          char *__item1) {
   ns1__removeSample *_p =
-      soap_instantiate_ns1__removeSample(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__removeSample(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__removeSample::sessionId = sessionId;
@@ -25591,14 +25771,15 @@ soap_instantiate_ns1__listInstrumentsResponse(struct soap *, int, const char *,
 
 inline ns1__listInstrumentsResponse *
 soap_new_ns1__listInstrumentsResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__listInstrumentsResponse(soap, n, NULL, NULL,
-                                                       NULL);
+  return soap_instantiate_ns1__listInstrumentsResponse(soap, n, nullptr,
+                                                       nullptr, nullptr);
 }
 
 inline ns1__listInstrumentsResponse *
 soap_new_req_ns1__listInstrumentsResponse(struct soap *soap) {
   ns1__listInstrumentsResponse *_p =
-      soap_instantiate_ns1__listInstrumentsResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__listInstrumentsResponse(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -25608,7 +25789,8 @@ soap_new_req_ns1__listInstrumentsResponse(struct soap *soap) {
 inline ns1__listInstrumentsResponse *soap_new_set_ns1__listInstrumentsResponse(
     struct soap *soap, std::vector<std::string> &return_, char *__item1) {
   ns1__listInstrumentsResponse *_p =
-      soap_instantiate_ns1__listInstrumentsResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__listInstrumentsResponse(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__listInstrumentsResponse::return_ = return_;
@@ -25665,13 +25847,14 @@ soap_instantiate_ns1__listInstruments(struct soap *, int, const char *,
 
 inline ns1__listInstruments *soap_new_ns1__listInstruments(struct soap *soap,
                                                            int n = -1) {
-  return soap_instantiate_ns1__listInstruments(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__listInstruments(soap, n, nullptr, nullptr,
+                                               nullptr);
 }
 
 inline ns1__listInstruments *
 soap_new_req_ns1__listInstruments(struct soap *soap) {
-  ns1__listInstruments *_p =
-      soap_instantiate_ns1__listInstruments(soap, -1, NULL, NULL, NULL);
+  ns1__listInstruments *_p = soap_instantiate_ns1__listInstruments(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -25681,8 +25864,8 @@ soap_new_req_ns1__listInstruments(struct soap *soap) {
 inline ns1__listInstruments *
 soap_new_set_ns1__listInstruments(struct soap *soap, std::string *sessionId,
                                   char *__item1) {
-  ns1__listInstruments *_p =
-      soap_instantiate_ns1__listInstruments(soap, -1, NULL, NULL, NULL);
+  ns1__listInstruments *_p = soap_instantiate_ns1__listInstruments(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__listInstruments::sessionId = sessionId;
@@ -25746,14 +25929,14 @@ inline ns1__searchDatafileByRestrictionResponse *
 soap_new_ns1__searchDatafileByRestrictionResponse(struct soap *soap,
                                                   int n = -1) {
   return soap_instantiate_ns1__searchDatafileByRestrictionResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatafileByRestrictionResponse *
 soap_new_req_ns1__searchDatafileByRestrictionResponse(struct soap *soap) {
   ns1__searchDatafileByRestrictionResponse *_p =
-      soap_instantiate_ns1__searchDatafileByRestrictionResponse(soap, -1, NULL,
-                                                                NULL, NULL);
+      soap_instantiate_ns1__searchDatafileByRestrictionResponse(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -25764,8 +25947,8 @@ inline ns1__searchDatafileByRestrictionResponse *
 soap_new_set_ns1__searchDatafileByRestrictionResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchDatafileByRestrictionResponse *_p =
-      soap_instantiate_ns1__searchDatafileByRestrictionResponse(soap, -1, NULL,
-                                                                NULL, NULL);
+      soap_instantiate_ns1__searchDatafileByRestrictionResponse(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatafileByRestrictionResponse::return_ = return_;
@@ -25826,15 +26009,15 @@ soap_instantiate_ns1__searchDatafileByRestriction(struct soap *, int,
 
 inline ns1__searchDatafileByRestriction *
 soap_new_ns1__searchDatafileByRestriction(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchDatafileByRestriction(soap, n, NULL, NULL,
-                                                           NULL);
+  return soap_instantiate_ns1__searchDatafileByRestriction(soap, n, nullptr,
+                                                           nullptr, nullptr);
 }
 
 inline ns1__searchDatafileByRestriction *
 soap_new_req_ns1__searchDatafileByRestriction(struct soap *soap) {
   ns1__searchDatafileByRestriction *_p =
-      soap_instantiate_ns1__searchDatafileByRestriction(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__searchDatafileByRestriction(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -25846,8 +26029,8 @@ soap_new_set_ns1__searchDatafileByRestriction(
     struct soap *soap, std::string *sessionId,
     ns1__restrictionCondition *restriction, char *__item1) {
   ns1__searchDatafileByRestriction *_p =
-      soap_instantiate_ns1__searchDatafileByRestriction(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__searchDatafileByRestriction(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatafileByRestriction::sessionId = sessionId;
@@ -25912,7 +26095,7 @@ inline ns1__searchSampleByRestrictionComparisonResponse *
 soap_new_ns1__searchSampleByRestrictionComparisonResponse(struct soap *soap,
                                                           int n = -1) {
   return soap_instantiate_ns1__searchSampleByRestrictionComparisonResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchSampleByRestrictionComparisonResponse *
@@ -25920,7 +26103,7 @@ soap_new_req_ns1__searchSampleByRestrictionComparisonResponse(
     struct soap *soap) {
   ns1__searchSampleByRestrictionComparisonResponse *_p =
       soap_instantiate_ns1__searchSampleByRestrictionComparisonResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -25932,7 +26115,7 @@ soap_new_set_ns1__searchSampleByRestrictionComparisonResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchSampleByRestrictionComparisonResponse *_p =
       soap_instantiate_ns1__searchSampleByRestrictionComparisonResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchSampleByRestrictionComparisonResponse::return_ = return_;
@@ -25994,8 +26177,8 @@ soap_instantiate_ns1__restrictionComparisonCondition(struct soap *, int,
 
 inline ns1__restrictionComparisonCondition *
 soap_new_ns1__restrictionComparisonCondition(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__restrictionComparisonCondition(soap, n, NULL,
-                                                              NULL, NULL);
+  return soap_instantiate_ns1__restrictionComparisonCondition(soap, n, nullptr,
+                                                              nullptr, nullptr);
 }
 
 inline ns1__restrictionComparisonCondition *
@@ -26003,8 +26186,8 @@ soap_new_req_ns1__restrictionComparisonCondition(
     struct soap *soap, int maxResults1, bool orderByAsc1, bool returnLongId1,
     bool negate2, bool sensitive2) {
   ns1__restrictionComparisonCondition *_p =
-      soap_instantiate_ns1__restrictionComparisonCondition(soap, -1, NULL, NULL,
-                                                           NULL);
+      soap_instantiate_ns1__restrictionComparisonCondition(soap, -1, nullptr,
+                                                           nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__restrictionCondition::maxResults = maxResults1;
@@ -26027,8 +26210,8 @@ soap_new_set_ns1__restrictionComparisonCondition(
     bool returnLongId1, enum ns1__sampleInclude *sampleInclude1, bool negate2,
     bool sensitive2, char *__item3) {
   ns1__restrictionComparisonCondition *_p =
-      soap_instantiate_ns1__restrictionComparisonCondition(soap, -1, NULL, NULL,
-                                                           NULL);
+      soap_instantiate_ns1__restrictionComparisonCondition(soap, -1, nullptr,
+                                                           nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__restrictionComparisonCondition::comparisonOperator =
@@ -26108,14 +26291,14 @@ inline ns1__searchSampleByRestrictionComparison *
 soap_new_ns1__searchSampleByRestrictionComparison(struct soap *soap,
                                                   int n = -1) {
   return soap_instantiate_ns1__searchSampleByRestrictionComparison(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchSampleByRestrictionComparison *
 soap_new_req_ns1__searchSampleByRestrictionComparison(struct soap *soap) {
   ns1__searchSampleByRestrictionComparison *_p =
-      soap_instantiate_ns1__searchSampleByRestrictionComparison(soap, -1, NULL,
-                                                                NULL, NULL);
+      soap_instantiate_ns1__searchSampleByRestrictionComparison(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -26128,8 +26311,8 @@ soap_new_set_ns1__searchSampleByRestrictionComparison(
     std::vector<ns1__restrictionComparisonCondition *> &restriction,
     char *__item1) {
   ns1__searchSampleByRestrictionComparison *_p =
-      soap_instantiate_ns1__searchSampleByRestrictionComparison(soap, -1, NULL,
-                                                                NULL, NULL);
+      soap_instantiate_ns1__searchSampleByRestrictionComparison(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchSampleByRestrictionComparison::sessionId = sessionId;
@@ -26191,15 +26374,15 @@ soap_instantiate_ns1__entityPrimaryKeyBaseBean(struct soap *, int, const char *,
 
 inline ns1__entityPrimaryKeyBaseBean *
 soap_new_ns1__entityPrimaryKeyBaseBean(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__entityPrimaryKeyBaseBean(soap, n, NULL, NULL,
-                                                        NULL);
+  return soap_instantiate_ns1__entityPrimaryKeyBaseBean(soap, n, nullptr,
+                                                        nullptr, nullptr);
 }
 
 inline ns1__entityPrimaryKeyBaseBean *
 soap_new_req_ns1__entityPrimaryKeyBaseBean(struct soap *soap) {
   ns1__entityPrimaryKeyBaseBean *_p =
-      soap_instantiate_ns1__entityPrimaryKeyBaseBean(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate_ns1__entityPrimaryKeyBaseBean(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -26209,8 +26392,8 @@ soap_new_req_ns1__entityPrimaryKeyBaseBean(struct soap *soap) {
 inline ns1__entityPrimaryKeyBaseBean *
 soap_new_set_ns1__entityPrimaryKeyBaseBean(struct soap *soap, char *__item1) {
   ns1__entityPrimaryKeyBaseBean *_p =
-      soap_instantiate_ns1__entityPrimaryKeyBaseBean(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate_ns1__entityPrimaryKeyBaseBean(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item1;
@@ -26266,13 +26449,14 @@ soap_instantiate_ns1__sampleParameterPK(struct soap *, int, const char *,
 
 inline ns1__sampleParameterPK *
 soap_new_ns1__sampleParameterPK(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__sampleParameterPK(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__sampleParameterPK(soap, n, nullptr, nullptr,
+                                                 nullptr);
 }
 
 inline ns1__sampleParameterPK *
 soap_new_req_ns1__sampleParameterPK(struct soap *soap) {
-  ns1__sampleParameterPK *_p =
-      soap_instantiate_ns1__sampleParameterPK(soap, -1, NULL, NULL, NULL);
+  ns1__sampleParameterPK *_p = soap_instantiate_ns1__sampleParameterPK(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -26283,8 +26467,8 @@ inline ns1__sampleParameterPK *
 soap_new_set_ns1__sampleParameterPK(struct soap *soap, std::string *name,
                                     LONG64 *sampleId, std::string *units,
                                     char *__item2) {
-  ns1__sampleParameterPK *_p =
-      soap_instantiate_ns1__sampleParameterPK(soap, -1, NULL, NULL, NULL);
+  ns1__sampleParameterPK *_p = soap_instantiate_ns1__sampleParameterPK(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__sampleParameterPK::name = name;
@@ -26342,14 +26526,15 @@ soap_instantiate_ns1__sampleParameter(struct soap *, int, const char *,
 
 inline ns1__sampleParameter *soap_new_ns1__sampleParameter(struct soap *soap,
                                                            int n = -1) {
-  return soap_instantiate_ns1__sampleParameter(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__sampleParameter(soap, n, nullptr, nullptr,
+                                               nullptr);
 }
 
 inline ns1__sampleParameter *
 soap_new_req_ns1__sampleParameter(struct soap *soap, bool facilityAcquiredData1,
                                   bool selected1) {
-  ns1__sampleParameter *_p =
-      soap_instantiate_ns1__sampleParameter(soap, -1, NULL, NULL, NULL);
+  ns1__sampleParameter *_p = soap_instantiate_ns1__sampleParameter(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__entityBaseBean::facilityAcquiredData = facilityAcquiredData1;
@@ -26365,8 +26550,8 @@ inline ns1__sampleParameter *soap_new_set_ns1__sampleParameter(
     std::string *stringValue, enum ns1__parameterValueType *valueType,
     bool facilityAcquiredData1, ns1__icatRole *icatRole1, bool selected1,
     std::string *uniqueId1, char *__item2) {
-  ns1__sampleParameter *_p =
-      soap_instantiate_ns1__sampleParameter(soap, -1, NULL, NULL, NULL);
+  ns1__sampleParameter *_p = soap_instantiate_ns1__sampleParameter(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__sampleParameter::dateTimeValue = dateTimeValue;
@@ -26430,13 +26615,14 @@ soap_instantiate_ns1__sample(struct soap *, int, const char *, const char *,
                              size_t *);
 
 inline ns1__sample *soap_new_ns1__sample(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__sample(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__sample(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__sample *soap_new_req_ns1__sample(struct soap *soap,
                                              bool facilityAcquiredData1,
                                              bool selected1) {
-  ns1__sample *_p = soap_instantiate_ns1__sample(soap, -1, NULL, NULL, NULL);
+  ns1__sample *_p =
+      soap_instantiate_ns1__sample(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__entityBaseBean::facilityAcquiredData = facilityAcquiredData1;
@@ -26452,7 +26638,8 @@ inline ns1__sample *soap_new_set_ns1__sample(
     std::vector<ns1__sampleParameter *> &sampleParameterCollection,
     bool facilityAcquiredData1, ns1__icatRole *icatRole1, bool selected1,
     std::string *uniqueId1, char *__item2) {
-  ns1__sample *_p = soap_instantiate_ns1__sample(soap, -1, NULL, NULL, NULL);
+  ns1__sample *_p =
+      soap_instantiate_ns1__sample(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__sample::chemicalFormula = chemicalFormula;
@@ -26522,15 +26709,15 @@ soap_instantiate_ns1__searchSamplesBySampleNameResponse(struct soap *, int,
 
 inline ns1__searchSamplesBySampleNameResponse *
 soap_new_ns1__searchSamplesBySampleNameResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchSamplesBySampleNameResponse(soap, n, NULL,
-                                                                 NULL, NULL);
+  return soap_instantiate_ns1__searchSamplesBySampleNameResponse(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchSamplesBySampleNameResponse *
 soap_new_req_ns1__searchSamplesBySampleNameResponse(struct soap *soap) {
   ns1__searchSamplesBySampleNameResponse *_p =
-      soap_instantiate_ns1__searchSamplesBySampleNameResponse(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate_ns1__searchSamplesBySampleNameResponse(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -26541,8 +26728,8 @@ inline ns1__searchSamplesBySampleNameResponse *
 soap_new_set_ns1__searchSamplesBySampleNameResponse(
     struct soap *soap, std::vector<ns1__sample *> &return_, char *__item1) {
   ns1__searchSamplesBySampleNameResponse *_p =
-      soap_instantiate_ns1__searchSamplesBySampleNameResponse(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate_ns1__searchSamplesBySampleNameResponse(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchSamplesBySampleNameResponse::return_ = return_;
@@ -26604,15 +26791,15 @@ soap_instantiate_ns1__searchSamplesBySampleName(struct soap *, int,
 
 inline ns1__searchSamplesBySampleName *
 soap_new_ns1__searchSamplesBySampleName(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchSamplesBySampleName(soap, n, NULL, NULL,
-                                                         NULL);
+  return soap_instantiate_ns1__searchSamplesBySampleName(soap, n, nullptr,
+                                                         nullptr, nullptr);
 }
 
 inline ns1__searchSamplesBySampleName *
 soap_new_req_ns1__searchSamplesBySampleName(struct soap *soap) {
   ns1__searchSamplesBySampleName *_p =
-      soap_instantiate_ns1__searchSamplesBySampleName(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__searchSamplesBySampleName(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -26625,8 +26812,8 @@ soap_new_set_ns1__searchSamplesBySampleName(struct soap *soap,
                                             std::string *sampleName,
                                             char *__item1) {
   ns1__searchSamplesBySampleName *_p =
-      soap_instantiate_ns1__searchSamplesBySampleName(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate_ns1__searchSamplesBySampleName(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchSamplesBySampleName::sessionId = sessionId;
@@ -26682,7 +26869,7 @@ soap_instantiate_ns1__icatRole(struct soap *, int, const char *, const char *,
                                size_t *);
 
 inline ns1__icatRole *soap_new_ns1__icatRole(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__icatRole(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__icatRole(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__icatRole *soap_new_req_ns1__icatRole(
@@ -26692,7 +26879,7 @@ inline ns1__icatRole *soap_new_req_ns1__icatRole(
     bool actionSelect, bool actionUpdate, bool facilityAcquiredData1,
     bool selected1) {
   ns1__icatRole *_p =
-      soap_instantiate_ns1__icatRole(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__icatRole(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__icatRole::actionDelete = actionDelete;
@@ -26719,7 +26906,7 @@ inline ns1__icatRole *soap_new_set_ns1__icatRole(
     bool facilityAcquiredData1, ns1__icatRole *icatRole1, bool selected1,
     std::string *uniqueId1, char *__item2) {
   ns1__icatRole *_p =
-      soap_instantiate_ns1__icatRole(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__icatRole(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__icatRole::actionDelete = actionDelete;
@@ -26788,14 +26975,15 @@ soap_instantiate_ns1__entityBaseBean(struct soap *, int, const char *,
 
 inline ns1__entityBaseBean *soap_new_ns1__entityBaseBean(struct soap *soap,
                                                          int n = -1) {
-  return soap_instantiate_ns1__entityBaseBean(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__entityBaseBean(soap, n, nullptr, nullptr,
+                                              nullptr);
 }
 
 inline ns1__entityBaseBean *
 soap_new_req_ns1__entityBaseBean(struct soap *soap, bool facilityAcquiredData,
                                  bool selected) {
   ns1__entityBaseBean *_p =
-      soap_instantiate_ns1__entityBaseBean(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__entityBaseBean(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__entityBaseBean::facilityAcquiredData = facilityAcquiredData;
@@ -26809,7 +26997,7 @@ soap_new_set_ns1__entityBaseBean(struct soap *soap, bool facilityAcquiredData,
                                  ns1__icatRole *icatRole, bool selected,
                                  std::string *uniqueId, char *__item1) {
   ns1__entityBaseBean *_p =
-      soap_instantiate_ns1__entityBaseBean(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__entityBaseBean(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__entityBaseBean::facilityAcquiredData = facilityAcquiredData;
@@ -26868,14 +27056,14 @@ soap_instantiate_ns1__facilityUser(struct soap *, int, const char *,
 
 inline ns1__facilityUser *soap_new_ns1__facilityUser(struct soap *soap,
                                                      int n = -1) {
-  return soap_instantiate_ns1__facilityUser(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__facilityUser(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__facilityUser *
 soap_new_req_ns1__facilityUser(struct soap *soap, bool facilityAcquiredData1,
                                bool selected1) {
   ns1__facilityUser *_p =
-      soap_instantiate_ns1__facilityUser(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__facilityUser(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__entityBaseBean::facilityAcquiredData = facilityAcquiredData1;
@@ -26891,7 +27079,7 @@ inline ns1__facilityUser *soap_new_set_ns1__facilityUser(
     ns1__icatRole *icatRole1, bool selected1, std::string *uniqueId1,
     char *__item2) {
   ns1__facilityUser *_p =
-      soap_instantiate_ns1__facilityUser(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__facilityUser(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__facilityUser::facilityUserId = facilityUserId;
@@ -26965,14 +27153,14 @@ inline ns1__searchFacilityUserByRestrictionResponse *
 soap_new_ns1__searchFacilityUserByRestrictionResponse(struct soap *soap,
                                                       int n = -1) {
   return soap_instantiate_ns1__searchFacilityUserByRestrictionResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchFacilityUserByRestrictionResponse *
 soap_new_req_ns1__searchFacilityUserByRestrictionResponse(struct soap *soap) {
   ns1__searchFacilityUserByRestrictionResponse *_p =
       soap_instantiate_ns1__searchFacilityUserByRestrictionResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -26985,7 +27173,7 @@ soap_new_set_ns1__searchFacilityUserByRestrictionResponse(
     char *__item1) {
   ns1__searchFacilityUserByRestrictionResponse *_p =
       soap_instantiate_ns1__searchFacilityUserByRestrictionResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchFacilityUserByRestrictionResponse::return_ = return_;
@@ -27046,15 +27234,15 @@ soap_instantiate_ns1__searchFacilityUserByRestriction(struct soap *, int,
 
 inline ns1__searchFacilityUserByRestriction *
 soap_new_ns1__searchFacilityUserByRestriction(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchFacilityUserByRestriction(soap, n, NULL,
-                                                               NULL, NULL);
+  return soap_instantiate_ns1__searchFacilityUserByRestriction(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchFacilityUserByRestriction *
 soap_new_req_ns1__searchFacilityUserByRestriction(struct soap *soap) {
   ns1__searchFacilityUserByRestriction *_p =
-      soap_instantiate_ns1__searchFacilityUserByRestriction(soap, -1, NULL,
-                                                            NULL, NULL);
+      soap_instantiate_ns1__searchFacilityUserByRestriction(soap, -1, nullptr,
+                                                            nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -27066,8 +27254,8 @@ soap_new_set_ns1__searchFacilityUserByRestriction(
     struct soap *soap, std::string *sessionId,
     ns1__restrictionCondition *restriction, char *__item1) {
   ns1__searchFacilityUserByRestriction *_p =
-      soap_instantiate_ns1__searchFacilityUserByRestriction(soap, -1, NULL,
-                                                            NULL, NULL);
+      soap_instantiate_ns1__searchFacilityUserByRestriction(soap, -1, nullptr,
+                                                            nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchFacilityUserByRestriction::sessionId = sessionId;
@@ -27128,15 +27316,15 @@ soap_instantiate_ns1__listDatasetTypesResponse(struct soap *, int, const char *,
 
 inline ns1__listDatasetTypesResponse *
 soap_new_ns1__listDatasetTypesResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__listDatasetTypesResponse(soap, n, NULL, NULL,
-                                                        NULL);
+  return soap_instantiate_ns1__listDatasetTypesResponse(soap, n, nullptr,
+                                                        nullptr, nullptr);
 }
 
 inline ns1__listDatasetTypesResponse *
 soap_new_req_ns1__listDatasetTypesResponse(struct soap *soap) {
   ns1__listDatasetTypesResponse *_p =
-      soap_instantiate_ns1__listDatasetTypesResponse(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate_ns1__listDatasetTypesResponse(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -27148,8 +27336,8 @@ soap_new_set_ns1__listDatasetTypesResponse(struct soap *soap,
                                            std::vector<std::string> &return_,
                                            char *__item1) {
   ns1__listDatasetTypesResponse *_p =
-      soap_instantiate_ns1__listDatasetTypesResponse(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate_ns1__listDatasetTypesResponse(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__listDatasetTypesResponse::return_ = return_;
@@ -27206,13 +27394,14 @@ soap_instantiate_ns1__listDatasetTypes(struct soap *, int, const char *,
 
 inline ns1__listDatasetTypes *soap_new_ns1__listDatasetTypes(struct soap *soap,
                                                              int n = -1) {
-  return soap_instantiate_ns1__listDatasetTypes(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__listDatasetTypes(soap, n, nullptr, nullptr,
+                                                nullptr);
 }
 
 inline ns1__listDatasetTypes *
 soap_new_req_ns1__listDatasetTypes(struct soap *soap) {
-  ns1__listDatasetTypes *_p =
-      soap_instantiate_ns1__listDatasetTypes(soap, -1, NULL, NULL, NULL);
+  ns1__listDatasetTypes *_p = soap_instantiate_ns1__listDatasetTypes(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -27222,8 +27411,8 @@ soap_new_req_ns1__listDatasetTypes(struct soap *soap) {
 inline ns1__listDatasetTypes *
 soap_new_set_ns1__listDatasetTypes(struct soap *soap, std::string *sessionId,
                                    char *__item1) {
-  ns1__listDatasetTypes *_p =
-      soap_instantiate_ns1__listDatasetTypes(soap, -1, NULL, NULL, NULL);
+  ns1__listDatasetTypes *_p = soap_instantiate_ns1__listDatasetTypes(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__listDatasetTypes::sessionId = sessionId;
@@ -27287,7 +27476,7 @@ inline ns1__searchDatasetByParameterRestrictionResponse *
 soap_new_ns1__searchDatasetByParameterRestrictionResponse(struct soap *soap,
                                                           int n = -1) {
   return soap_instantiate_ns1__searchDatasetByParameterRestrictionResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatasetByParameterRestrictionResponse *
@@ -27295,7 +27484,7 @@ soap_new_req_ns1__searchDatasetByParameterRestrictionResponse(
     struct soap *soap) {
   ns1__searchDatasetByParameterRestrictionResponse *_p =
       soap_instantiate_ns1__searchDatasetByParameterRestrictionResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -27307,7 +27496,7 @@ soap_new_set_ns1__searchDatasetByParameterRestrictionResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchDatasetByParameterRestrictionResponse *_p =
       soap_instantiate_ns1__searchDatasetByParameterRestrictionResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatasetByParameterRestrictionResponse::return_ = return_;
@@ -27365,14 +27554,15 @@ soap_instantiate_ns1__parameterCondition(struct soap *, int, const char *,
 
 inline ns1__parameterCondition *
 soap_new_ns1__parameterCondition(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__parameterCondition(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__parameterCondition(soap, n, nullptr, nullptr,
+                                                  nullptr);
 }
 
 inline ns1__parameterCondition *
 soap_new_req_ns1__parameterCondition(struct soap *soap, bool negate1,
                                      bool sensitive1) {
-  ns1__parameterCondition *_p =
-      soap_instantiate_ns1__parameterCondition(soap, -1, NULL, NULL, NULL);
+  ns1__parameterCondition *_p = soap_instantiate_ns1__parameterCondition(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__condition::negate = negate1;
@@ -27384,8 +27574,8 @@ soap_new_req_ns1__parameterCondition(struct soap *soap, bool negate1,
 inline ns1__parameterCondition *
 soap_new_set_ns1__parameterCondition(struct soap *soap, bool negate1,
                                      bool sensitive1, char *__item2) {
-  ns1__parameterCondition *_p =
-      soap_instantiate_ns1__parameterCondition(soap, -1, NULL, NULL, NULL);
+  ns1__parameterCondition *_p = soap_instantiate_ns1__parameterCondition(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__condition::negate = negate1;
@@ -27450,14 +27640,14 @@ inline ns1__searchDatasetByParameterRestriction *
 soap_new_ns1__searchDatasetByParameterRestriction(struct soap *soap,
                                                   int n = -1) {
   return soap_instantiate_ns1__searchDatasetByParameterRestriction(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatasetByParameterRestriction *
 soap_new_req_ns1__searchDatasetByParameterRestriction(struct soap *soap) {
   ns1__searchDatasetByParameterRestriction *_p =
-      soap_instantiate_ns1__searchDatasetByParameterRestriction(soap, -1, NULL,
-                                                                NULL, NULL);
+      soap_instantiate_ns1__searchDatasetByParameterRestriction(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -27470,8 +27660,8 @@ soap_new_set_ns1__searchDatasetByParameterRestriction(
     ns1__parameterCondition *parameterCondition,
     ns1__restrictionCondition *restrictions, char *__item1) {
   ns1__searchDatasetByParameterRestriction *_p =
-      soap_instantiate_ns1__searchDatasetByParameterRestriction(soap, -1, NULL,
-                                                                NULL, NULL);
+      soap_instantiate_ns1__searchDatasetByParameterRestriction(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatasetByParameterRestriction::sessionId = sessionId;
@@ -27538,14 +27728,14 @@ inline ns1__searchDatasetByRestrictionLogicalResponse *
 soap_new_ns1__searchDatasetByRestrictionLogicalResponse(struct soap *soap,
                                                         int n = -1) {
   return soap_instantiate_ns1__searchDatasetByRestrictionLogicalResponse(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatasetByRestrictionLogicalResponse *
 soap_new_req_ns1__searchDatasetByRestrictionLogicalResponse(struct soap *soap) {
   ns1__searchDatasetByRestrictionLogicalResponse *_p =
       soap_instantiate_ns1__searchDatasetByRestrictionLogicalResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -27557,7 +27747,7 @@ soap_new_set_ns1__searchDatasetByRestrictionLogicalResponse(
     struct soap *soap, std::vector<xsd__anyType *> &return_, char *__item1) {
   ns1__searchDatasetByRestrictionLogicalResponse *_p =
       soap_instantiate_ns1__searchDatasetByRestrictionLogicalResponse(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatasetByRestrictionLogicalResponse::return_ = return_;
@@ -27612,13 +27802,13 @@ soap_instantiate_ns1__condition(struct soap *, int, const char *, const char *,
                                 size_t *);
 
 inline ns1__condition *soap_new_ns1__condition(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__condition(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__condition(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__condition *
 soap_new_req_ns1__condition(struct soap *soap, bool negate, bool sensitive) {
   ns1__condition *_p =
-      soap_instantiate_ns1__condition(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__condition(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__condition::negate = negate;
@@ -27631,7 +27821,7 @@ inline ns1__condition *soap_new_set_ns1__condition(struct soap *soap,
                                                    bool negate, bool sensitive,
                                                    char *__item1) {
   ns1__condition *_p =
-      soap_instantiate_ns1__condition(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_ns1__condition(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__condition::negate = negate;
@@ -27688,15 +27878,16 @@ soap_instantiate_ns1__restrictionCondition(struct soap *, int, const char *,
 
 inline ns1__restrictionCondition *
 soap_new_ns1__restrictionCondition(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__restrictionCondition(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_ns1__restrictionCondition(soap, n, nullptr, nullptr,
+                                                    nullptr);
 }
 
 inline ns1__restrictionCondition *
 soap_new_req_ns1__restrictionCondition(struct soap *soap, int maxResults,
                                        bool orderByAsc, bool returnLongId,
                                        bool negate1, bool sensitive1) {
-  ns1__restrictionCondition *_p =
-      soap_instantiate_ns1__restrictionCondition(soap, -1, NULL, NULL, NULL);
+  ns1__restrictionCondition *_p = soap_instantiate_ns1__restrictionCondition(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__restrictionCondition::maxResults = maxResults;
@@ -27715,8 +27906,8 @@ inline ns1__restrictionCondition *soap_new_set_ns1__restrictionCondition(
     bool orderByAsc, enum ns1__restrictionAttributes *orderByAttribute,
     bool returnLongId, enum ns1__sampleInclude *sampleInclude, bool negate1,
     bool sensitive1, char *__item2) {
-  ns1__restrictionCondition *_p =
-      soap_instantiate_ns1__restrictionCondition(soap, -1, NULL, NULL, NULL);
+  ns1__restrictionCondition *_p = soap_instantiate_ns1__restrictionCondition(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__restrictionCondition::datafileInclude = datafileInclude;
@@ -27787,8 +27978,8 @@ soap_instantiate_ns1__restrictionLogicalCondition(struct soap *, int,
 
 inline ns1__restrictionLogicalCondition *
 soap_new_ns1__restrictionLogicalCondition(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__restrictionLogicalCondition(soap, n, NULL, NULL,
-                                                           NULL);
+  return soap_instantiate_ns1__restrictionLogicalCondition(soap, n, nullptr,
+                                                           nullptr, nullptr);
 }
 
 inline ns1__restrictionLogicalCondition *
@@ -27797,8 +27988,8 @@ soap_new_req_ns1__restrictionLogicalCondition(struct soap *soap,
                                               bool returnLongId1, bool negate2,
                                               bool sensitive2) {
   ns1__restrictionLogicalCondition *_p =
-      soap_instantiate_ns1__restrictionLogicalCondition(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__restrictionLogicalCondition(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__restrictionCondition::maxResults = maxResults1;
@@ -27821,8 +28012,8 @@ soap_new_set_ns1__restrictionLogicalCondition(
     bool returnLongId1, enum ns1__sampleInclude *sampleInclude1, bool negate2,
     bool sensitive2, char *__item3) {
   ns1__restrictionLogicalCondition *_p =
-      soap_instantiate_ns1__restrictionLogicalCondition(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate_ns1__restrictionLogicalCondition(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__restrictionLogicalCondition::operator_ = operator_;
@@ -27895,15 +28086,15 @@ soap_instantiate_ns1__searchDatasetByRestrictionLogical(struct soap *, int,
 
 inline ns1__searchDatasetByRestrictionLogical *
 soap_new_ns1__searchDatasetByRestrictionLogical(struct soap *soap, int n = -1) {
-  return soap_instantiate_ns1__searchDatasetByRestrictionLogical(soap, n, NULL,
-                                                                 NULL, NULL);
+  return soap_instantiate_ns1__searchDatasetByRestrictionLogical(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline ns1__searchDatasetByRestrictionLogical *
 soap_new_req_ns1__searchDatasetByRestrictionLogical(struct soap *soap) {
   ns1__searchDatasetByRestrictionLogical *_p =
-      soap_instantiate_ns1__searchDatasetByRestrictionLogical(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate_ns1__searchDatasetByRestrictionLogical(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -27915,8 +28106,8 @@ soap_new_set_ns1__searchDatasetByRestrictionLogical(
     struct soap *soap, std::string *sessionId,
     ns1__restrictionLogicalCondition *restriction, char *__item1) {
   ns1__searchDatasetByRestrictionLogical *_p =
-      soap_instantiate_ns1__searchDatasetByRestrictionLogical(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate_ns1__searchDatasetByRestrictionLogical(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->ns1__searchDatasetByRestrictionLogical::sessionId = sessionId;
@@ -27977,11 +28168,12 @@ soap_instantiate_std__string(struct soap *, int, const char *, const char *,
                              size_t *);
 
 inline std::string *soap_new_std__string(struct soap *soap, int n = -1) {
-  return soap_instantiate_std__string(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_std__string(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline std::string *soap_new_req_std__string(struct soap *soap) {
-  std::string *_p = soap_instantiate_std__string(soap, -1, NULL, NULL, NULL);
+  std::string *_p =
+      soap_instantiate_std__string(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default_std__string(soap, _p);
   }
@@ -27989,7 +28181,8 @@ inline std::string *soap_new_req_std__string(struct soap *soap) {
 }
 
 inline std::string *soap_new_set_std__string(struct soap *soap) {
-  std::string *_p = soap_instantiate_std__string(soap, -1, NULL, NULL, NULL);
+  std::string *_p =
+      soap_instantiate_std__string(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default_std__string(soap, _p);
   }
@@ -28038,12 +28231,13 @@ soap_instantiate_xsd__string(struct soap *, int, const char *, const char *,
                              size_t *);
 
 inline xsd__string *soap_new_xsd__string(struct soap *soap, int n = -1) {
-  return soap_instantiate_xsd__string(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_xsd__string(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline xsd__string *soap_new_req_xsd__string(struct soap *soap,
                                              std::string &__item) {
-  xsd__string *_p = soap_instantiate_xsd__string(soap, -1, NULL, NULL, NULL);
+  xsd__string *_p =
+      soap_instantiate_xsd__string(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__string::__item = __item;
@@ -28054,7 +28248,8 @@ inline xsd__string *soap_new_req_xsd__string(struct soap *soap,
 inline xsd__string *soap_new_set_xsd__string(struct soap *soap,
                                              std::string &__item,
                                              char *__item1) {
-  xsd__string *_p = soap_instantiate_xsd__string(soap, -1, NULL, NULL, NULL);
+  xsd__string *_p =
+      soap_instantiate_xsd__string(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__string::__item = __item;
@@ -28104,11 +28299,12 @@ soap_instantiate_xsd__long(struct soap *, int, const char *, const char *,
                            size_t *);
 
 inline xsd__long *soap_new_xsd__long(struct soap *soap, int n = -1) {
-  return soap_instantiate_xsd__long(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_xsd__long(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline xsd__long *soap_new_req_xsd__long(struct soap *soap, LONG64 __item) {
-  xsd__long *_p = soap_instantiate_xsd__long(soap, -1, NULL, NULL, NULL);
+  xsd__long *_p =
+      soap_instantiate_xsd__long(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__long::__item = __item;
@@ -28118,7 +28314,8 @@ inline xsd__long *soap_new_req_xsd__long(struct soap *soap, LONG64 __item) {
 
 inline xsd__long *soap_new_set_xsd__long(struct soap *soap, LONG64 __item,
                                          char *__item1) {
-  xsd__long *_p = soap_instantiate_xsd__long(soap, -1, NULL, NULL, NULL);
+  xsd__long *_p =
+      soap_instantiate_xsd__long(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__long::__item = __item;
@@ -28167,11 +28364,11 @@ soap_instantiate_xsd__int(struct soap *, int, const char *, const char *,
                           size_t *);
 
 inline xsd__int *soap_new_xsd__int(struct soap *soap, int n = -1) {
-  return soap_instantiate_xsd__int(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_xsd__int(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline xsd__int *soap_new_req_xsd__int(struct soap *soap, int __item) {
-  xsd__int *_p = soap_instantiate_xsd__int(soap, -1, NULL, NULL, NULL);
+  xsd__int *_p = soap_instantiate_xsd__int(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__int::__item = __item;
@@ -28181,7 +28378,7 @@ inline xsd__int *soap_new_req_xsd__int(struct soap *soap, int __item) {
 
 inline xsd__int *soap_new_set_xsd__int(struct soap *soap, int __item,
                                        char *__item1) {
-  xsd__int *_p = soap_instantiate_xsd__int(soap, -1, NULL, NULL, NULL);
+  xsd__int *_p = soap_instantiate_xsd__int(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__int::__item = __item;
@@ -28230,11 +28427,12 @@ soap_instantiate_xsd__float(struct soap *, int, const char *, const char *,
                             size_t *);
 
 inline xsd__float *soap_new_xsd__float(struct soap *soap, int n = -1) {
-  return soap_instantiate_xsd__float(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_xsd__float(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline xsd__float *soap_new_req_xsd__float(struct soap *soap, float __item) {
-  xsd__float *_p = soap_instantiate_xsd__float(soap, -1, NULL, NULL, NULL);
+  xsd__float *_p =
+      soap_instantiate_xsd__float(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__float::__item = __item;
@@ -28244,7 +28442,8 @@ inline xsd__float *soap_new_req_xsd__float(struct soap *soap, float __item) {
 
 inline xsd__float *soap_new_set_xsd__float(struct soap *soap, float __item,
                                            char *__item1) {
-  xsd__float *_p = soap_instantiate_xsd__float(soap, -1, NULL, NULL, NULL);
+  xsd__float *_p =
+      soap_instantiate_xsd__float(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__float::__item = __item;
@@ -28294,11 +28493,12 @@ soap_instantiate_xsd__double(struct soap *, int, const char *, const char *,
                              size_t *);
 
 inline xsd__double *soap_new_xsd__double(struct soap *soap, int n = -1) {
-  return soap_instantiate_xsd__double(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_xsd__double(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline xsd__double *soap_new_req_xsd__double(struct soap *soap, double __item) {
-  xsd__double *_p = soap_instantiate_xsd__double(soap, -1, NULL, NULL, NULL);
+  xsd__double *_p =
+      soap_instantiate_xsd__double(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__double::__item = __item;
@@ -28308,7 +28508,8 @@ inline xsd__double *soap_new_req_xsd__double(struct soap *soap, double __item) {
 
 inline xsd__double *soap_new_set_xsd__double(struct soap *soap, double __item,
                                              char *__item1) {
-  xsd__double *_p = soap_instantiate_xsd__double(soap, -1, NULL, NULL, NULL);
+  xsd__double *_p =
+      soap_instantiate_xsd__double(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__double::__item = __item;
@@ -28361,13 +28562,13 @@ soap_instantiate_xsd__dateTime(struct soap *, int, const char *, const char *,
                                size_t *);
 
 inline xsd__dateTime *soap_new_xsd__dateTime(struct soap *soap, int n = -1) {
-  return soap_instantiate_xsd__dateTime(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_xsd__dateTime(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline xsd__dateTime *soap_new_req_xsd__dateTime(struct soap *soap,
                                                  time_t __item) {
   xsd__dateTime *_p =
-      soap_instantiate_xsd__dateTime(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_xsd__dateTime(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__dateTime::__item = __item;
@@ -28378,7 +28579,7 @@ inline xsd__dateTime *soap_new_req_xsd__dateTime(struct soap *soap,
 inline xsd__dateTime *soap_new_set_xsd__dateTime(struct soap *soap,
                                                  time_t __item, char *__item1) {
   xsd__dateTime *_p =
-      soap_instantiate_xsd__dateTime(soap, -1, NULL, NULL, NULL);
+      soap_instantiate_xsd__dateTime(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__dateTime::__item = __item;
@@ -28430,11 +28631,12 @@ soap_instantiate_xsd__boolean(struct soap *, int, const char *, const char *,
                               size_t *);
 
 inline xsd__boolean *soap_new_xsd__boolean(struct soap *soap, int n = -1) {
-  return soap_instantiate_xsd__boolean(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_xsd__boolean(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline xsd__boolean *soap_new_req_xsd__boolean(struct soap *soap, bool __item) {
-  xsd__boolean *_p = soap_instantiate_xsd__boolean(soap, -1, NULL, NULL, NULL);
+  xsd__boolean *_p =
+      soap_instantiate_xsd__boolean(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__boolean::__item = __item;
@@ -28444,7 +28646,8 @@ inline xsd__boolean *soap_new_req_xsd__boolean(struct soap *soap, bool __item) {
 
 inline xsd__boolean *soap_new_set_xsd__boolean(struct soap *soap, bool __item,
                                                char *__item1) {
-  xsd__boolean *_p = soap_instantiate_xsd__boolean(soap, -1, NULL, NULL, NULL);
+  xsd__boolean *_p =
+      soap_instantiate_xsd__boolean(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__boolean::__item = __item;
@@ -28496,11 +28699,12 @@ soap_instantiate_xsd__anyType(struct soap *, int, const char *, const char *,
                               size_t *);
 
 inline xsd__anyType *soap_new_xsd__anyType(struct soap *soap, int n = -1) {
-  return soap_instantiate_xsd__anyType(soap, n, NULL, NULL, NULL);
+  return soap_instantiate_xsd__anyType(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline xsd__anyType *soap_new_req_xsd__anyType(struct soap *soap) {
-  xsd__anyType *_p = soap_instantiate_xsd__anyType(soap, -1, NULL, NULL, NULL);
+  xsd__anyType *_p =
+      soap_instantiate_xsd__anyType(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
   }
@@ -28509,7 +28713,8 @@ inline xsd__anyType *soap_new_req_xsd__anyType(struct soap *soap) {
 
 inline xsd__anyType *soap_new_set_xsd__anyType(struct soap *soap,
                                                char *__item) {
-  xsd__anyType *_p = soap_instantiate_xsd__anyType(soap, -1, NULL, NULL, NULL);
+  xsd__anyType *_p =
+      soap_instantiate_xsd__anyType(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     _p->soap_default(soap);
     _p->xsd__anyType::__item = __item;
@@ -28914,15 +29119,15 @@ soap_instantiate___ns1__searchFacilityUserByRestriction(struct soap *, int,
 
 inline struct __ns1__searchFacilityUserByRestriction *
 soap_new___ns1__searchFacilityUserByRestriction(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__searchFacilityUserByRestriction(soap, n, NULL,
-                                                                 NULL, NULL);
+  return soap_instantiate___ns1__searchFacilityUserByRestriction(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchFacilityUserByRestriction *
 soap_new_req___ns1__searchFacilityUserByRestriction(struct soap *soap) {
   struct __ns1__searchFacilityUserByRestriction *_p =
-      soap_instantiate___ns1__searchFacilityUserByRestriction(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate___ns1__searchFacilityUserByRestriction(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchFacilityUserByRestriction(soap, _p);
   }
@@ -28934,8 +29139,8 @@ soap_new_set___ns1__searchFacilityUserByRestriction(
     struct soap *soap, ns1__searchFacilityUserByRestriction *
                            ns1__searchFacilityUserByRestriction_) {
   struct __ns1__searchFacilityUserByRestriction *_p =
-      soap_instantiate___ns1__searchFacilityUserByRestriction(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate___ns1__searchFacilityUserByRestriction(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchFacilityUserByRestriction(soap, _p);
     _p->ns1__searchFacilityUserByRestriction_ =
@@ -29004,15 +29209,15 @@ soap_instantiate___ns1__searchSampleByParameterLogical(struct soap *, int,
 
 inline struct __ns1__searchSampleByParameterLogical *
 soap_new___ns1__searchSampleByParameterLogical(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__searchSampleByParameterLogical(soap, n, NULL,
-                                                                NULL, NULL);
+  return soap_instantiate___ns1__searchSampleByParameterLogical(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchSampleByParameterLogical *
 soap_new_req___ns1__searchSampleByParameterLogical(struct soap *soap) {
   struct __ns1__searchSampleByParameterLogical *_p =
-      soap_instantiate___ns1__searchSampleByParameterLogical(soap, -1, NULL,
-                                                             NULL, NULL);
+      soap_instantiate___ns1__searchSampleByParameterLogical(soap, -1, nullptr,
+                                                             nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchSampleByParameterLogical(soap, _p);
   }
@@ -29024,8 +29229,8 @@ soap_new_set___ns1__searchSampleByParameterLogical(
     struct soap *soap,
     ns1__searchSampleByParameterLogical *ns1__searchSampleByParameterLogical_) {
   struct __ns1__searchSampleByParameterLogical *_p =
-      soap_instantiate___ns1__searchSampleByParameterLogical(soap, -1, NULL,
-                                                             NULL, NULL);
+      soap_instantiate___ns1__searchSampleByParameterLogical(soap, -1, nullptr,
+                                                             nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchSampleByParameterLogical(soap, _p);
     _p->ns1__searchSampleByParameterLogical_ =
@@ -29094,15 +29299,15 @@ soap_instantiate___ns1__searchDatasetByParameterLogical(struct soap *, int,
 
 inline struct __ns1__searchDatasetByParameterLogical *
 soap_new___ns1__searchDatasetByParameterLogical(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__searchDatasetByParameterLogical(soap, n, NULL,
-                                                                 NULL, NULL);
+  return soap_instantiate___ns1__searchDatasetByParameterLogical(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchDatasetByParameterLogical *
 soap_new_req___ns1__searchDatasetByParameterLogical(struct soap *soap) {
   struct __ns1__searchDatasetByParameterLogical *_p =
-      soap_instantiate___ns1__searchDatasetByParameterLogical(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate___ns1__searchDatasetByParameterLogical(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatasetByParameterLogical(soap, _p);
   }
@@ -29114,8 +29319,8 @@ soap_new_set___ns1__searchDatasetByParameterLogical(
     struct soap *soap, ns1__searchDatasetByParameterLogical *
                            ns1__searchDatasetByParameterLogical_) {
   struct __ns1__searchDatasetByParameterLogical *_p =
-      soap_instantiate___ns1__searchDatasetByParameterLogical(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate___ns1__searchDatasetByParameterLogical(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatasetByParameterLogical(soap, _p);
     _p->ns1__searchDatasetByParameterLogical_ =
@@ -29187,15 +29392,15 @@ soap_instantiate___ns1__searchDatafileByParameterLogical(struct soap *, int,
 inline struct __ns1__searchDatafileByParameterLogical *
 soap_new___ns1__searchDatafileByParameterLogical(struct soap *soap,
                                                  int n = -1) {
-  return soap_instantiate___ns1__searchDatafileByParameterLogical(soap, n, NULL,
-                                                                  NULL, NULL);
+  return soap_instantiate___ns1__searchDatafileByParameterLogical(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchDatafileByParameterLogical *
 soap_new_req___ns1__searchDatafileByParameterLogical(struct soap *soap) {
   struct __ns1__searchDatafileByParameterLogical *_p =
-      soap_instantiate___ns1__searchDatafileByParameterLogical(soap, -1, NULL,
-                                                               NULL, NULL);
+      soap_instantiate___ns1__searchDatafileByParameterLogical(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatafileByParameterLogical(soap, _p);
   }
@@ -29207,8 +29412,8 @@ soap_new_set___ns1__searchDatafileByParameterLogical(
     struct soap *soap, ns1__searchDatafileByParameterLogical *
                            ns1__searchDatafileByParameterLogical_) {
   struct __ns1__searchDatafileByParameterLogical *_p =
-      soap_instantiate___ns1__searchDatafileByParameterLogical(soap, -1, NULL,
-                                                               NULL, NULL);
+      soap_instantiate___ns1__searchDatafileByParameterLogical(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatafileByParameterLogical(soap, _p);
     _p->ns1__searchDatafileByParameterLogical_ =
@@ -29283,14 +29488,14 @@ inline struct __ns1__searchInvestigationByParameterLogical *
 soap_new___ns1__searchInvestigationByParameterLogical(struct soap *soap,
                                                       int n = -1) {
   return soap_instantiate___ns1__searchInvestigationByParameterLogical(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchInvestigationByParameterLogical *
 soap_new_req___ns1__searchInvestigationByParameterLogical(struct soap *soap) {
   struct __ns1__searchInvestigationByParameterLogical *_p =
       soap_instantiate___ns1__searchInvestigationByParameterLogical(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchInvestigationByParameterLogical(soap, _p);
   }
@@ -29303,7 +29508,7 @@ soap_new_set___ns1__searchInvestigationByParameterLogical(
                            ns1__searchInvestigationByParameterLogical_) {
   struct __ns1__searchInvestigationByParameterLogical *_p =
       soap_instantiate___ns1__searchInvestigationByParameterLogical(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchInvestigationByParameterLogical(soap, _p);
     _p->ns1__searchInvestigationByParameterLogical_ =
@@ -29378,14 +29583,14 @@ inline struct __ns1__searchDatafileByRestrictionLogical *
 soap_new___ns1__searchDatafileByRestrictionLogical(struct soap *soap,
                                                    int n = -1) {
   return soap_instantiate___ns1__searchDatafileByRestrictionLogical(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchDatafileByRestrictionLogical *
 soap_new_req___ns1__searchDatafileByRestrictionLogical(struct soap *soap) {
   struct __ns1__searchDatafileByRestrictionLogical *_p =
-      soap_instantiate___ns1__searchDatafileByRestrictionLogical(soap, -1, NULL,
-                                                                 NULL, NULL);
+      soap_instantiate___ns1__searchDatafileByRestrictionLogical(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatafileByRestrictionLogical(soap, _p);
   }
@@ -29397,8 +29602,8 @@ soap_new_set___ns1__searchDatafileByRestrictionLogical(
     struct soap *soap, ns1__searchDatafileByRestrictionLogical *
                            ns1__searchDatafileByRestrictionLogical_) {
   struct __ns1__searchDatafileByRestrictionLogical *_p =
-      soap_instantiate___ns1__searchDatafileByRestrictionLogical(soap, -1, NULL,
-                                                                 NULL, NULL);
+      soap_instantiate___ns1__searchDatafileByRestrictionLogical(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatafileByRestrictionLogical(soap, _p);
     _p->ns1__searchDatafileByRestrictionLogical_ =
@@ -29477,14 +29682,14 @@ inline struct __ns1__searchInvestigationByRestrictionLogical *
 soap_new___ns1__searchInvestigationByRestrictionLogical(struct soap *soap,
                                                         int n = -1) {
   return soap_instantiate___ns1__searchInvestigationByRestrictionLogical(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchInvestigationByRestrictionLogical *
 soap_new_req___ns1__searchInvestigationByRestrictionLogical(struct soap *soap) {
   struct __ns1__searchInvestigationByRestrictionLogical *_p =
       soap_instantiate___ns1__searchInvestigationByRestrictionLogical(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchInvestigationByRestrictionLogical(soap, _p);
   }
@@ -29497,7 +29702,7 @@ soap_new_set___ns1__searchInvestigationByRestrictionLogical(
                            ns1__searchInvestigationByRestrictionLogical_) {
   struct __ns1__searchInvestigationByRestrictionLogical *_p =
       soap_instantiate___ns1__searchInvestigationByRestrictionLogical(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchInvestigationByRestrictionLogical(soap, _p);
     _p->ns1__searchInvestigationByRestrictionLogical_ =
@@ -29572,14 +29777,14 @@ inline struct __ns1__searchDatasetByRestrictionLogical *
 soap_new___ns1__searchDatasetByRestrictionLogical(struct soap *soap,
                                                   int n = -1) {
   return soap_instantiate___ns1__searchDatasetByRestrictionLogical(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchDatasetByRestrictionLogical *
 soap_new_req___ns1__searchDatasetByRestrictionLogical(struct soap *soap) {
   struct __ns1__searchDatasetByRestrictionLogical *_p =
-      soap_instantiate___ns1__searchDatasetByRestrictionLogical(soap, -1, NULL,
-                                                                NULL, NULL);
+      soap_instantiate___ns1__searchDatasetByRestrictionLogical(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatasetByRestrictionLogical(soap, _p);
   }
@@ -29591,8 +29796,8 @@ soap_new_set___ns1__searchDatasetByRestrictionLogical(
     struct soap *soap, ns1__searchDatasetByRestrictionLogical *
                            ns1__searchDatasetByRestrictionLogical_) {
   struct __ns1__searchDatasetByRestrictionLogical *_p =
-      soap_instantiate___ns1__searchDatasetByRestrictionLogical(soap, -1, NULL,
-                                                                NULL, NULL);
+      soap_instantiate___ns1__searchDatasetByRestrictionLogical(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatasetByRestrictionLogical(soap, _p);
     _p->ns1__searchDatasetByRestrictionLogical_ =
@@ -29664,15 +29869,15 @@ soap_instantiate___ns1__searchSampleByRestrictionLogical(struct soap *, int,
 inline struct __ns1__searchSampleByRestrictionLogical *
 soap_new___ns1__searchSampleByRestrictionLogical(struct soap *soap,
                                                  int n = -1) {
-  return soap_instantiate___ns1__searchSampleByRestrictionLogical(soap, n, NULL,
-                                                                  NULL, NULL);
+  return soap_instantiate___ns1__searchSampleByRestrictionLogical(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchSampleByRestrictionLogical *
 soap_new_req___ns1__searchSampleByRestrictionLogical(struct soap *soap) {
   struct __ns1__searchSampleByRestrictionLogical *_p =
-      soap_instantiate___ns1__searchSampleByRestrictionLogical(soap, -1, NULL,
-                                                               NULL, NULL);
+      soap_instantiate___ns1__searchSampleByRestrictionLogical(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchSampleByRestrictionLogical(soap, _p);
   }
@@ -29684,8 +29889,8 @@ soap_new_set___ns1__searchSampleByRestrictionLogical(
     struct soap *soap, ns1__searchSampleByRestrictionLogical *
                            ns1__searchSampleByRestrictionLogical_) {
   struct __ns1__searchSampleByRestrictionLogical *_p =
-      soap_instantiate___ns1__searchSampleByRestrictionLogical(soap, -1, NULL,
-                                                               NULL, NULL);
+      soap_instantiate___ns1__searchSampleByRestrictionLogical(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchSampleByRestrictionLogical(soap, _p);
     _p->ns1__searchSampleByRestrictionLogical_ =
@@ -29760,14 +29965,14 @@ inline struct __ns1__searchSampleByRestrictionComparison *
 soap_new___ns1__searchSampleByRestrictionComparison(struct soap *soap,
                                                     int n = -1) {
   return soap_instantiate___ns1__searchSampleByRestrictionComparison(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchSampleByRestrictionComparison *
 soap_new_req___ns1__searchSampleByRestrictionComparison(struct soap *soap) {
   struct __ns1__searchSampleByRestrictionComparison *_p =
       soap_instantiate___ns1__searchSampleByRestrictionComparison(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchSampleByRestrictionComparison(soap, _p);
   }
@@ -29780,7 +29985,7 @@ soap_new_set___ns1__searchSampleByRestrictionComparison(
                            ns1__searchSampleByRestrictionComparison_) {
   struct __ns1__searchSampleByRestrictionComparison *_p =
       soap_instantiate___ns1__searchSampleByRestrictionComparison(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchSampleByRestrictionComparison(soap, _p);
     _p->ns1__searchSampleByRestrictionComparison_ =
@@ -29855,14 +30060,14 @@ inline struct __ns1__searchDatafileByRestrictionComparison *
 soap_new___ns1__searchDatafileByRestrictionComparison(struct soap *soap,
                                                       int n = -1) {
   return soap_instantiate___ns1__searchDatafileByRestrictionComparison(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchDatafileByRestrictionComparison *
 soap_new_req___ns1__searchDatafileByRestrictionComparison(struct soap *soap) {
   struct __ns1__searchDatafileByRestrictionComparison *_p =
       soap_instantiate___ns1__searchDatafileByRestrictionComparison(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatafileByRestrictionComparison(soap, _p);
   }
@@ -29875,7 +30080,7 @@ soap_new_set___ns1__searchDatafileByRestrictionComparison(
                            ns1__searchDatafileByRestrictionComparison_) {
   struct __ns1__searchDatafileByRestrictionComparison *_p =
       soap_instantiate___ns1__searchDatafileByRestrictionComparison(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatafileByRestrictionComparison(soap, _p);
     _p->ns1__searchDatafileByRestrictionComparison_ =
@@ -29950,14 +30155,14 @@ inline struct __ns1__searchDatasetByRestrictionComparison *
 soap_new___ns1__searchDatasetByRestrictionComparison(struct soap *soap,
                                                      int n = -1) {
   return soap_instantiate___ns1__searchDatasetByRestrictionComparison(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchDatasetByRestrictionComparison *
 soap_new_req___ns1__searchDatasetByRestrictionComparison(struct soap *soap) {
   struct __ns1__searchDatasetByRestrictionComparison *_p =
       soap_instantiate___ns1__searchDatasetByRestrictionComparison(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatasetByRestrictionComparison(soap, _p);
   }
@@ -29970,7 +30175,7 @@ soap_new_set___ns1__searchDatasetByRestrictionComparison(
                            ns1__searchDatasetByRestrictionComparison_) {
   struct __ns1__searchDatasetByRestrictionComparison *_p =
       soap_instantiate___ns1__searchDatasetByRestrictionComparison(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatasetByRestrictionComparison(soap, _p);
     _p->ns1__searchDatasetByRestrictionComparison_ =
@@ -30052,7 +30257,7 @@ inline struct __ns1__searchInvestigationByRestrictionComparasion *
 soap_new___ns1__searchInvestigationByRestrictionComparasion(struct soap *soap,
                                                             int n = -1) {
   return soap_instantiate___ns1__searchInvestigationByRestrictionComparasion(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchInvestigationByRestrictionComparasion *
@@ -30060,7 +30265,7 @@ soap_new_req___ns1__searchInvestigationByRestrictionComparasion(
     struct soap *soap) {
   struct __ns1__searchInvestigationByRestrictionComparasion *_p =
       soap_instantiate___ns1__searchInvestigationByRestrictionComparasion(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchInvestigationByRestrictionComparasion(soap, _p);
   }
@@ -30073,7 +30278,7 @@ soap_new_set___ns1__searchInvestigationByRestrictionComparasion(
                            ns1__searchInvestigationByRestrictionComparasion_) {
   struct __ns1__searchInvestigationByRestrictionComparasion *_p =
       soap_instantiate___ns1__searchInvestigationByRestrictionComparasion(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchInvestigationByRestrictionComparasion(soap, _p);
     _p->ns1__searchInvestigationByRestrictionComparasion_ =
@@ -30142,15 +30347,15 @@ soap_instantiate___ns1__searchSampleByRestriction(struct soap *, int,
 
 inline struct __ns1__searchSampleByRestriction *
 soap_new___ns1__searchSampleByRestriction(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__searchSampleByRestriction(soap, n, NULL, NULL,
-                                                           NULL);
+  return soap_instantiate___ns1__searchSampleByRestriction(soap, n, nullptr,
+                                                           nullptr, nullptr);
 }
 
 inline struct __ns1__searchSampleByRestriction *
 soap_new_req___ns1__searchSampleByRestriction(struct soap *soap) {
   struct __ns1__searchSampleByRestriction *_p =
-      soap_instantiate___ns1__searchSampleByRestriction(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate___ns1__searchSampleByRestriction(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchSampleByRestriction(soap, _p);
   }
@@ -30162,8 +30367,8 @@ soap_new_set___ns1__searchSampleByRestriction(
     struct soap *soap,
     ns1__searchSampleByRestriction *ns1__searchSampleByRestriction_) {
   struct __ns1__searchSampleByRestriction *_p =
-      soap_instantiate___ns1__searchSampleByRestriction(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate___ns1__searchSampleByRestriction(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchSampleByRestriction(soap, _p);
     _p->ns1__searchSampleByRestriction_ = ns1__searchSampleByRestriction_;
@@ -30230,15 +30435,15 @@ soap_instantiate___ns1__searchDatafileByRestriction(struct soap *, int,
 
 inline struct __ns1__searchDatafileByRestriction *
 soap_new___ns1__searchDatafileByRestriction(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__searchDatafileByRestriction(soap, n, NULL,
-                                                             NULL, NULL);
+  return soap_instantiate___ns1__searchDatafileByRestriction(soap, n, nullptr,
+                                                             nullptr, nullptr);
 }
 
 inline struct __ns1__searchDatafileByRestriction *
 soap_new_req___ns1__searchDatafileByRestriction(struct soap *soap) {
   struct __ns1__searchDatafileByRestriction *_p =
-      soap_instantiate___ns1__searchDatafileByRestriction(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate___ns1__searchDatafileByRestriction(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatafileByRestriction(soap, _p);
   }
@@ -30250,8 +30455,8 @@ soap_new_set___ns1__searchDatafileByRestriction(
     struct soap *soap,
     ns1__searchDatafileByRestriction *ns1__searchDatafileByRestriction_) {
   struct __ns1__searchDatafileByRestriction *_p =
-      soap_instantiate___ns1__searchDatafileByRestriction(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate___ns1__searchDatafileByRestriction(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatafileByRestriction(soap, _p);
     _p->ns1__searchDatafileByRestriction_ = ns1__searchDatafileByRestriction_;
@@ -30318,15 +30523,15 @@ soap_instantiate___ns1__searchDatasetByRestriction(struct soap *, int,
 
 inline struct __ns1__searchDatasetByRestriction *
 soap_new___ns1__searchDatasetByRestriction(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__searchDatasetByRestriction(soap, n, NULL, NULL,
-                                                            NULL);
+  return soap_instantiate___ns1__searchDatasetByRestriction(soap, n, nullptr,
+                                                            nullptr, nullptr);
 }
 
 inline struct __ns1__searchDatasetByRestriction *
 soap_new_req___ns1__searchDatasetByRestriction(struct soap *soap) {
   struct __ns1__searchDatasetByRestriction *_p =
-      soap_instantiate___ns1__searchDatasetByRestriction(soap, -1, NULL, NULL,
-                                                         NULL);
+      soap_instantiate___ns1__searchDatasetByRestriction(soap, -1, nullptr,
+                                                         nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatasetByRestriction(soap, _p);
   }
@@ -30338,8 +30543,8 @@ soap_new_set___ns1__searchDatasetByRestriction(
     struct soap *soap,
     ns1__searchDatasetByRestriction *ns1__searchDatasetByRestriction_) {
   struct __ns1__searchDatasetByRestriction *_p =
-      soap_instantiate___ns1__searchDatasetByRestriction(soap, -1, NULL, NULL,
-                                                         NULL);
+      soap_instantiate___ns1__searchDatasetByRestriction(soap, -1, nullptr,
+                                                         nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatasetByRestriction(soap, _p);
     _p->ns1__searchDatasetByRestriction_ = ns1__searchDatasetByRestriction_;
@@ -30409,15 +30614,15 @@ soap_instantiate___ns1__searchInvestigationByRestriction(struct soap *, int,
 inline struct __ns1__searchInvestigationByRestriction *
 soap_new___ns1__searchInvestigationByRestriction(struct soap *soap,
                                                  int n = -1) {
-  return soap_instantiate___ns1__searchInvestigationByRestriction(soap, n, NULL,
-                                                                  NULL, NULL);
+  return soap_instantiate___ns1__searchInvestigationByRestriction(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchInvestigationByRestriction *
 soap_new_req___ns1__searchInvestigationByRestriction(struct soap *soap) {
   struct __ns1__searchInvestigationByRestriction *_p =
-      soap_instantiate___ns1__searchInvestigationByRestriction(soap, -1, NULL,
-                                                               NULL, NULL);
+      soap_instantiate___ns1__searchInvestigationByRestriction(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchInvestigationByRestriction(soap, _p);
   }
@@ -30429,8 +30634,8 @@ soap_new_set___ns1__searchInvestigationByRestriction(
     struct soap *soap, ns1__searchInvestigationByRestriction *
                            ns1__searchInvestigationByRestriction_) {
   struct __ns1__searchInvestigationByRestriction *_p =
-      soap_instantiate___ns1__searchInvestigationByRestriction(soap, -1, NULL,
-                                                               NULL, NULL);
+      soap_instantiate___ns1__searchInvestigationByRestriction(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchInvestigationByRestriction(soap, _p);
     _p->ns1__searchInvestigationByRestriction_ =
@@ -30510,7 +30715,7 @@ inline struct __ns1__searchInvestigationByParameterRestriction *
 soap_new___ns1__searchInvestigationByParameterRestriction(struct soap *soap,
                                                           int n = -1) {
   return soap_instantiate___ns1__searchInvestigationByParameterRestriction(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchInvestigationByParameterRestriction *
@@ -30518,7 +30723,7 @@ soap_new_req___ns1__searchInvestigationByParameterRestriction(
     struct soap *soap) {
   struct __ns1__searchInvestigationByParameterRestriction *_p =
       soap_instantiate___ns1__searchInvestigationByParameterRestriction(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchInvestigationByParameterRestriction(soap, _p);
   }
@@ -30531,7 +30736,7 @@ soap_new_set___ns1__searchInvestigationByParameterRestriction(
                            ns1__searchInvestigationByParameterRestriction_) {
   struct __ns1__searchInvestigationByParameterRestriction *_p =
       soap_instantiate___ns1__searchInvestigationByParameterRestriction(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchInvestigationByParameterRestriction(soap, _p);
     _p->ns1__searchInvestigationByParameterRestriction_ =
@@ -30608,14 +30813,14 @@ inline struct __ns1__searchDatafileByParameterRestriction *
 soap_new___ns1__searchDatafileByParameterRestriction(struct soap *soap,
                                                      int n = -1) {
   return soap_instantiate___ns1__searchDatafileByParameterRestriction(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchDatafileByParameterRestriction *
 soap_new_req___ns1__searchDatafileByParameterRestriction(struct soap *soap) {
   struct __ns1__searchDatafileByParameterRestriction *_p =
       soap_instantiate___ns1__searchDatafileByParameterRestriction(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatafileByParameterRestriction(soap, _p);
   }
@@ -30628,7 +30833,7 @@ soap_new_set___ns1__searchDatafileByParameterRestriction(
                            ns1__searchDatafileByParameterRestriction_) {
   struct __ns1__searchDatafileByParameterRestriction *_p =
       soap_instantiate___ns1__searchDatafileByParameterRestriction(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatafileByParameterRestriction(soap, _p);
     _p->ns1__searchDatafileByParameterRestriction_ =
@@ -30703,14 +30908,14 @@ inline struct __ns1__searchSampleByParameterRestriction *
 soap_new___ns1__searchSampleByParameterRestriction(struct soap *soap,
                                                    int n = -1) {
   return soap_instantiate___ns1__searchSampleByParameterRestriction(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchSampleByParameterRestriction *
 soap_new_req___ns1__searchSampleByParameterRestriction(struct soap *soap) {
   struct __ns1__searchSampleByParameterRestriction *_p =
-      soap_instantiate___ns1__searchSampleByParameterRestriction(soap, -1, NULL,
-                                                                 NULL, NULL);
+      soap_instantiate___ns1__searchSampleByParameterRestriction(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchSampleByParameterRestriction(soap, _p);
   }
@@ -30722,8 +30927,8 @@ soap_new_set___ns1__searchSampleByParameterRestriction(
     struct soap *soap, ns1__searchSampleByParameterRestriction *
                            ns1__searchSampleByParameterRestriction_) {
   struct __ns1__searchSampleByParameterRestriction *_p =
-      soap_instantiate___ns1__searchSampleByParameterRestriction(soap, -1, NULL,
-                                                                 NULL, NULL);
+      soap_instantiate___ns1__searchSampleByParameterRestriction(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchSampleByParameterRestriction(soap, _p);
     _p->ns1__searchSampleByParameterRestriction_ =
@@ -30798,14 +31003,14 @@ inline struct __ns1__searchDatasetByParameterRestriction *
 soap_new___ns1__searchDatasetByParameterRestriction(struct soap *soap,
                                                     int n = -1) {
   return soap_instantiate___ns1__searchDatasetByParameterRestriction(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchDatasetByParameterRestriction *
 soap_new_req___ns1__searchDatasetByParameterRestriction(struct soap *soap) {
   struct __ns1__searchDatasetByParameterRestriction *_p =
       soap_instantiate___ns1__searchDatasetByParameterRestriction(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatasetByParameterRestriction(soap, _p);
   }
@@ -30818,7 +31023,7 @@ soap_new_set___ns1__searchDatasetByParameterRestriction(
                            ns1__searchDatasetByParameterRestriction_) {
   struct __ns1__searchDatasetByParameterRestriction *_p =
       soap_instantiate___ns1__searchDatasetByParameterRestriction(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatasetByParameterRestriction(soap, _p);
     _p->ns1__searchDatasetByParameterRestriction_ =
@@ -30888,13 +31093,15 @@ soap_instantiate___ns1__getParameterByUnits(struct soap *, int, const char *,
 
 inline struct __ns1__getParameterByUnits *
 soap_new___ns1__getParameterByUnits(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__getParameterByUnits(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__getParameterByUnits(soap, n, nullptr, nullptr,
+                                                     nullptr);
 }
 
 inline struct __ns1__getParameterByUnits *
 soap_new_req___ns1__getParameterByUnits(struct soap *soap) {
   struct __ns1__getParameterByUnits *_p =
-      soap_instantiate___ns1__getParameterByUnits(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getParameterByUnits(soap, -1, nullptr, nullptr,
+                                                  nullptr);
   if (_p) {
     soap_default___ns1__getParameterByUnits(soap, _p);
   }
@@ -30905,7 +31112,8 @@ inline struct __ns1__getParameterByUnits *
 soap_new_set___ns1__getParameterByUnits(
     struct soap *soap, ns1__getParameterByUnits *ns1__getParameterByUnits_) {
   struct __ns1__getParameterByUnits *_p =
-      soap_instantiate___ns1__getParameterByUnits(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getParameterByUnits(soap, -1, nullptr, nullptr,
+                                                  nullptr);
   if (_p) {
     soap_default___ns1__getParameterByUnits(soap, _p);
     _p->ns1__getParameterByUnits_ = ns1__getParameterByUnits_;
@@ -30973,15 +31181,15 @@ soap_instantiate___ns1__getParameterByRestriction(struct soap *, int,
 
 inline struct __ns1__getParameterByRestriction *
 soap_new___ns1__getParameterByRestriction(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__getParameterByRestriction(soap, n, NULL, NULL,
-                                                           NULL);
+  return soap_instantiate___ns1__getParameterByRestriction(soap, n, nullptr,
+                                                           nullptr, nullptr);
 }
 
 inline struct __ns1__getParameterByRestriction *
 soap_new_req___ns1__getParameterByRestriction(struct soap *soap) {
   struct __ns1__getParameterByRestriction *_p =
-      soap_instantiate___ns1__getParameterByRestriction(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate___ns1__getParameterByRestriction(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getParameterByRestriction(soap, _p);
   }
@@ -30993,8 +31201,8 @@ soap_new_set___ns1__getParameterByRestriction(
     struct soap *soap,
     ns1__getParameterByRestriction *ns1__getParameterByRestriction_) {
   struct __ns1__getParameterByRestriction *_p =
-      soap_instantiate___ns1__getParameterByRestriction(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate___ns1__getParameterByRestriction(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getParameterByRestriction(soap, _p);
     _p->ns1__getParameterByRestriction_ = ns1__getParameterByRestriction_;
@@ -31062,13 +31270,15 @@ soap_instantiate___ns1__getParameterByName(struct soap *, int, const char *,
 
 inline struct __ns1__getParameterByName *
 soap_new___ns1__getParameterByName(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__getParameterByName(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__getParameterByName(soap, n, nullptr, nullptr,
+                                                    nullptr);
 }
 
 inline struct __ns1__getParameterByName *
 soap_new_req___ns1__getParameterByName(struct soap *soap) {
   struct __ns1__getParameterByName *_p =
-      soap_instantiate___ns1__getParameterByName(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getParameterByName(soap, -1, nullptr, nullptr,
+                                                 nullptr);
   if (_p) {
     soap_default___ns1__getParameterByName(soap, _p);
   }
@@ -31078,7 +31288,8 @@ soap_new_req___ns1__getParameterByName(struct soap *soap) {
 inline struct __ns1__getParameterByName *soap_new_set___ns1__getParameterByName(
     struct soap *soap, ns1__getParameterByName *ns1__getParameterByName_) {
   struct __ns1__getParameterByName *_p =
-      soap_instantiate___ns1__getParameterByName(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getParameterByName(soap, -1, nullptr, nullptr,
+                                                 nullptr);
   if (_p) {
     soap_default___ns1__getParameterByName(soap, _p);
     _p->ns1__getParameterByName_ = ns1__getParameterByName_;
@@ -31146,15 +31357,15 @@ soap_instantiate___ns1__getParameterByNameUnits(struct soap *, int,
 
 inline struct __ns1__getParameterByNameUnits *
 soap_new___ns1__getParameterByNameUnits(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__getParameterByNameUnits(soap, n, NULL, NULL,
-                                                         NULL);
+  return soap_instantiate___ns1__getParameterByNameUnits(soap, n, nullptr,
+                                                         nullptr, nullptr);
 }
 
 inline struct __ns1__getParameterByNameUnits *
 soap_new_req___ns1__getParameterByNameUnits(struct soap *soap) {
   struct __ns1__getParameterByNameUnits *_p =
-      soap_instantiate___ns1__getParameterByNameUnits(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate___ns1__getParameterByNameUnits(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getParameterByNameUnits(soap, _p);
   }
@@ -31166,8 +31377,8 @@ soap_new_set___ns1__getParameterByNameUnits(
     struct soap *soap,
     ns1__getParameterByNameUnits *ns1__getParameterByNameUnits_) {
   struct __ns1__getParameterByNameUnits *_p =
-      soap_instantiate___ns1__getParameterByNameUnits(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate___ns1__getParameterByNameUnits(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getParameterByNameUnits(soap, _p);
     _p->ns1__getParameterByNameUnits_ = ns1__getParameterByNameUnits_;
@@ -31234,15 +31445,15 @@ soap_instantiate___ns1__searchSampleByParameter(struct soap *, int,
 
 inline struct __ns1__searchSampleByParameter *
 soap_new___ns1__searchSampleByParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__searchSampleByParameter(soap, n, NULL, NULL,
-                                                         NULL);
+  return soap_instantiate___ns1__searchSampleByParameter(soap, n, nullptr,
+                                                         nullptr, nullptr);
 }
 
 inline struct __ns1__searchSampleByParameter *
 soap_new_req___ns1__searchSampleByParameter(struct soap *soap) {
   struct __ns1__searchSampleByParameter *_p =
-      soap_instantiate___ns1__searchSampleByParameter(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate___ns1__searchSampleByParameter(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchSampleByParameter(soap, _p);
   }
@@ -31254,8 +31465,8 @@ soap_new_set___ns1__searchSampleByParameter(
     struct soap *soap,
     ns1__searchSampleByParameter *ns1__searchSampleByParameter_) {
   struct __ns1__searchSampleByParameter *_p =
-      soap_instantiate___ns1__searchSampleByParameter(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate___ns1__searchSampleByParameter(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchSampleByParameter(soap, _p);
     _p->ns1__searchSampleByParameter_ = ns1__searchSampleByParameter_;
@@ -31322,15 +31533,15 @@ soap_instantiate___ns1__searchDatasetByParameter(struct soap *, int,
 
 inline struct __ns1__searchDatasetByParameter *
 soap_new___ns1__searchDatasetByParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__searchDatasetByParameter(soap, n, NULL, NULL,
-                                                          NULL);
+  return soap_instantiate___ns1__searchDatasetByParameter(soap, n, nullptr,
+                                                          nullptr, nullptr);
 }
 
 inline struct __ns1__searchDatasetByParameter *
 soap_new_req___ns1__searchDatasetByParameter(struct soap *soap) {
   struct __ns1__searchDatasetByParameter *_p =
-      soap_instantiate___ns1__searchDatasetByParameter(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate___ns1__searchDatasetByParameter(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatasetByParameter(soap, _p);
   }
@@ -31342,8 +31553,8 @@ soap_new_set___ns1__searchDatasetByParameter(
     struct soap *soap,
     ns1__searchDatasetByParameter *ns1__searchDatasetByParameter_) {
   struct __ns1__searchDatasetByParameter *_p =
-      soap_instantiate___ns1__searchDatasetByParameter(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate___ns1__searchDatasetByParameter(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatasetByParameter(soap, _p);
     _p->ns1__searchDatasetByParameter_ = ns1__searchDatasetByParameter_;
@@ -31410,15 +31621,15 @@ soap_instantiate___ns1__searchDatafileByParameter(struct soap *, int,
 
 inline struct __ns1__searchDatafileByParameter *
 soap_new___ns1__searchDatafileByParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__searchDatafileByParameter(soap, n, NULL, NULL,
-                                                           NULL);
+  return soap_instantiate___ns1__searchDatafileByParameter(soap, n, nullptr,
+                                                           nullptr, nullptr);
 }
 
 inline struct __ns1__searchDatafileByParameter *
 soap_new_req___ns1__searchDatafileByParameter(struct soap *soap) {
   struct __ns1__searchDatafileByParameter *_p =
-      soap_instantiate___ns1__searchDatafileByParameter(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate___ns1__searchDatafileByParameter(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatafileByParameter(soap, _p);
   }
@@ -31430,8 +31641,8 @@ soap_new_set___ns1__searchDatafileByParameter(
     struct soap *soap,
     ns1__searchDatafileByParameter *ns1__searchDatafileByParameter_) {
   struct __ns1__searchDatafileByParameter *_p =
-      soap_instantiate___ns1__searchDatafileByParameter(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate___ns1__searchDatafileByParameter(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatafileByParameter(soap, _p);
     _p->ns1__searchDatafileByParameter_ = ns1__searchDatafileByParameter_;
@@ -31498,15 +31709,15 @@ soap_instantiate___ns1__searchInvestigationByParameter(struct soap *, int,
 
 inline struct __ns1__searchInvestigationByParameter *
 soap_new___ns1__searchInvestigationByParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__searchInvestigationByParameter(soap, n, NULL,
-                                                                NULL, NULL);
+  return soap_instantiate___ns1__searchInvestigationByParameter(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchInvestigationByParameter *
 soap_new_req___ns1__searchInvestigationByParameter(struct soap *soap) {
   struct __ns1__searchInvestigationByParameter *_p =
-      soap_instantiate___ns1__searchInvestigationByParameter(soap, -1, NULL,
-                                                             NULL, NULL);
+      soap_instantiate___ns1__searchInvestigationByParameter(soap, -1, nullptr,
+                                                             nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchInvestigationByParameter(soap, _p);
   }
@@ -31518,8 +31729,8 @@ soap_new_set___ns1__searchInvestigationByParameter(
     struct soap *soap,
     ns1__searchInvestigationByParameter *ns1__searchInvestigationByParameter_) {
   struct __ns1__searchInvestigationByParameter *_p =
-      soap_instantiate___ns1__searchInvestigationByParameter(soap, -1, NULL,
-                                                             NULL, NULL);
+      soap_instantiate___ns1__searchInvestigationByParameter(soap, -1, nullptr,
+                                                             nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchInvestigationByParameter(soap, _p);
     _p->ns1__searchInvestigationByParameter_ =
@@ -31592,14 +31803,14 @@ inline struct __ns1__searchSampleByParameterComparison *
 soap_new___ns1__searchSampleByParameterComparison(struct soap *soap,
                                                   int n = -1) {
   return soap_instantiate___ns1__searchSampleByParameterComparison(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchSampleByParameterComparison *
 soap_new_req___ns1__searchSampleByParameterComparison(struct soap *soap) {
   struct __ns1__searchSampleByParameterComparison *_p =
-      soap_instantiate___ns1__searchSampleByParameterComparison(soap, -1, NULL,
-                                                                NULL, NULL);
+      soap_instantiate___ns1__searchSampleByParameterComparison(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchSampleByParameterComparison(soap, _p);
   }
@@ -31611,8 +31822,8 @@ soap_new_set___ns1__searchSampleByParameterComparison(
     struct soap *soap, ns1__searchSampleByParameterComparison *
                            ns1__searchSampleByParameterComparison_) {
   struct __ns1__searchSampleByParameterComparison *_p =
-      soap_instantiate___ns1__searchSampleByParameterComparison(soap, -1, NULL,
-                                                                NULL, NULL);
+      soap_instantiate___ns1__searchSampleByParameterComparison(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchSampleByParameterComparison(soap, _p);
     _p->ns1__searchSampleByParameterComparison_ =
@@ -31687,14 +31898,14 @@ inline struct __ns1__searchDatasetByParameterComparison *
 soap_new___ns1__searchDatasetByParameterComparison(struct soap *soap,
                                                    int n = -1) {
   return soap_instantiate___ns1__searchDatasetByParameterComparison(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchDatasetByParameterComparison *
 soap_new_req___ns1__searchDatasetByParameterComparison(struct soap *soap) {
   struct __ns1__searchDatasetByParameterComparison *_p =
-      soap_instantiate___ns1__searchDatasetByParameterComparison(soap, -1, NULL,
-                                                                 NULL, NULL);
+      soap_instantiate___ns1__searchDatasetByParameterComparison(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatasetByParameterComparison(soap, _p);
   }
@@ -31706,8 +31917,8 @@ soap_new_set___ns1__searchDatasetByParameterComparison(
     struct soap *soap, ns1__searchDatasetByParameterComparison *
                            ns1__searchDatasetByParameterComparison_) {
   struct __ns1__searchDatasetByParameterComparison *_p =
-      soap_instantiate___ns1__searchDatasetByParameterComparison(soap, -1, NULL,
-                                                                 NULL, NULL);
+      soap_instantiate___ns1__searchDatasetByParameterComparison(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatasetByParameterComparison(soap, _p);
     _p->ns1__searchDatasetByParameterComparison_ =
@@ -31782,14 +31993,14 @@ inline struct __ns1__searchDatafileByParameterComparison *
 soap_new___ns1__searchDatafileByParameterComparison(struct soap *soap,
                                                     int n = -1) {
   return soap_instantiate___ns1__searchDatafileByParameterComparison(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchDatafileByParameterComparison *
 soap_new_req___ns1__searchDatafileByParameterComparison(struct soap *soap) {
   struct __ns1__searchDatafileByParameterComparison *_p =
       soap_instantiate___ns1__searchDatafileByParameterComparison(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatafileByParameterComparison(soap, _p);
   }
@@ -31802,7 +32013,7 @@ soap_new_set___ns1__searchDatafileByParameterComparison(
                            ns1__searchDatafileByParameterComparison_) {
   struct __ns1__searchDatafileByParameterComparison *_p =
       soap_instantiate___ns1__searchDatafileByParameterComparison(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatafileByParameterComparison(soap, _p);
     _p->ns1__searchDatafileByParameterComparison_ =
@@ -31881,7 +32092,7 @@ inline struct __ns1__searchInvestigationByParameterComparison *
 soap_new___ns1__searchInvestigationByParameterComparison(struct soap *soap,
                                                          int n = -1) {
   return soap_instantiate___ns1__searchInvestigationByParameterComparison(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchInvestigationByParameterComparison *
@@ -31889,7 +32100,7 @@ soap_new_req___ns1__searchInvestigationByParameterComparison(
     struct soap *soap) {
   struct __ns1__searchInvestigationByParameterComparison *_p =
       soap_instantiate___ns1__searchInvestigationByParameterComparison(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchInvestigationByParameterComparison(soap, _p);
   }
@@ -31902,7 +32113,7 @@ soap_new_set___ns1__searchInvestigationByParameterComparison(
                            ns1__searchInvestigationByParameterComparison_) {
   struct __ns1__searchInvestigationByParameterComparison *_p =
       soap_instantiate___ns1__searchInvestigationByParameterComparison(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchInvestigationByParameterComparison(soap, _p);
     _p->ns1__searchInvestigationByParameterComparison_ =
@@ -31975,15 +32186,15 @@ soap_instantiate___ns1__searchSampleByParameterCondition(struct soap *, int,
 inline struct __ns1__searchSampleByParameterCondition *
 soap_new___ns1__searchSampleByParameterCondition(struct soap *soap,
                                                  int n = -1) {
-  return soap_instantiate___ns1__searchSampleByParameterCondition(soap, n, NULL,
-                                                                  NULL, NULL);
+  return soap_instantiate___ns1__searchSampleByParameterCondition(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchSampleByParameterCondition *
 soap_new_req___ns1__searchSampleByParameterCondition(struct soap *soap) {
   struct __ns1__searchSampleByParameterCondition *_p =
-      soap_instantiate___ns1__searchSampleByParameterCondition(soap, -1, NULL,
-                                                               NULL, NULL);
+      soap_instantiate___ns1__searchSampleByParameterCondition(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchSampleByParameterCondition(soap, _p);
   }
@@ -31995,8 +32206,8 @@ soap_new_set___ns1__searchSampleByParameterCondition(
     struct soap *soap, ns1__searchSampleByParameterCondition *
                            ns1__searchSampleByParameterCondition_) {
   struct __ns1__searchSampleByParameterCondition *_p =
-      soap_instantiate___ns1__searchSampleByParameterCondition(soap, -1, NULL,
-                                                               NULL, NULL);
+      soap_instantiate___ns1__searchSampleByParameterCondition(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchSampleByParameterCondition(soap, _p);
     _p->ns1__searchSampleByParameterCondition_ =
@@ -32070,14 +32281,14 @@ inline struct __ns1__searchDatasetByParameterCondition *
 soap_new___ns1__searchDatasetByParameterCondition(struct soap *soap,
                                                   int n = -1) {
   return soap_instantiate___ns1__searchDatasetByParameterCondition(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchDatasetByParameterCondition *
 soap_new_req___ns1__searchDatasetByParameterCondition(struct soap *soap) {
   struct __ns1__searchDatasetByParameterCondition *_p =
-      soap_instantiate___ns1__searchDatasetByParameterCondition(soap, -1, NULL,
-                                                                NULL, NULL);
+      soap_instantiate___ns1__searchDatasetByParameterCondition(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatasetByParameterCondition(soap, _p);
   }
@@ -32089,8 +32300,8 @@ soap_new_set___ns1__searchDatasetByParameterCondition(
     struct soap *soap, ns1__searchDatasetByParameterCondition *
                            ns1__searchDatasetByParameterCondition_) {
   struct __ns1__searchDatasetByParameterCondition *_p =
-      soap_instantiate___ns1__searchDatasetByParameterCondition(soap, -1, NULL,
-                                                                NULL, NULL);
+      soap_instantiate___ns1__searchDatasetByParameterCondition(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatasetByParameterCondition(soap, _p);
     _p->ns1__searchDatasetByParameterCondition_ =
@@ -32165,14 +32376,14 @@ inline struct __ns1__searchDatafileByParameterCondition *
 soap_new___ns1__searchDatafileByParameterCondition(struct soap *soap,
                                                    int n = -1) {
   return soap_instantiate___ns1__searchDatafileByParameterCondition(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchDatafileByParameterCondition *
 soap_new_req___ns1__searchDatafileByParameterCondition(struct soap *soap) {
   struct __ns1__searchDatafileByParameterCondition *_p =
-      soap_instantiate___ns1__searchDatafileByParameterCondition(soap, -1, NULL,
-                                                                 NULL, NULL);
+      soap_instantiate___ns1__searchDatafileByParameterCondition(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatafileByParameterCondition(soap, _p);
   }
@@ -32184,8 +32395,8 @@ soap_new_set___ns1__searchDatafileByParameterCondition(
     struct soap *soap, ns1__searchDatafileByParameterCondition *
                            ns1__searchDatafileByParameterCondition_) {
   struct __ns1__searchDatafileByParameterCondition *_p =
-      soap_instantiate___ns1__searchDatafileByParameterCondition(soap, -1, NULL,
-                                                                 NULL, NULL);
+      soap_instantiate___ns1__searchDatafileByParameterCondition(
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchDatafileByParameterCondition(soap, _p);
     _p->ns1__searchDatafileByParameterCondition_ =
@@ -32264,14 +32475,14 @@ inline struct __ns1__searchInvestigationByParameterCondition *
 soap_new___ns1__searchInvestigationByParameterCondition(struct soap *soap,
                                                         int n = -1) {
   return soap_instantiate___ns1__searchInvestigationByParameterCondition(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchInvestigationByParameterCondition *
 soap_new_req___ns1__searchInvestigationByParameterCondition(struct soap *soap) {
   struct __ns1__searchInvestigationByParameterCondition *_p =
       soap_instantiate___ns1__searchInvestigationByParameterCondition(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchInvestigationByParameterCondition(soap, _p);
   }
@@ -32284,7 +32495,7 @@ soap_new_set___ns1__searchInvestigationByParameterCondition(
                            ns1__searchInvestigationByParameterCondition_) {
   struct __ns1__searchInvestigationByParameterCondition *_p =
       soap_instantiate___ns1__searchInvestigationByParameterCondition(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchInvestigationByParameterCondition(soap, _p);
     _p->ns1__searchInvestigationByParameterCondition_ =
@@ -32354,15 +32565,15 @@ soap_instantiate___ns1__getFacilityUserByFederalId(struct soap *, int,
 
 inline struct __ns1__getFacilityUserByFederalId *
 soap_new___ns1__getFacilityUserByFederalId(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__getFacilityUserByFederalId(soap, n, NULL, NULL,
-                                                            NULL);
+  return soap_instantiate___ns1__getFacilityUserByFederalId(soap, n, nullptr,
+                                                            nullptr, nullptr);
 }
 
 inline struct __ns1__getFacilityUserByFederalId *
 soap_new_req___ns1__getFacilityUserByFederalId(struct soap *soap) {
   struct __ns1__getFacilityUserByFederalId *_p =
-      soap_instantiate___ns1__getFacilityUserByFederalId(soap, -1, NULL, NULL,
-                                                         NULL);
+      soap_instantiate___ns1__getFacilityUserByFederalId(soap, -1, nullptr,
+                                                         nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getFacilityUserByFederalId(soap, _p);
   }
@@ -32374,8 +32585,8 @@ soap_new_set___ns1__getFacilityUserByFederalId(
     struct soap *soap,
     ns1__getFacilityUserByFederalId *ns1__getFacilityUserByFederalId_) {
   struct __ns1__getFacilityUserByFederalId *_p =
-      soap_instantiate___ns1__getFacilityUserByFederalId(soap, -1, NULL, NULL,
-                                                         NULL);
+      soap_instantiate___ns1__getFacilityUserByFederalId(soap, -1, nullptr,
+                                                         nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getFacilityUserByFederalId(soap, _p);
     _p->ns1__getFacilityUserByFederalId_ = ns1__getFacilityUserByFederalId_;
@@ -32443,15 +32654,15 @@ soap_instantiate___ns1__getFacilityUserByFacilityUserId(struct soap *, int,
 
 inline struct __ns1__getFacilityUserByFacilityUserId *
 soap_new___ns1__getFacilityUserByFacilityUserId(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__getFacilityUserByFacilityUserId(soap, n, NULL,
-                                                                 NULL, NULL);
+  return soap_instantiate___ns1__getFacilityUserByFacilityUserId(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__getFacilityUserByFacilityUserId *
 soap_new_req___ns1__getFacilityUserByFacilityUserId(struct soap *soap) {
   struct __ns1__getFacilityUserByFacilityUserId *_p =
-      soap_instantiate___ns1__getFacilityUserByFacilityUserId(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate___ns1__getFacilityUserByFacilityUserId(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getFacilityUserByFacilityUserId(soap, _p);
   }
@@ -32463,8 +32674,8 @@ soap_new_set___ns1__getFacilityUserByFacilityUserId(
     struct soap *soap, ns1__getFacilityUserByFacilityUserId *
                            ns1__getFacilityUserByFacilityUserId_) {
   struct __ns1__getFacilityUserByFacilityUserId *_p =
-      soap_instantiate___ns1__getFacilityUserByFacilityUserId(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate___ns1__getFacilityUserByFacilityUserId(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getFacilityUserByFacilityUserId(soap, _p);
     _p->ns1__getFacilityUserByFacilityUserId_ =
@@ -32533,13 +32744,15 @@ soap_instantiate___ns1__getICATAPIVersion(struct soap *, int, const char *,
 
 inline struct __ns1__getICATAPIVersion *
 soap_new___ns1__getICATAPIVersion(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__getICATAPIVersion(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__getICATAPIVersion(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline struct __ns1__getICATAPIVersion *
 soap_new_req___ns1__getICATAPIVersion(struct soap *soap) {
   struct __ns1__getICATAPIVersion *_p =
-      soap_instantiate___ns1__getICATAPIVersion(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getICATAPIVersion(soap, -1, nullptr, nullptr,
+                                                nullptr);
   if (_p) {
     soap_default___ns1__getICATAPIVersion(soap, _p);
   }
@@ -32549,7 +32762,8 @@ soap_new_req___ns1__getICATAPIVersion(struct soap *soap) {
 inline struct __ns1__getICATAPIVersion *soap_new_set___ns1__getICATAPIVersion(
     struct soap *soap, ns1__getICATAPIVersion *ns1__getICATAPIVersion_) {
   struct __ns1__getICATAPIVersion *_p =
-      soap_instantiate___ns1__getICATAPIVersion(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getICATAPIVersion(soap, -1, nullptr, nullptr,
+                                                nullptr);
   if (_p) {
     soap_default___ns1__getICATAPIVersion(soap, _p);
     _p->ns1__getICATAPIVersion_ = ns1__getICATAPIVersion_;
@@ -32617,15 +32831,15 @@ soap_instantiate___ns1__checkDatasetDownloadAccess(struct soap *, int,
 
 inline struct __ns1__checkDatasetDownloadAccess *
 soap_new___ns1__checkDatasetDownloadAccess(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__checkDatasetDownloadAccess(soap, n, NULL, NULL,
-                                                            NULL);
+  return soap_instantiate___ns1__checkDatasetDownloadAccess(soap, n, nullptr,
+                                                            nullptr, nullptr);
 }
 
 inline struct __ns1__checkDatasetDownloadAccess *
 soap_new_req___ns1__checkDatasetDownloadAccess(struct soap *soap) {
   struct __ns1__checkDatasetDownloadAccess *_p =
-      soap_instantiate___ns1__checkDatasetDownloadAccess(soap, -1, NULL, NULL,
-                                                         NULL);
+      soap_instantiate___ns1__checkDatasetDownloadAccess(soap, -1, nullptr,
+                                                         nullptr, nullptr);
   if (_p) {
     soap_default___ns1__checkDatasetDownloadAccess(soap, _p);
   }
@@ -32637,8 +32851,8 @@ soap_new_set___ns1__checkDatasetDownloadAccess(
     struct soap *soap,
     ns1__checkDatasetDownloadAccess *ns1__checkDatasetDownloadAccess_) {
   struct __ns1__checkDatasetDownloadAccess *_p =
-      soap_instantiate___ns1__checkDatasetDownloadAccess(soap, -1, NULL, NULL,
-                                                         NULL);
+      soap_instantiate___ns1__checkDatasetDownloadAccess(soap, -1, nullptr,
+                                                         nullptr, nullptr);
   if (_p) {
     soap_default___ns1__checkDatasetDownloadAccess(soap, _p);
     _p->ns1__checkDatasetDownloadAccess_ = ns1__checkDatasetDownloadAccess_;
@@ -32705,15 +32919,15 @@ soap_instantiate___ns1__checkDatafileDownloadAccess(struct soap *, int,
 
 inline struct __ns1__checkDatafileDownloadAccess *
 soap_new___ns1__checkDatafileDownloadAccess(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__checkDatafileDownloadAccess(soap, n, NULL,
-                                                             NULL, NULL);
+  return soap_instantiate___ns1__checkDatafileDownloadAccess(soap, n, nullptr,
+                                                             nullptr, nullptr);
 }
 
 inline struct __ns1__checkDatafileDownloadAccess *
 soap_new_req___ns1__checkDatafileDownloadAccess(struct soap *soap) {
   struct __ns1__checkDatafileDownloadAccess *_p =
-      soap_instantiate___ns1__checkDatafileDownloadAccess(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate___ns1__checkDatafileDownloadAccess(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     soap_default___ns1__checkDatafileDownloadAccess(soap, _p);
   }
@@ -32725,8 +32939,8 @@ soap_new_set___ns1__checkDatafileDownloadAccess(
     struct soap *soap,
     ns1__checkDatafileDownloadAccess *ns1__checkDatafileDownloadAccess_) {
   struct __ns1__checkDatafileDownloadAccess *_p =
-      soap_instantiate___ns1__checkDatafileDownloadAccess(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate___ns1__checkDatafileDownloadAccess(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     soap_default___ns1__checkDatafileDownloadAccess(soap, _p);
     _p->ns1__checkDatafileDownloadAccess_ = ns1__checkDatafileDownloadAccess_;
@@ -32793,13 +33007,15 @@ soap_instantiate___ns1__downloadDatafiles(struct soap *, int, const char *,
 
 inline struct __ns1__downloadDatafiles *
 soap_new___ns1__downloadDatafiles(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__downloadDatafiles(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__downloadDatafiles(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline struct __ns1__downloadDatafiles *
 soap_new_req___ns1__downloadDatafiles(struct soap *soap) {
   struct __ns1__downloadDatafiles *_p =
-      soap_instantiate___ns1__downloadDatafiles(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__downloadDatafiles(soap, -1, nullptr, nullptr,
+                                                nullptr);
   if (_p) {
     soap_default___ns1__downloadDatafiles(soap, _p);
   }
@@ -32809,7 +33025,8 @@ soap_new_req___ns1__downloadDatafiles(struct soap *soap) {
 inline struct __ns1__downloadDatafiles *soap_new_set___ns1__downloadDatafiles(
     struct soap *soap, ns1__downloadDatafiles *ns1__downloadDatafiles_) {
   struct __ns1__downloadDatafiles *_p =
-      soap_instantiate___ns1__downloadDatafiles(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__downloadDatafiles(soap, -1, nullptr, nullptr,
+                                                nullptr);
   if (_p) {
     soap_default___ns1__downloadDatafiles(soap, _p);
     _p->ns1__downloadDatafiles_ = ns1__downloadDatafiles_;
@@ -32876,13 +33093,14 @@ soap_instantiate___ns1__downloadDataset(struct soap *, int, const char *,
 
 inline struct __ns1__downloadDataset *
 soap_new___ns1__downloadDataset(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__downloadDataset(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__downloadDataset(soap, n, nullptr, nullptr,
+                                                 nullptr);
 }
 
 inline struct __ns1__downloadDataset *
 soap_new_req___ns1__downloadDataset(struct soap *soap) {
-  struct __ns1__downloadDataset *_p =
-      soap_instantiate___ns1__downloadDataset(soap, -1, NULL, NULL, NULL);
+  struct __ns1__downloadDataset *_p = soap_instantiate___ns1__downloadDataset(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__downloadDataset(soap, _p);
   }
@@ -32891,8 +33109,8 @@ soap_new_req___ns1__downloadDataset(struct soap *soap) {
 
 inline struct __ns1__downloadDataset *soap_new_set___ns1__downloadDataset(
     struct soap *soap, ns1__downloadDataset *ns1__downloadDataset_) {
-  struct __ns1__downloadDataset *_p =
-      soap_instantiate___ns1__downloadDataset(soap, -1, NULL, NULL, NULL);
+  struct __ns1__downloadDataset *_p = soap_instantiate___ns1__downloadDataset(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__downloadDataset(soap, _p);
     _p->ns1__downloadDataset_ = ns1__downloadDataset_;
@@ -32960,13 +33178,14 @@ soap_instantiate___ns1__downloadDatafile(struct soap *, int, const char *,
 
 inline struct __ns1__downloadDatafile *
 soap_new___ns1__downloadDatafile(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__downloadDatafile(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__downloadDatafile(soap, n, nullptr, nullptr,
+                                                  nullptr);
 }
 
 inline struct __ns1__downloadDatafile *
 soap_new_req___ns1__downloadDatafile(struct soap *soap) {
-  struct __ns1__downloadDatafile *_p =
-      soap_instantiate___ns1__downloadDatafile(soap, -1, NULL, NULL, NULL);
+  struct __ns1__downloadDatafile *_p = soap_instantiate___ns1__downloadDatafile(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__downloadDatafile(soap, _p);
   }
@@ -32975,8 +33194,8 @@ soap_new_req___ns1__downloadDatafile(struct soap *soap) {
 
 inline struct __ns1__downloadDatafile *soap_new_set___ns1__downloadDatafile(
     struct soap *soap, ns1__downloadDatafile *ns1__downloadDatafile_) {
-  struct __ns1__downloadDatafile *_p =
-      soap_instantiate___ns1__downloadDatafile(soap, -1, NULL, NULL, NULL);
+  struct __ns1__downloadDatafile *_p = soap_instantiate___ns1__downloadDatafile(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__downloadDatafile(soap, _p);
     _p->ns1__downloadDatafile_ = ns1__downloadDatafile_;
@@ -33043,13 +33262,14 @@ soap_instantiate___ns1__ingestMetadata(struct soap *, int, const char *,
 
 inline struct __ns1__ingestMetadata *
 soap_new___ns1__ingestMetadata(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__ingestMetadata(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__ingestMetadata(soap, n, nullptr, nullptr,
+                                                nullptr);
 }
 
 inline struct __ns1__ingestMetadata *
 soap_new_req___ns1__ingestMetadata(struct soap *soap) {
-  struct __ns1__ingestMetadata *_p =
-      soap_instantiate___ns1__ingestMetadata(soap, -1, NULL, NULL, NULL);
+  struct __ns1__ingestMetadata *_p = soap_instantiate___ns1__ingestMetadata(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__ingestMetadata(soap, _p);
   }
@@ -33059,8 +33279,8 @@ soap_new_req___ns1__ingestMetadata(struct soap *soap) {
 inline struct __ns1__ingestMetadata *
 soap_new_set___ns1__ingestMetadata(struct soap *soap,
                                    ns1__ingestMetadata *ns1__ingestMetadata_) {
-  struct __ns1__ingestMetadata *_p =
-      soap_instantiate___ns1__ingestMetadata(soap, -1, NULL, NULL, NULL);
+  struct __ns1__ingestMetadata *_p = soap_instantiate___ns1__ingestMetadata(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__ingestMetadata(soap, _p);
     _p->ns1__ingestMetadata_ = ns1__ingestMetadata_;
@@ -33128,13 +33348,15 @@ soap_instantiate___ns1__updateAuthorisation(struct soap *, int, const char *,
 
 inline struct __ns1__updateAuthorisation *
 soap_new___ns1__updateAuthorisation(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__updateAuthorisation(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__updateAuthorisation(soap, n, nullptr, nullptr,
+                                                     nullptr);
 }
 
 inline struct __ns1__updateAuthorisation *
 soap_new_req___ns1__updateAuthorisation(struct soap *soap) {
   struct __ns1__updateAuthorisation *_p =
-      soap_instantiate___ns1__updateAuthorisation(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__updateAuthorisation(soap, -1, nullptr, nullptr,
+                                                  nullptr);
   if (_p) {
     soap_default___ns1__updateAuthorisation(soap, _p);
   }
@@ -33145,7 +33367,8 @@ inline struct __ns1__updateAuthorisation *
 soap_new_set___ns1__updateAuthorisation(
     struct soap *soap, ns1__updateAuthorisation *ns1__updateAuthorisation_) {
   struct __ns1__updateAuthorisation *_p =
-      soap_instantiate___ns1__updateAuthorisation(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__updateAuthorisation(soap, -1, nullptr, nullptr,
+                                                  nullptr);
   if (_p) {
     soap_default___ns1__updateAuthorisation(soap, _p);
     _p->ns1__updateAuthorisation_ = ns1__updateAuthorisation_;
@@ -33213,15 +33436,15 @@ soap_instantiate___ns1__updateAuthorisationResponse(struct soap *, int,
 
 inline struct __ns1__updateAuthorisationResponse *
 soap_new___ns1__updateAuthorisationResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__updateAuthorisationResponse(soap, n, NULL,
-                                                             NULL, NULL);
+  return soap_instantiate___ns1__updateAuthorisationResponse(soap, n, nullptr,
+                                                             nullptr, nullptr);
 }
 
 inline struct __ns1__updateAuthorisationResponse *
 soap_new_req___ns1__updateAuthorisationResponse(struct soap *soap) {
   struct __ns1__updateAuthorisationResponse *_p =
-      soap_instantiate___ns1__updateAuthorisationResponse(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate___ns1__updateAuthorisationResponse(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     soap_default___ns1__updateAuthorisationResponse(soap, _p);
   }
@@ -33233,8 +33456,8 @@ soap_new_set___ns1__updateAuthorisationResponse(
     struct soap *soap,
     ns1__updateAuthorisationResponse *ns1__updateAuthorisationResponse_) {
   struct __ns1__updateAuthorisationResponse *_p =
-      soap_instantiate___ns1__updateAuthorisationResponse(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate___ns1__updateAuthorisationResponse(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     soap_default___ns1__updateAuthorisationResponse(soap, _p);
     _p->ns1__updateAuthorisationResponse_ = ns1__updateAuthorisationResponse_;
@@ -33302,13 +33525,15 @@ soap_instantiate___ns1__removeAuthorisation(struct soap *, int, const char *,
 
 inline struct __ns1__removeAuthorisation *
 soap_new___ns1__removeAuthorisation(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__removeAuthorisation(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__removeAuthorisation(soap, n, nullptr, nullptr,
+                                                     nullptr);
 }
 
 inline struct __ns1__removeAuthorisation *
 soap_new_req___ns1__removeAuthorisation(struct soap *soap) {
   struct __ns1__removeAuthorisation *_p =
-      soap_instantiate___ns1__removeAuthorisation(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__removeAuthorisation(soap, -1, nullptr, nullptr,
+                                                  nullptr);
   if (_p) {
     soap_default___ns1__removeAuthorisation(soap, _p);
   }
@@ -33319,7 +33544,8 @@ inline struct __ns1__removeAuthorisation *
 soap_new_set___ns1__removeAuthorisation(
     struct soap *soap, ns1__removeAuthorisation *ns1__removeAuthorisation_) {
   struct __ns1__removeAuthorisation *_p =
-      soap_instantiate___ns1__removeAuthorisation(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__removeAuthorisation(soap, -1, nullptr, nullptr,
+                                                  nullptr);
   if (_p) {
     soap_default___ns1__removeAuthorisation(soap, _p);
     _p->ns1__removeAuthorisation_ = ns1__removeAuthorisation_;
@@ -33387,15 +33613,15 @@ soap_instantiate___ns1__removeAuthorisationResponse(struct soap *, int,
 
 inline struct __ns1__removeAuthorisationResponse *
 soap_new___ns1__removeAuthorisationResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__removeAuthorisationResponse(soap, n, NULL,
-                                                             NULL, NULL);
+  return soap_instantiate___ns1__removeAuthorisationResponse(soap, n, nullptr,
+                                                             nullptr, nullptr);
 }
 
 inline struct __ns1__removeAuthorisationResponse *
 soap_new_req___ns1__removeAuthorisationResponse(struct soap *soap) {
   struct __ns1__removeAuthorisationResponse *_p =
-      soap_instantiate___ns1__removeAuthorisationResponse(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate___ns1__removeAuthorisationResponse(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     soap_default___ns1__removeAuthorisationResponse(soap, _p);
   }
@@ -33407,8 +33633,8 @@ soap_new_set___ns1__removeAuthorisationResponse(
     struct soap *soap,
     ns1__removeAuthorisationResponse *ns1__removeAuthorisationResponse_) {
   struct __ns1__removeAuthorisationResponse *_p =
-      soap_instantiate___ns1__removeAuthorisationResponse(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate___ns1__removeAuthorisationResponse(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     soap_default___ns1__removeAuthorisationResponse(soap, _p);
     _p->ns1__removeAuthorisationResponse_ = ns1__removeAuthorisationResponse_;
@@ -33476,13 +33702,15 @@ soap_instantiate___ns1__deleteAuthorisation(struct soap *, int, const char *,
 
 inline struct __ns1__deleteAuthorisation *
 soap_new___ns1__deleteAuthorisation(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__deleteAuthorisation(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__deleteAuthorisation(soap, n, nullptr, nullptr,
+                                                     nullptr);
 }
 
 inline struct __ns1__deleteAuthorisation *
 soap_new_req___ns1__deleteAuthorisation(struct soap *soap) {
   struct __ns1__deleteAuthorisation *_p =
-      soap_instantiate___ns1__deleteAuthorisation(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__deleteAuthorisation(soap, -1, nullptr, nullptr,
+                                                  nullptr);
   if (_p) {
     soap_default___ns1__deleteAuthorisation(soap, _p);
   }
@@ -33493,7 +33721,8 @@ inline struct __ns1__deleteAuthorisation *
 soap_new_set___ns1__deleteAuthorisation(
     struct soap *soap, ns1__deleteAuthorisation *ns1__deleteAuthorisation_) {
   struct __ns1__deleteAuthorisation *_p =
-      soap_instantiate___ns1__deleteAuthorisation(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__deleteAuthorisation(soap, -1, nullptr, nullptr,
+                                                  nullptr);
   if (_p) {
     soap_default___ns1__deleteAuthorisation(soap, _p);
     _p->ns1__deleteAuthorisation_ = ns1__deleteAuthorisation_;
@@ -33561,15 +33790,15 @@ soap_instantiate___ns1__deleteAuthorisationResponse(struct soap *, int,
 
 inline struct __ns1__deleteAuthorisationResponse *
 soap_new___ns1__deleteAuthorisationResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__deleteAuthorisationResponse(soap, n, NULL,
-                                                             NULL, NULL);
+  return soap_instantiate___ns1__deleteAuthorisationResponse(soap, n, nullptr,
+                                                             nullptr, nullptr);
 }
 
 inline struct __ns1__deleteAuthorisationResponse *
 soap_new_req___ns1__deleteAuthorisationResponse(struct soap *soap) {
   struct __ns1__deleteAuthorisationResponse *_p =
-      soap_instantiate___ns1__deleteAuthorisationResponse(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate___ns1__deleteAuthorisationResponse(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     soap_default___ns1__deleteAuthorisationResponse(soap, _p);
   }
@@ -33581,8 +33810,8 @@ soap_new_set___ns1__deleteAuthorisationResponse(
     struct soap *soap,
     ns1__deleteAuthorisationResponse *ns1__deleteAuthorisationResponse_) {
   struct __ns1__deleteAuthorisationResponse *_p =
-      soap_instantiate___ns1__deleteAuthorisationResponse(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate___ns1__deleteAuthorisationResponse(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     soap_default___ns1__deleteAuthorisationResponse(soap, _p);
     _p->ns1__deleteAuthorisationResponse_ = ns1__deleteAuthorisationResponse_;
@@ -33649,13 +33878,14 @@ soap_instantiate___ns1__addAuthorisation(struct soap *, int, const char *,
 
 inline struct __ns1__addAuthorisation *
 soap_new___ns1__addAuthorisation(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__addAuthorisation(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__addAuthorisation(soap, n, nullptr, nullptr,
+                                                  nullptr);
 }
 
 inline struct __ns1__addAuthorisation *
 soap_new_req___ns1__addAuthorisation(struct soap *soap) {
-  struct __ns1__addAuthorisation *_p =
-      soap_instantiate___ns1__addAuthorisation(soap, -1, NULL, NULL, NULL);
+  struct __ns1__addAuthorisation *_p = soap_instantiate___ns1__addAuthorisation(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__addAuthorisation(soap, _p);
   }
@@ -33664,8 +33894,8 @@ soap_new_req___ns1__addAuthorisation(struct soap *soap) {
 
 inline struct __ns1__addAuthorisation *soap_new_set___ns1__addAuthorisation(
     struct soap *soap, ns1__addAuthorisation *ns1__addAuthorisation_) {
-  struct __ns1__addAuthorisation *_p =
-      soap_instantiate___ns1__addAuthorisation(soap, -1, NULL, NULL, NULL);
+  struct __ns1__addAuthorisation *_p = soap_instantiate___ns1__addAuthorisation(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__addAuthorisation(soap, _p);
     _p->ns1__addAuthorisation_ = ns1__addAuthorisation_;
@@ -33733,13 +33963,15 @@ soap_instantiate___ns1__getAuthorisations(struct soap *, int, const char *,
 
 inline struct __ns1__getAuthorisations *
 soap_new___ns1__getAuthorisations(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__getAuthorisations(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__getAuthorisations(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline struct __ns1__getAuthorisations *
 soap_new_req___ns1__getAuthorisations(struct soap *soap) {
   struct __ns1__getAuthorisations *_p =
-      soap_instantiate___ns1__getAuthorisations(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getAuthorisations(soap, -1, nullptr, nullptr,
+                                                nullptr);
   if (_p) {
     soap_default___ns1__getAuthorisations(soap, _p);
   }
@@ -33749,7 +33981,8 @@ soap_new_req___ns1__getAuthorisations(struct soap *soap) {
 inline struct __ns1__getAuthorisations *soap_new_set___ns1__getAuthorisations(
     struct soap *soap, ns1__getAuthorisations *ns1__getAuthorisations_) {
   struct __ns1__getAuthorisations *_p =
-      soap_instantiate___ns1__getAuthorisations(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getAuthorisations(soap, -1, nullptr, nullptr,
+                                                nullptr);
   if (_p) {
     soap_default___ns1__getAuthorisations(soap, _p);
     _p->ns1__getAuthorisations_ = ns1__getAuthorisations_;
@@ -33817,15 +34050,15 @@ soap_instantiate___ns1__removeDataFileParameter(struct soap *, int,
 
 inline struct __ns1__removeDataFileParameter *
 soap_new___ns1__removeDataFileParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__removeDataFileParameter(soap, n, NULL, NULL,
-                                                         NULL);
+  return soap_instantiate___ns1__removeDataFileParameter(soap, n, nullptr,
+                                                         nullptr, nullptr);
 }
 
 inline struct __ns1__removeDataFileParameter *
 soap_new_req___ns1__removeDataFileParameter(struct soap *soap) {
   struct __ns1__removeDataFileParameter *_p =
-      soap_instantiate___ns1__removeDataFileParameter(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate___ns1__removeDataFileParameter(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     soap_default___ns1__removeDataFileParameter(soap, _p);
   }
@@ -33837,8 +34070,8 @@ soap_new_set___ns1__removeDataFileParameter(
     struct soap *soap,
     ns1__removeDataFileParameter *ns1__removeDataFileParameter_) {
   struct __ns1__removeDataFileParameter *_p =
-      soap_instantiate___ns1__removeDataFileParameter(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate___ns1__removeDataFileParameter(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     soap_default___ns1__removeDataFileParameter(soap, _p);
     _p->ns1__removeDataFileParameter_ = ns1__removeDataFileParameter_;
@@ -33906,15 +34139,15 @@ soap_instantiate___ns1__removeDataFileParameterResponse(struct soap *, int,
 
 inline struct __ns1__removeDataFileParameterResponse *
 soap_new___ns1__removeDataFileParameterResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__removeDataFileParameterResponse(soap, n, NULL,
-                                                                 NULL, NULL);
+  return soap_instantiate___ns1__removeDataFileParameterResponse(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__removeDataFileParameterResponse *
 soap_new_req___ns1__removeDataFileParameterResponse(struct soap *soap) {
   struct __ns1__removeDataFileParameterResponse *_p =
-      soap_instantiate___ns1__removeDataFileParameterResponse(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate___ns1__removeDataFileParameterResponse(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     soap_default___ns1__removeDataFileParameterResponse(soap, _p);
   }
@@ -33926,8 +34159,8 @@ soap_new_set___ns1__removeDataFileParameterResponse(
     struct soap *soap, ns1__removeDataFileParameterResponse *
                            ns1__removeDataFileParameterResponse_) {
   struct __ns1__removeDataFileParameterResponse *_p =
-      soap_instantiate___ns1__removeDataFileParameterResponse(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate___ns1__removeDataFileParameterResponse(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     soap_default___ns1__removeDataFileParameterResponse(soap, _p);
     _p->ns1__removeDataFileParameterResponse_ =
@@ -33995,13 +34228,14 @@ soap_instantiate___ns1__removeDataFile(struct soap *, int, const char *,
 
 inline struct __ns1__removeDataFile *
 soap_new___ns1__removeDataFile(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__removeDataFile(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__removeDataFile(soap, n, nullptr, nullptr,
+                                                nullptr);
 }
 
 inline struct __ns1__removeDataFile *
 soap_new_req___ns1__removeDataFile(struct soap *soap) {
-  struct __ns1__removeDataFile *_p =
-      soap_instantiate___ns1__removeDataFile(soap, -1, NULL, NULL, NULL);
+  struct __ns1__removeDataFile *_p = soap_instantiate___ns1__removeDataFile(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__removeDataFile(soap, _p);
   }
@@ -34011,8 +34245,8 @@ soap_new_req___ns1__removeDataFile(struct soap *soap) {
 inline struct __ns1__removeDataFile *
 soap_new_set___ns1__removeDataFile(struct soap *soap,
                                    ns1__removeDataFile *ns1__removeDataFile_) {
-  struct __ns1__removeDataFile *_p =
-      soap_instantiate___ns1__removeDataFile(soap, -1, NULL, NULL, NULL);
+  struct __ns1__removeDataFile *_p = soap_instantiate___ns1__removeDataFile(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__removeDataFile(soap, _p);
     _p->ns1__removeDataFile_ = ns1__removeDataFile_;
@@ -34078,15 +34312,15 @@ soap_instantiate___ns1__removeDataFileResponse(struct soap *, int, const char *,
 
 inline struct __ns1__removeDataFileResponse *
 soap_new___ns1__removeDataFileResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__removeDataFileResponse(soap, n, NULL, NULL,
-                                                        NULL);
+  return soap_instantiate___ns1__removeDataFileResponse(soap, n, nullptr,
+                                                        nullptr, nullptr);
 }
 
 inline struct __ns1__removeDataFileResponse *
 soap_new_req___ns1__removeDataFileResponse(struct soap *soap) {
   struct __ns1__removeDataFileResponse *_p =
-      soap_instantiate___ns1__removeDataFileResponse(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate___ns1__removeDataFileResponse(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     soap_default___ns1__removeDataFileResponse(soap, _p);
   }
@@ -34098,8 +34332,8 @@ soap_new_set___ns1__removeDataFileResponse(
     struct soap *soap,
     ns1__removeDataFileResponse *ns1__removeDataFileResponse_) {
   struct __ns1__removeDataFileResponse *_p =
-      soap_instantiate___ns1__removeDataFileResponse(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate___ns1__removeDataFileResponse(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     soap_default___ns1__removeDataFileResponse(soap, _p);
     _p->ns1__removeDataFileResponse_ = ns1__removeDataFileResponse_;
@@ -34166,15 +34400,15 @@ soap_instantiate___ns1__deleteDataFileParameter(struct soap *, int,
 
 inline struct __ns1__deleteDataFileParameter *
 soap_new___ns1__deleteDataFileParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__deleteDataFileParameter(soap, n, NULL, NULL,
-                                                         NULL);
+  return soap_instantiate___ns1__deleteDataFileParameter(soap, n, nullptr,
+                                                         nullptr, nullptr);
 }
 
 inline struct __ns1__deleteDataFileParameter *
 soap_new_req___ns1__deleteDataFileParameter(struct soap *soap) {
   struct __ns1__deleteDataFileParameter *_p =
-      soap_instantiate___ns1__deleteDataFileParameter(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate___ns1__deleteDataFileParameter(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     soap_default___ns1__deleteDataFileParameter(soap, _p);
   }
@@ -34186,8 +34420,8 @@ soap_new_set___ns1__deleteDataFileParameter(
     struct soap *soap,
     ns1__deleteDataFileParameter *ns1__deleteDataFileParameter_) {
   struct __ns1__deleteDataFileParameter *_p =
-      soap_instantiate___ns1__deleteDataFileParameter(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate___ns1__deleteDataFileParameter(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     soap_default___ns1__deleteDataFileParameter(soap, _p);
     _p->ns1__deleteDataFileParameter_ = ns1__deleteDataFileParameter_;
@@ -34255,15 +34489,15 @@ soap_instantiate___ns1__deleteDataFileParameterResponse(struct soap *, int,
 
 inline struct __ns1__deleteDataFileParameterResponse *
 soap_new___ns1__deleteDataFileParameterResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__deleteDataFileParameterResponse(soap, n, NULL,
-                                                                 NULL, NULL);
+  return soap_instantiate___ns1__deleteDataFileParameterResponse(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__deleteDataFileParameterResponse *
 soap_new_req___ns1__deleteDataFileParameterResponse(struct soap *soap) {
   struct __ns1__deleteDataFileParameterResponse *_p =
-      soap_instantiate___ns1__deleteDataFileParameterResponse(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate___ns1__deleteDataFileParameterResponse(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     soap_default___ns1__deleteDataFileParameterResponse(soap, _p);
   }
@@ -34275,8 +34509,8 @@ soap_new_set___ns1__deleteDataFileParameterResponse(
     struct soap *soap, ns1__deleteDataFileParameterResponse *
                            ns1__deleteDataFileParameterResponse_) {
   struct __ns1__deleteDataFileParameterResponse *_p =
-      soap_instantiate___ns1__deleteDataFileParameterResponse(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate___ns1__deleteDataFileParameterResponse(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     soap_default___ns1__deleteDataFileParameterResponse(soap, _p);
     _p->ns1__deleteDataFileParameterResponse_ =
@@ -34345,15 +34579,15 @@ soap_instantiate___ns1__modifyDataFileParameter(struct soap *, int,
 
 inline struct __ns1__modifyDataFileParameter *
 soap_new___ns1__modifyDataFileParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__modifyDataFileParameter(soap, n, NULL, NULL,
-                                                         NULL);
+  return soap_instantiate___ns1__modifyDataFileParameter(soap, n, nullptr,
+                                                         nullptr, nullptr);
 }
 
 inline struct __ns1__modifyDataFileParameter *
 soap_new_req___ns1__modifyDataFileParameter(struct soap *soap) {
   struct __ns1__modifyDataFileParameter *_p =
-      soap_instantiate___ns1__modifyDataFileParameter(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate___ns1__modifyDataFileParameter(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     soap_default___ns1__modifyDataFileParameter(soap, _p);
   }
@@ -34365,8 +34599,8 @@ soap_new_set___ns1__modifyDataFileParameter(
     struct soap *soap,
     ns1__modifyDataFileParameter *ns1__modifyDataFileParameter_) {
   struct __ns1__modifyDataFileParameter *_p =
-      soap_instantiate___ns1__modifyDataFileParameter(soap, -1, NULL, NULL,
-                                                      NULL);
+      soap_instantiate___ns1__modifyDataFileParameter(soap, -1, nullptr,
+                                                      nullptr, nullptr);
   if (_p) {
     soap_default___ns1__modifyDataFileParameter(soap, _p);
     _p->ns1__modifyDataFileParameter_ = ns1__modifyDataFileParameter_;
@@ -34434,15 +34668,15 @@ soap_instantiate___ns1__modifyDataFileParameterResponse(struct soap *, int,
 
 inline struct __ns1__modifyDataFileParameterResponse *
 soap_new___ns1__modifyDataFileParameterResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__modifyDataFileParameterResponse(soap, n, NULL,
-                                                                 NULL, NULL);
+  return soap_instantiate___ns1__modifyDataFileParameterResponse(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__modifyDataFileParameterResponse *
 soap_new_req___ns1__modifyDataFileParameterResponse(struct soap *soap) {
   struct __ns1__modifyDataFileParameterResponse *_p =
-      soap_instantiate___ns1__modifyDataFileParameterResponse(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate___ns1__modifyDataFileParameterResponse(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     soap_default___ns1__modifyDataFileParameterResponse(soap, _p);
   }
@@ -34454,8 +34688,8 @@ soap_new_set___ns1__modifyDataFileParameterResponse(
     struct soap *soap, ns1__modifyDataFileParameterResponse *
                            ns1__modifyDataFileParameterResponse_) {
   struct __ns1__modifyDataFileParameterResponse *_p =
-      soap_instantiate___ns1__modifyDataFileParameterResponse(soap, -1, NULL,
-                                                              NULL, NULL);
+      soap_instantiate___ns1__modifyDataFileParameterResponse(soap, -1, nullptr,
+                                                              nullptr, nullptr);
   if (_p) {
     soap_default___ns1__modifyDataFileParameterResponse(soap, _p);
     _p->ns1__modifyDataFileParameterResponse_ =
@@ -34523,14 +34757,15 @@ soap_instantiate___ns1__addDataFileParameters(struct soap *, int, const char *,
 
 inline struct __ns1__addDataFileParameters *
 soap_new___ns1__addDataFileParameters(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__addDataFileParameters(soap, n, NULL, NULL,
-                                                       NULL);
+  return soap_instantiate___ns1__addDataFileParameters(soap, n, nullptr,
+                                                       nullptr, nullptr);
 }
 
 inline struct __ns1__addDataFileParameters *
 soap_new_req___ns1__addDataFileParameters(struct soap *soap) {
   struct __ns1__addDataFileParameters *_p =
-      soap_instantiate___ns1__addDataFileParameters(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__addDataFileParameters(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     soap_default___ns1__addDataFileParameters(soap, _p);
   }
@@ -34542,7 +34777,8 @@ soap_new_set___ns1__addDataFileParameters(
     struct soap *soap,
     ns1__addDataFileParameters *ns1__addDataFileParameters_) {
   struct __ns1__addDataFileParameters *_p =
-      soap_instantiate___ns1__addDataFileParameters(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__addDataFileParameters(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     soap_default___ns1__addDataFileParameters(soap, _p);
     _p->ns1__addDataFileParameters_ = ns1__addDataFileParameters_;
@@ -34610,14 +34846,15 @@ soap_instantiate___ns1__addDataFileParameter(struct soap *, int, const char *,
 
 inline struct __ns1__addDataFileParameter *
 soap_new___ns1__addDataFileParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__addDataFileParameter(soap, n, NULL, NULL,
-                                                      NULL);
+  return soap_instantiate___ns1__addDataFileParameter(soap, n, nullptr, nullptr,
+                                                      nullptr);
 }
 
 inline struct __ns1__addDataFileParameter *
 soap_new_req___ns1__addDataFileParameter(struct soap *soap) {
   struct __ns1__addDataFileParameter *_p =
-      soap_instantiate___ns1__addDataFileParameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__addDataFileParameter(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     soap_default___ns1__addDataFileParameter(soap, _p);
   }
@@ -34628,7 +34865,8 @@ inline struct __ns1__addDataFileParameter *
 soap_new_set___ns1__addDataFileParameter(
     struct soap *soap, ns1__addDataFileParameter *ns1__addDataFileParameter_) {
   struct __ns1__addDataFileParameter *_p =
-      soap_instantiate___ns1__addDataFileParameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__addDataFileParameter(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     soap_default___ns1__addDataFileParameter(soap, _p);
     _p->ns1__addDataFileParameter_ = ns1__addDataFileParameter_;
@@ -34695,13 +34933,14 @@ soap_instantiate___ns1__modifyDataFile(struct soap *, int, const char *,
 
 inline struct __ns1__modifyDataFile *
 soap_new___ns1__modifyDataFile(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__modifyDataFile(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__modifyDataFile(soap, n, nullptr, nullptr,
+                                                nullptr);
 }
 
 inline struct __ns1__modifyDataFile *
 soap_new_req___ns1__modifyDataFile(struct soap *soap) {
-  struct __ns1__modifyDataFile *_p =
-      soap_instantiate___ns1__modifyDataFile(soap, -1, NULL, NULL, NULL);
+  struct __ns1__modifyDataFile *_p = soap_instantiate___ns1__modifyDataFile(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__modifyDataFile(soap, _p);
   }
@@ -34711,8 +34950,8 @@ soap_new_req___ns1__modifyDataFile(struct soap *soap) {
 inline struct __ns1__modifyDataFile *
 soap_new_set___ns1__modifyDataFile(struct soap *soap,
                                    ns1__modifyDataFile *ns1__modifyDataFile_) {
-  struct __ns1__modifyDataFile *_p =
-      soap_instantiate___ns1__modifyDataFile(soap, -1, NULL, NULL, NULL);
+  struct __ns1__modifyDataFile *_p = soap_instantiate___ns1__modifyDataFile(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__modifyDataFile(soap, _p);
     _p->ns1__modifyDataFile_ = ns1__modifyDataFile_;
@@ -34778,15 +35017,15 @@ soap_instantiate___ns1__modifyDataFileResponse(struct soap *, int, const char *,
 
 inline struct __ns1__modifyDataFileResponse *
 soap_new___ns1__modifyDataFileResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__modifyDataFileResponse(soap, n, NULL, NULL,
-                                                        NULL);
+  return soap_instantiate___ns1__modifyDataFileResponse(soap, n, nullptr,
+                                                        nullptr, nullptr);
 }
 
 inline struct __ns1__modifyDataFileResponse *
 soap_new_req___ns1__modifyDataFileResponse(struct soap *soap) {
   struct __ns1__modifyDataFileResponse *_p =
-      soap_instantiate___ns1__modifyDataFileResponse(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate___ns1__modifyDataFileResponse(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     soap_default___ns1__modifyDataFileResponse(soap, _p);
   }
@@ -34798,8 +35037,8 @@ soap_new_set___ns1__modifyDataFileResponse(
     struct soap *soap,
     ns1__modifyDataFileResponse *ns1__modifyDataFileResponse_) {
   struct __ns1__modifyDataFileResponse *_p =
-      soap_instantiate___ns1__modifyDataFileResponse(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate___ns1__modifyDataFileResponse(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     soap_default___ns1__modifyDataFileResponse(soap, _p);
     _p->ns1__modifyDataFileResponse_ = ns1__modifyDataFileResponse_;
@@ -34865,13 +35104,14 @@ soap_instantiate___ns1__deleteDataFile(struct soap *, int, const char *,
 
 inline struct __ns1__deleteDataFile *
 soap_new___ns1__deleteDataFile(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__deleteDataFile(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__deleteDataFile(soap, n, nullptr, nullptr,
+                                                nullptr);
 }
 
 inline struct __ns1__deleteDataFile *
 soap_new_req___ns1__deleteDataFile(struct soap *soap) {
-  struct __ns1__deleteDataFile *_p =
-      soap_instantiate___ns1__deleteDataFile(soap, -1, NULL, NULL, NULL);
+  struct __ns1__deleteDataFile *_p = soap_instantiate___ns1__deleteDataFile(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__deleteDataFile(soap, _p);
   }
@@ -34881,8 +35121,8 @@ soap_new_req___ns1__deleteDataFile(struct soap *soap) {
 inline struct __ns1__deleteDataFile *
 soap_new_set___ns1__deleteDataFile(struct soap *soap,
                                    ns1__deleteDataFile *ns1__deleteDataFile_) {
-  struct __ns1__deleteDataFile *_p =
-      soap_instantiate___ns1__deleteDataFile(soap, -1, NULL, NULL, NULL);
+  struct __ns1__deleteDataFile *_p = soap_instantiate___ns1__deleteDataFile(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__deleteDataFile(soap, _p);
     _p->ns1__deleteDataFile_ = ns1__deleteDataFile_;
@@ -34948,15 +35188,15 @@ soap_instantiate___ns1__deleteDataFileResponse(struct soap *, int, const char *,
 
 inline struct __ns1__deleteDataFileResponse *
 soap_new___ns1__deleteDataFileResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__deleteDataFileResponse(soap, n, NULL, NULL,
-                                                        NULL);
+  return soap_instantiate___ns1__deleteDataFileResponse(soap, n, nullptr,
+                                                        nullptr, nullptr);
 }
 
 inline struct __ns1__deleteDataFileResponse *
 soap_new_req___ns1__deleteDataFileResponse(struct soap *soap) {
   struct __ns1__deleteDataFileResponse *_p =
-      soap_instantiate___ns1__deleteDataFileResponse(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate___ns1__deleteDataFileResponse(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     soap_default___ns1__deleteDataFileResponse(soap, _p);
   }
@@ -34968,8 +35208,8 @@ soap_new_set___ns1__deleteDataFileResponse(
     struct soap *soap,
     ns1__deleteDataFileResponse *ns1__deleteDataFileResponse_) {
   struct __ns1__deleteDataFileResponse *_p =
-      soap_instantiate___ns1__deleteDataFileResponse(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate___ns1__deleteDataFileResponse(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     soap_default___ns1__deleteDataFileResponse(soap, _p);
     _p->ns1__deleteDataFileResponse_ = ns1__deleteDataFileResponse_;
@@ -35035,13 +35275,14 @@ soap_instantiate___ns1__createDataFiles(struct soap *, int, const char *,
 
 inline struct __ns1__createDataFiles *
 soap_new___ns1__createDataFiles(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__createDataFiles(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__createDataFiles(soap, n, nullptr, nullptr,
+                                                 nullptr);
 }
 
 inline struct __ns1__createDataFiles *
 soap_new_req___ns1__createDataFiles(struct soap *soap) {
-  struct __ns1__createDataFiles *_p =
-      soap_instantiate___ns1__createDataFiles(soap, -1, NULL, NULL, NULL);
+  struct __ns1__createDataFiles *_p = soap_instantiate___ns1__createDataFiles(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__createDataFiles(soap, _p);
   }
@@ -35050,8 +35291,8 @@ soap_new_req___ns1__createDataFiles(struct soap *soap) {
 
 inline struct __ns1__createDataFiles *soap_new_set___ns1__createDataFiles(
     struct soap *soap, ns1__createDataFiles *ns1__createDataFiles_) {
-  struct __ns1__createDataFiles *_p =
-      soap_instantiate___ns1__createDataFiles(soap, -1, NULL, NULL, NULL);
+  struct __ns1__createDataFiles *_p = soap_instantiate___ns1__createDataFiles(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__createDataFiles(soap, _p);
     _p->ns1__createDataFiles_ = ns1__createDataFiles_;
@@ -35118,13 +35359,14 @@ soap_instantiate___ns1__createDataFile(struct soap *, int, const char *,
 
 inline struct __ns1__createDataFile *
 soap_new___ns1__createDataFile(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__createDataFile(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__createDataFile(soap, n, nullptr, nullptr,
+                                                nullptr);
 }
 
 inline struct __ns1__createDataFile *
 soap_new_req___ns1__createDataFile(struct soap *soap) {
-  struct __ns1__createDataFile *_p =
-      soap_instantiate___ns1__createDataFile(soap, -1, NULL, NULL, NULL);
+  struct __ns1__createDataFile *_p = soap_instantiate___ns1__createDataFile(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__createDataFile(soap, _p);
   }
@@ -35134,8 +35376,8 @@ soap_new_req___ns1__createDataFile(struct soap *soap) {
 inline struct __ns1__createDataFile *
 soap_new_set___ns1__createDataFile(struct soap *soap,
                                    ns1__createDataFile *ns1__createDataFile_) {
-  struct __ns1__createDataFile *_p =
-      soap_instantiate___ns1__createDataFile(soap, -1, NULL, NULL, NULL);
+  struct __ns1__createDataFile *_p = soap_instantiate___ns1__createDataFile(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__createDataFile(soap, _p);
     _p->ns1__createDataFile_ = ns1__createDataFile_;
@@ -35198,13 +35440,14 @@ soap_instantiate___ns1__getDatafiles(struct soap *, int, const char *,
 
 inline struct __ns1__getDatafiles *
 soap_new___ns1__getDatafiles(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__getDatafiles(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__getDatafiles(soap, n, nullptr, nullptr,
+                                              nullptr);
 }
 
 inline struct __ns1__getDatafiles *
 soap_new_req___ns1__getDatafiles(struct soap *soap) {
   struct __ns1__getDatafiles *_p =
-      soap_instantiate___ns1__getDatafiles(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getDatafiles(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getDatafiles(soap, _p);
   }
@@ -35215,7 +35458,7 @@ inline struct __ns1__getDatafiles *
 soap_new_set___ns1__getDatafiles(struct soap *soap,
                                  ns1__getDatafiles *ns1__getDatafiles_) {
   struct __ns1__getDatafiles *_p =
-      soap_instantiate___ns1__getDatafiles(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getDatafiles(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getDatafiles(soap, _p);
     _p->ns1__getDatafiles_ = ns1__getDatafiles_;
@@ -35278,13 +35521,14 @@ soap_instantiate___ns1__getDatafile(struct soap *, int, const char *,
 
 inline struct __ns1__getDatafile *soap_new___ns1__getDatafile(struct soap *soap,
                                                               int n = -1) {
-  return soap_instantiate___ns1__getDatafile(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__getDatafile(soap, n, nullptr, nullptr,
+                                             nullptr);
 }
 
 inline struct __ns1__getDatafile *
 soap_new_req___ns1__getDatafile(struct soap *soap) {
   struct __ns1__getDatafile *_p =
-      soap_instantiate___ns1__getDatafile(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getDatafile(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getDatafile(soap, _p);
   }
@@ -35295,7 +35539,7 @@ inline struct __ns1__getDatafile *
 soap_new_set___ns1__getDatafile(struct soap *soap,
                                 ns1__getDatafile *ns1__getDatafile_) {
   struct __ns1__getDatafile *_p =
-      soap_instantiate___ns1__getDatafile(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getDatafile(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getDatafile(soap, _p);
     _p->ns1__getDatafile_ = ns1__getDatafile_;
@@ -35361,15 +35605,15 @@ soap_instantiate___ns1__removeDataSetParameter(struct soap *, int, const char *,
 
 inline struct __ns1__removeDataSetParameter *
 soap_new___ns1__removeDataSetParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__removeDataSetParameter(soap, n, NULL, NULL,
-                                                        NULL);
+  return soap_instantiate___ns1__removeDataSetParameter(soap, n, nullptr,
+                                                        nullptr, nullptr);
 }
 
 inline struct __ns1__removeDataSetParameter *
 soap_new_req___ns1__removeDataSetParameter(struct soap *soap) {
   struct __ns1__removeDataSetParameter *_p =
-      soap_instantiate___ns1__removeDataSetParameter(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate___ns1__removeDataSetParameter(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     soap_default___ns1__removeDataSetParameter(soap, _p);
   }
@@ -35381,8 +35625,8 @@ soap_new_set___ns1__removeDataSetParameter(
     struct soap *soap,
     ns1__removeDataSetParameter *ns1__removeDataSetParameter_) {
   struct __ns1__removeDataSetParameter *_p =
-      soap_instantiate___ns1__removeDataSetParameter(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate___ns1__removeDataSetParameter(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     soap_default___ns1__removeDataSetParameter(soap, _p);
     _p->ns1__removeDataSetParameter_ = ns1__removeDataSetParameter_;
@@ -35449,15 +35693,15 @@ soap_instantiate___ns1__removeDataSetParameterResponse(struct soap *, int,
 
 inline struct __ns1__removeDataSetParameterResponse *
 soap_new___ns1__removeDataSetParameterResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__removeDataSetParameterResponse(soap, n, NULL,
-                                                                NULL, NULL);
+  return soap_instantiate___ns1__removeDataSetParameterResponse(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__removeDataSetParameterResponse *
 soap_new_req___ns1__removeDataSetParameterResponse(struct soap *soap) {
   struct __ns1__removeDataSetParameterResponse *_p =
-      soap_instantiate___ns1__removeDataSetParameterResponse(soap, -1, NULL,
-                                                             NULL, NULL);
+      soap_instantiate___ns1__removeDataSetParameterResponse(soap, -1, nullptr,
+                                                             nullptr, nullptr);
   if (_p) {
     soap_default___ns1__removeDataSetParameterResponse(soap, _p);
   }
@@ -35469,8 +35713,8 @@ soap_new_set___ns1__removeDataSetParameterResponse(
     struct soap *soap,
     ns1__removeDataSetParameterResponse *ns1__removeDataSetParameterResponse_) {
   struct __ns1__removeDataSetParameterResponse *_p =
-      soap_instantiate___ns1__removeDataSetParameterResponse(soap, -1, NULL,
-                                                             NULL, NULL);
+      soap_instantiate___ns1__removeDataSetParameterResponse(soap, -1, nullptr,
+                                                             nullptr, nullptr);
   if (_p) {
     soap_default___ns1__removeDataSetParameterResponse(soap, _p);
     _p->ns1__removeDataSetParameterResponse_ =
@@ -35536,13 +35780,14 @@ soap_instantiate___ns1__removeDataSet(struct soap *, int, const char *,
 
 inline struct __ns1__removeDataSet *
 soap_new___ns1__removeDataSet(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__removeDataSet(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__removeDataSet(soap, n, nullptr, nullptr,
+                                               nullptr);
 }
 
 inline struct __ns1__removeDataSet *
 soap_new_req___ns1__removeDataSet(struct soap *soap) {
-  struct __ns1__removeDataSet *_p =
-      soap_instantiate___ns1__removeDataSet(soap, -1, NULL, NULL, NULL);
+  struct __ns1__removeDataSet *_p = soap_instantiate___ns1__removeDataSet(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__removeDataSet(soap, _p);
   }
@@ -35552,8 +35797,8 @@ soap_new_req___ns1__removeDataSet(struct soap *soap) {
 inline struct __ns1__removeDataSet *
 soap_new_set___ns1__removeDataSet(struct soap *soap,
                                   ns1__removeDataSet *ns1__removeDataSet_) {
-  struct __ns1__removeDataSet *_p =
-      soap_instantiate___ns1__removeDataSet(soap, -1, NULL, NULL, NULL);
+  struct __ns1__removeDataSet *_p = soap_instantiate___ns1__removeDataSet(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__removeDataSet(soap, _p);
     _p->ns1__removeDataSet_ = ns1__removeDataSet_;
@@ -35619,14 +35864,15 @@ soap_instantiate___ns1__removeDataSetResponse(struct soap *, int, const char *,
 
 inline struct __ns1__removeDataSetResponse *
 soap_new___ns1__removeDataSetResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__removeDataSetResponse(soap, n, NULL, NULL,
-                                                       NULL);
+  return soap_instantiate___ns1__removeDataSetResponse(soap, n, nullptr,
+                                                       nullptr, nullptr);
 }
 
 inline struct __ns1__removeDataSetResponse *
 soap_new_req___ns1__removeDataSetResponse(struct soap *soap) {
   struct __ns1__removeDataSetResponse *_p =
-      soap_instantiate___ns1__removeDataSetResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__removeDataSetResponse(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     soap_default___ns1__removeDataSetResponse(soap, _p);
   }
@@ -35638,7 +35884,8 @@ soap_new_set___ns1__removeDataSetResponse(
     struct soap *soap,
     ns1__removeDataSetResponse *ns1__removeDataSetResponse_) {
   struct __ns1__removeDataSetResponse *_p =
-      soap_instantiate___ns1__removeDataSetResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__removeDataSetResponse(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     soap_default___ns1__removeDataSetResponse(soap, _p);
     _p->ns1__removeDataSetResponse_ = ns1__removeDataSetResponse_;
@@ -35706,14 +35953,15 @@ soap_instantiate___ns1__addDataSetParameters(struct soap *, int, const char *,
 
 inline struct __ns1__addDataSetParameters *
 soap_new___ns1__addDataSetParameters(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__addDataSetParameters(soap, n, NULL, NULL,
-                                                      NULL);
+  return soap_instantiate___ns1__addDataSetParameters(soap, n, nullptr, nullptr,
+                                                      nullptr);
 }
 
 inline struct __ns1__addDataSetParameters *
 soap_new_req___ns1__addDataSetParameters(struct soap *soap) {
   struct __ns1__addDataSetParameters *_p =
-      soap_instantiate___ns1__addDataSetParameters(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__addDataSetParameters(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     soap_default___ns1__addDataSetParameters(soap, _p);
   }
@@ -35724,7 +35972,8 @@ inline struct __ns1__addDataSetParameters *
 soap_new_set___ns1__addDataSetParameters(
     struct soap *soap, ns1__addDataSetParameters *ns1__addDataSetParameters_) {
   struct __ns1__addDataSetParameters *_p =
-      soap_instantiate___ns1__addDataSetParameters(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__addDataSetParameters(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     soap_default___ns1__addDataSetParameters(soap, _p);
     _p->ns1__addDataSetParameters_ = ns1__addDataSetParameters_;
@@ -35793,13 +36042,15 @@ soap_instantiate___ns1__addDataSetParameter(struct soap *, int, const char *,
 
 inline struct __ns1__addDataSetParameter *
 soap_new___ns1__addDataSetParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__addDataSetParameter(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__addDataSetParameter(soap, n, nullptr, nullptr,
+                                                     nullptr);
 }
 
 inline struct __ns1__addDataSetParameter *
 soap_new_req___ns1__addDataSetParameter(struct soap *soap) {
   struct __ns1__addDataSetParameter *_p =
-      soap_instantiate___ns1__addDataSetParameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__addDataSetParameter(soap, -1, nullptr, nullptr,
+                                                  nullptr);
   if (_p) {
     soap_default___ns1__addDataSetParameter(soap, _p);
   }
@@ -35810,7 +36061,8 @@ inline struct __ns1__addDataSetParameter *
 soap_new_set___ns1__addDataSetParameter(
     struct soap *soap, ns1__addDataSetParameter *ns1__addDataSetParameter_) {
   struct __ns1__addDataSetParameter *_p =
-      soap_instantiate___ns1__addDataSetParameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__addDataSetParameter(soap, -1, nullptr, nullptr,
+                                                  nullptr);
   if (_p) {
     soap_default___ns1__addDataSetParameter(soap, _p);
     _p->ns1__addDataSetParameter_ = ns1__addDataSetParameter_;
@@ -35878,13 +36130,14 @@ soap_instantiate___ns1__setDataSetSample(struct soap *, int, const char *,
 
 inline struct __ns1__setDataSetSample *
 soap_new___ns1__setDataSetSample(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__setDataSetSample(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__setDataSetSample(soap, n, nullptr, nullptr,
+                                                  nullptr);
 }
 
 inline struct __ns1__setDataSetSample *
 soap_new_req___ns1__setDataSetSample(struct soap *soap) {
-  struct __ns1__setDataSetSample *_p =
-      soap_instantiate___ns1__setDataSetSample(soap, -1, NULL, NULL, NULL);
+  struct __ns1__setDataSetSample *_p = soap_instantiate___ns1__setDataSetSample(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__setDataSetSample(soap, _p);
   }
@@ -35893,8 +36146,8 @@ soap_new_req___ns1__setDataSetSample(struct soap *soap) {
 
 inline struct __ns1__setDataSetSample *soap_new_set___ns1__setDataSetSample(
     struct soap *soap, ns1__setDataSetSample *ns1__setDataSetSample_) {
-  struct __ns1__setDataSetSample *_p =
-      soap_instantiate___ns1__setDataSetSample(soap, -1, NULL, NULL, NULL);
+  struct __ns1__setDataSetSample *_p = soap_instantiate___ns1__setDataSetSample(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__setDataSetSample(soap, _p);
     _p->ns1__setDataSetSample_ = ns1__setDataSetSample_;
@@ -35962,15 +36215,15 @@ soap_instantiate___ns1__setDataSetSampleResponse(struct soap *, int,
 
 inline struct __ns1__setDataSetSampleResponse *
 soap_new___ns1__setDataSetSampleResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__setDataSetSampleResponse(soap, n, NULL, NULL,
-                                                          NULL);
+  return soap_instantiate___ns1__setDataSetSampleResponse(soap, n, nullptr,
+                                                          nullptr, nullptr);
 }
 
 inline struct __ns1__setDataSetSampleResponse *
 soap_new_req___ns1__setDataSetSampleResponse(struct soap *soap) {
   struct __ns1__setDataSetSampleResponse *_p =
-      soap_instantiate___ns1__setDataSetSampleResponse(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate___ns1__setDataSetSampleResponse(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     soap_default___ns1__setDataSetSampleResponse(soap, _p);
   }
@@ -35982,8 +36235,8 @@ soap_new_set___ns1__setDataSetSampleResponse(
     struct soap *soap,
     ns1__setDataSetSampleResponse *ns1__setDataSetSampleResponse_) {
   struct __ns1__setDataSetSampleResponse *_p =
-      soap_instantiate___ns1__setDataSetSampleResponse(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate___ns1__setDataSetSampleResponse(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     soap_default___ns1__setDataSetSampleResponse(soap, _p);
     _p->ns1__setDataSetSampleResponse_ = ns1__setDataSetSampleResponse_;
@@ -36049,15 +36302,15 @@ soap_instantiate___ns1__modifyDataSetParameter(struct soap *, int, const char *,
 
 inline struct __ns1__modifyDataSetParameter *
 soap_new___ns1__modifyDataSetParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__modifyDataSetParameter(soap, n, NULL, NULL,
-                                                        NULL);
+  return soap_instantiate___ns1__modifyDataSetParameter(soap, n, nullptr,
+                                                        nullptr, nullptr);
 }
 
 inline struct __ns1__modifyDataSetParameter *
 soap_new_req___ns1__modifyDataSetParameter(struct soap *soap) {
   struct __ns1__modifyDataSetParameter *_p =
-      soap_instantiate___ns1__modifyDataSetParameter(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate___ns1__modifyDataSetParameter(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     soap_default___ns1__modifyDataSetParameter(soap, _p);
   }
@@ -36069,8 +36322,8 @@ soap_new_set___ns1__modifyDataSetParameter(
     struct soap *soap,
     ns1__modifyDataSetParameter *ns1__modifyDataSetParameter_) {
   struct __ns1__modifyDataSetParameter *_p =
-      soap_instantiate___ns1__modifyDataSetParameter(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate___ns1__modifyDataSetParameter(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     soap_default___ns1__modifyDataSetParameter(soap, _p);
     _p->ns1__modifyDataSetParameter_ = ns1__modifyDataSetParameter_;
@@ -36137,15 +36390,15 @@ soap_instantiate___ns1__modifyDataSetParameterResponse(struct soap *, int,
 
 inline struct __ns1__modifyDataSetParameterResponse *
 soap_new___ns1__modifyDataSetParameterResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__modifyDataSetParameterResponse(soap, n, NULL,
-                                                                NULL, NULL);
+  return soap_instantiate___ns1__modifyDataSetParameterResponse(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__modifyDataSetParameterResponse *
 soap_new_req___ns1__modifyDataSetParameterResponse(struct soap *soap) {
   struct __ns1__modifyDataSetParameterResponse *_p =
-      soap_instantiate___ns1__modifyDataSetParameterResponse(soap, -1, NULL,
-                                                             NULL, NULL);
+      soap_instantiate___ns1__modifyDataSetParameterResponse(soap, -1, nullptr,
+                                                             nullptr, nullptr);
   if (_p) {
     soap_default___ns1__modifyDataSetParameterResponse(soap, _p);
   }
@@ -36157,8 +36410,8 @@ soap_new_set___ns1__modifyDataSetParameterResponse(
     struct soap *soap,
     ns1__modifyDataSetParameterResponse *ns1__modifyDataSetParameterResponse_) {
   struct __ns1__modifyDataSetParameterResponse *_p =
-      soap_instantiate___ns1__modifyDataSetParameterResponse(soap, -1, NULL,
-                                                             NULL, NULL);
+      soap_instantiate___ns1__modifyDataSetParameterResponse(soap, -1, nullptr,
+                                                             nullptr, nullptr);
   if (_p) {
     soap_default___ns1__modifyDataSetParameterResponse(soap, _p);
     _p->ns1__modifyDataSetParameterResponse_ =
@@ -36224,13 +36477,14 @@ soap_instantiate___ns1__modifyDataSet(struct soap *, int, const char *,
 
 inline struct __ns1__modifyDataSet *
 soap_new___ns1__modifyDataSet(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__modifyDataSet(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__modifyDataSet(soap, n, nullptr, nullptr,
+                                               nullptr);
 }
 
 inline struct __ns1__modifyDataSet *
 soap_new_req___ns1__modifyDataSet(struct soap *soap) {
-  struct __ns1__modifyDataSet *_p =
-      soap_instantiate___ns1__modifyDataSet(soap, -1, NULL, NULL, NULL);
+  struct __ns1__modifyDataSet *_p = soap_instantiate___ns1__modifyDataSet(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__modifyDataSet(soap, _p);
   }
@@ -36240,8 +36494,8 @@ soap_new_req___ns1__modifyDataSet(struct soap *soap) {
 inline struct __ns1__modifyDataSet *
 soap_new_set___ns1__modifyDataSet(struct soap *soap,
                                   ns1__modifyDataSet *ns1__modifyDataSet_) {
-  struct __ns1__modifyDataSet *_p =
-      soap_instantiate___ns1__modifyDataSet(soap, -1, NULL, NULL, NULL);
+  struct __ns1__modifyDataSet *_p = soap_instantiate___ns1__modifyDataSet(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__modifyDataSet(soap, _p);
     _p->ns1__modifyDataSet_ = ns1__modifyDataSet_;
@@ -36307,14 +36561,15 @@ soap_instantiate___ns1__modifyDataSetResponse(struct soap *, int, const char *,
 
 inline struct __ns1__modifyDataSetResponse *
 soap_new___ns1__modifyDataSetResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__modifyDataSetResponse(soap, n, NULL, NULL,
-                                                       NULL);
+  return soap_instantiate___ns1__modifyDataSetResponse(soap, n, nullptr,
+                                                       nullptr, nullptr);
 }
 
 inline struct __ns1__modifyDataSetResponse *
 soap_new_req___ns1__modifyDataSetResponse(struct soap *soap) {
   struct __ns1__modifyDataSetResponse *_p =
-      soap_instantiate___ns1__modifyDataSetResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__modifyDataSetResponse(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     soap_default___ns1__modifyDataSetResponse(soap, _p);
   }
@@ -36326,7 +36581,8 @@ soap_new_set___ns1__modifyDataSetResponse(
     struct soap *soap,
     ns1__modifyDataSetResponse *ns1__modifyDataSetResponse_) {
   struct __ns1__modifyDataSetResponse *_p =
-      soap_instantiate___ns1__modifyDataSetResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__modifyDataSetResponse(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     soap_default___ns1__modifyDataSetResponse(soap, _p);
     _p->ns1__modifyDataSetResponse_ = ns1__modifyDataSetResponse_;
@@ -36392,15 +36648,15 @@ soap_instantiate___ns1__deleteDataSetParameter(struct soap *, int, const char *,
 
 inline struct __ns1__deleteDataSetParameter *
 soap_new___ns1__deleteDataSetParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__deleteDataSetParameter(soap, n, NULL, NULL,
-                                                        NULL);
+  return soap_instantiate___ns1__deleteDataSetParameter(soap, n, nullptr,
+                                                        nullptr, nullptr);
 }
 
 inline struct __ns1__deleteDataSetParameter *
 soap_new_req___ns1__deleteDataSetParameter(struct soap *soap) {
   struct __ns1__deleteDataSetParameter *_p =
-      soap_instantiate___ns1__deleteDataSetParameter(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate___ns1__deleteDataSetParameter(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     soap_default___ns1__deleteDataSetParameter(soap, _p);
   }
@@ -36412,8 +36668,8 @@ soap_new_set___ns1__deleteDataSetParameter(
     struct soap *soap,
     ns1__deleteDataSetParameter *ns1__deleteDataSetParameter_) {
   struct __ns1__deleteDataSetParameter *_p =
-      soap_instantiate___ns1__deleteDataSetParameter(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate___ns1__deleteDataSetParameter(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     soap_default___ns1__deleteDataSetParameter(soap, _p);
     _p->ns1__deleteDataSetParameter_ = ns1__deleteDataSetParameter_;
@@ -36480,15 +36736,15 @@ soap_instantiate___ns1__deleteDataSetParameterResponse(struct soap *, int,
 
 inline struct __ns1__deleteDataSetParameterResponse *
 soap_new___ns1__deleteDataSetParameterResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__deleteDataSetParameterResponse(soap, n, NULL,
-                                                                NULL, NULL);
+  return soap_instantiate___ns1__deleteDataSetParameterResponse(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__deleteDataSetParameterResponse *
 soap_new_req___ns1__deleteDataSetParameterResponse(struct soap *soap) {
   struct __ns1__deleteDataSetParameterResponse *_p =
-      soap_instantiate___ns1__deleteDataSetParameterResponse(soap, -1, NULL,
-                                                             NULL, NULL);
+      soap_instantiate___ns1__deleteDataSetParameterResponse(soap, -1, nullptr,
+                                                             nullptr, nullptr);
   if (_p) {
     soap_default___ns1__deleteDataSetParameterResponse(soap, _p);
   }
@@ -36500,8 +36756,8 @@ soap_new_set___ns1__deleteDataSetParameterResponse(
     struct soap *soap,
     ns1__deleteDataSetParameterResponse *ns1__deleteDataSetParameterResponse_) {
   struct __ns1__deleteDataSetParameterResponse *_p =
-      soap_instantiate___ns1__deleteDataSetParameterResponse(soap, -1, NULL,
-                                                             NULL, NULL);
+      soap_instantiate___ns1__deleteDataSetParameterResponse(soap, -1, nullptr,
+                                                             nullptr, nullptr);
   if (_p) {
     soap_default___ns1__deleteDataSetParameterResponse(soap, _p);
     _p->ns1__deleteDataSetParameterResponse_ =
@@ -36567,13 +36823,14 @@ soap_instantiate___ns1__deleteDataSet(struct soap *, int, const char *,
 
 inline struct __ns1__deleteDataSet *
 soap_new___ns1__deleteDataSet(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__deleteDataSet(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__deleteDataSet(soap, n, nullptr, nullptr,
+                                               nullptr);
 }
 
 inline struct __ns1__deleteDataSet *
 soap_new_req___ns1__deleteDataSet(struct soap *soap) {
-  struct __ns1__deleteDataSet *_p =
-      soap_instantiate___ns1__deleteDataSet(soap, -1, NULL, NULL, NULL);
+  struct __ns1__deleteDataSet *_p = soap_instantiate___ns1__deleteDataSet(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__deleteDataSet(soap, _p);
   }
@@ -36583,8 +36840,8 @@ soap_new_req___ns1__deleteDataSet(struct soap *soap) {
 inline struct __ns1__deleteDataSet *
 soap_new_set___ns1__deleteDataSet(struct soap *soap,
                                   ns1__deleteDataSet *ns1__deleteDataSet_) {
-  struct __ns1__deleteDataSet *_p =
-      soap_instantiate___ns1__deleteDataSet(soap, -1, NULL, NULL, NULL);
+  struct __ns1__deleteDataSet *_p = soap_instantiate___ns1__deleteDataSet(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__deleteDataSet(soap, _p);
     _p->ns1__deleteDataSet_ = ns1__deleteDataSet_;
@@ -36650,14 +36907,15 @@ soap_instantiate___ns1__deleteDataSetResponse(struct soap *, int, const char *,
 
 inline struct __ns1__deleteDataSetResponse *
 soap_new___ns1__deleteDataSetResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__deleteDataSetResponse(soap, n, NULL, NULL,
-                                                       NULL);
+  return soap_instantiate___ns1__deleteDataSetResponse(soap, n, nullptr,
+                                                       nullptr, nullptr);
 }
 
 inline struct __ns1__deleteDataSetResponse *
 soap_new_req___ns1__deleteDataSetResponse(struct soap *soap) {
   struct __ns1__deleteDataSetResponse *_p =
-      soap_instantiate___ns1__deleteDataSetResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__deleteDataSetResponse(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     soap_default___ns1__deleteDataSetResponse(soap, _p);
   }
@@ -36669,7 +36927,8 @@ soap_new_set___ns1__deleteDataSetResponse(
     struct soap *soap,
     ns1__deleteDataSetResponse *ns1__deleteDataSetResponse_) {
   struct __ns1__deleteDataSetResponse *_p =
-      soap_instantiate___ns1__deleteDataSetResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__deleteDataSetResponse(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     soap_default___ns1__deleteDataSetResponse(soap, _p);
     _p->ns1__deleteDataSetResponse_ = ns1__deleteDataSetResponse_;
@@ -36735,13 +36994,14 @@ soap_instantiate___ns1__createDataSets(struct soap *, int, const char *,
 
 inline struct __ns1__createDataSets *
 soap_new___ns1__createDataSets(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__createDataSets(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__createDataSets(soap, n, nullptr, nullptr,
+                                                nullptr);
 }
 
 inline struct __ns1__createDataSets *
 soap_new_req___ns1__createDataSets(struct soap *soap) {
-  struct __ns1__createDataSets *_p =
-      soap_instantiate___ns1__createDataSets(soap, -1, NULL, NULL, NULL);
+  struct __ns1__createDataSets *_p = soap_instantiate___ns1__createDataSets(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__createDataSets(soap, _p);
   }
@@ -36751,8 +37011,8 @@ soap_new_req___ns1__createDataSets(struct soap *soap) {
 inline struct __ns1__createDataSets *
 soap_new_set___ns1__createDataSets(struct soap *soap,
                                    ns1__createDataSets *ns1__createDataSets_) {
-  struct __ns1__createDataSets *_p =
-      soap_instantiate___ns1__createDataSets(soap, -1, NULL, NULL, NULL);
+  struct __ns1__createDataSets *_p = soap_instantiate___ns1__createDataSets(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__createDataSets(soap, _p);
     _p->ns1__createDataSets_ = ns1__createDataSets_;
@@ -36817,13 +37077,14 @@ soap_instantiate___ns1__createDataSet(struct soap *, int, const char *,
 
 inline struct __ns1__createDataSet *
 soap_new___ns1__createDataSet(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__createDataSet(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__createDataSet(soap, n, nullptr, nullptr,
+                                               nullptr);
 }
 
 inline struct __ns1__createDataSet *
 soap_new_req___ns1__createDataSet(struct soap *soap) {
-  struct __ns1__createDataSet *_p =
-      soap_instantiate___ns1__createDataSet(soap, -1, NULL, NULL, NULL);
+  struct __ns1__createDataSet *_p = soap_instantiate___ns1__createDataSet(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__createDataSet(soap, _p);
   }
@@ -36833,8 +37094,8 @@ soap_new_req___ns1__createDataSet(struct soap *soap) {
 inline struct __ns1__createDataSet *
 soap_new_set___ns1__createDataSet(struct soap *soap,
                                   ns1__createDataSet *ns1__createDataSet_) {
-  struct __ns1__createDataSet *_p =
-      soap_instantiate___ns1__createDataSet(soap, -1, NULL, NULL, NULL);
+  struct __ns1__createDataSet *_p = soap_instantiate___ns1__createDataSet(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__createDataSet(soap, _p);
     _p->ns1__createDataSet_ = ns1__createDataSet_;
@@ -36897,13 +37158,14 @@ soap_instantiate___ns1__getDatasets(struct soap *, int, const char *,
 
 inline struct __ns1__getDatasets *soap_new___ns1__getDatasets(struct soap *soap,
                                                               int n = -1) {
-  return soap_instantiate___ns1__getDatasets(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__getDatasets(soap, n, nullptr, nullptr,
+                                             nullptr);
 }
 
 inline struct __ns1__getDatasets *
 soap_new_req___ns1__getDatasets(struct soap *soap) {
   struct __ns1__getDatasets *_p =
-      soap_instantiate___ns1__getDatasets(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getDatasets(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getDatasets(soap, _p);
   }
@@ -36914,7 +37176,7 @@ inline struct __ns1__getDatasets *
 soap_new_set___ns1__getDatasets(struct soap *soap,
                                 ns1__getDatasets *ns1__getDatasets_) {
   struct __ns1__getDatasets *_p =
-      soap_instantiate___ns1__getDatasets(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getDatasets(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getDatasets(soap, _p);
     _p->ns1__getDatasets_ = ns1__getDatasets_;
@@ -36982,13 +37244,15 @@ soap_instantiate___ns1__getDatasetIncludes(struct soap *, int, const char *,
 
 inline struct __ns1__getDatasetIncludes *
 soap_new___ns1__getDatasetIncludes(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__getDatasetIncludes(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__getDatasetIncludes(soap, n, nullptr, nullptr,
+                                                    nullptr);
 }
 
 inline struct __ns1__getDatasetIncludes *
 soap_new_req___ns1__getDatasetIncludes(struct soap *soap) {
   struct __ns1__getDatasetIncludes *_p =
-      soap_instantiate___ns1__getDatasetIncludes(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getDatasetIncludes(soap, -1, nullptr, nullptr,
+                                                 nullptr);
   if (_p) {
     soap_default___ns1__getDatasetIncludes(soap, _p);
   }
@@ -36998,7 +37262,8 @@ soap_new_req___ns1__getDatasetIncludes(struct soap *soap) {
 inline struct __ns1__getDatasetIncludes *soap_new_set___ns1__getDatasetIncludes(
     struct soap *soap, ns1__getDatasetIncludes *ns1__getDatasetIncludes_) {
   struct __ns1__getDatasetIncludes *_p =
-      soap_instantiate___ns1__getDatasetIncludes(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getDatasetIncludes(soap, -1, nullptr, nullptr,
+                                                 nullptr);
   if (_p) {
     soap_default___ns1__getDatasetIncludes(soap, _p);
     _p->ns1__getDatasetIncludes_ = ns1__getDatasetIncludes_;
@@ -37062,13 +37327,13 @@ soap_instantiate___ns1__getDataset(struct soap *, int, const char *,
 
 inline struct __ns1__getDataset *soap_new___ns1__getDataset(struct soap *soap,
                                                             int n = -1) {
-  return soap_instantiate___ns1__getDataset(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__getDataset(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__getDataset *
 soap_new_req___ns1__getDataset(struct soap *soap) {
   struct __ns1__getDataset *_p =
-      soap_instantiate___ns1__getDataset(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getDataset(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getDataset(soap, _p);
   }
@@ -37079,7 +37344,7 @@ inline struct __ns1__getDataset *
 soap_new_set___ns1__getDataset(struct soap *soap,
                                ns1__getDataset *ns1__getDataset_) {
   struct __ns1__getDataset *_p =
-      soap_instantiate___ns1__getDataset(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getDataset(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getDataset(soap, _p);
     _p->ns1__getDataset_ = ns1__getDataset_;
@@ -37145,14 +37410,15 @@ soap_instantiate___ns1__removeSampleParameter(struct soap *, int, const char *,
 
 inline struct __ns1__removeSampleParameter *
 soap_new___ns1__removeSampleParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__removeSampleParameter(soap, n, NULL, NULL,
-                                                       NULL);
+  return soap_instantiate___ns1__removeSampleParameter(soap, n, nullptr,
+                                                       nullptr, nullptr);
 }
 
 inline struct __ns1__removeSampleParameter *
 soap_new_req___ns1__removeSampleParameter(struct soap *soap) {
   struct __ns1__removeSampleParameter *_p =
-      soap_instantiate___ns1__removeSampleParameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__removeSampleParameter(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     soap_default___ns1__removeSampleParameter(soap, _p);
   }
@@ -37164,7 +37430,8 @@ soap_new_set___ns1__removeSampleParameter(
     struct soap *soap,
     ns1__removeSampleParameter *ns1__removeSampleParameter_) {
   struct __ns1__removeSampleParameter *_p =
-      soap_instantiate___ns1__removeSampleParameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__removeSampleParameter(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     soap_default___ns1__removeSampleParameter(soap, _p);
     _p->ns1__removeSampleParameter_ = ns1__removeSampleParameter_;
@@ -37231,15 +37498,15 @@ soap_instantiate___ns1__removeSampleParameterResponse(struct soap *, int,
 
 inline struct __ns1__removeSampleParameterResponse *
 soap_new___ns1__removeSampleParameterResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__removeSampleParameterResponse(soap, n, NULL,
-                                                               NULL, NULL);
+  return soap_instantiate___ns1__removeSampleParameterResponse(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__removeSampleParameterResponse *
 soap_new_req___ns1__removeSampleParameterResponse(struct soap *soap) {
   struct __ns1__removeSampleParameterResponse *_p =
-      soap_instantiate___ns1__removeSampleParameterResponse(soap, -1, NULL,
-                                                            NULL, NULL);
+      soap_instantiate___ns1__removeSampleParameterResponse(soap, -1, nullptr,
+                                                            nullptr, nullptr);
   if (_p) {
     soap_default___ns1__removeSampleParameterResponse(soap, _p);
   }
@@ -37251,8 +37518,8 @@ soap_new_set___ns1__removeSampleParameterResponse(
     struct soap *soap,
     ns1__removeSampleParameterResponse *ns1__removeSampleParameterResponse_) {
   struct __ns1__removeSampleParameterResponse *_p =
-      soap_instantiate___ns1__removeSampleParameterResponse(soap, -1, NULL,
-                                                            NULL, NULL);
+      soap_instantiate___ns1__removeSampleParameterResponse(soap, -1, nullptr,
+                                                            nullptr, nullptr);
   if (_p) {
     soap_default___ns1__removeSampleParameterResponse(soap, _p);
     _p->ns1__removeSampleParameterResponse_ =
@@ -37316,13 +37583,14 @@ soap_instantiate___ns1__removeSample(struct soap *, int, const char *,
 
 inline struct __ns1__removeSample *
 soap_new___ns1__removeSample(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__removeSample(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__removeSample(soap, n, nullptr, nullptr,
+                                              nullptr);
 }
 
 inline struct __ns1__removeSample *
 soap_new_req___ns1__removeSample(struct soap *soap) {
   struct __ns1__removeSample *_p =
-      soap_instantiate___ns1__removeSample(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__removeSample(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__removeSample(soap, _p);
   }
@@ -37333,7 +37601,7 @@ inline struct __ns1__removeSample *
 soap_new_set___ns1__removeSample(struct soap *soap,
                                  ns1__removeSample *ns1__removeSample_) {
   struct __ns1__removeSample *_p =
-      soap_instantiate___ns1__removeSample(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__removeSample(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__removeSample(soap, _p);
     _p->ns1__removeSample_ = ns1__removeSample_;
@@ -37401,14 +37669,15 @@ soap_instantiate___ns1__removeSampleResponse(struct soap *, int, const char *,
 
 inline struct __ns1__removeSampleResponse *
 soap_new___ns1__removeSampleResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__removeSampleResponse(soap, n, NULL, NULL,
-                                                      NULL);
+  return soap_instantiate___ns1__removeSampleResponse(soap, n, nullptr, nullptr,
+                                                      nullptr);
 }
 
 inline struct __ns1__removeSampleResponse *
 soap_new_req___ns1__removeSampleResponse(struct soap *soap) {
   struct __ns1__removeSampleResponse *_p =
-      soap_instantiate___ns1__removeSampleResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__removeSampleResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     soap_default___ns1__removeSampleResponse(soap, _p);
   }
@@ -37419,7 +37688,8 @@ inline struct __ns1__removeSampleResponse *
 soap_new_set___ns1__removeSampleResponse(
     struct soap *soap, ns1__removeSampleResponse *ns1__removeSampleResponse_) {
   struct __ns1__removeSampleResponse *_p =
-      soap_instantiate___ns1__removeSampleResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__removeSampleResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     soap_default___ns1__removeSampleResponse(soap, _p);
     _p->ns1__removeSampleResponse_ = ns1__removeSampleResponse_;
@@ -37487,13 +37757,15 @@ soap_instantiate___ns1__removePublication(struct soap *, int, const char *,
 
 inline struct __ns1__removePublication *
 soap_new___ns1__removePublication(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__removePublication(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__removePublication(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline struct __ns1__removePublication *
 soap_new_req___ns1__removePublication(struct soap *soap) {
   struct __ns1__removePublication *_p =
-      soap_instantiate___ns1__removePublication(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__removePublication(soap, -1, nullptr, nullptr,
+                                                nullptr);
   if (_p) {
     soap_default___ns1__removePublication(soap, _p);
   }
@@ -37503,7 +37775,8 @@ soap_new_req___ns1__removePublication(struct soap *soap) {
 inline struct __ns1__removePublication *soap_new_set___ns1__removePublication(
     struct soap *soap, ns1__removePublication *ns1__removePublication_) {
   struct __ns1__removePublication *_p =
-      soap_instantiate___ns1__removePublication(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__removePublication(soap, -1, nullptr, nullptr,
+                                                nullptr);
   if (_p) {
     soap_default___ns1__removePublication(soap, _p);
     _p->ns1__removePublication_ = ns1__removePublication_;
@@ -37571,15 +37844,15 @@ soap_instantiate___ns1__removePublicationResponse(struct soap *, int,
 
 inline struct __ns1__removePublicationResponse *
 soap_new___ns1__removePublicationResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__removePublicationResponse(soap, n, NULL, NULL,
-                                                           NULL);
+  return soap_instantiate___ns1__removePublicationResponse(soap, n, nullptr,
+                                                           nullptr, nullptr);
 }
 
 inline struct __ns1__removePublicationResponse *
 soap_new_req___ns1__removePublicationResponse(struct soap *soap) {
   struct __ns1__removePublicationResponse *_p =
-      soap_instantiate___ns1__removePublicationResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate___ns1__removePublicationResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     soap_default___ns1__removePublicationResponse(soap, _p);
   }
@@ -37591,8 +37864,8 @@ soap_new_set___ns1__removePublicationResponse(
     struct soap *soap,
     ns1__removePublicationResponse *ns1__removePublicationResponse_) {
   struct __ns1__removePublicationResponse *_p =
-      soap_instantiate___ns1__removePublicationResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate___ns1__removePublicationResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     soap_default___ns1__removePublicationResponse(soap, _p);
     _p->ns1__removePublicationResponse_ = ns1__removePublicationResponse_;
@@ -37660,13 +37933,15 @@ soap_instantiate___ns1__removeInvestigator(struct soap *, int, const char *,
 
 inline struct __ns1__removeInvestigator *
 soap_new___ns1__removeInvestigator(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__removeInvestigator(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__removeInvestigator(soap, n, nullptr, nullptr,
+                                                    nullptr);
 }
 
 inline struct __ns1__removeInvestigator *
 soap_new_req___ns1__removeInvestigator(struct soap *soap) {
   struct __ns1__removeInvestigator *_p =
-      soap_instantiate___ns1__removeInvestigator(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__removeInvestigator(soap, -1, nullptr, nullptr,
+                                                 nullptr);
   if (_p) {
     soap_default___ns1__removeInvestigator(soap, _p);
   }
@@ -37676,7 +37951,8 @@ soap_new_req___ns1__removeInvestigator(struct soap *soap) {
 inline struct __ns1__removeInvestigator *soap_new_set___ns1__removeInvestigator(
     struct soap *soap, ns1__removeInvestigator *ns1__removeInvestigator_) {
   struct __ns1__removeInvestigator *_p =
-      soap_instantiate___ns1__removeInvestigator(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__removeInvestigator(soap, -1, nullptr, nullptr,
+                                                 nullptr);
   if (_p) {
     soap_default___ns1__removeInvestigator(soap, _p);
     _p->ns1__removeInvestigator_ = ns1__removeInvestigator_;
@@ -37744,15 +38020,15 @@ soap_instantiate___ns1__removeInvestigatorResponse(struct soap *, int,
 
 inline struct __ns1__removeInvestigatorResponse *
 soap_new___ns1__removeInvestigatorResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__removeInvestigatorResponse(soap, n, NULL, NULL,
-                                                            NULL);
+  return soap_instantiate___ns1__removeInvestigatorResponse(soap, n, nullptr,
+                                                            nullptr, nullptr);
 }
 
 inline struct __ns1__removeInvestigatorResponse *
 soap_new_req___ns1__removeInvestigatorResponse(struct soap *soap) {
   struct __ns1__removeInvestigatorResponse *_p =
-      soap_instantiate___ns1__removeInvestigatorResponse(soap, -1, NULL, NULL,
-                                                         NULL);
+      soap_instantiate___ns1__removeInvestigatorResponse(soap, -1, nullptr,
+                                                         nullptr, nullptr);
   if (_p) {
     soap_default___ns1__removeInvestigatorResponse(soap, _p);
   }
@@ -37764,8 +38040,8 @@ soap_new_set___ns1__removeInvestigatorResponse(
     struct soap *soap,
     ns1__removeInvestigatorResponse *ns1__removeInvestigatorResponse_) {
   struct __ns1__removeInvestigatorResponse *_p =
-      soap_instantiate___ns1__removeInvestigatorResponse(soap, -1, NULL, NULL,
-                                                         NULL);
+      soap_instantiate___ns1__removeInvestigatorResponse(soap, -1, nullptr,
+                                                         nullptr, nullptr);
   if (_p) {
     soap_default___ns1__removeInvestigatorResponse(soap, _p);
     _p->ns1__removeInvestigatorResponse_ = ns1__removeInvestigatorResponse_;
@@ -37830,13 +38106,14 @@ soap_instantiate___ns1__removeKeyword(struct soap *, int, const char *,
 
 inline struct __ns1__removeKeyword *
 soap_new___ns1__removeKeyword(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__removeKeyword(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__removeKeyword(soap, n, nullptr, nullptr,
+                                               nullptr);
 }
 
 inline struct __ns1__removeKeyword *
 soap_new_req___ns1__removeKeyword(struct soap *soap) {
-  struct __ns1__removeKeyword *_p =
-      soap_instantiate___ns1__removeKeyword(soap, -1, NULL, NULL, NULL);
+  struct __ns1__removeKeyword *_p = soap_instantiate___ns1__removeKeyword(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__removeKeyword(soap, _p);
   }
@@ -37846,8 +38123,8 @@ soap_new_req___ns1__removeKeyword(struct soap *soap) {
 inline struct __ns1__removeKeyword *
 soap_new_set___ns1__removeKeyword(struct soap *soap,
                                   ns1__removeKeyword *ns1__removeKeyword_) {
-  struct __ns1__removeKeyword *_p =
-      soap_instantiate___ns1__removeKeyword(soap, -1, NULL, NULL, NULL);
+  struct __ns1__removeKeyword *_p = soap_instantiate___ns1__removeKeyword(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__removeKeyword(soap, _p);
     _p->ns1__removeKeyword_ = ns1__removeKeyword_;
@@ -37913,14 +38190,15 @@ soap_instantiate___ns1__removeKeywordResponse(struct soap *, int, const char *,
 
 inline struct __ns1__removeKeywordResponse *
 soap_new___ns1__removeKeywordResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__removeKeywordResponse(soap, n, NULL, NULL,
-                                                       NULL);
+  return soap_instantiate___ns1__removeKeywordResponse(soap, n, nullptr,
+                                                       nullptr, nullptr);
 }
 
 inline struct __ns1__removeKeywordResponse *
 soap_new_req___ns1__removeKeywordResponse(struct soap *soap) {
   struct __ns1__removeKeywordResponse *_p =
-      soap_instantiate___ns1__removeKeywordResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__removeKeywordResponse(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     soap_default___ns1__removeKeywordResponse(soap, _p);
   }
@@ -37932,7 +38210,8 @@ soap_new_set___ns1__removeKeywordResponse(
     struct soap *soap,
     ns1__removeKeywordResponse *ns1__removeKeywordResponse_) {
   struct __ns1__removeKeywordResponse *_p =
-      soap_instantiate___ns1__removeKeywordResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__removeKeywordResponse(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     soap_default___ns1__removeKeywordResponse(soap, _p);
     _p->ns1__removeKeywordResponse_ = ns1__removeKeywordResponse_;
@@ -37998,14 +38277,15 @@ soap_instantiate___ns1__modifySampleParameter(struct soap *, int, const char *,
 
 inline struct __ns1__modifySampleParameter *
 soap_new___ns1__modifySampleParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__modifySampleParameter(soap, n, NULL, NULL,
-                                                       NULL);
+  return soap_instantiate___ns1__modifySampleParameter(soap, n, nullptr,
+                                                       nullptr, nullptr);
 }
 
 inline struct __ns1__modifySampleParameter *
 soap_new_req___ns1__modifySampleParameter(struct soap *soap) {
   struct __ns1__modifySampleParameter *_p =
-      soap_instantiate___ns1__modifySampleParameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__modifySampleParameter(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     soap_default___ns1__modifySampleParameter(soap, _p);
   }
@@ -38017,7 +38297,8 @@ soap_new_set___ns1__modifySampleParameter(
     struct soap *soap,
     ns1__modifySampleParameter *ns1__modifySampleParameter_) {
   struct __ns1__modifySampleParameter *_p =
-      soap_instantiate___ns1__modifySampleParameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__modifySampleParameter(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     soap_default___ns1__modifySampleParameter(soap, _p);
     _p->ns1__modifySampleParameter_ = ns1__modifySampleParameter_;
@@ -38084,15 +38365,15 @@ soap_instantiate___ns1__modifySampleParameterResponse(struct soap *, int,
 
 inline struct __ns1__modifySampleParameterResponse *
 soap_new___ns1__modifySampleParameterResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__modifySampleParameterResponse(soap, n, NULL,
-                                                               NULL, NULL);
+  return soap_instantiate___ns1__modifySampleParameterResponse(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__modifySampleParameterResponse *
 soap_new_req___ns1__modifySampleParameterResponse(struct soap *soap) {
   struct __ns1__modifySampleParameterResponse *_p =
-      soap_instantiate___ns1__modifySampleParameterResponse(soap, -1, NULL,
-                                                            NULL, NULL);
+      soap_instantiate___ns1__modifySampleParameterResponse(soap, -1, nullptr,
+                                                            nullptr, nullptr);
   if (_p) {
     soap_default___ns1__modifySampleParameterResponse(soap, _p);
   }
@@ -38104,8 +38385,8 @@ soap_new_set___ns1__modifySampleParameterResponse(
     struct soap *soap,
     ns1__modifySampleParameterResponse *ns1__modifySampleParameterResponse_) {
   struct __ns1__modifySampleParameterResponse *_p =
-      soap_instantiate___ns1__modifySampleParameterResponse(soap, -1, NULL,
-                                                            NULL, NULL);
+      soap_instantiate___ns1__modifySampleParameterResponse(soap, -1, nullptr,
+                                                            nullptr, nullptr);
   if (_p) {
     soap_default___ns1__modifySampleParameterResponse(soap, _p);
     _p->ns1__modifySampleParameterResponse_ =
@@ -38173,13 +38454,15 @@ soap_instantiate___ns1__modifyPublication(struct soap *, int, const char *,
 
 inline struct __ns1__modifyPublication *
 soap_new___ns1__modifyPublication(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__modifyPublication(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__modifyPublication(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline struct __ns1__modifyPublication *
 soap_new_req___ns1__modifyPublication(struct soap *soap) {
   struct __ns1__modifyPublication *_p =
-      soap_instantiate___ns1__modifyPublication(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__modifyPublication(soap, -1, nullptr, nullptr,
+                                                nullptr);
   if (_p) {
     soap_default___ns1__modifyPublication(soap, _p);
   }
@@ -38189,7 +38472,8 @@ soap_new_req___ns1__modifyPublication(struct soap *soap) {
 inline struct __ns1__modifyPublication *soap_new_set___ns1__modifyPublication(
     struct soap *soap, ns1__modifyPublication *ns1__modifyPublication_) {
   struct __ns1__modifyPublication *_p =
-      soap_instantiate___ns1__modifyPublication(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__modifyPublication(soap, -1, nullptr, nullptr,
+                                                nullptr);
   if (_p) {
     soap_default___ns1__modifyPublication(soap, _p);
     _p->ns1__modifyPublication_ = ns1__modifyPublication_;
@@ -38257,15 +38541,15 @@ soap_instantiate___ns1__modifyPublicationResponse(struct soap *, int,
 
 inline struct __ns1__modifyPublicationResponse *
 soap_new___ns1__modifyPublicationResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__modifyPublicationResponse(soap, n, NULL, NULL,
-                                                           NULL);
+  return soap_instantiate___ns1__modifyPublicationResponse(soap, n, nullptr,
+                                                           nullptr, nullptr);
 }
 
 inline struct __ns1__modifyPublicationResponse *
 soap_new_req___ns1__modifyPublicationResponse(struct soap *soap) {
   struct __ns1__modifyPublicationResponse *_p =
-      soap_instantiate___ns1__modifyPublicationResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate___ns1__modifyPublicationResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     soap_default___ns1__modifyPublicationResponse(soap, _p);
   }
@@ -38277,8 +38561,8 @@ soap_new_set___ns1__modifyPublicationResponse(
     struct soap *soap,
     ns1__modifyPublicationResponse *ns1__modifyPublicationResponse_) {
   struct __ns1__modifyPublicationResponse *_p =
-      soap_instantiate___ns1__modifyPublicationResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate___ns1__modifyPublicationResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     soap_default___ns1__modifyPublicationResponse(soap, _p);
     _p->ns1__modifyPublicationResponse_ = ns1__modifyPublicationResponse_;
@@ -38341,13 +38625,14 @@ soap_instantiate___ns1__modifySample(struct soap *, int, const char *,
 
 inline struct __ns1__modifySample *
 soap_new___ns1__modifySample(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__modifySample(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__modifySample(soap, n, nullptr, nullptr,
+                                              nullptr);
 }
 
 inline struct __ns1__modifySample *
 soap_new_req___ns1__modifySample(struct soap *soap) {
   struct __ns1__modifySample *_p =
-      soap_instantiate___ns1__modifySample(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__modifySample(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__modifySample(soap, _p);
   }
@@ -38358,7 +38643,7 @@ inline struct __ns1__modifySample *
 soap_new_set___ns1__modifySample(struct soap *soap,
                                  ns1__modifySample *ns1__modifySample_) {
   struct __ns1__modifySample *_p =
-      soap_instantiate___ns1__modifySample(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__modifySample(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__modifySample(soap, _p);
     _p->ns1__modifySample_ = ns1__modifySample_;
@@ -38426,14 +38711,15 @@ soap_instantiate___ns1__modifySampleResponse(struct soap *, int, const char *,
 
 inline struct __ns1__modifySampleResponse *
 soap_new___ns1__modifySampleResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__modifySampleResponse(soap, n, NULL, NULL,
-                                                      NULL);
+  return soap_instantiate___ns1__modifySampleResponse(soap, n, nullptr, nullptr,
+                                                      nullptr);
 }
 
 inline struct __ns1__modifySampleResponse *
 soap_new_req___ns1__modifySampleResponse(struct soap *soap) {
   struct __ns1__modifySampleResponse *_p =
-      soap_instantiate___ns1__modifySampleResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__modifySampleResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     soap_default___ns1__modifySampleResponse(soap, _p);
   }
@@ -38444,7 +38730,8 @@ inline struct __ns1__modifySampleResponse *
 soap_new_set___ns1__modifySampleResponse(
     struct soap *soap, ns1__modifySampleResponse *ns1__modifySampleResponse_) {
   struct __ns1__modifySampleResponse *_p =
-      soap_instantiate___ns1__modifySampleResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__modifySampleResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     soap_default___ns1__modifySampleResponse(soap, _p);
     _p->ns1__modifySampleResponse_ = ns1__modifySampleResponse_;
@@ -38513,13 +38800,15 @@ soap_instantiate___ns1__modifyInvestigator(struct soap *, int, const char *,
 
 inline struct __ns1__modifyInvestigator *
 soap_new___ns1__modifyInvestigator(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__modifyInvestigator(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__modifyInvestigator(soap, n, nullptr, nullptr,
+                                                    nullptr);
 }
 
 inline struct __ns1__modifyInvestigator *
 soap_new_req___ns1__modifyInvestigator(struct soap *soap) {
   struct __ns1__modifyInvestigator *_p =
-      soap_instantiate___ns1__modifyInvestigator(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__modifyInvestigator(soap, -1, nullptr, nullptr,
+                                                 nullptr);
   if (_p) {
     soap_default___ns1__modifyInvestigator(soap, _p);
   }
@@ -38529,7 +38818,8 @@ soap_new_req___ns1__modifyInvestigator(struct soap *soap) {
 inline struct __ns1__modifyInvestigator *soap_new_set___ns1__modifyInvestigator(
     struct soap *soap, ns1__modifyInvestigator *ns1__modifyInvestigator_) {
   struct __ns1__modifyInvestigator *_p =
-      soap_instantiate___ns1__modifyInvestigator(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__modifyInvestigator(soap, -1, nullptr, nullptr,
+                                                 nullptr);
   if (_p) {
     soap_default___ns1__modifyInvestigator(soap, _p);
     _p->ns1__modifyInvestigator_ = ns1__modifyInvestigator_;
@@ -38597,15 +38887,15 @@ soap_instantiate___ns1__modifyInvestigatorResponse(struct soap *, int,
 
 inline struct __ns1__modifyInvestigatorResponse *
 soap_new___ns1__modifyInvestigatorResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__modifyInvestigatorResponse(soap, n, NULL, NULL,
-                                                            NULL);
+  return soap_instantiate___ns1__modifyInvestigatorResponse(soap, n, nullptr,
+                                                            nullptr, nullptr);
 }
 
 inline struct __ns1__modifyInvestigatorResponse *
 soap_new_req___ns1__modifyInvestigatorResponse(struct soap *soap) {
   struct __ns1__modifyInvestigatorResponse *_p =
-      soap_instantiate___ns1__modifyInvestigatorResponse(soap, -1, NULL, NULL,
-                                                         NULL);
+      soap_instantiate___ns1__modifyInvestigatorResponse(soap, -1, nullptr,
+                                                         nullptr, nullptr);
   if (_p) {
     soap_default___ns1__modifyInvestigatorResponse(soap, _p);
   }
@@ -38617,8 +38907,8 @@ soap_new_set___ns1__modifyInvestigatorResponse(
     struct soap *soap,
     ns1__modifyInvestigatorResponse *ns1__modifyInvestigatorResponse_) {
   struct __ns1__modifyInvestigatorResponse *_p =
-      soap_instantiate___ns1__modifyInvestigatorResponse(soap, -1, NULL, NULL,
-                                                         NULL);
+      soap_instantiate___ns1__modifyInvestigatorResponse(soap, -1, nullptr,
+                                                         nullptr, nullptr);
   if (_p) {
     soap_default___ns1__modifyInvestigatorResponse(soap, _p);
     _p->ns1__modifyInvestigatorResponse_ = ns1__modifyInvestigatorResponse_;
@@ -38686,13 +38976,15 @@ soap_instantiate___ns1__modifyInvestigation(struct soap *, int, const char *,
 
 inline struct __ns1__modifyInvestigation *
 soap_new___ns1__modifyInvestigation(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__modifyInvestigation(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__modifyInvestigation(soap, n, nullptr, nullptr,
+                                                     nullptr);
 }
 
 inline struct __ns1__modifyInvestigation *
 soap_new_req___ns1__modifyInvestigation(struct soap *soap) {
   struct __ns1__modifyInvestigation *_p =
-      soap_instantiate___ns1__modifyInvestigation(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__modifyInvestigation(soap, -1, nullptr, nullptr,
+                                                  nullptr);
   if (_p) {
     soap_default___ns1__modifyInvestigation(soap, _p);
   }
@@ -38703,7 +38995,8 @@ inline struct __ns1__modifyInvestigation *
 soap_new_set___ns1__modifyInvestigation(
     struct soap *soap, ns1__modifyInvestigation *ns1__modifyInvestigation_) {
   struct __ns1__modifyInvestigation *_p =
-      soap_instantiate___ns1__modifyInvestigation(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__modifyInvestigation(soap, -1, nullptr, nullptr,
+                                                  nullptr);
   if (_p) {
     soap_default___ns1__modifyInvestigation(soap, _p);
     _p->ns1__modifyInvestigation_ = ns1__modifyInvestigation_;
@@ -38771,15 +39064,15 @@ soap_instantiate___ns1__modifyInvestigationResponse(struct soap *, int,
 
 inline struct __ns1__modifyInvestigationResponse *
 soap_new___ns1__modifyInvestigationResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__modifyInvestigationResponse(soap, n, NULL,
-                                                             NULL, NULL);
+  return soap_instantiate___ns1__modifyInvestigationResponse(soap, n, nullptr,
+                                                             nullptr, nullptr);
 }
 
 inline struct __ns1__modifyInvestigationResponse *
 soap_new_req___ns1__modifyInvestigationResponse(struct soap *soap) {
   struct __ns1__modifyInvestigationResponse *_p =
-      soap_instantiate___ns1__modifyInvestigationResponse(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate___ns1__modifyInvestigationResponse(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     soap_default___ns1__modifyInvestigationResponse(soap, _p);
   }
@@ -38791,8 +39084,8 @@ soap_new_set___ns1__modifyInvestigationResponse(
     struct soap *soap,
     ns1__modifyInvestigationResponse *ns1__modifyInvestigationResponse_) {
   struct __ns1__modifyInvestigationResponse *_p =
-      soap_instantiate___ns1__modifyInvestigationResponse(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate___ns1__modifyInvestigationResponse(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     soap_default___ns1__modifyInvestigationResponse(soap, _p);
     _p->ns1__modifyInvestigationResponse_ = ns1__modifyInvestigationResponse_;
@@ -38858,14 +39151,15 @@ soap_instantiate___ns1__deleteSampleParameter(struct soap *, int, const char *,
 
 inline struct __ns1__deleteSampleParameter *
 soap_new___ns1__deleteSampleParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__deleteSampleParameter(soap, n, NULL, NULL,
-                                                       NULL);
+  return soap_instantiate___ns1__deleteSampleParameter(soap, n, nullptr,
+                                                       nullptr, nullptr);
 }
 
 inline struct __ns1__deleteSampleParameter *
 soap_new_req___ns1__deleteSampleParameter(struct soap *soap) {
   struct __ns1__deleteSampleParameter *_p =
-      soap_instantiate___ns1__deleteSampleParameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__deleteSampleParameter(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     soap_default___ns1__deleteSampleParameter(soap, _p);
   }
@@ -38877,7 +39171,8 @@ soap_new_set___ns1__deleteSampleParameter(
     struct soap *soap,
     ns1__deleteSampleParameter *ns1__deleteSampleParameter_) {
   struct __ns1__deleteSampleParameter *_p =
-      soap_instantiate___ns1__deleteSampleParameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__deleteSampleParameter(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     soap_default___ns1__deleteSampleParameter(soap, _p);
     _p->ns1__deleteSampleParameter_ = ns1__deleteSampleParameter_;
@@ -38944,15 +39239,15 @@ soap_instantiate___ns1__deleteSampleParameterResponse(struct soap *, int,
 
 inline struct __ns1__deleteSampleParameterResponse *
 soap_new___ns1__deleteSampleParameterResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__deleteSampleParameterResponse(soap, n, NULL,
-                                                               NULL, NULL);
+  return soap_instantiate___ns1__deleteSampleParameterResponse(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__deleteSampleParameterResponse *
 soap_new_req___ns1__deleteSampleParameterResponse(struct soap *soap) {
   struct __ns1__deleteSampleParameterResponse *_p =
-      soap_instantiate___ns1__deleteSampleParameterResponse(soap, -1, NULL,
-                                                            NULL, NULL);
+      soap_instantiate___ns1__deleteSampleParameterResponse(soap, -1, nullptr,
+                                                            nullptr, nullptr);
   if (_p) {
     soap_default___ns1__deleteSampleParameterResponse(soap, _p);
   }
@@ -38964,8 +39259,8 @@ soap_new_set___ns1__deleteSampleParameterResponse(
     struct soap *soap,
     ns1__deleteSampleParameterResponse *ns1__deleteSampleParameterResponse_) {
   struct __ns1__deleteSampleParameterResponse *_p =
-      soap_instantiate___ns1__deleteSampleParameterResponse(soap, -1, NULL,
-                                                            NULL, NULL);
+      soap_instantiate___ns1__deleteSampleParameterResponse(soap, -1, nullptr,
+                                                            nullptr, nullptr);
   if (_p) {
     soap_default___ns1__deleteSampleParameterResponse(soap, _p);
     _p->ns1__deleteSampleParameterResponse_ =
@@ -39029,13 +39324,14 @@ soap_instantiate___ns1__deleteSample(struct soap *, int, const char *,
 
 inline struct __ns1__deleteSample *
 soap_new___ns1__deleteSample(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__deleteSample(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__deleteSample(soap, n, nullptr, nullptr,
+                                              nullptr);
 }
 
 inline struct __ns1__deleteSample *
 soap_new_req___ns1__deleteSample(struct soap *soap) {
   struct __ns1__deleteSample *_p =
-      soap_instantiate___ns1__deleteSample(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__deleteSample(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__deleteSample(soap, _p);
   }
@@ -39046,7 +39342,7 @@ inline struct __ns1__deleteSample *
 soap_new_set___ns1__deleteSample(struct soap *soap,
                                  ns1__deleteSample *ns1__deleteSample_) {
   struct __ns1__deleteSample *_p =
-      soap_instantiate___ns1__deleteSample(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__deleteSample(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__deleteSample(soap, _p);
     _p->ns1__deleteSample_ = ns1__deleteSample_;
@@ -39114,14 +39410,15 @@ soap_instantiate___ns1__deleteSampleResponse(struct soap *, int, const char *,
 
 inline struct __ns1__deleteSampleResponse *
 soap_new___ns1__deleteSampleResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__deleteSampleResponse(soap, n, NULL, NULL,
-                                                      NULL);
+  return soap_instantiate___ns1__deleteSampleResponse(soap, n, nullptr, nullptr,
+                                                      nullptr);
 }
 
 inline struct __ns1__deleteSampleResponse *
 soap_new_req___ns1__deleteSampleResponse(struct soap *soap) {
   struct __ns1__deleteSampleResponse *_p =
-      soap_instantiate___ns1__deleteSampleResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__deleteSampleResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     soap_default___ns1__deleteSampleResponse(soap, _p);
   }
@@ -39132,7 +39429,8 @@ inline struct __ns1__deleteSampleResponse *
 soap_new_set___ns1__deleteSampleResponse(
     struct soap *soap, ns1__deleteSampleResponse *ns1__deleteSampleResponse_) {
   struct __ns1__deleteSampleResponse *_p =
-      soap_instantiate___ns1__deleteSampleResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__deleteSampleResponse(soap, -1, nullptr, nullptr,
+                                                   nullptr);
   if (_p) {
     soap_default___ns1__deleteSampleResponse(soap, _p);
     _p->ns1__deleteSampleResponse_ = ns1__deleteSampleResponse_;
@@ -39200,13 +39498,15 @@ soap_instantiate___ns1__deletePublication(struct soap *, int, const char *,
 
 inline struct __ns1__deletePublication *
 soap_new___ns1__deletePublication(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__deletePublication(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__deletePublication(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline struct __ns1__deletePublication *
 soap_new_req___ns1__deletePublication(struct soap *soap) {
   struct __ns1__deletePublication *_p =
-      soap_instantiate___ns1__deletePublication(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__deletePublication(soap, -1, nullptr, nullptr,
+                                                nullptr);
   if (_p) {
     soap_default___ns1__deletePublication(soap, _p);
   }
@@ -39216,7 +39516,8 @@ soap_new_req___ns1__deletePublication(struct soap *soap) {
 inline struct __ns1__deletePublication *soap_new_set___ns1__deletePublication(
     struct soap *soap, ns1__deletePublication *ns1__deletePublication_) {
   struct __ns1__deletePublication *_p =
-      soap_instantiate___ns1__deletePublication(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__deletePublication(soap, -1, nullptr, nullptr,
+                                                nullptr);
   if (_p) {
     soap_default___ns1__deletePublication(soap, _p);
     _p->ns1__deletePublication_ = ns1__deletePublication_;
@@ -39284,15 +39585,15 @@ soap_instantiate___ns1__deletePublicationResponse(struct soap *, int,
 
 inline struct __ns1__deletePublicationResponse *
 soap_new___ns1__deletePublicationResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__deletePublicationResponse(soap, n, NULL, NULL,
-                                                           NULL);
+  return soap_instantiate___ns1__deletePublicationResponse(soap, n, nullptr,
+                                                           nullptr, nullptr);
 }
 
 inline struct __ns1__deletePublicationResponse *
 soap_new_req___ns1__deletePublicationResponse(struct soap *soap) {
   struct __ns1__deletePublicationResponse *_p =
-      soap_instantiate___ns1__deletePublicationResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate___ns1__deletePublicationResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     soap_default___ns1__deletePublicationResponse(soap, _p);
   }
@@ -39304,8 +39605,8 @@ soap_new_set___ns1__deletePublicationResponse(
     struct soap *soap,
     ns1__deletePublicationResponse *ns1__deletePublicationResponse_) {
   struct __ns1__deletePublicationResponse *_p =
-      soap_instantiate___ns1__deletePublicationResponse(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate___ns1__deletePublicationResponse(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     soap_default___ns1__deletePublicationResponse(soap, _p);
     _p->ns1__deletePublicationResponse_ = ns1__deletePublicationResponse_;
@@ -39370,13 +39671,14 @@ soap_instantiate___ns1__deleteKeyword(struct soap *, int, const char *,
 
 inline struct __ns1__deleteKeyword *
 soap_new___ns1__deleteKeyword(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__deleteKeyword(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__deleteKeyword(soap, n, nullptr, nullptr,
+                                               nullptr);
 }
 
 inline struct __ns1__deleteKeyword *
 soap_new_req___ns1__deleteKeyword(struct soap *soap) {
-  struct __ns1__deleteKeyword *_p =
-      soap_instantiate___ns1__deleteKeyword(soap, -1, NULL, NULL, NULL);
+  struct __ns1__deleteKeyword *_p = soap_instantiate___ns1__deleteKeyword(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__deleteKeyword(soap, _p);
   }
@@ -39386,8 +39688,8 @@ soap_new_req___ns1__deleteKeyword(struct soap *soap) {
 inline struct __ns1__deleteKeyword *
 soap_new_set___ns1__deleteKeyword(struct soap *soap,
                                   ns1__deleteKeyword *ns1__deleteKeyword_) {
-  struct __ns1__deleteKeyword *_p =
-      soap_instantiate___ns1__deleteKeyword(soap, -1, NULL, NULL, NULL);
+  struct __ns1__deleteKeyword *_p = soap_instantiate___ns1__deleteKeyword(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__deleteKeyword(soap, _p);
     _p->ns1__deleteKeyword_ = ns1__deleteKeyword_;
@@ -39453,14 +39755,15 @@ soap_instantiate___ns1__deleteKeywordResponse(struct soap *, int, const char *,
 
 inline struct __ns1__deleteKeywordResponse *
 soap_new___ns1__deleteKeywordResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__deleteKeywordResponse(soap, n, NULL, NULL,
-                                                       NULL);
+  return soap_instantiate___ns1__deleteKeywordResponse(soap, n, nullptr,
+                                                       nullptr, nullptr);
 }
 
 inline struct __ns1__deleteKeywordResponse *
 soap_new_req___ns1__deleteKeywordResponse(struct soap *soap) {
   struct __ns1__deleteKeywordResponse *_p =
-      soap_instantiate___ns1__deleteKeywordResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__deleteKeywordResponse(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     soap_default___ns1__deleteKeywordResponse(soap, _p);
   }
@@ -39472,7 +39775,8 @@ soap_new_set___ns1__deleteKeywordResponse(
     struct soap *soap,
     ns1__deleteKeywordResponse *ns1__deleteKeywordResponse_) {
   struct __ns1__deleteKeywordResponse *_p =
-      soap_instantiate___ns1__deleteKeywordResponse(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__deleteKeywordResponse(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     soap_default___ns1__deleteKeywordResponse(soap, _p);
     _p->ns1__deleteKeywordResponse_ = ns1__deleteKeywordResponse_;
@@ -39540,13 +39844,15 @@ soap_instantiate___ns1__deleteInvestigator(struct soap *, int, const char *,
 
 inline struct __ns1__deleteInvestigator *
 soap_new___ns1__deleteInvestigator(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__deleteInvestigator(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__deleteInvestigator(soap, n, nullptr, nullptr,
+                                                    nullptr);
 }
 
 inline struct __ns1__deleteInvestigator *
 soap_new_req___ns1__deleteInvestigator(struct soap *soap) {
   struct __ns1__deleteInvestigator *_p =
-      soap_instantiate___ns1__deleteInvestigator(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__deleteInvestigator(soap, -1, nullptr, nullptr,
+                                                 nullptr);
   if (_p) {
     soap_default___ns1__deleteInvestigator(soap, _p);
   }
@@ -39556,7 +39862,8 @@ soap_new_req___ns1__deleteInvestigator(struct soap *soap) {
 inline struct __ns1__deleteInvestigator *soap_new_set___ns1__deleteInvestigator(
     struct soap *soap, ns1__deleteInvestigator *ns1__deleteInvestigator_) {
   struct __ns1__deleteInvestigator *_p =
-      soap_instantiate___ns1__deleteInvestigator(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__deleteInvestigator(soap, -1, nullptr, nullptr,
+                                                 nullptr);
   if (_p) {
     soap_default___ns1__deleteInvestigator(soap, _p);
     _p->ns1__deleteInvestigator_ = ns1__deleteInvestigator_;
@@ -39624,15 +39931,15 @@ soap_instantiate___ns1__deleteInvestigatorResponse(struct soap *, int,
 
 inline struct __ns1__deleteInvestigatorResponse *
 soap_new___ns1__deleteInvestigatorResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__deleteInvestigatorResponse(soap, n, NULL, NULL,
-                                                            NULL);
+  return soap_instantiate___ns1__deleteInvestigatorResponse(soap, n, nullptr,
+                                                            nullptr, nullptr);
 }
 
 inline struct __ns1__deleteInvestigatorResponse *
 soap_new_req___ns1__deleteInvestigatorResponse(struct soap *soap) {
   struct __ns1__deleteInvestigatorResponse *_p =
-      soap_instantiate___ns1__deleteInvestigatorResponse(soap, -1, NULL, NULL,
-                                                         NULL);
+      soap_instantiate___ns1__deleteInvestigatorResponse(soap, -1, nullptr,
+                                                         nullptr, nullptr);
   if (_p) {
     soap_default___ns1__deleteInvestigatorResponse(soap, _p);
   }
@@ -39644,8 +39951,8 @@ soap_new_set___ns1__deleteInvestigatorResponse(
     struct soap *soap,
     ns1__deleteInvestigatorResponse *ns1__deleteInvestigatorResponse_) {
   struct __ns1__deleteInvestigatorResponse *_p =
-      soap_instantiate___ns1__deleteInvestigatorResponse(soap, -1, NULL, NULL,
-                                                         NULL);
+      soap_instantiate___ns1__deleteInvestigatorResponse(soap, -1, nullptr,
+                                                         nullptr, nullptr);
   if (_p) {
     soap_default___ns1__deleteInvestigatorResponse(soap, _p);
     _p->ns1__deleteInvestigatorResponse_ = ns1__deleteInvestigatorResponse_;
@@ -39713,13 +40020,15 @@ soap_instantiate___ns1__addSampleParameter(struct soap *, int, const char *,
 
 inline struct __ns1__addSampleParameter *
 soap_new___ns1__addSampleParameter(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__addSampleParameter(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__addSampleParameter(soap, n, nullptr, nullptr,
+                                                    nullptr);
 }
 
 inline struct __ns1__addSampleParameter *
 soap_new_req___ns1__addSampleParameter(struct soap *soap) {
   struct __ns1__addSampleParameter *_p =
-      soap_instantiate___ns1__addSampleParameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__addSampleParameter(soap, -1, nullptr, nullptr,
+                                                 nullptr);
   if (_p) {
     soap_default___ns1__addSampleParameter(soap, _p);
   }
@@ -39729,7 +40038,8 @@ soap_new_req___ns1__addSampleParameter(struct soap *soap) {
 inline struct __ns1__addSampleParameter *soap_new_set___ns1__addSampleParameter(
     struct soap *soap, ns1__addSampleParameter *ns1__addSampleParameter_) {
   struct __ns1__addSampleParameter *_p =
-      soap_instantiate___ns1__addSampleParameter(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__addSampleParameter(soap, -1, nullptr, nullptr,
+                                                 nullptr);
   if (_p) {
     soap_default___ns1__addSampleParameter(soap, _p);
     _p->ns1__addSampleParameter_ = ns1__addSampleParameter_;
@@ -39796,13 +40106,14 @@ soap_instantiate___ns1__addPublication(struct soap *, int, const char *,
 
 inline struct __ns1__addPublication *
 soap_new___ns1__addPublication(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__addPublication(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__addPublication(soap, n, nullptr, nullptr,
+                                                nullptr);
 }
 
 inline struct __ns1__addPublication *
 soap_new_req___ns1__addPublication(struct soap *soap) {
-  struct __ns1__addPublication *_p =
-      soap_instantiate___ns1__addPublication(soap, -1, NULL, NULL, NULL);
+  struct __ns1__addPublication *_p = soap_instantiate___ns1__addPublication(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__addPublication(soap, _p);
   }
@@ -39812,8 +40123,8 @@ soap_new_req___ns1__addPublication(struct soap *soap) {
 inline struct __ns1__addPublication *
 soap_new_set___ns1__addPublication(struct soap *soap,
                                    ns1__addPublication *ns1__addPublication_) {
-  struct __ns1__addPublication *_p =
-      soap_instantiate___ns1__addPublication(soap, -1, NULL, NULL, NULL);
+  struct __ns1__addPublication *_p = soap_instantiate___ns1__addPublication(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__addPublication(soap, _p);
     _p->ns1__addPublication_ = ns1__addPublication_;
@@ -39875,13 +40186,13 @@ soap_instantiate___ns1__addSample(struct soap *, int, const char *,
 
 inline struct __ns1__addSample *soap_new___ns1__addSample(struct soap *soap,
                                                           int n = -1) {
-  return soap_instantiate___ns1__addSample(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__addSample(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__addSample *
 soap_new_req___ns1__addSample(struct soap *soap) {
   struct __ns1__addSample *_p =
-      soap_instantiate___ns1__addSample(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__addSample(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__addSample(soap, _p);
   }
@@ -39892,7 +40203,7 @@ inline struct __ns1__addSample *
 soap_new_set___ns1__addSample(struct soap *soap,
                               ns1__addSample *ns1__addSample_) {
   struct __ns1__addSample *_p =
-      soap_instantiate___ns1__addSample(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__addSample(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__addSample(soap, _p);
     _p->ns1__addSample_ = ns1__addSample_;
@@ -39958,13 +40269,14 @@ soap_instantiate___ns1__addInvestigator(struct soap *, int, const char *,
 
 inline struct __ns1__addInvestigator *
 soap_new___ns1__addInvestigator(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__addInvestigator(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__addInvestigator(soap, n, nullptr, nullptr,
+                                                 nullptr);
 }
 
 inline struct __ns1__addInvestigator *
 soap_new_req___ns1__addInvestigator(struct soap *soap) {
-  struct __ns1__addInvestigator *_p =
-      soap_instantiate___ns1__addInvestigator(soap, -1, NULL, NULL, NULL);
+  struct __ns1__addInvestigator *_p = soap_instantiate___ns1__addInvestigator(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__addInvestigator(soap, _p);
   }
@@ -39973,8 +40285,8 @@ soap_new_req___ns1__addInvestigator(struct soap *soap) {
 
 inline struct __ns1__addInvestigator *soap_new_set___ns1__addInvestigator(
     struct soap *soap, ns1__addInvestigator *ns1__addInvestigator_) {
-  struct __ns1__addInvestigator *_p =
-      soap_instantiate___ns1__addInvestigator(soap, -1, NULL, NULL, NULL);
+  struct __ns1__addInvestigator *_p = soap_instantiate___ns1__addInvestigator(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__addInvestigator(soap, _p);
     _p->ns1__addInvestigator_ = ns1__addInvestigator_;
@@ -40038,13 +40350,13 @@ soap_instantiate___ns1__addKeyword(struct soap *, int, const char *,
 
 inline struct __ns1__addKeyword *soap_new___ns1__addKeyword(struct soap *soap,
                                                             int n = -1) {
-  return soap_instantiate___ns1__addKeyword(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__addKeyword(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__addKeyword *
 soap_new_req___ns1__addKeyword(struct soap *soap) {
   struct __ns1__addKeyword *_p =
-      soap_instantiate___ns1__addKeyword(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__addKeyword(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__addKeyword(soap, _p);
   }
@@ -40055,7 +40367,7 @@ inline struct __ns1__addKeyword *
 soap_new_set___ns1__addKeyword(struct soap *soap,
                                ns1__addKeyword *ns1__addKeyword_) {
   struct __ns1__addKeyword *_p =
-      soap_instantiate___ns1__addKeyword(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__addKeyword(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__addKeyword(soap, _p);
     _p->ns1__addKeyword_ = ns1__addKeyword_;
@@ -40123,13 +40435,15 @@ soap_instantiate___ns1__removeInvestigation(struct soap *, int, const char *,
 
 inline struct __ns1__removeInvestigation *
 soap_new___ns1__removeInvestigation(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__removeInvestigation(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__removeInvestigation(soap, n, nullptr, nullptr,
+                                                     nullptr);
 }
 
 inline struct __ns1__removeInvestigation *
 soap_new_req___ns1__removeInvestigation(struct soap *soap) {
   struct __ns1__removeInvestigation *_p =
-      soap_instantiate___ns1__removeInvestigation(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__removeInvestigation(soap, -1, nullptr, nullptr,
+                                                  nullptr);
   if (_p) {
     soap_default___ns1__removeInvestigation(soap, _p);
   }
@@ -40140,7 +40454,8 @@ inline struct __ns1__removeInvestigation *
 soap_new_set___ns1__removeInvestigation(
     struct soap *soap, ns1__removeInvestigation *ns1__removeInvestigation_) {
   struct __ns1__removeInvestigation *_p =
-      soap_instantiate___ns1__removeInvestigation(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__removeInvestigation(soap, -1, nullptr, nullptr,
+                                                  nullptr);
   if (_p) {
     soap_default___ns1__removeInvestigation(soap, _p);
     _p->ns1__removeInvestigation_ = ns1__removeInvestigation_;
@@ -40208,15 +40523,15 @@ soap_instantiate___ns1__removeInvestigationResponse(struct soap *, int,
 
 inline struct __ns1__removeInvestigationResponse *
 soap_new___ns1__removeInvestigationResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__removeInvestigationResponse(soap, n, NULL,
-                                                             NULL, NULL);
+  return soap_instantiate___ns1__removeInvestigationResponse(soap, n, nullptr,
+                                                             nullptr, nullptr);
 }
 
 inline struct __ns1__removeInvestigationResponse *
 soap_new_req___ns1__removeInvestigationResponse(struct soap *soap) {
   struct __ns1__removeInvestigationResponse *_p =
-      soap_instantiate___ns1__removeInvestigationResponse(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate___ns1__removeInvestigationResponse(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     soap_default___ns1__removeInvestigationResponse(soap, _p);
   }
@@ -40228,8 +40543,8 @@ soap_new_set___ns1__removeInvestigationResponse(
     struct soap *soap,
     ns1__removeInvestigationResponse *ns1__removeInvestigationResponse_) {
   struct __ns1__removeInvestigationResponse *_p =
-      soap_instantiate___ns1__removeInvestigationResponse(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate___ns1__removeInvestigationResponse(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     soap_default___ns1__removeInvestigationResponse(soap, _p);
     _p->ns1__removeInvestigationResponse_ = ns1__removeInvestigationResponse_;
@@ -40297,13 +40612,15 @@ soap_instantiate___ns1__deleteInvestigation(struct soap *, int, const char *,
 
 inline struct __ns1__deleteInvestigation *
 soap_new___ns1__deleteInvestigation(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__deleteInvestigation(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__deleteInvestigation(soap, n, nullptr, nullptr,
+                                                     nullptr);
 }
 
 inline struct __ns1__deleteInvestigation *
 soap_new_req___ns1__deleteInvestigation(struct soap *soap) {
   struct __ns1__deleteInvestigation *_p =
-      soap_instantiate___ns1__deleteInvestigation(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__deleteInvestigation(soap, -1, nullptr, nullptr,
+                                                  nullptr);
   if (_p) {
     soap_default___ns1__deleteInvestigation(soap, _p);
   }
@@ -40314,7 +40631,8 @@ inline struct __ns1__deleteInvestigation *
 soap_new_set___ns1__deleteInvestigation(
     struct soap *soap, ns1__deleteInvestigation *ns1__deleteInvestigation_) {
   struct __ns1__deleteInvestigation *_p =
-      soap_instantiate___ns1__deleteInvestigation(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__deleteInvestigation(soap, -1, nullptr, nullptr,
+                                                  nullptr);
   if (_p) {
     soap_default___ns1__deleteInvestigation(soap, _p);
     _p->ns1__deleteInvestigation_ = ns1__deleteInvestigation_;
@@ -40382,15 +40700,15 @@ soap_instantiate___ns1__deleteInvestigationResponse(struct soap *, int,
 
 inline struct __ns1__deleteInvestigationResponse *
 soap_new___ns1__deleteInvestigationResponse(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__deleteInvestigationResponse(soap, n, NULL,
-                                                             NULL, NULL);
+  return soap_instantiate___ns1__deleteInvestigationResponse(soap, n, nullptr,
+                                                             nullptr, nullptr);
 }
 
 inline struct __ns1__deleteInvestigationResponse *
 soap_new_req___ns1__deleteInvestigationResponse(struct soap *soap) {
   struct __ns1__deleteInvestigationResponse *_p =
-      soap_instantiate___ns1__deleteInvestigationResponse(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate___ns1__deleteInvestigationResponse(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     soap_default___ns1__deleteInvestigationResponse(soap, _p);
   }
@@ -40402,8 +40720,8 @@ soap_new_set___ns1__deleteInvestigationResponse(
     struct soap *soap,
     ns1__deleteInvestigationResponse *ns1__deleteInvestigationResponse_) {
   struct __ns1__deleteInvestigationResponse *_p =
-      soap_instantiate___ns1__deleteInvestigationResponse(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate___ns1__deleteInvestigationResponse(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     soap_default___ns1__deleteInvestigationResponse(soap, _p);
     _p->ns1__deleteInvestigationResponse_ = ns1__deleteInvestigationResponse_;
@@ -40471,13 +40789,15 @@ soap_instantiate___ns1__createInvestigation(struct soap *, int, const char *,
 
 inline struct __ns1__createInvestigation *
 soap_new___ns1__createInvestigation(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__createInvestigation(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__createInvestigation(soap, n, nullptr, nullptr,
+                                                     nullptr);
 }
 
 inline struct __ns1__createInvestigation *
 soap_new_req___ns1__createInvestigation(struct soap *soap) {
   struct __ns1__createInvestigation *_p =
-      soap_instantiate___ns1__createInvestigation(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__createInvestigation(soap, -1, nullptr, nullptr,
+                                                  nullptr);
   if (_p) {
     soap_default___ns1__createInvestigation(soap, _p);
   }
@@ -40488,7 +40808,8 @@ inline struct __ns1__createInvestigation *
 soap_new_set___ns1__createInvestigation(
     struct soap *soap, ns1__createInvestigation *ns1__createInvestigation_) {
   struct __ns1__createInvestigation *_p =
-      soap_instantiate___ns1__createInvestigation(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__createInvestigation(soap, -1, nullptr, nullptr,
+                                                  nullptr);
   if (_p) {
     soap_default___ns1__createInvestigation(soap, _p);
     _p->ns1__createInvestigation_ = ns1__createInvestigation_;
@@ -40556,15 +40877,15 @@ soap_instantiate___ns1__getInvestigationsIncludes(struct soap *, int,
 
 inline struct __ns1__getInvestigationsIncludes *
 soap_new___ns1__getInvestigationsIncludes(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__getInvestigationsIncludes(soap, n, NULL, NULL,
-                                                           NULL);
+  return soap_instantiate___ns1__getInvestigationsIncludes(soap, n, nullptr,
+                                                           nullptr, nullptr);
 }
 
 inline struct __ns1__getInvestigationsIncludes *
 soap_new_req___ns1__getInvestigationsIncludes(struct soap *soap) {
   struct __ns1__getInvestigationsIncludes *_p =
-      soap_instantiate___ns1__getInvestigationsIncludes(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate___ns1__getInvestigationsIncludes(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getInvestigationsIncludes(soap, _p);
   }
@@ -40576,8 +40897,8 @@ soap_new_set___ns1__getInvestigationsIncludes(
     struct soap *soap,
     ns1__getInvestigationsIncludes *ns1__getInvestigationsIncludes_) {
   struct __ns1__getInvestigationsIncludes *_p =
-      soap_instantiate___ns1__getInvestigationsIncludes(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate___ns1__getInvestigationsIncludes(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getInvestigationsIncludes(soap, _p);
     _p->ns1__getInvestigationsIncludes_ = ns1__getInvestigationsIncludes_;
@@ -40644,13 +40965,15 @@ soap_instantiate___ns1__getInvestigations(struct soap *, int, const char *,
 
 inline struct __ns1__getInvestigations *
 soap_new___ns1__getInvestigations(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__getInvestigations(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__getInvestigations(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline struct __ns1__getInvestigations *
 soap_new_req___ns1__getInvestigations(struct soap *soap) {
   struct __ns1__getInvestigations *_p =
-      soap_instantiate___ns1__getInvestigations(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getInvestigations(soap, -1, nullptr, nullptr,
+                                                nullptr);
   if (_p) {
     soap_default___ns1__getInvestigations(soap, _p);
   }
@@ -40660,7 +40983,8 @@ soap_new_req___ns1__getInvestigations(struct soap *soap) {
 inline struct __ns1__getInvestigations *soap_new_set___ns1__getInvestigations(
     struct soap *soap, ns1__getInvestigations *ns1__getInvestigations_) {
   struct __ns1__getInvestigations *_p =
-      soap_instantiate___ns1__getInvestigations(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getInvestigations(soap, -1, nullptr, nullptr,
+                                                nullptr);
   if (_p) {
     soap_default___ns1__getInvestigations(soap, _p);
     _p->ns1__getInvestigations_ = ns1__getInvestigations_;
@@ -40728,15 +41052,15 @@ soap_instantiate___ns1__getInvestigationIncludes(struct soap *, int,
 
 inline struct __ns1__getInvestigationIncludes *
 soap_new___ns1__getInvestigationIncludes(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__getInvestigationIncludes(soap, n, NULL, NULL,
-                                                          NULL);
+  return soap_instantiate___ns1__getInvestigationIncludes(soap, n, nullptr,
+                                                          nullptr, nullptr);
 }
 
 inline struct __ns1__getInvestigationIncludes *
 soap_new_req___ns1__getInvestigationIncludes(struct soap *soap) {
   struct __ns1__getInvestigationIncludes *_p =
-      soap_instantiate___ns1__getInvestigationIncludes(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate___ns1__getInvestigationIncludes(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getInvestigationIncludes(soap, _p);
   }
@@ -40748,8 +41072,8 @@ soap_new_set___ns1__getInvestigationIncludes(
     struct soap *soap,
     ns1__getInvestigationIncludes *ns1__getInvestigationIncludes_) {
   struct __ns1__getInvestigationIncludes *_p =
-      soap_instantiate___ns1__getInvestigationIncludes(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate___ns1__getInvestigationIncludes(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getInvestigationIncludes(soap, _p);
     _p->ns1__getInvestigationIncludes_ = ns1__getInvestigationIncludes_;
@@ -40816,13 +41140,14 @@ soap_instantiate___ns1__getInvestigation(struct soap *, int, const char *,
 
 inline struct __ns1__getInvestigation *
 soap_new___ns1__getInvestigation(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__getInvestigation(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__getInvestigation(soap, n, nullptr, nullptr,
+                                                  nullptr);
 }
 
 inline struct __ns1__getInvestigation *
 soap_new_req___ns1__getInvestigation(struct soap *soap) {
-  struct __ns1__getInvestigation *_p =
-      soap_instantiate___ns1__getInvestigation(soap, -1, NULL, NULL, NULL);
+  struct __ns1__getInvestigation *_p = soap_instantiate___ns1__getInvestigation(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getInvestigation(soap, _p);
   }
@@ -40831,8 +41156,8 @@ soap_new_req___ns1__getInvestigation(struct soap *soap) {
 
 inline struct __ns1__getInvestigation *soap_new_set___ns1__getInvestigation(
     struct soap *soap, ns1__getInvestigation *ns1__getInvestigation_) {
-  struct __ns1__getInvestigation *_p =
-      soap_instantiate___ns1__getInvestigation(soap, -1, NULL, NULL, NULL);
+  struct __ns1__getInvestigation *_p = soap_instantiate___ns1__getInvestigation(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getInvestigation(soap, _p);
     _p->ns1__getInvestigation_ = ns1__getInvestigation_;
@@ -40901,13 +41226,15 @@ soap_instantiate___ns1__listDatafileFormats(struct soap *, int, const char *,
 
 inline struct __ns1__listDatafileFormats *
 soap_new___ns1__listDatafileFormats(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__listDatafileFormats(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__listDatafileFormats(soap, n, nullptr, nullptr,
+                                                     nullptr);
 }
 
 inline struct __ns1__listDatafileFormats *
 soap_new_req___ns1__listDatafileFormats(struct soap *soap) {
   struct __ns1__listDatafileFormats *_p =
-      soap_instantiate___ns1__listDatafileFormats(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__listDatafileFormats(soap, -1, nullptr, nullptr,
+                                                  nullptr);
   if (_p) {
     soap_default___ns1__listDatafileFormats(soap, _p);
   }
@@ -40918,7 +41245,8 @@ inline struct __ns1__listDatafileFormats *
 soap_new_set___ns1__listDatafileFormats(
     struct soap *soap, ns1__listDatafileFormats *ns1__listDatafileFormats_) {
   struct __ns1__listDatafileFormats *_p =
-      soap_instantiate___ns1__listDatafileFormats(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__listDatafileFormats(soap, -1, nullptr, nullptr,
+                                                  nullptr);
   if (_p) {
     soap_default___ns1__listDatafileFormats(soap, _p);
     _p->ns1__listDatafileFormats_ = ns1__listDatafileFormats_;
@@ -40986,15 +41314,15 @@ soap_instantiate___ns1__searchByRunNumberPagination(struct soap *, int,
 
 inline struct __ns1__searchByRunNumberPagination *
 soap_new___ns1__searchByRunNumberPagination(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__searchByRunNumberPagination(soap, n, NULL,
-                                                             NULL, NULL);
+  return soap_instantiate___ns1__searchByRunNumberPagination(soap, n, nullptr,
+                                                             nullptr, nullptr);
 }
 
 inline struct __ns1__searchByRunNumberPagination *
 soap_new_req___ns1__searchByRunNumberPagination(struct soap *soap) {
   struct __ns1__searchByRunNumberPagination *_p =
-      soap_instantiate___ns1__searchByRunNumberPagination(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate___ns1__searchByRunNumberPagination(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchByRunNumberPagination(soap, _p);
   }
@@ -41006,8 +41334,8 @@ soap_new_set___ns1__searchByRunNumberPagination(
     struct soap *soap,
     ns1__searchByRunNumberPagination *ns1__searchByRunNumberPagination_) {
   struct __ns1__searchByRunNumberPagination *_p =
-      soap_instantiate___ns1__searchByRunNumberPagination(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate___ns1__searchByRunNumberPagination(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchByRunNumberPagination(soap, _p);
     _p->ns1__searchByRunNumberPagination_ = ns1__searchByRunNumberPagination_;
@@ -41074,13 +41402,15 @@ soap_instantiate___ns1__searchByRunNumber(struct soap *, int, const char *,
 
 inline struct __ns1__searchByRunNumber *
 soap_new___ns1__searchByRunNumber(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__searchByRunNumber(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__searchByRunNumber(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline struct __ns1__searchByRunNumber *
 soap_new_req___ns1__searchByRunNumber(struct soap *soap) {
   struct __ns1__searchByRunNumber *_p =
-      soap_instantiate___ns1__searchByRunNumber(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__searchByRunNumber(soap, -1, nullptr, nullptr,
+                                                nullptr);
   if (_p) {
     soap_default___ns1__searchByRunNumber(soap, _p);
   }
@@ -41090,7 +41420,8 @@ soap_new_req___ns1__searchByRunNumber(struct soap *soap) {
 inline struct __ns1__searchByRunNumber *soap_new_set___ns1__searchByRunNumber(
     struct soap *soap, ns1__searchByRunNumber *ns1__searchByRunNumber_) {
   struct __ns1__searchByRunNumber *_p =
-      soap_instantiate___ns1__searchByRunNumber(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__searchByRunNumber(soap, -1, nullptr, nullptr,
+                                                nullptr);
   if (_p) {
     soap_default___ns1__searchByRunNumber(soap, _p);
     _p->ns1__searchByRunNumber_ = ns1__searchByRunNumber_;
@@ -41158,13 +41489,15 @@ soap_instantiate___ns1__listDatasetStatus(struct soap *, int, const char *,
 
 inline struct __ns1__listDatasetStatus *
 soap_new___ns1__listDatasetStatus(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__listDatasetStatus(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__listDatasetStatus(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline struct __ns1__listDatasetStatus *
 soap_new_req___ns1__listDatasetStatus(struct soap *soap) {
   struct __ns1__listDatasetStatus *_p =
-      soap_instantiate___ns1__listDatasetStatus(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__listDatasetStatus(soap, -1, nullptr, nullptr,
+                                                nullptr);
   if (_p) {
     soap_default___ns1__listDatasetStatus(soap, _p);
   }
@@ -41174,7 +41507,8 @@ soap_new_req___ns1__listDatasetStatus(struct soap *soap) {
 inline struct __ns1__listDatasetStatus *soap_new_set___ns1__listDatasetStatus(
     struct soap *soap, ns1__listDatasetStatus *ns1__listDatasetStatus_) {
   struct __ns1__listDatasetStatus *_p =
-      soap_instantiate___ns1__listDatasetStatus(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__listDatasetStatus(soap, -1, nullptr, nullptr,
+                                                nullptr);
   if (_p) {
     soap_default___ns1__listDatasetStatus(soap, _p);
     _p->ns1__listDatasetStatus_ = ns1__listDatasetStatus_;
@@ -41242,13 +41576,14 @@ soap_instantiate___ns1__listDatasetTypes(struct soap *, int, const char *,
 
 inline struct __ns1__listDatasetTypes *
 soap_new___ns1__listDatasetTypes(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__listDatasetTypes(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__listDatasetTypes(soap, n, nullptr, nullptr,
+                                                  nullptr);
 }
 
 inline struct __ns1__listDatasetTypes *
 soap_new_req___ns1__listDatasetTypes(struct soap *soap) {
-  struct __ns1__listDatasetTypes *_p =
-      soap_instantiate___ns1__listDatasetTypes(soap, -1, NULL, NULL, NULL);
+  struct __ns1__listDatasetTypes *_p = soap_instantiate___ns1__listDatasetTypes(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__listDatasetTypes(soap, _p);
   }
@@ -41257,8 +41592,8 @@ soap_new_req___ns1__listDatasetTypes(struct soap *soap) {
 
 inline struct __ns1__listDatasetTypes *soap_new_set___ns1__listDatasetTypes(
     struct soap *soap, ns1__listDatasetTypes *ns1__listDatasetTypes_) {
-  struct __ns1__listDatasetTypes *_p =
-      soap_instantiate___ns1__listDatasetTypes(soap, -1, NULL, NULL, NULL);
+  struct __ns1__listDatasetTypes *_p = soap_instantiate___ns1__listDatasetTypes(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__listDatasetTypes(soap, _p);
     _p->ns1__listDatasetTypes_ = ns1__listDatasetTypes_;
@@ -41325,15 +41660,15 @@ soap_instantiate___ns1__searchDatasetsBySample(struct soap *, int, const char *,
 
 inline struct __ns1__searchDatasetsBySample *
 soap_new___ns1__searchDatasetsBySample(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__searchDatasetsBySample(soap, n, NULL, NULL,
-                                                        NULL);
+  return soap_instantiate___ns1__searchDatasetsBySample(soap, n, nullptr,
+                                                        nullptr, nullptr);
 }
 
 inline struct __ns1__searchDatasetsBySample *
 soap_new_req___ns1__searchDatasetsBySample(struct soap *soap) {
   struct __ns1__searchDatasetsBySample *_p =
-      soap_instantiate___ns1__searchDatasetsBySample(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate___ns1__searchDatasetsBySample(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     soap_default___ns1__searchDatasetsBySample(soap, _p);
   }
@@ -41345,8 +41680,8 @@ soap_new_set___ns1__searchDatasetsBySample(
     struct soap *soap,
     ns1__searchDatasetsBySample *ns1__searchDatasetsBySample_) {
   struct __ns1__searchDatasetsBySample *_p =
-      soap_instantiate___ns1__searchDatasetsBySample(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate___ns1__searchDatasetsBySample(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     soap_default___ns1__searchDatasetsBySample(soap, _p);
     _p->ns1__searchDatasetsBySample_ = ns1__searchDatasetsBySample_;
@@ -41413,15 +41748,15 @@ soap_instantiate___ns1__searchSamplesBySampleName(struct soap *, int,
 
 inline struct __ns1__searchSamplesBySampleName *
 soap_new___ns1__searchSamplesBySampleName(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__searchSamplesBySampleName(soap, n, NULL, NULL,
-                                                           NULL);
+  return soap_instantiate___ns1__searchSamplesBySampleName(soap, n, nullptr,
+                                                           nullptr, nullptr);
 }
 
 inline struct __ns1__searchSamplesBySampleName *
 soap_new_req___ns1__searchSamplesBySampleName(struct soap *soap) {
   struct __ns1__searchSamplesBySampleName *_p =
-      soap_instantiate___ns1__searchSamplesBySampleName(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate___ns1__searchSamplesBySampleName(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchSamplesBySampleName(soap, _p);
   }
@@ -41433,8 +41768,8 @@ soap_new_set___ns1__searchSamplesBySampleName(
     struct soap *soap,
     ns1__searchSamplesBySampleName *ns1__searchSamplesBySampleName_) {
   struct __ns1__searchSamplesBySampleName *_p =
-      soap_instantiate___ns1__searchSamplesBySampleName(soap, -1, NULL, NULL,
-                                                        NULL);
+      soap_instantiate___ns1__searchSamplesBySampleName(soap, -1, nullptr,
+                                                        nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchSamplesBySampleName(soap, _p);
     _p->ns1__searchSamplesBySampleName_ = ns1__searchSamplesBySampleName_;
@@ -41500,15 +41835,15 @@ soap_instantiate___ns1__listInvestigationTypes(struct soap *, int, const char *,
 
 inline struct __ns1__listInvestigationTypes *
 soap_new___ns1__listInvestigationTypes(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__listInvestigationTypes(soap, n, NULL, NULL,
-                                                        NULL);
+  return soap_instantiate___ns1__listInvestigationTypes(soap, n, nullptr,
+                                                        nullptr, nullptr);
 }
 
 inline struct __ns1__listInvestigationTypes *
 soap_new_req___ns1__listInvestigationTypes(struct soap *soap) {
   struct __ns1__listInvestigationTypes *_p =
-      soap_instantiate___ns1__listInvestigationTypes(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate___ns1__listInvestigationTypes(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     soap_default___ns1__listInvestigationTypes(soap, _p);
   }
@@ -41520,8 +41855,8 @@ soap_new_set___ns1__listInvestigationTypes(
     struct soap *soap,
     ns1__listInvestigationTypes *ns1__listInvestigationTypes_) {
   struct __ns1__listInvestigationTypes *_p =
-      soap_instantiate___ns1__listInvestigationTypes(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate___ns1__listInvestigationTypes(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     soap_default___ns1__listInvestigationTypes(soap, _p);
     _p->ns1__listInvestigationTypes_ = ns1__listInvestigationTypes_;
@@ -41587,15 +41922,15 @@ soap_instantiate___ns1__getInstrumentsWithData(struct soap *, int, const char *,
 
 inline struct __ns1__getInstrumentsWithData *
 soap_new___ns1__getInstrumentsWithData(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__getInstrumentsWithData(soap, n, NULL, NULL,
-                                                        NULL);
+  return soap_instantiate___ns1__getInstrumentsWithData(soap, n, nullptr,
+                                                        nullptr, nullptr);
 }
 
 inline struct __ns1__getInstrumentsWithData *
 soap_new_req___ns1__getInstrumentsWithData(struct soap *soap) {
   struct __ns1__getInstrumentsWithData *_p =
-      soap_instantiate___ns1__getInstrumentsWithData(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate___ns1__getInstrumentsWithData(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     soap_default___ns1__getInstrumentsWithData(soap, _p);
   }
@@ -41607,8 +41942,8 @@ soap_new_set___ns1__getInstrumentsWithData(
     struct soap *soap,
     ns1__getInstrumentsWithData *ns1__getInstrumentsWithData_) {
   struct __ns1__getInstrumentsWithData *_p =
-      soap_instantiate___ns1__getInstrumentsWithData(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate___ns1__getInstrumentsWithData(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     soap_default___ns1__getInstrumentsWithData(soap, _p);
     _p->ns1__getInstrumentsWithData_ = ns1__getInstrumentsWithData_;
@@ -41682,14 +42017,14 @@ inline struct __ns1__getFacilityCyclesWithDataForInstrument *
 soap_new___ns1__getFacilityCyclesWithDataForInstrument(struct soap *soap,
                                                        int n = -1) {
   return soap_instantiate___ns1__getFacilityCyclesWithDataForInstrument(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__getFacilityCyclesWithDataForInstrument *
 soap_new_req___ns1__getFacilityCyclesWithDataForInstrument(struct soap *soap) {
   struct __ns1__getFacilityCyclesWithDataForInstrument *_p =
       soap_instantiate___ns1__getFacilityCyclesWithDataForInstrument(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getFacilityCyclesWithDataForInstrument(soap, _p);
   }
@@ -41702,7 +42037,7 @@ soap_new_set___ns1__getFacilityCyclesWithDataForInstrument(
                            ns1__getFacilityCyclesWithDataForInstrument_) {
   struct __ns1__getFacilityCyclesWithDataForInstrument *_p =
       soap_instantiate___ns1__getFacilityCyclesWithDataForInstrument(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getFacilityCyclesWithDataForInstrument(soap, _p);
     _p->ns1__getFacilityCyclesWithDataForInstrument_ =
@@ -41773,13 +42108,15 @@ soap_instantiate___ns1__listFacilityCycles(struct soap *, int, const char *,
 
 inline struct __ns1__listFacilityCycles *
 soap_new___ns1__listFacilityCycles(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__listFacilityCycles(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__listFacilityCycles(soap, n, nullptr, nullptr,
+                                                    nullptr);
 }
 
 inline struct __ns1__listFacilityCycles *
 soap_new_req___ns1__listFacilityCycles(struct soap *soap) {
   struct __ns1__listFacilityCycles *_p =
-      soap_instantiate___ns1__listFacilityCycles(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__listFacilityCycles(soap, -1, nullptr, nullptr,
+                                                 nullptr);
   if (_p) {
     soap_default___ns1__listFacilityCycles(soap, _p);
   }
@@ -41789,7 +42126,8 @@ soap_new_req___ns1__listFacilityCycles(struct soap *soap) {
 inline struct __ns1__listFacilityCycles *soap_new_set___ns1__listFacilityCycles(
     struct soap *soap, ns1__listFacilityCycles *ns1__listFacilityCycles_) {
   struct __ns1__listFacilityCycles *_p =
-      soap_instantiate___ns1__listFacilityCycles(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__listFacilityCycles(soap, -1, nullptr, nullptr,
+                                                 nullptr);
   if (_p) {
     soap_default___ns1__listFacilityCycles(soap, _p);
     _p->ns1__listFacilityCycles_ = ns1__listFacilityCycles_;
@@ -41856,13 +42194,14 @@ soap_instantiate___ns1__listParameters(struct soap *, int, const char *,
 
 inline struct __ns1__listParameters *
 soap_new___ns1__listParameters(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__listParameters(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__listParameters(soap, n, nullptr, nullptr,
+                                                nullptr);
 }
 
 inline struct __ns1__listParameters *
 soap_new_req___ns1__listParameters(struct soap *soap) {
-  struct __ns1__listParameters *_p =
-      soap_instantiate___ns1__listParameters(soap, -1, NULL, NULL, NULL);
+  struct __ns1__listParameters *_p = soap_instantiate___ns1__listParameters(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__listParameters(soap, _p);
   }
@@ -41872,8 +42211,8 @@ soap_new_req___ns1__listParameters(struct soap *soap) {
 inline struct __ns1__listParameters *
 soap_new_set___ns1__listParameters(struct soap *soap,
                                    ns1__listParameters *ns1__listParameters_) {
-  struct __ns1__listParameters *_p =
-      soap_instantiate___ns1__listParameters(soap, -1, NULL, NULL, NULL);
+  struct __ns1__listParameters *_p = soap_instantiate___ns1__listParameters(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__listParameters(soap, _p);
     _p->ns1__listParameters_ = ns1__listParameters_;
@@ -41935,13 +42274,13 @@ soap_instantiate___ns1__listRoles(struct soap *, int, const char *,
 
 inline struct __ns1__listRoles *soap_new___ns1__listRoles(struct soap *soap,
                                                           int n = -1) {
-  return soap_instantiate___ns1__listRoles(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__listRoles(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__listRoles *
 soap_new_req___ns1__listRoles(struct soap *soap) {
   struct __ns1__listRoles *_p =
-      soap_instantiate___ns1__listRoles(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__listRoles(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__listRoles(soap, _p);
   }
@@ -41952,7 +42291,7 @@ inline struct __ns1__listRoles *
 soap_new_set___ns1__listRoles(struct soap *soap,
                               ns1__listRoles *ns1__listRoles_) {
   struct __ns1__listRoles *_p =
-      soap_instantiate___ns1__listRoles(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__listRoles(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__listRoles(soap, _p);
     _p->ns1__listRoles_ = ns1__listRoles_;
@@ -42019,13 +42358,15 @@ soap_instantiate___ns1__getAllInstruments(struct soap *, int, const char *,
 
 inline struct __ns1__getAllInstruments *
 soap_new___ns1__getAllInstruments(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__getAllInstruments(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__getAllInstruments(soap, n, nullptr, nullptr,
+                                                   nullptr);
 }
 
 inline struct __ns1__getAllInstruments *
 soap_new_req___ns1__getAllInstruments(struct soap *soap) {
   struct __ns1__getAllInstruments *_p =
-      soap_instantiate___ns1__getAllInstruments(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getAllInstruments(soap, -1, nullptr, nullptr,
+                                                nullptr);
   if (_p) {
     soap_default___ns1__getAllInstruments(soap, _p);
   }
@@ -42035,7 +42376,8 @@ soap_new_req___ns1__getAllInstruments(struct soap *soap) {
 inline struct __ns1__getAllInstruments *soap_new_set___ns1__getAllInstruments(
     struct soap *soap, ns1__getAllInstruments *ns1__getAllInstruments_) {
   struct __ns1__getAllInstruments *_p =
-      soap_instantiate___ns1__getAllInstruments(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getAllInstruments(soap, -1, nullptr, nullptr,
+                                                nullptr);
   if (_p) {
     soap_default___ns1__getAllInstruments(soap, _p);
     _p->ns1__getAllInstruments_ = ns1__getAllInstruments_;
@@ -42102,13 +42444,14 @@ soap_instantiate___ns1__listInstruments(struct soap *, int, const char *,
 
 inline struct __ns1__listInstruments *
 soap_new___ns1__listInstruments(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__listInstruments(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__listInstruments(soap, n, nullptr, nullptr,
+                                                 nullptr);
 }
 
 inline struct __ns1__listInstruments *
 soap_new_req___ns1__listInstruments(struct soap *soap) {
-  struct __ns1__listInstruments *_p =
-      soap_instantiate___ns1__listInstruments(soap, -1, NULL, NULL, NULL);
+  struct __ns1__listInstruments *_p = soap_instantiate___ns1__listInstruments(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__listInstruments(soap, _p);
   }
@@ -42117,8 +42460,8 @@ soap_new_req___ns1__listInstruments(struct soap *soap) {
 
 inline struct __ns1__listInstruments *soap_new_set___ns1__listInstruments(
     struct soap *soap, ns1__listInstruments *ns1__listInstruments_) {
-  struct __ns1__listInstruments *_p =
-      soap_instantiate___ns1__listInstruments(soap, -1, NULL, NULL, NULL);
+  struct __ns1__listInstruments *_p = soap_instantiate___ns1__listInstruments(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__listInstruments(soap, _p);
     _p->ns1__listInstruments_ = ns1__listInstruments_;
@@ -42186,15 +42529,15 @@ soap_instantiate___ns1__searchByUserSurnamePagination(struct soap *, int,
 
 inline struct __ns1__searchByUserSurnamePagination *
 soap_new___ns1__searchByUserSurnamePagination(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__searchByUserSurnamePagination(soap, n, NULL,
-                                                               NULL, NULL);
+  return soap_instantiate___ns1__searchByUserSurnamePagination(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__searchByUserSurnamePagination *
 soap_new_req___ns1__searchByUserSurnamePagination(struct soap *soap) {
   struct __ns1__searchByUserSurnamePagination *_p =
-      soap_instantiate___ns1__searchByUserSurnamePagination(soap, -1, NULL,
-                                                            NULL, NULL);
+      soap_instantiate___ns1__searchByUserSurnamePagination(soap, -1, nullptr,
+                                                            nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchByUserSurnamePagination(soap, _p);
   }
@@ -42206,8 +42549,8 @@ soap_new_set___ns1__searchByUserSurnamePagination(
     struct soap *soap,
     ns1__searchByUserSurnamePagination *ns1__searchByUserSurnamePagination_) {
   struct __ns1__searchByUserSurnamePagination *_p =
-      soap_instantiate___ns1__searchByUserSurnamePagination(soap, -1, NULL,
-                                                            NULL, NULL);
+      soap_instantiate___ns1__searchByUserSurnamePagination(soap, -1, nullptr,
+                                                            nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchByUserSurnamePagination(soap, _p);
     _p->ns1__searchByUserSurnamePagination_ =
@@ -42276,13 +42619,15 @@ soap_instantiate___ns1__searchByUserSurname(struct soap *, int, const char *,
 
 inline struct __ns1__searchByUserSurname *
 soap_new___ns1__searchByUserSurname(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__searchByUserSurname(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__searchByUserSurname(soap, n, nullptr, nullptr,
+                                                     nullptr);
 }
 
 inline struct __ns1__searchByUserSurname *
 soap_new_req___ns1__searchByUserSurname(struct soap *soap) {
   struct __ns1__searchByUserSurname *_p =
-      soap_instantiate___ns1__searchByUserSurname(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__searchByUserSurname(soap, -1, nullptr, nullptr,
+                                                  nullptr);
   if (_p) {
     soap_default___ns1__searchByUserSurname(soap, _p);
   }
@@ -42293,7 +42638,8 @@ inline struct __ns1__searchByUserSurname *
 soap_new_set___ns1__searchByUserSurname(
     struct soap *soap, ns1__searchByUserSurname *ns1__searchByUserSurname_) {
   struct __ns1__searchByUserSurname *_p =
-      soap_instantiate___ns1__searchByUserSurname(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__searchByUserSurname(soap, -1, nullptr, nullptr,
+                                                  nullptr);
   if (_p) {
     soap_default___ns1__searchByUserSurname(soap, _p);
     _p->ns1__searchByUserSurname_ = ns1__searchByUserSurname_;
@@ -42361,15 +42707,15 @@ soap_instantiate___ns1__searchByUserIDPagination(struct soap *, int,
 
 inline struct __ns1__searchByUserIDPagination *
 soap_new___ns1__searchByUserIDPagination(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__searchByUserIDPagination(soap, n, NULL, NULL,
-                                                          NULL);
+  return soap_instantiate___ns1__searchByUserIDPagination(soap, n, nullptr,
+                                                          nullptr, nullptr);
 }
 
 inline struct __ns1__searchByUserIDPagination *
 soap_new_req___ns1__searchByUserIDPagination(struct soap *soap) {
   struct __ns1__searchByUserIDPagination *_p =
-      soap_instantiate___ns1__searchByUserIDPagination(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate___ns1__searchByUserIDPagination(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchByUserIDPagination(soap, _p);
   }
@@ -42381,8 +42727,8 @@ soap_new_set___ns1__searchByUserIDPagination(
     struct soap *soap,
     ns1__searchByUserIDPagination *ns1__searchByUserIDPagination_) {
   struct __ns1__searchByUserIDPagination *_p =
-      soap_instantiate___ns1__searchByUserIDPagination(soap, -1, NULL, NULL,
-                                                       NULL);
+      soap_instantiate___ns1__searchByUserIDPagination(soap, -1, nullptr,
+                                                       nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchByUserIDPagination(soap, _p);
     _p->ns1__searchByUserIDPagination_ = ns1__searchByUserIDPagination_;
@@ -42448,13 +42794,14 @@ soap_instantiate___ns1__searchByUserID(struct soap *, int, const char *,
 
 inline struct __ns1__searchByUserID *
 soap_new___ns1__searchByUserID(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__searchByUserID(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__searchByUserID(soap, n, nullptr, nullptr,
+                                                nullptr);
 }
 
 inline struct __ns1__searchByUserID *
 soap_new_req___ns1__searchByUserID(struct soap *soap) {
-  struct __ns1__searchByUserID *_p =
-      soap_instantiate___ns1__searchByUserID(soap, -1, NULL, NULL, NULL);
+  struct __ns1__searchByUserID *_p = soap_instantiate___ns1__searchByUserID(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchByUserID(soap, _p);
   }
@@ -42464,8 +42811,8 @@ soap_new_req___ns1__searchByUserID(struct soap *soap) {
 inline struct __ns1__searchByUserID *
 soap_new_set___ns1__searchByUserID(struct soap *soap,
                                    ns1__searchByUserID *ns1__searchByUserID_) {
-  struct __ns1__searchByUserID *_p =
-      soap_instantiate___ns1__searchByUserID(soap, -1, NULL, NULL, NULL);
+  struct __ns1__searchByUserID *_p = soap_instantiate___ns1__searchByUserID(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchByUserID(soap, _p);
     _p->ns1__searchByUserID_ = ns1__searchByUserID_;
@@ -42538,14 +42885,14 @@ inline struct __ns1__getMyInvestigationsIncludesPagination *
 soap_new___ns1__getMyInvestigationsIncludesPagination(struct soap *soap,
                                                       int n = -1) {
   return soap_instantiate___ns1__getMyInvestigationsIncludesPagination(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__getMyInvestigationsIncludesPagination *
 soap_new_req___ns1__getMyInvestigationsIncludesPagination(struct soap *soap) {
   struct __ns1__getMyInvestigationsIncludesPagination *_p =
       soap_instantiate___ns1__getMyInvestigationsIncludesPagination(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getMyInvestigationsIncludesPagination(soap, _p);
   }
@@ -42558,7 +42905,7 @@ soap_new_set___ns1__getMyInvestigationsIncludesPagination(
                            ns1__getMyInvestigationsIncludesPagination_) {
   struct __ns1__getMyInvestigationsIncludesPagination *_p =
       soap_instantiate___ns1__getMyInvestigationsIncludesPagination(
-          soap, -1, NULL, NULL, NULL);
+          soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getMyInvestigationsIncludesPagination(soap, _p);
     _p->ns1__getMyInvestigationsIncludesPagination_ =
@@ -42627,15 +42974,15 @@ soap_instantiate___ns1__getMyInvestigationsIncludes(struct soap *, int,
 
 inline struct __ns1__getMyInvestigationsIncludes *
 soap_new___ns1__getMyInvestigationsIncludes(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__getMyInvestigationsIncludes(soap, n, NULL,
-                                                             NULL, NULL);
+  return soap_instantiate___ns1__getMyInvestigationsIncludes(soap, n, nullptr,
+                                                             nullptr, nullptr);
 }
 
 inline struct __ns1__getMyInvestigationsIncludes *
 soap_new_req___ns1__getMyInvestigationsIncludes(struct soap *soap) {
   struct __ns1__getMyInvestigationsIncludes *_p =
-      soap_instantiate___ns1__getMyInvestigationsIncludes(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate___ns1__getMyInvestigationsIncludes(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getMyInvestigationsIncludes(soap, _p);
   }
@@ -42647,8 +42994,8 @@ soap_new_set___ns1__getMyInvestigationsIncludes(
     struct soap *soap,
     ns1__getMyInvestigationsIncludes *ns1__getMyInvestigationsIncludes_) {
   struct __ns1__getMyInvestigationsIncludes *_p =
-      soap_instantiate___ns1__getMyInvestigationsIncludes(soap, -1, NULL, NULL,
-                                                          NULL);
+      soap_instantiate___ns1__getMyInvestigationsIncludes(soap, -1, nullptr,
+                                                          nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getMyInvestigationsIncludes(soap, _p);
     _p->ns1__getMyInvestigationsIncludes_ = ns1__getMyInvestigationsIncludes_;
@@ -42716,13 +43063,15 @@ soap_instantiate___ns1__getMyInvestigations(struct soap *, int, const char *,
 
 inline struct __ns1__getMyInvestigations *
 soap_new___ns1__getMyInvestigations(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__getMyInvestigations(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__getMyInvestigations(soap, n, nullptr, nullptr,
+                                                     nullptr);
 }
 
 inline struct __ns1__getMyInvestigations *
 soap_new_req___ns1__getMyInvestigations(struct soap *soap) {
   struct __ns1__getMyInvestigations *_p =
-      soap_instantiate___ns1__getMyInvestigations(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getMyInvestigations(soap, -1, nullptr, nullptr,
+                                                  nullptr);
   if (_p) {
     soap_default___ns1__getMyInvestigations(soap, _p);
   }
@@ -42733,7 +43082,8 @@ inline struct __ns1__getMyInvestigations *
 soap_new_set___ns1__getMyInvestigations(
     struct soap *soap, ns1__getMyInvestigations *ns1__getMyInvestigations_) {
   struct __ns1__getMyInvestigations *_p =
-      soap_instantiate___ns1__getMyInvestigations(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getMyInvestigations(soap, -1, nullptr, nullptr,
+                                                  nullptr);
   if (_p) {
     soap_default___ns1__getMyInvestigations(soap, _p);
     _p->ns1__getMyInvestigations_ = ns1__getMyInvestigations_;
@@ -42802,13 +43152,15 @@ soap_instantiate___ns1__searchByKeywordsAll(struct soap *, int, const char *,
 
 inline struct __ns1__searchByKeywordsAll *
 soap_new___ns1__searchByKeywordsAll(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__searchByKeywordsAll(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__searchByKeywordsAll(soap, n, nullptr, nullptr,
+                                                     nullptr);
 }
 
 inline struct __ns1__searchByKeywordsAll *
 soap_new_req___ns1__searchByKeywordsAll(struct soap *soap) {
   struct __ns1__searchByKeywordsAll *_p =
-      soap_instantiate___ns1__searchByKeywordsAll(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__searchByKeywordsAll(soap, -1, nullptr, nullptr,
+                                                  nullptr);
   if (_p) {
     soap_default___ns1__searchByKeywordsAll(soap, _p);
   }
@@ -42819,7 +43171,8 @@ inline struct __ns1__searchByKeywordsAll *
 soap_new_set___ns1__searchByKeywordsAll(
     struct soap *soap, ns1__searchByKeywordsAll *ns1__searchByKeywordsAll_) {
   struct __ns1__searchByKeywordsAll *_p =
-      soap_instantiate___ns1__searchByKeywordsAll(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__searchByKeywordsAll(soap, -1, nullptr, nullptr,
+                                                  nullptr);
   if (_p) {
     soap_default___ns1__searchByKeywordsAll(soap, _p);
     _p->ns1__searchByKeywordsAll_ = ns1__searchByKeywordsAll_;
@@ -42887,13 +43240,14 @@ soap_instantiate___ns1__searchByKeywords(struct soap *, int, const char *,
 
 inline struct __ns1__searchByKeywords *
 soap_new___ns1__searchByKeywords(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__searchByKeywords(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__searchByKeywords(soap, n, nullptr, nullptr,
+                                                  nullptr);
 }
 
 inline struct __ns1__searchByKeywords *
 soap_new_req___ns1__searchByKeywords(struct soap *soap) {
-  struct __ns1__searchByKeywords *_p =
-      soap_instantiate___ns1__searchByKeywords(soap, -1, NULL, NULL, NULL);
+  struct __ns1__searchByKeywords *_p = soap_instantiate___ns1__searchByKeywords(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchByKeywords(soap, _p);
   }
@@ -42902,8 +43256,8 @@ soap_new_req___ns1__searchByKeywords(struct soap *soap) {
 
 inline struct __ns1__searchByKeywords *soap_new_set___ns1__searchByKeywords(
     struct soap *soap, ns1__searchByKeywords *ns1__searchByKeywords_) {
-  struct __ns1__searchByKeywords *_p =
-      soap_instantiate___ns1__searchByKeywords(soap, -1, NULL, NULL, NULL);
+  struct __ns1__searchByKeywords *_p = soap_instantiate___ns1__searchByKeywords(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchByKeywords(soap, _p);
     _p->ns1__searchByKeywords_ = ns1__searchByKeywords_;
@@ -42971,15 +43325,15 @@ soap_instantiate___ns1__searchByAdvancedPagination(struct soap *, int,
 
 inline struct __ns1__searchByAdvancedPagination *
 soap_new___ns1__searchByAdvancedPagination(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__searchByAdvancedPagination(soap, n, NULL, NULL,
-                                                            NULL);
+  return soap_instantiate___ns1__searchByAdvancedPagination(soap, n, nullptr,
+                                                            nullptr, nullptr);
 }
 
 inline struct __ns1__searchByAdvancedPagination *
 soap_new_req___ns1__searchByAdvancedPagination(struct soap *soap) {
   struct __ns1__searchByAdvancedPagination *_p =
-      soap_instantiate___ns1__searchByAdvancedPagination(soap, -1, NULL, NULL,
-                                                         NULL);
+      soap_instantiate___ns1__searchByAdvancedPagination(soap, -1, nullptr,
+                                                         nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchByAdvancedPagination(soap, _p);
   }
@@ -42991,8 +43345,8 @@ soap_new_set___ns1__searchByAdvancedPagination(
     struct soap *soap,
     ns1__searchByAdvancedPagination *ns1__searchByAdvancedPagination_) {
   struct __ns1__searchByAdvancedPagination *_p =
-      soap_instantiate___ns1__searchByAdvancedPagination(soap, -1, NULL, NULL,
-                                                         NULL);
+      soap_instantiate___ns1__searchByAdvancedPagination(soap, -1, nullptr,
+                                                         nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchByAdvancedPagination(soap, _p);
     _p->ns1__searchByAdvancedPagination_ = ns1__searchByAdvancedPagination_;
@@ -43059,13 +43413,14 @@ soap_instantiate___ns1__searchByAdvanced(struct soap *, int, const char *,
 
 inline struct __ns1__searchByAdvanced *
 soap_new___ns1__searchByAdvanced(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__searchByAdvanced(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__searchByAdvanced(soap, n, nullptr, nullptr,
+                                                  nullptr);
 }
 
 inline struct __ns1__searchByAdvanced *
 soap_new_req___ns1__searchByAdvanced(struct soap *soap) {
-  struct __ns1__searchByAdvanced *_p =
-      soap_instantiate___ns1__searchByAdvanced(soap, -1, NULL, NULL, NULL);
+  struct __ns1__searchByAdvanced *_p = soap_instantiate___ns1__searchByAdvanced(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchByAdvanced(soap, _p);
   }
@@ -43074,8 +43429,8 @@ soap_new_req___ns1__searchByAdvanced(struct soap *soap) {
 
 inline struct __ns1__searchByAdvanced *soap_new_set___ns1__searchByAdvanced(
     struct soap *soap, ns1__searchByAdvanced *ns1__searchByAdvanced_) {
-  struct __ns1__searchByAdvanced *_p =
-      soap_instantiate___ns1__searchByAdvanced(soap, -1, NULL, NULL, NULL);
+  struct __ns1__searchByAdvanced *_p = soap_instantiate___ns1__searchByAdvanced(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__searchByAdvanced(soap, _p);
     _p->ns1__searchByAdvanced_ = ns1__searchByAdvanced_;
@@ -43142,13 +43497,14 @@ soap_instantiate___ns1__getAllKeywords(struct soap *, int, const char *,
 
 inline struct __ns1__getAllKeywords *
 soap_new___ns1__getAllKeywords(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__getAllKeywords(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__getAllKeywords(soap, n, nullptr, nullptr,
+                                                nullptr);
 }
 
 inline struct __ns1__getAllKeywords *
 soap_new_req___ns1__getAllKeywords(struct soap *soap) {
-  struct __ns1__getAllKeywords *_p =
-      soap_instantiate___ns1__getAllKeywords(soap, -1, NULL, NULL, NULL);
+  struct __ns1__getAllKeywords *_p = soap_instantiate___ns1__getAllKeywords(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getAllKeywords(soap, _p);
   }
@@ -43158,8 +43514,8 @@ soap_new_req___ns1__getAllKeywords(struct soap *soap) {
 inline struct __ns1__getAllKeywords *
 soap_new_set___ns1__getAllKeywords(struct soap *soap,
                                    ns1__getAllKeywords *ns1__getAllKeywords_) {
-  struct __ns1__getAllKeywords *_p =
-      soap_instantiate___ns1__getAllKeywords(soap, -1, NULL, NULL, NULL);
+  struct __ns1__getAllKeywords *_p = soap_instantiate___ns1__getAllKeywords(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getAllKeywords(soap, _p);
     _p->ns1__getAllKeywords_ = ns1__getAllKeywords_;
@@ -43225,15 +43581,15 @@ soap_instantiate___ns1__getKeywordsForUserType(struct soap *, int, const char *,
 
 inline struct __ns1__getKeywordsForUserType *
 soap_new___ns1__getKeywordsForUserType(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__getKeywordsForUserType(soap, n, NULL, NULL,
-                                                        NULL);
+  return soap_instantiate___ns1__getKeywordsForUserType(soap, n, nullptr,
+                                                        nullptr, nullptr);
 }
 
 inline struct __ns1__getKeywordsForUserType *
 soap_new_req___ns1__getKeywordsForUserType(struct soap *soap) {
   struct __ns1__getKeywordsForUserType *_p =
-      soap_instantiate___ns1__getKeywordsForUserType(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate___ns1__getKeywordsForUserType(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     soap_default___ns1__getKeywordsForUserType(soap, _p);
   }
@@ -43245,8 +43601,8 @@ soap_new_set___ns1__getKeywordsForUserType(
     struct soap *soap,
     ns1__getKeywordsForUserType *ns1__getKeywordsForUserType_) {
   struct __ns1__getKeywordsForUserType *_p =
-      soap_instantiate___ns1__getKeywordsForUserType(soap, -1, NULL, NULL,
-                                                     NULL);
+      soap_instantiate___ns1__getKeywordsForUserType(soap, -1, nullptr, nullptr,
+                                                     nullptr);
   if (_p) {
     soap_default___ns1__getKeywordsForUserType(soap, _p);
     _p->ns1__getKeywordsForUserType_ = ns1__getKeywordsForUserType_;
@@ -43312,14 +43668,15 @@ soap_instantiate___ns1__getKeywordsForUserMax(struct soap *, int, const char *,
 
 inline struct __ns1__getKeywordsForUserMax *
 soap_new___ns1__getKeywordsForUserMax(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__getKeywordsForUserMax(soap, n, NULL, NULL,
-                                                       NULL);
+  return soap_instantiate___ns1__getKeywordsForUserMax(soap, n, nullptr,
+                                                       nullptr, nullptr);
 }
 
 inline struct __ns1__getKeywordsForUserMax *
 soap_new_req___ns1__getKeywordsForUserMax(struct soap *soap) {
   struct __ns1__getKeywordsForUserMax *_p =
-      soap_instantiate___ns1__getKeywordsForUserMax(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getKeywordsForUserMax(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     soap_default___ns1__getKeywordsForUserMax(soap, _p);
   }
@@ -43331,7 +43688,8 @@ soap_new_set___ns1__getKeywordsForUserMax(
     struct soap *soap,
     ns1__getKeywordsForUserMax *ns1__getKeywordsForUserMax_) {
   struct __ns1__getKeywordsForUserMax *_p =
-      soap_instantiate___ns1__getKeywordsForUserMax(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getKeywordsForUserMax(soap, -1, nullptr, nullptr,
+                                                    nullptr);
   if (_p) {
     soap_default___ns1__getKeywordsForUserMax(soap, _p);
     _p->ns1__getKeywordsForUserMax_ = ns1__getKeywordsForUserMax_;
@@ -43398,15 +43756,15 @@ soap_instantiate___ns1__getKeywordsForUserStartWithMax(struct soap *, int,
 
 inline struct __ns1__getKeywordsForUserStartWithMax *
 soap_new___ns1__getKeywordsForUserStartWithMax(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__getKeywordsForUserStartWithMax(soap, n, NULL,
-                                                                NULL, NULL);
+  return soap_instantiate___ns1__getKeywordsForUserStartWithMax(
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__getKeywordsForUserStartWithMax *
 soap_new_req___ns1__getKeywordsForUserStartWithMax(struct soap *soap) {
   struct __ns1__getKeywordsForUserStartWithMax *_p =
-      soap_instantiate___ns1__getKeywordsForUserStartWithMax(soap, -1, NULL,
-                                                             NULL, NULL);
+      soap_instantiate___ns1__getKeywordsForUserStartWithMax(soap, -1, nullptr,
+                                                             nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getKeywordsForUserStartWithMax(soap, _p);
   }
@@ -43418,8 +43776,8 @@ soap_new_set___ns1__getKeywordsForUserStartWithMax(
     struct soap *soap,
     ns1__getKeywordsForUserStartWithMax *ns1__getKeywordsForUserStartWithMax_) {
   struct __ns1__getKeywordsForUserStartWithMax *_p =
-      soap_instantiate___ns1__getKeywordsForUserStartWithMax(soap, -1, NULL,
-                                                             NULL, NULL);
+      soap_instantiate___ns1__getKeywordsForUserStartWithMax(soap, -1, nullptr,
+                                                             nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getKeywordsForUserStartWithMax(soap, _p);
     _p->ns1__getKeywordsForUserStartWithMax_ =
@@ -43488,13 +43846,15 @@ soap_instantiate___ns1__getKeywordsForUser(struct soap *, int, const char *,
 
 inline struct __ns1__getKeywordsForUser *
 soap_new___ns1__getKeywordsForUser(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__getKeywordsForUser(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__getKeywordsForUser(soap, n, nullptr, nullptr,
+                                                    nullptr);
 }
 
 inline struct __ns1__getKeywordsForUser *
 soap_new_req___ns1__getKeywordsForUser(struct soap *soap) {
   struct __ns1__getKeywordsForUser *_p =
-      soap_instantiate___ns1__getKeywordsForUser(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getKeywordsForUser(soap, -1, nullptr, nullptr,
+                                                 nullptr);
   if (_p) {
     soap_default___ns1__getKeywordsForUser(soap, _p);
   }
@@ -43504,7 +43864,8 @@ soap_new_req___ns1__getKeywordsForUser(struct soap *soap) {
 inline struct __ns1__getKeywordsForUser *soap_new_set___ns1__getKeywordsForUser(
     struct soap *soap, ns1__getKeywordsForUser *ns1__getKeywordsForUser_) {
   struct __ns1__getKeywordsForUser *_p =
-      soap_instantiate___ns1__getKeywordsForUser(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__getKeywordsForUser(soap, -1, nullptr, nullptr,
+                                                 nullptr);
   if (_p) {
     soap_default___ns1__getKeywordsForUser(soap, _p);
     _p->ns1__getKeywordsForUser_ = ns1__getKeywordsForUser_;
@@ -43571,13 +43932,14 @@ soap_instantiate___ns1__isSessionValid(struct soap *, int, const char *,
 
 inline struct __ns1__isSessionValid *
 soap_new___ns1__isSessionValid(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__isSessionValid(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__isSessionValid(soap, n, nullptr, nullptr,
+                                                nullptr);
 }
 
 inline struct __ns1__isSessionValid *
 soap_new_req___ns1__isSessionValid(struct soap *soap) {
-  struct __ns1__isSessionValid *_p =
-      soap_instantiate___ns1__isSessionValid(soap, -1, NULL, NULL, NULL);
+  struct __ns1__isSessionValid *_p = soap_instantiate___ns1__isSessionValid(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__isSessionValid(soap, _p);
   }
@@ -43587,8 +43949,8 @@ soap_new_req___ns1__isSessionValid(struct soap *soap) {
 inline struct __ns1__isSessionValid *
 soap_new_set___ns1__isSessionValid(struct soap *soap,
                                    ns1__isSessionValid *ns1__isSessionValid_) {
-  struct __ns1__isSessionValid *_p =
-      soap_instantiate___ns1__isSessionValid(soap, -1, NULL, NULL, NULL);
+  struct __ns1__isSessionValid *_p = soap_instantiate___ns1__isSessionValid(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__isSessionValid(soap, _p);
     _p->ns1__isSessionValid_ = ns1__isSessionValid_;
@@ -43654,13 +44016,14 @@ soap_instantiate___ns1__getUserDetails(struct soap *, int, const char *,
 
 inline struct __ns1__getUserDetails *
 soap_new___ns1__getUserDetails(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__getUserDetails(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__getUserDetails(soap, n, nullptr, nullptr,
+                                                nullptr);
 }
 
 inline struct __ns1__getUserDetails *
 soap_new_req___ns1__getUserDetails(struct soap *soap) {
-  struct __ns1__getUserDetails *_p =
-      soap_instantiate___ns1__getUserDetails(soap, -1, NULL, NULL, NULL);
+  struct __ns1__getUserDetails *_p = soap_instantiate___ns1__getUserDetails(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getUserDetails(soap, _p);
   }
@@ -43670,8 +44033,8 @@ soap_new_req___ns1__getUserDetails(struct soap *soap) {
 inline struct __ns1__getUserDetails *
 soap_new_set___ns1__getUserDetails(struct soap *soap,
                                    ns3__getUserDetails *ns1__getUserDetails) {
-  struct __ns1__getUserDetails *_p =
-      soap_instantiate___ns1__getUserDetails(soap, -1, NULL, NULL, NULL);
+  struct __ns1__getUserDetails *_p = soap_instantiate___ns1__getUserDetails(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__getUserDetails(soap, _p);
     _p->ns1__getUserDetails = ns1__getUserDetails;
@@ -43733,12 +44096,12 @@ soap_instantiate___ns1__logout(struct soap *, int, const char *, const char *,
 
 inline struct __ns1__logout *soap_new___ns1__logout(struct soap *soap,
                                                     int n = -1) {
-  return soap_instantiate___ns1__logout(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__logout(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__logout *soap_new_req___ns1__logout(struct soap *soap) {
   struct __ns1__logout *_p =
-      soap_instantiate___ns1__logout(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__logout(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__logout(soap, _p);
   }
@@ -43748,7 +44111,7 @@ inline struct __ns1__logout *soap_new_req___ns1__logout(struct soap *soap) {
 inline struct __ns1__logout *
 soap_new_set___ns1__logout(struct soap *soap, ns1__logout *ns1__logout_) {
   struct __ns1__logout *_p =
-      soap_instantiate___ns1__logout(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__logout(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__logout(soap, _p);
     _p->ns1__logout_ = ns1__logout_;
@@ -43813,13 +44176,14 @@ soap_instantiate___ns1__loginLifetime(struct soap *, int, const char *,
 
 inline struct __ns1__loginLifetime *
 soap_new___ns1__loginLifetime(struct soap *soap, int n = -1) {
-  return soap_instantiate___ns1__loginLifetime(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__loginLifetime(soap, n, nullptr, nullptr,
+                                               nullptr);
 }
 
 inline struct __ns1__loginLifetime *
 soap_new_req___ns1__loginLifetime(struct soap *soap) {
-  struct __ns1__loginLifetime *_p =
-      soap_instantiate___ns1__loginLifetime(soap, -1, NULL, NULL, NULL);
+  struct __ns1__loginLifetime *_p = soap_instantiate___ns1__loginLifetime(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__loginLifetime(soap, _p);
   }
@@ -43829,8 +44193,8 @@ soap_new_req___ns1__loginLifetime(struct soap *soap) {
 inline struct __ns1__loginLifetime *
 soap_new_set___ns1__loginLifetime(struct soap *soap,
                                   ns1__loginLifetime *ns1__loginLifetime_) {
-  struct __ns1__loginLifetime *_p =
-      soap_instantiate___ns1__loginLifetime(soap, -1, NULL, NULL, NULL);
+  struct __ns1__loginLifetime *_p = soap_instantiate___ns1__loginLifetime(
+      soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__loginLifetime(soap, _p);
     _p->ns1__loginLifetime_ = ns1__loginLifetime_;
@@ -43892,12 +44256,12 @@ soap_instantiate___ns1__login(struct soap *, int, const char *, const char *,
 
 inline struct __ns1__login *soap_new___ns1__login(struct soap *soap,
                                                   int n = -1) {
-  return soap_instantiate___ns1__login(soap, n, NULL, NULL, NULL);
+  return soap_instantiate___ns1__login(soap, n, nullptr, nullptr, nullptr);
 }
 
 inline struct __ns1__login *soap_new_req___ns1__login(struct soap *soap) {
   struct __ns1__login *_p =
-      soap_instantiate___ns1__login(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__login(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__login(soap, _p);
   }
@@ -43907,7 +44271,7 @@ inline struct __ns1__login *soap_new_req___ns1__login(struct soap *soap) {
 inline struct __ns1__login *soap_new_set___ns1__login(struct soap *soap,
                                                       ns1__login *ns1__login_) {
   struct __ns1__login *_p =
-      soap_instantiate___ns1__login(soap, -1, NULL, NULL, NULL);
+      soap_instantiate___ns1__login(soap, -1, nullptr, nullptr, nullptr);
   if (_p) {
     soap_default___ns1__login(soap, _p);
     _p->ns1__login_ = ns1__login_;
@@ -58578,7 +58942,7 @@ inline std::vector<ns1__parameterCondition *> *
 soap_new_std__vectorTemplateOfPointerTons1__parameterCondition(
     struct soap *soap, int n = -1) {
   return soap_instantiate_std__vectorTemplateOfPointerTons1__parameterCondition(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline void soap_delete_std__vectorTemplateOfPointerTons1__parameterCondition(
@@ -58616,7 +58980,7 @@ inline std::vector<ns1__restrictionCondition *> *
 soap_new_std__vectorTemplateOfPointerTons1__restrictionCondition(
     struct soap *soap, int n = -1) {
   return soap_instantiate_std__vectorTemplateOfPointerTons1__restrictionCondition(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline void soap_delete_std__vectorTemplateOfPointerTons1__restrictionCondition(
@@ -58654,7 +59018,7 @@ inline std::vector<ns1__shift *> *
 soap_new_std__vectorTemplateOfPointerTons1__shift(struct soap *soap,
                                                   int n = -1) {
   return soap_instantiate_std__vectorTemplateOfPointerTons1__shift(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline void soap_delete_std__vectorTemplateOfPointerTons1__shift(
@@ -58692,7 +59056,7 @@ inline std::vector<ns1__publication *> *
 soap_new_std__vectorTemplateOfPointerTons1__publication(struct soap *soap,
                                                         int n = -1) {
   return soap_instantiate_std__vectorTemplateOfPointerTons1__publication(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline void soap_delete_std__vectorTemplateOfPointerTons1__publication(
@@ -58730,7 +59094,7 @@ inline std::vector<ns1__keyword *> *
 soap_new_std__vectorTemplateOfPointerTons1__keyword(struct soap *soap,
                                                     int n = -1) {
   return soap_instantiate_std__vectorTemplateOfPointerTons1__keyword(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline void soap_delete_std__vectorTemplateOfPointerTons1__keyword(
@@ -58768,7 +59132,7 @@ inline std::vector<ns1__investigator *> *
 soap_new_std__vectorTemplateOfPointerTons1__investigator(struct soap *soap,
                                                          int n = -1) {
   return soap_instantiate_std__vectorTemplateOfPointerTons1__investigator(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline void soap_delete_std__vectorTemplateOfPointerTons1__investigator(
@@ -58807,7 +59171,7 @@ inline std::vector<ns1__relatedDatafiles *> *
 soap_new_std__vectorTemplateOfPointerTons1__relatedDatafiles(struct soap *soap,
                                                              int n = -1) {
   return soap_instantiate_std__vectorTemplateOfPointerTons1__relatedDatafiles(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline void soap_delete_std__vectorTemplateOfPointerTons1__relatedDatafiles(
@@ -58844,7 +59208,7 @@ inline std::vector<ns1__sampleParameter *> *
 soap_new_std__vectorTemplateOfPointerTons1__sampleParameter(struct soap *soap,
                                                             int n = -1) {
   return soap_instantiate_std__vectorTemplateOfPointerTons1__sampleParameter(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline void soap_delete_std__vectorTemplateOfPointerTons1__sampleParameter(
@@ -58881,7 +59245,7 @@ inline std::vector<ns1__icatRole *> *
 soap_new_std__vectorTemplateOfPointerTons1__icatRole(struct soap *soap,
                                                      int n = -1) {
   return soap_instantiate_std__vectorTemplateOfPointerTons1__icatRole(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline void soap_delete_std__vectorTemplateOfPointerTons1__icatRole(
@@ -58919,7 +59283,7 @@ inline std::vector<ns1__datafileFormat *> *
 soap_new_std__vectorTemplateOfPointerTons1__datafileFormat(struct soap *soap,
                                                            int n = -1) {
   return soap_instantiate_std__vectorTemplateOfPointerTons1__datafileFormat(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline void soap_delete_std__vectorTemplateOfPointerTons1__datafileFormat(
@@ -58959,7 +59323,7 @@ inline std::vector<ns1__datasetParameter *> *
 soap_new_std__vectorTemplateOfPointerTons1__datasetParameter(struct soap *soap,
                                                              int n = -1) {
   return soap_instantiate_std__vectorTemplateOfPointerTons1__datasetParameter(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline void soap_delete_std__vectorTemplateOfPointerTons1__datasetParameter(
@@ -58997,7 +59361,7 @@ inline std::vector<ns1__icatAuthorisation *> *
 soap_new_std__vectorTemplateOfPointerTons1__icatAuthorisation(struct soap *soap,
                                                               int n = -1) {
   return soap_instantiate_std__vectorTemplateOfPointerTons1__icatAuthorisation(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline void soap_delete_std__vectorTemplateOfPointerTons1__icatAuthorisation(
@@ -59034,7 +59398,7 @@ inline std::vector<ns1__datafile *> *
 soap_new_std__vectorTemplateOfPointerTons1__datafile(struct soap *soap,
                                                      int n = -1) {
   return soap_instantiate_std__vectorTemplateOfPointerTons1__datafile(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline void soap_delete_std__vectorTemplateOfPointerTons1__datafile(
@@ -59072,7 +59436,7 @@ inline std::vector<ns1__investigation *> *
 soap_new_std__vectorTemplateOfPointerTons1__investigation(struct soap *soap,
                                                           int n = -1) {
   return soap_instantiate_std__vectorTemplateOfPointerTons1__investigation(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline void soap_delete_std__vectorTemplateOfPointerTons1__investigation(
@@ -59112,7 +59476,7 @@ inline std::vector<ns1__parameterComparisonCondition *> *
 soap_new_std__vectorTemplateOfPointerTons1__parameterComparisonCondition(
     struct soap *soap, int n = -1) {
   return soap_instantiate_std__vectorTemplateOfPointerTons1__parameterComparisonCondition(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline void
@@ -59145,8 +59509,8 @@ soap_instantiate_std__vectorTemplateOfLONG64(struct soap *, int, const char *,
 
 inline std::vector<LONG64> *
 soap_new_std__vectorTemplateOfLONG64(struct soap *soap, int n = -1) {
-  return soap_instantiate_std__vectorTemplateOfLONG64(soap, n, NULL, NULL,
-                                                      NULL);
+  return soap_instantiate_std__vectorTemplateOfLONG64(soap, n, nullptr, nullptr,
+                                                      nullptr);
 }
 
 inline void soap_delete_std__vectorTemplateOfLONG64(struct soap *soap,
@@ -59183,7 +59547,7 @@ inline std::vector<ns1__parameterSearch *> *
 soap_new_std__vectorTemplateOfPointerTons1__parameterSearch(struct soap *soap,
                                                             int n = -1) {
   return soap_instantiate_std__vectorTemplateOfPointerTons1__parameterSearch(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline void soap_delete_std__vectorTemplateOfPointerTons1__parameterSearch(
@@ -59220,7 +59584,7 @@ inline std::vector<ns1__dataset *> *
 soap_new_std__vectorTemplateOfPointerTons1__dataset(struct soap *soap,
                                                     int n = -1) {
   return soap_instantiate_std__vectorTemplateOfPointerTons1__dataset(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline void soap_delete_std__vectorTemplateOfPointerTons1__dataset(
@@ -59258,7 +59622,7 @@ inline std::vector<ns1__instrument *> *
 soap_new_std__vectorTemplateOfPointerTons1__instrument(struct soap *soap,
                                                        int n = -1) {
   return soap_instantiate_std__vectorTemplateOfPointerTons1__instrument(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline void soap_delete_std__vectorTemplateOfPointerTons1__instrument(
@@ -59297,7 +59661,7 @@ inline std::vector<ns1__datafileParameter *> *
 soap_new_std__vectorTemplateOfPointerTons1__datafileParameter(struct soap *soap,
                                                               int n = -1) {
   return soap_instantiate_std__vectorTemplateOfPointerTons1__datafileParameter(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline void soap_delete_std__vectorTemplateOfPointerTons1__datafileParameter(
@@ -59334,7 +59698,7 @@ inline std::vector<ns1__facilityCycle *> *
 soap_new_std__vectorTemplateOfPointerTons1__facilityCycle(struct soap *soap,
                                                           int n = -1) {
   return soap_instantiate_std__vectorTemplateOfPointerTons1__facilityCycle(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline void soap_delete_std__vectorTemplateOfPointerTons1__facilityCycle(
@@ -59373,7 +59737,7 @@ inline std::vector<ns1__parameter *> *
 soap_new_std__vectorTemplateOfPointerTons1__parameter(struct soap *soap,
                                                       int n = -1) {
   return soap_instantiate_std__vectorTemplateOfPointerTons1__parameter(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline void soap_delete_std__vectorTemplateOfPointerTons1__parameter(
@@ -59412,7 +59776,7 @@ inline std::vector<ns1__restrictionComparisonCondition *> *
 soap_new_std__vectorTemplateOfPointerTons1__restrictionComparisonCondition(
     struct soap *soap, int n = -1) {
   return soap_instantiate_std__vectorTemplateOfPointerTons1__restrictionComparisonCondition(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline void
@@ -59451,7 +59815,7 @@ inline std::vector<ns1__sample *> *
 soap_new_std__vectorTemplateOfPointerTons1__sample(struct soap *soap,
                                                    int n = -1) {
   return soap_instantiate_std__vectorTemplateOfPointerTons1__sample(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline void soap_delete_std__vectorTemplateOfPointerTons1__sample(
@@ -59489,7 +59853,7 @@ inline std::vector<ns1__facilityUser *> *
 soap_new_std__vectorTemplateOfPointerTons1__facilityUser(struct soap *soap,
                                                          int n = -1) {
   return soap_instantiate_std__vectorTemplateOfPointerTons1__facilityUser(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline void soap_delete_std__vectorTemplateOfPointerTons1__facilityUser(
@@ -59525,8 +59889,8 @@ soap_instantiate_std__vectorTemplateOfstd__string(struct soap *, int,
 
 inline std::vector<std::string> *
 soap_new_std__vectorTemplateOfstd__string(struct soap *soap, int n = -1) {
-  return soap_instantiate_std__vectorTemplateOfstd__string(soap, n, NULL, NULL,
-                                                           NULL);
+  return soap_instantiate_std__vectorTemplateOfstd__string(soap, n, nullptr,
+                                                           nullptr, nullptr);
 }
 
 inline void
@@ -59564,7 +59928,7 @@ inline std::vector<xsd__anyType *> *
 soap_new_std__vectorTemplateOfPointerToxsd__anyType(struct soap *soap,
                                                     int n = -1) {
   return soap_instantiate_std__vectorTemplateOfPointerToxsd__anyType(
-      soap, n, NULL, NULL, NULL);
+      soap, n, nullptr, nullptr, nullptr);
 }
 
 inline void soap_delete_std__vectorTemplateOfPointerToxsd__anyType(

--- a/Framework/ICat/inc/MantidICat/ICat3/GSoapGenerated/ICat3ICATPortBindingProxy.h
+++ b/Framework/ICat/inc/MantidICat/ICat3/GSoapGenerated/ICat3ICATPortBindingProxy.h
@@ -65,7 +65,7 @@ public:
   /// Web service operation 'login' (returns error code or SOAP_OK)
   virtual int login(ns1__login *ns1__login_,
                     ns1__loginResponse *ns1__loginResponse_) {
-    return this->login(NULL, NULL, ns1__login_, ns1__loginResponse_);
+    return this->login(nullptr, nullptr, ns1__login_, ns1__loginResponse_);
   }
   virtual int login(const char *endpoint, const char *soap_action,
                     ns1__login *ns1__login_,
@@ -75,7 +75,7 @@ public:
   virtual int
   loginLifetime(ns1__loginLifetime *ns1__loginLifetime_,
                 ns1__loginLifetimeResponse *ns1__loginLifetimeResponse_) {
-    return this->loginLifetime(NULL, NULL, ns1__loginLifetime_,
+    return this->loginLifetime(nullptr, nullptr, ns1__loginLifetime_,
                                ns1__loginLifetimeResponse_);
   }
   virtual int
@@ -86,7 +86,7 @@ public:
   /// Web service operation 'logout' (returns error code or SOAP_OK)
   virtual int logout(ns1__logout *ns1__logout_,
                      ns1__logoutResponse *ns1__logoutResponse_) {
-    return this->logout(NULL, NULL, ns1__logout_, ns1__logoutResponse_);
+    return this->logout(nullptr, nullptr, ns1__logout_, ns1__logoutResponse_);
   }
   virtual int logout(const char *endpoint, const char *soap_action,
                      ns1__logout *ns1__logout_,
@@ -96,7 +96,7 @@ public:
   virtual int
   getUserDetails(ns3__getUserDetails *ns1__getUserDetails,
                  ns3__getUserDetailsResponse *ns1__getUserDetailsResponse) {
-    return this->getUserDetails(NULL, NULL, ns1__getUserDetails,
+    return this->getUserDetails(nullptr, nullptr, ns1__getUserDetails,
                                 ns1__getUserDetailsResponse);
   }
   virtual int
@@ -108,7 +108,7 @@ public:
   virtual int
   isSessionValid(ns1__isSessionValid *ns1__isSessionValid_,
                  ns1__isSessionValidResponse *ns1__isSessionValidResponse_) {
-    return this->isSessionValid(NULL, NULL, ns1__isSessionValid_,
+    return this->isSessionValid(nullptr, nullptr, ns1__isSessionValid_,
                                 ns1__isSessionValidResponse_);
   }
   virtual int
@@ -120,7 +120,7 @@ public:
   virtual int getKeywordsForUser(
       ns1__getKeywordsForUser *ns1__getKeywordsForUser_,
       ns1__getKeywordsForUserResponse *ns1__getKeywordsForUserResponse_) {
-    return this->getKeywordsForUser(NULL, NULL, ns1__getKeywordsForUser_,
+    return this->getKeywordsForUser(nullptr, nullptr, ns1__getKeywordsForUser_,
                                     ns1__getKeywordsForUserResponse_);
   }
   virtual int getKeywordsForUser(
@@ -135,7 +135,7 @@ public:
       ns1__getKeywordsForUserStartWithMaxResponse *
           ns1__getKeywordsForUserStartWithMaxResponse_) {
     return this->getKeywordsForUserStartWithMax(
-        NULL, NULL, ns1__getKeywordsForUserStartWithMax_,
+        nullptr, nullptr, ns1__getKeywordsForUserStartWithMax_,
         ns1__getKeywordsForUserStartWithMaxResponse_);
   }
   virtual int getKeywordsForUserStartWithMax(
@@ -149,7 +149,8 @@ public:
   virtual int getKeywordsForUserMax(
       ns1__getKeywordsForUserMax *ns1__getKeywordsForUserMax_,
       ns1__getKeywordsForUserMaxResponse *ns1__getKeywordsForUserMaxResponse_) {
-    return this->getKeywordsForUserMax(NULL, NULL, ns1__getKeywordsForUserMax_,
+    return this->getKeywordsForUserMax(nullptr, nullptr,
+                                       ns1__getKeywordsForUserMax_,
                                        ns1__getKeywordsForUserMaxResponse_);
   }
   virtual int getKeywordsForUserMax(
@@ -163,7 +164,7 @@ public:
       ns1__getKeywordsForUserType *ns1__getKeywordsForUserType_,
       ns1__getKeywordsForUserTypeResponse *
           ns1__getKeywordsForUserTypeResponse_) {
-    return this->getKeywordsForUserType(NULL, NULL,
+    return this->getKeywordsForUserType(nullptr, nullptr,
                                         ns1__getKeywordsForUserType_,
                                         ns1__getKeywordsForUserTypeResponse_);
   }
@@ -177,7 +178,7 @@ public:
   virtual int
   getAllKeywords(ns1__getAllKeywords *ns1__getAllKeywords_,
                  ns1__getAllKeywordsResponse *ns1__getAllKeywordsResponse_) {
-    return this->getAllKeywords(NULL, NULL, ns1__getAllKeywords_,
+    return this->getAllKeywords(nullptr, nullptr, ns1__getAllKeywords_,
                                 ns1__getAllKeywordsResponse_);
   }
   virtual int
@@ -189,7 +190,7 @@ public:
   virtual int searchByAdvanced(
       ns1__searchByAdvanced *ns1__searchByAdvanced_,
       ns1__searchByAdvancedResponse *ns1__searchByAdvancedResponse_) {
-    return this->searchByAdvanced(NULL, NULL, ns1__searchByAdvanced_,
+    return this->searchByAdvanced(nullptr, nullptr, ns1__searchByAdvanced_,
                                   ns1__searchByAdvancedResponse_);
   }
   virtual int searchByAdvanced(
@@ -204,7 +205,7 @@ public:
       ns1__searchByAdvancedPaginationResponse *
           ns1__searchByAdvancedPaginationResponse_) {
     return this->searchByAdvancedPagination(
-        NULL, NULL, ns1__searchByAdvancedPagination_,
+        nullptr, nullptr, ns1__searchByAdvancedPagination_,
         ns1__searchByAdvancedPaginationResponse_);
   }
   virtual int searchByAdvancedPagination(
@@ -217,7 +218,7 @@ public:
   virtual int searchByKeywords(
       ns1__searchByKeywords *ns1__searchByKeywords_,
       ns1__searchByKeywordsResponse *ns1__searchByKeywordsResponse_) {
-    return this->searchByKeywords(NULL, NULL, ns1__searchByKeywords_,
+    return this->searchByKeywords(nullptr, nullptr, ns1__searchByKeywords_,
                                   ns1__searchByKeywordsResponse_);
   }
   virtual int searchByKeywords(
@@ -230,7 +231,8 @@ public:
   virtual int searchByKeywordsAll(
       ns1__searchByKeywordsAll *ns1__searchByKeywordsAll_,
       ns1__searchByKeywordsAllResponse *ns1__searchByKeywordsAllResponse_) {
-    return this->searchByKeywordsAll(NULL, NULL, ns1__searchByKeywordsAll_,
+    return this->searchByKeywordsAll(nullptr, nullptr,
+                                     ns1__searchByKeywordsAll_,
                                      ns1__searchByKeywordsAllResponse_);
   }
   virtual int searchByKeywordsAll(
@@ -243,7 +245,8 @@ public:
   virtual int getMyInvestigations(
       ns1__getMyInvestigations *ns1__getMyInvestigations_,
       ns1__getMyInvestigationsResponse *ns1__getMyInvestigationsResponse_) {
-    return this->getMyInvestigations(NULL, NULL, ns1__getMyInvestigations_,
+    return this->getMyInvestigations(nullptr, nullptr,
+                                     ns1__getMyInvestigations_,
                                      ns1__getMyInvestigationsResponse_);
   }
   virtual int getMyInvestigations(
@@ -258,7 +261,7 @@ public:
       ns1__getMyInvestigationsIncludesResponse *
           ns1__getMyInvestigationsIncludesResponse_) {
     return this->getMyInvestigationsIncludes(
-        NULL, NULL, ns1__getMyInvestigationsIncludes_,
+        nullptr, nullptr, ns1__getMyInvestigationsIncludes_,
         ns1__getMyInvestigationsIncludesResponse_);
   }
   virtual int getMyInvestigationsIncludes(
@@ -275,7 +278,7 @@ public:
       ns1__getMyInvestigationsIncludesPaginationResponse *
           ns1__getMyInvestigationsIncludesPaginationResponse_) {
     return this->getMyInvestigationsIncludesPagination(
-        NULL, NULL, ns1__getMyInvestigationsIncludesPagination_,
+        nullptr, nullptr, ns1__getMyInvestigationsIncludesPagination_,
         ns1__getMyInvestigationsIncludesPaginationResponse_);
   }
   virtual int getMyInvestigationsIncludesPagination(
@@ -289,7 +292,7 @@ public:
   virtual int
   searchByUserID(ns1__searchByUserID *ns1__searchByUserID_,
                  ns1__searchByUserIDResponse *ns1__searchByUserIDResponse_) {
-    return this->searchByUserID(NULL, NULL, ns1__searchByUserID_,
+    return this->searchByUserID(nullptr, nullptr, ns1__searchByUserID_,
                                 ns1__searchByUserIDResponse_);
   }
   virtual int
@@ -304,7 +307,7 @@ public:
       ns1__searchByUserIDPaginationResponse *
           ns1__searchByUserIDPaginationResponse_) {
     return this->searchByUserIDPagination(
-        NULL, NULL, ns1__searchByUserIDPagination_,
+        nullptr, nullptr, ns1__searchByUserIDPagination_,
         ns1__searchByUserIDPaginationResponse_);
   }
   virtual int searchByUserIDPagination(
@@ -318,7 +321,8 @@ public:
   virtual int searchByUserSurname(
       ns1__searchByUserSurname *ns1__searchByUserSurname_,
       ns1__searchByUserSurnameResponse *ns1__searchByUserSurnameResponse_) {
-    return this->searchByUserSurname(NULL, NULL, ns1__searchByUserSurname_,
+    return this->searchByUserSurname(nullptr, nullptr,
+                                     ns1__searchByUserSurname_,
                                      ns1__searchByUserSurnameResponse_);
   }
   virtual int searchByUserSurname(
@@ -333,7 +337,7 @@ public:
       ns1__searchByUserSurnamePaginationResponse *
           ns1__searchByUserSurnamePaginationResponse_) {
     return this->searchByUserSurnamePagination(
-        NULL, NULL, ns1__searchByUserSurnamePagination_,
+        nullptr, nullptr, ns1__searchByUserSurnamePagination_,
         ns1__searchByUserSurnamePaginationResponse_);
   }
   virtual int searchByUserSurnamePagination(
@@ -346,7 +350,7 @@ public:
   virtual int
   listInstruments(ns1__listInstruments *ns1__listInstruments_,
                   ns1__listInstrumentsResponse *ns1__listInstrumentsResponse_) {
-    return this->listInstruments(NULL, NULL, ns1__listInstruments_,
+    return this->listInstruments(nullptr, nullptr, ns1__listInstruments_,
                                  ns1__listInstrumentsResponse_);
   }
   virtual int
@@ -358,7 +362,7 @@ public:
   virtual int getAllInstruments(
       ns1__getAllInstruments *ns1__getAllInstruments_,
       ns1__getAllInstrumentsResponse *ns1__getAllInstrumentsResponse_) {
-    return this->getAllInstruments(NULL, NULL, ns1__getAllInstruments_,
+    return this->getAllInstruments(nullptr, nullptr, ns1__getAllInstruments_,
                                    ns1__getAllInstrumentsResponse_);
   }
   virtual int getAllInstruments(
@@ -369,7 +373,7 @@ public:
   /// Web service operation 'listRoles' (returns error code or SOAP_OK)
   virtual int listRoles(ns1__listRoles *ns1__listRoles_,
                         ns1__listRolesResponse *ns1__listRolesResponse_) {
-    return this->listRoles(NULL, NULL, ns1__listRoles_,
+    return this->listRoles(nullptr, nullptr, ns1__listRoles_,
                            ns1__listRolesResponse_);
   }
   virtual int listRoles(const char *endpoint, const char *soap_action,
@@ -380,7 +384,7 @@ public:
   virtual int
   listParameters(ns1__listParameters *ns1__listParameters_,
                  ns1__listParametersResponse *ns1__listParametersResponse_) {
-    return this->listParameters(NULL, NULL, ns1__listParameters_,
+    return this->listParameters(nullptr, nullptr, ns1__listParameters_,
                                 ns1__listParametersResponse_);
   }
   virtual int
@@ -392,7 +396,7 @@ public:
   virtual int listFacilityCycles(
       ns1__listFacilityCycles *ns1__listFacilityCycles_,
       ns1__listFacilityCyclesResponse *ns1__listFacilityCyclesResponse_) {
-    return this->listFacilityCycles(NULL, NULL, ns1__listFacilityCycles_,
+    return this->listFacilityCycles(nullptr, nullptr, ns1__listFacilityCycles_,
                                     ns1__listFacilityCyclesResponse_);
   }
   virtual int listFacilityCycles(
@@ -408,7 +412,7 @@ public:
       ns1__getFacilityCyclesWithDataForInstrumentResponse *
           ns1__getFacilityCyclesWithDataForInstrumentResponse_) {
     return this->getFacilityCyclesWithDataForInstrument(
-        NULL, NULL, ns1__getFacilityCyclesWithDataForInstrument_,
+        nullptr, nullptr, ns1__getFacilityCyclesWithDataForInstrument_,
         ns1__getFacilityCyclesWithDataForInstrumentResponse_);
   }
   virtual int getFacilityCyclesWithDataForInstrument(
@@ -424,7 +428,7 @@ public:
       ns1__getInstrumentsWithData *ns1__getInstrumentsWithData_,
       ns1__getInstrumentsWithDataResponse *
           ns1__getInstrumentsWithDataResponse_) {
-    return this->getInstrumentsWithData(NULL, NULL,
+    return this->getInstrumentsWithData(nullptr, nullptr,
                                         ns1__getInstrumentsWithData_,
                                         ns1__getInstrumentsWithDataResponse_);
   }
@@ -440,7 +444,7 @@ public:
       ns1__listInvestigationTypes *ns1__listInvestigationTypes_,
       ns1__listInvestigationTypesResponse *
           ns1__listInvestigationTypesResponse_) {
-    return this->listInvestigationTypes(NULL, NULL,
+    return this->listInvestigationTypes(nullptr, nullptr,
                                         ns1__listInvestigationTypes_,
                                         ns1__listInvestigationTypesResponse_);
   }
@@ -457,7 +461,7 @@ public:
       ns1__searchSamplesBySampleNameResponse *
           ns1__searchSamplesBySampleNameResponse_) {
     return this->searchSamplesBySampleName(
-        NULL, NULL, ns1__searchSamplesBySampleName_,
+        nullptr, nullptr, ns1__searchSamplesBySampleName_,
         ns1__searchSamplesBySampleNameResponse_);
   }
   virtual int searchSamplesBySampleName(
@@ -472,7 +476,7 @@ public:
       ns1__searchDatasetsBySample *ns1__searchDatasetsBySample_,
       ns1__searchDatasetsBySampleResponse *
           ns1__searchDatasetsBySampleResponse_) {
-    return this->searchDatasetsBySample(NULL, NULL,
+    return this->searchDatasetsBySample(nullptr, nullptr,
                                         ns1__searchDatasetsBySample_,
                                         ns1__searchDatasetsBySampleResponse_);
   }
@@ -486,7 +490,7 @@ public:
   virtual int listDatasetTypes(
       ns1__listDatasetTypes *ns1__listDatasetTypes_,
       ns1__listDatasetTypesResponse *ns1__listDatasetTypesResponse_) {
-    return this->listDatasetTypes(NULL, NULL, ns1__listDatasetTypes_,
+    return this->listDatasetTypes(nullptr, nullptr, ns1__listDatasetTypes_,
                                   ns1__listDatasetTypesResponse_);
   }
   virtual int listDatasetTypes(
@@ -498,7 +502,7 @@ public:
   virtual int listDatasetStatus(
       ns1__listDatasetStatus *ns1__listDatasetStatus_,
       ns1__listDatasetStatusResponse *ns1__listDatasetStatusResponse_) {
-    return this->listDatasetStatus(NULL, NULL, ns1__listDatasetStatus_,
+    return this->listDatasetStatus(nullptr, nullptr, ns1__listDatasetStatus_,
                                    ns1__listDatasetStatusResponse_);
   }
   virtual int listDatasetStatus(
@@ -510,7 +514,7 @@ public:
   virtual int searchByRunNumber(
       ns1__searchByRunNumber *ns1__searchByRunNumber_,
       ns1__searchByRunNumberResponse *ns1__searchByRunNumberResponse_) {
-    return this->searchByRunNumber(NULL, NULL, ns1__searchByRunNumber_,
+    return this->searchByRunNumber(nullptr, nullptr, ns1__searchByRunNumber_,
                                    ns1__searchByRunNumberResponse_);
   }
   virtual int searchByRunNumber(
@@ -525,7 +529,7 @@ public:
       ns1__searchByRunNumberPaginationResponse *
           ns1__searchByRunNumberPaginationResponse_) {
     return this->searchByRunNumberPagination(
-        NULL, NULL, ns1__searchByRunNumberPagination_,
+        nullptr, nullptr, ns1__searchByRunNumberPagination_,
         ns1__searchByRunNumberPaginationResponse_);
   }
   virtual int searchByRunNumberPagination(
@@ -539,7 +543,8 @@ public:
   virtual int listDatafileFormats(
       ns1__listDatafileFormats *ns1__listDatafileFormats_,
       ns1__listDatafileFormatsResponse *ns1__listDatafileFormatsResponse_) {
-    return this->listDatafileFormats(NULL, NULL, ns1__listDatafileFormats_,
+    return this->listDatafileFormats(nullptr, nullptr,
+                                     ns1__listDatafileFormats_,
                                      ns1__listDatafileFormatsResponse_);
   }
   virtual int listDatafileFormats(
@@ -551,7 +556,7 @@ public:
   virtual int getInvestigation(
       ns1__getInvestigation *ns1__getInvestigation_,
       ns1__getInvestigationResponse *ns1__getInvestigationResponse_) {
-    return this->getInvestigation(NULL, NULL, ns1__getInvestigation_,
+    return this->getInvestigation(nullptr, nullptr, ns1__getInvestigation_,
                                   ns1__getInvestigationResponse_);
   }
   virtual int getInvestigation(
@@ -566,7 +571,7 @@ public:
       ns1__getInvestigationIncludesResponse *
           ns1__getInvestigationIncludesResponse_) {
     return this->getInvestigationIncludes(
-        NULL, NULL, ns1__getInvestigationIncludes_,
+        nullptr, nullptr, ns1__getInvestigationIncludes_,
         ns1__getInvestigationIncludesResponse_);
   }
   virtual int getInvestigationIncludes(
@@ -579,7 +584,7 @@ public:
   virtual int getInvestigations(
       ns1__getInvestigations *ns1__getInvestigations_,
       ns1__getInvestigationsResponse *ns1__getInvestigationsResponse_) {
-    return this->getInvestigations(NULL, NULL, ns1__getInvestigations_,
+    return this->getInvestigations(nullptr, nullptr, ns1__getInvestigations_,
                                    ns1__getInvestigationsResponse_);
   }
   virtual int getInvestigations(
@@ -594,7 +599,7 @@ public:
       ns1__getInvestigationsIncludesResponse *
           ns1__getInvestigationsIncludesResponse_) {
     return this->getInvestigationsIncludes(
-        NULL, NULL, ns1__getInvestigationsIncludes_,
+        nullptr, nullptr, ns1__getInvestigationsIncludes_,
         ns1__getInvestigationsIncludesResponse_);
   }
   virtual int getInvestigationsIncludes(
@@ -608,7 +613,8 @@ public:
   virtual int createInvestigation(
       ns1__createInvestigation *ns1__createInvestigation_,
       ns1__createInvestigationResponse *ns1__createInvestigationResponse_) {
-    return this->createInvestigation(NULL, NULL, ns1__createInvestigation_,
+    return this->createInvestigation(nullptr, nullptr,
+                                     ns1__createInvestigation_,
                                      ns1__createInvestigationResponse_);
   }
   virtual int createInvestigation(
@@ -621,7 +627,8 @@ public:
   virtual int deleteInvestigation(
       ns1__deleteInvestigation *ns1__deleteInvestigation_,
       ns1__deleteInvestigationResponse *ns1__deleteInvestigationResponse_) {
-    return this->deleteInvestigation(NULL, NULL, ns1__deleteInvestigation_,
+    return this->deleteInvestigation(nullptr, nullptr,
+                                     ns1__deleteInvestigation_,
                                      ns1__deleteInvestigationResponse_);
   }
   virtual int deleteInvestigation(
@@ -634,7 +641,8 @@ public:
   virtual int removeInvestigation(
       ns1__removeInvestigation *ns1__removeInvestigation_,
       ns1__removeInvestigationResponse *ns1__removeInvestigationResponse_) {
-    return this->removeInvestigation(NULL, NULL, ns1__removeInvestigation_,
+    return this->removeInvestigation(nullptr, nullptr,
+                                     ns1__removeInvestigation_,
                                      ns1__removeInvestigationResponse_);
   }
   virtual int removeInvestigation(
@@ -645,7 +653,7 @@ public:
   /// Web service operation 'addKeyword' (returns error code or SOAP_OK)
   virtual int addKeyword(ns1__addKeyword *ns1__addKeyword_,
                          ns1__addKeywordResponse *ns1__addKeywordResponse_) {
-    return this->addKeyword(NULL, NULL, ns1__addKeyword_,
+    return this->addKeyword(nullptr, nullptr, ns1__addKeyword_,
                             ns1__addKeywordResponse_);
   }
   virtual int addKeyword(const char *endpoint, const char *soap_action,
@@ -656,7 +664,7 @@ public:
   virtual int
   addInvestigator(ns1__addInvestigator *ns1__addInvestigator_,
                   ns1__addInvestigatorResponse *ns1__addInvestigatorResponse_) {
-    return this->addInvestigator(NULL, NULL, ns1__addInvestigator_,
+    return this->addInvestigator(nullptr, nullptr, ns1__addInvestigator_,
                                  ns1__addInvestigatorResponse_);
   }
   virtual int
@@ -667,7 +675,7 @@ public:
   /// Web service operation 'addSample' (returns error code or SOAP_OK)
   virtual int addSample(ns1__addSample *ns1__addSample_,
                         ns1__addSampleResponse *ns1__addSampleResponse_) {
-    return this->addSample(NULL, NULL, ns1__addSample_,
+    return this->addSample(nullptr, nullptr, ns1__addSample_,
                            ns1__addSampleResponse_);
   }
   virtual int addSample(const char *endpoint, const char *soap_action,
@@ -678,7 +686,7 @@ public:
   virtual int
   addPublication(ns1__addPublication *ns1__addPublication_,
                  ns1__addPublicationResponse *ns1__addPublicationResponse_) {
-    return this->addPublication(NULL, NULL, ns1__addPublication_,
+    return this->addPublication(nullptr, nullptr, ns1__addPublication_,
                                 ns1__addPublicationResponse_);
   }
   virtual int
@@ -690,7 +698,7 @@ public:
   virtual int addSampleParameter(
       ns1__addSampleParameter *ns1__addSampleParameter_,
       ns1__addSampleParameterResponse *ns1__addSampleParameterResponse_) {
-    return this->addSampleParameter(NULL, NULL, ns1__addSampleParameter_,
+    return this->addSampleParameter(nullptr, nullptr, ns1__addSampleParameter_,
                                     ns1__addSampleParameterResponse_);
   }
   virtual int addSampleParameter(
@@ -702,7 +710,7 @@ public:
   virtual int deleteInvestigator(
       ns1__deleteInvestigator *ns1__deleteInvestigator_,
       ns1__deleteInvestigatorResponse *ns1__deleteInvestigatorResponse_) {
-    return this->deleteInvestigator(NULL, NULL, ns1__deleteInvestigator_,
+    return this->deleteInvestigator(nullptr, nullptr, ns1__deleteInvestigator_,
                                     ns1__deleteInvestigatorResponse_);
   }
   virtual int deleteInvestigator(
@@ -714,7 +722,7 @@ public:
   virtual int
   deleteKeyword(ns1__deleteKeyword *ns1__deleteKeyword_,
                 ns1__deleteKeywordResponse *ns1__deleteKeywordResponse_) {
-    return this->deleteKeyword(NULL, NULL, ns1__deleteKeyword_,
+    return this->deleteKeyword(nullptr, nullptr, ns1__deleteKeyword_,
                                ns1__deleteKeywordResponse_);
   }
   virtual int
@@ -726,7 +734,7 @@ public:
   virtual int deletePublication(
       ns1__deletePublication *ns1__deletePublication_,
       ns1__deletePublicationResponse *ns1__deletePublicationResponse_) {
-    return this->deletePublication(NULL, NULL, ns1__deletePublication_,
+    return this->deletePublication(nullptr, nullptr, ns1__deletePublication_,
                                    ns1__deletePublicationResponse_);
   }
   virtual int deletePublication(
@@ -738,7 +746,7 @@ public:
   virtual int
   deleteSample(ns1__deleteSample *ns1__deleteSample_,
                ns1__deleteSampleResponse *ns1__deleteSampleResponse_) {
-    return this->deleteSample(NULL, NULL, ns1__deleteSample_,
+    return this->deleteSample(nullptr, nullptr, ns1__deleteSample_,
                               ns1__deleteSampleResponse_);
   }
   virtual int
@@ -751,7 +759,8 @@ public:
   virtual int deleteSampleParameter(
       ns1__deleteSampleParameter *ns1__deleteSampleParameter_,
       ns1__deleteSampleParameterResponse *ns1__deleteSampleParameterResponse_) {
-    return this->deleteSampleParameter(NULL, NULL, ns1__deleteSampleParameter_,
+    return this->deleteSampleParameter(nullptr, nullptr,
+                                       ns1__deleteSampleParameter_,
                                        ns1__deleteSampleParameterResponse_);
   }
   virtual int deleteSampleParameter(
@@ -764,7 +773,8 @@ public:
   virtual int modifyInvestigation(
       ns1__modifyInvestigation *ns1__modifyInvestigation_,
       ns1__modifyInvestigationResponse *ns1__modifyInvestigationResponse_) {
-    return this->modifyInvestigation(NULL, NULL, ns1__modifyInvestigation_,
+    return this->modifyInvestigation(nullptr, nullptr,
+                                     ns1__modifyInvestigation_,
                                      ns1__modifyInvestigationResponse_);
   }
   virtual int modifyInvestigation(
@@ -776,7 +786,7 @@ public:
   virtual int modifyInvestigator(
       ns1__modifyInvestigator *ns1__modifyInvestigator_,
       ns1__modifyInvestigatorResponse *ns1__modifyInvestigatorResponse_) {
-    return this->modifyInvestigator(NULL, NULL, ns1__modifyInvestigator_,
+    return this->modifyInvestigator(nullptr, nullptr, ns1__modifyInvestigator_,
                                     ns1__modifyInvestigatorResponse_);
   }
   virtual int modifyInvestigator(
@@ -788,7 +798,7 @@ public:
   virtual int
   modifySample(ns1__modifySample *ns1__modifySample_,
                ns1__modifySampleResponse *ns1__modifySampleResponse_) {
-    return this->modifySample(NULL, NULL, ns1__modifySample_,
+    return this->modifySample(nullptr, nullptr, ns1__modifySample_,
                               ns1__modifySampleResponse_);
   }
   virtual int
@@ -800,7 +810,7 @@ public:
   virtual int modifyPublication(
       ns1__modifyPublication *ns1__modifyPublication_,
       ns1__modifyPublicationResponse *ns1__modifyPublicationResponse_) {
-    return this->modifyPublication(NULL, NULL, ns1__modifyPublication_,
+    return this->modifyPublication(nullptr, nullptr, ns1__modifyPublication_,
                                    ns1__modifyPublicationResponse_);
   }
   virtual int modifyPublication(
@@ -813,7 +823,8 @@ public:
   virtual int modifySampleParameter(
       ns1__modifySampleParameter *ns1__modifySampleParameter_,
       ns1__modifySampleParameterResponse *ns1__modifySampleParameterResponse_) {
-    return this->modifySampleParameter(NULL, NULL, ns1__modifySampleParameter_,
+    return this->modifySampleParameter(nullptr, nullptr,
+                                       ns1__modifySampleParameter_,
                                        ns1__modifySampleParameterResponse_);
   }
   virtual int modifySampleParameter(
@@ -825,7 +836,7 @@ public:
   virtual int
   removeKeyword(ns1__removeKeyword *ns1__removeKeyword_,
                 ns1__removeKeywordResponse *ns1__removeKeywordResponse_) {
-    return this->removeKeyword(NULL, NULL, ns1__removeKeyword_,
+    return this->removeKeyword(nullptr, nullptr, ns1__removeKeyword_,
                                ns1__removeKeywordResponse_);
   }
   virtual int
@@ -837,7 +848,7 @@ public:
   virtual int removeInvestigator(
       ns1__removeInvestigator *ns1__removeInvestigator_,
       ns1__removeInvestigatorResponse *ns1__removeInvestigatorResponse_) {
-    return this->removeInvestigator(NULL, NULL, ns1__removeInvestigator_,
+    return this->removeInvestigator(nullptr, nullptr, ns1__removeInvestigator_,
                                     ns1__removeInvestigatorResponse_);
   }
   virtual int removeInvestigator(
@@ -849,7 +860,7 @@ public:
   virtual int removePublication(
       ns1__removePublication *ns1__removePublication_,
       ns1__removePublicationResponse *ns1__removePublicationResponse_) {
-    return this->removePublication(NULL, NULL, ns1__removePublication_,
+    return this->removePublication(nullptr, nullptr, ns1__removePublication_,
                                    ns1__removePublicationResponse_);
   }
   virtual int removePublication(
@@ -861,7 +872,7 @@ public:
   virtual int
   removeSample(ns1__removeSample *ns1__removeSample_,
                ns1__removeSampleResponse *ns1__removeSampleResponse_) {
-    return this->removeSample(NULL, NULL, ns1__removeSample_,
+    return this->removeSample(nullptr, nullptr, ns1__removeSample_,
                               ns1__removeSampleResponse_);
   }
   virtual int
@@ -874,7 +885,8 @@ public:
   virtual int removeSampleParameter(
       ns1__removeSampleParameter *ns1__removeSampleParameter_,
       ns1__removeSampleParameterResponse *ns1__removeSampleParameterResponse_) {
-    return this->removeSampleParameter(NULL, NULL, ns1__removeSampleParameter_,
+    return this->removeSampleParameter(nullptr, nullptr,
+                                       ns1__removeSampleParameter_,
                                        ns1__removeSampleParameterResponse_);
   }
   virtual int removeSampleParameter(
@@ -885,7 +897,7 @@ public:
   /// Web service operation 'getDataset' (returns error code or SOAP_OK)
   virtual int getDataset(ns1__getDataset *ns1__getDataset_,
                          ns1__getDatasetResponse *ns1__getDatasetResponse_) {
-    return this->getDataset(NULL, NULL, ns1__getDataset_,
+    return this->getDataset(nullptr, nullptr, ns1__getDataset_,
                             ns1__getDatasetResponse_);
   }
   virtual int getDataset(const char *endpoint, const char *soap_action,
@@ -896,7 +908,7 @@ public:
   virtual int getDatasetIncludes(
       ns1__getDatasetIncludes *ns1__getDatasetIncludes_,
       ns1__getDatasetIncludesResponse *ns1__getDatasetIncludesResponse_) {
-    return this->getDatasetIncludes(NULL, NULL, ns1__getDatasetIncludes_,
+    return this->getDatasetIncludes(nullptr, nullptr, ns1__getDatasetIncludes_,
                                     ns1__getDatasetIncludesResponse_);
   }
   virtual int getDatasetIncludes(
@@ -907,7 +919,7 @@ public:
   /// Web service operation 'getDatasets' (returns error code or SOAP_OK)
   virtual int getDatasets(ns1__getDatasets *ns1__getDatasets_,
                           ns1__getDatasetsResponse *ns1__getDatasetsResponse_) {
-    return this->getDatasets(NULL, NULL, ns1__getDatasets_,
+    return this->getDatasets(nullptr, nullptr, ns1__getDatasets_,
                              ns1__getDatasetsResponse_);
   }
   virtual int getDatasets(const char *endpoint, const char *soap_action,
@@ -918,7 +930,7 @@ public:
   virtual int
   createDataSet(ns1__createDataSet *ns1__createDataSet_,
                 ns1__createDataSetResponse *ns1__createDataSetResponse_) {
-    return this->createDataSet(NULL, NULL, ns1__createDataSet_,
+    return this->createDataSet(nullptr, nullptr, ns1__createDataSet_,
                                ns1__createDataSetResponse_);
   }
   virtual int
@@ -930,7 +942,7 @@ public:
   virtual int
   createDataSets(ns1__createDataSets *ns1__createDataSets_,
                  ns1__createDataSetsResponse *ns1__createDataSetsResponse_) {
-    return this->createDataSets(NULL, NULL, ns1__createDataSets_,
+    return this->createDataSets(nullptr, nullptr, ns1__createDataSets_,
                                 ns1__createDataSetsResponse_);
   }
   virtual int
@@ -942,7 +954,7 @@ public:
   virtual int
   deleteDataSet(ns1__deleteDataSet *ns1__deleteDataSet_,
                 ns1__deleteDataSetResponse *ns1__deleteDataSetResponse_) {
-    return this->deleteDataSet(NULL, NULL, ns1__deleteDataSet_,
+    return this->deleteDataSet(nullptr, nullptr, ns1__deleteDataSet_,
                                ns1__deleteDataSetResponse_);
   }
   virtual int
@@ -956,7 +968,7 @@ public:
       ns1__deleteDataSetParameter *ns1__deleteDataSetParameter_,
       ns1__deleteDataSetParameterResponse *
           ns1__deleteDataSetParameterResponse_) {
-    return this->deleteDataSetParameter(NULL, NULL,
+    return this->deleteDataSetParameter(nullptr, nullptr,
                                         ns1__deleteDataSetParameter_,
                                         ns1__deleteDataSetParameterResponse_);
   }
@@ -970,7 +982,7 @@ public:
   virtual int
   modifyDataSet(ns1__modifyDataSet *ns1__modifyDataSet_,
                 ns1__modifyDataSetResponse *ns1__modifyDataSetResponse_) {
-    return this->modifyDataSet(NULL, NULL, ns1__modifyDataSet_,
+    return this->modifyDataSet(nullptr, nullptr, ns1__modifyDataSet_,
                                ns1__modifyDataSetResponse_);
   }
   virtual int
@@ -984,7 +996,7 @@ public:
       ns1__modifyDataSetParameter *ns1__modifyDataSetParameter_,
       ns1__modifyDataSetParameterResponse *
           ns1__modifyDataSetParameterResponse_) {
-    return this->modifyDataSetParameter(NULL, NULL,
+    return this->modifyDataSetParameter(nullptr, nullptr,
                                         ns1__modifyDataSetParameter_,
                                         ns1__modifyDataSetParameterResponse_);
   }
@@ -998,7 +1010,7 @@ public:
   virtual int setDataSetSample(
       ns1__setDataSetSample *ns1__setDataSetSample_,
       ns1__setDataSetSampleResponse *ns1__setDataSetSampleResponse_) {
-    return this->setDataSetSample(NULL, NULL, ns1__setDataSetSample_,
+    return this->setDataSetSample(nullptr, nullptr, ns1__setDataSetSample_,
                                   ns1__setDataSetSampleResponse_);
   }
   virtual int setDataSetSample(
@@ -1011,7 +1023,8 @@ public:
   virtual int addDataSetParameter(
       ns1__addDataSetParameter *ns1__addDataSetParameter_,
       ns1__addDataSetParameterResponse *ns1__addDataSetParameterResponse_) {
-    return this->addDataSetParameter(NULL, NULL, ns1__addDataSetParameter_,
+    return this->addDataSetParameter(nullptr, nullptr,
+                                     ns1__addDataSetParameter_,
                                      ns1__addDataSetParameterResponse_);
   }
   virtual int addDataSetParameter(
@@ -1024,7 +1037,8 @@ public:
   virtual int addDataSetParameters(
       ns1__addDataSetParameters *ns1__addDataSetParameters_,
       ns1__addDataSetParametersResponse *ns1__addDataSetParametersResponse_) {
-    return this->addDataSetParameters(NULL, NULL, ns1__addDataSetParameters_,
+    return this->addDataSetParameters(nullptr, nullptr,
+                                      ns1__addDataSetParameters_,
                                       ns1__addDataSetParametersResponse_);
   }
   virtual int addDataSetParameters(
@@ -1036,7 +1050,7 @@ public:
   virtual int
   removeDataSet(ns1__removeDataSet *ns1__removeDataSet_,
                 ns1__removeDataSetResponse *ns1__removeDataSetResponse_) {
-    return this->removeDataSet(NULL, NULL, ns1__removeDataSet_,
+    return this->removeDataSet(nullptr, nullptr, ns1__removeDataSet_,
                                ns1__removeDataSetResponse_);
   }
   virtual int
@@ -1050,7 +1064,7 @@ public:
       ns1__removeDataSetParameter *ns1__removeDataSetParameter_,
       ns1__removeDataSetParameterResponse *
           ns1__removeDataSetParameterResponse_) {
-    return this->removeDataSetParameter(NULL, NULL,
+    return this->removeDataSetParameter(nullptr, nullptr,
                                         ns1__removeDataSetParameter_,
                                         ns1__removeDataSetParameterResponse_);
   }
@@ -1063,7 +1077,7 @@ public:
   /// Web service operation 'getDatafile' (returns error code or SOAP_OK)
   virtual int getDatafile(ns1__getDatafile *ns1__getDatafile_,
                           ns1__getDatafileResponse *ns1__getDatafileResponse_) {
-    return this->getDatafile(NULL, NULL, ns1__getDatafile_,
+    return this->getDatafile(nullptr, nullptr, ns1__getDatafile_,
                              ns1__getDatafileResponse_);
   }
   virtual int getDatafile(const char *endpoint, const char *soap_action,
@@ -1074,7 +1088,7 @@ public:
   virtual int
   getDatafiles(ns1__getDatafiles *ns1__getDatafiles_,
                ns1__getDatafilesResponse *ns1__getDatafilesResponse_) {
-    return this->getDatafiles(NULL, NULL, ns1__getDatafiles_,
+    return this->getDatafiles(nullptr, nullptr, ns1__getDatafiles_,
                               ns1__getDatafilesResponse_);
   }
   virtual int
@@ -1086,7 +1100,7 @@ public:
   virtual int
   createDataFile(ns1__createDataFile *ns1__createDataFile_,
                  ns1__createDataFileResponse *ns1__createDataFileResponse_) {
-    return this->createDataFile(NULL, NULL, ns1__createDataFile_,
+    return this->createDataFile(nullptr, nullptr, ns1__createDataFile_,
                                 ns1__createDataFileResponse_);
   }
   virtual int
@@ -1098,7 +1112,7 @@ public:
   virtual int
   createDataFiles(ns1__createDataFiles *ns1__createDataFiles_,
                   ns1__createDataFilesResponse *ns1__createDataFilesResponse_) {
-    return this->createDataFiles(NULL, NULL, ns1__createDataFiles_,
+    return this->createDataFiles(nullptr, nullptr, ns1__createDataFiles_,
                                  ns1__createDataFilesResponse_);
   }
   virtual int
@@ -1110,7 +1124,7 @@ public:
   virtual int
   deleteDataFile(ns1__deleteDataFile *ns1__deleteDataFile_,
                  ns1__deleteDataFileResponse *ns1__deleteDataFileResponse_) {
-    return this->deleteDataFile(NULL, NULL, ns1__deleteDataFile_,
+    return this->deleteDataFile(nullptr, nullptr, ns1__deleteDataFile_,
                                 ns1__deleteDataFileResponse_);
   }
   virtual int
@@ -1122,7 +1136,7 @@ public:
   virtual int
   modifyDataFile(ns1__modifyDataFile *ns1__modifyDataFile_,
                  ns1__modifyDataFileResponse *ns1__modifyDataFileResponse_) {
-    return this->modifyDataFile(NULL, NULL, ns1__modifyDataFile_,
+    return this->modifyDataFile(nullptr, nullptr, ns1__modifyDataFile_,
                                 ns1__modifyDataFileResponse_);
   }
   virtual int
@@ -1135,7 +1149,8 @@ public:
   virtual int addDataFileParameter(
       ns1__addDataFileParameter *ns1__addDataFileParameter_,
       ns1__addDataFileParameterResponse *ns1__addDataFileParameterResponse_) {
-    return this->addDataFileParameter(NULL, NULL, ns1__addDataFileParameter_,
+    return this->addDataFileParameter(nullptr, nullptr,
+                                      ns1__addDataFileParameter_,
                                       ns1__addDataFileParameterResponse_);
   }
   virtual int addDataFileParameter(
@@ -1148,7 +1163,8 @@ public:
   virtual int addDataFileParameters(
       ns1__addDataFileParameters *ns1__addDataFileParameters_,
       ns1__addDataFileParametersResponse *ns1__addDataFileParametersResponse_) {
-    return this->addDataFileParameters(NULL, NULL, ns1__addDataFileParameters_,
+    return this->addDataFileParameters(nullptr, nullptr,
+                                       ns1__addDataFileParameters_,
                                        ns1__addDataFileParametersResponse_);
   }
   virtual int addDataFileParameters(
@@ -1162,7 +1178,7 @@ public:
       ns1__modifyDataFileParameter *ns1__modifyDataFileParameter_,
       ns1__modifyDataFileParameterResponse *
           ns1__modifyDataFileParameterResponse_) {
-    return this->modifyDataFileParameter(NULL, NULL,
+    return this->modifyDataFileParameter(nullptr, nullptr,
                                          ns1__modifyDataFileParameter_,
                                          ns1__modifyDataFileParameterResponse_);
   }
@@ -1178,7 +1194,7 @@ public:
       ns1__deleteDataFileParameter *ns1__deleteDataFileParameter_,
       ns1__deleteDataFileParameterResponse *
           ns1__deleteDataFileParameterResponse_) {
-    return this->deleteDataFileParameter(NULL, NULL,
+    return this->deleteDataFileParameter(nullptr, nullptr,
                                          ns1__deleteDataFileParameter_,
                                          ns1__deleteDataFileParameterResponse_);
   }
@@ -1192,7 +1208,7 @@ public:
   virtual int
   removeDataFile(ns1__removeDataFile *ns1__removeDataFile_,
                  ns1__removeDataFileResponse *ns1__removeDataFileResponse_) {
-    return this->removeDataFile(NULL, NULL, ns1__removeDataFile_,
+    return this->removeDataFile(nullptr, nullptr, ns1__removeDataFile_,
                                 ns1__removeDataFileResponse_);
   }
   virtual int
@@ -1206,7 +1222,7 @@ public:
       ns1__removeDataFileParameter *ns1__removeDataFileParameter_,
       ns1__removeDataFileParameterResponse *
           ns1__removeDataFileParameterResponse_) {
-    return this->removeDataFileParameter(NULL, NULL,
+    return this->removeDataFileParameter(nullptr, nullptr,
                                          ns1__removeDataFileParameter_,
                                          ns1__removeDataFileParameterResponse_);
   }
@@ -1220,7 +1236,7 @@ public:
   virtual int getAuthorisations(
       ns1__getAuthorisations *ns1__getAuthorisations_,
       ns1__getAuthorisationsResponse *ns1__getAuthorisationsResponse_) {
-    return this->getAuthorisations(NULL, NULL, ns1__getAuthorisations_,
+    return this->getAuthorisations(nullptr, nullptr, ns1__getAuthorisations_,
                                    ns1__getAuthorisationsResponse_);
   }
   virtual int getAuthorisations(
@@ -1232,7 +1248,7 @@ public:
   virtual int addAuthorisation(
       ns1__addAuthorisation *ns1__addAuthorisation_,
       ns1__addAuthorisationResponse *ns1__addAuthorisationResponse_) {
-    return this->addAuthorisation(NULL, NULL, ns1__addAuthorisation_,
+    return this->addAuthorisation(nullptr, nullptr, ns1__addAuthorisation_,
                                   ns1__addAuthorisationResponse_);
   }
   virtual int addAuthorisation(
@@ -1245,7 +1261,8 @@ public:
   virtual int deleteAuthorisation(
       ns1__deleteAuthorisation *ns1__deleteAuthorisation_,
       ns1__deleteAuthorisationResponse *ns1__deleteAuthorisationResponse_) {
-    return this->deleteAuthorisation(NULL, NULL, ns1__deleteAuthorisation_,
+    return this->deleteAuthorisation(nullptr, nullptr,
+                                     ns1__deleteAuthorisation_,
                                      ns1__deleteAuthorisationResponse_);
   }
   virtual int deleteAuthorisation(
@@ -1258,7 +1275,8 @@ public:
   virtual int removeAuthorisation(
       ns1__removeAuthorisation *ns1__removeAuthorisation_,
       ns1__removeAuthorisationResponse *ns1__removeAuthorisationResponse_) {
-    return this->removeAuthorisation(NULL, NULL, ns1__removeAuthorisation_,
+    return this->removeAuthorisation(nullptr, nullptr,
+                                     ns1__removeAuthorisation_,
                                      ns1__removeAuthorisationResponse_);
   }
   virtual int removeAuthorisation(
@@ -1271,7 +1289,8 @@ public:
   virtual int updateAuthorisation(
       ns1__updateAuthorisation *ns1__updateAuthorisation_,
       ns1__updateAuthorisationResponse *ns1__updateAuthorisationResponse_) {
-    return this->updateAuthorisation(NULL, NULL, ns1__updateAuthorisation_,
+    return this->updateAuthorisation(nullptr, nullptr,
+                                     ns1__updateAuthorisation_,
                                      ns1__updateAuthorisationResponse_);
   }
   virtual int updateAuthorisation(
@@ -1283,7 +1302,7 @@ public:
   virtual int
   ingestMetadata(ns1__ingestMetadata *ns1__ingestMetadata_,
                  ns1__ingestMetadataResponse *ns1__ingestMetadataResponse_) {
-    return this->ingestMetadata(NULL, NULL, ns1__ingestMetadata_,
+    return this->ingestMetadata(nullptr, nullptr, ns1__ingestMetadata_,
                                 ns1__ingestMetadataResponse_);
   }
   virtual int
@@ -1295,7 +1314,7 @@ public:
   virtual int downloadDatafile(
       ns1__downloadDatafile *ns1__downloadDatafile_,
       ns1__downloadDatafileResponse *ns1__downloadDatafileResponse_) {
-    return this->downloadDatafile(NULL, NULL, ns1__downloadDatafile_,
+    return this->downloadDatafile(nullptr, nullptr, ns1__downloadDatafile_,
                                   ns1__downloadDatafileResponse_);
   }
   virtual int downloadDatafile(
@@ -1307,7 +1326,7 @@ public:
   virtual int
   downloadDataset(ns1__downloadDataset *ns1__downloadDataset_,
                   ns1__downloadDatasetResponse *ns1__downloadDatasetResponse_) {
-    return this->downloadDataset(NULL, NULL, ns1__downloadDataset_,
+    return this->downloadDataset(nullptr, nullptr, ns1__downloadDataset_,
                                  ns1__downloadDatasetResponse_);
   }
   virtual int
@@ -1319,7 +1338,7 @@ public:
   virtual int downloadDatafiles(
       ns1__downloadDatafiles *ns1__downloadDatafiles_,
       ns1__downloadDatafilesResponse *ns1__downloadDatafilesResponse_) {
-    return this->downloadDatafiles(NULL, NULL, ns1__downloadDatafiles_,
+    return this->downloadDatafiles(nullptr, nullptr, ns1__downloadDatafiles_,
                                    ns1__downloadDatafilesResponse_);
   }
   virtual int downloadDatafiles(
@@ -1334,7 +1353,7 @@ public:
       ns1__checkDatafileDownloadAccessResponse *
           ns1__checkDatafileDownloadAccessResponse_) {
     return this->checkDatafileDownloadAccess(
-        NULL, NULL, ns1__checkDatafileDownloadAccess_,
+        nullptr, nullptr, ns1__checkDatafileDownloadAccess_,
         ns1__checkDatafileDownloadAccessResponse_);
   }
   virtual int checkDatafileDownloadAccess(
@@ -1350,7 +1369,7 @@ public:
       ns1__checkDatasetDownloadAccessResponse *
           ns1__checkDatasetDownloadAccessResponse_) {
     return this->checkDatasetDownloadAccess(
-        NULL, NULL, ns1__checkDatasetDownloadAccess_,
+        nullptr, nullptr, ns1__checkDatasetDownloadAccess_,
         ns1__checkDatasetDownloadAccessResponse_);
   }
   virtual int checkDatasetDownloadAccess(
@@ -1363,7 +1382,7 @@ public:
   virtual int getICATAPIVersion(
       ns1__getICATAPIVersion *ns1__getICATAPIVersion_,
       ns1__getICATAPIVersionResponse *ns1__getICATAPIVersionResponse_) {
-    return this->getICATAPIVersion(NULL, NULL, ns1__getICATAPIVersion_,
+    return this->getICATAPIVersion(nullptr, nullptr, ns1__getICATAPIVersion_,
                                    ns1__getICATAPIVersionResponse_);
   }
   virtual int getICATAPIVersion(
@@ -1379,7 +1398,7 @@ public:
       ns1__getFacilityUserByFacilityUserIdResponse *
           ns1__getFacilityUserByFacilityUserIdResponse_) {
     return this->getFacilityUserByFacilityUserId(
-        NULL, NULL, ns1__getFacilityUserByFacilityUserId_,
+        nullptr, nullptr, ns1__getFacilityUserByFacilityUserId_,
         ns1__getFacilityUserByFacilityUserIdResponse_);
   }
   virtual int getFacilityUserByFacilityUserId(
@@ -1396,7 +1415,7 @@ public:
       ns1__getFacilityUserByFederalIdResponse *
           ns1__getFacilityUserByFederalIdResponse_) {
     return this->getFacilityUserByFederalId(
-        NULL, NULL, ns1__getFacilityUserByFederalId_,
+        nullptr, nullptr, ns1__getFacilityUserByFederalId_,
         ns1__getFacilityUserByFederalIdResponse_);
   }
   virtual int getFacilityUserByFederalId(
@@ -1413,7 +1432,7 @@ public:
       ns1__searchInvestigationByParameterConditionResponse *
           ns1__searchInvestigationByParameterConditionResponse_) {
     return this->searchInvestigationByParameterCondition(
-        NULL, NULL, ns1__searchInvestigationByParameterCondition_,
+        nullptr, nullptr, ns1__searchInvestigationByParameterCondition_,
         ns1__searchInvestigationByParameterConditionResponse_);
   }
   virtual int searchInvestigationByParameterCondition(
@@ -1431,7 +1450,7 @@ public:
       ns1__searchDatafileByParameterConditionResponse *
           ns1__searchDatafileByParameterConditionResponse_) {
     return this->searchDatafileByParameterCondition(
-        NULL, NULL, ns1__searchDatafileByParameterCondition_,
+        nullptr, nullptr, ns1__searchDatafileByParameterCondition_,
         ns1__searchDatafileByParameterConditionResponse_);
   }
   virtual int searchDatafileByParameterCondition(
@@ -1449,7 +1468,7 @@ public:
       ns1__searchDatasetByParameterConditionResponse *
           ns1__searchDatasetByParameterConditionResponse_) {
     return this->searchDatasetByParameterCondition(
-        NULL, NULL, ns1__searchDatasetByParameterCondition_,
+        nullptr, nullptr, ns1__searchDatasetByParameterCondition_,
         ns1__searchDatasetByParameterConditionResponse_);
   }
   virtual int searchDatasetByParameterCondition(
@@ -1467,7 +1486,7 @@ public:
       ns1__searchSampleByParameterConditionResponse *
           ns1__searchSampleByParameterConditionResponse_) {
     return this->searchSampleByParameterCondition(
-        NULL, NULL, ns1__searchSampleByParameterCondition_,
+        nullptr, nullptr, ns1__searchSampleByParameterCondition_,
         ns1__searchSampleByParameterConditionResponse_);
   }
   virtual int searchSampleByParameterCondition(
@@ -1485,7 +1504,7 @@ public:
       ns1__searchInvestigationByParameterComparisonResponse *
           ns1__searchInvestigationByParameterComparisonResponse_) {
     return this->searchInvestigationByParameterComparison(
-        NULL, NULL, ns1__searchInvestigationByParameterComparison_,
+        nullptr, nullptr, ns1__searchInvestigationByParameterComparison_,
         ns1__searchInvestigationByParameterComparisonResponse_);
   }
   virtual int searchInvestigationByParameterComparison(
@@ -1503,7 +1522,7 @@ public:
       ns1__searchDatafileByParameterComparisonResponse *
           ns1__searchDatafileByParameterComparisonResponse_) {
     return this->searchDatafileByParameterComparison(
-        NULL, NULL, ns1__searchDatafileByParameterComparison_,
+        nullptr, nullptr, ns1__searchDatafileByParameterComparison_,
         ns1__searchDatafileByParameterComparisonResponse_);
   }
   virtual int searchDatafileByParameterComparison(
@@ -1521,7 +1540,7 @@ public:
       ns1__searchDatasetByParameterComparisonResponse *
           ns1__searchDatasetByParameterComparisonResponse_) {
     return this->searchDatasetByParameterComparison(
-        NULL, NULL, ns1__searchDatasetByParameterComparison_,
+        nullptr, nullptr, ns1__searchDatasetByParameterComparison_,
         ns1__searchDatasetByParameterComparisonResponse_);
   }
   virtual int searchDatasetByParameterComparison(
@@ -1539,7 +1558,7 @@ public:
       ns1__searchSampleByParameterComparisonResponse *
           ns1__searchSampleByParameterComparisonResponse_) {
     return this->searchSampleByParameterComparison(
-        NULL, NULL, ns1__searchSampleByParameterComparison_,
+        nullptr, nullptr, ns1__searchSampleByParameterComparison_,
         ns1__searchSampleByParameterComparisonResponse_);
   }
   virtual int searchSampleByParameterComparison(
@@ -1556,7 +1575,7 @@ public:
       ns1__searchInvestigationByParameterResponse *
           ns1__searchInvestigationByParameterResponse_) {
     return this->searchInvestigationByParameter(
-        NULL, NULL, ns1__searchInvestigationByParameter_,
+        nullptr, nullptr, ns1__searchInvestigationByParameter_,
         ns1__searchInvestigationByParameterResponse_);
   }
   virtual int searchInvestigationByParameter(
@@ -1572,7 +1591,7 @@ public:
       ns1__searchDatafileByParameterResponse *
           ns1__searchDatafileByParameterResponse_) {
     return this->searchDatafileByParameter(
-        NULL, NULL, ns1__searchDatafileByParameter_,
+        nullptr, nullptr, ns1__searchDatafileByParameter_,
         ns1__searchDatafileByParameterResponse_);
   }
   virtual int searchDatafileByParameter(
@@ -1588,7 +1607,7 @@ public:
       ns1__searchDatasetByParameterResponse *
           ns1__searchDatasetByParameterResponse_) {
     return this->searchDatasetByParameter(
-        NULL, NULL, ns1__searchDatasetByParameter_,
+        nullptr, nullptr, ns1__searchDatasetByParameter_,
         ns1__searchDatasetByParameterResponse_);
   }
   virtual int searchDatasetByParameter(
@@ -1603,7 +1622,7 @@ public:
       ns1__searchSampleByParameter *ns1__searchSampleByParameter_,
       ns1__searchSampleByParameterResponse *
           ns1__searchSampleByParameterResponse_) {
-    return this->searchSampleByParameter(NULL, NULL,
+    return this->searchSampleByParameter(nullptr, nullptr,
                                          ns1__searchSampleByParameter_,
                                          ns1__searchSampleByParameterResponse_);
   }
@@ -1619,7 +1638,7 @@ public:
       ns1__getParameterByNameUnits *ns1__getParameterByNameUnits_,
       ns1__getParameterByNameUnitsResponse *
           ns1__getParameterByNameUnitsResponse_) {
-    return this->getParameterByNameUnits(NULL, NULL,
+    return this->getParameterByNameUnits(nullptr, nullptr,
                                          ns1__getParameterByNameUnits_,
                                          ns1__getParameterByNameUnitsResponse_);
   }
@@ -1633,7 +1652,7 @@ public:
   virtual int getParameterByName(
       ns1__getParameterByName *ns1__getParameterByName_,
       ns1__getParameterByNameResponse *ns1__getParameterByNameResponse_) {
-    return this->getParameterByName(NULL, NULL, ns1__getParameterByName_,
+    return this->getParameterByName(nullptr, nullptr, ns1__getParameterByName_,
                                     ns1__getParameterByNameResponse_);
   }
   virtual int getParameterByName(
@@ -1648,7 +1667,7 @@ public:
       ns1__getParameterByRestrictionResponse *
           ns1__getParameterByRestrictionResponse_) {
     return this->getParameterByRestriction(
-        NULL, NULL, ns1__getParameterByRestriction_,
+        nullptr, nullptr, ns1__getParameterByRestriction_,
         ns1__getParameterByRestrictionResponse_);
   }
   virtual int getParameterByRestriction(
@@ -1662,7 +1681,8 @@ public:
   virtual int getParameterByUnits(
       ns1__getParameterByUnits *ns1__getParameterByUnits_,
       ns1__getParameterByUnitsResponse *ns1__getParameterByUnitsResponse_) {
-    return this->getParameterByUnits(NULL, NULL, ns1__getParameterByUnits_,
+    return this->getParameterByUnits(nullptr, nullptr,
+                                     ns1__getParameterByUnits_,
                                      ns1__getParameterByUnitsResponse_);
   }
   virtual int getParameterByUnits(
@@ -1678,7 +1698,7 @@ public:
       ns1__searchDatasetByParameterRestrictionResponse *
           ns1__searchDatasetByParameterRestrictionResponse_) {
     return this->searchDatasetByParameterRestriction(
-        NULL, NULL, ns1__searchDatasetByParameterRestriction_,
+        nullptr, nullptr, ns1__searchDatasetByParameterRestriction_,
         ns1__searchDatasetByParameterRestrictionResponse_);
   }
   virtual int searchDatasetByParameterRestriction(
@@ -1696,7 +1716,7 @@ public:
       ns1__searchSampleByParameterRestrictionResponse *
           ns1__searchSampleByParameterRestrictionResponse_) {
     return this->searchSampleByParameterRestriction(
-        NULL, NULL, ns1__searchSampleByParameterRestriction_,
+        nullptr, nullptr, ns1__searchSampleByParameterRestriction_,
         ns1__searchSampleByParameterRestrictionResponse_);
   }
   virtual int searchSampleByParameterRestriction(
@@ -1714,7 +1734,7 @@ public:
       ns1__searchDatafileByParameterRestrictionResponse *
           ns1__searchDatafileByParameterRestrictionResponse_) {
     return this->searchDatafileByParameterRestriction(
-        NULL, NULL, ns1__searchDatafileByParameterRestriction_,
+        nullptr, nullptr, ns1__searchDatafileByParameterRestriction_,
         ns1__searchDatafileByParameterRestrictionResponse_);
   }
   virtual int searchDatafileByParameterRestriction(
@@ -1732,7 +1752,7 @@ public:
       ns1__searchInvestigationByParameterRestrictionResponse *
           ns1__searchInvestigationByParameterRestrictionResponse_) {
     return this->searchInvestigationByParameterRestriction(
-        NULL, NULL, ns1__searchInvestigationByParameterRestriction_,
+        nullptr, nullptr, ns1__searchInvestigationByParameterRestriction_,
         ns1__searchInvestigationByParameterRestrictionResponse_);
   }
   virtual int searchInvestigationByParameterRestriction(
@@ -1750,7 +1770,7 @@ public:
       ns1__searchInvestigationByRestrictionResponse *
           ns1__searchInvestigationByRestrictionResponse_) {
     return this->searchInvestigationByRestriction(
-        NULL, NULL, ns1__searchInvestigationByRestriction_,
+        nullptr, nullptr, ns1__searchInvestigationByRestriction_,
         ns1__searchInvestigationByRestrictionResponse_);
   }
   virtual int searchInvestigationByRestriction(
@@ -1767,7 +1787,7 @@ public:
       ns1__searchDatasetByRestrictionResponse *
           ns1__searchDatasetByRestrictionResponse_) {
     return this->searchDatasetByRestriction(
-        NULL, NULL, ns1__searchDatasetByRestriction_,
+        nullptr, nullptr, ns1__searchDatasetByRestriction_,
         ns1__searchDatasetByRestrictionResponse_);
   }
   virtual int searchDatasetByRestriction(
@@ -1783,7 +1803,7 @@ public:
       ns1__searchDatafileByRestrictionResponse *
           ns1__searchDatafileByRestrictionResponse_) {
     return this->searchDatafileByRestriction(
-        NULL, NULL, ns1__searchDatafileByRestriction_,
+        nullptr, nullptr, ns1__searchDatafileByRestriction_,
         ns1__searchDatafileByRestrictionResponse_);
   }
   virtual int searchDatafileByRestriction(
@@ -1799,7 +1819,7 @@ public:
       ns1__searchSampleByRestrictionResponse *
           ns1__searchSampleByRestrictionResponse_) {
     return this->searchSampleByRestriction(
-        NULL, NULL, ns1__searchSampleByRestriction_,
+        nullptr, nullptr, ns1__searchSampleByRestriction_,
         ns1__searchSampleByRestrictionResponse_);
   }
   virtual int searchSampleByRestriction(
@@ -1816,7 +1836,7 @@ public:
       ns1__searchInvestigationByRestrictionComparasionResponse *
           ns1__searchInvestigationByRestrictionComparasionResponse_) {
     return this->searchInvestigationByRestrictionComparasion(
-        NULL, NULL, ns1__searchInvestigationByRestrictionComparasion_,
+        nullptr, nullptr, ns1__searchInvestigationByRestrictionComparasion_,
         ns1__searchInvestigationByRestrictionComparasionResponse_);
   }
   virtual int searchInvestigationByRestrictionComparasion(
@@ -1834,7 +1854,7 @@ public:
       ns1__searchDatasetByRestrictionComparisonResponse *
           ns1__searchDatasetByRestrictionComparisonResponse_) {
     return this->searchDatasetByRestrictionComparison(
-        NULL, NULL, ns1__searchDatasetByRestrictionComparison_,
+        nullptr, nullptr, ns1__searchDatasetByRestrictionComparison_,
         ns1__searchDatasetByRestrictionComparisonResponse_);
   }
   virtual int searchDatasetByRestrictionComparison(
@@ -1852,7 +1872,7 @@ public:
       ns1__searchDatafileByRestrictionComparisonResponse *
           ns1__searchDatafileByRestrictionComparisonResponse_) {
     return this->searchDatafileByRestrictionComparison(
-        NULL, NULL, ns1__searchDatafileByRestrictionComparison_,
+        nullptr, nullptr, ns1__searchDatafileByRestrictionComparison_,
         ns1__searchDatafileByRestrictionComparisonResponse_);
   }
   virtual int searchDatafileByRestrictionComparison(
@@ -1870,7 +1890,7 @@ public:
       ns1__searchSampleByRestrictionComparisonResponse *
           ns1__searchSampleByRestrictionComparisonResponse_) {
     return this->searchSampleByRestrictionComparison(
-        NULL, NULL, ns1__searchSampleByRestrictionComparison_,
+        nullptr, nullptr, ns1__searchSampleByRestrictionComparison_,
         ns1__searchSampleByRestrictionComparisonResponse_);
   }
   virtual int searchSampleByRestrictionComparison(
@@ -1888,7 +1908,7 @@ public:
       ns1__searchSampleByRestrictionLogicalResponse *
           ns1__searchSampleByRestrictionLogicalResponse_) {
     return this->searchSampleByRestrictionLogical(
-        NULL, NULL, ns1__searchSampleByRestrictionLogical_,
+        nullptr, nullptr, ns1__searchSampleByRestrictionLogical_,
         ns1__searchSampleByRestrictionLogicalResponse_);
   }
   virtual int searchSampleByRestrictionLogical(
@@ -1906,7 +1926,7 @@ public:
       ns1__searchDatasetByRestrictionLogicalResponse *
           ns1__searchDatasetByRestrictionLogicalResponse_) {
     return this->searchDatasetByRestrictionLogical(
-        NULL, NULL, ns1__searchDatasetByRestrictionLogical_,
+        nullptr, nullptr, ns1__searchDatasetByRestrictionLogical_,
         ns1__searchDatasetByRestrictionLogicalResponse_);
   }
   virtual int searchDatasetByRestrictionLogical(
@@ -1924,7 +1944,7 @@ public:
       ns1__searchInvestigationByRestrictionLogicalResponse *
           ns1__searchInvestigationByRestrictionLogicalResponse_) {
     return this->searchInvestigationByRestrictionLogical(
-        NULL, NULL, ns1__searchInvestigationByRestrictionLogical_,
+        nullptr, nullptr, ns1__searchInvestigationByRestrictionLogical_,
         ns1__searchInvestigationByRestrictionLogicalResponse_);
   }
   virtual int searchInvestigationByRestrictionLogical(
@@ -1942,7 +1962,7 @@ public:
       ns1__searchDatafileByRestrictionLogicalResponse *
           ns1__searchDatafileByRestrictionLogicalResponse_) {
     return this->searchDatafileByRestrictionLogical(
-        NULL, NULL, ns1__searchDatafileByRestrictionLogical_,
+        nullptr, nullptr, ns1__searchDatafileByRestrictionLogical_,
         ns1__searchDatafileByRestrictionLogicalResponse_);
   }
   virtual int searchDatafileByRestrictionLogical(
@@ -1960,7 +1980,7 @@ public:
       ns1__searchInvestigationByParameterLogicalResponse *
           ns1__searchInvestigationByParameterLogicalResponse_) {
     return this->searchInvestigationByParameterLogical(
-        NULL, NULL, ns1__searchInvestigationByParameterLogical_,
+        nullptr, nullptr, ns1__searchInvestigationByParameterLogical_,
         ns1__searchInvestigationByParameterLogicalResponse_);
   }
   virtual int searchInvestigationByParameterLogical(
@@ -1978,7 +1998,7 @@ public:
       ns1__searchDatafileByParameterLogicalResponse *
           ns1__searchDatafileByParameterLogicalResponse_) {
     return this->searchDatafileByParameterLogical(
-        NULL, NULL, ns1__searchDatafileByParameterLogical_,
+        nullptr, nullptr, ns1__searchDatafileByParameterLogical_,
         ns1__searchDatafileByParameterLogicalResponse_);
   }
   virtual int searchDatafileByParameterLogical(
@@ -1996,7 +2016,7 @@ public:
       ns1__searchDatasetByParameterLogicalResponse *
           ns1__searchDatasetByParameterLogicalResponse_) {
     return this->searchDatasetByParameterLogical(
-        NULL, NULL, ns1__searchDatasetByParameterLogical_,
+        nullptr, nullptr, ns1__searchDatasetByParameterLogical_,
         ns1__searchDatasetByParameterLogicalResponse_);
   }
   virtual int searchDatasetByParameterLogical(
@@ -2013,7 +2033,7 @@ public:
       ns1__searchSampleByParameterLogicalResponse *
           ns1__searchSampleByParameterLogicalResponse_) {
     return this->searchSampleByParameterLogical(
-        NULL, NULL, ns1__searchSampleByParameterLogical_,
+        nullptr, nullptr, ns1__searchSampleByParameterLogical_,
         ns1__searchSampleByParameterLogicalResponse_);
   }
   virtual int searchSampleByParameterLogical(
@@ -2030,7 +2050,7 @@ public:
       ns1__searchFacilityUserByRestrictionResponse *
           ns1__searchFacilityUserByRestrictionResponse_) {
     return this->searchFacilityUserByRestriction(
-        NULL, NULL, ns1__searchFacilityUserByRestriction_,
+        nullptr, nullptr, ns1__searchFacilityUserByRestriction_,
         ns1__searchFacilityUserByRestrictionResponse_);
   }
   virtual int searchFacilityUserByRestriction(

--- a/Framework/ICat/inc/MantidICat/ICat3/GSoapGenerated/ICat3Stub.h
+++ b/Framework/ICat/inc/MantidICat/ICat3/GSoapGenerated/ICat3Stub.h
@@ -291,7 +291,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  xsd__anyType() { xsd__anyType::soap_default(NULL); }
+  xsd__anyType() { xsd__anyType::soap_default(nullptr); }
   virtual ~xsd__anyType() = default;
 };
 #endif
@@ -313,7 +313,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  xsd__boolean() { xsd__boolean::soap_default(NULL); }
+  xsd__boolean() { xsd__boolean::soap_default(nullptr); }
   virtual ~xsd__boolean() = default;
 };
 #endif
@@ -335,7 +335,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  xsd__dateTime() { xsd__dateTime::soap_default(NULL); }
+  xsd__dateTime() { xsd__dateTime::soap_default(nullptr); }
   virtual ~xsd__dateTime() = default;
 };
 #endif
@@ -357,7 +357,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  xsd__double() { xsd__double::soap_default(NULL); }
+  xsd__double() { xsd__double::soap_default(nullptr); }
   virtual ~xsd__double() = default;
 };
 #endif
@@ -379,7 +379,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  xsd__float() { xsd__float::soap_default(NULL); }
+  xsd__float() { xsd__float::soap_default(nullptr); }
   virtual ~xsd__float() = default;
 };
 #endif
@@ -401,7 +401,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  xsd__int() { xsd__int::soap_default(NULL); }
+  xsd__int() { xsd__int::soap_default(nullptr); }
   virtual ~xsd__int() = default;
 };
 #endif
@@ -423,7 +423,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  xsd__long() { xsd__long::soap_default(NULL); }
+  xsd__long() { xsd__long::soap_default(nullptr); }
   virtual ~xsd__long() = default;
 };
 #endif
@@ -449,7 +449,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  xsd__string() { xsd__string::soap_default(NULL); }
+  xsd__string() { xsd__string::soap_default(nullptr); }
   virtual ~xsd__string() = default;
 };
 #endif
@@ -471,7 +471,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__logicalOperator_() { ns1__logicalOperator_::soap_default(NULL); }
+  ns1__logicalOperator_() { ns1__logicalOperator_::soap_default(nullptr); }
   virtual ~ns1__logicalOperator_() = default;
 };
 #endif
@@ -493,7 +493,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__datafileInclude_() { ns1__datafileInclude_::soap_default(NULL); }
+  ns1__datafileInclude_() { ns1__datafileInclude_::soap_default(nullptr); }
   virtual ~ns1__datafileInclude_() = default;
 };
 #endif
@@ -515,7 +515,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__datasetInclude_() { ns1__datasetInclude_::soap_default(NULL); }
+  ns1__datasetInclude_() { ns1__datasetInclude_::soap_default(nullptr); }
   virtual ~ns1__datasetInclude_() = default;
 };
 #endif
@@ -538,7 +538,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__investigationInclude_() {
-    ns1__investigationInclude_::soap_default(NULL);
+    ns1__investigationInclude_::soap_default(nullptr);
   }
   virtual ~ns1__investigationInclude_() = default;
 };
@@ -562,7 +562,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__restrictionAttributes_() {
-    ns1__restrictionAttributes_::soap_default(NULL);
+    ns1__restrictionAttributes_::soap_default(nullptr);
   }
   virtual ~ns1__restrictionAttributes_() = default;
 };
@@ -585,7 +585,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__sampleInclude_() { ns1__sampleInclude_::soap_default(NULL); }
+  ns1__sampleInclude_() { ns1__sampleInclude_::soap_default(nullptr); }
   virtual ~ns1__sampleInclude_() = default;
 };
 #endif
@@ -607,7 +607,9 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__parameterValueType_() { ns1__parameterValueType_::soap_default(NULL); }
+  ns1__parameterValueType_() {
+    ns1__parameterValueType_::soap_default(nullptr);
+  }
   virtual ~ns1__parameterValueType_() = default;
 };
 #endif
@@ -629,7 +631,9 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__comparisonOperator_() { ns1__comparisonOperator_::soap_default(NULL); }
+  ns1__comparisonOperator_() {
+    ns1__comparisonOperator_::soap_default(nullptr);
+  }
   virtual ~ns1__comparisonOperator_() = default;
 };
 #endif
@@ -651,7 +655,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__keywordType_() { ns1__keywordType_::soap_default(NULL); }
+  ns1__keywordType_() { ns1__keywordType_::soap_default(nullptr); }
   virtual ~ns1__keywordType_() = default;
 };
 #endif
@@ -673,7 +677,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__parameterType_() { ns1__parameterType_::soap_default(NULL); }
+  ns1__parameterType_() { ns1__parameterType_::soap_default(nullptr); }
   virtual ~ns1__parameterType_() = default;
 };
 #endif
@@ -695,7 +699,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__elementType_() { ns1__elementType_::soap_default(NULL); }
+  ns1__elementType_() { ns1__elementType_::soap_default(nullptr); }
   virtual ~ns1__elementType_() = default;
 };
 #endif
@@ -720,7 +724,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatasetByRestrictionLogical() {
-    ns1__searchDatasetByRestrictionLogical::soap_default(NULL);
+    ns1__searchDatasetByRestrictionLogical::soap_default(nullptr);
   }
   virtual ~ns1__searchDatasetByRestrictionLogical() = default;
 };
@@ -743,7 +747,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__condition() { ns1__condition::soap_default(NULL); }
+  ns1__condition() { ns1__condition::soap_default(nullptr); }
   virtual ~ns1__condition() = default;
 };
 #endif
@@ -772,7 +776,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatasetByRestrictionLogicalResponse() {
-    ns1__searchDatasetByRestrictionLogicalResponse::soap_default(NULL);
+    ns1__searchDatasetByRestrictionLogicalResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchDatasetByRestrictionLogicalResponse() = default;
 };
@@ -799,7 +803,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatasetByParameterRestriction() {
-    ns1__searchDatasetByParameterRestriction::soap_default(NULL);
+    ns1__searchDatasetByParameterRestriction::soap_default(nullptr);
   }
   virtual ~ns1__searchDatasetByParameterRestriction() = default;
 };
@@ -829,7 +833,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatasetByParameterRestrictionResponse() {
-    ns1__searchDatasetByParameterRestrictionResponse::soap_default(NULL);
+    ns1__searchDatasetByParameterRestrictionResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchDatasetByParameterRestrictionResponse() = default;
 };
@@ -851,7 +855,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__listDatasetTypes() { ns1__listDatasetTypes::soap_default(NULL); }
+  ns1__listDatasetTypes() { ns1__listDatasetTypes::soap_default(nullptr); }
   virtual ~ns1__listDatasetTypes() = default;
 };
 #endif
@@ -878,7 +882,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__listDatasetTypesResponse() {
-    ns1__listDatasetTypesResponse::soap_default(NULL);
+    ns1__listDatasetTypesResponse::soap_default(nullptr);
   }
   virtual ~ns1__listDatasetTypesResponse() = default;
 };
@@ -903,7 +907,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchFacilityUserByRestriction() {
-    ns1__searchFacilityUserByRestriction::soap_default(NULL);
+    ns1__searchFacilityUserByRestriction::soap_default(nullptr);
   }
   virtual ~ns1__searchFacilityUserByRestriction() = default;
 };
@@ -933,7 +937,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchFacilityUserByRestrictionResponse() {
-    ns1__searchFacilityUserByRestrictionResponse::soap_default(NULL);
+    ns1__searchFacilityUserByRestrictionResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchFacilityUserByRestrictionResponse() = default;
 };
@@ -958,7 +962,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__entityBaseBean() { ns1__entityBaseBean::soap_default(NULL); }
+  ns1__entityBaseBean() { ns1__entityBaseBean::soap_default(nullptr); }
   virtual ~ns1__entityBaseBean() = default;
 };
 #endif
@@ -981,7 +985,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchSamplesBySampleName() {
-    ns1__searchSamplesBySampleName::soap_default(NULL);
+    ns1__searchSamplesBySampleName::soap_default(nullptr);
   }
   virtual ~ns1__searchSamplesBySampleName() = default;
 };
@@ -1009,7 +1013,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchSamplesBySampleNameResponse() {
-    ns1__searchSamplesBySampleNameResponse::soap_default(NULL);
+    ns1__searchSamplesBySampleNameResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchSamplesBySampleNameResponse() = default;
 };
@@ -1030,7 +1034,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__entityPrimaryKeyBaseBean() {
-    ns1__entityPrimaryKeyBaseBean::soap_default(NULL);
+    ns1__entityPrimaryKeyBaseBean::soap_default(nullptr);
   }
   virtual ~ns1__entityPrimaryKeyBaseBean() = default;
 };
@@ -1056,7 +1060,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchSampleByRestrictionComparison() {
-    ns1__searchSampleByRestrictionComparison::soap_default(NULL);
+    ns1__searchSampleByRestrictionComparison::soap_default(nullptr);
   }
   virtual ~ns1__searchSampleByRestrictionComparison() = default;
 };
@@ -1086,7 +1090,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchSampleByRestrictionComparisonResponse() {
-    ns1__searchSampleByRestrictionComparisonResponse::soap_default(NULL);
+    ns1__searchSampleByRestrictionComparisonResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchSampleByRestrictionComparisonResponse() = default;
 };
@@ -1111,7 +1115,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatafileByRestriction() {
-    ns1__searchDatafileByRestriction::soap_default(NULL);
+    ns1__searchDatafileByRestriction::soap_default(nullptr);
   }
   virtual ~ns1__searchDatafileByRestriction() = default;
 };
@@ -1139,7 +1143,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatafileByRestrictionResponse() {
-    ns1__searchDatafileByRestrictionResponse::soap_default(NULL);
+    ns1__searchDatafileByRestrictionResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchDatafileByRestrictionResponse() = default;
 };
@@ -1161,7 +1165,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__listInstruments() { ns1__listInstruments::soap_default(NULL); }
+  ns1__listInstruments() { ns1__listInstruments::soap_default(nullptr); }
   virtual ~ns1__listInstruments() = default;
 };
 #endif
@@ -1188,7 +1192,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__listInstrumentsResponse() {
-    ns1__listInstrumentsResponse::soap_default(NULL);
+    ns1__listInstrumentsResponse::soap_default(nullptr);
   }
   virtual ~ns1__listInstrumentsResponse() = default;
 };
@@ -1211,7 +1215,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__removeSample() { ns1__removeSample::soap_default(NULL); }
+  ns1__removeSample() { ns1__removeSample::soap_default(nullptr); }
   virtual ~ns1__removeSample() = default;
 };
 #endif
@@ -1230,7 +1234,9 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__removeSampleResponse() { ns1__removeSampleResponse::soap_default(NULL); }
+  ns1__removeSampleResponse() {
+    ns1__removeSampleResponse::soap_default(nullptr);
+  }
   virtual ~ns1__removeSampleResponse() = default;
 };
 #endif
@@ -1254,7 +1260,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__InsufficientPrivilegesException() {
-    ns1__InsufficientPrivilegesException::soap_default(NULL);
+    ns1__InsufficientPrivilegesException::soap_default(nullptr);
   }
   virtual ~ns1__InsufficientPrivilegesException() = default;
 };
@@ -1278,7 +1284,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__createDataFile() { ns1__createDataFile::soap_default(NULL); }
+  ns1__createDataFile() { ns1__createDataFile::soap_default(nullptr); }
   virtual ~ns1__createDataFile() = default;
 };
 #endif
@@ -1305,7 +1311,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__createDataFileResponse() {
-    ns1__createDataFileResponse::soap_default(NULL);
+    ns1__createDataFileResponse::soap_default(nullptr);
   }
   virtual ~ns1__createDataFileResponse() = default;
 };
@@ -1328,7 +1334,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__modifySample() { ns1__modifySample::soap_default(NULL); }
+  ns1__modifySample() { ns1__modifySample::soap_default(nullptr); }
   virtual ~ns1__modifySample() = default;
 };
 #endif
@@ -1347,7 +1353,9 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__modifySampleResponse() { ns1__modifySampleResponse::soap_default(NULL); }
+  ns1__modifySampleResponse() {
+    ns1__modifySampleResponse::soap_default(nullptr);
+  }
   virtual ~ns1__modifySampleResponse() = default;
 };
 #endif
@@ -1373,7 +1381,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchInvestigationByParameterLogical() {
-    ns1__searchInvestigationByParameterLogical::soap_default(NULL);
+    ns1__searchInvestigationByParameterLogical::soap_default(nullptr);
   }
   virtual ~ns1__searchInvestigationByParameterLogical() = default;
 };
@@ -1403,7 +1411,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchInvestigationByParameterLogicalResponse() {
-    ns1__searchInvestigationByParameterLogicalResponse::soap_default(NULL);
+    ns1__searchInvestigationByParameterLogicalResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchInvestigationByParameterLogicalResponse() = default;
 };
@@ -1428,7 +1436,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getParameterByNameUnits() {
-    ns1__getParameterByNameUnits::soap_default(NULL);
+    ns1__getParameterByNameUnits::soap_default(nullptr);
   }
   virtual ~ns1__getParameterByNameUnits() = default;
 };
@@ -1456,7 +1464,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getParameterByNameUnitsResponse() {
-    ns1__getParameterByNameUnitsResponse::soap_default(NULL);
+    ns1__getParameterByNameUnitsResponse::soap_default(nullptr);
   }
   virtual ~ns1__getParameterByNameUnitsResponse() = default;
 };
@@ -1479,7 +1487,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__removeDataFile() { ns1__removeDataFile::soap_default(NULL); }
+  ns1__removeDataFile() { ns1__removeDataFile::soap_default(nullptr); }
   virtual ~ns1__removeDataFile() = default;
 };
 #endif
@@ -1499,7 +1507,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__removeDataFileResponse() {
-    ns1__removeDataFileResponse::soap_default(NULL);
+    ns1__removeDataFileResponse::soap_default(nullptr);
   }
   virtual ~ns1__removeDataFileResponse() = default;
 };
@@ -1522,7 +1530,9 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__removeAuthorisation() { ns1__removeAuthorisation::soap_default(NULL); }
+  ns1__removeAuthorisation() {
+    ns1__removeAuthorisation::soap_default(nullptr);
+  }
   virtual ~ns1__removeAuthorisation() = default;
 };
 #endif
@@ -1542,7 +1552,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__removeAuthorisationResponse() {
-    ns1__removeAuthorisationResponse::soap_default(NULL);
+    ns1__removeAuthorisationResponse::soap_default(nullptr);
   }
   virtual ~ns1__removeAuthorisationResponse() = default;
 };
@@ -1564,7 +1574,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__listFacilityCycles() { ns1__listFacilityCycles::soap_default(NULL); }
+  ns1__listFacilityCycles() { ns1__listFacilityCycles::soap_default(nullptr); }
   virtual ~ns1__listFacilityCycles() = default;
 };
 #endif
@@ -1591,7 +1601,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__listFacilityCyclesResponse() {
-    ns1__listFacilityCyclesResponse::soap_default(NULL);
+    ns1__listFacilityCyclesResponse::soap_default(nullptr);
   }
   virtual ~ns1__listFacilityCyclesResponse() = default;
 };
@@ -1617,7 +1627,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__addDataFileParameters() {
-    ns1__addDataFileParameters::soap_default(NULL);
+    ns1__addDataFileParameters::soap_default(nullptr);
   }
   virtual ~ns1__addDataFileParameters() = default;
 };
@@ -1645,7 +1655,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__addDataFileParametersResponse() {
-    ns1__addDataFileParametersResponse::soap_default(NULL);
+    ns1__addDataFileParametersResponse::soap_default(nullptr);
   }
   virtual ~ns1__addDataFileParametersResponse() = default;
 };
@@ -1667,7 +1677,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__logout() { ns1__logout::soap_default(NULL); }
+  ns1__logout() { ns1__logout::soap_default(nullptr); }
   virtual ~ns1__logout() = default;
 };
 #endif
@@ -1693,7 +1703,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__logoutResponse() { ns1__logoutResponse::soap_default(NULL); }
+  ns1__logoutResponse() { ns1__logoutResponse::soap_default(nullptr); }
   virtual ~ns1__logoutResponse() = default;
 };
 #endif
@@ -1715,7 +1725,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getInstrumentsWithData() {
-    ns1__getInstrumentsWithData::soap_default(NULL);
+    ns1__getInstrumentsWithData::soap_default(nullptr);
   }
   virtual ~ns1__getInstrumentsWithData() = default;
 };
@@ -1743,7 +1753,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getInstrumentsWithDataResponse() {
-    ns1__getInstrumentsWithDataResponse::soap_default(NULL);
+    ns1__getInstrumentsWithDataResponse::soap_default(nullptr);
   }
   virtual ~ns1__getInstrumentsWithDataResponse() = default;
 };
@@ -1766,7 +1776,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__downloadDataset() { ns1__downloadDataset::soap_default(NULL); }
+  ns1__downloadDataset() { ns1__downloadDataset::soap_default(nullptr); }
   virtual ~ns1__downloadDataset() = default;
 };
 #endif
@@ -1793,7 +1803,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__downloadDatasetResponse() {
-    ns1__downloadDatasetResponse::soap_default(NULL);
+    ns1__downloadDatasetResponse::soap_default(nullptr);
   }
   virtual ~ns1__downloadDatasetResponse() = default;
 };
@@ -1817,7 +1827,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getFacilityUserByFederalId() {
-    ns1__getFacilityUserByFederalId::soap_default(NULL);
+    ns1__getFacilityUserByFederalId::soap_default(nullptr);
   }
   virtual ~ns1__getFacilityUserByFederalId() = default;
 };
@@ -1845,7 +1855,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getFacilityUserByFederalIdResponse() {
-    ns1__getFacilityUserByFederalIdResponse::soap_default(NULL);
+    ns1__getFacilityUserByFederalIdResponse::soap_default(nullptr);
   }
   virtual ~ns1__getFacilityUserByFederalIdResponse() = default;
 };
@@ -1868,7 +1878,9 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__removeInvestigation() { ns1__removeInvestigation::soap_default(NULL); }
+  ns1__removeInvestigation() {
+    ns1__removeInvestigation::soap_default(nullptr);
+  }
   virtual ~ns1__removeInvestigation() = default;
 };
 #endif
@@ -1888,7 +1900,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__removeInvestigationResponse() {
-    ns1__removeInvestigationResponse::soap_default(NULL);
+    ns1__removeInvestigationResponse::soap_default(nullptr);
   }
   virtual ~ns1__removeInvestigationResponse() = default;
 };
@@ -1912,7 +1924,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__removeInvestigator() { ns1__removeInvestigator::soap_default(NULL); }
+  ns1__removeInvestigator() { ns1__removeInvestigator::soap_default(nullptr); }
   virtual ~ns1__removeInvestigator() = default;
 };
 #endif
@@ -1932,7 +1944,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__removeInvestigatorResponse() {
-    ns1__removeInvestigatorResponse::soap_default(NULL);
+    ns1__removeInvestigatorResponse::soap_default(nullptr);
   }
   virtual ~ns1__removeInvestigatorResponse() = default;
 };
@@ -1957,7 +1969,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getParameterByRestriction() {
-    ns1__getParameterByRestriction::soap_default(NULL);
+    ns1__getParameterByRestriction::soap_default(nullptr);
   }
   virtual ~ns1__getParameterByRestriction() = default;
 };
@@ -1985,7 +1997,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getParameterByRestrictionResponse() {
-    ns1__getParameterByRestrictionResponse::soap_default(NULL);
+    ns1__getParameterByRestrictionResponse::soap_default(nullptr);
   }
   virtual ~ns1__getParameterByRestrictionResponse() = default;
 };
@@ -2008,7 +2020,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__removeKeyword() { ns1__removeKeyword::soap_default(NULL); }
+  ns1__removeKeyword() { ns1__removeKeyword::soap_default(nullptr); }
   virtual ~ns1__removeKeyword() = default;
 };
 #endif
@@ -2028,7 +2040,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__removeKeywordResponse() {
-    ns1__removeKeywordResponse::soap_default(NULL);
+    ns1__removeKeywordResponse::soap_default(nullptr);
   }
   virtual ~ns1__removeKeywordResponse() = default;
 };
@@ -2051,7 +2063,9 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__deleteInvestigation() { ns1__deleteInvestigation::soap_default(NULL); }
+  ns1__deleteInvestigation() {
+    ns1__deleteInvestigation::soap_default(nullptr);
+  }
   virtual ~ns1__deleteInvestigation() = default;
 };
 #endif
@@ -2071,7 +2085,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__deleteInvestigationResponse() {
-    ns1__deleteInvestigationResponse::soap_default(NULL);
+    ns1__deleteInvestigationResponse::soap_default(nullptr);
   }
   virtual ~ns1__deleteInvestigationResponse() = default;
 };
@@ -2096,7 +2110,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__createDataSets() { ns1__createDataSets::soap_default(NULL); }
+  ns1__createDataSets() { ns1__createDataSets::soap_default(nullptr); }
   virtual ~ns1__createDataSets() = default;
 };
 #endif
@@ -2123,7 +2137,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__createDataSetsResponse() {
-    ns1__createDataSetsResponse::soap_default(NULL);
+    ns1__createDataSetsResponse::soap_default(nullptr);
   }
   virtual ~ns1__createDataSetsResponse() = default;
 };
@@ -2146,7 +2160,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__removePublication() { ns1__removePublication::soap_default(NULL); }
+  ns1__removePublication() { ns1__removePublication::soap_default(nullptr); }
   virtual ~ns1__removePublication() = default;
 };
 #endif
@@ -2166,7 +2180,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__removePublicationResponse() {
-    ns1__removePublicationResponse::soap_default(NULL);
+    ns1__removePublicationResponse::soap_default(nullptr);
   }
   virtual ~ns1__removePublicationResponse() = default;
 };
@@ -2189,7 +2203,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__getAllKeywords() { ns1__getAllKeywords::soap_default(NULL); }
+  ns1__getAllKeywords() { ns1__getAllKeywords::soap_default(nullptr); }
   virtual ~ns1__getAllKeywords() = default;
 };
 #endif
@@ -2216,7 +2230,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getAllKeywordsResponse() {
-    ns1__getAllKeywordsResponse::soap_default(NULL);
+    ns1__getAllKeywordsResponse::soap_default(nullptr);
   }
   virtual ~ns1__getAllKeywordsResponse() = default;
 };
@@ -2243,7 +2257,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatafileByRestrictionComparison() {
-    ns1__searchDatafileByRestrictionComparison::soap_default(NULL);
+    ns1__searchDatafileByRestrictionComparison::soap_default(nullptr);
   }
   virtual ~ns1__searchDatafileByRestrictionComparison() = default;
 };
@@ -2273,7 +2287,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatafileByRestrictionComparisonResponse() {
-    ns1__searchDatafileByRestrictionComparisonResponse::soap_default(NULL);
+    ns1__searchDatafileByRestrictionComparisonResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchDatafileByRestrictionComparisonResponse() = default;
 };
@@ -2303,7 +2317,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__userDetails() { ns1__userDetails::soap_default(NULL); }
+  ns1__userDetails() { ns1__userDetails::soap_default(nullptr); }
   virtual ~ns1__userDetails() = default;
 };
 #endif
@@ -2327,7 +2341,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatafileByParameter() {
-    ns1__searchDatafileByParameter::soap_default(NULL);
+    ns1__searchDatafileByParameter::soap_default(nullptr);
   }
   virtual ~ns1__searchDatafileByParameter() = default;
 };
@@ -2355,7 +2369,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatafileByParameterResponse() {
-    ns1__searchDatafileByParameterResponse::soap_default(NULL);
+    ns1__searchDatafileByParameterResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchDatafileByParameterResponse() = default;
 };
@@ -2382,7 +2396,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchInvestigationByParameterCondition() {
-    ns1__searchInvestigationByParameterCondition::soap_default(NULL);
+    ns1__searchInvestigationByParameterCondition::soap_default(nullptr);
   }
   virtual ~ns1__searchInvestigationByParameterCondition() = default;
 };
@@ -2413,7 +2427,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchInvestigationByParameterConditionResponse() {
-    ns1__searchInvestigationByParameterConditionResponse::soap_default(NULL);
+    ns1__searchInvestigationByParameterConditionResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchInvestigationByParameterConditionResponse() = default;
 };
@@ -2436,7 +2450,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__downloadDatafiles() { ns1__downloadDatafiles::soap_default(NULL); }
+  ns1__downloadDatafiles() { ns1__downloadDatafiles::soap_default(nullptr); }
   virtual ~ns1__downloadDatafiles() = default;
 };
 #endif
@@ -2463,7 +2477,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__downloadDatafilesResponse() {
-    ns1__downloadDatafilesResponse::soap_default(NULL);
+    ns1__downloadDatafilesResponse::soap_default(nullptr);
   }
   virtual ~ns1__downloadDatafilesResponse() = default;
 };
@@ -2488,7 +2502,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchSampleByRestriction() {
-    ns1__searchSampleByRestriction::soap_default(NULL);
+    ns1__searchSampleByRestriction::soap_default(nullptr);
   }
   virtual ~ns1__searchSampleByRestriction() = default;
 };
@@ -2516,7 +2530,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchSampleByRestrictionResponse() {
-    ns1__searchSampleByRestrictionResponse::soap_default(NULL);
+    ns1__searchSampleByRestrictionResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchSampleByRestrictionResponse() = default;
 };
@@ -2542,7 +2556,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatasetByParameterComparison() {
-    ns1__searchDatasetByParameterComparison::soap_default(NULL);
+    ns1__searchDatasetByParameterComparison::soap_default(nullptr);
   }
   virtual ~ns1__searchDatasetByParameterComparison() = default;
 };
@@ -2572,7 +2586,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatasetByParameterComparisonResponse() {
-    ns1__searchDatasetByParameterComparisonResponse::soap_default(NULL);
+    ns1__searchDatasetByParameterComparisonResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchDatasetByParameterComparisonResponse() = default;
 };
@@ -2595,7 +2609,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__modifyDataSet() { ns1__modifyDataSet::soap_default(NULL); }
+  ns1__modifyDataSet() { ns1__modifyDataSet::soap_default(nullptr); }
   virtual ~ns1__modifyDataSet() = default;
 };
 #endif
@@ -2615,7 +2629,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__modifyDataSetResponse() {
-    ns1__modifyDataSetResponse::soap_default(NULL);
+    ns1__modifyDataSetResponse::soap_default(nullptr);
   }
   virtual ~ns1__modifyDataSetResponse() = default;
 };
@@ -2640,7 +2654,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__addSampleParameter() { ns1__addSampleParameter::soap_default(NULL); }
+  ns1__addSampleParameter() { ns1__addSampleParameter::soap_default(nullptr); }
   virtual ~ns1__addSampleParameter() = default;
 };
 #endif
@@ -2667,7 +2681,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__addSampleParameterResponse() {
-    ns1__addSampleParameterResponse::soap_default(NULL);
+    ns1__addSampleParameterResponse::soap_default(nullptr);
   }
   virtual ~ns1__addSampleParameterResponse() = default;
 };
@@ -2693,7 +2707,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getFacilityCyclesWithDataForInstrument() {
-    ns1__getFacilityCyclesWithDataForInstrument::soap_default(NULL);
+    ns1__getFacilityCyclesWithDataForInstrument::soap_default(nullptr);
   }
   virtual ~ns1__getFacilityCyclesWithDataForInstrument() = default;
 };
@@ -2724,7 +2738,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getFacilityCyclesWithDataForInstrumentResponse() {
-    ns1__getFacilityCyclesWithDataForInstrumentResponse::soap_default(NULL);
+    ns1__getFacilityCyclesWithDataForInstrumentResponse::soap_default(nullptr);
   }
   virtual ~ns1__getFacilityCyclesWithDataForInstrumentResponse() = default;
 };
@@ -2748,7 +2762,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getFacilityUserByFacilityUserId() {
-    ns1__getFacilityUserByFacilityUserId::soap_default(NULL);
+    ns1__getFacilityUserByFacilityUserId::soap_default(nullptr);
   }
   virtual ~ns1__getFacilityUserByFacilityUserId() = default;
 };
@@ -2778,7 +2792,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getFacilityUserByFacilityUserIdResponse() {
-    ns1__getFacilityUserByFacilityUserIdResponse::soap_default(NULL);
+    ns1__getFacilityUserByFacilityUserIdResponse::soap_default(nullptr);
   }
   virtual ~ns1__getFacilityUserByFacilityUserIdResponse() = default;
 };
@@ -2802,7 +2816,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__checkDatafileDownloadAccess() {
-    ns1__checkDatafileDownloadAccess::soap_default(NULL);
+    ns1__checkDatafileDownloadAccess::soap_default(nullptr);
   }
   virtual ~ns1__checkDatafileDownloadAccess() = default;
 };
@@ -2830,7 +2844,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__checkDatafileDownloadAccessResponse() {
-    ns1__checkDatafileDownloadAccessResponse::soap_default(NULL);
+    ns1__checkDatafileDownloadAccessResponse::soap_default(nullptr);
   }
   virtual ~ns1__checkDatafileDownloadAccessResponse() = default;
 };
@@ -2857,7 +2871,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__downloadInfo() { ns1__downloadInfo::soap_default(NULL); }
+  ns1__downloadInfo() { ns1__downloadInfo::soap_default(nullptr); }
   virtual ~ns1__downloadInfo() = default;
 };
 #endif
@@ -2879,7 +2893,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__deleteDataFile() { ns1__deleteDataFile::soap_default(NULL); }
+  ns1__deleteDataFile() { ns1__deleteDataFile::soap_default(nullptr); }
   virtual ~ns1__deleteDataFile() = default;
 };
 #endif
@@ -2899,7 +2913,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__deleteDataFileResponse() {
-    ns1__deleteDataFileResponse::soap_default(NULL);
+    ns1__deleteDataFileResponse::soap_default(nullptr);
   }
   virtual ~ns1__deleteDataFileResponse() = default;
 };
@@ -2922,7 +2936,9 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__searchByUserSurname() { ns1__searchByUserSurname::soap_default(NULL); }
+  ns1__searchByUserSurname() {
+    ns1__searchByUserSurname::soap_default(nullptr);
+  }
   virtual ~ns1__searchByUserSurname() = default;
 };
 #endif
@@ -2949,7 +2965,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchByUserSurnameResponse() {
-    ns1__searchByUserSurnameResponse::soap_default(NULL);
+    ns1__searchByUserSurnameResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchByUserSurnameResponse() = default;
 };
@@ -2975,7 +2991,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchByUserSurnamePagination() {
-    ns1__searchByUserSurnamePagination::soap_default(NULL);
+    ns1__searchByUserSurnamePagination::soap_default(nullptr);
   }
   virtual ~ns1__searchByUserSurnamePagination() = default;
 };
@@ -3004,7 +3020,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchByUserSurnamePaginationResponse() {
-    ns1__searchByUserSurnamePaginationResponse::soap_default(NULL);
+    ns1__searchByUserSurnamePaginationResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchByUserSurnamePaginationResponse() = default;
 };
@@ -3029,7 +3045,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatafileByParameterCondition() {
-    ns1__searchDatafileByParameterCondition::soap_default(NULL);
+    ns1__searchDatafileByParameterCondition::soap_default(nullptr);
   }
   virtual ~ns1__searchDatafileByParameterCondition() = default;
 };
@@ -3059,7 +3075,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatafileByParameterConditionResponse() {
-    ns1__searchDatafileByParameterConditionResponse::soap_default(NULL);
+    ns1__searchDatafileByParameterConditionResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchDatafileByParameterConditionResponse() = default;
 };
@@ -3083,7 +3099,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__checkDatasetDownloadAccess() {
-    ns1__checkDatasetDownloadAccess::soap_default(NULL);
+    ns1__checkDatasetDownloadAccess::soap_default(nullptr);
   }
   virtual ~ns1__checkDatasetDownloadAccess() = default;
 };
@@ -3111,7 +3127,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__checkDatasetDownloadAccessResponse() {
-    ns1__checkDatasetDownloadAccessResponse::soap_default(NULL);
+    ns1__checkDatasetDownloadAccessResponse::soap_default(nullptr);
   }
   virtual ~ns1__checkDatasetDownloadAccessResponse() = default;
 };
@@ -3134,7 +3150,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__searchByKeywords() { ns1__searchByKeywords::soap_default(NULL); }
+  ns1__searchByKeywords() { ns1__searchByKeywords::soap_default(nullptr); }
   virtual ~ns1__searchByKeywords() = default;
 };
 #endif
@@ -3161,7 +3177,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchByKeywordsResponse() {
-    ns1__searchByKeywordsResponse::soap_default(NULL);
+    ns1__searchByKeywordsResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchByKeywordsResponse() = default;
 };
@@ -3187,7 +3203,9 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__searchByKeywordsAll() { ns1__searchByKeywordsAll::soap_default(NULL); }
+  ns1__searchByKeywordsAll() {
+    ns1__searchByKeywordsAll::soap_default(nullptr);
+  }
   virtual ~ns1__searchByKeywordsAll() = default;
 };
 #endif
@@ -3212,7 +3230,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__keywordDetails() { ns1__keywordDetails::soap_default(NULL); }
+  ns1__keywordDetails() { ns1__keywordDetails::soap_default(nullptr); }
   virtual ~ns1__keywordDetails() = default;
 };
 #endif
@@ -3239,7 +3257,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchByKeywordsAllResponse() {
-    ns1__searchByKeywordsAllResponse::soap_default(NULL);
+    ns1__searchByKeywordsAllResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchByKeywordsAllResponse() = default;
 };
@@ -3261,7 +3279,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__getAllInstruments() { ns1__getAllInstruments::soap_default(NULL); }
+  ns1__getAllInstruments() { ns1__getAllInstruments::soap_default(nullptr); }
   virtual ~ns1__getAllInstruments() = default;
 };
 #endif
@@ -3288,7 +3306,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getAllInstrumentsResponse() {
-    ns1__getAllInstrumentsResponse::soap_default(NULL);
+    ns1__getAllInstrumentsResponse::soap_default(nullptr);
   }
   virtual ~ns1__getAllInstrumentsResponse() = default;
 };
@@ -3314,7 +3332,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatafileByRestrictionLogical() {
-    ns1__searchDatafileByRestrictionLogical::soap_default(NULL);
+    ns1__searchDatafileByRestrictionLogical::soap_default(nullptr);
   }
   virtual ~ns1__searchDatafileByRestrictionLogical() = default;
 };
@@ -3344,7 +3362,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatafileByRestrictionLogicalResponse() {
-    ns1__searchDatafileByRestrictionLogicalResponse::soap_default(NULL);
+    ns1__searchDatafileByRestrictionLogicalResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchDatafileByRestrictionLogicalResponse() = default;
 };
@@ -3366,7 +3384,9 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__getMyInvestigations() { ns1__getMyInvestigations::soap_default(NULL); }
+  ns1__getMyInvestigations() {
+    ns1__getMyInvestigations::soap_default(nullptr);
+  }
   virtual ~ns1__getMyInvestigations() = default;
 };
 #endif
@@ -3393,7 +3413,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getMyInvestigationsResponse() {
-    ns1__getMyInvestigationsResponse::soap_default(NULL);
+    ns1__getMyInvestigationsResponse::soap_default(nullptr);
   }
   virtual ~ns1__getMyInvestigationsResponse() = default;
 };
@@ -3419,7 +3439,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getMyInvestigationsIncludes() {
-    ns1__getMyInvestigationsIncludes::soap_default(NULL);
+    ns1__getMyInvestigationsIncludes::soap_default(nullptr);
   }
   virtual ~ns1__getMyInvestigationsIncludes() = default;
 };
@@ -3447,7 +3467,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getMyInvestigationsIncludesResponse() {
-    ns1__getMyInvestigationsIncludesResponse::soap_default(NULL);
+    ns1__getMyInvestigationsIncludesResponse::soap_default(nullptr);
   }
   virtual ~ns1__getMyInvestigationsIncludesResponse() = default;
 };
@@ -3476,7 +3496,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getMyInvestigationsIncludesPagination() {
-    ns1__getMyInvestigationsIncludesPagination::soap_default(NULL);
+    ns1__getMyInvestigationsIncludesPagination::soap_default(nullptr);
   }
   virtual ~ns1__getMyInvestigationsIncludesPagination() = default;
 };
@@ -3506,7 +3526,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getMyInvestigationsIncludesPaginationResponse() {
-    ns1__getMyInvestigationsIncludesPaginationResponse::soap_default(NULL);
+    ns1__getMyInvestigationsIncludesPaginationResponse::soap_default(nullptr);
   }
   virtual ~ns1__getMyInvestigationsIncludesPaginationResponse() = default;
 };
@@ -3533,7 +3553,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchSampleByParameterRestriction() {
-    ns1__searchSampleByParameterRestriction::soap_default(NULL);
+    ns1__searchSampleByParameterRestriction::soap_default(nullptr);
   }
   virtual ~ns1__searchSampleByParameterRestriction() = default;
 };
@@ -3563,7 +3583,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchSampleByParameterRestrictionResponse() {
-    ns1__searchSampleByParameterRestrictionResponse::soap_default(NULL);
+    ns1__searchSampleByParameterRestrictionResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchSampleByParameterRestrictionResponse() = default;
 };
@@ -3588,7 +3608,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__removeDataSetParameter() {
-    ns1__removeDataSetParameter::soap_default(NULL);
+    ns1__removeDataSetParameter::soap_default(nullptr);
   }
   virtual ~ns1__removeDataSetParameter() = default;
 };
@@ -3609,7 +3629,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__removeDataSetParameterResponse() {
-    ns1__removeDataSetParameterResponse::soap_default(NULL);
+    ns1__removeDataSetParameterResponse::soap_default(nullptr);
   }
   virtual ~ns1__removeDataSetParameterResponse() = default;
 };
@@ -3634,7 +3654,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchSampleByParameterCondition() {
-    ns1__searchSampleByParameterCondition::soap_default(NULL);
+    ns1__searchSampleByParameterCondition::soap_default(nullptr);
   }
   virtual ~ns1__searchSampleByParameterCondition() = default;
 };
@@ -3664,7 +3684,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchSampleByParameterConditionResponse() {
-    ns1__searchSampleByParameterConditionResponse::soap_default(NULL);
+    ns1__searchSampleByParameterConditionResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchSampleByParameterConditionResponse() = default;
 };
@@ -3693,7 +3713,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchInvestigationByParameterRestriction() {
-    ns1__searchInvestigationByParameterRestriction::soap_default(NULL);
+    ns1__searchInvestigationByParameterRestriction::soap_default(nullptr);
   }
   virtual ~ns1__searchInvestigationByParameterRestriction() = default;
 };
@@ -3724,7 +3744,8 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchInvestigationByParameterRestrictionResponse() {
-    ns1__searchInvestigationByParameterRestrictionResponse::soap_default(NULL);
+    ns1__searchInvestigationByParameterRestrictionResponse::soap_default(
+        nullptr);
   }
   virtual ~ns1__searchInvestigationByParameterRestrictionResponse() = default;
 };
@@ -3748,7 +3769,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__modifyPublication() { ns1__modifyPublication::soap_default(NULL); }
+  ns1__modifyPublication() { ns1__modifyPublication::soap_default(nullptr); }
   virtual ~ns1__modifyPublication() = default;
 };
 #endif
@@ -3768,7 +3789,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__modifyPublicationResponse() {
-    ns1__modifyPublicationResponse::soap_default(NULL);
+    ns1__modifyPublicationResponse::soap_default(nullptr);
   }
   virtual ~ns1__modifyPublicationResponse() = default;
 };
@@ -3791,7 +3812,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__searchByUserID() { ns1__searchByUserID::soap_default(NULL); }
+  ns1__searchByUserID() { ns1__searchByUserID::soap_default(nullptr); }
   virtual ~ns1__searchByUserID() = default;
 };
 #endif
@@ -3818,7 +3839,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchByUserIDResponse() {
-    ns1__searchByUserIDResponse::soap_default(NULL);
+    ns1__searchByUserIDResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchByUserIDResponse() = default;
 };
@@ -3844,7 +3865,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchByUserIDPagination() {
-    ns1__searchByUserIDPagination::soap_default(NULL);
+    ns1__searchByUserIDPagination::soap_default(nullptr);
   }
   virtual ~ns1__searchByUserIDPagination() = default;
 };
@@ -3872,7 +3893,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchByUserIDPaginationResponse() {
-    ns1__searchByUserIDPaginationResponse::soap_default(NULL);
+    ns1__searchByUserIDPaginationResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchByUserIDPaginationResponse() = default;
 };
@@ -3898,7 +3919,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatasetByParameterLogical() {
-    ns1__searchDatasetByParameterLogical::soap_default(NULL);
+    ns1__searchDatasetByParameterLogical::soap_default(nullptr);
   }
   virtual ~ns1__searchDatasetByParameterLogical() = default;
 };
@@ -3928,7 +3949,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatasetByParameterLogicalResponse() {
-    ns1__searchDatasetByParameterLogicalResponse::soap_default(NULL);
+    ns1__searchDatasetByParameterLogicalResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchDatasetByParameterLogicalResponse() = default;
 };
@@ -3954,7 +3975,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__removeDataFileParameter() {
-    ns1__removeDataFileParameter::soap_default(NULL);
+    ns1__removeDataFileParameter::soap_default(nullptr);
   }
   virtual ~ns1__removeDataFileParameter() = default;
 };
@@ -3975,7 +3996,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__removeDataFileParameterResponse() {
-    ns1__removeDataFileParameterResponse::soap_default(NULL);
+    ns1__removeDataFileParameterResponse::soap_default(nullptr);
   }
   virtual ~ns1__removeDataFileParameterResponse() = default;
 };
@@ -4000,7 +4021,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatasetByParameterCondition() {
-    ns1__searchDatasetByParameterCondition::soap_default(NULL);
+    ns1__searchDatasetByParameterCondition::soap_default(nullptr);
   }
   virtual ~ns1__searchDatasetByParameterCondition() = default;
 };
@@ -4030,7 +4051,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatasetByParameterConditionResponse() {
-    ns1__searchDatasetByParameterConditionResponse::soap_default(NULL);
+    ns1__searchDatasetByParameterConditionResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchDatasetByParameterConditionResponse() = default;
 };
@@ -4055,7 +4076,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchSampleByParameter() {
-    ns1__searchSampleByParameter::soap_default(NULL);
+    ns1__searchSampleByParameter::soap_default(nullptr);
   }
   virtual ~ns1__searchSampleByParameter() = default;
 };
@@ -4083,7 +4104,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchSampleByParameterResponse() {
-    ns1__searchSampleByParameterResponse::soap_default(NULL);
+    ns1__searchSampleByParameterResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchSampleByParameterResponse() = default;
 };
@@ -4110,7 +4131,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getInvestigationsIncludes() {
-    ns1__getInvestigationsIncludes::soap_default(NULL);
+    ns1__getInvestigationsIncludes::soap_default(nullptr);
   }
   virtual ~ns1__getInvestigationsIncludes() = default;
 };
@@ -4138,7 +4159,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getInvestigationsIncludesResponse() {
-    ns1__getInvestigationsIncludesResponse::soap_default(NULL);
+    ns1__getInvestigationsIncludesResponse::soap_default(nullptr);
   }
   virtual ~ns1__getInvestigationsIncludesResponse() = default;
 };
@@ -4161,7 +4182,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__getInvestigations() { ns1__getInvestigations::soap_default(NULL); }
+  ns1__getInvestigations() { ns1__getInvestigations::soap_default(nullptr); }
   virtual ~ns1__getInvestigations() = default;
 };
 #endif
@@ -4188,7 +4209,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getInvestigationsResponse() {
-    ns1__getInvestigationsResponse::soap_default(NULL);
+    ns1__getInvestigationsResponse::soap_default(nullptr);
   }
   virtual ~ns1__getInvestigationsResponse() = default;
 };
@@ -4211,7 +4232,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__deleteDataSet() { ns1__deleteDataSet::soap_default(NULL); }
+  ns1__deleteDataSet() { ns1__deleteDataSet::soap_default(nullptr); }
   virtual ~ns1__deleteDataSet() = default;
 };
 #endif
@@ -4231,7 +4252,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__deleteDataSetResponse() {
-    ns1__deleteDataSetResponse::soap_default(NULL);
+    ns1__deleteDataSetResponse::soap_default(nullptr);
   }
   virtual ~ns1__deleteDataSetResponse() = default;
 };
@@ -4259,7 +4280,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchInvestigationByParameterComparison() {
-    ns1__searchInvestigationByParameterComparison::soap_default(NULL);
+    ns1__searchInvestigationByParameterComparison::soap_default(nullptr);
   }
   virtual ~ns1__searchInvestigationByParameterComparison() = default;
 };
@@ -4290,7 +4311,8 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchInvestigationByParameterComparisonResponse() {
-    ns1__searchInvestigationByParameterComparisonResponse::soap_default(NULL);
+    ns1__searchInvestigationByParameterComparisonResponse::soap_default(
+        nullptr);
   }
   virtual ~ns1__searchInvestigationByParameterComparisonResponse() = default;
 };
@@ -4312,7 +4334,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__isSessionValid() { ns1__isSessionValid::soap_default(NULL); }
+  ns1__isSessionValid() { ns1__isSessionValid::soap_default(nullptr); }
   virtual ~ns1__isSessionValid() = default;
 };
 #endif
@@ -4339,7 +4361,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__isSessionValidResponse() {
-    ns1__isSessionValidResponse::soap_default(NULL);
+    ns1__isSessionValidResponse::soap_default(nullptr);
   }
   virtual ~ns1__isSessionValidResponse() = default;
 };
@@ -4362,7 +4384,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__getDatafiles() { ns1__getDatafiles::soap_default(NULL); }
+  ns1__getDatafiles() { ns1__getDatafiles::soap_default(nullptr); }
   virtual ~ns1__getDatafiles() = default;
 };
 #endif
@@ -4388,7 +4410,9 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__getDatafilesResponse() { ns1__getDatafilesResponse::soap_default(NULL); }
+  ns1__getDatafilesResponse() {
+    ns1__getDatafilesResponse::soap_default(nullptr);
+  }
   virtual ~ns1__getDatafilesResponse() = default;
 };
 #endif
@@ -4409,7 +4433,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__getICATAPIVersion() { ns1__getICATAPIVersion::soap_default(NULL); }
+  ns1__getICATAPIVersion() { ns1__getICATAPIVersion::soap_default(nullptr); }
   virtual ~ns1__getICATAPIVersion() = default;
 };
 #endif
@@ -4436,7 +4460,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getICATAPIVersionResponse() {
-    ns1__getICATAPIVersionResponse::soap_default(NULL);
+    ns1__getICATAPIVersionResponse::soap_default(nullptr);
   }
   virtual ~ns1__getICATAPIVersionResponse() = default;
 };
@@ -4461,7 +4485,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchInvestigationByRestriction() {
-    ns1__searchInvestigationByRestriction::soap_default(NULL);
+    ns1__searchInvestigationByRestriction::soap_default(nullptr);
   }
   virtual ~ns1__searchInvestigationByRestriction() = default;
 };
@@ -4491,7 +4515,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchInvestigationByRestrictionResponse() {
-    ns1__searchInvestigationByRestrictionResponse::soap_default(NULL);
+    ns1__searchInvestigationByRestrictionResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchInvestigationByRestrictionResponse() = default;
 };
@@ -4515,7 +4539,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__deleteInvestigator() { ns1__deleteInvestigator::soap_default(NULL); }
+  ns1__deleteInvestigator() { ns1__deleteInvestigator::soap_default(nullptr); }
   virtual ~ns1__deleteInvestigator() = default;
 };
 #endif
@@ -4535,7 +4559,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__deleteInvestigatorResponse() {
-    ns1__deleteInvestigatorResponse::soap_default(NULL);
+    ns1__deleteInvestigatorResponse::soap_default(nullptr);
   }
   virtual ~ns1__deleteInvestigatorResponse() = default;
 };
@@ -4560,7 +4584,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__addInvestigator() { ns1__addInvestigator::soap_default(NULL); }
+  ns1__addInvestigator() { ns1__addInvestigator::soap_default(nullptr); }
   virtual ~ns1__addInvestigator() = default;
 };
 #endif
@@ -4587,7 +4611,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__addInvestigatorResponse() {
-    ns1__addInvestigatorResponse::soap_default(NULL);
+    ns1__addInvestigatorResponse::soap_default(nullptr);
   }
   virtual ~ns1__addInvestigatorResponse() = default;
 };
@@ -4613,7 +4637,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatafileByParameterLogical() {
-    ns1__searchDatafileByParameterLogical::soap_default(NULL);
+    ns1__searchDatafileByParameterLogical::soap_default(nullptr);
   }
   virtual ~ns1__searchDatafileByParameterLogical() = default;
 };
@@ -4643,7 +4667,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatafileByParameterLogicalResponse() {
-    ns1__searchDatafileByParameterLogicalResponse::soap_default(NULL);
+    ns1__searchDatafileByParameterLogicalResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchDatafileByParameterLogicalResponse() = default;
 };
@@ -4667,7 +4691,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__createDataSet() { ns1__createDataSet::soap_default(NULL); }
+  ns1__createDataSet() { ns1__createDataSet::soap_default(nullptr); }
   virtual ~ns1__createDataSet() = default;
 };
 #endif
@@ -4694,7 +4718,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__createDataSetResponse() {
-    ns1__createDataSetResponse::soap_default(NULL);
+    ns1__createDataSetResponse::soap_default(nullptr);
   }
   virtual ~ns1__createDataSetResponse() = default;
 };
@@ -4722,7 +4746,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatafileByParameterRestriction() {
-    ns1__searchDatafileByParameterRestriction::soap_default(NULL);
+    ns1__searchDatafileByParameterRestriction::soap_default(nullptr);
   }
   virtual ~ns1__searchDatafileByParameterRestriction() = default;
 };
@@ -4752,7 +4776,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatafileByParameterRestrictionResponse() {
-    ns1__searchDatafileByParameterRestrictionResponse::soap_default(NULL);
+    ns1__searchDatafileByParameterRestrictionResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchDatafileByParameterRestrictionResponse() = default;
 };
@@ -4780,7 +4804,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchInvestigationByRestrictionLogical() {
-    ns1__searchInvestigationByRestrictionLogical::soap_default(NULL);
+    ns1__searchInvestigationByRestrictionLogical::soap_default(nullptr);
   }
   virtual ~ns1__searchInvestigationByRestrictionLogical() = default;
 };
@@ -4811,7 +4835,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchInvestigationByRestrictionLogicalResponse() {
-    ns1__searchInvestigationByRestrictionLogicalResponse::soap_default(NULL);
+    ns1__searchInvestigationByRestrictionLogicalResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchInvestigationByRestrictionLogicalResponse() = default;
 };
@@ -4836,7 +4860,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__removeSampleParameter() {
-    ns1__removeSampleParameter::soap_default(NULL);
+    ns1__removeSampleParameter::soap_default(nullptr);
   }
   virtual ~ns1__removeSampleParameter() = default;
 };
@@ -4857,7 +4881,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__removeSampleParameterResponse() {
-    ns1__removeSampleParameterResponse::soap_default(NULL);
+    ns1__removeSampleParameterResponse::soap_default(nullptr);
   }
   virtual ~ns1__removeSampleParameterResponse() = default;
 };
@@ -4882,7 +4906,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__deleteDataSetParameter() {
-    ns1__deleteDataSetParameter::soap_default(NULL);
+    ns1__deleteDataSetParameter::soap_default(nullptr);
   }
   virtual ~ns1__deleteDataSetParameter() = default;
 };
@@ -4903,7 +4927,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__deleteDataSetParameterResponse() {
-    ns1__deleteDataSetParameterResponse::soap_default(NULL);
+    ns1__deleteDataSetParameterResponse::soap_default(nullptr);
   }
   virtual ~ns1__deleteDataSetParameterResponse() = default;
 };
@@ -4927,7 +4951,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__setDataSetSample() { ns1__setDataSetSample::soap_default(NULL); }
+  ns1__setDataSetSample() { ns1__setDataSetSample::soap_default(nullptr); }
   virtual ~ns1__setDataSetSample() = default;
 };
 #endif
@@ -4947,7 +4971,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__setDataSetSampleResponse() {
-    ns1__setDataSetSampleResponse::soap_default(NULL);
+    ns1__setDataSetSampleResponse::soap_default(nullptr);
   }
   virtual ~ns1__setDataSetSampleResponse() = default;
 };
@@ -4970,7 +4994,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__downloadDatafile() { ns1__downloadDatafile::soap_default(NULL); }
+  ns1__downloadDatafile() { ns1__downloadDatafile::soap_default(nullptr); }
   virtual ~ns1__downloadDatafile() = default;
 };
 #endif
@@ -4997,7 +5021,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__downloadDatafileResponse() {
-    ns1__downloadDatafileResponse::soap_default(NULL);
+    ns1__downloadDatafileResponse::soap_default(nullptr);
   }
   virtual ~ns1__downloadDatafileResponse() = default;
 };
@@ -5020,7 +5044,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__getParameterByName() { ns1__getParameterByName::soap_default(NULL); }
+  ns1__getParameterByName() { ns1__getParameterByName::soap_default(nullptr); }
   virtual ~ns1__getParameterByName() = default;
 };
 #endif
@@ -5047,7 +5071,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getParameterByNameResponse() {
-    ns1__getParameterByNameResponse::soap_default(NULL);
+    ns1__getParameterByNameResponse::soap_default(nullptr);
   }
   virtual ~ns1__getParameterByNameResponse() = default;
 };
@@ -5072,7 +5096,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getKeywordsForUserType() {
-    ns1__getKeywordsForUserType::soap_default(NULL);
+    ns1__getKeywordsForUserType::soap_default(nullptr);
   }
   virtual ~ns1__getKeywordsForUserType() = default;
 };
@@ -5100,7 +5124,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getKeywordsForUserTypeResponse() {
-    ns1__getKeywordsForUserTypeResponse::soap_default(NULL);
+    ns1__getKeywordsForUserTypeResponse::soap_default(nullptr);
   }
   virtual ~ns1__getKeywordsForUserTypeResponse() = default;
 };
@@ -5124,7 +5148,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getKeywordsForUserMax() {
-    ns1__getKeywordsForUserMax::soap_default(NULL);
+    ns1__getKeywordsForUserMax::soap_default(nullptr);
   }
   virtual ~ns1__getKeywordsForUserMax() = default;
 };
@@ -5152,7 +5176,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getKeywordsForUserMaxResponse() {
-    ns1__getKeywordsForUserMaxResponse::soap_default(NULL);
+    ns1__getKeywordsForUserMaxResponse::soap_default(nullptr);
   }
   virtual ~ns1__getKeywordsForUserMaxResponse() = default;
 };
@@ -5177,7 +5201,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getKeywordsForUserStartWithMax() {
-    ns1__getKeywordsForUserStartWithMax::soap_default(NULL);
+    ns1__getKeywordsForUserStartWithMax::soap_default(nullptr);
   }
   virtual ~ns1__getKeywordsForUserStartWithMax() = default;
 };
@@ -5207,7 +5231,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getKeywordsForUserStartWithMaxResponse() {
-    ns1__getKeywordsForUserStartWithMaxResponse::soap_default(NULL);
+    ns1__getKeywordsForUserStartWithMaxResponse::soap_default(nullptr);
   }
   virtual ~ns1__getKeywordsForUserStartWithMaxResponse() = default;
 };
@@ -5229,7 +5253,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__getKeywordsForUser() { ns1__getKeywordsForUser::soap_default(NULL); }
+  ns1__getKeywordsForUser() { ns1__getKeywordsForUser::soap_default(nullptr); }
   virtual ~ns1__getKeywordsForUser() = default;
 };
 #endif
@@ -5256,7 +5280,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getKeywordsForUserResponse() {
-    ns1__getKeywordsForUserResponse::soap_default(NULL);
+    ns1__getKeywordsForUserResponse::soap_default(nullptr);
   }
   virtual ~ns1__getKeywordsForUserResponse() = default;
 };
@@ -5279,7 +5303,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__listInvestigationTypes() {
-    ns1__listInvestigationTypes::soap_default(NULL);
+    ns1__listInvestigationTypes::soap_default(nullptr);
   }
   virtual ~ns1__listInvestigationTypes() = default;
 };
@@ -5307,7 +5331,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__listInvestigationTypesResponse() {
-    ns1__listInvestigationTypesResponse::soap_default(NULL);
+    ns1__listInvestigationTypesResponse::soap_default(nullptr);
   }
   virtual ~ns1__listInvestigationTypesResponse() = default;
 };
@@ -5332,7 +5356,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__modifyDataSetParameter() {
-    ns1__modifyDataSetParameter::soap_default(NULL);
+    ns1__modifyDataSetParameter::soap_default(nullptr);
   }
   virtual ~ns1__modifyDataSetParameter() = default;
 };
@@ -5353,7 +5377,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__modifyDataSetParameterResponse() {
-    ns1__modifyDataSetParameterResponse::soap_default(NULL);
+    ns1__modifyDataSetParameterResponse::soap_default(nullptr);
   }
   virtual ~ns1__modifyDataSetParameterResponse() = default;
 };
@@ -5376,7 +5400,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__removeDataSet() { ns1__removeDataSet::soap_default(NULL); }
+  ns1__removeDataSet() { ns1__removeDataSet::soap_default(nullptr); }
   virtual ~ns1__removeDataSet() = default;
 };
 #endif
@@ -5396,7 +5420,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__removeDataSetResponse() {
-    ns1__removeDataSetResponse::soap_default(NULL);
+    ns1__removeDataSetResponse::soap_default(nullptr);
   }
   virtual ~ns1__removeDataSetResponse() = default;
 };
@@ -5422,7 +5446,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchSampleByParameterLogical() {
-    ns1__searchSampleByParameterLogical::soap_default(NULL);
+    ns1__searchSampleByParameterLogical::soap_default(nullptr);
   }
   virtual ~ns1__searchSampleByParameterLogical() = default;
 };
@@ -5452,7 +5476,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchSampleByParameterLogicalResponse() {
-    ns1__searchSampleByParameterLogicalResponse::soap_default(NULL);
+    ns1__searchSampleByParameterLogicalResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchSampleByParameterLogicalResponse() = default;
 };
@@ -5479,7 +5503,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatasetByRestrictionComparison() {
-    ns1__searchDatasetByRestrictionComparison::soap_default(NULL);
+    ns1__searchDatasetByRestrictionComparison::soap_default(nullptr);
   }
   virtual ~ns1__searchDatasetByRestrictionComparison() = default;
 };
@@ -5509,7 +5533,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatasetByRestrictionComparisonResponse() {
-    ns1__searchDatasetByRestrictionComparisonResponse::soap_default(NULL);
+    ns1__searchDatasetByRestrictionComparisonResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchDatasetByRestrictionComparisonResponse() = default;
 };
@@ -5533,7 +5557,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__addKeyword() { ns1__addKeyword::soap_default(NULL); }
+  ns1__addKeyword() { ns1__addKeyword::soap_default(nullptr); }
   virtual ~ns1__addKeyword() = default;
 };
 #endif
@@ -5559,7 +5583,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__addKeywordResponse() { ns1__addKeywordResponse::soap_default(NULL); }
+  ns1__addKeywordResponse() { ns1__addKeywordResponse::soap_default(nullptr); }
   virtual ~ns1__addKeywordResponse() = default;
 };
 #endif
@@ -5583,7 +5607,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__getAuthorisations() { ns1__getAuthorisations::soap_default(NULL); }
+  ns1__getAuthorisations() { ns1__getAuthorisations::soap_default(nullptr); }
   virtual ~ns1__getAuthorisations() = default;
 };
 #endif
@@ -5610,7 +5634,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getAuthorisationsResponse() {
-    ns1__getAuthorisationsResponse::soap_default(NULL);
+    ns1__getAuthorisationsResponse::soap_default(nullptr);
   }
   virtual ~ns1__getAuthorisationsResponse() = default;
 };
@@ -5634,7 +5658,9 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__modifyInvestigation() { ns1__modifyInvestigation::soap_default(NULL); }
+  ns1__modifyInvestigation() {
+    ns1__modifyInvestigation::soap_default(nullptr);
+  }
   virtual ~ns1__modifyInvestigation() = default;
 };
 #endif
@@ -5654,7 +5680,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__modifyInvestigationResponse() {
-    ns1__modifyInvestigationResponse::soap_default(NULL);
+    ns1__modifyInvestigationResponse::soap_default(nullptr);
   }
   virtual ~ns1__modifyInvestigationResponse() = default;
 };
@@ -5676,7 +5702,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__listDatasetStatus() { ns1__listDatasetStatus::soap_default(NULL); }
+  ns1__listDatasetStatus() { ns1__listDatasetStatus::soap_default(nullptr); }
   virtual ~ns1__listDatasetStatus() = default;
 };
 #endif
@@ -5703,7 +5729,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__listDatasetStatusResponse() {
-    ns1__listDatasetStatusResponse::soap_default(NULL);
+    ns1__listDatasetStatusResponse::soap_default(nullptr);
   }
   virtual ~ns1__listDatasetStatusResponse() = default;
 };
@@ -5726,7 +5752,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__deleteSample() { ns1__deleteSample::soap_default(NULL); }
+  ns1__deleteSample() { ns1__deleteSample::soap_default(nullptr); }
   virtual ~ns1__deleteSample() = default;
 };
 #endif
@@ -5745,7 +5771,9 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__deleteSampleResponse() { ns1__deleteSampleResponse::soap_default(NULL); }
+  ns1__deleteSampleResponse() {
+    ns1__deleteSampleResponse::soap_default(nullptr);
+  }
   virtual ~ns1__deleteSampleResponse() = default;
 };
 #endif
@@ -5769,7 +5797,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatasetByParameter() {
-    ns1__searchDatasetByParameter::soap_default(NULL);
+    ns1__searchDatasetByParameter::soap_default(nullptr);
   }
   virtual ~ns1__searchDatasetByParameter() = default;
 };
@@ -5797,7 +5825,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatasetByParameterResponse() {
-    ns1__searchDatasetByParameterResponse::soap_default(NULL);
+    ns1__searchDatasetByParameterResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchDatasetByParameterResponse() = default;
 };
@@ -5820,7 +5848,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__deleteKeyword() { ns1__deleteKeyword::soap_default(NULL); }
+  ns1__deleteKeyword() { ns1__deleteKeyword::soap_default(nullptr); }
   virtual ~ns1__deleteKeyword() = default;
 };
 #endif
@@ -5840,7 +5868,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__deleteKeywordResponse() {
-    ns1__deleteKeywordResponse::soap_default(NULL);
+    ns1__deleteKeywordResponse::soap_default(nullptr);
   }
   virtual ~ns1__deleteKeywordResponse() = default;
 };
@@ -5865,7 +5893,9 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__addDataSetParameters() { ns1__addDataSetParameters::soap_default(NULL); }
+  ns1__addDataSetParameters() {
+    ns1__addDataSetParameters::soap_default(nullptr);
+  }
   virtual ~ns1__addDataSetParameters() = default;
 };
 #endif
@@ -5892,7 +5922,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__addDataSetParametersResponse() {
-    ns1__addDataSetParametersResponse::soap_default(NULL);
+    ns1__addDataSetParametersResponse::soap_default(nullptr);
   }
   virtual ~ns1__addDataSetParametersResponse() = default;
 };
@@ -5921,7 +5951,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchByRunNumberPagination() {
-    ns1__searchByRunNumberPagination::soap_default(NULL);
+    ns1__searchByRunNumberPagination::soap_default(nullptr);
   }
   virtual ~ns1__searchByRunNumberPagination() = default;
 };
@@ -5949,7 +5979,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchByRunNumberPaginationResponse() {
-    ns1__searchByRunNumberPaginationResponse::soap_default(NULL);
+    ns1__searchByRunNumberPaginationResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchByRunNumberPaginationResponse() = default;
 };
@@ -5975,7 +6005,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__searchByRunNumber() { ns1__searchByRunNumber::soap_default(NULL); }
+  ns1__searchByRunNumber() { ns1__searchByRunNumber::soap_default(nullptr); }
   virtual ~ns1__searchByRunNumber() = default;
 };
 #endif
@@ -6002,7 +6032,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchByRunNumberResponse() {
-    ns1__searchByRunNumberResponse::soap_default(NULL);
+    ns1__searchByRunNumberResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchByRunNumberResponse() = default;
 };
@@ -6028,7 +6058,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatafileByParameterComparison() {
-    ns1__searchDatafileByParameterComparison::soap_default(NULL);
+    ns1__searchDatafileByParameterComparison::soap_default(nullptr);
   }
   virtual ~ns1__searchDatafileByParameterComparison() = default;
 };
@@ -6058,7 +6088,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatafileByParameterComparisonResponse() {
-    ns1__searchDatafileByParameterComparisonResponse::soap_default(NULL);
+    ns1__searchDatafileByParameterComparisonResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchDatafileByParameterComparisonResponse() = default;
 };
@@ -6086,7 +6116,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchByAdvancedPagination() {
-    ns1__searchByAdvancedPagination::soap_default(NULL);
+    ns1__searchByAdvancedPagination::soap_default(nullptr);
   }
   virtual ~ns1__searchByAdvancedPagination() = default;
 };
@@ -6131,7 +6161,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__advancedSearchDetails() {
-    ns1__advancedSearchDetails::soap_default(NULL);
+    ns1__advancedSearchDetails::soap_default(nullptr);
   }
   virtual ~ns1__advancedSearchDetails() = default;
 };
@@ -6159,7 +6189,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchByAdvancedPaginationResponse() {
-    ns1__searchByAdvancedPaginationResponse::soap_default(NULL);
+    ns1__searchByAdvancedPaginationResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchByAdvancedPaginationResponse() = default;
 };
@@ -6184,7 +6214,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__searchByAdvanced() { ns1__searchByAdvanced::soap_default(NULL); }
+  ns1__searchByAdvanced() { ns1__searchByAdvanced::soap_default(nullptr); }
   virtual ~ns1__searchByAdvanced() = default;
 };
 #endif
@@ -6211,7 +6241,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchByAdvancedResponse() {
-    ns1__searchByAdvancedResponse::soap_default(NULL);
+    ns1__searchByAdvancedResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchByAdvancedResponse() = default;
 };
@@ -6236,7 +6266,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchInvestigationByParameter() {
-    ns1__searchInvestigationByParameter::soap_default(NULL);
+    ns1__searchInvestigationByParameter::soap_default(nullptr);
   }
   virtual ~ns1__searchInvestigationByParameter() = default;
 };
@@ -6266,7 +6296,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchInvestigationByParameterResponse() {
-    ns1__searchInvestigationByParameterResponse::soap_default(NULL);
+    ns1__searchInvestigationByParameterResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchInvestigationByParameterResponse() = default;
 };
@@ -6288,7 +6318,9 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__listDatafileFormats() { ns1__listDatafileFormats::soap_default(NULL); }
+  ns1__listDatafileFormats() {
+    ns1__listDatafileFormats::soap_default(nullptr);
+  }
   virtual ~ns1__listDatafileFormats() = default;
 };
 #endif
@@ -6315,7 +6347,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__listDatafileFormatsResponse() {
-    ns1__listDatafileFormatsResponse::soap_default(NULL);
+    ns1__listDatafileFormatsResponse::soap_default(nullptr);
   }
   virtual ~ns1__listDatafileFormatsResponse() = default;
 };
@@ -6340,7 +6372,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__modifySampleParameter() {
-    ns1__modifySampleParameter::soap_default(NULL);
+    ns1__modifySampleParameter::soap_default(nullptr);
   }
   virtual ~ns1__modifySampleParameter() = default;
 };
@@ -6361,7 +6393,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__modifySampleParameterResponse() {
-    ns1__modifySampleParameterResponse::soap_default(NULL);
+    ns1__modifySampleParameterResponse::soap_default(nullptr);
   }
   virtual ~ns1__modifySampleParameterResponse() = default;
 };
@@ -6385,7 +6417,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__modifyInvestigator() { ns1__modifyInvestigator::soap_default(NULL); }
+  ns1__modifyInvestigator() { ns1__modifyInvestigator::soap_default(nullptr); }
   virtual ~ns1__modifyInvestigator() = default;
 };
 #endif
@@ -6405,7 +6437,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__modifyInvestigatorResponse() {
-    ns1__modifyInvestigatorResponse::soap_default(NULL);
+    ns1__modifyInvestigatorResponse::soap_default(nullptr);
   }
   virtual ~ns1__modifyInvestigatorResponse() = default;
 };
@@ -6430,7 +6462,9 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__addDataSetParameter() { ns1__addDataSetParameter::soap_default(NULL); }
+  ns1__addDataSetParameter() {
+    ns1__addDataSetParameter::soap_default(nullptr);
+  }
   virtual ~ns1__addDataSetParameter() = default;
 };
 #endif
@@ -6457,7 +6491,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__addDataSetParameterResponse() {
-    ns1__addDataSetParameterResponse::soap_default(NULL);
+    ns1__addDataSetParameterResponse::soap_default(nullptr);
   }
   virtual ~ns1__addDataSetParameterResponse() = default;
 };
@@ -6482,7 +6516,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__createDataFiles() { ns1__createDataFiles::soap_default(NULL); }
+  ns1__createDataFiles() { ns1__createDataFiles::soap_default(nullptr); }
   virtual ~ns1__createDataFiles() = default;
 };
 #endif
@@ -6509,7 +6543,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__createDataFilesResponse() {
-    ns1__createDataFilesResponse::soap_default(NULL);
+    ns1__createDataFilesResponse::soap_default(nullptr);
   }
   virtual ~ns1__createDataFilesResponse() = default;
 };
@@ -6536,7 +6570,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__addAuthorisation() { ns1__addAuthorisation::soap_default(NULL); }
+  ns1__addAuthorisation() { ns1__addAuthorisation::soap_default(nullptr); }
   virtual ~ns1__addAuthorisation() = default;
 };
 #endif
@@ -6563,7 +6597,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__addAuthorisationResponse() {
-    ns1__addAuthorisationResponse::soap_default(NULL);
+    ns1__addAuthorisationResponse::soap_default(nullptr);
   }
   virtual ~ns1__addAuthorisationResponse() = default;
 };
@@ -6587,7 +6621,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__addSample() { ns1__addSample::soap_default(NULL); }
+  ns1__addSample() { ns1__addSample::soap_default(nullptr); }
   virtual ~ns1__addSample() = default;
 };
 #endif
@@ -6613,7 +6647,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__addSampleResponse() { ns1__addSampleResponse::soap_default(NULL); }
+  ns1__addSampleResponse() { ns1__addSampleResponse::soap_default(nullptr); }
   virtual ~ns1__addSampleResponse() = default;
 };
 #endif
@@ -6635,7 +6669,9 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__getParameterByUnits() { ns1__getParameterByUnits::soap_default(NULL); }
+  ns1__getParameterByUnits() {
+    ns1__getParameterByUnits::soap_default(nullptr);
+  }
   virtual ~ns1__getParameterByUnits() = default;
 };
 #endif
@@ -6662,7 +6698,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getParameterByUnitsResponse() {
-    ns1__getParameterByUnitsResponse::soap_default(NULL);
+    ns1__getParameterByUnitsResponse::soap_default(nullptr);
   }
   virtual ~ns1__getParameterByUnitsResponse() = default;
 };
@@ -6686,7 +6722,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__loginLifetime() { ns1__loginLifetime::soap_default(NULL); }
+  ns1__loginLifetime() { ns1__loginLifetime::soap_default(nullptr); }
   virtual ~ns1__loginLifetime() = default;
 };
 #endif
@@ -6713,7 +6749,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__loginLifetimeResponse() {
-    ns1__loginLifetimeResponse::soap_default(NULL);
+    ns1__loginLifetimeResponse::soap_default(nullptr);
   }
   virtual ~ns1__loginLifetimeResponse() = default;
 };
@@ -6736,7 +6772,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__login() { ns1__login::soap_default(NULL); }
+  ns1__login() { ns1__login::soap_default(nullptr); }
   virtual ~ns1__login() = default;
 };
 #endif
@@ -6762,7 +6798,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__loginResponse() { ns1__loginResponse::soap_default(NULL); }
+  ns1__loginResponse() { ns1__loginResponse::soap_default(nullptr); }
   virtual ~ns1__loginResponse() = default;
 };
 #endif
@@ -6784,7 +6820,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__deletePublication() { ns1__deletePublication::soap_default(NULL); }
+  ns1__deletePublication() { ns1__deletePublication::soap_default(nullptr); }
   virtual ~ns1__deletePublication() = default;
 };
 #endif
@@ -6804,7 +6840,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__deletePublicationResponse() {
-    ns1__deletePublicationResponse::soap_default(NULL);
+    ns1__deletePublicationResponse::soap_default(nullptr);
   }
   virtual ~ns1__deletePublicationResponse() = default;
 };
@@ -6827,7 +6863,9 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__deleteAuthorisation() { ns1__deleteAuthorisation::soap_default(NULL); }
+  ns1__deleteAuthorisation() {
+    ns1__deleteAuthorisation::soap_default(nullptr);
+  }
   virtual ~ns1__deleteAuthorisation() = default;
 };
 #endif
@@ -6847,7 +6885,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__deleteAuthorisationResponse() {
-    ns1__deleteAuthorisationResponse::soap_default(NULL);
+    ns1__deleteAuthorisationResponse::soap_default(nullptr);
   }
   virtual ~ns1__deleteAuthorisationResponse() = default;
 };
@@ -6870,7 +6908,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__getDataset() { ns1__getDataset::soap_default(NULL); }
+  ns1__getDataset() { ns1__getDataset::soap_default(nullptr); }
   virtual ~ns1__getDataset() = default;
 };
 #endif
@@ -6896,7 +6934,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__getDatasetResponse() { ns1__getDatasetResponse::soap_default(NULL); }
+  ns1__getDatasetResponse() { ns1__getDatasetResponse::soap_default(nullptr); }
   virtual ~ns1__getDatasetResponse() = default;
 };
 #endif
@@ -6920,7 +6958,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__getDatasetIncludes() { ns1__getDatasetIncludes::soap_default(NULL); }
+  ns1__getDatasetIncludes() { ns1__getDatasetIncludes::soap_default(nullptr); }
   virtual ~ns1__getDatasetIncludes() = default;
 };
 #endif
@@ -6947,7 +6985,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getDatasetIncludesResponse() {
-    ns1__getDatasetIncludesResponse::soap_default(NULL);
+    ns1__getDatasetIncludesResponse::soap_default(nullptr);
   }
   virtual ~ns1__getDatasetIncludesResponse() = default;
 };
@@ -6971,7 +7009,9 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__updateAuthorisation() { ns1__updateAuthorisation::soap_default(NULL); }
+  ns1__updateAuthorisation() {
+    ns1__updateAuthorisation::soap_default(nullptr);
+  }
   virtual ~ns1__updateAuthorisation() = default;
 };
 #endif
@@ -6991,7 +7031,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__updateAuthorisationResponse() {
-    ns1__updateAuthorisationResponse::soap_default(NULL);
+    ns1__updateAuthorisationResponse::soap_default(nullptr);
   }
   virtual ~ns1__updateAuthorisationResponse() = default;
 };
@@ -7013,7 +7053,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__listRoles() { ns1__listRoles::soap_default(NULL); }
+  ns1__listRoles() { ns1__listRoles::soap_default(nullptr); }
   virtual ~ns1__listRoles() = default;
 };
 #endif
@@ -7039,7 +7079,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__listRolesResponse() { ns1__listRolesResponse::soap_default(NULL); }
+  ns1__listRolesResponse() { ns1__listRolesResponse::soap_default(nullptr); }
   virtual ~ns1__listRolesResponse() = default;
 };
 #endif
@@ -7063,7 +7103,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatasetByRestriction() {
-    ns1__searchDatasetByRestriction::soap_default(NULL);
+    ns1__searchDatasetByRestriction::soap_default(nullptr);
   }
   virtual ~ns1__searchDatasetByRestriction() = default;
 };
@@ -7091,7 +7131,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatasetByRestrictionResponse() {
-    ns1__searchDatasetByRestrictionResponse::soap_default(NULL);
+    ns1__searchDatasetByRestrictionResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchDatasetByRestrictionResponse() = default;
 };
@@ -7114,7 +7154,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__ingestMetadata() { ns1__ingestMetadata::soap_default(NULL); }
+  ns1__ingestMetadata() { ns1__ingestMetadata::soap_default(nullptr); }
   virtual ~ns1__ingestMetadata() = default;
 };
 #endif
@@ -7141,7 +7181,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__ingestMetadataResponse() {
-    ns1__ingestMetadataResponse::soap_default(NULL);
+    ns1__ingestMetadataResponse::soap_default(nullptr);
   }
   virtual ~ns1__ingestMetadataResponse() = default;
 };
@@ -7165,7 +7205,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__ICATAPIException() { ns1__ICATAPIException::soap_default(NULL); }
+  ns1__ICATAPIException() { ns1__ICATAPIException::soap_default(nullptr); }
   virtual ~ns1__ICATAPIException() = default;
 };
 #endif
@@ -7187,7 +7227,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__getDatafile() { ns1__getDatafile::soap_default(NULL); }
+  ns1__getDatafile() { ns1__getDatafile::soap_default(nullptr); }
   virtual ~ns1__getDatafile() = default;
 };
 #endif
@@ -7213,7 +7253,9 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__getDatafileResponse() { ns1__getDatafileResponse::soap_default(NULL); }
+  ns1__getDatafileResponse() {
+    ns1__getDatafileResponse::soap_default(nullptr);
+  }
   virtual ~ns1__getDatafileResponse() = default;
 };
 #endif
@@ -7235,7 +7277,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__modifyDataFile() { ns1__modifyDataFile::soap_default(NULL); }
+  ns1__modifyDataFile() { ns1__modifyDataFile::soap_default(nullptr); }
   virtual ~ns1__modifyDataFile() = default;
 };
 #endif
@@ -7255,7 +7297,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__modifyDataFileResponse() {
-    ns1__modifyDataFileResponse::soap_default(NULL);
+    ns1__modifyDataFileResponse::soap_default(nullptr);
   }
   virtual ~ns1__modifyDataFileResponse() = default;
 };
@@ -7282,7 +7324,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getInvestigationIncludes() {
-    ns1__getInvestigationIncludes::soap_default(NULL);
+    ns1__getInvestigationIncludes::soap_default(nullptr);
   }
   virtual ~ns1__getInvestigationIncludes() = default;
 };
@@ -7310,7 +7352,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getInvestigationIncludesResponse() {
-    ns1__getInvestigationIncludesResponse::soap_default(NULL);
+    ns1__getInvestigationIncludesResponse::soap_default(nullptr);
   }
   virtual ~ns1__getInvestigationIncludesResponse() = default;
 };
@@ -7333,7 +7375,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__getInvestigation() { ns1__getInvestigation::soap_default(NULL); }
+  ns1__getInvestigation() { ns1__getInvestigation::soap_default(nullptr); }
   virtual ~ns1__getInvestigation() = default;
 };
 #endif
@@ -7360,7 +7402,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__getInvestigationResponse() {
-    ns1__getInvestigationResponse::soap_default(NULL);
+    ns1__getInvestigationResponse::soap_default(nullptr);
   }
   virtual ~ns1__getInvestigationResponse() = default;
 };
@@ -7385,7 +7427,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__deleteDataFileParameter() {
-    ns1__deleteDataFileParameter::soap_default(NULL);
+    ns1__deleteDataFileParameter::soap_default(nullptr);
   }
   virtual ~ns1__deleteDataFileParameter() = default;
 };
@@ -7406,7 +7448,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__deleteDataFileParameterResponse() {
-    ns1__deleteDataFileParameterResponse::soap_default(NULL);
+    ns1__deleteDataFileParameterResponse::soap_default(nullptr);
   }
   virtual ~ns1__deleteDataFileParameterResponse() = default;
 };
@@ -7430,7 +7472,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__addPublication() { ns1__addPublication::soap_default(NULL); }
+  ns1__addPublication() { ns1__addPublication::soap_default(nullptr); }
   virtual ~ns1__addPublication() = default;
 };
 #endif
@@ -7457,7 +7499,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__addPublicationResponse() {
-    ns1__addPublicationResponse::soap_default(NULL);
+    ns1__addPublicationResponse::soap_default(nullptr);
   }
   virtual ~ns1__addPublicationResponse() = default;
 };
@@ -7481,7 +7523,9 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__createInvestigation() { ns1__createInvestigation::soap_default(NULL); }
+  ns1__createInvestigation() {
+    ns1__createInvestigation::soap_default(nullptr);
+  }
   virtual ~ns1__createInvestigation() = default;
 };
 #endif
@@ -7508,7 +7552,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__createInvestigationResponse() {
-    ns1__createInvestigationResponse::soap_default(NULL);
+    ns1__createInvestigationResponse::soap_default(nullptr);
   }
   virtual ~ns1__createInvestigationResponse() = default;
 };
@@ -7532,7 +7576,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatasetsBySample() {
-    ns1__searchDatasetsBySample::soap_default(NULL);
+    ns1__searchDatasetsBySample::soap_default(nullptr);
   }
   virtual ~ns1__searchDatasetsBySample() = default;
 };
@@ -7560,7 +7604,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchDatasetsBySampleResponse() {
-    ns1__searchDatasetsBySampleResponse::soap_default(NULL);
+    ns1__searchDatasetsBySampleResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchDatasetsBySampleResponse() = default;
 };
@@ -7585,7 +7629,9 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__addDataFileParameter() { ns1__addDataFileParameter::soap_default(NULL); }
+  ns1__addDataFileParameter() {
+    ns1__addDataFileParameter::soap_default(nullptr);
+  }
   virtual ~ns1__addDataFileParameter() = default;
 };
 #endif
@@ -7612,7 +7658,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__addDataFileParameterResponse() {
-    ns1__addDataFileParameterResponse::soap_default(NULL);
+    ns1__addDataFileParameterResponse::soap_default(nullptr);
   }
   virtual ~ns1__addDataFileParameterResponse() = default;
 };
@@ -7638,7 +7684,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchSampleByRestrictionLogical() {
-    ns1__searchSampleByRestrictionLogical::soap_default(NULL);
+    ns1__searchSampleByRestrictionLogical::soap_default(nullptr);
   }
   virtual ~ns1__searchSampleByRestrictionLogical() = default;
 };
@@ -7668,7 +7714,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchSampleByRestrictionLogicalResponse() {
-    ns1__searchSampleByRestrictionLogicalResponse::soap_default(NULL);
+    ns1__searchSampleByRestrictionLogicalResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchSampleByRestrictionLogicalResponse() = default;
 };
@@ -7693,7 +7739,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__deleteSampleParameter() {
-    ns1__deleteSampleParameter::soap_default(NULL);
+    ns1__deleteSampleParameter::soap_default(nullptr);
   }
   virtual ~ns1__deleteSampleParameter() = default;
 };
@@ -7714,7 +7760,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__deleteSampleParameterResponse() {
-    ns1__deleteSampleParameterResponse::soap_default(NULL);
+    ns1__deleteSampleParameterResponse::soap_default(nullptr);
   }
   virtual ~ns1__deleteSampleParameterResponse() = default;
 };
@@ -7740,7 +7786,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchSampleByParameterComparison() {
-    ns1__searchSampleByParameterComparison::soap_default(NULL);
+    ns1__searchSampleByParameterComparison::soap_default(nullptr);
   }
   virtual ~ns1__searchSampleByParameterComparison() = default;
 };
@@ -7770,7 +7816,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchSampleByParameterComparisonResponse() {
-    ns1__searchSampleByParameterComparisonResponse::soap_default(NULL);
+    ns1__searchSampleByParameterComparisonResponse::soap_default(nullptr);
   }
   virtual ~ns1__searchSampleByParameterComparisonResponse() = default;
 };
@@ -7792,7 +7838,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__listParameters() { ns1__listParameters::soap_default(NULL); }
+  ns1__listParameters() { ns1__listParameters::soap_default(nullptr); }
   virtual ~ns1__listParameters() = default;
 };
 #endif
@@ -7819,7 +7865,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__listParametersResponse() {
-    ns1__listParametersResponse::soap_default(NULL);
+    ns1__listParametersResponse::soap_default(nullptr);
   }
   virtual ~ns1__listParametersResponse() = default;
 };
@@ -7844,7 +7890,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__modifyDataFileParameter() {
-    ns1__modifyDataFileParameter::soap_default(NULL);
+    ns1__modifyDataFileParameter::soap_default(nullptr);
   }
   virtual ~ns1__modifyDataFileParameter() = default;
 };
@@ -7865,7 +7911,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__modifyDataFileParameterResponse() {
-    ns1__modifyDataFileParameterResponse::soap_default(NULL);
+    ns1__modifyDataFileParameterResponse::soap_default(nullptr);
   }
   virtual ~ns1__modifyDataFileParameterResponse() = default;
 };
@@ -7888,7 +7934,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__getDatasets() { ns1__getDatasets::soap_default(NULL); }
+  ns1__getDatasets() { ns1__getDatasets::soap_default(nullptr); }
   virtual ~ns1__getDatasets() = default;
 };
 #endif
@@ -7914,7 +7960,9 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__getDatasetsResponse() { ns1__getDatasetsResponse::soap_default(NULL); }
+  ns1__getDatasetsResponse() {
+    ns1__getDatasetsResponse::soap_default(nullptr);
+  }
   virtual ~ns1__getDatasetsResponse() = default;
 };
 #endif
@@ -7941,7 +7989,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchInvestigationByRestrictionComparasion() {
-    ns1__searchInvestigationByRestrictionComparasion::soap_default(NULL);
+    ns1__searchInvestigationByRestrictionComparasion::soap_default(nullptr);
   }
   virtual ~ns1__searchInvestigationByRestrictionComparasion() = default;
 };
@@ -7974,7 +8022,7 @@ public:
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__searchInvestigationByRestrictionComparasionResponse() {
     ns1__searchInvestigationByRestrictionComparasionResponse::soap_default(
-        NULL);
+        nullptr);
   }
   virtual ~ns1__searchInvestigationByRestrictionComparasionResponse() = default;
 };
@@ -7998,7 +8046,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns3__SessionException() { ns3__SessionException::soap_default(NULL); }
+  ns3__SessionException() { ns3__SessionException::soap_default(nullptr); }
   virtual ~ns3__SessionException() = default;
 };
 #endif
@@ -8022,7 +8070,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns3__NoSuchObjectFoundException() {
-    ns3__NoSuchObjectFoundException::soap_default(NULL);
+    ns3__NoSuchObjectFoundException::soap_default(nullptr);
   }
   virtual ~ns3__NoSuchObjectFoundException() = default;
 };
@@ -8046,7 +8094,9 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns3__ValidationException() { ns3__ValidationException::soap_default(NULL); }
+  ns3__ValidationException() {
+    ns3__ValidationException::soap_default(nullptr);
+  }
   virtual ~ns3__ValidationException() = default;
 };
 #endif
@@ -8068,7 +8118,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns3__getUserDetails() { ns3__getUserDetails::soap_default(NULL); }
+  ns3__getUserDetails() { ns3__getUserDetails::soap_default(nullptr); }
   virtual ~ns3__getUserDetails() = default;
 };
 #endif
@@ -8095,7 +8145,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns3__getUserDetailsResponse() {
-    ns3__getUserDetailsResponse::soap_default(NULL);
+    ns3__getUserDetailsResponse::soap_default(nullptr);
   }
   virtual ~ns3__getUserDetailsResponse() = default;
 };
@@ -8119,7 +8169,9 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns3__NoSuchUserException() { ns3__NoSuchUserException::soap_default(NULL); }
+  ns3__NoSuchUserException() {
+    ns3__NoSuchUserException::soap_default(nullptr);
+  }
   virtual ~ns3__NoSuchUserException() = default;
 };
 #endif
@@ -8154,7 +8206,9 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__restrictionCondition() { ns1__restrictionCondition::soap_default(NULL); }
+  ns1__restrictionCondition() {
+    ns1__restrictionCondition::soap_default(nullptr);
+  }
   virtual ~ns1__restrictionCondition() = default;
 };
 #endif
@@ -8173,7 +8227,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__parameterCondition() { ns1__parameterCondition::soap_default(NULL); }
+  ns1__parameterCondition() { ns1__parameterCondition::soap_default(nullptr); }
   virtual ~ns1__parameterCondition() = default;
 };
 #endif
@@ -8200,7 +8254,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__facilityUser() { ns1__facilityUser::soap_default(NULL); }
+  ns1__facilityUser() { ns1__facilityUser::soap_default(nullptr); }
   virtual ~ns1__facilityUser() = default;
 };
 #endif
@@ -8231,7 +8285,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__icatRole() { ns1__icatRole::soap_default(NULL); }
+  ns1__icatRole() { ns1__icatRole::soap_default(nullptr); }
   virtual ~ns1__icatRole() = default;
 };
 #endif
@@ -8260,7 +8314,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__sample() { ns1__sample::soap_default(NULL); }
+  ns1__sample() { ns1__sample::soap_default(nullptr); }
   virtual ~ns1__sample() = default;
 };
 #endif
@@ -8291,7 +8345,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__sampleParameter() { ns1__sampleParameter::soap_default(NULL); }
+  ns1__sampleParameter() { ns1__sampleParameter::soap_default(nullptr); }
   virtual ~ns1__sampleParameter() = default;
 };
 #endif
@@ -8314,7 +8368,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__sampleParameterPK() { ns1__sampleParameterPK::soap_default(NULL); }
+  ns1__sampleParameterPK() { ns1__sampleParameterPK::soap_default(nullptr); }
   virtual ~ns1__sampleParameterPK() = default;
 };
 #endif
@@ -8360,7 +8414,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__datafile() { ns1__datafile::soap_default(NULL); }
+  ns1__datafile() { ns1__datafile::soap_default(nullptr); }
   virtual ~ns1__datafile() = default;
 };
 #endif
@@ -8384,7 +8438,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__datafileFormat() { ns1__datafileFormat::soap_default(NULL); }
+  ns1__datafileFormat() { ns1__datafileFormat::soap_default(nullptr); }
   virtual ~ns1__datafileFormat() = default;
 };
 #endif
@@ -8406,7 +8460,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__datafileFormatPK() { ns1__datafileFormatPK::soap_default(NULL); }
+  ns1__datafileFormatPK() { ns1__datafileFormatPK::soap_default(nullptr); }
   virtual ~ns1__datafileFormatPK() = default;
 };
 #endif
@@ -8437,7 +8491,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__datafileParameter() { ns1__datafileParameter::soap_default(NULL); }
+  ns1__datafileParameter() { ns1__datafileParameter::soap_default(nullptr); }
   virtual ~ns1__datafileParameter() = default;
 };
 #endif
@@ -8461,7 +8515,9 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__datafileParameterPK() { ns1__datafileParameterPK::soap_default(NULL); }
+  ns1__datafileParameterPK() {
+    ns1__datafileParameterPK::soap_default(nullptr);
+  }
   virtual ~ns1__datafileParameterPK() = default;
 };
 #endif
@@ -8484,7 +8540,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__relatedDatafiles() { ns1__relatedDatafiles::soap_default(NULL); }
+  ns1__relatedDatafiles() { ns1__relatedDatafiles::soap_default(nullptr); }
   virtual ~ns1__relatedDatafiles() = default;
 };
 #endif
@@ -8506,7 +8562,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__relatedDatafilesPK() { ns1__relatedDatafilesPK::soap_default(NULL); }
+  ns1__relatedDatafilesPK() { ns1__relatedDatafilesPK::soap_default(nullptr); }
   virtual ~ns1__relatedDatafilesPK() = default;
 };
 #endif
@@ -8538,7 +8594,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__parameter() { ns1__parameter::soap_default(NULL); }
+  ns1__parameter() { ns1__parameter::soap_default(nullptr); }
   virtual ~ns1__parameter() = default;
 };
 #endif
@@ -8560,7 +8616,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__parameterPK() { ns1__parameterPK::soap_default(NULL); }
+  ns1__parameterPK() { ns1__parameterPK::soap_default(nullptr); }
   virtual ~ns1__parameterPK() = default;
 };
 #endif
@@ -8584,7 +8640,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__facilityCycle() { ns1__facilityCycle::soap_default(NULL); }
+  ns1__facilityCycle() { ns1__facilityCycle::soap_default(nullptr); }
   virtual ~ns1__facilityCycle() = default;
 };
 #endif
@@ -8608,7 +8664,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__instrument() { ns1__instrument::soap_default(NULL); }
+  ns1__instrument() { ns1__instrument::soap_default(nullptr); }
   virtual ~ns1__instrument() = default;
 };
 #endif
@@ -8630,7 +8686,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__investigatorPK() { ns1__investigatorPK::soap_default(NULL); }
+  ns1__investigatorPK() { ns1__investigatorPK::soap_default(nullptr); }
   virtual ~ns1__investigatorPK() = default;
 };
 #endif
@@ -8652,7 +8708,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__keywordPK() { ns1__keywordPK::soap_default(NULL); }
+  ns1__keywordPK() { ns1__keywordPK::soap_default(nullptr); }
   virtual ~ns1__keywordPK() = default;
 };
 #endif
@@ -8685,7 +8741,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__dataset() { ns1__dataset::soap_default(NULL); }
+  ns1__dataset() { ns1__dataset::soap_default(nullptr); }
   virtual ~ns1__dataset() = default;
 };
 #endif
@@ -8717,7 +8773,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__datasetParameter() { ns1__datasetParameter::soap_default(NULL); }
+  ns1__datasetParameter() { ns1__datasetParameter::soap_default(nullptr); }
   virtual ~ns1__datasetParameter() = default;
 };
 #endif
@@ -8740,7 +8796,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__datasetParameterPK() { ns1__datasetParameterPK::soap_default(NULL); }
+  ns1__datasetParameterPK() { ns1__datasetParameterPK::soap_default(nullptr); }
   virtual ~ns1__datasetParameterPK() = default;
 };
 #endif
@@ -8790,7 +8846,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__investigation() { ns1__investigation::soap_default(NULL); }
+  ns1__investigation() { ns1__investigation::soap_default(nullptr); }
   virtual ~ns1__investigation() = default;
 };
 #endif
@@ -8815,7 +8871,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__investigator() { ns1__investigator::soap_default(NULL); }
+  ns1__investigator() { ns1__investigator::soap_default(nullptr); }
   virtual ~ns1__investigator() = default;
 };
 #endif
@@ -8836,7 +8892,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__keyword() { ns1__keyword::soap_default(NULL); }
+  ns1__keyword() { ns1__keyword::soap_default(nullptr); }
   virtual ~ns1__keyword() = default;
 };
 #endif
@@ -8861,7 +8917,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__publication() { ns1__publication::soap_default(NULL); }
+  ns1__publication() { ns1__publication::soap_default(nullptr); }
   virtual ~ns1__publication() = default;
 };
 #endif
@@ -8883,7 +8939,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__shift() { ns1__shift::soap_default(NULL); }
+  ns1__shift() { ns1__shift::soap_default(nullptr); }
   virtual ~ns1__shift() = default;
 };
 #endif
@@ -8906,7 +8962,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__shiftPK() { ns1__shiftPK::soap_default(NULL); }
+  ns1__shiftPK() { ns1__shiftPK::soap_default(nullptr); }
   virtual ~ns1__shiftPK() = default;
 };
 #endif
@@ -8933,7 +8989,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__icatAuthorisation() { ns1__icatAuthorisation::soap_default(NULL); }
+  ns1__icatAuthorisation() { ns1__icatAuthorisation::soap_default(nullptr); }
   virtual ~ns1__icatAuthorisation() = default;
 };
 #endif
@@ -8959,7 +9015,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__restrictionLogicalCondition() {
-    ns1__restrictionLogicalCondition::soap_default(NULL);
+    ns1__restrictionLogicalCondition::soap_default(nullptr);
   }
   virtual ~ns1__restrictionLogicalCondition() = default;
 };
@@ -8989,7 +9045,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__restrictionComparisonCondition() {
-    ns1__restrictionComparisonCondition::soap_default(NULL);
+    ns1__restrictionComparisonCondition::soap_default(nullptr);
   }
   virtual ~ns1__restrictionComparisonCondition() = default;
 };
@@ -9016,7 +9072,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__parameterLogicalCondition() {
-    ns1__parameterLogicalCondition::soap_default(NULL);
+    ns1__parameterLogicalCondition::soap_default(nullptr);
   }
   virtual ~ns1__parameterLogicalCondition() = default;
 };
@@ -9040,7 +9096,7 @@ public:
   virtual int soap_out(struct soap *, const char *, int, const char *) const;
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
-  ns1__parameterSearch() { ns1__parameterSearch::soap_default(NULL); }
+  ns1__parameterSearch() { ns1__parameterSearch::soap_default(nullptr); }
   virtual ~ns1__parameterSearch() = default;
 };
 #endif
@@ -9068,7 +9124,7 @@ public:
   virtual void *soap_get(struct soap *, const char *, const char *);
   virtual void *soap_in(struct soap *, const char *, const char *);
   ns1__parameterComparisonCondition() {
-    ns1__parameterComparisonCondition::soap_default(NULL);
+    ns1__parameterComparisonCondition::soap_default(nullptr);
   }
   virtual ~ns1__parameterComparisonCondition() = default;
 };

--- a/Framework/ICat/src/GSoap/soapserializersC.cpp
+++ b/Framework/ICat/src/GSoap/soapserializersC.cpp
@@ -591,7 +591,7 @@ soap_in_SOAP_ENV__Fault(struct soap *soap, const char *tag,
     return nullptr;
   a = (struct SOAP_ENV__Fault *)soap_id_enter(
       soap, soap->id, a, SOAP_TYPE_SOAP_ENV__Fault,
-      sizeof(struct SOAP_ENV__Fault), 0, nullptr, NULL, NULL);
+      sizeof(struct SOAP_ENV__Fault), 0, nullptr, nullptr, nullptr);
   if (!a)
     return nullptr;
   soap_default_SOAP_ENV__Fault(soap, a);
@@ -779,7 +779,7 @@ soap_in_SOAP_ENV__Reason(struct soap *soap, const char *tag,
     return nullptr;
   a = (struct SOAP_ENV__Reason *)soap_id_enter(
       soap, soap->id, a, SOAP_TYPE_SOAP_ENV__Reason,
-      sizeof(struct SOAP_ENV__Reason), 0, nullptr, NULL, NULL);
+      sizeof(struct SOAP_ENV__Reason), 0, nullptr, nullptr, nullptr);
   if (!a)
     return nullptr;
   soap_default_SOAP_ENV__Reason(soap, a);
@@ -921,7 +921,7 @@ soap_in_SOAP_ENV__Detail(struct soap *soap, const char *tag,
     return nullptr;
   a = (struct SOAP_ENV__Detail *)soap_id_enter(
       soap, soap->id, a, SOAP_TYPE_SOAP_ENV__Detail,
-      sizeof(struct SOAP_ENV__Detail), 0, nullptr, NULL, NULL);
+      sizeof(struct SOAP_ENV__Detail), 0, nullptr, nullptr, nullptr);
   if (!a)
     return nullptr;
   soap_default_SOAP_ENV__Detail(soap, a);
@@ -1071,7 +1071,7 @@ soap_in_SOAP_ENV__Code(struct soap *soap, const char *tag,
     return nullptr;
   a = (struct SOAP_ENV__Code *)soap_id_enter(
       soap, soap->id, a, SOAP_TYPE_SOAP_ENV__Code,
-      sizeof(struct SOAP_ENV__Code), 0, nullptr, NULL, NULL);
+      sizeof(struct SOAP_ENV__Code), 0, nullptr, nullptr, nullptr);
   if (!a)
     return nullptr;
   soap_default_SOAP_ENV__Code(soap, a);
@@ -1208,7 +1208,7 @@ soap_in_SOAP_ENV__Header(struct soap *soap, const char *tag,
     return nullptr;
   a = (struct SOAP_ENV__Header *)soap_id_enter(
       soap, soap->id, a, SOAP_TYPE_SOAP_ENV__Header,
-      sizeof(struct SOAP_ENV__Header), 0, nullptr, NULL, NULL);
+      sizeof(struct SOAP_ENV__Header), 0, nullptr, nullptr, nullptr);
   if (!a)
     return nullptr;
   soap_default_SOAP_ENV__Header(soap, a);

--- a/Framework/ICat/src/GSoap/stdsoap2.cpp
+++ b/Framework/ICat/src/GSoap/stdsoap2.cpp
@@ -4533,7 +4533,7 @@ again:
         }
 #else
         names = (GENERAL_NAMES *)X509_get_ext_d2i(peer, NID_subject_alt_name,
-                                                  nullptr, NULL);
+                                                  nullptr, nullptr);
         if (names) {
           val = i2v_GENERAL_NAMES(nullptr, names, val);
           sk_GENERAL_NAME_pop_free(names, GENERAL_NAME_free);
@@ -12002,7 +12002,7 @@ end:
     soap->error = SOAP_LENGTH;
     return nullptr;
   }
-  s = (wchar_t *)soap_save_block(soap, nullptr, NULL, 0);
+  s = (wchar_t *)soap_save_block(soap, nullptr, nullptr, 0);
 #ifdef WITH_DOM
   if ((soap->mode & SOAP_XML_DOM) && soap->dom)
     soap->dom->wide = s;
@@ -12080,8 +12080,8 @@ int *SOAP_FMAC2 soap_inint(struct soap *soap, const char *tag, int *p,
     return nullptr;
   }
 #endif
-  p = (int *)soap_id_enter(soap, soap->id, p, t, sizeof(int), 0, nullptr, NULL,
-                           NULL);
+  p = (int *)soap_id_enter(soap, soap->id, p, t, sizeof(int), 0, nullptr,
+                           nullptr, nullptr);
   if (*soap->href)
     p = (int *)soap_id_forward(soap, soap->href, p, 0, t, 0, sizeof(int), 0,
                                nullptr);
@@ -12160,7 +12160,7 @@ long *SOAP_FMAC2 soap_inlong(struct soap *soap, const char *tag, long *p,
   }
 #endif
   p = (long *)soap_id_enter(soap, soap->id, p, t, sizeof(long), 0, nullptr,
-                            NULL, NULL);
+                            nullptr, nullptr);
   if (*soap->href)
     p = (long *)soap_id_forward(soap, soap->href, p, 0, t, 0, sizeof(long), 0,
                                 nullptr);
@@ -12251,7 +12251,7 @@ LONG64 *SOAP_FMAC2 soap_inLONG64(struct soap *soap, const char *tag, LONG64 *p,
   }
 #endif
   p = (LONG64 *)soap_id_enter(soap, soap->id, p, t, sizeof(LONG64), 0, nullptr,
-                              NULL, NULL);
+                              nullptr, nullptr);
   if (*soap->href)
     p = (LONG64 *)soap_id_forward(soap, soap->href, p, 0, t, 0, sizeof(LONG64),
                                   0, nullptr);
@@ -12318,7 +12318,7 @@ char *SOAP_FMAC2 soap_inbyte(struct soap *soap, const char *tag, char *p,
   }
 #endif
   p = (char *)soap_id_enter(soap, soap->id, p, t, sizeof(char), 0, nullptr,
-                            NULL, NULL);
+                            nullptr, nullptr);
   if (*soap->href)
     p = (char *)soap_id_forward(soap, soap->href, p, 0, t, 0, sizeof(char), 0,
                                 nullptr);
@@ -12386,7 +12386,7 @@ short *SOAP_FMAC2 soap_inshort(struct soap *soap, const char *tag, short *p,
   }
 #endif
   p = (short *)soap_id_enter(soap, soap->id, p, t, sizeof(short), 0, nullptr,
-                             NULL, NULL);
+                             nullptr, nullptr);
   if (*soap->href)
     p = (short *)soap_id_forward(soap, soap->href, p, 0, t, 0, sizeof(short), 0,
                                  nullptr);
@@ -12538,7 +12538,7 @@ float *SOAP_FMAC2 soap_infloat(struct soap *soap, const char *tag, float *p,
     return nullptr;
 #endif
   p = (float *)soap_id_enter(soap, soap->id, p, t, sizeof(float), 0, nullptr,
-                             NULL, NULL);
+                             nullptr, nullptr);
   if (*soap->href)
     p = (float *)soap_id_forward(soap, soap->href, p, 0, t, 0, sizeof(float), 0,
                                  nullptr);
@@ -12652,7 +12652,7 @@ double *SOAP_FMAC2 soap_indouble(struct soap *soap, const char *tag, double *p,
     return nullptr;
 #endif
   p = (double *)soap_id_enter(soap, soap->id, p, t, sizeof(double), 0, nullptr,
-                              NULL, NULL);
+                              nullptr, nullptr);
   if (*soap->href)
     p = (double *)soap_id_forward(soap, soap->href, p, 0, t, 0, sizeof(double),
                                   0, nullptr);
@@ -12721,8 +12721,9 @@ unsigned char *SOAP_FMAC2 soap_inunsignedByte(struct soap *soap,
     return nullptr;
   }
 #endif
-  p = (unsigned char *)soap_id_enter(
-      soap, soap->id, p, t, sizeof(unsigned char), 0, nullptr, NULL, NULL);
+  p = (unsigned char *)soap_id_enter(soap, soap->id, p, t,
+                                     sizeof(unsigned char), 0, nullptr, nullptr,
+                                     nullptr);
   if (*soap->href)
     p = (unsigned char *)soap_id_forward(soap, soap->href, p, 0, t, 0,
                                          sizeof(unsigned char), 0, nullptr);
@@ -12793,8 +12794,9 @@ soap_inunsignedShort(struct soap *soap, const char *tag, unsigned short *p,
     return nullptr;
   }
 #endif
-  p = (unsigned short *)soap_id_enter(
-      soap, soap->id, p, t, sizeof(unsigned short), 0, nullptr, NULL, NULL);
+  p = (unsigned short *)soap_id_enter(soap, soap->id, p, t,
+                                      sizeof(unsigned short), 0, nullptr,
+                                      nullptr, nullptr);
   if (*soap->href)
     p = (unsigned short *)soap_id_forward(soap, soap->href, p, 0, t, 0,
                                           sizeof(unsigned short), 0, nullptr);
@@ -12875,7 +12877,7 @@ unsigned int *SOAP_FMAC2 soap_inunsignedInt(struct soap *soap, const char *tag,
   }
 #endif
   p = (unsigned int *)soap_id_enter(soap, soap->id, p, t, sizeof(unsigned int),
-                                    0, nullptr, NULL, NULL);
+                                    0, nullptr, nullptr, nullptr);
   if (*soap->href)
     p = (unsigned int *)soap_id_forward(soap, soap->href, p, 0, t, 0,
                                         sizeof(unsigned int), 0, nullptr);
@@ -12956,8 +12958,9 @@ unsigned long *SOAP_FMAC2 soap_inunsignedLong(struct soap *soap,
     return nullptr;
   }
 #endif
-  p = (unsigned long *)soap_id_enter(
-      soap, soap->id, p, t, sizeof(unsigned long), 0, nullptr, NULL, NULL);
+  p = (unsigned long *)soap_id_enter(soap, soap->id, p, t,
+                                     sizeof(unsigned long), 0, nullptr, nullptr,
+                                     nullptr);
   if (*soap->href)
     p = (unsigned long *)soap_id_forward(soap, soap->href, p, 0, t, 0,
                                          sizeof(unsigned long), 0, nullptr);
@@ -13043,7 +13046,7 @@ ULONG64 *SOAP_FMAC2 soap_inULONG64(struct soap *soap, const char *tag,
     return nullptr;
   }
   p = (ULONG64 *)soap_id_enter(soap, soap->id, p, t, sizeof(ULONG64), 0,
-                               nullptr, NULL, NULL);
+                               nullptr, nullptr, nullptr);
   if (*soap->href)
     p = (ULONG64 *)soap_id_forward(soap, soap->href, p, 0, t, 0,
                                    sizeof(ULONG64), 0, nullptr);
@@ -13404,7 +13407,7 @@ char **SOAP_FMAC2 soap_instring(struct soap *soap, const char *tag, char **p,
     *p = soap_string_in(soap, flag, minlen, maxlen);
     if (!*p ||
         !(char *)soap_id_enter(soap, soap->id, *p, t, sizeof(char *), 0,
-                               nullptr, NULL, NULL))
+                               nullptr, nullptr, nullptr))
       return nullptr;
     if (!**p && tag && *tag == '-') {
       soap->error = SOAP_NO_TAG;
@@ -13467,7 +13470,7 @@ wchar_t **SOAP_FMAC2 soap_inwstring(struct soap *soap, const char *tag,
     *p = soap_wstring_in(soap, 1, minlen, maxlen);
     if (!*p ||
         !(wchar_t *)soap_id_enter(soap, soap->id, *p, t, sizeof(wchar_t *), 0,
-                                  nullptr, NULL, NULL))
+                                  nullptr, nullptr, nullptr))
       return nullptr;
     if (!**p && tag && *tag == '-') {
       soap->error = SOAP_NO_TAG;
@@ -13689,7 +13692,7 @@ time_t *SOAP_FMAC2 soap_indateTime(struct soap *soap, const char *tag,
     return nullptr;
   }
   p = (time_t *)soap_id_enter(soap, soap->id, p, t, sizeof(time_t), 0, nullptr,
-                              NULL, NULL);
+                              nullptr, nullptr);
   if (*soap->href)
     p = (time_t *)soap_id_forward(soap, soap->href, p, 0, t, 0, sizeof(time_t),
                                   0, nullptr);

--- a/Framework/ICat/src/ICat3/GSoapGenerated/ICat3ICATPortBindingProxy.cpp
+++ b/Framework/ICat/src/ICat3/GSoapGenerated/ICat3ICATPortBindingProxy.cpp
@@ -41,19 +41,19 @@ void ICATPortBindingProxy::ICATPortBindingProxy_init(soap_mode imode,
                                                      soap_mode omode) {
   soap_imode(this, imode);
   soap_omode(this, omode);
-  soap_endpoint = NULL;
+  soap_endpoint = nullptr;
   static const struct Namespace namespaces[] = {
       {"SOAP-ENV", "http://schemas.xmlsoap.org/soap/envelope/",
-       "http://www.w3.org/*/soap-envelope", NULL},
+       "http://www.w3.org/*/soap-envelope", nullptr},
       {"SOAP-ENC", "http://schemas.xmlsoap.org/soap/encoding/",
-       "http://www.w3.org/*/soap-encoding", NULL},
+       "http://www.w3.org/*/soap-encoding", nullptr},
       {"xsi", "http://www.w3.org/2001/XMLSchema-instance",
-       "http://www.w3.org/*/XMLSchema-instance", NULL},
+       "http://www.w3.org/*/XMLSchema-instance", nullptr},
       {"xsd", "http://www.w3.org/2001/XMLSchema",
-       "http://www.w3.org/*/XMLSchema", NULL},
-      {"ns3", "admin.client.icat3.uk", NULL, NULL},
-      {"ns1", "client.icat3.uk", NULL, NULL},
-      {NULL, NULL, NULL, NULL}};
+       "http://www.w3.org/*/XMLSchema", nullptr},
+      {"ns3", "admin.client.icat3.uk", nullptr, nullptr},
+      {"ns1", "client.icat3.uk", nullptr, nullptr},
+      {nullptr, nullptr, nullptr, nullptr}};
   soap_set_namespaces(this, namespaces);
 }
 
@@ -69,7 +69,7 @@ void ICATPortBindingProxy::reset() {
   ICATPortBindingProxy_init(SOAP_IO_DEFAULT, SOAP_IO_DEFAULT);
 }
 
-void ICATPortBindingProxy::soap_noheader() { this->header = NULL; }
+void ICATPortBindingProxy::soap_noheader() { this->header = nullptr; }
 
 const SOAP_ENV__Header *ICATPortBindingProxy::soap_header() {
   return this->header;
@@ -116,11 +116,11 @@ int ICATPortBindingProxy::login(const char *endpoint, const char *soap_action,
   struct __ns1__login soap_tmp___ns1__login;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/loginRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__login.ns1__login_ = ns1__login_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -131,16 +131,17 @@ int ICATPortBindingProxy::login(const char *endpoint, const char *soap_action,
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__login(soap, &soap_tmp___ns1__login, "-ns1:login",
-                              NULL) ||
+                              nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
-      soap_put___ns1__login(soap, &soap_tmp___ns1__login, "-ns1:login", NULL) ||
+      soap_put___ns1__login(soap, &soap_tmp___ns1__login, "-ns1:login",
+                            nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -167,11 +168,11 @@ int ICATPortBindingProxy::loginLifetime(
   struct __ns1__loginLifetime soap_tmp___ns1__loginLifetime;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/loginLifetimeRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__loginLifetime.ns1__loginLifetime_ = ns1__loginLifetime_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -182,17 +183,17 @@ int ICATPortBindingProxy::loginLifetime(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__loginLifetime(soap, &soap_tmp___ns1__loginLifetime,
-                                      "-ns1:loginLifetime", NULL) ||
+                                      "-ns1:loginLifetime", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__loginLifetime(soap, &soap_tmp___ns1__loginLifetime,
-                                    "-ns1:loginLifetime", NULL) ||
+                                    "-ns1:loginLifetime", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -219,11 +220,11 @@ int ICATPortBindingProxy::logout(const char *endpoint, const char *soap_action,
   struct __ns1__logout soap_tmp___ns1__logout;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/logoutRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__logout.ns1__logout_ = ns1__logout_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -234,17 +235,17 @@ int ICATPortBindingProxy::logout(const char *endpoint, const char *soap_action,
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__logout(soap, &soap_tmp___ns1__logout, "-ns1:logout",
-                               NULL) ||
+                               nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__logout(soap, &soap_tmp___ns1__logout, "-ns1:logout",
-                             NULL) ||
+                             nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -272,11 +273,11 @@ int ICATPortBindingProxy::getUserDetails(
   struct __ns1__getUserDetails soap_tmp___ns1__getUserDetails;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/getUserDetailsRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getUserDetails.ns1__getUserDetails = ns1__getUserDetails;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -287,17 +288,17 @@ int ICATPortBindingProxy::getUserDetails(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__getUserDetails(soap, &soap_tmp___ns1__getUserDetails,
-                                       "-ns1:getUserDetails", NULL) ||
+                                       "-ns1:getUserDetails", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getUserDetails(soap, &soap_tmp___ns1__getUserDetails,
-                                     "-ns1:getUserDetails", NULL) ||
+                                     "-ns1:getUserDetails", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -325,11 +326,11 @@ int ICATPortBindingProxy::isSessionValid(
   struct __ns1__isSessionValid soap_tmp___ns1__isSessionValid;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/isSessionValidRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__isSessionValid.ns1__isSessionValid_ = ns1__isSessionValid_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -340,17 +341,17 @@ int ICATPortBindingProxy::isSessionValid(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__isSessionValid(soap, &soap_tmp___ns1__isSessionValid,
-                                       "-ns1:isSessionValid", NULL) ||
+                                       "-ns1:isSessionValid", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__isSessionValid(soap, &soap_tmp___ns1__isSessionValid,
-                                     "-ns1:isSessionValid", NULL) ||
+                                     "-ns1:isSessionValid", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -378,11 +379,11 @@ int ICATPortBindingProxy::getKeywordsForUser(
   struct __ns1__getKeywordsForUser soap_tmp___ns1__getKeywordsForUser;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/getKeywordsForUserRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getKeywordsForUser.ns1__getKeywordsForUser_ =
       ns1__getKeywordsForUser_;
   soap_begin(soap);
@@ -394,20 +395,20 @@ int ICATPortBindingProxy::getKeywordsForUser(
   if (soap->mode & SOAP_IO_LENGTH) {
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
-        soap_put___ns1__getKeywordsForUser(soap,
-                                           &soap_tmp___ns1__getKeywordsForUser,
-                                           "-ns1:getKeywordsForUser", NULL) ||
+        soap_put___ns1__getKeywordsForUser(
+            soap, &soap_tmp___ns1__getKeywordsForUser,
+            "-ns1:getKeywordsForUser", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getKeywordsForUser(soap,
                                          &soap_tmp___ns1__getKeywordsForUser,
-                                         "-ns1:getKeywordsForUser", NULL) ||
+                                         "-ns1:getKeywordsForUser", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -437,11 +438,11 @@ int ICATPortBindingProxy::getKeywordsForUserStartWithMax(
       soap_tmp___ns1__getKeywordsForUserStartWithMax;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/getKeywordsForUserStartWithMaxRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getKeywordsForUserStartWithMax
       .ns1__getKeywordsForUserStartWithMax_ =
       ns1__getKeywordsForUserStartWithMax_;
@@ -456,18 +457,18 @@ int ICATPortBindingProxy::getKeywordsForUserStartWithMax(
         soap_body_begin_out(soap) ||
         soap_put___ns1__getKeywordsForUserStartWithMax(
             soap, &soap_tmp___ns1__getKeywordsForUserStartWithMax,
-            "-ns1:getKeywordsForUserStartWithMax", NULL) ||
+            "-ns1:getKeywordsForUserStartWithMax", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getKeywordsForUserStartWithMax(
           soap, &soap_tmp___ns1__getKeywordsForUserStartWithMax,
-          "-ns1:getKeywordsForUserStartWithMax", NULL) ||
+          "-ns1:getKeywordsForUserStartWithMax", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -496,11 +497,11 @@ int ICATPortBindingProxy::getKeywordsForUserMax(
   struct __ns1__getKeywordsForUserMax soap_tmp___ns1__getKeywordsForUserMax;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/getKeywordsForUserMaxRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getKeywordsForUserMax.ns1__getKeywordsForUserMax_ =
       ns1__getKeywordsForUserMax_;
   soap_begin(soap);
@@ -514,18 +515,18 @@ int ICATPortBindingProxy::getKeywordsForUserMax(
         soap_body_begin_out(soap) ||
         soap_put___ns1__getKeywordsForUserMax(
             soap, &soap_tmp___ns1__getKeywordsForUserMax,
-            "-ns1:getKeywordsForUserMax", NULL) ||
+            "-ns1:getKeywordsForUserMax", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getKeywordsForUserMax(
           soap, &soap_tmp___ns1__getKeywordsForUserMax,
-          "-ns1:getKeywordsForUserMax", NULL) ||
+          "-ns1:getKeywordsForUserMax", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -554,11 +555,11 @@ int ICATPortBindingProxy::getKeywordsForUserType(
   struct __ns1__getKeywordsForUserType soap_tmp___ns1__getKeywordsForUserType;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/getKeywordsForUserTypeRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getKeywordsForUserType.ns1__getKeywordsForUserType_ =
       ns1__getKeywordsForUserType_;
   soap_begin(soap);
@@ -572,18 +573,18 @@ int ICATPortBindingProxy::getKeywordsForUserType(
         soap_body_begin_out(soap) ||
         soap_put___ns1__getKeywordsForUserType(
             soap, &soap_tmp___ns1__getKeywordsForUserType,
-            "-ns1:getKeywordsForUserType", NULL) ||
+            "-ns1:getKeywordsForUserType", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getKeywordsForUserType(
           soap, &soap_tmp___ns1__getKeywordsForUserType,
-          "-ns1:getKeywordsForUserType", NULL) ||
+          "-ns1:getKeywordsForUserType", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -612,11 +613,11 @@ int ICATPortBindingProxy::getAllKeywords(
   struct __ns1__getAllKeywords soap_tmp___ns1__getAllKeywords;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/getAllKeywordsRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getAllKeywords.ns1__getAllKeywords_ = ns1__getAllKeywords_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -627,17 +628,17 @@ int ICATPortBindingProxy::getAllKeywords(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__getAllKeywords(soap, &soap_tmp___ns1__getAllKeywords,
-                                       "-ns1:getAllKeywords", NULL) ||
+                                       "-ns1:getAllKeywords", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getAllKeywords(soap, &soap_tmp___ns1__getAllKeywords,
-                                     "-ns1:getAllKeywords", NULL) ||
+                                     "-ns1:getAllKeywords", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -665,11 +666,11 @@ int ICATPortBindingProxy::searchByAdvanced(
   struct __ns1__searchByAdvanced soap_tmp___ns1__searchByAdvanced;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/searchByAdvancedRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchByAdvanced.ns1__searchByAdvanced_ =
       ns1__searchByAdvanced_;
   soap_begin(soap);
@@ -683,17 +684,17 @@ int ICATPortBindingProxy::searchByAdvanced(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchByAdvanced(soap,
                                          &soap_tmp___ns1__searchByAdvanced,
-                                         "-ns1:searchByAdvanced", NULL) ||
+                                         "-ns1:searchByAdvanced", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchByAdvanced(soap, &soap_tmp___ns1__searchByAdvanced,
-                                       "-ns1:searchByAdvanced", NULL) ||
+                                       "-ns1:searchByAdvanced", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -723,11 +724,11 @@ int ICATPortBindingProxy::searchByAdvancedPagination(
       soap_tmp___ns1__searchByAdvancedPagination;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/searchByAdvancedPaginationRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchByAdvancedPagination.ns1__searchByAdvancedPagination_ =
       ns1__searchByAdvancedPagination_;
   soap_begin(soap);
@@ -741,18 +742,18 @@ int ICATPortBindingProxy::searchByAdvancedPagination(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchByAdvancedPagination(
             soap, &soap_tmp___ns1__searchByAdvancedPagination,
-            "-ns1:searchByAdvancedPagination", NULL) ||
+            "-ns1:searchByAdvancedPagination", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchByAdvancedPagination(
           soap, &soap_tmp___ns1__searchByAdvancedPagination,
-          "-ns1:searchByAdvancedPagination", NULL) ||
+          "-ns1:searchByAdvancedPagination", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -781,11 +782,11 @@ int ICATPortBindingProxy::searchByKeywords(
   struct __ns1__searchByKeywords soap_tmp___ns1__searchByKeywords;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/searchByKeywordsRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchByKeywords.ns1__searchByKeywords_ =
       ns1__searchByKeywords_;
   soap_begin(soap);
@@ -799,17 +800,17 @@ int ICATPortBindingProxy::searchByKeywords(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchByKeywords(soap,
                                          &soap_tmp___ns1__searchByKeywords,
-                                         "-ns1:searchByKeywords", NULL) ||
+                                         "-ns1:searchByKeywords", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchByKeywords(soap, &soap_tmp___ns1__searchByKeywords,
-                                       "-ns1:searchByKeywords", NULL) ||
+                                       "-ns1:searchByKeywords", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -837,11 +838,11 @@ int ICATPortBindingProxy::searchByKeywordsAll(
   struct __ns1__searchByKeywordsAll soap_tmp___ns1__searchByKeywordsAll;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/searchByKeywordsAllRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchByKeywordsAll.ns1__searchByKeywordsAll_ =
       ns1__searchByKeywordsAll_;
   soap_begin(soap);
@@ -855,18 +856,18 @@ int ICATPortBindingProxy::searchByKeywordsAll(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchByKeywordsAll(
             soap, &soap_tmp___ns1__searchByKeywordsAll,
-            "-ns1:searchByKeywordsAll", NULL) ||
+            "-ns1:searchByKeywordsAll", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
-      soap_put___ns1__searchByKeywordsAll(soap,
-                                          &soap_tmp___ns1__searchByKeywordsAll,
-                                          "-ns1:searchByKeywordsAll", NULL) ||
+      soap_put___ns1__searchByKeywordsAll(
+          soap, &soap_tmp___ns1__searchByKeywordsAll,
+          "-ns1:searchByKeywordsAll", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -895,11 +896,11 @@ int ICATPortBindingProxy::getMyInvestigations(
   struct __ns1__getMyInvestigations soap_tmp___ns1__getMyInvestigations;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/getMyInvestigationsRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getMyInvestigations.ns1__getMyInvestigations_ =
       ns1__getMyInvestigations_;
   soap_begin(soap);
@@ -913,18 +914,18 @@ int ICATPortBindingProxy::getMyInvestigations(
         soap_body_begin_out(soap) ||
         soap_put___ns1__getMyInvestigations(
             soap, &soap_tmp___ns1__getMyInvestigations,
-            "-ns1:getMyInvestigations", NULL) ||
+            "-ns1:getMyInvestigations", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
-      soap_put___ns1__getMyInvestigations(soap,
-                                          &soap_tmp___ns1__getMyInvestigations,
-                                          "-ns1:getMyInvestigations", NULL) ||
+      soap_put___ns1__getMyInvestigations(
+          soap, &soap_tmp___ns1__getMyInvestigations,
+          "-ns1:getMyInvestigations", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -955,11 +956,11 @@ int ICATPortBindingProxy::getMyInvestigationsIncludes(
       soap_tmp___ns1__getMyInvestigationsIncludes;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/getMyInvestigationsIncludesRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getMyInvestigationsIncludes
       .ns1__getMyInvestigationsIncludes_ = ns1__getMyInvestigationsIncludes_;
   soap_begin(soap);
@@ -973,18 +974,18 @@ int ICATPortBindingProxy::getMyInvestigationsIncludes(
         soap_body_begin_out(soap) ||
         soap_put___ns1__getMyInvestigationsIncludes(
             soap, &soap_tmp___ns1__getMyInvestigationsIncludes,
-            "-ns1:getMyInvestigationsIncludes", NULL) ||
+            "-ns1:getMyInvestigationsIncludes", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getMyInvestigationsIncludes(
           soap, &soap_tmp___ns1__getMyInvestigationsIncludes,
-          "-ns1:getMyInvestigationsIncludes", NULL) ||
+          "-ns1:getMyInvestigationsIncludes", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -1016,12 +1017,12 @@ int ICATPortBindingProxy::getMyInvestigationsIncludesPagination(
       soap_tmp___ns1__getMyInvestigationsIncludesPagination;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action =
         "client.icat3.uk/ICAT/getMyInvestigationsIncludesPaginationRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getMyInvestigationsIncludesPagination
       .ns1__getMyInvestigationsIncludesPagination_ =
       ns1__getMyInvestigationsIncludesPagination_;
@@ -1036,18 +1037,18 @@ int ICATPortBindingProxy::getMyInvestigationsIncludesPagination(
         soap_body_begin_out(soap) ||
         soap_put___ns1__getMyInvestigationsIncludesPagination(
             soap, &soap_tmp___ns1__getMyInvestigationsIncludesPagination,
-            "-ns1:getMyInvestigationsIncludesPagination", NULL) ||
+            "-ns1:getMyInvestigationsIncludesPagination", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getMyInvestigationsIncludesPagination(
           soap, &soap_tmp___ns1__getMyInvestigationsIncludesPagination,
-          "-ns1:getMyInvestigationsIncludesPagination", NULL) ||
+          "-ns1:getMyInvestigationsIncludesPagination", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -1076,11 +1077,11 @@ int ICATPortBindingProxy::searchByUserID(
   struct __ns1__searchByUserID soap_tmp___ns1__searchByUserID;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/searchByUserIDRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchByUserID.ns1__searchByUserID_ = ns1__searchByUserID_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -1091,17 +1092,17 @@ int ICATPortBindingProxy::searchByUserID(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchByUserID(soap, &soap_tmp___ns1__searchByUserID,
-                                       "-ns1:searchByUserID", NULL) ||
+                                       "-ns1:searchByUserID", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchByUserID(soap, &soap_tmp___ns1__searchByUserID,
-                                     "-ns1:searchByUserID", NULL) ||
+                                     "-ns1:searchByUserID", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -1131,11 +1132,11 @@ int ICATPortBindingProxy::searchByUserIDPagination(
       soap_tmp___ns1__searchByUserIDPagination;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/searchByUserIDPaginationRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchByUserIDPagination.ns1__searchByUserIDPagination_ =
       ns1__searchByUserIDPagination_;
   soap_begin(soap);
@@ -1149,18 +1150,18 @@ int ICATPortBindingProxy::searchByUserIDPagination(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchByUserIDPagination(
             soap, &soap_tmp___ns1__searchByUserIDPagination,
-            "-ns1:searchByUserIDPagination", NULL) ||
+            "-ns1:searchByUserIDPagination", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchByUserIDPagination(
           soap, &soap_tmp___ns1__searchByUserIDPagination,
-          "-ns1:searchByUserIDPagination", NULL) ||
+          "-ns1:searchByUserIDPagination", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -1189,11 +1190,11 @@ int ICATPortBindingProxy::searchByUserSurname(
   struct __ns1__searchByUserSurname soap_tmp___ns1__searchByUserSurname;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/searchByUserSurnameRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchByUserSurname.ns1__searchByUserSurname_ =
       ns1__searchByUserSurname_;
   soap_begin(soap);
@@ -1207,18 +1208,18 @@ int ICATPortBindingProxy::searchByUserSurname(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchByUserSurname(
             soap, &soap_tmp___ns1__searchByUserSurname,
-            "-ns1:searchByUserSurname", NULL) ||
+            "-ns1:searchByUserSurname", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
-      soap_put___ns1__searchByUserSurname(soap,
-                                          &soap_tmp___ns1__searchByUserSurname,
-                                          "-ns1:searchByUserSurname", NULL) ||
+      soap_put___ns1__searchByUserSurname(
+          soap, &soap_tmp___ns1__searchByUserSurname,
+          "-ns1:searchByUserSurname", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -1249,11 +1250,11 @@ int ICATPortBindingProxy::searchByUserSurnamePagination(
       soap_tmp___ns1__searchByUserSurnamePagination;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/searchByUserSurnamePaginationRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchByUserSurnamePagination
       .ns1__searchByUserSurnamePagination_ =
       ns1__searchByUserSurnamePagination_;
@@ -1268,18 +1269,18 @@ int ICATPortBindingProxy::searchByUserSurnamePagination(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchByUserSurnamePagination(
             soap, &soap_tmp___ns1__searchByUserSurnamePagination,
-            "-ns1:searchByUserSurnamePagination", NULL) ||
+            "-ns1:searchByUserSurnamePagination", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchByUserSurnamePagination(
           soap, &soap_tmp___ns1__searchByUserSurnamePagination,
-          "-ns1:searchByUserSurnamePagination", NULL) ||
+          "-ns1:searchByUserSurnamePagination", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -1308,11 +1309,11 @@ int ICATPortBindingProxy::listInstruments(
   struct __ns1__listInstruments soap_tmp___ns1__listInstruments;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/listInstrumentsRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__listInstruments.ns1__listInstruments_ = ns1__listInstruments_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -1323,17 +1324,17 @@ int ICATPortBindingProxy::listInstruments(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__listInstruments(soap, &soap_tmp___ns1__listInstruments,
-                                        "-ns1:listInstruments", NULL) ||
+                                        "-ns1:listInstruments", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__listInstruments(soap, &soap_tmp___ns1__listInstruments,
-                                      "-ns1:listInstruments", NULL) ||
+                                      "-ns1:listInstruments", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -1361,11 +1362,11 @@ int ICATPortBindingProxy::getAllInstruments(
   struct __ns1__getAllInstruments soap_tmp___ns1__getAllInstruments;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/getAllInstrumentsRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getAllInstruments.ns1__getAllInstruments_ =
       ns1__getAllInstruments_;
   soap_begin(soap);
@@ -1379,17 +1380,17 @@ int ICATPortBindingProxy::getAllInstruments(
         soap_body_begin_out(soap) ||
         soap_put___ns1__getAllInstruments(soap,
                                           &soap_tmp___ns1__getAllInstruments,
-                                          "-ns1:getAllInstruments", NULL) ||
+                                          "-ns1:getAllInstruments", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) || soap_put___ns1__getAllInstruments(
                                        soap, &soap_tmp___ns1__getAllInstruments,
-                                       "-ns1:getAllInstruments", NULL) ||
+                                       "-ns1:getAllInstruments", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -1417,11 +1418,11 @@ int ICATPortBindingProxy::listRoles(
   struct __ns1__listRoles soap_tmp___ns1__listRoles;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/listRolesRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__listRoles.ns1__listRoles_ = ns1__listRoles_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -1432,17 +1433,17 @@ int ICATPortBindingProxy::listRoles(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__listRoles(soap, &soap_tmp___ns1__listRoles,
-                                  "-ns1:listRoles", NULL) ||
+                                  "-ns1:listRoles", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__listRoles(soap, &soap_tmp___ns1__listRoles,
-                                "-ns1:listRoles", NULL) ||
+                                "-ns1:listRoles", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -1470,11 +1471,11 @@ int ICATPortBindingProxy::listParameters(
   struct __ns1__listParameters soap_tmp___ns1__listParameters;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/listParametersRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__listParameters.ns1__listParameters_ = ns1__listParameters_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -1485,17 +1486,17 @@ int ICATPortBindingProxy::listParameters(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__listParameters(soap, &soap_tmp___ns1__listParameters,
-                                       "-ns1:listParameters", NULL) ||
+                                       "-ns1:listParameters", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__listParameters(soap, &soap_tmp___ns1__listParameters,
-                                     "-ns1:listParameters", NULL) ||
+                                     "-ns1:listParameters", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -1523,11 +1524,11 @@ int ICATPortBindingProxy::listFacilityCycles(
   struct __ns1__listFacilityCycles soap_tmp___ns1__listFacilityCycles;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/listFacilityCyclesRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__listFacilityCycles.ns1__listFacilityCycles_ =
       ns1__listFacilityCycles_;
   soap_begin(soap);
@@ -1539,20 +1540,20 @@ int ICATPortBindingProxy::listFacilityCycles(
   if (soap->mode & SOAP_IO_LENGTH) {
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
-        soap_put___ns1__listFacilityCycles(soap,
-                                           &soap_tmp___ns1__listFacilityCycles,
-                                           "-ns1:listFacilityCycles", NULL) ||
+        soap_put___ns1__listFacilityCycles(
+            soap, &soap_tmp___ns1__listFacilityCycles,
+            "-ns1:listFacilityCycles", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__listFacilityCycles(soap,
                                          &soap_tmp___ns1__listFacilityCycles,
-                                         "-ns1:listFacilityCycles", NULL) ||
+                                         "-ns1:listFacilityCycles", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -1583,12 +1584,12 @@ int ICATPortBindingProxy::getFacilityCyclesWithDataForInstrument(
       soap_tmp___ns1__getFacilityCyclesWithDataForInstrument;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action =
         "client.icat3.uk/ICAT/getFacilityCyclesWithDataForInstrumentRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getFacilityCyclesWithDataForInstrument
       .ns1__getFacilityCyclesWithDataForInstrument_ =
       ns1__getFacilityCyclesWithDataForInstrument_;
@@ -1603,18 +1604,18 @@ int ICATPortBindingProxy::getFacilityCyclesWithDataForInstrument(
         soap_body_begin_out(soap) ||
         soap_put___ns1__getFacilityCyclesWithDataForInstrument(
             soap, &soap_tmp___ns1__getFacilityCyclesWithDataForInstrument,
-            "-ns1:getFacilityCyclesWithDataForInstrument", NULL) ||
+            "-ns1:getFacilityCyclesWithDataForInstrument", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getFacilityCyclesWithDataForInstrument(
           soap, &soap_tmp___ns1__getFacilityCyclesWithDataForInstrument,
-          "-ns1:getFacilityCyclesWithDataForInstrument", NULL) ||
+          "-ns1:getFacilityCyclesWithDataForInstrument", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -1643,11 +1644,11 @@ int ICATPortBindingProxy::getInstrumentsWithData(
   struct __ns1__getInstrumentsWithData soap_tmp___ns1__getInstrumentsWithData;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/getInstrumentsWithDataRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getInstrumentsWithData.ns1__getInstrumentsWithData_ =
       ns1__getInstrumentsWithData_;
   soap_begin(soap);
@@ -1661,18 +1662,18 @@ int ICATPortBindingProxy::getInstrumentsWithData(
         soap_body_begin_out(soap) ||
         soap_put___ns1__getInstrumentsWithData(
             soap, &soap_tmp___ns1__getInstrumentsWithData,
-            "-ns1:getInstrumentsWithData", NULL) ||
+            "-ns1:getInstrumentsWithData", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getInstrumentsWithData(
           soap, &soap_tmp___ns1__getInstrumentsWithData,
-          "-ns1:getInstrumentsWithData", NULL) ||
+          "-ns1:getInstrumentsWithData", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -1701,11 +1702,11 @@ int ICATPortBindingProxy::listInvestigationTypes(
   struct __ns1__listInvestigationTypes soap_tmp___ns1__listInvestigationTypes;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/listInvestigationTypesRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__listInvestigationTypes.ns1__listInvestigationTypes_ =
       ns1__listInvestigationTypes_;
   soap_begin(soap);
@@ -1719,18 +1720,18 @@ int ICATPortBindingProxy::listInvestigationTypes(
         soap_body_begin_out(soap) ||
         soap_put___ns1__listInvestigationTypes(
             soap, &soap_tmp___ns1__listInvestigationTypes,
-            "-ns1:listInvestigationTypes", NULL) ||
+            "-ns1:listInvestigationTypes", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__listInvestigationTypes(
           soap, &soap_tmp___ns1__listInvestigationTypes,
-          "-ns1:listInvestigationTypes", NULL) ||
+          "-ns1:listInvestigationTypes", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -1761,11 +1762,11 @@ int ICATPortBindingProxy::searchSamplesBySampleName(
       soap_tmp___ns1__searchSamplesBySampleName;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/searchSamplesBySampleNameRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchSamplesBySampleName.ns1__searchSamplesBySampleName_ =
       ns1__searchSamplesBySampleName_;
   soap_begin(soap);
@@ -1779,18 +1780,18 @@ int ICATPortBindingProxy::searchSamplesBySampleName(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchSamplesBySampleName(
             soap, &soap_tmp___ns1__searchSamplesBySampleName,
-            "-ns1:searchSamplesBySampleName", NULL) ||
+            "-ns1:searchSamplesBySampleName", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchSamplesBySampleName(
           soap, &soap_tmp___ns1__searchSamplesBySampleName,
-          "-ns1:searchSamplesBySampleName", NULL) ||
+          "-ns1:searchSamplesBySampleName", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -1819,11 +1820,11 @@ int ICATPortBindingProxy::searchDatasetsBySample(
   struct __ns1__searchDatasetsBySample soap_tmp___ns1__searchDatasetsBySample;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/searchDatasetsBySampleRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchDatasetsBySample.ns1__searchDatasetsBySample_ =
       ns1__searchDatasetsBySample_;
   soap_begin(soap);
@@ -1837,18 +1838,18 @@ int ICATPortBindingProxy::searchDatasetsBySample(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchDatasetsBySample(
             soap, &soap_tmp___ns1__searchDatasetsBySample,
-            "-ns1:searchDatasetsBySample", NULL) ||
+            "-ns1:searchDatasetsBySample", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchDatasetsBySample(
           soap, &soap_tmp___ns1__searchDatasetsBySample,
-          "-ns1:searchDatasetsBySample", NULL) ||
+          "-ns1:searchDatasetsBySample", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -1877,11 +1878,11 @@ int ICATPortBindingProxy::listDatasetTypes(
   struct __ns1__listDatasetTypes soap_tmp___ns1__listDatasetTypes;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/listDatasetTypesRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__listDatasetTypes.ns1__listDatasetTypes_ =
       ns1__listDatasetTypes_;
   soap_begin(soap);
@@ -1895,17 +1896,17 @@ int ICATPortBindingProxy::listDatasetTypes(
         soap_body_begin_out(soap) ||
         soap_put___ns1__listDatasetTypes(soap,
                                          &soap_tmp___ns1__listDatasetTypes,
-                                         "-ns1:listDatasetTypes", NULL) ||
+                                         "-ns1:listDatasetTypes", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__listDatasetTypes(soap, &soap_tmp___ns1__listDatasetTypes,
-                                       "-ns1:listDatasetTypes", NULL) ||
+                                       "-ns1:listDatasetTypes", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -1933,11 +1934,11 @@ int ICATPortBindingProxy::listDatasetStatus(
   struct __ns1__listDatasetStatus soap_tmp___ns1__listDatasetStatus;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/listDatasetStatusRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__listDatasetStatus.ns1__listDatasetStatus_ =
       ns1__listDatasetStatus_;
   soap_begin(soap);
@@ -1951,17 +1952,17 @@ int ICATPortBindingProxy::listDatasetStatus(
         soap_body_begin_out(soap) ||
         soap_put___ns1__listDatasetStatus(soap,
                                           &soap_tmp___ns1__listDatasetStatus,
-                                          "-ns1:listDatasetStatus", NULL) ||
+                                          "-ns1:listDatasetStatus", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) || soap_put___ns1__listDatasetStatus(
                                        soap, &soap_tmp___ns1__listDatasetStatus,
-                                       "-ns1:listDatasetStatus", NULL) ||
+                                       "-ns1:listDatasetStatus", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -1989,11 +1990,11 @@ int ICATPortBindingProxy::searchByRunNumber(
   struct __ns1__searchByRunNumber soap_tmp___ns1__searchByRunNumber;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/searchByRunNumberRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchByRunNumber.ns1__searchByRunNumber_ =
       ns1__searchByRunNumber_;
   soap_begin(soap);
@@ -2007,17 +2008,17 @@ int ICATPortBindingProxy::searchByRunNumber(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchByRunNumber(soap,
                                           &soap_tmp___ns1__searchByRunNumber,
-                                          "-ns1:searchByRunNumber", NULL) ||
+                                          "-ns1:searchByRunNumber", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) || soap_put___ns1__searchByRunNumber(
                                        soap, &soap_tmp___ns1__searchByRunNumber,
-                                       "-ns1:searchByRunNumber", NULL) ||
+                                       "-ns1:searchByRunNumber", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -2047,11 +2048,11 @@ int ICATPortBindingProxy::searchByRunNumberPagination(
       soap_tmp___ns1__searchByRunNumberPagination;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/searchByRunNumberPaginationRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchByRunNumberPagination
       .ns1__searchByRunNumberPagination_ = ns1__searchByRunNumberPagination_;
   soap_begin(soap);
@@ -2065,18 +2066,18 @@ int ICATPortBindingProxy::searchByRunNumberPagination(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchByRunNumberPagination(
             soap, &soap_tmp___ns1__searchByRunNumberPagination,
-            "-ns1:searchByRunNumberPagination", NULL) ||
+            "-ns1:searchByRunNumberPagination", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchByRunNumberPagination(
           soap, &soap_tmp___ns1__searchByRunNumberPagination,
-          "-ns1:searchByRunNumberPagination", NULL) ||
+          "-ns1:searchByRunNumberPagination", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -2105,11 +2106,11 @@ int ICATPortBindingProxy::listDatafileFormats(
   struct __ns1__listDatafileFormats soap_tmp___ns1__listDatafileFormats;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/listDatafileFormatsRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__listDatafileFormats.ns1__listDatafileFormats_ =
       ns1__listDatafileFormats_;
   soap_begin(soap);
@@ -2123,18 +2124,18 @@ int ICATPortBindingProxy::listDatafileFormats(
         soap_body_begin_out(soap) ||
         soap_put___ns1__listDatafileFormats(
             soap, &soap_tmp___ns1__listDatafileFormats,
-            "-ns1:listDatafileFormats", NULL) ||
+            "-ns1:listDatafileFormats", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
-      soap_put___ns1__listDatafileFormats(soap,
-                                          &soap_tmp___ns1__listDatafileFormats,
-                                          "-ns1:listDatafileFormats", NULL) ||
+      soap_put___ns1__listDatafileFormats(
+          soap, &soap_tmp___ns1__listDatafileFormats,
+          "-ns1:listDatafileFormats", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -2163,11 +2164,11 @@ int ICATPortBindingProxy::getInvestigation(
   struct __ns1__getInvestigation soap_tmp___ns1__getInvestigation;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/getInvestigationRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getInvestigation.ns1__getInvestigation_ =
       ns1__getInvestigation_;
   soap_begin(soap);
@@ -2181,17 +2182,17 @@ int ICATPortBindingProxy::getInvestigation(
         soap_body_begin_out(soap) ||
         soap_put___ns1__getInvestigation(soap,
                                          &soap_tmp___ns1__getInvestigation,
-                                         "-ns1:getInvestigation", NULL) ||
+                                         "-ns1:getInvestigation", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getInvestigation(soap, &soap_tmp___ns1__getInvestigation,
-                                       "-ns1:getInvestigation", NULL) ||
+                                       "-ns1:getInvestigation", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -2221,11 +2222,11 @@ int ICATPortBindingProxy::getInvestigationIncludes(
       soap_tmp___ns1__getInvestigationIncludes;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/getInvestigationIncludesRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getInvestigationIncludes.ns1__getInvestigationIncludes_ =
       ns1__getInvestigationIncludes_;
   soap_begin(soap);
@@ -2239,18 +2240,18 @@ int ICATPortBindingProxy::getInvestigationIncludes(
         soap_body_begin_out(soap) ||
         soap_put___ns1__getInvestigationIncludes(
             soap, &soap_tmp___ns1__getInvestigationIncludes,
-            "-ns1:getInvestigationIncludes", NULL) ||
+            "-ns1:getInvestigationIncludes", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getInvestigationIncludes(
           soap, &soap_tmp___ns1__getInvestigationIncludes,
-          "-ns1:getInvestigationIncludes", NULL) ||
+          "-ns1:getInvestigationIncludes", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -2279,11 +2280,11 @@ int ICATPortBindingProxy::getInvestigations(
   struct __ns1__getInvestigations soap_tmp___ns1__getInvestigations;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/getInvestigationsRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getInvestigations.ns1__getInvestigations_ =
       ns1__getInvestigations_;
   soap_begin(soap);
@@ -2297,17 +2298,17 @@ int ICATPortBindingProxy::getInvestigations(
         soap_body_begin_out(soap) ||
         soap_put___ns1__getInvestigations(soap,
                                           &soap_tmp___ns1__getInvestigations,
-                                          "-ns1:getInvestigations", NULL) ||
+                                          "-ns1:getInvestigations", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) || soap_put___ns1__getInvestigations(
                                        soap, &soap_tmp___ns1__getInvestigations,
-                                       "-ns1:getInvestigations", NULL) ||
+                                       "-ns1:getInvestigations", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -2337,11 +2338,11 @@ int ICATPortBindingProxy::getInvestigationsIncludes(
       soap_tmp___ns1__getInvestigationsIncludes;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/getInvestigationsIncludesRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getInvestigationsIncludes.ns1__getInvestigationsIncludes_ =
       ns1__getInvestigationsIncludes_;
   soap_begin(soap);
@@ -2355,18 +2356,18 @@ int ICATPortBindingProxy::getInvestigationsIncludes(
         soap_body_begin_out(soap) ||
         soap_put___ns1__getInvestigationsIncludes(
             soap, &soap_tmp___ns1__getInvestigationsIncludes,
-            "-ns1:getInvestigationsIncludes", NULL) ||
+            "-ns1:getInvestigationsIncludes", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getInvestigationsIncludes(
           soap, &soap_tmp___ns1__getInvestigationsIncludes,
-          "-ns1:getInvestigationsIncludes", NULL) ||
+          "-ns1:getInvestigationsIncludes", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -2395,11 +2396,11 @@ int ICATPortBindingProxy::createInvestigation(
   struct __ns1__createInvestigation soap_tmp___ns1__createInvestigation;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/createInvestigationRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__createInvestigation.ns1__createInvestigation_ =
       ns1__createInvestigation_;
   soap_begin(soap);
@@ -2413,18 +2414,18 @@ int ICATPortBindingProxy::createInvestigation(
         soap_body_begin_out(soap) ||
         soap_put___ns1__createInvestigation(
             soap, &soap_tmp___ns1__createInvestigation,
-            "-ns1:createInvestigation", NULL) ||
+            "-ns1:createInvestigation", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
-      soap_put___ns1__createInvestigation(soap,
-                                          &soap_tmp___ns1__createInvestigation,
-                                          "-ns1:createInvestigation", NULL) ||
+      soap_put___ns1__createInvestigation(
+          soap, &soap_tmp___ns1__createInvestigation,
+          "-ns1:createInvestigation", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -2455,11 +2456,11 @@ int ICATPortBindingProxy::deleteInvestigation(
       soap_tmp___ns1__deleteInvestigationResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/deleteInvestigationRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__deleteInvestigation.ns1__deleteInvestigation_ =
       ns1__deleteInvestigation_;
   soap_begin(soap);
@@ -2473,18 +2474,18 @@ int ICATPortBindingProxy::deleteInvestigation(
         soap_body_begin_out(soap) ||
         soap_put___ns1__deleteInvestigation(
             soap, &soap_tmp___ns1__deleteInvestigation,
-            "-ns1:deleteInvestigation", NULL) ||
+            "-ns1:deleteInvestigation", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
-      soap_put___ns1__deleteInvestigation(soap,
-                                          &soap_tmp___ns1__deleteInvestigation,
-                                          "-ns1:deleteInvestigation", NULL) ||
+      soap_put___ns1__deleteInvestigation(
+          soap, &soap_tmp___ns1__deleteInvestigation,
+          "-ns1:deleteInvestigation", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -2496,7 +2497,7 @@ int ICATPortBindingProxy::deleteInvestigation(
     return soap_closesock(soap);
   soap_tmp___ns1__deleteInvestigationResponse =
       soap_get___ns1__deleteInvestigationResponse(
-          soap, NULL, "-ns1:deleteInvestigationResponse",
+          soap, nullptr, "-ns1:deleteInvestigationResponse",
           "ns1:deleteInvestigationResponse");
   if (!soap_tmp___ns1__deleteInvestigationResponse || soap->error)
     return soap_recv_fault(soap, 0);
@@ -2522,11 +2523,11 @@ int ICATPortBindingProxy::removeInvestigation(
       soap_tmp___ns1__removeInvestigationResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/removeInvestigationRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__removeInvestigation.ns1__removeInvestigation_ =
       ns1__removeInvestigation_;
   soap_begin(soap);
@@ -2540,18 +2541,18 @@ int ICATPortBindingProxy::removeInvestigation(
         soap_body_begin_out(soap) ||
         soap_put___ns1__removeInvestigation(
             soap, &soap_tmp___ns1__removeInvestigation,
-            "-ns1:removeInvestigation", NULL) ||
+            "-ns1:removeInvestigation", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
-      soap_put___ns1__removeInvestigation(soap,
-                                          &soap_tmp___ns1__removeInvestigation,
-                                          "-ns1:removeInvestigation", NULL) ||
+      soap_put___ns1__removeInvestigation(
+          soap, &soap_tmp___ns1__removeInvestigation,
+          "-ns1:removeInvestigation", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -2563,7 +2564,7 @@ int ICATPortBindingProxy::removeInvestigation(
     return soap_closesock(soap);
   soap_tmp___ns1__removeInvestigationResponse =
       soap_get___ns1__removeInvestigationResponse(
-          soap, NULL, "-ns1:removeInvestigationResponse",
+          soap, nullptr, "-ns1:removeInvestigationResponse",
           "ns1:removeInvestigationResponse");
   if (!soap_tmp___ns1__removeInvestigationResponse || soap->error)
     return soap_recv_fault(soap, 0);
@@ -2587,11 +2588,11 @@ int ICATPortBindingProxy::addKeyword(
   struct __ns1__addKeyword soap_tmp___ns1__addKeyword;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/addKeywordRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__addKeyword.ns1__addKeyword_ = ns1__addKeyword_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -2602,17 +2603,17 @@ int ICATPortBindingProxy::addKeyword(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__addKeyword(soap, &soap_tmp___ns1__addKeyword,
-                                   "-ns1:addKeyword", NULL) ||
+                                   "-ns1:addKeyword", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__addKeyword(soap, &soap_tmp___ns1__addKeyword,
-                                 "-ns1:addKeyword", NULL) ||
+                                 "-ns1:addKeyword", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -2640,11 +2641,11 @@ int ICATPortBindingProxy::addInvestigator(
   struct __ns1__addInvestigator soap_tmp___ns1__addInvestigator;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/addInvestigatorRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__addInvestigator.ns1__addInvestigator_ = ns1__addInvestigator_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -2655,17 +2656,17 @@ int ICATPortBindingProxy::addInvestigator(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__addInvestigator(soap, &soap_tmp___ns1__addInvestigator,
-                                        "-ns1:addInvestigator", NULL) ||
+                                        "-ns1:addInvestigator", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__addInvestigator(soap, &soap_tmp___ns1__addInvestigator,
-                                      "-ns1:addInvestigator", NULL) ||
+                                      "-ns1:addInvestigator", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -2693,11 +2694,11 @@ int ICATPortBindingProxy::addSample(
   struct __ns1__addSample soap_tmp___ns1__addSample;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/addSampleRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__addSample.ns1__addSample_ = ns1__addSample_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -2708,17 +2709,17 @@ int ICATPortBindingProxy::addSample(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__addSample(soap, &soap_tmp___ns1__addSample,
-                                  "-ns1:addSample", NULL) ||
+                                  "-ns1:addSample", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__addSample(soap, &soap_tmp___ns1__addSample,
-                                "-ns1:addSample", NULL) ||
+                                "-ns1:addSample", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -2746,11 +2747,11 @@ int ICATPortBindingProxy::addPublication(
   struct __ns1__addPublication soap_tmp___ns1__addPublication;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/addPublicationRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__addPublication.ns1__addPublication_ = ns1__addPublication_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -2761,17 +2762,17 @@ int ICATPortBindingProxy::addPublication(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__addPublication(soap, &soap_tmp___ns1__addPublication,
-                                       "-ns1:addPublication", NULL) ||
+                                       "-ns1:addPublication", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__addPublication(soap, &soap_tmp___ns1__addPublication,
-                                     "-ns1:addPublication", NULL) ||
+                                     "-ns1:addPublication", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -2799,11 +2800,11 @@ int ICATPortBindingProxy::addSampleParameter(
   struct __ns1__addSampleParameter soap_tmp___ns1__addSampleParameter;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/addSampleParameterRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__addSampleParameter.ns1__addSampleParameter_ =
       ns1__addSampleParameter_;
   soap_begin(soap);
@@ -2815,20 +2816,20 @@ int ICATPortBindingProxy::addSampleParameter(
   if (soap->mode & SOAP_IO_LENGTH) {
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
-        soap_put___ns1__addSampleParameter(soap,
-                                           &soap_tmp___ns1__addSampleParameter,
-                                           "-ns1:addSampleParameter", NULL) ||
+        soap_put___ns1__addSampleParameter(
+            soap, &soap_tmp___ns1__addSampleParameter,
+            "-ns1:addSampleParameter", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__addSampleParameter(soap,
                                          &soap_tmp___ns1__addSampleParameter,
-                                         "-ns1:addSampleParameter", NULL) ||
+                                         "-ns1:addSampleParameter", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -2858,11 +2859,11 @@ int ICATPortBindingProxy::deleteInvestigator(
       soap_tmp___ns1__deleteInvestigatorResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/deleteInvestigatorRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__deleteInvestigator.ns1__deleteInvestigator_ =
       ns1__deleteInvestigator_;
   soap_begin(soap);
@@ -2874,20 +2875,20 @@ int ICATPortBindingProxy::deleteInvestigator(
   if (soap->mode & SOAP_IO_LENGTH) {
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
-        soap_put___ns1__deleteInvestigator(soap,
-                                           &soap_tmp___ns1__deleteInvestigator,
-                                           "-ns1:deleteInvestigator", NULL) ||
+        soap_put___ns1__deleteInvestigator(
+            soap, &soap_tmp___ns1__deleteInvestigator,
+            "-ns1:deleteInvestigator", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__deleteInvestigator(soap,
                                          &soap_tmp___ns1__deleteInvestigator,
-                                         "-ns1:deleteInvestigator", NULL) ||
+                                         "-ns1:deleteInvestigator", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -2899,7 +2900,7 @@ int ICATPortBindingProxy::deleteInvestigator(
     return soap_closesock(soap);
   soap_tmp___ns1__deleteInvestigatorResponse =
       soap_get___ns1__deleteInvestigatorResponse(
-          soap, NULL, "-ns1:deleteInvestigatorResponse",
+          soap, nullptr, "-ns1:deleteInvestigatorResponse",
           "ns1:deleteInvestigatorResponse");
   if (!soap_tmp___ns1__deleteInvestigatorResponse || soap->error)
     return soap_recv_fault(soap, 0);
@@ -2924,11 +2925,11 @@ int ICATPortBindingProxy::deleteKeyword(
   struct __ns1__deleteKeywordResponse *soap_tmp___ns1__deleteKeywordResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/deleteKeywordRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__deleteKeyword.ns1__deleteKeyword_ = ns1__deleteKeyword_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -2939,17 +2940,17 @@ int ICATPortBindingProxy::deleteKeyword(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__deleteKeyword(soap, &soap_tmp___ns1__deleteKeyword,
-                                      "-ns1:deleteKeyword", NULL) ||
+                                      "-ns1:deleteKeyword", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__deleteKeyword(soap, &soap_tmp___ns1__deleteKeyword,
-                                    "-ns1:deleteKeyword", NULL) ||
+                                    "-ns1:deleteKeyword", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -2960,7 +2961,7 @@ int ICATPortBindingProxy::deleteKeyword(
       soap_recv_header(soap) || soap_body_begin_in(soap))
     return soap_closesock(soap);
   soap_tmp___ns1__deleteKeywordResponse = soap_get___ns1__deleteKeywordResponse(
-      soap, NULL, "-ns1:deleteKeywordResponse", "ns1:deleteKeywordResponse");
+      soap, nullptr, "-ns1:deleteKeywordResponse", "ns1:deleteKeywordResponse");
   if (!soap_tmp___ns1__deleteKeywordResponse || soap->error)
     return soap_recv_fault(soap, 0);
   if (soap_body_end_in(soap) || soap_envelope_end_in(soap) ||
@@ -2983,11 +2984,11 @@ int ICATPortBindingProxy::deletePublication(
       soap_tmp___ns1__deletePublicationResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/deletePublicationRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__deletePublication.ns1__deletePublication_ =
       ns1__deletePublication_;
   soap_begin(soap);
@@ -3001,17 +3002,17 @@ int ICATPortBindingProxy::deletePublication(
         soap_body_begin_out(soap) ||
         soap_put___ns1__deletePublication(soap,
                                           &soap_tmp___ns1__deletePublication,
-                                          "-ns1:deletePublication", NULL) ||
+                                          "-ns1:deletePublication", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) || soap_put___ns1__deletePublication(
                                        soap, &soap_tmp___ns1__deletePublication,
-                                       "-ns1:deletePublication", NULL) ||
+                                       "-ns1:deletePublication", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -3023,7 +3024,7 @@ int ICATPortBindingProxy::deletePublication(
     return soap_closesock(soap);
   soap_tmp___ns1__deletePublicationResponse =
       soap_get___ns1__deletePublicationResponse(
-          soap, NULL, "-ns1:deletePublicationResponse",
+          soap, nullptr, "-ns1:deletePublicationResponse",
           "ns1:deletePublicationResponse");
   if (!soap_tmp___ns1__deletePublicationResponse || soap->error)
     return soap_recv_fault(soap, 0);
@@ -3048,11 +3049,11 @@ int ICATPortBindingProxy::deleteSample(
   struct __ns1__deleteSampleResponse *soap_tmp___ns1__deleteSampleResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/deleteSampleRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__deleteSample.ns1__deleteSample_ = ns1__deleteSample_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -3063,17 +3064,17 @@ int ICATPortBindingProxy::deleteSample(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__deleteSample(soap, &soap_tmp___ns1__deleteSample,
-                                     "-ns1:deleteSample", NULL) ||
+                                     "-ns1:deleteSample", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__deleteSample(soap, &soap_tmp___ns1__deleteSample,
-                                   "-ns1:deleteSample", NULL) ||
+                                   "-ns1:deleteSample", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -3084,7 +3085,7 @@ int ICATPortBindingProxy::deleteSample(
       soap_recv_header(soap) || soap_body_begin_in(soap))
     return soap_closesock(soap);
   soap_tmp___ns1__deleteSampleResponse = soap_get___ns1__deleteSampleResponse(
-      soap, NULL, "-ns1:deleteSampleResponse", "ns1:deleteSampleResponse");
+      soap, nullptr, "-ns1:deleteSampleResponse", "ns1:deleteSampleResponse");
   if (!soap_tmp___ns1__deleteSampleResponse || soap->error)
     return soap_recv_fault(soap, 0);
   if (soap_body_end_in(soap) || soap_envelope_end_in(soap) ||
@@ -3107,11 +3108,11 @@ int ICATPortBindingProxy::deleteSampleParameter(
       soap_tmp___ns1__deleteSampleParameterResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/deleteSampleParameterRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__deleteSampleParameter.ns1__deleteSampleParameter_ =
       ns1__deleteSampleParameter_;
   soap_begin(soap);
@@ -3125,18 +3126,18 @@ int ICATPortBindingProxy::deleteSampleParameter(
         soap_body_begin_out(soap) ||
         soap_put___ns1__deleteSampleParameter(
             soap, &soap_tmp___ns1__deleteSampleParameter,
-            "-ns1:deleteSampleParameter", NULL) ||
+            "-ns1:deleteSampleParameter", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__deleteSampleParameter(
           soap, &soap_tmp___ns1__deleteSampleParameter,
-          "-ns1:deleteSampleParameter", NULL) ||
+          "-ns1:deleteSampleParameter", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -3148,7 +3149,7 @@ int ICATPortBindingProxy::deleteSampleParameter(
     return soap_closesock(soap);
   soap_tmp___ns1__deleteSampleParameterResponse =
       soap_get___ns1__deleteSampleParameterResponse(
-          soap, NULL, "-ns1:deleteSampleParameterResponse",
+          soap, nullptr, "-ns1:deleteSampleParameterResponse",
           "ns1:deleteSampleParameterResponse");
   if (!soap_tmp___ns1__deleteSampleParameterResponse || soap->error)
     return soap_recv_fault(soap, 0);
@@ -3174,11 +3175,11 @@ int ICATPortBindingProxy::modifyInvestigation(
       soap_tmp___ns1__modifyInvestigationResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/modifyInvestigationRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__modifyInvestigation.ns1__modifyInvestigation_ =
       ns1__modifyInvestigation_;
   soap_begin(soap);
@@ -3192,18 +3193,18 @@ int ICATPortBindingProxy::modifyInvestigation(
         soap_body_begin_out(soap) ||
         soap_put___ns1__modifyInvestigation(
             soap, &soap_tmp___ns1__modifyInvestigation,
-            "-ns1:modifyInvestigation", NULL) ||
+            "-ns1:modifyInvestigation", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
-      soap_put___ns1__modifyInvestigation(soap,
-                                          &soap_tmp___ns1__modifyInvestigation,
-                                          "-ns1:modifyInvestigation", NULL) ||
+      soap_put___ns1__modifyInvestigation(
+          soap, &soap_tmp___ns1__modifyInvestigation,
+          "-ns1:modifyInvestigation", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -3215,7 +3216,7 @@ int ICATPortBindingProxy::modifyInvestigation(
     return soap_closesock(soap);
   soap_tmp___ns1__modifyInvestigationResponse =
       soap_get___ns1__modifyInvestigationResponse(
-          soap, NULL, "-ns1:modifyInvestigationResponse",
+          soap, nullptr, "-ns1:modifyInvestigationResponse",
           "ns1:modifyInvestigationResponse");
   if (!soap_tmp___ns1__modifyInvestigationResponse || soap->error)
     return soap_recv_fault(soap, 0);
@@ -3241,11 +3242,11 @@ int ICATPortBindingProxy::modifyInvestigator(
       soap_tmp___ns1__modifyInvestigatorResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/modifyInvestigatorRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__modifyInvestigator.ns1__modifyInvestigator_ =
       ns1__modifyInvestigator_;
   soap_begin(soap);
@@ -3257,20 +3258,20 @@ int ICATPortBindingProxy::modifyInvestigator(
   if (soap->mode & SOAP_IO_LENGTH) {
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
-        soap_put___ns1__modifyInvestigator(soap,
-                                           &soap_tmp___ns1__modifyInvestigator,
-                                           "-ns1:modifyInvestigator", NULL) ||
+        soap_put___ns1__modifyInvestigator(
+            soap, &soap_tmp___ns1__modifyInvestigator,
+            "-ns1:modifyInvestigator", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__modifyInvestigator(soap,
                                          &soap_tmp___ns1__modifyInvestigator,
-                                         "-ns1:modifyInvestigator", NULL) ||
+                                         "-ns1:modifyInvestigator", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -3282,7 +3283,7 @@ int ICATPortBindingProxy::modifyInvestigator(
     return soap_closesock(soap);
   soap_tmp___ns1__modifyInvestigatorResponse =
       soap_get___ns1__modifyInvestigatorResponse(
-          soap, NULL, "-ns1:modifyInvestigatorResponse",
+          soap, nullptr, "-ns1:modifyInvestigatorResponse",
           "ns1:modifyInvestigatorResponse");
   if (!soap_tmp___ns1__modifyInvestigatorResponse || soap->error)
     return soap_recv_fault(soap, 0);
@@ -3307,11 +3308,11 @@ int ICATPortBindingProxy::modifySample(
   struct __ns1__modifySampleResponse *soap_tmp___ns1__modifySampleResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/modifySampleRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__modifySample.ns1__modifySample_ = ns1__modifySample_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -3322,17 +3323,17 @@ int ICATPortBindingProxy::modifySample(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__modifySample(soap, &soap_tmp___ns1__modifySample,
-                                     "-ns1:modifySample", NULL) ||
+                                     "-ns1:modifySample", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__modifySample(soap, &soap_tmp___ns1__modifySample,
-                                   "-ns1:modifySample", NULL) ||
+                                   "-ns1:modifySample", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -3343,7 +3344,7 @@ int ICATPortBindingProxy::modifySample(
       soap_recv_header(soap) || soap_body_begin_in(soap))
     return soap_closesock(soap);
   soap_tmp___ns1__modifySampleResponse = soap_get___ns1__modifySampleResponse(
-      soap, NULL, "-ns1:modifySampleResponse", "ns1:modifySampleResponse");
+      soap, nullptr, "-ns1:modifySampleResponse", "ns1:modifySampleResponse");
   if (!soap_tmp___ns1__modifySampleResponse || soap->error)
     return soap_recv_fault(soap, 0);
   if (soap_body_end_in(soap) || soap_envelope_end_in(soap) ||
@@ -3366,11 +3367,11 @@ int ICATPortBindingProxy::modifyPublication(
       soap_tmp___ns1__modifyPublicationResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/modifyPublicationRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__modifyPublication.ns1__modifyPublication_ =
       ns1__modifyPublication_;
   soap_begin(soap);
@@ -3384,17 +3385,17 @@ int ICATPortBindingProxy::modifyPublication(
         soap_body_begin_out(soap) ||
         soap_put___ns1__modifyPublication(soap,
                                           &soap_tmp___ns1__modifyPublication,
-                                          "-ns1:modifyPublication", NULL) ||
+                                          "-ns1:modifyPublication", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) || soap_put___ns1__modifyPublication(
                                        soap, &soap_tmp___ns1__modifyPublication,
-                                       "-ns1:modifyPublication", NULL) ||
+                                       "-ns1:modifyPublication", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -3406,7 +3407,7 @@ int ICATPortBindingProxy::modifyPublication(
     return soap_closesock(soap);
   soap_tmp___ns1__modifyPublicationResponse =
       soap_get___ns1__modifyPublicationResponse(
-          soap, NULL, "-ns1:modifyPublicationResponse",
+          soap, nullptr, "-ns1:modifyPublicationResponse",
           "ns1:modifyPublicationResponse");
   if (!soap_tmp___ns1__modifyPublicationResponse || soap->error)
     return soap_recv_fault(soap, 0);
@@ -3432,11 +3433,11 @@ int ICATPortBindingProxy::modifySampleParameter(
       soap_tmp___ns1__modifySampleParameterResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/modifySampleParameterRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__modifySampleParameter.ns1__modifySampleParameter_ =
       ns1__modifySampleParameter_;
   soap_begin(soap);
@@ -3450,18 +3451,18 @@ int ICATPortBindingProxy::modifySampleParameter(
         soap_body_begin_out(soap) ||
         soap_put___ns1__modifySampleParameter(
             soap, &soap_tmp___ns1__modifySampleParameter,
-            "-ns1:modifySampleParameter", NULL) ||
+            "-ns1:modifySampleParameter", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__modifySampleParameter(
           soap, &soap_tmp___ns1__modifySampleParameter,
-          "-ns1:modifySampleParameter", NULL) ||
+          "-ns1:modifySampleParameter", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -3473,7 +3474,7 @@ int ICATPortBindingProxy::modifySampleParameter(
     return soap_closesock(soap);
   soap_tmp___ns1__modifySampleParameterResponse =
       soap_get___ns1__modifySampleParameterResponse(
-          soap, NULL, "-ns1:modifySampleParameterResponse",
+          soap, nullptr, "-ns1:modifySampleParameterResponse",
           "ns1:modifySampleParameterResponse");
   if (!soap_tmp___ns1__modifySampleParameterResponse || soap->error)
     return soap_recv_fault(soap, 0);
@@ -3498,11 +3499,11 @@ int ICATPortBindingProxy::removeKeyword(
   struct __ns1__removeKeywordResponse *soap_tmp___ns1__removeKeywordResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/removeKeywordRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__removeKeyword.ns1__removeKeyword_ = ns1__removeKeyword_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -3513,17 +3514,17 @@ int ICATPortBindingProxy::removeKeyword(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__removeKeyword(soap, &soap_tmp___ns1__removeKeyword,
-                                      "-ns1:removeKeyword", NULL) ||
+                                      "-ns1:removeKeyword", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__removeKeyword(soap, &soap_tmp___ns1__removeKeyword,
-                                    "-ns1:removeKeyword", NULL) ||
+                                    "-ns1:removeKeyword", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -3534,7 +3535,7 @@ int ICATPortBindingProxy::removeKeyword(
       soap_recv_header(soap) || soap_body_begin_in(soap))
     return soap_closesock(soap);
   soap_tmp___ns1__removeKeywordResponse = soap_get___ns1__removeKeywordResponse(
-      soap, NULL, "-ns1:removeKeywordResponse", "ns1:removeKeywordResponse");
+      soap, nullptr, "-ns1:removeKeywordResponse", "ns1:removeKeywordResponse");
   if (!soap_tmp___ns1__removeKeywordResponse || soap->error)
     return soap_recv_fault(soap, 0);
   if (soap_body_end_in(soap) || soap_envelope_end_in(soap) ||
@@ -3557,11 +3558,11 @@ int ICATPortBindingProxy::removeInvestigator(
       soap_tmp___ns1__removeInvestigatorResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/removeInvestigatorRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__removeInvestigator.ns1__removeInvestigator_ =
       ns1__removeInvestigator_;
   soap_begin(soap);
@@ -3573,20 +3574,20 @@ int ICATPortBindingProxy::removeInvestigator(
   if (soap->mode & SOAP_IO_LENGTH) {
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
-        soap_put___ns1__removeInvestigator(soap,
-                                           &soap_tmp___ns1__removeInvestigator,
-                                           "-ns1:removeInvestigator", NULL) ||
+        soap_put___ns1__removeInvestigator(
+            soap, &soap_tmp___ns1__removeInvestigator,
+            "-ns1:removeInvestigator", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__removeInvestigator(soap,
                                          &soap_tmp___ns1__removeInvestigator,
-                                         "-ns1:removeInvestigator", NULL) ||
+                                         "-ns1:removeInvestigator", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -3598,7 +3599,7 @@ int ICATPortBindingProxy::removeInvestigator(
     return soap_closesock(soap);
   soap_tmp___ns1__removeInvestigatorResponse =
       soap_get___ns1__removeInvestigatorResponse(
-          soap, NULL, "-ns1:removeInvestigatorResponse",
+          soap, nullptr, "-ns1:removeInvestigatorResponse",
           "ns1:removeInvestigatorResponse");
   if (!soap_tmp___ns1__removeInvestigatorResponse || soap->error)
     return soap_recv_fault(soap, 0);
@@ -3624,11 +3625,11 @@ int ICATPortBindingProxy::removePublication(
       soap_tmp___ns1__removePublicationResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/removePublicationRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__removePublication.ns1__removePublication_ =
       ns1__removePublication_;
   soap_begin(soap);
@@ -3642,17 +3643,17 @@ int ICATPortBindingProxy::removePublication(
         soap_body_begin_out(soap) ||
         soap_put___ns1__removePublication(soap,
                                           &soap_tmp___ns1__removePublication,
-                                          "-ns1:removePublication", NULL) ||
+                                          "-ns1:removePublication", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) || soap_put___ns1__removePublication(
                                        soap, &soap_tmp___ns1__removePublication,
-                                       "-ns1:removePublication", NULL) ||
+                                       "-ns1:removePublication", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -3664,7 +3665,7 @@ int ICATPortBindingProxy::removePublication(
     return soap_closesock(soap);
   soap_tmp___ns1__removePublicationResponse =
       soap_get___ns1__removePublicationResponse(
-          soap, NULL, "-ns1:removePublicationResponse",
+          soap, nullptr, "-ns1:removePublicationResponse",
           "ns1:removePublicationResponse");
   if (!soap_tmp___ns1__removePublicationResponse || soap->error)
     return soap_recv_fault(soap, 0);
@@ -3689,11 +3690,11 @@ int ICATPortBindingProxy::removeSample(
   struct __ns1__removeSampleResponse *soap_tmp___ns1__removeSampleResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/removeSampleRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__removeSample.ns1__removeSample_ = ns1__removeSample_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -3704,17 +3705,17 @@ int ICATPortBindingProxy::removeSample(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__removeSample(soap, &soap_tmp___ns1__removeSample,
-                                     "-ns1:removeSample", NULL) ||
+                                     "-ns1:removeSample", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__removeSample(soap, &soap_tmp___ns1__removeSample,
-                                   "-ns1:removeSample", NULL) ||
+                                   "-ns1:removeSample", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -3725,7 +3726,7 @@ int ICATPortBindingProxy::removeSample(
       soap_recv_header(soap) || soap_body_begin_in(soap))
     return soap_closesock(soap);
   soap_tmp___ns1__removeSampleResponse = soap_get___ns1__removeSampleResponse(
-      soap, NULL, "-ns1:removeSampleResponse", "ns1:removeSampleResponse");
+      soap, nullptr, "-ns1:removeSampleResponse", "ns1:removeSampleResponse");
   if (!soap_tmp___ns1__removeSampleResponse || soap->error)
     return soap_recv_fault(soap, 0);
   if (soap_body_end_in(soap) || soap_envelope_end_in(soap) ||
@@ -3748,11 +3749,11 @@ int ICATPortBindingProxy::removeSampleParameter(
       soap_tmp___ns1__removeSampleParameterResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/removeSampleParameterRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__removeSampleParameter.ns1__removeSampleParameter_ =
       ns1__removeSampleParameter_;
   soap_begin(soap);
@@ -3766,18 +3767,18 @@ int ICATPortBindingProxy::removeSampleParameter(
         soap_body_begin_out(soap) ||
         soap_put___ns1__removeSampleParameter(
             soap, &soap_tmp___ns1__removeSampleParameter,
-            "-ns1:removeSampleParameter", NULL) ||
+            "-ns1:removeSampleParameter", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__removeSampleParameter(
           soap, &soap_tmp___ns1__removeSampleParameter,
-          "-ns1:removeSampleParameter", NULL) ||
+          "-ns1:removeSampleParameter", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -3789,7 +3790,7 @@ int ICATPortBindingProxy::removeSampleParameter(
     return soap_closesock(soap);
   soap_tmp___ns1__removeSampleParameterResponse =
       soap_get___ns1__removeSampleParameterResponse(
-          soap, NULL, "-ns1:removeSampleParameterResponse",
+          soap, nullptr, "-ns1:removeSampleParameterResponse",
           "ns1:removeSampleParameterResponse");
   if (!soap_tmp___ns1__removeSampleParameterResponse || soap->error)
     return soap_recv_fault(soap, 0);
@@ -3813,11 +3814,11 @@ int ICATPortBindingProxy::getDataset(
   struct __ns1__getDataset soap_tmp___ns1__getDataset;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/getDatasetRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getDataset.ns1__getDataset_ = ns1__getDataset_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -3828,17 +3829,17 @@ int ICATPortBindingProxy::getDataset(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__getDataset(soap, &soap_tmp___ns1__getDataset,
-                                   "-ns1:getDataset", NULL) ||
+                                   "-ns1:getDataset", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getDataset(soap, &soap_tmp___ns1__getDataset,
-                                 "-ns1:getDataset", NULL) ||
+                                 "-ns1:getDataset", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -3866,11 +3867,11 @@ int ICATPortBindingProxy::getDatasetIncludes(
   struct __ns1__getDatasetIncludes soap_tmp___ns1__getDatasetIncludes;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/getDatasetIncludesRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getDatasetIncludes.ns1__getDatasetIncludes_ =
       ns1__getDatasetIncludes_;
   soap_begin(soap);
@@ -3882,20 +3883,20 @@ int ICATPortBindingProxy::getDatasetIncludes(
   if (soap->mode & SOAP_IO_LENGTH) {
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
-        soap_put___ns1__getDatasetIncludes(soap,
-                                           &soap_tmp___ns1__getDatasetIncludes,
-                                           "-ns1:getDatasetIncludes", NULL) ||
+        soap_put___ns1__getDatasetIncludes(
+            soap, &soap_tmp___ns1__getDatasetIncludes,
+            "-ns1:getDatasetIncludes", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getDatasetIncludes(soap,
                                          &soap_tmp___ns1__getDatasetIncludes,
-                                         "-ns1:getDatasetIncludes", NULL) ||
+                                         "-ns1:getDatasetIncludes", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -3923,11 +3924,11 @@ int ICATPortBindingProxy::getDatasets(
   struct __ns1__getDatasets soap_tmp___ns1__getDatasets;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/getDatasetsRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getDatasets.ns1__getDatasets_ = ns1__getDatasets_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -3938,17 +3939,17 @@ int ICATPortBindingProxy::getDatasets(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__getDatasets(soap, &soap_tmp___ns1__getDatasets,
-                                    "-ns1:getDatasets", NULL) ||
+                                    "-ns1:getDatasets", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getDatasets(soap, &soap_tmp___ns1__getDatasets,
-                                  "-ns1:getDatasets", NULL) ||
+                                  "-ns1:getDatasets", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -3976,11 +3977,11 @@ int ICATPortBindingProxy::createDataSet(
   struct __ns1__createDataSet soap_tmp___ns1__createDataSet;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/createDataSetRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__createDataSet.ns1__createDataSet_ = ns1__createDataSet_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -3991,17 +3992,17 @@ int ICATPortBindingProxy::createDataSet(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__createDataSet(soap, &soap_tmp___ns1__createDataSet,
-                                      "-ns1:createDataSet", NULL) ||
+                                      "-ns1:createDataSet", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__createDataSet(soap, &soap_tmp___ns1__createDataSet,
-                                    "-ns1:createDataSet", NULL) ||
+                                    "-ns1:createDataSet", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -4029,11 +4030,11 @@ int ICATPortBindingProxy::createDataSets(
   struct __ns1__createDataSets soap_tmp___ns1__createDataSets;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/createDataSetsRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__createDataSets.ns1__createDataSets_ = ns1__createDataSets_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -4044,17 +4045,17 @@ int ICATPortBindingProxy::createDataSets(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__createDataSets(soap, &soap_tmp___ns1__createDataSets,
-                                       "-ns1:createDataSets", NULL) ||
+                                       "-ns1:createDataSets", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__createDataSets(soap, &soap_tmp___ns1__createDataSets,
-                                     "-ns1:createDataSets", NULL) ||
+                                     "-ns1:createDataSets", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -4083,11 +4084,11 @@ int ICATPortBindingProxy::deleteDataSet(
   struct __ns1__deleteDataSetResponse *soap_tmp___ns1__deleteDataSetResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/deleteDataSetRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__deleteDataSet.ns1__deleteDataSet_ = ns1__deleteDataSet_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -4098,17 +4099,17 @@ int ICATPortBindingProxy::deleteDataSet(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__deleteDataSet(soap, &soap_tmp___ns1__deleteDataSet,
-                                      "-ns1:deleteDataSet", NULL) ||
+                                      "-ns1:deleteDataSet", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__deleteDataSet(soap, &soap_tmp___ns1__deleteDataSet,
-                                    "-ns1:deleteDataSet", NULL) ||
+                                    "-ns1:deleteDataSet", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -4119,7 +4120,7 @@ int ICATPortBindingProxy::deleteDataSet(
       soap_recv_header(soap) || soap_body_begin_in(soap))
     return soap_closesock(soap);
   soap_tmp___ns1__deleteDataSetResponse = soap_get___ns1__deleteDataSetResponse(
-      soap, NULL, "-ns1:deleteDataSetResponse", "ns1:deleteDataSetResponse");
+      soap, nullptr, "-ns1:deleteDataSetResponse", "ns1:deleteDataSetResponse");
   if (!soap_tmp___ns1__deleteDataSetResponse || soap->error)
     return soap_recv_fault(soap, 0);
   if (soap_body_end_in(soap) || soap_envelope_end_in(soap) ||
@@ -4142,11 +4143,11 @@ int ICATPortBindingProxy::deleteDataSetParameter(
       soap_tmp___ns1__deleteDataSetParameterResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/deleteDataSetParameterRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__deleteDataSetParameter.ns1__deleteDataSetParameter_ =
       ns1__deleteDataSetParameter_;
   soap_begin(soap);
@@ -4160,18 +4161,18 @@ int ICATPortBindingProxy::deleteDataSetParameter(
         soap_body_begin_out(soap) ||
         soap_put___ns1__deleteDataSetParameter(
             soap, &soap_tmp___ns1__deleteDataSetParameter,
-            "-ns1:deleteDataSetParameter", NULL) ||
+            "-ns1:deleteDataSetParameter", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__deleteDataSetParameter(
           soap, &soap_tmp___ns1__deleteDataSetParameter,
-          "-ns1:deleteDataSetParameter", NULL) ||
+          "-ns1:deleteDataSetParameter", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -4183,7 +4184,7 @@ int ICATPortBindingProxy::deleteDataSetParameter(
     return soap_closesock(soap);
   soap_tmp___ns1__deleteDataSetParameterResponse =
       soap_get___ns1__deleteDataSetParameterResponse(
-          soap, NULL, "-ns1:deleteDataSetParameterResponse",
+          soap, nullptr, "-ns1:deleteDataSetParameterResponse",
           "ns1:deleteDataSetParameterResponse");
   if (!soap_tmp___ns1__deleteDataSetParameterResponse || soap->error)
     return soap_recv_fault(soap, 0);
@@ -4208,11 +4209,11 @@ int ICATPortBindingProxy::modifyDataSet(
   struct __ns1__modifyDataSetResponse *soap_tmp___ns1__modifyDataSetResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/modifyDataSetRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__modifyDataSet.ns1__modifyDataSet_ = ns1__modifyDataSet_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -4223,17 +4224,17 @@ int ICATPortBindingProxy::modifyDataSet(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__modifyDataSet(soap, &soap_tmp___ns1__modifyDataSet,
-                                      "-ns1:modifyDataSet", NULL) ||
+                                      "-ns1:modifyDataSet", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__modifyDataSet(soap, &soap_tmp___ns1__modifyDataSet,
-                                    "-ns1:modifyDataSet", NULL) ||
+                                    "-ns1:modifyDataSet", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -4244,7 +4245,7 @@ int ICATPortBindingProxy::modifyDataSet(
       soap_recv_header(soap) || soap_body_begin_in(soap))
     return soap_closesock(soap);
   soap_tmp___ns1__modifyDataSetResponse = soap_get___ns1__modifyDataSetResponse(
-      soap, NULL, "-ns1:modifyDataSetResponse", "ns1:modifyDataSetResponse");
+      soap, nullptr, "-ns1:modifyDataSetResponse", "ns1:modifyDataSetResponse");
   if (!soap_tmp___ns1__modifyDataSetResponse || soap->error)
     return soap_recv_fault(soap, 0);
   if (soap_body_end_in(soap) || soap_envelope_end_in(soap) ||
@@ -4267,11 +4268,11 @@ int ICATPortBindingProxy::modifyDataSetParameter(
       soap_tmp___ns1__modifyDataSetParameterResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/modifyDataSetParameterRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__modifyDataSetParameter.ns1__modifyDataSetParameter_ =
       ns1__modifyDataSetParameter_;
   soap_begin(soap);
@@ -4285,18 +4286,18 @@ int ICATPortBindingProxy::modifyDataSetParameter(
         soap_body_begin_out(soap) ||
         soap_put___ns1__modifyDataSetParameter(
             soap, &soap_tmp___ns1__modifyDataSetParameter,
-            "-ns1:modifyDataSetParameter", NULL) ||
+            "-ns1:modifyDataSetParameter", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__modifyDataSetParameter(
           soap, &soap_tmp___ns1__modifyDataSetParameter,
-          "-ns1:modifyDataSetParameter", NULL) ||
+          "-ns1:modifyDataSetParameter", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -4308,7 +4309,7 @@ int ICATPortBindingProxy::modifyDataSetParameter(
     return soap_closesock(soap);
   soap_tmp___ns1__modifyDataSetParameterResponse =
       soap_get___ns1__modifyDataSetParameterResponse(
-          soap, NULL, "-ns1:modifyDataSetParameterResponse",
+          soap, nullptr, "-ns1:modifyDataSetParameterResponse",
           "ns1:modifyDataSetParameterResponse");
   if (!soap_tmp___ns1__modifyDataSetParameterResponse || soap->error)
     return soap_recv_fault(soap, 0);
@@ -4334,11 +4335,11 @@ int ICATPortBindingProxy::setDataSetSample(
       soap_tmp___ns1__setDataSetSampleResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/setDataSetSampleRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__setDataSetSample.ns1__setDataSetSample_ =
       ns1__setDataSetSample_;
   soap_begin(soap);
@@ -4352,17 +4353,17 @@ int ICATPortBindingProxy::setDataSetSample(
         soap_body_begin_out(soap) ||
         soap_put___ns1__setDataSetSample(soap,
                                          &soap_tmp___ns1__setDataSetSample,
-                                         "-ns1:setDataSetSample", NULL) ||
+                                         "-ns1:setDataSetSample", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__setDataSetSample(soap, &soap_tmp___ns1__setDataSetSample,
-                                       "-ns1:setDataSetSample", NULL) ||
+                                       "-ns1:setDataSetSample", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -4373,7 +4374,7 @@ int ICATPortBindingProxy::setDataSetSample(
       soap_recv_header(soap) || soap_body_begin_in(soap))
     return soap_closesock(soap);
   soap_tmp___ns1__setDataSetSampleResponse =
-      soap_get___ns1__setDataSetSampleResponse(soap, NULL,
+      soap_get___ns1__setDataSetSampleResponse(soap, nullptr,
                                                "-ns1:setDataSetSampleResponse",
                                                "ns1:setDataSetSampleResponse");
   if (!soap_tmp___ns1__setDataSetSampleResponse || soap->error)
@@ -4396,11 +4397,11 @@ int ICATPortBindingProxy::addDataSetParameter(
   struct __ns1__addDataSetParameter soap_tmp___ns1__addDataSetParameter;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/addDataSetParameterRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__addDataSetParameter.ns1__addDataSetParameter_ =
       ns1__addDataSetParameter_;
   soap_begin(soap);
@@ -4414,18 +4415,18 @@ int ICATPortBindingProxy::addDataSetParameter(
         soap_body_begin_out(soap) ||
         soap_put___ns1__addDataSetParameter(
             soap, &soap_tmp___ns1__addDataSetParameter,
-            "-ns1:addDataSetParameter", NULL) ||
+            "-ns1:addDataSetParameter", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
-      soap_put___ns1__addDataSetParameter(soap,
-                                          &soap_tmp___ns1__addDataSetParameter,
-                                          "-ns1:addDataSetParameter", NULL) ||
+      soap_put___ns1__addDataSetParameter(
+          soap, &soap_tmp___ns1__addDataSetParameter,
+          "-ns1:addDataSetParameter", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -4454,11 +4455,11 @@ int ICATPortBindingProxy::addDataSetParameters(
   struct __ns1__addDataSetParameters soap_tmp___ns1__addDataSetParameters;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/addDataSetParametersRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__addDataSetParameters.ns1__addDataSetParameters_ =
       ns1__addDataSetParameters_;
   soap_begin(soap);
@@ -4472,18 +4473,18 @@ int ICATPortBindingProxy::addDataSetParameters(
         soap_body_begin_out(soap) ||
         soap_put___ns1__addDataSetParameters(
             soap, &soap_tmp___ns1__addDataSetParameters,
-            "-ns1:addDataSetParameters", NULL) ||
+            "-ns1:addDataSetParameters", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__addDataSetParameters(
           soap, &soap_tmp___ns1__addDataSetParameters,
-          "-ns1:addDataSetParameters", NULL) ||
+          "-ns1:addDataSetParameters", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -4513,11 +4514,11 @@ int ICATPortBindingProxy::removeDataSet(
   struct __ns1__removeDataSetResponse *soap_tmp___ns1__removeDataSetResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/removeDataSetRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__removeDataSet.ns1__removeDataSet_ = ns1__removeDataSet_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -4528,17 +4529,17 @@ int ICATPortBindingProxy::removeDataSet(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__removeDataSet(soap, &soap_tmp___ns1__removeDataSet,
-                                      "-ns1:removeDataSet", NULL) ||
+                                      "-ns1:removeDataSet", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__removeDataSet(soap, &soap_tmp___ns1__removeDataSet,
-                                    "-ns1:removeDataSet", NULL) ||
+                                    "-ns1:removeDataSet", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -4549,7 +4550,7 @@ int ICATPortBindingProxy::removeDataSet(
       soap_recv_header(soap) || soap_body_begin_in(soap))
     return soap_closesock(soap);
   soap_tmp___ns1__removeDataSetResponse = soap_get___ns1__removeDataSetResponse(
-      soap, NULL, "-ns1:removeDataSetResponse", "ns1:removeDataSetResponse");
+      soap, nullptr, "-ns1:removeDataSetResponse", "ns1:removeDataSetResponse");
   if (!soap_tmp___ns1__removeDataSetResponse || soap->error)
     return soap_recv_fault(soap, 0);
   if (soap_body_end_in(soap) || soap_envelope_end_in(soap) ||
@@ -4572,11 +4573,11 @@ int ICATPortBindingProxy::removeDataSetParameter(
       soap_tmp___ns1__removeDataSetParameterResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/removeDataSetParameterRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__removeDataSetParameter.ns1__removeDataSetParameter_ =
       ns1__removeDataSetParameter_;
   soap_begin(soap);
@@ -4590,18 +4591,18 @@ int ICATPortBindingProxy::removeDataSetParameter(
         soap_body_begin_out(soap) ||
         soap_put___ns1__removeDataSetParameter(
             soap, &soap_tmp___ns1__removeDataSetParameter,
-            "-ns1:removeDataSetParameter", NULL) ||
+            "-ns1:removeDataSetParameter", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__removeDataSetParameter(
           soap, &soap_tmp___ns1__removeDataSetParameter,
-          "-ns1:removeDataSetParameter", NULL) ||
+          "-ns1:removeDataSetParameter", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -4613,7 +4614,7 @@ int ICATPortBindingProxy::removeDataSetParameter(
     return soap_closesock(soap);
   soap_tmp___ns1__removeDataSetParameterResponse =
       soap_get___ns1__removeDataSetParameterResponse(
-          soap, NULL, "-ns1:removeDataSetParameterResponse",
+          soap, nullptr, "-ns1:removeDataSetParameterResponse",
           "ns1:removeDataSetParameterResponse");
   if (!soap_tmp___ns1__removeDataSetParameterResponse || soap->error)
     return soap_recv_fault(soap, 0);
@@ -4637,11 +4638,11 @@ int ICATPortBindingProxy::getDatafile(
   struct __ns1__getDatafile soap_tmp___ns1__getDatafile;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/getDatafileRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getDatafile.ns1__getDatafile_ = ns1__getDatafile_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -4652,17 +4653,17 @@ int ICATPortBindingProxy::getDatafile(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__getDatafile(soap, &soap_tmp___ns1__getDatafile,
-                                    "-ns1:getDatafile", NULL) ||
+                                    "-ns1:getDatafile", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getDatafile(soap, &soap_tmp___ns1__getDatafile,
-                                  "-ns1:getDatafile", NULL) ||
+                                  "-ns1:getDatafile", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -4690,11 +4691,11 @@ int ICATPortBindingProxy::getDatafiles(
   struct __ns1__getDatafiles soap_tmp___ns1__getDatafiles;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/getDatafilesRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getDatafiles.ns1__getDatafiles_ = ns1__getDatafiles_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -4705,17 +4706,17 @@ int ICATPortBindingProxy::getDatafiles(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__getDatafiles(soap, &soap_tmp___ns1__getDatafiles,
-                                     "-ns1:getDatafiles", NULL) ||
+                                     "-ns1:getDatafiles", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getDatafiles(soap, &soap_tmp___ns1__getDatafiles,
-                                   "-ns1:getDatafiles", NULL) ||
+                                   "-ns1:getDatafiles", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -4743,11 +4744,11 @@ int ICATPortBindingProxy::createDataFile(
   struct __ns1__createDataFile soap_tmp___ns1__createDataFile;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/createDataFileRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__createDataFile.ns1__createDataFile_ = ns1__createDataFile_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -4758,17 +4759,17 @@ int ICATPortBindingProxy::createDataFile(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__createDataFile(soap, &soap_tmp___ns1__createDataFile,
-                                       "-ns1:createDataFile", NULL) ||
+                                       "-ns1:createDataFile", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__createDataFile(soap, &soap_tmp___ns1__createDataFile,
-                                     "-ns1:createDataFile", NULL) ||
+                                     "-ns1:createDataFile", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -4796,11 +4797,11 @@ int ICATPortBindingProxy::createDataFiles(
   struct __ns1__createDataFiles soap_tmp___ns1__createDataFiles;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/createDataFilesRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__createDataFiles.ns1__createDataFiles_ = ns1__createDataFiles_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -4811,17 +4812,17 @@ int ICATPortBindingProxy::createDataFiles(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__createDataFiles(soap, &soap_tmp___ns1__createDataFiles,
-                                        "-ns1:createDataFiles", NULL) ||
+                                        "-ns1:createDataFiles", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__createDataFiles(soap, &soap_tmp___ns1__createDataFiles,
-                                      "-ns1:createDataFiles", NULL) ||
+                                      "-ns1:createDataFiles", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -4850,11 +4851,11 @@ int ICATPortBindingProxy::deleteDataFile(
   struct __ns1__deleteDataFileResponse *soap_tmp___ns1__deleteDataFileResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/deleteDataFileRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__deleteDataFile.ns1__deleteDataFile_ = ns1__deleteDataFile_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -4865,17 +4866,17 @@ int ICATPortBindingProxy::deleteDataFile(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__deleteDataFile(soap, &soap_tmp___ns1__deleteDataFile,
-                                       "-ns1:deleteDataFile", NULL) ||
+                                       "-ns1:deleteDataFile", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__deleteDataFile(soap, &soap_tmp___ns1__deleteDataFile,
-                                     "-ns1:deleteDataFile", NULL) ||
+                                     "-ns1:deleteDataFile", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -4886,7 +4887,7 @@ int ICATPortBindingProxy::deleteDataFile(
       soap_recv_header(soap) || soap_body_begin_in(soap))
     return soap_closesock(soap);
   soap_tmp___ns1__deleteDataFileResponse =
-      soap_get___ns1__deleteDataFileResponse(soap, NULL,
+      soap_get___ns1__deleteDataFileResponse(soap, nullptr,
                                              "-ns1:deleteDataFileResponse",
                                              "ns1:deleteDataFileResponse");
   if (!soap_tmp___ns1__deleteDataFileResponse || soap->error)
@@ -4910,11 +4911,11 @@ int ICATPortBindingProxy::modifyDataFile(
   struct __ns1__modifyDataFileResponse *soap_tmp___ns1__modifyDataFileResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/modifyDataFileRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__modifyDataFile.ns1__modifyDataFile_ = ns1__modifyDataFile_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -4925,17 +4926,17 @@ int ICATPortBindingProxy::modifyDataFile(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__modifyDataFile(soap, &soap_tmp___ns1__modifyDataFile,
-                                       "-ns1:modifyDataFile", NULL) ||
+                                       "-ns1:modifyDataFile", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__modifyDataFile(soap, &soap_tmp___ns1__modifyDataFile,
-                                     "-ns1:modifyDataFile", NULL) ||
+                                     "-ns1:modifyDataFile", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -4946,7 +4947,7 @@ int ICATPortBindingProxy::modifyDataFile(
       soap_recv_header(soap) || soap_body_begin_in(soap))
     return soap_closesock(soap);
   soap_tmp___ns1__modifyDataFileResponse =
-      soap_get___ns1__modifyDataFileResponse(soap, NULL,
+      soap_get___ns1__modifyDataFileResponse(soap, nullptr,
                                              "-ns1:modifyDataFileResponse",
                                              "ns1:modifyDataFileResponse");
   if (!soap_tmp___ns1__modifyDataFileResponse || soap->error)
@@ -4969,11 +4970,11 @@ int ICATPortBindingProxy::addDataFileParameter(
   struct __ns1__addDataFileParameter soap_tmp___ns1__addDataFileParameter;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/addDataFileParameterRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__addDataFileParameter.ns1__addDataFileParameter_ =
       ns1__addDataFileParameter_;
   soap_begin(soap);
@@ -4987,18 +4988,18 @@ int ICATPortBindingProxy::addDataFileParameter(
         soap_body_begin_out(soap) ||
         soap_put___ns1__addDataFileParameter(
             soap, &soap_tmp___ns1__addDataFileParameter,
-            "-ns1:addDataFileParameter", NULL) ||
+            "-ns1:addDataFileParameter", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__addDataFileParameter(
           soap, &soap_tmp___ns1__addDataFileParameter,
-          "-ns1:addDataFileParameter", NULL) ||
+          "-ns1:addDataFileParameter", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -5027,11 +5028,11 @@ int ICATPortBindingProxy::addDataFileParameters(
   struct __ns1__addDataFileParameters soap_tmp___ns1__addDataFileParameters;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/addDataFileParametersRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__addDataFileParameters.ns1__addDataFileParameters_ =
       ns1__addDataFileParameters_;
   soap_begin(soap);
@@ -5045,18 +5046,18 @@ int ICATPortBindingProxy::addDataFileParameters(
         soap_body_begin_out(soap) ||
         soap_put___ns1__addDataFileParameters(
             soap, &soap_tmp___ns1__addDataFileParameters,
-            "-ns1:addDataFileParameters", NULL) ||
+            "-ns1:addDataFileParameters", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__addDataFileParameters(
           soap, &soap_tmp___ns1__addDataFileParameters,
-          "-ns1:addDataFileParameters", NULL) ||
+          "-ns1:addDataFileParameters", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -5088,11 +5089,11 @@ int ICATPortBindingProxy::modifyDataFileParameter(
       soap_tmp___ns1__modifyDataFileParameterResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/modifyDataFileParameterRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__modifyDataFileParameter.ns1__modifyDataFileParameter_ =
       ns1__modifyDataFileParameter_;
   soap_begin(soap);
@@ -5106,18 +5107,18 @@ int ICATPortBindingProxy::modifyDataFileParameter(
         soap_body_begin_out(soap) ||
         soap_put___ns1__modifyDataFileParameter(
             soap, &soap_tmp___ns1__modifyDataFileParameter,
-            "-ns1:modifyDataFileParameter", NULL) ||
+            "-ns1:modifyDataFileParameter", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__modifyDataFileParameter(
           soap, &soap_tmp___ns1__modifyDataFileParameter,
-          "-ns1:modifyDataFileParameter", NULL) ||
+          "-ns1:modifyDataFileParameter", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -5129,7 +5130,7 @@ int ICATPortBindingProxy::modifyDataFileParameter(
     return soap_closesock(soap);
   soap_tmp___ns1__modifyDataFileParameterResponse =
       soap_get___ns1__modifyDataFileParameterResponse(
-          soap, NULL, "-ns1:modifyDataFileParameterResponse",
+          soap, nullptr, "-ns1:modifyDataFileParameterResponse",
           "ns1:modifyDataFileParameterResponse");
   if (!soap_tmp___ns1__modifyDataFileParameterResponse || soap->error)
     return soap_recv_fault(soap, 0);
@@ -5156,11 +5157,11 @@ int ICATPortBindingProxy::deleteDataFileParameter(
       soap_tmp___ns1__deleteDataFileParameterResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/deleteDataFileParameterRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__deleteDataFileParameter.ns1__deleteDataFileParameter_ =
       ns1__deleteDataFileParameter_;
   soap_begin(soap);
@@ -5174,18 +5175,18 @@ int ICATPortBindingProxy::deleteDataFileParameter(
         soap_body_begin_out(soap) ||
         soap_put___ns1__deleteDataFileParameter(
             soap, &soap_tmp___ns1__deleteDataFileParameter,
-            "-ns1:deleteDataFileParameter", NULL) ||
+            "-ns1:deleteDataFileParameter", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__deleteDataFileParameter(
           soap, &soap_tmp___ns1__deleteDataFileParameter,
-          "-ns1:deleteDataFileParameter", NULL) ||
+          "-ns1:deleteDataFileParameter", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -5197,7 +5198,7 @@ int ICATPortBindingProxy::deleteDataFileParameter(
     return soap_closesock(soap);
   soap_tmp___ns1__deleteDataFileParameterResponse =
       soap_get___ns1__deleteDataFileParameterResponse(
-          soap, NULL, "-ns1:deleteDataFileParameterResponse",
+          soap, nullptr, "-ns1:deleteDataFileParameterResponse",
           "ns1:deleteDataFileParameterResponse");
   if (!soap_tmp___ns1__deleteDataFileParameterResponse || soap->error)
     return soap_recv_fault(soap, 0);
@@ -5222,11 +5223,11 @@ int ICATPortBindingProxy::removeDataFile(
   struct __ns1__removeDataFileResponse *soap_tmp___ns1__removeDataFileResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/removeDataFileRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__removeDataFile.ns1__removeDataFile_ = ns1__removeDataFile_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -5237,17 +5238,17 @@ int ICATPortBindingProxy::removeDataFile(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__removeDataFile(soap, &soap_tmp___ns1__removeDataFile,
-                                       "-ns1:removeDataFile", NULL) ||
+                                       "-ns1:removeDataFile", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__removeDataFile(soap, &soap_tmp___ns1__removeDataFile,
-                                     "-ns1:removeDataFile", NULL) ||
+                                     "-ns1:removeDataFile", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -5258,7 +5259,7 @@ int ICATPortBindingProxy::removeDataFile(
       soap_recv_header(soap) || soap_body_begin_in(soap))
     return soap_closesock(soap);
   soap_tmp___ns1__removeDataFileResponse =
-      soap_get___ns1__removeDataFileResponse(soap, NULL,
+      soap_get___ns1__removeDataFileResponse(soap, nullptr,
                                              "-ns1:removeDataFileResponse",
                                              "ns1:removeDataFileResponse");
   if (!soap_tmp___ns1__removeDataFileResponse || soap->error)
@@ -5284,11 +5285,11 @@ int ICATPortBindingProxy::removeDataFileParameter(
       soap_tmp___ns1__removeDataFileParameterResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/removeDataFileParameterRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__removeDataFileParameter.ns1__removeDataFileParameter_ =
       ns1__removeDataFileParameter_;
   soap_begin(soap);
@@ -5302,18 +5303,18 @@ int ICATPortBindingProxy::removeDataFileParameter(
         soap_body_begin_out(soap) ||
         soap_put___ns1__removeDataFileParameter(
             soap, &soap_tmp___ns1__removeDataFileParameter,
-            "-ns1:removeDataFileParameter", NULL) ||
+            "-ns1:removeDataFileParameter", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__removeDataFileParameter(
           soap, &soap_tmp___ns1__removeDataFileParameter,
-          "-ns1:removeDataFileParameter", NULL) ||
+          "-ns1:removeDataFileParameter", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -5325,7 +5326,7 @@ int ICATPortBindingProxy::removeDataFileParameter(
     return soap_closesock(soap);
   soap_tmp___ns1__removeDataFileParameterResponse =
       soap_get___ns1__removeDataFileParameterResponse(
-          soap, NULL, "-ns1:removeDataFileParameterResponse",
+          soap, nullptr, "-ns1:removeDataFileParameterResponse",
           "ns1:removeDataFileParameterResponse");
   if (!soap_tmp___ns1__removeDataFileParameterResponse || soap->error)
     return soap_recv_fault(soap, 0);
@@ -5349,11 +5350,11 @@ int ICATPortBindingProxy::getAuthorisations(
   struct __ns1__getAuthorisations soap_tmp___ns1__getAuthorisations;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/getAuthorisationsRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getAuthorisations.ns1__getAuthorisations_ =
       ns1__getAuthorisations_;
   soap_begin(soap);
@@ -5367,17 +5368,17 @@ int ICATPortBindingProxy::getAuthorisations(
         soap_body_begin_out(soap) ||
         soap_put___ns1__getAuthorisations(soap,
                                           &soap_tmp___ns1__getAuthorisations,
-                                          "-ns1:getAuthorisations", NULL) ||
+                                          "-ns1:getAuthorisations", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) || soap_put___ns1__getAuthorisations(
                                        soap, &soap_tmp___ns1__getAuthorisations,
-                                       "-ns1:getAuthorisations", NULL) ||
+                                       "-ns1:getAuthorisations", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -5405,11 +5406,11 @@ int ICATPortBindingProxy::addAuthorisation(
   struct __ns1__addAuthorisation soap_tmp___ns1__addAuthorisation;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/addAuthorisationRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__addAuthorisation.ns1__addAuthorisation_ =
       ns1__addAuthorisation_;
   soap_begin(soap);
@@ -5423,17 +5424,17 @@ int ICATPortBindingProxy::addAuthorisation(
         soap_body_begin_out(soap) ||
         soap_put___ns1__addAuthorisation(soap,
                                          &soap_tmp___ns1__addAuthorisation,
-                                         "-ns1:addAuthorisation", NULL) ||
+                                         "-ns1:addAuthorisation", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__addAuthorisation(soap, &soap_tmp___ns1__addAuthorisation,
-                                       "-ns1:addAuthorisation", NULL) ||
+                                       "-ns1:addAuthorisation", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -5463,11 +5464,11 @@ int ICATPortBindingProxy::deleteAuthorisation(
       soap_tmp___ns1__deleteAuthorisationResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/deleteAuthorisationRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__deleteAuthorisation.ns1__deleteAuthorisation_ =
       ns1__deleteAuthorisation_;
   soap_begin(soap);
@@ -5481,18 +5482,18 @@ int ICATPortBindingProxy::deleteAuthorisation(
         soap_body_begin_out(soap) ||
         soap_put___ns1__deleteAuthorisation(
             soap, &soap_tmp___ns1__deleteAuthorisation,
-            "-ns1:deleteAuthorisation", NULL) ||
+            "-ns1:deleteAuthorisation", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
-      soap_put___ns1__deleteAuthorisation(soap,
-                                          &soap_tmp___ns1__deleteAuthorisation,
-                                          "-ns1:deleteAuthorisation", NULL) ||
+      soap_put___ns1__deleteAuthorisation(
+          soap, &soap_tmp___ns1__deleteAuthorisation,
+          "-ns1:deleteAuthorisation", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -5504,7 +5505,7 @@ int ICATPortBindingProxy::deleteAuthorisation(
     return soap_closesock(soap);
   soap_tmp___ns1__deleteAuthorisationResponse =
       soap_get___ns1__deleteAuthorisationResponse(
-          soap, NULL, "-ns1:deleteAuthorisationResponse",
+          soap, nullptr, "-ns1:deleteAuthorisationResponse",
           "ns1:deleteAuthorisationResponse");
   if (!soap_tmp___ns1__deleteAuthorisationResponse || soap->error)
     return soap_recv_fault(soap, 0);
@@ -5530,11 +5531,11 @@ int ICATPortBindingProxy::removeAuthorisation(
       soap_tmp___ns1__removeAuthorisationResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/removeAuthorisationRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__removeAuthorisation.ns1__removeAuthorisation_ =
       ns1__removeAuthorisation_;
   soap_begin(soap);
@@ -5548,18 +5549,18 @@ int ICATPortBindingProxy::removeAuthorisation(
         soap_body_begin_out(soap) ||
         soap_put___ns1__removeAuthorisation(
             soap, &soap_tmp___ns1__removeAuthorisation,
-            "-ns1:removeAuthorisation", NULL) ||
+            "-ns1:removeAuthorisation", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
-      soap_put___ns1__removeAuthorisation(soap,
-                                          &soap_tmp___ns1__removeAuthorisation,
-                                          "-ns1:removeAuthorisation", NULL) ||
+      soap_put___ns1__removeAuthorisation(
+          soap, &soap_tmp___ns1__removeAuthorisation,
+          "-ns1:removeAuthorisation", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -5571,7 +5572,7 @@ int ICATPortBindingProxy::removeAuthorisation(
     return soap_closesock(soap);
   soap_tmp___ns1__removeAuthorisationResponse =
       soap_get___ns1__removeAuthorisationResponse(
-          soap, NULL, "-ns1:removeAuthorisationResponse",
+          soap, nullptr, "-ns1:removeAuthorisationResponse",
           "ns1:removeAuthorisationResponse");
   if (!soap_tmp___ns1__removeAuthorisationResponse || soap->error)
     return soap_recv_fault(soap, 0);
@@ -5597,11 +5598,11 @@ int ICATPortBindingProxy::updateAuthorisation(
       soap_tmp___ns1__updateAuthorisationResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/updateAuthorisationRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__updateAuthorisation.ns1__updateAuthorisation_ =
       ns1__updateAuthorisation_;
   soap_begin(soap);
@@ -5615,18 +5616,18 @@ int ICATPortBindingProxy::updateAuthorisation(
         soap_body_begin_out(soap) ||
         soap_put___ns1__updateAuthorisation(
             soap, &soap_tmp___ns1__updateAuthorisation,
-            "-ns1:updateAuthorisation", NULL) ||
+            "-ns1:updateAuthorisation", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
-      soap_put___ns1__updateAuthorisation(soap,
-                                          &soap_tmp___ns1__updateAuthorisation,
-                                          "-ns1:updateAuthorisation", NULL) ||
+      soap_put___ns1__updateAuthorisation(
+          soap, &soap_tmp___ns1__updateAuthorisation,
+          "-ns1:updateAuthorisation", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -5638,7 +5639,7 @@ int ICATPortBindingProxy::updateAuthorisation(
     return soap_closesock(soap);
   soap_tmp___ns1__updateAuthorisationResponse =
       soap_get___ns1__updateAuthorisationResponse(
-          soap, NULL, "-ns1:updateAuthorisationResponse",
+          soap, nullptr, "-ns1:updateAuthorisationResponse",
           "ns1:updateAuthorisationResponse");
   if (!soap_tmp___ns1__updateAuthorisationResponse || soap->error)
     return soap_recv_fault(soap, 0);
@@ -5662,11 +5663,11 @@ int ICATPortBindingProxy::ingestMetadata(
   struct __ns1__ingestMetadata soap_tmp___ns1__ingestMetadata;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/ingestMetadataRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__ingestMetadata.ns1__ingestMetadata_ = ns1__ingestMetadata_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -5677,17 +5678,17 @@ int ICATPortBindingProxy::ingestMetadata(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__ingestMetadata(soap, &soap_tmp___ns1__ingestMetadata,
-                                       "-ns1:ingestMetadata", NULL) ||
+                                       "-ns1:ingestMetadata", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__ingestMetadata(soap, &soap_tmp___ns1__ingestMetadata,
-                                     "-ns1:ingestMetadata", NULL) ||
+                                     "-ns1:ingestMetadata", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -5715,11 +5716,11 @@ int ICATPortBindingProxy::downloadDatafile(
   struct __ns1__downloadDatafile soap_tmp___ns1__downloadDatafile;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/downloadDatafileRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__downloadDatafile.ns1__downloadDatafile_ =
       ns1__downloadDatafile_;
   soap_begin(soap);
@@ -5733,17 +5734,17 @@ int ICATPortBindingProxy::downloadDatafile(
         soap_body_begin_out(soap) ||
         soap_put___ns1__downloadDatafile(soap,
                                          &soap_tmp___ns1__downloadDatafile,
-                                         "-ns1:downloadDatafile", NULL) ||
+                                         "-ns1:downloadDatafile", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__downloadDatafile(soap, &soap_tmp___ns1__downloadDatafile,
-                                       "-ns1:downloadDatafile", NULL) ||
+                                       "-ns1:downloadDatafile", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -5771,11 +5772,11 @@ int ICATPortBindingProxy::downloadDataset(
   struct __ns1__downloadDataset soap_tmp___ns1__downloadDataset;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/downloadDatasetRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__downloadDataset.ns1__downloadDataset_ = ns1__downloadDataset_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -5786,17 +5787,17 @@ int ICATPortBindingProxy::downloadDataset(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__downloadDataset(soap, &soap_tmp___ns1__downloadDataset,
-                                        "-ns1:downloadDataset", NULL) ||
+                                        "-ns1:downloadDataset", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__downloadDataset(soap, &soap_tmp___ns1__downloadDataset,
-                                      "-ns1:downloadDataset", NULL) ||
+                                      "-ns1:downloadDataset", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -5824,11 +5825,11 @@ int ICATPortBindingProxy::downloadDatafiles(
   struct __ns1__downloadDatafiles soap_tmp___ns1__downloadDatafiles;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/downloadDatafilesRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__downloadDatafiles.ns1__downloadDatafiles_ =
       ns1__downloadDatafiles_;
   soap_begin(soap);
@@ -5842,17 +5843,17 @@ int ICATPortBindingProxy::downloadDatafiles(
         soap_body_begin_out(soap) ||
         soap_put___ns1__downloadDatafiles(soap,
                                           &soap_tmp___ns1__downloadDatafiles,
-                                          "-ns1:downloadDatafiles", NULL) ||
+                                          "-ns1:downloadDatafiles", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) || soap_put___ns1__downloadDatafiles(
                                        soap, &soap_tmp___ns1__downloadDatafiles,
-                                       "-ns1:downloadDatafiles", NULL) ||
+                                       "-ns1:downloadDatafiles", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -5882,11 +5883,11 @@ int ICATPortBindingProxy::checkDatafileDownloadAccess(
       soap_tmp___ns1__checkDatafileDownloadAccess;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/checkDatafileDownloadAccessRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__checkDatafileDownloadAccess
       .ns1__checkDatafileDownloadAccess_ = ns1__checkDatafileDownloadAccess_;
   soap_begin(soap);
@@ -5900,18 +5901,18 @@ int ICATPortBindingProxy::checkDatafileDownloadAccess(
         soap_body_begin_out(soap) ||
         soap_put___ns1__checkDatafileDownloadAccess(
             soap, &soap_tmp___ns1__checkDatafileDownloadAccess,
-            "-ns1:checkDatafileDownloadAccess", NULL) ||
+            "-ns1:checkDatafileDownloadAccess", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__checkDatafileDownloadAccess(
           soap, &soap_tmp___ns1__checkDatafileDownloadAccess,
-          "-ns1:checkDatafileDownloadAccess", NULL) ||
+          "-ns1:checkDatafileDownloadAccess", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -5942,11 +5943,11 @@ int ICATPortBindingProxy::checkDatasetDownloadAccess(
       soap_tmp___ns1__checkDatasetDownloadAccess;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/checkDatasetDownloadAccessRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__checkDatasetDownloadAccess.ns1__checkDatasetDownloadAccess_ =
       ns1__checkDatasetDownloadAccess_;
   soap_begin(soap);
@@ -5960,18 +5961,18 @@ int ICATPortBindingProxy::checkDatasetDownloadAccess(
         soap_body_begin_out(soap) ||
         soap_put___ns1__checkDatasetDownloadAccess(
             soap, &soap_tmp___ns1__checkDatasetDownloadAccess,
-            "-ns1:checkDatasetDownloadAccess", NULL) ||
+            "-ns1:checkDatasetDownloadAccess", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__checkDatasetDownloadAccess(
           soap, &soap_tmp___ns1__checkDatasetDownloadAccess,
-          "-ns1:checkDatasetDownloadAccess", NULL) ||
+          "-ns1:checkDatasetDownloadAccess", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -6000,11 +6001,11 @@ int ICATPortBindingProxy::getICATAPIVersion(
   struct __ns1__getICATAPIVersion soap_tmp___ns1__getICATAPIVersion;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/getICATAPIVersionRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getICATAPIVersion.ns1__getICATAPIVersion_ =
       ns1__getICATAPIVersion_;
   soap_begin(soap);
@@ -6018,17 +6019,17 @@ int ICATPortBindingProxy::getICATAPIVersion(
         soap_body_begin_out(soap) ||
         soap_put___ns1__getICATAPIVersion(soap,
                                           &soap_tmp___ns1__getICATAPIVersion,
-                                          "-ns1:getICATAPIVersion", NULL) ||
+                                          "-ns1:getICATAPIVersion", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) || soap_put___ns1__getICATAPIVersion(
                                        soap, &soap_tmp___ns1__getICATAPIVersion,
-                                       "-ns1:getICATAPIVersion", NULL) ||
+                                       "-ns1:getICATAPIVersion", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -6058,11 +6059,11 @@ int ICATPortBindingProxy::getFacilityUserByFacilityUserId(
       soap_tmp___ns1__getFacilityUserByFacilityUserId;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/getFacilityUserByFacilityUserIdRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getFacilityUserByFacilityUserId
       .ns1__getFacilityUserByFacilityUserId_ =
       ns1__getFacilityUserByFacilityUserId_;
@@ -6077,18 +6078,18 @@ int ICATPortBindingProxy::getFacilityUserByFacilityUserId(
         soap_body_begin_out(soap) ||
         soap_put___ns1__getFacilityUserByFacilityUserId(
             soap, &soap_tmp___ns1__getFacilityUserByFacilityUserId,
-            "-ns1:getFacilityUserByFacilityUserId", NULL) ||
+            "-ns1:getFacilityUserByFacilityUserId", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getFacilityUserByFacilityUserId(
           soap, &soap_tmp___ns1__getFacilityUserByFacilityUserId,
-          "-ns1:getFacilityUserByFacilityUserId", NULL) ||
+          "-ns1:getFacilityUserByFacilityUserId", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -6119,11 +6120,11 @@ int ICATPortBindingProxy::getFacilityUserByFederalId(
       soap_tmp___ns1__getFacilityUserByFederalId;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/getFacilityUserByFederalIdRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getFacilityUserByFederalId.ns1__getFacilityUserByFederalId_ =
       ns1__getFacilityUserByFederalId_;
   soap_begin(soap);
@@ -6137,18 +6138,18 @@ int ICATPortBindingProxy::getFacilityUserByFederalId(
         soap_body_begin_out(soap) ||
         soap_put___ns1__getFacilityUserByFederalId(
             soap, &soap_tmp___ns1__getFacilityUserByFederalId,
-            "-ns1:getFacilityUserByFederalId", NULL) ||
+            "-ns1:getFacilityUserByFederalId", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getFacilityUserByFederalId(
           soap, &soap_tmp___ns1__getFacilityUserByFederalId,
-          "-ns1:getFacilityUserByFederalId", NULL) ||
+          "-ns1:getFacilityUserByFederalId", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -6180,12 +6181,12 @@ int ICATPortBindingProxy::searchInvestigationByParameterCondition(
       soap_tmp___ns1__searchInvestigationByParameterCondition;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action =
         "client.icat3.uk/ICAT/searchInvestigationByParameterConditionRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchInvestigationByParameterCondition
       .ns1__searchInvestigationByParameterCondition_ =
       ns1__searchInvestigationByParameterCondition_;
@@ -6200,18 +6201,18 @@ int ICATPortBindingProxy::searchInvestigationByParameterCondition(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchInvestigationByParameterCondition(
             soap, &soap_tmp___ns1__searchInvestigationByParameterCondition,
-            "-ns1:searchInvestigationByParameterCondition", NULL) ||
+            "-ns1:searchInvestigationByParameterCondition", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchInvestigationByParameterCondition(
           soap, &soap_tmp___ns1__searchInvestigationByParameterCondition,
-          "-ns1:searchInvestigationByParameterCondition", NULL) ||
+          "-ns1:searchInvestigationByParameterCondition", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -6243,12 +6244,12 @@ int ICATPortBindingProxy::searchDatafileByParameterCondition(
       soap_tmp___ns1__searchDatafileByParameterCondition;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action =
         "client.icat3.uk/ICAT/searchDatafileByParameterConditionRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchDatafileByParameterCondition
       .ns1__searchDatafileByParameterCondition_ =
       ns1__searchDatafileByParameterCondition_;
@@ -6263,18 +6264,18 @@ int ICATPortBindingProxy::searchDatafileByParameterCondition(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchDatafileByParameterCondition(
             soap, &soap_tmp___ns1__searchDatafileByParameterCondition,
-            "-ns1:searchDatafileByParameterCondition", NULL) ||
+            "-ns1:searchDatafileByParameterCondition", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchDatafileByParameterCondition(
           soap, &soap_tmp___ns1__searchDatafileByParameterCondition,
-          "-ns1:searchDatafileByParameterCondition", NULL) ||
+          "-ns1:searchDatafileByParameterCondition", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -6306,12 +6307,12 @@ int ICATPortBindingProxy::searchDatasetByParameterCondition(
       soap_tmp___ns1__searchDatasetByParameterCondition;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action =
         "client.icat3.uk/ICAT/searchDatasetByParameterConditionRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchDatasetByParameterCondition
       .ns1__searchDatasetByParameterCondition_ =
       ns1__searchDatasetByParameterCondition_;
@@ -6326,18 +6327,18 @@ int ICATPortBindingProxy::searchDatasetByParameterCondition(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchDatasetByParameterCondition(
             soap, &soap_tmp___ns1__searchDatasetByParameterCondition,
-            "-ns1:searchDatasetByParameterCondition", NULL) ||
+            "-ns1:searchDatasetByParameterCondition", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchDatasetByParameterCondition(
           soap, &soap_tmp___ns1__searchDatasetByParameterCondition,
-          "-ns1:searchDatasetByParameterCondition", NULL) ||
+          "-ns1:searchDatasetByParameterCondition", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -6369,12 +6370,12 @@ int ICATPortBindingProxy::searchSampleByParameterCondition(
       soap_tmp___ns1__searchSampleByParameterCondition;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action =
         "client.icat3.uk/ICAT/searchSampleByParameterConditionRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchSampleByParameterCondition
       .ns1__searchSampleByParameterCondition_ =
       ns1__searchSampleByParameterCondition_;
@@ -6389,18 +6390,18 @@ int ICATPortBindingProxy::searchSampleByParameterCondition(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchSampleByParameterCondition(
             soap, &soap_tmp___ns1__searchSampleByParameterCondition,
-            "-ns1:searchSampleByParameterCondition", NULL) ||
+            "-ns1:searchSampleByParameterCondition", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchSampleByParameterCondition(
           soap, &soap_tmp___ns1__searchSampleByParameterCondition,
-          "-ns1:searchSampleByParameterCondition", NULL) ||
+          "-ns1:searchSampleByParameterCondition", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -6432,12 +6433,12 @@ int ICATPortBindingProxy::searchInvestigationByParameterComparison(
       soap_tmp___ns1__searchInvestigationByParameterComparison;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action =
         "client.icat3.uk/ICAT/searchInvestigationByParameterComparisonRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchInvestigationByParameterComparison
       .ns1__searchInvestigationByParameterComparison_ =
       ns1__searchInvestigationByParameterComparison_;
@@ -6452,18 +6453,18 @@ int ICATPortBindingProxy::searchInvestigationByParameterComparison(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchInvestigationByParameterComparison(
             soap, &soap_tmp___ns1__searchInvestigationByParameterComparison,
-            "-ns1:searchInvestigationByParameterComparison", NULL) ||
+            "-ns1:searchInvestigationByParameterComparison", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchInvestigationByParameterComparison(
           soap, &soap_tmp___ns1__searchInvestigationByParameterComparison,
-          "-ns1:searchInvestigationByParameterComparison", NULL) ||
+          "-ns1:searchInvestigationByParameterComparison", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -6495,12 +6496,12 @@ int ICATPortBindingProxy::searchDatafileByParameterComparison(
       soap_tmp___ns1__searchDatafileByParameterComparison;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action =
         "client.icat3.uk/ICAT/searchDatafileByParameterComparisonRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchDatafileByParameterComparison
       .ns1__searchDatafileByParameterComparison_ =
       ns1__searchDatafileByParameterComparison_;
@@ -6515,18 +6516,18 @@ int ICATPortBindingProxy::searchDatafileByParameterComparison(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchDatafileByParameterComparison(
             soap, &soap_tmp___ns1__searchDatafileByParameterComparison,
-            "-ns1:searchDatafileByParameterComparison", NULL) ||
+            "-ns1:searchDatafileByParameterComparison", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchDatafileByParameterComparison(
           soap, &soap_tmp___ns1__searchDatafileByParameterComparison,
-          "-ns1:searchDatafileByParameterComparison", NULL) ||
+          "-ns1:searchDatafileByParameterComparison", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -6558,12 +6559,12 @@ int ICATPortBindingProxy::searchDatasetByParameterComparison(
       soap_tmp___ns1__searchDatasetByParameterComparison;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action =
         "client.icat3.uk/ICAT/searchDatasetByParameterComparisonRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchDatasetByParameterComparison
       .ns1__searchDatasetByParameterComparison_ =
       ns1__searchDatasetByParameterComparison_;
@@ -6578,18 +6579,18 @@ int ICATPortBindingProxy::searchDatasetByParameterComparison(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchDatasetByParameterComparison(
             soap, &soap_tmp___ns1__searchDatasetByParameterComparison,
-            "-ns1:searchDatasetByParameterComparison", NULL) ||
+            "-ns1:searchDatasetByParameterComparison", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchDatasetByParameterComparison(
           soap, &soap_tmp___ns1__searchDatasetByParameterComparison,
-          "-ns1:searchDatasetByParameterComparison", NULL) ||
+          "-ns1:searchDatasetByParameterComparison", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -6621,12 +6622,12 @@ int ICATPortBindingProxy::searchSampleByParameterComparison(
       soap_tmp___ns1__searchSampleByParameterComparison;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action =
         "client.icat3.uk/ICAT/searchSampleByParameterComparisonRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchSampleByParameterComparison
       .ns1__searchSampleByParameterComparison_ =
       ns1__searchSampleByParameterComparison_;
@@ -6641,18 +6642,18 @@ int ICATPortBindingProxy::searchSampleByParameterComparison(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchSampleByParameterComparison(
             soap, &soap_tmp___ns1__searchSampleByParameterComparison,
-            "-ns1:searchSampleByParameterComparison", NULL) ||
+            "-ns1:searchSampleByParameterComparison", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchSampleByParameterComparison(
           soap, &soap_tmp___ns1__searchSampleByParameterComparison,
-          "-ns1:searchSampleByParameterComparison", NULL) ||
+          "-ns1:searchSampleByParameterComparison", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -6683,11 +6684,11 @@ int ICATPortBindingProxy::searchInvestigationByParameter(
       soap_tmp___ns1__searchInvestigationByParameter;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/searchInvestigationByParameterRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchInvestigationByParameter
       .ns1__searchInvestigationByParameter_ =
       ns1__searchInvestigationByParameter_;
@@ -6702,18 +6703,18 @@ int ICATPortBindingProxy::searchInvestigationByParameter(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchInvestigationByParameter(
             soap, &soap_tmp___ns1__searchInvestigationByParameter,
-            "-ns1:searchInvestigationByParameter", NULL) ||
+            "-ns1:searchInvestigationByParameter", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchInvestigationByParameter(
           soap, &soap_tmp___ns1__searchInvestigationByParameter,
-          "-ns1:searchInvestigationByParameter", NULL) ||
+          "-ns1:searchInvestigationByParameter", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -6744,11 +6745,11 @@ int ICATPortBindingProxy::searchDatafileByParameter(
       soap_tmp___ns1__searchDatafileByParameter;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/searchDatafileByParameterRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchDatafileByParameter.ns1__searchDatafileByParameter_ =
       ns1__searchDatafileByParameter_;
   soap_begin(soap);
@@ -6762,18 +6763,18 @@ int ICATPortBindingProxy::searchDatafileByParameter(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchDatafileByParameter(
             soap, &soap_tmp___ns1__searchDatafileByParameter,
-            "-ns1:searchDatafileByParameter", NULL) ||
+            "-ns1:searchDatafileByParameter", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchDatafileByParameter(
           soap, &soap_tmp___ns1__searchDatafileByParameter,
-          "-ns1:searchDatafileByParameter", NULL) ||
+          "-ns1:searchDatafileByParameter", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -6804,11 +6805,11 @@ int ICATPortBindingProxy::searchDatasetByParameter(
       soap_tmp___ns1__searchDatasetByParameter;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/searchDatasetByParameterRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchDatasetByParameter.ns1__searchDatasetByParameter_ =
       ns1__searchDatasetByParameter_;
   soap_begin(soap);
@@ -6822,18 +6823,18 @@ int ICATPortBindingProxy::searchDatasetByParameter(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchDatasetByParameter(
             soap, &soap_tmp___ns1__searchDatasetByParameter,
-            "-ns1:searchDatasetByParameter", NULL) ||
+            "-ns1:searchDatasetByParameter", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchDatasetByParameter(
           soap, &soap_tmp___ns1__searchDatasetByParameter,
-          "-ns1:searchDatasetByParameter", NULL) ||
+          "-ns1:searchDatasetByParameter", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -6863,11 +6864,11 @@ int ICATPortBindingProxy::searchSampleByParameter(
   struct __ns1__searchSampleByParameter soap_tmp___ns1__searchSampleByParameter;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/searchSampleByParameterRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchSampleByParameter.ns1__searchSampleByParameter_ =
       ns1__searchSampleByParameter_;
   soap_begin(soap);
@@ -6881,18 +6882,18 @@ int ICATPortBindingProxy::searchSampleByParameter(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchSampleByParameter(
             soap, &soap_tmp___ns1__searchSampleByParameter,
-            "-ns1:searchSampleByParameter", NULL) ||
+            "-ns1:searchSampleByParameter", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchSampleByParameter(
           soap, &soap_tmp___ns1__searchSampleByParameter,
-          "-ns1:searchSampleByParameter", NULL) ||
+          "-ns1:searchSampleByParameter", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -6922,11 +6923,11 @@ int ICATPortBindingProxy::getParameterByNameUnits(
   struct __ns1__getParameterByNameUnits soap_tmp___ns1__getParameterByNameUnits;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/getParameterByNameUnitsRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getParameterByNameUnits.ns1__getParameterByNameUnits_ =
       ns1__getParameterByNameUnits_;
   soap_begin(soap);
@@ -6940,18 +6941,18 @@ int ICATPortBindingProxy::getParameterByNameUnits(
         soap_body_begin_out(soap) ||
         soap_put___ns1__getParameterByNameUnits(
             soap, &soap_tmp___ns1__getParameterByNameUnits,
-            "-ns1:getParameterByNameUnits", NULL) ||
+            "-ns1:getParameterByNameUnits", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getParameterByNameUnits(
           soap, &soap_tmp___ns1__getParameterByNameUnits,
-          "-ns1:getParameterByNameUnits", NULL) ||
+          "-ns1:getParameterByNameUnits", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -6980,11 +6981,11 @@ int ICATPortBindingProxy::getParameterByName(
   struct __ns1__getParameterByName soap_tmp___ns1__getParameterByName;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/getParameterByNameRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getParameterByName.ns1__getParameterByName_ =
       ns1__getParameterByName_;
   soap_begin(soap);
@@ -6996,20 +6997,20 @@ int ICATPortBindingProxy::getParameterByName(
   if (soap->mode & SOAP_IO_LENGTH) {
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
-        soap_put___ns1__getParameterByName(soap,
-                                           &soap_tmp___ns1__getParameterByName,
-                                           "-ns1:getParameterByName", NULL) ||
+        soap_put___ns1__getParameterByName(
+            soap, &soap_tmp___ns1__getParameterByName,
+            "-ns1:getParameterByName", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getParameterByName(soap,
                                          &soap_tmp___ns1__getParameterByName,
-                                         "-ns1:getParameterByName", NULL) ||
+                                         "-ns1:getParameterByName", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -7039,11 +7040,11 @@ int ICATPortBindingProxy::getParameterByRestriction(
       soap_tmp___ns1__getParameterByRestriction;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/getParameterByRestrictionRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getParameterByRestriction.ns1__getParameterByRestriction_ =
       ns1__getParameterByRestriction_;
   soap_begin(soap);
@@ -7057,18 +7058,18 @@ int ICATPortBindingProxy::getParameterByRestriction(
         soap_body_begin_out(soap) ||
         soap_put___ns1__getParameterByRestriction(
             soap, &soap_tmp___ns1__getParameterByRestriction,
-            "-ns1:getParameterByRestriction", NULL) ||
+            "-ns1:getParameterByRestriction", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getParameterByRestriction(
           soap, &soap_tmp___ns1__getParameterByRestriction,
-          "-ns1:getParameterByRestriction", NULL) ||
+          "-ns1:getParameterByRestriction", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -7097,11 +7098,11 @@ int ICATPortBindingProxy::getParameterByUnits(
   struct __ns1__getParameterByUnits soap_tmp___ns1__getParameterByUnits;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/getParameterByUnitsRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getParameterByUnits.ns1__getParameterByUnits_ =
       ns1__getParameterByUnits_;
   soap_begin(soap);
@@ -7115,18 +7116,18 @@ int ICATPortBindingProxy::getParameterByUnits(
         soap_body_begin_out(soap) ||
         soap_put___ns1__getParameterByUnits(
             soap, &soap_tmp___ns1__getParameterByUnits,
-            "-ns1:getParameterByUnits", NULL) ||
+            "-ns1:getParameterByUnits", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
-      soap_put___ns1__getParameterByUnits(soap,
-                                          &soap_tmp___ns1__getParameterByUnits,
-                                          "-ns1:getParameterByUnits", NULL) ||
+      soap_put___ns1__getParameterByUnits(
+          soap, &soap_tmp___ns1__getParameterByUnits,
+          "-ns1:getParameterByUnits", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -7158,12 +7159,12 @@ int ICATPortBindingProxy::searchDatasetByParameterRestriction(
       soap_tmp___ns1__searchDatasetByParameterRestriction;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action =
         "client.icat3.uk/ICAT/searchDatasetByParameterRestrictionRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchDatasetByParameterRestriction
       .ns1__searchDatasetByParameterRestriction_ =
       ns1__searchDatasetByParameterRestriction_;
@@ -7178,18 +7179,18 @@ int ICATPortBindingProxy::searchDatasetByParameterRestriction(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchDatasetByParameterRestriction(
             soap, &soap_tmp___ns1__searchDatasetByParameterRestriction,
-            "-ns1:searchDatasetByParameterRestriction", NULL) ||
+            "-ns1:searchDatasetByParameterRestriction", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchDatasetByParameterRestriction(
           soap, &soap_tmp___ns1__searchDatasetByParameterRestriction,
-          "-ns1:searchDatasetByParameterRestriction", NULL) ||
+          "-ns1:searchDatasetByParameterRestriction", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -7221,12 +7222,12 @@ int ICATPortBindingProxy::searchSampleByParameterRestriction(
       soap_tmp___ns1__searchSampleByParameterRestriction;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action =
         "client.icat3.uk/ICAT/searchSampleByParameterRestrictionRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchSampleByParameterRestriction
       .ns1__searchSampleByParameterRestriction_ =
       ns1__searchSampleByParameterRestriction_;
@@ -7241,18 +7242,18 @@ int ICATPortBindingProxy::searchSampleByParameterRestriction(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchSampleByParameterRestriction(
             soap, &soap_tmp___ns1__searchSampleByParameterRestriction,
-            "-ns1:searchSampleByParameterRestriction", NULL) ||
+            "-ns1:searchSampleByParameterRestriction", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchSampleByParameterRestriction(
           soap, &soap_tmp___ns1__searchSampleByParameterRestriction,
-          "-ns1:searchSampleByParameterRestriction", NULL) ||
+          "-ns1:searchSampleByParameterRestriction", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -7284,12 +7285,12 @@ int ICATPortBindingProxy::searchDatafileByParameterRestriction(
       soap_tmp___ns1__searchDatafileByParameterRestriction;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action =
         "client.icat3.uk/ICAT/searchDatafileByParameterRestrictionRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchDatafileByParameterRestriction
       .ns1__searchDatafileByParameterRestriction_ =
       ns1__searchDatafileByParameterRestriction_;
@@ -7304,18 +7305,18 @@ int ICATPortBindingProxy::searchDatafileByParameterRestriction(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchDatafileByParameterRestriction(
             soap, &soap_tmp___ns1__searchDatafileByParameterRestriction,
-            "-ns1:searchDatafileByParameterRestriction", NULL) ||
+            "-ns1:searchDatafileByParameterRestriction", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchDatafileByParameterRestriction(
           soap, &soap_tmp___ns1__searchDatafileByParameterRestriction,
-          "-ns1:searchDatafileByParameterRestriction", NULL) ||
+          "-ns1:searchDatafileByParameterRestriction", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -7347,12 +7348,12 @@ int ICATPortBindingProxy::searchInvestigationByParameterRestriction(
       soap_tmp___ns1__searchInvestigationByParameterRestriction;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action =
         "client.icat3.uk/ICAT/searchInvestigationByParameterRestrictionRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchInvestigationByParameterRestriction
       .ns1__searchInvestigationByParameterRestriction_ =
       ns1__searchInvestigationByParameterRestriction_;
@@ -7367,18 +7368,18 @@ int ICATPortBindingProxy::searchInvestigationByParameterRestriction(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchInvestigationByParameterRestriction(
             soap, &soap_tmp___ns1__searchInvestigationByParameterRestriction,
-            "-ns1:searchInvestigationByParameterRestriction", NULL) ||
+            "-ns1:searchInvestigationByParameterRestriction", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchInvestigationByParameterRestriction(
           soap, &soap_tmp___ns1__searchInvestigationByParameterRestriction,
-          "-ns1:searchInvestigationByParameterRestriction", NULL) ||
+          "-ns1:searchInvestigationByParameterRestriction", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -7410,12 +7411,12 @@ int ICATPortBindingProxy::searchInvestigationByRestriction(
       soap_tmp___ns1__searchInvestigationByRestriction;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action =
         "client.icat3.uk/ICAT/searchInvestigationByRestrictionRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchInvestigationByRestriction
       .ns1__searchInvestigationByRestriction_ =
       ns1__searchInvestigationByRestriction_;
@@ -7430,18 +7431,18 @@ int ICATPortBindingProxy::searchInvestigationByRestriction(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchInvestigationByRestriction(
             soap, &soap_tmp___ns1__searchInvestigationByRestriction,
-            "-ns1:searchInvestigationByRestriction", NULL) ||
+            "-ns1:searchInvestigationByRestriction", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchInvestigationByRestriction(
           soap, &soap_tmp___ns1__searchInvestigationByRestriction,
-          "-ns1:searchInvestigationByRestriction", NULL) ||
+          "-ns1:searchInvestigationByRestriction", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -7472,11 +7473,11 @@ int ICATPortBindingProxy::searchDatasetByRestriction(
       soap_tmp___ns1__searchDatasetByRestriction;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/searchDatasetByRestrictionRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchDatasetByRestriction.ns1__searchDatasetByRestriction_ =
       ns1__searchDatasetByRestriction_;
   soap_begin(soap);
@@ -7490,18 +7491,18 @@ int ICATPortBindingProxy::searchDatasetByRestriction(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchDatasetByRestriction(
             soap, &soap_tmp___ns1__searchDatasetByRestriction,
-            "-ns1:searchDatasetByRestriction", NULL) ||
+            "-ns1:searchDatasetByRestriction", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchDatasetByRestriction(
           soap, &soap_tmp___ns1__searchDatasetByRestriction,
-          "-ns1:searchDatasetByRestriction", NULL) ||
+          "-ns1:searchDatasetByRestriction", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -7532,11 +7533,11 @@ int ICATPortBindingProxy::searchDatafileByRestriction(
       soap_tmp___ns1__searchDatafileByRestriction;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/searchDatafileByRestrictionRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchDatafileByRestriction
       .ns1__searchDatafileByRestriction_ = ns1__searchDatafileByRestriction_;
   soap_begin(soap);
@@ -7550,18 +7551,18 @@ int ICATPortBindingProxy::searchDatafileByRestriction(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchDatafileByRestriction(
             soap, &soap_tmp___ns1__searchDatafileByRestriction,
-            "-ns1:searchDatafileByRestriction", NULL) ||
+            "-ns1:searchDatafileByRestriction", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchDatafileByRestriction(
           soap, &soap_tmp___ns1__searchDatafileByRestriction,
-          "-ns1:searchDatafileByRestriction", NULL) ||
+          "-ns1:searchDatafileByRestriction", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -7592,11 +7593,11 @@ int ICATPortBindingProxy::searchSampleByRestriction(
       soap_tmp___ns1__searchSampleByRestriction;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/searchSampleByRestrictionRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchSampleByRestriction.ns1__searchSampleByRestriction_ =
       ns1__searchSampleByRestriction_;
   soap_begin(soap);
@@ -7610,18 +7611,18 @@ int ICATPortBindingProxy::searchSampleByRestriction(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchSampleByRestriction(
             soap, &soap_tmp___ns1__searchSampleByRestriction,
-            "-ns1:searchSampleByRestriction", NULL) ||
+            "-ns1:searchSampleByRestriction", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchSampleByRestriction(
           soap, &soap_tmp___ns1__searchSampleByRestriction,
-          "-ns1:searchSampleByRestriction", NULL) ||
+          "-ns1:searchSampleByRestriction", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -7653,12 +7654,12 @@ int ICATPortBindingProxy::searchInvestigationByRestrictionComparasion(
       soap_tmp___ns1__searchInvestigationByRestrictionComparasion;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/"
                   "searchInvestigationByRestrictionComparasionRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchInvestigationByRestrictionComparasion
       .ns1__searchInvestigationByRestrictionComparasion_ =
       ns1__searchInvestigationByRestrictionComparasion_;
@@ -7673,18 +7674,18 @@ int ICATPortBindingProxy::searchInvestigationByRestrictionComparasion(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchInvestigationByRestrictionComparasion(
             soap, &soap_tmp___ns1__searchInvestigationByRestrictionComparasion,
-            "-ns1:searchInvestigationByRestrictionComparasion", NULL) ||
+            "-ns1:searchInvestigationByRestrictionComparasion", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchInvestigationByRestrictionComparasion(
           soap, &soap_tmp___ns1__searchInvestigationByRestrictionComparasion,
-          "-ns1:searchInvestigationByRestrictionComparasion", NULL) ||
+          "-ns1:searchInvestigationByRestrictionComparasion", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -7716,12 +7717,12 @@ int ICATPortBindingProxy::searchDatasetByRestrictionComparison(
       soap_tmp___ns1__searchDatasetByRestrictionComparison;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action =
         "client.icat3.uk/ICAT/searchDatasetByRestrictionComparisonRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchDatasetByRestrictionComparison
       .ns1__searchDatasetByRestrictionComparison_ =
       ns1__searchDatasetByRestrictionComparison_;
@@ -7736,18 +7737,18 @@ int ICATPortBindingProxy::searchDatasetByRestrictionComparison(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchDatasetByRestrictionComparison(
             soap, &soap_tmp___ns1__searchDatasetByRestrictionComparison,
-            "-ns1:searchDatasetByRestrictionComparison", NULL) ||
+            "-ns1:searchDatasetByRestrictionComparison", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchDatasetByRestrictionComparison(
           soap, &soap_tmp___ns1__searchDatasetByRestrictionComparison,
-          "-ns1:searchDatasetByRestrictionComparison", NULL) ||
+          "-ns1:searchDatasetByRestrictionComparison", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -7779,12 +7780,12 @@ int ICATPortBindingProxy::searchDatafileByRestrictionComparison(
       soap_tmp___ns1__searchDatafileByRestrictionComparison;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action =
         "client.icat3.uk/ICAT/searchDatafileByRestrictionComparisonRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchDatafileByRestrictionComparison
       .ns1__searchDatafileByRestrictionComparison_ =
       ns1__searchDatafileByRestrictionComparison_;
@@ -7799,18 +7800,18 @@ int ICATPortBindingProxy::searchDatafileByRestrictionComparison(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchDatafileByRestrictionComparison(
             soap, &soap_tmp___ns1__searchDatafileByRestrictionComparison,
-            "-ns1:searchDatafileByRestrictionComparison", NULL) ||
+            "-ns1:searchDatafileByRestrictionComparison", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchDatafileByRestrictionComparison(
           soap, &soap_tmp___ns1__searchDatafileByRestrictionComparison,
-          "-ns1:searchDatafileByRestrictionComparison", NULL) ||
+          "-ns1:searchDatafileByRestrictionComparison", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -7842,12 +7843,12 @@ int ICATPortBindingProxy::searchSampleByRestrictionComparison(
       soap_tmp___ns1__searchSampleByRestrictionComparison;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action =
         "client.icat3.uk/ICAT/searchSampleByRestrictionComparisonRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchSampleByRestrictionComparison
       .ns1__searchSampleByRestrictionComparison_ =
       ns1__searchSampleByRestrictionComparison_;
@@ -7862,18 +7863,18 @@ int ICATPortBindingProxy::searchSampleByRestrictionComparison(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchSampleByRestrictionComparison(
             soap, &soap_tmp___ns1__searchSampleByRestrictionComparison,
-            "-ns1:searchSampleByRestrictionComparison", NULL) ||
+            "-ns1:searchSampleByRestrictionComparison", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchSampleByRestrictionComparison(
           soap, &soap_tmp___ns1__searchSampleByRestrictionComparison,
-          "-ns1:searchSampleByRestrictionComparison", NULL) ||
+          "-ns1:searchSampleByRestrictionComparison", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -7905,12 +7906,12 @@ int ICATPortBindingProxy::searchSampleByRestrictionLogical(
       soap_tmp___ns1__searchSampleByRestrictionLogical;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action =
         "client.icat3.uk/ICAT/searchSampleByRestrictionLogicalRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchSampleByRestrictionLogical
       .ns1__searchSampleByRestrictionLogical_ =
       ns1__searchSampleByRestrictionLogical_;
@@ -7925,18 +7926,18 @@ int ICATPortBindingProxy::searchSampleByRestrictionLogical(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchSampleByRestrictionLogical(
             soap, &soap_tmp___ns1__searchSampleByRestrictionLogical,
-            "-ns1:searchSampleByRestrictionLogical", NULL) ||
+            "-ns1:searchSampleByRestrictionLogical", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchSampleByRestrictionLogical(
           soap, &soap_tmp___ns1__searchSampleByRestrictionLogical,
-          "-ns1:searchSampleByRestrictionLogical", NULL) ||
+          "-ns1:searchSampleByRestrictionLogical", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -7968,12 +7969,12 @@ int ICATPortBindingProxy::searchDatasetByRestrictionLogical(
       soap_tmp___ns1__searchDatasetByRestrictionLogical;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action =
         "client.icat3.uk/ICAT/searchDatasetByRestrictionLogicalRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchDatasetByRestrictionLogical
       .ns1__searchDatasetByRestrictionLogical_ =
       ns1__searchDatasetByRestrictionLogical_;
@@ -7988,18 +7989,18 @@ int ICATPortBindingProxy::searchDatasetByRestrictionLogical(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchDatasetByRestrictionLogical(
             soap, &soap_tmp___ns1__searchDatasetByRestrictionLogical,
-            "-ns1:searchDatasetByRestrictionLogical", NULL) ||
+            "-ns1:searchDatasetByRestrictionLogical", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchDatasetByRestrictionLogical(
           soap, &soap_tmp___ns1__searchDatasetByRestrictionLogical,
-          "-ns1:searchDatasetByRestrictionLogical", NULL) ||
+          "-ns1:searchDatasetByRestrictionLogical", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -8031,12 +8032,12 @@ int ICATPortBindingProxy::searchInvestigationByRestrictionLogical(
       soap_tmp___ns1__searchInvestigationByRestrictionLogical;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action =
         "client.icat3.uk/ICAT/searchInvestigationByRestrictionLogicalRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchInvestigationByRestrictionLogical
       .ns1__searchInvestigationByRestrictionLogical_ =
       ns1__searchInvestigationByRestrictionLogical_;
@@ -8051,18 +8052,18 @@ int ICATPortBindingProxy::searchInvestigationByRestrictionLogical(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchInvestigationByRestrictionLogical(
             soap, &soap_tmp___ns1__searchInvestigationByRestrictionLogical,
-            "-ns1:searchInvestigationByRestrictionLogical", NULL) ||
+            "-ns1:searchInvestigationByRestrictionLogical", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchInvestigationByRestrictionLogical(
           soap, &soap_tmp___ns1__searchInvestigationByRestrictionLogical,
-          "-ns1:searchInvestigationByRestrictionLogical", NULL) ||
+          "-ns1:searchInvestigationByRestrictionLogical", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -8094,12 +8095,12 @@ int ICATPortBindingProxy::searchDatafileByRestrictionLogical(
       soap_tmp___ns1__searchDatafileByRestrictionLogical;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action =
         "client.icat3.uk/ICAT/searchDatafileByRestrictionLogicalRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchDatafileByRestrictionLogical
       .ns1__searchDatafileByRestrictionLogical_ =
       ns1__searchDatafileByRestrictionLogical_;
@@ -8114,18 +8115,18 @@ int ICATPortBindingProxy::searchDatafileByRestrictionLogical(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchDatafileByRestrictionLogical(
             soap, &soap_tmp___ns1__searchDatafileByRestrictionLogical,
-            "-ns1:searchDatafileByRestrictionLogical", NULL) ||
+            "-ns1:searchDatafileByRestrictionLogical", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchDatafileByRestrictionLogical(
           soap, &soap_tmp___ns1__searchDatafileByRestrictionLogical,
-          "-ns1:searchDatafileByRestrictionLogical", NULL) ||
+          "-ns1:searchDatafileByRestrictionLogical", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -8157,12 +8158,12 @@ int ICATPortBindingProxy::searchInvestigationByParameterLogical(
       soap_tmp___ns1__searchInvestigationByParameterLogical;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action =
         "client.icat3.uk/ICAT/searchInvestigationByParameterLogicalRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchInvestigationByParameterLogical
       .ns1__searchInvestigationByParameterLogical_ =
       ns1__searchInvestigationByParameterLogical_;
@@ -8177,18 +8178,18 @@ int ICATPortBindingProxy::searchInvestigationByParameterLogical(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchInvestigationByParameterLogical(
             soap, &soap_tmp___ns1__searchInvestigationByParameterLogical,
-            "-ns1:searchInvestigationByParameterLogical", NULL) ||
+            "-ns1:searchInvestigationByParameterLogical", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchInvestigationByParameterLogical(
           soap, &soap_tmp___ns1__searchInvestigationByParameterLogical,
-          "-ns1:searchInvestigationByParameterLogical", NULL) ||
+          "-ns1:searchInvestigationByParameterLogical", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -8220,12 +8221,12 @@ int ICATPortBindingProxy::searchDatafileByParameterLogical(
       soap_tmp___ns1__searchDatafileByParameterLogical;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action =
         "client.icat3.uk/ICAT/searchDatafileByParameterLogicalRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchDatafileByParameterLogical
       .ns1__searchDatafileByParameterLogical_ =
       ns1__searchDatafileByParameterLogical_;
@@ -8240,18 +8241,18 @@ int ICATPortBindingProxy::searchDatafileByParameterLogical(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchDatafileByParameterLogical(
             soap, &soap_tmp___ns1__searchDatafileByParameterLogical,
-            "-ns1:searchDatafileByParameterLogical", NULL) ||
+            "-ns1:searchDatafileByParameterLogical", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchDatafileByParameterLogical(
           soap, &soap_tmp___ns1__searchDatafileByParameterLogical,
-          "-ns1:searchDatafileByParameterLogical", NULL) ||
+          "-ns1:searchDatafileByParameterLogical", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -8282,11 +8283,11 @@ int ICATPortBindingProxy::searchDatasetByParameterLogical(
       soap_tmp___ns1__searchDatasetByParameterLogical;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/searchDatasetByParameterLogicalRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchDatasetByParameterLogical
       .ns1__searchDatasetByParameterLogical_ =
       ns1__searchDatasetByParameterLogical_;
@@ -8301,18 +8302,18 @@ int ICATPortBindingProxy::searchDatasetByParameterLogical(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchDatasetByParameterLogical(
             soap, &soap_tmp___ns1__searchDatasetByParameterLogical,
-            "-ns1:searchDatasetByParameterLogical", NULL) ||
+            "-ns1:searchDatasetByParameterLogical", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchDatasetByParameterLogical(
           soap, &soap_tmp___ns1__searchDatasetByParameterLogical,
-          "-ns1:searchDatasetByParameterLogical", NULL) ||
+          "-ns1:searchDatasetByParameterLogical", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -8343,11 +8344,11 @@ int ICATPortBindingProxy::searchSampleByParameterLogical(
       soap_tmp___ns1__searchSampleByParameterLogical;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/searchSampleByParameterLogicalRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchSampleByParameterLogical
       .ns1__searchSampleByParameterLogical_ =
       ns1__searchSampleByParameterLogical_;
@@ -8362,18 +8363,18 @@ int ICATPortBindingProxy::searchSampleByParameterLogical(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchSampleByParameterLogical(
             soap, &soap_tmp___ns1__searchSampleByParameterLogical,
-            "-ns1:searchSampleByParameterLogical", NULL) ||
+            "-ns1:searchSampleByParameterLogical", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchSampleByParameterLogical(
           soap, &soap_tmp___ns1__searchSampleByParameterLogical,
-          "-ns1:searchSampleByParameterLogical", NULL) ||
+          "-ns1:searchSampleByParameterLogical", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -8404,11 +8405,11 @@ int ICATPortBindingProxy::searchFacilityUserByRestriction(
       soap_tmp___ns1__searchFacilityUserByRestriction;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://facilities01.esc.rl.ac.uk:8181/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "client.icat3.uk/ICAT/searchFacilityUserByRestrictionRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchFacilityUserByRestriction
       .ns1__searchFacilityUserByRestriction_ =
       ns1__searchFacilityUserByRestriction_;
@@ -8423,18 +8424,18 @@ int ICATPortBindingProxy::searchFacilityUserByRestriction(
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchFacilityUserByRestriction(
             soap, &soap_tmp___ns1__searchFacilityUserByRestriction,
-            "-ns1:searchFacilityUserByRestriction", NULL) ||
+            "-ns1:searchFacilityUserByRestriction", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchFacilityUserByRestriction(
           soap, &soap_tmp___ns1__searchFacilityUserByRestriction,
-          "-ns1:searchFacilityUserByRestriction", NULL) ||
+          "-ns1:searchFacilityUserByRestriction", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);

--- a/Framework/ICat/src/ICat4/GSoapGenerated/ICat4C.cpp
+++ b/Framework/ICat/src/ICat4/GSoapGenerated/ICat4C.cpp
@@ -172,557 +172,591 @@ SOAP_FMAC3 int SOAP_FMAC4 soap_getindependent(struct soap *soap) {
 SOAP_FMAC3 void *SOAP_FMAC4 soap_getelement(struct soap *soap, int *type) {
   (void)type;
   if (soap_peek_element(soap))
-    return NULL;
+    return nullptr;
 #ifndef WITH_NOIDREF
   if (!*soap->id || !(*type = soap_lookup_type(soap, soap->id)))
     *type = soap_lookup_type(soap, soap->href);
   switch (*type) {
   case SOAP_TYPE_ICat4_byte:
-    return soap_in_byte(soap, NULL, NULL, "xsd:byte");
+    return soap_in_byte(soap, nullptr, nullptr, "xsd:byte");
   case SOAP_TYPE_ICat4_int:
-    return soap_in_int(soap, NULL, NULL, "xsd:int");
+    return soap_in_int(soap, nullptr, nullptr, "xsd:int");
   case SOAP_TYPE_ICat4_LONG64:
-    return soap_in_LONG64(soap, NULL, NULL, "xsd:long");
+    return soap_in_LONG64(soap, nullptr, nullptr, "xsd:long");
   case SOAP_TYPE_ICat4_double:
-    return soap_in_double(soap, NULL, NULL, "xsd:double");
+    return soap_in_double(soap, nullptr, nullptr, "xsd:double");
   case SOAP_TYPE_ICat4_time:
-    return soap_in_time(soap, NULL, NULL, "xsd:dateTime");
+    return soap_in_time(soap, nullptr, nullptr, "xsd:dateTime");
   case SOAP_TYPE_ICat4_ns1__accessType:
-    return soap_in_ns1__accessType(soap, NULL, NULL, "ns1:accessType");
+    return soap_in_ns1__accessType(soap, nullptr, nullptr, "ns1:accessType");
   case SOAP_TYPE_ICat4_ns1__relType:
-    return soap_in_ns1__relType(soap, NULL, NULL, "ns1:relType");
+    return soap_in_ns1__relType(soap, nullptr, nullptr, "ns1:relType");
   case SOAP_TYPE_ICat4_ns1__parameterValueType:
-    return soap_in_ns1__parameterValueType(soap, NULL, NULL,
+    return soap_in_ns1__parameterValueType(soap, nullptr, nullptr,
                                            "ns1:parameterValueType");
   case SOAP_TYPE_ICat4_ns1__studyStatus:
-    return soap_in_ns1__studyStatus(soap, NULL, NULL, "ns1:studyStatus");
+    return soap_in_ns1__studyStatus(soap, nullptr, nullptr, "ns1:studyStatus");
   case SOAP_TYPE_ICat4_ns1__icatExceptionType:
-    return soap_in_ns1__icatExceptionType(soap, NULL, NULL,
+    return soap_in_ns1__icatExceptionType(soap, nullptr, nullptr,
                                           "ns1:icatExceptionType");
   case SOAP_TYPE_ICat4_bool:
-    return soap_in_bool(soap, NULL, NULL, "xsd:boolean");
+    return soap_in_bool(soap, nullptr, nullptr, "xsd:boolean");
   case SOAP_TYPE_ICat4_ns1__accessType_:
-    return soap_in_ns1__accessType_(soap, NULL, NULL, "ns1:accessType");
+    return soap_in_ns1__accessType_(soap, nullptr, nullptr, "ns1:accessType");
   case SOAP_TYPE_ICat4_ns1__relType_:
-    return soap_in_ns1__relType_(soap, NULL, NULL, "ns1:relType");
+    return soap_in_ns1__relType_(soap, nullptr, nullptr, "ns1:relType");
   case SOAP_TYPE_ICat4_ns1__parameterValueType_:
-    return soap_in_ns1__parameterValueType_(soap, NULL, NULL,
+    return soap_in_ns1__parameterValueType_(soap, nullptr, nullptr,
                                             "ns1:parameterValueType");
   case SOAP_TYPE_ICat4_ns1__studyStatus_:
-    return soap_in_ns1__studyStatus_(soap, NULL, NULL, "ns1:studyStatus");
+    return soap_in_ns1__studyStatus_(soap, nullptr, nullptr, "ns1:studyStatus");
   case SOAP_TYPE_ICat4_ns1__icatExceptionType_:
-    return soap_in_ns1__icatExceptionType_(soap, NULL, NULL,
+    return soap_in_ns1__icatExceptionType_(soap, nullptr, nullptr,
                                            "ns1:icatExceptionType");
   case SOAP_TYPE_ICat4_ns1__getRemainingMinutesResponse:
     return soap_in_ns1__getRemainingMinutesResponse(
-        soap, NULL, NULL, "ns1:getRemainingMinutesResponse");
+        soap, nullptr, nullptr, "ns1:getRemainingMinutesResponse");
   case SOAP_TYPE_ICat4_ns1__getRemainingMinutes:
-    return soap_in_ns1__getRemainingMinutes(soap, NULL, NULL,
+    return soap_in_ns1__getRemainingMinutes(soap, nullptr, nullptr,
                                             "ns1:getRemainingMinutes");
   case SOAP_TYPE_ICat4_ns1__logoutResponse:
-    return soap_in_ns1__logoutResponse(soap, NULL, NULL, "ns1:logoutResponse");
+    return soap_in_ns1__logoutResponse(soap, nullptr, nullptr,
+                                       "ns1:logoutResponse");
   case SOAP_TYPE_ICat4_ns1__logout:
-    return soap_in_ns1__logout(soap, NULL, NULL, "ns1:logout");
+    return soap_in_ns1__logout(soap, nullptr, nullptr, "ns1:logout");
   case SOAP_TYPE_ICat4_ns1__searchResponse:
-    return soap_in_ns1__searchResponse(soap, NULL, NULL, "ns1:searchResponse");
+    return soap_in_ns1__searchResponse(soap, nullptr, nullptr,
+                                       "ns1:searchResponse");
   case SOAP_TYPE_ICat4_ns1__search:
-    return soap_in_ns1__search(soap, NULL, NULL, "ns1:search");
+    return soap_in_ns1__search(soap, nullptr, nullptr, "ns1:search");
   case SOAP_TYPE_ICat4_ns1__isAccessAllowedResponse:
-    return soap_in_ns1__isAccessAllowedResponse(soap, NULL, NULL,
+    return soap_in_ns1__isAccessAllowedResponse(soap, nullptr, nullptr,
                                                 "ns1:isAccessAllowedResponse");
   case SOAP_TYPE_ICat4_ns1__isAccessAllowed:
-    return soap_in_ns1__isAccessAllowed(soap, NULL, NULL,
+    return soap_in_ns1__isAccessAllowed(soap, nullptr, nullptr,
                                         "ns1:isAccessAllowed");
   case SOAP_TYPE_ICat4_ns1__deleteResponse:
-    return soap_in_ns1__deleteResponse(soap, NULL, NULL, "ns1:deleteResponse");
+    return soap_in_ns1__deleteResponse(soap, nullptr, nullptr,
+                                       "ns1:deleteResponse");
   case SOAP_TYPE_ICat4_ns1__delete:
-    return soap_in_ns1__delete(soap, NULL, NULL, "ns1:delete");
+    return soap_in_ns1__delete(soap, nullptr, nullptr, "ns1:delete");
   case SOAP_TYPE_ICat4_ns1__searchTextResponse:
-    return soap_in_ns1__searchTextResponse(soap, NULL, NULL,
+    return soap_in_ns1__searchTextResponse(soap, nullptr, nullptr,
                                            "ns1:searchTextResponse");
   case SOAP_TYPE_ICat4_ns1__searchText:
-    return soap_in_ns1__searchText(soap, NULL, NULL, "ns1:searchText");
+    return soap_in_ns1__searchText(soap, nullptr, nullptr, "ns1:searchText");
   case SOAP_TYPE_ICat4_ns1__luceneCommitResponse:
-    return soap_in_ns1__luceneCommitResponse(soap, NULL, NULL,
+    return soap_in_ns1__luceneCommitResponse(soap, nullptr, nullptr,
                                              "ns1:luceneCommitResponse");
   case SOAP_TYPE_ICat4_ns1__luceneCommit:
-    return soap_in_ns1__luceneCommit(soap, NULL, NULL, "ns1:luceneCommit");
+    return soap_in_ns1__luceneCommit(soap, nullptr, nullptr,
+                                     "ns1:luceneCommit");
   case SOAP_TYPE_ICat4_ns1__entityField:
-    return soap_in_ns1__entityField(soap, NULL, NULL, "ns1:entityField");
+    return soap_in_ns1__entityField(soap, nullptr, nullptr, "ns1:entityField");
   case SOAP_TYPE_ICat4_ns1__constraint:
-    return soap_in_ns1__constraint(soap, NULL, NULL, "ns1:constraint");
+    return soap_in_ns1__constraint(soap, nullptr, nullptr, "ns1:constraint");
   case SOAP_TYPE_ICat4_ns1__entityInfo:
-    return soap_in_ns1__entityInfo(soap, NULL, NULL, "ns1:entityInfo");
+    return soap_in_ns1__entityInfo(soap, nullptr, nullptr, "ns1:entityInfo");
   case SOAP_TYPE_ICat4_ns1__getEntityInfoResponse:
-    return soap_in_ns1__getEntityInfoResponse(soap, NULL, NULL,
+    return soap_in_ns1__getEntityInfoResponse(soap, nullptr, nullptr,
                                               "ns1:getEntityInfoResponse");
   case SOAP_TYPE_ICat4_ns1__getEntityInfo:
-    return soap_in_ns1__getEntityInfo(soap, NULL, NULL, "ns1:getEntityInfo");
+    return soap_in_ns1__getEntityInfo(soap, nullptr, nullptr,
+                                      "ns1:getEntityInfo");
   case SOAP_TYPE_ICat4_ns1__dummyResponse:
-    return soap_in_ns1__dummyResponse(soap, NULL, NULL, "ns1:dummyResponse");
+    return soap_in_ns1__dummyResponse(soap, nullptr, nullptr,
+                                      "ns1:dummyResponse");
   case SOAP_TYPE_ICat4_ns1__publicStep:
-    return soap_in_ns1__publicStep(soap, NULL, NULL, "ns1:publicStep");
+    return soap_in_ns1__publicStep(soap, nullptr, nullptr, "ns1:publicStep");
   case SOAP_TYPE_ICat4_ns1__log:
-    return soap_in_ns1__log(soap, NULL, NULL, "ns1:log");
+    return soap_in_ns1__log(soap, nullptr, nullptr, "ns1:log");
   case SOAP_TYPE_ICat4_ns1__relatedDatafile:
-    return soap_in_ns1__relatedDatafile(soap, NULL, NULL,
+    return soap_in_ns1__relatedDatafile(soap, nullptr, nullptr,
                                         "ns1:relatedDatafile");
   case SOAP_TYPE_ICat4_ns1__shift:
-    return soap_in_ns1__shift(soap, NULL, NULL, "ns1:shift");
+    return soap_in_ns1__shift(soap, nullptr, nullptr, "ns1:shift");
   case SOAP_TYPE_ICat4_ns1__publication:
-    return soap_in_ns1__publication(soap, NULL, NULL, "ns1:publication");
+    return soap_in_ns1__publication(soap, nullptr, nullptr, "ns1:publication");
   case SOAP_TYPE_ICat4_ns1__keyword:
-    return soap_in_ns1__keyword(soap, NULL, NULL, "ns1:keyword");
+    return soap_in_ns1__keyword(soap, nullptr, nullptr, "ns1:keyword");
   case SOAP_TYPE_ICat4_ns1__sampleType:
-    return soap_in_ns1__sampleType(soap, NULL, NULL, "ns1:sampleType");
+    return soap_in_ns1__sampleType(soap, nullptr, nullptr, "ns1:sampleType");
   case SOAP_TYPE_ICat4_ns1__sample:
-    return soap_in_ns1__sample(soap, NULL, NULL, "ns1:sample");
+    return soap_in_ns1__sample(soap, nullptr, nullptr, "ns1:sample");
   case SOAP_TYPE_ICat4_ns1__sampleParameter:
-    return soap_in_ns1__sampleParameter(soap, NULL, NULL,
+    return soap_in_ns1__sampleParameter(soap, nullptr, nullptr,
                                         "ns1:sampleParameter");
   case SOAP_TYPE_ICat4_ns1__permissibleStringValue:
-    return soap_in_ns1__permissibleStringValue(soap, NULL, NULL,
+    return soap_in_ns1__permissibleStringValue(soap, nullptr, nullptr,
                                                "ns1:permissibleStringValue");
   case SOAP_TYPE_ICat4_ns1__investigationParameter:
-    return soap_in_ns1__investigationParameter(soap, NULL, NULL,
+    return soap_in_ns1__investigationParameter(soap, nullptr, nullptr,
                                                "ns1:investigationParameter");
   case SOAP_TYPE_ICat4_ns1__datasetParameter:
-    return soap_in_ns1__datasetParameter(soap, NULL, NULL,
+    return soap_in_ns1__datasetParameter(soap, nullptr, nullptr,
                                          "ns1:datasetParameter");
   case SOAP_TYPE_ICat4_ns1__datafileParameter:
-    return soap_in_ns1__datafileParameter(soap, NULL, NULL,
+    return soap_in_ns1__datafileParameter(soap, nullptr, nullptr,
                                           "ns1:datafileParameter");
   case SOAP_TYPE_ICat4_ns1__parameter:
-    return soap_in_ns1__parameter(soap, NULL, NULL, "ns1:parameter");
+    return soap_in_ns1__parameter(soap, nullptr, nullptr, "ns1:parameter");
   case SOAP_TYPE_ICat4_ns1__dataCollectionParameter:
-    return soap_in_ns1__dataCollectionParameter(soap, NULL, NULL,
+    return soap_in_ns1__dataCollectionParameter(soap, nullptr, nullptr,
                                                 "ns1:dataCollectionParameter");
   case SOAP_TYPE_ICat4_ns1__parameterType:
-    return soap_in_ns1__parameterType(soap, NULL, NULL, "ns1:parameterType");
+    return soap_in_ns1__parameterType(soap, nullptr, nullptr,
+                                      "ns1:parameterType");
   case SOAP_TYPE_ICat4_ns1__investigationType:
-    return soap_in_ns1__investigationType(soap, NULL, NULL,
+    return soap_in_ns1__investigationType(soap, nullptr, nullptr,
                                           "ns1:investigationType");
   case SOAP_TYPE_ICat4_ns1__investigationInstrument:
-    return soap_in_ns1__investigationInstrument(soap, NULL, NULL,
+    return soap_in_ns1__investigationInstrument(soap, nullptr, nullptr,
                                                 "ns1:investigationInstrument");
   case SOAP_TYPE_ICat4_ns1__rule:
-    return soap_in_ns1__rule(soap, NULL, NULL, "ns1:rule");
+    return soap_in_ns1__rule(soap, nullptr, nullptr, "ns1:rule");
   case SOAP_TYPE_ICat4_ns1__grouping:
-    return soap_in_ns1__grouping(soap, NULL, NULL, "ns1:grouping");
+    return soap_in_ns1__grouping(soap, nullptr, nullptr, "ns1:grouping");
   case SOAP_TYPE_ICat4_ns1__userGroup:
-    return soap_in_ns1__userGroup(soap, NULL, NULL, "ns1:userGroup");
+    return soap_in_ns1__userGroup(soap, nullptr, nullptr, "ns1:userGroup");
   case SOAP_TYPE_ICat4_ns1__studyInvestigation:
-    return soap_in_ns1__studyInvestigation(soap, NULL, NULL,
+    return soap_in_ns1__studyInvestigation(soap, nullptr, nullptr,
                                            "ns1:studyInvestigation");
   case SOAP_TYPE_ICat4_ns1__study:
-    return soap_in_ns1__study(soap, NULL, NULL, "ns1:study");
+    return soap_in_ns1__study(soap, nullptr, nullptr, "ns1:study");
   case SOAP_TYPE_ICat4_ns1__investigationUser:
-    return soap_in_ns1__investigationUser(soap, NULL, NULL,
+    return soap_in_ns1__investigationUser(soap, nullptr, nullptr,
                                           "ns1:investigationUser");
   case SOAP_TYPE_ICat4_ns1__user:
-    return soap_in_ns1__user(soap, NULL, NULL, "ns1:user");
+    return soap_in_ns1__user(soap, nullptr, nullptr, "ns1:user");
   case SOAP_TYPE_ICat4_ns1__instrumentScientist:
-    return soap_in_ns1__instrumentScientist(soap, NULL, NULL,
+    return soap_in_ns1__instrumentScientist(soap, nullptr, nullptr,
                                             "ns1:instrumentScientist");
   case SOAP_TYPE_ICat4_ns1__instrument:
-    return soap_in_ns1__instrument(soap, NULL, NULL, "ns1:instrument");
+    return soap_in_ns1__instrument(soap, nullptr, nullptr, "ns1:instrument");
   case SOAP_TYPE_ICat4_ns1__facilityCycle:
-    return soap_in_ns1__facilityCycle(soap, NULL, NULL, "ns1:facilityCycle");
+    return soap_in_ns1__facilityCycle(soap, nullptr, nullptr,
+                                      "ns1:facilityCycle");
   case SOAP_TYPE_ICat4_ns1__datasetType:
-    return soap_in_ns1__datasetType(soap, NULL, NULL, "ns1:datasetType");
+    return soap_in_ns1__datasetType(soap, nullptr, nullptr, "ns1:datasetType");
   case SOAP_TYPE_ICat4_ns1__datafileFormat:
-    return soap_in_ns1__datafileFormat(soap, NULL, NULL, "ns1:datafileFormat");
+    return soap_in_ns1__datafileFormat(soap, nullptr, nullptr,
+                                       "ns1:datafileFormat");
   case SOAP_TYPE_ICat4_ns1__job:
-    return soap_in_ns1__job(soap, NULL, NULL, "ns1:job");
+    return soap_in_ns1__job(soap, nullptr, nullptr, "ns1:job");
   case SOAP_TYPE_ICat4_ns1__application:
-    return soap_in_ns1__application(soap, NULL, NULL, "ns1:application");
+    return soap_in_ns1__application(soap, nullptr, nullptr, "ns1:application");
   case SOAP_TYPE_ICat4_ns1__facility:
-    return soap_in_ns1__facility(soap, NULL, NULL, "ns1:facility");
+    return soap_in_ns1__facility(soap, nullptr, nullptr, "ns1:facility");
   case SOAP_TYPE_ICat4_ns1__investigation:
-    return soap_in_ns1__investigation(soap, NULL, NULL, "ns1:investigation");
+    return soap_in_ns1__investigation(soap, nullptr, nullptr,
+                                      "ns1:investigation");
   case SOAP_TYPE_ICat4_ns1__dataset:
-    return soap_in_ns1__dataset(soap, NULL, NULL, "ns1:dataset");
+    return soap_in_ns1__dataset(soap, nullptr, nullptr, "ns1:dataset");
   case SOAP_TYPE_ICat4_ns1__dataCollectionDataset:
-    return soap_in_ns1__dataCollectionDataset(soap, NULL, NULL,
+    return soap_in_ns1__dataCollectionDataset(soap, nullptr, nullptr,
                                               "ns1:dataCollectionDataset");
   case SOAP_TYPE_ICat4_ns1__dataCollection:
-    return soap_in_ns1__dataCollection(soap, NULL, NULL, "ns1:dataCollection");
+    return soap_in_ns1__dataCollection(soap, nullptr, nullptr,
+                                       "ns1:dataCollection");
   case SOAP_TYPE_ICat4_ns1__dataCollectionDatafile:
-    return soap_in_ns1__dataCollectionDatafile(soap, NULL, NULL,
+    return soap_in_ns1__dataCollectionDatafile(soap, nullptr, nullptr,
                                                "ns1:dataCollectionDatafile");
   case SOAP_TYPE_ICat4_ns1__datafile:
-    return soap_in_ns1__datafile(soap, NULL, NULL, "ns1:datafile");
+    return soap_in_ns1__datafile(soap, nullptr, nullptr, "ns1:datafile");
   case SOAP_TYPE_ICat4_ns1__dummy:
-    return soap_in_ns1__dummy(soap, NULL, NULL, "ns1:dummy");
+    return soap_in_ns1__dummy(soap, nullptr, nullptr, "ns1:dummy");
   case SOAP_TYPE_ICat4_ns1__loginResponse:
-    return soap_in_ns1__loginResponse(soap, NULL, NULL, "ns1:loginResponse");
+    return soap_in_ns1__loginResponse(soap, nullptr, nullptr,
+                                      "ns1:loginResponse");
   case SOAP_TYPE_ICat4_ns1__login:
-    return soap_in_ns1__login(soap, NULL, NULL, "ns1:login");
+    return soap_in_ns1__login(soap, nullptr, nullptr, "ns1:login");
   case SOAP_TYPE_ICat4_ns1__refreshResponse:
-    return soap_in_ns1__refreshResponse(soap, NULL, NULL,
+    return soap_in_ns1__refreshResponse(soap, nullptr, nullptr,
                                         "ns1:refreshResponse");
   case SOAP_TYPE_ICat4_ns1__refresh:
-    return soap_in_ns1__refresh(soap, NULL, NULL, "ns1:refresh");
+    return soap_in_ns1__refresh(soap, nullptr, nullptr, "ns1:refresh");
   case SOAP_TYPE_ICat4_ns1__getUserNameResponse:
-    return soap_in_ns1__getUserNameResponse(soap, NULL, NULL,
+    return soap_in_ns1__getUserNameResponse(soap, nullptr, nullptr,
                                             "ns1:getUserNameResponse");
   case SOAP_TYPE_ICat4_ns1__getUserName:
-    return soap_in_ns1__getUserName(soap, NULL, NULL, "ns1:getUserName");
+    return soap_in_ns1__getUserName(soap, nullptr, nullptr, "ns1:getUserName");
   case SOAP_TYPE_ICat4_ns1__deleteManyResponse:
-    return soap_in_ns1__deleteManyResponse(soap, NULL, NULL,
+    return soap_in_ns1__deleteManyResponse(soap, nullptr, nullptr,
                                            "ns1:deleteManyResponse");
   case SOAP_TYPE_ICat4_ns1__deleteMany:
-    return soap_in_ns1__deleteMany(soap, NULL, NULL, "ns1:deleteMany");
+    return soap_in_ns1__deleteMany(soap, nullptr, nullptr, "ns1:deleteMany");
   case SOAP_TYPE_ICat4_ns1__updateResponse:
-    return soap_in_ns1__updateResponse(soap, NULL, NULL, "ns1:updateResponse");
+    return soap_in_ns1__updateResponse(soap, nullptr, nullptr,
+                                       "ns1:updateResponse");
   case SOAP_TYPE_ICat4_ns1__update:
-    return soap_in_ns1__update(soap, NULL, NULL, "ns1:update");
+    return soap_in_ns1__update(soap, nullptr, nullptr, "ns1:update");
   case SOAP_TYPE_ICat4_ns1__luceneGetPopulatingResponse:
     return soap_in_ns1__luceneGetPopulatingResponse(
-        soap, NULL, NULL, "ns1:luceneGetPopulatingResponse");
+        soap, nullptr, nullptr, "ns1:luceneGetPopulatingResponse");
   case SOAP_TYPE_ICat4_ns1__luceneGetPopulating:
-    return soap_in_ns1__luceneGetPopulating(soap, NULL, NULL,
+    return soap_in_ns1__luceneGetPopulating(soap, nullptr, nullptr,
                                             "ns1:luceneGetPopulating");
   case SOAP_TYPE_ICat4_ns1__getApiVersionResponse:
-    return soap_in_ns1__getApiVersionResponse(soap, NULL, NULL,
+    return soap_in_ns1__getApiVersionResponse(soap, nullptr, nullptr,
                                               "ns1:getApiVersionResponse");
   case SOAP_TYPE_ICat4_ns1__getApiVersion:
-    return soap_in_ns1__getApiVersion(soap, NULL, NULL, "ns1:getApiVersion");
+    return soap_in_ns1__getApiVersion(soap, nullptr, nullptr,
+                                      "ns1:getApiVersion");
   case SOAP_TYPE_ICat4_ns1__getEntityNamesResponse:
-    return soap_in_ns1__getEntityNamesResponse(soap, NULL, NULL,
+    return soap_in_ns1__getEntityNamesResponse(soap, nullptr, nullptr,
                                                "ns1:getEntityNamesResponse");
   case SOAP_TYPE_ICat4_ns1__getEntityNames:
-    return soap_in_ns1__getEntityNames(soap, NULL, NULL, "ns1:getEntityNames");
+    return soap_in_ns1__getEntityNames(soap, nullptr, nullptr,
+                                       "ns1:getEntityNames");
   case SOAP_TYPE_ICat4_ns1__getResponse:
-    return soap_in_ns1__getResponse(soap, NULL, NULL, "ns1:getResponse");
+    return soap_in_ns1__getResponse(soap, nullptr, nullptr, "ns1:getResponse");
   case SOAP_TYPE_ICat4_ns1__get:
-    return soap_in_ns1__get(soap, NULL, NULL, "ns1:get");
+    return soap_in_ns1__get(soap, nullptr, nullptr, "ns1:get");
   case SOAP_TYPE_ICat4_ns1__lucenePopulateResponse:
-    return soap_in_ns1__lucenePopulateResponse(soap, NULL, NULL,
+    return soap_in_ns1__lucenePopulateResponse(soap, nullptr, nullptr,
                                                "ns1:lucenePopulateResponse");
   case SOAP_TYPE_ICat4_ns1__lucenePopulate:
-    return soap_in_ns1__lucenePopulate(soap, NULL, NULL, "ns1:lucenePopulate");
+    return soap_in_ns1__lucenePopulate(soap, nullptr, nullptr,
+                                       "ns1:lucenePopulate");
   case SOAP_TYPE_ICat4_ns1__luceneSearchResponse:
-    return soap_in_ns1__luceneSearchResponse(soap, NULL, NULL,
+    return soap_in_ns1__luceneSearchResponse(soap, nullptr, nullptr,
                                              "ns1:luceneSearchResponse");
   case SOAP_TYPE_ICat4_ns1__luceneSearch:
-    return soap_in_ns1__luceneSearch(soap, NULL, NULL, "ns1:luceneSearch");
+    return soap_in_ns1__luceneSearch(soap, nullptr, nullptr,
+                                     "ns1:luceneSearch");
   case SOAP_TYPE_ICat4_ns1__getPropertiesResponse:
-    return soap_in_ns1__getPropertiesResponse(soap, NULL, NULL,
+    return soap_in_ns1__getPropertiesResponse(soap, nullptr, nullptr,
                                               "ns1:getPropertiesResponse");
   case SOAP_TYPE_ICat4_ns1__getProperties:
-    return soap_in_ns1__getProperties(soap, NULL, NULL, "ns1:getProperties");
+    return soap_in_ns1__getProperties(soap, nullptr, nullptr,
+                                      "ns1:getProperties");
   case SOAP_TYPE_ICat4_ns1__createResponse:
-    return soap_in_ns1__createResponse(soap, NULL, NULL, "ns1:createResponse");
+    return soap_in_ns1__createResponse(soap, nullptr, nullptr,
+                                       "ns1:createResponse");
   case SOAP_TYPE_ICat4_ns1__create:
-    return soap_in_ns1__create(soap, NULL, NULL, "ns1:create");
+    return soap_in_ns1__create(soap, nullptr, nullptr, "ns1:create");
   case SOAP_TYPE_ICat4_ns1__createManyResponse:
-    return soap_in_ns1__createManyResponse(soap, NULL, NULL,
+    return soap_in_ns1__createManyResponse(soap, nullptr, nullptr,
                                            "ns1:createManyResponse");
   case SOAP_TYPE_ICat4_ns1__entityBaseBean:
-    return soap_in_ns1__entityBaseBean(soap, NULL, NULL, "ns1:entityBaseBean");
+    return soap_in_ns1__entityBaseBean(soap, nullptr, nullptr,
+                                       "ns1:entityBaseBean");
   case SOAP_TYPE_ICat4_ns1__createMany:
-    return soap_in_ns1__createMany(soap, NULL, NULL, "ns1:createMany");
+    return soap_in_ns1__createMany(soap, nullptr, nullptr, "ns1:createMany");
   case SOAP_TYPE_ICat4_ns1__IcatException:
-    return soap_in_ns1__IcatException(soap, NULL, NULL, "ns1:IcatException");
+    return soap_in_ns1__IcatException(soap, nullptr, nullptr,
+                                      "ns1:IcatException");
   case SOAP_TYPE_ICat4_ns1__luceneClearResponse:
-    return soap_in_ns1__luceneClearResponse(soap, NULL, NULL,
+    return soap_in_ns1__luceneClearResponse(soap, nullptr, nullptr,
                                             "ns1:luceneClearResponse");
   case SOAP_TYPE_ICat4_ns1__luceneClear:
-    return soap_in_ns1__luceneClear(soap, NULL, NULL, "ns1:luceneClear");
+    return soap_in_ns1__luceneClear(soap, nullptr, nullptr, "ns1:luceneClear");
   case SOAP_TYPE_ICat4_std__string:
-    return soap_in_std__string(soap, NULL, NULL, "xsd:string");
+    return soap_in_std__string(soap, nullptr, nullptr, "xsd:string");
   case SOAP_TYPE_ICat4_xsd__string:
-    return soap_in_xsd__string(soap, NULL, NULL, "xsd:string");
+    return soap_in_xsd__string(soap, nullptr, nullptr, "xsd:string");
   case SOAP_TYPE_ICat4_xsd__long:
-    return soap_in_xsd__long(soap, NULL, NULL, "xsd:long");
+    return soap_in_xsd__long(soap, nullptr, nullptr, "xsd:long");
   case SOAP_TYPE_ICat4_xsd__int:
-    return soap_in_xsd__int(soap, NULL, NULL, "xsd:int");
+    return soap_in_xsd__int(soap, nullptr, nullptr, "xsd:int");
   case SOAP_TYPE_ICat4_xsd__double:
-    return soap_in_xsd__double(soap, NULL, NULL, "xsd:double");
+    return soap_in_xsd__double(soap, nullptr, nullptr, "xsd:double");
   case SOAP_TYPE_ICat4_xsd__dateTime:
-    return soap_in_xsd__dateTime(soap, NULL, NULL, "xsd:dateTime");
+    return soap_in_xsd__dateTime(soap, nullptr, nullptr, "xsd:dateTime");
   case SOAP_TYPE_ICat4_xsd__boolean:
-    return soap_in_xsd__boolean(soap, NULL, NULL, "xsd:boolean");
+    return soap_in_xsd__boolean(soap, nullptr, nullptr, "xsd:boolean");
   case SOAP_TYPE_ICat4_xsd__anyType:
-    return soap_in_xsd__anyType(soap, NULL, NULL, "xsd:anyType");
+    return soap_in_xsd__anyType(soap, nullptr, nullptr, "xsd:anyType");
   case SOAP_TYPE_ICat4_PointerTons1__getEntityInfoResponse:
     return soap_in_PointerTons1__getEntityInfoResponse(
-        soap, NULL, NULL, "ns1:getEntityInfoResponse");
+        soap, nullptr, nullptr, "ns1:getEntityInfoResponse");
   case SOAP_TYPE_ICat4_PointerTons1__getEntityInfo:
-    return soap_in_PointerTons1__getEntityInfo(soap, NULL, NULL,
+    return soap_in_PointerTons1__getEntityInfo(soap, nullptr, nullptr,
                                                "ns1:getEntityInfo");
   case SOAP_TYPE_ICat4_PointerTons1__deleteManyResponse:
-    return soap_in_PointerTons1__deleteManyResponse(soap, NULL, NULL,
+    return soap_in_PointerTons1__deleteManyResponse(soap, nullptr, nullptr,
                                                     "ns1:deleteManyResponse");
   case SOAP_TYPE_ICat4_PointerTons1__deleteMany:
-    return soap_in_PointerTons1__deleteMany(soap, NULL, NULL, "ns1:deleteMany");
+    return soap_in_PointerTons1__deleteMany(soap, nullptr, nullptr,
+                                            "ns1:deleteMany");
   case SOAP_TYPE_ICat4_PointerTons1__createManyResponse:
-    return soap_in_PointerTons1__createManyResponse(soap, NULL, NULL,
+    return soap_in_PointerTons1__createManyResponse(soap, nullptr, nullptr,
                                                     "ns1:createManyResponse");
   case SOAP_TYPE_ICat4_PointerTons1__createMany:
-    return soap_in_PointerTons1__createMany(soap, NULL, NULL, "ns1:createMany");
+    return soap_in_PointerTons1__createMany(soap, nullptr, nullptr,
+                                            "ns1:createMany");
   case SOAP_TYPE_ICat4_PointerTons1__luceneGetPopulatingResponse:
     return soap_in_PointerTons1__luceneGetPopulatingResponse(
-        soap, NULL, NULL, "ns1:luceneGetPopulatingResponse");
+        soap, nullptr, nullptr, "ns1:luceneGetPopulatingResponse");
   case SOAP_TYPE_ICat4_PointerTons1__luceneGetPopulating:
-    return soap_in_PointerTons1__luceneGetPopulating(soap, NULL, NULL,
+    return soap_in_PointerTons1__luceneGetPopulating(soap, nullptr, nullptr,
                                                      "ns1:luceneGetPopulating");
   case SOAP_TYPE_ICat4_PointerTons1__luceneSearchResponse:
     return soap_in_PointerTons1__luceneSearchResponse(
-        soap, NULL, NULL, "ns1:luceneSearchResponse");
+        soap, nullptr, nullptr, "ns1:luceneSearchResponse");
   case SOAP_TYPE_ICat4_PointerTons1__luceneSearch:
-    return soap_in_PointerTons1__luceneSearch(soap, NULL, NULL,
+    return soap_in_PointerTons1__luceneSearch(soap, nullptr, nullptr,
                                               "ns1:luceneSearch");
   case SOAP_TYPE_ICat4_PointerTons1__luceneCommitResponse:
     return soap_in_PointerTons1__luceneCommitResponse(
-        soap, NULL, NULL, "ns1:luceneCommitResponse");
+        soap, nullptr, nullptr, "ns1:luceneCommitResponse");
   case SOAP_TYPE_ICat4_PointerTons1__luceneCommit:
-    return soap_in_PointerTons1__luceneCommit(soap, NULL, NULL,
+    return soap_in_PointerTons1__luceneCommit(soap, nullptr, nullptr,
                                               "ns1:luceneCommit");
   case SOAP_TYPE_ICat4_PointerTons1__luceneClearResponse:
-    return soap_in_PointerTons1__luceneClearResponse(soap, NULL, NULL,
+    return soap_in_PointerTons1__luceneClearResponse(soap, nullptr, nullptr,
                                                      "ns1:luceneClearResponse");
   case SOAP_TYPE_ICat4_PointerTons1__luceneClear:
-    return soap_in_PointerTons1__luceneClear(soap, NULL, NULL,
+    return soap_in_PointerTons1__luceneClear(soap, nullptr, nullptr,
                                              "ns1:luceneClear");
   case SOAP_TYPE_ICat4_PointerTons1__lucenePopulateResponse:
     return soap_in_PointerTons1__lucenePopulateResponse(
-        soap, NULL, NULL, "ns1:lucenePopulateResponse");
+        soap, nullptr, nullptr, "ns1:lucenePopulateResponse");
   case SOAP_TYPE_ICat4_PointerTons1__lucenePopulate:
-    return soap_in_PointerTons1__lucenePopulate(soap, NULL, NULL,
+    return soap_in_PointerTons1__lucenePopulate(soap, nullptr, nullptr,
                                                 "ns1:lucenePopulate");
   case SOAP_TYPE_ICat4_PointerTons1__isAccessAllowedResponse:
     return soap_in_PointerTons1__isAccessAllowedResponse(
-        soap, NULL, NULL, "ns1:isAccessAllowedResponse");
+        soap, nullptr, nullptr, "ns1:isAccessAllowedResponse");
   case SOAP_TYPE_ICat4_PointerTons1__isAccessAllowed:
-    return soap_in_PointerTons1__isAccessAllowed(soap, NULL, NULL,
+    return soap_in_PointerTons1__isAccessAllowed(soap, nullptr, nullptr,
                                                  "ns1:isAccessAllowed");
   case SOAP_TYPE_ICat4_PointerTons1__searchTextResponse:
-    return soap_in_PointerTons1__searchTextResponse(soap, NULL, NULL,
+    return soap_in_PointerTons1__searchTextResponse(soap, nullptr, nullptr,
                                                     "ns1:searchTextResponse");
   case SOAP_TYPE_ICat4_PointerTons1__searchText:
-    return soap_in_PointerTons1__searchText(soap, NULL, NULL, "ns1:searchText");
+    return soap_in_PointerTons1__searchText(soap, nullptr, nullptr,
+                                            "ns1:searchText");
   case SOAP_TYPE_ICat4_PointerTons1__getRemainingMinutesResponse:
     return soap_in_PointerTons1__getRemainingMinutesResponse(
-        soap, NULL, NULL, "ns1:getRemainingMinutesResponse");
+        soap, nullptr, nullptr, "ns1:getRemainingMinutesResponse");
   case SOAP_TYPE_ICat4_PointerTons1__getRemainingMinutes:
-    return soap_in_PointerTons1__getRemainingMinutes(soap, NULL, NULL,
+    return soap_in_PointerTons1__getRemainingMinutes(soap, nullptr, nullptr,
                                                      "ns1:getRemainingMinutes");
   case SOAP_TYPE_ICat4_PointerTons1__logoutResponse:
-    return soap_in_PointerTons1__logoutResponse(soap, NULL, NULL,
+    return soap_in_PointerTons1__logoutResponse(soap, nullptr, nullptr,
                                                 "ns1:logoutResponse");
   case SOAP_TYPE_ICat4_PointerTons1__logout:
-    return soap_in_PointerTons1__logout(soap, NULL, NULL, "ns1:logout");
+    return soap_in_PointerTons1__logout(soap, nullptr, nullptr, "ns1:logout");
   case SOAP_TYPE_ICat4_PointerTons1__dummyResponse:
-    return soap_in_PointerTons1__dummyResponse(soap, NULL, NULL,
+    return soap_in_PointerTons1__dummyResponse(soap, nullptr, nullptr,
                                                "ns1:dummyResponse");
   case SOAP_TYPE_ICat4_PointerTons1__dummy:
-    return soap_in_PointerTons1__dummy(soap, NULL, NULL, "ns1:dummy");
+    return soap_in_PointerTons1__dummy(soap, nullptr, nullptr, "ns1:dummy");
   case SOAP_TYPE_ICat4_PointerTons1__refreshResponse:
-    return soap_in_PointerTons1__refreshResponse(soap, NULL, NULL,
+    return soap_in_PointerTons1__refreshResponse(soap, nullptr, nullptr,
                                                  "ns1:refreshResponse");
   case SOAP_TYPE_ICat4_PointerTons1__refresh:
-    return soap_in_PointerTons1__refresh(soap, NULL, NULL, "ns1:refresh");
+    return soap_in_PointerTons1__refresh(soap, nullptr, nullptr, "ns1:refresh");
   case SOAP_TYPE_ICat4_PointerTons1__getEntityNamesResponse:
     return soap_in_PointerTons1__getEntityNamesResponse(
-        soap, NULL, NULL, "ns1:getEntityNamesResponse");
+        soap, nullptr, nullptr, "ns1:getEntityNamesResponse");
   case SOAP_TYPE_ICat4_PointerTons1__getEntityNames:
-    return soap_in_PointerTons1__getEntityNames(soap, NULL, NULL,
+    return soap_in_PointerTons1__getEntityNames(soap, nullptr, nullptr,
                                                 "ns1:getEntityNames");
   case SOAP_TYPE_ICat4_PointerTons1__getApiVersionResponse:
     return soap_in_PointerTons1__getApiVersionResponse(
-        soap, NULL, NULL, "ns1:getApiVersionResponse");
+        soap, nullptr, nullptr, "ns1:getApiVersionResponse");
   case SOAP_TYPE_ICat4_PointerTons1__getApiVersion:
-    return soap_in_PointerTons1__getApiVersion(soap, NULL, NULL,
+    return soap_in_PointerTons1__getApiVersion(soap, nullptr, nullptr,
                                                "ns1:getApiVersion");
   case SOAP_TYPE_ICat4_PointerTons1__updateResponse:
-    return soap_in_PointerTons1__updateResponse(soap, NULL, NULL,
+    return soap_in_PointerTons1__updateResponse(soap, nullptr, nullptr,
                                                 "ns1:updateResponse");
   case SOAP_TYPE_ICat4_PointerTons1__update:
-    return soap_in_PointerTons1__update(soap, NULL, NULL, "ns1:update");
+    return soap_in_PointerTons1__update(soap, nullptr, nullptr, "ns1:update");
   case SOAP_TYPE_ICat4_PointerTons1__createResponse:
-    return soap_in_PointerTons1__createResponse(soap, NULL, NULL,
+    return soap_in_PointerTons1__createResponse(soap, nullptr, nullptr,
                                                 "ns1:createResponse");
   case SOAP_TYPE_ICat4_PointerTons1__create:
-    return soap_in_PointerTons1__create(soap, NULL, NULL, "ns1:create");
+    return soap_in_PointerTons1__create(soap, nullptr, nullptr, "ns1:create");
   case SOAP_TYPE_ICat4_PointerTons1__searchResponse:
-    return soap_in_PointerTons1__searchResponse(soap, NULL, NULL,
+    return soap_in_PointerTons1__searchResponse(soap, nullptr, nullptr,
                                                 "ns1:searchResponse");
   case SOAP_TYPE_ICat4_PointerTons1__search:
-    return soap_in_PointerTons1__search(soap, NULL, NULL, "ns1:search");
+    return soap_in_PointerTons1__search(soap, nullptr, nullptr, "ns1:search");
   case SOAP_TYPE_ICat4_PointerTons1__deleteResponse:
-    return soap_in_PointerTons1__deleteResponse(soap, NULL, NULL,
+    return soap_in_PointerTons1__deleteResponse(soap, nullptr, nullptr,
                                                 "ns1:deleteResponse");
   case SOAP_TYPE_ICat4_PointerTons1__delete:
-    return soap_in_PointerTons1__delete(soap, NULL, NULL, "ns1:delete");
+    return soap_in_PointerTons1__delete(soap, nullptr, nullptr, "ns1:delete");
   case SOAP_TYPE_ICat4_PointerTons1__getPropertiesResponse:
     return soap_in_PointerTons1__getPropertiesResponse(
-        soap, NULL, NULL, "ns1:getPropertiesResponse");
+        soap, nullptr, nullptr, "ns1:getPropertiesResponse");
   case SOAP_TYPE_ICat4_PointerTons1__getProperties:
-    return soap_in_PointerTons1__getProperties(soap, NULL, NULL,
+    return soap_in_PointerTons1__getProperties(soap, nullptr, nullptr,
                                                "ns1:getProperties");
   case SOAP_TYPE_ICat4_PointerTons1__getResponse:
-    return soap_in_PointerTons1__getResponse(soap, NULL, NULL,
+    return soap_in_PointerTons1__getResponse(soap, nullptr, nullptr,
                                              "ns1:getResponse");
   case SOAP_TYPE_ICat4_PointerTons1__get:
-    return soap_in_PointerTons1__get(soap, NULL, NULL, "ns1:get");
+    return soap_in_PointerTons1__get(soap, nullptr, nullptr, "ns1:get");
   case SOAP_TYPE_ICat4_PointerTons1__getUserNameResponse:
-    return soap_in_PointerTons1__getUserNameResponse(soap, NULL, NULL,
+    return soap_in_PointerTons1__getUserNameResponse(soap, nullptr, nullptr,
                                                      "ns1:getUserNameResponse");
   case SOAP_TYPE_ICat4_PointerTons1__getUserName:
-    return soap_in_PointerTons1__getUserName(soap, NULL, NULL,
+    return soap_in_PointerTons1__getUserName(soap, nullptr, nullptr,
                                              "ns1:getUserName");
   case SOAP_TYPE_ICat4_PointerTons1__loginResponse:
-    return soap_in_PointerTons1__loginResponse(soap, NULL, NULL,
+    return soap_in_PointerTons1__loginResponse(soap, nullptr, nullptr,
                                                "ns1:loginResponse");
   case SOAP_TYPE_ICat4_PointerTons1__login:
-    return soap_in_PointerTons1__login(soap, NULL, NULL, "ns1:login");
+    return soap_in_PointerTons1__login(soap, nullptr, nullptr, "ns1:login");
   case SOAP_TYPE_ICat4_PointerTons1__IcatException:
-    return soap_in_PointerTons1__IcatException(soap, NULL, NULL,
+    return soap_in_PointerTons1__IcatException(soap, nullptr, nullptr,
                                                "ns1:IcatException");
   case SOAP_TYPE_ICat4_PointerTons1__parameterValueType:
-    return soap_in_PointerTons1__parameterValueType(soap, NULL, NULL,
+    return soap_in_PointerTons1__parameterValueType(soap, nullptr, nullptr,
                                                     "ns1:parameterValueType");
   case SOAP_TYPE_ICat4_PointerTons1__permissibleStringValue:
     return soap_in_PointerTons1__permissibleStringValue(
-        soap, NULL, NULL, "ns1:permissibleStringValue");
+        soap, nullptr, nullptr, "ns1:permissibleStringValue");
   case SOAP_TYPE_ICat4_PointerTodouble:
-    return soap_in_PointerTodouble(soap, NULL, NULL, "xsd:double");
+    return soap_in_PointerTodouble(soap, nullptr, nullptr, "xsd:double");
   case SOAP_TYPE_ICat4_PointerTons1__rule:
-    return soap_in_PointerTons1__rule(soap, NULL, NULL, "ns1:rule");
+    return soap_in_PointerTons1__rule(soap, nullptr, nullptr, "ns1:rule");
   case SOAP_TYPE_ICat4_PointerTons1__sampleType:
-    return soap_in_PointerTons1__sampleType(soap, NULL, NULL, "ns1:sampleType");
+    return soap_in_PointerTons1__sampleType(soap, nullptr, nullptr,
+                                            "ns1:sampleType");
   case SOAP_TYPE_ICat4_PointerTons1__investigationParameter:
     return soap_in_PointerTons1__investigationParameter(
-        soap, NULL, NULL, "ns1:investigationParameter");
+        soap, nullptr, nullptr, "ns1:investigationParameter");
   case SOAP_TYPE_ICat4_PointerTons1__investigationInstrument:
     return soap_in_PointerTons1__investigationInstrument(
-        soap, NULL, NULL, "ns1:investigationInstrument");
+        soap, nullptr, nullptr, "ns1:investigationInstrument");
   case SOAP_TYPE_ICat4_PointerTons1__accessType:
-    return soap_in_PointerTons1__accessType(soap, NULL, NULL, "ns1:accessType");
+    return soap_in_PointerTons1__accessType(soap, nullptr, nullptr,
+                                            "ns1:accessType");
   case SOAP_TYPE_ICat4_PointerToxsd__anyType:
-    return soap_in_PointerToxsd__anyType(soap, NULL, NULL, "xsd:anyType");
+    return soap_in_PointerToxsd__anyType(soap, nullptr, nullptr, "xsd:anyType");
   case SOAP_TYPE_ICat4_PointerToint:
-    return soap_in_PointerToint(soap, NULL, NULL, "xsd:int");
+    return soap_in_PointerToint(soap, nullptr, nullptr, "xsd:int");
   case SOAP_TYPE_ICat4_PointerTons1__relType:
-    return soap_in_PointerTons1__relType(soap, NULL, NULL, "ns1:relType");
+    return soap_in_PointerTons1__relType(soap, nullptr, nullptr, "ns1:relType");
   case SOAP_TYPE_ICat4_PointerTons1__entityField:
-    return soap_in_PointerTons1__entityField(soap, NULL, NULL,
+    return soap_in_PointerTons1__entityField(soap, nullptr, nullptr,
                                              "ns1:entityField");
   case SOAP_TYPE_ICat4_PointerTons1__constraint:
-    return soap_in_PointerTons1__constraint(soap, NULL, NULL, "ns1:constraint");
+    return soap_in_PointerTons1__constraint(soap, nullptr, nullptr,
+                                            "ns1:constraint");
   case SOAP_TYPE_ICat4_PointerTons1__entityInfo:
-    return soap_in_PointerTons1__entityInfo(soap, NULL, NULL, "ns1:entityInfo");
+    return soap_in_PointerTons1__entityInfo(soap, nullptr, nullptr,
+                                            "ns1:entityInfo");
   case SOAP_TYPE_ICat4_PointerTons1__publicStep:
-    return soap_in_PointerTons1__publicStep(soap, NULL, NULL, "ns1:publicStep");
+    return soap_in_PointerTons1__publicStep(soap, nullptr, nullptr,
+                                            "ns1:publicStep");
   case SOAP_TYPE_ICat4_PointerTons1__log:
-    return soap_in_PointerTons1__log(soap, NULL, NULL, "ns1:log");
+    return soap_in_PointerTons1__log(soap, nullptr, nullptr, "ns1:log");
   case SOAP_TYPE_ICat4_PointerTons1__userGroup:
-    return soap_in_PointerTons1__userGroup(soap, NULL, NULL, "ns1:userGroup");
+    return soap_in_PointerTons1__userGroup(soap, nullptr, nullptr,
+                                           "ns1:userGroup");
   case SOAP_TYPE_ICat4_PointerTons1__grouping:
-    return soap_in_PointerTons1__grouping(soap, NULL, NULL, "ns1:grouping");
+    return soap_in_PointerTons1__grouping(soap, nullptr, nullptr,
+                                          "ns1:grouping");
   case SOAP_TYPE_ICat4_PointerTons1__dataCollectionDatafile:
     return soap_in_PointerTons1__dataCollectionDatafile(
-        soap, NULL, NULL, "ns1:dataCollectionDatafile");
+        soap, nullptr, nullptr, "ns1:dataCollectionDatafile");
   case SOAP_TYPE_ICat4_PointerTons1__dataCollectionDataset:
     return soap_in_PointerTons1__dataCollectionDataset(
-        soap, NULL, NULL, "ns1:dataCollectionDataset");
+        soap, nullptr, nullptr, "ns1:dataCollectionDataset");
   case SOAP_TYPE_ICat4_PointerTons1__dataCollectionParameter:
     return soap_in_PointerTons1__dataCollectionParameter(
-        soap, NULL, NULL, "ns1:dataCollectionParameter");
+        soap, nullptr, nullptr, "ns1:dataCollectionParameter");
   case SOAP_TYPE_ICat4_PointerTons1__dataCollection:
-    return soap_in_PointerTons1__dataCollection(soap, NULL, NULL,
+    return soap_in_PointerTons1__dataCollection(soap, nullptr, nullptr,
                                                 "ns1:dataCollection");
   case SOAP_TYPE_ICat4_PointerTons1__job:
-    return soap_in_PointerTons1__job(soap, NULL, NULL, "ns1:job");
+    return soap_in_PointerTons1__job(soap, nullptr, nullptr, "ns1:job");
   case SOAP_TYPE_ICat4_PointerTons1__application:
-    return soap_in_PointerTons1__application(soap, NULL, NULL,
+    return soap_in_PointerTons1__application(soap, nullptr, nullptr,
                                              "ns1:application");
   case SOAP_TYPE_ICat4_PointerTons1__studyStatus:
-    return soap_in_PointerTons1__studyStatus(soap, NULL, NULL,
+    return soap_in_PointerTons1__studyStatus(soap, nullptr, nullptr,
                                              "ns1:studyStatus");
   case SOAP_TYPE_ICat4_PointerTons1__studyInvestigation:
-    return soap_in_PointerTons1__studyInvestigation(soap, NULL, NULL,
+    return soap_in_PointerTons1__studyInvestigation(soap, nullptr, nullptr,
                                                     "ns1:studyInvestigation");
   case SOAP_TYPE_ICat4_PointerTons1__study:
-    return soap_in_PointerTons1__study(soap, NULL, NULL, "ns1:study");
+    return soap_in_PointerTons1__study(soap, nullptr, nullptr, "ns1:study");
   case SOAP_TYPE_ICat4_PointerTons1__shift:
-    return soap_in_PointerTons1__shift(soap, NULL, NULL, "ns1:shift");
+    return soap_in_PointerTons1__shift(soap, nullptr, nullptr, "ns1:shift");
   case SOAP_TYPE_ICat4_PointerTons1__sampleParameter:
-    return soap_in_PointerTons1__sampleParameter(soap, NULL, NULL,
+    return soap_in_PointerTons1__sampleParameter(soap, nullptr, nullptr,
                                                  "ns1:sampleParameter");
   case SOAP_TYPE_ICat4_PointerTons1__sample:
-    return soap_in_PointerTons1__sample(soap, NULL, NULL, "ns1:sample");
+    return soap_in_PointerTons1__sample(soap, nullptr, nullptr, "ns1:sample");
   case SOAP_TYPE_ICat4_PointerTons1__relatedDatafile:
-    return soap_in_PointerTons1__relatedDatafile(soap, NULL, NULL,
+    return soap_in_PointerTons1__relatedDatafile(soap, nullptr, nullptr,
                                                  "ns1:relatedDatafile");
   case SOAP_TYPE_ICat4_PointerTons1__publication:
-    return soap_in_PointerTons1__publication(soap, NULL, NULL,
+    return soap_in_PointerTons1__publication(soap, nullptr, nullptr,
                                              "ns1:publication");
   case SOAP_TYPE_ICat4_PointerTons1__parameterType:
-    return soap_in_PointerTons1__parameterType(soap, NULL, NULL,
+    return soap_in_PointerTons1__parameterType(soap, nullptr, nullptr,
                                                "ns1:parameterType");
   case SOAP_TYPE_ICat4_PointerTons1__keyword:
-    return soap_in_PointerTons1__keyword(soap, NULL, NULL, "ns1:keyword");
+    return soap_in_PointerTons1__keyword(soap, nullptr, nullptr, "ns1:keyword");
   case SOAP_TYPE_ICat4_PointerTons1__investigationUser:
-    return soap_in_PointerTons1__investigationUser(soap, NULL, NULL,
+    return soap_in_PointerTons1__investigationUser(soap, nullptr, nullptr,
                                                    "ns1:investigationUser");
   case SOAP_TYPE_ICat4_PointerTons1__investigationType:
-    return soap_in_PointerTons1__investigationType(soap, NULL, NULL,
+    return soap_in_PointerTons1__investigationType(soap, nullptr, nullptr,
                                                    "ns1:investigationType");
   case SOAP_TYPE_ICat4_PointerTons1__investigation:
-    return soap_in_PointerTons1__investigation(soap, NULL, NULL,
+    return soap_in_PointerTons1__investigation(soap, nullptr, nullptr,
                                                "ns1:investigation");
   case SOAP_TYPE_ICat4_PointerTons1__instrument:
-    return soap_in_PointerTons1__instrument(soap, NULL, NULL, "ns1:instrument");
+    return soap_in_PointerTons1__instrument(soap, nullptr, nullptr,
+                                            "ns1:instrument");
   case SOAP_TYPE_ICat4_PointerTons1__user:
-    return soap_in_PointerTons1__user(soap, NULL, NULL, "ns1:user");
+    return soap_in_PointerTons1__user(soap, nullptr, nullptr, "ns1:user");
   case SOAP_TYPE_ICat4_PointerTons1__instrumentScientist:
-    return soap_in_PointerTons1__instrumentScientist(soap, NULL, NULL,
+    return soap_in_PointerTons1__instrumentScientist(soap, nullptr, nullptr,
                                                      "ns1:instrumentScientist");
   case SOAP_TYPE_ICat4_PointerTons1__facilityCycle:
-    return soap_in_PointerTons1__facilityCycle(soap, NULL, NULL,
+    return soap_in_PointerTons1__facilityCycle(soap, nullptr, nullptr,
                                                "ns1:facilityCycle");
   case SOAP_TYPE_ICat4_PointerTons1__facility:
-    return soap_in_PointerTons1__facility(soap, NULL, NULL, "ns1:facility");
+    return soap_in_PointerTons1__facility(soap, nullptr, nullptr,
+                                          "ns1:facility");
   case SOAP_TYPE_ICat4_PointerTons1__datasetType:
-    return soap_in_PointerTons1__datasetType(soap, NULL, NULL,
+    return soap_in_PointerTons1__datasetType(soap, nullptr, nullptr,
                                              "ns1:datasetType");
   case SOAP_TYPE_ICat4_PointerTons1__datasetParameter:
-    return soap_in_PointerTons1__datasetParameter(soap, NULL, NULL,
+    return soap_in_PointerTons1__datasetParameter(soap, nullptr, nullptr,
                                                   "ns1:datasetParameter");
   case SOAP_TYPE_ICat4_PointerTons1__dataset:
-    return soap_in_PointerTons1__dataset(soap, NULL, NULL, "ns1:dataset");
+    return soap_in_PointerTons1__dataset(soap, nullptr, nullptr, "ns1:dataset");
   case SOAP_TYPE_ICat4_PointerTons1__datafileParameter:
-    return soap_in_PointerTons1__datafileParameter(soap, NULL, NULL,
+    return soap_in_PointerTons1__datafileParameter(soap, nullptr, nullptr,
                                                    "ns1:datafileParameter");
   case SOAP_TYPE_ICat4_PointerTons1__datafileFormat:
-    return soap_in_PointerTons1__datafileFormat(soap, NULL, NULL,
+    return soap_in_PointerTons1__datafileFormat(soap, nullptr, nullptr,
                                                 "ns1:datafileFormat");
   case SOAP_TYPE_ICat4_PointerTons1__datafile:
-    return soap_in_PointerTons1__datafile(soap, NULL, NULL, "ns1:datafile");
+    return soap_in_PointerTons1__datafile(soap, nullptr, nullptr,
+                                          "ns1:datafile");
   case SOAP_TYPE_ICat4_PointerToLONG64:
-    return soap_in_PointerToLONG64(soap, NULL, NULL, "xsd:long");
+    return soap_in_PointerToLONG64(soap, nullptr, nullptr, "xsd:long");
   case SOAP_TYPE_ICat4_PointerTotime:
-    return soap_in_PointerTotime(soap, NULL, NULL, "xsd:dateTime");
+    return soap_in_PointerTotime(soap, nullptr, nullptr, "xsd:dateTime");
   case SOAP_TYPE_ICat4_PointerTons1__entityBaseBean:
-    return soap_in_PointerTons1__entityBaseBean(soap, NULL, NULL,
+    return soap_in_PointerTons1__entityBaseBean(soap, nullptr, nullptr,
                                                 "ns1:entityBaseBean");
   case SOAP_TYPE_ICat4_PointerTons1__icatExceptionType:
-    return soap_in_PointerTons1__icatExceptionType(soap, NULL, NULL,
+    return soap_in_PointerTons1__icatExceptionType(soap, nullptr, nullptr,
                                                    "ns1:icatExceptionType");
   case SOAP_TYPE_ICat4_PointerTostd__string:
-    return soap_in_PointerTostd__string(soap, NULL, NULL, "xsd:string");
+    return soap_in_PointerTostd__string(soap, nullptr, nullptr, "xsd:string");
   case SOAP_TYPE_ICat4__QName: {
     char **s;
-    s = soap_in__QName(soap, NULL, NULL, "xsd:QName");
-    return s ? *s : NULL;
+    s = soap_in__QName(soap, nullptr, nullptr, "xsd:QName");
+    return s ? *s : nullptr;
   }
   case SOAP_TYPE_ICat4_string: {
     char **s;
-    s = soap_in_string(soap, NULL, NULL, "xsd:string");
-    return s ? *s : NULL;
+    s = soap_in_string(soap, nullptr, nullptr, "xsd:string");
+    return s ? *s : nullptr;
   }
   default:
 #endif
@@ -732,495 +766,510 @@ SOAP_FMAC3 void *SOAP_FMAC4 soap_getelement(struct soap *soap, int *type) {
       t = soap->tag;
     if (!soap_match_tag(soap, t, "ns1:accessType")) {
       *type = SOAP_TYPE_ICat4_ns1__accessType_;
-      return soap_in_ns1__accessType_(soap, NULL, NULL, NULL);
+      return soap_in_ns1__accessType_(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:relType")) {
       *type = SOAP_TYPE_ICat4_ns1__relType_;
-      return soap_in_ns1__relType_(soap, NULL, NULL, NULL);
+      return soap_in_ns1__relType_(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:parameterValueType")) {
       *type = SOAP_TYPE_ICat4_ns1__parameterValueType_;
-      return soap_in_ns1__parameterValueType_(soap, NULL, NULL, NULL);
+      return soap_in_ns1__parameterValueType_(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:studyStatus")) {
       *type = SOAP_TYPE_ICat4_ns1__studyStatus_;
-      return soap_in_ns1__studyStatus_(soap, NULL, NULL, NULL);
+      return soap_in_ns1__studyStatus_(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:icatExceptionType")) {
       *type = SOAP_TYPE_ICat4_ns1__icatExceptionType_;
-      return soap_in_ns1__icatExceptionType_(soap, NULL, NULL, NULL);
+      return soap_in_ns1__icatExceptionType_(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:getRemainingMinutesResponse")) {
       *type = SOAP_TYPE_ICat4_ns1__getRemainingMinutesResponse;
-      return soap_in_ns1__getRemainingMinutesResponse(soap, NULL, NULL, NULL);
+      return soap_in_ns1__getRemainingMinutesResponse(soap, nullptr, nullptr,
+                                                      nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:getRemainingMinutes")) {
       *type = SOAP_TYPE_ICat4_ns1__getRemainingMinutes;
-      return soap_in_ns1__getRemainingMinutes(soap, NULL, NULL, NULL);
+      return soap_in_ns1__getRemainingMinutes(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:logoutResponse")) {
       *type = SOAP_TYPE_ICat4_ns1__logoutResponse;
-      return soap_in_ns1__logoutResponse(soap, NULL, NULL, NULL);
+      return soap_in_ns1__logoutResponse(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:logout")) {
       *type = SOAP_TYPE_ICat4_ns1__logout;
-      return soap_in_ns1__logout(soap, NULL, NULL, NULL);
+      return soap_in_ns1__logout(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:searchResponse")) {
       *type = SOAP_TYPE_ICat4_ns1__searchResponse;
-      return soap_in_ns1__searchResponse(soap, NULL, NULL, NULL);
+      return soap_in_ns1__searchResponse(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:search")) {
       *type = SOAP_TYPE_ICat4_ns1__search;
-      return soap_in_ns1__search(soap, NULL, NULL, NULL);
+      return soap_in_ns1__search(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:isAccessAllowedResponse")) {
       *type = SOAP_TYPE_ICat4_ns1__isAccessAllowedResponse;
-      return soap_in_ns1__isAccessAllowedResponse(soap, NULL, NULL, NULL);
+      return soap_in_ns1__isAccessAllowedResponse(soap, nullptr, nullptr,
+                                                  nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:isAccessAllowed")) {
       *type = SOAP_TYPE_ICat4_ns1__isAccessAllowed;
-      return soap_in_ns1__isAccessAllowed(soap, NULL, NULL, NULL);
+      return soap_in_ns1__isAccessAllowed(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:deleteResponse")) {
       *type = SOAP_TYPE_ICat4_ns1__deleteResponse;
-      return soap_in_ns1__deleteResponse(soap, NULL, NULL, NULL);
+      return soap_in_ns1__deleteResponse(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:delete")) {
       *type = SOAP_TYPE_ICat4_ns1__delete;
-      return soap_in_ns1__delete(soap, NULL, NULL, NULL);
+      return soap_in_ns1__delete(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:searchTextResponse")) {
       *type = SOAP_TYPE_ICat4_ns1__searchTextResponse;
-      return soap_in_ns1__searchTextResponse(soap, NULL, NULL, NULL);
+      return soap_in_ns1__searchTextResponse(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:searchText")) {
       *type = SOAP_TYPE_ICat4_ns1__searchText;
-      return soap_in_ns1__searchText(soap, NULL, NULL, NULL);
+      return soap_in_ns1__searchText(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:luceneCommitResponse")) {
       *type = SOAP_TYPE_ICat4_ns1__luceneCommitResponse;
-      return soap_in_ns1__luceneCommitResponse(soap, NULL, NULL, NULL);
+      return soap_in_ns1__luceneCommitResponse(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:luceneCommit")) {
       *type = SOAP_TYPE_ICat4_ns1__luceneCommit;
-      return soap_in_ns1__luceneCommit(soap, NULL, NULL, NULL);
+      return soap_in_ns1__luceneCommit(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:entityField")) {
       *type = SOAP_TYPE_ICat4_ns1__entityField;
-      return soap_in_ns1__entityField(soap, NULL, NULL, NULL);
+      return soap_in_ns1__entityField(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:constraint")) {
       *type = SOAP_TYPE_ICat4_ns1__constraint;
-      return soap_in_ns1__constraint(soap, NULL, NULL, NULL);
+      return soap_in_ns1__constraint(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:entityInfo")) {
       *type = SOAP_TYPE_ICat4_ns1__entityInfo;
-      return soap_in_ns1__entityInfo(soap, NULL, NULL, NULL);
+      return soap_in_ns1__entityInfo(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:getEntityInfoResponse")) {
       *type = SOAP_TYPE_ICat4_ns1__getEntityInfoResponse;
-      return soap_in_ns1__getEntityInfoResponse(soap, NULL, NULL, NULL);
+      return soap_in_ns1__getEntityInfoResponse(soap, nullptr, nullptr,
+                                                nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:getEntityInfo")) {
       *type = SOAP_TYPE_ICat4_ns1__getEntityInfo;
-      return soap_in_ns1__getEntityInfo(soap, NULL, NULL, NULL);
+      return soap_in_ns1__getEntityInfo(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:dummyResponse")) {
       *type = SOAP_TYPE_ICat4_ns1__dummyResponse;
-      return soap_in_ns1__dummyResponse(soap, NULL, NULL, NULL);
+      return soap_in_ns1__dummyResponse(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:publicStep")) {
       *type = SOAP_TYPE_ICat4_ns1__publicStep;
-      return soap_in_ns1__publicStep(soap, NULL, NULL, NULL);
+      return soap_in_ns1__publicStep(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:log")) {
       *type = SOAP_TYPE_ICat4_ns1__log;
-      return soap_in_ns1__log(soap, NULL, NULL, NULL);
+      return soap_in_ns1__log(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:relatedDatafile")) {
       *type = SOAP_TYPE_ICat4_ns1__relatedDatafile;
-      return soap_in_ns1__relatedDatafile(soap, NULL, NULL, NULL);
+      return soap_in_ns1__relatedDatafile(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:shift")) {
       *type = SOAP_TYPE_ICat4_ns1__shift;
-      return soap_in_ns1__shift(soap, NULL, NULL, NULL);
+      return soap_in_ns1__shift(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:publication")) {
       *type = SOAP_TYPE_ICat4_ns1__publication;
-      return soap_in_ns1__publication(soap, NULL, NULL, NULL);
+      return soap_in_ns1__publication(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:keyword")) {
       *type = SOAP_TYPE_ICat4_ns1__keyword;
-      return soap_in_ns1__keyword(soap, NULL, NULL, NULL);
+      return soap_in_ns1__keyword(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:sampleType")) {
       *type = SOAP_TYPE_ICat4_ns1__sampleType;
-      return soap_in_ns1__sampleType(soap, NULL, NULL, NULL);
+      return soap_in_ns1__sampleType(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:sample")) {
       *type = SOAP_TYPE_ICat4_ns1__sample;
-      return soap_in_ns1__sample(soap, NULL, NULL, NULL);
+      return soap_in_ns1__sample(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:sampleParameter")) {
       *type = SOAP_TYPE_ICat4_ns1__sampleParameter;
-      return soap_in_ns1__sampleParameter(soap, NULL, NULL, NULL);
+      return soap_in_ns1__sampleParameter(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:permissibleStringValue")) {
       *type = SOAP_TYPE_ICat4_ns1__permissibleStringValue;
-      return soap_in_ns1__permissibleStringValue(soap, NULL, NULL, NULL);
+      return soap_in_ns1__permissibleStringValue(soap, nullptr, nullptr,
+                                                 nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:investigationParameter")) {
       *type = SOAP_TYPE_ICat4_ns1__investigationParameter;
-      return soap_in_ns1__investigationParameter(soap, NULL, NULL, NULL);
+      return soap_in_ns1__investigationParameter(soap, nullptr, nullptr,
+                                                 nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:datasetParameter")) {
       *type = SOAP_TYPE_ICat4_ns1__datasetParameter;
-      return soap_in_ns1__datasetParameter(soap, NULL, NULL, NULL);
+      return soap_in_ns1__datasetParameter(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:datafileParameter")) {
       *type = SOAP_TYPE_ICat4_ns1__datafileParameter;
-      return soap_in_ns1__datafileParameter(soap, NULL, NULL, NULL);
+      return soap_in_ns1__datafileParameter(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:parameter")) {
       *type = SOAP_TYPE_ICat4_ns1__parameter;
-      return soap_in_ns1__parameter(soap, NULL, NULL, NULL);
+      return soap_in_ns1__parameter(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:dataCollectionParameter")) {
       *type = SOAP_TYPE_ICat4_ns1__dataCollectionParameter;
-      return soap_in_ns1__dataCollectionParameter(soap, NULL, NULL, NULL);
+      return soap_in_ns1__dataCollectionParameter(soap, nullptr, nullptr,
+                                                  nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:parameterType")) {
       *type = SOAP_TYPE_ICat4_ns1__parameterType;
-      return soap_in_ns1__parameterType(soap, NULL, NULL, NULL);
+      return soap_in_ns1__parameterType(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:investigationType")) {
       *type = SOAP_TYPE_ICat4_ns1__investigationType;
-      return soap_in_ns1__investigationType(soap, NULL, NULL, NULL);
+      return soap_in_ns1__investigationType(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:investigationInstrument")) {
       *type = SOAP_TYPE_ICat4_ns1__investigationInstrument;
-      return soap_in_ns1__investigationInstrument(soap, NULL, NULL, NULL);
+      return soap_in_ns1__investigationInstrument(soap, nullptr, nullptr,
+                                                  nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:rule")) {
       *type = SOAP_TYPE_ICat4_ns1__rule;
-      return soap_in_ns1__rule(soap, NULL, NULL, NULL);
+      return soap_in_ns1__rule(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:grouping")) {
       *type = SOAP_TYPE_ICat4_ns1__grouping;
-      return soap_in_ns1__grouping(soap, NULL, NULL, NULL);
+      return soap_in_ns1__grouping(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:userGroup")) {
       *type = SOAP_TYPE_ICat4_ns1__userGroup;
-      return soap_in_ns1__userGroup(soap, NULL, NULL, NULL);
+      return soap_in_ns1__userGroup(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:studyInvestigation")) {
       *type = SOAP_TYPE_ICat4_ns1__studyInvestigation;
-      return soap_in_ns1__studyInvestigation(soap, NULL, NULL, NULL);
+      return soap_in_ns1__studyInvestigation(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:study")) {
       *type = SOAP_TYPE_ICat4_ns1__study;
-      return soap_in_ns1__study(soap, NULL, NULL, NULL);
+      return soap_in_ns1__study(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:investigationUser")) {
       *type = SOAP_TYPE_ICat4_ns1__investigationUser;
-      return soap_in_ns1__investigationUser(soap, NULL, NULL, NULL);
+      return soap_in_ns1__investigationUser(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:user")) {
       *type = SOAP_TYPE_ICat4_ns1__user;
-      return soap_in_ns1__user(soap, NULL, NULL, NULL);
+      return soap_in_ns1__user(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:instrumentScientist")) {
       *type = SOAP_TYPE_ICat4_ns1__instrumentScientist;
-      return soap_in_ns1__instrumentScientist(soap, NULL, NULL, NULL);
+      return soap_in_ns1__instrumentScientist(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:instrument")) {
       *type = SOAP_TYPE_ICat4_ns1__instrument;
-      return soap_in_ns1__instrument(soap, NULL, NULL, NULL);
+      return soap_in_ns1__instrument(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:facilityCycle")) {
       *type = SOAP_TYPE_ICat4_ns1__facilityCycle;
-      return soap_in_ns1__facilityCycle(soap, NULL, NULL, NULL);
+      return soap_in_ns1__facilityCycle(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:datasetType")) {
       *type = SOAP_TYPE_ICat4_ns1__datasetType;
-      return soap_in_ns1__datasetType(soap, NULL, NULL, NULL);
+      return soap_in_ns1__datasetType(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:datafileFormat")) {
       *type = SOAP_TYPE_ICat4_ns1__datafileFormat;
-      return soap_in_ns1__datafileFormat(soap, NULL, NULL, NULL);
+      return soap_in_ns1__datafileFormat(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:job")) {
       *type = SOAP_TYPE_ICat4_ns1__job;
-      return soap_in_ns1__job(soap, NULL, NULL, NULL);
+      return soap_in_ns1__job(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:application")) {
       *type = SOAP_TYPE_ICat4_ns1__application;
-      return soap_in_ns1__application(soap, NULL, NULL, NULL);
+      return soap_in_ns1__application(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:facility")) {
       *type = SOAP_TYPE_ICat4_ns1__facility;
-      return soap_in_ns1__facility(soap, NULL, NULL, NULL);
+      return soap_in_ns1__facility(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:investigation")) {
       *type = SOAP_TYPE_ICat4_ns1__investigation;
-      return soap_in_ns1__investigation(soap, NULL, NULL, NULL);
+      return soap_in_ns1__investigation(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:dataset")) {
       *type = SOAP_TYPE_ICat4_ns1__dataset;
-      return soap_in_ns1__dataset(soap, NULL, NULL, NULL);
+      return soap_in_ns1__dataset(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:dataCollectionDataset")) {
       *type = SOAP_TYPE_ICat4_ns1__dataCollectionDataset;
-      return soap_in_ns1__dataCollectionDataset(soap, NULL, NULL, NULL);
+      return soap_in_ns1__dataCollectionDataset(soap, nullptr, nullptr,
+                                                nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:dataCollection")) {
       *type = SOAP_TYPE_ICat4_ns1__dataCollection;
-      return soap_in_ns1__dataCollection(soap, NULL, NULL, NULL);
+      return soap_in_ns1__dataCollection(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:dataCollectionDatafile")) {
       *type = SOAP_TYPE_ICat4_ns1__dataCollectionDatafile;
-      return soap_in_ns1__dataCollectionDatafile(soap, NULL, NULL, NULL);
+      return soap_in_ns1__dataCollectionDatafile(soap, nullptr, nullptr,
+                                                 nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:datafile")) {
       *type = SOAP_TYPE_ICat4_ns1__datafile;
-      return soap_in_ns1__datafile(soap, NULL, NULL, NULL);
+      return soap_in_ns1__datafile(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:dummy")) {
       *type = SOAP_TYPE_ICat4_ns1__dummy;
-      return soap_in_ns1__dummy(soap, NULL, NULL, NULL);
+      return soap_in_ns1__dummy(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:loginResponse")) {
       *type = SOAP_TYPE_ICat4_ns1__loginResponse;
-      return soap_in_ns1__loginResponse(soap, NULL, NULL, NULL);
+      return soap_in_ns1__loginResponse(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:login")) {
       *type = SOAP_TYPE_ICat4_ns1__login;
-      return soap_in_ns1__login(soap, NULL, NULL, NULL);
+      return soap_in_ns1__login(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:refreshResponse")) {
       *type = SOAP_TYPE_ICat4_ns1__refreshResponse;
-      return soap_in_ns1__refreshResponse(soap, NULL, NULL, NULL);
+      return soap_in_ns1__refreshResponse(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:refresh")) {
       *type = SOAP_TYPE_ICat4_ns1__refresh;
-      return soap_in_ns1__refresh(soap, NULL, NULL, NULL);
+      return soap_in_ns1__refresh(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:getUserNameResponse")) {
       *type = SOAP_TYPE_ICat4_ns1__getUserNameResponse;
-      return soap_in_ns1__getUserNameResponse(soap, NULL, NULL, NULL);
+      return soap_in_ns1__getUserNameResponse(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:getUserName")) {
       *type = SOAP_TYPE_ICat4_ns1__getUserName;
-      return soap_in_ns1__getUserName(soap, NULL, NULL, NULL);
+      return soap_in_ns1__getUserName(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:deleteManyResponse")) {
       *type = SOAP_TYPE_ICat4_ns1__deleteManyResponse;
-      return soap_in_ns1__deleteManyResponse(soap, NULL, NULL, NULL);
+      return soap_in_ns1__deleteManyResponse(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:deleteMany")) {
       *type = SOAP_TYPE_ICat4_ns1__deleteMany;
-      return soap_in_ns1__deleteMany(soap, NULL, NULL, NULL);
+      return soap_in_ns1__deleteMany(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:updateResponse")) {
       *type = SOAP_TYPE_ICat4_ns1__updateResponse;
-      return soap_in_ns1__updateResponse(soap, NULL, NULL, NULL);
+      return soap_in_ns1__updateResponse(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:update")) {
       *type = SOAP_TYPE_ICat4_ns1__update;
-      return soap_in_ns1__update(soap, NULL, NULL, NULL);
+      return soap_in_ns1__update(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:luceneGetPopulatingResponse")) {
       *type = SOAP_TYPE_ICat4_ns1__luceneGetPopulatingResponse;
-      return soap_in_ns1__luceneGetPopulatingResponse(soap, NULL, NULL, NULL);
+      return soap_in_ns1__luceneGetPopulatingResponse(soap, nullptr, nullptr,
+                                                      nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:luceneGetPopulating")) {
       *type = SOAP_TYPE_ICat4_ns1__luceneGetPopulating;
-      return soap_in_ns1__luceneGetPopulating(soap, NULL, NULL, NULL);
+      return soap_in_ns1__luceneGetPopulating(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:getApiVersionResponse")) {
       *type = SOAP_TYPE_ICat4_ns1__getApiVersionResponse;
-      return soap_in_ns1__getApiVersionResponse(soap, NULL, NULL, NULL);
+      return soap_in_ns1__getApiVersionResponse(soap, nullptr, nullptr,
+                                                nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:getApiVersion")) {
       *type = SOAP_TYPE_ICat4_ns1__getApiVersion;
-      return soap_in_ns1__getApiVersion(soap, NULL, NULL, NULL);
+      return soap_in_ns1__getApiVersion(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:getEntityNamesResponse")) {
       *type = SOAP_TYPE_ICat4_ns1__getEntityNamesResponse;
-      return soap_in_ns1__getEntityNamesResponse(soap, NULL, NULL, NULL);
+      return soap_in_ns1__getEntityNamesResponse(soap, nullptr, nullptr,
+                                                 nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:getEntityNames")) {
       *type = SOAP_TYPE_ICat4_ns1__getEntityNames;
-      return soap_in_ns1__getEntityNames(soap, NULL, NULL, NULL);
+      return soap_in_ns1__getEntityNames(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:getResponse")) {
       *type = SOAP_TYPE_ICat4_ns1__getResponse;
-      return soap_in_ns1__getResponse(soap, NULL, NULL, NULL);
+      return soap_in_ns1__getResponse(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:get")) {
       *type = SOAP_TYPE_ICat4_ns1__get;
-      return soap_in_ns1__get(soap, NULL, NULL, NULL);
+      return soap_in_ns1__get(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:lucenePopulateResponse")) {
       *type = SOAP_TYPE_ICat4_ns1__lucenePopulateResponse;
-      return soap_in_ns1__lucenePopulateResponse(soap, NULL, NULL, NULL);
+      return soap_in_ns1__lucenePopulateResponse(soap, nullptr, nullptr,
+                                                 nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:lucenePopulate")) {
       *type = SOAP_TYPE_ICat4_ns1__lucenePopulate;
-      return soap_in_ns1__lucenePopulate(soap, NULL, NULL, NULL);
+      return soap_in_ns1__lucenePopulate(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:luceneSearchResponse")) {
       *type = SOAP_TYPE_ICat4_ns1__luceneSearchResponse;
-      return soap_in_ns1__luceneSearchResponse(soap, NULL, NULL, NULL);
+      return soap_in_ns1__luceneSearchResponse(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:luceneSearch")) {
       *type = SOAP_TYPE_ICat4_ns1__luceneSearch;
-      return soap_in_ns1__luceneSearch(soap, NULL, NULL, NULL);
+      return soap_in_ns1__luceneSearch(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:getPropertiesResponse")) {
       *type = SOAP_TYPE_ICat4_ns1__getPropertiesResponse;
-      return soap_in_ns1__getPropertiesResponse(soap, NULL, NULL, NULL);
+      return soap_in_ns1__getPropertiesResponse(soap, nullptr, nullptr,
+                                                nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:getProperties")) {
       *type = SOAP_TYPE_ICat4_ns1__getProperties;
-      return soap_in_ns1__getProperties(soap, NULL, NULL, NULL);
+      return soap_in_ns1__getProperties(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:createResponse")) {
       *type = SOAP_TYPE_ICat4_ns1__createResponse;
-      return soap_in_ns1__createResponse(soap, NULL, NULL, NULL);
+      return soap_in_ns1__createResponse(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:create")) {
       *type = SOAP_TYPE_ICat4_ns1__create;
-      return soap_in_ns1__create(soap, NULL, NULL, NULL);
+      return soap_in_ns1__create(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:createManyResponse")) {
       *type = SOAP_TYPE_ICat4_ns1__createManyResponse;
-      return soap_in_ns1__createManyResponse(soap, NULL, NULL, NULL);
+      return soap_in_ns1__createManyResponse(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:entityBaseBean")) {
       *type = SOAP_TYPE_ICat4_ns1__entityBaseBean;
-      return soap_in_ns1__entityBaseBean(soap, NULL, NULL, NULL);
+      return soap_in_ns1__entityBaseBean(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:createMany")) {
       *type = SOAP_TYPE_ICat4_ns1__createMany;
-      return soap_in_ns1__createMany(soap, NULL, NULL, NULL);
+      return soap_in_ns1__createMany(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:IcatException")) {
       *type = SOAP_TYPE_ICat4_ns1__IcatException;
-      return soap_in_ns1__IcatException(soap, NULL, NULL, NULL);
+      return soap_in_ns1__IcatException(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:luceneClearResponse")) {
       *type = SOAP_TYPE_ICat4_ns1__luceneClearResponse;
-      return soap_in_ns1__luceneClearResponse(soap, NULL, NULL, NULL);
+      return soap_in_ns1__luceneClearResponse(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:luceneClear")) {
       *type = SOAP_TYPE_ICat4_ns1__luceneClear;
-      return soap_in_ns1__luceneClear(soap, NULL, NULL, NULL);
+      return soap_in_ns1__luceneClear(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "xsd:string")) {
       *type = SOAP_TYPE_ICat4_std__string;
-      return soap_in_std__string(soap, NULL, NULL, NULL);
+      return soap_in_std__string(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "xsd:string")) {
       *type = SOAP_TYPE_ICat4_xsd__string;
-      return soap_in_xsd__string(soap, NULL, NULL, NULL);
+      return soap_in_xsd__string(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "xsd:long")) {
       *type = SOAP_TYPE_ICat4_xsd__long;
-      return soap_in_xsd__long(soap, NULL, NULL, NULL);
+      return soap_in_xsd__long(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "xsd:int")) {
       *type = SOAP_TYPE_ICat4_xsd__int;
-      return soap_in_xsd__int(soap, NULL, NULL, NULL);
+      return soap_in_xsd__int(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "xsd:double")) {
       *type = SOAP_TYPE_ICat4_xsd__double;
-      return soap_in_xsd__double(soap, NULL, NULL, NULL);
+      return soap_in_xsd__double(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "xsd:dateTime")) {
       *type = SOAP_TYPE_ICat4_xsd__dateTime;
-      return soap_in_xsd__dateTime(soap, NULL, NULL, NULL);
+      return soap_in_xsd__dateTime(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "xsd:boolean")) {
       *type = SOAP_TYPE_ICat4_xsd__boolean;
-      return soap_in_xsd__boolean(soap, NULL, NULL, NULL);
+      return soap_in_xsd__boolean(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "xsd:anyType")) {
       *type = SOAP_TYPE_ICat4_xsd__anyType;
-      return soap_in_xsd__anyType(soap, NULL, NULL, NULL);
+      return soap_in_xsd__anyType(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "xsd:byte")) {
       *type = SOAP_TYPE_ICat4_byte;
-      return soap_in_byte(soap, NULL, NULL, NULL);
+      return soap_in_byte(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "xsd:int")) {
       *type = SOAP_TYPE_ICat4_int;
-      return soap_in_int(soap, NULL, NULL, NULL);
+      return soap_in_int(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "xsd:long")) {
       *type = SOAP_TYPE_ICat4_LONG64;
-      return soap_in_LONG64(soap, NULL, NULL, NULL);
+      return soap_in_LONG64(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "xsd:double")) {
       *type = SOAP_TYPE_ICat4_double;
-      return soap_in_double(soap, NULL, NULL, NULL);
+      return soap_in_double(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "xsd:dateTime")) {
       *type = SOAP_TYPE_ICat4_time;
-      return soap_in_time(soap, NULL, NULL, NULL);
+      return soap_in_time(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:accessType")) {
       *type = SOAP_TYPE_ICat4_ns1__accessType;
-      return soap_in_ns1__accessType(soap, NULL, NULL, NULL);
+      return soap_in_ns1__accessType(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:relType")) {
       *type = SOAP_TYPE_ICat4_ns1__relType;
-      return soap_in_ns1__relType(soap, NULL, NULL, NULL);
+      return soap_in_ns1__relType(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:parameterValueType")) {
       *type = SOAP_TYPE_ICat4_ns1__parameterValueType;
-      return soap_in_ns1__parameterValueType(soap, NULL, NULL, NULL);
+      return soap_in_ns1__parameterValueType(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:studyStatus")) {
       *type = SOAP_TYPE_ICat4_ns1__studyStatus;
-      return soap_in_ns1__studyStatus(soap, NULL, NULL, NULL);
+      return soap_in_ns1__studyStatus(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:icatExceptionType")) {
       *type = SOAP_TYPE_ICat4_ns1__icatExceptionType;
-      return soap_in_ns1__icatExceptionType(soap, NULL, NULL, NULL);
+      return soap_in_ns1__icatExceptionType(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "xsd:boolean")) {
       *type = SOAP_TYPE_ICat4_bool;
-      return soap_in_bool(soap, NULL, NULL, NULL);
+      return soap_in_bool(soap, nullptr, nullptr, nullptr);
     }
     if (!soap_match_tag(soap, t, "xsd:QName")) {
       char **s;
       *type = SOAP_TYPE_ICat4__QName;
-      s = soap_in__QName(soap, NULL, NULL, NULL);
-      return s ? *s : NULL;
+      s = soap_in__QName(soap, nullptr, nullptr, nullptr);
+      return s ? *s : nullptr;
     }
     if (!soap_match_tag(soap, t, "xsd:string")) {
       char **s;
       *type = SOAP_TYPE_ICat4_string;
-      s = soap_in_string(soap, NULL, NULL, NULL);
-      return s ? *s : NULL;
+      s = soap_in_string(soap, nullptr, nullptr, nullptr);
+      return s ? *s : nullptr;
     }
     t = soap->tag;
     if (!soap_match_tag(soap, t, "ns1:login-credentials-entry")) {
       *type = SOAP_TYPE_ICat4__ns1__login_credentials_entry;
-      return soap_in__ns1__login_credentials_entry(soap, NULL, NULL, NULL);
+      return soap_in__ns1__login_credentials_entry(soap, nullptr, nullptr,
+                                                   nullptr);
     }
     if (!soap_match_tag(soap, t, "ns1:login-credentials")) {
       *type = SOAP_TYPE_ICat4__ns1__login_credentials;
-      return soap_in__ns1__login_credentials(soap, NULL, NULL, NULL);
+      return soap_in__ns1__login_credentials(soap, nullptr, nullptr, nullptr);
     }
 #ifndef WITH_NOIDREF
   }
 #endif
   }
   soap->error = SOAP_TAG_MISMATCH;
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC3 int SOAP_FMAC4 soap_ignore_element(struct soap *soap) {
@@ -1250,7 +1299,7 @@ SOAP_FMAC3 int SOAP_FMAC4 soap_ignore_element(struct soap *soap) {
         while (!soap_ignore_element(soap))
           ;
         if (soap->error == SOAP_NO_TAG)
-          soap->error = soap_element_end_in(soap, NULL);
+          soap->error = soap_element_end_in(soap, nullptr);
       }
     }
   }
@@ -1306,10 +1355,10 @@ SOAP_FMAC3 int SOAP_FMAC4 soap_putelement(struct soap *soap, const void *ptr,
     return soap_out_bool(soap, tag, id, (const bool *)ptr, "xsd:boolean");
   case SOAP_TYPE_ICat4__ns1__login_credentials_entry:
     return ((_ns1__login_credentials_entry *)ptr)
-        ->soap_out(soap, "ns1:login-credentials-entry", id, NULL);
+        ->soap_out(soap, "ns1:login-credentials-entry", id, nullptr);
   case SOAP_TYPE_ICat4__ns1__login_credentials:
     return ((_ns1__login_credentials *)ptr)
-        ->soap_out(soap, "ns1:login-credentials", id, NULL);
+        ->soap_out(soap, "ns1:login-credentials", id, nullptr);
   case SOAP_TYPE_ICat4_ns1__accessType_:
     return ((ns1__accessType_ *)ptr)->soap_out(soap, tag, id, "ns1:accessType");
   case SOAP_TYPE_ICat4_ns1__relType_:
@@ -3342,7 +3391,7 @@ ICat4_instantiate(struct soap *soap, int t, const char *type,
         soap_instantiate_std__vectorTemplateOfPointerTons1__entityBaseBean(
             soap, -1, type, arrayType, n);
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC3 int SOAP_FMAC4 ICat4_fdelete(struct soap_clist *p) {
@@ -4824,7 +4873,7 @@ soap_in_byte(struct soap *soap, const char *tag, char *a, const char *type) {
 
 SOAP_FMAC3 int SOAP_FMAC4 soap_put_byte(struct soap *soap, const char *a,
                                         const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag, SOAP_TYPE_ICat4_byte);
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag, SOAP_TYPE_ICat4_byte);
   if (soap_out_byte(soap, tag ? tag : "byte", id, a, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -4834,7 +4883,7 @@ SOAP_FMAC3 char *SOAP_FMAC4
 soap_get_byte(struct soap *soap, char *p, const char *tag, const char *type) {
   if ((p = soap_in_byte(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -4865,7 +4914,7 @@ soap_in_int(struct soap *soap, const char *tag, int *a, const char *type) {
 
 SOAP_FMAC3 int SOAP_FMAC4 soap_put_int(struct soap *soap, const int *a,
                                        const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag, SOAP_TYPE_ICat4_int);
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag, SOAP_TYPE_ICat4_int);
   if (soap_out_int(soap, tag ? tag : "int", id, a, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -4875,7 +4924,7 @@ SOAP_FMAC3 int *SOAP_FMAC4
 soap_get_int(struct soap *soap, int *p, const char *tag, const char *type) {
   if ((p = soap_in_int(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -4907,7 +4956,7 @@ SOAP_FMAC3 LONG64 *SOAP_FMAC4 soap_in_LONG64(struct soap *soap, const char *tag,
 
 SOAP_FMAC3 int SOAP_FMAC4 soap_put_LONG64(struct soap *soap, const LONG64 *a,
                                           const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag, SOAP_TYPE_ICat4_LONG64);
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag, SOAP_TYPE_ICat4_LONG64);
   if (soap_out_LONG64(soap, tag ? tag : "long", id, a, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -4918,7 +4967,7 @@ SOAP_FMAC3 LONG64 *SOAP_FMAC4 soap_get_LONG64(struct soap *soap, LONG64 *p,
                                               const char *type) {
   if ((p = soap_in_LONG64(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -4950,7 +4999,7 @@ SOAP_FMAC3 double *SOAP_FMAC4 soap_in_double(struct soap *soap, const char *tag,
 
 SOAP_FMAC3 int SOAP_FMAC4 soap_put_double(struct soap *soap, const double *a,
                                           const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag, SOAP_TYPE_ICat4_double);
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag, SOAP_TYPE_ICat4_double);
   if (soap_out_double(soap, tag ? tag : "double", id, a, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -4961,7 +5010,7 @@ SOAP_FMAC3 double *SOAP_FMAC4 soap_get_double(struct soap *soap, double *p,
                                               const char *type) {
   if ((p = soap_in_double(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -4993,7 +5042,7 @@ soap_in_time(struct soap *soap, const char *tag, time_t *a, const char *type) {
 
 SOAP_FMAC3 int SOAP_FMAC4 soap_put_time(struct soap *soap, const time_t *a,
                                         const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag, SOAP_TYPE_ICat4_time);
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag, SOAP_TYPE_ICat4_time);
   if (soap_out_time(soap, tag ? tag : "dateTime", id, a, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -5003,7 +5052,7 @@ SOAP_FMAC3 time_t *SOAP_FMAC4
 soap_get_time(struct soap *soap, time_t *p, const char *tag, const char *type) {
   if ((p = soap_in_time(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -5022,7 +5071,7 @@ static const struct soap_code_map soap_codes_ns1__accessType[] = {
     {(long)ns1__accessType__UPDATE, "UPDATE"},
     {(long)ns1__accessType__DELETE, "DELETE"},
     {(long)ns1__accessType__CREATE, "CREATE"},
-    {0, NULL}};
+    {0, nullptr}};
 
 SOAP_FMAC3S const char *SOAP_FMAC4S
 soap_ns1__accessType2s(struct soap *soap, enum ns1__accessType n) {
@@ -5067,22 +5116,22 @@ SOAP_FMAC3 enum ns1__accessType *SOAP_FMAC4
 soap_in_ns1__accessType(struct soap *soap, const char *tag,
                         enum ns1__accessType *a, const char *type) {
   if (soap_element_begin_in(soap, tag, 0, type))
-    return NULL;
+    return nullptr;
   a = (enum ns1__accessType *)soap_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__accessType,
-      sizeof(enum ns1__accessType), 0, NULL, NULL, NULL);
+      sizeof(enum ns1__accessType), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->body && !*soap->href) {
     if (!a || soap_s2ns1__accessType(soap, soap_value(soap), a) ||
         soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (enum ns1__accessType *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__accessType, 0,
-        sizeof(enum ns1__accessType), 0, NULL);
+        sizeof(enum ns1__accessType), 0, nullptr);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -5090,7 +5139,7 @@ soap_in_ns1__accessType(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_ns1__accessType(struct soap *soap, const enum ns1__accessType *a,
                          const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__accessType);
   if (soap_out_ns1__accessType(soap, tag ? tag : "ns1:accessType", id, a, type))
     return soap->error;
@@ -5102,7 +5151,7 @@ soap_get_ns1__accessType(struct soap *soap, enum ns1__accessType *p,
                          const char *tag, const char *type) {
   if ((p = soap_in_ns1__accessType(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -5120,7 +5169,7 @@ static const struct soap_code_map soap_codes_ns1__relType[] = {
     {(long)ns1__relType__ATTRIBUTE, "ATTRIBUTE"},
     {(long)ns1__relType__MANY, "MANY"},
     {(long)ns1__relType__ONE, "ONE"},
-    {0, NULL}};
+    {0, nullptr}};
 
 SOAP_FMAC3S const char *SOAP_FMAC4S
 soap_ns1__relType2s(struct soap *soap, enum ns1__relType n) {
@@ -5163,22 +5212,22 @@ SOAP_FMAC3 enum ns1__relType *SOAP_FMAC4
 soap_in_ns1__relType(struct soap *soap, const char *tag, enum ns1__relType *a,
                      const char *type) {
   if (soap_element_begin_in(soap, tag, 0, type))
-    return NULL;
+    return nullptr;
   a = (enum ns1__relType *)soap_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__relType,
-      sizeof(enum ns1__relType), 0, NULL, NULL, NULL);
+      sizeof(enum ns1__relType), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->body && !*soap->href) {
     if (!a || soap_s2ns1__relType(soap, soap_value(soap), a) ||
         soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (enum ns1__relType *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__relType, 0,
-        sizeof(enum ns1__relType), 0, NULL);
+        sizeof(enum ns1__relType), 0, nullptr);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -5186,8 +5235,8 @@ soap_in_ns1__relType(struct soap *soap, const char *tag, enum ns1__relType *a,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_ns1__relType(struct soap *soap, const enum ns1__relType *a,
                       const char *tag, const char *type) {
-  int id =
-      soap_embed(soap, (void *)a, NULL, 0, tag, SOAP_TYPE_ICat4_ns1__relType);
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
+                      SOAP_TYPE_ICat4_ns1__relType);
   if (soap_out_ns1__relType(soap, tag ? tag : "ns1:relType", id, a, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -5198,7 +5247,7 @@ soap_get_ns1__relType(struct soap *soap, enum ns1__relType *p, const char *tag,
                       const char *type) {
   if ((p = soap_in_ns1__relType(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -5217,7 +5266,7 @@ static const struct soap_code_map soap_codes_ns1__parameterValueType[] = {
     {(long)ns1__parameterValueType__DATE_USCOREAND_USCORETIME, "DATE_AND_TIME"},
     {(long)ns1__parameterValueType__NUMERIC, "NUMERIC"},
     {(long)ns1__parameterValueType__STRING, "STRING"},
-    {0, NULL}};
+    {0, nullptr}};
 
 SOAP_FMAC3S const char *SOAP_FMAC4S
 soap_ns1__parameterValueType2s(struct soap *soap,
@@ -5265,22 +5314,22 @@ soap_in_ns1__parameterValueType(struct soap *soap, const char *tag,
                                 enum ns1__parameterValueType *a,
                                 const char *type) {
   if (soap_element_begin_in(soap, tag, 0, type))
-    return NULL;
+    return nullptr;
   a = (enum ns1__parameterValueType *)soap_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__parameterValueType,
-      sizeof(enum ns1__parameterValueType), 0, NULL, NULL, NULL);
+      sizeof(enum ns1__parameterValueType), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->body && !*soap->href) {
     if (!a || soap_s2ns1__parameterValueType(soap, soap_value(soap), a) ||
         soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (enum ns1__parameterValueType *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__parameterValueType,
-        0, sizeof(enum ns1__parameterValueType), 0, NULL);
+        0, sizeof(enum ns1__parameterValueType), 0, nullptr);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -5289,7 +5338,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_ns1__parameterValueType(struct soap *soap,
                                  const enum ns1__parameterValueType *a,
                                  const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__parameterValueType);
   if (soap_out_ns1__parameterValueType(
           soap, tag ? tag : "ns1:parameterValueType", id, a, type))
@@ -5303,7 +5352,7 @@ soap_get_ns1__parameterValueType(struct soap *soap,
                                  const char *tag, const char *type) {
   if ((p = soap_in_ns1__parameterValueType(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -5322,7 +5371,7 @@ static const struct soap_code_map soap_codes_ns1__studyStatus[] = {
     {(long)ns1__studyStatus__IN_USCOREPROGRESS, "IN_PROGRESS"},
     {(long)ns1__studyStatus__COMPLETE, "COMPLETE"},
     {(long)ns1__studyStatus__CANCELLED, "CANCELLED"},
-    {0, NULL}};
+    {0, nullptr}};
 
 SOAP_FMAC3S const char *SOAP_FMAC4S
 soap_ns1__studyStatus2s(struct soap *soap, enum ns1__studyStatus n) {
@@ -5367,22 +5416,22 @@ SOAP_FMAC3 enum ns1__studyStatus *SOAP_FMAC4
 soap_in_ns1__studyStatus(struct soap *soap, const char *tag,
                          enum ns1__studyStatus *a, const char *type) {
   if (soap_element_begin_in(soap, tag, 0, type))
-    return NULL;
+    return nullptr;
   a = (enum ns1__studyStatus *)soap_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__studyStatus,
-      sizeof(enum ns1__studyStatus), 0, NULL, NULL, NULL);
+      sizeof(enum ns1__studyStatus), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->body && !*soap->href) {
     if (!a || soap_s2ns1__studyStatus(soap, soap_value(soap), a) ||
         soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (enum ns1__studyStatus *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__studyStatus, 0,
-        sizeof(enum ns1__studyStatus), 0, NULL);
+        sizeof(enum ns1__studyStatus), 0, nullptr);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -5390,7 +5439,7 @@ soap_in_ns1__studyStatus(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_ns1__studyStatus(struct soap *soap, const enum ns1__studyStatus *a,
                           const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__studyStatus);
   if (soap_out_ns1__studyStatus(soap, tag ? tag : "ns1:studyStatus", id, a,
                                 type))
@@ -5403,7 +5452,7 @@ soap_get_ns1__studyStatus(struct soap *soap, enum ns1__studyStatus *p,
                           const char *tag, const char *type) {
   if ((p = soap_in_ns1__studyStatus(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -5429,7 +5478,7 @@ static const struct soap_code_map soap_codes_ns1__icatExceptionType[] = {
      "OBJECT_ALREADY_EXISTS"},
     {(long)ns1__icatExceptionType__SESSION, "SESSION"},
     {(long)ns1__icatExceptionType__VALIDATION, "VALIDATION"},
-    {0, NULL}};
+    {0, nullptr}};
 
 SOAP_FMAC3S const char *SOAP_FMAC4S
 soap_ns1__icatExceptionType2s(struct soap *soap,
@@ -5477,22 +5526,22 @@ soap_in_ns1__icatExceptionType(struct soap *soap, const char *tag,
                                enum ns1__icatExceptionType *a,
                                const char *type) {
   if (soap_element_begin_in(soap, tag, 0, type))
-    return NULL;
+    return nullptr;
   a = (enum ns1__icatExceptionType *)soap_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__icatExceptionType,
-      sizeof(enum ns1__icatExceptionType), 0, NULL, NULL, NULL);
+      sizeof(enum ns1__icatExceptionType), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->body && !*soap->href) {
     if (!a || soap_s2ns1__icatExceptionType(soap, soap_value(soap), a) ||
         soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (enum ns1__icatExceptionType *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__icatExceptionType,
-        0, sizeof(enum ns1__icatExceptionType), 0, NULL);
+        0, sizeof(enum ns1__icatExceptionType), 0, nullptr);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -5501,7 +5550,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_ns1__icatExceptionType(struct soap *soap,
                                 const enum ns1__icatExceptionType *a,
                                 const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__icatExceptionType);
   if (soap_out_ns1__icatExceptionType(soap, tag ? tag : "ns1:icatExceptionType",
                                       id, a, type))
@@ -5515,7 +5564,7 @@ soap_get_ns1__icatExceptionType(struct soap *soap,
                                 const char *type) {
   if ((p = soap_in_ns1__icatExceptionType(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -5529,7 +5578,7 @@ SOAP_FMAC3 void SOAP_FMAC4 soap_default_bool(struct soap *soap, bool *a) {
 }
 
 static const struct soap_code_map soap_codes_bool[] = {
-    {(long)false, "false"}, {(long)true, "true"}, {0, NULL}};
+    {(long)false, "false"}, {(long)true, "true"}, {0, nullptr}};
 
 SOAP_FMAC3S const char *SOAP_FMAC4S soap_bool2s(struct soap *soap, bool n) {
   (void)soap; /* appease -Wall -Werror */
@@ -5566,33 +5615,34 @@ soap_s2bool(struct soap *soap, const char *s, bool *a) {
 
 SOAP_FMAC3 bool *SOAP_FMAC4
 soap_in_bool(struct soap *soap, const char *tag, bool *a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   if (*soap->type && soap_match_tag(soap, soap->type, type) &&
       soap_match_tag(soap, soap->type, ":boolean")) {
     soap->error = SOAP_TYPE;
-    return NULL;
+    return nullptr;
   }
   a = (bool *)soap_id_enter(soap, soap->id, a, SOAP_TYPE_ICat4_bool,
-                            sizeof(bool), 0, NULL, NULL, NULL);
+                            sizeof(bool), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->body && !*soap->href) {
     if (!a || soap_s2bool(soap, soap_value(soap), a) ||
         soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (bool *)soap_id_forward(soap, soap->href, (void *)a, 0,
-                                SOAP_TYPE_ICat4_bool, 0, sizeof(bool), 0, NULL);
+                                SOAP_TYPE_ICat4_bool, 0, sizeof(bool), 0,
+                                nullptr);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 SOAP_FMAC3 int SOAP_FMAC4 soap_put_bool(struct soap *soap, const bool *a,
                                         const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag, SOAP_TYPE_ICat4_bool);
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag, SOAP_TYPE_ICat4_bool);
   if (soap_out_bool(soap, tag ? tag : "boolean", id, a, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -5602,14 +5652,14 @@ SOAP_FMAC3 bool *SOAP_FMAC4
 soap_get_bool(struct soap *soap, bool *p, const char *tag, const char *type) {
   if ((p = soap_in_bool(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
 void _ns1__login_credentials_entry::soap_default(struct soap *soap) {
   (void)soap; /* appease -Wall -Werror */
-  this->_ns1__login_credentials_entry::key = NULL;
-  this->_ns1__login_credentials_entry::value = NULL;
+  this->_ns1__login_credentials_entry::key = nullptr;
+  this->_ns1__login_credentials_entry::value = nullptr;
 }
 
 void _ns1__login_credentials_entry::soap_serialize(struct soap *soap) const {
@@ -5657,13 +5707,13 @@ soap_in__ns1__login_credentials_entry(struct soap *soap, const char *tag,
                                       _ns1__login_credentials_entry *a,
                                       const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (_ns1__login_credentials_entry *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4__ns1__login_credentials_entry,
       sizeof(_ns1__login_credentials_entry), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4__ns1__login_credentials_entry) {
@@ -5698,10 +5748,10 @@ soap_in__ns1__login_credentials_entry(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (_ns1__login_credentials_entry *)soap_id_forward(
         soap, soap->href, (void *)a, 0,
@@ -5709,14 +5759,14 @@ soap_in__ns1__login_credentials_entry(struct soap *soap, const char *tag,
         sizeof(_ns1__login_credentials_entry), 0,
         soap_copy__ns1__login_credentials_entry);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int _ns1__login_credentials_entry::soap_put(struct soap *soap, const char *tag,
                                             const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4__ns1__login_credentials_entry);
   if (this->soap_out(soap, tag ? tag : "ns1:login-credentials-entry", id, type))
     return soap->error;
@@ -5735,7 +5785,7 @@ soap_get__ns1__login_credentials_entry(struct soap *soap,
                                        const char *tag, const char *type) {
   if ((p = soap_in__ns1__login_credentials_entry(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -5752,10 +5802,10 @@ soap_instantiate__ns1__login_credentials_entry(struct soap *soap, int n,
              "soap_instantiate__ns1__login_credentials_entry(%d, %s, %s)\n", n,
              type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4__ns1__login_credentials_entry, n,
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4__ns1__login_credentials_entry, n,
                 ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(_ns1__login_credentials_entry);
     if (size)
@@ -5788,7 +5838,7 @@ soap_copy__ns1__login_credentials_entry(struct soap *soap, int st, int tt,
 
 void _ns1__login_credentials::soap_default(struct soap *soap) {
   (void)soap; /* appease -Wall -Werror */
-  this->_ns1__login_credentials::entry = NULL;
+  this->_ns1__login_credentials::entry = nullptr;
 }
 
 void _ns1__login_credentials::soap_serialize(struct soap *soap) const {
@@ -5828,13 +5878,13 @@ SOAP_FMAC3 _ns1__login_credentials *SOAP_FMAC4
 soap_in__ns1__login_credentials(struct soap *soap, const char *tag,
                                 _ns1__login_credentials *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (_ns1__login_credentials *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4__ns1__login_credentials,
       sizeof(_ns1__login_credentials), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4__ns1__login_credentials) {
@@ -5855,24 +5905,24 @@ soap_in__ns1__login_credentials(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (_ns1__login_credentials *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4__ns1__login_credentials,
         0, sizeof(_ns1__login_credentials), 0,
         soap_copy__ns1__login_credentials);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int _ns1__login_credentials::soap_put(struct soap *soap, const char *tag,
                                       const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4__ns1__login_credentials);
   if (this->soap_out(soap, tag ? tag : "ns1:login-credentials", id, type))
     return soap->error;
@@ -5889,7 +5939,7 @@ soap_get__ns1__login_credentials(struct soap *soap, _ns1__login_credentials *p,
                                  const char *tag, const char *type) {
   if ((p = soap_in__ns1__login_credentials(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -5904,9 +5954,9 @@ soap_instantiate__ns1__login_credentials(struct soap *soap, int n,
                       "soap_instantiate__ns1__login_credentials(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4__ns1__login_credentials, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4__ns1__login_credentials, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(_ns1__login_credentials);
     if (size)
@@ -5971,13 +6021,13 @@ SOAP_FMAC3 ns1__accessType_ *SOAP_FMAC4
 soap_in_ns1__accessType_(struct soap *soap, const char *tag,
                          ns1__accessType_ *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!(a = (ns1__accessType_ *)soap_class_id_enter(
             soap, soap->id, a, SOAP_TYPE_ICat4_ns1__accessType_,
             sizeof(ns1__accessType_), soap->type, soap->arrayType))) {
     soap->error = SOAP_TAG_MISMATCH;
-    return NULL;
+    return nullptr;
   }
   soap_revert(soap);
   *soap->id = '\0';
@@ -5988,13 +6038,13 @@ soap_in_ns1__accessType_(struct soap *soap, const char *tag,
   }
   if (!soap_in_ns1__accessType(soap, tag, &(a->ns1__accessType_::__item),
                                "ns1:accessType"))
-    return NULL;
+    return nullptr;
   return a;
 }
 
 int ns1__accessType_::soap_put(struct soap *soap, const char *tag,
                                const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__accessType_);
   if (this->soap_out(soap, tag ? tag : "ns1:accessType", id, type))
     return soap->error;
@@ -6011,7 +6061,7 @@ soap_get_ns1__accessType_(struct soap *soap, ns1__accessType_ *p,
                           const char *tag, const char *type) {
   if ((p = soap_in_ns1__accessType_(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -6023,10 +6073,10 @@ soap_instantiate_ns1__accessType_(struct soap *soap, int n, const char *type,
   DBGLOG(TEST,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__accessType_(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__accessType_, n, ICat4_fdelete);
+  struct soap_clist *cp = soap_link(
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__accessType_, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__accessType_);
     if (size)
@@ -6095,13 +6145,13 @@ SOAP_FMAC3 ns1__relType_ *SOAP_FMAC4
 soap_in_ns1__relType_(struct soap *soap, const char *tag, ns1__relType_ *a,
                       const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!(a = (ns1__relType_ *)soap_class_id_enter(
             soap, soap->id, a, SOAP_TYPE_ICat4_ns1__relType_,
             sizeof(ns1__relType_), soap->type, soap->arrayType))) {
     soap->error = SOAP_TAG_MISMATCH;
-    return NULL;
+    return nullptr;
   }
   soap_revert(soap);
   *soap->id = '\0';
@@ -6112,13 +6162,13 @@ soap_in_ns1__relType_(struct soap *soap, const char *tag, ns1__relType_ *a,
   }
   if (!soap_in_ns1__relType(soap, tag, &(a->ns1__relType_::__item),
                             "ns1:relType"))
-    return NULL;
+    return nullptr;
   return a;
 }
 
 int ns1__relType_::soap_put(struct soap *soap, const char *tag,
                             const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__relType_);
   if (this->soap_out(soap, tag ? tag : "ns1:relType", id, type))
     return soap->error;
@@ -6135,7 +6185,7 @@ soap_get_ns1__relType_(struct soap *soap, ns1__relType_ *p, const char *tag,
                        const char *type) {
   if ((p = soap_in_ns1__relType_(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -6148,9 +6198,9 @@ soap_instantiate_ns1__relType_(struct soap *soap, int n, const char *type,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__relType_(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__relType_, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__relType_, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__relType_);
     if (size)
@@ -6222,13 +6272,13 @@ soap_in_ns1__parameterValueType_(struct soap *soap, const char *tag,
                                  ns1__parameterValueType_ *a,
                                  const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!(a = (ns1__parameterValueType_ *)soap_class_id_enter(
             soap, soap->id, a, SOAP_TYPE_ICat4_ns1__parameterValueType_,
             sizeof(ns1__parameterValueType_), soap->type, soap->arrayType))) {
     soap->error = SOAP_TAG_MISMATCH;
-    return NULL;
+    return nullptr;
   }
   soap_revert(soap);
   *soap->id = '\0';
@@ -6240,13 +6290,13 @@ soap_in_ns1__parameterValueType_(struct soap *soap, const char *tag,
   if (!soap_in_ns1__parameterValueType(soap, tag,
                                        &(a->ns1__parameterValueType_::__item),
                                        "ns1:parameterValueType"))
-    return NULL;
+    return nullptr;
   return a;
 }
 
 int ns1__parameterValueType_::soap_put(struct soap *soap, const char *tag,
                                        const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__parameterValueType_);
   if (this->soap_out(soap, tag ? tag : "ns1:parameterValueType", id, type))
     return soap->error;
@@ -6264,7 +6314,7 @@ soap_get_ns1__parameterValueType_(struct soap *soap,
                                   const char *type) {
   if ((p = soap_in_ns1__parameterValueType_(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -6278,10 +6328,11 @@ soap_instantiate_ns1__parameterValueType_(struct soap *soap, int n,
          SOAP_MESSAGE(fdebug,
                       "soap_instantiate_ns1__parameterValueType_(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__parameterValueType_, n, ICat4_fdelete);
+  struct soap_clist *cp =
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__parameterValueType_, n,
+                ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__parameterValueType_);
     if (size)
@@ -6351,13 +6402,13 @@ SOAP_FMAC3 ns1__studyStatus_ *SOAP_FMAC4
 soap_in_ns1__studyStatus_(struct soap *soap, const char *tag,
                           ns1__studyStatus_ *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!(a = (ns1__studyStatus_ *)soap_class_id_enter(
             soap, soap->id, a, SOAP_TYPE_ICat4_ns1__studyStatus_,
             sizeof(ns1__studyStatus_), soap->type, soap->arrayType))) {
     soap->error = SOAP_TAG_MISMATCH;
-    return NULL;
+    return nullptr;
   }
   soap_revert(soap);
   *soap->id = '\0';
@@ -6368,13 +6419,13 @@ soap_in_ns1__studyStatus_(struct soap *soap, const char *tag,
   }
   if (!soap_in_ns1__studyStatus(soap, tag, &(a->ns1__studyStatus_::__item),
                                 "ns1:studyStatus"))
-    return NULL;
+    return nullptr;
   return a;
 }
 
 int ns1__studyStatus_::soap_put(struct soap *soap, const char *tag,
                                 const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__studyStatus_);
   if (this->soap_out(soap, tag ? tag : "ns1:studyStatus", id, type))
     return soap->error;
@@ -6391,7 +6442,7 @@ soap_get_ns1__studyStatus_(struct soap *soap, ns1__studyStatus_ *p,
                            const char *tag, const char *type) {
   if ((p = soap_in_ns1__studyStatus_(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -6404,9 +6455,9 @@ soap_instantiate_ns1__studyStatus_(struct soap *soap, int n, const char *type,
                             "soap_instantiate_ns1__studyStatus_(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__studyStatus_, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__studyStatus_, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__studyStatus_);
     if (size)
@@ -6478,13 +6529,13 @@ SOAP_FMAC3 ns1__icatExceptionType_ *SOAP_FMAC4
 soap_in_ns1__icatExceptionType_(struct soap *soap, const char *tag,
                                 ns1__icatExceptionType_ *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!(a = (ns1__icatExceptionType_ *)soap_class_id_enter(
             soap, soap->id, a, SOAP_TYPE_ICat4_ns1__icatExceptionType_,
             sizeof(ns1__icatExceptionType_), soap->type, soap->arrayType))) {
     soap->error = SOAP_TAG_MISMATCH;
-    return NULL;
+    return nullptr;
   }
   soap_revert(soap);
   *soap->id = '\0';
@@ -6496,13 +6547,13 @@ soap_in_ns1__icatExceptionType_(struct soap *soap, const char *tag,
   if (!soap_in_ns1__icatExceptionType(soap, tag,
                                       &(a->ns1__icatExceptionType_::__item),
                                       "ns1:icatExceptionType"))
-    return NULL;
+    return nullptr;
   return a;
 }
 
 int ns1__icatExceptionType_::soap_put(struct soap *soap, const char *tag,
                                       const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__icatExceptionType_);
   if (this->soap_out(soap, tag ? tag : "ns1:icatExceptionType", id, type))
     return soap->error;
@@ -6519,7 +6570,7 @@ soap_get_ns1__icatExceptionType_(struct soap *soap, ns1__icatExceptionType_ *p,
                                  const char *tag, const char *type) {
   if ((p = soap_in_ns1__icatExceptionType_(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -6534,9 +6585,9 @@ soap_instantiate_ns1__icatExceptionType_(struct soap *soap, int n,
                       "soap_instantiate_ns1__icatExceptionType_(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__icatExceptionType_, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__icatExceptionType_, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__icatExceptionType_);
     if (size)
@@ -6617,13 +6668,13 @@ soap_in_ns1__getRemainingMinutesResponse(struct soap *soap, const char *tag,
                                          ns1__getRemainingMinutesResponse *a,
                                          const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__getRemainingMinutesResponse *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__getRemainingMinutesResponse,
       sizeof(ns1__getRemainingMinutesResponse), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__getRemainingMinutesResponse) {
@@ -6656,10 +6707,10 @@ soap_in_ns1__getRemainingMinutesResponse(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__getRemainingMinutesResponse *)soap_id_forward(
         soap, soap->href, (void *)a, 0,
@@ -6667,11 +6718,11 @@ soap_in_ns1__getRemainingMinutesResponse(struct soap *soap, const char *tag,
         sizeof(ns1__getRemainingMinutesResponse), 0,
         soap_copy_ns1__getRemainingMinutesResponse);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   if ((soap->mode & SOAP_XML_STRICT) && (soap_flag_return_1 > 0)) {
     soap->error = SOAP_OCCURS;
-    return NULL;
+    return nullptr;
   }
   return a;
 }
@@ -6679,7 +6730,7 @@ soap_in_ns1__getRemainingMinutesResponse(struct soap *soap, const char *tag,
 int ns1__getRemainingMinutesResponse::soap_put(struct soap *soap,
                                                const char *tag,
                                                const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__getRemainingMinutesResponse);
   if (this->soap_out(soap, tag ? tag : "ns1:getRemainingMinutesResponse", id,
                      type))
@@ -6699,7 +6750,7 @@ soap_get_ns1__getRemainingMinutesResponse(struct soap *soap,
                                           const char *tag, const char *type) {
   if ((p = soap_in_ns1__getRemainingMinutesResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -6716,10 +6767,10 @@ soap_instantiate_ns1__getRemainingMinutesResponse(struct soap *soap, int n,
              "soap_instantiate_ns1__getRemainingMinutesResponse(%d, %s, %s)\n",
              n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__getRemainingMinutesResponse, n,
-                ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__getRemainingMinutesResponse,
+                n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__getRemainingMinutesResponse);
     if (size)
@@ -6759,7 +6810,7 @@ soap_copy_ns1__getRemainingMinutesResponse(struct soap *soap, int st, int tt,
 void ns1__getRemainingMinutes::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__getRemainingMinutes::sessionId = NULL;
+  this->ns1__getRemainingMinutes::sessionId = nullptr;
 }
 
 void ns1__getRemainingMinutes::soap_serialize(struct soap *soap) const {
@@ -6802,13 +6853,13 @@ soap_in_ns1__getRemainingMinutes(struct soap *soap, const char *tag,
                                  ns1__getRemainingMinutes *a,
                                  const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__getRemainingMinutes *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__getRemainingMinutes,
       sizeof(ns1__getRemainingMinutes), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__getRemainingMinutes) {
@@ -6842,10 +6893,10 @@ soap_in_ns1__getRemainingMinutes(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__getRemainingMinutes *)soap_id_forward(
         soap, soap->href, (void *)a, 0,
@@ -6853,14 +6904,14 @@ soap_in_ns1__getRemainingMinutes(struct soap *soap, const char *tag,
         sizeof(ns1__getRemainingMinutes), 0,
         soap_copy_ns1__getRemainingMinutes);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__getRemainingMinutes::soap_put(struct soap *soap, const char *tag,
                                        const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__getRemainingMinutes);
   if (this->soap_out(soap, tag ? tag : "ns1:getRemainingMinutes", id, type))
     return soap->error;
@@ -6878,7 +6929,7 @@ soap_get_ns1__getRemainingMinutes(struct soap *soap,
                                   const char *type) {
   if ((p = soap_in_ns1__getRemainingMinutes(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -6892,10 +6943,11 @@ soap_instantiate_ns1__getRemainingMinutes(struct soap *soap, int n,
          SOAP_MESSAGE(fdebug,
                       "soap_instantiate_ns1__getRemainingMinutes(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__getRemainingMinutes, n, ICat4_fdelete);
+  struct soap_clist *cp =
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__getRemainingMinutes, n,
+                ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__getRemainingMinutes);
     if (size)
@@ -6962,13 +7014,13 @@ SOAP_FMAC3 ns1__logoutResponse *SOAP_FMAC4
 soap_in_ns1__logoutResponse(struct soap *soap, const char *tag,
                             ns1__logoutResponse *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!(a = (ns1__logoutResponse *)soap_class_id_enter(
             soap, soap->id, a, SOAP_TYPE_ICat4_ns1__logoutResponse,
             sizeof(ns1__logoutResponse), soap->type, soap->arrayType))) {
     soap->error = SOAP_TAG_MISMATCH;
-    return NULL;
+    return nullptr;
   }
   soap_revert(soap);
   *soap->id = '\0';
@@ -6978,13 +7030,13 @@ soap_in_ns1__logoutResponse(struct soap *soap, const char *tag,
       return (ns1__logoutResponse *)a->soap_in(soap, tag, type);
   }
   if (!soap_inliteral(soap, tag, &(a->xsd__anyType::__item)))
-    return NULL;
+    return nullptr;
   return a;
 }
 
 int ns1__logoutResponse::soap_put(struct soap *soap, const char *tag,
                                   const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__logoutResponse);
   if (this->soap_out(soap, tag ? tag : "ns1:logoutResponse", id, type))
     return soap->error;
@@ -7001,7 +7053,7 @@ soap_get_ns1__logoutResponse(struct soap *soap, ns1__logoutResponse *p,
                              const char *tag, const char *type) {
   if ((p = soap_in_ns1__logoutResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -7014,9 +7066,9 @@ soap_instantiate_ns1__logoutResponse(struct soap *soap, int n, const char *type,
                    fdebug, "soap_instantiate_ns1__logoutResponse(%d, %s, %s)\n",
                    n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__logoutResponse, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__logoutResponse, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__logoutResponse);
     if (size)
@@ -7052,7 +7104,7 @@ soap_copy_ns1__logoutResponse(struct soap *soap, int st, int tt, void *p,
 void ns1__logout::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__logout::sessionId = NULL;
+  this->ns1__logout::sessionId = nullptr;
 }
 
 void ns1__logout::soap_serialize(struct soap *soap) const {
@@ -7091,13 +7143,13 @@ SOAP_FMAC3 ns1__logout *SOAP_FMAC4
 soap_in_ns1__logout(struct soap *soap, const char *tag, ns1__logout *a,
                     const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__logout *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__logout, sizeof(ns1__logout),
       soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__logout) {
@@ -7131,24 +7183,24 @@ soap_in_ns1__logout(struct soap *soap, const char *tag, ns1__logout *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__logout *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__logout, 0,
         sizeof(ns1__logout), 0, soap_copy_ns1__logout);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__logout::soap_put(struct soap *soap, const char *tag,
                           const char *type) const {
-  int id =
-      soap_embed(soap, (void *)this, NULL, 0, tag, SOAP_TYPE_ICat4_ns1__logout);
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
+                      SOAP_TYPE_ICat4_ns1__logout);
   if (this->soap_out(soap, tag ? tag : "ns1:logout", id, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -7164,7 +7216,7 @@ soap_get_ns1__logout(struct soap *soap, ns1__logout *p, const char *tag,
                      const char *type) {
   if ((p = soap_in_ns1__logout(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -7177,9 +7229,9 @@ soap_instantiate_ns1__logout(struct soap *soap, int n, const char *type,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__logout(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__logout, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__logout, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__logout);
     if (size)
@@ -7256,13 +7308,13 @@ SOAP_FMAC3 ns1__searchResponse *SOAP_FMAC4
 soap_in_ns1__searchResponse(struct soap *soap, const char *tag,
                             ns1__searchResponse *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__searchResponse *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__searchResponse,
       sizeof(ns1__searchResponse), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__searchResponse) {
@@ -7292,23 +7344,23 @@ soap_in_ns1__searchResponse(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__searchResponse *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__searchResponse, 0,
         sizeof(ns1__searchResponse), 0, soap_copy_ns1__searchResponse);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__searchResponse::soap_put(struct soap *soap, const char *tag,
                                   const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__searchResponse);
   if (this->soap_out(soap, tag ? tag : "ns1:searchResponse", id, type))
     return soap->error;
@@ -7325,7 +7377,7 @@ soap_get_ns1__searchResponse(struct soap *soap, ns1__searchResponse *p,
                              const char *tag, const char *type) {
   if ((p = soap_in_ns1__searchResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -7338,9 +7390,9 @@ soap_instantiate_ns1__searchResponse(struct soap *soap, int n, const char *type,
                    fdebug, "soap_instantiate_ns1__searchResponse(%d, %s, %s)\n",
                    n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__searchResponse, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__searchResponse, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__searchResponse);
     if (size)
@@ -7376,8 +7428,8 @@ soap_copy_ns1__searchResponse(struct soap *soap, int st, int tt, void *p,
 void ns1__search::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__search::sessionId = NULL;
-  this->ns1__search::query = NULL;
+  this->ns1__search::sessionId = nullptr;
+  this->ns1__search::query = nullptr;
 }
 
 void ns1__search::soap_serialize(struct soap *soap) const {
@@ -7420,13 +7472,13 @@ SOAP_FMAC3 ns1__search *SOAP_FMAC4
 soap_in_ns1__search(struct soap *soap, const char *tag, ns1__search *a,
                     const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__search *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__search, sizeof(ns1__search),
       soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__search) {
@@ -7468,24 +7520,24 @@ soap_in_ns1__search(struct soap *soap, const char *tag, ns1__search *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__search *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__search, 0,
         sizeof(ns1__search), 0, soap_copy_ns1__search);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__search::soap_put(struct soap *soap, const char *tag,
                           const char *type) const {
-  int id =
-      soap_embed(soap, (void *)this, NULL, 0, tag, SOAP_TYPE_ICat4_ns1__search);
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
+                      SOAP_TYPE_ICat4_ns1__search);
   if (this->soap_out(soap, tag ? tag : "ns1:search", id, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -7501,7 +7553,7 @@ soap_get_ns1__search(struct soap *soap, ns1__search *p, const char *tag,
                      const char *type) {
   if ((p = soap_in_ns1__search(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -7514,9 +7566,9 @@ soap_instantiate_ns1__search(struct soap *soap, int n, const char *type,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__search(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__search, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__search, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__search);
     if (size)
@@ -7594,13 +7646,13 @@ soap_in_ns1__isAccessAllowedResponse(struct soap *soap, const char *tag,
                                      ns1__isAccessAllowedResponse *a,
                                      const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__isAccessAllowedResponse *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__isAccessAllowedResponse,
       sizeof(ns1__isAccessAllowedResponse), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__isAccessAllowedResponse) {
@@ -7633,10 +7685,10 @@ soap_in_ns1__isAccessAllowedResponse(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__isAccessAllowedResponse *)soap_id_forward(
         soap, soap->href, (void *)a, 0,
@@ -7644,18 +7696,18 @@ soap_in_ns1__isAccessAllowedResponse(struct soap *soap, const char *tag,
         sizeof(ns1__isAccessAllowedResponse), 0,
         soap_copy_ns1__isAccessAllowedResponse);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   if ((soap->mode & SOAP_XML_STRICT) && (soap_flag_return_1 > 0)) {
     soap->error = SOAP_OCCURS;
-    return NULL;
+    return nullptr;
   }
   return a;
 }
 
 int ns1__isAccessAllowedResponse::soap_put(struct soap *soap, const char *tag,
                                            const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__isAccessAllowedResponse);
   if (this->soap_out(soap, tag ? tag : "ns1:isAccessAllowedResponse", id, type))
     return soap->error;
@@ -7673,7 +7725,7 @@ soap_get_ns1__isAccessAllowedResponse(struct soap *soap,
                                       const char *tag, const char *type) {
   if ((p = soap_in_ns1__isAccessAllowedResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -7690,10 +7742,10 @@ soap_instantiate_ns1__isAccessAllowedResponse(struct soap *soap, int n,
              "soap_instantiate_ns1__isAccessAllowedResponse(%d, %s, %s)\n", n,
              type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__isAccessAllowedResponse, n,
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__isAccessAllowedResponse, n,
                 ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__isAccessAllowedResponse);
     if (size)
@@ -7731,9 +7783,9 @@ soap_copy_ns1__isAccessAllowedResponse(struct soap *soap, int st, int tt,
 void ns1__isAccessAllowed::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__isAccessAllowed::sessionId = NULL;
-  this->ns1__isAccessAllowed::bean = NULL;
-  this->ns1__isAccessAllowed::accessType = NULL;
+  this->ns1__isAccessAllowed::sessionId = nullptr;
+  this->ns1__isAccessAllowed::bean = nullptr;
+  this->ns1__isAccessAllowed::accessType = nullptr;
 }
 
 void ns1__isAccessAllowed::soap_serialize(struct soap *soap) const {
@@ -7784,13 +7836,13 @@ SOAP_FMAC3 ns1__isAccessAllowed *SOAP_FMAC4
 soap_in_ns1__isAccessAllowed(struct soap *soap, const char *tag,
                              ns1__isAccessAllowed *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__isAccessAllowed *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__isAccessAllowed,
       sizeof(ns1__isAccessAllowed), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__isAccessAllowed) {
@@ -7840,23 +7892,23 @@ soap_in_ns1__isAccessAllowed(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__isAccessAllowed *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__isAccessAllowed, 0,
         sizeof(ns1__isAccessAllowed), 0, soap_copy_ns1__isAccessAllowed);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__isAccessAllowed::soap_put(struct soap *soap, const char *tag,
                                    const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__isAccessAllowed);
   if (this->soap_out(soap, tag ? tag : "ns1:isAccessAllowed", id, type))
     return soap->error;
@@ -7873,7 +7925,7 @@ soap_get_ns1__isAccessAllowed(struct soap *soap, ns1__isAccessAllowed *p,
                               const char *tag, const char *type) {
   if ((p = soap_in_ns1__isAccessAllowed(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -7888,9 +7940,9 @@ soap_instantiate_ns1__isAccessAllowed(struct soap *soap, int n,
                       "soap_instantiate_ns1__isAccessAllowed(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__isAccessAllowed, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__isAccessAllowed, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__isAccessAllowed);
     if (size)
@@ -7956,13 +8008,13 @@ SOAP_FMAC3 ns1__deleteResponse *SOAP_FMAC4
 soap_in_ns1__deleteResponse(struct soap *soap, const char *tag,
                             ns1__deleteResponse *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!(a = (ns1__deleteResponse *)soap_class_id_enter(
             soap, soap->id, a, SOAP_TYPE_ICat4_ns1__deleteResponse,
             sizeof(ns1__deleteResponse), soap->type, soap->arrayType))) {
     soap->error = SOAP_TAG_MISMATCH;
-    return NULL;
+    return nullptr;
   }
   soap_revert(soap);
   *soap->id = '\0';
@@ -7972,13 +8024,13 @@ soap_in_ns1__deleteResponse(struct soap *soap, const char *tag,
       return (ns1__deleteResponse *)a->soap_in(soap, tag, type);
   }
   if (!soap_inliteral(soap, tag, &(a->xsd__anyType::__item)))
-    return NULL;
+    return nullptr;
   return a;
 }
 
 int ns1__deleteResponse::soap_put(struct soap *soap, const char *tag,
                                   const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__deleteResponse);
   if (this->soap_out(soap, tag ? tag : "ns1:deleteResponse", id, type))
     return soap->error;
@@ -7995,7 +8047,7 @@ soap_get_ns1__deleteResponse(struct soap *soap, ns1__deleteResponse *p,
                              const char *tag, const char *type) {
   if ((p = soap_in_ns1__deleteResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -8008,9 +8060,9 @@ soap_instantiate_ns1__deleteResponse(struct soap *soap, int n, const char *type,
                    fdebug, "soap_instantiate_ns1__deleteResponse(%d, %s, %s)\n",
                    n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__deleteResponse, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__deleteResponse, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__deleteResponse);
     if (size)
@@ -8046,8 +8098,8 @@ soap_copy_ns1__deleteResponse(struct soap *soap, int st, int tt, void *p,
 void ns1__delete::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__delete::sessionId = NULL;
-  this->ns1__delete::bean = NULL;
+  this->ns1__delete::sessionId = nullptr;
+  this->ns1__delete::bean = nullptr;
 }
 
 void ns1__delete::soap_serialize(struct soap *soap) const {
@@ -8090,13 +8142,13 @@ SOAP_FMAC3 ns1__delete *SOAP_FMAC4
 soap_in_ns1__delete(struct soap *soap, const char *tag, ns1__delete *a,
                     const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__delete *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__delete, sizeof(ns1__delete),
       soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__delete) {
@@ -8137,24 +8189,24 @@ soap_in_ns1__delete(struct soap *soap, const char *tag, ns1__delete *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__delete *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__delete, 0,
         sizeof(ns1__delete), 0, soap_copy_ns1__delete);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__delete::soap_put(struct soap *soap, const char *tag,
                           const char *type) const {
-  int id =
-      soap_embed(soap, (void *)this, NULL, 0, tag, SOAP_TYPE_ICat4_ns1__delete);
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
+                      SOAP_TYPE_ICat4_ns1__delete);
   if (this->soap_out(soap, tag ? tag : "ns1:delete", id, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -8170,7 +8222,7 @@ soap_get_ns1__delete(struct soap *soap, ns1__delete *p, const char *tag,
                      const char *type) {
   if ((p = soap_in_ns1__delete(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -8183,9 +8235,9 @@ soap_instantiate_ns1__delete(struct soap *soap, int n, const char *type,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__delete(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__delete, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__delete, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__delete);
     if (size)
@@ -8263,13 +8315,13 @@ SOAP_FMAC3 ns1__searchTextResponse *SOAP_FMAC4
 soap_in_ns1__searchTextResponse(struct soap *soap, const char *tag,
                                 ns1__searchTextResponse *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__searchTextResponse *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__searchTextResponse,
       sizeof(ns1__searchTextResponse), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__searchTextResponse) {
@@ -8299,24 +8351,24 @@ soap_in_ns1__searchTextResponse(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__searchTextResponse *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__searchTextResponse,
         0, sizeof(ns1__searchTextResponse), 0,
         soap_copy_ns1__searchTextResponse);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__searchTextResponse::soap_put(struct soap *soap, const char *tag,
                                       const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__searchTextResponse);
   if (this->soap_out(soap, tag ? tag : "ns1:searchTextResponse", id, type))
     return soap->error;
@@ -8333,7 +8385,7 @@ soap_get_ns1__searchTextResponse(struct soap *soap, ns1__searchTextResponse *p,
                                  const char *tag, const char *type) {
   if ((p = soap_in_ns1__searchTextResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -8348,9 +8400,9 @@ soap_instantiate_ns1__searchTextResponse(struct soap *soap, int n,
                       "soap_instantiate_ns1__searchTextResponse(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__searchTextResponse, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__searchTextResponse, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__searchTextResponse);
     if (size)
@@ -8386,10 +8438,10 @@ soap_copy_ns1__searchTextResponse(struct soap *soap, int st, int tt, void *p,
 void ns1__searchText::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__searchText::sessionId = NULL;
-  this->ns1__searchText::query = NULL;
+  this->ns1__searchText::sessionId = nullptr;
+  this->ns1__searchText::query = nullptr;
   soap_default_int(soap, &this->ns1__searchText::maxCount);
-  this->ns1__searchText::entityName = NULL;
+  this->ns1__searchText::entityName = nullptr;
 }
 
 void ns1__searchText::soap_serialize(struct soap *soap) const {
@@ -8440,13 +8492,13 @@ SOAP_FMAC3 ns1__searchText *SOAP_FMAC4
 soap_in_ns1__searchText(struct soap *soap, const char *tag, ns1__searchText *a,
                         const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__searchText *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__searchText,
       sizeof(ns1__searchText), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__searchText) {
@@ -8504,27 +8556,27 @@ soap_in_ns1__searchText(struct soap *soap, const char *tag, ns1__searchText *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__searchText *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__searchText, 0,
         sizeof(ns1__searchText), 0, soap_copy_ns1__searchText);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   if ((soap->mode & SOAP_XML_STRICT) && (soap_flag_maxCount1 > 0)) {
     soap->error = SOAP_OCCURS;
-    return NULL;
+    return nullptr;
   }
   return a;
 }
 
 int ns1__searchText::soap_put(struct soap *soap, const char *tag,
                               const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__searchText);
   if (this->soap_out(soap, tag ? tag : "ns1:searchText", id, type))
     return soap->error;
@@ -8541,7 +8593,7 @@ soap_get_ns1__searchText(struct soap *soap, ns1__searchText *p, const char *tag,
                          const char *type) {
   if ((p = soap_in_ns1__searchText(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -8553,10 +8605,10 @@ soap_instantiate_ns1__searchText(struct soap *soap, int n, const char *type,
   DBGLOG(TEST,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__searchText(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__searchText, n, ICat4_fdelete);
+  struct soap_clist *cp = soap_link(
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__searchText, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__searchText);
     if (size)
@@ -8624,13 +8676,13 @@ soap_in_ns1__luceneCommitResponse(struct soap *soap, const char *tag,
                                   ns1__luceneCommitResponse *a,
                                   const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!(a = (ns1__luceneCommitResponse *)soap_class_id_enter(
             soap, soap->id, a, SOAP_TYPE_ICat4_ns1__luceneCommitResponse,
             sizeof(ns1__luceneCommitResponse), soap->type, soap->arrayType))) {
     soap->error = SOAP_TAG_MISMATCH;
-    return NULL;
+    return nullptr;
   }
   soap_revert(soap);
   *soap->id = '\0';
@@ -8640,13 +8692,13 @@ soap_in_ns1__luceneCommitResponse(struct soap *soap, const char *tag,
       return (ns1__luceneCommitResponse *)a->soap_in(soap, tag, type);
   }
   if (!soap_inliteral(soap, tag, &(a->xsd__anyType::__item)))
-    return NULL;
+    return nullptr;
   return a;
 }
 
 int ns1__luceneCommitResponse::soap_put(struct soap *soap, const char *tag,
                                         const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__luceneCommitResponse);
   if (this->soap_out(soap, tag ? tag : "ns1:luceneCommitResponse", id, type))
     return soap->error;
@@ -8664,7 +8716,7 @@ soap_get_ns1__luceneCommitResponse(struct soap *soap,
                                    const char *tag, const char *type) {
   if ((p = soap_in_ns1__luceneCommitResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -8679,10 +8731,11 @@ soap_instantiate_ns1__luceneCommitResponse(struct soap *soap, int n,
          SOAP_MESSAGE(
              fdebug, "soap_instantiate_ns1__luceneCommitResponse(%d, %s, %s)\n",
              n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__luceneCommitResponse, n, ICat4_fdelete);
+  struct soap_clist *cp =
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__luceneCommitResponse, n,
+                ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__luceneCommitResponse);
     if (size)
@@ -8719,7 +8772,7 @@ soap_copy_ns1__luceneCommitResponse(struct soap *soap, int st, int tt, void *p,
 void ns1__luceneCommit::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__luceneCommit::sessionId = NULL;
+  this->ns1__luceneCommit::sessionId = nullptr;
 }
 
 void ns1__luceneCommit::soap_serialize(struct soap *soap) const {
@@ -8760,13 +8813,13 @@ SOAP_FMAC3 ns1__luceneCommit *SOAP_FMAC4
 soap_in_ns1__luceneCommit(struct soap *soap, const char *tag,
                           ns1__luceneCommit *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__luceneCommit *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__luceneCommit,
       sizeof(ns1__luceneCommit), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__luceneCommit) {
@@ -8800,23 +8853,23 @@ soap_in_ns1__luceneCommit(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__luceneCommit *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__luceneCommit, 0,
         sizeof(ns1__luceneCommit), 0, soap_copy_ns1__luceneCommit);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__luceneCommit::soap_put(struct soap *soap, const char *tag,
                                 const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__luceneCommit);
   if (this->soap_out(soap, tag ? tag : "ns1:luceneCommit", id, type))
     return soap->error;
@@ -8833,7 +8886,7 @@ soap_get_ns1__luceneCommit(struct soap *soap, ns1__luceneCommit *p,
                            const char *tag, const char *type) {
   if ((p = soap_in_ns1__luceneCommit(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -8846,9 +8899,9 @@ soap_instantiate_ns1__luceneCommit(struct soap *soap, int n, const char *type,
                             "soap_instantiate_ns1__luceneCommit(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__luceneCommit, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__luceneCommit, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__luceneCommit);
     if (size)
@@ -8884,12 +8937,12 @@ soap_copy_ns1__luceneCommit(struct soap *soap, int st, int tt, void *p,
 void ns1__entityField::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__entityField::comment = NULL;
-  this->ns1__entityField::name = NULL;
+  this->ns1__entityField::comment = nullptr;
+  this->ns1__entityField::name = nullptr;
   soap_default_bool(soap, &this->ns1__entityField::notNullable);
-  this->ns1__entityField::relType = NULL;
-  this->ns1__entityField::stringLength = NULL;
-  this->ns1__entityField::type = NULL;
+  this->ns1__entityField::relType = nullptr;
+  this->ns1__entityField::stringLength = nullptr;
+  this->ns1__entityField::type = nullptr;
 }
 
 void ns1__entityField::soap_serialize(struct soap *soap) const {
@@ -8948,13 +9001,13 @@ SOAP_FMAC3 ns1__entityField *SOAP_FMAC4
 soap_in_ns1__entityField(struct soap *soap, const char *tag,
                          ns1__entityField *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__entityField *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__entityField,
       sizeof(ns1__entityField), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__entityField) {
@@ -9027,27 +9080,27 @@ soap_in_ns1__entityField(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__entityField *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__entityField, 0,
         sizeof(ns1__entityField), 0, soap_copy_ns1__entityField);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   if ((soap->mode & SOAP_XML_STRICT) && (soap_flag_notNullable1 > 0)) {
     soap->error = SOAP_OCCURS;
-    return NULL;
+    return nullptr;
   }
   return a;
 }
 
 int ns1__entityField::soap_put(struct soap *soap, const char *tag,
                                const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__entityField);
   if (this->soap_out(soap, tag ? tag : "ns1:entityField", id, type))
     return soap->error;
@@ -9064,7 +9117,7 @@ soap_get_ns1__entityField(struct soap *soap, ns1__entityField *p,
                           const char *tag, const char *type) {
   if ((p = soap_in_ns1__entityField(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -9076,10 +9129,10 @@ soap_instantiate_ns1__entityField(struct soap *soap, int n, const char *type,
   DBGLOG(TEST,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__entityField(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__entityField, n, ICat4_fdelete);
+  struct soap_clist *cp = soap_link(
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__entityField, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__entityField);
     if (size)
@@ -9157,13 +9210,13 @@ SOAP_FMAC3 ns1__constraint *SOAP_FMAC4
 soap_in_ns1__constraint(struct soap *soap, const char *tag, ns1__constraint *a,
                         const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__constraint *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__constraint,
       sizeof(ns1__constraint), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__constraint) {
@@ -9193,23 +9246,23 @@ soap_in_ns1__constraint(struct soap *soap, const char *tag, ns1__constraint *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__constraint *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__constraint, 0,
         sizeof(ns1__constraint), 0, soap_copy_ns1__constraint);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__constraint::soap_put(struct soap *soap, const char *tag,
                               const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__constraint);
   if (this->soap_out(soap, tag ? tag : "ns1:constraint", id, type))
     return soap->error;
@@ -9226,7 +9279,7 @@ soap_get_ns1__constraint(struct soap *soap, ns1__constraint *p, const char *tag,
                          const char *type) {
   if ((p = soap_in_ns1__constraint(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -9238,10 +9291,10 @@ soap_instantiate_ns1__constraint(struct soap *soap, int n, const char *type,
   DBGLOG(TEST,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__constraint(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__constraint, n, ICat4_fdelete);
+  struct soap_clist *cp = soap_link(
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__constraint, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__constraint);
     if (size)
@@ -9277,7 +9330,7 @@ soap_copy_ns1__constraint(struct soap *soap, int st, int tt, void *p,
 void ns1__entityInfo::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__entityInfo::classComment = NULL;
+  this->ns1__entityInfo::classComment = nullptr;
   soap_default_std__vectorTemplateOfPointerTons1__constraint(
       soap, &this->ns1__entityInfo::constraints);
   soap_default_std__vectorTemplateOfPointerTons1__entityField(
@@ -9332,13 +9385,13 @@ SOAP_FMAC3 ns1__entityInfo *SOAP_FMAC4
 soap_in_ns1__entityInfo(struct soap *soap, const char *tag, ns1__entityInfo *a,
                         const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__entityInfo *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__entityInfo,
       sizeof(ns1__entityInfo), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__entityInfo) {
@@ -9382,23 +9435,23 @@ soap_in_ns1__entityInfo(struct soap *soap, const char *tag, ns1__entityInfo *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__entityInfo *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__entityInfo, 0,
         sizeof(ns1__entityInfo), 0, soap_copy_ns1__entityInfo);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__entityInfo::soap_put(struct soap *soap, const char *tag,
                               const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__entityInfo);
   if (this->soap_out(soap, tag ? tag : "ns1:entityInfo", id, type))
     return soap->error;
@@ -9415,7 +9468,7 @@ soap_get_ns1__entityInfo(struct soap *soap, ns1__entityInfo *p, const char *tag,
                          const char *type) {
   if ((p = soap_in_ns1__entityInfo(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -9427,10 +9480,10 @@ soap_instantiate_ns1__entityInfo(struct soap *soap, int n, const char *type,
   DBGLOG(TEST,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__entityInfo(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__entityInfo, n, ICat4_fdelete);
+  struct soap_clist *cp = soap_link(
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__entityInfo, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__entityInfo);
     if (size)
@@ -9466,7 +9519,7 @@ soap_copy_ns1__entityInfo(struct soap *soap, int st, int tt, void *p,
 void ns1__getEntityInfoResponse::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__getEntityInfoResponse::return_ = NULL;
+  this->ns1__getEntityInfoResponse::return_ = nullptr;
 }
 
 void ns1__getEntityInfoResponse::soap_serialize(struct soap *soap) const {
@@ -9510,13 +9563,13 @@ soap_in_ns1__getEntityInfoResponse(struct soap *soap, const char *tag,
                                    ns1__getEntityInfoResponse *a,
                                    const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__getEntityInfoResponse *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__getEntityInfoResponse,
       sizeof(ns1__getEntityInfoResponse), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__getEntityInfoResponse) {
@@ -9549,10 +9602,10 @@ soap_in_ns1__getEntityInfoResponse(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__getEntityInfoResponse *)soap_id_forward(
         soap, soap->href, (void *)a, 0,
@@ -9560,14 +9613,14 @@ soap_in_ns1__getEntityInfoResponse(struct soap *soap, const char *tag,
         sizeof(ns1__getEntityInfoResponse), 0,
         soap_copy_ns1__getEntityInfoResponse);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__getEntityInfoResponse::soap_put(struct soap *soap, const char *tag,
                                          const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__getEntityInfoResponse);
   if (this->soap_out(soap, tag ? tag : "ns1:getEntityInfoResponse", id, type))
     return soap->error;
@@ -9585,7 +9638,7 @@ soap_get_ns1__getEntityInfoResponse(struct soap *soap,
                                     const char *tag, const char *type) {
   if ((p = soap_in_ns1__getEntityInfoResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -9600,10 +9653,11 @@ soap_instantiate_ns1__getEntityInfoResponse(struct soap *soap, int n,
                    fdebug,
                    "soap_instantiate_ns1__getEntityInfoResponse(%d, %s, %s)\n",
                    n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__getEntityInfoResponse, n, ICat4_fdelete);
+  struct soap_clist *cp =
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__getEntityInfoResponse, n,
+                ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__getEntityInfoResponse);
     if (size)
@@ -9640,7 +9694,7 @@ soap_copy_ns1__getEntityInfoResponse(struct soap *soap, int st, int tt, void *p,
 void ns1__getEntityInfo::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__getEntityInfo::beanName = NULL;
+  this->ns1__getEntityInfo::beanName = nullptr;
 }
 
 void ns1__getEntityInfo::soap_serialize(struct soap *soap) const {
@@ -9681,13 +9735,13 @@ SOAP_FMAC3 ns1__getEntityInfo *SOAP_FMAC4
 soap_in_ns1__getEntityInfo(struct soap *soap, const char *tag,
                            ns1__getEntityInfo *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__getEntityInfo *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__getEntityInfo,
       sizeof(ns1__getEntityInfo), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__getEntityInfo) {
@@ -9721,23 +9775,23 @@ soap_in_ns1__getEntityInfo(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__getEntityInfo *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__getEntityInfo, 0,
         sizeof(ns1__getEntityInfo), 0, soap_copy_ns1__getEntityInfo);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__getEntityInfo::soap_put(struct soap *soap, const char *tag,
                                  const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__getEntityInfo);
   if (this->soap_out(soap, tag ? tag : "ns1:getEntityInfo", id, type))
     return soap->error;
@@ -9754,7 +9808,7 @@ soap_get_ns1__getEntityInfo(struct soap *soap, ns1__getEntityInfo *p,
                             const char *tag, const char *type) {
   if ((p = soap_in_ns1__getEntityInfo(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -9767,9 +9821,9 @@ soap_instantiate_ns1__getEntityInfo(struct soap *soap, int n, const char *type,
                             "soap_instantiate_ns1__getEntityInfo(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__getEntityInfo, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__getEntityInfo, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__getEntityInfo);
     if (size)
@@ -9835,13 +9889,13 @@ SOAP_FMAC3 ns1__dummyResponse *SOAP_FMAC4
 soap_in_ns1__dummyResponse(struct soap *soap, const char *tag,
                            ns1__dummyResponse *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!(a = (ns1__dummyResponse *)soap_class_id_enter(
             soap, soap->id, a, SOAP_TYPE_ICat4_ns1__dummyResponse,
             sizeof(ns1__dummyResponse), soap->type, soap->arrayType))) {
     soap->error = SOAP_TAG_MISMATCH;
-    return NULL;
+    return nullptr;
   }
   soap_revert(soap);
   *soap->id = '\0';
@@ -9851,13 +9905,13 @@ soap_in_ns1__dummyResponse(struct soap *soap, const char *tag,
       return (ns1__dummyResponse *)a->soap_in(soap, tag, type);
   }
   if (!soap_inliteral(soap, tag, &(a->xsd__anyType::__item)))
-    return NULL;
+    return nullptr;
   return a;
 }
 
 int ns1__dummyResponse::soap_put(struct soap *soap, const char *tag,
                                  const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__dummyResponse);
   if (this->soap_out(soap, tag ? tag : "ns1:dummyResponse", id, type))
     return soap->error;
@@ -9874,7 +9928,7 @@ soap_get_ns1__dummyResponse(struct soap *soap, ns1__dummyResponse *p,
                             const char *tag, const char *type) {
   if ((p = soap_in_ns1__dummyResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -9887,9 +9941,9 @@ soap_instantiate_ns1__dummyResponse(struct soap *soap, int n, const char *type,
                             "soap_instantiate_ns1__dummyResponse(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__dummyResponse, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__dummyResponse, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__dummyResponse);
     if (size)
@@ -9926,8 +9980,8 @@ void ns1__publicStep::soap_default(struct soap *soap) {
   this->soap = soap;
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__publicStep::field = NULL;
-  this->ns1__publicStep::origin = NULL;
+  this->ns1__publicStep::field = nullptr;
+  this->ns1__publicStep::origin = nullptr;
 }
 
 void ns1__publicStep::soap_serialize(struct soap *soap) const {
@@ -9987,13 +10041,13 @@ SOAP_FMAC3 ns1__publicStep *SOAP_FMAC4
 soap_in_ns1__publicStep(struct soap *soap, const char *tag, ns1__publicStep *a,
                         const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__publicStep *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__publicStep,
       sizeof(ns1__publicStep), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__publicStep) {
@@ -10075,23 +10129,23 @@ soap_in_ns1__publicStep(struct soap *soap, const char *tag, ns1__publicStep *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__publicStep *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__publicStep, 0,
         sizeof(ns1__publicStep), 0, soap_copy_ns1__publicStep);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__publicStep::soap_put(struct soap *soap, const char *tag,
                               const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__publicStep);
   if (this->soap_out(soap, tag ? tag : "ns1:publicStep", id, type))
     return soap->error;
@@ -10108,7 +10162,7 @@ soap_get_ns1__publicStep(struct soap *soap, ns1__publicStep *p, const char *tag,
                          const char *type) {
   if ((p = soap_in_ns1__publicStep(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -10120,10 +10174,10 @@ soap_instantiate_ns1__publicStep(struct soap *soap, int n, const char *type,
   DBGLOG(TEST,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__publicStep(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__publicStep, n, ICat4_fdelete);
+  struct soap_clist *cp = soap_link(
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__publicStep, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__publicStep);
     if (size)
@@ -10161,10 +10215,10 @@ void ns1__log::soap_default(struct soap *soap) {
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
   soap_default_LONG64(soap, &this->ns1__log::duration);
-  this->ns1__log::entityId = NULL;
-  this->ns1__log::entityName = NULL;
-  this->ns1__log::operation = NULL;
-  this->ns1__log::query = NULL;
+  this->ns1__log::entityId = nullptr;
+  this->ns1__log::entityName = nullptr;
+  this->ns1__log::operation = nullptr;
+  this->ns1__log::query = nullptr;
 }
 
 void ns1__log::soap_serialize(struct soap *soap) const {
@@ -10233,13 +10287,13 @@ SOAP_FMAC3 ns1__log *SOAP_FMAC4 soap_in_ns1__log(struct soap *soap,
                                                  const char *tag, ns1__log *a,
                                                  const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__log *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__log, sizeof(ns1__log), soap->type,
       soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__log) {
@@ -10343,20 +10397,20 @@ SOAP_FMAC3 ns1__log *SOAP_FMAC4 soap_in_ns1__log(struct soap *soap,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__log *)soap_id_forward(soap, soap->href, (void *)a, 0,
                                     SOAP_TYPE_ICat4_ns1__log, 0,
                                     sizeof(ns1__log), 0, soap_copy_ns1__log);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   if ((soap->mode & SOAP_XML_STRICT) && (soap_flag_duration1 > 0)) {
     soap->error = SOAP_OCCURS;
-    return NULL;
+    return nullptr;
   }
   return a;
 }
@@ -10364,7 +10418,7 @@ SOAP_FMAC3 ns1__log *SOAP_FMAC4 soap_in_ns1__log(struct soap *soap,
 int ns1__log::soap_put(struct soap *soap, const char *tag,
                        const char *type) const {
   int id =
-      soap_embed(soap, (void *)this, NULL, 0, tag, SOAP_TYPE_ICat4_ns1__log);
+      soap_embed(soap, (void *)this, nullptr, 0, tag, SOAP_TYPE_ICat4_ns1__log);
   if (this->soap_out(soap, tag ? tag : "ns1:log", id, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -10379,7 +10433,7 @@ SOAP_FMAC3 ns1__log *SOAP_FMAC4 soap_get_ns1__log(struct soap *soap,
                                                   const char *type) {
   if ((p = soap_in_ns1__log(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -10391,9 +10445,9 @@ soap_instantiate_ns1__log(struct soap *soap, int n, const char *type,
   DBGLOG(TEST, SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__log(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__log, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__log, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__log);
     if (size)
@@ -10429,9 +10483,9 @@ void ns1__relatedDatafile::soap_default(struct soap *soap) {
   this->soap = soap;
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__relatedDatafile::destDatafile = NULL;
-  this->ns1__relatedDatafile::relation = NULL;
-  this->ns1__relatedDatafile::sourceDatafile = NULL;
+  this->ns1__relatedDatafile::destDatafile = nullptr;
+  this->ns1__relatedDatafile::relation = nullptr;
+  this->ns1__relatedDatafile::sourceDatafile = nullptr;
 }
 
 void ns1__relatedDatafile::soap_serialize(struct soap *soap) const {
@@ -10500,13 +10554,13 @@ SOAP_FMAC3 ns1__relatedDatafile *SOAP_FMAC4
 soap_in_ns1__relatedDatafile(struct soap *soap, const char *tag,
                              ns1__relatedDatafile *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__relatedDatafile *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__relatedDatafile,
       sizeof(ns1__relatedDatafile), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__relatedDatafile) {
@@ -10597,23 +10651,23 @@ soap_in_ns1__relatedDatafile(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__relatedDatafile *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__relatedDatafile, 0,
         sizeof(ns1__relatedDatafile), 0, soap_copy_ns1__relatedDatafile);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__relatedDatafile::soap_put(struct soap *soap, const char *tag,
                                    const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__relatedDatafile);
   if (this->soap_out(soap, tag ? tag : "ns1:relatedDatafile", id, type))
     return soap->error;
@@ -10630,7 +10684,7 @@ soap_get_ns1__relatedDatafile(struct soap *soap, ns1__relatedDatafile *p,
                               const char *tag, const char *type) {
   if ((p = soap_in_ns1__relatedDatafile(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -10645,9 +10699,9 @@ soap_instantiate_ns1__relatedDatafile(struct soap *soap, int n,
                       "soap_instantiate_ns1__relatedDatafile(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__relatedDatafile, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__relatedDatafile, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__relatedDatafile);
     if (size)
@@ -10684,10 +10738,10 @@ void ns1__shift::soap_default(struct soap *soap) {
   this->soap = soap;
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__shift::comment = NULL;
-  this->ns1__shift::endDate = NULL;
-  this->ns1__shift::investigation = NULL;
-  this->ns1__shift::startDate = NULL;
+  this->ns1__shift::comment = nullptr;
+  this->ns1__shift::endDate = nullptr;
+  this->ns1__shift::investigation = nullptr;
+  this->ns1__shift::startDate = nullptr;
 }
 
 void ns1__shift::soap_serialize(struct soap *soap) const {
@@ -10755,13 +10809,13 @@ SOAP_FMAC3 ns1__shift *SOAP_FMAC4
 soap_in_ns1__shift(struct soap *soap, const char *tag, ns1__shift *a,
                    const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__shift *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__shift, sizeof(ns1__shift),
       soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__shift) {
@@ -10858,24 +10912,24 @@ soap_in_ns1__shift(struct soap *soap, const char *tag, ns1__shift *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__shift *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__shift, 0,
         sizeof(ns1__shift), 0, soap_copy_ns1__shift);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__shift::soap_put(struct soap *soap, const char *tag,
                          const char *type) const {
-  int id =
-      soap_embed(soap, (void *)this, NULL, 0, tag, SOAP_TYPE_ICat4_ns1__shift);
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
+                      SOAP_TYPE_ICat4_ns1__shift);
   if (this->soap_out(soap, tag ? tag : "ns1:shift", id, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -10891,7 +10945,7 @@ soap_get_ns1__shift(struct soap *soap, ns1__shift *p, const char *tag,
                     const char *type) {
   if ((p = soap_in_ns1__shift(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -10903,9 +10957,9 @@ soap_instantiate_ns1__shift(struct soap *soap, int n, const char *type,
   DBGLOG(TEST, SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__shift(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__shift, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__shift, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__shift);
     if (size)
@@ -10941,12 +10995,12 @@ void ns1__publication::soap_default(struct soap *soap) {
   this->soap = soap;
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__publication::doi = NULL;
-  this->ns1__publication::fullReference = NULL;
-  this->ns1__publication::investigation = NULL;
-  this->ns1__publication::repository = NULL;
-  this->ns1__publication::repositoryId = NULL;
-  this->ns1__publication::url = NULL;
+  this->ns1__publication::doi = nullptr;
+  this->ns1__publication::fullReference = nullptr;
+  this->ns1__publication::investigation = nullptr;
+  this->ns1__publication::repository = nullptr;
+  this->ns1__publication::repositoryId = nullptr;
+  this->ns1__publication::url = nullptr;
 }
 
 void ns1__publication::soap_serialize(struct soap *soap) const {
@@ -11026,13 +11080,13 @@ SOAP_FMAC3 ns1__publication *SOAP_FMAC4
 soap_in_ns1__publication(struct soap *soap, const char *tag,
                          ns1__publication *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__publication *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__publication,
       sizeof(ns1__publication), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__publication) {
@@ -11149,23 +11203,23 @@ soap_in_ns1__publication(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__publication *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__publication, 0,
         sizeof(ns1__publication), 0, soap_copy_ns1__publication);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__publication::soap_put(struct soap *soap, const char *tag,
                                const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__publication);
   if (this->soap_out(soap, tag ? tag : "ns1:publication", id, type))
     return soap->error;
@@ -11182,7 +11236,7 @@ soap_get_ns1__publication(struct soap *soap, ns1__publication *p,
                           const char *tag, const char *type) {
   if ((p = soap_in_ns1__publication(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -11194,10 +11248,10 @@ soap_instantiate_ns1__publication(struct soap *soap, int n, const char *type,
   DBGLOG(TEST,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__publication(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__publication, n, ICat4_fdelete);
+  struct soap_clist *cp = soap_link(
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__publication, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__publication);
     if (size)
@@ -11234,8 +11288,8 @@ void ns1__keyword::soap_default(struct soap *soap) {
   this->soap = soap;
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__keyword::investigation = NULL;
-  this->ns1__keyword::name = NULL;
+  this->ns1__keyword::investigation = nullptr;
+  this->ns1__keyword::name = nullptr;
 }
 
 void ns1__keyword::soap_serialize(struct soap *soap) const {
@@ -11296,13 +11350,13 @@ SOAP_FMAC3 ns1__keyword *SOAP_FMAC4
 soap_in_ns1__keyword(struct soap *soap, const char *tag, ns1__keyword *a,
                      const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__keyword *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__keyword, sizeof(ns1__keyword),
       soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__keyword) {
@@ -11384,23 +11438,23 @@ soap_in_ns1__keyword(struct soap *soap, const char *tag, ns1__keyword *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__keyword *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__keyword, 0,
         sizeof(ns1__keyword), 0, soap_copy_ns1__keyword);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__keyword::soap_put(struct soap *soap, const char *tag,
                            const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__keyword);
   if (this->soap_out(soap, tag ? tag : "ns1:keyword", id, type))
     return soap->error;
@@ -11417,7 +11471,7 @@ soap_get_ns1__keyword(struct soap *soap, ns1__keyword *p, const char *tag,
                       const char *type) {
   if ((p = soap_in_ns1__keyword(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -11430,9 +11484,9 @@ soap_instantiate_ns1__keyword(struct soap *soap, int n, const char *type,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__keyword(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__keyword, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__keyword, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__keyword);
     if (size)
@@ -11468,10 +11522,10 @@ void ns1__sampleType::soap_default(struct soap *soap) {
   this->soap = soap;
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__sampleType::facility = NULL;
-  this->ns1__sampleType::molecularFormula = NULL;
-  this->ns1__sampleType::name = NULL;
-  this->ns1__sampleType::safetyInformation = NULL;
+  this->ns1__sampleType::facility = nullptr;
+  this->ns1__sampleType::molecularFormula = nullptr;
+  this->ns1__sampleType::name = nullptr;
+  this->ns1__sampleType::safetyInformation = nullptr;
   soap_default_std__vectorTemplateOfPointerTons1__sample(
       soap, &this->ns1__sampleType::samples);
 }
@@ -11550,13 +11604,13 @@ SOAP_FMAC3 ns1__sampleType *SOAP_FMAC4
 soap_in_ns1__sampleType(struct soap *soap, const char *tag, ns1__sampleType *a,
                         const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__sampleType *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__sampleType,
       sizeof(ns1__sampleType), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__sampleType) {
@@ -11660,23 +11714,23 @@ soap_in_ns1__sampleType(struct soap *soap, const char *tag, ns1__sampleType *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__sampleType *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__sampleType, 0,
         sizeof(ns1__sampleType), 0, soap_copy_ns1__sampleType);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__sampleType::soap_put(struct soap *soap, const char *tag,
                               const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__sampleType);
   if (this->soap_out(soap, tag ? tag : "ns1:sampleType", id, type))
     return soap->error;
@@ -11693,7 +11747,7 @@ soap_get_ns1__sampleType(struct soap *soap, ns1__sampleType *p, const char *tag,
                          const char *type) {
   if ((p = soap_in_ns1__sampleType(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -11705,10 +11759,10 @@ soap_instantiate_ns1__sampleType(struct soap *soap, int n, const char *type,
   DBGLOG(TEST,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__sampleType(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__sampleType, n, ICat4_fdelete);
+  struct soap_clist *cp = soap_link(
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__sampleType, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__sampleType);
     if (size)
@@ -11747,11 +11801,11 @@ void ns1__sample::soap_default(struct soap *soap) {
   this->xsd__anyType::soap_default(soap);
   soap_default_std__vectorTemplateOfPointerTons1__dataset(
       soap, &this->ns1__sample::datasets);
-  this->ns1__sample::investigation = NULL;
-  this->ns1__sample::name = NULL;
+  this->ns1__sample::investigation = nullptr;
+  this->ns1__sample::name = nullptr;
   soap_default_std__vectorTemplateOfPointerTons1__sampleParameter(
       soap, &this->ns1__sample::parameters);
-  this->ns1__sample::type = NULL;
+  this->ns1__sample::type = nullptr;
 }
 
 void ns1__sample::soap_serialize(struct soap *soap) const {
@@ -11825,13 +11879,13 @@ SOAP_FMAC3 ns1__sample *SOAP_FMAC4
 soap_in_ns1__sample(struct soap *soap, const char *tag, ns1__sample *a,
                     const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__sample *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__sample, sizeof(ns1__sample),
       soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__sample) {
@@ -11929,24 +11983,24 @@ soap_in_ns1__sample(struct soap *soap, const char *tag, ns1__sample *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__sample *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__sample, 0,
         sizeof(ns1__sample), 0, soap_copy_ns1__sample);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__sample::soap_put(struct soap *soap, const char *tag,
                           const char *type) const {
-  int id =
-      soap_embed(soap, (void *)this, NULL, 0, tag, SOAP_TYPE_ICat4_ns1__sample);
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
+                      SOAP_TYPE_ICat4_ns1__sample);
   if (this->soap_out(soap, tag ? tag : "ns1:sample", id, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -11962,7 +12016,7 @@ soap_get_ns1__sample(struct soap *soap, ns1__sample *p, const char *tag,
                      const char *type) {
   if ((p = soap_in_ns1__sample(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -11975,9 +12029,9 @@ soap_instantiate_ns1__sample(struct soap *soap, int n, const char *type,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__sample(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__sample, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__sample, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__sample);
     if (size)
@@ -12014,7 +12068,7 @@ void ns1__sampleParameter::soap_default(struct soap *soap) {
   this->ns1__parameter::soap_default(soap);
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__sampleParameter::sample = NULL;
+  this->ns1__sampleParameter::sample = nullptr;
 }
 
 void ns1__sampleParameter::soap_serialize(struct soap *soap) const {
@@ -12093,13 +12147,13 @@ SOAP_FMAC3 ns1__sampleParameter *SOAP_FMAC4
 soap_in_ns1__sampleParameter(struct soap *soap, const char *tag,
                              ns1__sampleParameter *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__sampleParameter *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__sampleParameter,
       sizeof(ns1__sampleParameter), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__sampleParameter) {
@@ -12229,23 +12283,23 @@ soap_in_ns1__sampleParameter(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__sampleParameter *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__sampleParameter, 0,
         sizeof(ns1__sampleParameter), 0, soap_copy_ns1__sampleParameter);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__sampleParameter::soap_put(struct soap *soap, const char *tag,
                                    const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__sampleParameter);
   if (this->soap_out(soap, tag ? tag : "ns1:sampleParameter", id, type))
     return soap->error;
@@ -12262,7 +12316,7 @@ soap_get_ns1__sampleParameter(struct soap *soap, ns1__sampleParameter *p,
                               const char *tag, const char *type) {
   if ((p = soap_in_ns1__sampleParameter(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -12277,9 +12331,9 @@ soap_instantiate_ns1__sampleParameter(struct soap *soap, int n,
                       "soap_instantiate_ns1__sampleParameter(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__sampleParameter, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__sampleParameter, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__sampleParameter);
     if (size)
@@ -12316,8 +12370,8 @@ void ns1__permissibleStringValue::soap_default(struct soap *soap) {
   this->soap = soap;
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__permissibleStringValue::type = NULL;
-  this->ns1__permissibleStringValue::value = NULL;
+  this->ns1__permissibleStringValue::type = nullptr;
+  this->ns1__permissibleStringValue::value = nullptr;
 }
 
 void ns1__permissibleStringValue::soap_serialize(struct soap *soap) const {
@@ -12382,13 +12436,13 @@ soap_in_ns1__permissibleStringValue(struct soap *soap, const char *tag,
                                     ns1__permissibleStringValue *a,
                                     const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__permissibleStringValue *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__permissibleStringValue,
       sizeof(ns1__permissibleStringValue), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__permissibleStringValue) {
@@ -12471,10 +12525,10 @@ soap_in_ns1__permissibleStringValue(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__permissibleStringValue *)soap_id_forward(
         soap, soap->href, (void *)a, 0,
@@ -12482,14 +12536,14 @@ soap_in_ns1__permissibleStringValue(struct soap *soap, const char *tag,
         sizeof(ns1__permissibleStringValue), 0,
         soap_copy_ns1__permissibleStringValue);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__permissibleStringValue::soap_put(struct soap *soap, const char *tag,
                                           const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__permissibleStringValue);
   if (this->soap_out(soap, tag ? tag : "ns1:permissibleStringValue", id, type))
     return soap->error;
@@ -12507,7 +12561,7 @@ soap_get_ns1__permissibleStringValue(struct soap *soap,
                                      const char *tag, const char *type) {
   if ((p = soap_in_ns1__permissibleStringValue(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -12523,10 +12577,10 @@ soap_instantiate_ns1__permissibleStringValue(struct soap *soap, int n,
                    "soap_instantiate_ns1__permissibleStringValue(%d, %s, %s)\n",
                    n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__permissibleStringValue, n,
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__permissibleStringValue, n,
                 ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__permissibleStringValue);
     if (size)
@@ -12566,7 +12620,7 @@ void ns1__investigationParameter::soap_default(struct soap *soap) {
   this->ns1__parameter::soap_default(soap);
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__investigationParameter::investigation = NULL;
+  this->ns1__investigationParameter::investigation = nullptr;
 }
 
 void ns1__investigationParameter::soap_serialize(struct soap *soap) const {
@@ -12649,13 +12703,13 @@ soap_in_ns1__investigationParameter(struct soap *soap, const char *tag,
                                     ns1__investigationParameter *a,
                                     const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__investigationParameter *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__investigationParameter,
       sizeof(ns1__investigationParameter), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__investigationParameter) {
@@ -12786,10 +12840,10 @@ soap_in_ns1__investigationParameter(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__investigationParameter *)soap_id_forward(
         soap, soap->href, (void *)a, 0,
@@ -12797,14 +12851,14 @@ soap_in_ns1__investigationParameter(struct soap *soap, const char *tag,
         sizeof(ns1__investigationParameter), 0,
         soap_copy_ns1__investigationParameter);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__investigationParameter::soap_put(struct soap *soap, const char *tag,
                                           const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__investigationParameter);
   if (this->soap_out(soap, tag ? tag : "ns1:investigationParameter", id, type))
     return soap->error;
@@ -12822,7 +12876,7 @@ soap_get_ns1__investigationParameter(struct soap *soap,
                                      const char *tag, const char *type) {
   if ((p = soap_in_ns1__investigationParameter(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -12838,10 +12892,10 @@ soap_instantiate_ns1__investigationParameter(struct soap *soap, int n,
                    "soap_instantiate_ns1__investigationParameter(%d, %s, %s)\n",
                    n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__investigationParameter, n,
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__investigationParameter, n,
                 ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__investigationParameter);
     if (size)
@@ -12881,7 +12935,7 @@ void ns1__datasetParameter::soap_default(struct soap *soap) {
   this->ns1__parameter::soap_default(soap);
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__datasetParameter::dataset = NULL;
+  this->ns1__datasetParameter::dataset = nullptr;
 }
 
 void ns1__datasetParameter::soap_serialize(struct soap *soap) const {
@@ -12961,13 +13015,13 @@ SOAP_FMAC3 ns1__datasetParameter *SOAP_FMAC4
 soap_in_ns1__datasetParameter(struct soap *soap, const char *tag,
                               ns1__datasetParameter *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__datasetParameter *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__datasetParameter,
       sizeof(ns1__datasetParameter), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__datasetParameter) {
@@ -13097,23 +13151,23 @@ soap_in_ns1__datasetParameter(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__datasetParameter *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__datasetParameter,
         0, sizeof(ns1__datasetParameter), 0, soap_copy_ns1__datasetParameter);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__datasetParameter::soap_put(struct soap *soap, const char *tag,
                                     const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__datasetParameter);
   if (this->soap_out(soap, tag ? tag : "ns1:datasetParameter", id, type))
     return soap->error;
@@ -13130,7 +13184,7 @@ soap_get_ns1__datasetParameter(struct soap *soap, ns1__datasetParameter *p,
                                const char *tag, const char *type) {
   if ((p = soap_in_ns1__datasetParameter(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -13145,9 +13199,9 @@ soap_instantiate_ns1__datasetParameter(struct soap *soap, int n,
                       "soap_instantiate_ns1__datasetParameter(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__datasetParameter, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__datasetParameter, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__datasetParameter);
     if (size)
@@ -13185,7 +13239,7 @@ void ns1__datafileParameter::soap_default(struct soap *soap) {
   this->ns1__parameter::soap_default(soap);
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__datafileParameter::datafile = NULL;
+  this->ns1__datafileParameter::datafile = nullptr;
 }
 
 void ns1__datafileParameter::soap_serialize(struct soap *soap) const {
@@ -13265,13 +13319,13 @@ SOAP_FMAC3 ns1__datafileParameter *SOAP_FMAC4
 soap_in_ns1__datafileParameter(struct soap *soap, const char *tag,
                                ns1__datafileParameter *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__datafileParameter *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__datafileParameter,
       sizeof(ns1__datafileParameter), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__datafileParameter) {
@@ -13401,23 +13455,23 @@ soap_in_ns1__datafileParameter(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__datafileParameter *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__datafileParameter,
         0, sizeof(ns1__datafileParameter), 0, soap_copy_ns1__datafileParameter);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__datafileParameter::soap_put(struct soap *soap, const char *tag,
                                      const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__datafileParameter);
   if (this->soap_out(soap, tag ? tag : "ns1:datafileParameter", id, type))
     return soap->error;
@@ -13434,7 +13488,7 @@ soap_get_ns1__datafileParameter(struct soap *soap, ns1__datafileParameter *p,
                                 const char *tag, const char *type) {
   if ((p = soap_in_ns1__datafileParameter(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -13449,9 +13503,9 @@ soap_instantiate_ns1__datafileParameter(struct soap *soap, int n,
                       "soap_instantiate_ns1__datafileParameter(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__datafileParameter, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__datafileParameter, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__datafileParameter);
     if (size)
@@ -13488,13 +13542,13 @@ void ns1__parameter::soap_default(struct soap *soap) {
   this->soap = soap;
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__parameter::dateTimeValue = NULL;
-  this->ns1__parameter::error = NULL;
-  this->ns1__parameter::numericValue = NULL;
-  this->ns1__parameter::rangeBottom = NULL;
-  this->ns1__parameter::rangeTop = NULL;
-  this->ns1__parameter::stringValue = NULL;
-  this->ns1__parameter::type = NULL;
+  this->ns1__parameter::dateTimeValue = nullptr;
+  this->ns1__parameter::error = nullptr;
+  this->ns1__parameter::numericValue = nullptr;
+  this->ns1__parameter::rangeBottom = nullptr;
+  this->ns1__parameter::rangeTop = nullptr;
+  this->ns1__parameter::stringValue = nullptr;
+  this->ns1__parameter::type = nullptr;
 }
 
 void ns1__parameter::soap_serialize(struct soap *soap) const {
@@ -13574,13 +13628,13 @@ SOAP_FMAC3 ns1__parameter *SOAP_FMAC4
 soap_in_ns1__parameter(struct soap *soap, const char *tag, ns1__parameter *a,
                        const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__parameter *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__parameter, sizeof(ns1__parameter),
       soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__parameter) {
@@ -13702,23 +13756,23 @@ soap_in_ns1__parameter(struct soap *soap, const char *tag, ns1__parameter *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__parameter *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__parameter, 0,
         sizeof(ns1__parameter), 0, soap_copy_ns1__parameter);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__parameter::soap_put(struct soap *soap, const char *tag,
                              const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__parameter);
   if (this->soap_out(soap, tag ? tag : "ns1:parameter", id, type))
     return soap->error;
@@ -13735,7 +13789,7 @@ soap_get_ns1__parameter(struct soap *soap, ns1__parameter *p, const char *tag,
                         const char *type) {
   if ((p = soap_in_ns1__parameter(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -13747,10 +13801,10 @@ soap_instantiate_ns1__parameter(struct soap *soap, int n, const char *type,
   DBGLOG(TEST,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__parameter(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__parameter, n, ICat4_fdelete);
+  struct soap_clist *cp = soap_link(
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__parameter, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (type && !soap_match_tag(soap, type, "ns1:dataCollectionParameter")) {
     cp->type = SOAP_TYPE_ICat4_ns1__dataCollectionParameter;
     if (n < 0) {
@@ -13887,7 +13941,7 @@ void ns1__dataCollectionParameter::soap_default(struct soap *soap) {
   this->ns1__parameter::soap_default(soap);
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__dataCollectionParameter::dataCollection = NULL;
+  this->ns1__dataCollectionParameter::dataCollection = nullptr;
 }
 
 void ns1__dataCollectionParameter::soap_serialize(struct soap *soap) const {
@@ -13971,13 +14025,13 @@ soap_in_ns1__dataCollectionParameter(struct soap *soap, const char *tag,
                                      ns1__dataCollectionParameter *a,
                                      const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__dataCollectionParameter *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__dataCollectionParameter,
       sizeof(ns1__dataCollectionParameter), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__dataCollectionParameter) {
@@ -14108,10 +14162,10 @@ soap_in_ns1__dataCollectionParameter(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__dataCollectionParameter *)soap_id_forward(
         soap, soap->href, (void *)a, 0,
@@ -14119,14 +14173,14 @@ soap_in_ns1__dataCollectionParameter(struct soap *soap, const char *tag,
         sizeof(ns1__dataCollectionParameter), 0,
         soap_copy_ns1__dataCollectionParameter);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__dataCollectionParameter::soap_put(struct soap *soap, const char *tag,
                                            const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__dataCollectionParameter);
   if (this->soap_out(soap, tag ? tag : "ns1:dataCollectionParameter", id, type))
     return soap->error;
@@ -14144,7 +14198,7 @@ soap_get_ns1__dataCollectionParameter(struct soap *soap,
                                       const char *tag, const char *type) {
   if ((p = soap_in_ns1__dataCollectionParameter(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -14161,10 +14215,10 @@ soap_instantiate_ns1__dataCollectionParameter(struct soap *soap, int n,
              "soap_instantiate_ns1__dataCollectionParameter(%d, %s, %s)\n", n,
              type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__dataCollectionParameter, n,
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__dataCollectionParameter, n,
                 ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__dataCollectionParameter);
     if (size)
@@ -14215,21 +14269,21 @@ void ns1__parameterType::soap_default(struct soap *soap) {
       soap, &this->ns1__parameterType::datafileParameters);
   soap_default_std__vectorTemplateOfPointerTons1__datasetParameter(
       soap, &this->ns1__parameterType::datasetParameters);
-  this->ns1__parameterType::description = NULL;
+  this->ns1__parameterType::description = nullptr;
   soap_default_bool(soap, &this->ns1__parameterType::enforced);
-  this->ns1__parameterType::facility = NULL;
+  this->ns1__parameterType::facility = nullptr;
   soap_default_std__vectorTemplateOfPointerTons1__investigationParameter(
       soap, &this->ns1__parameterType::investigationParameters);
-  this->ns1__parameterType::maximumNumericValue = NULL;
-  this->ns1__parameterType::minimumNumericValue = NULL;
-  this->ns1__parameterType::name = NULL;
+  this->ns1__parameterType::maximumNumericValue = nullptr;
+  this->ns1__parameterType::minimumNumericValue = nullptr;
+  this->ns1__parameterType::name = nullptr;
   soap_default_std__vectorTemplateOfPointerTons1__permissibleStringValue(
       soap, &this->ns1__parameterType::permissibleStringValues);
   soap_default_std__vectorTemplateOfPointerTons1__sampleParameter(
       soap, &this->ns1__parameterType::sampleParameters);
-  this->ns1__parameterType::units = NULL;
-  this->ns1__parameterType::unitsFullName = NULL;
-  this->ns1__parameterType::valueType = NULL;
+  this->ns1__parameterType::units = nullptr;
+  this->ns1__parameterType::unitsFullName = nullptr;
+  this->ns1__parameterType::valueType = nullptr;
   soap_default_bool(soap, &this->ns1__parameterType::verified);
 }
 
@@ -14380,13 +14434,13 @@ SOAP_FMAC3 ns1__parameterType *SOAP_FMAC4
 soap_in_ns1__parameterType(struct soap *soap, const char *tag,
                            ns1__parameterType *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__parameterType *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__parameterType,
       sizeof(ns1__parameterType), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__parameterType) {
@@ -14610,16 +14664,16 @@ soap_in_ns1__parameterType(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__parameterType *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__parameterType, 0,
         sizeof(ns1__parameterType), 0, soap_copy_ns1__parameterType);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   if ((soap->mode & SOAP_XML_STRICT) &&
       (soap_flag_applicableToDataCollection1 > 0 ||
@@ -14629,14 +14683,14 @@ soap_in_ns1__parameterType(struct soap *soap, const char *tag,
        soap_flag_applicableToSample1 > 0 || soap_flag_enforced1 > 0 ||
        soap_flag_verified1 > 0)) {
     soap->error = SOAP_OCCURS;
-    return NULL;
+    return nullptr;
   }
   return a;
 }
 
 int ns1__parameterType::soap_put(struct soap *soap, const char *tag,
                                  const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__parameterType);
   if (this->soap_out(soap, tag ? tag : "ns1:parameterType", id, type))
     return soap->error;
@@ -14653,7 +14707,7 @@ soap_get_ns1__parameterType(struct soap *soap, ns1__parameterType *p,
                             const char *tag, const char *type) {
   if ((p = soap_in_ns1__parameterType(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -14666,9 +14720,9 @@ soap_instantiate_ns1__parameterType(struct soap *soap, int n, const char *type,
                             "soap_instantiate_ns1__parameterType(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__parameterType, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__parameterType, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__parameterType);
     if (size)
@@ -14705,11 +14759,11 @@ void ns1__investigationType::soap_default(struct soap *soap) {
   this->soap = soap;
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__investigationType::description = NULL;
-  this->ns1__investigationType::facility = NULL;
+  this->ns1__investigationType::description = nullptr;
+  this->ns1__investigationType::facility = nullptr;
   soap_default_std__vectorTemplateOfPointerTons1__investigation(
       soap, &this->ns1__investigationType::investigations);
-  this->ns1__investigationType::name = NULL;
+  this->ns1__investigationType::name = nullptr;
 }
 
 void ns1__investigationType::soap_serialize(struct soap *soap) const {
@@ -14784,13 +14838,13 @@ SOAP_FMAC3 ns1__investigationType *SOAP_FMAC4
 soap_in_ns1__investigationType(struct soap *soap, const char *tag,
                                ns1__investigationType *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__investigationType *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__investigationType,
       sizeof(ns1__investigationType), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__investigationType) {
@@ -14888,23 +14942,23 @@ soap_in_ns1__investigationType(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__investigationType *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__investigationType,
         0, sizeof(ns1__investigationType), 0, soap_copy_ns1__investigationType);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__investigationType::soap_put(struct soap *soap, const char *tag,
                                      const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__investigationType);
   if (this->soap_out(soap, tag ? tag : "ns1:investigationType", id, type))
     return soap->error;
@@ -14921,7 +14975,7 @@ soap_get_ns1__investigationType(struct soap *soap, ns1__investigationType *p,
                                 const char *tag, const char *type) {
   if ((p = soap_in_ns1__investigationType(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -14936,9 +14990,9 @@ soap_instantiate_ns1__investigationType(struct soap *soap, int n,
                       "soap_instantiate_ns1__investigationType(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__investigationType, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__investigationType, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__investigationType);
     if (size)
@@ -14975,8 +15029,8 @@ void ns1__investigationInstrument::soap_default(struct soap *soap) {
   this->soap = soap;
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__investigationInstrument::instrument = NULL;
-  this->ns1__investigationInstrument::investigation = NULL;
+  this->ns1__investigationInstrument::instrument = nullptr;
+  this->ns1__investigationInstrument::investigation = nullptr;
 }
 
 void ns1__investigationInstrument::soap_serialize(struct soap *soap) const {
@@ -15044,13 +15098,13 @@ soap_in_ns1__investigationInstrument(struct soap *soap, const char *tag,
                                      ns1__investigationInstrument *a,
                                      const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__investigationInstrument *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__investigationInstrument,
       sizeof(ns1__investigationInstrument), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__investigationInstrument) {
@@ -15134,10 +15188,10 @@ soap_in_ns1__investigationInstrument(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__investigationInstrument *)soap_id_forward(
         soap, soap->href, (void *)a, 0,
@@ -15145,14 +15199,14 @@ soap_in_ns1__investigationInstrument(struct soap *soap, const char *tag,
         sizeof(ns1__investigationInstrument), 0,
         soap_copy_ns1__investigationInstrument);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__investigationInstrument::soap_put(struct soap *soap, const char *tag,
                                            const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__investigationInstrument);
   if (this->soap_out(soap, tag ? tag : "ns1:investigationInstrument", id, type))
     return soap->error;
@@ -15170,7 +15224,7 @@ soap_get_ns1__investigationInstrument(struct soap *soap,
                                       const char *tag, const char *type) {
   if ((p = soap_in_ns1__investigationInstrument(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -15187,10 +15241,10 @@ soap_instantiate_ns1__investigationInstrument(struct soap *soap, int n,
              "soap_instantiate_ns1__investigationInstrument(%d, %s, %s)\n", n,
              type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__investigationInstrument, n,
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__investigationInstrument, n,
                 ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__investigationInstrument);
     if (size)
@@ -15229,9 +15283,9 @@ void ns1__rule::soap_default(struct soap *soap) {
   this->soap = soap;
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__rule::crudFlags = NULL;
-  this->ns1__rule::grouping = NULL;
-  this->ns1__rule::what = NULL;
+  this->ns1__rule::crudFlags = nullptr;
+  this->ns1__rule::grouping = nullptr;
+  this->ns1__rule::what = nullptr;
 }
 
 void ns1__rule::soap_serialize(struct soap *soap) const {
@@ -15293,13 +15347,13 @@ SOAP_FMAC3 ns1__rule *SOAP_FMAC4
 soap_in_ns1__rule(struct soap *soap, const char *tag, ns1__rule *a,
                   const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__rule *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__rule, sizeof(ns1__rule),
       soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__rule) {
@@ -15388,24 +15442,24 @@ soap_in_ns1__rule(struct soap *soap, const char *tag, ns1__rule *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__rule *)soap_id_forward(soap, soap->href, (void *)a, 0,
                                      SOAP_TYPE_ICat4_ns1__rule, 0,
                                      sizeof(ns1__rule), 0, soap_copy_ns1__rule);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__rule::soap_put(struct soap *soap, const char *tag,
                         const char *type) const {
-  int id =
-      soap_embed(soap, (void *)this, NULL, 0, tag, SOAP_TYPE_ICat4_ns1__rule);
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
+                      SOAP_TYPE_ICat4_ns1__rule);
   if (this->soap_out(soap, tag ? tag : "ns1:rule", id, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -15421,7 +15475,7 @@ soap_get_ns1__rule(struct soap *soap, ns1__rule *p, const char *tag,
                    const char *type) {
   if ((p = soap_in_ns1__rule(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -15433,9 +15487,9 @@ soap_instantiate_ns1__rule(struct soap *soap, int n, const char *type,
   DBGLOG(TEST, SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__rule(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__rule, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__rule, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__rule);
     if (size)
@@ -15471,7 +15525,7 @@ void ns1__grouping::soap_default(struct soap *soap) {
   this->soap = soap;
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__grouping::name = NULL;
+  this->ns1__grouping::name = nullptr;
   soap_default_std__vectorTemplateOfPointerTons1__rule(
       soap, &this->ns1__grouping::rules);
   soap_default_std__vectorTemplateOfPointerTons1__userGroup(
@@ -15541,13 +15595,13 @@ SOAP_FMAC3 ns1__grouping *SOAP_FMAC4
 soap_in_ns1__grouping(struct soap *soap, const char *tag, ns1__grouping *a,
                       const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__grouping *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__grouping, sizeof(ns1__grouping),
       soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__grouping) {
@@ -15630,23 +15684,23 @@ soap_in_ns1__grouping(struct soap *soap, const char *tag, ns1__grouping *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__grouping *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__grouping, 0,
         sizeof(ns1__grouping), 0, soap_copy_ns1__grouping);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__grouping::soap_put(struct soap *soap, const char *tag,
                             const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__grouping);
   if (this->soap_out(soap, tag ? tag : "ns1:grouping", id, type))
     return soap->error;
@@ -15663,7 +15717,7 @@ soap_get_ns1__grouping(struct soap *soap, ns1__grouping *p, const char *tag,
                        const char *type) {
   if ((p = soap_in_ns1__grouping(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -15676,9 +15730,9 @@ soap_instantiate_ns1__grouping(struct soap *soap, int n, const char *type,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__grouping(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__grouping, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__grouping, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__grouping);
     if (size)
@@ -15714,8 +15768,8 @@ void ns1__userGroup::soap_default(struct soap *soap) {
   this->soap = soap;
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__userGroup::grouping = NULL;
-  this->ns1__userGroup::user = NULL;
+  this->ns1__userGroup::grouping = nullptr;
+  this->ns1__userGroup::user = nullptr;
 }
 
 void ns1__userGroup::soap_serialize(struct soap *soap) const {
@@ -15775,13 +15829,13 @@ SOAP_FMAC3 ns1__userGroup *SOAP_FMAC4
 soap_in_ns1__userGroup(struct soap *soap, const char *tag, ns1__userGroup *a,
                        const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__userGroup *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__userGroup, sizeof(ns1__userGroup),
       soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__userGroup) {
@@ -15862,23 +15916,23 @@ soap_in_ns1__userGroup(struct soap *soap, const char *tag, ns1__userGroup *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__userGroup *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__userGroup, 0,
         sizeof(ns1__userGroup), 0, soap_copy_ns1__userGroup);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__userGroup::soap_put(struct soap *soap, const char *tag,
                              const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__userGroup);
   if (this->soap_out(soap, tag ? tag : "ns1:userGroup", id, type))
     return soap->error;
@@ -15895,7 +15949,7 @@ soap_get_ns1__userGroup(struct soap *soap, ns1__userGroup *p, const char *tag,
                         const char *type) {
   if ((p = soap_in_ns1__userGroup(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -15907,10 +15961,10 @@ soap_instantiate_ns1__userGroup(struct soap *soap, int n, const char *type,
   DBGLOG(TEST,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__userGroup(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__userGroup, n, ICat4_fdelete);
+  struct soap_clist *cp = soap_link(
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__userGroup, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__userGroup);
     if (size)
@@ -15946,8 +16000,8 @@ void ns1__studyInvestigation::soap_default(struct soap *soap) {
   this->soap = soap;
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__studyInvestigation::investigation = NULL;
-  this->ns1__studyInvestigation::study = NULL;
+  this->ns1__studyInvestigation::investigation = nullptr;
+  this->ns1__studyInvestigation::study = nullptr;
 }
 
 void ns1__studyInvestigation::soap_serialize(struct soap *soap) const {
@@ -16011,13 +16065,13 @@ SOAP_FMAC3 ns1__studyInvestigation *SOAP_FMAC4
 soap_in_ns1__studyInvestigation(struct soap *soap, const char *tag,
                                 ns1__studyInvestigation *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__studyInvestigation *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__studyInvestigation,
       sizeof(ns1__studyInvestigation), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__studyInvestigation) {
@@ -16100,24 +16154,24 @@ soap_in_ns1__studyInvestigation(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__studyInvestigation *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__studyInvestigation,
         0, sizeof(ns1__studyInvestigation), 0,
         soap_copy_ns1__studyInvestigation);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__studyInvestigation::soap_put(struct soap *soap, const char *tag,
                                       const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__studyInvestigation);
   if (this->soap_out(soap, tag ? tag : "ns1:studyInvestigation", id, type))
     return soap->error;
@@ -16134,7 +16188,7 @@ soap_get_ns1__studyInvestigation(struct soap *soap, ns1__studyInvestigation *p,
                                  const char *tag, const char *type) {
   if ((p = soap_in_ns1__studyInvestigation(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -16149,9 +16203,9 @@ soap_instantiate_ns1__studyInvestigation(struct soap *soap, int n,
                       "soap_instantiate_ns1__studyInvestigation(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__studyInvestigation, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__studyInvestigation, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__studyInvestigation);
     if (size)
@@ -16188,13 +16242,13 @@ void ns1__study::soap_default(struct soap *soap) {
   this->soap = soap;
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__study::description = NULL;
-  this->ns1__study::name = NULL;
-  this->ns1__study::startDate = NULL;
-  this->ns1__study::status = NULL;
+  this->ns1__study::description = nullptr;
+  this->ns1__study::name = nullptr;
+  this->ns1__study::startDate = nullptr;
+  this->ns1__study::status = nullptr;
   soap_default_std__vectorTemplateOfPointerTons1__studyInvestigation(
       soap, &this->ns1__study::studyInvestigations);
-  this->ns1__study::user = NULL;
+  this->ns1__study::user = nullptr;
 }
 
 void ns1__study::soap_serialize(struct soap *soap) const {
@@ -16270,13 +16324,13 @@ SOAP_FMAC3 ns1__study *SOAP_FMAC4
 soap_in_ns1__study(struct soap *soap, const char *tag, ns1__study *a,
                    const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__study *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__study, sizeof(ns1__study),
       soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__study) {
@@ -16387,24 +16441,24 @@ soap_in_ns1__study(struct soap *soap, const char *tag, ns1__study *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__study *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__study, 0,
         sizeof(ns1__study), 0, soap_copy_ns1__study);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__study::soap_put(struct soap *soap, const char *tag,
                          const char *type) const {
-  int id =
-      soap_embed(soap, (void *)this, NULL, 0, tag, SOAP_TYPE_ICat4_ns1__study);
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
+                      SOAP_TYPE_ICat4_ns1__study);
   if (this->soap_out(soap, tag ? tag : "ns1:study", id, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -16420,7 +16474,7 @@ soap_get_ns1__study(struct soap *soap, ns1__study *p, const char *tag,
                     const char *type) {
   if ((p = soap_in_ns1__study(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -16432,9 +16486,9 @@ soap_instantiate_ns1__study(struct soap *soap, int n, const char *type,
   DBGLOG(TEST, SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__study(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__study, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__study, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__study);
     if (size)
@@ -16470,9 +16524,9 @@ void ns1__investigationUser::soap_default(struct soap *soap) {
   this->soap = soap;
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__investigationUser::investigation = NULL;
-  this->ns1__investigationUser::role = NULL;
-  this->ns1__investigationUser::user = NULL;
+  this->ns1__investigationUser::investigation = nullptr;
+  this->ns1__investigationUser::role = nullptr;
+  this->ns1__investigationUser::user = nullptr;
 }
 
 void ns1__investigationUser::soap_serialize(struct soap *soap) const {
@@ -16540,13 +16594,13 @@ SOAP_FMAC3 ns1__investigationUser *SOAP_FMAC4
 soap_in_ns1__investigationUser(struct soap *soap, const char *tag,
                                ns1__investigationUser *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__investigationUser *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__investigationUser,
       sizeof(ns1__investigationUser), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__investigationUser) {
@@ -16637,23 +16691,23 @@ soap_in_ns1__investigationUser(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__investigationUser *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__investigationUser,
         0, sizeof(ns1__investigationUser), 0, soap_copy_ns1__investigationUser);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__investigationUser::soap_put(struct soap *soap, const char *tag,
                                      const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__investigationUser);
   if (this->soap_out(soap, tag ? tag : "ns1:investigationUser", id, type))
     return soap->error;
@@ -16670,7 +16724,7 @@ soap_get_ns1__investigationUser(struct soap *soap, ns1__investigationUser *p,
                                 const char *tag, const char *type) {
   if ((p = soap_in_ns1__investigationUser(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -16685,9 +16739,9 @@ soap_instantiate_ns1__investigationUser(struct soap *soap, int n,
                       "soap_instantiate_ns1__investigationUser(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__investigationUser, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__investigationUser, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__investigationUser);
     if (size)
@@ -16724,12 +16778,12 @@ void ns1__user::soap_default(struct soap *soap) {
   this->soap = soap;
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__user::fullName = NULL;
+  this->ns1__user::fullName = nullptr;
   soap_default_std__vectorTemplateOfPointerTons1__instrumentScientist(
       soap, &this->ns1__user::instrumentScientists);
   soap_default_std__vectorTemplateOfPointerTons1__investigationUser(
       soap, &this->ns1__user::investigationUsers);
-  this->ns1__user::name = NULL;
+  this->ns1__user::name = nullptr;
   soap_default_std__vectorTemplateOfPointerTons1__study(
       soap, &this->ns1__user::studies);
   soap_default_std__vectorTemplateOfPointerTons1__userGroup(
@@ -16813,13 +16867,13 @@ SOAP_FMAC3 ns1__user *SOAP_FMAC4
 soap_in_ns1__user(struct soap *soap, const char *tag, ns1__user *a,
                   const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__user *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__user, sizeof(ns1__user),
       soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__user) {
@@ -16921,24 +16975,24 @@ soap_in_ns1__user(struct soap *soap, const char *tag, ns1__user *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__user *)soap_id_forward(soap, soap->href, (void *)a, 0,
                                      SOAP_TYPE_ICat4_ns1__user, 0,
                                      sizeof(ns1__user), 0, soap_copy_ns1__user);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__user::soap_put(struct soap *soap, const char *tag,
                         const char *type) const {
-  int id =
-      soap_embed(soap, (void *)this, NULL, 0, tag, SOAP_TYPE_ICat4_ns1__user);
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
+                      SOAP_TYPE_ICat4_ns1__user);
   if (this->soap_out(soap, tag ? tag : "ns1:user", id, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -16954,7 +17008,7 @@ soap_get_ns1__user(struct soap *soap, ns1__user *p, const char *tag,
                    const char *type) {
   if ((p = soap_in_ns1__user(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -16966,9 +17020,9 @@ soap_instantiate_ns1__user(struct soap *soap, int n, const char *type,
   DBGLOG(TEST, SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__user(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__user, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__user, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__user);
     if (size)
@@ -17004,8 +17058,8 @@ void ns1__instrumentScientist::soap_default(struct soap *soap) {
   this->soap = soap;
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__instrumentScientist::instrument = NULL;
-  this->ns1__instrumentScientist::user = NULL;
+  this->ns1__instrumentScientist::instrument = nullptr;
+  this->ns1__instrumentScientist::user = nullptr;
 }
 
 void ns1__instrumentScientist::soap_serialize(struct soap *soap) const {
@@ -17070,13 +17124,13 @@ soap_in_ns1__instrumentScientist(struct soap *soap, const char *tag,
                                  ns1__instrumentScientist *a,
                                  const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__instrumentScientist *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__instrumentScientist,
       sizeof(ns1__instrumentScientist), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__instrumentScientist) {
@@ -17158,10 +17212,10 @@ soap_in_ns1__instrumentScientist(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__instrumentScientist *)soap_id_forward(
         soap, soap->href, (void *)a, 0,
@@ -17169,14 +17223,14 @@ soap_in_ns1__instrumentScientist(struct soap *soap, const char *tag,
         sizeof(ns1__instrumentScientist), 0,
         soap_copy_ns1__instrumentScientist);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__instrumentScientist::soap_put(struct soap *soap, const char *tag,
                                        const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__instrumentScientist);
   if (this->soap_out(soap, tag ? tag : "ns1:instrumentScientist", id, type))
     return soap->error;
@@ -17194,7 +17248,7 @@ soap_get_ns1__instrumentScientist(struct soap *soap,
                                   const char *type) {
   if ((p = soap_in_ns1__instrumentScientist(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -17208,10 +17262,11 @@ soap_instantiate_ns1__instrumentScientist(struct soap *soap, int n,
          SOAP_MESSAGE(fdebug,
                       "soap_instantiate_ns1__instrumentScientist(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__instrumentScientist, n, ICat4_fdelete);
+  struct soap_clist *cp =
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__instrumentScientist, n,
+                ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__instrumentScientist);
     if (size)
@@ -17249,16 +17304,16 @@ void ns1__instrument::soap_default(struct soap *soap) {
   this->soap = soap;
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__instrument::description = NULL;
-  this->ns1__instrument::facility = NULL;
-  this->ns1__instrument::fullName = NULL;
+  this->ns1__instrument::description = nullptr;
+  this->ns1__instrument::facility = nullptr;
+  this->ns1__instrument::fullName = nullptr;
   soap_default_std__vectorTemplateOfPointerTons1__instrumentScientist(
       soap, &this->ns1__instrument::instrumentScientists);
   soap_default_std__vectorTemplateOfPointerTons1__investigationInstrument(
       soap, &this->ns1__instrument::investigationInstruments);
-  this->ns1__instrument::name = NULL;
-  this->ns1__instrument::type = NULL;
-  this->ns1__instrument::url = NULL;
+  this->ns1__instrument::name = nullptr;
+  this->ns1__instrument::type = nullptr;
+  this->ns1__instrument::url = nullptr;
 }
 
 void ns1__instrument::soap_serialize(struct soap *soap) const {
@@ -17347,13 +17402,13 @@ SOAP_FMAC3 ns1__instrument *SOAP_FMAC4
 soap_in_ns1__instrument(struct soap *soap, const char *tag, ns1__instrument *a,
                         const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__instrument *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__instrument,
       sizeof(ns1__instrument), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__instrument) {
@@ -17481,23 +17536,23 @@ soap_in_ns1__instrument(struct soap *soap, const char *tag, ns1__instrument *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__instrument *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__instrument, 0,
         sizeof(ns1__instrument), 0, soap_copy_ns1__instrument);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__instrument::soap_put(struct soap *soap, const char *tag,
                               const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__instrument);
   if (this->soap_out(soap, tag ? tag : "ns1:instrument", id, type))
     return soap->error;
@@ -17514,7 +17569,7 @@ soap_get_ns1__instrument(struct soap *soap, ns1__instrument *p, const char *tag,
                          const char *type) {
   if ((p = soap_in_ns1__instrument(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -17526,10 +17581,10 @@ soap_instantiate_ns1__instrument(struct soap *soap, int n, const char *type,
   DBGLOG(TEST,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__instrument(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__instrument, n, ICat4_fdelete);
+  struct soap_clist *cp = soap_link(
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__instrument, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__instrument);
     if (size)
@@ -17566,11 +17621,11 @@ void ns1__facilityCycle::soap_default(struct soap *soap) {
   this->soap = soap;
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__facilityCycle::description = NULL;
-  this->ns1__facilityCycle::endDate = NULL;
-  this->ns1__facilityCycle::facility = NULL;
-  this->ns1__facilityCycle::name = NULL;
-  this->ns1__facilityCycle::startDate = NULL;
+  this->ns1__facilityCycle::description = nullptr;
+  this->ns1__facilityCycle::endDate = nullptr;
+  this->ns1__facilityCycle::facility = nullptr;
+  this->ns1__facilityCycle::name = nullptr;
+  this->ns1__facilityCycle::startDate = nullptr;
 }
 
 void ns1__facilityCycle::soap_serialize(struct soap *soap) const {
@@ -17644,13 +17699,13 @@ SOAP_FMAC3 ns1__facilityCycle *SOAP_FMAC4
 soap_in_ns1__facilityCycle(struct soap *soap, const char *tag,
                            ns1__facilityCycle *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__facilityCycle *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__facilityCycle,
       sizeof(ns1__facilityCycle), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__facilityCycle) {
@@ -17757,23 +17812,23 @@ soap_in_ns1__facilityCycle(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__facilityCycle *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__facilityCycle, 0,
         sizeof(ns1__facilityCycle), 0, soap_copy_ns1__facilityCycle);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__facilityCycle::soap_put(struct soap *soap, const char *tag,
                                  const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__facilityCycle);
   if (this->soap_out(soap, tag ? tag : "ns1:facilityCycle", id, type))
     return soap->error;
@@ -17790,7 +17845,7 @@ soap_get_ns1__facilityCycle(struct soap *soap, ns1__facilityCycle *p,
                             const char *tag, const char *type) {
   if ((p = soap_in_ns1__facilityCycle(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -17803,9 +17858,9 @@ soap_instantiate_ns1__facilityCycle(struct soap *soap, int n, const char *type,
                             "soap_instantiate_ns1__facilityCycle(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__facilityCycle, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__facilityCycle, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__facilityCycle);
     if (size)
@@ -17844,9 +17899,9 @@ void ns1__datasetType::soap_default(struct soap *soap) {
   this->xsd__anyType::soap_default(soap);
   soap_default_std__vectorTemplateOfPointerTons1__dataset(
       soap, &this->ns1__datasetType::datasets);
-  this->ns1__datasetType::description = NULL;
-  this->ns1__datasetType::facility = NULL;
-  this->ns1__datasetType::name = NULL;
+  this->ns1__datasetType::description = nullptr;
+  this->ns1__datasetType::facility = nullptr;
+  this->ns1__datasetType::name = nullptr;
 }
 
 void ns1__datasetType::soap_serialize(struct soap *soap) const {
@@ -17917,13 +17972,13 @@ SOAP_FMAC3 ns1__datasetType *SOAP_FMAC4
 soap_in_ns1__datasetType(struct soap *soap, const char *tag,
                          ns1__datasetType *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__datasetType *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__datasetType,
       sizeof(ns1__datasetType), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__datasetType) {
@@ -18019,23 +18074,23 @@ soap_in_ns1__datasetType(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__datasetType *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__datasetType, 0,
         sizeof(ns1__datasetType), 0, soap_copy_ns1__datasetType);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__datasetType::soap_put(struct soap *soap, const char *tag,
                                const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__datasetType);
   if (this->soap_out(soap, tag ? tag : "ns1:datasetType", id, type))
     return soap->error;
@@ -18052,7 +18107,7 @@ soap_get_ns1__datasetType(struct soap *soap, ns1__datasetType *p,
                           const char *tag, const char *type) {
   if ((p = soap_in_ns1__datasetType(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -18064,10 +18119,10 @@ soap_instantiate_ns1__datasetType(struct soap *soap, int n, const char *type,
   DBGLOG(TEST,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__datasetType(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__datasetType, n, ICat4_fdelete);
+  struct soap_clist *cp = soap_link(
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__datasetType, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__datasetType);
     if (size)
@@ -18106,11 +18161,11 @@ void ns1__datafileFormat::soap_default(struct soap *soap) {
   this->xsd__anyType::soap_default(soap);
   soap_default_std__vectorTemplateOfPointerTons1__datafile(
       soap, &this->ns1__datafileFormat::datafiles);
-  this->ns1__datafileFormat::description = NULL;
-  this->ns1__datafileFormat::facility = NULL;
-  this->ns1__datafileFormat::name = NULL;
-  this->ns1__datafileFormat::type = NULL;
-  this->ns1__datafileFormat::version = NULL;
+  this->ns1__datafileFormat::description = nullptr;
+  this->ns1__datafileFormat::facility = nullptr;
+  this->ns1__datafileFormat::name = nullptr;
+  this->ns1__datafileFormat::type = nullptr;
+  this->ns1__datafileFormat::version = nullptr;
 }
 
 void ns1__datafileFormat::soap_serialize(struct soap *soap) const {
@@ -18190,13 +18245,13 @@ SOAP_FMAC3 ns1__datafileFormat *SOAP_FMAC4
 soap_in_ns1__datafileFormat(struct soap *soap, const char *tag,
                             ns1__datafileFormat *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__datafileFormat *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__datafileFormat,
       sizeof(ns1__datafileFormat), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__datafileFormat) {
@@ -18309,23 +18364,23 @@ soap_in_ns1__datafileFormat(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__datafileFormat *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__datafileFormat, 0,
         sizeof(ns1__datafileFormat), 0, soap_copy_ns1__datafileFormat);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__datafileFormat::soap_put(struct soap *soap, const char *tag,
                                   const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__datafileFormat);
   if (this->soap_out(soap, tag ? tag : "ns1:datafileFormat", id, type))
     return soap->error;
@@ -18342,7 +18397,7 @@ soap_get_ns1__datafileFormat(struct soap *soap, ns1__datafileFormat *p,
                              const char *tag, const char *type) {
   if ((p = soap_in_ns1__datafileFormat(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -18355,9 +18410,9 @@ soap_instantiate_ns1__datafileFormat(struct soap *soap, int n, const char *type,
                    fdebug, "soap_instantiate_ns1__datafileFormat(%d, %s, %s)\n",
                    n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__datafileFormat, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__datafileFormat, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__datafileFormat);
     if (size)
@@ -18394,10 +18449,10 @@ void ns1__job::soap_default(struct soap *soap) {
   this->soap = soap;
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__job::application = NULL;
-  this->ns1__job::arguments = NULL;
-  this->ns1__job::inputDataCollection = NULL;
-  this->ns1__job::outputDataCollection = NULL;
+  this->ns1__job::application = nullptr;
+  this->ns1__job::arguments = nullptr;
+  this->ns1__job::inputDataCollection = nullptr;
+  this->ns1__job::outputDataCollection = nullptr;
 }
 
 void ns1__job::soap_serialize(struct soap *soap) const {
@@ -18467,13 +18522,13 @@ SOAP_FMAC3 ns1__job *SOAP_FMAC4 soap_in_ns1__job(struct soap *soap,
                                                  const char *tag, ns1__job *a,
                                                  const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__job *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__job, sizeof(ns1__job), soap->type,
       soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__job) {
@@ -18571,16 +18626,16 @@ SOAP_FMAC3 ns1__job *SOAP_FMAC4 soap_in_ns1__job(struct soap *soap,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__job *)soap_id_forward(soap, soap->href, (void *)a, 0,
                                     SOAP_TYPE_ICat4_ns1__job, 0,
                                     sizeof(ns1__job), 0, soap_copy_ns1__job);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -18588,7 +18643,7 @@ SOAP_FMAC3 ns1__job *SOAP_FMAC4 soap_in_ns1__job(struct soap *soap,
 int ns1__job::soap_put(struct soap *soap, const char *tag,
                        const char *type) const {
   int id =
-      soap_embed(soap, (void *)this, NULL, 0, tag, SOAP_TYPE_ICat4_ns1__job);
+      soap_embed(soap, (void *)this, nullptr, 0, tag, SOAP_TYPE_ICat4_ns1__job);
   if (this->soap_out(soap, tag ? tag : "ns1:job", id, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -18603,7 +18658,7 @@ SOAP_FMAC3 ns1__job *SOAP_FMAC4 soap_get_ns1__job(struct soap *soap,
                                                   const char *type) {
   if ((p = soap_in_ns1__job(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -18615,9 +18670,9 @@ soap_instantiate_ns1__job(struct soap *soap, int n, const char *type,
   DBGLOG(TEST, SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__job(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__job, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__job, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__job);
     if (size)
@@ -18653,11 +18708,11 @@ void ns1__application::soap_default(struct soap *soap) {
   this->soap = soap;
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__application::facility = NULL;
+  this->ns1__application::facility = nullptr;
   soap_default_std__vectorTemplateOfPointerTons1__job(
       soap, &this->ns1__application::jobs);
-  this->ns1__application::name = NULL;
-  this->ns1__application::version = NULL;
+  this->ns1__application::name = nullptr;
+  this->ns1__application::version = nullptr;
 }
 
 void ns1__application::soap_serialize(struct soap *soap) const {
@@ -18727,13 +18782,13 @@ SOAP_FMAC3 ns1__application *SOAP_FMAC4
 soap_in_ns1__application(struct soap *soap, const char *tag,
                          ns1__application *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__application *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__application,
       sizeof(ns1__application), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__application) {
@@ -18828,23 +18883,23 @@ soap_in_ns1__application(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__application *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__application, 0,
         sizeof(ns1__application), 0, soap_copy_ns1__application);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__application::soap_put(struct soap *soap, const char *tag,
                                const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__application);
   if (this->soap_out(soap, tag ? tag : "ns1:application", id, type))
     return soap->error;
@@ -18861,7 +18916,7 @@ soap_get_ns1__application(struct soap *soap, ns1__application *p,
                           const char *tag, const char *type) {
   if ((p = soap_in_ns1__application(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -18873,10 +18928,10 @@ soap_instantiate_ns1__application(struct soap *soap, int n, const char *type,
   DBGLOG(TEST,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__application(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__application, n, ICat4_fdelete);
+  struct soap_clist *cp = soap_link(
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__application, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__application);
     if (size)
@@ -18919,23 +18974,23 @@ void ns1__facility::soap_default(struct soap *soap) {
       soap, &this->ns1__facility::datafileFormats);
   soap_default_std__vectorTemplateOfPointerTons1__datasetType(
       soap, &this->ns1__facility::datasetTypes);
-  this->ns1__facility::daysUntilRelease = NULL;
-  this->ns1__facility::description = NULL;
+  this->ns1__facility::daysUntilRelease = nullptr;
+  this->ns1__facility::description = nullptr;
   soap_default_std__vectorTemplateOfPointerTons1__facilityCycle(
       soap, &this->ns1__facility::facilityCycles);
-  this->ns1__facility::fullName = NULL;
+  this->ns1__facility::fullName = nullptr;
   soap_default_std__vectorTemplateOfPointerTons1__instrument(
       soap, &this->ns1__facility::instruments);
   soap_default_std__vectorTemplateOfPointerTons1__investigationType(
       soap, &this->ns1__facility::investigationTypes);
   soap_default_std__vectorTemplateOfPointerTons1__investigation(
       soap, &this->ns1__facility::investigations);
-  this->ns1__facility::name = NULL;
+  this->ns1__facility::name = nullptr;
   soap_default_std__vectorTemplateOfPointerTons1__parameterType(
       soap, &this->ns1__facility::parameterTypes);
   soap_default_std__vectorTemplateOfPointerTons1__sampleType(
       soap, &this->ns1__facility::sampleTypes);
-  this->ns1__facility::url = NULL;
+  this->ns1__facility::url = nullptr;
 }
 
 void ns1__facility::soap_serialize(struct soap *soap) const {
@@ -19054,13 +19109,13 @@ SOAP_FMAC3 ns1__facility *SOAP_FMAC4
 soap_in_ns1__facility(struct soap *soap, const char *tag, ns1__facility *a,
                       const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__facility *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__facility, sizeof(ns1__facility),
       soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__facility) {
@@ -19214,23 +19269,23 @@ soap_in_ns1__facility(struct soap *soap, const char *tag, ns1__facility *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__facility *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__facility, 0,
         sizeof(ns1__facility), 0, soap_copy_ns1__facility);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__facility::soap_put(struct soap *soap, const char *tag,
                             const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__facility);
   if (this->soap_out(soap, tag ? tag : "ns1:facility", id, type))
     return soap->error;
@@ -19247,7 +19302,7 @@ soap_get_ns1__facility(struct soap *soap, ns1__facility *p, const char *tag,
                        const char *type) {
   if ((p = soap_in_ns1__facility(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -19260,9 +19315,9 @@ soap_instantiate_ns1__facility(struct soap *soap, int n, const char *type,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__facility(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__facility, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__facility, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__facility);
     if (size)
@@ -19300,32 +19355,32 @@ void ns1__investigation::soap_default(struct soap *soap) {
   this->xsd__anyType::soap_default(soap);
   soap_default_std__vectorTemplateOfPointerTons1__dataset(
       soap, &this->ns1__investigation::datasets);
-  this->ns1__investigation::doi = NULL;
-  this->ns1__investigation::endDate = NULL;
-  this->ns1__investigation::facility = NULL;
+  this->ns1__investigation::doi = nullptr;
+  this->ns1__investigation::endDate = nullptr;
+  this->ns1__investigation::facility = nullptr;
   soap_default_std__vectorTemplateOfPointerTons1__investigationInstrument(
       soap, &this->ns1__investigation::investigationInstruments);
   soap_default_std__vectorTemplateOfPointerTons1__investigationUser(
       soap, &this->ns1__investigation::investigationUsers);
   soap_default_std__vectorTemplateOfPointerTons1__keyword(
       soap, &this->ns1__investigation::keywords);
-  this->ns1__investigation::name = NULL;
+  this->ns1__investigation::name = nullptr;
   soap_default_std__vectorTemplateOfPointerTons1__investigationParameter(
       soap, &this->ns1__investigation::parameters);
   soap_default_std__vectorTemplateOfPointerTons1__publication(
       soap, &this->ns1__investigation::publications);
-  this->ns1__investigation::releaseDate = NULL;
+  this->ns1__investigation::releaseDate = nullptr;
   soap_default_std__vectorTemplateOfPointerTons1__sample(
       soap, &this->ns1__investigation::samples);
   soap_default_std__vectorTemplateOfPointerTons1__shift(
       soap, &this->ns1__investigation::shifts);
-  this->ns1__investigation::startDate = NULL;
+  this->ns1__investigation::startDate = nullptr;
   soap_default_std__vectorTemplateOfPointerTons1__studyInvestigation(
       soap, &this->ns1__investigation::studyInvestigations);
-  this->ns1__investigation::summary = NULL;
-  this->ns1__investigation::title = NULL;
-  this->ns1__investigation::type = NULL;
-  this->ns1__investigation::visitId = NULL;
+  this->ns1__investigation::summary = nullptr;
+  this->ns1__investigation::title = nullptr;
+  this->ns1__investigation::type = nullptr;
+  this->ns1__investigation::visitId = nullptr;
 }
 
 void ns1__investigation::soap_serialize(struct soap *soap) const {
@@ -19467,13 +19522,13 @@ SOAP_FMAC3 ns1__investigation *SOAP_FMAC4
 soap_in_ns1__investigation(struct soap *soap, const char *tag,
                            ns1__investigation *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__investigation *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__investigation,
       sizeof(ns1__investigation), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__investigation) {
@@ -19668,23 +19723,23 @@ soap_in_ns1__investigation(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__investigation *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__investigation, 0,
         sizeof(ns1__investigation), 0, soap_copy_ns1__investigation);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__investigation::soap_put(struct soap *soap, const char *tag,
                                  const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__investigation);
   if (this->soap_out(soap, tag ? tag : "ns1:investigation", id, type))
     return soap->error;
@@ -19701,7 +19756,7 @@ soap_get_ns1__investigation(struct soap *soap, ns1__investigation *p,
                             const char *tag, const char *type) {
   if ((p = soap_in_ns1__investigation(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -19714,9 +19769,9 @@ soap_instantiate_ns1__investigation(struct soap *soap, int n, const char *type,
                             "soap_instantiate_ns1__investigation(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__investigation, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__investigation, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__investigation);
     if (size)
@@ -19758,17 +19813,17 @@ void ns1__dataset::soap_default(struct soap *soap) {
       soap, &this->ns1__dataset::dataCollectionDatasets);
   soap_default_std__vectorTemplateOfPointerTons1__datafile(
       soap, &this->ns1__dataset::datafiles);
-  this->ns1__dataset::description = NULL;
-  this->ns1__dataset::doi = NULL;
-  this->ns1__dataset::endDate = NULL;
-  this->ns1__dataset::investigation = NULL;
-  this->ns1__dataset::location = NULL;
-  this->ns1__dataset::name = NULL;
+  this->ns1__dataset::description = nullptr;
+  this->ns1__dataset::doi = nullptr;
+  this->ns1__dataset::endDate = nullptr;
+  this->ns1__dataset::investigation = nullptr;
+  this->ns1__dataset::location = nullptr;
+  this->ns1__dataset::name = nullptr;
   soap_default_std__vectorTemplateOfPointerTons1__datasetParameter(
       soap, &this->ns1__dataset::parameters);
-  this->ns1__dataset::sample = NULL;
-  this->ns1__dataset::startDate = NULL;
-  this->ns1__dataset::type = NULL;
+  this->ns1__dataset::sample = nullptr;
+  this->ns1__dataset::startDate = nullptr;
+  this->ns1__dataset::type = nullptr;
 }
 
 void ns1__dataset::soap_serialize(struct soap *soap) const {
@@ -19875,13 +19930,13 @@ SOAP_FMAC3 ns1__dataset *SOAP_FMAC4
 soap_in_ns1__dataset(struct soap *soap, const char *tag, ns1__dataset *a,
                      const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__dataset *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__dataset, sizeof(ns1__dataset),
       soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__dataset) {
@@ -20040,27 +20095,27 @@ soap_in_ns1__dataset(struct soap *soap, const char *tag, ns1__dataset *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__dataset *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__dataset, 0,
         sizeof(ns1__dataset), 0, soap_copy_ns1__dataset);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   if ((soap->mode & SOAP_XML_STRICT) && (soap_flag_complete1 > 0)) {
     soap->error = SOAP_OCCURS;
-    return NULL;
+    return nullptr;
   }
   return a;
 }
 
 int ns1__dataset::soap_put(struct soap *soap, const char *tag,
                            const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__dataset);
   if (this->soap_out(soap, tag ? tag : "ns1:dataset", id, type))
     return soap->error;
@@ -20077,7 +20132,7 @@ soap_get_ns1__dataset(struct soap *soap, ns1__dataset *p, const char *tag,
                       const char *type) {
   if ((p = soap_in_ns1__dataset(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -20090,9 +20145,9 @@ soap_instantiate_ns1__dataset(struct soap *soap, int n, const char *type,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__dataset(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__dataset, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__dataset, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__dataset);
     if (size)
@@ -20128,8 +20183,8 @@ void ns1__dataCollectionDataset::soap_default(struct soap *soap) {
   this->soap = soap;
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__dataCollectionDataset::dataCollection = NULL;
-  this->ns1__dataCollectionDataset::dataset = NULL;
+  this->ns1__dataCollectionDataset::dataCollection = nullptr;
+  this->ns1__dataCollectionDataset::dataset = nullptr;
 }
 
 void ns1__dataCollectionDataset::soap_serialize(struct soap *soap) const {
@@ -20195,13 +20250,13 @@ soap_in_ns1__dataCollectionDataset(struct soap *soap, const char *tag,
                                    ns1__dataCollectionDataset *a,
                                    const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__dataCollectionDataset *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__dataCollectionDataset,
       sizeof(ns1__dataCollectionDataset), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__dataCollectionDataset) {
@@ -20284,10 +20339,10 @@ soap_in_ns1__dataCollectionDataset(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__dataCollectionDataset *)soap_id_forward(
         soap, soap->href, (void *)a, 0,
@@ -20295,14 +20350,14 @@ soap_in_ns1__dataCollectionDataset(struct soap *soap, const char *tag,
         sizeof(ns1__dataCollectionDataset), 0,
         soap_copy_ns1__dataCollectionDataset);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__dataCollectionDataset::soap_put(struct soap *soap, const char *tag,
                                          const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__dataCollectionDataset);
   if (this->soap_out(soap, tag ? tag : "ns1:dataCollectionDataset", id, type))
     return soap->error;
@@ -20320,7 +20375,7 @@ soap_get_ns1__dataCollectionDataset(struct soap *soap,
                                     const char *tag, const char *type) {
   if ((p = soap_in_ns1__dataCollectionDataset(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -20335,10 +20390,11 @@ soap_instantiate_ns1__dataCollectionDataset(struct soap *soap, int n,
                    fdebug,
                    "soap_instantiate_ns1__dataCollectionDataset(%d, %s, %s)\n",
                    n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__dataCollectionDataset, n, ICat4_fdelete);
+  struct soap_clist *cp =
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__dataCollectionDataset, n,
+                ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__dataCollectionDataset);
     if (size)
@@ -20465,13 +20521,13 @@ SOAP_FMAC3 ns1__dataCollection *SOAP_FMAC4
 soap_in_ns1__dataCollection(struct soap *soap, const char *tag,
                             ns1__dataCollection *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__dataCollection *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__dataCollection,
       sizeof(ns1__dataCollection), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__dataCollection) {
@@ -20564,23 +20620,23 @@ soap_in_ns1__dataCollection(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__dataCollection *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__dataCollection, 0,
         sizeof(ns1__dataCollection), 0, soap_copy_ns1__dataCollection);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__dataCollection::soap_put(struct soap *soap, const char *tag,
                                   const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__dataCollection);
   if (this->soap_out(soap, tag ? tag : "ns1:dataCollection", id, type))
     return soap->error;
@@ -20597,7 +20653,7 @@ soap_get_ns1__dataCollection(struct soap *soap, ns1__dataCollection *p,
                              const char *tag, const char *type) {
   if ((p = soap_in_ns1__dataCollection(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -20610,9 +20666,9 @@ soap_instantiate_ns1__dataCollection(struct soap *soap, int n, const char *type,
                    fdebug, "soap_instantiate_ns1__dataCollection(%d, %s, %s)\n",
                    n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__dataCollection, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__dataCollection, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__dataCollection);
     if (size)
@@ -20649,8 +20705,8 @@ void ns1__dataCollectionDatafile::soap_default(struct soap *soap) {
   this->soap = soap;
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__dataCollectionDatafile::dataCollection = NULL;
-  this->ns1__dataCollectionDatafile::datafile = NULL;
+  this->ns1__dataCollectionDatafile::dataCollection = nullptr;
+  this->ns1__dataCollectionDatafile::datafile = nullptr;
 }
 
 void ns1__dataCollectionDatafile::soap_serialize(struct soap *soap) const {
@@ -20717,13 +20773,13 @@ soap_in_ns1__dataCollectionDatafile(struct soap *soap, const char *tag,
                                     ns1__dataCollectionDatafile *a,
                                     const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__dataCollectionDatafile *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__dataCollectionDatafile,
       sizeof(ns1__dataCollectionDatafile), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__dataCollectionDatafile) {
@@ -20806,10 +20862,10 @@ soap_in_ns1__dataCollectionDatafile(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__dataCollectionDatafile *)soap_id_forward(
         soap, soap->href, (void *)a, 0,
@@ -20817,14 +20873,14 @@ soap_in_ns1__dataCollectionDatafile(struct soap *soap, const char *tag,
         sizeof(ns1__dataCollectionDatafile), 0,
         soap_copy_ns1__dataCollectionDatafile);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__dataCollectionDatafile::soap_put(struct soap *soap, const char *tag,
                                           const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__dataCollectionDatafile);
   if (this->soap_out(soap, tag ? tag : "ns1:dataCollectionDatafile", id, type))
     return soap->error;
@@ -20842,7 +20898,7 @@ soap_get_ns1__dataCollectionDatafile(struct soap *soap,
                                      const char *tag, const char *type) {
   if ((p = soap_in_ns1__dataCollectionDatafile(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -20858,10 +20914,10 @@ soap_instantiate_ns1__dataCollectionDatafile(struct soap *soap, int n,
                    "soap_instantiate_ns1__dataCollectionDatafile(%d, %s, %s)\n",
                    n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__dataCollectionDatafile, n,
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__dataCollectionDatafile, n,
                 ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__dataCollectionDatafile);
     if (size)
@@ -20900,20 +20956,20 @@ void ns1__datafile::soap_default(struct soap *soap) {
   this->soap = soap;
   this->ns1__entityBaseBean::soap_default(soap);
   this->xsd__anyType::soap_default(soap);
-  this->ns1__datafile::checksum = NULL;
+  this->ns1__datafile::checksum = nullptr;
   soap_default_std__vectorTemplateOfPointerTons1__dataCollectionDatafile(
       soap, &this->ns1__datafile::dataCollectionDatafiles);
-  this->ns1__datafile::datafileCreateTime = NULL;
-  this->ns1__datafile::datafileFormat = NULL;
-  this->ns1__datafile::datafileModTime = NULL;
-  this->ns1__datafile::dataset = NULL;
-  this->ns1__datafile::description = NULL;
+  this->ns1__datafile::datafileCreateTime = nullptr;
+  this->ns1__datafile::datafileFormat = nullptr;
+  this->ns1__datafile::datafileModTime = nullptr;
+  this->ns1__datafile::dataset = nullptr;
+  this->ns1__datafile::description = nullptr;
   soap_default_std__vectorTemplateOfPointerTons1__relatedDatafile(
       soap, &this->ns1__datafile::destDatafiles);
-  this->ns1__datafile::doi = NULL;
-  this->ns1__datafile::fileSize = NULL;
-  this->ns1__datafile::location = NULL;
-  this->ns1__datafile::name = NULL;
+  this->ns1__datafile::doi = nullptr;
+  this->ns1__datafile::fileSize = nullptr;
+  this->ns1__datafile::location = nullptr;
+  this->ns1__datafile::name = nullptr;
   soap_default_std__vectorTemplateOfPointerTons1__datafileParameter(
       soap, &this->ns1__datafile::parameters);
   soap_default_std__vectorTemplateOfPointerTons1__relatedDatafile(
@@ -21032,13 +21088,13 @@ SOAP_FMAC3 ns1__datafile *SOAP_FMAC4
 soap_in_ns1__datafile(struct soap *soap, const char *tag, ns1__datafile *a,
                       const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__datafile *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__datafile, sizeof(ns1__datafile),
       soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__datafile) {
@@ -21206,23 +21262,23 @@ soap_in_ns1__datafile(struct soap *soap, const char *tag, ns1__datafile *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__datafile *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__datafile, 0,
         sizeof(ns1__datafile), 0, soap_copy_ns1__datafile);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__datafile::soap_put(struct soap *soap, const char *tag,
                             const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__datafile);
   if (this->soap_out(soap, tag ? tag : "ns1:datafile", id, type))
     return soap->error;
@@ -21239,7 +21295,7 @@ soap_get_ns1__datafile(struct soap *soap, ns1__datafile *p, const char *tag,
                        const char *type) {
   if ((p = soap_in_ns1__datafile(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -21252,9 +21308,9 @@ soap_instantiate_ns1__datafile(struct soap *soap, int n, const char *type,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__datafile(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__datafile, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__datafile, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__datafile);
     if (size)
@@ -21289,40 +21345,40 @@ SOAP_FMAC3 void SOAP_FMAC4 soap_copy_ns1__datafile(struct soap *soap, int st,
 void ns1__dummy::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__dummy::arg0 = NULL;
-  this->ns1__dummy::arg1 = NULL;
-  this->ns1__dummy::arg2 = NULL;
-  this->ns1__dummy::arg3 = NULL;
-  this->ns1__dummy::arg4 = NULL;
-  this->ns1__dummy::arg5 = NULL;
-  this->ns1__dummy::arg6 = NULL;
-  this->ns1__dummy::arg7 = NULL;
-  this->ns1__dummy::arg8 = NULL;
-  this->ns1__dummy::arg9 = NULL;
-  this->ns1__dummy::arg10 = NULL;
-  this->ns1__dummy::arg11 = NULL;
-  this->ns1__dummy::arg12 = NULL;
-  this->ns1__dummy::arg13 = NULL;
-  this->ns1__dummy::arg14 = NULL;
-  this->ns1__dummy::arg15 = NULL;
-  this->ns1__dummy::arg16 = NULL;
-  this->ns1__dummy::arg17 = NULL;
-  this->ns1__dummy::arg18 = NULL;
-  this->ns1__dummy::arg19 = NULL;
-  this->ns1__dummy::arg20 = NULL;
-  this->ns1__dummy::arg21 = NULL;
-  this->ns1__dummy::arg22 = NULL;
-  this->ns1__dummy::arg23 = NULL;
-  this->ns1__dummy::arg24 = NULL;
-  this->ns1__dummy::arg25 = NULL;
-  this->ns1__dummy::arg26 = NULL;
-  this->ns1__dummy::arg27 = NULL;
-  this->ns1__dummy::arg28 = NULL;
-  this->ns1__dummy::arg29 = NULL;
-  this->ns1__dummy::arg30 = NULL;
-  this->ns1__dummy::arg31 = NULL;
-  this->ns1__dummy::arg32 = NULL;
-  this->ns1__dummy::arg33 = NULL;
+  this->ns1__dummy::arg0 = nullptr;
+  this->ns1__dummy::arg1 = nullptr;
+  this->ns1__dummy::arg2 = nullptr;
+  this->ns1__dummy::arg3 = nullptr;
+  this->ns1__dummy::arg4 = nullptr;
+  this->ns1__dummy::arg5 = nullptr;
+  this->ns1__dummy::arg6 = nullptr;
+  this->ns1__dummy::arg7 = nullptr;
+  this->ns1__dummy::arg8 = nullptr;
+  this->ns1__dummy::arg9 = nullptr;
+  this->ns1__dummy::arg10 = nullptr;
+  this->ns1__dummy::arg11 = nullptr;
+  this->ns1__dummy::arg12 = nullptr;
+  this->ns1__dummy::arg13 = nullptr;
+  this->ns1__dummy::arg14 = nullptr;
+  this->ns1__dummy::arg15 = nullptr;
+  this->ns1__dummy::arg16 = nullptr;
+  this->ns1__dummy::arg17 = nullptr;
+  this->ns1__dummy::arg18 = nullptr;
+  this->ns1__dummy::arg19 = nullptr;
+  this->ns1__dummy::arg20 = nullptr;
+  this->ns1__dummy::arg21 = nullptr;
+  this->ns1__dummy::arg22 = nullptr;
+  this->ns1__dummy::arg23 = nullptr;
+  this->ns1__dummy::arg24 = nullptr;
+  this->ns1__dummy::arg25 = nullptr;
+  this->ns1__dummy::arg26 = nullptr;
+  this->ns1__dummy::arg27 = nullptr;
+  this->ns1__dummy::arg28 = nullptr;
+  this->ns1__dummy::arg29 = nullptr;
+  this->ns1__dummy::arg30 = nullptr;
+  this->ns1__dummy::arg31 = nullptr;
+  this->ns1__dummy::arg32 = nullptr;
+  this->ns1__dummy::arg33 = nullptr;
 }
 
 void ns1__dummy::soap_serialize(struct soap *soap) const {
@@ -21499,13 +21555,13 @@ SOAP_FMAC3 ns1__dummy *SOAP_FMAC4
 soap_in_ns1__dummy(struct soap *soap, const char *tag, ns1__dummy *a,
                    const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__dummy *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__dummy, sizeof(ns1__dummy),
       soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__dummy) {
@@ -21778,24 +21834,24 @@ soap_in_ns1__dummy(struct soap *soap, const char *tag, ns1__dummy *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__dummy *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__dummy, 0,
         sizeof(ns1__dummy), 0, soap_copy_ns1__dummy);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__dummy::soap_put(struct soap *soap, const char *tag,
                          const char *type) const {
-  int id =
-      soap_embed(soap, (void *)this, NULL, 0, tag, SOAP_TYPE_ICat4_ns1__dummy);
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
+                      SOAP_TYPE_ICat4_ns1__dummy);
   if (this->soap_out(soap, tag ? tag : "ns1:dummy", id, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -21811,7 +21867,7 @@ soap_get_ns1__dummy(struct soap *soap, ns1__dummy *p, const char *tag,
                     const char *type) {
   if ((p = soap_in_ns1__dummy(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -21823,9 +21879,9 @@ soap_instantiate_ns1__dummy(struct soap *soap, int n, const char *type,
   DBGLOG(TEST, SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__dummy(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__dummy, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__dummy, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__dummy);
     if (size)
@@ -21860,7 +21916,7 @@ SOAP_FMAC3 void SOAP_FMAC4 soap_copy_ns1__dummy(struct soap *soap, int st,
 void ns1__loginResponse::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__loginResponse::return_ = NULL;
+  this->ns1__loginResponse::return_ = nullptr;
 }
 
 void ns1__loginResponse::soap_serialize(struct soap *soap) const {
@@ -21900,13 +21956,13 @@ SOAP_FMAC3 ns1__loginResponse *SOAP_FMAC4
 soap_in_ns1__loginResponse(struct soap *soap, const char *tag,
                            ns1__loginResponse *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__loginResponse *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__loginResponse,
       sizeof(ns1__loginResponse), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__loginResponse) {
@@ -21940,23 +21996,23 @@ soap_in_ns1__loginResponse(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__loginResponse *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__loginResponse, 0,
         sizeof(ns1__loginResponse), 0, soap_copy_ns1__loginResponse);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__loginResponse::soap_put(struct soap *soap, const char *tag,
                                  const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__loginResponse);
   if (this->soap_out(soap, tag ? tag : "ns1:loginResponse", id, type))
     return soap->error;
@@ -21973,7 +22029,7 @@ soap_get_ns1__loginResponse(struct soap *soap, ns1__loginResponse *p,
                             const char *tag, const char *type) {
   if ((p = soap_in_ns1__loginResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -21986,9 +22042,9 @@ soap_instantiate_ns1__loginResponse(struct soap *soap, int n, const char *type,
                             "soap_instantiate_ns1__loginResponse(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__loginResponse, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__loginResponse, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__loginResponse);
     if (size)
@@ -22024,7 +22080,7 @@ soap_copy_ns1__loginResponse(struct soap *soap, int st, int tt, void *p,
 void ns1__login::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__login::plugin = NULL;
+  this->ns1__login::plugin = nullptr;
   this->ns1__login::credentials._ns1__login_credentials::soap_default(soap);
 }
 
@@ -22067,13 +22123,13 @@ SOAP_FMAC3 ns1__login *SOAP_FMAC4
 soap_in_ns1__login(struct soap *soap, const char *tag, ns1__login *a,
                    const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__login *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__login, sizeof(ns1__login),
       soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__login) {
@@ -22112,28 +22168,28 @@ soap_in_ns1__login(struct soap *soap, const char *tag, ns1__login *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__login *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__login, 0,
         sizeof(ns1__login), 0, soap_copy_ns1__login);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   if ((soap->mode & SOAP_XML_STRICT) && (soap_flag_credentials1 > 0)) {
     soap->error = SOAP_OCCURS;
-    return NULL;
+    return nullptr;
   }
   return a;
 }
 
 int ns1__login::soap_put(struct soap *soap, const char *tag,
                          const char *type) const {
-  int id =
-      soap_embed(soap, (void *)this, NULL, 0, tag, SOAP_TYPE_ICat4_ns1__login);
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
+                      SOAP_TYPE_ICat4_ns1__login);
   if (this->soap_out(soap, tag ? tag : "ns1:login", id, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -22149,7 +22205,7 @@ soap_get_ns1__login(struct soap *soap, ns1__login *p, const char *tag,
                     const char *type) {
   if ((p = soap_in_ns1__login(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -22161,9 +22217,9 @@ soap_instantiate_ns1__login(struct soap *soap, int n, const char *type,
   DBGLOG(TEST, SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__login(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__login, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__login, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__login);
     if (size)
@@ -22228,13 +22284,13 @@ SOAP_FMAC3 ns1__refreshResponse *SOAP_FMAC4
 soap_in_ns1__refreshResponse(struct soap *soap, const char *tag,
                              ns1__refreshResponse *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!(a = (ns1__refreshResponse *)soap_class_id_enter(
             soap, soap->id, a, SOAP_TYPE_ICat4_ns1__refreshResponse,
             sizeof(ns1__refreshResponse), soap->type, soap->arrayType))) {
     soap->error = SOAP_TAG_MISMATCH;
-    return NULL;
+    return nullptr;
   }
   soap_revert(soap);
   *soap->id = '\0';
@@ -22244,13 +22300,13 @@ soap_in_ns1__refreshResponse(struct soap *soap, const char *tag,
       return (ns1__refreshResponse *)a->soap_in(soap, tag, type);
   }
   if (!soap_inliteral(soap, tag, &(a->xsd__anyType::__item)))
-    return NULL;
+    return nullptr;
   return a;
 }
 
 int ns1__refreshResponse::soap_put(struct soap *soap, const char *tag,
                                    const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__refreshResponse);
   if (this->soap_out(soap, tag ? tag : "ns1:refreshResponse", id, type))
     return soap->error;
@@ -22267,7 +22323,7 @@ soap_get_ns1__refreshResponse(struct soap *soap, ns1__refreshResponse *p,
                               const char *tag, const char *type) {
   if ((p = soap_in_ns1__refreshResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -22282,9 +22338,9 @@ soap_instantiate_ns1__refreshResponse(struct soap *soap, int n,
                       "soap_instantiate_ns1__refreshResponse(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__refreshResponse, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__refreshResponse, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__refreshResponse);
     if (size)
@@ -22320,7 +22376,7 @@ soap_copy_ns1__refreshResponse(struct soap *soap, int st, int tt, void *p,
 void ns1__refresh::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__refresh::sessionId = NULL;
+  this->ns1__refresh::sessionId = nullptr;
 }
 
 void ns1__refresh::soap_serialize(struct soap *soap) const {
@@ -22360,13 +22416,13 @@ SOAP_FMAC3 ns1__refresh *SOAP_FMAC4
 soap_in_ns1__refresh(struct soap *soap, const char *tag, ns1__refresh *a,
                      const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__refresh *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__refresh, sizeof(ns1__refresh),
       soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__refresh) {
@@ -22400,23 +22456,23 @@ soap_in_ns1__refresh(struct soap *soap, const char *tag, ns1__refresh *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__refresh *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__refresh, 0,
         sizeof(ns1__refresh), 0, soap_copy_ns1__refresh);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__refresh::soap_put(struct soap *soap, const char *tag,
                            const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__refresh);
   if (this->soap_out(soap, tag ? tag : "ns1:refresh", id, type))
     return soap->error;
@@ -22433,7 +22489,7 @@ soap_get_ns1__refresh(struct soap *soap, ns1__refresh *p, const char *tag,
                       const char *type) {
   if ((p = soap_in_ns1__refresh(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -22446,9 +22502,9 @@ soap_instantiate_ns1__refresh(struct soap *soap, int n, const char *type,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__refresh(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__refresh, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__refresh, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__refresh);
     if (size)
@@ -22483,7 +22539,7 @@ SOAP_FMAC3 void SOAP_FMAC4 soap_copy_ns1__refresh(struct soap *soap, int st,
 void ns1__getUserNameResponse::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__getUserNameResponse::return_ = NULL;
+  this->ns1__getUserNameResponse::return_ = nullptr;
 }
 
 void ns1__getUserNameResponse::soap_serialize(struct soap *soap) const {
@@ -22526,13 +22582,13 @@ soap_in_ns1__getUserNameResponse(struct soap *soap, const char *tag,
                                  ns1__getUserNameResponse *a,
                                  const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__getUserNameResponse *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__getUserNameResponse,
       sizeof(ns1__getUserNameResponse), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__getUserNameResponse) {
@@ -22566,10 +22622,10 @@ soap_in_ns1__getUserNameResponse(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__getUserNameResponse *)soap_id_forward(
         soap, soap->href, (void *)a, 0,
@@ -22577,14 +22633,14 @@ soap_in_ns1__getUserNameResponse(struct soap *soap, const char *tag,
         sizeof(ns1__getUserNameResponse), 0,
         soap_copy_ns1__getUserNameResponse);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__getUserNameResponse::soap_put(struct soap *soap, const char *tag,
                                        const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__getUserNameResponse);
   if (this->soap_out(soap, tag ? tag : "ns1:getUserNameResponse", id, type))
     return soap->error;
@@ -22602,7 +22658,7 @@ soap_get_ns1__getUserNameResponse(struct soap *soap,
                                   const char *type) {
   if ((p = soap_in_ns1__getUserNameResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -22616,10 +22672,11 @@ soap_instantiate_ns1__getUserNameResponse(struct soap *soap, int n,
          SOAP_MESSAGE(fdebug,
                       "soap_instantiate_ns1__getUserNameResponse(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__getUserNameResponse, n, ICat4_fdelete);
+  struct soap_clist *cp =
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__getUserNameResponse, n,
+                ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__getUserNameResponse);
     if (size)
@@ -22656,7 +22713,7 @@ soap_copy_ns1__getUserNameResponse(struct soap *soap, int st, int tt, void *p,
 void ns1__getUserName::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__getUserName::sessionId = NULL;
+  this->ns1__getUserName::sessionId = nullptr;
 }
 
 void ns1__getUserName::soap_serialize(struct soap *soap) const {
@@ -22696,13 +22753,13 @@ SOAP_FMAC3 ns1__getUserName *SOAP_FMAC4
 soap_in_ns1__getUserName(struct soap *soap, const char *tag,
                          ns1__getUserName *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__getUserName *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__getUserName,
       sizeof(ns1__getUserName), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__getUserName) {
@@ -22736,23 +22793,23 @@ soap_in_ns1__getUserName(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__getUserName *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__getUserName, 0,
         sizeof(ns1__getUserName), 0, soap_copy_ns1__getUserName);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__getUserName::soap_put(struct soap *soap, const char *tag,
                                const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__getUserName);
   if (this->soap_out(soap, tag ? tag : "ns1:getUserName", id, type))
     return soap->error;
@@ -22769,7 +22826,7 @@ soap_get_ns1__getUserName(struct soap *soap, ns1__getUserName *p,
                           const char *tag, const char *type) {
   if ((p = soap_in_ns1__getUserName(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -22781,10 +22838,10 @@ soap_instantiate_ns1__getUserName(struct soap *soap, int n, const char *type,
   DBGLOG(TEST,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__getUserName(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__getUserName, n, ICat4_fdelete);
+  struct soap_clist *cp = soap_link(
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__getUserName, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__getUserName);
     if (size)
@@ -22851,13 +22908,13 @@ SOAP_FMAC3 ns1__deleteManyResponse *SOAP_FMAC4
 soap_in_ns1__deleteManyResponse(struct soap *soap, const char *tag,
                                 ns1__deleteManyResponse *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!(a = (ns1__deleteManyResponse *)soap_class_id_enter(
             soap, soap->id, a, SOAP_TYPE_ICat4_ns1__deleteManyResponse,
             sizeof(ns1__deleteManyResponse), soap->type, soap->arrayType))) {
     soap->error = SOAP_TAG_MISMATCH;
-    return NULL;
+    return nullptr;
   }
   soap_revert(soap);
   *soap->id = '\0';
@@ -22867,13 +22924,13 @@ soap_in_ns1__deleteManyResponse(struct soap *soap, const char *tag,
       return (ns1__deleteManyResponse *)a->soap_in(soap, tag, type);
   }
   if (!soap_inliteral(soap, tag, &(a->xsd__anyType::__item)))
-    return NULL;
+    return nullptr;
   return a;
 }
 
 int ns1__deleteManyResponse::soap_put(struct soap *soap, const char *tag,
                                       const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__deleteManyResponse);
   if (this->soap_out(soap, tag ? tag : "ns1:deleteManyResponse", id, type))
     return soap->error;
@@ -22890,7 +22947,7 @@ soap_get_ns1__deleteManyResponse(struct soap *soap, ns1__deleteManyResponse *p,
                                  const char *tag, const char *type) {
   if ((p = soap_in_ns1__deleteManyResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -22905,9 +22962,9 @@ soap_instantiate_ns1__deleteManyResponse(struct soap *soap, int n,
                       "soap_instantiate_ns1__deleteManyResponse(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__deleteManyResponse, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__deleteManyResponse, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__deleteManyResponse);
     if (size)
@@ -22943,7 +23000,7 @@ soap_copy_ns1__deleteManyResponse(struct soap *soap, int st, int tt, void *p,
 void ns1__deleteMany::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__deleteMany::sessionId = NULL;
+  this->ns1__deleteMany::sessionId = nullptr;
   soap_default_std__vectorTemplateOfPointerTons1__entityBaseBean(
       soap, &this->ns1__deleteMany::beans);
 }
@@ -22990,13 +23047,13 @@ SOAP_FMAC3 ns1__deleteMany *SOAP_FMAC4
 soap_in_ns1__deleteMany(struct soap *soap, const char *tag, ns1__deleteMany *a,
                         const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__deleteMany *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__deleteMany,
       sizeof(ns1__deleteMany), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__deleteMany) {
@@ -23035,23 +23092,23 @@ soap_in_ns1__deleteMany(struct soap *soap, const char *tag, ns1__deleteMany *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__deleteMany *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__deleteMany, 0,
         sizeof(ns1__deleteMany), 0, soap_copy_ns1__deleteMany);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__deleteMany::soap_put(struct soap *soap, const char *tag,
                               const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__deleteMany);
   if (this->soap_out(soap, tag ? tag : "ns1:deleteMany", id, type))
     return soap->error;
@@ -23068,7 +23125,7 @@ soap_get_ns1__deleteMany(struct soap *soap, ns1__deleteMany *p, const char *tag,
                          const char *type) {
   if ((p = soap_in_ns1__deleteMany(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -23080,10 +23137,10 @@ soap_instantiate_ns1__deleteMany(struct soap *soap, int n, const char *type,
   DBGLOG(TEST,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__deleteMany(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__deleteMany, n, ICat4_fdelete);
+  struct soap_clist *cp = soap_link(
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__deleteMany, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__deleteMany);
     if (size)
@@ -23149,13 +23206,13 @@ SOAP_FMAC3 ns1__updateResponse *SOAP_FMAC4
 soap_in_ns1__updateResponse(struct soap *soap, const char *tag,
                             ns1__updateResponse *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!(a = (ns1__updateResponse *)soap_class_id_enter(
             soap, soap->id, a, SOAP_TYPE_ICat4_ns1__updateResponse,
             sizeof(ns1__updateResponse), soap->type, soap->arrayType))) {
     soap->error = SOAP_TAG_MISMATCH;
-    return NULL;
+    return nullptr;
   }
   soap_revert(soap);
   *soap->id = '\0';
@@ -23165,13 +23222,13 @@ soap_in_ns1__updateResponse(struct soap *soap, const char *tag,
       return (ns1__updateResponse *)a->soap_in(soap, tag, type);
   }
   if (!soap_inliteral(soap, tag, &(a->xsd__anyType::__item)))
-    return NULL;
+    return nullptr;
   return a;
 }
 
 int ns1__updateResponse::soap_put(struct soap *soap, const char *tag,
                                   const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__updateResponse);
   if (this->soap_out(soap, tag ? tag : "ns1:updateResponse", id, type))
     return soap->error;
@@ -23188,7 +23245,7 @@ soap_get_ns1__updateResponse(struct soap *soap, ns1__updateResponse *p,
                              const char *tag, const char *type) {
   if ((p = soap_in_ns1__updateResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -23201,9 +23258,9 @@ soap_instantiate_ns1__updateResponse(struct soap *soap, int n, const char *type,
                    fdebug, "soap_instantiate_ns1__updateResponse(%d, %s, %s)\n",
                    n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__updateResponse, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__updateResponse, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__updateResponse);
     if (size)
@@ -23239,8 +23296,8 @@ soap_copy_ns1__updateResponse(struct soap *soap, int st, int tt, void *p,
 void ns1__update::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__update::sessionId = NULL;
-  this->ns1__update::bean = NULL;
+  this->ns1__update::sessionId = nullptr;
+  this->ns1__update::bean = nullptr;
 }
 
 void ns1__update::soap_serialize(struct soap *soap) const {
@@ -23283,13 +23340,13 @@ SOAP_FMAC3 ns1__update *SOAP_FMAC4
 soap_in_ns1__update(struct soap *soap, const char *tag, ns1__update *a,
                     const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__update *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__update, sizeof(ns1__update),
       soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__update) {
@@ -23330,24 +23387,24 @@ soap_in_ns1__update(struct soap *soap, const char *tag, ns1__update *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__update *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__update, 0,
         sizeof(ns1__update), 0, soap_copy_ns1__update);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__update::soap_put(struct soap *soap, const char *tag,
                           const char *type) const {
-  int id =
-      soap_embed(soap, (void *)this, NULL, 0, tag, SOAP_TYPE_ICat4_ns1__update);
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
+                      SOAP_TYPE_ICat4_ns1__update);
   if (this->soap_out(soap, tag ? tag : "ns1:update", id, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -23363,7 +23420,7 @@ soap_get_ns1__update(struct soap *soap, ns1__update *p, const char *tag,
                      const char *type) {
   if ((p = soap_in_ns1__update(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -23376,9 +23433,9 @@ soap_instantiate_ns1__update(struct soap *soap, int n, const char *type,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__update(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__update, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__update, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__update);
     if (size)
@@ -23460,13 +23517,13 @@ soap_in_ns1__luceneGetPopulatingResponse(struct soap *soap, const char *tag,
                                          ns1__luceneGetPopulatingResponse *a,
                                          const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__luceneGetPopulatingResponse *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__luceneGetPopulatingResponse,
       sizeof(ns1__luceneGetPopulatingResponse), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__luceneGetPopulatingResponse) {
@@ -23496,10 +23553,10 @@ soap_in_ns1__luceneGetPopulatingResponse(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__luceneGetPopulatingResponse *)soap_id_forward(
         soap, soap->href, (void *)a, 0,
@@ -23507,7 +23564,7 @@ soap_in_ns1__luceneGetPopulatingResponse(struct soap *soap, const char *tag,
         sizeof(ns1__luceneGetPopulatingResponse), 0,
         soap_copy_ns1__luceneGetPopulatingResponse);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -23515,7 +23572,7 @@ soap_in_ns1__luceneGetPopulatingResponse(struct soap *soap, const char *tag,
 int ns1__luceneGetPopulatingResponse::soap_put(struct soap *soap,
                                                const char *tag,
                                                const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__luceneGetPopulatingResponse);
   if (this->soap_out(soap, tag ? tag : "ns1:luceneGetPopulatingResponse", id,
                      type))
@@ -23535,7 +23592,7 @@ soap_get_ns1__luceneGetPopulatingResponse(struct soap *soap,
                                           const char *tag, const char *type) {
   if ((p = soap_in_ns1__luceneGetPopulatingResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -23552,10 +23609,10 @@ soap_instantiate_ns1__luceneGetPopulatingResponse(struct soap *soap, int n,
              "soap_instantiate_ns1__luceneGetPopulatingResponse(%d, %s, %s)\n",
              n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__luceneGetPopulatingResponse, n,
-                ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__luceneGetPopulatingResponse,
+                n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__luceneGetPopulatingResponse);
     if (size)
@@ -23595,7 +23652,7 @@ soap_copy_ns1__luceneGetPopulatingResponse(struct soap *soap, int st, int tt,
 void ns1__luceneGetPopulating::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__luceneGetPopulating::sessionId = NULL;
+  this->ns1__luceneGetPopulating::sessionId = nullptr;
 }
 
 void ns1__luceneGetPopulating::soap_serialize(struct soap *soap) const {
@@ -23638,13 +23695,13 @@ soap_in_ns1__luceneGetPopulating(struct soap *soap, const char *tag,
                                  ns1__luceneGetPopulating *a,
                                  const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__luceneGetPopulating *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__luceneGetPopulating,
       sizeof(ns1__luceneGetPopulating), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__luceneGetPopulating) {
@@ -23678,10 +23735,10 @@ soap_in_ns1__luceneGetPopulating(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__luceneGetPopulating *)soap_id_forward(
         soap, soap->href, (void *)a, 0,
@@ -23689,14 +23746,14 @@ soap_in_ns1__luceneGetPopulating(struct soap *soap, const char *tag,
         sizeof(ns1__luceneGetPopulating), 0,
         soap_copy_ns1__luceneGetPopulating);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__luceneGetPopulating::soap_put(struct soap *soap, const char *tag,
                                        const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__luceneGetPopulating);
   if (this->soap_out(soap, tag ? tag : "ns1:luceneGetPopulating", id, type))
     return soap->error;
@@ -23714,7 +23771,7 @@ soap_get_ns1__luceneGetPopulating(struct soap *soap,
                                   const char *type) {
   if ((p = soap_in_ns1__luceneGetPopulating(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -23728,10 +23785,11 @@ soap_instantiate_ns1__luceneGetPopulating(struct soap *soap, int n,
          SOAP_MESSAGE(fdebug,
                       "soap_instantiate_ns1__luceneGetPopulating(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__luceneGetPopulating, n, ICat4_fdelete);
+  struct soap_clist *cp =
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__luceneGetPopulating, n,
+                ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__luceneGetPopulating);
     if (size)
@@ -23768,7 +23826,7 @@ soap_copy_ns1__luceneGetPopulating(struct soap *soap, int st, int tt, void *p,
 void ns1__getApiVersionResponse::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__getApiVersionResponse::return_ = NULL;
+  this->ns1__getApiVersionResponse::return_ = nullptr;
 }
 
 void ns1__getApiVersionResponse::soap_serialize(struct soap *soap) const {
@@ -23812,13 +23870,13 @@ soap_in_ns1__getApiVersionResponse(struct soap *soap, const char *tag,
                                    ns1__getApiVersionResponse *a,
                                    const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__getApiVersionResponse *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__getApiVersionResponse,
       sizeof(ns1__getApiVersionResponse), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__getApiVersionResponse) {
@@ -23852,10 +23910,10 @@ soap_in_ns1__getApiVersionResponse(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__getApiVersionResponse *)soap_id_forward(
         soap, soap->href, (void *)a, 0,
@@ -23863,14 +23921,14 @@ soap_in_ns1__getApiVersionResponse(struct soap *soap, const char *tag,
         sizeof(ns1__getApiVersionResponse), 0,
         soap_copy_ns1__getApiVersionResponse);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__getApiVersionResponse::soap_put(struct soap *soap, const char *tag,
                                          const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__getApiVersionResponse);
   if (this->soap_out(soap, tag ? tag : "ns1:getApiVersionResponse", id, type))
     return soap->error;
@@ -23888,7 +23946,7 @@ soap_get_ns1__getApiVersionResponse(struct soap *soap,
                                     const char *tag, const char *type) {
   if ((p = soap_in_ns1__getApiVersionResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -23903,10 +23961,11 @@ soap_instantiate_ns1__getApiVersionResponse(struct soap *soap, int n,
                    fdebug,
                    "soap_instantiate_ns1__getApiVersionResponse(%d, %s, %s)\n",
                    n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__getApiVersionResponse, n, ICat4_fdelete);
+  struct soap_clist *cp =
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__getApiVersionResponse, n,
+                ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__getApiVersionResponse);
     if (size)
@@ -23973,13 +24032,13 @@ SOAP_FMAC3 ns1__getApiVersion *SOAP_FMAC4
 soap_in_ns1__getApiVersion(struct soap *soap, const char *tag,
                            ns1__getApiVersion *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!(a = (ns1__getApiVersion *)soap_class_id_enter(
             soap, soap->id, a, SOAP_TYPE_ICat4_ns1__getApiVersion,
             sizeof(ns1__getApiVersion), soap->type, soap->arrayType))) {
     soap->error = SOAP_TAG_MISMATCH;
-    return NULL;
+    return nullptr;
   }
   soap_revert(soap);
   *soap->id = '\0';
@@ -23989,13 +24048,13 @@ soap_in_ns1__getApiVersion(struct soap *soap, const char *tag,
       return (ns1__getApiVersion *)a->soap_in(soap, tag, type);
   }
   if (!soap_inliteral(soap, tag, &(a->xsd__anyType::__item)))
-    return NULL;
+    return nullptr;
   return a;
 }
 
 int ns1__getApiVersion::soap_put(struct soap *soap, const char *tag,
                                  const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__getApiVersion);
   if (this->soap_out(soap, tag ? tag : "ns1:getApiVersion", id, type))
     return soap->error;
@@ -24012,7 +24071,7 @@ soap_get_ns1__getApiVersion(struct soap *soap, ns1__getApiVersion *p,
                             const char *tag, const char *type) {
   if ((p = soap_in_ns1__getApiVersion(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -24025,9 +24084,9 @@ soap_instantiate_ns1__getApiVersion(struct soap *soap, int n, const char *type,
                             "soap_instantiate_ns1__getApiVersion(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__getApiVersion, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__getApiVersion, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__getApiVersion);
     if (size)
@@ -24108,13 +24167,13 @@ soap_in_ns1__getEntityNamesResponse(struct soap *soap, const char *tag,
                                     ns1__getEntityNamesResponse *a,
                                     const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__getEntityNamesResponse *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__getEntityNamesResponse,
       sizeof(ns1__getEntityNamesResponse), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__getEntityNamesResponse) {
@@ -24144,10 +24203,10 @@ soap_in_ns1__getEntityNamesResponse(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__getEntityNamesResponse *)soap_id_forward(
         soap, soap->href, (void *)a, 0,
@@ -24155,14 +24214,14 @@ soap_in_ns1__getEntityNamesResponse(struct soap *soap, const char *tag,
         sizeof(ns1__getEntityNamesResponse), 0,
         soap_copy_ns1__getEntityNamesResponse);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__getEntityNamesResponse::soap_put(struct soap *soap, const char *tag,
                                           const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__getEntityNamesResponse);
   if (this->soap_out(soap, tag ? tag : "ns1:getEntityNamesResponse", id, type))
     return soap->error;
@@ -24180,7 +24239,7 @@ soap_get_ns1__getEntityNamesResponse(struct soap *soap,
                                      const char *tag, const char *type) {
   if ((p = soap_in_ns1__getEntityNamesResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -24196,10 +24255,10 @@ soap_instantiate_ns1__getEntityNamesResponse(struct soap *soap, int n,
                    "soap_instantiate_ns1__getEntityNamesResponse(%d, %s, %s)\n",
                    n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__getEntityNamesResponse, n,
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__getEntityNamesResponse, n,
                 ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__getEntityNamesResponse);
     if (size)
@@ -24267,13 +24326,13 @@ SOAP_FMAC3 ns1__getEntityNames *SOAP_FMAC4
 soap_in_ns1__getEntityNames(struct soap *soap, const char *tag,
                             ns1__getEntityNames *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!(a = (ns1__getEntityNames *)soap_class_id_enter(
             soap, soap->id, a, SOAP_TYPE_ICat4_ns1__getEntityNames,
             sizeof(ns1__getEntityNames), soap->type, soap->arrayType))) {
     soap->error = SOAP_TAG_MISMATCH;
-    return NULL;
+    return nullptr;
   }
   soap_revert(soap);
   *soap->id = '\0';
@@ -24283,13 +24342,13 @@ soap_in_ns1__getEntityNames(struct soap *soap, const char *tag,
       return (ns1__getEntityNames *)a->soap_in(soap, tag, type);
   }
   if (!soap_inliteral(soap, tag, &(a->xsd__anyType::__item)))
-    return NULL;
+    return nullptr;
   return a;
 }
 
 int ns1__getEntityNames::soap_put(struct soap *soap, const char *tag,
                                   const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__getEntityNames);
   if (this->soap_out(soap, tag ? tag : "ns1:getEntityNames", id, type))
     return soap->error;
@@ -24306,7 +24365,7 @@ soap_get_ns1__getEntityNames(struct soap *soap, ns1__getEntityNames *p,
                              const char *tag, const char *type) {
   if ((p = soap_in_ns1__getEntityNames(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -24319,9 +24378,9 @@ soap_instantiate_ns1__getEntityNames(struct soap *soap, int n, const char *type,
                    fdebug, "soap_instantiate_ns1__getEntityNames(%d, %s, %s)\n",
                    n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__getEntityNames, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__getEntityNames, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__getEntityNames);
     if (size)
@@ -24357,7 +24416,7 @@ soap_copy_ns1__getEntityNames(struct soap *soap, int st, int tt, void *p,
 void ns1__getResponse::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__getResponse::return_ = NULL;
+  this->ns1__getResponse::return_ = nullptr;
 }
 
 void ns1__getResponse::soap_serialize(struct soap *soap) const {
@@ -24398,13 +24457,13 @@ SOAP_FMAC3 ns1__getResponse *SOAP_FMAC4
 soap_in_ns1__getResponse(struct soap *soap, const char *tag,
                          ns1__getResponse *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__getResponse *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__getResponse,
       sizeof(ns1__getResponse), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__getResponse) {
@@ -24437,23 +24496,23 @@ soap_in_ns1__getResponse(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__getResponse *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__getResponse, 0,
         sizeof(ns1__getResponse), 0, soap_copy_ns1__getResponse);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__getResponse::soap_put(struct soap *soap, const char *tag,
                                const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__getResponse);
   if (this->soap_out(soap, tag ? tag : "ns1:getResponse", id, type))
     return soap->error;
@@ -24470,7 +24529,7 @@ soap_get_ns1__getResponse(struct soap *soap, ns1__getResponse *p,
                           const char *tag, const char *type) {
   if ((p = soap_in_ns1__getResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -24482,10 +24541,10 @@ soap_instantiate_ns1__getResponse(struct soap *soap, int n, const char *type,
   DBGLOG(TEST,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__getResponse(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__getResponse, n, ICat4_fdelete);
+  struct soap_clist *cp = soap_link(
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__getResponse, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__getResponse);
     if (size)
@@ -24521,8 +24580,8 @@ soap_copy_ns1__getResponse(struct soap *soap, int st, int tt, void *p,
 void ns1__get::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__get::sessionId = NULL;
-  this->ns1__get::query = NULL;
+  this->ns1__get::sessionId = nullptr;
+  this->ns1__get::query = nullptr;
   soap_default_LONG64(soap, &this->ns1__get::primaryKey);
 }
 
@@ -24568,13 +24627,13 @@ SOAP_FMAC3 ns1__get *SOAP_FMAC4 soap_in_ns1__get(struct soap *soap,
                                                  const char *tag, ns1__get *a,
                                                  const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__get *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__get, sizeof(ns1__get), soap->type,
       soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__get) {
@@ -24622,20 +24681,20 @@ SOAP_FMAC3 ns1__get *SOAP_FMAC4 soap_in_ns1__get(struct soap *soap,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__get *)soap_id_forward(soap, soap->href, (void *)a, 0,
                                     SOAP_TYPE_ICat4_ns1__get, 0,
                                     sizeof(ns1__get), 0, soap_copy_ns1__get);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   if ((soap->mode & SOAP_XML_STRICT) && (soap_flag_primaryKey1 > 0)) {
     soap->error = SOAP_OCCURS;
-    return NULL;
+    return nullptr;
   }
   return a;
 }
@@ -24643,7 +24702,7 @@ SOAP_FMAC3 ns1__get *SOAP_FMAC4 soap_in_ns1__get(struct soap *soap,
 int ns1__get::soap_put(struct soap *soap, const char *tag,
                        const char *type) const {
   int id =
-      soap_embed(soap, (void *)this, NULL, 0, tag, SOAP_TYPE_ICat4_ns1__get);
+      soap_embed(soap, (void *)this, nullptr, 0, tag, SOAP_TYPE_ICat4_ns1__get);
   if (this->soap_out(soap, tag ? tag : "ns1:get", id, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -24658,7 +24717,7 @@ SOAP_FMAC3 ns1__get *SOAP_FMAC4 soap_get_ns1__get(struct soap *soap,
                                                   const char *type) {
   if ((p = soap_in_ns1__get(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -24670,9 +24729,9 @@ soap_instantiate_ns1__get(struct soap *soap, int n, const char *type,
   DBGLOG(TEST, SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__get(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__get, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__get, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__get);
     if (size)
@@ -24739,14 +24798,14 @@ soap_in_ns1__lucenePopulateResponse(struct soap *soap, const char *tag,
                                     ns1__lucenePopulateResponse *a,
                                     const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!(a = (ns1__lucenePopulateResponse *)soap_class_id_enter(
             soap, soap->id, a, SOAP_TYPE_ICat4_ns1__lucenePopulateResponse,
             sizeof(ns1__lucenePopulateResponse), soap->type,
             soap->arrayType))) {
     soap->error = SOAP_TAG_MISMATCH;
-    return NULL;
+    return nullptr;
   }
   soap_revert(soap);
   *soap->id = '\0';
@@ -24756,13 +24815,13 @@ soap_in_ns1__lucenePopulateResponse(struct soap *soap, const char *tag,
       return (ns1__lucenePopulateResponse *)a->soap_in(soap, tag, type);
   }
   if (!soap_inliteral(soap, tag, &(a->xsd__anyType::__item)))
-    return NULL;
+    return nullptr;
   return a;
 }
 
 int ns1__lucenePopulateResponse::soap_put(struct soap *soap, const char *tag,
                                           const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__lucenePopulateResponse);
   if (this->soap_out(soap, tag ? tag : "ns1:lucenePopulateResponse", id, type))
     return soap->error;
@@ -24780,7 +24839,7 @@ soap_get_ns1__lucenePopulateResponse(struct soap *soap,
                                      const char *tag, const char *type) {
   if ((p = soap_in_ns1__lucenePopulateResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -24796,10 +24855,10 @@ soap_instantiate_ns1__lucenePopulateResponse(struct soap *soap, int n,
                    "soap_instantiate_ns1__lucenePopulateResponse(%d, %s, %s)\n",
                    n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__lucenePopulateResponse, n,
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__lucenePopulateResponse, n,
                 ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__lucenePopulateResponse);
     if (size)
@@ -24837,8 +24896,8 @@ soap_copy_ns1__lucenePopulateResponse(struct soap *soap, int st, int tt,
 void ns1__lucenePopulate::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__lucenePopulate::sessionId = NULL;
-  this->ns1__lucenePopulate::entityName = NULL;
+  this->ns1__lucenePopulate::sessionId = nullptr;
+  this->ns1__lucenePopulate::entityName = nullptr;
 }
 
 void ns1__lucenePopulate::soap_serialize(struct soap *soap) const {
@@ -24884,13 +24943,13 @@ SOAP_FMAC3 ns1__lucenePopulate *SOAP_FMAC4
 soap_in_ns1__lucenePopulate(struct soap *soap, const char *tag,
                             ns1__lucenePopulate *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__lucenePopulate *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__lucenePopulate,
       sizeof(ns1__lucenePopulate), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__lucenePopulate) {
@@ -24933,23 +24992,23 @@ soap_in_ns1__lucenePopulate(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__lucenePopulate *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__lucenePopulate, 0,
         sizeof(ns1__lucenePopulate), 0, soap_copy_ns1__lucenePopulate);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__lucenePopulate::soap_put(struct soap *soap, const char *tag,
                                   const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__lucenePopulate);
   if (this->soap_out(soap, tag ? tag : "ns1:lucenePopulate", id, type))
     return soap->error;
@@ -24966,7 +25025,7 @@ soap_get_ns1__lucenePopulate(struct soap *soap, ns1__lucenePopulate *p,
                              const char *tag, const char *type) {
   if ((p = soap_in_ns1__lucenePopulate(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -24979,9 +25038,9 @@ soap_instantiate_ns1__lucenePopulate(struct soap *soap, int n, const char *type,
                    fdebug, "soap_instantiate_ns1__lucenePopulate(%d, %s, %s)\n",
                    n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__lucenePopulate, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__lucenePopulate, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__lucenePopulate);
     if (size)
@@ -25062,13 +25121,13 @@ soap_in_ns1__luceneSearchResponse(struct soap *soap, const char *tag,
                                   ns1__luceneSearchResponse *a,
                                   const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__luceneSearchResponse *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__luceneSearchResponse,
       sizeof(ns1__luceneSearchResponse), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__luceneSearchResponse) {
@@ -25098,10 +25157,10 @@ soap_in_ns1__luceneSearchResponse(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__luceneSearchResponse *)soap_id_forward(
         soap, soap->href, (void *)a, 0,
@@ -25109,14 +25168,14 @@ soap_in_ns1__luceneSearchResponse(struct soap *soap, const char *tag,
         sizeof(ns1__luceneSearchResponse), 0,
         soap_copy_ns1__luceneSearchResponse);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__luceneSearchResponse::soap_put(struct soap *soap, const char *tag,
                                         const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__luceneSearchResponse);
   if (this->soap_out(soap, tag ? tag : "ns1:luceneSearchResponse", id, type))
     return soap->error;
@@ -25134,7 +25193,7 @@ soap_get_ns1__luceneSearchResponse(struct soap *soap,
                                    const char *tag, const char *type) {
   if ((p = soap_in_ns1__luceneSearchResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -25149,10 +25208,11 @@ soap_instantiate_ns1__luceneSearchResponse(struct soap *soap, int n,
          SOAP_MESSAGE(
              fdebug, "soap_instantiate_ns1__luceneSearchResponse(%d, %s, %s)\n",
              n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__luceneSearchResponse, n, ICat4_fdelete);
+  struct soap_clist *cp =
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__luceneSearchResponse, n,
+                ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__luceneSearchResponse);
     if (size)
@@ -25189,10 +25249,10 @@ soap_copy_ns1__luceneSearchResponse(struct soap *soap, int st, int tt, void *p,
 void ns1__luceneSearch::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__luceneSearch::sessionId = NULL;
-  this->ns1__luceneSearch::query = NULL;
+  this->ns1__luceneSearch::sessionId = nullptr;
+  this->ns1__luceneSearch::query = nullptr;
   soap_default_int(soap, &this->ns1__luceneSearch::maxCount);
-  this->ns1__luceneSearch::entityName = NULL;
+  this->ns1__luceneSearch::entityName = nullptr;
 }
 
 void ns1__luceneSearch::soap_serialize(struct soap *soap) const {
@@ -25245,13 +25305,13 @@ SOAP_FMAC3 ns1__luceneSearch *SOAP_FMAC4
 soap_in_ns1__luceneSearch(struct soap *soap, const char *tag,
                           ns1__luceneSearch *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__luceneSearch *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__luceneSearch,
       sizeof(ns1__luceneSearch), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__luceneSearch) {
@@ -25309,27 +25369,27 @@ soap_in_ns1__luceneSearch(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__luceneSearch *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__luceneSearch, 0,
         sizeof(ns1__luceneSearch), 0, soap_copy_ns1__luceneSearch);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   if ((soap->mode & SOAP_XML_STRICT) && (soap_flag_maxCount1 > 0)) {
     soap->error = SOAP_OCCURS;
-    return NULL;
+    return nullptr;
   }
   return a;
 }
 
 int ns1__luceneSearch::soap_put(struct soap *soap, const char *tag,
                                 const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__luceneSearch);
   if (this->soap_out(soap, tag ? tag : "ns1:luceneSearch", id, type))
     return soap->error;
@@ -25346,7 +25406,7 @@ soap_get_ns1__luceneSearch(struct soap *soap, ns1__luceneSearch *p,
                            const char *tag, const char *type) {
   if ((p = soap_in_ns1__luceneSearch(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -25359,9 +25419,9 @@ soap_instantiate_ns1__luceneSearch(struct soap *soap, int n, const char *type,
                             "soap_instantiate_ns1__luceneSearch(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__luceneSearch, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__luceneSearch, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__luceneSearch);
     if (size)
@@ -25442,13 +25502,13 @@ soap_in_ns1__getPropertiesResponse(struct soap *soap, const char *tag,
                                    ns1__getPropertiesResponse *a,
                                    const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__getPropertiesResponse *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__getPropertiesResponse,
       sizeof(ns1__getPropertiesResponse), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__getPropertiesResponse) {
@@ -25478,10 +25538,10 @@ soap_in_ns1__getPropertiesResponse(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__getPropertiesResponse *)soap_id_forward(
         soap, soap->href, (void *)a, 0,
@@ -25489,14 +25549,14 @@ soap_in_ns1__getPropertiesResponse(struct soap *soap, const char *tag,
         sizeof(ns1__getPropertiesResponse), 0,
         soap_copy_ns1__getPropertiesResponse);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__getPropertiesResponse::soap_put(struct soap *soap, const char *tag,
                                          const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__getPropertiesResponse);
   if (this->soap_out(soap, tag ? tag : "ns1:getPropertiesResponse", id, type))
     return soap->error;
@@ -25514,7 +25574,7 @@ soap_get_ns1__getPropertiesResponse(struct soap *soap,
                                     const char *tag, const char *type) {
   if ((p = soap_in_ns1__getPropertiesResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -25529,10 +25589,11 @@ soap_instantiate_ns1__getPropertiesResponse(struct soap *soap, int n,
                    fdebug,
                    "soap_instantiate_ns1__getPropertiesResponse(%d, %s, %s)\n",
                    n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__getPropertiesResponse, n, ICat4_fdelete);
+  struct soap_clist *cp =
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__getPropertiesResponse, n,
+                ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__getPropertiesResponse);
     if (size)
@@ -25569,7 +25630,7 @@ soap_copy_ns1__getPropertiesResponse(struct soap *soap, int st, int tt, void *p,
 void ns1__getProperties::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__getProperties::sessionId = NULL;
+  this->ns1__getProperties::sessionId = nullptr;
 }
 
 void ns1__getProperties::soap_serialize(struct soap *soap) const {
@@ -25610,13 +25671,13 @@ SOAP_FMAC3 ns1__getProperties *SOAP_FMAC4
 soap_in_ns1__getProperties(struct soap *soap, const char *tag,
                            ns1__getProperties *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__getProperties *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__getProperties,
       sizeof(ns1__getProperties), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__getProperties) {
@@ -25650,23 +25711,23 @@ soap_in_ns1__getProperties(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__getProperties *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__getProperties, 0,
         sizeof(ns1__getProperties), 0, soap_copy_ns1__getProperties);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__getProperties::soap_put(struct soap *soap, const char *tag,
                                  const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__getProperties);
   if (this->soap_out(soap, tag ? tag : "ns1:getProperties", id, type))
     return soap->error;
@@ -25683,7 +25744,7 @@ soap_get_ns1__getProperties(struct soap *soap, ns1__getProperties *p,
                             const char *tag, const char *type) {
   if ((p = soap_in_ns1__getProperties(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -25696,9 +25757,9 @@ soap_instantiate_ns1__getProperties(struct soap *soap, int n, const char *type,
                             "soap_instantiate_ns1__getProperties(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__getProperties, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__getProperties, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__getProperties);
     if (size)
@@ -25775,13 +25836,13 @@ SOAP_FMAC3 ns1__createResponse *SOAP_FMAC4
 soap_in_ns1__createResponse(struct soap *soap, const char *tag,
                             ns1__createResponse *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__createResponse *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__createResponse,
       sizeof(ns1__createResponse), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__createResponse) {
@@ -25813,27 +25874,27 @@ soap_in_ns1__createResponse(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__createResponse *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__createResponse, 0,
         sizeof(ns1__createResponse), 0, soap_copy_ns1__createResponse);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   if ((soap->mode & SOAP_XML_STRICT) && (soap_flag_return_1 > 0)) {
     soap->error = SOAP_OCCURS;
-    return NULL;
+    return nullptr;
   }
   return a;
 }
 
 int ns1__createResponse::soap_put(struct soap *soap, const char *tag,
                                   const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__createResponse);
   if (this->soap_out(soap, tag ? tag : "ns1:createResponse", id, type))
     return soap->error;
@@ -25850,7 +25911,7 @@ soap_get_ns1__createResponse(struct soap *soap, ns1__createResponse *p,
                              const char *tag, const char *type) {
   if ((p = soap_in_ns1__createResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -25863,9 +25924,9 @@ soap_instantiate_ns1__createResponse(struct soap *soap, int n, const char *type,
                    fdebug, "soap_instantiate_ns1__createResponse(%d, %s, %s)\n",
                    n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__createResponse, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__createResponse, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__createResponse);
     if (size)
@@ -25901,8 +25962,8 @@ soap_copy_ns1__createResponse(struct soap *soap, int st, int tt, void *p,
 void ns1__create::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__create::sessionId = NULL;
-  this->ns1__create::bean = NULL;
+  this->ns1__create::sessionId = nullptr;
+  this->ns1__create::bean = nullptr;
 }
 
 void ns1__create::soap_serialize(struct soap *soap) const {
@@ -25945,13 +26006,13 @@ SOAP_FMAC3 ns1__create *SOAP_FMAC4
 soap_in_ns1__create(struct soap *soap, const char *tag, ns1__create *a,
                     const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__create *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__create, sizeof(ns1__create),
       soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__create) {
@@ -25992,24 +26053,24 @@ soap_in_ns1__create(struct soap *soap, const char *tag, ns1__create *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__create *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__create, 0,
         sizeof(ns1__create), 0, soap_copy_ns1__create);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__create::soap_put(struct soap *soap, const char *tag,
                           const char *type) const {
-  int id =
-      soap_embed(soap, (void *)this, NULL, 0, tag, SOAP_TYPE_ICat4_ns1__create);
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
+                      SOAP_TYPE_ICat4_ns1__create);
   if (this->soap_out(soap, tag ? tag : "ns1:create", id, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -26025,7 +26086,7 @@ soap_get_ns1__create(struct soap *soap, ns1__create *p, const char *tag,
                      const char *type) {
   if ((p = soap_in_ns1__create(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -26038,9 +26099,9 @@ soap_instantiate_ns1__create(struct soap *soap, int n, const char *type,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__create(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__create, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__create, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__create);
     if (size)
@@ -26118,13 +26179,13 @@ SOAP_FMAC3 ns1__createManyResponse *SOAP_FMAC4
 soap_in_ns1__createManyResponse(struct soap *soap, const char *tag,
                                 ns1__createManyResponse *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__createManyResponse *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__createManyResponse,
       sizeof(ns1__createManyResponse), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__createManyResponse) {
@@ -26154,24 +26215,24 @@ soap_in_ns1__createManyResponse(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__createManyResponse *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__createManyResponse,
         0, sizeof(ns1__createManyResponse), 0,
         soap_copy_ns1__createManyResponse);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__createManyResponse::soap_put(struct soap *soap, const char *tag,
                                       const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__createManyResponse);
   if (this->soap_out(soap, tag ? tag : "ns1:createManyResponse", id, type))
     return soap->error;
@@ -26188,7 +26249,7 @@ soap_get_ns1__createManyResponse(struct soap *soap, ns1__createManyResponse *p,
                                  const char *tag, const char *type) {
   if ((p = soap_in_ns1__createManyResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -26203,9 +26264,9 @@ soap_instantiate_ns1__createManyResponse(struct soap *soap, int n,
                       "soap_instantiate_ns1__createManyResponse(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__createManyResponse, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__createManyResponse, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__createManyResponse);
     if (size)
@@ -26241,11 +26302,11 @@ soap_copy_ns1__createManyResponse(struct soap *soap, int st, int tt, void *p,
 void ns1__entityBaseBean::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__entityBaseBean::createId = NULL;
-  this->ns1__entityBaseBean::createTime = NULL;
-  this->ns1__entityBaseBean::modTime = NULL;
-  this->ns1__entityBaseBean::id = NULL;
-  this->ns1__entityBaseBean::modId = NULL;
+  this->ns1__entityBaseBean::createId = nullptr;
+  this->ns1__entityBaseBean::createTime = nullptr;
+  this->ns1__entityBaseBean::modTime = nullptr;
+  this->ns1__entityBaseBean::id = nullptr;
+  this->ns1__entityBaseBean::modId = nullptr;
 }
 
 void ns1__entityBaseBean::soap_serialize(struct soap *soap) const {
@@ -26302,13 +26363,13 @@ SOAP_FMAC3 ns1__entityBaseBean *SOAP_FMAC4
 soap_in_ns1__entityBaseBean(struct soap *soap, const char *tag,
                             ns1__entityBaseBean *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__entityBaseBean *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__entityBaseBean,
       sizeof(ns1__entityBaseBean), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__entityBaseBean) {
@@ -26374,23 +26435,23 @@ soap_in_ns1__entityBaseBean(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__entityBaseBean *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__entityBaseBean, 0,
         sizeof(ns1__entityBaseBean), 0, soap_copy_ns1__entityBaseBean);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__entityBaseBean::soap_put(struct soap *soap, const char *tag,
                                   const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__entityBaseBean);
   if (this->soap_out(soap, tag ? tag : "ns1:entityBaseBean", id, type))
     return soap->error;
@@ -26407,7 +26468,7 @@ soap_get_ns1__entityBaseBean(struct soap *soap, ns1__entityBaseBean *p,
                              const char *tag, const char *type) {
   if ((p = soap_in_ns1__entityBaseBean(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -26420,9 +26481,9 @@ soap_instantiate_ns1__entityBaseBean(struct soap *soap, int n, const char *type,
                    fdebug, "soap_instantiate_ns1__entityBaseBean(%d, %s, %s)\n",
                    n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__entityBaseBean, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__entityBaseBean, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (type && !soap_match_tag(soap, type, "ns1:datafile")) {
     cp->type = SOAP_TYPE_ICat4_ns1__datafile;
     if (n < 0) {
@@ -27238,7 +27299,7 @@ soap_copy_ns1__entityBaseBean(struct soap *soap, int st, int tt, void *p,
 void ns1__createMany::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__createMany::sessionId = NULL;
+  this->ns1__createMany::sessionId = nullptr;
   soap_default_std__vectorTemplateOfPointerTons1__entityBaseBean(
       soap, &this->ns1__createMany::beans);
 }
@@ -27285,13 +27346,13 @@ SOAP_FMAC3 ns1__createMany *SOAP_FMAC4
 soap_in_ns1__createMany(struct soap *soap, const char *tag, ns1__createMany *a,
                         const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__createMany *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__createMany,
       sizeof(ns1__createMany), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__createMany) {
@@ -27330,23 +27391,23 @@ soap_in_ns1__createMany(struct soap *soap, const char *tag, ns1__createMany *a,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__createMany *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__createMany, 0,
         sizeof(ns1__createMany), 0, soap_copy_ns1__createMany);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__createMany::soap_put(struct soap *soap, const char *tag,
                               const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__createMany);
   if (this->soap_out(soap, tag ? tag : "ns1:createMany", id, type))
     return soap->error;
@@ -27363,7 +27424,7 @@ soap_get_ns1__createMany(struct soap *soap, ns1__createMany *p, const char *tag,
                          const char *type) {
   if ((p = soap_in_ns1__createMany(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -27375,10 +27436,10 @@ soap_instantiate_ns1__createMany(struct soap *soap, int n, const char *type,
   DBGLOG(TEST,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__createMany(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__createMany, n, ICat4_fdelete);
+  struct soap_clist *cp = soap_link(
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__createMany, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__createMany);
     if (size)
@@ -27414,9 +27475,9 @@ soap_copy_ns1__createMany(struct soap *soap, int st, int tt, void *p,
 void ns1__IcatException::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__IcatException::message = NULL;
+  this->ns1__IcatException::message = nullptr;
   soap_default_int(soap, &this->ns1__IcatException::offset);
-  this->ns1__IcatException::type = NULL;
+  this->ns1__IcatException::type = nullptr;
 }
 
 void ns1__IcatException::soap_serialize(struct soap *soap) const {
@@ -27464,13 +27525,13 @@ SOAP_FMAC3 ns1__IcatException *SOAP_FMAC4
 soap_in_ns1__IcatException(struct soap *soap, const char *tag,
                            ns1__IcatException *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__IcatException *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__IcatException,
       sizeof(ns1__IcatException), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__IcatException) {
@@ -27519,27 +27580,27 @@ soap_in_ns1__IcatException(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__IcatException *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__IcatException, 0,
         sizeof(ns1__IcatException), 0, soap_copy_ns1__IcatException);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   if ((soap->mode & SOAP_XML_STRICT) && (soap_flag_offset1 > 0)) {
     soap->error = SOAP_OCCURS;
-    return NULL;
+    return nullptr;
   }
   return a;
 }
 
 int ns1__IcatException::soap_put(struct soap *soap, const char *tag,
                                  const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__IcatException);
   if (this->soap_out(soap, tag ? tag : "ns1:IcatException", id, type))
     return soap->error;
@@ -27556,7 +27617,7 @@ soap_get_ns1__IcatException(struct soap *soap, ns1__IcatException *p,
                             const char *tag, const char *type) {
   if ((p = soap_in_ns1__IcatException(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -27569,9 +27630,9 @@ soap_instantiate_ns1__IcatException(struct soap *soap, int n, const char *type,
                             "soap_instantiate_ns1__IcatException(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__IcatException, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__IcatException, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__IcatException);
     if (size)
@@ -27639,13 +27700,13 @@ soap_in_ns1__luceneClearResponse(struct soap *soap, const char *tag,
                                  ns1__luceneClearResponse *a,
                                  const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!(a = (ns1__luceneClearResponse *)soap_class_id_enter(
             soap, soap->id, a, SOAP_TYPE_ICat4_ns1__luceneClearResponse,
             sizeof(ns1__luceneClearResponse), soap->type, soap->arrayType))) {
     soap->error = SOAP_TAG_MISMATCH;
-    return NULL;
+    return nullptr;
   }
   soap_revert(soap);
   *soap->id = '\0';
@@ -27655,13 +27716,13 @@ soap_in_ns1__luceneClearResponse(struct soap *soap, const char *tag,
       return (ns1__luceneClearResponse *)a->soap_in(soap, tag, type);
   }
   if (!soap_inliteral(soap, tag, &(a->xsd__anyType::__item)))
-    return NULL;
+    return nullptr;
   return a;
 }
 
 int ns1__luceneClearResponse::soap_put(struct soap *soap, const char *tag,
                                        const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__luceneClearResponse);
   if (this->soap_out(soap, tag ? tag : "ns1:luceneClearResponse", id, type))
     return soap->error;
@@ -27679,7 +27740,7 @@ soap_get_ns1__luceneClearResponse(struct soap *soap,
                                   const char *type) {
   if ((p = soap_in_ns1__luceneClearResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -27693,10 +27754,11 @@ soap_instantiate_ns1__luceneClearResponse(struct soap *soap, int n,
          SOAP_MESSAGE(fdebug,
                       "soap_instantiate_ns1__luceneClearResponse(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_ns1__luceneClearResponse, n, ICat4_fdelete);
+  struct soap_clist *cp =
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_ns1__luceneClearResponse, n,
+                ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__luceneClearResponse);
     if (size)
@@ -27733,7 +27795,7 @@ soap_copy_ns1__luceneClearResponse(struct soap *soap, int st, int tt, void *p,
 void ns1__luceneClear::soap_default(struct soap *soap) {
   this->soap = soap;
   this->xsd__anyType::soap_default(soap);
-  this->ns1__luceneClear::sessionId = NULL;
+  this->ns1__luceneClear::sessionId = nullptr;
 }
 
 void ns1__luceneClear::soap_serialize(struct soap *soap) const {
@@ -27773,13 +27835,13 @@ SOAP_FMAC3 ns1__luceneClear *SOAP_FMAC4
 soap_in_ns1__luceneClear(struct soap *soap, const char *tag,
                          ns1__luceneClear *a, const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 0, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 0, nullptr))
+    return nullptr;
   a = (ns1__luceneClear *)soap_class_id_enter(
       soap, soap->id, a, SOAP_TYPE_ICat4_ns1__luceneClear,
       sizeof(ns1__luceneClear), soap->type, soap->arrayType);
   if (!a)
-    return NULL;
+    return nullptr;
   if (soap->alloced) {
     a->soap_default(soap);
     if (soap->clist->type != SOAP_TYPE_ICat4_ns1__luceneClear) {
@@ -27813,23 +27875,23 @@ soap_in_ns1__luceneClear(struct soap *soap, const char *tag,
       if (soap->error == SOAP_NO_TAG)
         break;
       if (soap->error)
-        return NULL;
+        return nullptr;
     }
     if (soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   } else {
     a = (ns1__luceneClear *)soap_id_forward(
         soap, soap->href, (void *)a, 0, SOAP_TYPE_ICat4_ns1__luceneClear, 0,
         sizeof(ns1__luceneClear), 0, soap_copy_ns1__luceneClear);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
 
 int ns1__luceneClear::soap_put(struct soap *soap, const char *tag,
                                const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_ns1__luceneClear);
   if (this->soap_out(soap, tag ? tag : "ns1:luceneClear", id, type))
     return soap->error;
@@ -27846,7 +27908,7 @@ soap_get_ns1__luceneClear(struct soap *soap, ns1__luceneClear *p,
                           const char *tag, const char *type) {
   if ((p = soap_in_ns1__luceneClear(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -27858,10 +27920,10 @@ soap_instantiate_ns1__luceneClear(struct soap *soap, int n, const char *type,
   DBGLOG(TEST,
          SOAP_MESSAGE(fdebug, "soap_instantiate_ns1__luceneClear(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_ns1__luceneClear, n, ICat4_fdelete);
+  struct soap_clist *cp = soap_link(
+      soap, nullptr, SOAP_TYPE_ICat4_ns1__luceneClear, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(ns1__luceneClear);
     if (size)
@@ -27922,8 +27984,8 @@ SOAP_FMAC3 std::string *SOAP_FMAC4
 soap_in_std__string(struct soap *soap, const char *tag, std::string *s,
                     const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!s)
     s = soap_new_std__string(soap, -1);
   if (soap->null)
@@ -27936,7 +27998,7 @@ soap_in_std__string(struct soap *soap, const char *tag, std::string *s,
         soap->type, soap->arrayType);
     if (s) {
       if (!(t = soap_string_in(soap, 1, 0, -1)))
-        return NULL;
+        return nullptr;
       s->assign(t);
     }
   } else
@@ -27947,7 +28009,7 @@ soap_in_std__string(struct soap *soap, const char *tag, std::string *s,
         0, SOAP_TYPE_ICat4_std__string, 0, sizeof(std::string), 0,
         soap_copy_std__string);
   if (soap->body && soap_element_end_in(soap, tag))
-    return NULL;
+    return nullptr;
   return s;
 }
 
@@ -27955,7 +28017,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_std__string(struct soap *soap, const std::string *a, const char *tag,
                      const char *type) {
   int id =
-      soap_embed(soap, (void *)a, NULL, 0, tag, SOAP_TYPE_ICat4_std__string);
+      soap_embed(soap, (void *)a, nullptr, 0, tag, SOAP_TYPE_ICat4_std__string);
   if (soap_out_std__string(soap, tag ? tag : "string", id, a, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -27966,7 +28028,7 @@ soap_get_std__string(struct soap *soap, std::string *p, const char *tag,
                      const char *type) {
   if ((p = soap_in_std__string(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -27979,9 +28041,9 @@ soap_instantiate_std__string(struct soap *soap, int n, const char *type,
          SOAP_MESSAGE(fdebug, "soap_instantiate_std__string(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_std__string, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_std__string, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::string);
     if (size)
@@ -28045,13 +28107,13 @@ SOAP_FMAC3 xsd__string *SOAP_FMAC4
 soap_in_xsd__string(struct soap *soap, const char *tag, xsd__string *a,
                     const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!(a = (xsd__string *)soap_class_id_enter(
             soap, soap->id, a, SOAP_TYPE_ICat4_xsd__string, sizeof(xsd__string),
             soap->type, soap->arrayType))) {
     soap->error = SOAP_TAG_MISMATCH;
-    return NULL;
+    return nullptr;
   }
   soap_revert(soap);
   *soap->id = '\0';
@@ -28061,14 +28123,14 @@ soap_in_xsd__string(struct soap *soap, const char *tag, xsd__string *a,
       return (xsd__string *)a->soap_in(soap, tag, type);
   }
   if (!soap_in_std__string(soap, tag, &(a->xsd__string::__item), "xsd:string"))
-    return NULL;
+    return nullptr;
   return a;
 }
 
 int xsd__string::soap_put(struct soap *soap, const char *tag,
                           const char *type) const {
-  int id =
-      soap_embed(soap, (void *)this, NULL, 0, tag, SOAP_TYPE_ICat4_xsd__string);
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
+                      SOAP_TYPE_ICat4_xsd__string);
   if (this->soap_out(soap, tag ? tag : "xsd:string", id, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -28084,7 +28146,7 @@ soap_get_xsd__string(struct soap *soap, xsd__string *p, const char *tag,
                      const char *type) {
   if ((p = soap_in_xsd__string(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -28097,9 +28159,9 @@ soap_instantiate_xsd__string(struct soap *soap, int n, const char *type,
          SOAP_MESSAGE(fdebug, "soap_instantiate_xsd__string(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_xsd__string, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_xsd__string, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(xsd__string);
     if (size)
@@ -28164,13 +28226,13 @@ SOAP_FMAC3 xsd__long *SOAP_FMAC4
 soap_in_xsd__long(struct soap *soap, const char *tag, xsd__long *a,
                   const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!(a = (xsd__long *)soap_class_id_enter(
             soap, soap->id, a, SOAP_TYPE_ICat4_xsd__long, sizeof(xsd__long),
             soap->type, soap->arrayType))) {
     soap->error = SOAP_TAG_MISMATCH;
-    return NULL;
+    return nullptr;
   }
   soap_revert(soap);
   *soap->id = '\0';
@@ -28180,14 +28242,14 @@ soap_in_xsd__long(struct soap *soap, const char *tag, xsd__long *a,
       return (xsd__long *)a->soap_in(soap, tag, type);
   }
   if (!soap_in_LONG64(soap, tag, &(a->xsd__long::__item), "xsd:long"))
-    return NULL;
+    return nullptr;
   return a;
 }
 
 int xsd__long::soap_put(struct soap *soap, const char *tag,
                         const char *type) const {
-  int id =
-      soap_embed(soap, (void *)this, NULL, 0, tag, SOAP_TYPE_ICat4_xsd__long);
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
+                      SOAP_TYPE_ICat4_xsd__long);
   if (this->soap_out(soap, tag ? tag : "xsd:long", id, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -28203,7 +28265,7 @@ soap_get_xsd__long(struct soap *soap, xsd__long *p, const char *tag,
                    const char *type) {
   if ((p = soap_in_xsd__long(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -28215,9 +28277,9 @@ soap_instantiate_xsd__long(struct soap *soap, int n, const char *type,
   DBGLOG(TEST, SOAP_MESSAGE(fdebug, "soap_instantiate_xsd__long(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_xsd__long, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_xsd__long, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(xsd__long);
     if (size)
@@ -28282,13 +28344,13 @@ SOAP_FMAC3 xsd__int *SOAP_FMAC4 soap_in_xsd__int(struct soap *soap,
                                                  const char *tag, xsd__int *a,
                                                  const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!(a = (xsd__int *)soap_class_id_enter(
             soap, soap->id, a, SOAP_TYPE_ICat4_xsd__int, sizeof(xsd__int),
             soap->type, soap->arrayType))) {
     soap->error = SOAP_TAG_MISMATCH;
-    return NULL;
+    return nullptr;
   }
   soap_revert(soap);
   *soap->id = '\0';
@@ -28298,14 +28360,14 @@ SOAP_FMAC3 xsd__int *SOAP_FMAC4 soap_in_xsd__int(struct soap *soap,
       return (xsd__int *)a->soap_in(soap, tag, type);
   }
   if (!soap_in_int(soap, tag, &(a->xsd__int::__item), "xsd:int"))
-    return NULL;
+    return nullptr;
   return a;
 }
 
 int xsd__int::soap_put(struct soap *soap, const char *tag,
                        const char *type) const {
   int id =
-      soap_embed(soap, (void *)this, NULL, 0, tag, SOAP_TYPE_ICat4_xsd__int);
+      soap_embed(soap, (void *)this, nullptr, 0, tag, SOAP_TYPE_ICat4_xsd__int);
   if (this->soap_out(soap, tag ? tag : "xsd:int", id, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -28320,7 +28382,7 @@ SOAP_FMAC3 xsd__int *SOAP_FMAC4 soap_get_xsd__int(struct soap *soap,
                                                   const char *type) {
   if ((p = soap_in_xsd__int(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -28332,9 +28394,9 @@ soap_instantiate_xsd__int(struct soap *soap, int n, const char *type,
   DBGLOG(TEST, SOAP_MESSAGE(fdebug, "soap_instantiate_xsd__int(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_xsd__int, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_xsd__int, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(xsd__int);
     if (size)
@@ -28401,13 +28463,13 @@ SOAP_FMAC3 xsd__double *SOAP_FMAC4
 soap_in_xsd__double(struct soap *soap, const char *tag, xsd__double *a,
                     const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!(a = (xsd__double *)soap_class_id_enter(
             soap, soap->id, a, SOAP_TYPE_ICat4_xsd__double, sizeof(xsd__double),
             soap->type, soap->arrayType))) {
     soap->error = SOAP_TAG_MISMATCH;
-    return NULL;
+    return nullptr;
   }
   soap_revert(soap);
   *soap->id = '\0';
@@ -28417,14 +28479,14 @@ soap_in_xsd__double(struct soap *soap, const char *tag, xsd__double *a,
       return (xsd__double *)a->soap_in(soap, tag, type);
   }
   if (!soap_in_double(soap, tag, &(a->xsd__double::__item), "xsd:double"))
-    return NULL;
+    return nullptr;
   return a;
 }
 
 int xsd__double::soap_put(struct soap *soap, const char *tag,
                           const char *type) const {
-  int id =
-      soap_embed(soap, (void *)this, NULL, 0, tag, SOAP_TYPE_ICat4_xsd__double);
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
+                      SOAP_TYPE_ICat4_xsd__double);
   if (this->soap_out(soap, tag ? tag : "xsd:double", id, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -28440,7 +28502,7 @@ soap_get_xsd__double(struct soap *soap, xsd__double *p, const char *tag,
                      const char *type) {
   if ((p = soap_in_xsd__double(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -28453,9 +28515,9 @@ soap_instantiate_xsd__double(struct soap *soap, int n, const char *type,
          SOAP_MESSAGE(fdebug, "soap_instantiate_xsd__double(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_xsd__double, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_xsd__double, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(xsd__double);
     if (size)
@@ -28522,13 +28584,13 @@ SOAP_FMAC3 xsd__dateTime *SOAP_FMAC4
 soap_in_xsd__dateTime(struct soap *soap, const char *tag, xsd__dateTime *a,
                       const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!(a = (xsd__dateTime *)soap_class_id_enter(
             soap, soap->id, a, SOAP_TYPE_ICat4_xsd__dateTime,
             sizeof(xsd__dateTime), soap->type, soap->arrayType))) {
     soap->error = SOAP_TAG_MISMATCH;
-    return NULL;
+    return nullptr;
   }
   soap_revert(soap);
   *soap->id = '\0';
@@ -28538,13 +28600,13 @@ soap_in_xsd__dateTime(struct soap *soap, const char *tag, xsd__dateTime *a,
       return (xsd__dateTime *)a->soap_in(soap, tag, type);
   }
   if (!soap_in_time(soap, tag, &(a->xsd__dateTime::__item), "xsd:dateTime"))
-    return NULL;
+    return nullptr;
   return a;
 }
 
 int xsd__dateTime::soap_put(struct soap *soap, const char *tag,
                             const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_xsd__dateTime);
   if (this->soap_out(soap, tag ? tag : "xsd:dateTime", id, type))
     return soap->error;
@@ -28561,7 +28623,7 @@ soap_get_xsd__dateTime(struct soap *soap, xsd__dateTime *p, const char *tag,
                        const char *type) {
   if ((p = soap_in_xsd__dateTime(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -28574,9 +28636,9 @@ soap_instantiate_xsd__dateTime(struct soap *soap, int n, const char *type,
          SOAP_MESSAGE(fdebug, "soap_instantiate_xsd__dateTime(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_xsd__dateTime, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_xsd__dateTime, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(xsd__dateTime);
     if (size)
@@ -28642,13 +28704,13 @@ SOAP_FMAC3 xsd__boolean *SOAP_FMAC4
 soap_in_xsd__boolean(struct soap *soap, const char *tag, xsd__boolean *a,
                      const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!(a = (xsd__boolean *)soap_class_id_enter(
             soap, soap->id, a, SOAP_TYPE_ICat4_xsd__boolean,
             sizeof(xsd__boolean), soap->type, soap->arrayType))) {
     soap->error = SOAP_TAG_MISMATCH;
-    return NULL;
+    return nullptr;
   }
   soap_revert(soap);
   *soap->id = '\0';
@@ -28658,13 +28720,13 @@ soap_in_xsd__boolean(struct soap *soap, const char *tag, xsd__boolean *a,
       return (xsd__boolean *)a->soap_in(soap, tag, type);
   }
   if (!soap_in_bool(soap, tag, &(a->xsd__boolean::__item), "xsd:boolean"))
-    return NULL;
+    return nullptr;
   return a;
 }
 
 int xsd__boolean::soap_put(struct soap *soap, const char *tag,
                            const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_xsd__boolean);
   if (this->soap_out(soap, tag ? tag : "xsd:boolean", id, type))
     return soap->error;
@@ -28681,7 +28743,7 @@ soap_get_xsd__boolean(struct soap *soap, xsd__boolean *p, const char *tag,
                       const char *type) {
   if ((p = soap_in_xsd__boolean(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -28694,9 +28756,9 @@ soap_instantiate_xsd__boolean(struct soap *soap, int n, const char *type,
          SOAP_MESSAGE(fdebug, "soap_instantiate_xsd__boolean(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_xsd__boolean, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_xsd__boolean, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(xsd__boolean);
     if (size)
@@ -28730,7 +28792,7 @@ SOAP_FMAC3 void SOAP_FMAC4 soap_copy_xsd__boolean(struct soap *soap, int st,
 
 void xsd__anyType::soap_default(struct soap *soap) {
   this->soap = soap;
-  this->xsd__anyType::__item = NULL;
+  this->xsd__anyType::__item = nullptr;
   /* transient soap skipped */
 }
 
@@ -28749,7 +28811,7 @@ int xsd__anyType::soap_out(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_xsd__anyType(struct soap *soap, const char *tag, int id,
                       const xsd__anyType *a, const char *type) {
-  return soap_outliteral(soap, tag, &(a->xsd__anyType::__item), NULL);
+  return soap_outliteral(soap, tag, &(a->xsd__anyType::__item), nullptr);
 }
 
 void *xsd__anyType::soap_in(struct soap *soap, const char *tag,
@@ -28761,13 +28823,13 @@ SOAP_FMAC3 xsd__anyType *SOAP_FMAC4
 soap_in_xsd__anyType(struct soap *soap, const char *tag, xsd__anyType *a,
                      const char *type) {
   (void)type; /* appease -Wall -Werror */
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!(a = (xsd__anyType *)soap_class_id_enter(
             soap, soap->id, a, SOAP_TYPE_ICat4_xsd__anyType,
             sizeof(xsd__anyType), soap->type, soap->arrayType))) {
     soap->error = SOAP_TAG_MISMATCH;
-    return NULL;
+    return nullptr;
   }
   soap_revert(soap);
   *soap->id = '\0';
@@ -28777,13 +28839,13 @@ soap_in_xsd__anyType(struct soap *soap, const char *tag, xsd__anyType *a,
       return (xsd__anyType *)a->soap_in(soap, tag, type);
   }
   if (!soap_inliteral(soap, tag, &(a->xsd__anyType::__item)))
-    return NULL;
+    return nullptr;
   return a;
 }
 
 int xsd__anyType::soap_put(struct soap *soap, const char *tag,
                            const char *type) const {
-  int id = soap_embed(soap, (void *)this, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)this, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_xsd__anyType);
   if (this->soap_out(soap, tag ? tag : "xsd:anyType", id, type))
     return soap->error;
@@ -28800,7 +28862,7 @@ soap_get_xsd__anyType(struct soap *soap, xsd__anyType *p, const char *tag,
                       const char *type) {
   if ((p = soap_in_xsd__anyType(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -28813,9 +28875,9 @@ soap_instantiate_xsd__anyType(struct soap *soap, int n, const char *type,
          SOAP_MESSAGE(fdebug, "soap_instantiate_xsd__anyType(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_xsd__anyType, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_xsd__anyType, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (type && !soap_match_tag(soap, type, "xsd:boolean")) {
     cp->type = SOAP_TYPE_ICat4_xsd__boolean;
     if (n < 0) {
@@ -31561,7 +31623,7 @@ soap_default___ns1__getEntityInfo(struct soap *soap,
                                   struct __ns1__getEntityInfo *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__getEntityInfo_ = NULL;
+  a->ns1__getEntityInfo_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4
@@ -31595,9 +31657,9 @@ soap_in___ns1__getEntityInfo(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__getEntityInfo *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__getEntityInfo,
-      sizeof(struct __ns1__getEntityInfo), 0, NULL, NULL, NULL);
+      sizeof(struct __ns1__getEntityInfo), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__getEntityInfo(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -31616,7 +31678,7 @@ soap_in___ns1__getEntityInfo(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -31637,7 +31699,7 @@ soap_get___ns1__getEntityInfo(struct soap *soap, struct __ns1__getEntityInfo *p,
                               const char *tag, const char *type) {
   if ((p = soap_in___ns1__getEntityInfo(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -31652,9 +31714,9 @@ soap_instantiate___ns1__getEntityInfo(struct soap *soap, int n,
                       "soap_instantiate___ns1__getEntityInfo(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4___ns1__getEntityInfo, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4___ns1__getEntityInfo, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__getEntityInfo);
     if (size)
@@ -31688,7 +31750,7 @@ SOAP_FMAC3 void SOAP_FMAC4
 soap_default___ns1__deleteMany(struct soap *soap, struct __ns1__deleteMany *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__deleteMany_ = NULL;
+  a->ns1__deleteMany_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4
@@ -31722,9 +31784,9 @@ soap_in___ns1__deleteMany(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__deleteMany *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__deleteMany,
-      sizeof(struct __ns1__deleteMany), 0, NULL, NULL, NULL);
+      sizeof(struct __ns1__deleteMany), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__deleteMany(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -31742,7 +31804,7 @@ soap_in___ns1__deleteMany(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -31762,7 +31824,7 @@ soap_get___ns1__deleteMany(struct soap *soap, struct __ns1__deleteMany *p,
                            const char *tag, const char *type) {
   if ((p = soap_in___ns1__deleteMany(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -31775,9 +31837,9 @@ soap_instantiate___ns1__deleteMany(struct soap *soap, int n, const char *type,
                             "soap_instantiate___ns1__deleteMany(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4___ns1__deleteMany, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4___ns1__deleteMany, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__deleteMany);
     if (size)
@@ -31812,7 +31874,7 @@ soap_default___ns1__deleteManyResponse(struct soap *soap,
                                        struct __ns1__deleteManyResponse *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__deleteManyResponse_ = NULL;
+  a->ns1__deleteManyResponse_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4 soap_serialize___ns1__deleteManyResponse(
@@ -31849,9 +31911,9 @@ soap_in___ns1__deleteManyResponse(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__deleteManyResponse *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__deleteManyResponse,
-      sizeof(struct __ns1__deleteManyResponse), 0, NULL, NULL, NULL);
+      sizeof(struct __ns1__deleteManyResponse), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__deleteManyResponse(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -31871,7 +31933,7 @@ soap_in___ns1__deleteManyResponse(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -31893,7 +31955,7 @@ soap_get___ns1__deleteManyResponse(struct soap *soap,
                                    const char *tag, const char *type) {
   if ((p = soap_in___ns1__deleteManyResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -31908,10 +31970,11 @@ soap_instantiate___ns1__deleteManyResponse(struct soap *soap, int n,
          SOAP_MESSAGE(
              fdebug, "soap_instantiate___ns1__deleteManyResponse(%d, %s, %s)\n",
              n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4___ns1__deleteManyResponse, n, ICat4_fdelete);
+  struct soap_clist *cp =
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4___ns1__deleteManyResponse, n,
+                ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__deleteManyResponse);
     if (size)
@@ -31947,7 +32010,7 @@ SOAP_FMAC3 void SOAP_FMAC4
 soap_default___ns1__createMany(struct soap *soap, struct __ns1__createMany *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__createMany_ = NULL;
+  a->ns1__createMany_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4
@@ -31981,9 +32044,9 @@ soap_in___ns1__createMany(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__createMany *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__createMany,
-      sizeof(struct __ns1__createMany), 0, NULL, NULL, NULL);
+      sizeof(struct __ns1__createMany), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__createMany(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -32001,7 +32064,7 @@ soap_in___ns1__createMany(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -32021,7 +32084,7 @@ soap_get___ns1__createMany(struct soap *soap, struct __ns1__createMany *p,
                            const char *tag, const char *type) {
   if ((p = soap_in___ns1__createMany(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -32034,9 +32097,9 @@ soap_instantiate___ns1__createMany(struct soap *soap, int n, const char *type,
                             "soap_instantiate___ns1__createMany(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4___ns1__createMany, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4___ns1__createMany, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__createMany);
     if (size)
@@ -32071,7 +32134,7 @@ soap_default___ns1__luceneGetPopulating(struct soap *soap,
                                         struct __ns1__luceneGetPopulating *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__luceneGetPopulating_ = NULL;
+  a->ns1__luceneGetPopulating_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4 soap_serialize___ns1__luceneGetPopulating(
@@ -32107,9 +32170,9 @@ soap_in___ns1__luceneGetPopulating(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__luceneGetPopulating *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__luceneGetPopulating,
-      sizeof(struct __ns1__luceneGetPopulating), 0, NULL, NULL, NULL);
+      sizeof(struct __ns1__luceneGetPopulating), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__luceneGetPopulating(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -32128,7 +32191,7 @@ soap_in___ns1__luceneGetPopulating(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -32150,7 +32213,7 @@ soap_get___ns1__luceneGetPopulating(struct soap *soap,
                                     const char *tag, const char *type) {
   if ((p = soap_in___ns1__luceneGetPopulating(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -32165,10 +32228,11 @@ soap_instantiate___ns1__luceneGetPopulating(struct soap *soap, int n,
                    fdebug,
                    "soap_instantiate___ns1__luceneGetPopulating(%d, %s, %s)\n",
                    n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4___ns1__luceneGetPopulating, n, ICat4_fdelete);
+  struct soap_clist *cp =
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4___ns1__luceneGetPopulating, n,
+                ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__luceneGetPopulating);
     if (size)
@@ -32205,7 +32269,7 @@ soap_default___ns1__luceneSearch(struct soap *soap,
                                  struct __ns1__luceneSearch *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__luceneSearch_ = NULL;
+  a->ns1__luceneSearch_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4
@@ -32239,9 +32303,9 @@ soap_in___ns1__luceneSearch(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__luceneSearch *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__luceneSearch,
-      sizeof(struct __ns1__luceneSearch), 0, NULL, NULL, NULL);
+      sizeof(struct __ns1__luceneSearch), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__luceneSearch(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -32260,7 +32324,7 @@ soap_in___ns1__luceneSearch(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -32281,7 +32345,7 @@ soap_get___ns1__luceneSearch(struct soap *soap, struct __ns1__luceneSearch *p,
                              const char *tag, const char *type) {
   if ((p = soap_in___ns1__luceneSearch(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -32294,9 +32358,9 @@ soap_instantiate___ns1__luceneSearch(struct soap *soap, int n, const char *type,
                    fdebug, "soap_instantiate___ns1__luceneSearch(%d, %s, %s)\n",
                    n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4___ns1__luceneSearch, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4___ns1__luceneSearch, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__luceneSearch);
     if (size)
@@ -32331,7 +32395,7 @@ soap_default___ns1__luceneCommit(struct soap *soap,
                                  struct __ns1__luceneCommit *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__luceneCommit_ = NULL;
+  a->ns1__luceneCommit_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4
@@ -32365,9 +32429,9 @@ soap_in___ns1__luceneCommit(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__luceneCommit *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__luceneCommit,
-      sizeof(struct __ns1__luceneCommit), 0, NULL, NULL, NULL);
+      sizeof(struct __ns1__luceneCommit), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__luceneCommit(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -32386,7 +32450,7 @@ soap_in___ns1__luceneCommit(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -32407,7 +32471,7 @@ soap_get___ns1__luceneCommit(struct soap *soap, struct __ns1__luceneCommit *p,
                              const char *tag, const char *type) {
   if ((p = soap_in___ns1__luceneCommit(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -32420,9 +32484,9 @@ soap_instantiate___ns1__luceneCommit(struct soap *soap, int n, const char *type,
                    fdebug, "soap_instantiate___ns1__luceneCommit(%d, %s, %s)\n",
                    n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4___ns1__luceneCommit, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4___ns1__luceneCommit, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__luceneCommit);
     if (size)
@@ -32456,7 +32520,7 @@ SOAP_FMAC3 void SOAP_FMAC4 soap_default___ns1__luceneCommitResponse(
     struct soap *soap, struct __ns1__luceneCommitResponse *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__luceneCommitResponse_ = NULL;
+  a->ns1__luceneCommitResponse_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4 soap_serialize___ns1__luceneCommitResponse(
@@ -32493,9 +32557,9 @@ soap_in___ns1__luceneCommitResponse(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__luceneCommitResponse *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__luceneCommitResponse,
-      sizeof(struct __ns1__luceneCommitResponse), 0, NULL, NULL, NULL);
+      sizeof(struct __ns1__luceneCommitResponse), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__luceneCommitResponse(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -32516,7 +32580,7 @@ soap_in___ns1__luceneCommitResponse(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -32537,7 +32601,7 @@ soap_get___ns1__luceneCommitResponse(struct soap *soap,
                                      const char *tag, const char *type) {
   if ((p = soap_in___ns1__luceneCommitResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -32553,10 +32617,10 @@ soap_instantiate___ns1__luceneCommitResponse(struct soap *soap, int n,
                    "soap_instantiate___ns1__luceneCommitResponse(%d, %s, %s)\n",
                    n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4___ns1__luceneCommitResponse, n,
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4___ns1__luceneCommitResponse, n,
                 ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__luceneCommitResponse);
     if (size)
@@ -32594,7 +32658,7 @@ soap_default___ns1__luceneClear(struct soap *soap,
                                 struct __ns1__luceneClear *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__luceneClear_ = NULL;
+  a->ns1__luceneClear_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4
@@ -32628,9 +32692,9 @@ soap_in___ns1__luceneClear(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__luceneClear *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__luceneClear,
-      sizeof(struct __ns1__luceneClear), 0, NULL, NULL, NULL);
+      sizeof(struct __ns1__luceneClear), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__luceneClear(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -32649,7 +32713,7 @@ soap_in___ns1__luceneClear(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -32670,7 +32734,7 @@ soap_get___ns1__luceneClear(struct soap *soap, struct __ns1__luceneClear *p,
                             const char *tag, const char *type) {
   if ((p = soap_in___ns1__luceneClear(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -32683,9 +32747,9 @@ soap_instantiate___ns1__luceneClear(struct soap *soap, int n, const char *type,
                             "soap_instantiate___ns1__luceneClear(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4___ns1__luceneClear, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4___ns1__luceneClear, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__luceneClear);
     if (size)
@@ -32720,7 +32784,7 @@ soap_default___ns1__luceneClearResponse(struct soap *soap,
                                         struct __ns1__luceneClearResponse *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__luceneClearResponse_ = NULL;
+  a->ns1__luceneClearResponse_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4 soap_serialize___ns1__luceneClearResponse(
@@ -32758,9 +32822,9 @@ soap_in___ns1__luceneClearResponse(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__luceneClearResponse *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__luceneClearResponse,
-      sizeof(struct __ns1__luceneClearResponse), 0, NULL, NULL, NULL);
+      sizeof(struct __ns1__luceneClearResponse), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__luceneClearResponse(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -32780,7 +32844,7 @@ soap_in___ns1__luceneClearResponse(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -32802,7 +32866,7 @@ soap_get___ns1__luceneClearResponse(struct soap *soap,
                                     const char *tag, const char *type) {
   if ((p = soap_in___ns1__luceneClearResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -32817,10 +32881,11 @@ soap_instantiate___ns1__luceneClearResponse(struct soap *soap, int n,
                    fdebug,
                    "soap_instantiate___ns1__luceneClearResponse(%d, %s, %s)\n",
                    n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4___ns1__luceneClearResponse, n, ICat4_fdelete);
+  struct soap_clist *cp =
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4___ns1__luceneClearResponse, n,
+                ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__luceneClearResponse);
     if (size)
@@ -32857,7 +32922,7 @@ soap_default___ns1__lucenePopulate(struct soap *soap,
                                    struct __ns1__lucenePopulate *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__lucenePopulate_ = NULL;
+  a->ns1__lucenePopulate_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4
@@ -32892,9 +32957,9 @@ soap_in___ns1__lucenePopulate(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__lucenePopulate *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__lucenePopulate,
-      sizeof(struct __ns1__lucenePopulate), 0, NULL, NULL, NULL);
+      sizeof(struct __ns1__lucenePopulate), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__lucenePopulate(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -32913,7 +32978,7 @@ soap_in___ns1__lucenePopulate(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -32935,7 +33000,7 @@ soap_get___ns1__lucenePopulate(struct soap *soap,
                                const char *type) {
   if ((p = soap_in___ns1__lucenePopulate(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -32950,9 +33015,9 @@ soap_instantiate___ns1__lucenePopulate(struct soap *soap, int n,
                       "soap_instantiate___ns1__lucenePopulate(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4___ns1__lucenePopulate, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4___ns1__lucenePopulate, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__lucenePopulate);
     if (size)
@@ -32986,7 +33051,7 @@ SOAP_FMAC3 void SOAP_FMAC4 soap_default___ns1__lucenePopulateResponse(
     struct soap *soap, struct __ns1__lucenePopulateResponse *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__lucenePopulateResponse_ = NULL;
+  a->ns1__lucenePopulateResponse_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4 soap_serialize___ns1__lucenePopulateResponse(
@@ -33023,9 +33088,10 @@ soap_in___ns1__lucenePopulateResponse(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__lucenePopulateResponse *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__lucenePopulateResponse,
-      sizeof(struct __ns1__lucenePopulateResponse), 0, NULL, NULL, NULL);
+      sizeof(struct __ns1__lucenePopulateResponse), 0, nullptr, nullptr,
+      nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__lucenePopulateResponse(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -33046,7 +33112,7 @@ soap_in___ns1__lucenePopulateResponse(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -33067,7 +33133,7 @@ soap_get___ns1__lucenePopulateResponse(struct soap *soap,
                                        const char *tag, const char *type) {
   if ((p = soap_in___ns1__lucenePopulateResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -33084,10 +33150,10 @@ soap_instantiate___ns1__lucenePopulateResponse(struct soap *soap, int n,
              "soap_instantiate___ns1__lucenePopulateResponse(%d, %s, %s)\n", n,
              type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4___ns1__lucenePopulateResponse, n,
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4___ns1__lucenePopulateResponse, n,
                 ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__lucenePopulateResponse);
     if (size)
@@ -33125,7 +33191,7 @@ soap_default___ns1__isAccessAllowed(struct soap *soap,
                                     struct __ns1__isAccessAllowed *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__isAccessAllowed_ = NULL;
+  a->ns1__isAccessAllowed_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4
@@ -33160,9 +33226,9 @@ soap_in___ns1__isAccessAllowed(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__isAccessAllowed *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__isAccessAllowed,
-      sizeof(struct __ns1__isAccessAllowed), 0, NULL, NULL, NULL);
+      sizeof(struct __ns1__isAccessAllowed), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__isAccessAllowed(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -33181,7 +33247,7 @@ soap_in___ns1__isAccessAllowed(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -33203,7 +33269,7 @@ soap_get___ns1__isAccessAllowed(struct soap *soap,
                                 const char *tag, const char *type) {
   if ((p = soap_in___ns1__isAccessAllowed(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -33218,9 +33284,9 @@ soap_instantiate___ns1__isAccessAllowed(struct soap *soap, int n,
                       "soap_instantiate___ns1__isAccessAllowed(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4___ns1__isAccessAllowed, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4___ns1__isAccessAllowed, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__isAccessAllowed);
     if (size)
@@ -33254,7 +33320,7 @@ SOAP_FMAC3 void SOAP_FMAC4
 soap_default___ns1__searchText(struct soap *soap, struct __ns1__searchText *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__searchText_ = NULL;
+  a->ns1__searchText_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4
@@ -33288,9 +33354,9 @@ soap_in___ns1__searchText(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__searchText *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__searchText,
-      sizeof(struct __ns1__searchText), 0, NULL, NULL, NULL);
+      sizeof(struct __ns1__searchText), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__searchText(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -33308,7 +33374,7 @@ soap_in___ns1__searchText(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -33328,7 +33394,7 @@ soap_get___ns1__searchText(struct soap *soap, struct __ns1__searchText *p,
                            const char *tag, const char *type) {
   if ((p = soap_in___ns1__searchText(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -33341,9 +33407,9 @@ soap_instantiate___ns1__searchText(struct soap *soap, int n, const char *type,
                             "soap_instantiate___ns1__searchText(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4___ns1__searchText, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4___ns1__searchText, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__searchText);
     if (size)
@@ -33378,7 +33444,7 @@ soap_default___ns1__getRemainingMinutes(struct soap *soap,
                                         struct __ns1__getRemainingMinutes *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__getRemainingMinutes_ = NULL;
+  a->ns1__getRemainingMinutes_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4 soap_serialize___ns1__getRemainingMinutes(
@@ -33414,9 +33480,9 @@ soap_in___ns1__getRemainingMinutes(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__getRemainingMinutes *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__getRemainingMinutes,
-      sizeof(struct __ns1__getRemainingMinutes), 0, NULL, NULL, NULL);
+      sizeof(struct __ns1__getRemainingMinutes), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__getRemainingMinutes(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -33435,7 +33501,7 @@ soap_in___ns1__getRemainingMinutes(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -33457,7 +33523,7 @@ soap_get___ns1__getRemainingMinutes(struct soap *soap,
                                     const char *tag, const char *type) {
   if ((p = soap_in___ns1__getRemainingMinutes(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -33472,10 +33538,11 @@ soap_instantiate___ns1__getRemainingMinutes(struct soap *soap, int n,
                    fdebug,
                    "soap_instantiate___ns1__getRemainingMinutes(%d, %s, %s)\n",
                    n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4___ns1__getRemainingMinutes, n, ICat4_fdelete);
+  struct soap_clist *cp =
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4___ns1__getRemainingMinutes, n,
+                ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__getRemainingMinutes);
     if (size)
@@ -33511,7 +33578,7 @@ SOAP_FMAC3 void SOAP_FMAC4
 soap_default___ns1__logout(struct soap *soap, struct __ns1__logout *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__logout_ = NULL;
+  a->ns1__logout_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4
@@ -33543,9 +33610,9 @@ soap_in___ns1__logout(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__logout *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__logout, sizeof(struct __ns1__logout),
-      0, NULL, NULL, NULL);
+      0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__logout(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -33563,7 +33630,7 @@ soap_in___ns1__logout(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -33582,7 +33649,7 @@ soap_get___ns1__logout(struct soap *soap, struct __ns1__logout *p,
                        const char *tag, const char *type) {
   if ((p = soap_in___ns1__logout(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -33595,9 +33662,9 @@ soap_instantiate___ns1__logout(struct soap *soap, int n, const char *type,
          SOAP_MESSAGE(fdebug, "soap_instantiate___ns1__logout(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4___ns1__logout, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4___ns1__logout, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__logout);
     if (size)
@@ -33631,7 +33698,7 @@ soap_default___ns1__logoutResponse(struct soap *soap,
                                    struct __ns1__logoutResponse *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__logoutResponse_ = NULL;
+  a->ns1__logoutResponse_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4
@@ -33668,9 +33735,9 @@ soap_in___ns1__logoutResponse(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__logoutResponse *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__logoutResponse,
-      sizeof(struct __ns1__logoutResponse), 0, NULL, NULL, NULL);
+      sizeof(struct __ns1__logoutResponse), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__logoutResponse(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -33690,7 +33757,7 @@ soap_in___ns1__logoutResponse(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -33712,7 +33779,7 @@ soap_get___ns1__logoutResponse(struct soap *soap,
                                const char *type) {
   if ((p = soap_in___ns1__logoutResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -33727,9 +33794,9 @@ soap_instantiate___ns1__logoutResponse(struct soap *soap, int n,
                       "soap_instantiate___ns1__logoutResponse(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4___ns1__logoutResponse, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4___ns1__logoutResponse, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__logoutResponse);
     if (size)
@@ -33763,7 +33830,7 @@ SOAP_FMAC3 void SOAP_FMAC4
 soap_default___ns1__dummy(struct soap *soap, struct __ns1__dummy *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__dummy_ = NULL;
+  a->ns1__dummy_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4
@@ -33794,9 +33861,9 @@ soap_in___ns1__dummy(struct soap *soap, const char *tag, struct __ns1__dummy *a,
   short soap_flag;
   a = (struct __ns1__dummy *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__dummy, sizeof(struct __ns1__dummy), 0,
-      NULL, NULL, NULL);
+      nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__dummy(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -33814,7 +33881,7 @@ soap_in___ns1__dummy(struct soap *soap, const char *tag, struct __ns1__dummy *a,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -33833,7 +33900,7 @@ soap_get___ns1__dummy(struct soap *soap, struct __ns1__dummy *p,
                       const char *tag, const char *type) {
   if ((p = soap_in___ns1__dummy(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -33846,9 +33913,9 @@ soap_instantiate___ns1__dummy(struct soap *soap, int n, const char *type,
          SOAP_MESSAGE(fdebug, "soap_instantiate___ns1__dummy(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4___ns1__dummy, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4___ns1__dummy, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__dummy);
     if (size)
@@ -33882,7 +33949,7 @@ soap_default___ns1__dummyResponse(struct soap *soap,
                                   struct __ns1__dummyResponse *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__dummyResponse_ = NULL;
+  a->ns1__dummyResponse_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4
@@ -33918,9 +33985,9 @@ soap_in___ns1__dummyResponse(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__dummyResponse *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__dummyResponse,
-      sizeof(struct __ns1__dummyResponse), 0, NULL, NULL, NULL);
+      sizeof(struct __ns1__dummyResponse), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__dummyResponse(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -33940,7 +34007,7 @@ soap_in___ns1__dummyResponse(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -33961,7 +34028,7 @@ soap_get___ns1__dummyResponse(struct soap *soap, struct __ns1__dummyResponse *p,
                               const char *tag, const char *type) {
   if ((p = soap_in___ns1__dummyResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -33976,9 +34043,9 @@ soap_instantiate___ns1__dummyResponse(struct soap *soap, int n,
                       "soap_instantiate___ns1__dummyResponse(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4___ns1__dummyResponse, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4___ns1__dummyResponse, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__dummyResponse);
     if (size)
@@ -34012,7 +34079,7 @@ SOAP_FMAC3 void SOAP_FMAC4
 soap_default___ns1__refresh(struct soap *soap, struct __ns1__refresh *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__refresh_ = NULL;
+  a->ns1__refresh_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4
@@ -34045,9 +34112,9 @@ soap_in___ns1__refresh(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__refresh *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__refresh,
-      sizeof(struct __ns1__refresh), 0, NULL, NULL, NULL);
+      sizeof(struct __ns1__refresh), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__refresh(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -34065,7 +34132,7 @@ soap_in___ns1__refresh(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -34084,7 +34151,7 @@ soap_get___ns1__refresh(struct soap *soap, struct __ns1__refresh *p,
                         const char *tag, const char *type) {
   if ((p = soap_in___ns1__refresh(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -34096,10 +34163,10 @@ soap_instantiate___ns1__refresh(struct soap *soap, int n, const char *type,
   DBGLOG(TEST,
          SOAP_MESSAGE(fdebug, "soap_instantiate___ns1__refresh(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4___ns1__refresh, n, ICat4_fdelete);
+  struct soap_clist *cp = soap_link(
+      soap, nullptr, SOAP_TYPE_ICat4___ns1__refresh, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__refresh);
     if (size)
@@ -34133,7 +34200,7 @@ soap_default___ns1__refreshResponse(struct soap *soap,
                                     struct __ns1__refreshResponse *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__refreshResponse_ = NULL;
+  a->ns1__refreshResponse_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4
@@ -34170,9 +34237,9 @@ soap_in___ns1__refreshResponse(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__refreshResponse *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__refreshResponse,
-      sizeof(struct __ns1__refreshResponse), 0, NULL, NULL, NULL);
+      sizeof(struct __ns1__refreshResponse), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__refreshResponse(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -34192,7 +34259,7 @@ soap_in___ns1__refreshResponse(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -34214,7 +34281,7 @@ soap_get___ns1__refreshResponse(struct soap *soap,
                                 const char *tag, const char *type) {
   if ((p = soap_in___ns1__refreshResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -34229,9 +34296,9 @@ soap_instantiate___ns1__refreshResponse(struct soap *soap, int n,
                       "soap_instantiate___ns1__refreshResponse(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4___ns1__refreshResponse, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4___ns1__refreshResponse, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__refreshResponse);
     if (size)
@@ -34266,7 +34333,7 @@ soap_default___ns1__getEntityNames(struct soap *soap,
                                    struct __ns1__getEntityNames *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__getEntityNames_ = NULL;
+  a->ns1__getEntityNames_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4
@@ -34301,9 +34368,9 @@ soap_in___ns1__getEntityNames(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__getEntityNames *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__getEntityNames,
-      sizeof(struct __ns1__getEntityNames), 0, NULL, NULL, NULL);
+      sizeof(struct __ns1__getEntityNames), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__getEntityNames(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -34322,7 +34389,7 @@ soap_in___ns1__getEntityNames(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -34344,7 +34411,7 @@ soap_get___ns1__getEntityNames(struct soap *soap,
                                const char *type) {
   if ((p = soap_in___ns1__getEntityNames(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -34359,9 +34426,9 @@ soap_instantiate___ns1__getEntityNames(struct soap *soap, int n,
                       "soap_instantiate___ns1__getEntityNames(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4___ns1__getEntityNames, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4___ns1__getEntityNames, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__getEntityNames);
     if (size)
@@ -34396,7 +34463,7 @@ soap_default___ns1__getApiVersion(struct soap *soap,
                                   struct __ns1__getApiVersion *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__getApiVersion_ = NULL;
+  a->ns1__getApiVersion_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4
@@ -34430,9 +34497,9 @@ soap_in___ns1__getApiVersion(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__getApiVersion *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__getApiVersion,
-      sizeof(struct __ns1__getApiVersion), 0, NULL, NULL, NULL);
+      sizeof(struct __ns1__getApiVersion), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__getApiVersion(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -34451,7 +34518,7 @@ soap_in___ns1__getApiVersion(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -34472,7 +34539,7 @@ soap_get___ns1__getApiVersion(struct soap *soap, struct __ns1__getApiVersion *p,
                               const char *tag, const char *type) {
   if ((p = soap_in___ns1__getApiVersion(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -34487,9 +34554,9 @@ soap_instantiate___ns1__getApiVersion(struct soap *soap, int n,
                       "soap_instantiate___ns1__getApiVersion(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4___ns1__getApiVersion, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4___ns1__getApiVersion, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__getApiVersion);
     if (size)
@@ -34523,7 +34590,7 @@ SOAP_FMAC3 void SOAP_FMAC4
 soap_default___ns1__update(struct soap *soap, struct __ns1__update *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__update_ = NULL;
+  a->ns1__update_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4
@@ -34555,9 +34622,9 @@ soap_in___ns1__update(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__update *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__update, sizeof(struct __ns1__update),
-      0, NULL, NULL, NULL);
+      0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__update(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -34575,7 +34642,7 @@ soap_in___ns1__update(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -34594,7 +34661,7 @@ soap_get___ns1__update(struct soap *soap, struct __ns1__update *p,
                        const char *tag, const char *type) {
   if ((p = soap_in___ns1__update(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -34607,9 +34674,9 @@ soap_instantiate___ns1__update(struct soap *soap, int n, const char *type,
          SOAP_MESSAGE(fdebug, "soap_instantiate___ns1__update(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4___ns1__update, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4___ns1__update, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__update);
     if (size)
@@ -34643,7 +34710,7 @@ soap_default___ns1__updateResponse(struct soap *soap,
                                    struct __ns1__updateResponse *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__updateResponse_ = NULL;
+  a->ns1__updateResponse_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4
@@ -34680,9 +34747,9 @@ soap_in___ns1__updateResponse(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__updateResponse *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__updateResponse,
-      sizeof(struct __ns1__updateResponse), 0, NULL, NULL, NULL);
+      sizeof(struct __ns1__updateResponse), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__updateResponse(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -34702,7 +34769,7 @@ soap_in___ns1__updateResponse(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -34724,7 +34791,7 @@ soap_get___ns1__updateResponse(struct soap *soap,
                                const char *type) {
   if ((p = soap_in___ns1__updateResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -34739,9 +34806,9 @@ soap_instantiate___ns1__updateResponse(struct soap *soap, int n,
                       "soap_instantiate___ns1__updateResponse(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4___ns1__updateResponse, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4___ns1__updateResponse, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__updateResponse);
     if (size)
@@ -34775,7 +34842,7 @@ SOAP_FMAC3 void SOAP_FMAC4
 soap_default___ns1__create(struct soap *soap, struct __ns1__create *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__create_ = NULL;
+  a->ns1__create_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4
@@ -34807,9 +34874,9 @@ soap_in___ns1__create(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__create *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__create, sizeof(struct __ns1__create),
-      0, NULL, NULL, NULL);
+      0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__create(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -34827,7 +34894,7 @@ soap_in___ns1__create(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -34846,7 +34913,7 @@ soap_get___ns1__create(struct soap *soap, struct __ns1__create *p,
                        const char *tag, const char *type) {
   if ((p = soap_in___ns1__create(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -34859,9 +34926,9 @@ soap_instantiate___ns1__create(struct soap *soap, int n, const char *type,
          SOAP_MESSAGE(fdebug, "soap_instantiate___ns1__create(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4___ns1__create, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4___ns1__create, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__create);
     if (size)
@@ -34894,7 +34961,7 @@ SOAP_FMAC3 void SOAP_FMAC4
 soap_default___ns1__search(struct soap *soap, struct __ns1__search *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__search_ = NULL;
+  a->ns1__search_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4
@@ -34926,9 +34993,9 @@ soap_in___ns1__search(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__search *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__search, sizeof(struct __ns1__search),
-      0, NULL, NULL, NULL);
+      0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__search(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -34946,7 +35013,7 @@ soap_in___ns1__search(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -34965,7 +35032,7 @@ soap_get___ns1__search(struct soap *soap, struct __ns1__search *p,
                        const char *tag, const char *type) {
   if ((p = soap_in___ns1__search(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -34978,9 +35045,9 @@ soap_instantiate___ns1__search(struct soap *soap, int n, const char *type,
          SOAP_MESSAGE(fdebug, "soap_instantiate___ns1__search(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4___ns1__search, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4___ns1__search, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__search);
     if (size)
@@ -35013,7 +35080,7 @@ SOAP_FMAC3 void SOAP_FMAC4
 soap_default___ns1__delete(struct soap *soap, struct __ns1__delete *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__delete_ = NULL;
+  a->ns1__delete_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4
@@ -35045,9 +35112,9 @@ soap_in___ns1__delete(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__delete *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__delete, sizeof(struct __ns1__delete),
-      0, NULL, NULL, NULL);
+      0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__delete(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -35065,7 +35132,7 @@ soap_in___ns1__delete(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -35084,7 +35151,7 @@ soap_get___ns1__delete(struct soap *soap, struct __ns1__delete *p,
                        const char *tag, const char *type) {
   if ((p = soap_in___ns1__delete(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -35097,9 +35164,9 @@ soap_instantiate___ns1__delete(struct soap *soap, int n, const char *type,
          SOAP_MESSAGE(fdebug, "soap_instantiate___ns1__delete(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4___ns1__delete, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4___ns1__delete, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__delete);
     if (size)
@@ -35133,7 +35200,7 @@ soap_default___ns1__deleteResponse(struct soap *soap,
                                    struct __ns1__deleteResponse *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__deleteResponse_ = NULL;
+  a->ns1__deleteResponse_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4
@@ -35170,9 +35237,9 @@ soap_in___ns1__deleteResponse(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__deleteResponse *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__deleteResponse,
-      sizeof(struct __ns1__deleteResponse), 0, NULL, NULL, NULL);
+      sizeof(struct __ns1__deleteResponse), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__deleteResponse(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -35192,7 +35259,7 @@ soap_in___ns1__deleteResponse(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -35214,7 +35281,7 @@ soap_get___ns1__deleteResponse(struct soap *soap,
                                const char *type) {
   if ((p = soap_in___ns1__deleteResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -35229,9 +35296,9 @@ soap_instantiate___ns1__deleteResponse(struct soap *soap, int n,
                       "soap_instantiate___ns1__deleteResponse(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4___ns1__deleteResponse, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4___ns1__deleteResponse, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__deleteResponse);
     if (size)
@@ -35266,7 +35333,7 @@ soap_default___ns1__getProperties(struct soap *soap,
                                   struct __ns1__getProperties *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__getProperties_ = NULL;
+  a->ns1__getProperties_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4
@@ -35300,9 +35367,9 @@ soap_in___ns1__getProperties(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__getProperties *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__getProperties,
-      sizeof(struct __ns1__getProperties), 0, NULL, NULL, NULL);
+      sizeof(struct __ns1__getProperties), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__getProperties(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -35321,7 +35388,7 @@ soap_in___ns1__getProperties(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -35342,7 +35409,7 @@ soap_get___ns1__getProperties(struct soap *soap, struct __ns1__getProperties *p,
                               const char *tag, const char *type) {
   if ((p = soap_in___ns1__getProperties(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -35357,9 +35424,9 @@ soap_instantiate___ns1__getProperties(struct soap *soap, int n,
                       "soap_instantiate___ns1__getProperties(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4___ns1__getProperties, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4___ns1__getProperties, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__getProperties);
     if (size)
@@ -35393,7 +35460,7 @@ SOAP_FMAC3 void SOAP_FMAC4
 soap_default___ns1__get(struct soap *soap, struct __ns1__get *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__get_ = NULL;
+  a->ns1__get_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4
@@ -35424,9 +35491,9 @@ soap_in___ns1__get(struct soap *soap, const char *tag, struct __ns1__get *a,
   short soap_flag;
   a = (struct __ns1__get *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__get, sizeof(struct __ns1__get), 0,
-      NULL, NULL, NULL);
+      nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__get(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -35444,7 +35511,7 @@ soap_in___ns1__get(struct soap *soap, const char *tag, struct __ns1__get *a,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -35463,7 +35530,7 @@ soap_get___ns1__get(struct soap *soap, struct __ns1__get *p, const char *tag,
                     const char *type) {
   if ((p = soap_in___ns1__get(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -35475,9 +35542,9 @@ soap_instantiate___ns1__get(struct soap *soap, int n, const char *type,
   DBGLOG(TEST, SOAP_MESSAGE(fdebug, "soap_instantiate___ns1__get(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4___ns1__get, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4___ns1__get, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__get);
     if (size)
@@ -35511,7 +35578,7 @@ soap_default___ns1__getUserName(struct soap *soap,
                                 struct __ns1__getUserName *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__getUserName_ = NULL;
+  a->ns1__getUserName_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4
@@ -35545,9 +35612,9 @@ soap_in___ns1__getUserName(struct soap *soap, const char *tag,
   short soap_flag;
   a = (struct __ns1__getUserName *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__getUserName,
-      sizeof(struct __ns1__getUserName), 0, NULL, NULL, NULL);
+      sizeof(struct __ns1__getUserName), 0, nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__getUserName(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -35566,7 +35633,7 @@ soap_in___ns1__getUserName(struct soap *soap, const char *tag,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -35587,7 +35654,7 @@ soap_get___ns1__getUserName(struct soap *soap, struct __ns1__getUserName *p,
                             const char *tag, const char *type) {
   if ((p = soap_in___ns1__getUserName(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -35600,9 +35667,9 @@ soap_instantiate___ns1__getUserName(struct soap *soap, int n, const char *type,
                             "soap_instantiate___ns1__getUserName(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4___ns1__getUserName, n, ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4___ns1__getUserName, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__getUserName);
     if (size)
@@ -35636,7 +35703,7 @@ SOAP_FMAC3 void SOAP_FMAC4
 soap_default___ns1__login(struct soap *soap, struct __ns1__login *a) {
   (void)soap;
   (void)a; /* appease -Wall -Werror */
-  a->ns1__login_ = NULL;
+  a->ns1__login_ = nullptr;
 }
 
 SOAP_FMAC3 void SOAP_FMAC4
@@ -35667,9 +35734,9 @@ soap_in___ns1__login(struct soap *soap, const char *tag, struct __ns1__login *a,
   short soap_flag;
   a = (struct __ns1__login *)soap_id_enter(
       soap, "", a, SOAP_TYPE_ICat4___ns1__login, sizeof(struct __ns1__login), 0,
-      NULL, NULL, NULL);
+      nullptr, nullptr, nullptr);
   if (!a)
-    return NULL;
+    return nullptr;
   soap_default___ns1__login(soap, a);
   for (soap_flag = 0;; soap_flag = 1) {
     soap->error = SOAP_TAG_MISMATCH;
@@ -35687,7 +35754,7 @@ soap_in___ns1__login(struct soap *soap, const char *tag, struct __ns1__login *a,
     if (soap_flag && soap->error == SOAP_NO_TAG)
       break;
     if (soap->error)
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -35706,7 +35773,7 @@ soap_get___ns1__login(struct soap *soap, struct __ns1__login *p,
                       const char *tag, const char *type) {
   if ((p = soap_in___ns1__login(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -35719,9 +35786,9 @@ soap_instantiate___ns1__login(struct soap *soap, int n, const char *type,
          SOAP_MESSAGE(fdebug, "soap_instantiate___ns1__login(%d, %s, %s)\n", n,
                       type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4___ns1__login, n, ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4___ns1__login, n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(struct __ns1__login);
     if (size)
@@ -36136,7 +36203,7 @@ SOAP_FMAC3 void SOAP_FMAC4 soap_serialize_PointerTons1__getEntityInfoResponse(
 SOAP_FMAC3 int SOAP_FMAC4 soap_out_PointerTons1__getEntityInfoResponse(
     struct soap *soap, const char *tag, int id,
     ns1__getEntityInfoResponse *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__getEntityInfoResponse);
   if (id < 0)
     return soap->error;
@@ -36147,22 +36214,22 @@ SOAP_FMAC3 ns1__getEntityInfoResponse **SOAP_FMAC4
 soap_in_PointerTons1__getEntityInfoResponse(struct soap *soap, const char *tag,
                                             ns1__getEntityInfoResponse **a,
                                             const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__getEntityInfoResponse **)soap_malloc(
               soap, sizeof(ns1__getEntityInfoResponse *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__getEntityInfoResponse *)
               soap_instantiate_ns1__getEntityInfoResponse(
-                  soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__getEntityInfoResponse **p =
         (ns1__getEntityInfoResponse **)soap_id_lookup(
@@ -36171,7 +36238,7 @@ soap_in_PointerTons1__getEntityInfoResponse(struct soap *soap, const char *tag,
             sizeof(ns1__getEntityInfoResponse), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -36179,7 +36246,7 @@ soap_in_PointerTons1__getEntityInfoResponse(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4 soap_put_PointerTons1__getEntityInfoResponse(
     struct soap *soap, ns1__getEntityInfoResponse *const *a, const char *tag,
     const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__getEntityInfoResponse);
   if (soap_out_PointerTons1__getEntityInfoResponse(
           soap, tag ? tag : "ns1:getEntityInfoResponse", id, a, type))
@@ -36194,7 +36261,7 @@ soap_get_PointerTons1__getEntityInfoResponse(struct soap *soap,
                                              const char *type) {
   if ((p = soap_in_PointerTons1__getEntityInfoResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -36211,7 +36278,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__getEntityInfo(struct soap *soap, const char *tag, int id,
                                      ns1__getEntityInfo *const *a,
                                      const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__getEntityInfo);
   if (id < 0)
     return soap->error;
@@ -36221,28 +36288,28 @@ soap_out_PointerTons1__getEntityInfo(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__getEntityInfo **SOAP_FMAC4
 soap_in_PointerTons1__getEntityInfo(struct soap *soap, const char *tag,
                                     ns1__getEntityInfo **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__getEntityInfo **)soap_malloc(soap,
                                                  sizeof(ns1__getEntityInfo *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__getEntityInfo *)soap_instantiate_ns1__getEntityInfo(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__getEntityInfo **p = (ns1__getEntityInfo **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__getEntityInfo,
         sizeof(ns1__getEntityInfo), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -36251,7 +36318,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__getEntityInfo(struct soap *soap,
                                      ns1__getEntityInfo *const *a,
                                      const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__getEntityInfo);
   if (soap_out_PointerTons1__getEntityInfo(
           soap, tag ? tag : "ns1:getEntityInfo", id, a, type))
@@ -36264,7 +36331,7 @@ soap_get_PointerTons1__getEntityInfo(struct soap *soap, ns1__getEntityInfo **p,
                                      const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__getEntityInfo(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -36281,7 +36348,7 @@ soap_out_PointerTons1__deleteManyResponse(struct soap *soap, const char *tag,
                                           int id,
                                           ns1__deleteManyResponse *const *a,
                                           const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__deleteManyResponse);
   if (id < 0)
     return soap->error;
@@ -36292,29 +36359,29 @@ SOAP_FMAC3 ns1__deleteManyResponse **SOAP_FMAC4
 soap_in_PointerTons1__deleteManyResponse(struct soap *soap, const char *tag,
                                          ns1__deleteManyResponse **a,
                                          const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__deleteManyResponse **)soap_malloc(
               soap, sizeof(ns1__deleteManyResponse *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__deleteManyResponse *)
-              soap_instantiate_ns1__deleteManyResponse(soap, -1, soap->type,
-                                                       soap->arrayType, NULL)))
-      return NULL;
+              soap_instantiate_ns1__deleteManyResponse(
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__deleteManyResponse **p = (ns1__deleteManyResponse **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__deleteManyResponse,
         sizeof(ns1__deleteManyResponse), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -36323,7 +36390,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__deleteManyResponse(struct soap *soap,
                                           ns1__deleteManyResponse *const *a,
                                           const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__deleteManyResponse);
   if (soap_out_PointerTons1__deleteManyResponse(
           soap, tag ? tag : "ns1:deleteManyResponse", id, a, type))
@@ -36337,7 +36404,7 @@ soap_get_PointerTons1__deleteManyResponse(struct soap *soap,
                                           const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__deleteManyResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -36353,7 +36420,7 @@ soap_serialize_PointerTons1__deleteMany(struct soap *soap,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__deleteMany(struct soap *soap, const char *tag, int id,
                                   ns1__deleteMany *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__deleteMany);
   if (id < 0)
     return soap->error;
@@ -36363,27 +36430,27 @@ soap_out_PointerTons1__deleteMany(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__deleteMany **SOAP_FMAC4
 soap_in_PointerTons1__deleteMany(struct soap *soap, const char *tag,
                                  ns1__deleteMany **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__deleteMany **)soap_malloc(soap, sizeof(ns1__deleteMany *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__deleteMany *)soap_instantiate_ns1__deleteMany(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__deleteMany **p = (ns1__deleteMany **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__deleteMany,
         sizeof(ns1__deleteMany), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -36391,7 +36458,7 @@ soap_in_PointerTons1__deleteMany(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__deleteMany(struct soap *soap, ns1__deleteMany *const *a,
                                   const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__deleteMany);
   if (soap_out_PointerTons1__deleteMany(soap, tag ? tag : "ns1:deleteMany", id,
                                         a, type))
@@ -36404,7 +36471,7 @@ soap_get_PointerTons1__deleteMany(struct soap *soap, ns1__deleteMany **p,
                                   const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__deleteMany(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -36421,7 +36488,7 @@ soap_out_PointerTons1__createManyResponse(struct soap *soap, const char *tag,
                                           int id,
                                           ns1__createManyResponse *const *a,
                                           const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__createManyResponse);
   if (id < 0)
     return soap->error;
@@ -36432,29 +36499,29 @@ SOAP_FMAC3 ns1__createManyResponse **SOAP_FMAC4
 soap_in_PointerTons1__createManyResponse(struct soap *soap, const char *tag,
                                          ns1__createManyResponse **a,
                                          const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__createManyResponse **)soap_malloc(
               soap, sizeof(ns1__createManyResponse *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__createManyResponse *)
-              soap_instantiate_ns1__createManyResponse(soap, -1, soap->type,
-                                                       soap->arrayType, NULL)))
-      return NULL;
+              soap_instantiate_ns1__createManyResponse(
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__createManyResponse **p = (ns1__createManyResponse **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__createManyResponse,
         sizeof(ns1__createManyResponse), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -36463,7 +36530,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__createManyResponse(struct soap *soap,
                                           ns1__createManyResponse *const *a,
                                           const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__createManyResponse);
   if (soap_out_PointerTons1__createManyResponse(
           soap, tag ? tag : "ns1:createManyResponse", id, a, type))
@@ -36477,7 +36544,7 @@ soap_get_PointerTons1__createManyResponse(struct soap *soap,
                                           const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__createManyResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -36493,7 +36560,7 @@ soap_serialize_PointerTons1__createMany(struct soap *soap,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__createMany(struct soap *soap, const char *tag, int id,
                                   ns1__createMany *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__createMany);
   if (id < 0)
     return soap->error;
@@ -36503,27 +36570,27 @@ soap_out_PointerTons1__createMany(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__createMany **SOAP_FMAC4
 soap_in_PointerTons1__createMany(struct soap *soap, const char *tag,
                                  ns1__createMany **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__createMany **)soap_malloc(soap, sizeof(ns1__createMany *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__createMany *)soap_instantiate_ns1__createMany(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__createMany **p = (ns1__createMany **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__createMany,
         sizeof(ns1__createMany), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -36531,7 +36598,7 @@ soap_in_PointerTons1__createMany(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__createMany(struct soap *soap, ns1__createMany *const *a,
                                   const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__createMany);
   if (soap_out_PointerTons1__createMany(soap, tag ? tag : "ns1:createMany", id,
                                         a, type))
@@ -36544,7 +36611,7 @@ soap_get_PointerTons1__createMany(struct soap *soap, ns1__createMany **p,
                                   const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__createMany(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -36561,7 +36628,7 @@ soap_serialize_PointerTons1__luceneGetPopulatingResponse(
 SOAP_FMAC3 int SOAP_FMAC4 soap_out_PointerTons1__luceneGetPopulatingResponse(
     struct soap *soap, const char *tag, int id,
     ns1__luceneGetPopulatingResponse *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__luceneGetPopulatingResponse);
   if (id < 0)
     return soap->error;
@@ -36572,22 +36639,22 @@ SOAP_FMAC3 ns1__luceneGetPopulatingResponse **SOAP_FMAC4
 soap_in_PointerTons1__luceneGetPopulatingResponse(
     struct soap *soap, const char *tag, ns1__luceneGetPopulatingResponse **a,
     const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__luceneGetPopulatingResponse **)soap_malloc(
               soap, sizeof(ns1__luceneGetPopulatingResponse *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__luceneGetPopulatingResponse *)
               soap_instantiate_ns1__luceneGetPopulatingResponse(
-                  soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__luceneGetPopulatingResponse **p =
         (ns1__luceneGetPopulatingResponse **)soap_id_lookup(
@@ -36596,7 +36663,7 @@ soap_in_PointerTons1__luceneGetPopulatingResponse(
             sizeof(ns1__luceneGetPopulatingResponse), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -36605,7 +36672,7 @@ SOAP_FMAC3 int SOAP_FMAC4 soap_put_PointerTons1__luceneGetPopulatingResponse(
     struct soap *soap, ns1__luceneGetPopulatingResponse *const *a,
     const char *tag, const char *type) {
   int id =
-      soap_embed(soap, (void *)a, NULL, 0, tag,
+      soap_embed(soap, (void *)a, nullptr, 0, tag,
                  SOAP_TYPE_ICat4_PointerTons1__luceneGetPopulatingResponse);
   if (soap_out_PointerTons1__luceneGetPopulatingResponse(
           soap, tag ? tag : "ns1:luceneGetPopulatingResponse", id, a, type))
@@ -36620,7 +36687,7 @@ soap_get_PointerTons1__luceneGetPopulatingResponse(
   if ((p = soap_in_PointerTons1__luceneGetPopulatingResponse(soap, tag, p,
                                                              type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -36637,7 +36704,7 @@ soap_out_PointerTons1__luceneGetPopulating(struct soap *soap, const char *tag,
                                            int id,
                                            ns1__luceneGetPopulating *const *a,
                                            const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__luceneGetPopulating);
   if (id < 0)
     return soap->error;
@@ -36648,29 +36715,29 @@ SOAP_FMAC3 ns1__luceneGetPopulating **SOAP_FMAC4
 soap_in_PointerTons1__luceneGetPopulating(struct soap *soap, const char *tag,
                                           ns1__luceneGetPopulating **a,
                                           const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__luceneGetPopulating **)soap_malloc(
               soap, sizeof(ns1__luceneGetPopulating *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__luceneGetPopulating *)
-              soap_instantiate_ns1__luceneGetPopulating(soap, -1, soap->type,
-                                                        soap->arrayType, NULL)))
-      return NULL;
+              soap_instantiate_ns1__luceneGetPopulating(
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__luceneGetPopulating **p = (ns1__luceneGetPopulating **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__luceneGetPopulating,
         sizeof(ns1__luceneGetPopulating), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -36679,7 +36746,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__luceneGetPopulating(struct soap *soap,
                                            ns1__luceneGetPopulating *const *a,
                                            const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__luceneGetPopulating);
   if (soap_out_PointerTons1__luceneGetPopulating(
           soap, tag ? tag : "ns1:luceneGetPopulating", id, a, type))
@@ -36693,7 +36760,7 @@ soap_get_PointerTons1__luceneGetPopulating(struct soap *soap,
                                            const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__luceneGetPopulating(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -36710,7 +36777,7 @@ soap_out_PointerTons1__luceneSearchResponse(struct soap *soap, const char *tag,
                                             int id,
                                             ns1__luceneSearchResponse *const *a,
                                             const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__luceneSearchResponse);
   if (id < 0)
     return soap->error;
@@ -36721,22 +36788,22 @@ SOAP_FMAC3 ns1__luceneSearchResponse **SOAP_FMAC4
 soap_in_PointerTons1__luceneSearchResponse(struct soap *soap, const char *tag,
                                            ns1__luceneSearchResponse **a,
                                            const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__luceneSearchResponse **)soap_malloc(
               soap, sizeof(ns1__luceneSearchResponse *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__luceneSearchResponse *)
               soap_instantiate_ns1__luceneSearchResponse(
-                  soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__luceneSearchResponse **p =
         (ns1__luceneSearchResponse **)soap_id_lookup(
@@ -36745,7 +36812,7 @@ soap_in_PointerTons1__luceneSearchResponse(struct soap *soap, const char *tag,
             sizeof(ns1__luceneSearchResponse), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -36754,7 +36821,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__luceneSearchResponse(struct soap *soap,
                                             ns1__luceneSearchResponse *const *a,
                                             const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__luceneSearchResponse);
   if (soap_out_PointerTons1__luceneSearchResponse(
           soap, tag ? tag : "ns1:luceneSearchResponse", id, a, type))
@@ -36768,7 +36835,7 @@ soap_get_PointerTons1__luceneSearchResponse(struct soap *soap,
                                             const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__luceneSearchResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -36785,7 +36852,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__luceneSearch(struct soap *soap, const char *tag, int id,
                                     ns1__luceneSearch *const *a,
                                     const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__luceneSearch);
   if (id < 0)
     return soap->error;
@@ -36795,28 +36862,28 @@ soap_out_PointerTons1__luceneSearch(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__luceneSearch **SOAP_FMAC4
 soap_in_PointerTons1__luceneSearch(struct soap *soap, const char *tag,
                                    ns1__luceneSearch **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__luceneSearch **)soap_malloc(soap,
                                                 sizeof(ns1__luceneSearch *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__luceneSearch *)soap_instantiate_ns1__luceneSearch(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__luceneSearch **p = (ns1__luceneSearch **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__luceneSearch,
         sizeof(ns1__luceneSearch), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -36825,7 +36892,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__luceneSearch(struct soap *soap,
                                     ns1__luceneSearch *const *a,
                                     const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__luceneSearch);
   if (soap_out_PointerTons1__luceneSearch(soap, tag ? tag : "ns1:luceneSearch",
                                           id, a, type))
@@ -36838,7 +36905,7 @@ soap_get_PointerTons1__luceneSearch(struct soap *soap, ns1__luceneSearch **p,
                                     const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__luceneSearch(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -36855,7 +36922,7 @@ soap_out_PointerTons1__luceneCommitResponse(struct soap *soap, const char *tag,
                                             int id,
                                             ns1__luceneCommitResponse *const *a,
                                             const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__luceneCommitResponse);
   if (id < 0)
     return soap->error;
@@ -36866,22 +36933,22 @@ SOAP_FMAC3 ns1__luceneCommitResponse **SOAP_FMAC4
 soap_in_PointerTons1__luceneCommitResponse(struct soap *soap, const char *tag,
                                            ns1__luceneCommitResponse **a,
                                            const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__luceneCommitResponse **)soap_malloc(
               soap, sizeof(ns1__luceneCommitResponse *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__luceneCommitResponse *)
               soap_instantiate_ns1__luceneCommitResponse(
-                  soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__luceneCommitResponse **p =
         (ns1__luceneCommitResponse **)soap_id_lookup(
@@ -36890,7 +36957,7 @@ soap_in_PointerTons1__luceneCommitResponse(struct soap *soap, const char *tag,
             sizeof(ns1__luceneCommitResponse), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -36899,7 +36966,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__luceneCommitResponse(struct soap *soap,
                                             ns1__luceneCommitResponse *const *a,
                                             const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__luceneCommitResponse);
   if (soap_out_PointerTons1__luceneCommitResponse(
           soap, tag ? tag : "ns1:luceneCommitResponse", id, a, type))
@@ -36913,7 +36980,7 @@ soap_get_PointerTons1__luceneCommitResponse(struct soap *soap,
                                             const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__luceneCommitResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -36930,7 +36997,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__luceneCommit(struct soap *soap, const char *tag, int id,
                                     ns1__luceneCommit *const *a,
                                     const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__luceneCommit);
   if (id < 0)
     return soap->error;
@@ -36940,28 +37007,28 @@ soap_out_PointerTons1__luceneCommit(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__luceneCommit **SOAP_FMAC4
 soap_in_PointerTons1__luceneCommit(struct soap *soap, const char *tag,
                                    ns1__luceneCommit **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__luceneCommit **)soap_malloc(soap,
                                                 sizeof(ns1__luceneCommit *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__luceneCommit *)soap_instantiate_ns1__luceneCommit(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__luceneCommit **p = (ns1__luceneCommit **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__luceneCommit,
         sizeof(ns1__luceneCommit), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -36970,7 +37037,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__luceneCommit(struct soap *soap,
                                     ns1__luceneCommit *const *a,
                                     const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__luceneCommit);
   if (soap_out_PointerTons1__luceneCommit(soap, tag ? tag : "ns1:luceneCommit",
                                           id, a, type))
@@ -36983,7 +37050,7 @@ soap_get_PointerTons1__luceneCommit(struct soap *soap, ns1__luceneCommit **p,
                                     const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__luceneCommit(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -37000,7 +37067,7 @@ soap_out_PointerTons1__luceneClearResponse(struct soap *soap, const char *tag,
                                            int id,
                                            ns1__luceneClearResponse *const *a,
                                            const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__luceneClearResponse);
   if (id < 0)
     return soap->error;
@@ -37011,29 +37078,29 @@ SOAP_FMAC3 ns1__luceneClearResponse **SOAP_FMAC4
 soap_in_PointerTons1__luceneClearResponse(struct soap *soap, const char *tag,
                                           ns1__luceneClearResponse **a,
                                           const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__luceneClearResponse **)soap_malloc(
               soap, sizeof(ns1__luceneClearResponse *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__luceneClearResponse *)
-              soap_instantiate_ns1__luceneClearResponse(soap, -1, soap->type,
-                                                        soap->arrayType, NULL)))
-      return NULL;
+              soap_instantiate_ns1__luceneClearResponse(
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__luceneClearResponse **p = (ns1__luceneClearResponse **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__luceneClearResponse,
         sizeof(ns1__luceneClearResponse), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -37042,7 +37109,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__luceneClearResponse(struct soap *soap,
                                            ns1__luceneClearResponse *const *a,
                                            const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__luceneClearResponse);
   if (soap_out_PointerTons1__luceneClearResponse(
           soap, tag ? tag : "ns1:luceneClearResponse", id, a, type))
@@ -37056,7 +37123,7 @@ soap_get_PointerTons1__luceneClearResponse(struct soap *soap,
                                            const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__luceneClearResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -37073,7 +37140,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__luceneClear(struct soap *soap, const char *tag, int id,
                                    ns1__luceneClear *const *a,
                                    const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__luceneClear);
   if (id < 0)
     return soap->error;
@@ -37083,28 +37150,28 @@ soap_out_PointerTons1__luceneClear(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__luceneClear **SOAP_FMAC4
 soap_in_PointerTons1__luceneClear(struct soap *soap, const char *tag,
                                   ns1__luceneClear **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__luceneClear **)soap_malloc(soap,
                                                sizeof(ns1__luceneClear *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__luceneClear *)soap_instantiate_ns1__luceneClear(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__luceneClear **p = (ns1__luceneClear **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__luceneClear,
         sizeof(ns1__luceneClear), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -37113,7 +37180,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__luceneClear(struct soap *soap,
                                    ns1__luceneClear *const *a, const char *tag,
                                    const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__luceneClear);
   if (soap_out_PointerTons1__luceneClear(soap, tag ? tag : "ns1:luceneClear",
                                          id, a, type))
@@ -37126,7 +37193,7 @@ soap_get_PointerTons1__luceneClear(struct soap *soap, ns1__luceneClear **p,
                                    const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__luceneClear(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -37141,7 +37208,7 @@ SOAP_FMAC3 void SOAP_FMAC4 soap_serialize_PointerTons1__lucenePopulateResponse(
 SOAP_FMAC3 int SOAP_FMAC4 soap_out_PointerTons1__lucenePopulateResponse(
     struct soap *soap, const char *tag, int id,
     ns1__lucenePopulateResponse *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__lucenePopulateResponse);
   if (id < 0)
     return soap->error;
@@ -37152,22 +37219,22 @@ SOAP_FMAC3 ns1__lucenePopulateResponse **SOAP_FMAC4
 soap_in_PointerTons1__lucenePopulateResponse(struct soap *soap, const char *tag,
                                              ns1__lucenePopulateResponse **a,
                                              const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__lucenePopulateResponse **)soap_malloc(
               soap, sizeof(ns1__lucenePopulateResponse *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__lucenePopulateResponse *)
               soap_instantiate_ns1__lucenePopulateResponse(
-                  soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__lucenePopulateResponse **p =
         (ns1__lucenePopulateResponse **)soap_id_lookup(
@@ -37176,7 +37243,7 @@ soap_in_PointerTons1__lucenePopulateResponse(struct soap *soap, const char *tag,
             sizeof(ns1__lucenePopulateResponse), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -37184,7 +37251,7 @@ soap_in_PointerTons1__lucenePopulateResponse(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4 soap_put_PointerTons1__lucenePopulateResponse(
     struct soap *soap, ns1__lucenePopulateResponse *const *a, const char *tag,
     const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__lucenePopulateResponse);
   if (soap_out_PointerTons1__lucenePopulateResponse(
           soap, tag ? tag : "ns1:lucenePopulateResponse", id, a, type))
@@ -37199,7 +37266,7 @@ soap_get_PointerTons1__lucenePopulateResponse(struct soap *soap,
                                               const char *type) {
   if ((p = soap_in_PointerTons1__lucenePopulateResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -37216,7 +37283,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__lucenePopulate(struct soap *soap, const char *tag,
                                       int id, ns1__lucenePopulate *const *a,
                                       const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__lucenePopulate);
   if (id < 0)
     return soap->error;
@@ -37227,28 +37294,28 @@ SOAP_FMAC3 ns1__lucenePopulate **SOAP_FMAC4
 soap_in_PointerTons1__lucenePopulate(struct soap *soap, const char *tag,
                                      ns1__lucenePopulate **a,
                                      const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__lucenePopulate **)soap_malloc(
               soap, sizeof(ns1__lucenePopulate *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__lucenePopulate *)soap_instantiate_ns1__lucenePopulate(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__lucenePopulate **p = (ns1__lucenePopulate **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__lucenePopulate,
         sizeof(ns1__lucenePopulate), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -37257,7 +37324,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__lucenePopulate(struct soap *soap,
                                       ns1__lucenePopulate *const *a,
                                       const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__lucenePopulate);
   if (soap_out_PointerTons1__lucenePopulate(
           soap, tag ? tag : "ns1:lucenePopulate", id, a, type))
@@ -37271,7 +37338,7 @@ soap_get_PointerTons1__lucenePopulate(struct soap *soap,
                                       const char *type) {
   if ((p = soap_in_PointerTons1__lucenePopulate(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -37286,7 +37353,7 @@ SOAP_FMAC3 void SOAP_FMAC4 soap_serialize_PointerTons1__isAccessAllowedResponse(
 SOAP_FMAC3 int SOAP_FMAC4 soap_out_PointerTons1__isAccessAllowedResponse(
     struct soap *soap, const char *tag, int id,
     ns1__isAccessAllowedResponse *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__isAccessAllowedResponse);
   if (id < 0)
     return soap->error;
@@ -37298,22 +37365,22 @@ soap_in_PointerTons1__isAccessAllowedResponse(struct soap *soap,
                                               const char *tag,
                                               ns1__isAccessAllowedResponse **a,
                                               const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__isAccessAllowedResponse **)soap_malloc(
               soap, sizeof(ns1__isAccessAllowedResponse *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__isAccessAllowedResponse *)
               soap_instantiate_ns1__isAccessAllowedResponse(
-                  soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__isAccessAllowedResponse **p =
         (ns1__isAccessAllowedResponse **)soap_id_lookup(
@@ -37322,7 +37389,7 @@ soap_in_PointerTons1__isAccessAllowedResponse(struct soap *soap,
             sizeof(ns1__isAccessAllowedResponse), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -37330,7 +37397,7 @@ soap_in_PointerTons1__isAccessAllowedResponse(struct soap *soap,
 SOAP_FMAC3 int SOAP_FMAC4 soap_put_PointerTons1__isAccessAllowedResponse(
     struct soap *soap, ns1__isAccessAllowedResponse *const *a, const char *tag,
     const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__isAccessAllowedResponse);
   if (soap_out_PointerTons1__isAccessAllowedResponse(
           soap, tag ? tag : "ns1:isAccessAllowedResponse", id, a, type))
@@ -37345,7 +37412,7 @@ soap_get_PointerTons1__isAccessAllowedResponse(struct soap *soap,
                                                const char *type) {
   if ((p = soap_in_PointerTons1__isAccessAllowedResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -37362,7 +37429,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__isAccessAllowed(struct soap *soap, const char *tag,
                                        int id, ns1__isAccessAllowed *const *a,
                                        const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__isAccessAllowed);
   if (id < 0)
     return soap->error;
@@ -37373,28 +37440,28 @@ SOAP_FMAC3 ns1__isAccessAllowed **SOAP_FMAC4
 soap_in_PointerTons1__isAccessAllowed(struct soap *soap, const char *tag,
                                       ns1__isAccessAllowed **a,
                                       const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__isAccessAllowed **)soap_malloc(
               soap, sizeof(ns1__isAccessAllowed *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__isAccessAllowed *)soap_instantiate_ns1__isAccessAllowed(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__isAccessAllowed **p = (ns1__isAccessAllowed **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__isAccessAllowed,
         sizeof(ns1__isAccessAllowed), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -37403,7 +37470,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__isAccessAllowed(struct soap *soap,
                                        ns1__isAccessAllowed *const *a,
                                        const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__isAccessAllowed);
   if (soap_out_PointerTons1__isAccessAllowed(
           soap, tag ? tag : "ns1:isAccessAllowed", id, a, type))
@@ -37417,7 +37484,7 @@ soap_get_PointerTons1__isAccessAllowed(struct soap *soap,
                                        const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__isAccessAllowed(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -37434,7 +37501,7 @@ soap_out_PointerTons1__searchTextResponse(struct soap *soap, const char *tag,
                                           int id,
                                           ns1__searchTextResponse *const *a,
                                           const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__searchTextResponse);
   if (id < 0)
     return soap->error;
@@ -37445,29 +37512,29 @@ SOAP_FMAC3 ns1__searchTextResponse **SOAP_FMAC4
 soap_in_PointerTons1__searchTextResponse(struct soap *soap, const char *tag,
                                          ns1__searchTextResponse **a,
                                          const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__searchTextResponse **)soap_malloc(
               soap, sizeof(ns1__searchTextResponse *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__searchTextResponse *)
-              soap_instantiate_ns1__searchTextResponse(soap, -1, soap->type,
-                                                       soap->arrayType, NULL)))
-      return NULL;
+              soap_instantiate_ns1__searchTextResponse(
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__searchTextResponse **p = (ns1__searchTextResponse **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__searchTextResponse,
         sizeof(ns1__searchTextResponse), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -37476,7 +37543,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__searchTextResponse(struct soap *soap,
                                           ns1__searchTextResponse *const *a,
                                           const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__searchTextResponse);
   if (soap_out_PointerTons1__searchTextResponse(
           soap, tag ? tag : "ns1:searchTextResponse", id, a, type))
@@ -37490,7 +37557,7 @@ soap_get_PointerTons1__searchTextResponse(struct soap *soap,
                                           const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__searchTextResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -37506,7 +37573,7 @@ soap_serialize_PointerTons1__searchText(struct soap *soap,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__searchText(struct soap *soap, const char *tag, int id,
                                   ns1__searchText *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__searchText);
   if (id < 0)
     return soap->error;
@@ -37516,27 +37583,27 @@ soap_out_PointerTons1__searchText(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__searchText **SOAP_FMAC4
 soap_in_PointerTons1__searchText(struct soap *soap, const char *tag,
                                  ns1__searchText **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__searchText **)soap_malloc(soap, sizeof(ns1__searchText *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__searchText *)soap_instantiate_ns1__searchText(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__searchText **p = (ns1__searchText **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__searchText,
         sizeof(ns1__searchText), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -37544,7 +37611,7 @@ soap_in_PointerTons1__searchText(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__searchText(struct soap *soap, ns1__searchText *const *a,
                                   const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__searchText);
   if (soap_out_PointerTons1__searchText(soap, tag ? tag : "ns1:searchText", id,
                                         a, type))
@@ -37557,7 +37624,7 @@ soap_get_PointerTons1__searchText(struct soap *soap, ns1__searchText **p,
                                   const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__searchText(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -37574,7 +37641,7 @@ soap_serialize_PointerTons1__getRemainingMinutesResponse(
 SOAP_FMAC3 int SOAP_FMAC4 soap_out_PointerTons1__getRemainingMinutesResponse(
     struct soap *soap, const char *tag, int id,
     ns1__getRemainingMinutesResponse *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__getRemainingMinutesResponse);
   if (id < 0)
     return soap->error;
@@ -37585,22 +37652,22 @@ SOAP_FMAC3 ns1__getRemainingMinutesResponse **SOAP_FMAC4
 soap_in_PointerTons1__getRemainingMinutesResponse(
     struct soap *soap, const char *tag, ns1__getRemainingMinutesResponse **a,
     const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__getRemainingMinutesResponse **)soap_malloc(
               soap, sizeof(ns1__getRemainingMinutesResponse *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__getRemainingMinutesResponse *)
               soap_instantiate_ns1__getRemainingMinutesResponse(
-                  soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__getRemainingMinutesResponse **p =
         (ns1__getRemainingMinutesResponse **)soap_id_lookup(
@@ -37609,7 +37676,7 @@ soap_in_PointerTons1__getRemainingMinutesResponse(
             sizeof(ns1__getRemainingMinutesResponse), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -37618,7 +37685,7 @@ SOAP_FMAC3 int SOAP_FMAC4 soap_put_PointerTons1__getRemainingMinutesResponse(
     struct soap *soap, ns1__getRemainingMinutesResponse *const *a,
     const char *tag, const char *type) {
   int id =
-      soap_embed(soap, (void *)a, NULL, 0, tag,
+      soap_embed(soap, (void *)a, nullptr, 0, tag,
                  SOAP_TYPE_ICat4_PointerTons1__getRemainingMinutesResponse);
   if (soap_out_PointerTons1__getRemainingMinutesResponse(
           soap, tag ? tag : "ns1:getRemainingMinutesResponse", id, a, type))
@@ -37633,7 +37700,7 @@ soap_get_PointerTons1__getRemainingMinutesResponse(
   if ((p = soap_in_PointerTons1__getRemainingMinutesResponse(soap, tag, p,
                                                              type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -37650,7 +37717,7 @@ soap_out_PointerTons1__getRemainingMinutes(struct soap *soap, const char *tag,
                                            int id,
                                            ns1__getRemainingMinutes *const *a,
                                            const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__getRemainingMinutes);
   if (id < 0)
     return soap->error;
@@ -37661,29 +37728,29 @@ SOAP_FMAC3 ns1__getRemainingMinutes **SOAP_FMAC4
 soap_in_PointerTons1__getRemainingMinutes(struct soap *soap, const char *tag,
                                           ns1__getRemainingMinutes **a,
                                           const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__getRemainingMinutes **)soap_malloc(
               soap, sizeof(ns1__getRemainingMinutes *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__getRemainingMinutes *)
-              soap_instantiate_ns1__getRemainingMinutes(soap, -1, soap->type,
-                                                        soap->arrayType, NULL)))
-      return NULL;
+              soap_instantiate_ns1__getRemainingMinutes(
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__getRemainingMinutes **p = (ns1__getRemainingMinutes **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__getRemainingMinutes,
         sizeof(ns1__getRemainingMinutes), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -37692,7 +37759,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__getRemainingMinutes(struct soap *soap,
                                            ns1__getRemainingMinutes *const *a,
                                            const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__getRemainingMinutes);
   if (soap_out_PointerTons1__getRemainingMinutes(
           soap, tag ? tag : "ns1:getRemainingMinutes", id, a, type))
@@ -37706,7 +37773,7 @@ soap_get_PointerTons1__getRemainingMinutes(struct soap *soap,
                                            const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__getRemainingMinutes(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -37723,7 +37790,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__logoutResponse(struct soap *soap, const char *tag,
                                       int id, ns1__logoutResponse *const *a,
                                       const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__logoutResponse);
   if (id < 0)
     return soap->error;
@@ -37734,28 +37801,28 @@ SOAP_FMAC3 ns1__logoutResponse **SOAP_FMAC4
 soap_in_PointerTons1__logoutResponse(struct soap *soap, const char *tag,
                                      ns1__logoutResponse **a,
                                      const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__logoutResponse **)soap_malloc(
               soap, sizeof(ns1__logoutResponse *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__logoutResponse *)soap_instantiate_ns1__logoutResponse(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__logoutResponse **p = (ns1__logoutResponse **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__logoutResponse,
         sizeof(ns1__logoutResponse), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -37764,7 +37831,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__logoutResponse(struct soap *soap,
                                       ns1__logoutResponse *const *a,
                                       const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__logoutResponse);
   if (soap_out_PointerTons1__logoutResponse(
           soap, tag ? tag : "ns1:logoutResponse", id, a, type))
@@ -37778,7 +37845,7 @@ soap_get_PointerTons1__logoutResponse(struct soap *soap,
                                       const char *type) {
   if ((p = soap_in_PointerTons1__logoutResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -37793,7 +37860,7 @@ soap_serialize_PointerTons1__logout(struct soap *soap, ns1__logout *const *a) {
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__logout(struct soap *soap, const char *tag, int id,
                               ns1__logout *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__logout);
   if (id < 0)
     return soap->error;
@@ -37803,27 +37870,27 @@ soap_out_PointerTons1__logout(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__logout **SOAP_FMAC4
 soap_in_PointerTons1__logout(struct soap *soap, const char *tag,
                              ns1__logout **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__logout **)soap_malloc(soap, sizeof(ns1__logout *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__logout *)soap_instantiate_ns1__logout(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__logout **p = (ns1__logout **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__logout,
         sizeof(ns1__logout), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -37831,7 +37898,7 @@ soap_in_PointerTons1__logout(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__logout(struct soap *soap, ns1__logout *const *a,
                               const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__logout);
   if (soap_out_PointerTons1__logout(soap, tag ? tag : "ns1:logout", id, a,
                                     type))
@@ -37844,7 +37911,7 @@ soap_get_PointerTons1__logout(struct soap *soap, ns1__logout **p,
                               const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__logout(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -37861,7 +37928,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__dummyResponse(struct soap *soap, const char *tag, int id,
                                      ns1__dummyResponse *const *a,
                                      const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__dummyResponse);
   if (id < 0)
     return soap->error;
@@ -37871,28 +37938,28 @@ soap_out_PointerTons1__dummyResponse(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__dummyResponse **SOAP_FMAC4
 soap_in_PointerTons1__dummyResponse(struct soap *soap, const char *tag,
                                     ns1__dummyResponse **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__dummyResponse **)soap_malloc(soap,
                                                  sizeof(ns1__dummyResponse *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__dummyResponse *)soap_instantiate_ns1__dummyResponse(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__dummyResponse **p = (ns1__dummyResponse **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__dummyResponse,
         sizeof(ns1__dummyResponse), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -37901,7 +37968,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__dummyResponse(struct soap *soap,
                                      ns1__dummyResponse *const *a,
                                      const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__dummyResponse);
   if (soap_out_PointerTons1__dummyResponse(
           soap, tag ? tag : "ns1:dummyResponse", id, a, type))
@@ -37914,7 +37981,7 @@ soap_get_PointerTons1__dummyResponse(struct soap *soap, ns1__dummyResponse **p,
                                      const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__dummyResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -37929,7 +37996,7 @@ soap_serialize_PointerTons1__dummy(struct soap *soap, ns1__dummy *const *a) {
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__dummy(struct soap *soap, const char *tag, int id,
                              ns1__dummy *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__dummy);
   if (id < 0)
     return soap->error;
@@ -37939,27 +38006,27 @@ soap_out_PointerTons1__dummy(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__dummy **SOAP_FMAC4
 soap_in_PointerTons1__dummy(struct soap *soap, const char *tag, ns1__dummy **a,
                             const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__dummy **)soap_malloc(soap, sizeof(ns1__dummy *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__dummy *)soap_instantiate_ns1__dummy(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__dummy **p = (ns1__dummy **)soap_id_lookup(soap, soap->href, (void **)a,
                                                    SOAP_TYPE_ICat4_ns1__dummy,
                                                    sizeof(ns1__dummy), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -37967,7 +38034,7 @@ soap_in_PointerTons1__dummy(struct soap *soap, const char *tag, ns1__dummy **a,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__dummy(struct soap *soap, ns1__dummy *const *a,
                              const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__dummy);
   if (soap_out_PointerTons1__dummy(soap, tag ? tag : "ns1:dummy", id, a, type))
     return soap->error;
@@ -37979,7 +38046,7 @@ soap_get_PointerTons1__dummy(struct soap *soap, ns1__dummy **p, const char *tag,
                              const char *type) {
   if ((p = soap_in_PointerTons1__dummy(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -37996,7 +38063,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__refreshResponse(struct soap *soap, const char *tag,
                                        int id, ns1__refreshResponse *const *a,
                                        const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__refreshResponse);
   if (id < 0)
     return soap->error;
@@ -38007,28 +38074,28 @@ SOAP_FMAC3 ns1__refreshResponse **SOAP_FMAC4
 soap_in_PointerTons1__refreshResponse(struct soap *soap, const char *tag,
                                       ns1__refreshResponse **a,
                                       const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__refreshResponse **)soap_malloc(
               soap, sizeof(ns1__refreshResponse *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__refreshResponse *)soap_instantiate_ns1__refreshResponse(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__refreshResponse **p = (ns1__refreshResponse **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__refreshResponse,
         sizeof(ns1__refreshResponse), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -38037,7 +38104,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__refreshResponse(struct soap *soap,
                                        ns1__refreshResponse *const *a,
                                        const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__refreshResponse);
   if (soap_out_PointerTons1__refreshResponse(
           soap, tag ? tag : "ns1:refreshResponse", id, a, type))
@@ -38051,7 +38118,7 @@ soap_get_PointerTons1__refreshResponse(struct soap *soap,
                                        const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__refreshResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -38067,7 +38134,7 @@ soap_serialize_PointerTons1__refresh(struct soap *soap,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__refresh(struct soap *soap, const char *tag, int id,
                                ns1__refresh *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__refresh);
   if (id < 0)
     return soap->error;
@@ -38077,27 +38144,27 @@ soap_out_PointerTons1__refresh(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__refresh **SOAP_FMAC4
 soap_in_PointerTons1__refresh(struct soap *soap, const char *tag,
                               ns1__refresh **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__refresh **)soap_malloc(soap, sizeof(ns1__refresh *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__refresh *)soap_instantiate_ns1__refresh(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__refresh **p = (ns1__refresh **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__refresh,
         sizeof(ns1__refresh), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -38105,7 +38172,7 @@ soap_in_PointerTons1__refresh(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__refresh(struct soap *soap, ns1__refresh *const *a,
                                const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__refresh);
   if (soap_out_PointerTons1__refresh(soap, tag ? tag : "ns1:refresh", id, a,
                                      type))
@@ -38118,7 +38185,7 @@ soap_get_PointerTons1__refresh(struct soap *soap, ns1__refresh **p,
                                const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__refresh(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -38133,7 +38200,7 @@ SOAP_FMAC3 void SOAP_FMAC4 soap_serialize_PointerTons1__getEntityNamesResponse(
 SOAP_FMAC3 int SOAP_FMAC4 soap_out_PointerTons1__getEntityNamesResponse(
     struct soap *soap, const char *tag, int id,
     ns1__getEntityNamesResponse *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__getEntityNamesResponse);
   if (id < 0)
     return soap->error;
@@ -38144,22 +38211,22 @@ SOAP_FMAC3 ns1__getEntityNamesResponse **SOAP_FMAC4
 soap_in_PointerTons1__getEntityNamesResponse(struct soap *soap, const char *tag,
                                              ns1__getEntityNamesResponse **a,
                                              const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__getEntityNamesResponse **)soap_malloc(
               soap, sizeof(ns1__getEntityNamesResponse *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__getEntityNamesResponse *)
               soap_instantiate_ns1__getEntityNamesResponse(
-                  soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__getEntityNamesResponse **p =
         (ns1__getEntityNamesResponse **)soap_id_lookup(
@@ -38168,7 +38235,7 @@ soap_in_PointerTons1__getEntityNamesResponse(struct soap *soap, const char *tag,
             sizeof(ns1__getEntityNamesResponse), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -38176,7 +38243,7 @@ soap_in_PointerTons1__getEntityNamesResponse(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4 soap_put_PointerTons1__getEntityNamesResponse(
     struct soap *soap, ns1__getEntityNamesResponse *const *a, const char *tag,
     const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__getEntityNamesResponse);
   if (soap_out_PointerTons1__getEntityNamesResponse(
           soap, tag ? tag : "ns1:getEntityNamesResponse", id, a, type))
@@ -38191,7 +38258,7 @@ soap_get_PointerTons1__getEntityNamesResponse(struct soap *soap,
                                               const char *type) {
   if ((p = soap_in_PointerTons1__getEntityNamesResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -38208,7 +38275,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__getEntityNames(struct soap *soap, const char *tag,
                                       int id, ns1__getEntityNames *const *a,
                                       const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__getEntityNames);
   if (id < 0)
     return soap->error;
@@ -38219,28 +38286,28 @@ SOAP_FMAC3 ns1__getEntityNames **SOAP_FMAC4
 soap_in_PointerTons1__getEntityNames(struct soap *soap, const char *tag,
                                      ns1__getEntityNames **a,
                                      const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__getEntityNames **)soap_malloc(
               soap, sizeof(ns1__getEntityNames *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__getEntityNames *)soap_instantiate_ns1__getEntityNames(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__getEntityNames **p = (ns1__getEntityNames **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__getEntityNames,
         sizeof(ns1__getEntityNames), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -38249,7 +38316,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__getEntityNames(struct soap *soap,
                                       ns1__getEntityNames *const *a,
                                       const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__getEntityNames);
   if (soap_out_PointerTons1__getEntityNames(
           soap, tag ? tag : "ns1:getEntityNames", id, a, type))
@@ -38263,7 +38330,7 @@ soap_get_PointerTons1__getEntityNames(struct soap *soap,
                                       const char *type) {
   if ((p = soap_in_PointerTons1__getEntityNames(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -38278,7 +38345,7 @@ SOAP_FMAC3 void SOAP_FMAC4 soap_serialize_PointerTons1__getApiVersionResponse(
 SOAP_FMAC3 int SOAP_FMAC4 soap_out_PointerTons1__getApiVersionResponse(
     struct soap *soap, const char *tag, int id,
     ns1__getApiVersionResponse *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__getApiVersionResponse);
   if (id < 0)
     return soap->error;
@@ -38289,22 +38356,22 @@ SOAP_FMAC3 ns1__getApiVersionResponse **SOAP_FMAC4
 soap_in_PointerTons1__getApiVersionResponse(struct soap *soap, const char *tag,
                                             ns1__getApiVersionResponse **a,
                                             const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__getApiVersionResponse **)soap_malloc(
               soap, sizeof(ns1__getApiVersionResponse *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__getApiVersionResponse *)
               soap_instantiate_ns1__getApiVersionResponse(
-                  soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__getApiVersionResponse **p =
         (ns1__getApiVersionResponse **)soap_id_lookup(
@@ -38313,7 +38380,7 @@ soap_in_PointerTons1__getApiVersionResponse(struct soap *soap, const char *tag,
             sizeof(ns1__getApiVersionResponse), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -38321,7 +38388,7 @@ soap_in_PointerTons1__getApiVersionResponse(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4 soap_put_PointerTons1__getApiVersionResponse(
     struct soap *soap, ns1__getApiVersionResponse *const *a, const char *tag,
     const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__getApiVersionResponse);
   if (soap_out_PointerTons1__getApiVersionResponse(
           soap, tag ? tag : "ns1:getApiVersionResponse", id, a, type))
@@ -38336,7 +38403,7 @@ soap_get_PointerTons1__getApiVersionResponse(struct soap *soap,
                                              const char *type) {
   if ((p = soap_in_PointerTons1__getApiVersionResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -38353,7 +38420,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__getApiVersion(struct soap *soap, const char *tag, int id,
                                      ns1__getApiVersion *const *a,
                                      const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__getApiVersion);
   if (id < 0)
     return soap->error;
@@ -38363,28 +38430,28 @@ soap_out_PointerTons1__getApiVersion(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__getApiVersion **SOAP_FMAC4
 soap_in_PointerTons1__getApiVersion(struct soap *soap, const char *tag,
                                     ns1__getApiVersion **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__getApiVersion **)soap_malloc(soap,
                                                  sizeof(ns1__getApiVersion *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__getApiVersion *)soap_instantiate_ns1__getApiVersion(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__getApiVersion **p = (ns1__getApiVersion **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__getApiVersion,
         sizeof(ns1__getApiVersion), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -38393,7 +38460,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__getApiVersion(struct soap *soap,
                                      ns1__getApiVersion *const *a,
                                      const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__getApiVersion);
   if (soap_out_PointerTons1__getApiVersion(
           soap, tag ? tag : "ns1:getApiVersion", id, a, type))
@@ -38406,7 +38473,7 @@ soap_get_PointerTons1__getApiVersion(struct soap *soap, ns1__getApiVersion **p,
                                      const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__getApiVersion(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -38423,7 +38490,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__updateResponse(struct soap *soap, const char *tag,
                                       int id, ns1__updateResponse *const *a,
                                       const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__updateResponse);
   if (id < 0)
     return soap->error;
@@ -38434,28 +38501,28 @@ SOAP_FMAC3 ns1__updateResponse **SOAP_FMAC4
 soap_in_PointerTons1__updateResponse(struct soap *soap, const char *tag,
                                      ns1__updateResponse **a,
                                      const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__updateResponse **)soap_malloc(
               soap, sizeof(ns1__updateResponse *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__updateResponse *)soap_instantiate_ns1__updateResponse(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__updateResponse **p = (ns1__updateResponse **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__updateResponse,
         sizeof(ns1__updateResponse), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -38464,7 +38531,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__updateResponse(struct soap *soap,
                                       ns1__updateResponse *const *a,
                                       const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__updateResponse);
   if (soap_out_PointerTons1__updateResponse(
           soap, tag ? tag : "ns1:updateResponse", id, a, type))
@@ -38478,7 +38545,7 @@ soap_get_PointerTons1__updateResponse(struct soap *soap,
                                       const char *type) {
   if ((p = soap_in_PointerTons1__updateResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -38493,7 +38560,7 @@ soap_serialize_PointerTons1__update(struct soap *soap, ns1__update *const *a) {
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__update(struct soap *soap, const char *tag, int id,
                               ns1__update *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__update);
   if (id < 0)
     return soap->error;
@@ -38503,27 +38570,27 @@ soap_out_PointerTons1__update(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__update **SOAP_FMAC4
 soap_in_PointerTons1__update(struct soap *soap, const char *tag,
                              ns1__update **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__update **)soap_malloc(soap, sizeof(ns1__update *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__update *)soap_instantiate_ns1__update(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__update **p = (ns1__update **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__update,
         sizeof(ns1__update), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -38531,7 +38598,7 @@ soap_in_PointerTons1__update(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__update(struct soap *soap, ns1__update *const *a,
                               const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__update);
   if (soap_out_PointerTons1__update(soap, tag ? tag : "ns1:update", id, a,
                                     type))
@@ -38544,7 +38611,7 @@ soap_get_PointerTons1__update(struct soap *soap, ns1__update **p,
                               const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__update(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -38561,7 +38628,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__createResponse(struct soap *soap, const char *tag,
                                       int id, ns1__createResponse *const *a,
                                       const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__createResponse);
   if (id < 0)
     return soap->error;
@@ -38572,28 +38639,28 @@ SOAP_FMAC3 ns1__createResponse **SOAP_FMAC4
 soap_in_PointerTons1__createResponse(struct soap *soap, const char *tag,
                                      ns1__createResponse **a,
                                      const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__createResponse **)soap_malloc(
               soap, sizeof(ns1__createResponse *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__createResponse *)soap_instantiate_ns1__createResponse(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__createResponse **p = (ns1__createResponse **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__createResponse,
         sizeof(ns1__createResponse), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -38602,7 +38669,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__createResponse(struct soap *soap,
                                       ns1__createResponse *const *a,
                                       const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__createResponse);
   if (soap_out_PointerTons1__createResponse(
           soap, tag ? tag : "ns1:createResponse", id, a, type))
@@ -38616,7 +38683,7 @@ soap_get_PointerTons1__createResponse(struct soap *soap,
                                       const char *type) {
   if ((p = soap_in_PointerTons1__createResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -38631,7 +38698,7 @@ soap_serialize_PointerTons1__create(struct soap *soap, ns1__create *const *a) {
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__create(struct soap *soap, const char *tag, int id,
                               ns1__create *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__create);
   if (id < 0)
     return soap->error;
@@ -38641,27 +38708,27 @@ soap_out_PointerTons1__create(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__create **SOAP_FMAC4
 soap_in_PointerTons1__create(struct soap *soap, const char *tag,
                              ns1__create **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__create **)soap_malloc(soap, sizeof(ns1__create *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__create *)soap_instantiate_ns1__create(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__create **p = (ns1__create **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__create,
         sizeof(ns1__create), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -38669,7 +38736,7 @@ soap_in_PointerTons1__create(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__create(struct soap *soap, ns1__create *const *a,
                               const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__create);
   if (soap_out_PointerTons1__create(soap, tag ? tag : "ns1:create", id, a,
                                     type))
@@ -38682,7 +38749,7 @@ soap_get_PointerTons1__create(struct soap *soap, ns1__create **p,
                               const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__create(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -38699,7 +38766,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__searchResponse(struct soap *soap, const char *tag,
                                       int id, ns1__searchResponse *const *a,
                                       const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__searchResponse);
   if (id < 0)
     return soap->error;
@@ -38710,28 +38777,28 @@ SOAP_FMAC3 ns1__searchResponse **SOAP_FMAC4
 soap_in_PointerTons1__searchResponse(struct soap *soap, const char *tag,
                                      ns1__searchResponse **a,
                                      const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__searchResponse **)soap_malloc(
               soap, sizeof(ns1__searchResponse *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__searchResponse *)soap_instantiate_ns1__searchResponse(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__searchResponse **p = (ns1__searchResponse **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__searchResponse,
         sizeof(ns1__searchResponse), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -38740,7 +38807,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__searchResponse(struct soap *soap,
                                       ns1__searchResponse *const *a,
                                       const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__searchResponse);
   if (soap_out_PointerTons1__searchResponse(
           soap, tag ? tag : "ns1:searchResponse", id, a, type))
@@ -38754,7 +38821,7 @@ soap_get_PointerTons1__searchResponse(struct soap *soap,
                                       const char *type) {
   if ((p = soap_in_PointerTons1__searchResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -38769,7 +38836,7 @@ soap_serialize_PointerTons1__search(struct soap *soap, ns1__search *const *a) {
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__search(struct soap *soap, const char *tag, int id,
                               ns1__search *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__search);
   if (id < 0)
     return soap->error;
@@ -38779,27 +38846,27 @@ soap_out_PointerTons1__search(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__search **SOAP_FMAC4
 soap_in_PointerTons1__search(struct soap *soap, const char *tag,
                              ns1__search **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__search **)soap_malloc(soap, sizeof(ns1__search *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__search *)soap_instantiate_ns1__search(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__search **p = (ns1__search **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__search,
         sizeof(ns1__search), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -38807,7 +38874,7 @@ soap_in_PointerTons1__search(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__search(struct soap *soap, ns1__search *const *a,
                               const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__search);
   if (soap_out_PointerTons1__search(soap, tag ? tag : "ns1:search", id, a,
                                     type))
@@ -38820,7 +38887,7 @@ soap_get_PointerTons1__search(struct soap *soap, ns1__search **p,
                               const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__search(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -38837,7 +38904,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__deleteResponse(struct soap *soap, const char *tag,
                                       int id, ns1__deleteResponse *const *a,
                                       const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__deleteResponse);
   if (id < 0)
     return soap->error;
@@ -38848,28 +38915,28 @@ SOAP_FMAC3 ns1__deleteResponse **SOAP_FMAC4
 soap_in_PointerTons1__deleteResponse(struct soap *soap, const char *tag,
                                      ns1__deleteResponse **a,
                                      const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__deleteResponse **)soap_malloc(
               soap, sizeof(ns1__deleteResponse *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__deleteResponse *)soap_instantiate_ns1__deleteResponse(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__deleteResponse **p = (ns1__deleteResponse **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__deleteResponse,
         sizeof(ns1__deleteResponse), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -38878,7 +38945,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__deleteResponse(struct soap *soap,
                                       ns1__deleteResponse *const *a,
                                       const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__deleteResponse);
   if (soap_out_PointerTons1__deleteResponse(
           soap, tag ? tag : "ns1:deleteResponse", id, a, type))
@@ -38892,7 +38959,7 @@ soap_get_PointerTons1__deleteResponse(struct soap *soap,
                                       const char *type) {
   if ((p = soap_in_PointerTons1__deleteResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -38907,7 +38974,7 @@ soap_serialize_PointerTons1__delete(struct soap *soap, ns1__delete *const *a) {
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__delete(struct soap *soap, const char *tag, int id,
                               ns1__delete *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__delete);
   if (id < 0)
     return soap->error;
@@ -38917,27 +38984,27 @@ soap_out_PointerTons1__delete(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__delete **SOAP_FMAC4
 soap_in_PointerTons1__delete(struct soap *soap, const char *tag,
                              ns1__delete **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__delete **)soap_malloc(soap, sizeof(ns1__delete *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__delete *)soap_instantiate_ns1__delete(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__delete **p = (ns1__delete **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__delete,
         sizeof(ns1__delete), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -38945,7 +39012,7 @@ soap_in_PointerTons1__delete(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__delete(struct soap *soap, ns1__delete *const *a,
                               const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__delete);
   if (soap_out_PointerTons1__delete(soap, tag ? tag : "ns1:delete", id, a,
                                     type))
@@ -38958,7 +39025,7 @@ soap_get_PointerTons1__delete(struct soap *soap, ns1__delete **p,
                               const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__delete(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -38973,7 +39040,7 @@ SOAP_FMAC3 void SOAP_FMAC4 soap_serialize_PointerTons1__getPropertiesResponse(
 SOAP_FMAC3 int SOAP_FMAC4 soap_out_PointerTons1__getPropertiesResponse(
     struct soap *soap, const char *tag, int id,
     ns1__getPropertiesResponse *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__getPropertiesResponse);
   if (id < 0)
     return soap->error;
@@ -38984,22 +39051,22 @@ SOAP_FMAC3 ns1__getPropertiesResponse **SOAP_FMAC4
 soap_in_PointerTons1__getPropertiesResponse(struct soap *soap, const char *tag,
                                             ns1__getPropertiesResponse **a,
                                             const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__getPropertiesResponse **)soap_malloc(
               soap, sizeof(ns1__getPropertiesResponse *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__getPropertiesResponse *)
               soap_instantiate_ns1__getPropertiesResponse(
-                  soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__getPropertiesResponse **p =
         (ns1__getPropertiesResponse **)soap_id_lookup(
@@ -39008,7 +39075,7 @@ soap_in_PointerTons1__getPropertiesResponse(struct soap *soap, const char *tag,
             sizeof(ns1__getPropertiesResponse), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -39016,7 +39083,7 @@ soap_in_PointerTons1__getPropertiesResponse(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4 soap_put_PointerTons1__getPropertiesResponse(
     struct soap *soap, ns1__getPropertiesResponse *const *a, const char *tag,
     const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__getPropertiesResponse);
   if (soap_out_PointerTons1__getPropertiesResponse(
           soap, tag ? tag : "ns1:getPropertiesResponse", id, a, type))
@@ -39031,7 +39098,7 @@ soap_get_PointerTons1__getPropertiesResponse(struct soap *soap,
                                              const char *type) {
   if ((p = soap_in_PointerTons1__getPropertiesResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -39048,7 +39115,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__getProperties(struct soap *soap, const char *tag, int id,
                                      ns1__getProperties *const *a,
                                      const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__getProperties);
   if (id < 0)
     return soap->error;
@@ -39058,28 +39125,28 @@ soap_out_PointerTons1__getProperties(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__getProperties **SOAP_FMAC4
 soap_in_PointerTons1__getProperties(struct soap *soap, const char *tag,
                                     ns1__getProperties **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__getProperties **)soap_malloc(soap,
                                                  sizeof(ns1__getProperties *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__getProperties *)soap_instantiate_ns1__getProperties(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__getProperties **p = (ns1__getProperties **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__getProperties,
         sizeof(ns1__getProperties), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -39088,7 +39155,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__getProperties(struct soap *soap,
                                      ns1__getProperties *const *a,
                                      const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__getProperties);
   if (soap_out_PointerTons1__getProperties(
           soap, tag ? tag : "ns1:getProperties", id, a, type))
@@ -39101,7 +39168,7 @@ soap_get_PointerTons1__getProperties(struct soap *soap, ns1__getProperties **p,
                                      const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__getProperties(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -39118,7 +39185,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__getResponse(struct soap *soap, const char *tag, int id,
                                    ns1__getResponse *const *a,
                                    const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__getResponse);
   if (id < 0)
     return soap->error;
@@ -39128,28 +39195,28 @@ soap_out_PointerTons1__getResponse(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__getResponse **SOAP_FMAC4
 soap_in_PointerTons1__getResponse(struct soap *soap, const char *tag,
                                   ns1__getResponse **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__getResponse **)soap_malloc(soap,
                                                sizeof(ns1__getResponse *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__getResponse *)soap_instantiate_ns1__getResponse(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__getResponse **p = (ns1__getResponse **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__getResponse,
         sizeof(ns1__getResponse), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -39158,7 +39225,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__getResponse(struct soap *soap,
                                    ns1__getResponse *const *a, const char *tag,
                                    const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__getResponse);
   if (soap_out_PointerTons1__getResponse(soap, tag ? tag : "ns1:getResponse",
                                          id, a, type))
@@ -39171,7 +39238,7 @@ soap_get_PointerTons1__getResponse(struct soap *soap, ns1__getResponse **p,
                                    const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__getResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -39186,7 +39253,7 @@ soap_serialize_PointerTons1__get(struct soap *soap, ns1__get *const *a) {
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__get(struct soap *soap, const char *tag, int id,
                            ns1__get *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__get);
   if (id < 0)
     return soap->error;
@@ -39196,27 +39263,27 @@ soap_out_PointerTons1__get(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__get **SOAP_FMAC4
 soap_in_PointerTons1__get(struct soap *soap, const char *tag, ns1__get **a,
                           const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__get **)soap_malloc(soap, sizeof(ns1__get *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__get *)soap_instantiate_ns1__get(soap, -1, soap->type,
-                                                     soap->arrayType, NULL)))
-      return NULL;
+                                                     soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__get **p = (ns1__get **)soap_id_lookup(soap, soap->href, (void **)a,
                                                SOAP_TYPE_ICat4_ns1__get,
                                                sizeof(ns1__get), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -39224,7 +39291,7 @@ soap_in_PointerTons1__get(struct soap *soap, const char *tag, ns1__get **a,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__get(struct soap *soap, ns1__get *const *a,
                            const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__get);
   if (soap_out_PointerTons1__get(soap, tag ? tag : "ns1:get", id, a, type))
     return soap->error;
@@ -39236,7 +39303,7 @@ soap_get_PointerTons1__get(struct soap *soap, ns1__get **p, const char *tag,
                            const char *type) {
   if ((p = soap_in_PointerTons1__get(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -39253,7 +39320,7 @@ soap_out_PointerTons1__getUserNameResponse(struct soap *soap, const char *tag,
                                            int id,
                                            ns1__getUserNameResponse *const *a,
                                            const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__getUserNameResponse);
   if (id < 0)
     return soap->error;
@@ -39264,29 +39331,29 @@ SOAP_FMAC3 ns1__getUserNameResponse **SOAP_FMAC4
 soap_in_PointerTons1__getUserNameResponse(struct soap *soap, const char *tag,
                                           ns1__getUserNameResponse **a,
                                           const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__getUserNameResponse **)soap_malloc(
               soap, sizeof(ns1__getUserNameResponse *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__getUserNameResponse *)
-              soap_instantiate_ns1__getUserNameResponse(soap, -1, soap->type,
-                                                        soap->arrayType, NULL)))
-      return NULL;
+              soap_instantiate_ns1__getUserNameResponse(
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__getUserNameResponse **p = (ns1__getUserNameResponse **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__getUserNameResponse,
         sizeof(ns1__getUserNameResponse), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -39295,7 +39362,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__getUserNameResponse(struct soap *soap,
                                            ns1__getUserNameResponse *const *a,
                                            const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__getUserNameResponse);
   if (soap_out_PointerTons1__getUserNameResponse(
           soap, tag ? tag : "ns1:getUserNameResponse", id, a, type))
@@ -39309,7 +39376,7 @@ soap_get_PointerTons1__getUserNameResponse(struct soap *soap,
                                            const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__getUserNameResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -39326,7 +39393,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__getUserName(struct soap *soap, const char *tag, int id,
                                    ns1__getUserName *const *a,
                                    const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__getUserName);
   if (id < 0)
     return soap->error;
@@ -39336,28 +39403,28 @@ soap_out_PointerTons1__getUserName(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__getUserName **SOAP_FMAC4
 soap_in_PointerTons1__getUserName(struct soap *soap, const char *tag,
                                   ns1__getUserName **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__getUserName **)soap_malloc(soap,
                                                sizeof(ns1__getUserName *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__getUserName *)soap_instantiate_ns1__getUserName(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__getUserName **p = (ns1__getUserName **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__getUserName,
         sizeof(ns1__getUserName), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -39366,7 +39433,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__getUserName(struct soap *soap,
                                    ns1__getUserName *const *a, const char *tag,
                                    const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__getUserName);
   if (soap_out_PointerTons1__getUserName(soap, tag ? tag : "ns1:getUserName",
                                          id, a, type))
@@ -39379,7 +39446,7 @@ soap_get_PointerTons1__getUserName(struct soap *soap, ns1__getUserName **p,
                                    const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__getUserName(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -39396,7 +39463,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__loginResponse(struct soap *soap, const char *tag, int id,
                                      ns1__loginResponse *const *a,
                                      const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__loginResponse);
   if (id < 0)
     return soap->error;
@@ -39406,28 +39473,28 @@ soap_out_PointerTons1__loginResponse(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__loginResponse **SOAP_FMAC4
 soap_in_PointerTons1__loginResponse(struct soap *soap, const char *tag,
                                     ns1__loginResponse **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__loginResponse **)soap_malloc(soap,
                                                  sizeof(ns1__loginResponse *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__loginResponse *)soap_instantiate_ns1__loginResponse(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__loginResponse **p = (ns1__loginResponse **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__loginResponse,
         sizeof(ns1__loginResponse), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -39436,7 +39503,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__loginResponse(struct soap *soap,
                                      ns1__loginResponse *const *a,
                                      const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__loginResponse);
   if (soap_out_PointerTons1__loginResponse(
           soap, tag ? tag : "ns1:loginResponse", id, a, type))
@@ -39449,7 +39516,7 @@ soap_get_PointerTons1__loginResponse(struct soap *soap, ns1__loginResponse **p,
                                      const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__loginResponse(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -39464,7 +39531,7 @@ soap_serialize_PointerTons1__login(struct soap *soap, ns1__login *const *a) {
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__login(struct soap *soap, const char *tag, int id,
                              ns1__login *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__login);
   if (id < 0)
     return soap->error;
@@ -39474,27 +39541,27 @@ soap_out_PointerTons1__login(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__login **SOAP_FMAC4
 soap_in_PointerTons1__login(struct soap *soap, const char *tag, ns1__login **a,
                             const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__login **)soap_malloc(soap, sizeof(ns1__login *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__login *)soap_instantiate_ns1__login(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__login **p = (ns1__login **)soap_id_lookup(soap, soap->href, (void **)a,
                                                    SOAP_TYPE_ICat4_ns1__login,
                                                    sizeof(ns1__login), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -39502,7 +39569,7 @@ soap_in_PointerTons1__login(struct soap *soap, const char *tag, ns1__login **a,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__login(struct soap *soap, ns1__login *const *a,
                              const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__login);
   if (soap_out_PointerTons1__login(soap, tag ? tag : "ns1:login", id, a, type))
     return soap->error;
@@ -39514,7 +39581,7 @@ soap_get_PointerTons1__login(struct soap *soap, ns1__login **p, const char *tag,
                              const char *type) {
   if ((p = soap_in_PointerTons1__login(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -39531,7 +39598,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__IcatException(struct soap *soap, const char *tag, int id,
                                      ns1__IcatException *const *a,
                                      const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__IcatException);
   if (id < 0)
     return soap->error;
@@ -39541,28 +39608,28 @@ soap_out_PointerTons1__IcatException(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__IcatException **SOAP_FMAC4
 soap_in_PointerTons1__IcatException(struct soap *soap, const char *tag,
                                     ns1__IcatException **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__IcatException **)soap_malloc(soap,
                                                  sizeof(ns1__IcatException *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__IcatException *)soap_instantiate_ns1__IcatException(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__IcatException **p = (ns1__IcatException **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__IcatException,
         sizeof(ns1__IcatException), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -39571,7 +39638,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__IcatException(struct soap *soap,
                                      ns1__IcatException *const *a,
                                      const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__IcatException);
   if (soap_out_PointerTons1__IcatException(
           soap, tag ? tag : "ns1:IcatException", id, a, type))
@@ -39584,7 +39651,7 @@ soap_get_PointerTons1__IcatException(struct soap *soap, ns1__IcatException **p,
                                      const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__IcatException(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -39598,7 +39665,7 @@ SOAP_FMAC3 void SOAP_FMAC4 soap_serialize_PointerTons1__parameterValueType(
 SOAP_FMAC3 int SOAP_FMAC4 soap_out_PointerTons1__parameterValueType(
     struct soap *soap, const char *tag, int id,
     enum ns1__parameterValueType *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__parameterValueType);
   if (id < 0)
     return soap->error;
@@ -39609,23 +39676,23 @@ SOAP_FMAC3 enum ns1__parameterValueType **SOAP_FMAC4
 soap_in_PointerTons1__parameterValueType(struct soap *soap, const char *tag,
                                          enum ns1__parameterValueType **a,
                                          const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (enum ns1__parameterValueType **)soap_malloc(
               soap, sizeof(enum ns1__parameterValueType *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = soap_in_ns1__parameterValueType(soap, tag, *a, type)))
-      return NULL;
+      return nullptr;
   } else {
     a = (enum ns1__parameterValueType **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__parameterValueType,
         sizeof(enum ns1__parameterValueType), 0);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -39633,7 +39700,7 @@ soap_in_PointerTons1__parameterValueType(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4 soap_put_PointerTons1__parameterValueType(
     struct soap *soap, enum ns1__parameterValueType *const *a, const char *tag,
     const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__parameterValueType);
   if (soap_out_PointerTons1__parameterValueType(
           soap, tag ? tag : "ns1:parameterValueType", id, a, type))
@@ -39647,7 +39714,7 @@ soap_get_PointerTons1__parameterValueType(struct soap *soap,
                                           const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__parameterValueType(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -39662,7 +39729,7 @@ SOAP_FMAC3 void SOAP_FMAC4 soap_serialize_PointerTons1__permissibleStringValue(
 SOAP_FMAC3 int SOAP_FMAC4 soap_out_PointerTons1__permissibleStringValue(
     struct soap *soap, const char *tag, int id,
     ns1__permissibleStringValue *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__permissibleStringValue);
   if (id < 0)
     return soap->error;
@@ -39673,22 +39740,22 @@ SOAP_FMAC3 ns1__permissibleStringValue **SOAP_FMAC4
 soap_in_PointerTons1__permissibleStringValue(struct soap *soap, const char *tag,
                                              ns1__permissibleStringValue **a,
                                              const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__permissibleStringValue **)soap_malloc(
               soap, sizeof(ns1__permissibleStringValue *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__permissibleStringValue *)
               soap_instantiate_ns1__permissibleStringValue(
-                  soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__permissibleStringValue **p =
         (ns1__permissibleStringValue **)soap_id_lookup(
@@ -39697,7 +39764,7 @@ soap_in_PointerTons1__permissibleStringValue(struct soap *soap, const char *tag,
             sizeof(ns1__permissibleStringValue), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -39705,7 +39772,7 @@ soap_in_PointerTons1__permissibleStringValue(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4 soap_put_PointerTons1__permissibleStringValue(
     struct soap *soap, ns1__permissibleStringValue *const *a, const char *tag,
     const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__permissibleStringValue);
   if (soap_out_PointerTons1__permissibleStringValue(
           soap, tag ? tag : "ns1:permissibleStringValue", id, a, type))
@@ -39720,7 +39787,7 @@ soap_get_PointerTons1__permissibleStringValue(struct soap *soap,
                                               const char *type) {
   if ((p = soap_in_PointerTons1__permissibleStringValue(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -39734,8 +39801,8 @@ soap_serialize_PointerTodouble(struct soap *soap, double *const *a) {
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTodouble(struct soap *soap, const char *tag, int id,
                          double *const *a, const char *type) {
-  id =
-      soap_element_id(soap, tag, id, *a, NULL, 0, type, SOAP_TYPE_ICat4_double);
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
+                       SOAP_TYPE_ICat4_double);
   if (id < 0)
     return soap->error;
   return soap_out_double(soap, tag, id, *a, type);
@@ -39744,21 +39811,21 @@ soap_out_PointerTodouble(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 double **SOAP_FMAC4
 soap_in_PointerTodouble(struct soap *soap, const char *tag, double **a,
                         const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (double **)soap_malloc(soap, sizeof(double *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = soap_in_double(soap, tag, *a, type)))
-      return NULL;
+      return nullptr;
   } else {
     a = (double **)soap_id_lookup(soap, soap->href, (void **)a,
                                   SOAP_TYPE_ICat4_double, sizeof(double), 0);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -39766,7 +39833,7 @@ soap_in_PointerTodouble(struct soap *soap, const char *tag, double **a,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTodouble(struct soap *soap, double *const *a, const char *tag,
                          const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTodouble);
   if (soap_out_PointerTodouble(soap, tag ? tag : "double", id, a, type))
     return soap->error;
@@ -39778,7 +39845,7 @@ soap_get_PointerTodouble(struct soap *soap, double **p, const char *tag,
                          const char *type) {
   if ((p = soap_in_PointerTodouble(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -39793,7 +39860,7 @@ soap_serialize_PointerTons1__rule(struct soap *soap, ns1__rule *const *a) {
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__rule(struct soap *soap, const char *tag, int id,
                             ns1__rule *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__rule);
   if (id < 0)
     return soap->error;
@@ -39803,27 +39870,27 @@ soap_out_PointerTons1__rule(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__rule **SOAP_FMAC4
 soap_in_PointerTons1__rule(struct soap *soap, const char *tag, ns1__rule **a,
                            const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__rule **)soap_malloc(soap, sizeof(ns1__rule *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
-    if (!(*a = (ns1__rule *)soap_instantiate_ns1__rule(soap, -1, soap->type,
-                                                       soap->arrayType, NULL)))
-      return NULL;
+    if (!(*a = (ns1__rule *)soap_instantiate_ns1__rule(
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__rule **p = (ns1__rule **)soap_id_lookup(soap, soap->href, (void **)a,
                                                  SOAP_TYPE_ICat4_ns1__rule,
                                                  sizeof(ns1__rule), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -39831,7 +39898,7 @@ soap_in_PointerTons1__rule(struct soap *soap, const char *tag, ns1__rule **a,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__rule(struct soap *soap, ns1__rule *const *a,
                             const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__rule);
   if (soap_out_PointerTons1__rule(soap, tag ? tag : "ns1:rule", id, a, type))
     return soap->error;
@@ -39843,7 +39910,7 @@ soap_get_PointerTons1__rule(struct soap *soap, ns1__rule **p, const char *tag,
                             const char *type) {
   if ((p = soap_in_PointerTons1__rule(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -39859,7 +39926,7 @@ soap_serialize_PointerTons1__sampleType(struct soap *soap,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__sampleType(struct soap *soap, const char *tag, int id,
                                   ns1__sampleType *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__sampleType);
   if (id < 0)
     return soap->error;
@@ -39869,27 +39936,27 @@ soap_out_PointerTons1__sampleType(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__sampleType **SOAP_FMAC4
 soap_in_PointerTons1__sampleType(struct soap *soap, const char *tag,
                                  ns1__sampleType **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__sampleType **)soap_malloc(soap, sizeof(ns1__sampleType *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__sampleType *)soap_instantiate_ns1__sampleType(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__sampleType **p = (ns1__sampleType **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__sampleType,
         sizeof(ns1__sampleType), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -39897,7 +39964,7 @@ soap_in_PointerTons1__sampleType(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__sampleType(struct soap *soap, ns1__sampleType *const *a,
                                   const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__sampleType);
   if (soap_out_PointerTons1__sampleType(soap, tag ? tag : "ns1:sampleType", id,
                                         a, type))
@@ -39910,7 +39977,7 @@ soap_get_PointerTons1__sampleType(struct soap *soap, ns1__sampleType **p,
                                   const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__sampleType(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -39925,7 +39992,7 @@ SOAP_FMAC3 void SOAP_FMAC4 soap_serialize_PointerTons1__investigationParameter(
 SOAP_FMAC3 int SOAP_FMAC4 soap_out_PointerTons1__investigationParameter(
     struct soap *soap, const char *tag, int id,
     ns1__investigationParameter *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__investigationParameter);
   if (id < 0)
     return soap->error;
@@ -39936,22 +40003,22 @@ SOAP_FMAC3 ns1__investigationParameter **SOAP_FMAC4
 soap_in_PointerTons1__investigationParameter(struct soap *soap, const char *tag,
                                              ns1__investigationParameter **a,
                                              const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__investigationParameter **)soap_malloc(
               soap, sizeof(ns1__investigationParameter *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__investigationParameter *)
               soap_instantiate_ns1__investigationParameter(
-                  soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__investigationParameter **p =
         (ns1__investigationParameter **)soap_id_lookup(
@@ -39960,7 +40027,7 @@ soap_in_PointerTons1__investigationParameter(struct soap *soap, const char *tag,
             sizeof(ns1__investigationParameter), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -39968,7 +40035,7 @@ soap_in_PointerTons1__investigationParameter(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4 soap_put_PointerTons1__investigationParameter(
     struct soap *soap, ns1__investigationParameter *const *a, const char *tag,
     const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__investigationParameter);
   if (soap_out_PointerTons1__investigationParameter(
           soap, tag ? tag : "ns1:investigationParameter", id, a, type))
@@ -39983,7 +40050,7 @@ soap_get_PointerTons1__investigationParameter(struct soap *soap,
                                               const char *type) {
   if ((p = soap_in_PointerTons1__investigationParameter(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -39998,7 +40065,7 @@ SOAP_FMAC3 void SOAP_FMAC4 soap_serialize_PointerTons1__investigationInstrument(
 SOAP_FMAC3 int SOAP_FMAC4 soap_out_PointerTons1__investigationInstrument(
     struct soap *soap, const char *tag, int id,
     ns1__investigationInstrument *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__investigationInstrument);
   if (id < 0)
     return soap->error;
@@ -40010,22 +40077,22 @@ soap_in_PointerTons1__investigationInstrument(struct soap *soap,
                                               const char *tag,
                                               ns1__investigationInstrument **a,
                                               const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__investigationInstrument **)soap_malloc(
               soap, sizeof(ns1__investigationInstrument *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__investigationInstrument *)
               soap_instantiate_ns1__investigationInstrument(
-                  soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__investigationInstrument **p =
         (ns1__investigationInstrument **)soap_id_lookup(
@@ -40034,7 +40101,7 @@ soap_in_PointerTons1__investigationInstrument(struct soap *soap,
             sizeof(ns1__investigationInstrument), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -40042,7 +40109,7 @@ soap_in_PointerTons1__investigationInstrument(struct soap *soap,
 SOAP_FMAC3 int SOAP_FMAC4 soap_put_PointerTons1__investigationInstrument(
     struct soap *soap, ns1__investigationInstrument *const *a, const char *tag,
     const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__investigationInstrument);
   if (soap_out_PointerTons1__investigationInstrument(
           soap, tag ? tag : "ns1:investigationInstrument", id, a, type))
@@ -40057,7 +40124,7 @@ soap_get_PointerTons1__investigationInstrument(struct soap *soap,
                                                const char *type) {
   if ((p = soap_in_PointerTons1__investigationInstrument(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -40073,7 +40140,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__accessType(struct soap *soap, const char *tag, int id,
                                   enum ns1__accessType *const *a,
                                   const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__accessType);
   if (id < 0)
     return soap->error;
@@ -40083,23 +40150,23 @@ soap_out_PointerTons1__accessType(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 enum ns1__accessType **SOAP_FMAC4
 soap_in_PointerTons1__accessType(struct soap *soap, const char *tag,
                                  enum ns1__accessType **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (enum ns1__accessType **)soap_malloc(
               soap, sizeof(enum ns1__accessType *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = soap_in_ns1__accessType(soap, tag, *a, type)))
-      return NULL;
+      return nullptr;
   } else {
     a = (enum ns1__accessType **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__accessType,
         sizeof(enum ns1__accessType), 0);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -40108,7 +40175,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__accessType(struct soap *soap,
                                   enum ns1__accessType *const *a,
                                   const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__accessType);
   if (soap_out_PointerTons1__accessType(soap, tag ? tag : "ns1:accessType", id,
                                         a, type))
@@ -40121,7 +40188,7 @@ soap_get_PointerTons1__accessType(struct soap *soap, enum ns1__accessType **p,
                                   const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__accessType(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -40137,7 +40204,7 @@ soap_serialize_PointerToxsd__anyType(struct soap *soap,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerToxsd__anyType(struct soap *soap, const char *tag, int id,
                                xsd__anyType *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_xsd__anyType);
   if (id < 0)
     return soap->error;
@@ -40147,20 +40214,20 @@ soap_out_PointerToxsd__anyType(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 xsd__anyType **SOAP_FMAC4
 soap_in_PointerToxsd__anyType(struct soap *soap, const char *tag,
                               xsd__anyType **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (xsd__anyType **)soap_malloc(soap, sizeof(xsd__anyType *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (xsd__anyType *)soap_instantiate_xsd__anyType(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     xsd__anyType **p = (xsd__anyType **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_xsd__anyType,
@@ -40807,7 +40874,7 @@ soap_in_PointerToxsd__anyType(struct soap *soap, const char *tag,
     }
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -40815,7 +40882,7 @@ soap_in_PointerToxsd__anyType(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerToxsd__anyType(struct soap *soap, xsd__anyType *const *a,
                                const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerToxsd__anyType);
   if (soap_out_PointerToxsd__anyType(soap, tag ? tag : "xsd:anyType", id, a,
                                      type))
@@ -40828,7 +40895,7 @@ soap_get_PointerToxsd__anyType(struct soap *soap, xsd__anyType **p,
                                const char *tag, const char *type) {
   if ((p = soap_in_PointerToxsd__anyType(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -40842,7 +40909,8 @@ soap_serialize_PointerToint(struct soap *soap, int *const *a) {
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerToint(struct soap *soap, const char *tag, int id, int *const *a,
                       const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type, SOAP_TYPE_ICat4_int);
+  id =
+      soap_element_id(soap, tag, id, *a, nullptr, 0, type, SOAP_TYPE_ICat4_int);
   if (id < 0)
     return soap->error;
   return soap_out_int(soap, tag, id, *a, type);
@@ -40851,21 +40919,21 @@ soap_out_PointerToint(struct soap *soap, const char *tag, int id, int *const *a,
 SOAP_FMAC3 int **SOAP_FMAC4 soap_in_PointerToint(struct soap *soap,
                                                  const char *tag, int **a,
                                                  const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (int **)soap_malloc(soap, sizeof(int *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = soap_in_int(soap, tag, *a, type)))
-      return NULL;
+      return nullptr;
   } else {
     a = (int **)soap_id_lookup(soap, soap->href, (void **)a,
                                SOAP_TYPE_ICat4_int, sizeof(int), 0);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -40873,8 +40941,8 @@ SOAP_FMAC3 int **SOAP_FMAC4 soap_in_PointerToint(struct soap *soap,
 SOAP_FMAC3 int SOAP_FMAC4 soap_put_PointerToint(struct soap *soap,
                                                 int *const *a, const char *tag,
                                                 const char *type) {
-  int id =
-      soap_embed(soap, (void *)a, NULL, 0, tag, SOAP_TYPE_ICat4_PointerToint);
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
+                      SOAP_TYPE_ICat4_PointerToint);
   if (soap_out_PointerToint(soap, tag ? tag : "int", id, a, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -40885,7 +40953,7 @@ SOAP_FMAC3 int **SOAP_FMAC4 soap_get_PointerToint(struct soap *soap, int **p,
                                                   const char *type) {
   if ((p = soap_in_PointerToint(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -40900,7 +40968,7 @@ soap_serialize_PointerTons1__relType(struct soap *soap,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__relType(struct soap *soap, const char *tag, int id,
                                enum ns1__relType *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__relType);
   if (id < 0)
     return soap->error;
@@ -40910,23 +40978,23 @@ soap_out_PointerTons1__relType(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 enum ns1__relType **SOAP_FMAC4
 soap_in_PointerTons1__relType(struct soap *soap, const char *tag,
                               enum ns1__relType **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (enum ns1__relType **)soap_malloc(soap,
                                                 sizeof(enum ns1__relType *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = soap_in_ns1__relType(soap, tag, *a, type)))
-      return NULL;
+      return nullptr;
   } else {
     a = (enum ns1__relType **)soap_id_lookup(soap, soap->href, (void **)a,
                                              SOAP_TYPE_ICat4_ns1__relType,
                                              sizeof(enum ns1__relType), 0);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -40934,7 +41002,7 @@ soap_in_PointerTons1__relType(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__relType(struct soap *soap, enum ns1__relType *const *a,
                                const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__relType);
   if (soap_out_PointerTons1__relType(soap, tag ? tag : "ns1:relType", id, a,
                                      type))
@@ -40947,7 +41015,7 @@ soap_get_PointerTons1__relType(struct soap *soap, enum ns1__relType **p,
                                const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__relType(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -40964,7 +41032,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__entityField(struct soap *soap, const char *tag, int id,
                                    ns1__entityField *const *a,
                                    const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__entityField);
   if (id < 0)
     return soap->error;
@@ -40974,28 +41042,28 @@ soap_out_PointerTons1__entityField(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__entityField **SOAP_FMAC4
 soap_in_PointerTons1__entityField(struct soap *soap, const char *tag,
                                   ns1__entityField **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__entityField **)soap_malloc(soap,
                                                sizeof(ns1__entityField *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__entityField *)soap_instantiate_ns1__entityField(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__entityField **p = (ns1__entityField **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__entityField,
         sizeof(ns1__entityField), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -41004,7 +41072,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__entityField(struct soap *soap,
                                    ns1__entityField *const *a, const char *tag,
                                    const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__entityField);
   if (soap_out_PointerTons1__entityField(soap, tag ? tag : "ns1:entityField",
                                          id, a, type))
@@ -41017,7 +41085,7 @@ soap_get_PointerTons1__entityField(struct soap *soap, ns1__entityField **p,
                                    const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__entityField(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -41033,7 +41101,7 @@ soap_serialize_PointerTons1__constraint(struct soap *soap,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__constraint(struct soap *soap, const char *tag, int id,
                                   ns1__constraint *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__constraint);
   if (id < 0)
     return soap->error;
@@ -41043,27 +41111,27 @@ soap_out_PointerTons1__constraint(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__constraint **SOAP_FMAC4
 soap_in_PointerTons1__constraint(struct soap *soap, const char *tag,
                                  ns1__constraint **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__constraint **)soap_malloc(soap, sizeof(ns1__constraint *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__constraint *)soap_instantiate_ns1__constraint(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__constraint **p = (ns1__constraint **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__constraint,
         sizeof(ns1__constraint), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -41071,7 +41139,7 @@ soap_in_PointerTons1__constraint(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__constraint(struct soap *soap, ns1__constraint *const *a,
                                   const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__constraint);
   if (soap_out_PointerTons1__constraint(soap, tag ? tag : "ns1:constraint", id,
                                         a, type))
@@ -41084,7 +41152,7 @@ soap_get_PointerTons1__constraint(struct soap *soap, ns1__constraint **p,
                                   const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__constraint(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -41100,7 +41168,7 @@ soap_serialize_PointerTons1__entityInfo(struct soap *soap,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__entityInfo(struct soap *soap, const char *tag, int id,
                                   ns1__entityInfo *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__entityInfo);
   if (id < 0)
     return soap->error;
@@ -41110,27 +41178,27 @@ soap_out_PointerTons1__entityInfo(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__entityInfo **SOAP_FMAC4
 soap_in_PointerTons1__entityInfo(struct soap *soap, const char *tag,
                                  ns1__entityInfo **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__entityInfo **)soap_malloc(soap, sizeof(ns1__entityInfo *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__entityInfo *)soap_instantiate_ns1__entityInfo(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__entityInfo **p = (ns1__entityInfo **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__entityInfo,
         sizeof(ns1__entityInfo), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -41138,7 +41206,7 @@ soap_in_PointerTons1__entityInfo(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__entityInfo(struct soap *soap, ns1__entityInfo *const *a,
                                   const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__entityInfo);
   if (soap_out_PointerTons1__entityInfo(soap, tag ? tag : "ns1:entityInfo", id,
                                         a, type))
@@ -41151,7 +41219,7 @@ soap_get_PointerTons1__entityInfo(struct soap *soap, ns1__entityInfo **p,
                                   const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__entityInfo(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -41167,7 +41235,7 @@ soap_serialize_PointerTons1__publicStep(struct soap *soap,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__publicStep(struct soap *soap, const char *tag, int id,
                                   ns1__publicStep *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__publicStep);
   if (id < 0)
     return soap->error;
@@ -41177,27 +41245,27 @@ soap_out_PointerTons1__publicStep(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__publicStep **SOAP_FMAC4
 soap_in_PointerTons1__publicStep(struct soap *soap, const char *tag,
                                  ns1__publicStep **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__publicStep **)soap_malloc(soap, sizeof(ns1__publicStep *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__publicStep *)soap_instantiate_ns1__publicStep(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__publicStep **p = (ns1__publicStep **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__publicStep,
         sizeof(ns1__publicStep), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -41205,7 +41273,7 @@ soap_in_PointerTons1__publicStep(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__publicStep(struct soap *soap, ns1__publicStep *const *a,
                                   const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__publicStep);
   if (soap_out_PointerTons1__publicStep(soap, tag ? tag : "ns1:publicStep", id,
                                         a, type))
@@ -41218,7 +41286,7 @@ soap_get_PointerTons1__publicStep(struct soap *soap, ns1__publicStep **p,
                                   const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__publicStep(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -41233,7 +41301,7 @@ soap_serialize_PointerTons1__log(struct soap *soap, ns1__log *const *a) {
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__log(struct soap *soap, const char *tag, int id,
                            ns1__log *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__log);
   if (id < 0)
     return soap->error;
@@ -41243,27 +41311,27 @@ soap_out_PointerTons1__log(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__log **SOAP_FMAC4
 soap_in_PointerTons1__log(struct soap *soap, const char *tag, ns1__log **a,
                           const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__log **)soap_malloc(soap, sizeof(ns1__log *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__log *)soap_instantiate_ns1__log(soap, -1, soap->type,
-                                                     soap->arrayType, NULL)))
-      return NULL;
+                                                     soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__log **p = (ns1__log **)soap_id_lookup(soap, soap->href, (void **)a,
                                                SOAP_TYPE_ICat4_ns1__log,
                                                sizeof(ns1__log), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -41271,7 +41339,7 @@ soap_in_PointerTons1__log(struct soap *soap, const char *tag, ns1__log **a,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__log(struct soap *soap, ns1__log *const *a,
                            const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__log);
   if (soap_out_PointerTons1__log(soap, tag ? tag : "ns1:log", id, a, type))
     return soap->error;
@@ -41283,7 +41351,7 @@ soap_get_PointerTons1__log(struct soap *soap, ns1__log **p, const char *tag,
                            const char *type) {
   if ((p = soap_in_PointerTons1__log(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -41299,7 +41367,7 @@ soap_serialize_PointerTons1__userGroup(struct soap *soap,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__userGroup(struct soap *soap, const char *tag, int id,
                                  ns1__userGroup *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__userGroup);
   if (id < 0)
     return soap->error;
@@ -41309,27 +41377,27 @@ soap_out_PointerTons1__userGroup(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__userGroup **SOAP_FMAC4
 soap_in_PointerTons1__userGroup(struct soap *soap, const char *tag,
                                 ns1__userGroup **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__userGroup **)soap_malloc(soap, sizeof(ns1__userGroup *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__userGroup *)soap_instantiate_ns1__userGroup(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__userGroup **p = (ns1__userGroup **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__userGroup,
         sizeof(ns1__userGroup), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -41337,7 +41405,7 @@ soap_in_PointerTons1__userGroup(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__userGroup(struct soap *soap, ns1__userGroup *const *a,
                                  const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__userGroup);
   if (soap_out_PointerTons1__userGroup(soap, tag ? tag : "ns1:userGroup", id, a,
                                        type))
@@ -41350,7 +41418,7 @@ soap_get_PointerTons1__userGroup(struct soap *soap, ns1__userGroup **p,
                                  const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__userGroup(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -41366,7 +41434,7 @@ soap_serialize_PointerTons1__grouping(struct soap *soap,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__grouping(struct soap *soap, const char *tag, int id,
                                 ns1__grouping *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__grouping);
   if (id < 0)
     return soap->error;
@@ -41376,27 +41444,27 @@ soap_out_PointerTons1__grouping(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__grouping **SOAP_FMAC4
 soap_in_PointerTons1__grouping(struct soap *soap, const char *tag,
                                ns1__grouping **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__grouping **)soap_malloc(soap, sizeof(ns1__grouping *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__grouping *)soap_instantiate_ns1__grouping(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__grouping **p = (ns1__grouping **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__grouping,
         sizeof(ns1__grouping), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -41404,7 +41472,7 @@ soap_in_PointerTons1__grouping(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__grouping(struct soap *soap, ns1__grouping *const *a,
                                 const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__grouping);
   if (soap_out_PointerTons1__grouping(soap, tag ? tag : "ns1:grouping", id, a,
                                       type))
@@ -41417,7 +41485,7 @@ soap_get_PointerTons1__grouping(struct soap *soap, ns1__grouping **p,
                                 const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__grouping(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -41432,7 +41500,7 @@ SOAP_FMAC3 void SOAP_FMAC4 soap_serialize_PointerTons1__dataCollectionDatafile(
 SOAP_FMAC3 int SOAP_FMAC4 soap_out_PointerTons1__dataCollectionDatafile(
     struct soap *soap, const char *tag, int id,
     ns1__dataCollectionDatafile *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__dataCollectionDatafile);
   if (id < 0)
     return soap->error;
@@ -41443,22 +41511,22 @@ SOAP_FMAC3 ns1__dataCollectionDatafile **SOAP_FMAC4
 soap_in_PointerTons1__dataCollectionDatafile(struct soap *soap, const char *tag,
                                              ns1__dataCollectionDatafile **a,
                                              const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__dataCollectionDatafile **)soap_malloc(
               soap, sizeof(ns1__dataCollectionDatafile *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__dataCollectionDatafile *)
               soap_instantiate_ns1__dataCollectionDatafile(
-                  soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__dataCollectionDatafile **p =
         (ns1__dataCollectionDatafile **)soap_id_lookup(
@@ -41467,7 +41535,7 @@ soap_in_PointerTons1__dataCollectionDatafile(struct soap *soap, const char *tag,
             sizeof(ns1__dataCollectionDatafile), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -41475,7 +41543,7 @@ soap_in_PointerTons1__dataCollectionDatafile(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4 soap_put_PointerTons1__dataCollectionDatafile(
     struct soap *soap, ns1__dataCollectionDatafile *const *a, const char *tag,
     const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__dataCollectionDatafile);
   if (soap_out_PointerTons1__dataCollectionDatafile(
           soap, tag ? tag : "ns1:dataCollectionDatafile", id, a, type))
@@ -41490,7 +41558,7 @@ soap_get_PointerTons1__dataCollectionDatafile(struct soap *soap,
                                               const char *type) {
   if ((p = soap_in_PointerTons1__dataCollectionDatafile(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -41505,7 +41573,7 @@ SOAP_FMAC3 void SOAP_FMAC4 soap_serialize_PointerTons1__dataCollectionDataset(
 SOAP_FMAC3 int SOAP_FMAC4 soap_out_PointerTons1__dataCollectionDataset(
     struct soap *soap, const char *tag, int id,
     ns1__dataCollectionDataset *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__dataCollectionDataset);
   if (id < 0)
     return soap->error;
@@ -41516,22 +41584,22 @@ SOAP_FMAC3 ns1__dataCollectionDataset **SOAP_FMAC4
 soap_in_PointerTons1__dataCollectionDataset(struct soap *soap, const char *tag,
                                             ns1__dataCollectionDataset **a,
                                             const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__dataCollectionDataset **)soap_malloc(
               soap, sizeof(ns1__dataCollectionDataset *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__dataCollectionDataset *)
               soap_instantiate_ns1__dataCollectionDataset(
-                  soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__dataCollectionDataset **p =
         (ns1__dataCollectionDataset **)soap_id_lookup(
@@ -41540,7 +41608,7 @@ soap_in_PointerTons1__dataCollectionDataset(struct soap *soap, const char *tag,
             sizeof(ns1__dataCollectionDataset), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -41548,7 +41616,7 @@ soap_in_PointerTons1__dataCollectionDataset(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4 soap_put_PointerTons1__dataCollectionDataset(
     struct soap *soap, ns1__dataCollectionDataset *const *a, const char *tag,
     const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__dataCollectionDataset);
   if (soap_out_PointerTons1__dataCollectionDataset(
           soap, tag ? tag : "ns1:dataCollectionDataset", id, a, type))
@@ -41563,7 +41631,7 @@ soap_get_PointerTons1__dataCollectionDataset(struct soap *soap,
                                              const char *type) {
   if ((p = soap_in_PointerTons1__dataCollectionDataset(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -41578,7 +41646,7 @@ SOAP_FMAC3 void SOAP_FMAC4 soap_serialize_PointerTons1__dataCollectionParameter(
 SOAP_FMAC3 int SOAP_FMAC4 soap_out_PointerTons1__dataCollectionParameter(
     struct soap *soap, const char *tag, int id,
     ns1__dataCollectionParameter *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__dataCollectionParameter);
   if (id < 0)
     return soap->error;
@@ -41590,22 +41658,22 @@ soap_in_PointerTons1__dataCollectionParameter(struct soap *soap,
                                               const char *tag,
                                               ns1__dataCollectionParameter **a,
                                               const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__dataCollectionParameter **)soap_malloc(
               soap, sizeof(ns1__dataCollectionParameter *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__dataCollectionParameter *)
               soap_instantiate_ns1__dataCollectionParameter(
-                  soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__dataCollectionParameter **p =
         (ns1__dataCollectionParameter **)soap_id_lookup(
@@ -41614,7 +41682,7 @@ soap_in_PointerTons1__dataCollectionParameter(struct soap *soap,
             sizeof(ns1__dataCollectionParameter), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -41622,7 +41690,7 @@ soap_in_PointerTons1__dataCollectionParameter(struct soap *soap,
 SOAP_FMAC3 int SOAP_FMAC4 soap_put_PointerTons1__dataCollectionParameter(
     struct soap *soap, ns1__dataCollectionParameter *const *a, const char *tag,
     const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__dataCollectionParameter);
   if (soap_out_PointerTons1__dataCollectionParameter(
           soap, tag ? tag : "ns1:dataCollectionParameter", id, a, type))
@@ -41637,7 +41705,7 @@ soap_get_PointerTons1__dataCollectionParameter(struct soap *soap,
                                                const char *type) {
   if ((p = soap_in_PointerTons1__dataCollectionParameter(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -41654,7 +41722,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__dataCollection(struct soap *soap, const char *tag,
                                       int id, ns1__dataCollection *const *a,
                                       const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__dataCollection);
   if (id < 0)
     return soap->error;
@@ -41665,28 +41733,28 @@ SOAP_FMAC3 ns1__dataCollection **SOAP_FMAC4
 soap_in_PointerTons1__dataCollection(struct soap *soap, const char *tag,
                                      ns1__dataCollection **a,
                                      const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__dataCollection **)soap_malloc(
               soap, sizeof(ns1__dataCollection *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__dataCollection *)soap_instantiate_ns1__dataCollection(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__dataCollection **p = (ns1__dataCollection **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__dataCollection,
         sizeof(ns1__dataCollection), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -41695,7 +41763,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__dataCollection(struct soap *soap,
                                       ns1__dataCollection *const *a,
                                       const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__dataCollection);
   if (soap_out_PointerTons1__dataCollection(
           soap, tag ? tag : "ns1:dataCollection", id, a, type))
@@ -41709,7 +41777,7 @@ soap_get_PointerTons1__dataCollection(struct soap *soap,
                                       const char *type) {
   if ((p = soap_in_PointerTons1__dataCollection(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -41724,7 +41792,7 @@ soap_serialize_PointerTons1__job(struct soap *soap, ns1__job *const *a) {
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__job(struct soap *soap, const char *tag, int id,
                            ns1__job *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__job);
   if (id < 0)
     return soap->error;
@@ -41734,27 +41802,27 @@ soap_out_PointerTons1__job(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__job **SOAP_FMAC4
 soap_in_PointerTons1__job(struct soap *soap, const char *tag, ns1__job **a,
                           const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__job **)soap_malloc(soap, sizeof(ns1__job *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__job *)soap_instantiate_ns1__job(soap, -1, soap->type,
-                                                     soap->arrayType, NULL)))
-      return NULL;
+                                                     soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__job **p = (ns1__job **)soap_id_lookup(soap, soap->href, (void **)a,
                                                SOAP_TYPE_ICat4_ns1__job,
                                                sizeof(ns1__job), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -41762,7 +41830,7 @@ soap_in_PointerTons1__job(struct soap *soap, const char *tag, ns1__job **a,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__job(struct soap *soap, ns1__job *const *a,
                            const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__job);
   if (soap_out_PointerTons1__job(soap, tag ? tag : "ns1:job", id, a, type))
     return soap->error;
@@ -41774,7 +41842,7 @@ soap_get_PointerTons1__job(struct soap *soap, ns1__job **p, const char *tag,
                            const char *type) {
   if ((p = soap_in_PointerTons1__job(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -41791,7 +41859,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__application(struct soap *soap, const char *tag, int id,
                                    ns1__application *const *a,
                                    const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__application);
   if (id < 0)
     return soap->error;
@@ -41801,28 +41869,28 @@ soap_out_PointerTons1__application(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__application **SOAP_FMAC4
 soap_in_PointerTons1__application(struct soap *soap, const char *tag,
                                   ns1__application **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__application **)soap_malloc(soap,
                                                sizeof(ns1__application *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__application *)soap_instantiate_ns1__application(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__application **p = (ns1__application **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__application,
         sizeof(ns1__application), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -41831,7 +41899,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__application(struct soap *soap,
                                    ns1__application *const *a, const char *tag,
                                    const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__application);
   if (soap_out_PointerTons1__application(soap, tag ? tag : "ns1:application",
                                          id, a, type))
@@ -41844,7 +41912,7 @@ soap_get_PointerTons1__application(struct soap *soap, ns1__application **p,
                                    const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__application(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -41860,7 +41928,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__studyStatus(struct soap *soap, const char *tag, int id,
                                    enum ns1__studyStatus *const *a,
                                    const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__studyStatus);
   if (id < 0)
     return soap->error;
@@ -41870,23 +41938,23 @@ soap_out_PointerTons1__studyStatus(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 enum ns1__studyStatus **SOAP_FMAC4
 soap_in_PointerTons1__studyStatus(struct soap *soap, const char *tag,
                                   enum ns1__studyStatus **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (enum ns1__studyStatus **)soap_malloc(
               soap, sizeof(enum ns1__studyStatus *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = soap_in_ns1__studyStatus(soap, tag, *a, type)))
-      return NULL;
+      return nullptr;
   } else {
     a = (enum ns1__studyStatus **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__studyStatus,
         sizeof(enum ns1__studyStatus), 0);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -41895,7 +41963,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__studyStatus(struct soap *soap,
                                    enum ns1__studyStatus *const *a,
                                    const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__studyStatus);
   if (soap_out_PointerTons1__studyStatus(soap, tag ? tag : "ns1:studyStatus",
                                          id, a, type))
@@ -41908,7 +41976,7 @@ soap_get_PointerTons1__studyStatus(struct soap *soap, enum ns1__studyStatus **p,
                                    const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__studyStatus(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -41925,7 +41993,7 @@ soap_out_PointerTons1__studyInvestigation(struct soap *soap, const char *tag,
                                           int id,
                                           ns1__studyInvestigation *const *a,
                                           const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__studyInvestigation);
   if (id < 0)
     return soap->error;
@@ -41936,29 +42004,29 @@ SOAP_FMAC3 ns1__studyInvestigation **SOAP_FMAC4
 soap_in_PointerTons1__studyInvestigation(struct soap *soap, const char *tag,
                                          ns1__studyInvestigation **a,
                                          const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__studyInvestigation **)soap_malloc(
               soap, sizeof(ns1__studyInvestigation *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__studyInvestigation *)
-              soap_instantiate_ns1__studyInvestigation(soap, -1, soap->type,
-                                                       soap->arrayType, NULL)))
-      return NULL;
+              soap_instantiate_ns1__studyInvestigation(
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__studyInvestigation **p = (ns1__studyInvestigation **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__studyInvestigation,
         sizeof(ns1__studyInvestigation), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -41967,7 +42035,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__studyInvestigation(struct soap *soap,
                                           ns1__studyInvestigation *const *a,
                                           const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__studyInvestigation);
   if (soap_out_PointerTons1__studyInvestigation(
           soap, tag ? tag : "ns1:studyInvestigation", id, a, type))
@@ -41981,7 +42049,7 @@ soap_get_PointerTons1__studyInvestigation(struct soap *soap,
                                           const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__studyInvestigation(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -41996,7 +42064,7 @@ soap_serialize_PointerTons1__study(struct soap *soap, ns1__study *const *a) {
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__study(struct soap *soap, const char *tag, int id,
                              ns1__study *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__study);
   if (id < 0)
     return soap->error;
@@ -42006,27 +42074,27 @@ soap_out_PointerTons1__study(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__study **SOAP_FMAC4
 soap_in_PointerTons1__study(struct soap *soap, const char *tag, ns1__study **a,
                             const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__study **)soap_malloc(soap, sizeof(ns1__study *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__study *)soap_instantiate_ns1__study(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__study **p = (ns1__study **)soap_id_lookup(soap, soap->href, (void **)a,
                                                    SOAP_TYPE_ICat4_ns1__study,
                                                    sizeof(ns1__study), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -42034,7 +42102,7 @@ soap_in_PointerTons1__study(struct soap *soap, const char *tag, ns1__study **a,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__study(struct soap *soap, ns1__study *const *a,
                              const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__study);
   if (soap_out_PointerTons1__study(soap, tag ? tag : "ns1:study", id, a, type))
     return soap->error;
@@ -42046,7 +42114,7 @@ soap_get_PointerTons1__study(struct soap *soap, ns1__study **p, const char *tag,
                              const char *type) {
   if ((p = soap_in_PointerTons1__study(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -42061,7 +42129,7 @@ soap_serialize_PointerTons1__shift(struct soap *soap, ns1__shift *const *a) {
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__shift(struct soap *soap, const char *tag, int id,
                              ns1__shift *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__shift);
   if (id < 0)
     return soap->error;
@@ -42071,27 +42139,27 @@ soap_out_PointerTons1__shift(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__shift **SOAP_FMAC4
 soap_in_PointerTons1__shift(struct soap *soap, const char *tag, ns1__shift **a,
                             const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__shift **)soap_malloc(soap, sizeof(ns1__shift *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__shift *)soap_instantiate_ns1__shift(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__shift **p = (ns1__shift **)soap_id_lookup(soap, soap->href, (void **)a,
                                                    SOAP_TYPE_ICat4_ns1__shift,
                                                    sizeof(ns1__shift), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -42099,7 +42167,7 @@ soap_in_PointerTons1__shift(struct soap *soap, const char *tag, ns1__shift **a,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__shift(struct soap *soap, ns1__shift *const *a,
                              const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__shift);
   if (soap_out_PointerTons1__shift(soap, tag ? tag : "ns1:shift", id, a, type))
     return soap->error;
@@ -42111,7 +42179,7 @@ soap_get_PointerTons1__shift(struct soap *soap, ns1__shift **p, const char *tag,
                              const char *type) {
   if ((p = soap_in_PointerTons1__shift(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -42128,7 +42196,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__sampleParameter(struct soap *soap, const char *tag,
                                        int id, ns1__sampleParameter *const *a,
                                        const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__sampleParameter);
   if (id < 0)
     return soap->error;
@@ -42139,28 +42207,28 @@ SOAP_FMAC3 ns1__sampleParameter **SOAP_FMAC4
 soap_in_PointerTons1__sampleParameter(struct soap *soap, const char *tag,
                                       ns1__sampleParameter **a,
                                       const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__sampleParameter **)soap_malloc(
               soap, sizeof(ns1__sampleParameter *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__sampleParameter *)soap_instantiate_ns1__sampleParameter(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__sampleParameter **p = (ns1__sampleParameter **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__sampleParameter,
         sizeof(ns1__sampleParameter), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -42169,7 +42237,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__sampleParameter(struct soap *soap,
                                        ns1__sampleParameter *const *a,
                                        const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__sampleParameter);
   if (soap_out_PointerTons1__sampleParameter(
           soap, tag ? tag : "ns1:sampleParameter", id, a, type))
@@ -42183,7 +42251,7 @@ soap_get_PointerTons1__sampleParameter(struct soap *soap,
                                        const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__sampleParameter(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -42198,7 +42266,7 @@ soap_serialize_PointerTons1__sample(struct soap *soap, ns1__sample *const *a) {
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__sample(struct soap *soap, const char *tag, int id,
                               ns1__sample *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__sample);
   if (id < 0)
     return soap->error;
@@ -42208,27 +42276,27 @@ soap_out_PointerTons1__sample(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__sample **SOAP_FMAC4
 soap_in_PointerTons1__sample(struct soap *soap, const char *tag,
                              ns1__sample **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__sample **)soap_malloc(soap, sizeof(ns1__sample *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__sample *)soap_instantiate_ns1__sample(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__sample **p = (ns1__sample **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__sample,
         sizeof(ns1__sample), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -42236,7 +42304,7 @@ soap_in_PointerTons1__sample(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__sample(struct soap *soap, ns1__sample *const *a,
                               const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__sample);
   if (soap_out_PointerTons1__sample(soap, tag ? tag : "ns1:sample", id, a,
                                     type))
@@ -42249,7 +42317,7 @@ soap_get_PointerTons1__sample(struct soap *soap, ns1__sample **p,
                               const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__sample(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -42266,7 +42334,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__relatedDatafile(struct soap *soap, const char *tag,
                                        int id, ns1__relatedDatafile *const *a,
                                        const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__relatedDatafile);
   if (id < 0)
     return soap->error;
@@ -42277,28 +42345,28 @@ SOAP_FMAC3 ns1__relatedDatafile **SOAP_FMAC4
 soap_in_PointerTons1__relatedDatafile(struct soap *soap, const char *tag,
                                       ns1__relatedDatafile **a,
                                       const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__relatedDatafile **)soap_malloc(
               soap, sizeof(ns1__relatedDatafile *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__relatedDatafile *)soap_instantiate_ns1__relatedDatafile(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__relatedDatafile **p = (ns1__relatedDatafile **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__relatedDatafile,
         sizeof(ns1__relatedDatafile), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -42307,7 +42375,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__relatedDatafile(struct soap *soap,
                                        ns1__relatedDatafile *const *a,
                                        const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__relatedDatafile);
   if (soap_out_PointerTons1__relatedDatafile(
           soap, tag ? tag : "ns1:relatedDatafile", id, a, type))
@@ -42321,7 +42389,7 @@ soap_get_PointerTons1__relatedDatafile(struct soap *soap,
                                        const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__relatedDatafile(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -42338,7 +42406,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__publication(struct soap *soap, const char *tag, int id,
                                    ns1__publication *const *a,
                                    const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__publication);
   if (id < 0)
     return soap->error;
@@ -42348,28 +42416,28 @@ soap_out_PointerTons1__publication(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__publication **SOAP_FMAC4
 soap_in_PointerTons1__publication(struct soap *soap, const char *tag,
                                   ns1__publication **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__publication **)soap_malloc(soap,
                                                sizeof(ns1__publication *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__publication *)soap_instantiate_ns1__publication(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__publication **p = (ns1__publication **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__publication,
         sizeof(ns1__publication), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -42378,7 +42446,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__publication(struct soap *soap,
                                    ns1__publication *const *a, const char *tag,
                                    const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__publication);
   if (soap_out_PointerTons1__publication(soap, tag ? tag : "ns1:publication",
                                          id, a, type))
@@ -42391,7 +42459,7 @@ soap_get_PointerTons1__publication(struct soap *soap, ns1__publication **p,
                                    const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__publication(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -42408,7 +42476,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__parameterType(struct soap *soap, const char *tag, int id,
                                      ns1__parameterType *const *a,
                                      const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__parameterType);
   if (id < 0)
     return soap->error;
@@ -42418,28 +42486,28 @@ soap_out_PointerTons1__parameterType(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__parameterType **SOAP_FMAC4
 soap_in_PointerTons1__parameterType(struct soap *soap, const char *tag,
                                     ns1__parameterType **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__parameterType **)soap_malloc(soap,
                                                  sizeof(ns1__parameterType *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__parameterType *)soap_instantiate_ns1__parameterType(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__parameterType **p = (ns1__parameterType **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__parameterType,
         sizeof(ns1__parameterType), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -42448,7 +42516,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__parameterType(struct soap *soap,
                                      ns1__parameterType *const *a,
                                      const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__parameterType);
   if (soap_out_PointerTons1__parameterType(
           soap, tag ? tag : "ns1:parameterType", id, a, type))
@@ -42461,7 +42529,7 @@ soap_get_PointerTons1__parameterType(struct soap *soap, ns1__parameterType **p,
                                      const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__parameterType(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -42477,7 +42545,7 @@ soap_serialize_PointerTons1__keyword(struct soap *soap,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__keyword(struct soap *soap, const char *tag, int id,
                                ns1__keyword *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__keyword);
   if (id < 0)
     return soap->error;
@@ -42487,27 +42555,27 @@ soap_out_PointerTons1__keyword(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__keyword **SOAP_FMAC4
 soap_in_PointerTons1__keyword(struct soap *soap, const char *tag,
                               ns1__keyword **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__keyword **)soap_malloc(soap, sizeof(ns1__keyword *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__keyword *)soap_instantiate_ns1__keyword(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__keyword **p = (ns1__keyword **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__keyword,
         sizeof(ns1__keyword), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -42515,7 +42583,7 @@ soap_in_PointerTons1__keyword(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__keyword(struct soap *soap, ns1__keyword *const *a,
                                const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__keyword);
   if (soap_out_PointerTons1__keyword(soap, tag ? tag : "ns1:keyword", id, a,
                                      type))
@@ -42528,7 +42596,7 @@ soap_get_PointerTons1__keyword(struct soap *soap, ns1__keyword **p,
                                const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__keyword(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -42545,7 +42613,7 @@ soap_out_PointerTons1__investigationUser(struct soap *soap, const char *tag,
                                          int id,
                                          ns1__investigationUser *const *a,
                                          const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__investigationUser);
   if (id < 0)
     return soap->error;
@@ -42556,29 +42624,29 @@ SOAP_FMAC3 ns1__investigationUser **SOAP_FMAC4
 soap_in_PointerTons1__investigationUser(struct soap *soap, const char *tag,
                                         ns1__investigationUser **a,
                                         const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__investigationUser **)soap_malloc(
               soap, sizeof(ns1__investigationUser *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a =
               (ns1__investigationUser *)soap_instantiate_ns1__investigationUser(
-                  soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__investigationUser **p = (ns1__investigationUser **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__investigationUser,
         sizeof(ns1__investigationUser), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -42587,7 +42655,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__investigationUser(struct soap *soap,
                                          ns1__investigationUser *const *a,
                                          const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__investigationUser);
   if (soap_out_PointerTons1__investigationUser(
           soap, tag ? tag : "ns1:investigationUser", id, a, type))
@@ -42601,7 +42669,7 @@ soap_get_PointerTons1__investigationUser(struct soap *soap,
                                          const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__investigationUser(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -42618,7 +42686,7 @@ soap_out_PointerTons1__investigationType(struct soap *soap, const char *tag,
                                          int id,
                                          ns1__investigationType *const *a,
                                          const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__investigationType);
   if (id < 0)
     return soap->error;
@@ -42629,29 +42697,29 @@ SOAP_FMAC3 ns1__investigationType **SOAP_FMAC4
 soap_in_PointerTons1__investigationType(struct soap *soap, const char *tag,
                                         ns1__investigationType **a,
                                         const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__investigationType **)soap_malloc(
               soap, sizeof(ns1__investigationType *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a =
               (ns1__investigationType *)soap_instantiate_ns1__investigationType(
-                  soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__investigationType **p = (ns1__investigationType **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__investigationType,
         sizeof(ns1__investigationType), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -42660,7 +42728,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__investigationType(struct soap *soap,
                                          ns1__investigationType *const *a,
                                          const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__investigationType);
   if (soap_out_PointerTons1__investigationType(
           soap, tag ? tag : "ns1:investigationType", id, a, type))
@@ -42674,7 +42742,7 @@ soap_get_PointerTons1__investigationType(struct soap *soap,
                                          const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__investigationType(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -42691,7 +42759,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__investigation(struct soap *soap, const char *tag, int id,
                                      ns1__investigation *const *a,
                                      const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__investigation);
   if (id < 0)
     return soap->error;
@@ -42701,28 +42769,28 @@ soap_out_PointerTons1__investigation(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__investigation **SOAP_FMAC4
 soap_in_PointerTons1__investigation(struct soap *soap, const char *tag,
                                     ns1__investigation **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__investigation **)soap_malloc(soap,
                                                  sizeof(ns1__investigation *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__investigation *)soap_instantiate_ns1__investigation(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__investigation **p = (ns1__investigation **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__investigation,
         sizeof(ns1__investigation), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -42731,7 +42799,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__investigation(struct soap *soap,
                                      ns1__investigation *const *a,
                                      const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__investigation);
   if (soap_out_PointerTons1__investigation(
           soap, tag ? tag : "ns1:investigation", id, a, type))
@@ -42744,7 +42812,7 @@ soap_get_PointerTons1__investigation(struct soap *soap, ns1__investigation **p,
                                      const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__investigation(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -42760,7 +42828,7 @@ soap_serialize_PointerTons1__instrument(struct soap *soap,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__instrument(struct soap *soap, const char *tag, int id,
                                   ns1__instrument *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__instrument);
   if (id < 0)
     return soap->error;
@@ -42770,27 +42838,27 @@ soap_out_PointerTons1__instrument(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__instrument **SOAP_FMAC4
 soap_in_PointerTons1__instrument(struct soap *soap, const char *tag,
                                  ns1__instrument **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__instrument **)soap_malloc(soap, sizeof(ns1__instrument *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__instrument *)soap_instantiate_ns1__instrument(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__instrument **p = (ns1__instrument **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__instrument,
         sizeof(ns1__instrument), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -42798,7 +42866,7 @@ soap_in_PointerTons1__instrument(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__instrument(struct soap *soap, ns1__instrument *const *a,
                                   const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__instrument);
   if (soap_out_PointerTons1__instrument(soap, tag ? tag : "ns1:instrument", id,
                                         a, type))
@@ -42811,7 +42879,7 @@ soap_get_PointerTons1__instrument(struct soap *soap, ns1__instrument **p,
                                   const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__instrument(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -42826,7 +42894,7 @@ soap_serialize_PointerTons1__user(struct soap *soap, ns1__user *const *a) {
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__user(struct soap *soap, const char *tag, int id,
                             ns1__user *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__user);
   if (id < 0)
     return soap->error;
@@ -42836,27 +42904,27 @@ soap_out_PointerTons1__user(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__user **SOAP_FMAC4
 soap_in_PointerTons1__user(struct soap *soap, const char *tag, ns1__user **a,
                            const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__user **)soap_malloc(soap, sizeof(ns1__user *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
-    if (!(*a = (ns1__user *)soap_instantiate_ns1__user(soap, -1, soap->type,
-                                                       soap->arrayType, NULL)))
-      return NULL;
+    if (!(*a = (ns1__user *)soap_instantiate_ns1__user(
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__user **p = (ns1__user **)soap_id_lookup(soap, soap->href, (void **)a,
                                                  SOAP_TYPE_ICat4_ns1__user,
                                                  sizeof(ns1__user), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -42864,7 +42932,7 @@ soap_in_PointerTons1__user(struct soap *soap, const char *tag, ns1__user **a,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__user(struct soap *soap, ns1__user *const *a,
                             const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__user);
   if (soap_out_PointerTons1__user(soap, tag ? tag : "ns1:user", id, a, type))
     return soap->error;
@@ -42876,7 +42944,7 @@ soap_get_PointerTons1__user(struct soap *soap, ns1__user **p, const char *tag,
                             const char *type) {
   if ((p = soap_in_PointerTons1__user(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -42893,7 +42961,7 @@ soap_out_PointerTons1__instrumentScientist(struct soap *soap, const char *tag,
                                            int id,
                                            ns1__instrumentScientist *const *a,
                                            const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__instrumentScientist);
   if (id < 0)
     return soap->error;
@@ -42904,29 +42972,29 @@ SOAP_FMAC3 ns1__instrumentScientist **SOAP_FMAC4
 soap_in_PointerTons1__instrumentScientist(struct soap *soap, const char *tag,
                                           ns1__instrumentScientist **a,
                                           const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__instrumentScientist **)soap_malloc(
               soap, sizeof(ns1__instrumentScientist *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__instrumentScientist *)
-              soap_instantiate_ns1__instrumentScientist(soap, -1, soap->type,
-                                                        soap->arrayType, NULL)))
-      return NULL;
+              soap_instantiate_ns1__instrumentScientist(
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__instrumentScientist **p = (ns1__instrumentScientist **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__instrumentScientist,
         sizeof(ns1__instrumentScientist), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -42935,7 +43003,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__instrumentScientist(struct soap *soap,
                                            ns1__instrumentScientist *const *a,
                                            const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__instrumentScientist);
   if (soap_out_PointerTons1__instrumentScientist(
           soap, tag ? tag : "ns1:instrumentScientist", id, a, type))
@@ -42949,7 +43017,7 @@ soap_get_PointerTons1__instrumentScientist(struct soap *soap,
                                            const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__instrumentScientist(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -42966,7 +43034,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__facilityCycle(struct soap *soap, const char *tag, int id,
                                      ns1__facilityCycle *const *a,
                                      const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__facilityCycle);
   if (id < 0)
     return soap->error;
@@ -42976,28 +43044,28 @@ soap_out_PointerTons1__facilityCycle(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__facilityCycle **SOAP_FMAC4
 soap_in_PointerTons1__facilityCycle(struct soap *soap, const char *tag,
                                     ns1__facilityCycle **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__facilityCycle **)soap_malloc(soap,
                                                  sizeof(ns1__facilityCycle *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__facilityCycle *)soap_instantiate_ns1__facilityCycle(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__facilityCycle **p = (ns1__facilityCycle **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__facilityCycle,
         sizeof(ns1__facilityCycle), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -43006,7 +43074,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__facilityCycle(struct soap *soap,
                                      ns1__facilityCycle *const *a,
                                      const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__facilityCycle);
   if (soap_out_PointerTons1__facilityCycle(
           soap, tag ? tag : "ns1:facilityCycle", id, a, type))
@@ -43019,7 +43087,7 @@ soap_get_PointerTons1__facilityCycle(struct soap *soap, ns1__facilityCycle **p,
                                      const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__facilityCycle(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -43035,7 +43103,7 @@ soap_serialize_PointerTons1__facility(struct soap *soap,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__facility(struct soap *soap, const char *tag, int id,
                                 ns1__facility *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__facility);
   if (id < 0)
     return soap->error;
@@ -43045,27 +43113,27 @@ soap_out_PointerTons1__facility(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__facility **SOAP_FMAC4
 soap_in_PointerTons1__facility(struct soap *soap, const char *tag,
                                ns1__facility **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__facility **)soap_malloc(soap, sizeof(ns1__facility *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__facility *)soap_instantiate_ns1__facility(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__facility **p = (ns1__facility **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__facility,
         sizeof(ns1__facility), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -43073,7 +43141,7 @@ soap_in_PointerTons1__facility(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__facility(struct soap *soap, ns1__facility *const *a,
                                 const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__facility);
   if (soap_out_PointerTons1__facility(soap, tag ? tag : "ns1:facility", id, a,
                                       type))
@@ -43086,7 +43154,7 @@ soap_get_PointerTons1__facility(struct soap *soap, ns1__facility **p,
                                 const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__facility(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -43103,7 +43171,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__datasetType(struct soap *soap, const char *tag, int id,
                                    ns1__datasetType *const *a,
                                    const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__datasetType);
   if (id < 0)
     return soap->error;
@@ -43113,28 +43181,28 @@ soap_out_PointerTons1__datasetType(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__datasetType **SOAP_FMAC4
 soap_in_PointerTons1__datasetType(struct soap *soap, const char *tag,
                                   ns1__datasetType **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__datasetType **)soap_malloc(soap,
                                                sizeof(ns1__datasetType *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__datasetType *)soap_instantiate_ns1__datasetType(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__datasetType **p = (ns1__datasetType **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__datasetType,
         sizeof(ns1__datasetType), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -43143,7 +43211,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__datasetType(struct soap *soap,
                                    ns1__datasetType *const *a, const char *tag,
                                    const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__datasetType);
   if (soap_out_PointerTons1__datasetType(soap, tag ? tag : "ns1:datasetType",
                                          id, a, type))
@@ -43156,7 +43224,7 @@ soap_get_PointerTons1__datasetType(struct soap *soap, ns1__datasetType **p,
                                    const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__datasetType(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -43173,7 +43241,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__datasetParameter(struct soap *soap, const char *tag,
                                         int id, ns1__datasetParameter *const *a,
                                         const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__datasetParameter);
   if (id < 0)
     return soap->error;
@@ -43184,28 +43252,28 @@ SOAP_FMAC3 ns1__datasetParameter **SOAP_FMAC4
 soap_in_PointerTons1__datasetParameter(struct soap *soap, const char *tag,
                                        ns1__datasetParameter **a,
                                        const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__datasetParameter **)soap_malloc(
               soap, sizeof(ns1__datasetParameter *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__datasetParameter *)soap_instantiate_ns1__datasetParameter(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__datasetParameter **p = (ns1__datasetParameter **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__datasetParameter,
         sizeof(ns1__datasetParameter), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -43214,7 +43282,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__datasetParameter(struct soap *soap,
                                         ns1__datasetParameter *const *a,
                                         const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__datasetParameter);
   if (soap_out_PointerTons1__datasetParameter(
           soap, tag ? tag : "ns1:datasetParameter", id, a, type))
@@ -43228,7 +43296,7 @@ soap_get_PointerTons1__datasetParameter(struct soap *soap,
                                         const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__datasetParameter(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -43244,7 +43312,7 @@ soap_serialize_PointerTons1__dataset(struct soap *soap,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__dataset(struct soap *soap, const char *tag, int id,
                                ns1__dataset *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__dataset);
   if (id < 0)
     return soap->error;
@@ -43254,27 +43322,27 @@ soap_out_PointerTons1__dataset(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__dataset **SOAP_FMAC4
 soap_in_PointerTons1__dataset(struct soap *soap, const char *tag,
                               ns1__dataset **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__dataset **)soap_malloc(soap, sizeof(ns1__dataset *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__dataset *)soap_instantiate_ns1__dataset(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__dataset **p = (ns1__dataset **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__dataset,
         sizeof(ns1__dataset), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -43282,7 +43350,7 @@ soap_in_PointerTons1__dataset(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__dataset(struct soap *soap, ns1__dataset *const *a,
                                const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__dataset);
   if (soap_out_PointerTons1__dataset(soap, tag ? tag : "ns1:dataset", id, a,
                                      type))
@@ -43295,7 +43363,7 @@ soap_get_PointerTons1__dataset(struct soap *soap, ns1__dataset **p,
                                const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__dataset(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -43312,7 +43380,7 @@ soap_out_PointerTons1__datafileParameter(struct soap *soap, const char *tag,
                                          int id,
                                          ns1__datafileParameter *const *a,
                                          const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__datafileParameter);
   if (id < 0)
     return soap->error;
@@ -43323,29 +43391,29 @@ SOAP_FMAC3 ns1__datafileParameter **SOAP_FMAC4
 soap_in_PointerTons1__datafileParameter(struct soap *soap, const char *tag,
                                         ns1__datafileParameter **a,
                                         const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__datafileParameter **)soap_malloc(
               soap, sizeof(ns1__datafileParameter *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a =
               (ns1__datafileParameter *)soap_instantiate_ns1__datafileParameter(
-                  soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+                  soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__datafileParameter **p = (ns1__datafileParameter **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__datafileParameter,
         sizeof(ns1__datafileParameter), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -43354,7 +43422,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__datafileParameter(struct soap *soap,
                                          ns1__datafileParameter *const *a,
                                          const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__datafileParameter);
   if (soap_out_PointerTons1__datafileParameter(
           soap, tag ? tag : "ns1:datafileParameter", id, a, type))
@@ -43368,7 +43436,7 @@ soap_get_PointerTons1__datafileParameter(struct soap *soap,
                                          const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__datafileParameter(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -43385,7 +43453,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__datafileFormat(struct soap *soap, const char *tag,
                                       int id, ns1__datafileFormat *const *a,
                                       const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__datafileFormat);
   if (id < 0)
     return soap->error;
@@ -43396,28 +43464,28 @@ SOAP_FMAC3 ns1__datafileFormat **SOAP_FMAC4
 soap_in_PointerTons1__datafileFormat(struct soap *soap, const char *tag,
                                      ns1__datafileFormat **a,
                                      const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__datafileFormat **)soap_malloc(
               soap, sizeof(ns1__datafileFormat *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__datafileFormat *)soap_instantiate_ns1__datafileFormat(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__datafileFormat **p = (ns1__datafileFormat **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__datafileFormat,
         sizeof(ns1__datafileFormat), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -43426,7 +43494,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__datafileFormat(struct soap *soap,
                                       ns1__datafileFormat *const *a,
                                       const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__datafileFormat);
   if (soap_out_PointerTons1__datafileFormat(
           soap, tag ? tag : "ns1:datafileFormat", id, a, type))
@@ -43440,7 +43508,7 @@ soap_get_PointerTons1__datafileFormat(struct soap *soap,
                                       const char *type) {
   if ((p = soap_in_PointerTons1__datafileFormat(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -43456,7 +43524,7 @@ soap_serialize_PointerTons1__datafile(struct soap *soap,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__datafile(struct soap *soap, const char *tag, int id,
                                 ns1__datafile *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__datafile);
   if (id < 0)
     return soap->error;
@@ -43466,27 +43534,27 @@ soap_out_PointerTons1__datafile(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 ns1__datafile **SOAP_FMAC4
 soap_in_PointerTons1__datafile(struct soap *soap, const char *tag,
                                ns1__datafile **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__datafile **)soap_malloc(soap, sizeof(ns1__datafile *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__datafile *)soap_instantiate_ns1__datafile(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__datafile **p = (ns1__datafile **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__datafile,
         sizeof(ns1__datafile), 0);
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -43494,7 +43562,7 @@ soap_in_PointerTons1__datafile(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__datafile(struct soap *soap, ns1__datafile *const *a,
                                 const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__datafile);
   if (soap_out_PointerTons1__datafile(soap, tag ? tag : "ns1:datafile", id, a,
                                       type))
@@ -43507,7 +43575,7 @@ soap_get_PointerTons1__datafile(struct soap *soap, ns1__datafile **p,
                                 const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__datafile(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -43536,18 +43604,18 @@ SOAP_FMAC3 std::vector<_ns1__login_credentials_entry> **SOAP_FMAC4
 soap_in_PointerTostd__vectorTemplateOf_ns1__login_credentials_entry(
     struct soap *soap, const char *tag,
     std::vector<_ns1__login_credentials_entry> **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   soap_revert(soap);
   if (!a) {
     if (!(a = (std::vector<_ns1__login_credentials_entry> **)soap_malloc(
               soap, sizeof(std::vector<_ns1__login_credentials_entry> *))))
-      return NULL;
-    *a = NULL;
+      return nullptr;
+    *a = nullptr;
   }
   if (!(*a = soap_in_std__vectorTemplateOf_ns1__login_credentials_entry(
             soap, tag, *a, type)))
-    return NULL;
+    return nullptr;
   return a;
 }
 
@@ -43556,7 +43624,7 @@ soap_put_PointerTostd__vectorTemplateOf_ns1__login_credentials_entry(
     struct soap *soap, std::vector<_ns1__login_credentials_entry> *const *a,
     const char *tag, const char *type) {
   int id = soap_embed(
-      soap, (void *)a, NULL, 0, tag,
+      soap, (void *)a, nullptr, 0, tag,
       SOAP_TYPE_ICat4_PointerTostd__vectorTemplateOf_ns1__login_credentials_entry);
   if (soap_out_PointerTostd__vectorTemplateOf_ns1__login_credentials_entry(
           soap, tag ? tag : "", id, a, type))
@@ -43571,7 +43639,7 @@ soap_get_PointerTostd__vectorTemplateOf_ns1__login_credentials_entry(
   if ((p = soap_in_PointerTostd__vectorTemplateOf_ns1__login_credentials_entry(
            soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -43585,8 +43653,8 @@ soap_serialize_PointerToLONG64(struct soap *soap, LONG64 *const *a) {
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerToLONG64(struct soap *soap, const char *tag, int id,
                          LONG64 *const *a, const char *type) {
-  id =
-      soap_element_id(soap, tag, id, *a, NULL, 0, type, SOAP_TYPE_ICat4_LONG64);
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
+                       SOAP_TYPE_ICat4_LONG64);
   if (id < 0)
     return soap->error;
   return soap_out_LONG64(soap, tag, id, *a, type);
@@ -43595,21 +43663,21 @@ soap_out_PointerToLONG64(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 LONG64 **SOAP_FMAC4
 soap_in_PointerToLONG64(struct soap *soap, const char *tag, LONG64 **a,
                         const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (LONG64 **)soap_malloc(soap, sizeof(LONG64 *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = soap_in_LONG64(soap, tag, *a, type)))
-      return NULL;
+      return nullptr;
   } else {
     a = (LONG64 **)soap_id_lookup(soap, soap->href, (void **)a,
                                   SOAP_TYPE_ICat4_LONG64, sizeof(LONG64), 0);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -43617,7 +43685,7 @@ soap_in_PointerToLONG64(struct soap *soap, const char *tag, LONG64 **a,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerToLONG64(struct soap *soap, LONG64 *const *a, const char *tag,
                          const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerToLONG64);
   if (soap_out_PointerToLONG64(soap, tag ? tag : "long", id, a, type))
     return soap->error;
@@ -43629,7 +43697,7 @@ soap_get_PointerToLONG64(struct soap *soap, LONG64 **p, const char *tag,
                          const char *type) {
   if ((p = soap_in_PointerToLONG64(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -43643,7 +43711,8 @@ soap_serialize_PointerTotime(struct soap *soap, time_t *const *a) {
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTotime(struct soap *soap, const char *tag, int id,
                        time_t *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type, SOAP_TYPE_ICat4_time);
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
+                       SOAP_TYPE_ICat4_time);
   if (id < 0)
     return soap->error;
   return soap_out_time(soap, tag, id, *a, type);
@@ -43652,21 +43721,21 @@ soap_out_PointerTotime(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 time_t **SOAP_FMAC4
 soap_in_PointerTotime(struct soap *soap, const char *tag, time_t **a,
                       const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (time_t **)soap_malloc(soap, sizeof(time_t *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = soap_in_time(soap, tag, *a, type)))
-      return NULL;
+      return nullptr;
   } else {
     a = (time_t **)soap_id_lookup(soap, soap->href, (void **)a,
                                   SOAP_TYPE_ICat4_time, sizeof(time_t), 0);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -43674,8 +43743,8 @@ soap_in_PointerTotime(struct soap *soap, const char *tag, time_t **a,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTotime(struct soap *soap, time_t *const *a, const char *tag,
                        const char *type) {
-  int id =
-      soap_embed(soap, (void *)a, NULL, 0, tag, SOAP_TYPE_ICat4_PointerTotime);
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
+                      SOAP_TYPE_ICat4_PointerTotime);
   if (soap_out_PointerTotime(soap, tag ? tag : "dateTime", id, a, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -43686,7 +43755,7 @@ soap_get_PointerTotime(struct soap *soap, time_t **p, const char *tag,
                        const char *type) {
   if ((p = soap_in_PointerTotime(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -43703,7 +43772,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTons1__entityBaseBean(struct soap *soap, const char *tag,
                                       int id, ns1__entityBaseBean *const *a,
                                       const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__entityBaseBean);
   if (id < 0)
     return soap->error;
@@ -43714,21 +43783,21 @@ SOAP_FMAC3 ns1__entityBaseBean **SOAP_FMAC4
 soap_in_PointerTons1__entityBaseBean(struct soap *soap, const char *tag,
                                      ns1__entityBaseBean **a,
                                      const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (ns1__entityBaseBean **)soap_malloc(
               soap, sizeof(ns1__entityBaseBean *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = (ns1__entityBaseBean *)soap_instantiate_ns1__entityBaseBean(
-              soap, -1, soap->type, soap->arrayType, NULL)))
-      return NULL;
+              soap, -1, soap->type, soap->arrayType, nullptr)))
+      return nullptr;
     (*a)->soap_default(soap);
-    if (!(*a)->soap_in(soap, tag, NULL))
-      return NULL;
+    if (!(*a)->soap_in(soap, tag, nullptr))
+      return nullptr;
   } else {
     ns1__entityBaseBean **p = (ns1__entityBaseBean **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__entityBaseBean,
@@ -43976,7 +44045,7 @@ soap_in_PointerTons1__entityBaseBean(struct soap *soap, const char *tag,
     }
     a = p;
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -43985,7 +44054,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__entityBaseBean(struct soap *soap,
                                       ns1__entityBaseBean *const *a,
                                       const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__entityBaseBean);
   if (soap_out_PointerTons1__entityBaseBean(
           soap, tag ? tag : "ns1:entityBaseBean", id, a, type))
@@ -43999,7 +44068,7 @@ soap_get_PointerTons1__entityBaseBean(struct soap *soap,
                                       const char *type) {
   if ((p = soap_in_PointerTons1__entityBaseBean(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -44015,7 +44084,7 @@ soap_out_PointerTons1__icatExceptionType(struct soap *soap, const char *tag,
                                          int id,
                                          enum ns1__icatExceptionType *const *a,
                                          const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_ns1__icatExceptionType);
   if (id < 0)
     return soap->error;
@@ -44026,23 +44095,23 @@ SOAP_FMAC3 enum ns1__icatExceptionType **SOAP_FMAC4
 soap_in_PointerTons1__icatExceptionType(struct soap *soap, const char *tag,
                                         enum ns1__icatExceptionType **a,
                                         const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (enum ns1__icatExceptionType **)soap_malloc(
               soap, sizeof(enum ns1__icatExceptionType *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = soap_in_ns1__icatExceptionType(soap, tag, *a, type)))
-      return NULL;
+      return nullptr;
   } else {
     a = (enum ns1__icatExceptionType **)soap_id_lookup(
         soap, soap->href, (void **)a, SOAP_TYPE_ICat4_ns1__icatExceptionType,
         sizeof(enum ns1__icatExceptionType), 0);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -44051,7 +44120,7 @@ SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTons1__icatExceptionType(struct soap *soap,
                                          enum ns1__icatExceptionType *const *a,
                                          const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTons1__icatExceptionType);
   if (soap_out_PointerTons1__icatExceptionType(
           soap, tag ? tag : "ns1:icatExceptionType", id, a, type))
@@ -44065,7 +44134,7 @@ soap_get_PointerTons1__icatExceptionType(struct soap *soap,
                                          const char *tag, const char *type) {
   if ((p = soap_in_PointerTons1__icatExceptionType(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -44080,7 +44149,7 @@ soap_serialize_PointerTostd__string(struct soap *soap, std::string *const *a) {
 SOAP_FMAC3 int SOAP_FMAC4
 soap_out_PointerTostd__string(struct soap *soap, const char *tag, int id,
                               std::string *const *a, const char *type) {
-  id = soap_element_id(soap, tag, id, *a, NULL, 0, type,
+  id = soap_element_id(soap, tag, id, *a, nullptr, 0, type,
                        SOAP_TYPE_ICat4_std__string);
   if (id < 0)
     return soap->error;
@@ -44090,22 +44159,22 @@ soap_out_PointerTostd__string(struct soap *soap, const char *tag, int id,
 SOAP_FMAC3 std::string **SOAP_FMAC4
 soap_in_PointerTostd__string(struct soap *soap, const char *tag,
                              std::string **a, const char *type) {
-  if (soap_element_begin_in(soap, tag, 1, NULL))
-    return NULL;
+  if (soap_element_begin_in(soap, tag, 1, nullptr))
+    return nullptr;
   if (!a)
     if (!(a = (std::string **)soap_malloc(soap, sizeof(std::string *))))
-      return NULL;
-  *a = NULL;
+      return nullptr;
+  *a = nullptr;
   if (!soap->null && *soap->href != '#') {
     soap_revert(soap);
     if (!(*a = soap_in_std__string(soap, tag, *a, type)))
-      return NULL;
+      return nullptr;
   } else {
     a = (std::string **)soap_id_lookup(soap, soap->href, (void **)a,
                                        SOAP_TYPE_ICat4_std__string,
                                        sizeof(std::string), 0);
     if (soap->body && soap_element_end_in(soap, tag))
-      return NULL;
+      return nullptr;
   }
   return a;
 }
@@ -44113,7 +44182,7 @@ soap_in_PointerTostd__string(struct soap *soap, const char *tag,
 SOAP_FMAC3 int SOAP_FMAC4
 soap_put_PointerTostd__string(struct soap *soap, std::string *const *a,
                               const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag,
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag,
                       SOAP_TYPE_ICat4_PointerTostd__string);
   if (soap_out_PointerTostd__string(soap, tag ? tag : "string", id, a, type))
     return soap->error;
@@ -44125,7 +44194,7 @@ soap_get_PointerTostd__string(struct soap *soap, std::string **p,
                               const char *tag, const char *type) {
   if ((p = soap_in_PointerTostd__string(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -44151,7 +44220,7 @@ soap_in__QName(struct soap *soap, const char *tag, char **a, const char *type) {
 
 SOAP_FMAC3 int SOAP_FMAC4 soap_put__QName(struct soap *soap, char *const *a,
                                           const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag, SOAP_TYPE_ICat4__QName);
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag, SOAP_TYPE_ICat4__QName);
   if (soap_out__QName(soap, tag ? tag : "byte", id, a, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -44162,7 +44231,7 @@ SOAP_FMAC3 char **SOAP_FMAC4 soap_get__QName(struct soap *soap, char **p,
                                              const char *type) {
   if ((p = soap_in__QName(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -44171,7 +44240,7 @@ SOAP_FMAC3 void SOAP_FMAC4 soap_default_string(struct soap *soap, char **a) {
 #ifdef SOAP_DEFAULT_string
   *a = SOAP_DEFAULT_string;
 #else
-  *a = (char *)0;
+  *a = (char *)nullptr;
 #endif
 }
 
@@ -44197,7 +44266,7 @@ soap_in_string(struct soap *soap, const char *tag, char **a, const char *type) {
 
 SOAP_FMAC3 int SOAP_FMAC4 soap_put_string(struct soap *soap, char *const *a,
                                           const char *tag, const char *type) {
-  int id = soap_embed(soap, (void *)a, NULL, 0, tag, SOAP_TYPE_ICat4_string);
+  int id = soap_embed(soap, (void *)a, nullptr, 0, tag, SOAP_TYPE_ICat4_string);
   if (soap_out_string(soap, tag ? tag : "byte", id, a, type))
     return soap->error;
   return soap_putindependent(soap);
@@ -44208,7 +44277,7 @@ SOAP_FMAC3 char **SOAP_FMAC4 soap_get_string(struct soap *soap, char **p,
                                              const char *type) {
   if ((p = soap_in_string(soap, tag, p, type)))
     if (soap_getindependent(soap))
-      return NULL;
+      return nullptr;
   return p;
 }
 
@@ -44249,11 +44318,11 @@ soap_in_std__vectorTemplateOfPointerTons1__sampleParameter(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__sampleParameter *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -44261,7 +44330,7 @@ soap_in_std__vectorTemplateOfPointerTons1__sampleParameter(
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__sampleParameter,
               sizeof(ns1__sampleParameter), 1))
         break;
-      if (!soap_in_PointerTons1__sampleParameter(soap, tag, NULL,
+      if (!soap_in_PointerTons1__sampleParameter(soap, tag, nullptr,
                                                  "ns1:sampleParameter"))
         break;
     } else if (!soap_in_PointerTons1__sampleParameter(soap, tag, &n,
@@ -44270,7 +44339,7 @@ soap_in_std__vectorTemplateOfPointerTons1__sampleParameter(
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__sampleParameter(soap,
                                                                           -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -44280,7 +44349,7 @@ soap_in_std__vectorTemplateOfPointerTons1__sampleParameter(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__sampleParameter *> *SOAP_FMAC2
@@ -44294,11 +44363,11 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__sampleParameter(
                                     "sampleParameter(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL,
+      soap, nullptr,
       SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__sampleParameter, n,
       ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__sampleParameter *>);
     if (size)
@@ -44370,11 +44439,11 @@ soap_in_std__vectorTemplateOfPointerTons1__permissibleStringValue(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__permissibleStringValue *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -44383,7 +44452,7 @@ soap_in_std__vectorTemplateOfPointerTons1__permissibleStringValue(
               sizeof(ns1__permissibleStringValue), 1))
         break;
       if (!soap_in_PointerTons1__permissibleStringValue(
-              soap, tag, NULL, "ns1:permissibleStringValue"))
+              soap, tag, nullptr, "ns1:permissibleStringValue"))
         break;
     } else if (!soap_in_PointerTons1__permissibleStringValue(
                    soap, tag, &n, "ns1:permissibleStringValue"))
@@ -44391,7 +44460,7 @@ soap_in_std__vectorTemplateOfPointerTons1__permissibleStringValue(
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__permissibleStringValue(
               soap, -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -44401,7 +44470,7 @@ soap_in_std__vectorTemplateOfPointerTons1__permissibleStringValue(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__permissibleStringValue *> *SOAP_FMAC2
@@ -44415,11 +44484,11 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__permissibleStringValue(
                                     "permissibleStringValue(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL,
+      soap, nullptr,
       SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__permissibleStringValue,
       n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__permissibleStringValue *>);
     if (size)
@@ -44490,11 +44559,11 @@ soap_in_std__vectorTemplateOfPointerTons1__rule(struct soap *soap,
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__rule *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -44502,12 +44571,12 @@ soap_in_std__vectorTemplateOfPointerTons1__rule(struct soap *soap,
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__rule,
               sizeof(ns1__rule), 1))
         break;
-      if (!soap_in_PointerTons1__rule(soap, tag, NULL, "ns1:rule"))
+      if (!soap_in_PointerTons1__rule(soap, tag, nullptr, "ns1:rule"))
         break;
     } else if (!soap_in_PointerTons1__rule(soap, tag, &n, "ns1:rule"))
       break;
     if (!a && !(a = soap_new_std__vectorTemplateOfPointerTons1__rule(soap, -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -44517,7 +44586,7 @@ soap_in_std__vectorTemplateOfPointerTons1__rule(struct soap *soap,
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__rule *> *SOAP_FMAC2
@@ -44533,10 +44602,10 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__rule(struct soap *soap,
                                     "%s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__rule, n,
+      soap, nullptr, SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__rule, n,
       ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__rule *>);
     if (size)
@@ -44603,11 +44672,11 @@ soap_in_std__vectorTemplateOfPointerTons1__userGroup(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__userGroup *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -44615,13 +44684,13 @@ soap_in_std__vectorTemplateOfPointerTons1__userGroup(
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__userGroup,
               sizeof(ns1__userGroup), 1))
         break;
-      if (!soap_in_PointerTons1__userGroup(soap, tag, NULL, "ns1:userGroup"))
+      if (!soap_in_PointerTons1__userGroup(soap, tag, nullptr, "ns1:userGroup"))
         break;
     } else if (!soap_in_PointerTons1__userGroup(soap, tag, &n, "ns1:userGroup"))
       break;
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__userGroup(soap, -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -44631,7 +44700,7 @@ soap_in_std__vectorTemplateOfPointerTons1__userGroup(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__userGroup *> *SOAP_FMAC2
@@ -44644,11 +44713,12 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__userGroup(
                                     "vectorTemplateOfPointerTons1__userGroup(%"
                                     "d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__userGroup,
-      n, ICat4_fdelete);
+  struct soap_clist *cp =
+      soap_link(soap, nullptr,
+                SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__userGroup, n,
+                ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__userGroup *>);
     if (size)
@@ -44718,11 +44788,11 @@ soap_in_std__vectorTemplateOfPointerTons1__study(struct soap *soap,
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__study *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -44730,13 +44800,13 @@ soap_in_std__vectorTemplateOfPointerTons1__study(struct soap *soap,
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__study,
               sizeof(ns1__study), 1))
         break;
-      if (!soap_in_PointerTons1__study(soap, tag, NULL, "ns1:study"))
+      if (!soap_in_PointerTons1__study(soap, tag, nullptr, "ns1:study"))
         break;
     } else if (!soap_in_PointerTons1__study(soap, tag, &n, "ns1:study"))
       break;
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__study(soap, -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -44746,7 +44816,7 @@ soap_in_std__vectorTemplateOfPointerTons1__study(struct soap *soap,
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__study *> *SOAP_FMAC2
@@ -44762,10 +44832,10 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__study(struct soap *soap,
                                     "%s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__study, n,
-      ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__study,
+      n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__study *>);
     if (size)
@@ -44833,11 +44903,11 @@ soap_in_std__vectorTemplateOfPointerTons1__instrumentScientist(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__instrumentScientist *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -44845,7 +44915,7 @@ soap_in_std__vectorTemplateOfPointerTons1__instrumentScientist(
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__instrumentScientist,
               sizeof(ns1__instrumentScientist), 1))
         break;
-      if (!soap_in_PointerTons1__instrumentScientist(soap, tag, NULL,
+      if (!soap_in_PointerTons1__instrumentScientist(soap, tag, nullptr,
                                                      "ns1:instrumentScientist"))
         break;
     } else if (!soap_in_PointerTons1__instrumentScientist(
@@ -44854,7 +44924,7 @@ soap_in_std__vectorTemplateOfPointerTons1__instrumentScientist(
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__instrumentScientist(
               soap, -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -44864,7 +44934,7 @@ soap_in_std__vectorTemplateOfPointerTons1__instrumentScientist(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__instrumentScientist *> *SOAP_FMAC2
@@ -44878,11 +44948,11 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__instrumentScientist(
                                     "instrumentScientist(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL,
+      soap, nullptr,
       SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__instrumentScientist, n,
       ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__instrumentScientist *>);
     if (size)
@@ -44954,11 +45024,11 @@ soap_in_std__vectorTemplateOfPointerTons1__sampleType(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__sampleType *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -44966,14 +45036,15 @@ soap_in_std__vectorTemplateOfPointerTons1__sampleType(
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__sampleType,
               sizeof(ns1__sampleType), 1))
         break;
-      if (!soap_in_PointerTons1__sampleType(soap, tag, NULL, "ns1:sampleType"))
+      if (!soap_in_PointerTons1__sampleType(soap, tag, nullptr,
+                                            "ns1:sampleType"))
         break;
     } else if (!soap_in_PointerTons1__sampleType(soap, tag, &n,
                                                  "ns1:sampleType"))
       break;
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__sampleType(soap, -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -44983,7 +45054,7 @@ soap_in_std__vectorTemplateOfPointerTons1__sampleType(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__sampleType *> *SOAP_FMAC2
@@ -44996,11 +45067,12 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__sampleType(
                                     "vectorTemplateOfPointerTons1__sampleType(%"
                                     "d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__sampleType,
-      n, ICat4_fdelete);
+  struct soap_clist *cp =
+      soap_link(soap, nullptr,
+                SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__sampleType,
+                n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__sampleType *>);
     if (size)
@@ -45070,11 +45142,11 @@ soap_in_std__vectorTemplateOfPointerTons1__parameterType(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__parameterType *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -45082,7 +45154,7 @@ soap_in_std__vectorTemplateOfPointerTons1__parameterType(
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__parameterType,
               sizeof(ns1__parameterType), 1))
         break;
-      if (!soap_in_PointerTons1__parameterType(soap, tag, NULL,
+      if (!soap_in_PointerTons1__parameterType(soap, tag, nullptr,
                                                "ns1:parameterType"))
         break;
     } else if (!soap_in_PointerTons1__parameterType(soap, tag, &n,
@@ -45091,7 +45163,7 @@ soap_in_std__vectorTemplateOfPointerTons1__parameterType(
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__parameterType(soap,
                                                                         -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -45101,7 +45173,7 @@ soap_in_std__vectorTemplateOfPointerTons1__parameterType(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__parameterType *> *SOAP_FMAC2
@@ -45115,11 +45187,11 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__parameterType(
                                     "parameterType(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL,
+      soap, nullptr,
       SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__parameterType, n,
       ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__parameterType *>);
     if (size)
@@ -45191,11 +45263,11 @@ soap_in_std__vectorTemplateOfPointerTons1__investigation(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__investigation *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -45203,7 +45275,7 @@ soap_in_std__vectorTemplateOfPointerTons1__investigation(
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__investigation,
               sizeof(ns1__investigation), 1))
         break;
-      if (!soap_in_PointerTons1__investigation(soap, tag, NULL,
+      if (!soap_in_PointerTons1__investigation(soap, tag, nullptr,
                                                "ns1:investigation"))
         break;
     } else if (!soap_in_PointerTons1__investigation(soap, tag, &n,
@@ -45212,7 +45284,7 @@ soap_in_std__vectorTemplateOfPointerTons1__investigation(
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__investigation(soap,
                                                                         -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -45222,7 +45294,7 @@ soap_in_std__vectorTemplateOfPointerTons1__investigation(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__investigation *> *SOAP_FMAC2
@@ -45236,11 +45308,11 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__investigation(
                                     "investigation(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL,
+      soap, nullptr,
       SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__investigation, n,
       ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__investigation *>);
     if (size)
@@ -45312,11 +45384,11 @@ soap_in_std__vectorTemplateOfPointerTons1__investigationType(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__investigationType *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -45324,7 +45396,7 @@ soap_in_std__vectorTemplateOfPointerTons1__investigationType(
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__investigationType,
               sizeof(ns1__investigationType), 1))
         break;
-      if (!soap_in_PointerTons1__investigationType(soap, tag, NULL,
+      if (!soap_in_PointerTons1__investigationType(soap, tag, nullptr,
                                                    "ns1:investigationType"))
         break;
     } else if (!soap_in_PointerTons1__investigationType(
@@ -45333,7 +45405,7 @@ soap_in_std__vectorTemplateOfPointerTons1__investigationType(
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__investigationType(
               soap, -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -45343,7 +45415,7 @@ soap_in_std__vectorTemplateOfPointerTons1__investigationType(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__investigationType *> *SOAP_FMAC2
@@ -45357,11 +45429,11 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__investigationType(
                                     "investigationType(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL,
+      soap, nullptr,
       SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__investigationType, n,
       ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__investigationType *>);
     if (size)
@@ -45431,11 +45503,11 @@ soap_in_std__vectorTemplateOfPointerTons1__instrument(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__instrument *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -45443,14 +45515,15 @@ soap_in_std__vectorTemplateOfPointerTons1__instrument(
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__instrument,
               sizeof(ns1__instrument), 1))
         break;
-      if (!soap_in_PointerTons1__instrument(soap, tag, NULL, "ns1:instrument"))
+      if (!soap_in_PointerTons1__instrument(soap, tag, nullptr,
+                                            "ns1:instrument"))
         break;
     } else if (!soap_in_PointerTons1__instrument(soap, tag, &n,
                                                  "ns1:instrument"))
       break;
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__instrument(soap, -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -45460,7 +45533,7 @@ soap_in_std__vectorTemplateOfPointerTons1__instrument(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__instrument *> *SOAP_FMAC2
@@ -45473,11 +45546,12 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__instrument(
                                     "vectorTemplateOfPointerTons1__instrument(%"
                                     "d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__instrument,
-      n, ICat4_fdelete);
+  struct soap_clist *cp =
+      soap_link(soap, nullptr,
+                SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__instrument,
+                n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__instrument *>);
     if (size)
@@ -45547,11 +45621,11 @@ soap_in_std__vectorTemplateOfPointerTons1__facilityCycle(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__facilityCycle *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -45559,7 +45633,7 @@ soap_in_std__vectorTemplateOfPointerTons1__facilityCycle(
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__facilityCycle,
               sizeof(ns1__facilityCycle), 1))
         break;
-      if (!soap_in_PointerTons1__facilityCycle(soap, tag, NULL,
+      if (!soap_in_PointerTons1__facilityCycle(soap, tag, nullptr,
                                                "ns1:facilityCycle"))
         break;
     } else if (!soap_in_PointerTons1__facilityCycle(soap, tag, &n,
@@ -45568,7 +45642,7 @@ soap_in_std__vectorTemplateOfPointerTons1__facilityCycle(
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__facilityCycle(soap,
                                                                         -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -45578,7 +45652,7 @@ soap_in_std__vectorTemplateOfPointerTons1__facilityCycle(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__facilityCycle *> *SOAP_FMAC2
@@ -45592,11 +45666,11 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__facilityCycle(
                                     "facilityCycle(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL,
+      soap, nullptr,
       SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__facilityCycle, n,
       ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__facilityCycle *>);
     if (size)
@@ -45668,11 +45742,11 @@ soap_in_std__vectorTemplateOfPointerTons1__datasetType(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__datasetType *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -45680,7 +45754,7 @@ soap_in_std__vectorTemplateOfPointerTons1__datasetType(
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__datasetType,
               sizeof(ns1__datasetType), 1))
         break;
-      if (!soap_in_PointerTons1__datasetType(soap, tag, NULL,
+      if (!soap_in_PointerTons1__datasetType(soap, tag, nullptr,
                                              "ns1:datasetType"))
         break;
     } else if (!soap_in_PointerTons1__datasetType(soap, tag, &n,
@@ -45689,7 +45763,7 @@ soap_in_std__vectorTemplateOfPointerTons1__datasetType(
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__datasetType(soap,
                                                                       -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -45699,7 +45773,7 @@ soap_in_std__vectorTemplateOfPointerTons1__datasetType(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__datasetType *> *SOAP_FMAC2
@@ -45713,11 +45787,11 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__datasetType(
                                     "%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL,
+      soap_link(soap, nullptr,
                 SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__datasetType,
                 n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__datasetType *>);
     if (size)
@@ -45788,11 +45862,11 @@ soap_in_std__vectorTemplateOfPointerTons1__datafileFormat(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__datafileFormat *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -45800,7 +45874,7 @@ soap_in_std__vectorTemplateOfPointerTons1__datafileFormat(
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__datafileFormat,
               sizeof(ns1__datafileFormat), 1))
         break;
-      if (!soap_in_PointerTons1__datafileFormat(soap, tag, NULL,
+      if (!soap_in_PointerTons1__datafileFormat(soap, tag, nullptr,
                                                 "ns1:datafileFormat"))
         break;
     } else if (!soap_in_PointerTons1__datafileFormat(soap, tag, &n,
@@ -45809,7 +45883,7 @@ soap_in_std__vectorTemplateOfPointerTons1__datafileFormat(
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__datafileFormat(soap,
                                                                          -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -45819,7 +45893,7 @@ soap_in_std__vectorTemplateOfPointerTons1__datafileFormat(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__datafileFormat *> *SOAP_FMAC2
@@ -45833,11 +45907,11 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__datafileFormat(
                                     "datafileFormat(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL,
+      soap, nullptr,
       SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__datafileFormat, n,
       ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__datafileFormat *>);
     if (size)
@@ -45909,11 +45983,11 @@ soap_in_std__vectorTemplateOfPointerTons1__application(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__application *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -45921,7 +45995,7 @@ soap_in_std__vectorTemplateOfPointerTons1__application(
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__application,
               sizeof(ns1__application), 1))
         break;
-      if (!soap_in_PointerTons1__application(soap, tag, NULL,
+      if (!soap_in_PointerTons1__application(soap, tag, nullptr,
                                              "ns1:application"))
         break;
     } else if (!soap_in_PointerTons1__application(soap, tag, &n,
@@ -45930,7 +46004,7 @@ soap_in_std__vectorTemplateOfPointerTons1__application(
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__application(soap,
                                                                       -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -45940,7 +46014,7 @@ soap_in_std__vectorTemplateOfPointerTons1__application(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__application *> *SOAP_FMAC2
@@ -45954,11 +46028,11 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__application(
                                     "%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL,
+      soap_link(soap, nullptr,
                 SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__application,
                 n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__application *>);
     if (size)
@@ -46029,11 +46103,11 @@ soap_in_std__vectorTemplateOfPointerTons1__studyInvestigation(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__studyInvestigation *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -46041,7 +46115,7 @@ soap_in_std__vectorTemplateOfPointerTons1__studyInvestigation(
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__studyInvestigation,
               sizeof(ns1__studyInvestigation), 1))
         break;
-      if (!soap_in_PointerTons1__studyInvestigation(soap, tag, NULL,
+      if (!soap_in_PointerTons1__studyInvestigation(soap, tag, nullptr,
                                                     "ns1:studyInvestigation"))
         break;
     } else if (!soap_in_PointerTons1__studyInvestigation(
@@ -46050,7 +46124,7 @@ soap_in_std__vectorTemplateOfPointerTons1__studyInvestigation(
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__studyInvestigation(
               soap, -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -46060,7 +46134,7 @@ soap_in_std__vectorTemplateOfPointerTons1__studyInvestigation(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__studyInvestigation *> *SOAP_FMAC2
@@ -46074,11 +46148,11 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__studyInvestigation(
                                     "studyInvestigation(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL,
+      soap, nullptr,
       SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__studyInvestigation, n,
       ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__studyInvestigation *>);
     if (size)
@@ -46148,11 +46222,11 @@ soap_in_std__vectorTemplateOfPointerTons1__shift(struct soap *soap,
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__shift *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -46160,13 +46234,13 @@ soap_in_std__vectorTemplateOfPointerTons1__shift(struct soap *soap,
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__shift,
               sizeof(ns1__shift), 1))
         break;
-      if (!soap_in_PointerTons1__shift(soap, tag, NULL, "ns1:shift"))
+      if (!soap_in_PointerTons1__shift(soap, tag, nullptr, "ns1:shift"))
         break;
     } else if (!soap_in_PointerTons1__shift(soap, tag, &n, "ns1:shift"))
       break;
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__shift(soap, -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -46176,7 +46250,7 @@ soap_in_std__vectorTemplateOfPointerTons1__shift(struct soap *soap,
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__shift *> *SOAP_FMAC2
@@ -46192,10 +46266,10 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__shift(struct soap *soap,
                                     "%s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__shift, n,
-      ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__shift,
+      n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__shift *>);
     if (size)
@@ -46263,11 +46337,11 @@ soap_in_std__vectorTemplateOfPointerTons1__sample(struct soap *soap,
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__sample *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -46275,13 +46349,13 @@ soap_in_std__vectorTemplateOfPointerTons1__sample(struct soap *soap,
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__sample,
               sizeof(ns1__sample), 1))
         break;
-      if (!soap_in_PointerTons1__sample(soap, tag, NULL, "ns1:sample"))
+      if (!soap_in_PointerTons1__sample(soap, tag, nullptr, "ns1:sample"))
         break;
     } else if (!soap_in_PointerTons1__sample(soap, tag, &n, "ns1:sample"))
       break;
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__sample(soap, -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -46291,7 +46365,7 @@ soap_in_std__vectorTemplateOfPointerTons1__sample(struct soap *soap,
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__sample *> *SOAP_FMAC2
@@ -46305,10 +46379,10 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__sample(
                                     "%s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__sample, n,
-      ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__sample,
+      n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__sample *>);
     if (size)
@@ -46376,11 +46450,11 @@ soap_in_std__vectorTemplateOfPointerTons1__publication(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__publication *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -46388,7 +46462,7 @@ soap_in_std__vectorTemplateOfPointerTons1__publication(
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__publication,
               sizeof(ns1__publication), 1))
         break;
-      if (!soap_in_PointerTons1__publication(soap, tag, NULL,
+      if (!soap_in_PointerTons1__publication(soap, tag, nullptr,
                                              "ns1:publication"))
         break;
     } else if (!soap_in_PointerTons1__publication(soap, tag, &n,
@@ -46397,7 +46471,7 @@ soap_in_std__vectorTemplateOfPointerTons1__publication(
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__publication(soap,
                                                                       -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -46407,7 +46481,7 @@ soap_in_std__vectorTemplateOfPointerTons1__publication(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__publication *> *SOAP_FMAC2
@@ -46421,11 +46495,11 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__publication(
                                     "%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL,
+      soap_link(soap, nullptr,
                 SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__publication,
                 n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__publication *>);
     if (size)
@@ -46498,11 +46572,11 @@ soap_in_std__vectorTemplateOfPointerTons1__investigationParameter(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__investigationParameter *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -46511,7 +46585,7 @@ soap_in_std__vectorTemplateOfPointerTons1__investigationParameter(
               sizeof(ns1__investigationParameter), 1))
         break;
       if (!soap_in_PointerTons1__investigationParameter(
-              soap, tag, NULL, "ns1:investigationParameter"))
+              soap, tag, nullptr, "ns1:investigationParameter"))
         break;
     } else if (!soap_in_PointerTons1__investigationParameter(
                    soap, tag, &n, "ns1:investigationParameter"))
@@ -46519,7 +46593,7 @@ soap_in_std__vectorTemplateOfPointerTons1__investigationParameter(
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__investigationParameter(
               soap, -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -46529,7 +46603,7 @@ soap_in_std__vectorTemplateOfPointerTons1__investigationParameter(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__investigationParameter *> *SOAP_FMAC2
@@ -46543,11 +46617,11 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__investigationParameter(
                                     "investigationParameter(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL,
+      soap, nullptr,
       SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__investigationParameter,
       n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__investigationParameter *>);
     if (size)
@@ -46618,11 +46692,11 @@ soap_in_std__vectorTemplateOfPointerTons1__keyword(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__keyword *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -46630,13 +46704,13 @@ soap_in_std__vectorTemplateOfPointerTons1__keyword(
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__keyword,
               sizeof(ns1__keyword), 1))
         break;
-      if (!soap_in_PointerTons1__keyword(soap, tag, NULL, "ns1:keyword"))
+      if (!soap_in_PointerTons1__keyword(soap, tag, nullptr, "ns1:keyword"))
         break;
     } else if (!soap_in_PointerTons1__keyword(soap, tag, &n, "ns1:keyword"))
       break;
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__keyword(soap, -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -46646,7 +46720,7 @@ soap_in_std__vectorTemplateOfPointerTons1__keyword(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__keyword *> *SOAP_FMAC2
@@ -46660,10 +46734,10 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__keyword(
                                     "%s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__keyword, n,
-      ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__keyword,
+      n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__keyword *>);
     if (size)
@@ -46732,11 +46806,11 @@ soap_in_std__vectorTemplateOfPointerTons1__investigationUser(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__investigationUser *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -46744,7 +46818,7 @@ soap_in_std__vectorTemplateOfPointerTons1__investigationUser(
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__investigationUser,
               sizeof(ns1__investigationUser), 1))
         break;
-      if (!soap_in_PointerTons1__investigationUser(soap, tag, NULL,
+      if (!soap_in_PointerTons1__investigationUser(soap, tag, nullptr,
                                                    "ns1:investigationUser"))
         break;
     } else if (!soap_in_PointerTons1__investigationUser(
@@ -46753,7 +46827,7 @@ soap_in_std__vectorTemplateOfPointerTons1__investigationUser(
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__investigationUser(
               soap, -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -46763,7 +46837,7 @@ soap_in_std__vectorTemplateOfPointerTons1__investigationUser(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__investigationUser *> *SOAP_FMAC2
@@ -46777,11 +46851,11 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__investigationUser(
                                     "investigationUser(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL,
+      soap, nullptr,
       SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__investigationUser, n,
       ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__investigationUser *>);
     if (size)
@@ -46854,11 +46928,11 @@ soap_in_std__vectorTemplateOfPointerTons1__investigationInstrument(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__investigationInstrument *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -46867,7 +46941,7 @@ soap_in_std__vectorTemplateOfPointerTons1__investigationInstrument(
               sizeof(ns1__investigationInstrument), 1))
         break;
       if (!soap_in_PointerTons1__investigationInstrument(
-              soap, tag, NULL, "ns1:investigationInstrument"))
+              soap, tag, nullptr, "ns1:investigationInstrument"))
         break;
     } else if (!soap_in_PointerTons1__investigationInstrument(
                    soap, tag, &n, "ns1:investigationInstrument"))
@@ -46875,7 +46949,7 @@ soap_in_std__vectorTemplateOfPointerTons1__investigationInstrument(
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__investigationInstrument(
               soap, -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -46885,7 +46959,7 @@ soap_in_std__vectorTemplateOfPointerTons1__investigationInstrument(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__investigationInstrument *> *SOAP_FMAC2
@@ -46899,11 +46973,11 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__investigationInstrument(
                                     "investigationInstrument(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL,
+      soap, nullptr,
       SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__investigationInstrument,
       n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__investigationInstrument *>);
     if (size)
@@ -46974,11 +47048,11 @@ soap_in_std__vectorTemplateOfPointerTons1__dataset(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__dataset *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -46986,13 +47060,13 @@ soap_in_std__vectorTemplateOfPointerTons1__dataset(
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__dataset,
               sizeof(ns1__dataset), 1))
         break;
-      if (!soap_in_PointerTons1__dataset(soap, tag, NULL, "ns1:dataset"))
+      if (!soap_in_PointerTons1__dataset(soap, tag, nullptr, "ns1:dataset"))
         break;
     } else if (!soap_in_PointerTons1__dataset(soap, tag, &n, "ns1:dataset"))
       break;
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__dataset(soap, -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -47002,7 +47076,7 @@ soap_in_std__vectorTemplateOfPointerTons1__dataset(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__dataset *> *SOAP_FMAC2
@@ -47016,10 +47090,10 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__dataset(
                                     "%s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__dataset, n,
-      ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__dataset,
+      n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__dataset *>);
     if (size)
@@ -47088,11 +47162,11 @@ soap_in_std__vectorTemplateOfPointerTons1__datasetParameter(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__datasetParameter *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -47100,7 +47174,7 @@ soap_in_std__vectorTemplateOfPointerTons1__datasetParameter(
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__datasetParameter,
               sizeof(ns1__datasetParameter), 1))
         break;
-      if (!soap_in_PointerTons1__datasetParameter(soap, tag, NULL,
+      if (!soap_in_PointerTons1__datasetParameter(soap, tag, nullptr,
                                                   "ns1:datasetParameter"))
         break;
     } else if (!soap_in_PointerTons1__datasetParameter(soap, tag, &n,
@@ -47109,7 +47183,7 @@ soap_in_std__vectorTemplateOfPointerTons1__datasetParameter(
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__datasetParameter(soap,
                                                                            -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -47119,7 +47193,7 @@ soap_in_std__vectorTemplateOfPointerTons1__datasetParameter(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__datasetParameter *> *SOAP_FMAC2
@@ -47133,11 +47207,11 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__datasetParameter(
                                     "datasetParameter(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL,
+      soap, nullptr,
       SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__datasetParameter, n,
       ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__datasetParameter *>);
     if (size)
@@ -47206,11 +47280,11 @@ soap_in_std__vectorTemplateOfPointerTons1__datafile(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__datafile *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -47218,13 +47292,13 @@ soap_in_std__vectorTemplateOfPointerTons1__datafile(
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__datafile,
               sizeof(ns1__datafile), 1))
         break;
-      if (!soap_in_PointerTons1__datafile(soap, tag, NULL, "ns1:datafile"))
+      if (!soap_in_PointerTons1__datafile(soap, tag, nullptr, "ns1:datafile"))
         break;
     } else if (!soap_in_PointerTons1__datafile(soap, tag, &n, "ns1:datafile"))
       break;
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__datafile(soap, -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -47234,7 +47308,7 @@ soap_in_std__vectorTemplateOfPointerTons1__datafile(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__datafile *> *SOAP_FMAC2
@@ -47247,11 +47321,12 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__datafile(
                                     "vectorTemplateOfPointerTons1__datafile(%d,"
                                     " %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__datafile,
-      n, ICat4_fdelete);
+  struct soap_clist *cp =
+      soap_link(soap, nullptr,
+                SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__datafile, n,
+                ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__datafile *>);
     if (size)
@@ -47323,11 +47398,11 @@ soap_in_std__vectorTemplateOfPointerTons1__dataCollectionParameter(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__dataCollectionParameter *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -47336,7 +47411,7 @@ soap_in_std__vectorTemplateOfPointerTons1__dataCollectionParameter(
               sizeof(ns1__dataCollectionParameter), 1))
         break;
       if (!soap_in_PointerTons1__dataCollectionParameter(
-              soap, tag, NULL, "ns1:dataCollectionParameter"))
+              soap, tag, nullptr, "ns1:dataCollectionParameter"))
         break;
     } else if (!soap_in_PointerTons1__dataCollectionParameter(
                    soap, tag, &n, "ns1:dataCollectionParameter"))
@@ -47344,7 +47419,7 @@ soap_in_std__vectorTemplateOfPointerTons1__dataCollectionParameter(
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__dataCollectionParameter(
               soap, -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -47354,7 +47429,7 @@ soap_in_std__vectorTemplateOfPointerTons1__dataCollectionParameter(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__dataCollectionParameter *> *SOAP_FMAC2
@@ -47368,11 +47443,11 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__dataCollectionParameter(
                                     "dataCollectionParameter(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL,
+      soap, nullptr,
       SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__dataCollectionParameter,
       n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__dataCollectionParameter *>);
     if (size)
@@ -47443,11 +47518,11 @@ soap_in_std__vectorTemplateOfPointerTons1__job(struct soap *soap,
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__job *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -47455,12 +47530,12 @@ soap_in_std__vectorTemplateOfPointerTons1__job(struct soap *soap,
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__job,
               sizeof(ns1__job), 1))
         break;
-      if (!soap_in_PointerTons1__job(soap, tag, NULL, "ns1:job"))
+      if (!soap_in_PointerTons1__job(soap, tag, nullptr, "ns1:job"))
         break;
     } else if (!soap_in_PointerTons1__job(soap, tag, &n, "ns1:job"))
       break;
     if (!a && !(a = soap_new_std__vectorTemplateOfPointerTons1__job(soap, -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -47470,7 +47545,7 @@ soap_in_std__vectorTemplateOfPointerTons1__job(struct soap *soap,
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__job *> *SOAP_FMAC2
@@ -47485,10 +47560,10 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__job(struct soap *soap,
                               "vectorTemplateOfPointerTons1__job(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__job, n,
+      soap, nullptr, SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__job, n,
       ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__job *>);
     if (size)
@@ -47556,11 +47631,11 @@ soap_in_std__vectorTemplateOfPointerTons1__dataCollectionDataset(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__dataCollectionDataset *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -47569,7 +47644,7 @@ soap_in_std__vectorTemplateOfPointerTons1__dataCollectionDataset(
               sizeof(ns1__dataCollectionDataset), 1))
         break;
       if (!soap_in_PointerTons1__dataCollectionDataset(
-              soap, tag, NULL, "ns1:dataCollectionDataset"))
+              soap, tag, nullptr, "ns1:dataCollectionDataset"))
         break;
     } else if (!soap_in_PointerTons1__dataCollectionDataset(
                    soap, tag, &n, "ns1:dataCollectionDataset"))
@@ -47577,7 +47652,7 @@ soap_in_std__vectorTemplateOfPointerTons1__dataCollectionDataset(
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__dataCollectionDataset(
               soap, -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -47587,7 +47662,7 @@ soap_in_std__vectorTemplateOfPointerTons1__dataCollectionDataset(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__dataCollectionDataset *> *SOAP_FMAC2
@@ -47601,11 +47676,11 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__dataCollectionDataset(
                                     "dataCollectionDataset(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL,
+      soap, nullptr,
       SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__dataCollectionDataset,
       n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__dataCollectionDataset *>);
     if (size)
@@ -47677,11 +47752,11 @@ soap_in_std__vectorTemplateOfPointerTons1__datafileParameter(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__datafileParameter *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -47689,7 +47764,7 @@ soap_in_std__vectorTemplateOfPointerTons1__datafileParameter(
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__datafileParameter,
               sizeof(ns1__datafileParameter), 1))
         break;
-      if (!soap_in_PointerTons1__datafileParameter(soap, tag, NULL,
+      if (!soap_in_PointerTons1__datafileParameter(soap, tag, nullptr,
                                                    "ns1:datafileParameter"))
         break;
     } else if (!soap_in_PointerTons1__datafileParameter(
@@ -47698,7 +47773,7 @@ soap_in_std__vectorTemplateOfPointerTons1__datafileParameter(
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__datafileParameter(
               soap, -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -47708,7 +47783,7 @@ soap_in_std__vectorTemplateOfPointerTons1__datafileParameter(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__datafileParameter *> *SOAP_FMAC2
@@ -47722,11 +47797,11 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__datafileParameter(
                                     "datafileParameter(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL,
+      soap, nullptr,
       SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__datafileParameter, n,
       ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__datafileParameter *>);
     if (size)
@@ -47796,11 +47871,11 @@ soap_in_std__vectorTemplateOfPointerTons1__relatedDatafile(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__relatedDatafile *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -47808,7 +47883,7 @@ soap_in_std__vectorTemplateOfPointerTons1__relatedDatafile(
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__relatedDatafile,
               sizeof(ns1__relatedDatafile), 1))
         break;
-      if (!soap_in_PointerTons1__relatedDatafile(soap, tag, NULL,
+      if (!soap_in_PointerTons1__relatedDatafile(soap, tag, nullptr,
                                                  "ns1:relatedDatafile"))
         break;
     } else if (!soap_in_PointerTons1__relatedDatafile(soap, tag, &n,
@@ -47817,7 +47892,7 @@ soap_in_std__vectorTemplateOfPointerTons1__relatedDatafile(
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__relatedDatafile(soap,
                                                                           -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -47827,7 +47902,7 @@ soap_in_std__vectorTemplateOfPointerTons1__relatedDatafile(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__relatedDatafile *> *SOAP_FMAC2
@@ -47841,11 +47916,11 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__relatedDatafile(
                                     "relatedDatafile(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL,
+      soap, nullptr,
       SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__relatedDatafile, n,
       ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__relatedDatafile *>);
     if (size)
@@ -47917,11 +47992,11 @@ soap_in_std__vectorTemplateOfPointerTons1__dataCollectionDatafile(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__dataCollectionDatafile *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -47930,7 +48005,7 @@ soap_in_std__vectorTemplateOfPointerTons1__dataCollectionDatafile(
               sizeof(ns1__dataCollectionDatafile), 1))
         break;
       if (!soap_in_PointerTons1__dataCollectionDatafile(
-              soap, tag, NULL, "ns1:dataCollectionDatafile"))
+              soap, tag, nullptr, "ns1:dataCollectionDatafile"))
         break;
     } else if (!soap_in_PointerTons1__dataCollectionDatafile(
                    soap, tag, &n, "ns1:dataCollectionDatafile"))
@@ -47938,7 +48013,7 @@ soap_in_std__vectorTemplateOfPointerTons1__dataCollectionDatafile(
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__dataCollectionDatafile(
               soap, -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -47948,7 +48023,7 @@ soap_in_std__vectorTemplateOfPointerTons1__dataCollectionDatafile(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__dataCollectionDatafile *> *SOAP_FMAC2
@@ -47962,11 +48037,11 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__dataCollectionDatafile(
                                     "dataCollectionDatafile(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL,
+      soap, nullptr,
       SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__dataCollectionDatafile,
       n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__dataCollectionDatafile *>);
     if (size)
@@ -48037,11 +48112,11 @@ soap_in_std__vectorTemplateOfPointerToxsd__anyType(
   for (soap_flag = 0;; soap_flag = 1) {
     xsd__anyType *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -48049,13 +48124,13 @@ soap_in_std__vectorTemplateOfPointerToxsd__anyType(
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerToxsd__anyType,
               sizeof(xsd__anyType), 1))
         break;
-      if (!soap_in_PointerToxsd__anyType(soap, tag, NULL, "xsd:anyType"))
+      if (!soap_in_PointerToxsd__anyType(soap, tag, nullptr, "xsd:anyType"))
         break;
     } else if (!soap_in_PointerToxsd__anyType(soap, tag, &n, "xsd:anyType"))
       break;
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerToxsd__anyType(soap, -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -48065,7 +48140,7 @@ soap_in_std__vectorTemplateOfPointerToxsd__anyType(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<xsd__anyType *> *SOAP_FMAC2
@@ -48079,10 +48154,10 @@ soap_instantiate_std__vectorTemplateOfPointerToxsd__anyType(
                                     "%s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_std__vectorTemplateOfPointerToxsd__anyType, n,
-      ICat4_fdelete);
+      soap, nullptr, SOAP_TYPE_ICat4_std__vectorTemplateOfPointerToxsd__anyType,
+      n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<xsd__anyType *>);
     if (size)
@@ -48151,11 +48226,11 @@ soap_in_std__vectorTemplateOfPointerTons1__entityField(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__entityField *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -48163,7 +48238,7 @@ soap_in_std__vectorTemplateOfPointerTons1__entityField(
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__entityField,
               sizeof(ns1__entityField), 1))
         break;
-      if (!soap_in_PointerTons1__entityField(soap, tag, NULL,
+      if (!soap_in_PointerTons1__entityField(soap, tag, nullptr,
                                              "ns1:entityField"))
         break;
     } else if (!soap_in_PointerTons1__entityField(soap, tag, &n,
@@ -48172,7 +48247,7 @@ soap_in_std__vectorTemplateOfPointerTons1__entityField(
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__entityField(soap,
                                                                       -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -48182,7 +48257,7 @@ soap_in_std__vectorTemplateOfPointerTons1__entityField(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__entityField *> *SOAP_FMAC2
@@ -48196,11 +48271,11 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__entityField(
                                     "%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL,
+      soap_link(soap, nullptr,
                 SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__entityField,
                 n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__entityField *>);
     if (size)
@@ -48271,11 +48346,11 @@ soap_in_std__vectorTemplateOfPointerTons1__constraint(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__constraint *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -48283,14 +48358,15 @@ soap_in_std__vectorTemplateOfPointerTons1__constraint(
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__constraint,
               sizeof(ns1__constraint), 1))
         break;
-      if (!soap_in_PointerTons1__constraint(soap, tag, NULL, "ns1:constraint"))
+      if (!soap_in_PointerTons1__constraint(soap, tag, nullptr,
+                                            "ns1:constraint"))
         break;
     } else if (!soap_in_PointerTons1__constraint(soap, tag, &n,
                                                  "ns1:constraint"))
       break;
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__constraint(soap, -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -48300,7 +48376,7 @@ soap_in_std__vectorTemplateOfPointerTons1__constraint(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__constraint *> *SOAP_FMAC2
@@ -48313,11 +48389,12 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__constraint(
                                     "vectorTemplateOfPointerTons1__constraint(%"
                                     "d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
-  struct soap_clist *cp = soap_link(
-      soap, NULL, SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__constraint,
-      n, ICat4_fdelete);
+  struct soap_clist *cp =
+      soap_link(soap, nullptr,
+                SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__constraint,
+                n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__constraint *>);
     if (size)
@@ -48389,7 +48466,7 @@ soap_in_std__vectorTemplateOf_ns1__login_credentials_entry(
   for (soap_flag = 0;; soap_flag = 1) {
     _ns1__login_credentials_entry n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
@@ -48401,14 +48478,14 @@ soap_in_std__vectorTemplateOf_ns1__login_credentials_entry(
               SOAP_TYPE_ICat4_std__vectorTemplateOf_ns1__login_credentials_entry,
               sizeof(_ns1__login_credentials_entry), 0))
         break;
-      if (!soap_in__ns1__login_credentials_entry(soap, tag, NULL, ""))
+      if (!soap_in__ns1__login_credentials_entry(soap, tag, nullptr, ""))
         break;
     } else if (!soap_in__ns1__login_credentials_entry(soap, tag, &n, ""))
       break;
     if (!a &&
         !(a = soap_new_std__vectorTemplateOf_ns1__login_credentials_entry(soap,
                                                                           -1)))
-      return NULL;
+      return nullptr;
     soap_update_pointers(soap, (char *)&n, (char *)&n + sizeof(n),
                          (char *)&(*a->insert(a->end(), n)), (char *)&n);
     if (!tag || *tag == '-')
@@ -48419,7 +48496,7 @@ soap_in_std__vectorTemplateOf_ns1__login_credentials_entry(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<_ns1__login_credentials_entry> *SOAP_FMAC2
@@ -48433,11 +48510,11 @@ soap_instantiate_std__vectorTemplateOf_ns1__login_credentials_entry(
                               "login_credentials_entry(%d, %s, %s)\n",
                       n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL,
+      soap, nullptr,
       SOAP_TYPE_ICat4_std__vectorTemplateOf_ns1__login_credentials_entry, n,
       ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<_ns1__login_credentials_entry>);
     if (size)
@@ -48509,7 +48586,7 @@ soap_in_std__vectorTemplateOfstd__string(struct soap *soap, const char *tag,
   for (soap_flag = 0;; soap_flag = 1) {
     std::string n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
@@ -48521,12 +48598,12 @@ soap_in_std__vectorTemplateOfstd__string(struct soap *soap, const char *tag,
               SOAP_TYPE_ICat4_std__vectorTemplateOfstd__string,
               sizeof(std::string), 0))
         break;
-      if (!soap_in_std__string(soap, tag, NULL, "xsd:string"))
+      if (!soap_in_std__string(soap, tag, nullptr, "xsd:string"))
         break;
     } else if (!soap_in_std__string(soap, tag, &n, "xsd:string"))
       break;
     if (!a && !(a = soap_new_std__vectorTemplateOfstd__string(soap, -1)))
-      return NULL;
+      return nullptr;
     soap_update_pointers(soap, (char *)&n, (char *)&n + sizeof(n),
                          (char *)&(*a->insert(a->end(), n)), (char *)&n);
     if (!tag || *tag == '-')
@@ -48537,7 +48614,7 @@ soap_in_std__vectorTemplateOfstd__string(struct soap *soap, const char *tag,
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<std::string> *SOAP_FMAC2
@@ -48553,10 +48630,10 @@ soap_instantiate_std__vectorTemplateOfstd__string(struct soap *soap, int n,
              "soap_instantiate_std__vectorTemplateOfstd__string(%d, %s, %s)\n",
              n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_std__vectorTemplateOfstd__string, n,
-                ICat4_fdelete);
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_std__vectorTemplateOfstd__string,
+                n, ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<std::string>);
     if (size)
@@ -48619,7 +48696,7 @@ soap_in_std__vectorTemplateOfLONG64(struct soap *soap, const char *tag,
   for (soap_flag = 0;; soap_flag = 1) {
     LONG64 n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
@@ -48630,12 +48707,12 @@ soap_in_std__vectorTemplateOfLONG64(struct soap *soap, const char *tag,
               SOAP_TYPE_ICat4_LONG64,
               SOAP_TYPE_ICat4_std__vectorTemplateOfLONG64, sizeof(LONG64), 0))
         break;
-      if (!soap_in_LONG64(soap, tag, NULL, "xsd:long"))
+      if (!soap_in_LONG64(soap, tag, nullptr, "xsd:long"))
         break;
     } else if (!soap_in_LONG64(soap, tag, &n, "xsd:long"))
       break;
     if (!a && !(a = soap_new_std__vectorTemplateOfLONG64(soap, -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -48645,7 +48722,7 @@ soap_in_std__vectorTemplateOfLONG64(struct soap *soap, const char *tag,
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<LONG64> *SOAP_FMAC2
@@ -48660,10 +48737,10 @@ soap_instantiate_std__vectorTemplateOfLONG64(struct soap *soap, int n,
                    "soap_instantiate_std__vectorTemplateOfLONG64(%d, %s, %s)\n",
                    n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp =
-      soap_link(soap, NULL, SOAP_TYPE_ICat4_std__vectorTemplateOfLONG64, n,
+      soap_link(soap, nullptr, SOAP_TYPE_ICat4_std__vectorTemplateOfLONG64, n,
                 ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<LONG64>);
     if (size)
@@ -48730,11 +48807,11 @@ soap_in_std__vectorTemplateOfPointerTons1__entityBaseBean(
   for (soap_flag = 0;; soap_flag = 1) {
     ns1__entityBaseBean *n;
     if (tag && *tag != '-') {
-      if (soap_element_begin_in(soap, tag, 1, NULL))
+      if (soap_element_begin_in(soap, tag, 1, nullptr))
         break;
       soap_revert(soap);
     }
-    n = NULL;
+    n = nullptr;
     if (tag && *tag != '-' && (*soap->id || *soap->href)) {
       if (!soap_container_id_forward(
               soap, *soap->id ? soap->id : soap->href, a, (size_t)a->size(),
@@ -48742,7 +48819,7 @@ soap_in_std__vectorTemplateOfPointerTons1__entityBaseBean(
               SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__entityBaseBean,
               sizeof(ns1__entityBaseBean), 1))
         break;
-      if (!soap_in_PointerTons1__entityBaseBean(soap, tag, NULL,
+      if (!soap_in_PointerTons1__entityBaseBean(soap, tag, nullptr,
                                                 "ns1:entityBaseBean"))
         break;
     } else if (!soap_in_PointerTons1__entityBaseBean(soap, tag, &n,
@@ -48751,7 +48828,7 @@ soap_in_std__vectorTemplateOfPointerTons1__entityBaseBean(
     if (!a &&
         !(a = soap_new_std__vectorTemplateOfPointerTons1__entityBaseBean(soap,
                                                                          -1)))
-      return NULL;
+      return nullptr;
     a->push_back(n);
     if (!tag || *tag == '-')
       return a;
@@ -48761,7 +48838,7 @@ soap_in_std__vectorTemplateOfPointerTons1__entityBaseBean(
     soap->error = SOAP_OK;
     return a;
   }
-  return NULL;
+  return nullptr;
 }
 
 SOAP_FMAC1 std::vector<ns1__entityBaseBean *> *SOAP_FMAC2
@@ -48775,11 +48852,11 @@ soap_instantiate_std__vectorTemplateOfPointerTons1__entityBaseBean(
                                     "entityBaseBean(%d, %s, %s)\n",
                             n, type ? type : "", arrayType ? arrayType : ""));
   struct soap_clist *cp = soap_link(
-      soap, NULL,
+      soap, nullptr,
       SOAP_TYPE_ICat4_std__vectorTemplateOfPointerTons1__entityBaseBean, n,
       ICat4_fdelete);
   if (!cp)
-    return NULL;
+    return nullptr;
   if (n < 0) {
     cp->ptr = (void *)SOAP_NEW(std::vector<ns1__entityBaseBean *>);
     if (size)

--- a/Framework/ICat/src/ICat4/GSoapGenerated/ICat4ICATPortBindingProxy.cpp
+++ b/Framework/ICat/src/ICat4/GSoapGenerated/ICat4ICATPortBindingProxy.cpp
@@ -41,18 +41,18 @@ void ICATPortBindingProxy::ICATPortBindingProxy_init(soap_mode imode,
                                                      soap_mode omode) {
   soap_imode(this, imode);
   soap_omode(this, omode);
-  soap_endpoint = NULL;
+  soap_endpoint = nullptr;
   static const struct Namespace namespaces[] = {
       {"SOAP-ENV", "http://schemas.xmlsoap.org/soap/envelope/",
-       "http://www.w3.org/*/soap-envelope", NULL},
+       "http://www.w3.org/*/soap-envelope", nullptr},
       {"SOAP-ENC", "http://schemas.xmlsoap.org/soap/encoding/",
-       "http://www.w3.org/*/soap-encoding", NULL},
+       "http://www.w3.org/*/soap-encoding", nullptr},
       {"xsi", "http://www.w3.org/2001/XMLSchema-instance",
-       "http://www.w3.org/*/XMLSchema-instance", NULL},
+       "http://www.w3.org/*/XMLSchema-instance", nullptr},
       {"xsd", "http://www.w3.org/2001/XMLSchema",
-       "http://www.w3.org/*/XMLSchema", NULL},
-      {"ns1", "http://icatproject.org", NULL, NULL},
-      {NULL, NULL, NULL, NULL}};
+       "http://www.w3.org/*/XMLSchema", nullptr},
+      {"ns1", "http://icatproject.org", nullptr, nullptr},
+      {nullptr, nullptr, nullptr, nullptr}};
   soap_set_namespaces(this, namespaces);
 }
 
@@ -68,7 +68,7 @@ void ICATPortBindingProxy::reset() {
   ICATPortBindingProxy_init(SOAP_IO_DEFAULT, SOAP_IO_DEFAULT);
 }
 
-void ICATPortBindingProxy::soap_noheader() { this->header = NULL; }
+void ICATPortBindingProxy::soap_noheader() { this->header = nullptr; }
 
 const SOAP_ENV__Header *ICATPortBindingProxy::soap_header() {
   return this->header;
@@ -115,11 +115,11 @@ int ICATPortBindingProxy::login(const char *endpoint, const char *soap_action,
   struct __ns1__login soap_tmp___ns1__login;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://icatisis.esc.rl.ac.uk:443/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "http://icatproject.org/ICAT/loginRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__login.ns1__login_ = ns1__login_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -130,16 +130,17 @@ int ICATPortBindingProxy::login(const char *endpoint, const char *soap_action,
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__login(soap, &soap_tmp___ns1__login, "-ns1:login",
-                              NULL) ||
+                              nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
-      soap_put___ns1__login(soap, &soap_tmp___ns1__login, "-ns1:login", NULL) ||
+      soap_put___ns1__login(soap, &soap_tmp___ns1__login, "-ns1:login",
+                            nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -166,11 +167,11 @@ int ICATPortBindingProxy::getUserName(
   struct __ns1__getUserName soap_tmp___ns1__getUserName;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://icatisis.esc.rl.ac.uk:443/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "http://icatproject.org/ICAT/getUserNameRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getUserName.ns1__getUserName_ = ns1__getUserName_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -181,17 +182,17 @@ int ICATPortBindingProxy::getUserName(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__getUserName(soap, &soap_tmp___ns1__getUserName,
-                                    "-ns1:getUserName", NULL) ||
+                                    "-ns1:getUserName", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getUserName(soap, &soap_tmp___ns1__getUserName,
-                                  "-ns1:getUserName", NULL) ||
+                                  "-ns1:getUserName", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -218,11 +219,11 @@ int ICATPortBindingProxy::get(const char *endpoint, const char *soap_action,
   struct __ns1__get soap_tmp___ns1__get;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://icatisis.esc.rl.ac.uk:443/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "http://icatproject.org/ICAT/getRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__get.ns1__get_ = ns1__get_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -232,16 +233,16 @@ int ICATPortBindingProxy::get(const char *endpoint, const char *soap_action,
   if (soap->mode & SOAP_IO_LENGTH) {
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
-        soap_put___ns1__get(soap, &soap_tmp___ns1__get, "-ns1:get", NULL) ||
+        soap_put___ns1__get(soap, &soap_tmp___ns1__get, "-ns1:get", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
-      soap_put___ns1__get(soap, &soap_tmp___ns1__get, "-ns1:get", NULL) ||
+      soap_put___ns1__get(soap, &soap_tmp___ns1__get, "-ns1:get", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -268,11 +269,11 @@ int ICATPortBindingProxy::getProperties(
   struct __ns1__getProperties soap_tmp___ns1__getProperties;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://icatisis.esc.rl.ac.uk:443/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "http://icatproject.org/ICAT/getPropertiesRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getProperties.ns1__getProperties_ = ns1__getProperties_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -283,17 +284,17 @@ int ICATPortBindingProxy::getProperties(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__getProperties(soap, &soap_tmp___ns1__getProperties,
-                                      "-ns1:getProperties", NULL) ||
+                                      "-ns1:getProperties", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getProperties(soap, &soap_tmp___ns1__getProperties,
-                                    "-ns1:getProperties", NULL) ||
+                                    "-ns1:getProperties", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -321,11 +322,11 @@ int ICATPortBindingProxy::delete_(const char *endpoint, const char *soap_action,
   struct __ns1__deleteResponse *soap_tmp___ns1__deleteResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://icatisis.esc.rl.ac.uk:443/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "http://icatproject.org/ICAT/deleteRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__delete.ns1__delete_ = ns1__delete_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -336,17 +337,17 @@ int ICATPortBindingProxy::delete_(const char *endpoint, const char *soap_action,
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__delete(soap, &soap_tmp___ns1__delete, "-ns1:delete",
-                               NULL) ||
+                               nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__delete(soap, &soap_tmp___ns1__delete, "-ns1:delete",
-                             NULL) ||
+                             nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -357,7 +358,7 @@ int ICATPortBindingProxy::delete_(const char *endpoint, const char *soap_action,
       soap_recv_header(soap) || soap_body_begin_in(soap))
     return soap_closesock(soap);
   soap_tmp___ns1__deleteResponse = soap_get___ns1__deleteResponse(
-      soap, NULL, "-ns1:deleteResponse", "ns1:deleteResponse");
+      soap, nullptr, "-ns1:deleteResponse", "ns1:deleteResponse");
   if (!soap_tmp___ns1__deleteResponse || soap->error)
     return soap_recv_fault(soap, 0);
   if (soap_body_end_in(soap) || soap_envelope_end_in(soap) ||
@@ -377,11 +378,11 @@ int ICATPortBindingProxy::search(const char *endpoint, const char *soap_action,
   struct __ns1__search soap_tmp___ns1__search;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://icatisis.esc.rl.ac.uk:443/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "http://icatproject.org/ICAT/searchRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__search.ns1__search_ = ns1__search_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -392,17 +393,17 @@ int ICATPortBindingProxy::search(const char *endpoint, const char *soap_action,
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__search(soap, &soap_tmp___ns1__search, "-ns1:search",
-                               NULL) ||
+                               nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__search(soap, &soap_tmp___ns1__search, "-ns1:search",
-                             NULL) ||
+                             nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -429,11 +430,11 @@ int ICATPortBindingProxy::create(const char *endpoint, const char *soap_action,
   struct __ns1__create soap_tmp___ns1__create;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://icatisis.esc.rl.ac.uk:443/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "http://icatproject.org/ICAT/createRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__create.ns1__create_ = ns1__create_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -444,17 +445,17 @@ int ICATPortBindingProxy::create(const char *endpoint, const char *soap_action,
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__create(soap, &soap_tmp___ns1__create, "-ns1:create",
-                               NULL) ||
+                               nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__create(soap, &soap_tmp___ns1__create, "-ns1:create",
-                             NULL) ||
+                             nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -482,11 +483,11 @@ int ICATPortBindingProxy::update(const char *endpoint, const char *soap_action,
   struct __ns1__updateResponse *soap_tmp___ns1__updateResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://icatisis.esc.rl.ac.uk:443/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "http://icatproject.org/ICAT/updateRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__update.ns1__update_ = ns1__update_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -497,17 +498,17 @@ int ICATPortBindingProxy::update(const char *endpoint, const char *soap_action,
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__update(soap, &soap_tmp___ns1__update, "-ns1:update",
-                               NULL) ||
+                               nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__update(soap, &soap_tmp___ns1__update, "-ns1:update",
-                             NULL) ||
+                             nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -518,7 +519,7 @@ int ICATPortBindingProxy::update(const char *endpoint, const char *soap_action,
       soap_recv_header(soap) || soap_body_begin_in(soap))
     return soap_closesock(soap);
   soap_tmp___ns1__updateResponse = soap_get___ns1__updateResponse(
-      soap, NULL, "-ns1:updateResponse", "ns1:updateResponse");
+      soap, nullptr, "-ns1:updateResponse", "ns1:updateResponse");
   if (!soap_tmp___ns1__updateResponse || soap->error)
     return soap_recv_fault(soap, 0);
   if (soap_body_end_in(soap) || soap_envelope_end_in(soap) ||
@@ -539,11 +540,11 @@ int ICATPortBindingProxy::getApiVersion(
   struct __ns1__getApiVersion soap_tmp___ns1__getApiVersion;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://icatisis.esc.rl.ac.uk:443/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "http://icatproject.org/ICAT/getApiVersionRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getApiVersion.ns1__getApiVersion_ = ns1__getApiVersion_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -554,17 +555,17 @@ int ICATPortBindingProxy::getApiVersion(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__getApiVersion(soap, &soap_tmp___ns1__getApiVersion,
-                                      "-ns1:getApiVersion", NULL) ||
+                                      "-ns1:getApiVersion", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getApiVersion(soap, &soap_tmp___ns1__getApiVersion,
-                                    "-ns1:getApiVersion", NULL) ||
+                                    "-ns1:getApiVersion", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -592,11 +593,11 @@ int ICATPortBindingProxy::getEntityNames(
   struct __ns1__getEntityNames soap_tmp___ns1__getEntityNames;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://icatisis.esc.rl.ac.uk:443/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "http://icatproject.org/ICAT/getEntityNamesRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getEntityNames.ns1__getEntityNames_ = ns1__getEntityNames_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -607,17 +608,17 @@ int ICATPortBindingProxy::getEntityNames(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__getEntityNames(soap, &soap_tmp___ns1__getEntityNames,
-                                       "-ns1:getEntityNames", NULL) ||
+                                       "-ns1:getEntityNames", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getEntityNames(soap, &soap_tmp___ns1__getEntityNames,
-                                     "-ns1:getEntityNames", NULL) ||
+                                     "-ns1:getEntityNames", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -645,11 +646,11 @@ int ICATPortBindingProxy::refresh(const char *endpoint, const char *soap_action,
   struct __ns1__refreshResponse *soap_tmp___ns1__refreshResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://icatisis.esc.rl.ac.uk:443/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "http://icatproject.org/ICAT/refreshRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__refresh.ns1__refresh_ = ns1__refresh_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -660,17 +661,17 @@ int ICATPortBindingProxy::refresh(const char *endpoint, const char *soap_action,
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__refresh(soap, &soap_tmp___ns1__refresh, "-ns1:refresh",
-                                NULL) ||
+                                nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__refresh(soap, &soap_tmp___ns1__refresh, "-ns1:refresh",
-                              NULL) ||
+                              nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -681,7 +682,7 @@ int ICATPortBindingProxy::refresh(const char *endpoint, const char *soap_action,
       soap_recv_header(soap) || soap_body_begin_in(soap))
     return soap_closesock(soap);
   soap_tmp___ns1__refreshResponse = soap_get___ns1__refreshResponse(
-      soap, NULL, "-ns1:refreshResponse", "ns1:refreshResponse");
+      soap, nullptr, "-ns1:refreshResponse", "ns1:refreshResponse");
   if (!soap_tmp___ns1__refreshResponse || soap->error)
     return soap_recv_fault(soap, 0);
   if (soap_body_end_in(soap) || soap_envelope_end_in(soap) ||
@@ -702,11 +703,11 @@ int ICATPortBindingProxy::dummy(const char *endpoint, const char *soap_action,
   struct __ns1__dummyResponse *soap_tmp___ns1__dummyResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://icatisis.esc.rl.ac.uk:443/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "http://icatproject.org/ICAT/dummyRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__dummy.ns1__dummy_ = ns1__dummy_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -717,16 +718,17 @@ int ICATPortBindingProxy::dummy(const char *endpoint, const char *soap_action,
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__dummy(soap, &soap_tmp___ns1__dummy, "-ns1:dummy",
-                              NULL) ||
+                              nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
-      soap_put___ns1__dummy(soap, &soap_tmp___ns1__dummy, "-ns1:dummy", NULL) ||
+      soap_put___ns1__dummy(soap, &soap_tmp___ns1__dummy, "-ns1:dummy",
+                            nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -737,7 +739,7 @@ int ICATPortBindingProxy::dummy(const char *endpoint, const char *soap_action,
       soap_recv_header(soap) || soap_body_begin_in(soap))
     return soap_closesock(soap);
   soap_tmp___ns1__dummyResponse = soap_get___ns1__dummyResponse(
-      soap, NULL, "-ns1:dummyResponse", "ns1:dummyResponse");
+      soap, nullptr, "-ns1:dummyResponse", "ns1:dummyResponse");
   if (!soap_tmp___ns1__dummyResponse || soap->error)
     return soap_recv_fault(soap, 0);
   if (soap_body_end_in(soap) || soap_envelope_end_in(soap) ||
@@ -756,11 +758,11 @@ int ICATPortBindingProxy::logout(const char *endpoint, const char *soap_action,
   struct __ns1__logoutResponse *soap_tmp___ns1__logoutResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://icatisis.esc.rl.ac.uk:443/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "http://icatproject.org/ICAT/logoutRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__logout.ns1__logout_ = ns1__logout_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -771,17 +773,17 @@ int ICATPortBindingProxy::logout(const char *endpoint, const char *soap_action,
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__logout(soap, &soap_tmp___ns1__logout, "-ns1:logout",
-                               NULL) ||
+                               nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__logout(soap, &soap_tmp___ns1__logout, "-ns1:logout",
-                             NULL) ||
+                             nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -792,7 +794,7 @@ int ICATPortBindingProxy::logout(const char *endpoint, const char *soap_action,
       soap_recv_header(soap) || soap_body_begin_in(soap))
     return soap_closesock(soap);
   soap_tmp___ns1__logoutResponse = soap_get___ns1__logoutResponse(
-      soap, NULL, "-ns1:logoutResponse", "ns1:logoutResponse");
+      soap, nullptr, "-ns1:logoutResponse", "ns1:logoutResponse");
   if (!soap_tmp___ns1__logoutResponse || soap->error)
     return soap_recv_fault(soap, 0);
   if (soap_body_end_in(soap) || soap_envelope_end_in(soap) ||
@@ -813,11 +815,11 @@ int ICATPortBindingProxy::getRemainingMinutes(
   struct __ns1__getRemainingMinutes soap_tmp___ns1__getRemainingMinutes;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://icatisis.esc.rl.ac.uk:443/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "http://icatproject.org/ICAT/getRemainingMinutesRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getRemainingMinutes.ns1__getRemainingMinutes_ =
       ns1__getRemainingMinutes_;
   soap_begin(soap);
@@ -831,18 +833,18 @@ int ICATPortBindingProxy::getRemainingMinutes(
         soap_body_begin_out(soap) ||
         soap_put___ns1__getRemainingMinutes(
             soap, &soap_tmp___ns1__getRemainingMinutes,
-            "-ns1:getRemainingMinutes", NULL) ||
+            "-ns1:getRemainingMinutes", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
-      soap_put___ns1__getRemainingMinutes(soap,
-                                          &soap_tmp___ns1__getRemainingMinutes,
-                                          "-ns1:getRemainingMinutes", NULL) ||
+      soap_put___ns1__getRemainingMinutes(
+          soap, &soap_tmp___ns1__getRemainingMinutes,
+          "-ns1:getRemainingMinutes", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -871,11 +873,11 @@ int ICATPortBindingProxy::searchText(
   struct __ns1__searchText soap_tmp___ns1__searchText;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://icatisis.esc.rl.ac.uk:443/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "http://icatproject.org/ICAT/searchTextRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__searchText.ns1__searchText_ = ns1__searchText_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -886,17 +888,17 @@ int ICATPortBindingProxy::searchText(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__searchText(soap, &soap_tmp___ns1__searchText,
-                                   "-ns1:searchText", NULL) ||
+                                   "-ns1:searchText", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__searchText(soap, &soap_tmp___ns1__searchText,
-                                 "-ns1:searchText", NULL) ||
+                                 "-ns1:searchText", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -924,11 +926,11 @@ int ICATPortBindingProxy::isAccessAllowed(
   struct __ns1__isAccessAllowed soap_tmp___ns1__isAccessAllowed;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://icatisis.esc.rl.ac.uk:443/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "http://icatproject.org/ICAT/isAccessAllowedRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__isAccessAllowed.ns1__isAccessAllowed_ = ns1__isAccessAllowed_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -939,17 +941,17 @@ int ICATPortBindingProxy::isAccessAllowed(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__isAccessAllowed(soap, &soap_tmp___ns1__isAccessAllowed,
-                                        "-ns1:isAccessAllowed", NULL) ||
+                                        "-ns1:isAccessAllowed", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__isAccessAllowed(soap, &soap_tmp___ns1__isAccessAllowed,
-                                      "-ns1:isAccessAllowed", NULL) ||
+                                      "-ns1:isAccessAllowed", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -978,11 +980,11 @@ int ICATPortBindingProxy::lucenePopulate(
   struct __ns1__lucenePopulateResponse *soap_tmp___ns1__lucenePopulateResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://icatisis.esc.rl.ac.uk:443/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "http://icatproject.org/ICAT/lucenePopulateRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__lucenePopulate.ns1__lucenePopulate_ = ns1__lucenePopulate_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -993,17 +995,17 @@ int ICATPortBindingProxy::lucenePopulate(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__lucenePopulate(soap, &soap_tmp___ns1__lucenePopulate,
-                                       "-ns1:lucenePopulate", NULL) ||
+                                       "-ns1:lucenePopulate", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__lucenePopulate(soap, &soap_tmp___ns1__lucenePopulate,
-                                     "-ns1:lucenePopulate", NULL) ||
+                                     "-ns1:lucenePopulate", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -1014,7 +1016,7 @@ int ICATPortBindingProxy::lucenePopulate(
       soap_recv_header(soap) || soap_body_begin_in(soap))
     return soap_closesock(soap);
   soap_tmp___ns1__lucenePopulateResponse =
-      soap_get___ns1__lucenePopulateResponse(soap, NULL,
+      soap_get___ns1__lucenePopulateResponse(soap, nullptr,
                                              "-ns1:lucenePopulateResponse",
                                              "ns1:lucenePopulateResponse");
   if (!soap_tmp___ns1__lucenePopulateResponse || soap->error)
@@ -1038,11 +1040,11 @@ int ICATPortBindingProxy::luceneClear(
   struct __ns1__luceneClearResponse *soap_tmp___ns1__luceneClearResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://icatisis.esc.rl.ac.uk:443/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "http://icatproject.org/ICAT/luceneClearRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__luceneClear.ns1__luceneClear_ = ns1__luceneClear_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -1053,17 +1055,17 @@ int ICATPortBindingProxy::luceneClear(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__luceneClear(soap, &soap_tmp___ns1__luceneClear,
-                                    "-ns1:luceneClear", NULL) ||
+                                    "-ns1:luceneClear", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__luceneClear(soap, &soap_tmp___ns1__luceneClear,
-                                  "-ns1:luceneClear", NULL) ||
+                                  "-ns1:luceneClear", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -1074,7 +1076,7 @@ int ICATPortBindingProxy::luceneClear(
       soap_recv_header(soap) || soap_body_begin_in(soap))
     return soap_closesock(soap);
   soap_tmp___ns1__luceneClearResponse = soap_get___ns1__luceneClearResponse(
-      soap, NULL, "-ns1:luceneClearResponse", "ns1:luceneClearResponse");
+      soap, nullptr, "-ns1:luceneClearResponse", "ns1:luceneClearResponse");
   if (!soap_tmp___ns1__luceneClearResponse || soap->error)
     return soap_recv_fault(soap, 0);
   if (soap_body_end_in(soap) || soap_envelope_end_in(soap) ||
@@ -1096,11 +1098,11 @@ int ICATPortBindingProxy::luceneCommit(
   struct __ns1__luceneCommitResponse *soap_tmp___ns1__luceneCommitResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://icatisis.esc.rl.ac.uk:443/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "http://icatproject.org/ICAT/luceneCommitRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__luceneCommit.ns1__luceneCommit_ = ns1__luceneCommit_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -1111,17 +1113,17 @@ int ICATPortBindingProxy::luceneCommit(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__luceneCommit(soap, &soap_tmp___ns1__luceneCommit,
-                                     "-ns1:luceneCommit", NULL) ||
+                                     "-ns1:luceneCommit", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__luceneCommit(soap, &soap_tmp___ns1__luceneCommit,
-                                   "-ns1:luceneCommit", NULL) ||
+                                   "-ns1:luceneCommit", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -1132,7 +1134,7 @@ int ICATPortBindingProxy::luceneCommit(
       soap_recv_header(soap) || soap_body_begin_in(soap))
     return soap_closesock(soap);
   soap_tmp___ns1__luceneCommitResponse = soap_get___ns1__luceneCommitResponse(
-      soap, NULL, "-ns1:luceneCommitResponse", "ns1:luceneCommitResponse");
+      soap, nullptr, "-ns1:luceneCommitResponse", "ns1:luceneCommitResponse");
   if (!soap_tmp___ns1__luceneCommitResponse || soap->error)
     return soap_recv_fault(soap, 0);
   if (soap_body_end_in(soap) || soap_envelope_end_in(soap) ||
@@ -1153,11 +1155,11 @@ int ICATPortBindingProxy::luceneSearch(
   struct __ns1__luceneSearch soap_tmp___ns1__luceneSearch;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://icatisis.esc.rl.ac.uk:443/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "http://icatproject.org/ICAT/luceneSearchRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__luceneSearch.ns1__luceneSearch_ = ns1__luceneSearch_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -1168,17 +1170,17 @@ int ICATPortBindingProxy::luceneSearch(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__luceneSearch(soap, &soap_tmp___ns1__luceneSearch,
-                                     "-ns1:luceneSearch", NULL) ||
+                                     "-ns1:luceneSearch", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__luceneSearch(soap, &soap_tmp___ns1__luceneSearch,
-                                   "-ns1:luceneSearch", NULL) ||
+                                   "-ns1:luceneSearch", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -1206,11 +1208,11 @@ int ICATPortBindingProxy::luceneGetPopulating(
   struct __ns1__luceneGetPopulating soap_tmp___ns1__luceneGetPopulating;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://icatisis.esc.rl.ac.uk:443/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "http://icatproject.org/ICAT/luceneGetPopulatingRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__luceneGetPopulating.ns1__luceneGetPopulating_ =
       ns1__luceneGetPopulating_;
   soap_begin(soap);
@@ -1224,18 +1226,18 @@ int ICATPortBindingProxy::luceneGetPopulating(
         soap_body_begin_out(soap) ||
         soap_put___ns1__luceneGetPopulating(
             soap, &soap_tmp___ns1__luceneGetPopulating,
-            "-ns1:luceneGetPopulating", NULL) ||
+            "-ns1:luceneGetPopulating", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
-      soap_put___ns1__luceneGetPopulating(soap,
-                                          &soap_tmp___ns1__luceneGetPopulating,
-                                          "-ns1:luceneGetPopulating", NULL) ||
+      soap_put___ns1__luceneGetPopulating(
+          soap, &soap_tmp___ns1__luceneGetPopulating,
+          "-ns1:luceneGetPopulating", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -1264,11 +1266,11 @@ int ICATPortBindingProxy::createMany(
   struct __ns1__createMany soap_tmp___ns1__createMany;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://icatisis.esc.rl.ac.uk:443/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "http://icatproject.org/ICAT/createManyRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__createMany.ns1__createMany_ = ns1__createMany_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -1279,17 +1281,17 @@ int ICATPortBindingProxy::createMany(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__createMany(soap, &soap_tmp___ns1__createMany,
-                                   "-ns1:createMany", NULL) ||
+                                   "-ns1:createMany", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__createMany(soap, &soap_tmp___ns1__createMany,
-                                 "-ns1:createMany", NULL) ||
+                                 "-ns1:createMany", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -1318,11 +1320,11 @@ int ICATPortBindingProxy::deleteMany(
   struct __ns1__deleteManyResponse *soap_tmp___ns1__deleteManyResponse;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://icatisis.esc.rl.ac.uk:443/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "http://icatproject.org/ICAT/deleteManyRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__deleteMany.ns1__deleteMany_ = ns1__deleteMany_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -1333,17 +1335,17 @@ int ICATPortBindingProxy::deleteMany(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__deleteMany(soap, &soap_tmp___ns1__deleteMany,
-                                   "-ns1:deleteMany", NULL) ||
+                                   "-ns1:deleteMany", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__deleteMany(soap, &soap_tmp___ns1__deleteMany,
-                                 "-ns1:deleteMany", NULL) ||
+                                 "-ns1:deleteMany", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);
@@ -1354,7 +1356,7 @@ int ICATPortBindingProxy::deleteMany(
       soap_recv_header(soap) || soap_body_begin_in(soap))
     return soap_closesock(soap);
   soap_tmp___ns1__deleteManyResponse = soap_get___ns1__deleteManyResponse(
-      soap, NULL, "-ns1:deleteManyResponse", "ns1:deleteManyResponse");
+      soap, nullptr, "-ns1:deleteManyResponse", "ns1:deleteManyResponse");
   if (!soap_tmp___ns1__deleteManyResponse || soap->error)
     return soap_recv_fault(soap, 0);
   if (soap_body_end_in(soap) || soap_envelope_end_in(soap) ||
@@ -1375,11 +1377,11 @@ int ICATPortBindingProxy::getEntityInfo(
   struct __ns1__getEntityInfo soap_tmp___ns1__getEntityInfo;
   if (endpoint)
     soap_endpoint = endpoint;
-  if (soap_endpoint == NULL)
+  if (soap_endpoint == nullptr)
     soap_endpoint = "https://icatisis.esc.rl.ac.uk:443/ICATService/ICAT";
-  if (soap_action == NULL)
+  if (soap_action == nullptr)
     soap_action = "http://icatproject.org/ICAT/getEntityInfoRequest";
-  soap->encodingStyle = NULL;
+  soap->encodingStyle = nullptr;
   soap_tmp___ns1__getEntityInfo.ns1__getEntityInfo_ = ns1__getEntityInfo_;
   soap_begin(soap);
   soap_serializeheader(soap);
@@ -1390,17 +1392,17 @@ int ICATPortBindingProxy::getEntityInfo(
     if (soap_envelope_begin_out(soap) || soap_putheader(soap) ||
         soap_body_begin_out(soap) ||
         soap_put___ns1__getEntityInfo(soap, &soap_tmp___ns1__getEntityInfo,
-                                      "-ns1:getEntityInfo", NULL) ||
+                                      "-ns1:getEntityInfo", nullptr) ||
         soap_body_end_out(soap) || soap_envelope_end_out(soap))
       return soap->error;
   }
   if (soap_end_count(soap))
     return soap->error;
-  if (soap_connect(soap, soap_url(soap, soap_endpoint, NULL), soap_action) ||
+  if (soap_connect(soap, soap_url(soap, soap_endpoint, nullptr), soap_action) ||
       soap_envelope_begin_out(soap) || soap_putheader(soap) ||
       soap_body_begin_out(soap) ||
       soap_put___ns1__getEntityInfo(soap, &soap_tmp___ns1__getEntityInfo,
-                                    "-ns1:getEntityInfo", NULL) ||
+                                    "-ns1:getEntityInfo", nullptr) ||
       soap_body_end_out(soap) || soap_envelope_end_out(soap) ||
       soap_end_send(soap))
     return soap_closesock(soap);

--- a/Framework/MDAlgorithms/test/LoadDNSSCDTest.h
+++ b/Framework/MDAlgorithms/test/LoadDNSSCDTest.h
@@ -204,7 +204,7 @@ public:
             outWSName));
     TS_ASSERT(iws);
 
-    std::vector<API::IMDNode *> boxes(0, NULL);
+    std::vector<API::IMDNode *> boxes(0, nullptr);
     iws->getBoxes(boxes, 10000, false);
     TSM_ASSERT_EQUALS("Number of boxes", boxes.size(), 1);
     API::IMDNode *box = boxes[0];
@@ -332,7 +332,7 @@ public:
             normWSName));
     TS_ASSERT(nws);
 
-    std::vector<API::IMDNode *> boxes(0, NULL);
+    std::vector<API::IMDNode *> boxes(0, nullptr);
     nws->getBoxes(boxes, 10000, false);
     TSM_ASSERT_EQUALS("Number of boxes", boxes.size(), 1);
     API::IMDNode *box = boxes[0];
@@ -418,7 +418,7 @@ public:
             normWSName));
     TS_ASSERT(nws);
 
-    std::vector<API::IMDNode *> boxes(0, NULL);
+    std::vector<API::IMDNode *> boxes(0, nullptr);
     nws->getBoxes(boxes, 10000, false);
     TSM_ASSERT_EQUALS("Number of boxes", boxes.size(), 1);
     API::IMDNode *box = boxes[0];
@@ -601,7 +601,7 @@ public:
             outWSName));
     TS_ASSERT(iws);
 
-    std::vector<API::IMDNode *> boxes(0, NULL);
+    std::vector<API::IMDNode *> boxes(0, nullptr);
     iws->getBoxes(boxes, 10000, false);
     TSM_ASSERT_EQUALS("Number of boxes", boxes.size(), 1);
     API::IMDNode *box = boxes[0];

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -339,7 +339,7 @@ void ApplicationWindow::init(bool factorySettings, const QStringList &args) {
   setAttribute(Qt::WA_DeleteOnClose);
 
 #ifdef SHARED_MENUBAR
-  m_sharedMenuBar = new QMenuBar(NULL);
+  m_sharedMenuBar = new QMenuBar(nullptr);
   m_sharedMenuBar->setNativeMenuBar(true);
 #endif
   setWindowTitle(tr("MantidPlot - untitled")); // Mantid
@@ -893,7 +893,7 @@ void ApplicationWindow::initGlobalConstants() {
 
 QMenuBar *ApplicationWindow::myMenuBar() {
 #ifdef SHARED_MENUBAR
-  return m_sharedMenuBar == NULL ? menuBar() : m_sharedMenuBar;
+  return m_sharedMenuBar == nullptr ? menuBar() : m_sharedMenuBar;
 #else
   return menuBar();
 #endif

--- a/MantidPlot/src/Process.cpp
+++ b/MantidPlot/src/Process.cpp
@@ -133,7 +133,7 @@ bool isAnotherInstanceRunning() {
   void *memory{nullptr};
   while (attempts-- > 0) {
     size_t size = 0;
-    if (sysctl((int *)sysctlQuery, 3, NULL, &size, NULL, 0) == -1) {
+    if (sysctl((int *)sysctlQuery, 3, nullptr, &size, nullptr, 0) == -1) {
       throw std::runtime_error("Unable to retrieve process list");
     }
     const size_t size2 =
@@ -150,7 +150,7 @@ bool isAnotherInstanceRunning() {
     if (memory == nullptr)
       throw std::runtime_error(
           "Unable to allocate memory to retrieve process list");
-    if (sysctl((int *)sysctlQuery, 3, memory, &size, NULL, 0) == -1) {
+    if (sysctl((int *)sysctlQuery, 3, memory, &size, nullptr, 0) == -1) {
       free(memory);
       throw std::runtime_error("Unable to retrieve process list");
     } else {

--- a/qt/widgets/common/src/DropEventHelper.cpp
+++ b/qt/widgets/common/src/DropEventHelper.cpp
@@ -34,7 +34,7 @@ QUrl fixupURL(const QUrl &url) {
         kCFAllocatorDefault, relCFStringRef, kCFURLPOSIXPathStyle,
         false // isDirectory
         );
-    CFErrorRef error = 0;
+    CFErrorRef error = nullptr;
     CFURLRef absCFURL =
         CFURLCreateFilePathURL(kCFAllocatorDefault, relCFURL, &error);
     if (!error) {

--- a/qt/widgets/common/src/InterfaceManager.cpp
+++ b/qt/widgets/common/src/InterfaceManager.cpp
@@ -83,7 +83,7 @@ AlgorithmDialog *InterfaceManager::createDialog(
   // Work around to ensure that floating windows remain on top of the main
   // application window, but below other applications on Mac
   // Note: Qt::Tool cannot have both a max and min button on OSX
-  flags = 0;
+  flags = nullptr;
   flags |= Qt::Tool;
   flags |= Qt::CustomizeWindowHint;
   flags |= Qt::WindowMinimizeButtonHint;

--- a/qt/widgets/common/src/InterfaceManager.cpp
+++ b/qt/widgets/common/src/InterfaceManager.cpp
@@ -83,7 +83,7 @@ AlgorithmDialog *InterfaceManager::createDialog(
   // Work around to ensure that floating windows remain on top of the main
   // application window, but below other applications on Mac
   // Note: Qt::Tool cannot have both a max and min button on OSX
-  flags = nullptr;
+  flags = 0; // NOLINT
   flags |= Qt::Tool;
   flags |= Qt::CustomizeWindowHint;
   flags |= Qt::WindowMinimizeButtonHint;

--- a/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
@@ -1535,7 +1535,7 @@ void DetectorPlotController::savePlotToWorkspace() {
         actor.sumDetectors(dets, x, y);
         unitX = parentWorkspace->getAxis(0)->unit()->unitID();
       } else {
-        QMessageBox::warning(NULL, "MantidPlot - Warning",
+        QMessageBox::warning(nullptr, "MantidPlot - Warning",
                              "Cannot save the stored curves.\nOnly the current "
                              "curve will be saved.");
       }
@@ -1561,7 +1561,7 @@ void DetectorPlotController::savePlotToWorkspace() {
     }
     if (!x.empty()) {
       if (nbins > 0 && x.size() != nbins) {
-        QMessageBox::critical(NULL, "MantidPlot - Error",
+        QMessageBox::critical(nullptr, "MantidPlot - Error",
                               "Curves have different sizes.");
         return;
       } else {

--- a/qt/widgets/instrumentview/src/RotationSurface.cpp
+++ b/qt/widgets/instrumentview/src/RotationSurface.cpp
@@ -211,7 +211,7 @@ void RotationSurface::findAndCorrectUGap() {
   double bin_width = fabs(m_u_max - m_u_min) / (nbins - 1);
   if (bin_width == 0.0) {
     QApplication::setOverrideCursor(QCursor(Qt::ArrowCursor));
-    QMessageBox::warning(NULL, tr("MantidPLot - Instrument view error"),
+    QMessageBox::warning(nullptr, tr("MantidPLot - Instrument view error"),
                          tr("Failed to build unwrapped surface"));
     QApplication::restoreOverrideCursor();
     m_u_min = 0.0;


### PR DESCRIPTION
**Description of work.**
Fixes the clang-tidy warnings for uses of `NULL` in favour of `nullptr` in the code base.

**To test:**

 - Code review
 - Builds pass

_No associated issue_

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
