### PR TITLE
Refs #0 Update AlgorithmMPISupport.rst

### DIFF
--- a/dev-docs/source/AlgorithmMPISupport.rst
+++ b/dev-docs/source/AlgorithmMPISupport.rst
@@ -152,6 +152,9 @@ Furthermore, to avoid pollution of usage reports, usage reporting should be disa
   CheckMantidVersion.OnStartup = 0
   usagereports.enabled = 0
 
+In addition, Mantid has been found to sometimes hang when trying to execute algorithms on more than 10 ranks. Setting ``logging.channels.fileFilterChannel.level=`` to nothing appears to solve this problem.
+
+
 Writing and running Python scripts
 ----------------------------------
 


### PR DESCRIPTION
**Description of work.**

Added a note in the documentation on disabling some logging when using more than 10 ranks to prevent Mantid from hanging.

**To test:**

When using MPI support, running for example the `SNSPowderReduction` workflow with 10 ranks completes with no issues. It doesn't complete when using 11 or more ranks, it simply hangs at `AlignAndFocusPowder-[Warning] null output` after starting `DiffractionFocussing`. All the CPUs are still working, at 100% but the workflow never progresses.

Setting
```
logging.channels.fileFilterChannel.level=
```
to nothing in the `Mantid.user.properties` files seems to fix this, probably due to some conflict in the logging between ranks.

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
