### PR TITLE
Fix Python extensions when compiled with clang on Linux 

### DIFF
--- a/Framework/PythonInterface/mantid/__init__.py
+++ b/Framework/PythonInterface/mantid/__init__.py
@@ -70,12 +70,41 @@ if _os.path.exists(_os.path.join(_bindir, 'Mantid.properties')):
 ###############################################################################
 # Ensure the sub package C libraries are loaded
 ###############################################################################
-import mantid.kernel as kernel
-import mantid.geometry as geometry
-import mantid.api as api
-import mantid.dataobjects as dataobjects
-import mantid._plugins as _plugins
-import mantid.plots as plots
+import contextlib as _context
+
+@_context.contextmanager
+def _shared_cextension():
+    """Our extensions need to shared symbols amongst them due to:
+      - the static boost python type registry
+      - static singleton instances marked as weak symbols by clang
+    gcc uses an extension to mark these attributes as globally unique
+    but clang marks them as weak and without RTLD_GLOBAL each shared
+    library has its own copy of each singleton.
+
+    See https://docs.python.org/3/library/sys.html#sys.setdlopenflags
+    """
+    import sys
+    if not sys.platform.startswith('linux'):
+        yield
+        return
+
+    import six
+    if six.PY2:
+        import DLFCN as dl
+    else:
+        import os as dl
+    flags_orig = sys.getdlopenflags()
+    sys.setdlopenflags(dl.RTLD_NOW | dl.RTLD_GLOBAL)
+    yield
+    sys.setdlopenflags(flags_orig)
+
+with _shared_cextension():
+    import mantid.kernel as kernel
+    import mantid.geometry as geometry
+    import mantid.api as api
+    import mantid.dataobjects as dataobjects
+    import mantid._plugins as _plugins
+    import mantid.plots as plots
 
 ###############################################################################
 # Make the aliases from each module accessible in a the mantid namspace

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/PeaksWorkspaceProperty.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/PeaksWorkspaceProperty.cpp
@@ -7,7 +7,7 @@ using Mantid::API::WorkspaceProperty; // NOLINT
 
 GET_POINTER_SPECIALIZATION(WorkspaceProperty<PeaksWorkspace>)
 
-void export_IPeaksWorkspaceProperty() {
+void export_PeaksWorkspaceProperty() {
   using Mantid::PythonInterface::WorkspacePropertyExporter;
   WorkspacePropertyExporter<PeaksWorkspace>::define("PeaksWorkspaceProperty");
 }

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -131,7 +131,7 @@ if [[ "$CLEANBUILD" == true ]]; then
   rm -rf $BUILD_DIR
 fi
 if [ -d $BUILD_DIR ]; then
-  git clean -fdx --exclude=${BUILD_DIR_REL}
+  git clean -fdx --exclude=${BUILD_DIR_REL} --exclude=".Xauthority-*"
   rm -rf ${BUILD_DIR:?}/bin ${BUILD_DIR:?}/ExternalData
   find ${BUILD_DIR:?} -name 'TEST-*.xml' -delete
   if [[ -n ${CLEAN_EXTERNAL_PROJECTS} && "${CLEAN_EXTERNAL_PROJECTS}" == true ]]; then


### PR DESCRIPTION
**Description of work.**

Open python extensions on Linux with `RTLD_GLOBAL` so that they share symbols across the process.

**Report to:** nobody

**To test:**

Compile mantid with clang on Linux. Fire up `bin/mantidpython` and `import mantid` - there should be no errors raised. Try out some algorithms.

*There is no associated issue*

*This does not require release notes* because **it is an internal change that users will not see.**

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
