### PR TITLE
Improve error handling for TableWorkspace

### DIFF
--- a/Framework/DataHandling/src/LoadTBL.cpp
+++ b/Framework/DataHandling/src/LoadTBL.cpp
@@ -317,16 +317,16 @@ void LoadTBL::exec() {
   if (isOld) {
     /**THIS IS ESSENTIALLY THE OLD LoadReflTBL CODE**/
     // create the column headings
-    auto colStitch = ws->addColumn("str", "StitchGroup");
-    auto colRuns = ws->addColumn("str", "Run(s)");
-    auto colTheta = ws->addColumn("str", "ThetaIn");
-    auto colTrans = ws->addColumn("str", "TransRun(s)");
-    auto colQmin = ws->addColumn("str", "Qmin");
-    auto colQmax = ws->addColumn("str", "Qmax");
-    auto colDqq = ws->addColumn("str", "dq/q");
-    auto colScale = ws->addColumn("str", "Scale");
-    auto colOptions = ws->addColumn("str", "Options");
-    auto colHiddenOptions = ws->addColumn("str", "HiddenOptions");
+    ws->addColumn("str", "StitchGroup");
+    ws->addColumn("str", "Run(s)");
+    ws->addColumn("str", "ThetaIn");
+    ws->addColumn("str", "TransRun(s)");
+    ws->addColumn("str", "Qmin");
+    ws->addColumn("str", "Qmax");
+    ws->addColumn("str", "dq/q");
+    ws->addColumn("str", "Scale");
+    ws->addColumn("str", "Options");
+    ws->addColumn("str", "HiddenOptions");
 
     for (size_t i = 0; i < ws->columnCount(); i++) {
       auto col = ws->getColumn(i);

--- a/Framework/DataObjects/inc/MantidDataObjects/TableWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/TableWorkspace.h
@@ -337,7 +337,7 @@ private:
     }
   }
 
-  bool addColumn(boost::shared_ptr<API::Column> column);
+  void addColumn(boost::shared_ptr<API::Column> column);
 
   /** This method finds the row and column index of an integer cell value in a
   * table workspace

--- a/Framework/DataObjects/src/TableWorkspace.cpp
+++ b/Framework/DataObjects/src/TableWorkspace.cpp
@@ -59,18 +59,18 @@ API::Column_sptr TableWorkspace::addColumn(const std::string &type,
                                            const std::string &name) {
   API::Column_sptr c;
   if (type.empty()) {
-    g_log.error("Empty string passed as type argument of createColumn.");
-    return c;
+    throw std::invalid_argument("Empty string passed as type argument of addColumn.");
   }
   if (name.empty()) {
-    g_log.error("Empty string passed as name argument of createColumn.");
+    throw std::invalid_argument("Empty string passed as name argument of addColumn.");
     return c;
   }
   // Check that there is no column with the same name.
   auto ci = std::find_if(m_columns.begin(), m_columns.end(), FindName(name));
   if (ci != m_columns.end()) {
-    g_log.error() << "Column with name " << name << " already exists.\n";
-    return c;
+    std::stringstream ss;
+    ss << "Column with name " << name << " already exists.\n";
+    throw std::invalid_argument(ss.str());
   }
   try {
     c = API::ColumnFactory::Instance().create(type);
@@ -78,10 +78,11 @@ API::Column_sptr TableWorkspace::addColumn(const std::string &type,
     c->setName(name);
     resizeColumn(c.get(), rowCount());
   } catch (Kernel::Exception::NotFoundError &e) {
-    g_log.error() << "Column of type " << type << " and name " << name
-                  << " has not been created.\n";
-    g_log.error() << e.what() << '\n';
-    return c;
+    std::stringstream ss;
+    ss << "Column of type " << type << " and name " << name
+                  << " has not been added.\n";
+    ss << e.what() << '\n';
+    throw std::invalid_argument(ss.str());
   }
   return c;
 }
@@ -104,7 +105,6 @@ API::Column_sptr TableWorkspace::getColumn(const std::string &name) {
   auto ci = std::find_if(m_columns.begin(), m_columns.end(), FindName(name));
   if (ci == m_columns.end()) {
     std::string str = "Column " + name + " does not exist.\n";
-    g_log.error(str);
     throw std::runtime_error(str);
   }
   return *ci;
@@ -118,16 +118,15 @@ TableWorkspace::getColumn(const std::string &name) const {
     }
   }
   std::string str = "Column " + name + " does not exist.\n";
-  g_log.error(str);
   throw std::runtime_error(str);
 }
 
 /// Gets the shared pointer to a column.
 API::Column_sptr TableWorkspace::getColumn(size_t index) {
   if (index >= columnCount()) {
-    std::string str = "Column index is out of range";
-    g_log.error() << str << ": " << index << "(" << columnCount() << ")\n";
-    throw std::range_error(str);
+    std::stringstream ss;
+    ss << "Column index is out of range: " << index << "(" << columnCount() << ")\n";
+    throw std::range_error(ss.str());
   }
   return m_columns[index];
 }
@@ -135,9 +134,9 @@ API::Column_sptr TableWorkspace::getColumn(size_t index) {
 /// Gets the shared pointer to a column.
 API::Column_const_sptr TableWorkspace::getColumn(size_t index) const {
   if (index >= columnCount()) {
-    std::string str = "Column index is out of range";
-    g_log.error() << str << ": " << index << "(" << columnCount() << ")\n";
-    throw std::range_error(str);
+    std::stringstream ss;
+    ss << "Column index is out of range: " << index << "(" << columnCount() << ")\n";
+    throw std::range_error(ss.str());
   }
   return m_columns[index];
 }
@@ -168,8 +167,9 @@ size_t TableWorkspace::insertRow(size_t index) {
 */
 void TableWorkspace::removeRow(size_t index) {
   if (index >= rowCount()) {
-    g_log.error() << "Attempt to delete a non-existing row (" << index << ")\n";
-    return;
+    std::stringstream ss;
+    ss << "Attempt to delete a non-existing row (" << index << ")\n";
+    throw std::range_error(ss.str());
   }
   for (auto &column : m_columns)
     removeFromColumn(column.get(), index);
@@ -184,17 +184,17 @@ std::vector<std::string> TableWorkspace::getColumnNames() const {
   return nameList;
 }
 
-bool TableWorkspace::addColumn(boost::shared_ptr<API::Column> column) {
+void TableWorkspace::addColumn(boost::shared_ptr<API::Column> column) {
   auto ci = std::find_if(m_columns.begin(), m_columns.end(),
                          FindName(column->name()));
   if (ci != m_columns.end()) {
-    g_log.error() << "Column with name " << column->name()
-                  << " already exists.\n";
-    return false;
+    std::stringstream ss;
+    ss << "Column with name " << column->name()
+      << " already exists.\n";
+    throw std::invalid_argument(ss.str());
   } else {
     m_columns.push_back(column);
   }
-  return true;
 }
 
 /**

--- a/Framework/DataObjects/src/TableWorkspace.cpp
+++ b/Framework/DataObjects/src/TableWorkspace.cpp
@@ -59,10 +59,12 @@ API::Column_sptr TableWorkspace::addColumn(const std::string &type,
                                            const std::string &name) {
   API::Column_sptr c;
   if (type.empty()) {
-    throw std::invalid_argument("Empty string passed as type argument of addColumn.");
+    throw std::invalid_argument(
+        "Empty string passed as type argument of addColumn.");
   }
   if (name.empty()) {
-    throw std::invalid_argument("Empty string passed as name argument of addColumn.");
+    throw std::invalid_argument(
+        "Empty string passed as name argument of addColumn.");
     return c;
   }
   // Check that there is no column with the same name.
@@ -80,7 +82,7 @@ API::Column_sptr TableWorkspace::addColumn(const std::string &type,
   } catch (Kernel::Exception::NotFoundError &e) {
     std::stringstream ss;
     ss << "Column of type " << type << " and name " << name
-                  << " has not been added.\n";
+       << " has not been added.\n";
     ss << e.what() << '\n';
     throw std::invalid_argument(ss.str());
   }
@@ -125,7 +127,8 @@ TableWorkspace::getColumn(const std::string &name) const {
 API::Column_sptr TableWorkspace::getColumn(size_t index) {
   if (index >= columnCount()) {
     std::stringstream ss;
-    ss << "Column index is out of range: " << index << "(" << columnCount() << ")\n";
+    ss << "Column index is out of range: " << index << "(" << columnCount()
+       << ")\n";
     throw std::range_error(ss.str());
   }
   return m_columns[index];
@@ -135,7 +138,8 @@ API::Column_sptr TableWorkspace::getColumn(size_t index) {
 API::Column_const_sptr TableWorkspace::getColumn(size_t index) const {
   if (index >= columnCount()) {
     std::stringstream ss;
-    ss << "Column index is out of range: " << index << "(" << columnCount() << ")\n";
+    ss << "Column index is out of range: " << index << "(" << columnCount()
+       << ")\n";
     throw std::range_error(ss.str());
   }
   return m_columns[index];
@@ -189,8 +193,7 @@ void TableWorkspace::addColumn(boost::shared_ptr<API::Column> column) {
                          FindName(column->name()));
   if (ci != m_columns.end()) {
     std::stringstream ss;
-    ss << "Column with name " << column->name()
-      << " already exists.\n";
+    ss << "Column with name " << column->name() << " already exists.\n";
     throw std::invalid_argument(ss.str());
   } else {
     m_columns.push_back(column);

--- a/Framework/DataObjects/test/TableWorkspaceTest.h
+++ b/Framework/DataObjects/test/TableWorkspaceTest.h
@@ -112,7 +112,7 @@ public:
     TS_ASSERT_EQUALS(tw.getColumn("Name"), strCol);
     TS_ASSERT_EQUALS(tw.getColumn("Position"), v3dCol);
     // Test trying to add existing column returns null pointer
-    TS_ASSERT(!tw.addColumn("int", "Number"))
+    TS_ASSERT_THROWS(tw.addColumn("int", "Number"), std::invalid_argument);
 
     tw.getRef<int>("Number", 1) = 17;
     tw.cell<std::string>(2, 1) = "STRiNG";

--- a/Framework/MDAlgorithms/src/PreprocessDetectorsToMD.cpp
+++ b/Framework/MDAlgorithms/src/PreprocessDetectorsToMD.cpp
@@ -133,38 +133,28 @@ PreprocessDetectorsToMD::createTableWorkspace(
   // set the target workspace
   auto targWS = boost::make_shared<TableWorkspace>(nHist);
   // detectors positions
-  if (!targWS->addColumn("V3D", "DetDirections"))
-    throw(std::runtime_error("Can not add column DetDirectrions"));
+  targWS->addColumn("V3D", "DetDirections");
   // sample-detector distance;
-  if (!targWS->addColumn("double", "L2"))
-    throw(std::runtime_error("Can not add column L2"));
+  targWS->addColumn("double", "L2");
   // Diffraction angle
-  if (!targWS->addColumn("double", "TwoTheta"))
-    throw(std::runtime_error("Can not add column TwoTheta"));
-  if (!targWS->addColumn("double", "Azimuthal"))
-    throw(std::runtime_error("Can not add column Azimuthal"));
+  targWS->addColumn("double", "TwoTheta");
+  targWS->addColumn("double", "Azimuthal");
   // the detector ID;
-  if (!targWS->addColumn("int", "DetectorID"))
-    throw(std::runtime_error("Can not add column DetectorID"));
+  targWS->addColumn("int", "DetectorID");
   // stores spectra index which corresponds to a valid detector index;
-  if (!targWS->addColumn("size_t", "detIDMap"))
-    throw(std::runtime_error("Can not add column detIDMap"));
+  targWS->addColumn("size_t", "detIDMap");
   // stores detector index which corresponds to the workspace index;
-  if (!targWS->addColumn("size_t", "spec2detMap"))
-    throw(std::runtime_error("Can not add column spec2detMap"));
+  targWS->addColumn("size_t", "spec2detMap");
 
   m_getIsMasked = this->getProperty("GetMaskState");
   if (m_getIsMasked) // as bool is presented in vectors as a class, we are using
                      // int instead of bool
-    if (!targWS->addColumn("int", "detMask"))
-      throw(std::runtime_error(
-          "Can not add column containing for detector masks"));
+    targWS->addColumn("int", "detMask");
 
   // check if one wants to obtain detector's efixed"
   m_getEFixed = this->getProperty("GetEFixed");
   if (m_getEFixed)
-    if (!targWS->addColumn("float", "eFixed"))
-      throw(std::runtime_error("Can not add column containing efixed"));
+    targWS->addColumn("float", "eFixed");
 
   // will see about that
   // sin^2(Theta)

--- a/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+++ b/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
@@ -1365,25 +1365,18 @@ createTableWorkspace(const API::MatrixWorkspace_const_sptr &inputWS) {
   // set the target workspace
   auto targWS = boost::make_shared<TableWorkspace>(nHist);
   // detectors positions
-  if (!targWS->addColumn("V3D", "DetDirections"))
-    throw(std::runtime_error("Can not add column DetDirectrions"));
+  targWS->addColumn("V3D", "DetDirections");
   // sample-detector distance;
-  if (!targWS->addColumn("double", "L2"))
-    throw(std::runtime_error("Can not add column L2"));
+  targWS->addColumn("double", "L2");
   // Diffraction angle
-  if (!targWS->addColumn("double", "TwoTheta"))
-    throw(std::runtime_error("Can not add column TwoTheta"));
-  if (!targWS->addColumn("double", "Azimuthal"))
-    throw(std::runtime_error("Can not add column Azimuthal"));
+  targWS->addColumn("double", "TwoTheta");
+  targWS->addColumn("double", "Azimuthal");
   // the detector ID;
-  if (!targWS->addColumn("int", "DetectorID"))
-    throw(std::runtime_error("Can not add column DetectorID"));
+  targWS->addColumn("int", "DetectorID");
   // stores spectra index which corresponds to a valid detector index;
-  if (!targWS->addColumn("size_t", "detIDMap"))
-    throw(std::runtime_error("Can not add column detIDMap"));
+  targWS->addColumn("size_t", "detIDMap");
   // stores detector index which corresponds to the workspace index;
-  if (!targWS->addColumn("size_t", "spec2detMap"))
-    throw(std::runtime_error("Can not add column spec2detMap"));
+  targWS->addColumn("size_t", "spec2detMap");
 
   // will see about that
   // sin^2(Theta)
@@ -1396,7 +1389,7 @@ createTableWorkspace(const API::MatrixWorkspace_const_sptr &inputWS) {
 
 /** method does preliminary calculations of the detectors positions to convert
  results into k-dE space ;
- and places the resutls into static cash to be used in subsequent calls to this
+ and places the results into static cash to be used in subsequent calls to this
  algorithm */
 void processDetectorsPositions(const API::MatrixWorkspace_const_sptr &inputWS,
                                DataObjects::TableWorkspace_sptr &targWS,
@@ -1408,7 +1401,7 @@ void processDetectorsPositions(const API::MatrixWorkspace_const_sptr &inputWS,
   if ((!source) || (!sample)) {
 
     throw Kernel::Exception::InstrumentDefinitionError(
-        "Instrubment not sufficiently defined: failed to get source and/or "
+        "Instrument not sufficiently defined: failed to get source and/or "
         "sample");
   }
 

--- a/Framework/WorkflowAlgorithms/src/MuonGroupAsymmetryCalculator.cpp
+++ b/Framework/WorkflowAlgorithms/src/MuonGroupAsymmetryCalculator.cpp
@@ -130,7 +130,6 @@ MuonGroupAsymmetryCalculator::estimateAsymmetry(const Workspace_sptr &inputWS,
     table->addColumn("double", "norm");
     table->addColumn("str", "name");
     table->addColumn("str", "method");
-    table->removeRow(0);
   }
 
   MatrixWorkspace_sptr outWS;

--- a/qt/scientific_interfaces/test/MuonAnalysisResultTableCreatorTest.h
+++ b/qt/scientific_interfaces/test/MuonAnalysisResultTableCreatorTest.h
@@ -340,13 +340,13 @@ public:
     // of its columns when they are deleted
     const auto table = []() {
       auto tab = WorkspaceFactory::Instance().createTable();
-      /*auto col = */ tab->addColumn("str", "Run");
-      /*auto col = */ tab->addColumn("double", "A0");
-      /*auto col = */ tab->addColumn("double", "A0Error");
-      /*auto col = */ tab->addColumn("double", "A1");
-      /*auto col = */ tab->addColumn("double", "A1Error");
-      /*auto col = */ tab->addColumn("double", "Cost function");
-      /*auto col = */ tab->addColumn("double", "Cost function Error");
+      tab->addColumn("str", "Run");
+      tab->addColumn("double", "A0");
+      tab->addColumn("double", "A0Error");
+      tab->addColumn("double", "A1");
+      tab->addColumn("double", "A1Error");
+      tab->addColumn("double", "Cost function");
+      tab->addColumn("double", "Cost function Error");
 
       TableRow row1 = tab->appendRow();
       TableRow row2 = tab->appendRow();


### PR DESCRIPTION
**Description of work.**
Primarily throwing exceptions rather than logging when there is an error.
This reports better to python, and prevents silent problems.

**Report to:** Sam Jackson

**To test:**

1.  All unit and sytem tests pass
2. Code review.
3. The last line of this shold return a useful error.
```python

from mantid.api import WorkspaceFactory
tbl = CreateEmptyTableWorkspace()

tbl.addColumn("double", "k")
tbl.addColumn("double", "h")

tbl.addColumn("l", "double")
```

Fixes #22918. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
