### PR TITLE
Fix a bug where a checkbox is hidden by another widget

### DIFF
--- a/docs/source/release/v3.14.0/reflectometry.rst
+++ b/docs/source/release/v3.14.0/reflectometry.rst
@@ -9,4 +9,13 @@ Reflectometry Changes
     putting new features at the top of the section, followed by
     improvements, followed by bug fixes.
 
+
+ISIS Reflectometry Interface
+----------------------------
+
+Bug fixes
+#########
+
+- A bug has been fixed on the Settings tab where the IncludePartialBins check box had been hidden by a misplaced text entry box.
+
 :ref:`Release 3.14.0 <v3.14.0>`

--- a/qt/scientific_interfaces/ISISReflectometry/ReflSettingsWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflSettingsWidget.ui
@@ -364,7 +364,7 @@
           <widget class="QWidget" name="pageParamFile">
            <layout class="QHBoxLayout" name="horizontalLayout_3">
             <item>
-             <widget class="QLabel" name="label">
+             <widget class="QLabel" name="parametersLabel">
               <property name="text">
                <string>Use parameters from the instrument parameter file</string>
               </property>
@@ -403,7 +403,7 @@
          </widget>
         </item>
         <item row="2" column="2">
-         <widget class="QLabel" name="stitchLabel">
+         <widget class="QLabel" name="includePartialBinsLabel">
           <property name="text">
            <string>IncludePartialBins</string>
           </property>
@@ -433,14 +433,14 @@
          </widget>
         </item>
         <item row="7" column="0">
-         <widget class="QLabel" name="stitchLabel_2">
+         <widget class="QLabel" name="stitchLabel">
           <property name="text">
            <string>Stitch1DMany</string>
           </property>
          </widget>
         </item>
         <item row="0" column="2">
-         <widget class="QLabel" name="label1">
+         <widget class="QLabel" name="debugLabel">
           <property name="text">
            <string>Debug</string>
           </property>


### PR DESCRIPTION
- This PR fixes a bug where the IncludePartialBins check box on the reflectometry GUI had an incorrect name for its label. The name was associated with another widget (the stitching params) whose position gets dynamically assigned, and due to the incorrect name this widget was being placed over the top of the IncludePartialBins check box.
- The PR also updates the names for a couple of other labels to be more specific.

**To test:**
- Open the `ISIS Reflectometry` interface.
- Select the `Settings` tab
- IncludePartialBins should be a check box and Stitch1DMany should be a text entry box:
![layout_bug_on_gui_fixed](https://user-images.githubusercontent.com/12895056/43963710-f7c69cb6-9cb2-11e8-8cb8-0bc25c5e345f.png)

Not like this where IncludePartialBins had "stolen" the text entry box:
![layout_bug_on_refl_gui](https://user-images.githubusercontent.com/12895056/43963635-c58d4d30-9cb2-11e8-8444-caa504d9ae33.png)

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
