### PR TITLE
Move time-weighted statistics to object

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/ITimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/ITimeSeriesProperty.h
@@ -61,8 +61,6 @@ public:
   virtual std::vector<Types::Core::DateAndTime> timesAsVector() const = 0;
   /// Returns the calculated time weighted average value
   virtual double timeAverageValue() const = 0;
-  /// Returns the calculated time weighted average value and standard deviation
-  virtual std::pair<double, double> timeAverageValueAndStdDev() const = 0;
   /// Returns the real size of the time series property map:
   virtual int realSize() const = 0;
   /// Deletes the series of values in the property

--- a/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
@@ -39,6 +39,10 @@ struct TimeSeriesPropertyStatistics {
   double median;
   /// standard_deviation of the values
   double standard_deviation;
+  /// time weighted average
+  double time_mean;
+  /// time weighted standard deviation
+  double time_standard_deviation;
   /// Duration in seconds
   double duration;
 };
@@ -185,10 +189,8 @@ public:
   /// @copydoc Mantid::Kernel::ITimeSeriesProperty::averageAndStdDevInFilter()
   std::pair<double, double> averageAndStdDevInFilter(
       const std::vector<SplittingInterval> &filter) const override;
-  /// Calculate the time-weighted average of a property
+  /// @copydoc Mantid::Kernel::ITimeSeriesProperty::timeAverageValue()
   double timeAverageValue() const override;
-  /// @copydoc Mantid::Kernel::ITimeSeriesProperty::timeAverageValueAndStdDev()
-  std::pair<double, double> timeAverageValueAndStdDev() const override;
   /// generate constant time-step histogram from the property values
   void histogramData(const Types::Core::DateAndTime &tMin,
                      const Types::Core::DateAndTime &tMax,
@@ -339,6 +341,8 @@ private:
   std::string setValueFromProperty(const Property &right) override;
   /// Find if time lies in a filtered region
   bool isTimeFiltered(const Types::Core::DateAndTime &time) const;
+  /// Time weighted mean and standard deviation
+  std::pair<double, double> timeAverageValueAndStdDev() const;
 
   /// Holds the time series data
   mutable std::vector<TimeValueUnit<TYPE>> m_values;

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -2002,7 +2002,12 @@ TimeSeriesPropertyStatistics TimeSeriesProperty<TYPE>::getStatistics() const {
       duration_sec += interval.duration();
     }
     out.duration = duration_sec;
+    const auto time_weighted = this->timeAverageValueAndStdDev();
+    out.time_mean = time_weighted.first;
+    out.time_standard_deviation = time_weighted.second;
   } else {
+    out.time_mean = std::numeric_limits<double>::quiet_NaN();
+    out.time_standard_deviation = std::numeric_limits<double>::quiet_NaN();
     out.duration = std::numeric_limits<double>::quiet_NaN();
   }
 

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -619,14 +619,6 @@ public:
     const double intMean = intLog->timeAverageValue();
     TS_ASSERT_DELTA(intMean, 2.5, .0001);
 
-    // average is unchanged, standard deviation within tolerance
-    const auto dblPair = dblLog->timeAverageValueAndStdDev();
-    TS_ASSERT_EQUALS(dblPair.first, dblMean);
-    TS_ASSERT_DELTA(dblPair.second, 1.8156, .0001);
-    const auto intPair = intLog->timeAverageValueAndStdDev();
-    TS_ASSERT_EQUALS(intPair.first, intMean);
-    TS_ASSERT_DELTA(intPair.second, 1.1180, .0001);
-
     // Clean up
     delete dblLog;
     delete intLog;
@@ -1055,6 +1047,8 @@ public:
     TS_ASSERT_DELTA(stats.duration, 100.0, 1e-3);
     TS_ASSERT_DELTA(stats.standard_deviation, 3.1622, 1e-3);
     TS_ASSERT_DELTA(log->timeAverageValue(), 5.5, 1e-3);
+    TS_ASSERT_DELTA(stats.time_mean, 5.5, 1e-3);
+    TS_ASSERT_DELTA(stats.time_standard_deviation, 2.872, 1e-3);
 
     delete log;
   }
@@ -1068,6 +1062,8 @@ public:
     TS_ASSERT(std::isnan(stats.median));
     TS_ASSERT(std::isnan(stats.mean));
     TS_ASSERT(std::isnan(stats.standard_deviation));
+    TS_ASSERT(std::isnan(stats.time_mean));
+    TS_ASSERT(std::isnan(stats.time_standard_deviation));
     TS_ASSERT(std::isnan(stats.duration));
 
     delete log;

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
@@ -37,12 +37,6 @@ void addPyTimeValue(TimeSeriesProperty<TYPE> &self,
   self.addValue(*dateandtime, value);
 }
 
-template <typename TYPE>
-tuple pyTimeAverageValueAndStdDev(const TimeSeriesProperty<TYPE> &self) {
-  const std::pair<double, double> value = self.timeAverageValueAndStdDev();
-  return make_tuple(value.first, value.second);
-}
-
 // Call the dtype helper function
 template <typename TYPE> std::string dtype(TimeSeriesProperty<TYPE> &self) {
   return Mantid::PythonInterface::Converters::dtype(self);
@@ -94,8 +88,6 @@ template <typename TYPE> std::string dtype(TimeSeriesProperty<TYPE> &self) {
            "returns :class:`mantid.kernel.TimeSeriesPropertyStatistics`")      \
       .def("timeAverageValue", &TimeSeriesProperty<TYPE>::timeAverageValue,    \
            arg("self"))                                                        \
-      .def("timeAverageValueAndStdDev", &pyTimeAverageValueAndStdDev<TYPE>,    \
-           arg("self"), "Time average value and standard deviation")           \
       .def("dtype", &dtype<TYPE>, arg("self"));
 
 } // namespace
@@ -131,6 +123,11 @@ void export_TimeSeriesPropertyStatistics() {
       .add_property(
            "standard_deviation",
            &Mantid::Kernel::TimeSeriesPropertyStatistics::standard_deviation)
+      .add_property("time_mean",
+                    &Mantid::Kernel::TimeSeriesPropertyStatistics::time_mean)
+      .add_property("time_standard_deviation",
+                    &Mantid::Kernel::TimeSeriesPropertyStatistics::
+                        time_standard_deviation)
       .add_property("duration",
                     &Mantid::Kernel::TimeSeriesPropertyStatistics::duration);
 }

--- a/Framework/PythonInterface/test/python/mantid/kernel/TimeSeriesPropertyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/TimeSeriesPropertyTest.py
@@ -95,5 +95,15 @@ class TimeSeriesPropertyTest(unittest.TestCase):
         self.assertTrue(isinstance(values, values_type))
         self.assertEquals(log.size(), len(values))
 
+        # check the statistics
+        stats = log.getStatistics()
+        self.assertTrue(hasattr(stats, 'mean'))
+        self.assertTrue(hasattr(stats, 'median'))
+        self.assertTrue(hasattr(stats, 'minimum'))
+        self.assertTrue(hasattr(stats, 'maximum'))
+        self.assertTrue(hasattr(stats, 'standard_deviation'))
+        self.assertTrue(hasattr(stats, 'time_mean'))
+        self.assertTrue(hasattr(stats, 'time_standard_deviation'))
+
 if __name__ == '__main__':
     unittest.main()

--- a/MantidPlot/src/Mantid/SampleLogDialogBase.cpp
+++ b/MantidPlot/src/Mantid/SampleLogDialogBase.cpp
@@ -138,17 +138,14 @@ void SampleLogDialogBase::showLogStatisticsOfItem(
         dynamic_cast<TimeSeriesProperty<double> *>(logData);
     Mantid::Kernel::TimeSeriesProperty<int> *tspi =
         dynamic_cast<TimeSeriesProperty<int> *>(logData);
-    std::pair<double, double> timeAvgStdDev{0., 0.};
     LogFilterGenerator generator(filter, m_ei->run());
     const auto &logFilter = generator.generateFilter(logName);
     if (tspd) {
       ScopedFilter<double> applyFilter(tspd, std::move(logFilter));
       stats = tspd->getStatistics();
-      timeAvgStdDev = tspd->timeAverageValueAndStdDev();
     } else if (tspi) {
       ScopedFilter<int> applyFilter(tspi, std::move(logFilter));
       stats = tspi->getStatistics();
-      timeAvgStdDev = tspi->timeAverageValueAndStdDev();
     } else
       return;
 
@@ -158,8 +155,8 @@ void SampleLogDialogBase::showLogStatisticsOfItem(
     statValues[2]->setText(QString::number(stats.mean));
     statValues[3]->setText(QString::number(stats.median));
     statValues[4]->setText(QString::number(stats.standard_deviation));
-    statValues[5]->setText(QString::number(timeAvgStdDev.first));
-    statValues[6]->setText(QString::number(timeAvgStdDev.second));
+    statValues[5]->setText(QString::number(stats.time_mean));
+    statValues[6]->setText(QString::number(stats.time_standard_deviation));
     statValues[7]->setText(QString::number(stats.duration));
     return;
     break;


### PR DESCRIPTION
**Description of work.**

Rather than requiring users to call a second function, add the time-weighted values to the `TimeSeriesPropertyStatistics` object. This was a request after seeing #23083.


**To test:**

The unit tests have been updated. The sample log dialog is the only thing that needs to be tested manually.

*There is no associated issue.* 

*This is already covered by existing release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
