### PR TITLE
Remove old logging configuration variable

### DIFF
--- a/Testing/SystemTests/lib/systemtests/stresstesting.py
+++ b/Testing/SystemTests/lib/systemtests/stresstesting.py
@@ -933,7 +933,6 @@ class MantidFrameworkConfig:
 
         # Up the log level so that failures can give useful information
         config['logging.loggers.root.level'] = self.__loglevel
-        config['logging.channels.consoleFilterChannel.level'] = self.__loglevel
         # Set the correct search path
         config['datasearch.directories'] = self.__dataDirs
 


### PR DESCRIPTION
**Description of work.**

I noticed in a recent [system test build](http://builds.mantidproject.org/view/Master%20Pipeline/job/master_systemtests-ubuntu-16.04/464/testReport/junit/SystemTests/SANS2DMultiPeriod/LARMORMultiPeriodEventModeLoading/) that there is an warning regarding an obselete configuration key related to logging. This removes the key.

**Report to:** [nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

The system test build should pass and the console logging should still be at the correct level.

*There is no associated issue.*

*This does not require release notes* because **it relates to our internal testing setup.**

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
