### PR TITLE
Activate core dumps on Linux before running tests

### DIFF
--- a/Framework/API/src/FrameworkManager.cpp
+++ b/Framework/API/src/FrameworkManager.cpp
@@ -96,17 +96,6 @@ void terminateHandler() {
   exit(1);
 }
 
-/**
- * Designed as a SIGSEGV handler for detecting segfaults
- * and printing a backtrace to std::cerr. It exits with
- * code -1
- */
-void sigsegvHandler(int) {
-  std::cerr << "\n********* SEGMENTATION FAULT *********\n";
-  backtraceToStream(std::cerr);
-  exit(-1);
-}
-
 #endif
 
 /// Default constructor
@@ -117,7 +106,6 @@ FrameworkManagerImpl::FrameworkManagerImpl()
 {
 #ifdef __linux__
   std::set_terminate(terminateHandler);
-  std::signal(SIGSEGV, sigsegvHandler);
 #endif
   setGlobalNumericLocaleToC();
   Kernel::MemoryOptions::initAllocatorOptions();

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -35,7 +35,7 @@ function onexit {
     ulimit -c $ULIMIT_CORE_ORIG
   fi
 }
-trap onexit EXIT
+trap onexit INT TERM EXIT
 
 ###############################################################################
 # All nodes currently have PARAVIEW_DIR and PARAVIEW_NEXT_DIR set

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -14,6 +14,7 @@ SCRIPT_DIR=$(dirname "$0")
 ###############################################################################
 # System discovery
 ###############################################################################
+USE_CORE_DUMPS=true
 if [[ ${NODE_LABELS} == *rhel7* ]] || [[ ${NODE_LABELS} == *centos7* ]] || [[ ${NODE_LABELS} == *scilin7* ]]; then
   ON_RHEL7=true
 fi
@@ -22,7 +23,19 @@ if [[ ${NODE_LABELS} == *ubuntu* ]]; then
 fi
 if [[ ${NODE_LABELS} == *osx* ]]; then
   ON_MACOS=true
+  USE_CORE_DUMPS=false
 fi
+
+###############################################################################
+# Script cleanup
+###############################################################################
+ULIMIT_CORE_ORIG=$(ulimit -c)
+function onexit {
+  if [[ ${USE_CORE_DUMPS} == true ]]; then
+    ulimit -c $ULIMIT_CORE_ORIG
+  fi
+}
+trap onexit EXIT
 
 ###############################################################################
 # All nodes currently have PARAVIEW_DIR and PARAVIEW_NEXT_DIR set
@@ -319,6 +332,11 @@ fi
 ###############################################################################
 # Run the unit tests
 ###############################################################################
+# Activate core dumps. They are deactivated by the registered EXIT function
+# at the top of this script
+if [[ ${USE_CORE_DUMPS} == true ]]; then
+  ulimit -c unlimited
+fi
 # Prevent race conditions when creating the user config directory
 userconfig_dir=$HOME/.mantid
 rm -fr $userconfig_dir


### PR DESCRIPTION
**Description of work.**

Activates core dumps in Linux scripts to facilitate debugging segfaulting tests.

**Report to:** [nobody]. 

**To test:**

Code review and the builds should pass.

*There is no associated issue.*

*This does not require release notes* because **it is an internal change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
