### PR TITLE
Expose iadd and isub to python

### DIFF
--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/EventList.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/EventList.cpp
@@ -2,6 +2,7 @@
 #include "MantidPythonInterface/kernel/GetPointer.h"
 #include <boost/python/class.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
+#include <boost/python/return_arg.hpp>
 
 using namespace boost::python;
 using namespace Mantid::DataObjects;
@@ -22,5 +23,13 @@ void export_EventList() {
       "EventList")
       .def("addEventQuickly", &addEventToEventList,
            args("self", "tof", "pulsetime"),
-           "Create TofEvent and add to EventList.");
+           "Create TofEvent and add to EventList.")
+      .def("__iadd__",
+           (EventList & (EventList::*)(const EventList &)) &
+               EventList::operator+=,
+           return_self<>(), (arg("self"), arg("other")))
+      .def("__isub__",
+           (EventList & (EventList::*)(const EventList &)) &
+               EventList::operator-=,
+           return_self<>(), (arg("self"), arg("other")));
 }

--- a/Framework/PythonInterface/test/python/mantid/dataobjects/EventListTest.py
+++ b/Framework/PythonInterface/test/python/mantid/dataobjects/EventListTest.py
@@ -9,6 +9,12 @@ from mantid.dataobjects import EventList
 
 class EventListTest(unittest.TestCase):
 
+    def createRandomEventList(self, length):
+        el = EventList()
+        for i in range(length):
+            el.addEventQuickly(float(i), DateAndTime(i))
+        return el
+
     def test_event_list_constructor(self):
         el = EventList()
         self.assertEquals(el.getNumberEvents(), 0)
@@ -22,6 +28,32 @@ class EventListTest(unittest.TestCase):
         self.assertEquals(el.getTofs()[0], float(0.123))
         self.assertEquals(el.getPulseTimes()[0], DateAndTime(42))
 
+
+    def test_event_list_iadd(self):
+        left = self.createRandomEventList(10)
+        rght = self.createRandomEventList(20)
+
+        left += rght
+
+        self.assertEquals(left.getEventType(), EventType.TOF)
+        self.assertEquals(rght.getEventType(), EventType.TOF)
+
+        self.assertEquals(left.getNumberEvents(), 30)
+        self.assertEquals(rght.getNumberEvents(), 20)
+
+    def test_event_list_isub(self):
+        left = self.createRandomEventList(10)
+        rght = self.createRandomEventList(20)
+
+        left -= rght
+
+        self.assertEquals(left.getEventType(), EventType.WEIGHTED)
+        self.assertEquals(rght.getEventType(), EventType.TOF)
+
+        self.assertEquals(left.getNumberEvents(), 30)
+        self.assertEquals(rght.getNumberEvents(), 20)
+
+        self.assertEquals(left.integrate(-1.,31., True), -10.)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
@jmborr requested that `__iadd__` and `__isub__` be exposed to python for `EventList`. This does it.

**To test:**

You have to get your hands on two different spectra themselves.
```python
LoadEventNexus(Filename='PG3_12345', OutputWorkspace='PG3_12345')
wksp = mtd['PG3_12345']
left = wksp.getSpectrum(0)
rght = wksp.getSpectrum(1)
print(left.getNumberEvents(), rght.getNumberEvents())
left += rght
print(left.getNumberEvents(), rght.getNumberEvents())
print(wksp.getSpectrum(0).getNumberEvents(), wksp.getSpectrum(1).getNumberEvents())
```

Fixes #23192.

*This does not require release notes* because it is intended for developer use only.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
