### PR TITLE
Enable archive search in system tests

### DIFF
--- a/Testing/SystemTests/lib/systemtests/stresstesting.py
+++ b/Testing/SystemTests/lib/systemtests/stresstesting.py
@@ -778,7 +778,7 @@ class TestManager(object):
         for suite in self._tests[self._lastTestRun:]:
             suite.setOutputMsg(reason)
             suite.reportResults(self._reporters) # just let people know you were skipped
-         
+
     def loadTestsFromDir(self, test_dir):
         ''' Load all of the tests defined in the given directory'''
         entries = os.listdir(test_dir)
@@ -945,7 +945,7 @@ class MantidFrameworkConfig:
 
         # Do not update instrument definitions
         config['UpdateInstrumentDefinitions.OnStartup'] = "0"
-        
+
         # Do not perform a version check
         config['CheckMantidVersion.OnStartup'] = "0"
 
@@ -954,10 +954,11 @@ class MantidFrameworkConfig:
 
         # Case insensitive
         config['filefinder.casesensitive'] = 'Off'
-        
+
         # datasearch
         if self.__datasearch:
-            config["datasearch.searcharchive"] = 'On'
+            # turn on for 'all' facilties, 'on' is only for default facility
+            config["datasearch.searcharchive"] = 'all'
             config['network.default.timeout'] = '5'
 
         # Save this configuration


### PR DESCRIPTION
A change in #21089 meant that archive searching was only getting turned
on for the default facility. This restores the old behavior that for
system tests, archive searching can be turned on for all facilities.

This should re-enable the ability for [master_systemtests-ornl](http://builds.mantidproject.org/view/Master%20Pipeline/job/master_systemtests-ornl/) to look for mounted files.

**To test:**

The issue was found when 
```shell
./systemtest --archivesearch -R SNAPRedux
```
failed to find files. This makes that test run again.

*There is no associated issue.*

*This does not need to be in the release notes* because it only affects searching for files (that aren't from ISIS) when running system tests.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
