### PR TITLE
Set bin count in CentroidPeaksMD

### DIFF
--- a/Framework/MDAlgorithms/src/CentroidPeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/CentroidPeaksMD2.cpp
@@ -115,6 +115,7 @@ void CentroidPeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
           centroid[d] /= static_cast<coord_t>(signal);
 
         V3D vecCentroid(centroid[0], centroid[1], centroid[2]);
+        p.setBinCount(static_cast<double>(signal));
 
         // Save it back in the peak object, in the dimension specified.
         try {

--- a/Framework/MDAlgorithms/test/CentroidPeaksMD2Test.h
+++ b/Framework/MDAlgorithms/test/CentroidPeaksMD2Test.h
@@ -93,7 +93,7 @@ public:
 
   //-------------------------------------------------------------------------------
   /** Run the CentroidPeaksMD2 with the given peak radius param */
-  void doRun(V3D startPos, double PeakRadius, V3D expectedResult,
+  void doRun(V3D startPos, double PeakRadius, double binCount, V3D expectedResult,
              std::string message,
              std::string OutputWorkspace = "CentroidPeaksMD2Test_Peaks") {
     // Make a fake instrument - doesn't matter, we won't use it really
@@ -145,6 +145,7 @@ public:
       result = p.getQSampleFrame();
     } else if (CoordinatesToUse == "HKL")
       result = p.getHKL();
+    TSM_ASSERT_DELTA(message, p.getBinCount(), binCount, 0.05);
 
     for (size_t i = 0; i < 3; i++)
       TSM_ASSERT_DELTA(message, result[i], expectedResult[i], 0.05);
@@ -169,28 +170,28 @@ public:
 
     if (CoordinatesToUse == "HKL") {
       mdews->setCoordinateSystem(Mantid::Kernel::HKL);
-      doRun(V3D(0., 0., 0.), 1.0, V3D(0., 0., 0.),
+      doRun(V3D(0., 0., 0.), 1.0, 1000., V3D(0., 0., 0.),
             "Start at the center, get the center");
 
-      doRun(V3D(0.2, 0.2, 0.2), 1.8, V3D(0., 0., 0.), "Somewhat off center");
+      doRun(V3D(0.2, 0.2, 0.2), 1.8, 1000., V3D(0., 0., 0.), "Somewhat off center");
     } else if (CoordinatesToUse == "Q (lab frame)") {
       mdews->setCoordinateSystem(Mantid::Kernel::QLab);
     } else if (CoordinatesToUse == "Q (sample frame)") {
       mdews->setCoordinateSystem(Mantid::Kernel::QSample);
     }
 
-    doRun(V3D(2., 3., 4.), 1.0, V3D(2., 3., 4.),
+    doRun(V3D(2., 3., 4.), 1.0, 1000., V3D(2., 3., 4.),
           "Start at the center, get the center");
 
-    doRun(V3D(1.5, 2.5, 3.5), 3.0, V3D(2., 3., 4.), "Pretty far off");
+    doRun(V3D(1.5, 2.5, 3.5), 3.0, 1000., V3D(2., 3., 4.), "Pretty far off");
 
-    doRun(V3D(1.0, 1.5, 2.0), 4.0, V3D(1.0, 1.5, 2.0),
+    doRun(V3D(1.0, 1.5, 2.0), 4.0, 2000., V3D(1.0, 1.5, 2.0),
           "Include two peaks, get the centroid of the two");
 
-    doRun(V3D(8.0, 0.0, 1.0), 1.0, V3D(8.0, 0.0, 1.0),
+    doRun(V3D(8.0, 0.0, 1.0), 1.0, 0., V3D(8.0, 0.0, 1.0),
           "Include no events, get no change");
 
-    doRun(V3D(6., 6., 6.), 0.1, V3D(6., 6., 6.), "Small radius still works");
+    doRun(V3D(6., 6., 6.), 0.1, 0., V3D(6., 6., 6.), "Small radius still works");
 
     AnalysisDataService::Instance().remove("CentroidPeaksMD2Test_MDEWS");
   }
@@ -214,7 +215,7 @@ public:
     CoordinatesToUse = "HKL";
     createMDEW(CoordinatesToUse);
     addPeak(1000, 0, 0., 0., 1.0);
-    doRun(V3D(0., 0., 0.), 1.0, V3D(0., 0., 0.),
+    doRun(V3D(0., 0., 0.), 1.0, 1000., V3D(0., 0., 0.),
           "Start at the center, get the center",
           "CentroidPeaksMD2Test_MDEWS_outputCopy");
   }

--- a/Framework/MDAlgorithms/test/CentroidPeaksMD2Test.h
+++ b/Framework/MDAlgorithms/test/CentroidPeaksMD2Test.h
@@ -93,8 +93,8 @@ public:
 
   //-------------------------------------------------------------------------------
   /** Run the CentroidPeaksMD2 with the given peak radius param */
-  void doRun(V3D startPos, double PeakRadius, double binCount, V3D expectedResult,
-             std::string message,
+  void doRun(V3D startPos, double PeakRadius, double binCount,
+             V3D expectedResult, std::string message,
              std::string OutputWorkspace = "CentroidPeaksMD2Test_Peaks") {
     // Make a fake instrument - doesn't matter, we won't use it really
     Instrument_sptr inst =
@@ -173,7 +173,8 @@ public:
       doRun(V3D(0., 0., 0.), 1.0, 1000., V3D(0., 0., 0.),
             "Start at the center, get the center");
 
-      doRun(V3D(0.2, 0.2, 0.2), 1.8, 1000., V3D(0., 0., 0.), "Somewhat off center");
+      doRun(V3D(0.2, 0.2, 0.2), 1.8, 1000., V3D(0., 0., 0.),
+            "Somewhat off center");
     } else if (CoordinatesToUse == "Q (lab frame)") {
       mdews->setCoordinateSystem(Mantid::Kernel::QLab);
     } else if (CoordinatesToUse == "Q (sample frame)") {
@@ -191,7 +192,8 @@ public:
     doRun(V3D(8.0, 0.0, 1.0), 1.0, 0., V3D(8.0, 0.0, 1.0),
           "Include no events, get no change");
 
-    doRun(V3D(6., 6., 6.), 0.1, 0., V3D(6., 6., 6.), "Small radius still works");
+    doRun(V3D(6., 6., 6.), 0.1, 0., V3D(6., 6., 6.),
+          "Small radius still works");
 
     AnalysisDataService::Instance().remove("CentroidPeaksMD2Test_MDEWS");
   }

--- a/docs/source/release/v3.14.0/diffraction.rst
+++ b/docs/source/release/v3.14.0/diffraction.rst
@@ -24,3 +24,9 @@ Improvements
 ############
 
 - :ref:`IntegratePeaksProfileFitting <algm-IntegratePeaksProfileFitting>` now supports MaNDi, TOPAZ, and CORELLI. Other instruments can easily be added as well.
+
+Bugfixes
+########
+
+- :ref:`CentroidPeaksMD <algm-CentroidPeaksMD>` now updates peak bin counts.
+


### PR DESCRIPTION
**Description of work.**
Bin count set in CentroidPeaksMD.  Reviewer did not want this in larger pull request, but needed for satellite peak work.


**To test:**
```python
Load(Filename='~/mantid/release/ExternalData/Testing/Data/SystemTest/TOPAZ_3132_event.nxs', OutputWorkspace='TOPAZ_3132_event', FilterByTofMin=500, FilterByTofMax=16666, LoadMonitors=True)
ConvertToMD(InputWorkspace='TOPAZ_3132_event', QDimensions='Q3D', dEAnalysisMode='Elastic', Q3DFrames='Q_sample', LorentzCorrection=True, OutputWorkspace='TOPAZ_3132_md', MinValues='-25,-25,-25', MaxValues='25,25,25', SplitInto='2', SplitThreshold=50, MaxRecursionDepth=13, MinRecursionDepth=7)
FindPeaksMD(InputWorkspace='TOPAZ_3132_md', PeakDistanceThreshold=0.37680000000000002, MaxPeaks=50, DensityThresholdFactor=100, OutputWorkspace='TOPAZ_3132_peaks')
FindUBUsingFFT(PeaksWorkspace='TOPAZ_3132_peaks', MinD=3, MaxD=15, Tolerance=0.12)
PredictPeaks(InputWorkspace='TOPAZ_3132_peaks', WavelengthMin=0.40000000000000002, WavelengthMax=3.5, MinDSpacing=0.40000000000000002, MaxDSpacing=8.5, OutputWorkspace='TOPAZ_3132_peaks')
CentroidPeaksMD(InputWorkspace='TOPAZ_3132_md', PeakRadius=0.050000000000000003, PeaksWorkspace='TOPAZ_3132_peaks', OutputWorkspace='TOPAZ_3132_md_centroid')

```

Fixes #23200 
<!-- alternative
*There is no associated issue.*
-->





---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
