### PR TITLE
 Muon results table includes log values with value of 0

### DIFF
--- a/docs/source/release/v3.14.0/muon.rst
+++ b/docs/source/release/v3.14.0/muon.rst
@@ -9,4 +9,27 @@ MuSR Changes
     putting new features at the top of the section, followed by
     improvements, followed by bug fixes.
 
+  
+Interface
+---------
+
+Improvements
+############
+
+Bugfixes
+########
+- Results table now includes all logs that are common to all of the loaded files.
+
+Algorithms
+----------
+
+New
+###
+
+Improvements
+############
+
+Bugfixes
+########
+	
 :ref:`Release 3.14.0 <v3.14.0>`

--- a/qt/scientific_interfaces/Muon/MuonAnalysisResultTableTab.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisResultTableTab.cpp
@@ -531,7 +531,6 @@ void MuonAnalysisResultTableTab::populateLogsAndValues(
       if (TimeSeriesProperty<double> *log =
               dynamic_cast<TimeSeriesProperty<double> *>(prop)) {
         QString logName = QString::fromStdString(prop->name());
-        std::string fdsadf = logName.toStdString();
         auto mylog = log->clone();
         if (foundRunning) {
           mylog->filterWith(runningLog);
@@ -543,7 +542,6 @@ void MuonAnalysisResultTableTab::populateLogsAndValues(
       } else // Should be a non-timeseries one
       {
         QString logName = QString::fromStdString(prop->name());
-        std::string fdsadf = logName.toStdString();
         // Check if we should display it
         if (NON_TIMESERIES_LOGS.contains(logName)) {
 

--- a/qt/scientific_interfaces/Muon/MuonAnalysisResultTableTab.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisResultTableTab.cpp
@@ -530,8 +530,8 @@ void MuonAnalysisResultTableTab::populateLogsAndValues(
       // Check if is a timeseries log
       if (TimeSeriesProperty<double> *log =
               dynamic_cast<TimeSeriesProperty<double> *>(prop)) {
-		  QString logName = QString::fromStdString(prop->name());
-		  std::string fdsadf = logName.toStdString();
+        QString logName = QString::fromStdString(prop->name());
+        std::string fdsadf = logName.toStdString();
         auto mylog = log->clone();
         if (foundRunning) {
           mylog->filterWith(runningLog);
@@ -543,7 +543,7 @@ void MuonAnalysisResultTableTab::populateLogsAndValues(
       } else // Should be a non-timeseries one
       {
         QString logName = QString::fromStdString(prop->name());
-		std::string fdsadf = logName.toStdString();
+        std::string fdsadf = logName.toStdString();
         // Check if we should display it
         if (NON_TIMESERIES_LOGS.contains(logName)) {
 

--- a/qt/scientific_interfaces/Muon/MuonAnalysisResultTableTab.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisResultTableTab.cpp
@@ -530,21 +530,20 @@ void MuonAnalysisResultTableTab::populateLogsAndValues(
       // Check if is a timeseries log
       if (TimeSeriesProperty<double> *log =
               dynamic_cast<TimeSeriesProperty<double> *>(prop)) {
-
+		  QString logName = QString::fromStdString(prop->name());
+		  std::string fdsadf = logName.toStdString();
         auto mylog = log->clone();
         if (foundRunning) {
           mylog->filterWith(runningLog);
         }
         QString logFile(QFileInfo(prop->name().c_str()).fileName());
         auto time_ave = mylog->timeAverageValue(); // get the time average
-        if (time_ave != 0) {
-          // Return average
-          wsLogValues[logFile] = time_ave;
-        }
+        // Return average
+        wsLogValues[logFile] = time_ave;
       } else // Should be a non-timeseries one
       {
         QString logName = QString::fromStdString(prop->name());
-
+		std::string fdsadf = logName.toStdString();
         // Check if we should display it
         if (NON_TIMESERIES_LOGS.contains(logName)) {
 


### PR DESCRIPTION
**Description of work.**
The results table tab of muon analysis was not allowing users to select sample logs if the time average value happened to be zero.

**Report to:** James - done

**To test:**
Open Muon analysis and load HIFI 134129
Do a fit on the data analysis tab. 
Go to the results table tab and look at the available logs
Laser_Delay should be available - tick it
Create a table
The table should have zero for the Laser_Delay
<!-- Instructions for testing. -->

Fixes #23166. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

Does this update require release notes?
- [x ] Yes
- [ ] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
