### PR TITLE
Convert developer documentation to sphinx

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@ Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
 
 #### Reviewer ####
 
-Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
+Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):
 
 ##### Code Review #####
 

--- a/dev-docs/source/IndividualTicketTesting.rst
+++ b/dev-docs/source/IndividualTicketTesting.rst
@@ -1,0 +1,50 @@
+.. _IndividualTicketTesting:
+
+=========================
+Individual Ticket Testing
+=========================
+
+An important step in our :ref:`development workflow <GitWorkflow>` is the testing of individual issues/tickets after the development on them is complete, and before the code is merges into the master branch. Developers pick one from `the list <https://github.com/mantidproject/mantid/pulls>`_ of completed issues and perform a number of verification steps on it. The mechanics of testing a pull request (e.g. the git commands to use) are described :ref:`here <GitWorkflow>`. This page is concerned with the aspects that should be considered in deciding whether a pull request should be recommended to merge or sent back to the developer for further work. *There should be very little reluctance to reopen a ticket even for minor issues.*
+
+Code Review
+===========
+
+The code changes should be manually reviewed (the github compare view is ideal for this). A couple of pieces on the value of code review can be found at `scientopia <http://scientopia.org/blogs/goodmath/2011/07/06/things-everyone-should-do-code-review>`_ and `codinghorror <http://www.codinghorror.com/blog/2006/01/code-reviews-just-do-it.html>`_.
+
+* The primary aim is to find bugs that the developer and tests so far have not spotted.
+* But also consider whether the code is 'clean', well-structured and easy to read/maintain.
+* Part of this is that:
+
+  * There should be are no compiler (or doxygen) warnings coming from any modified classes
+  * The code conforms to our :ref:`coding standards <MantidStandards>`.
+
+* Unit tests (or system tests if more appropriate) should be checked that they:
+
+  * Exist and give adequate coverage (see :ref:`unit testing practices <UnitTestGoodPractice>`).
+  * If the ticket is fixing a bug there should be a test that makes sure we don't have to fix the same bug again!
+  * Do not load real data (data loading algorithms get a free pass on this one).
+  * Leave the system in the same state that they found it (i.e. clean up).
+  * Have a performance test, if appropriate.
+
+* Check that any user documentation is adequate and that there are release notes.  In the case of new algorithms, there should be an accompanying ``*.rst`` file that has been added, containing an explanation of what exactly the algorithm does along with Python usage examples.
+
+Functional Testing
+==================
+
+The first thing to note is that this should **not** just be a quick check of whatever the ticket says it does. Testing should be as much, if not more, about making sure the code *does not do what it's not supposed to do* as that it *does do what it's supposed to*.
+
+* All of the builds pass
+* The developer should have included instructions in the ticket of how to test things work.
+* But, as noted above, don’t just do that – also try to break it: click random buttons on GUIs, give unexpected/invalid inputs, etc.
+* Note down what you did in the ticket, and the platform you did it on.
+
+If all the requirements have been met and documented approve the PR using `GitHub's review mechanism <https://help.github.com/articles/about-pull-request-reviews/>`_.
+
+Gatekeeper
+==========
+
+The ``@mantidproject/gatekeepers`` group is who is meant to merge pull requests into master. This is done by social contract. A gatekeeper can ``merge`` code if:
+
+* Green tick on the last build indicating all automated testing has succeeded
+* Adequate tests, both success and failure cases have been performed
+* There is comment on the code being reviewed

--- a/dev-docs/source/Standards/MantidStandards.rst
+++ b/dev-docs/source/Standards/MantidStandards.rst
@@ -1,3 +1,5 @@
+.. _MantidStandards:
+
 ================
 Mantid Standards
 ================
@@ -106,7 +108,7 @@ Parameter names must:
 - Start with a capital letter
 - Have a capital letter for each new word (e.g. 'InputWorkspace')
 - Use alphanumeric characters only (i.e. cannot contain any of these ``/,._-'\"`` or whitespace)
-- Can contain numbers but only allowed after the first character. 
+- Can contain numbers but only allowed after the first character.
 
 Notable exceptions to these rules are lattice constants (i.e. a, b, c,
 alpha, beta, gamma).

--- a/dev-docs/source/index.rst
+++ b/dev-docs/source/index.rst
@@ -125,7 +125,7 @@ Tools
 
 :doc:`GettingStartedWithPyCharm`
    Describes how to set up the PyCharm interpreter, and debug python code (Windows/Linux only).
-   
+
 :doc:`Eclipse`
    Guide to setting up Eclipse on Ubuntu
 
@@ -139,6 +139,7 @@ Testing
    RunningTheUnitTests
    DebuggingUnitTests
    UnitTestGoodPractice
+   IndividualTicketTesting
    WritingPerformanceTests
    SystemTests
    DataFilesForTesting
@@ -152,6 +153,9 @@ Testing
 
 :doc:`UnitTestGoodPractice`
    Guidance on writing good unit tests.
+
+:doc:`IndividualTicketTesting`
+   What to expect and inspect when reviewing an individual contribution to mantid.
 
 :doc:`WritingPerformanceTests`
    A walk through of how to write a performance test.
@@ -206,4 +210,3 @@ Component Overviews
    RemoteJobSubmissionAPI
    WritingAnAlgorithm
    WritingCustomConvertToMDTransformation
-


### PR DESCRIPTION
Convert another wiki page to sphinx. Was in the wiki as
https://www.mantidproject.org/Individual_Ticket_Testing


**Report to:** @martyngigg to add the server side redirects

**To test:**

Build it and see that it is formatted ok.

*There is no associated issue.*

*This does not require release notes* because it is developer documentation.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
