### PR TITLE
Add Mask workspace option to WANDPowderReduction

### DIFF
--- a/docs/source/release/v3.14.0/diffraction.rst
+++ b/docs/source/release/v3.14.0/diffraction.rst
@@ -13,6 +13,7 @@ Improvements
 ############
 
 - :ref:`SNAPReduce <algm-SNAPReduce>` now has progress bar and all output workspaces have history
+- Mask workspace option added to :ref:`WANDPowderReduction <algm-WANDPowderReduction>`
 
 :ref:`Release 3.14.0 <v3.14.0>`
 


### PR DESCRIPTION
This gives an option to supply a Mask workspace for additional masking. They like the option of selecting different ROI's and then use this for masking.

I also change from `RemoveMaskedSpectra` to `ExtractUnmaskedSpectra` as it appears to be faster.

**To test:**

Create a mask workspace _e.g._
```
LoadEmptyInstrument(InstrumentName='WAND', OutputWorkspace='mask')
MaskBTP(Workspace='mask', Bank='1-4,6-8')
ExtractMask(InputWorkspace='mask', OutputWorkspace='mask')
```
Run the first [usage example](http://docs.mantidproject.org/nightly/algorithms/WANDPowderReduction-v1.html#usage) and compare when setting `MaskWorkspace='mask'`.


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
