### PR TITLE
Fix mantid.dataobjects.TableWorkspace() for Linux clang

### DIFF
--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/TableWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/TableWorkspace.cpp
@@ -14,9 +14,11 @@ using namespace boost::python;
 
 GET_POINTER_SPECIALIZATION(TableWorkspace)
 
+namespace {
 ITableWorkspace_sptr makeTableWorkspace() {
   return WorkspaceFactory::Instance().createTable();
 }
+} // namespace
 
 void export_TableWorkspace() {
 


### PR DESCRIPTION
For some reason `¯\_(ツ)_/¯` `makeTableWorkspace` was getting called from the wrong scope, using the one from `ITableWorkspace` [here](https://github.com/mantidproject/mantid/blob/master/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp#L479). Renaming it forces it to call the correct one.

This fixes the failing unit test [here](http://builds.mantidproject.org/job/master_clean-ubuntu-18.04-clang/20/testReport/ITableWorkspaceTest/ITableWorkspaceTest/test_pickle_table_workspace/)

**To test:**
Build mantid with clang on Linux.

Before running
```
import mantid.dataobjects
mantid.dataobjects.TableWorkspace()
```
would fail with
```
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-2-e5f7775431bf> in <module>()
----> 1 mantid.dataobjects.TableWorkspace()

RuntimeError: Add Data Object with empty name
```
now it works.