### PR TITLE
Fix RunNumber bug in PeaksWorkspaces

### DIFF
--- a/Framework/DataObjects/src/PeakColumn.cpp
+++ b/Framework/DataObjects/src/PeakColumn.cpp
@@ -135,7 +135,7 @@ const std::type_info &PeakColumn::get_pointer_type_info() const {
  */
 void PeakColumn::print(size_t index, std::ostream &s) const {
   Peak &peak = m_peaks[index];
-
+  s.imbue(std::locale("C"));
   std::ios::fmtflags fflags(s.flags());
   if (m_name == "RunNumber")
     s << peak.getRunNumber();


### PR DESCRIPTION
**Description of work.**
Fixes old behavior running test below:
First time the RunNumber is 23,767 and the second time it is 23. This is because the RunNumber is printed in the table workspace with a comma because of locale and then read back in case the user changed it.

**To test:**
```LoadIsawPeaks(Filename='~/mantid/release/ExternalData/Testing/Data/DocTest/SXD23767.peaks', OutputWorkspace='peaks')```
Show Data twice for workspace peaks.  

Fixes #23160 

Does this update require release notes?
- [ ] Yes
- [ X] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
