### PR TITLE
Ignore whitespace when patching gtest

### DIFF
--- a/buildconfig/CMake/GoogleTest.in
+++ b/buildconfig/CMake/GoogleTest.in
@@ -7,16 +7,18 @@ find_package(Git)
 include(ExternalProject)
 
 set ( _tag release-@gtest_version@ )
+set ( _apply_flags --ignore-space-change --whitespace=fix )
+
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
   GIT_TAG           "${_tag}"
   SOURCE_DIR        "@CMAKE_BINARY_DIR@/googletest-src"
   BINARY_DIR        "@CMAKE_BINARY_DIR@/googletest-build"
   PATCH_COMMAND     "@GIT_EXECUTABLE@" reset --hard ${_tag}
-            COMMAND "@GIT_EXECUTABLE@" apply --whitespace fix "@CMAKE_SOURCE_DIR@/buildconfig/CMake/googletest_override.patch"
-            COMMAND "@GIT_EXECUTABLE@" apply --whitespace fix "@CMAKE_SOURCE_DIR@/buildconfig/CMake/googletest_static.patch"
-            COMMAND "@GIT_EXECUTABLE@" apply --whitespace fix "@CMAKE_SOURCE_DIR@/buildconfig/CMake/googletest_msvc_cpp11.patch"
-            COMMAND "@GIT_EXECUTABLE@" apply --whitespace fix "@CMAKE_SOURCE_DIR@/buildconfig/CMake/googletest_wconversion.patch"
+            COMMAND "@GIT_EXECUTABLE@" apply ${_apply_flags} "@CMAKE_SOURCE_DIR@/buildconfig/CMake/googletest_override.patch"
+            COMMAND "@GIT_EXECUTABLE@" apply ${_apply_flags} "@CMAKE_SOURCE_DIR@/buildconfig/CMake/googletest_static.patch"
+            COMMAND "@GIT_EXECUTABLE@" apply ${_apply_flags} "@CMAKE_SOURCE_DIR@/buildconfig/CMake/googletest_msvc_cpp11.patch"
+            COMMAND "@GIT_EXECUTABLE@" apply ${_apply_flags} "@CMAKE_SOURCE_DIR@/buildconfig/CMake/googletest_wconversion.patch"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
   INSTALL_COMMAND   ""


### PR DESCRIPTION
**Description of work.**
Ignore whitespace when patching gtest to avoid a failure in CMake. This
is because Mantid has a .gitattribute which forces auto CRLF, however
Google do not. So if the config option is set to false the clone will
have differing line endings causing the patch to fail without these
changes


**To test:**
- On Windows go to .gitconfig
- Set `autocrlf` to false
- Clone Mantid into a fresh repo
- Run CMake, the patch step should fail
- Merge these changes in, patching should work

Does this update require release notes?
- [ ] Yes
- [x] No

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
