### PR TITLE
Solved fit constraints boundary problem Re #23089

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,16 +48,19 @@ set_property(CACHE CPACK_PACKAGE_SUFFIX PROPERTY STRINGS nightly unstable "") #e
 #Set package name here
 set ( CPACK_PACKAGE_NAME "mantid${CPACK_PACKAGE_SUFFIX}" )
 
+
+###########################################################################
+# Bootstrap any dependencies
+###########################################################################
+include ( Bootstrap )
+
 ###########################################################################
 # Include Eigen as an external project
 ###########################################################################
 include ( Eigen )
 
 ###########################################################################
-# Bootstrap any dependencies
-###########################################################################
-include ( Bootstrap )
-###########################################################################
+
 # Set ParaView information since later items depend on it
 ###########################################################################
 # VATES flag. Requires ParaView

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,19 +48,17 @@ set_property(CACHE CPACK_PACKAGE_SUFFIX PROPERTY STRINGS nightly unstable "") #e
 #Set package name here
 set ( CPACK_PACKAGE_NAME "mantid${CPACK_PACKAGE_SUFFIX}" )
 
-
 ###########################################################################
 # Bootstrap any dependencies
 ###########################################################################
 include ( Bootstrap )
 
 ###########################################################################
-# Include Eigen as an external project
+# Configure Eigen early
 ###########################################################################
 include ( Eigen )
 
 ###########################################################################
-
 # Set ParaView information since later items depend on it
 ###########################################################################
 # VATES flag. Requires ParaView

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -2790,8 +2790,8 @@ void FitPropertyBrowser::setupMultifit() {
           }
         }
         QString wsParam = ",WSParam=(WorkspaceIndex=" + QString::number(i);
-        wsParam += ",StartX=" + QString::number(startX()) +
-                   ",EndX=" + QString::number(endX()) + ")";
+        wsParam += ",StartX=" + QString::number(startX()) + ",EndX=" +
+                   QString::number(endX()) + ")";
         funIni += fun1Ini + ",Workspace=" + wsName + wsParam + ";";
       }
       if (!tieStr.isEmpty()) {

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -2211,7 +2211,6 @@ void FitPropertyBrowser::addConstraint(int f, bool lo, bool up) {
   if (!h)
     return;
 
-  // double x = m_doubleManager->value(parProp);
   double x = parProp->valueText().toDouble();
   double loBound = x * (1 - 0.01 * f);
   double upBound = x * (1 + 0.01 * f);
@@ -2791,8 +2790,8 @@ void FitPropertyBrowser::setupMultifit() {
           }
         }
         QString wsParam = ",WSParam=(WorkspaceIndex=" + QString::number(i);
-        wsParam += ",StartX=" + QString::number(startX()) + ",EndX=" +
-                   QString::number(endX()) + ")";
+        wsParam += ",StartX=" + QString::number(startX()) +
+                   ",EndX=" + QString::number(endX()) + ")";
         funIni += fun1Ini + ",Workspace=" + wsName + wsParam + ";";
       }
       if (!tieStr.isEmpty()) {

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -2211,7 +2211,7 @@ void FitPropertyBrowser::addConstraint(int f, bool lo, bool up) {
   if (!h)
     return;
 
-  //double x = m_doubleManager->value(parProp);
+  // double x = m_doubleManager->value(parProp);
   double x = parProp->valueText().toDouble();
   double loBound = x * (1 - 0.01 * f);
   double upBound = x * (1 + 0.01 * f);

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -2211,7 +2211,8 @@ void FitPropertyBrowser::addConstraint(int f, bool lo, bool up) {
   if (!h)
     return;
 
-  double x = m_doubleManager->value(parProp);
+  //double x = m_doubleManager->value(parProp);
+  double x = parProp->valueText().toDouble();
   double loBound = x * (1 - 0.01 * f);
   double upBound = x * (1 + 0.01 * f);
 


### PR DESCRIPTION
**Description of work.**
changed the way the current value about which the bounds are obtained from
`double x = m_doubleManager->value(parProp);`
to
`double x = parProp->valueText().toDouble();`.

**Report to:** [@NickDraper] <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**
Open MantidPlot
Load some data
Try to do a fit with constraints
The upper and lower bounds are not set to zero now
Click on the fit button
The fit should be successful 
<!-- Instructions for testing. -->

Fixes #23089 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
