### PR TITLE
DPDReduction: error reading MomentumTransfer bins

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
@@ -112,7 +112,7 @@ class DPDFreduction(api.PythonAlgorithm):
         # check momentum transfer bins
         qbins = self.getProperty('MomentumTransferBins').value
         print(type(qbins))
-        if len(qbins) not in (0, 3):
+        if len(qbins) not in (0, 1, 3):
             issues['MomentumTransferBins'] =\
                 'Momentum transfer bins is a list of zero (empty list), one, or three values'
         return issues

--- a/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
@@ -111,7 +111,6 @@ class DPDFreduction(api.PythonAlgorithm):
             issues['EnergyBins'] = 'Energy bins is a list of either one or three values'
         # check momentum transfer bins
         qbins = self.getProperty('MomentumTransferBins').value
-        print(type(qbins))
         if len(qbins) not in (0, 1, 3):
             issues['MomentumTransferBins'] =\
                 'Momentum transfer bins is a list of zero (empty list), one, or three values'

--- a/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
@@ -42,7 +42,8 @@ class DPDFreduction(api.PythonAlgorithm):
         self.declareProperty('RunNumbers', '', 'Sample run numbers')
         self.setPropertyGroup("RunNumbers", titleInputOptions)
         self.declareProperty(api.FileProperty(name='Vanadium', defaultValue='',
-                                              action=api.FileAction.OptionalLoad, extensions=['.nxs']),
+                                              action=api.FileAction.OptionalLoad,
+                                              extensions=['.nxs']),
                              'Preprocessed white-beam vanadium file.')
         self.setPropertyGroup("Vanadium", titleInputOptions)
         self.declareProperty('EmptyCanRunNumbers', '', 'Empty can run numbers')
@@ -50,25 +51,35 @@ class DPDFreduction(api.PythonAlgorithm):
 
         # Configuration parameters
         titleConfigurationOptions = "Configuration"
+
         e_validator = kapi.FloatArrayLengthValidator(1,3)
-        self.declareProperty(kapi.FloatArrayProperty('EnergyBins', [1.5,] ,validator=e_validator),
+        self.declareProperty(kapi.FloatArrayProperty('EnergyBins', [1.5],
+                                                     validator=e_validator),
                              'Energy transfer binning scheme (in meV)')
         self.setPropertyGroup("EnergyBins", titleConfigurationOptions)
+
         q_validator = kapi.FloatArrayLengthValidator(0, 3)
-        self.declareProperty(kapi.FloatArrayProperty('MomentumTransferBins', list(), validator=q_validator),
+        self.declareProperty(kapi.FloatArrayProperty('MomentumTransferBins',
+                                                     list(),
+                                                     validator=q_validator),
                              'Momentum transfer binning scheme (in inverse Angstroms)')
         self.setPropertyGroup("MomentumTransferBins", titleConfigurationOptions)
+
         self.declareProperty('NormalizeSlices', False,
-                             'Do we normalize each slice?', direction=kapi.Direction.Input)
+                             'Do we normalize each slice?',
+                             direction=kapi.Direction.Input)
         self.setPropertyGroup("NormalizeSlices", titleConfigurationOptions)
 
         # Ouptut parameters
         titleOuptutOptions = "Output"
         self.declareProperty('CleanWorkspaces', True,
-                             'Do we clean intermediate steps?', direction=kapi.Direction.Input)
+                             'Do we clean intermediate steps?',
+                             direction=kapi.Direction.Input)
         self.setPropertyGroup("CleanWorkspaces", titleOuptutOptions)
-        self.declareProperty(api.MatrixWorkspaceProperty('OutputWorkspace', 'S_Q_E_sliced',
-                                                         kapi.Direction.Output), "Output workspace")
+        self.declareProperty(api.MatrixWorkspaceProperty('OutputWorkspace',
+                                                         'S_Q_E_sliced',
+                                                         kapi.Direction.Output),
+                             "Output workspace")
         self.setPropertyGroup("OutputWorkspace", titleOuptutOptions)
 
     def validateInputs(self):
@@ -86,7 +97,8 @@ class DPDFreduction(api.PythonAlgorithm):
             elif re.compile(r'^\s*\d+\s*-\s*\d+\s*$').match(runs_string):
                 first, second = [int(x) for x in runs_string.split('-')]
                 if first >= second:
-                    issues[runs_property_name] = runs_property_name + ' should be increasing'
+                    issues[runs_property_name] = runs_property_name +\
+                                                 ' should be increasing'
 
         # check syntax for RunNumbers
         checkrunnumbers('RunNumbers')
@@ -94,13 +106,15 @@ class DPDFreduction(api.PythonAlgorithm):
         if self.getPropertyValue('EmptyCanRunNumbers'):
             checkrunnumbers('EmptyCanRunNumbers')
         # check energy bins
-        ebins = self.getPropertyValue('EnergyBins')
+        ebins = self.getProperty('EnergyBins').value
         if len(ebins) not in (1, 3):
             issues['EnergyBins'] = 'Energy bins is a list of either one or three values'
         # check momentum transfer bins
-        qbins = self.getPropertyValue('MomentumTransferBins')
-        if len(qbins) not in (0, 1, 3):
-            issues['MomentumTransferBins'] = 'Momentum transfer bins is a list of zero, one, or three values'
+        qbins = self.getProperty('MomentumTransferBins').value
+        print(type(qbins))
+        if len(qbins) not in (0, 3):
+            issues['MomentumTransferBins'] =\
+                'Momentum transfer bins is a list of zero (empty list), one, or three values'
         return issues
 
     #pylint: disable=too-many-locals, too-many-branches


### PR DESCRIPTION
**To test:**
The following snippet should run with no problems
```
DPDFreduction(RunNumbers="88708", CleanWorkspaces=False,
    Vanadium="/SNS/ARCS/shared/autoreduce/vanadium_files/van88344.nxs",
    EnergyBins=1.5,
    MomentumTransferBins=0.01,
    OutputWorkspace="slices_QE")
```

Fixes #23173

Does this update require release notes?
- [ ] Yes
- [x] No
<!--
If yes, edit the file docs/source/release/... 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
