### PR TITLE
No longer check if file is writable

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/funcinspect.py
+++ b/Framework/PythonInterface/mantid/kernel/funcinspect.py
@@ -148,7 +148,7 @@ __operator_names = set(['CALL_FUNCTION', 'CALL_FUNCTION_VAR', 'CALL_FUNCTION_KW'
                         'INPLACE_MODULO', 'INPLACE_ADD', 'INPLACE_SUBTRACT',
                         'INPLACE_LSHIFT','INPLACE_RSHIFT','INPLACE_AND', 'INPLACE_XOR',
                         'INPLACE_OR', 'COMPARE_OP',
-                        'CALL_FUNCTION_EX'])
+                        'CALL_FUNCTION_EX', 'LOAD_METHOD', 'CALL_METHOD'])
 #--------------------------------------------------------------------------------------
 
 def process_frame(frame):

--- a/MantidPlot/CMakeLists.txt
+++ b/MantidPlot/CMakeLists.txt
@@ -455,7 +455,7 @@ add_custom_command ( OUTPUT ${SIP_SRC_AUTO}
                           -I ${PYQT4_SIP_DIR} ${MANTIDQTPYTHON_SIP_INCLUDES}  ${PYQT4_SIP_FLAGS}
                           -c ${CMAKE_CURRENT_BINARY_DIR} -j1 -w -o
                           ${SIP_SPEC}
-                     DEPENDS ${SIP_INCLUDE_DIRECTORY}/sip.h src/qti.sip ${QTI_SIP_HDRS} ../qt/python/mantidqtpython/mantidqtpython_def.sip
+                     DEPENDS ${SIP_INCLUDE_DIR}/sip.h src/qti.sip ${QTI_SIP_HDRS} ../qt/python/mantidqtpython/mantidqtpython_def.sip
                      COMMENT "Generating python bindings using sip"
 )
 

--- a/MantidPlot/pymantidplot/__init__.py
+++ b/MantidPlot/pymantidplot/__init__.py
@@ -57,17 +57,17 @@ def _get_analysis_data_service():
 
 # -------------------------- Wrapped MantidPlot functions -----------------
 
-def runPythonScript(code, async=False, quiet=False, redirect=True):
+def runPythonScript(code, asynchronous=False, quiet=False, redirect=True):
     """
         Redirects the runPythonScript method to the app object
         @param code :: A string of code to execute
-        @param async :: If the true the code is executed in a separate thread
+        @param asynchronous :: If the true the code is executed in a separate thread
         @param quiet :: If true no messages reporting status are issued
         @param redirect :: If true then output is redirected to MantidPlot
     """
-    if async and QtCore.QThread.currentThread() != QtGui.qApp.thread():
-        async = False
-    threadsafe_call(_qti.app.runPythonScript, code, async, quiet, redirect)
+    if asynchronous and QtCore.QThread.currentThread() != QtGui.qApp.thread():
+        asynchronous = False
+    threadsafe_call(_qti.app.runPythonScript, code, asynchronous, quiet, redirect)
 
 
 # Overload for consistency with qtiplot table(..) & matrix(..) commands

--- a/MantidPlot/src/ApplicationWindow.h
+++ b/MantidPlot/src/ApplicationWindow.h
@@ -257,7 +257,7 @@ public slots:
                             int lineNumber);
   /// Runs an arbitrary lump of python code, return true/false on
   /// success/failure.
-  bool runPythonScript(const QString &code, bool async = false,
+  bool runPythonScript(const QString &code, bool asynchronous = false,
                        bool quiet = false, bool redirect = true);
 
   QList<MdiSubWindow *> windowsList() const;

--- a/MantidPlot/src/qti.sip
+++ b/MantidPlot/src/qti.sip
@@ -1103,7 +1103,7 @@ sipType=sipFindType(sipCpp->metaObject()->className());
 
 public:
   void setExitCode(int code);
-  bool runPythonScript(const QString & code, const bool async = false,
+  bool runPythonScript(const QString & code, const bool asynchronous = false,
       bool quiet=false, bool redirect=true);
 
   enum MatrixToTableConversion{Direct, XYZ, YXZ};


### PR DESCRIPTION
Rerunning data as a different user in a proposal would generate errors that the file cannot be writable even though it is. Rather than checking that the file can be written, just try writing it and generate a less helpful error message if the permissions do not allow it. 

**Report to:** Antonio

**To test:**

Just a code review since you need to get a file into an unusual state on luster at ORNL to trigger the error.

*There is no associated issue.*

*This does not require release notes* because it only changes what type of error message is presented to the user.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
