### PR TITLE
Use a fixed number of omp threads for unit tests on builders

### DIFF
--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -342,7 +342,8 @@ fi
 userconfig_dir=$HOME/.mantid
 rm -fr $userconfig_dir
 mkdir -p $userconfig_dir
-touch $userconfig_dir/Mantid.user.properties
+# use a fixed number of openmp threads to avoid overloading the system
+echo MultiThreaded.MaxCores=2 > $userconfig_dir/Mantid.user.properties
 
 if [[ ${DO_UNITTESTS} == true ]]; then
   $CTEST_EXE -j${BUILD_THREADS:?} --schedule-random --output-on-failure

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -343,7 +343,8 @@ userconfig_dir=$HOME/.mantid
 rm -fr $userconfig_dir
 mkdir -p $userconfig_dir
 # use a fixed number of openmp threads to avoid overloading the system
-echo MultiThreaded.MaxCores=2 > $userconfig_dir/Mantid.user.properties
+userprops_file=$userconfig_dir/Mantid.user.properties
+echo MultiThreaded.MaxCores=2 > $userprops_file
 
 if [[ ${DO_UNITTESTS} == true ]]; then
   $CTEST_EXE -j${BUILD_THREADS:?} --schedule-random --output-on-failure
@@ -353,6 +354,8 @@ fi
 # User Documentation
 ###############################################################################
 if [[ ${DO_DOCTESTS_USER} == true ]]; then
+  # use default configuration
+  rm -f $userprops_file
   # Remove doctrees directory so it forces a full reparse. It seems that
   # without this newly added doctests are not executed
   if [ -d $BUILD_DIR/docs/doctrees ]; then

--- a/buildconfig/Jenkins/buildscript.bat
+++ b/buildconfig/Jenkins/buildscript.bat
@@ -170,7 +170,9 @@ del %USERPROPS%
 set CONFIGDIR=%APPDATA%\mantidproject\mantid
 rmdir /S /Q %CONFIGDIR%
 mkdir %CONFIGDIR%
-call cmake.exe -E touch %USERPROPS%
+:: use a fixed number of openmp threads to avoid overloading the system
+echo MultiThreaded.MaxCores=2 > %USERPROPS%
+
 call ctest.exe -C %BUILD_CONFIG% -j%BUILD_THREADS% --schedule-random --output-on-failure
 if ERRORLEVEL 1 exit /B %ERRORLEVEL%
 

--- a/buildconfig/Jenkins/buildscript.bat
+++ b/buildconfig/Jenkins/buildscript.bat
@@ -181,6 +181,7 @@ if ERRORLEVEL 1 exit /B %ERRORLEVEL%
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 echo Note: not running doc-test target as it currently takes too long
 :: if not "%JOB_NAME%"=="%JOB_NAME:debug=%" (
+::   del /Q %USERPROPS%
 ::   call cmake.exe --build . --target StandardTestData
 ::   call cmake.exe --build . --target docs-test
 :: )


### PR DESCRIPTION
**Description of work.**

Avoids thread contention on the builders by settings a maximum number of the OpenMP threads that are used for the unit tests on the builders

**To test:**

* All test jobs should complete.

*There is no associated issue.*

*This does not require release notes* because **it is not a user-facing change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
