### PR TITLE
Check axis type before table transposition Refs #23155

### DIFF
--- a/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
@@ -280,20 +280,6 @@ createGroup(const std::vector<MatrixWorkspace_sptr> &workspaces) {
   return group;
 }
 
-IAlgorithm_sptr createProcessIndirectFitParametersAlgorithm(
-    ITableWorkspace_sptr parameterWorkspace, const std::string &xAxisUnit,
-    const std::vector<std::string> &parameterNames) {
-  auto pifp =
-      AlgorithmManager::Instance().create("ProcessIndirectFitParameters");
-  pifp->setChild(true);
-  pifp->setAlwaysStoreInADS(false);
-  pifp->setProperty("InputWorkspace", parameterWorkspace);
-  pifp->setProperty("ColumnX", "axis-1");
-  pifp->setProperty("XAxisUnit", xAxisUnit);
-  pifp->setProperty("ParameterNames", parameterNames);
-  return pifp;
-}
-
 WorkspaceGroup_sptr
 runParameterProcessingWithGrouping(IAlgorithm &processingAlgorithm,
                                    const std::vector<std::size_t> &grouping) {
@@ -649,14 +635,15 @@ std::vector<std::size_t> QENSFitSequential::getDatasetGrouping(
 WorkspaceGroup_sptr QENSFitSequential::processIndirectFitParameters(
     ITableWorkspace_sptr parameterWorkspace,
     const std::vector<std::size_t> &grouping) {
-  Progress logAdderProg(this, 0.91, 0.95, 1);
-
   std::string const xAxisUnit = getProperty("ResultXAxisUnit");
-  auto pifp = createProcessIndirectFitParametersAlgorithm(
-      parameterWorkspace, xAxisUnit, getFitParameterNames());
-  auto group = runParameterProcessingWithGrouping(*pifp, grouping);
-  logAdderProg.report("Result workspace created.");
-  return group;
+  auto pifp =
+      createChildAlgorithm("ProcessIndirectFitParameters", 0.91, 0.95, false);
+  pifp->setAlwaysStoreInADS(false);
+  pifp->setProperty("InputWorkspace", parameterWorkspace);
+  pifp->setProperty("ColumnX", "axis-1");
+  pifp->setProperty("XAxisUnit", xAxisUnit);
+  pifp->setProperty("ParameterNames", getFitParameterNames());
+  return runParameterProcessingWithGrouping(*pifp, grouping);
 }
 
 ITableWorkspace_sptr

--- a/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
@@ -285,6 +285,7 @@ IAlgorithm_sptr createProcessIndirectFitParametersAlgorithm(
     const std::vector<std::string> &parameterNames) {
   auto pifp =
       AlgorithmManager::Instance().create("ProcessIndirectFitParameters");
+  pifp->setChild(true);
   pifp->setAlwaysStoreInADS(false);
   pifp->setProperty("InputWorkspace", parameterWorkspace);
   pifp->setProperty("ColumnX", "axis-1");

--- a/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
@@ -379,9 +379,9 @@ void QENSFitSequential::init() {
   std::vector<std::string> unitOptions = UnitFactory::Instance().getKeys();
   unitOptions.emplace_back("");
   declareProperty("ResultXAxisUnit", "MomentumTransfer",
-	  boost::make_shared<StringListValidator>(unitOptions),
-	  "The unit to assign to the X Axis of the result workspace, "
-	  "defaults to MomentumTransfer");
+                  boost::make_shared<StringListValidator>(unitOptions),
+                  "The unit to assign to the X Axis of the result workspace, "
+                  "defaults to MomentumTransfer");
 
   declareProperty(make_unique<WorkspaceProperty<WorkspaceGroup>>(
                       "OutputWorkspace", "", Direction::Output),

--- a/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
@@ -10,6 +10,7 @@
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/MandatoryValidator.h"
+#include "MantidKernel/UnitFactory.h"
 
 #include <boost/cast.hpp>
 #include <boost/regex.hpp>
@@ -278,6 +279,36 @@ createGroup(const std::vector<MatrixWorkspace_sptr> &workspaces) {
     group->addWorkspace(workspace);
   return group;
 }
+
+IAlgorithm_sptr createProcessIndirectFitParametersAlgorithm(
+    ITableWorkspace_sptr parameterWorkspace, const std::string &xAxisUnit,
+    const std::vector<std::string> &parameterNames) {
+  auto pifp =
+      AlgorithmManager::Instance().create("ProcessIndirectFitParameters");
+  pifp->setAlwaysStoreInADS(false);
+  pifp->setProperty("InputWorkspace", parameterWorkspace);
+  pifp->setProperty("ColumnX", "axis-1");
+  pifp->setProperty("XAxisUnit", xAxisUnit);
+  pifp->setProperty("ParameterNames", parameterNames);
+  return pifp;
+}
+
+WorkspaceGroup_sptr
+runParameterProcessingWithGrouping(IAlgorithm &processingAlgorithm,
+                                   const std::vector<std::size_t> &grouping) {
+  std::vector<MatrixWorkspace_sptr> results;
+  results.reserve(grouping.size() - 1);
+  for (auto i = 0u; i < grouping.size() - 1; ++i) {
+    processingAlgorithm.setProperty("StartRowIndex",
+                                    static_cast<int>(grouping[i]));
+    processingAlgorithm.setProperty("EndRowIndex",
+                                    static_cast<int>(grouping[i + 1]) - 1);
+    processingAlgorithm.setProperty("OutputWorkspace", "__Result");
+    processingAlgorithm.execute();
+    results.push_back(processingAlgorithm.getProperty("OutputWorkspace"));
+  }
+  return createGroup(results);
+}
 } // namespace
 
 namespace Mantid {
@@ -344,6 +375,13 @@ void QENSFitSequential::init() {
       "by a list of spectra/workspace-indices \n"
       "or values using the notation described in the description section of "
       "the help page.");
+
+  std::vector<std::string> unitOptions = UnitFactory::Instance().getKeys();
+  unitOptions.emplace_back("");
+  declareProperty("ResultXAxisUnit", "MomentumTransfer",
+	  boost::make_shared<StringListValidator>(unitOptions),
+	  "The unit to assign to the X Axis of the result workspace, "
+	  "defaults to MomentumTransfer");
 
   declareProperty(make_unique<WorkspaceProperty<WorkspaceGroup>>(
                       "OutputWorkspace", "", Direction::Output),
@@ -610,23 +648,14 @@ std::vector<std::size_t> QENSFitSequential::getDatasetGrouping(
 WorkspaceGroup_sptr QENSFitSequential::processIndirectFitParameters(
     ITableWorkspace_sptr parameterWorkspace,
     const std::vector<std::size_t> &grouping) {
-  auto pifp =
-      createChildAlgorithm("ProcessIndirectFitParameters", 0.91, 0.95, true);
-  pifp->setProperty("InputWorkspace", parameterWorkspace);
-  pifp->setProperty("ColumnX", "axis-1");
-  pifp->setProperty("XAxisUnit", "MomentumTransfer");
-  pifp->setProperty("ParameterNames", getFitParameterNames());
+  Progress logAdderProg(this, 0.91, 0.95, 1);
 
-  std::vector<MatrixWorkspace_sptr> results;
-  results.reserve(grouping.size() - 1);
-  for (auto i = 0u; i < grouping.size() - 1; ++i) {
-    pifp->setProperty("StartRowIndex", static_cast<int>(grouping[i]));
-    pifp->setProperty("EndRowIndex", static_cast<int>(grouping[i + 1]) - 1);
-    pifp->setProperty("OutputWorkspace", "__Result");
-    pifp->executeAsChildAlg();
-    results.push_back(pifp->getProperty("OutputWorkspace"));
-  }
-  return createGroup(results);
+  std::string const xAxisUnit = getProperty("ResultXAxisUnit");
+  auto pifp = createProcessIndirectFitParametersAlgorithm(
+      parameterWorkspace, xAxisUnit, getFitParameterNames());
+  auto group = runParameterProcessingWithGrouping(*pifp, grouping);
+  logAdderProg.report("Result workspace created.");
+  return group;
 }
 
 ITableWorkspace_sptr

--- a/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
@@ -165,20 +165,6 @@ WorkspaceGroup_sptr makeGroup(Workspace_sptr workspace) {
   return group;
 }
 
-IAlgorithm_sptr createProcessIndirectFitParametersAlgorithm(
-    ITableWorkspace_sptr parameterWorkspace, const std::string &xAxisUnit,
-    const std::vector<std::string> &parameterNames) {
-  auto pifp =
-      AlgorithmManager::Instance().create("ProcessIndirectFitParameters");
-  pifp->setChild(true);
-  pifp->setAlwaysStoreInADS(false);
-  pifp->setProperty("InputWorkspace", parameterWorkspace);
-  pifp->setProperty("ColumnX", "axis-1");
-  pifp->setProperty("XAxisUnit", xAxisUnit);
-  pifp->setProperty("ParameterNames", parameterNames);
-  return pifp;
-}
-
 ITableWorkspace_sptr transposeFitTable(ITableWorkspace_sptr table,
                                        const IFunction &function,
                                        const std::string &yAxisType) {
@@ -499,14 +485,15 @@ QENSFitSimultaneous::performFit(
 WorkspaceGroup_sptr QENSFitSimultaneous::processIndirectFitParameters(
     ITableWorkspace_sptr parameterWorkspace,
     const std::vector<std::size_t> &grouping) {
-  Progress logAdderProg(this, 0.91, 0.95, 1);
-
   std::string const xAxisUnit = getProperty("ResultXAxisUnit");
-  auto pifp = createProcessIndirectFitParametersAlgorithm(
-      parameterWorkspace, xAxisUnit, getFitParameterNames());
-  auto group = runParameterProcessingWithGrouping(*pifp, grouping);
-  logAdderProg.report("Result workspace created.");
-  return group;
+  auto pifp =
+      createChildAlgorithm("ProcessIndirectFitParameters", 0.91, 0.95, false);
+  pifp->setAlwaysStoreInADS(false);
+  pifp->setProperty("InputWorkspace", parameterWorkspace);
+  pifp->setProperty("ColumnX", "axis-1");
+  pifp->setProperty("XAxisUnit", xAxisUnit);
+  pifp->setProperty("ParameterNames", getFitParameterNames());
+  return runParameterProcessingWithGrouping(*pifp, grouping);
 }
 
 void QENSFitSimultaneous::copyLogs(

--- a/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
@@ -170,6 +170,7 @@ IAlgorithm_sptr createProcessIndirectFitParametersAlgorithm(
     const std::vector<std::string> &parameterNames) {
   auto pifp =
       AlgorithmManager::Instance().create("ProcessIndirectFitParameters");
+  pifp->setChild(true);
   pifp->setAlwaysStoreInADS(false);
   pifp->setProperty("InputWorkspace", parameterWorkspace);
   pifp->setProperty("ColumnX", "axis-1");
@@ -179,12 +180,12 @@ IAlgorithm_sptr createProcessIndirectFitParametersAlgorithm(
 }
 
 ITableWorkspace_sptr transposeFitTable(ITableWorkspace_sptr table,
-                                       IFunction_sptr function,
+                                       const IFunction &function,
                                        const std::string &yAxisType) {
   auto transposed = WorkspaceFactory::Instance().createTable();
   transposed->addColumn(yAxisType, "axis-1");
 
-  auto parameters = function->getParameterNames();
+  auto parameters = function.getParameterNames();
   for (const auto &parameter : parameters) {
     transposed->addColumn("double", parameter);
     transposed->addColumn("double", parameter + "_Err");

--- a/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
@@ -220,7 +220,7 @@ auto getTextAxisValueReader(std::size_t axisIndex) {
 
 template <typename T, typename GetValue>
 void addValuesToColumn(
-    Column_sptr column, const std::vector<MatrixWorkspace_sptr> workspaces,
+    Column_sptr column, const std::vector<MatrixWorkspace_sptr> &workspaces,
     const Mantid::Kernel::PropertyManagerOwner &indexProperties,
     const GetValue &getValue) {
   const std::string prefix = "WorkspaceIndex";

--- a/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
@@ -438,7 +438,7 @@ void QENSFitSimultaneous::execConcrete() {
   const auto fitResult = performFit(inputWorkspaces, outputBaseName);
   const auto yAxisType = getAxisType(*workspaces.front(), 1);
   auto transposedTable =
-      transposeFitTable(fitResult.first, singleDomainFunction, yAxisType);
+      transposeFitTable(fitResult.first, *singleDomainFunction, yAxisType);
   addValuesToTableColumn(*transposedTable, workspaces, *this, 0);
   const auto parameterWs = processParameterTable(transposedTable);
   const auto groupWs = makeGroup(fitResult.second);

--- a/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
@@ -2,7 +2,6 @@
 #include "MantidCurveFitting/CostFunctions/CostFuncFitting.h"
 
 #include "MantidAPI/AlgorithmManager.h"
-#include "MantidAPI/ColumnFactory.h"
 #include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/FuncMinimizerFactory.h"
 #include "MantidAPI/IFuncMinimizer.h"

--- a/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
@@ -165,7 +165,8 @@ WorkspaceGroup_sptr makeGroup(Workspace_sptr workspace) {
 }
 
 ITableWorkspace_sptr transposeFitTable(ITableWorkspace_sptr table,
-                                       IFunction_sptr function, const std::string &yAxisType) {
+                                       IFunction_sptr function,
+                                       const std::string &yAxisType) {
   auto transposed = WorkspaceFactory::Instance().createTable();
   transposed->addColumn(yAxisType, "axis-1");
 
@@ -193,46 +194,46 @@ std::string getAxisType(MatrixWorkspace_sptr workspace, std::size_t axisIndex) {
 }
 
 NumericAxis *getNumericAxis(MatrixWorkspace_sptr workspace,
-	std::size_t axisIndex) {
+                            std::size_t axisIndex) {
   return dynamic_cast<NumericAxis *>(workspace->getAxis(axisIndex));
 }
 
-TextAxis *getTextAxis(MatrixWorkspace_sptr workspace,
-	std::size_t axisIndex) {
-	return dynamic_cast<TextAxis *>(workspace->getAxis(axisIndex));
+TextAxis *getTextAxis(MatrixWorkspace_sptr workspace, std::size_t axisIndex) {
+  return dynamic_cast<TextAxis *>(workspace->getAxis(axisIndex));
 }
 
 auto getNumericAxisValueReader(std::size_t axisIndex) {
-	return [axisIndex](MatrixWorkspace_sptr workspace, std::size_t index) {
-		if (auto const axis = getNumericAxis(workspace, axisIndex))
-			return axis->getValue(index);
-		return 0.0;
-	};
+  return [axisIndex](MatrixWorkspace_sptr workspace, std::size_t index) {
+    if (auto const axis = getNumericAxis(workspace, axisIndex))
+      return axis->getValue(index);
+    return 0.0;
+  };
 }
 
 auto getTextAxisValueReader(std::size_t axisIndex) {
-	return [axisIndex](MatrixWorkspace_sptr workspace, std::size_t index) {
-		if (auto const axis = getTextAxis(workspace, axisIndex))
-		  return axis->label(index);
-		return std::string();
-	};
+  return [axisIndex](MatrixWorkspace_sptr workspace, std::size_t index) {
+    if (auto const axis = getTextAxis(workspace, axisIndex))
+      return axis->label(index);
+    return std::string();
+  };
 }
 
 template <typename T, typename GetValue>
-void addValuesToColumn(Column_sptr column, const std::vector<MatrixWorkspace_sptr> workspaces,
-	const Mantid::Kernel::PropertyManagerOwner &indexProperties, const GetValue &getValue) {
-	const std::string prefix = "WorkspaceIndex";
+void addValuesToColumn(
+    Column_sptr column, const std::vector<MatrixWorkspace_sptr> workspaces,
+    const Mantid::Kernel::PropertyManagerOwner &indexProperties,
+    const GetValue &getValue) {
+  const std::string prefix = "WorkspaceIndex";
 
-	int index = indexProperties.getProperty(prefix);
-	column->cell<T>(0) = getValue(
-		workspaces[0], static_cast<std::size_t>(index));
-	
-	for (auto i = 1u; i < workspaces.size(); ++i) {
-		const auto indexName = prefix + "_" + std::to_string(i);
-		index = indexProperties.getProperty(indexName);
-		column->cell<T>(i) = getValue(
-			workspaces[i], static_cast<std::size_t>(index));
-	}
+  int index = indexProperties.getProperty(prefix);
+  column->cell<T>(0) = getValue(workspaces[0], static_cast<std::size_t>(index));
+
+  for (auto i = 1u; i < workspaces.size(); ++i) {
+    const auto indexName = prefix + "_" + std::to_string(i);
+    index = indexProperties.getProperty(indexName);
+    column->cell<T>(i) =
+        getValue(workspaces[i], static_cast<std::size_t>(index));
+  }
 }
 
 void addValuesToTableColumn(
@@ -244,9 +245,11 @@ void addValuesToTableColumn(
 
   const auto column = table.getColumn(columnIndex);
   if (auto numericAxis = getNumericAxis(workspaces.front(), 1))
-	  addValuesToColumn<double>(column, workspaces, indexProperties, getNumericAxisValueReader(1));
+    addValuesToColumn<double>(column, workspaces, indexProperties,
+                              getNumericAxisValueReader(1));
   else if (auto textAxis = getTextAxis(workspaces.front(), 1))
-	  addValuesToColumn<std::string>(column, workspaces, indexProperties, getTextAxisValueReader(1));
+    addValuesToColumn<std::string>(column, workspaces, indexProperties,
+                                   getTextAxisValueReader(1));
 }
 
 std::vector<std::size_t>

--- a/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
@@ -14,6 +14,7 @@
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/StartsWithValidator.h"
+#include "MantidKernel/UnitFactory.h"
 
 #include <boost/algorithm/string/join.hpp>
 
@@ -374,6 +375,13 @@ void QENSFitSimultaneous::initConcrete() {
                   "Convolution are output convolved\n"
                   "with corresponding resolution");
 
+  std::vector<std::string> unitOptions = UnitFactory::Instance().getKeys();
+  unitOptions.emplace_back("");
+  declareProperty("ResultXAxisUnit", "MomentumTransfer",
+                  boost::make_shared<StringListValidator>(unitOptions),
+                  "The unit to assign to the X Axis of the result workspace, "
+                  "defaults to MomentumTransfer");
+
   declareProperty(make_unique<WorkspaceProperty<WorkspaceGroup>>(
                       "OutputWorkspace", "", Direction::Output),
                   "The output result workspace(s)");
@@ -492,8 +500,7 @@ WorkspaceGroup_sptr QENSFitSimultaneous::processIndirectFitParameters(
     const std::vector<std::size_t> &grouping) {
   Progress logAdderProg(this, 0.91, 0.95, 1);
 
-  auto const xAxisUnit =
-      parameterWorkspace->getColumn(0)->isNumber() ? "MomentumTransfer" : "";
+  std::string const xAxisUnit = getProperty("ResultXAxisUnit");
   auto pifp = createProcessIndirectFitParametersAlgorithm(
       parameterWorkspace, xAxisUnit, getFitParameterNames());
   auto group = runParameterProcessingWithGrouping(*pifp, grouping);

--- a/Framework/WorkflowAlgorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Framework/WorkflowAlgorithms/src/ProcessIndirectFitParameters.cpp
@@ -92,9 +92,10 @@ std::vector<T> getColumnValues(Column const &column, std::size_t startRow,
 std::vector<double> getNumericColumnValuesOrIndices(Column const &column,
                                                     std::size_t startRow,
                                                     std::size_t endRow) {
+  auto const length = startRow >= endRow ? 1 + startRow - endRow : 0;
   if (column.isNumber())
     return getColumnValues<double>(column, startRow, endRow);
-  return getIncrementingSequence(0.0, endRow - startRow + 1);
+  return getIncrementingSequence(0.0, length);
 }
 
 std::string getColumnName(Column_const_sptr column) { return column->name(); }

--- a/Framework/WorkflowAlgorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Framework/WorkflowAlgorithms/src/ProcessIndirectFitParameters.cpp
@@ -26,6 +26,13 @@ std::vector<T, Ts...> repeat(std::vector<T, Ts...> const &vec, std::size_t n) {
   return result;
 }
 
+template <typename T>
+std::vector<T> getIncrementingSequence(const T &from, std::size_t length) {
+  std::vector<T> sequence(length);
+  std::iota(sequence.begin(), sequence.end(), from);
+  return sequence;
+}
+
 std::vector<std::string> appendSuffix(std::vector<std::string> const &vec,
                                       std::string const &suffix) {
   std::vector<std::string> appended;
@@ -80,6 +87,14 @@ std::vector<T> getColumnValues(Column const &column, std::size_t startRow,
   values.reserve(1 + (endRow - startRow));
   extractColumnValues<T>(column, startRow, endRow, std::back_inserter(values));
   return values;
+}
+
+std::vector<double> getNumericColumnValuesOrIndices(Column const &column,
+                                                    std::size_t startRow,
+                                                    std::size_t endRow) {
+  if (column.isNumber())
+    return getColumnValues<double>(column, startRow, endRow);
+  return getIncrementingSequence(0.0, endRow - startRow + 1);
 }
 
 std::string getColumnName(Column_const_sptr column) { return column->name(); }
@@ -256,8 +271,8 @@ void ProcessIndirectFitParameters::exec() {
   auto const startRow = getStartRow();
   auto const endRow = getEndRow(inputWs->rowCount() - 1);
 
-  auto const x =
-      getColumnValues<double>(*inputWs->getColumn(xColumn), startRow, endRow);
+  auto const x = getNumericColumnValuesOrIndices(*inputWs->getColumn(xColumn),
+                                                 startRow, endRow);
   auto const yFilter =
       makeColumnNameFilter(EndsWithOneOf(std::move(parameterNames)));
   auto const eFilter =

--- a/Framework/WorkflowAlgorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Framework/WorkflowAlgorithms/src/ProcessIndirectFitParameters.cpp
@@ -92,7 +92,7 @@ std::vector<T> getColumnValues(Column const &column, std::size_t startRow,
 std::vector<double> getNumericColumnValuesOrIndices(Column const &column,
                                                     std::size_t startRow,
                                                     std::size_t endRow) {
-  auto const length = startRow >= endRow ? 1 + startRow - endRow : 0;
+  auto const length = startRow > endRow ? 0 : 1 + endRow - startRow;
   if (column.isNumber())
     return getColumnValues<double>(column, startRow, endRow);
   return getIncrementingSequence(0.0, length);

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
@@ -149,8 +149,7 @@ protected:
 
 private:
   Mantid::API::IAlgorithm_sptr
-  createSequentialFit(Mantid::API::IFunction_sptr function,
-                      const std::string &input,
+  createSequentialFit(Mantid::API::IFunction_sptr function, const std::string &input,
                       IndirectFitData *initialFitData) const;
   virtual Mantid::API::IAlgorithm_sptr sequentialFitAlgorithm() const;
   virtual Mantid::API::IAlgorithm_sptr simultaneousFitAlgorithm() const;
@@ -164,8 +163,6 @@ private:
   virtual std::string getResultXAxisUnit() const;
 
   bool isPreviousModelSelected() const;
-
-  void addFitProperties(Mantid::API::IAlgorithm &algorithm) const;
 
   virtual IndirectFitOutput
   createFitOutput(Mantid::API::WorkspaceGroup_sptr resultGroup,

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
@@ -149,7 +149,8 @@ protected:
 
 private:
   Mantid::API::IAlgorithm_sptr
-  createSequentialFit(Mantid::API::IFunction_sptr function, const std::string &input,
+  createSequentialFit(Mantid::API::IFunction_sptr function,
+                      const std::string &input,
                       IndirectFitData *initialFitData) const;
   virtual Mantid::API::IAlgorithm_sptr sequentialFitAlgorithm() const;
   virtual Mantid::API::IAlgorithm_sptr simultaneousFitAlgorithm() const;

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
@@ -161,7 +161,11 @@ private:
   virtual std::unordered_map<std::string, ParameterValue>
   createDefaultParameters(std::size_t index) const;
 
+  virtual std::string getResultXAxisUnit() const;
+
   bool isPreviousModelSelected() const;
+
+  void addFitProperties(Mantid::API::IAlgorithm &algorithm) const;
 
   virtual IndirectFitOutput
   createFitOutput(Mantid::API::WorkspaceGroup_sptr resultGroup,

--- a/qt/scientific_interfaces/Indirect/JumpFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFitModel.cpp
@@ -326,6 +326,8 @@ std::string JumpFitModel::singleFitOutputName(std::size_t, std::size_t) const {
   return sequentialFitOutputName();
 }
 
+std::string JumpFitModel::getResultXAxisUnit() const { return ""; }
+
 std::string JumpFitModel::constructOutputName() const {
   auto name = createOutputName("%1%_FofQFit_" + m_fitType, "", 0);
   auto position = name.find("_Result");

--- a/qt/scientific_interfaces/Indirect/JumpFitModel.h
+++ b/qt/scientific_interfaces/Indirect/JumpFitModel.h
@@ -42,6 +42,7 @@ public:
   std::string singleFitOutputName(std::size_t index,
                                   std::size_t spectrum) const override;
 
+
 private:
   std::string constructOutputName() const;
   bool allWorkspacesEqual(Mantid::API::MatrixWorkspace_sptr workspace) const;
@@ -50,6 +51,7 @@ private:
                        const std::string &hwhmName);
   std::unordered_map<std::string, JumpFitParameters>::const_iterator
   findJumpFitParameters(std::size_t dataIndex) const;
+  std::string getResultXAxisUnit() const override;
 
   std::string m_fitType;
   std::unordered_map<std::string, JumpFitParameters> m_jumpParameters;

--- a/qt/scientific_interfaces/Indirect/JumpFitModel.h
+++ b/qt/scientific_interfaces/Indirect/JumpFitModel.h
@@ -42,7 +42,6 @@ public:
   std::string singleFitOutputName(std::size_t index,
                                   std::size_t spectrum) const override;
 
-
 private:
   std::string constructOutputName() const;
   bool allWorkspacesEqual(Mantid::API::MatrixWorkspace_sptr workspace) const;

--- a/qt/scientific_interfaces/Indirect/MSDFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/MSDFitModel.cpp
@@ -26,6 +26,8 @@ std::string MSDFitModel::singleFitOutputName(std::size_t index,
                                    spectrum);
 }
 
+std::string MSDFitModel::getResultXAxisUnit() const { return ""; }
+
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/MSDFitModel.h
+++ b/qt/scientific_interfaces/Indirect/MSDFitModel.h
@@ -17,6 +17,8 @@ public:
                                   std::size_t spectrum) const override;
 
 private:
+  std::string getResultXAxisUnit() const override;
+
   std::string m_fitType;
 };
 


### PR DESCRIPTION
**Description of work.**
This PR adds a check on the y-axis type (i.e. Text or Numeric) of the input workspace(s) and correctly extracts the axis values/labels into the parameters table and the result workspace.

**To test:**
- Open Indirect > Data Analysis > F(Q)
- Enter the provided test data
- Select 'Chudley Elliot' in the 'Fit Type' drop-down menu
- Click the 'Fit Single Spectrum Button'
- Ensure the fit completes successfully
- Open the *_Parameters workspace and ensure that the axis-1 column contains f1.f1.FWHM

**Test Files**
[IN16B_125878_QLd_Result.nxs.zip](https://github.com/mantidproject/mantid/files/2249669/IN16B_125878_QLd_Result.nxs.zip)

Fixes #23155 

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
