### PR TITLE
Restructure of  muon analysis 2 py file for saving

### DIFF
--- a/scripts/Muon/GUI/Common/dummy/dummy_widget.py
+++ b/scripts/Muon/GUI/Common/dummy/dummy_widget.py
@@ -11,16 +11,16 @@ class DummyWidget(object):
     def __init__(self,name,parent=None):
         view=DummyView(name,parent)
         model=None
-        self.presenter = DummyPresenter(view,model)
+        self._presenter = DummyPresenter(view,model)
 
     @property
     def presenter(self):
-        return self.presenter
+        return self._presenter
 
     @property
     def widget(self):
-        return self.presenter.widget
+        return self._presenter.widget
 
     def setButtonConnection(self,slot):
-        view=self.presenter.widget
+        view=self._presenter.widget
         view.buttonSignal.connect(slot)

--- a/scripts/Muon/GUI/MuonAnalysis/dock/dock_widget.py
+++ b/scripts/Muon/GUI/MuonAnalysis/dock/dock_widget.py
@@ -43,6 +43,9 @@ class DockWidget(QtGui.QWidget):
 
         self.dockWidget.setLayout(QHbox)
 
+    def loadFromProject(self, project):
+        self.label.updateLabel(project)
+
     def handleButton(self, message):
         self.label.updateLabel(message)
 

--- a/scripts/Muon_Analysis_2.py
+++ b/scripts/Muon_Analysis_2.py
@@ -33,6 +33,7 @@ class MuonAnalysis2Gui(QtGui.QMainWindow):
     # cancel algs if window is closed
     def closeEvent(self, event):
         self.dockWidget.closeEvent(event)
+		global muonGUI = None
 
 
 def qapp():
@@ -46,7 +47,7 @@ def qapp():
 def main():
     app = qapp()
     try:
-        muonGUI = MuonAnalysis2Gui()
+        global muonGUI = MuonAnalysis2Gui()
         muonGUI.resize(700, 700)
         muonGUI.show()
         app.exec_()
@@ -71,10 +72,3 @@ def loadFromProject(project):
 
 if __name__ == '__main__':
     muonGUI = main()
-    #test 2
-    #muonGUI = loadFromProject("Test basic load")
-    #test 3
-    #muonGUI = main()
-    #print("test 3: ",saveToProject())
-    #test 4
-    #print("test 4: ",saveToProject())

--- a/scripts/Muon_Analysis_2.py
+++ b/scripts/Muon_Analysis_2.py
@@ -33,6 +33,7 @@ class MuonAnalysis2Gui(QtGui.QMainWindow):
     # cancel algs if window is closed
     def closeEvent(self, event):
         self.dockWidget.closeEvent(event)
+        global muonGUI
         muonGUI = None
 
 
@@ -47,6 +48,7 @@ def qapp():
 def main():
     app = qapp()
     try:
+        global muonGUI
         muonGUI = MuonAnalysis2Gui()
         muonGUI.resize(700, 700)
         muonGUI.show()

--- a/scripts/Muon_Analysis_2.py
+++ b/scripts/Muon_Analysis_2.py
@@ -11,6 +11,7 @@ from Muon.GUI.MuonAnalysis.dock.dock_widget import DockWidget
 
 muonGUI = None
 
+
 class MuonAnalysis2Gui(QtGui.QMainWindow):
 
     def __init__(self, parent=None):
@@ -55,11 +56,13 @@ def main():
         QtGui.QMessageBox.warning(muonGUI, "Muon Analysis version 2", str(error))
         return muonGUI
 
+
 def saveToProject():
     if muonGUI is None:
         return ""
     project = "test"
-    return project	
+    return project
+
 
 def loadFromProject(project):
     muonGUI = main()
@@ -69,8 +72,8 @@ def loadFromProject(project):
 if __name__ == '__main__':
     muonGUI = main()
     #test 2
-	#muonGUI = loadFromProject("Test basic load")
-	#test 3
+    #muonGUI = loadFromProject("Test basic load")
+    #test 3
     #muonGUI = main()
     #print("test 3: ",saveToProject())
     #test 4

--- a/scripts/Muon_Analysis_2.py
+++ b/scripts/Muon_Analysis_2.py
@@ -47,7 +47,7 @@ def qapp():
 def main():
     app = qapp()
     try:
-        global muonGUI = MuonAnalysis2Gui()
+        muonGUI = MuonAnalysis2Gui()
         muonGUI.resize(700, 700)
         muonGUI.show()
         app.exec_()

--- a/scripts/Muon_Analysis_2.py
+++ b/scripts/Muon_Analysis_2.py
@@ -33,7 +33,7 @@ class MuonAnalysis2Gui(QtGui.QMainWindow):
     # cancel algs if window is closed
     def closeEvent(self, event):
         self.dockWidget.closeEvent(event)
-		global muonGUI = None
+        global muonGUI = None
 
 
 def qapp():

--- a/scripts/Muon_Analysis_2.py
+++ b/scripts/Muon_Analysis_2.py
@@ -9,6 +9,7 @@ import PyQt4.QtCore as QtCore
 from Muon.GUI.Common.dummy_label.dummy_label_widget import DummyLabelWidget
 from Muon.GUI.MuonAnalysis.dock.dock_widget import DockWidget
 
+muonGUI = None
 
 class MuonAnalysis2Gui(QtGui.QMainWindow):
 
@@ -41,12 +42,36 @@ def qapp():
     return _app
 
 
-app = qapp()
-try:
-    ex = MuonAnalysis2Gui()
-    ex.resize(700, 700)
-    ex.show()
-    app.exec_()
-except RuntimeError as error:
-    ex = QtGui.QWidget()
-    QtGui.QMessageBox.warning(ex, "Muon Analysis version 2", str(error))
+def main():
+    app = qapp()
+    try:
+        muonGUI = MuonAnalysis2Gui()
+        muonGUI.resize(700, 700)
+        muonGUI.show()
+        app.exec_()
+        return muonGUI
+    except RuntimeError as error:
+        muonGUI = QtGui.QWidget()
+        QtGui.QMessageBox.warning(muonGUI, "Muon Analysis version 2", str(error))
+        return muonGUI
+
+def saveToProject():
+    if muonGUI is None:
+        return ""
+    project = "test"
+    return project	
+
+def loadFromProject(project):
+    muonGUI = main()
+    muonGUI.dockWidget.loadFromProject(project)
+    return muonGUI
+
+if __name__ == '__main__':
+    muonGUI = main()
+    #test 2
+	#muonGUI = loadFromProject("Test basic load")
+	#test 3
+    #muonGUI = main()
+    #print("test 3: ",saveToProject())
+    #test 4
+    #print("test 4: ",saveToProject())

--- a/scripts/Muon_Analysis_2.py
+++ b/scripts/Muon_Analysis_2.py
@@ -33,7 +33,7 @@ class MuonAnalysis2Gui(QtGui.QMainWindow):
     # cancel algs if window is closed
     def closeEvent(self, event):
         self.dockWidget.closeEvent(event)
-        global muonGUI = None
+        muonGUI = None
 
 
 def qapp():


### PR DESCRIPTION
These changes a part 1 for allowing project saving of python interfaces. In this PR we create methods to access load, save and the main window.


**To test:**
You will have to add `Muon/Muon_Analysis_2.py` to the interface list in `Framework/Properties/Mantid.properties.templateFramework/Properties/Mantid.properties.template`

1. If you open Muon analysis 2 and it should appear (its a dummy). Notice the message on tab 2.

2. Comment out line 70 of `Muon_analysis_2.py` and un-comment the code in test 2. Then open Muon analysis 2, go to tab 2 and the message will be different.

3. Comment out test 2 and un-comment the two lines under test 3. When you open muon analysis 2 the message `test 3: test` will be printed to the logger.

4. Comment out the two lines from test 3 and un-comment test 4. When you try to open muon analysis 2 it will not appear and the logger will only say `test 4:`
<!-- Instructions for testing. -->

Fixes #23232. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->
Does not need to be in release as it is not complete.
---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
