### PR TITLE
LR: Update default x range for scaling factors

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LRScalingFactors.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRScalingFactors.py
@@ -63,7 +63,9 @@ class LRScalingFactors(PythonAlgorithm):
                              "Pixel range defining the data peak")
         self.declareProperty(IntArrayProperty("SignalBackgroundPixelRange", [147, 163]),
                              "Pixel range defining the background")
-        self.declareProperty(IntArrayProperty("LowResolutionPixelRange", [94, 160]),
+        self.declareProperty(IntArrayProperty("LowResolutionPixelRange",
+                                              [Property.EMPTY_INT, Property.EMPTY_INT],
+                                              direction=Direction.Input),
                              "Pixel range defining the region to use in the low-resolution direction")
         self.declareProperty("IncidentMedium", "Medium", doc="Name of the incident medium")
         self.declareProperty("FrontSlitName", "S1", doc="Name of the front slit")
@@ -454,6 +456,12 @@ class LRScalingFactors(PythonAlgorithm):
             @param background_range: range of pixels defining the background
             @param low_res_range: range of pixels in the x-direction
         """
+        # Check low-res axis
+        if low_res_range[0] == Property.EMPTY_INT:
+            low_res_range[0] = 0
+        if low_res_range[1] == Property.EMPTY_INT:
+            low_res_range[1] = int(workspace.getInstrument().getNumberParameter("number-of-x-pixels")[0])-1
+
         # Rebin TOF axis
         tof_range = self.getProperty("TOFRange").value
         tof_step = self.getProperty("TOFSteps").value

--- a/Testing/SystemTests/tests/analysis/LRScalingFactorsTest.py
+++ b/Testing/SystemTests/tests/analysis/LRScalingFactorsTest.py
@@ -25,6 +25,7 @@ class LRPrimaryFractionTest(stresstesting.MantidStressTest):
                          TOFRange=[10008, 35000], TOFSteps=200,
                          SignalPeakPixelRange=[150, 160],
                          SignalBackgroundPixelRange=[147, 163],
+                         LowResolutionPixelRange=[94, 160],
                          ScalingFactorFile=self.cfg_file)
 
     def validate(self):

--- a/docs/source/release/v3.14.0/reflectometry.rst
+++ b/docs/source/release/v3.14.0/reflectometry.rst
@@ -9,4 +9,8 @@ Reflectometry Changes
     putting new features at the top of the section, followed by
     improvements, followed by bug fixes.
 
+Liquids Reflectometer
+---------------------
+- Default x-direction pixel range for the scaling factor calculation is now set to the full width of the detector as opposed to a restricted guess.
+
 :ref:`Release 3.14.0 <v3.14.0>`


### PR DESCRIPTION
**Description of work.**

The scaling factor calculation (BL-4B) used to have a "good default" to select the x-pixel range to integrate over when summing counts. Since the upgrade, the beam has moved sideways on the face of the detector and that default is no longer "good". This is not a problem for the automated calculation, since that region is properly set every time. But it is a problem for RefRed, since it calls the scaling factor algorithm without setting the x-range (which we never really use).

Change the default to be the full with of the detector instead of a particular range.

**To test:**
 - [ ] Review code
 - [ ] Make sure tests pass 

*There is no associated issue.*

*Release notes have been udpated.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
