### PR TITLE
Minimal change to prevent a crash

### DIFF
--- a/qt/widgets/common/src/UserFunctionDialog.cpp
+++ b/qt/widgets/common/src/UserFunctionDialog.cpp
@@ -383,9 +383,11 @@ void UserFunctionDialog::saveToFile() {
  */
 void UserFunctionDialog::removeCurrentFunction() {
   QString cat = m_uiForm.lstCategory->currentItem()->text();
-  if (isBuiltin(cat)) {
+  if (isBuiltin(cat) || 
+    (m_uiForm.lstFunction->currentItem() == nullptr)) {
     return;
   }
+
   QString fun = m_uiForm.lstFunction->currentItem()->text();
   if (QMessageBox::question(
           this, "Mantid",

--- a/qt/widgets/common/src/UserFunctionDialog.cpp
+++ b/qt/widgets/common/src/UserFunctionDialog.cpp
@@ -383,8 +383,7 @@ void UserFunctionDialog::saveToFile() {
  */
 void UserFunctionDialog::removeCurrentFunction() {
   QString cat = m_uiForm.lstCategory->currentItem()->text();
-  if (isBuiltin(cat) || 
-    (m_uiForm.lstFunction->currentItem() == nullptr)) {
+  if (isBuiltin(cat) || (m_uiForm.lstFunction->currentItem() == nullptr)) {
     return;
   }
 


### PR DESCRIPTION
Minimal change to prevent a crash
This dialog is not used enough to justify much more time being spent on neatening things up

**Description of work.**
Minimal change to prevent a crash.
It just spots that there is no function selected and exits the remove function.
This dialog is not used enough to justify much more time being spent on neatening things up.

**Report to:** nobody

**To test:**

1. Plot a spectrum
1. Try fit a function to a peak
1. Right click on spectrum, select add other function
1. Select UserFunction and press Ok
1. In the Fit Function Browser, create your own formula (under f0-UserFunction) and Save it
1. Remove this new formula, then try remove it again
1. No crash!

Fixes #22965. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
