### PR TITLE
Use stack-based object to avoid memory leak in SaveNexusProcessed

### DIFF
--- a/Framework/DataHandling/src/SaveNexusProcessed.cpp
+++ b/Framework/DataHandling/src/SaveNexusProcessed.cpp
@@ -220,7 +220,7 @@ void SaveNexusProcessed::doExec(
   nexusFile->openNexusWrite(m_filename, entryNumber);
 
   // Equivalent C++ API handle
-  auto cppFile = new ::NeXus::File(nexusFile->fileID);
+  ::NeXus::File cppFile(nexusFile->fileID);
 
   prog_init.reportIncrement(1, "Opening file");
   if (nexusFile->writeNexusProcessedHeader(m_title, wsName) != 0)
@@ -231,7 +231,7 @@ void SaveNexusProcessed::doExec(
   // write instrument data, if present and writer enabled
   if (matrixWorkspace) {
     // Save the instrument names, ParameterMap, sample, run
-    matrixWorkspace->saveExperimentInfoNexus(cppFile);
+    matrixWorkspace->saveExperimentInfoNexus(&cppFile);
     prog_init.reportIncrement(1, "Writing sample and instrument");
 
     // check if all X() are in fact the same array
@@ -256,23 +256,21 @@ void SaveNexusProcessed::doExec(
                                            spec, "workspace", true);
     }
 
-    cppFile->openGroup("instrument", "NXinstrument");
-    saveSpectraMapNexus(*matrixWorkspace, cppFile, spec, ::NeXus::LZW);
-    cppFile->closeGroup();
+    cppFile.openGroup("instrument", "NXinstrument");
+    saveSpectraMapNexus(*matrixWorkspace, &cppFile, spec, ::NeXus::LZW);
+    cppFile.closeGroup();
 
   } // finish matrix workspace specifics
 
   if (peaksWorkspace) {
     // Save the instrument names, ParameterMap, sample, run
-    peaksWorkspace->saveExperimentInfoNexus(cppFile);
+    peaksWorkspace->saveExperimentInfoNexus(&cppFile);
     prog_init.reportIncrement(1, "Writing sample and instrument");
   }
 
   // peaks workspace specifics
   if (peaksWorkspace) {
-    //  g_log.information("Peaks Workspace saving to Nexus would be done");
-    //  int pNum = peaksWorkspace->getNumberPeaks();
-    peaksWorkspace->saveNexus(cppFile);
+    peaksWorkspace->saveNexus(&cppFile);
 
   }                        // finish peaks workspace specifics
   else if (tableWorkspace) // Table workspace specifics
@@ -294,7 +292,7 @@ void SaveNexusProcessed::doExec(
     }
   }
 
-  inputWorkspace->history().saveNexus(cppFile);
+  inputWorkspace->history().saveNexus(&cppFile);
   nexusFile->closeGroup();
 }
 


### PR DESCRIPTION
**Description of work.**

Resolves a memory leak spotted by Valgrind when trying to debug another issue.

**Report to:** nobody. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

A code review should suffice.

*There is no associated issue.*

*This does not require release notes* because **it is not substantial enough a leak to warrant announcing.**

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
