### PR TITLE
Progress indicator works correctly for errors and exec

### DIFF
--- a/qt/python/mantidqt/widgets/codeeditor/interpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/interpreter.py
@@ -232,10 +232,7 @@ class PythonFileInterpreterPresenter(QObject):
         else:
             code_str = editor.text()
             line_from = 0
-        # Pad code out with empty lines so that reported line numbers
-        # do not have to be adjusted
-        padded = '\n'*line_from + code_str
-        return padded, line_from
+        return code_str, line_from
 
     def _on_exec_success(self, task_result):
         self.view.editor.updateCompletionAPI(self.model.generate_calltips())
@@ -245,9 +242,9 @@ class PythonFileInterpreterPresenter(QObject):
         exc_type, exc_value, exc_stack = task_error.exc_type, task_error.exc_value, \
                                          task_error.stack
         if hasattr(exc_value, 'lineno'):
-            lineno = exc_value.lineno
+            lineno = exc_value.lineno + self._code_start_offset
         elif exc_stack is not None:
-            lineno = exc_stack[-1][1]
+            lineno = exc_stack[-1][1] + self._code_start_offset
         else:
             lineno = -1
         sys.stderr.write(self._error_formatter.format(exc_type, exc_value, exc_stack) + '\n')


### PR DESCRIPTION
**Description of work.**

The progress indicator in the workbench would not show the correct line number when executing a script selection, see issue for an example.

This issue was introduded when fixing the progress indicator for errors -  see https://github.com/mantidproject/mantid/pull/22491.

**To test:**

Functional testing - try out different combinations of executing whole scripts and selections of scripts. Check for both errors and successes the green or red arrow shows correctly. The following script gives one example to try:

```python
import time
time.sleep(1)
time.sleep(1)

dict = {}
dict['notavalue']
```

Try adding some syntax issues, random indents, if statements with missing `:` etc.

Fixes #22994.

Does this update require release notes?
- [ ] Yes
- [ ] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
