### PR TITLE
Indirect - F(Q) Fit - Only display EISF/Width in drop-down menu if found in workspace

### DIFF
--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -29,6 +29,7 @@ Improvements
 ############
 
 - The Run button is now above the output options, and is disabled during fitting along with the output buttons.
+- The Run button in the Data Analysis tabs is now above the output options, and is disabled during fitting.
 - The Fit Single Spectrum buttons in the Data Analysis tabs MSDFit, ConvFit, I(Q,t)Fit and F(Q)Fit are now disabled
   during fitting.
 - When the InelasticDiffSphere, InelasticDiffRotDiscreteCircle, ElasticDiffSphere or ElasticDiffRotDiscreteCircle

--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -45,9 +45,12 @@ Improvements
 - The WorkspaceIndex and Q value in the FitPropertyBrowser are now updated when the Plot Spectrum number is changed.
   This improvement can be seen in ConvFit when functions which depend on Q value are selected.
 
+
 Bugfixes
 ########
 
+- The workspace(s) loaded into F(Q) Fit are checked for EISF or Width values, and an error message is displayed
+  if neither are present. This prevents an unexpected crash.
 - The parameter values for a selected spectrum are now updated properly when a Fit is run using the Fit String
   option in ConvFit.
 - An unexpected crash is prevented when Plot Current Preview is clicked when no data is loaded. A meaningful error

--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -45,7 +45,6 @@ Improvements
 - The WorkspaceIndex and Q value in the FitPropertyBrowser are now updated when the Plot Spectrum number is changed.
   This improvement can be seen in ConvFit when functions which depend on Q value are selected.
 
-
 Bugfixes
 ########
 

--- a/qt/scientific_interfaces/Indirect/ConvFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFitDataPresenter.cpp
@@ -8,17 +8,17 @@
 #include "ConvFitAddWorkspaceDialog.h"
 #include "ConvFitDataTablePresenter.h"
 
-#include "MantidKernel/make_unique.h"
 #include "MantidAPI/AnalysisDataService.h"
+#include "MantidKernel/make_unique.h"
 
 namespace {
 using namespace Mantid::API;
 
 bool isWorkspaceLoaded(std::string const &workspaceName) {
-	return AnalysisDataService::Instance().doesExist(workspaceName);
+  return AnalysisDataService::Instance().doesExist(workspaceName);
 }
 
-}
+} // namespace
 
 namespace MantidQt {
 namespace CustomInterfaces {

--- a/qt/scientific_interfaces/Indirect/ConvFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFitDataPresenter.cpp
@@ -9,6 +9,16 @@
 #include "ConvFitDataTablePresenter.h"
 
 #include "MantidKernel/make_unique.h"
+#include "MantidAPI/AnalysisDataService.h"
+
+namespace {
+using namespace Mantid::API;
+
+bool isWorkspaceLoaded(std::string const &workspaceName) {
+	return AnalysisDataService::Instance().doesExist(workspaceName);
+}
+
+}
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -53,7 +63,7 @@ void ConvFitDataPresenter::addWorkspace(ConvFitAddWorkspaceDialog const *dialog,
 void ConvFitDataPresenter::addModelData(const std::string &name) {
   IndirectFitDataPresenter::addModelData(name);
   const auto resolution = getView()->getSelectedResolution();
-  if (!resolution.empty())
+  if (!resolution.empty() && isWorkspaceLoaded(resolution))
     m_convModel->setResolution(resolution, 0);
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -991,6 +991,9 @@ bool IndirectFitAnalysisTab::validate() {
   const auto invalidFunction = m_fittingModel->isInvalidFunction();
   if (invalidFunction)
     validator.addErrorMessage(QString::fromStdString(*invalidFunction));
+  if (m_fittingModel->numberOfWorkspaces() == 0)
+    validator.addErrorMessage(
+        QString::fromStdString("No data has been selected for a fit."));
 
   const auto error = validator.generateErrorMessage();
   emit showMessageBox(error);

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -155,8 +155,8 @@ void IndirectFitAnalysisTab::setup() {
 
   connect(m_dataPresenter.get(), SIGNAL(dataChanged()), this,
           SLOT(updateResultOptions()));
-  connect(m_dataPresenter.get(), SIGNAL(dataChanged()), this,
-          SLOT(emitUpdateFitTypes()));
+  connect(m_dataPresenter.get(), SIGNAL(updateAvailableFitTypes()), this,
+          SLOT(updateAvailableFitTypes()));
 
   connectDataAndSpectrumPresenters();
   connectDataAndPlotPresenters();
@@ -1126,8 +1126,6 @@ void IndirectFitAnalysisTab::updateResultOptions() {
   setPlotResultEnabled(isFit);
   setSaveResultEnabled(isFit);
 }
-
-void IndirectFitAnalysisTab::emitUpdateFitTypes() { emit updateFitTypes(); }
 
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -159,7 +159,6 @@ signals:
   void functionChanged();
   void parameterChanged(const Mantid::API::IFunction *);
   void customBoolChanged(const QString &key, bool value);
-  void updateFitTypes();
 
 protected slots:
 
@@ -214,7 +213,6 @@ protected slots:
 
 private slots:
   void updatePlotGuess();
-  void emitUpdateFitTypes();
 
 private:
   /// Overidden by child class.

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
@@ -194,6 +194,8 @@ void IndirectFitDataPresenter::addModelData(const std::string &name) {
     m_model->addWorkspace(name);
   } catch (const std::runtime_error &ex) {
     displayWarning("Unable to load workspace:\n" + std::string(ex.what()));
+  } catch (const std::invalid_argument &ex) {
+    displayWarning("Invalid workspace:\n" + std::string(ex.what()));
   }
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
@@ -37,8 +37,8 @@ IndirectFitDataPresenter::IndirectFitDataPresenter(
 
   connect(m_view, SIGNAL(sampleLoaded(const QString &)), this,
           SLOT(setModelWorkspace(const QString &)));
-	connect(m_view, SIGNAL(sampleLoaded(const QString &)), this,
-		      SIGNAL(singleSampleLoaded()));
+  connect(m_view, SIGNAL(sampleLoaded(const QString &)), this,
+          SIGNAL(singleSampleLoaded()));
   connect(m_view, SIGNAL(sampleLoaded(const QString &)), this,
           SIGNAL(dataChanged()));
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
@@ -37,8 +37,8 @@ IndirectFitDataPresenter::IndirectFitDataPresenter(
 
   connect(m_view, SIGNAL(sampleLoaded(const QString &)), this,
           SLOT(setModelWorkspace(const QString &)));
-  connect(m_view, SIGNAL(sampleLoaded(const QString &)), this,
-          SIGNAL(singleSampleLoaded()));
+	connect(m_view, SIGNAL(sampleLoaded(const QString &)), this,
+		      SIGNAL(singleSampleLoaded()));
   connect(m_view, SIGNAL(sampleLoaded(const QString &)), this,
           SIGNAL(dataChanged()));
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataView.cpp
@@ -8,6 +8,14 @@
 
 using namespace Mantid::API;
 
+namespace {
+
+bool isWorkspaceLoaded(std::string const &workspaceName) {
+	return AnalysisDataService::Instance().doesExist(workspaceName);
+}
+
+}
+
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
@@ -105,11 +113,19 @@ IndirectFitDataView::validateMultipleData(UserInputValidator &validator) {
 
 UserInputValidator &
 IndirectFitDataView::validateSingleData(UserInputValidator &validator) {
+	const auto sampleIsLoaded = isWorkspaceLoaded(getSelectedSample());
   validator.checkDataSelectorIsValid("Sample Input", m_dataForm->dsSample);
+	
+	if (!sampleIsLoaded)
+	  emit sampleLoaded(QString::fromStdString(getSelectedSample()));
 
-  if (!isResolutionHidden())
-    validator.checkDataSelectorIsValid("Resolution Input",
-                                       m_dataForm->dsResolution);
+	if (!isResolutionHidden()) {
+		const auto resolutionIsLoaded = isWorkspaceLoaded(getSelectedResolution());
+		validator.checkDataSelectorIsValid("Resolution Input",
+			m_dataForm->dsResolution);
+		if (!resolutionIsLoaded)
+		  emit resolutionLoaded(QString::fromStdString(getSelectedResolution()));
+	}
   return validator;
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataView.cpp
@@ -113,20 +113,28 @@ IndirectFitDataView::validateMultipleData(UserInputValidator &validator) {
 
 UserInputValidator &
 IndirectFitDataView::validateSingleData(UserInputValidator &validator) {
-	const auto sampleIsLoaded = isWorkspaceLoaded(getSelectedSample());
-  validator.checkDataSelectorIsValid("Sample Input", m_dataForm->dsSample);
-	
-	if (!sampleIsLoaded)
-	  emit sampleLoaded(QString::fromStdString(getSelectedSample()));
-
-	if (!isResolutionHidden()) {
-		const auto resolutionIsLoaded = isWorkspaceLoaded(getSelectedResolution());
-		validator.checkDataSelectorIsValid("Resolution Input",
-			m_dataForm->dsResolution);
-		if (!resolutionIsLoaded)
-		  emit resolutionLoaded(QString::fromStdString(getSelectedResolution()));
-	}
+	validator = validateSample(validator);
+	if (!isResolutionHidden()) 
+		validator = validateResolution(validator);
   return validator;
+}
+
+UserInputValidator &IndirectFitDataView::validateSample(UserInputValidator &validator) {
+	const auto sampleIsLoaded = isWorkspaceLoaded(getSelectedSample());
+	validator.checkDataSelectorIsValid("Sample Input", m_dataForm->dsSample);
+
+	if (!sampleIsLoaded)
+		emit sampleLoaded(QString::fromStdString(getSelectedSample()));
+	return validator;
+}
+
+UserInputValidator &IndirectFitDataView::validateResolution(UserInputValidator &validator) {
+	const auto resolutionIsLoaded = isWorkspaceLoaded(getSelectedResolution());
+	validator.checkDataSelectorIsValid("Resolution Input", m_dataForm->dsResolution);
+
+	if (!resolutionIsLoaded)
+		emit resolutionLoaded(QString::fromStdString(getSelectedResolution()));
+	return validator;
 }
 
 void IndirectFitDataView::displayWarning(const std::string &warning) {

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataView.cpp
@@ -11,10 +11,10 @@ using namespace Mantid::API;
 namespace {
 
 bool isWorkspaceLoaded(std::string const &workspaceName) {
-	return AnalysisDataService::Instance().doesExist(workspaceName);
+  return AnalysisDataService::Instance().doesExist(workspaceName);
 }
 
-}
+} // namespace
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -113,28 +113,31 @@ IndirectFitDataView::validateMultipleData(UserInputValidator &validator) {
 
 UserInputValidator &
 IndirectFitDataView::validateSingleData(UserInputValidator &validator) {
-	validator = validateSample(validator);
-	if (!isResolutionHidden()) 
-		validator = validateResolution(validator);
+  validator = validateSample(validator);
+  if (!isResolutionHidden())
+    validator = validateResolution(validator);
   return validator;
 }
 
-UserInputValidator &IndirectFitDataView::validateSample(UserInputValidator &validator) {
-	const auto sampleIsLoaded = isWorkspaceLoaded(getSelectedSample());
-	validator.checkDataSelectorIsValid("Sample Input", m_dataForm->dsSample);
+UserInputValidator &
+IndirectFitDataView::validateSample(UserInputValidator &validator) {
+  const auto sampleIsLoaded = isWorkspaceLoaded(getSelectedSample());
+  validator.checkDataSelectorIsValid("Sample Input", m_dataForm->dsSample);
 
-	if (!sampleIsLoaded)
-		emit sampleLoaded(QString::fromStdString(getSelectedSample()));
-	return validator;
+  if (!sampleIsLoaded)
+    emit sampleLoaded(QString::fromStdString(getSelectedSample()));
+  return validator;
 }
 
-UserInputValidator &IndirectFitDataView::validateResolution(UserInputValidator &validator) {
-	const auto resolutionIsLoaded = isWorkspaceLoaded(getSelectedResolution());
-	validator.checkDataSelectorIsValid("Resolution Input", m_dataForm->dsResolution);
+UserInputValidator &
+IndirectFitDataView::validateResolution(UserInputValidator &validator) {
+  const auto resolutionIsLoaded = isWorkspaceLoaded(getSelectedResolution());
+  validator.checkDataSelectorIsValid("Resolution Input",
+                                     m_dataForm->dsResolution);
 
-	if (!resolutionIsLoaded)
-		emit resolutionLoaded(QString::fromStdString(getSelectedResolution()));
-	return validator;
+  if (!resolutionIsLoaded)
+    emit resolutionLoaded(QString::fromStdString(getSelectedResolution()));
+  return validator;
 }
 
 void IndirectFitDataView::displayWarning(const std::string &warning) {

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataView.h
@@ -62,8 +62,8 @@ protected slots:
 private:
   UserInputValidator &validateMultipleData(UserInputValidator &validator);
   UserInputValidator &validateSingleData(UserInputValidator &validator);
-	UserInputValidator &validateSample(UserInputValidator &validator);
-	UserInputValidator &validateResolution(UserInputValidator &validator);
+  UserInputValidator &validateSample(UserInputValidator &validator);
+  UserInputValidator &validateResolution(UserInputValidator &validator);
 
   std::unique_ptr<Ui::IndirectFitDataForm> m_dataForm;
 };

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataView.h
@@ -62,6 +62,8 @@ protected slots:
 private:
   UserInputValidator &validateMultipleData(UserInputValidator &validator);
   UserInputValidator &validateSingleData(UserInputValidator &validator);
+	UserInputValidator &validateSample(UserInputValidator &validator);
+	UserInputValidator &validateResolution(UserInputValidator &validator);
 
   std::unique_ptr<Ui::IndirectFitDataForm> m_dataForm;
 };

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -116,15 +116,15 @@ bool equivalentFunctions(IFunction_const_sptr func1,
 std::ostringstream &addInputString(IndirectFitData *fitData,
                                    std::ostringstream &stream) {
   const auto &name = fitData->workspace()->getName();
-	if (!name.empty()) {
-		auto addToStream = [&](std::size_t spectrum) {
-			stream << name << ",i" << spectrum << ";";
-		};
-		fitData->applySpectra(addToStream);
-		return stream;
-	}
-	else
-		throw std::runtime_error("Workspace name is empty. The sample workspace may not be loaded.");
+  if (!name.empty()) {
+    auto addToStream = [&](std::size_t spectrum) {
+      stream << name << ",i" << spectrum << ";";
+    };
+    fitData->applySpectra(addToStream);
+    return stream;
+  } else
+    throw std::runtime_error(
+        "Workspace name is empty. The sample workspace may not be loaded.");
 }
 
 std::string constructInputString(

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -116,11 +116,15 @@ bool equivalentFunctions(IFunction_const_sptr func1,
 std::ostringstream &addInputString(IndirectFitData *fitData,
                                    std::ostringstream &stream) {
   const auto &name = fitData->workspace()->getName();
-  auto addToStream = [&](std::size_t spectrum) {
-    stream << name << ",i" << spectrum << ";";
-  };
-  fitData->applySpectra(addToStream);
-  return stream;
+	if (!name.empty()) {
+		auto addToStream = [&](std::size_t spectrum) {
+			stream << name << ",i" << spectrum << ";";
+		};
+		fitData->applySpectra(addToStream);
+		return stream;
+	}
+	else
+		throw std::runtime_error("Workspace name is empty. The sample workspace may not be loaded.");
 }
 
 std::string constructInputString(

--- a/qt/scientific_interfaces/Indirect/JumpFit.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFit.cpp
@@ -26,11 +26,11 @@ using namespace Mantid::API;
 
 namespace {
 
-std::vector<std::string> const &getEISFFunctions() {
+std::vector<std::string> getEISFFunctions() {
 	return { "EISFDiffCylinder", "EISFDiffSphere", "EISFDiffSphereAlkyl" };
 }
 
-std::vector<std::string> const &getWidthFunctions() {
+std::vector<std::string> getWidthFunctions() {
 	return { "ChudleyElliot", "HallRoss", "FickDiffusion", "TeixeiraWater" };
 }
 

--- a/qt/scientific_interfaces/Indirect/JumpFit.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFit.cpp
@@ -27,14 +27,14 @@ using namespace Mantid::API;
 namespace {
 
 std::vector<std::string> getEISFFunctions() {
-	return { "EISFDiffCylinder", "EISFDiffSphere", "EISFDiffSphereAlkyl" };
+  return {"EISFDiffCylinder", "EISFDiffSphere", "EISFDiffSphereAlkyl"};
 }
 
 std::vector<std::string> getWidthFunctions() {
-	return { "ChudleyElliot", "HallRoss", "FickDiffusion", "TeixeiraWater" };
+  return {"ChudleyElliot", "HallRoss", "FickDiffusion", "TeixeiraWater"};
 }
 
-}
+} // namespace
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -61,8 +61,8 @@ void JumpFit::setupFitTab() {
   setSampleWSSuffices({"_Result"});
   setSampleFBSuffices({"_Result.nxs"});
 
-	addFunctions(getWidthFunctions());
-	addFunctions(getEISFFunctions());
+  addFunctions(getWidthFunctions());
+  addFunctions(getEISFFunctions());
 
   m_uiForm->cbParameter->setEnabled(false);
 
@@ -80,15 +80,16 @@ void JumpFit::updateAvailableFitTypes() {
   auto const parameter = m_uiForm->cbParameterType->currentText().toStdString();
   clearFitTypeComboBox();
   if (parameter == "Width")
-		addFunctions(getWidthFunctions());
+    addFunctions(getWidthFunctions());
   else if (parameter == "EISF")
-		addFunctions(getEISFFunctions());
+    addFunctions(getEISFFunctions());
 }
 
 void JumpFit::addFunctions(std::vector<std::string> const &functions) {
-	auto &factory = FunctionFactory::Instance();
-	for (auto const &function : functions)
-		addComboBoxFunctionGroup(QString::fromStdString(function), { factory.createFunction(function) });
+  auto &factory = FunctionFactory::Instance();
+  for (auto const &function : functions)
+    addComboBoxFunctionGroup(QString::fromStdString(function),
+                             {factory.createFunction(function)});
 }
 
 void JumpFit::updateModelFitTypeString() {

--- a/qt/scientific_interfaces/Indirect/JumpFit.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFit.cpp
@@ -24,6 +24,18 @@
 
 using namespace Mantid::API;
 
+namespace {
+
+std::vector<std::string> const &getEISFFunctions() {
+	return { "EISFDiffCylinder", "EISFDiffSphere", "EISFDiffSphereAlkyl" };
+}
+
+std::vector<std::string> const &getWidthFunctions() {
+	return { "ChudleyElliot", "HallRoss", "FickDiffusion", "TeixeiraWater" };
+}
+
+}
+
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
@@ -49,8 +61,8 @@ void JumpFit::setupFitTab() {
   setSampleWSSuffices({"_Result"});
   setSampleFBSuffices({"_Result.nxs"});
 
-  addWidthFunctionsToFitTypeComboBox();
-  addEISFFunctionsToFitTypeComboBox();
+	addFunctions(getWidthFunctions());
+	addFunctions(getEISFFunctions());
 
   m_uiForm->cbParameter->setEnabled(false);
 
@@ -61,42 +73,22 @@ void JumpFit::setupFitTab() {
   connect(this, SIGNAL(functionChanged()), this,
           SLOT(updateModelFitTypeString()));
   connect(m_uiForm->cbParameterType, SIGNAL(currentIndexChanged(int)), this,
-          SLOT(updateParameterFitTypes()));
-  connect(this, SIGNAL(updateFitTypes()), this,
-          SLOT(updateParameterFitTypes()));
+          SLOT(updateAvailableFitTypes()));
 }
 
-void JumpFit::addEISFFunctionsToFitTypeComboBox() {
-  auto &functionFactory = FunctionFactory::Instance();
-  auto const eisfDiffCylinder =
-      functionFactory.createFunction("EISFDiffCylinder");
-  auto const eisfDiffSphere = functionFactory.createFunction("EISFDiffSphere");
-  auto const eisfDiffSphereAklyl =
-      functionFactory.createFunction("EISFDiffSphereAlkyl");
-  addComboBoxFunctionGroup("EISFDiffCylinder", {eisfDiffCylinder});
-  addComboBoxFunctionGroup("EISFDiffSphere", {eisfDiffSphere});
-  addComboBoxFunctionGroup("EISFDiffSphereAlkyl", {eisfDiffSphereAklyl});
-}
-
-void JumpFit::addWidthFunctionsToFitTypeComboBox() {
-  auto &functionFactory = FunctionFactory::Instance();
-  auto const chudleyElliot = functionFactory.createFunction("ChudleyElliot");
-  auto const hallRoss = functionFactory.createFunction("HallRoss");
-  auto const fickDiffusion = functionFactory.createFunction("FickDiffusion");
-  auto const teixeiraWater = functionFactory.createFunction("TeixeiraWater");
-  addComboBoxFunctionGroup("ChudleyElliot", {chudleyElliot});
-  addComboBoxFunctionGroup("HallRoss", {hallRoss});
-  addComboBoxFunctionGroup("FickDiffusion", {fickDiffusion});
-  addComboBoxFunctionGroup("TeixeiraWater", {teixeiraWater});
-}
-
-void JumpFit::updateParameterFitTypes() {
+void JumpFit::updateAvailableFitTypes() {
   auto const parameter = m_uiForm->cbParameterType->currentText().toStdString();
   clearFitTypeComboBox();
-  if (parameter == "EISF")
-    addEISFFunctionsToFitTypeComboBox();
-  else if (parameter == "Width")
-    addWidthFunctionsToFitTypeComboBox();
+  if (parameter == "Width")
+		addFunctions(getWidthFunctions());
+  else if (parameter == "EISF")
+		addFunctions(getEISFFunctions());
+}
+
+void JumpFit::addFunctions(std::vector<std::string> const &functions) {
+	auto &factory = FunctionFactory::Instance();
+	for (auto const &function : functions)
+		addComboBoxFunctionGroup(QString::fromStdString(function), { factory.createFunction(function) });
 }
 
 void JumpFit::updateModelFitTypeString() {

--- a/qt/scientific_interfaces/Indirect/JumpFit.h
+++ b/qt/scientific_interfaces/Indirect/JumpFit.h
@@ -38,11 +38,10 @@ protected:
   void setSaveResultEnabled(bool enabled) override;
 
 private slots:
-  void updateParameterFitTypes();
+  void updateAvailableFitTypes();
 
 private:
-  void addEISFFunctionsToFitTypeComboBox();
-  void addWidthFunctionsToFitTypeComboBox();
+	void addFunctions(std::vector<std::string> const &functions);
 
   void setPlotResultIsPlotting(bool plotting);
   void setButtonsEnabled(bool enabled);

--- a/qt/scientific_interfaces/Indirect/JumpFit.h
+++ b/qt/scientific_interfaces/Indirect/JumpFit.h
@@ -41,7 +41,7 @@ private slots:
   void updateAvailableFitTypes();
 
 private:
-	void addFunctions(std::vector<std::string> const &functions);
+  void addFunctions(std::vector<std::string> const &functions);
 
   void setPlotResultIsPlotting(bool plotting);
   void setButtonsEnabled(bool enabled);

--- a/qt/scientific_interfaces/Indirect/JumpFitAddWorkspaceDialog.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFitAddWorkspaceDialog.cpp
@@ -20,12 +20,17 @@ JumpFitAddWorkspaceDialog::JumpFitAddWorkspaceDialog(QWidget *parent)
 
   connect(m_uiForm.dsWorkspace, SIGNAL(dataReady(const QString &)), this,
           SLOT(emitWorkspaceChanged(const QString &)));
-  connect(m_uiForm.cbParameterType, SIGNAL(currentIndexChanged(int)), this,
-          SLOT(emitParameterTypeChanged(int)));
+  connect(m_uiForm.cbParameterType,
+          SIGNAL(currentIndexChanged(const QString &)), this,
+          SLOT(emitParameterTypeChanged(const QString &)));
 }
 
 std::string JumpFitAddWorkspaceDialog::workspaceName() const {
   return m_uiForm.dsWorkspace->getCurrentDataName().toStdString();
+}
+
+std::string JumpFitAddWorkspaceDialog::parameterType() const {
+  return m_uiForm.cbParameterType->currentText().toStdString();
 }
 
 int JumpFitAddWorkspaceDialog::parameterNameIndex() const {
@@ -69,8 +74,8 @@ void JumpFitAddWorkspaceDialog::emitWorkspaceChanged(const QString &name) {
   emit workspaceChanged(this, name.toStdString());
 }
 
-void JumpFitAddWorkspaceDialog::emitParameterTypeChanged(int type) {
-  emit parameterTypeChanged(this, type);
+void JumpFitAddWorkspaceDialog::emitParameterTypeChanged(const QString &type) {
+  emit parameterTypeChanged(this, type.toStdString());
 }
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Indirect/JumpFitAddWorkspaceDialog.h
+++ b/qt/scientific_interfaces/Indirect/JumpFitAddWorkspaceDialog.h
@@ -20,6 +20,7 @@ public:
   explicit JumpFitAddWorkspaceDialog(QWidget *parent);
 
   std::string workspaceName() const override;
+  std::string parameterType() const;
   int parameterNameIndex() const;
 
   void setParameterTypes(const std::vector<std::string> &types);
@@ -32,12 +33,13 @@ public:
 
 public slots:
   void emitWorkspaceChanged(const QString &name);
-  void emitParameterTypeChanged(int index);
+  void emitParameterTypeChanged(const QString &index);
 
 signals:
   void workspaceChanged(JumpFitAddWorkspaceDialog *dialog,
                         const std::string &workspace);
-  void parameterTypeChanged(JumpFitAddWorkspaceDialog *dialog, int type);
+  void parameterTypeChanged(JumpFitAddWorkspaceDialog *dialog,
+                            const std::string &type);
 
 private:
   Ui::JumpFitAddWorkspaceDialog m_uiForm;

--- a/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.cpp
@@ -51,8 +51,8 @@ JumpFitDataPresenter::JumpFitDataPresenter(
           SLOT(updateAvailableParameters()));
   connect(view, SIGNAL(sampleLoaded(const QString &)), this,
           SLOT(updateParameterSelectionEnabled()));
-	connect(view, SIGNAL(sampleLoaded(const QString &)), this,
-		      SIGNAL(updateAvailableFitTypes()));
+  connect(view, SIGNAL(sampleLoaded(const QString &)), this,
+          SIGNAL(updateAvailableFitTypes()));
 
   updateParameterSelectionEnabled();
 }

--- a/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.cpp
@@ -51,6 +51,8 @@ JumpFitDataPresenter::JumpFitDataPresenter(
           SLOT(updateAvailableParameters()));
   connect(view, SIGNAL(sampleLoaded(const QString &)), this,
           SLOT(updateParameterSelectionEnabled()));
+	connect(view, SIGNAL(sampleLoaded(const QString &)), this,
+		      SIGNAL(updateAvailableFitTypes()));
 
   updateParameterSelectionEnabled();
 }

--- a/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.h
@@ -29,7 +29,7 @@ public:
                        QLabel *lbParameterType, QLabel *lbParameter);
 
 signals:
-	void updateAvailableFitTypes();
+  void updateAvailableFitTypes();
 
 private slots:
   void hideParameterComboBoxes();

--- a/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.h
@@ -28,6 +28,9 @@ public:
                        QComboBox *cbParameterType, QComboBox *cbParameter,
                        QLabel *lbParameterType, QLabel *lbParameter);
 
+signals:
+	void updateAvailableFitTypes();
+
 private slots:
   void hideParameterComboBoxes();
   void showParameterComboBoxes();

--- a/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.h
@@ -32,14 +32,15 @@ private slots:
   void hideParameterComboBoxes();
   void showParameterComboBoxes();
   void updateAvailableParameters();
-  void updateAvailableParameters(int typeIndex);
+  void updateAvailableParameterTypes();
+  void updateAvailableParameters(const QString &type);
   void updateParameterSelectionEnabled();
   void setParameterLabel(const QString &parameter);
+  void dialogParameterTypeUpdated(JumpFitAddWorkspaceDialog *dialog,
+                                  const std::string &type);
   void setDialogParameterNames(JumpFitAddWorkspaceDialog *dialog,
                                const std::string &workspace);
-  void setDialogParameterNames(JumpFitAddWorkspaceDialog *dialog,
-                               int parameterType);
-  void setActiveParameterType(int type);
+  void setActiveParameterType(const std::string &type);
   void updateActiveDataIndex();
   void setSingleModelSpectrum(int index);
 
@@ -56,7 +57,7 @@ private:
   void addWorkspace(IndirectFittingModel *model, const std::string &name);
   void setModelSpectrum(int index);
 
-  int m_activeParameterType;
+  std::string m_activeParameterType;
   std::size_t m_dataIndex;
 
   QComboBox *m_cbParameterType;

--- a/qt/scientific_interfaces/Indirect/JumpFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFitModel.cpp
@@ -227,6 +227,7 @@ void JumpFitModel::addWorkspace(Mantid::API::MatrixWorkspace_sptr workspace,
 }
 
 void JumpFitModel::removeWorkspace(std::size_t index) {
+  m_jumpParameters.erase(getWorkspace(index)->getName());
   IndirectFittingModel::removeFittingData(index);
 }
 


### PR DESCRIPTION
**Description**
This PR ensures that the EISF and Width options only appear in the parameter type drop-down menu (both in single and multiple input modes) when they are available within the selected input workspace.

If neither are available, the user is presented with a meaningful error message.

**To test:**
1. `Interfaces` -> `Indirect Data Analysis` -> `F(Q) Fit` Tab
2. Load in the data below
3. There should be no crash, and no unexpected exception.

**Test Files**
[iris26176_graphite002_s0-50_Result.zip](https://github.com/mantidproject/mantid/files/2366840/iris26176_graphite002_s0-50_Result.zip) - This file doesn't have an EISF or Width and so a meaningful error message should be displayed.
[IN16B_125878_QLd_Result.zip](https://github.com/mantidproject/mantid/files/2366863/IN16B_125878_QLd_Result.zip) - This file should work, and the Width and EISF options should be displayed in the `Fit Parameter` combobox.

Fixes #23204 

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
