### PR TITLE
Updated ISIS Powder Polaris chopper mode error

### DIFF
--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_advanced_config.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_advanced_config.py
@@ -94,10 +94,9 @@ variables = {
 
 def get_mode_specific_dict(mode):
     if mode is None:
-        err_text = "The parameter with name: 'mode' is required but "
-        err_text += "was not set or passed.\n"
-        err_text += "Acceptable values for this parameter are: PDF, Rietveld."
-        raise RuntimeError(err_text)
+        raise RuntimeError("The parameter with name: 'mode' is required but "
+                           "was not set or passed.\n"
+                           "Acceptable values for this parameter are: PDF, Rietveld.")
 
     mode = mode.lower()
     if mode == "pdf":

--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_advanced_config.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_advanced_config.py
@@ -94,7 +94,10 @@ variables = {
 
 def get_mode_specific_dict(mode):
     if mode is None:
-        raise RuntimeError("Failed to supply chopper mode")
+        err_text = "The parameter with name: 'mode' is required but "
+        err_text += "was not set or passed.\n"
+        err_text += "Acceptable values for this parameter are: PDF, Rietveld."
+        raise RuntimeError(err_text)
 
     mode = mode.lower()
     if mode == "pdf":

--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_advanced_config.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_advanced_config.py
@@ -97,7 +97,7 @@ def get_mode_specific_dict(mode):
         err_text = "The parameter with name: 'mode' is required but "
         err_text += "was not set or passed.\n"
         err_text += "Acceptable values for this parameter are: PDF, Rietveld."
-        raise AttributeError(err_text)
+        raise RuntimeError(err_text)
 
     mode = mode.lower()
     if mode == "pdf":

--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_advanced_config.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_advanced_config.py
@@ -97,7 +97,7 @@ def get_mode_specific_dict(mode):
         err_text = "The parameter with name: 'mode' is required but "
         err_text += "was not set or passed.\n"
         err_text += "Acceptable values for this parameter are: PDF, Rietveld."
-        raise RuntimeError(err_text)
+        raise AttributeError(err_text)
 
     mode = mode.lower()
     if mode == "pdf":


### PR DESCRIPTION
**Description of work.**
Updated Error message from missing chopper mode to explain which mandatory parameter is missing in a way more consistent with other ISIS Powder errors
**To test:**
Run the following in mantid plot
```
from isis_powder import Polaris

pol = Polaris(user_name='',
                    calibration_directory='',
                    output_directory='')
pol.focus()
```
Fixes #23220
---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
