### PR TITLE
Change getStoredPropertyValue to getPreviousValue

### DIFF
--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmDialog.h
@@ -252,7 +252,7 @@ protected:
   /// argument
   /// @param propName :: Name of the property
   /// @return Previous value. If there is no value, empty string is returned
-  QString getPreviousValue(const QString &propName);
+  QString getPreviousValue(const QString &propName) const;
   /// Set a value based on any old input that we have
   void setPreviousValue(QWidget *widget, const QString &property);
   /// Handle completion of algorithm started while staying open

--- a/qt/widgets/common/src/AlgorithmDialog.cpp
+++ b/qt/widgets/common/src/AlgorithmDialog.cpp
@@ -944,7 +944,7 @@ QString AlgorithmDialog::getValue(QWidget *widget) {
   }
 }
 
-QString AlgorithmDialog::getPreviousValue(const QString &propName) {
+QString AlgorithmDialog::getPreviousValue(const QString &propName) const {
   QString value;
 
   if (!isForScript()) {

--- a/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/FitDialog.h
+++ b/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/FitDialog.h
@@ -95,8 +95,6 @@ private:
   /// Get the domain type: Simple, Sequential, or Parallel
   QString getDomainTypeString() const;
 
-  /// Return property value stored in history
-  QString getStoredPropertyValue(const QString &propName) const;
   /// Get allowed values for a property
   QStringList getAllowedPropertyValues(const QString &propName) const;
   /// Set i-th workspace name
@@ -123,7 +121,7 @@ public:
   InputWorkspaceWidget(FitDialog *parent, int domainIndex = 0);
   /// Return property value stored in history
   QString getStoredPropertyValue(const QString &propName) const {
-    return m_fitDialog->getStoredPropertyValue(propName);
+    return m_fitDialog->getPreviousValue(propName);
   }
   /// Get allowed values for a property
   QStringList getAllowedPropertyValues(const QString &propName) const {

--- a/qt/widgets/plugins/algorithm_dialogs/src/FitDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/FitDialog.cpp
@@ -364,7 +364,7 @@ void FitDialog::parseInput() {
  * @param readHistory :: If true then the history will be re read.
  */
 void FitDialog::tieStaticWidgets(const bool readHistory) {
-  QString funValue = getStoredPropertyValue("Function");
+  QString funValue = getPreviousValue("Function");
   if (!funValue.isEmpty()) {
     m_form.function->setFunction(funValue);
   }
@@ -386,7 +386,7 @@ void FitDialog::tieStaticWidgets(const bool readHistory) {
   // tie(m_form.cbDomainType, "DomainType", m_form.staticLayout, readHistory);
   connect(m_form.cbDomainType, SIGNAL(currentIndexChanged(int)), this,
           SLOT(domainTypeChanged()));
-  QString domainTypeValue = getStoredPropertyValue("DomainType");
+  QString domainTypeValue = getPreviousValue("DomainType");
   if (!domainTypeValue.isEmpty()) {
     m_form.cbDomainType->setItemText(-1, domainTypeValue);
   }
@@ -398,7 +398,7 @@ void FitDialog::tieStaticWidgets(const bool readHistory) {
   // read value from history
   tie(m_form.cbMinimizer, "Minimizer", m_form.staticLayout, readHistory);
 
-  auto value = getStoredPropertyValue("InputWorkspace");
+  auto value = getPreviousValue("InputWorkspace");
   setWorkspaceName(0, value);
 }
 
@@ -484,29 +484,6 @@ void FitDialog::functionChanged() {
   // this->setPropertyValues();
   // removeOldInputWidgets();
   // createDynamicLayout();
-}
-
-/**
- * Return property value stored in history
- * @param propName :: A property name
- */
-QString FitDialog::getStoredPropertyValue(const QString &propName) const {
-  // Get the value from either the previous input store or from Python argument
-  QString value("");
-  Mantid::Kernel::Property *property = getAlgorithmProperty(propName);
-
-  if (!isForScript()) {
-    value = m_propertyValueMap.value(propName);
-    if (value.isEmpty()) {
-      value =
-          AlgorithmInputHistory::Instance().previousInput(m_algName, propName);
-    }
-  } else {
-    if (!property)
-      return "";
-    value = m_propertyValueMap.value(propName);
-  }
-  return value;
 }
 
 /**


### PR DESCRIPTION
`FitDialog::getStoredPropertyValue` was a duplicate version of [`AlgorithmDialog::getPreviousValue`](https://github.com/mantidproject/mantid/blob/master/qt/widgets/common/src/AlgorithmDialog.cpp#L947). This just changes from one to the other.

**Report to:** nobody

**To test:**

A code review should be sufficient. 

*There is no associated issue.*


*This does not require release notes* because it is a minor refactor.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
