### PR TITLE
Fix mantid for Python 3.7

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/funcinspect.py
+++ b/Framework/PythonInterface/mantid/kernel/funcinspect.py
@@ -148,7 +148,7 @@ __operator_names = set(['CALL_FUNCTION', 'CALL_FUNCTION_VAR', 'CALL_FUNCTION_KW'
                         'INPLACE_MODULO', 'INPLACE_ADD', 'INPLACE_SUBTRACT',
                         'INPLACE_LSHIFT','INPLACE_RSHIFT','INPLACE_AND', 'INPLACE_XOR',
                         'INPLACE_OR', 'COMPARE_OP',
-                        'CALL_FUNCTION_EX'])
+                        'CALL_FUNCTION_EX', 'LOAD_METHOD', 'CALL_METHOD'])
 #--------------------------------------------------------------------------------------
 
 def process_frame(frame):

--- a/MantidPlot/CMakeLists.txt
+++ b/MantidPlot/CMakeLists.txt
@@ -455,7 +455,7 @@ add_custom_command ( OUTPUT ${SIP_SRC_AUTO}
                           -I ${PYQT4_SIP_DIR} ${MANTIDQTPYTHON_SIP_INCLUDES}  ${PYQT4_SIP_FLAGS}
                           -c ${CMAKE_CURRENT_BINARY_DIR} -j1 -w -o
                           ${SIP_SPEC}
-                     DEPENDS ${SIP_INCLUDE_DIRECTORY}/sip.h src/qti.sip ${QTI_SIP_HDRS} ../qt/python/mantidqtpython/mantidqtpython_def.sip
+                     DEPENDS ${SIP_INCLUDE_DIR}/sip.h src/qti.sip ${QTI_SIP_HDRS} ../qt/python/mantidqtpython/mantidqtpython_def.sip
                      COMMENT "Generating python bindings using sip"
 )
 

--- a/MantidPlot/pymantidplot/__init__.py
+++ b/MantidPlot/pymantidplot/__init__.py
@@ -57,17 +57,17 @@ def _get_analysis_data_service():
 
 # -------------------------- Wrapped MantidPlot functions -----------------
 
-def runPythonScript(code, async=False, quiet=False, redirect=True):
+def runPythonScript(code, asynchronous=False, quiet=False, redirect=True):
     """
         Redirects the runPythonScript method to the app object
         @param code :: A string of code to execute
-        @param async :: If the true the code is executed in a separate thread
+        @param asynchronous :: If the true the code is executed in a separate thread
         @param quiet :: If true no messages reporting status are issued
         @param redirect :: If true then output is redirected to MantidPlot
     """
-    if async and QtCore.QThread.currentThread() != QtGui.qApp.thread():
-        async = False
-    threadsafe_call(_qti.app.runPythonScript, code, async, quiet, redirect)
+    if asynchronous and QtCore.QThread.currentThread() != QtGui.qApp.thread():
+        asynchronous = False
+    threadsafe_call(_qti.app.runPythonScript, code, asynchronous, quiet, redirect)
 
 
 # Overload for consistency with qtiplot table(..) & matrix(..) commands

--- a/MantidPlot/src/ApplicationWindow.h
+++ b/MantidPlot/src/ApplicationWindow.h
@@ -257,7 +257,7 @@ public slots:
                             int lineNumber);
   /// Runs an arbitrary lump of python code, return true/false on
   /// success/failure.
-  bool runPythonScript(const QString &code, bool async = false,
+  bool runPythonScript(const QString &code, bool asynchronous = false,
                        bool quiet = false, bool redirect = true);
 
   QList<MdiSubWindow *> windowsList() const;

--- a/MantidPlot/src/qti.sip
+++ b/MantidPlot/src/qti.sip
@@ -1103,7 +1103,7 @@ sipType=sipFindType(sipCpp->metaObject()->className());
 
 public:
   void setExitCode(int code);
-  bool runPythonScript(const QString & code, const bool async = false,
+  bool runPythonScript(const QString & code, const bool asynchronous = false,
       bool quiet=false, bool redirect=true);
 
   enum MatrixToTableConversion{Direct, XYZ, YXZ};


### PR DESCRIPTION
* [`async` is now a reserved keyword in python 3.7](https://docs.python.org/3/whatsnew/3.7.html#changes-in-python-behavior), I changed it to `asynchronous`, is there a better name?
* [New opcodes were added for python 3.7](https://docs.python.org/3/whatsnew/3.7.html#cpython-bytecode-changes)
* At least in Arch Linux `sip.h` was moved form `/usr/include/python2.7/sip.h` and `/usr/include/python3.6m/sip.h` to a common `/usr/include/sip.h`, this required changing `SIP_INCLUDE_DIRECTORY` to `SIP_INCLUDE_DIR` to get the correct location but this _should_ work everywhere.


**To test:**
Code review
If you have python 3.7 you can test everything works now.

Fixes #23208 

*This does not require release notes* because 

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
