### PR TITLE
Fix pearl long mode

### DIFF
--- a/scripts/Diffraction/isis_powder/pearl.py
+++ b/scripts/Diffraction/isis_powder/pearl.py
@@ -176,5 +176,4 @@ class Pearl(AbstractInst):
                                                             absorb_ws=absorb_corrections)
 
     def _switch_long_mode_inst_settings(self, long_mode_on):
-        self._inst_settings.update_attributes(advanced_config=pearl_advanced_config.get_long_mode_dict(long_mode_on),
-                                              suppress_warnings=True)
+        self._inst_settings.update_attributes(advanced_config=pearl_advanced_config.get_long_mode_dict(long_mode_on))

--- a/scripts/Diffraction/isis_powder/pearl.py
+++ b/scripts/Diffraction/isis_powder/pearl.py
@@ -141,7 +141,10 @@ class Pearl(AbstractInst):
                                                         run_details=run_details, focus_mode=output_mode,
                                                         attenuation_filepath=attenuation_path)
         group_name = "PEARL" + str(run_details.output_run_string)
-        group_name += '_' + self._inst_settings.tt_mode + "-Results-D-Grp"
+        group_name += '_' + self._inst_settings.tt_mode
+        group_name += "_long" if self._inst_settings.long_mode else ""
+        group_name += "-Results-D-Grp"
+
         grouped_d_spacing = mantid.GroupWorkspaces(InputWorkspaces=output_spectra, OutputWorkspace=group_name)
         return grouped_d_spacing, None
 

--- a/scripts/Diffraction/isis_powder/pearl.py
+++ b/scripts/Diffraction/isis_powder/pearl.py
@@ -140,11 +140,10 @@ class Pearl(AbstractInst):
             pearl_output.generate_and_save_focus_output(self, processed_spectra=processed_spectra,
                                                         run_details=run_details, focus_mode=output_mode,
                                                         attenuation_filepath=attenuation_path)
-        group_name = "PEARL" + str(run_details.output_run_string)
-        group_name += '_' + self._inst_settings.tt_mode
-        group_name += "_long" if self._inst_settings.long_mode else ""
-        group_name += "-Results-D-Grp"
 
+        group_name = "PEARL{0!s}_{1}{2}-Results-D-Grp"
+        mode = "_long" if self._inst_settings.long_mode else ""
+        group_name = group_name.format(run_details.output_run_string, self._inst_settings.tt_mode, mode)
         grouped_d_spacing = mantid.GroupWorkspaces(InputWorkspaces=output_spectra, OutputWorkspace=group_name)
         return grouped_d_spacing, None
 

--- a/scripts/Diffraction/isis_powder/routines/instrument_settings.py
+++ b/scripts/Diffraction/isis_powder/routines/instrument_settings.py
@@ -126,9 +126,12 @@ class InstrumentSettings(object):
             param_val = _check_value_is_in_enum(param_val, param_map.enum_class)
 
         # Does the attribute exist - has it changed and are we suppressing warnings
+
         if not suppress_warnings:
+
             previous_value = getattr(self, attribute_name) if hasattr(self, attribute_name) else None
-            if previous_value and previous_value != param_val:
+            if previous_value is not None and previous_value != param_val:
+
                 # Print warning of what we value we are replacing for which parameter
                 warnings.warn("Replacing parameter: '" + str(param_map.ext_name) + "' which was previously set to: '" +
                               str(getattr(self, attribute_name)) + "' with new value: '" + str(param_val) + "'")


### PR DESCRIPTION
Changed Long mode to append long to output workspace names, and added warnings for when long mode values are changed.


**To test:**
slack me a message for setup, once setup run one of the following script, the warnings should include "Replacing parameter: 'long_mode' which was previously set to: 'False' with new value: 'True'" and the output workspace name should contain the word "long".
```
from isis_powder import Pearl

config_file_path = r"Path\to\pearl_shared_config.yaml"
pearl_example = Pearl(config_file=config_file_path,user_name="test",long_mode=False)
pearl_example.create_vanadium(long_mode=True,tt_mode="tt88",run_in_cycle="95634")
```
or
```
from isis_powder import Pearl

config_file_path = r"Path\to\pearl_shared_config.yaml"
pearl_example = Pearl(config_file=config_file_path,user_name="test",long_mode=False)

pearl_example.focus(long_mode=True,tt_mode="tt88",vanadium_normalisation=True,run_number=97500)
```




[test.zip](https://github.com/mantidproject/mantid/files/2273362/test.zip)

Fixes #23129

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
