### PR TITLE
Change the check for rpm uninstall/upgrade to use $1

### DIFF
--- a/buildconfig/CMake/Packaging/rpm/scripts/rpm_post_uninstall.sh.in
+++ b/buildconfig/CMake/Packaging/rpm/scripts/rpm_post_uninstall.sh.in
@@ -8,9 +8,8 @@
 ENVVARS_ON_INSTALL=@ENVVARS_ON_INSTALL_INT@
 
 # Remove exe and links only if it looks like we were removed
-# and not upgraded. If launch_mantidplot.sh exists then package
-# has been upgraded and MantidPlot_exe replaced so don't touch anything
-if [ ! -e $RPM_INSTALL_PREFIX0/@BIN_DIR@/launch_mantidplot.sh ]; then
+# and not upgraded. If $1 == 0 then it's uninstall not upgrade
+if [ $1 -eq 0 ]; then
     if [ -e $RPM_INSTALL_PREFIX0/@BIN_DIR@/MantidPlot_exe ]; then
         rm $RPM_INSTALL_PREFIX0/@BIN_DIR@/MantidPlot_exe
     fi


### PR DESCRIPTION
As detailed at https://fedoraproject.org/wiki/Packaging:Scriptlets#Syntax

This will allow us to remove our dependency of `launch_mantidplot.sh` in the future


**To test:**
Try both upgrade from this package and uninstall of this package to check correct behaviour 
