### PR TITLE
LoadDNSLegacy: add elastic channel property

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadDNSLegacyTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadDNSLegacyTest.py
@@ -161,7 +161,7 @@ class LoadDNSLegacyTest(unittest.TestCase):
         filename = "dnstof.d_dat"
         tof1 = 424.668     # must be changed if L1 will change
         alg_test = run_algorithm("LoadDNSLegacy", Filename=filename, Normalization='no',
-                                 OutputWorkspace=outputWorkspaceName)
+                                 ElasticChannel=65, OutputWorkspace=outputWorkspaceName)
         self.assertTrue(alg_test.isExecuted())
 
         # Verify some values
@@ -170,7 +170,7 @@ class LoadDNSLegacyTest(unittest.TestCase):
         self.assertEqual(24, ws.getNumberHistograms())
         self.assertEqual(100,  ws.getNumberBins())
         # data array
-        self.assertEqual(8, ws.readY(19)[37])       # must be changed after comissioning will be finished
+        self.assertEqual(8, ws.readY(19)[23])
         self.assertAlmostEqual(tof1, ws.readX(0)[0], 3)
         self.assertAlmostEqual(tof1+40.1*100, ws.readX(0)[100], 3)
         # sample logs
@@ -179,7 +179,7 @@ class LoadDNSLegacyTest(unittest.TestCase):
         self.assertEqual(100, run.getProperty('tof_channels').value)
         self.assertEqual(51428, run.getProperty('mon_sum').value)
         self.assertEqual('z', run.getProperty('polarisation').value)
-        self.assertEqual(33, run.getProperty('EPP').value)  # check that EPP is taken from file
+        self.assertEqual(65, run.getProperty('EPP').value)  # check that EPP is not taken from file
         self.assertEqual('7', str(run.getProperty('polarisation_comment').value))
         self.assertEqual('no', run.getProperty('normalized').value)
         # check whether detector bank is rotated

--- a/docs/source/algorithms/LoadDNSLegacy-v1.rst
+++ b/docs/source/algorithms/LoadDNSLegacy-v1.rst
@@ -21,11 +21,8 @@ in the position given in the data file.
 
 - For diffraction mode data (only one time channel) output is the :ref:`Workspace2D <Workspace2D>` with the X-axis in the wavelength units.
 
-- For TOF data (more than one time channel) output is the :ref:`Workspace2D <Workspace2D>` with the X-axis in TOF units.
-The lower bin boundary for the channel :math:`i`, :math:`t_i` is calculated as :math:`t_i = t_1 + t_{delay} + i*\Delta t`,
-where :math:`\Delta t` is the channel width and :math:`t_1` is the time-of-flight from the source (chopper) to sample.
-Given in the data file channel width is scaled by the *channel_width_factor* which can be set in
-the :ref:`parameter file <InstrumentParameterFile>`.
+- For TOF data (more than one time channel) output is the :ref:`Workspace2D <Workspace2D>` with the X-axis in TOF units. The lower bin boundary for the channel :math:`i`, :math:`t_i` is calculated as :math:`t_i = t_1 + t_{delay} + i*\Delta t`, where :math:`\Delta t` is the channel width and :math:`t_1` is the time-of-flight from the source (chopper) to sample. Given in the data file channel width is scaled by the *channel_width_factor* which can be set in the :ref:`parameter file <InstrumentParameterFile>`.
+
 
 .. note::
 
@@ -70,7 +67,7 @@ Usage
 
 **Example 1 - Load DNS diffraction mode .d_dat file:**
 
-.. code-block:: python
+.. testcode:: LoadDNSLegacyEx1
 
    # data file
    datafile = 'dn134011vana.d_dat'
@@ -80,14 +77,16 @@ Usage
 
    print("This workspace has {} dimensions and has {} histograms.".format(ws.getNumDims(), ws.getNumberHistograms()))
 
-Output:
+**Output:**
+
+.. testoutput:: LoadDNSLegacyEx1
 
    This workspace has 2 dimensions and has 24 histograms.
 
 
 **Example 2 - Load DNS TOF mode .d_dat file and find the elastic channel:**
 
-.. code-block:: python
+.. testcode:: LoadDNSLegacyEx2
 
    # data file
    datafile = 'dnstof.d_dat'
@@ -112,7 +111,9 @@ Output:
    print("The channel width is {} microseconds.".format(channel_width))
    print("The elastic channel number is: {}.".format(epp))
 
-Output:
+**Output:**
+
+.. testoutput:: LoadDNSLegacyEx2
 
    This workspace has 2 dimensions and has 24 histograms.
    Elastic peak center is at 3023 microseconds and has sigma=62.
@@ -122,7 +123,7 @@ Output:
 
 **Example 3 - Load DNS TOF mode .d_dat file and specify the elastic channel:**
 
-.. code-block:: python
+.. testcode:: LoadDNSLegacyEx3
 
    # data file
    datafile = 'dnstof.d_dat'
@@ -158,7 +159,9 @@ Output:
          .format(round(tof_elastic - peak_center), channel_width, round(sigma)))
    channel_width = ws.getRun().getProperty("channel_width").value
 
-Output:
+**Output:**
+
+.. testoutput:: LoadDNSLegacyEx3
 
    Calculated elastic TOF: 1327 microseconds
    Elastic TOF in the workspace: 1299 microseconds

--- a/docs/source/algorithms/LoadDNSLegacy-v1.rst
+++ b/docs/source/algorithms/LoadDNSLegacy-v1.rst
@@ -100,7 +100,7 @@ Usage
    # perform fit
    # Warning: this will work only if elastic peak is stronger than the other peaks!
    peak_center, sigma = FitGaussian(ws_sum, 0)
-   print("Elastic peak center is at {} microseconds and has sigma={}.".format(round(peak_center), round(sigma)))
+   print("Elastic peak center is at {:.0f} microseconds and has sigma={:.0f}.".format(round(peak_center), round(sigma)))
 
    # calculate the elastic channel number
    channel_width = ws.getRun().getProperty("channel_width").value
@@ -109,7 +109,7 @@ Usage
    epp = round((peak_center - tof1 - t_delay)/channel_width)
 
    print("The channel width is {} microseconds.".format(channel_width))
-   print("The elastic channel number is: {}.".format(epp))
+   print("The elastic channel number is: {:.0f}.".format(epp))
 
 **Output:**
 
@@ -146,16 +146,16 @@ Usage
    tof1 = ws.getRun().getProperty("TOF1").value
    t_delay = ws.getRun().getProperty("delay_time").value
    tof_elastic = t_delay + tof1 + tof2_elastic
-   print ("Calculated elastic TOF: {} microseconds".format(round(tof_elastic)))
+   print ("Calculated elastic TOF: {:.0f} microseconds".format(round(tof_elastic)))
 
    # get elastic TOF from file
    ws_sum = SumSpectra(ws)
    peak_center, sigma = FitGaussian(ws_sum, 0)
-   print ("Elastic TOF in the workspace: {} microseconds".format(round(peak_center)))
+   print ("Elastic TOF in the workspace: {:.0f} microseconds".format(round(peak_center)))
 
    # compare difference to the channel width
    channel_width = ws.getRun().getProperty("channel_width").value
-   print("Difference = {} microseconds < channel width = {} microseconds."
+   print("Difference = {:.0f} microseconds < channel width = {} microseconds."
          .format(round(tof_elastic - peak_center), channel_width, round(sigma)))
    channel_width = ws.getRun().getProperty("channel_width").value
 

--- a/docs/source/algorithms/LoadDNSLegacy-v1.rst
+++ b/docs/source/algorithms/LoadDNSLegacy-v1.rst
@@ -14,13 +14,24 @@ Description
    This algorithm is being developed for a specific instrument. It might get changed or even 
    removed without a notification, should instrument scientists decide to do so.
 
-This algorithm loads a DNS legacy data file into a :ref:`Workspace2D <Workspace2D>`. The loader rotates the detector bank in the position given in the data file.
+This algorithm loads a DNS legacy data file into a :ref:`Workspace2D <Workspace2D>`. The loader rotates the detector bank
+in the position given in the data file.
 
 **Output**
 
 - For diffraction mode data (only one time channel) output is the :ref:`Workspace2D <Workspace2D>` with the X-axis in the wavelength units.
 
-- For TOF data (more than one time channel) output is the :ref:`Workspace2D <Workspace2D>` with the X-axis in TOF units. The lower bin boundary for the channel :math:`i`, :math:`t_i` is calculated as :math:`t_i = t_1 + t_{delay} + i*\Delta t`, where :math:`\Delta t` is the channel width and :math:`t_1` is the time-of-flight from the source (chopper) to sample. Given in the data file channel width is scaled by the *channel_width_factor* which can be set in the :ref:`parameter file <InstrumentParameterFile>`.
+- For TOF data (more than one time channel) output is the :ref:`Workspace2D <Workspace2D>` with the X-axis in TOF units.
+The lower bin boundary for the channel :math:`i`, :math:`t_i` is calculated as :math:`t_i = t_1 + t_{delay} + i*\Delta t`,
+where :math:`\Delta t` is the channel width and :math:`t_1` is the time-of-flight from the source (chopper) to sample.
+Given in the data file channel width is scaled by the *channel_width_factor* which can be set in
+the :ref:`parameter file <InstrumentParameterFile>`.
+
+.. note::
+
+   Since zero time channel is not specified, the algorithm can roll the TOF data to get elastic peak at the right position.
+   For this the **ElasticChannel** - channel number where the elastic peak is observed without correction - should be specified.
+   For comissioning period, the algorithm ignores the elastic channel number given in the data file.
 
 **Normalization**
 
@@ -57,21 +68,101 @@ This algorithm only supports DNS instrument in its configuration with one detect
 Usage
 -----
 
-**Example - Load DNS legacy .d_dat files:**
+**Example 1 - Load DNS diffraction mode .d_dat file:**
 
 .. code-block:: python
 
-   # data file.
-   datafiles = 'dn134011vana.d_dat,dnstof.d_dat'
+   # data file
+   datafile = 'dn134011vana.d_dat'
 
    # Load dataset
-   ws = LoadDNSLegacy(datafiles, Normalization='monitor')
+   ws = LoadDNSLegacy(datafile, Normalization='monitor')
 
    print("This workspace has {} dimensions and has {} histograms.".format(ws.getNumDims(), ws.getNumberHistograms()))
 
 Output:
 
    This workspace has 2 dimensions and has 24 histograms.
+
+
+**Example 2 - Load DNS TOF mode .d_dat file and find the elastic channel:**
+
+.. code-block:: python
+
+   # data file
+   datafile = 'dnstof.d_dat'
+
+   # Load dataset
+   ws = LoadDNSLegacy(datafile, Normalization='no')
+   print("This workspace has {} dimensions and has {} histograms.".format(ws.getNumDims(), ws.getNumberHistograms()))
+
+   # sum spectra over all detectors
+   ws_sum = SumSpectra(ws)
+   # perform fit
+   # Warning: this will work only if elastic peak is stronger than the other peaks!
+   peak_center, sigma = FitGaussian(ws_sum, 0)
+   print("Elastic peak center is at {} microseconds and has sigma={}.".format(round(peak_center), round(sigma)))
+
+   # calculate the elastic channel number
+   channel_width = ws.getRun().getProperty("channel_width").value
+   tof1 = ws.getRun().getProperty("TOF1").value
+   t_delay = ws.getRun().getProperty("delay_time").value
+   epp = round((peak_center - tof1 - t_delay)/channel_width)
+
+   print("The channel width is {} microseconds.".format(channel_width))
+   print("The elastic channel number is: {}.".format(epp))
+
+Output:
+
+   This workspace has 2 dimensions and has 24 histograms.
+   Elastic peak center is at 3023 microseconds and has sigma=62.
+   The channel width is 40.1 microseconds.
+   The elastic channel number is: 65.
+
+
+**Example 3 - Load DNS TOF mode .d_dat file and specify the elastic channel:**
+
+.. code-block:: python
+
+   # data file
+   datafile = 'dnstof.d_dat'
+
+   # Load dataset
+   ws = LoadDNSLegacy(datafile, ElasticChannel=65, Normalization='no')
+
+   # let's check that the elastic peak is at the right position
+   from scipy.constants import m_n, h
+
+   l1 = 0.4     # distance from chopper to sample, m
+   l2 = 0.85   # distance from sample to detector, m
+   wavelength = ws.getRun().getProperty("wavelength").value   # neutron wavelength, Angstrom
+
+   # neutron velocity
+   velocity = h/(m_n*wavelength*1e-10)
+
+   # calculate elastic TOF (total)
+   tof2_elastic = 1e+06*l2/velocity
+   tof1 = ws.getRun().getProperty("TOF1").value
+   t_delay = ws.getRun().getProperty("delay_time").value
+   tof_elastic = t_delay + tof1 + tof2_elastic
+   print ("Calculated elastic TOF: {} microseconds".format(round(tof_elastic)))
+
+   # get elastic TOF from file
+   ws_sum = SumSpectra(ws)
+   peak_center, sigma = FitGaussian(ws_sum, 0)
+   print ("Elastic TOF in the workspace: {} microseconds".format(round(peak_center)))
+
+   # compare difference to the channel width
+   channel_width = ws.getRun().getProperty("channel_width").value
+   print("Difference = {} microseconds < channel width = {} microseconds."
+         .format(round(tof_elastic - peak_center), channel_width, round(sigma)))
+   channel_width = ws.getRun().getProperty("channel_width").value
+
+Output:
+
+   Calculated elastic TOF: 1327 microseconds
+   Elastic TOF in the workspace: 1299 microseconds
+   Difference = 28 microseconds < channel width = 40.1 microseconds.
 
 .. categories::
 

--- a/docs/source/release/v3.14.0/direct_inelastic.rst
+++ b/docs/source/release/v3.14.0/direct_inelastic.rst
@@ -23,7 +23,8 @@ New features
 Improvements
 ############
 
-- improved ``Save``-section of the TOFTOF reduction dialog.
+- Improved ``Save``-section of the TOFTOF reduction dialog.
+- Behavior of the :ref:`LoadDNSLegacy <algm-LoadDNSLegacy>` for TOF data has been changed: the algorithm does not try to guess elastic channel any more, but asks for the user input.
 
 :ref:`Release 3.14.0 <v3.14.0>`
 


### PR DESCRIPTION
This PR changes behavior of `LoadDNSLegacy` algorithm for TOF data. The algorithm does not determine the elastic peak position by itself, but provides user an option to specify the elastic time channel.

The elastic time channel given in the data file is ignored, since it is not relevant during the comissioning period. This behavior can be easily changed by setting `tof_comissioning=no` in the instrument parameter file.

**To test:**

See the unit tests and examples in the documentation. A couple of DNS data files are available in the test data. More DNS data files for testing are attached to PR #23029.

Fixes #23030 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

Does this update require release notes?
- [x] Yes
- [ ] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
