### PR TITLE
Correct default doc string for empty property managers to dict()

### DIFF
--- a/docs/sphinxext/mantiddoc/directives/properties.py
+++ b/docs/sphinxext/mantiddoc/directives/properties.py
@@ -207,6 +207,10 @@ class PropertiesDirective(AlgorithmBaseDirective):
             else:
                 defaultstr = "False"
 
+        if str(prop.type) == "Dictionary":
+            if defaultstr == r"null\\n":
+                defaultstr = "dict()"
+
         return defaultstr
 
     def _create_property_description_string(self, prop):


### PR DESCRIPTION
**Description of work.**
Corrected the  default doc string for empty property managers to dict() in the properties directive in sphinx

**To test:**

1. Code review might do
1. but if you want to go further build the docs and look at LoadAndMerge.rst at the properties table, it used to look like
![image](https://user-images.githubusercontent.com/1017173/43585512-34d56e04-965d-11e8-99c1-2e942a2c3fee.png)

now it looks like

![image](https://user-images.githubusercontent.com/1017173/43585527-42912fd8-965d-11e8-9277-642bdd7d6d7d.png)

Fixes #22807. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
