### PR TITLE
Check existence of Poco debug libraries before using them

### DIFF
--- a/buildconfig/CMake/FindPoco.cmake
+++ b/buildconfig/CMake/FindPoco.cmake
@@ -22,7 +22,7 @@ find_library ( POCO_LIB_NETSSL_DEBUG NAMES PocoNetSSLd )
 function( add_poco_lib POCO_LIB_MODULE POCO_DEBUG_LIB_MODULE )
   # Add poco library to list and also the corresponding debug library if it is available
 
-  if ( POCO_DEBUG_LIB_MODULE )
+  if ( EXISTS "${POCO_DEBUG_LIB_MODULE}" )
     set ( POCO_LIBRARIES ${POCO_LIBRARIES}
         optimized ${POCO_LIB_MODULE}
         debug ${POCO_DEBUG_LIB_MODULE}


### PR DESCRIPTION
**Description of work.**

On Ubuntu 16.04 and earlier the `libpoco-dev` packages install symlinks for the debug libraries but not the libraries themselves; they must be installed using the corresponding `-dbg` packages. The presence of the symlink confused our cmake into thinking they were present and would then cause an error at build time.

This forces a check for the existence of the symlink target before configuring to use the debug libs.

**To test:**

Needs a clean cmake build on Ubuntu 16.04.

* Remove the `libpocofoundation31-dbg` package
* run a cmake config and check the `Found Poco` line does not include the debug libraries
* remove the build
* reinstall the debug package for foundation
* re-run a clean cmake configure and check the `Found Poco:` line again and see it contains the debug library for Foundation but not anything else.

*No associated issue*

Does this update require release notes?
- [ ] Yes
- [X] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
