### PR TITLE
Use atomic bool for common bins flag

### DIFF
--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -602,9 +602,9 @@ private:
 
   /// Flag indicating whether the m_isCommonBinsFlag has been set. False by
   /// default
-  mutable bool m_isCommonBinsFlagSet{false};
+  mutable std::atomic<bool> m_isCommonBinsFlagSet{false};
   /// Flag indicating whether the data has common bins. False by default
-  mutable bool m_isCommonBinsFlag{false};
+  mutable std::atomic<bool> m_isCommonBinsFlag{false};
 
   /// The set of masked bins in a map keyed on workspace index
   std::map<int64_t, MaskList> m_masks;

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -63,8 +63,8 @@ MatrixWorkspace::MatrixWorkspace(const MatrixWorkspace &other)
   m_isInitialized = other.m_isInitialized;
   m_YUnit = other.m_YUnit;
   m_YUnitLabel = other.m_YUnitLabel;
-  m_isCommonBinsFlagSet = other.m_isCommonBinsFlagSet;
-  m_isCommonBinsFlag = other.m_isCommonBinsFlag;
+  m_isCommonBinsFlagSet.store(other.m_isCommonBinsFlagSet);
+  m_isCommonBinsFlag.store(other.m_isCommonBinsFlag);
   m_masks = other.m_masks;
   // TODO: Do we need to init m_monitorWorkspace?
 }


### PR DESCRIPTION
**Description of work.**

Valgrind's helgrind tool showed a race condition with the common bins flags in `MatrixWorkspace`. This changes them to be `atomic<bool>` to ensure consistency.

**To test:**

Code review.

*There is no associated issue.*

*This does not require release notes* because **it should not be visible to the user.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
