### PR TITLE
Add missing unit test boilerplate

### DIFF
--- a/Framework/API/test/FrameworkManagerTest.h
+++ b/Framework/API/test/FrameworkManagerTest.h
@@ -37,6 +37,12 @@ using namespace Mantid;
 
 class FrameworkManagerTest : public CxxTest::TestSuite {
 public:
+  // This means the constructor isn't called when running other tests
+  static FrameworkManagerTest *createSuite() {
+    return new FrameworkManagerTest();
+  }
+  static void destroySuite(FrameworkManagerTest *suite) { delete suite; }
+
 #ifdef MPI_EXPERIMENTAL
   // Make sure FrameworkManager is always instantiated. This is needed to
   // initialize the MPI environment.

--- a/Framework/Algorithms/test/Rebin2DTest.h
+++ b/Framework/Algorithms/test/Rebin2DTest.h
@@ -81,6 +81,10 @@ MatrixWorkspace_sptr runAlgorithm(MatrixWorkspace_sptr inputWS,
 
 class Rebin2DTest : public CxxTest::TestSuite {
 public:
+  // This means the constructor isn't called when running other tests
+  static Rebin2DTest *createSuite() { return new Rebin2DTest(); }
+  static void destroySuite(Rebin2DTest *suite) { delete suite; }
+
   void test_Init() {
     Rebin2D alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
@@ -212,6 +216,13 @@ private:
 class Rebin2DTestPerformance : public CxxTest::TestSuite {
 
 public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static Rebin2DTestPerformance *createSuite() {
+    return new Rebin2DTestPerformance();
+  }
+  static void destroySuite(Rebin2DTestPerformance *suite) { delete suite; }
+
   Rebin2DTestPerformance() {
     m_inputWS = makeInputWS(distribution, perf_test, small_bins);
   }

--- a/Framework/Algorithms/test/SpecularReflectionAlgorithmTest.h
+++ b/Framework/Algorithms/test/SpecularReflectionAlgorithmTest.h
@@ -25,6 +25,15 @@ using namespace Mantid::Kernel;
 using VerticalHorizontalOffsetType = boost::tuple<double, double>;
 
 class SpecularReflectionAlgorithmTest {
+public:
+  // This means the constructor isn't called when running other tests
+  static SpecularReflectionAlgorithmTest *createSuite() {
+    return new SpecularReflectionAlgorithmTest();
+  }
+  static void destroySuite(SpecularReflectionAlgorithmTest *suite) {
+    delete suite;
+  }
+
 protected:
   MatrixWorkspace_sptr pointDetectorWS;
 

--- a/Framework/ICat/test/CatalogDownloadDataFilesTest.h
+++ b/Framework/ICat/test/CatalogDownloadDataFilesTest.h
@@ -3,6 +3,7 @@
 
 #include "ICatTestHelper.h"
 #include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/FrameworkManager.h"
 #include "MantidDataObjects/WorkspaceSingleValue.h"
 #include "MantidICat/CatalogDownloadDataFiles.h"
 #include "MantidICat/CatalogGetDataFiles.h"
@@ -18,34 +19,21 @@
 using namespace Mantid;
 using namespace Mantid::ICat;
 using namespace Mantid::API;
+
 class CatalogDownloadDataFilesTest : public CxxTest::TestSuite {
 public:
-  /** Ping the  download.mantidproject.org and
-   * skip all tests if internet/server is down.
-   */
-  bool skipTests() override {
-#ifdef _WIN32
-    // I don't know how to get exit status from windows.
-    return false;
-#else
-    // Ping once, with a 1 second wait.
-    std::string cmdstring = "ping download.mantidproject.org -c 1 -w 1";
-
-    int status;
-    status = system(cmdstring.c_str());
-    if (status == -1) {
-      // Some kind of system() failure
-    } else
-      // Get the exit code
-      status = WEXITSTATUS(status);
-
-    if (status != 0) {
-      std::cout << "Skipping test since '" << cmdstring << "' FAILED!\n";
-      return true;
-    }
-    return false;
-#endif
+  // This means the constructor isn't called when running other tests
+  static CatalogDownloadDataFilesTest *createSuite() {
+    return new CatalogDownloadDataFilesTest();
   }
+  static void destroySuite(CatalogDownloadDataFilesTest *suite) {
+    delete suite;
+  }
+
+  /// Skip all unit tests if ICat server is down
+  bool skipTests() override { return ICatTestHelper::skipTests(); }
+
+  CatalogDownloadDataFilesTest() { FrameworkManager::Instance(); }
 
   void testInit() {
     TS_ASSERT_THROWS_NOTHING(downloadobj.initialize());

--- a/Framework/ICat/test/CatalogGetDataFilesTest.h
+++ b/Framework/ICat/test/CatalogGetDataFilesTest.h
@@ -2,6 +2,7 @@
 #define GETINVESTIGATION_H_
 
 #include "ICatTestHelper.h"
+#include "MantidAPI/FrameworkManager.h"
 #include "MantidDataObjects/WorkspaceSingleValue.h"
 #include "MantidICat/CatalogGetDataFiles.h"
 #include "MantidICat/CatalogLogin.h"
@@ -13,8 +14,16 @@ using namespace Mantid::ICat;
 
 class CatalogGetDataFilesTest : public CxxTest::TestSuite {
 public:
+  // This means the constructor isn't called when running other tests
+  static CatalogGetDataFilesTest *createSuite() {
+    return new CatalogGetDataFilesTest();
+  }
+  static void destroySuite(CatalogGetDataFilesTest *suite) { delete suite; }
+
   /// Skip all unit tests if ICat server is down
   bool skipTests() override { return ICatTestHelper::skipTests(); }
+
+  CatalogGetDataFilesTest() { API::FrameworkManager::Instance(); }
 
   void testInit() {
     Mantid::Kernel::ConfigService::Instance().setString("default.facility",

--- a/Framework/ICat/test/CatalogGetDataSetsTest.h
+++ b/Framework/ICat/test/CatalogGetDataSetsTest.h
@@ -2,6 +2,7 @@
 #define GETIDATASETS_H_
 
 #include "ICatTestHelper.h"
+#include "MantidAPI/FrameworkManager.h"
 #include "MantidDataObjects/WorkspaceSingleValue.h"
 #include "MantidICat/CatalogGetDataSets.h"
 #include "MantidICat/CatalogLogin.h"
@@ -13,8 +14,16 @@ using namespace Mantid::ICat;
 
 class CatalogGetDataSetsTest : public CxxTest::TestSuite {
 public:
+  // This means the constructor isn't called when running other tests
+  static CatalogGetDataSetsTest *createSuite() {
+    return new CatalogGetDataSetsTest();
+  }
+  static void destroySuite(CatalogGetDataSetsTest *suite) { delete suite; }
+
   /// Skip all unit tests if ICat server is down
   bool skipTests() override { return ICatTestHelper::skipTests(); }
+
+  CatalogGetDataSetsTest() { API::FrameworkManager::Instance(); }
 
   void testInit() {
     Mantid::Kernel::ConfigService::Instance().setString("default.facility",

--- a/Framework/ICat/test/CatalogListInstrumentsTest.h
+++ b/Framework/ICat/test/CatalogListInstrumentsTest.h
@@ -12,6 +12,12 @@ using namespace Mantid::ICat;
 
 class CatalogListInstrumentsTest : public CxxTest::TestSuite {
 public:
+  // This means the constructor isn't called when running other tests
+  static CatalogListInstrumentsTest *createSuite() {
+    return new CatalogListInstrumentsTest();
+  }
+  static void destroySuite(CatalogListInstrumentsTest *suite) { delete suite; }
+
   /// Skip all unit tests if ICat server is down
   bool skipTests() override { return ICatTestHelper::skipTests(); }
 

--- a/Framework/ICat/test/CatalogListInvestigationTypesTest.h
+++ b/Framework/ICat/test/CatalogListInvestigationTypesTest.h
@@ -12,6 +12,14 @@ using namespace Mantid::ICat;
 
 class CatalogListInvestigationTypesTest : public CxxTest::TestSuite {
 public:
+  // This means the constructor isn't called when running other tests
+  static CatalogListInvestigationTypesTest *createSuite() {
+    return new CatalogListInvestigationTypesTest();
+  }
+  static void destroySuite(CatalogListInvestigationTypesTest *suite) {
+    delete suite;
+  }
+
   /// Skip all unit tests if ICat server is down
   bool skipTests() override { return ICatTestHelper::skipTests(); }
 

--- a/Framework/ICat/test/CatalogLoginTest.h
+++ b/Framework/ICat/test/CatalogLoginTest.h
@@ -8,6 +8,10 @@
 using namespace Mantid::ICat;
 class CatalogLoginTest : public CxxTest::TestSuite {
 public:
+  // This means the constructor isn't called when running other tests
+  static CatalogLoginTest *createSuite() { return new CatalogLoginTest(); }
+  static void destroySuite(CatalogLoginTest *suite) { delete suite; }
+
   /// Skip all unit tests if ICat server is down
   bool skipTests() override { return ICatTestHelper::skipTests(); }
 

--- a/Framework/ICat/test/CatalogMyDataSearchTest.h
+++ b/Framework/ICat/test/CatalogMyDataSearchTest.h
@@ -2,6 +2,7 @@
 #define MYDATASEARCH_H_
 
 #include "ICatTestHelper.h"
+#include "MantidAPI/FrameworkManager.h"
 #include "MantidDataObjects/WorkspaceSingleValue.h"
 #include "MantidICat/CatalogLogin.h"
 #include "MantidICat/CatalogMyDataSearch.h"
@@ -12,8 +13,16 @@ using namespace Mantid::ICat;
 
 class CatalogMyDataSearchTest : public CxxTest::TestSuite {
 public:
+  // This means the constructor isn't called when running other tests
+  static CatalogMyDataSearchTest *createSuite() {
+    return new CatalogMyDataSearchTest();
+  }
+  static void destroySuite(CatalogMyDataSearchTest *suite) { delete suite; }
+
   /// Skip all unit tests if ICat server is down
   bool skipTests() override { return ICatTestHelper::skipTests(); }
+
+  CatalogMyDataSearchTest() { API::FrameworkManager::Instance(); }
 
   void testInit() {
     Mantid::Kernel::ConfigService::Instance().setString("default.facility",

--- a/Framework/ICat/test/CatalogSearchTest.h
+++ b/Framework/ICat/test/CatalogSearchTest.h
@@ -12,6 +12,10 @@ using namespace Mantid;
 using namespace Mantid::ICat;
 class CatalogSearchTest : public CxxTest::TestSuite {
 public:
+  // This means the constructor isn't called when running other tests
+  static CatalogSearchTest *createSuite() { return new CatalogSearchTest(); }
+  static void destroySuite(CatalogSearchTest *suite) { delete suite; }
+
   /// Skip all unit tests if ICat server is down
   bool skipTests() override { return ICatTestHelper::skipTests(); }
 

--- a/Framework/ICat/test/CompositeCatalogTest.h
+++ b/Framework/ICat/test/CompositeCatalogTest.h
@@ -1,9 +1,11 @@
 #ifndef MANTID_ICAT_COMPOSITECATALOGTEST_H_
 #define MANTID_ICAT_COMPOSITECATALOGTEST_H_
 
+#include "ICatTestHelper.h"
 #include <cxxtest/TestSuite.h>
 
 #include "MantidAPI/CompositeCatalog.h"
+#include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidICat/CatalogSearchParam.h"
@@ -80,6 +82,17 @@ int DummyCatalog::m_counter(0);
 
 class CompositeCatalogTest : public CxxTest::TestSuite {
 public:
+  // This means the constructor isn't called when running other tests
+  static CompositeCatalogTest *createSuite() {
+    return new CompositeCatalogTest();
+  }
+  static void destroySuite(CompositeCatalogTest *suite) { delete suite; }
+
+  /// Skip all unit tests if ICat server is down
+  bool skipTests() override { return ICatTestHelper::skipTests(); }
+
+  CompositeCatalogTest() { Mantid::API::FrameworkManager::Instance(); }
+
   /// Verifies that multiple catalogs are being logged in to.
   void testLogin() {
     std::string temp = "";

--- a/Framework/Kernel/test/InterpolationTest.h
+++ b/Framework/Kernel/test/InterpolationTest.h
@@ -9,6 +9,10 @@ using namespace Mantid::Kernel;
 
 class InterpolationTest : public CxxTest::TestSuite {
 public:
+  // This means the constructor isn't called when running other tests
+  static InterpolationTest *createSuite() { return new InterpolationTest(); }
+  static void destroySuite(InterpolationTest *suite) { delete suite; }
+
   /* In the constructor some vectors with values are setup,
    * which make the tests easier later on.
    *

--- a/Framework/Kernel/test/NearestNeighboursTest.h
+++ b/Framework/Kernel/test/NearestNeighboursTest.h
@@ -9,6 +9,12 @@ using namespace Eigen;
 
 class NearestNeighboursTest : public CxxTest::TestSuite {
 public:
+  // This means the constructor isn't called when running other tests
+  static NearestNeighboursTest *createSuite() {
+    return new NearestNeighboursTest();
+  }
+  static void destroySuite(NearestNeighboursTest *suite) { delete suite; }
+
   NearestNeighboursTest() {}
 
   void test_construct() {

--- a/Framework/MDAlgorithms/test/IntegratePeaksMDHKLTest.h
+++ b/Framework/MDAlgorithms/test/IntegratePeaksMDHKLTest.h
@@ -31,6 +31,12 @@ using Mantid::Kernel::V3D;
 
 class IntegratePeaksMDHKLTest : public CxxTest::TestSuite {
 public:
+  // This means the constructor isn't called when running other tests
+  static IntegratePeaksMDHKLTest *createSuite() {
+    return new IntegratePeaksMDHKLTest();
+  }
+  static void destroySuite(IntegratePeaksMDHKLTest *suite) { delete suite; }
+
   IntegratePeaksMDHKLTest() { Mantid::API::FrameworkManager::Instance(); }
   ~IntegratePeaksMDHKLTest() override {}
 

--- a/qt/widgets/common/test/DataProcessorUI/QOneLevelTreeModelTest.h
+++ b/qt/widgets/common/test/DataProcessorUI/QOneLevelTreeModelTest.h
@@ -14,6 +14,12 @@ using namespace Mantid::API;
 class QOneLevelTreeModelTest : public CxxTest::TestSuite {
 
 public:
+  // This means the constructor isn't called when running other tests
+  static QOneLevelTreeModelTest *createSuite() {
+    return new QOneLevelTreeModelTest();
+  }
+  static void destroySuite(QOneLevelTreeModelTest *suite) { delete suite; }
+
   // Create a white list
   QOneLevelTreeModelTest() {
     m_whitelist.addElement("Column1", "Property1", "Description1");

--- a/qt/widgets/common/test/DataProcessorUI/QTwoLevelTreeModelTest.h
+++ b/qt/widgets/common/test/DataProcessorUI/QTwoLevelTreeModelTest.h
@@ -12,8 +12,13 @@ using namespace MantidQt::MantidWidgets::DataProcessor;
 using namespace Mantid::API;
 
 class QTwoLevelTreeModelTest : public CxxTest::TestSuite {
-
 public:
+  // This means the constructor isn't called when running other tests
+  static QTwoLevelTreeModelTest *createSuite() {
+    return new QTwoLevelTreeModelTest();
+  }
+  static void destroySuite(QTwoLevelTreeModelTest *suite) { delete suite; }
+
   // Constructor (initializes whitelist)
   QTwoLevelTreeModelTest() {
     m_whitelist.addElement("Column1", "Property1", "Description1");


### PR DESCRIPTION
**Description of work.**

Adds the boilerplate `createSuite/destroySuite` methods to unit test classes that define a constructor. This avoids the constructors from running when they are not executed, such as when `bin/TestExec TestClass` is used. If these functions are not present then the suites are constructed statically and run regardless of whether the test is executed or not.

**Report to:** [nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

Code review.

*There is no associated issue.*

*This does not require release notes* because **it is an internal change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
