### PR TITLE
Make project recovery properties more findable

### DIFF
--- a/docs/source/concepts/ProjectRecovery.rst
+++ b/docs/source/concepts/ProjectRecovery.rst
@@ -25,11 +25,11 @@ If Mantid has crashed, then on the subsequent reboot you will be presented with 
     :align: center
     :alt: alternate text
 
-You can choose to attempt a full recovery, to open a recovery script or not to attempt a recovery. Full recovery will attempt to recover all workspaces present at the time of the crash as well as additional dialogs like plots or data windows. Script mode will attempt to construct a script that contains the history of all workspaces at the time of the crash. 
+You can choose to attempt a full recovery, to open a recovery script or not to attempt a recovery. Full recovery will attempt to recover all workspaces present at the time of the crash as well as additional dialogs like plots or data windows. Script mode will attempt to construct a script that contains the history of all workspaces at the time of the crash.
 
 If full project recovery runs succesfully the scripting window will remain open in MantidPlot. It is safe to close this after a recovery.
 
-**NB** This is an early version of project recovery. We think that it is a lot better than nothing, but we know it won't always work. Known caveats are listed below. Moreover, we would sincerely appreciate feedback and input from users. Contact us at `mantid-help@mantidproject.org` 
+**NB** This is an early version of project recovery. We think that it is a lot better than nothing, but we know it won't always work. Known caveats are listed below. Moreover, we would sincerely appreciate feedback and input from users. Contact us at `mantid-help@mantidproject.org <mailto:mantid-help@mantidproject.org>`__.
 
 The settings for project recovery, including switiching the feature on/off, and how to set them, are listed at the bottom of this page.
 
@@ -48,25 +48,16 @@ Caveats
 
 * Dictionary properties
 	* Affects: SANS interface, SetSample algorithm
-	* Cause: Currently the history writer does not serialise Python dictionaries correctly. 
+	* Cause: Currently the history writer does not serialise Python dictionaries correctly.
 
 * If full project recovery does not work:
 	* If the project recovery process has managed to create a script of the ordered workspace histories, this will appear in MantidPlot, it will have a red arrow beside the line where the process failed. In many cases it is possible to edit the script by hand to get it to run.
 	* If project recovery did not manage to generate the ordered history script then it will return to MantidPlot as normal, with an error message.
- 
-	
+
+
 Settings
 --------
 
-* Project recovery behaviour can be edited by editing the `Mantid.user.properties` file
-	* Windows: `$MantidInstallDirectory\bin\Mantid.user.properties`
-	*  OSX: `$HOME/.mantid/Mantid.user.properties`
-	*  Linux:`$HOME/.mantid/Mantid.user.properties` 
-	
-
-* Three settings you can add to this file:
-	* **On/off:** `projectRecovery.enabled=true`
-	* **Regularity:** `projectRecovery.secondsBetween = 60`
-	* **Number of backups to keep:** `projectRecovery.numberOfCheckpoints = 5`
+Specific behavior of this can be configured in the :ref:`properties file <Properties File>`.
 
 .. categories:: Concepts

--- a/docs/source/concepts/PropertiesFile.rst
+++ b/docs/source/concepts/PropertiesFile.rst
@@ -209,7 +209,7 @@ ScriptRepository Properties
 Project Recovery
 ****************
 
-Details of :ref:`project recovery <Project Recovery>` are elsewhere.
+See :ref:`project recovery <Project Recovery>` for more details.
 
 +-----------------------------------------+-----------------------------------------------+------------------+
 |Property                                 |Description                                    |Example value     |

--- a/docs/source/concepts/PropertiesFile.rst
+++ b/docs/source/concepts/PropertiesFile.rst
@@ -12,6 +12,12 @@ The Mantid framework is configured using up to three simple text ``*.properties`
 2. ``/etc/mantid.local.properties`` is an optional, linux only file that sets shared defaults on a shared system. This is commonly used for setting the ``default.facility``, ``default.instrument``, and ``datasearch.searcharchive`` properties.
 3. Home directory ``Mantid.user.properties`` is where users may override any property setting in Mantid. Any Property setting in this file will override anything set in the ``Mantid.properties`` file. Simply either enter the property you wish to override in this file together with it's new value. The change will take effect the next time Mantid is started. Subsequent installs or upgrades of Mantid will never alter this file.
 
+The user properties file, ``Mantid.user.properties``, can be found
+
+* windows: ``$MantidInstallDirectory\bin\Mantid.user.properties``
+* linux and mac-os: ``$HOME/.mantid/Mantid.user.properties``
+
+
 The Properties
 --------------
 
@@ -198,6 +204,22 @@ ScriptRepository Properties
 | ``ScriptRepositoryIgnore`` |CSV patterns for paths that should not be      | ``*pyc;``                                                            |
 |                            |listed at ScriptRepository.                    |                                                                      |
 +----------------------------+-----------------------------------------------+----------------------------------------------------------------------+
+
+
+Project Recovery
+****************
+
+Details of :ref:`project recovery <Project Recovery>` are elsewhere.
+
++-----------------------------------------+-----------------------------------------------+------------------+
+|Property                                 |Description                                    |Example value     |
++=========================================+===============================================+==================+
+| ``projectRecovery.enabled``             |Whether project recovery is enabled            |  ``On``, ``Off`` |
++-----------------------------------------+-----------------------------------------------+------------------+
+| ``projectRecovery.numberOfCheckpoints`` |How many checkpoints/backups to keep           | ``5``            |
++-----------------------------------------+-----------------------------------------------+------------------+
+| ``projectRecovery.secondsBetween``      |How often to save checkpoints in seconds       | ``60``           |
++-----------------------------------------+-----------------------------------------------+------------------+
 
 
 Getting access to Mantid properties

--- a/docs/source/tutorials/ill_training/introduction/GettingHelp.rst
+++ b/docs/source/tutorials/ill_training/introduction/GettingHelp.rst
@@ -22,7 +22,7 @@ Bug Reporting
 
 Please report any bugs you find, so that we can keep improving Mantid. The easiest way is to contact the development team in the CS group, especially for any issues that are causing major problems.
 
-There is also an option to report bugs in Mantid, via Help -> Report a Bug, but please only use this for minor bugs. This link allows bugs to be posted on the forums. Alternatively you can use the `contact form <https://www.mantidproject.org/Contact>`__ or email mantid-help@mantidproject.org.
+There is also an option to report bugs in Mantid, via Help -> Report a Bug, but please only use this for minor bugs. This link allows bugs to be posted on the forums. Alternatively you can use the `contact form <https://www.mantidproject.org/Contact>`__ or email `mantid-help@mantidproject.org <mailto:mantid-help@mantidproject.org>`__.
 
 .. figure:: /images/Training/Introduction/Mantid_report_a_bug.png
    :align: center


### PR DESCRIPTION
They were described on the project recovery page, which is probably not
where users are going to look for properties.

**To test:**

Build the documentation and see if it is an improvement.

*There is no associated issue.*

*This does not require release notes* because it is a minor documentation improvement.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
