### PR TITLE
Adding connection tests to muon GUI

### DIFF
--- a/scripts/test/Muon/FFTPresenter_test.py
+++ b/scripts/test/Muon/FFTPresenter_test.py
@@ -28,6 +28,8 @@ class FFTPresenterTest(unittest.TestCase):
         self.view.phaseCheckSignal = mock.Mock(return_value=True)
         # needed for connect in presenter
         self.view.buttonSignal = mock.Mock()
+        self.view.tableClickSignal = mock.Mock()
+        self.view.phaseCheckSignal = mock.Mock()
         self.view.changed = mock.MagicMock()
         self.view.changedHideUnTick = mock.MagicMock()
         self.view.initFFTInput = mock.Mock(
@@ -74,9 +76,19 @@ class FFTPresenterTest(unittest.TestCase):
         row, col = self.view.tableClickSignal()
         self.presenter.tableClicked(row, col)
 
+    def test_connects(self):
+        assert(self.view.tableClickSignal.connect.call_count==1)
+        self.view.tableClickSignal.connect.called_with(self.presenter.tableClicked)
+
+        assert(self.view.buttonSignal.connect.call_count==1)
+        self.view.buttonSignal.connect.called_with(self.presenter.handleButton)
+
+        assert(self.view.phaseCheckSignal.connect.call_count==1)
+        self.view.phaseCheckSignal.connect.called_with(self.presenter.phaseCheck)
+
     def test_ImBox(self):
-        self.sendSignal()
         self.view.tableClickSignal = mock.Mock(return_value=[3, 1])
+        self.sendSignal()
         assert(self.view.changedHideUnTick.call_count == 1)
         assert(self.view.changed.call_count == 0)
 

--- a/scripts/test/Muon/FFTPresenter_test.py
+++ b/scripts/test/Muon/FFTPresenter_test.py
@@ -78,13 +78,13 @@ class FFTPresenterTest(unittest.TestCase):
 
     def test_connects(self):
         assert(self.view.tableClickSignal.connect.call_count==1)
-        self.view.tableClickSignal.connect.called_with(self.presenter.tableClicked)
+        self.view.tableClickSignal.connect.assert_called_with(self.presenter.tableClicked)
 
         assert(self.view.buttonSignal.connect.call_count==1)
-        self.view.buttonSignal.connect.called_with(self.presenter.handleButton)
+        self.view.buttonSignal.connect.assert_called_with(self.presenter.handleButton)
 
         assert(self.view.phaseCheckSignal.connect.call_count==1)
-        self.view.phaseCheckSignal.connect.called_with(self.presenter.phaseCheck)
+        self.view.phaseCheckSignal.connect.assert_called_with(self.presenter.phaseCheck)
 
     def test_ImBox(self):
         self.view.tableClickSignal = mock.Mock(return_value=[3, 1])

--- a/scripts/test/Muon/MaxEntPresenter_test.py
+++ b/scripts/test/Muon/MaxEntPresenter_test.py
@@ -49,13 +49,24 @@ class MaxEntPresenterTest(unittest.TestCase):
         self.thread.threadWrapperSetup = mock.Mock()
         self.thread.threadWrapperTearDown = mock.Mock()
 
-        self.presenter.createThread=mock.Mock(return_value=self.thread)
-        self.presenter.createPhaseThread=mock.Mock(return_value=self.thread)
+    def test_connects(self):
+        assert(self.view.cancelSignal.connect.call_count==1)
+        self.view.cancelSignal.connect.called_with(self.presenter.cancel)
+
+        assert(self.view.maxEntButtonSignal.connect.call_count==1)
+        self.view.maxEntButtonSignal.connect.called_with(self.presenter.handleMaxEntButton)
+
+        assert(self.view.phaseSignal.connect.call_count==1)
+        self.view.phaseSignal.connect.called_with(self.presenter.handlePhase)
 
     def test_button(self):
+        self.presenter.createThread = lambda *args:self.thread
+
         self.presenter.handleMaxEntButton()
         assert(self.view.initMaxEntInput.call_count==1)
         assert(self.thread.start.call_count==1)
+
+        assert(self.thread.threadWrapperSetUp.call_count==1)
 
     def test_dataHasChanged(self):
         self.load.hasDataChanged = mock.MagicMock(return_value=True)

--- a/scripts/test/Muon/MaxEntPresenter_test.py
+++ b/scripts/test/Muon/MaxEntPresenter_test.py
@@ -51,13 +51,13 @@ class MaxEntPresenterTest(unittest.TestCase):
 
     def test_connects(self):
         assert(self.view.cancelSignal.connect.call_count==1)
-        self.view.cancelSignal.connect.called_with(self.presenter.cancel)
+        self.view.cancelSignal.connect.assert_called_with(self.presenter.cancel)
 
         assert(self.view.maxEntButtonSignal.connect.call_count==1)
-        self.view.maxEntButtonSignal.connect.called_with(self.presenter.handleMaxEntButton)
+        self.view.maxEntButtonSignal.connect.assert_called_with(self.presenter.handleMaxEntButton)
 
         assert(self.view.phaseSignal.connect.call_count==1)
-        self.view.phaseSignal.connect.called_with(self.presenter.handlePhase)
+        self.view.phaseSignal.connect.assert_called_with(self.presenter.handlePhase)
 
     def test_button(self):
         self.presenter.createThread = lambda *args:self.thread

--- a/scripts/test/Muon/transformWidget_test.py
+++ b/scripts/test/Muon/transformWidget_test.py
@@ -16,7 +16,7 @@ if sys.version_info.major == 3:
 else:
     import mock
 
-class FFTTransformTest(unittest.TestCase):
+class TransformTest(unittest.TestCase):
     def setUp(self):
         self._qapp = mock_widget.mockQapp()
         self.load=  mock.create_autospec( load_utils.LoadUtils,spec_set=True)


### PR DESCRIPTION
**Description of work.**
I have added some tests to check that connections are set up in the new muon GUI. 

**To test:**
You will need to run each of the unit tests. 

1. Make sure the changed tests all pass

2. Change one of the arguments (either the number in the `call_count` assert or the method called in the `assert_called_with`) but only change one at a time and make sure the test fails.

<!-- Instructions for testing. -->

Fixes #23060. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

Does this update require release notes?
- [ ] Yes
- [x ] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
