### PR TITLE
Add isGroup() method to Workspace.h and WorkspaceGroup.h

### DIFF
--- a/Framework/API/inc/MantidAPI/Workspace.h
+++ b/Framework/API/inc/MantidAPI/Workspace.h
@@ -89,6 +89,7 @@ public:
   const std::string &getComment() const;
   const std::string &getName() const override;
   bool isDirty(const int n = 1) const;
+  virtual bool isGroup() const { return false; }
   /// Get the footprint in memory in bytes.
   virtual size_t getMemorySize() const = 0;
   /// Returns the memory footprint in sensible units

--- a/Framework/API/inc/MantidAPI/WorkspaceGroup.h
+++ b/Framework/API/inc/MantidAPI/WorkspaceGroup.h
@@ -82,7 +82,7 @@ public:
   void removeItem(const size_t index);
   /// Remove all names from the group but do not touch the ADS
   void removeAll();
-  bool isGroup() const override { return true; } 
+  bool isGroup() const override { return true; }
   /// This method returns true if the group is empty (no member workspace)
   bool isEmpty() const;
   bool areNamesSimilar() const;

--- a/Framework/API/inc/MantidAPI/WorkspaceGroup.h
+++ b/Framework/API/inc/MantidAPI/WorkspaceGroup.h
@@ -82,6 +82,7 @@ public:
   void removeItem(const size_t index);
   /// Remove all names from the group but do not touch the ADS
   void removeAll();
+  bool isGroup() const override { return true; } 
   /// This method returns true if the group is empty (no member workspace)
   bool isEmpty() const;
   bool areNamesSimilar() const;

--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -2036,6 +2036,11 @@ public:
         ws->hasOrientedLattice(), false);
   }
 
+  void test_isGroup() {
+    boost::shared_ptr<MatrixWorkspace> ws(makeWorkspaceWithDetectors(3, 1));
+    TS_ASSERT_EQUALS(ws->isGroup(), false);
+  }
+
 private:
   WorkspaceTester m_workspace;
   WorkspaceTester m_workspaceSans;

--- a/Framework/API/test/WorkspaceGroupTest.h
+++ b/Framework/API/test/WorkspaceGroupTest.h
@@ -347,6 +347,11 @@ public:
     TS_ASSERT(group->isMultiperiod());
   }
 
+  void test_isGroup() {
+    WorkspaceGroup_sptr group = makeGroup();
+    TS_ASSERT_EQUALS(group->isGroup(), true);
+  }
+
   void test_isInGroup() {
     WorkspaceGroup_sptr group = makeGroup();
     auto ws1 = group->getItem(1);


### PR DESCRIPTION
**Description of work.**
I added a method to the Workspace interface that returned false if it was not a polymorphic implementation of WorkspaceGroup, called isGroup().

**To test:**
The Unit tests are probably sufficient with a code review
Fixes #23280  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->
This is only a code side improvement and thus no release notes required

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
