### PR TITLE
Fix handling of runIndex in MergeMD

### DIFF
--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MergeMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MergeMD.h
@@ -59,6 +59,9 @@ private:
   /// Vector of input MDWorkspaces
   std::vector<Mantid::API::IMDEventWorkspace_sptr> m_workspaces;
 
+  /// Vector of number of experimentalInfos for each input workspace
+  std::vector<uint16_t> experimentInfoNo = {0};
+
   /// Output MDEventWorkspace
   Mantid::API::IMDEventWorkspace_sptr out;
 };

--- a/Framework/MDAlgorithms/test/MergeMDTest.h
+++ b/Framework/MDAlgorithms/test/MergeMDTest.h
@@ -141,6 +141,91 @@ public:
     // Remove workspace from the data service.
     AnalysisDataService::Instance().remove(outWSName);
   }
+
+  void test_runIndex() {
+    // Name of the output workspace.
+    std::string outWSName("MergeMDTest_OutputWS");
+
+    MergeMD alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("InputWorkspaces", "mde3,mde3,mde3"));
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", outWSName));
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+
+    // Retrieve the workspace from data service.
+    MDEventWorkspace3::sptr ws;
+    TS_ASSERT_THROWS_NOTHING(
+        ws = AnalysisDataService::Instance().retrieveWS<MDEventWorkspace3>(
+            outWSName);)
+    TS_ASSERT(ws);
+
+    typename std::vector<API::IMDNode *> boxes;
+    ws->getBox()->getBoxes(boxes, 10, true);
+
+    API::IMDNode *box = boxes[0];
+    TS_ASSERT_EQUALS(box->getNPoints(), 3);
+    std::vector<coord_t> events;
+    size_t ncols;
+    box->getEventsData(events, ncols);
+    // 7 columns: I, err^2, run_num, det_id, x, y, z
+    TS_ASSERT_EQUALS(ncols, 7);
+    // 7*3 = 21
+    TS_ASSERT_EQUALS(events.size(), 21);
+
+    // reference vector, 3 identical events except for incremented run numbers
+    const std::vector<coord_t> ref = {1, 1, 0, 0, 6.25, 6.25, 6.25,
+                                      1, 1, 1, 0, 6.25, 6.25, 6.25,
+                                      1, 1, 2, 0, 6.25, 6.25, 6.25};
+
+    for (auto i = 0; i < 21; i++) {
+      TS_ASSERT_EQUALS(events[i], ref[i]);
+    }
+
+    // Merge merged ws with self
+    MergeMD alg2;
+    TS_ASSERT_THROWS_NOTHING(alg2.initialize())
+    TS_ASSERT(alg2.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg2.setPropertyValue(
+        "InputWorkspaces", "MergeMDTest_OutputWS,MergeMDTest_OutputWS"));
+    TS_ASSERT_THROWS_NOTHING(
+        alg2.setPropertyValue("OutputWorkspace", outWSName));
+    TS_ASSERT_THROWS_NOTHING(alg2.execute(););
+    TS_ASSERT(alg2.isExecuted());
+
+    // Retrieve the workspace from data service.
+    TS_ASSERT_THROWS_NOTHING(
+        ws = AnalysisDataService::Instance().retrieveWS<MDEventWorkspace3>(
+            outWSName);)
+    TS_ASSERT(ws);
+
+    typename std::vector<API::IMDNode *> boxes2;
+    ws->getBox()->getBoxes(boxes2, 10, true);
+
+    API::IMDNode *box2 = boxes2[0];
+    TS_ASSERT_EQUALS(box2->getNPoints(), 6);
+    box2->getEventsData(events, ncols);
+    // 7 columns: I, err^2, run_num, det_id, x, y, z
+    TS_ASSERT_EQUALS(ncols, 7);
+    // 7*6 = 42
+    TS_ASSERT_EQUALS(events.size(), 42);
+
+    // reference vector, 6 identical events except for incremented run numbers
+    const std::vector<coord_t> ref2 = {
+        1, 1, 0, 0, 6.25, 6.25, 6.25, 1, 1, 1, 0, 6.25, 6.25, 6.25,
+        1, 1, 2, 0, 6.25, 6.25, 6.25, 1, 1, 3, 0, 6.25, 6.25, 6.25,
+        1, 1, 4, 0, 6.25, 6.25, 6.25, 1, 1, 5, 0, 6.25, 6.25, 6.25};
+
+    for (auto i = 0; i < 42; i++) {
+      TS_ASSERT_EQUALS(events[i], ref2[i]);
+    }
+
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(outWSName);
+  }
 };
 
 #endif /* MANTID_MDALGORITHMS_MERGEMDTEST_H_ */


### PR DESCRIPTION
MergeMD simply [copies the MDEvents](https://github.com/mantidproject/mantid/blob/master/Framework/MDAlgorithms/src/MergeMD.cpp#L197) from the input workspaces into the output workspace without updating [run_index](https://github.com/mantidproject/mantid/blob/master/Framework/DataObjects/inc/MantidDataObjects/MDEvent.h#L19). This means that the MDEvents in the output workspace don't have the correct run_index. MergeMD will need to inspect every event [getRunIndex()](https://github.com/mantidproject/mantid/blob/master/Framework/DataObjects/inc/MantidDataObjects/MDEvent.h#L164) for the input workspace and [setRunIndex()](https://github.com/mantidproject/mantid/blob/master/Framework/DataObjects/inc/MantidDataObjects/MDEvent.h#L168) so it's correct for the output workspace.


**To test:**
 * ...


Fixes #20338

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
