### PR TITLE
Only sleep after doctests if free memory is below 75%

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -109,10 +109,9 @@ from mantid.api import FrameworkManager
 from mantid.kernel import MemoryStats
 
 FrameworkManager.Instance().clear()
-if MemoryStats().getFreeRatio() < 0.5:
+if MemoryStats().getFreeRatio() < 0.75:
     # sleep for short period to allow memory to be freed
     time.sleep(2)
-
 """
 
 # -- Options for pngmath --------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,7 +8,7 @@ import os
 from sphinx import __version__ as sphinx_version
 import sphinx_bootstrap_theme # checked at cmake time
 import mantid
-from mantid import ConfigService
+from mantid.kernel import ConfigService
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -106,9 +106,13 @@ except TypeError:
 doctest_global_cleanup = """
 import time
 from mantid.api import FrameworkManager
+from mantid.kernel import MemoryStats
+
 FrameworkManager.Instance().clear()
-# sleep for short period to allow memory to be freed
-time.sleep(2)
+if MemoryStats().getFreeRatio() < 0.5:
+    # sleep for short period to allow memory to be freed
+    time.sleep(2)
+
 """
 
 # -- Options for pngmath --------------------------------------------------


### PR DESCRIPTION
**Description of work.**

Decreases the number of calls to `time.sleep` in the doctest clean up to hopefully reduce the time the tests take.

**To test:**

The doctests build should pass.

*No associated issue*

Does this update require release notes?
- [ ] Yes
- [X] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
