### PR TITLE
Pressing Cancel when Closing Workbench

### DIFF
--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -335,14 +335,16 @@ class MainWindow(QMainWindow):
     # ----------------------- Events ---------------------------------
     def closeEvent(self, event):
         # Close editors
-        self.editor.app_closing()
+        if self.editor.app_closing():
+            # Close all open plots
+            # We don't want this at module scope here
+            import matplotlib.pyplot as plt  #noqa
+            plt.close('all')
 
-        # Close all open plots
-        # We don't want this at module scope here
-        import matplotlib.pyplot as plt  #noqa
-        plt.close('all')
-
-        event.accept()
+            event.accept()
+        else:
+            # Cancel was pressed when closing an editor
+            event.ignore()
 
     # ----------------------- Slots ---------------------------------
     def open_file(self):

--- a/qt/applications/workbench/workbench/plugins/editor.py
+++ b/qt/applications/workbench/workbench/plugins/editor.py
@@ -69,7 +69,11 @@ class MultiFileEditor(PluginWidget):
     # ----------- Plugin API --------------------
 
     def app_closing(self):
-        self.editors.close_all()
+        """
+        Tries to close all editors
+        :return: True if editors can be closed, false if cancelled
+        """
+        return self.editors.close_all()
 
     def get_plugin_title(self):
         return "Editor"

--- a/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
@@ -70,9 +70,9 @@ class MultiPythonFileInterpreter(QWidget):
         interpreter.sig_editor_modified.connect(self.mark_current_tab_modified)
         interpreter.sig_filename_modified.connect(self.on_filename_modified)
 
-        tab_title, tab_toolip = _tab_title_and_toolip(filename)
+        tab_title, tab_tooltip = _tab_title_and_toolip(filename)
         tab_idx = self._tabs.addTab(interpreter, tab_title)
-        self._tabs.setTabToolTip(tab_idx, tab_toolip)
+        self._tabs.setTabToolTip(tab_idx, tab_tooltip)
         self._tabs.setCurrentIndex(tab_idx)
         return tab_idx
 
@@ -99,8 +99,10 @@ class MultiPythonFileInterpreter(QWidget):
         """
         if idx >= self.editor_count:
             return True
-        editor = self.editor_at(idx)
-        if editor.confirm_close():
+        # Make the current tab active so that it is clear what you
+        # are being prompted to save
+        self._tabs.setCurrentIndex(idx)
+        if self.current_editor().confirm_close():
             self._tabs.removeTab(idx)
         else:
             return False

--- a/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
@@ -81,21 +81,35 @@ class MultiPythonFileInterpreter(QWidget):
         self.current_editor().abort()
 
     def close_all(self):
-        """Close all tabs"""
+        """
+        Close all tabs
+        :return: True if all tabs are closed, False if cancelled
+        """
         for idx in reversed(range(self.editor_count)):
-            self.close_tab(idx)
+            if not self.close_tab(idx):
+                return False
+
+        return True
 
     def close_tab(self, idx):
-        """Close the tab at the given index."""
+        """
+        Close the tab at the given index.
+        :param idx: The tab index
+        :return: True if tab is to be closed, False if cancelled
+        """
         if idx >= self.editor_count:
-            return
+            return True
         editor = self.editor_at(idx)
         if editor.confirm_close():
             self._tabs.removeTab(idx)
+        else:
+            return False
 
         # we never want an empty widget
         if self.editor_count == 0:
             self.append_new_editor(content=self.default_content)
+
+        return True
 
     def create_tabwidget(self):
         """Create a new QTabWidget with a button to add new tabs"""


### PR DESCRIPTION
**Description of work.**

When the workbench is closed a prompt is shown for each editor tab, asking if you want to save, with options of `Cancel`, `No` and `Yes`. If `Cancel` is selected the workbench closes anyway.

This fixes this bug, and also shows the correct tab that you are being asked about saving when closing the workbench.

**To test:**

Open up the workbench and make a number of script editor tabs. Type something different in each script editor but do not save.

Then close the workbench. Check `Cancel`, `No` and `Yes` work as expected, and you can tell which tab you are being asked about for each prompt.

Fixes #22993.

Does this update require release notes?
- [ ] Yes
- [x] No

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
