### PR TITLE
Fixed run box selection issue and SampleShape change 

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/sans/SANSScaleTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/sans/SANSScaleTest.py
@@ -53,7 +53,7 @@ class SANSScaleTest(unittest.TestCase):
         height = 2.0
         scale = 7.2
         state = self._get_sample_state(width=width, height=height, thickness=3.0, scale=scale,
-                                       shape=SampleShape.CylinderAxisUp)
+                                       shape=SampleShape.Cylinder)
         serialized_state = state.property_manager
         scale_name = "SANSScale"
         scale_options = {"SANSState": serialized_state,

--- a/docs/source/interfaces/ISIS SANS v2.rst
+++ b/docs/source/interfaces/ISIS SANS v2.rst
@@ -251,7 +251,7 @@ information. Note that the geometry information is in millimetres.
 +-------+--------------------+------------------------------------------------------------------+
 | **2** | **Geometry**       | A geometry selection. *Read from file* will use the settings     |
 |       |                    | that are stored in the data file. The other options are          |
-|       |                    | *Cylinder*, *FlatPlate* and *Disc*.            |
+|       |                    | *Cylinder*, *FlatPlate* and *Disc*.                              |
 +-------+--------------------+------------------------------------------------------------------+
 | **3** | **Height**         | The sample height. If this is not specified,                     |
 |       |                    | the information from the file will be used.                      |

--- a/docs/source/interfaces/ISIS SANS v2.rst
+++ b/docs/source/interfaces/ISIS SANS v2.rst
@@ -251,7 +251,7 @@ information. Note that the geometry information is in millimetres.
 +-------+--------------------+------------------------------------------------------------------+
 | **2** | **Geometry**       | A geometry selection. *Read from file* will use the settings     |
 |       |                    | that are stored in the data file. The other options are          |
-|       |                    | *Cylinder AxisUp*, *Cuboid* and *Cylinder AxisAlong*.            |
+|       |                    | *Cylinder*, *FlatPlate* and *Disc*.            |
 +-------+--------------------+------------------------------------------------------------------+
 | **3** | **Height**         | The sample height. If this is not specified,                     |
 |       |                    | the information from the file will be used.                      |

--- a/docs/source/release/v3.14.0/sans.rst
+++ b/docs/source/release/v3.14.0/sans.rst
@@ -5,8 +5,17 @@ SANS Changes
 .. contents:: Table of Contents
    :local:
 
-.. warning:: **Developers:** Sort changes under appropriate heading
-    putting new features at the top of the section, followed by
-    improvements, followed by bug fixes.
+ISIS SANS Interface
+----------------------------
+New
+###
+
+Improved
+########
+
+Bug fixes
+#########
+* Fixed an issue where the run tab was difficult to select.
+* Changed the geometry names from CylinderAxisUP, Cuboid and CylinderAxisAlong to Cylinder, FlatPlate and Disc
 
 :ref:`Release 3.14.0 <v3.14.0>`

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -676,7 +676,7 @@ class SANSDataProcessorGui(QtGui.QMainWindow, ui_sans_data_processor_window.Ui_S
 
     def _add_list_element_to_combo_box(self, gui_element, element, expected_type=None):
         if expected_type is not None and isclass(element) and issubclass(element, expected_type):
-            self._set_enum_as_element_in_combo_box(gui_element=gui_element, element=element,
+            self._add_enum_as_element_in_combo_box(gui_element=gui_element, element=element,
                                                    expected_type=expected_type)
         else:
             gui_element.addItem(element)
@@ -690,6 +690,10 @@ class SANSDataProcessorGui(QtGui.QMainWindow, ui_sans_data_processor_window.Ui_S
         index = gui_element.findText(value_as_string)
         if index != -1:
             gui_element.setCurrentIndex(index)
+
+    def _add_enum_as_element_in_combo_box(self, gui_element, element, expected_type):
+        value_as_string = expected_type.to_string(element)
+        gui_element.addItem(value_as_string)
 
     def get_simple_line_edit_field(self, expected_type, line_edit):
         gui_element = getattr(self, line_edit)

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
@@ -2079,17 +2079,6 @@ QGroupBox::title {
      </layout>
     </item>
    </layout>
-   <widget class="QWidget" name="layoutWidget">
-    <property name="geometry">
-     <rect>
-      <x>0</x>
-      <y>0</y>
-      <width>100</width>
-      <height>30</height>
-     </rect>
-    </property>
-    <layout class="QHBoxLayout" name="horizontalLayout_9"/>
-   </widget>
   </widget>
   <widget class="QMenuBar" name="menuBar">
    <property name="geometry">

--- a/scripts/SANS/sans/algorithm_detail/scale_helpers.py
+++ b/scripts/SANS/sans/algorithm_detail/scale_helpers.py
@@ -56,15 +56,15 @@ class DivideByVolumeISIS(DivideByVolume):
         shape = scale_info.shape if scale_info.shape is not None else scale_info.shape_from_file
 
         # Now we calculate the volume
-        if shape is SampleShape.CylinderAxisUp:
+        if shape is SampleShape.Cylinder:
             # Volume = circle area * height
             # Factor of four comes from radius = width/2
             volume = height * math.pi
             volume *= math.pow(width, 2) / 4.0
-        elif shape is SampleShape.Cuboid:
+        elif shape is SampleShape.FlatPlate:
             # Flat plate sample
             volume = width * height * thickness
-        elif shape is SampleShape.CylinderAxisAlong:
+        elif shape is SampleShape.Disc:
             # Factor of four comes from radius = width/2
             # Disc - where height is not used
             volume = thickness * math.pi

--- a/scripts/SANS/sans/common/enums.py
+++ b/scripts/SANS/sans/common/enums.py
@@ -283,7 +283,7 @@ class FitType(object):
 #  SampleShape
 # --------------------------
 @string_convertible
-@serializable_enum("CylinderAxisUp", "Cuboid", "CylinderAxisAlong")
+@serializable_enum("Cylinder", "FlatPlate", "Disc")
 class SampleShape(object):
     """
     Defines the sample shape types

--- a/scripts/SANS/sans/common/file_information.py
+++ b/scripts/SANS/sans/common/file_information.py
@@ -273,11 +273,11 @@ def convert_to_shape(shape_flag):
     :return: a shape object
     """
     if shape_flag == 1:
-        shape = SampleShape.CylinderAxisUp
+        shape = SampleShape.Cylinder
     elif shape_flag == 2:
-        shape = SampleShape.Cuboid
+        shape = SampleShape.FlatPlate
     elif shape_flag == 3:
-        shape = SampleShape.CylinderAxisAlong
+        shape = SampleShape.Disc
     else:
         shape = None
     return shape
@@ -407,11 +407,11 @@ def get_geometry_information_isis_nexus(file_name):
         thickness = float(sample[THICKNESS][0])
         shape_as_string = sample[SHAPE][0].upper().decode("utf-8")
         if shape_as_string == CYLINDER:
-            shape = SampleShape.CylinderAxisUp
+            shape = SampleShape.Cylinder
         elif shape_as_string == FLAT_PLATE:
-            shape = SampleShape.Cuboid
+            shape = SampleShape.FlatPlate
         elif shape_as_string == DISC:
-            shape = SampleShape.CylinderAxisAlong
+            shape = SampleShape.Disc
         else:
             shape = None
     return height, width, thickness, shape
@@ -843,7 +843,7 @@ class SANSFileInformationISISNexus(SANSFileInformation):
         self._height = height if height is not None else 1.
         self._width = width if width is not None else 1.
         self._thickness = thickness if thickness is not None else 1.
-        self._shape = shape if shape is not None else SampleShape.CylinderAxisAlong
+        self._shape = shape if shape is not None else SampleShape.Disc
 
     def get_file_name(self):
         return self._full_file_name
@@ -908,7 +908,7 @@ class SANSFileInformationISISAdded(SANSFileInformation):
         self._height = height if height is not None else 1.
         self._width = width if width is not None else 1.
         self._thickness = thickness if thickness is not None else 1.
-        self._shape = shape if shape is not None else SampleShape.CylinderAxisAlong
+        self._shape = shape if shape is not None else SampleShape.Disc
 
     def get_file_name(self):
         return self._full_file_name
@@ -975,7 +975,7 @@ class SANSFileInformationRaw(SANSFileInformation):
         self._height = height if height is not None else 1.
         self._width = width if width is not None else 1.
         self._thickness = thickness if thickness is not None else 1.
-        self._shape = shape if shape is not None else SampleShape.CylinderAxisAlong
+        self._shape = shape if shape is not None else SampleShape.Disc
 
     def get_file_name(self):
         return self._full_file_name

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -216,8 +216,7 @@ class RunTabPresenter(object):
             # 5. Update the views.
             self._update_view_from_state_model()
             self._beam_centre_presenter.update_centre_positions(self._state_model)
-            import pydevd
-            pydevd.settrace('localhost', port=5434, stdoutToServer=True, stderrToServer=True)
+
             # 6. Perform calls on child presenters
             self._masking_table_presenter.on_update_rows()
             self._beam_centre_presenter.on_update_rows()
@@ -424,7 +423,7 @@ class RunTabPresenter(object):
         """
         global_options = {}
 
-        # Check if should be used
+        # Check if optimizations should be used
         global_options['UseOptimizations'] = "1" if self._view.use_optimizations else "0"
 
         # Get the output mode

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -139,9 +139,9 @@ class RunTabPresenter(object):
 
         # Set the geometry options. This needs to include the option to read the sample shape from file.
         sample_shape = ["Read from file",
-                        SampleShape.to_string(SampleShape.CylinderAxisUp),
-                        SampleShape.to_string(SampleShape.Cuboid),
-                        SampleShape.to_string(SampleShape.CylinderAxisAlong)]
+                        SampleShape.Cylinder,
+                        SampleShape.FlatPlate,
+                        SampleShape.Disc]
         self._view.sample_shape = sample_shape
 
         # Set the q range
@@ -216,7 +216,8 @@ class RunTabPresenter(object):
             # 5. Update the views.
             self._update_view_from_state_model()
             self._beam_centre_presenter.update_centre_positions(self._state_model)
-
+            import pydevd
+            pydevd.settrace('localhost', port=5434, stdoutToServer=True, stderrToServer=True)
             # 6. Perform calls on child presenters
             self._masking_table_presenter.on_update_rows()
             self._beam_centre_presenter.on_update_rows()
@@ -423,7 +424,7 @@ class RunTabPresenter(object):
         """
         global_options = {}
 
-        # Check if optimizations should be used
+        # Check if should be used
         global_options['UseOptimizations'] = "1" if self._view.use_optimizations else "0"
 
         # Get the output mode

--- a/scripts/SANS/sans/state/scale.py
+++ b/scripts/SANS/sans/state/scale.py
@@ -28,7 +28,7 @@ class StateScale(StateBase):
         super(StateScale, self).__init__()
 
         # The default geometry
-        self.shape_from_file = SampleShape.CylinderAxisAlong
+        self.shape_from_file = SampleShape.Disc
 
         # The default values are 1mm
         self.thickness_from_file = 1.

--- a/scripts/SANS/sans/test_helper/file_information_mock.py
+++ b/scripts/SANS/sans/test_helper/file_information_mock.py
@@ -5,7 +5,7 @@ from sans.common.enums import (SANSFacility, SANSInstrument, FileType, SampleSha
 
 class SANSFileInformationMock(SANSFileInformation):
     def __init__(self, instrument=SANSInstrument.LOQ, facility=SANSFacility.ISIS, run_number=00000, file_name='file_name',
-                 height=8.0, width=8.0, thickness=1.0, shape=SampleShape.Cuboid, date='2012-10-22T22:41:27', periods=1,
+                 height=8.0, width=8.0, thickness=1.0, shape=SampleShape.FlatPlate, date='2012-10-22T22:41:27', periods=1,
                  event_mode=True, added_data=False):
         super(SANSFileInformationMock, self).__init__(file_name)
         self._instrument = instrument

--- a/scripts/SANS/sans/test_helper/test_director.py
+++ b/scripts/SANS/sans/test_helper/test_director.py
@@ -113,7 +113,7 @@ class TestDirector(object):
         # Build the SANSStateScale
         if self.scale_state is None:
             scale_builder = get_scale_builder(self.data_state, file_information)
-            scale_builder.set_shape(SampleShape.Cuboid)
+            scale_builder.set_shape(SampleShape.FlatPlate)
             scale_builder.set_width(1.0)
             scale_builder.set_height(2.0)
             scale_builder.set_thickness(3.0)

--- a/scripts/test/SANS/algorithm_detail/scale_helper_test.py
+++ b/scripts/test/SANS/algorithm_detail/scale_helper_test.py
@@ -46,7 +46,7 @@ class ScaleHelperTest(unittest.TestCase):
         # Arrange
         facility = SANSFacility.ISIS
         file_information = SANSFileInformationMock(instrument=SANSInstrument.SANS2D, run_number=22024, height=8.0,
-                                                   width=8.0, thickness=1.0, shape=SampleShape.CylinderAxisAlong)
+                                                   width=8.0, thickness=1.0, shape=SampleShape.Disc)
         data_builder = get_data_builder(facility, file_information)
         data_builder.set_sample_scatter("SANS2D00022024")
         data_state = data_builder.build()
@@ -90,7 +90,7 @@ class ScaleHelperTest(unittest.TestCase):
         width = 10.
         height = 5.
         thickness = 2.
-        scale_builder.set_shape(SampleShape.CylinderAxisAlong)
+        scale_builder.set_shape(SampleShape.Disc)
         scale_builder.set_thickness(thickness)
         scale_builder.set_width(width)
         scale_builder.set_height(height)

--- a/scripts/test/SANS/common/file_information_test.py
+++ b/scripts/test/SANS/common/file_information_test.py
@@ -29,7 +29,7 @@ class SANSFileInformationTest(unittest.TestCase):
         self.assertTrue(file_information.get_width() == 8.0)
         self.assertTrue(file_information.get_height() == 8.0)
         self.assertTrue(file_information.get_thickness() == 1.0)
-        self.assertTrue(file_information.get_shape() is SampleShape.CylinderAxisAlong)
+        self.assertTrue(file_information.get_shape() is SampleShape.Disc)
 
     def test_that_can_extract_information_from_file_for_LOQ_single_period_and_raw_format(self):
         # Arrange
@@ -50,7 +50,7 @@ class SANSFileInformationTest(unittest.TestCase):
         self.assertTrue(file_information.get_width() == 8.0)
         self.assertTrue(file_information.get_height() == 8.0)
         self.assertTrue(file_information.get_thickness() == 1.0)
-        self.assertTrue(file_information.get_shape() is SampleShape.CylinderAxisAlong)
+        self.assertTrue(file_information.get_shape() is SampleShape.Disc)
 
     def test_that_can_extract_information_from_file_for_SANS2D_multi_period_event_and_nexus_format(self):
         # Arrange
@@ -72,7 +72,7 @@ class SANSFileInformationTest(unittest.TestCase):
         self.assertTrue(file_information.get_width() == 8.0)
         self.assertTrue(file_information.get_height() == 8.0)
         self.assertTrue(file_information.get_thickness() == 2.0)
-        self.assertTrue(file_information.get_shape() is SampleShape.Cuboid)
+        self.assertTrue(file_information.get_shape() is SampleShape.FlatPlate)
 
     def test_that_can_extract_information_for_added_histogram_data_and_nexus_format(self):
         # Arrange
@@ -94,7 +94,7 @@ class SANSFileInformationTest(unittest.TestCase):
         self.assertTrue(file_information.get_width() == 8.0)
         self.assertTrue(file_information.get_height() == 8.0)
         self.assertTrue(file_information.get_thickness() == 1.0)
-        self.assertTrue(file_information.get_shape() is SampleShape.CylinderAxisAlong)
+        self.assertTrue(file_information.get_shape() is SampleShape.Disc)
 
     def test_that_can_extract_information_for_LARMOR_added_event_data_and_multi_period_and_nexus_format(self):
         # Arrange
@@ -116,7 +116,7 @@ class SANSFileInformationTest(unittest.TestCase):
         self.assertTrue(file_information.get_width() == 6.0)
         self.assertTrue(file_information.get_height() == 8.0)
         self.assertTrue(file_information.get_thickness() == 1.0)
-        self.assertTrue(file_information.get_shape() is SampleShape.Cuboid)
+        self.assertTrue(file_information.get_shape() is SampleShape.FlatPlate)
 
 
 class SANSFileInformationGeneralFunctionsTest(unittest.TestCase):

--- a/scripts/test/SANS/gui_logic/state_gui_model_test.py
+++ b/scripts/test/SANS/gui_logic/state_gui_model_test.py
@@ -252,12 +252,12 @@ class StateGuiModelTest(unittest.TestCase):
         state_gui_model.sample_height = 1.6
         state_gui_model.sample_thickness = 1.8
         state_gui_model.z_offset = 1.78
-        state_gui_model.sample_shape = SampleShape.Cuboid
+        state_gui_model.sample_shape = SampleShape.FlatPlate
         self.assertTrue(state_gui_model.sample_width == 1.2)
         self.assertTrue(state_gui_model.sample_height == 1.6)
         self.assertTrue(state_gui_model.sample_thickness == 1.8)
         self.assertTrue(state_gui_model.z_offset == 1.78)
-        self.assertTrue(state_gui_model.sample_shape is SampleShape.Cuboid)
+        self.assertTrue(state_gui_model.sample_shape is SampleShape.FlatPlate)
 
     # ==================================================================================================================
     # ==================================================================================================================

--- a/scripts/test/SANS/state/scale_test.py
+++ b/scripts/test/SANS/state/scale_test.py
@@ -32,14 +32,14 @@ class StateSliceEventBuilderTest(unittest.TestCase):
         self.assertTrue(builder)
 
         builder.set_scale(1.0)
-        builder.set_shape(SampleShape.Cuboid)
+        builder.set_shape(SampleShape.FlatPlate)
         builder.set_thickness(3.6)
         builder.set_width(3.7)
         builder.set_height(5.8)
 
         # Assert
         state = builder.build()
-        self.assertTrue(state.shape is SampleShape.Cuboid)
+        self.assertTrue(state.shape is SampleShape.FlatPlate)
         self.assertTrue(state.scale == 1.0)
         self.assertTrue(state.thickness == 3.6)
         self.assertTrue(state.width == 3.7)

--- a/scripts/test/SANS/user_file/state_director_test.py
+++ b/scripts/test/SANS/user_file/state_director_test.py
@@ -215,7 +215,7 @@ class UserFileStateDirectorISISTest(unittest.TestCase):
         director.set_scale_builder_width(1.)
         director.set_scale_builder_height(1.5)
         director.set_scale_builder_thickness(12.)
-        director.set_scale_builder_shape(SampleShape.Cuboid)
+        director.set_scale_builder_shape(SampleShape.FlatPlate)
 
         # Act
         state = director.construct()
@@ -226,7 +226,7 @@ class UserFileStateDirectorISISTest(unittest.TestCase):
         self.assertTrue(state.scale.width == 1.)
         self.assertTrue(state.scale.height == 1.5)
         self.assertTrue(state.scale.thickness == 12.)
-        self.assertTrue(state.scale.shape is SampleShape.Cuboid)
+        self.assertTrue(state.scale.shape is SampleShape.FlatPlate)
 
         # clean up
         if os.path.exists(user_file_path):


### PR DESCRIPTION
**Description of work.**
This implements two usability changes to the Sans ISIS GUI. The first is that the run tab selector on the top left had an odd selection box. The second is that the geometry options were CylinderAxisUp, Cuboid and CylinderAxisAlong rather than Cylinder, FlatPlate and Disc
**Report to:** [user name]/[nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**
* Check that the selection box for the runs tab has a sensible selection box
* Check that on the settings tab the geometry options are updated appropriately
* Load batch_mode_reduction.csv as the batch file
* Click process and check the reduction still works.

<!-- Instructions for testing. -->

Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
