### PR TITLE
Avoid multiple loading of instrument data in ISISHistoDataListener

### DIFF
--- a/Framework/LiveData/inc/MantidLiveData/ISIS/ISISHistoDataListener.h
+++ b/Framework/LiveData/inc/MantidLiveData/ISIS/ISISHistoDataListener.h
@@ -131,7 +131,7 @@ private:
 
   /// Buffer workspace to store instrument data (or not only instrument in the
   /// future), prevents loading for every chank of data
-  API::MatrixWorkspace_sptr bufferWorkspace;
+  API::MatrixWorkspace_sptr m_bufferWorkspace;
 
   /// reporter function called when the IDC reading routines raise an error
   static void IDCReporter(int status, int code, const char *message);

--- a/Framework/LiveData/inc/MantidLiveData/ISIS/ISISHistoDataListener.h
+++ b/Framework/LiveData/inc/MantidLiveData/ISIS/ISISHistoDataListener.h
@@ -129,8 +129,8 @@ private:
   /// Time regime to load
   int m_timeRegime;
 
-  /// Buffer workspace to store instrument data (or not only instrument in the future),
-  /// prevents loading for every chank of data
+  /// Buffer workspace to store instrument data (or not only instrument in the
+  /// future), prevents loading for every chank of data
   API::MatrixWorkspace_sptr bufferWorkspace;
 
   /// reporter function called when the IDC reading routines raise an error

--- a/Framework/LiveData/inc/MantidLiveData/ISIS/ISISHistoDataListener.h
+++ b/Framework/LiveData/inc/MantidLiveData/ISIS/ISISHistoDataListener.h
@@ -5,8 +5,8 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidAPI/LiveListener.h"
+#include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidKernel/cow_ptr.h"
-
 //----------------------------------------------------------------------
 // Forward declarations
 //----------------------------------------------------------------------
@@ -18,9 +18,7 @@ namespace Mantid {
 //----------------------------------------------------------------------
 // Forward declarations
 //----------------------------------------------------------------------
-namespace API {
-class MatrixWorkspace;
-}
+
 namespace HistogramData {
 class BinEdges;
 }
@@ -130,6 +128,10 @@ private:
 
   /// Time regime to load
   int m_timeRegime;
+
+  /// Buffer workspace to store instrument data (or not only instrument in the future),
+  /// prevents loading for every chank of data
+  API::MatrixWorkspace_sptr bufferWorkspace;
 
   /// reporter function called when the IDC reading routines raise an error
   static void IDCReporter(int status, int code, const char *message);

--- a/Framework/LiveData/src/ISIS/ISISHistoDataListener.cpp
+++ b/Framework/LiveData/src/ISIS/ISISHistoDataListener.cpp
@@ -124,6 +124,17 @@ bool ISISHistoDataListener::connect(const Poco::Net::SocketAddress &address) {
 
   loadTimeRegimes();
 
+  // Create dummy workspace to store instrument data
+  bufferWorkspace = WorkspaceFactory::Instance().create(
+      "Workspace2D", 1,1,1);
+
+  bufferWorkspace->getAxis(0)->unit() =
+      Kernel::UnitFactory::Instance().create("TOF");
+  bufferWorkspace->setYUnit("Counts");
+
+  // Only run the loading of instrument once
+  runLoadInstrument(bufferWorkspace, getString("NAME"));
+
   return true;
 }
 
@@ -196,13 +207,9 @@ boost::shared_ptr<Workspace> ISISHistoDataListener::extractData() {
 
   // Create the 2D workspace for the output
   auto localWorkspace = WorkspaceFactory::Instance().create(
-      "Workspace2D", numberOfHistograms, m_numberOfBins[m_timeRegime] + 1,
+      bufferWorkspace, numberOfHistograms, m_numberOfBins[m_timeRegime] + 1,
       m_numberOfBins[m_timeRegime]);
 
-  // Set the unit on the workspace to TOF
-  localWorkspace->getAxis(0)->unit() =
-      Kernel::UnitFactory::Instance().create("TOF");
-  localWorkspace->setYUnit("Counts");
   localWorkspace->updateSpectraUsing(
       SpectrumDetectorMapping(m_specIDs, m_detIDs));
 
@@ -232,8 +239,6 @@ boost::shared_ptr<Workspace> ISISHistoDataListener::extractData() {
     }
 
     if (period == firstPeriod) {
-      // Only run the Child Algorithms once
-      runLoadInstrument(localWorkspace, getString("NAME"));
       if (m_numberOfPeriods > 1) {
         // adding first ws to the group after loading instrument
         // otherwise ws can be lost.

--- a/Framework/LiveData/src/ISIS/ISISHistoDataListener.cpp
+++ b/Framework/LiveData/src/ISIS/ISISHistoDataListener.cpp
@@ -130,6 +130,8 @@ bool ISISHistoDataListener::connect(const Poco::Net::SocketAddress &address) {
   bufferWorkspace->getAxis(0)->unit() =
       Kernel::UnitFactory::Instance().create("TOF");
   bufferWorkspace->setYUnit("Counts");
+  bufferWorkspace->updateSpectraUsing(
+      SpectrumDetectorMapping(m_specIDs, m_detIDs));
 
   // Only run the loading of instrument once
   runLoadInstrument(bufferWorkspace, getString("NAME"));
@@ -208,9 +210,6 @@ boost::shared_ptr<Workspace> ISISHistoDataListener::extractData() {
   auto localWorkspace = WorkspaceFactory::Instance().create(
       bufferWorkspace, numberOfHistograms, m_numberOfBins[m_timeRegime] + 1,
       m_numberOfBins[m_timeRegime]);
-
-  localWorkspace->updateSpectraUsing(
-      SpectrumDetectorMapping(m_specIDs, m_detIDs));
 
   // cut the spectra numbers into chunks
   std::vector<int> index, count;

--- a/Framework/LiveData/src/ISIS/ISISHistoDataListener.cpp
+++ b/Framework/LiveData/src/ISIS/ISISHistoDataListener.cpp
@@ -130,10 +130,7 @@ bool ISISHistoDataListener::connect(const Poco::Net::SocketAddress &address) {
   bufferWorkspace->getAxis(0)->unit() =
       Kernel::UnitFactory::Instance().create("TOF");
   bufferWorkspace->setYUnit("Counts");
-  bufferWorkspace->updateSpectraUsing(
-      SpectrumDetectorMapping(m_specIDs, m_detIDs));
 
-  // Only run the loading of instrument once
   runLoadInstrument(bufferWorkspace, getString("NAME"));
 
   return true;
@@ -210,6 +207,9 @@ boost::shared_ptr<Workspace> ISISHistoDataListener::extractData() {
   auto localWorkspace = WorkspaceFactory::Instance().create(
       bufferWorkspace, numberOfHistograms, m_numberOfBins[m_timeRegime] + 1,
       m_numberOfBins[m_timeRegime]);
+
+  localWorkspace->updateSpectraUsing(
+      SpectrumDetectorMapping(m_specIDs, m_detIDs));
 
   // cut the spectra numbers into chunks
   std::vector<int> index, count;

--- a/Framework/LiveData/src/ISIS/ISISHistoDataListener.cpp
+++ b/Framework/LiveData/src/ISIS/ISISHistoDataListener.cpp
@@ -125,7 +125,8 @@ bool ISISHistoDataListener::connect(const Poco::Net::SocketAddress &address) {
   loadTimeRegimes();
 
   // Create dummy workspace to store instrument data
-  m_bufferWorkspace = WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
+  m_bufferWorkspace =
+      WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
 
   m_bufferWorkspace->getAxis(0)->unit() =
       Kernel::UnitFactory::Instance().create("TOF");

--- a/Framework/LiveData/src/ISIS/ISISHistoDataListener.cpp
+++ b/Framework/LiveData/src/ISIS/ISISHistoDataListener.cpp
@@ -125,13 +125,13 @@ bool ISISHistoDataListener::connect(const Poco::Net::SocketAddress &address) {
   loadTimeRegimes();
 
   // Create dummy workspace to store instrument data
-  bufferWorkspace = WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
+  m_bufferWorkspace = WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
 
-  bufferWorkspace->getAxis(0)->unit() =
+  m_bufferWorkspace->getAxis(0)->unit() =
       Kernel::UnitFactory::Instance().create("TOF");
-  bufferWorkspace->setYUnit("Counts");
+  m_bufferWorkspace->setYUnit("Counts");
 
-  runLoadInstrument(bufferWorkspace, getString("NAME"));
+  runLoadInstrument(m_bufferWorkspace, getString("NAME"));
 
   return true;
 }
@@ -205,7 +205,7 @@ boost::shared_ptr<Workspace> ISISHistoDataListener::extractData() {
 
   // Create the 2D workspace for the output
   auto localWorkspace = WorkspaceFactory::Instance().create(
-      bufferWorkspace, numberOfHistograms, m_numberOfBins[m_timeRegime] + 1,
+      m_bufferWorkspace, numberOfHistograms, m_numberOfBins[m_timeRegime] + 1,
       m_numberOfBins[m_timeRegime]);
 
   localWorkspace->updateSpectraUsing(

--- a/Framework/LiveData/src/ISIS/ISISHistoDataListener.cpp
+++ b/Framework/LiveData/src/ISIS/ISISHistoDataListener.cpp
@@ -125,8 +125,7 @@ bool ISISHistoDataListener::connect(const Poco::Net::SocketAddress &address) {
   loadTimeRegimes();
 
   // Create dummy workspace to store instrument data
-  bufferWorkspace = WorkspaceFactory::Instance().create(
-      "Workspace2D", 1,1,1);
+  bufferWorkspace = WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
 
   bufferWorkspace->getAxis(0)->unit() =
       Kernel::UnitFactory::Instance().create("TOF");


### PR DESCRIPTION
**Description of work.**
The buffer workspace is added to store instrument data and
axis names. Loading the instrument data is moved to "connect" function
to avoid multiple loading during streaming.

**To test:**
Is code review sufficient?
<!-- Instructions for testing. -->

Fixes #20525. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because **fill in an explanation of why**
No release notes. Just an internal change.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
