### PR TITLE
Algorithm history in python

### DIFF
--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/TableWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/TableWorkspace.cpp
@@ -14,9 +14,11 @@ using namespace boost::python;
 
 GET_POINTER_SPECIALIZATION(TableWorkspace)
 
+namespace {
 ITableWorkspace_sptr makeTableWorkspace() {
   return WorkspaceFactory::Instance().createTable();
 }
+} // namespace
 
 void export_TableWorkspace() {
 

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -5327,7 +5327,7 @@ void ApplicationWindow::saveSettings() {
 #endif
 
   // Root level is named "General" by Qt
-  resultsLog->writeSettings(&settings);
+  resultsLog->writeSettings(settings);
 
   // Our named group General, displayed as %General in the file
   settings.beginGroup("/General");

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -49,6 +49,7 @@ from qtpy.QtGui import (QColor, QPixmap)  # noqa
 from qtpy.QtWidgets import (QApplication, QDesktopWidget, QFileDialog,
                             QMainWindow, QSplashScreen)  # noqa
 from mantidqt.utils.qt import plugins, widget_updates_disabled  # noqa
+from mantidqt.algorithminputhistory import AlgorithmInputHistory  # noqa
 
 # Pre-application setup
 plugins.setup_library_paths()
@@ -397,10 +398,16 @@ class MainWindow(QMainWindow):
         else:
             self.setWindowState(Qt.WindowMaximized)
 
+        # have algorithm dialogs do their thing
+        AlgorithmInputHistory().readSettings(settings)
+
     def writeSettings(self, settings):
         settings.set('main/window/size', self.size()) # QSize
         settings.set('main/window/position', self.pos()) # QPoint
         settings.set('main/window/state', self.saveState()) # QByteArray
+
+        # have algorithm dialogs do their thing
+        AlgorithmInputHistory().writeSettings(settings)
 
 
 def initialize():

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -37,12 +37,31 @@ class Configurable {
 
 public:
   void readSettings(const QSettings &storage);
-  void writeSettings(QSettings *storage);
+  void writeSettings(QSettings &storage);
 
 private:
   // Not constructible or copyable
   Configurable();
   Configurable(const Configurable&);
+};
+
+class AlgorithmInputHistoryImpl : Configurable /PyName=AlgorithmInputHistory/ {
+%TypeHeaderCode
+#include "MantidQtWidgets/Common/AlgorithmInputHistory.h"
+%End
+
+public:
+static SIP_PYOBJECT Instance() const;
+%MethodCode
+  auto &cppInstance = MantidQt::API::AlgorithmInputHistory::Instance();
+  return sipConvertFromType(&cppInstance, sipType_AlgorithmInputHistoryImpl, nullptr);
+%End
+
+private:
+  // lifetime management is with C++ so don't generate any of that in Python
+  AlgorithmInputHistoryImpl();
+  ~AlgorithmInputHistoryImpl();
+  AlgorithmInputHistoryImpl(const AlgorithmInputHistoryImpl &);
 };
 
 class MessageDisplay : QWidget, Configurable {

--- a/qt/python/mantidqt/algorithminputhistory.py
+++ b/qt/python/mantidqt/algorithminputhistory.py
@@ -1,0 +1,46 @@
+#  This file is part of the mantidqt package
+#
+#  Copyright (C) 2017 mantidproject
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import (absolute_import)
+
+from mantidqt.utils.qt import import_qt
+
+
+_AlgorithmInputHistory = import_qt('._common', 'mantidqt', 'AlgorithmInputHistory')
+
+
+def _toQSettings(settings):
+    '''Utility function to convert supplied settings object to a qtpy.QtCore.QSettings
+    '''
+    try: # workbench.config.user
+        return settings.qsettings
+    except: # must be a QSettings already
+        return settings
+
+
+class AlgorithmInputHistory(object):
+    '''Wrapper class around MantidQtWidgets::Common::AlgorithmInputHistory
+    '''
+    _singleton = _AlgorithmInputHistory.Instance()
+
+    def __init__(self):
+        pass
+
+    def readSettings(self, settings):
+        self._singleton.readSettings(_toQSettings(settings))
+
+    def writeSettings(self, settings):
+        self._singleton.writeSettings(_toQSettings(settings))

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmInputHistory.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmInputHistory.h
@@ -6,6 +6,7 @@
 //----------------------------------
 #include "DllOption.h"
 #include "MantidKernel/SingletonHolder.h"
+#include "MantidQtWidgets/Common/Configurable.h"
 #include <QHash>
 #include <QString>
 
@@ -33,7 +34,8 @@ namespace API {
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-class EXPORT_OPT_MANTIDQT_COMMON AbstractAlgorithmInputHistory {
+class EXPORT_OPT_MANTIDQT_COMMON AbstractAlgorithmInputHistory
+    : public MantidWidgets::Configurable {
 public:
   AbstractAlgorithmInputHistory(const AbstractAlgorithmInputHistory &) = delete;
   AbstractAlgorithmInputHistory &
@@ -62,6 +64,12 @@ public:
 
   /// Save the values stored here to persistent storage
   void save() const;
+
+  /// @copydoc MantidWidgets::Configurable::readSettings
+  void readSettings(const QSettings &storage) override;
+
+  /// @copydoc MantidWidgets::Configurable::writeSettings
+  void writeSettings(QSettings &storage) const override;
 
 protected:
   /// Constructor

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/Configurable.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/Configurable.h
@@ -41,7 +41,7 @@ class EXPORT_OPT_MANTIDQT_COMMON Configurable {
 public:
   virtual ~Configurable() = default;
   virtual void readSettings(const QSettings &) = 0;
-  virtual void writeSettings(QSettings *) = 0;
+  virtual void writeSettings(QSettings &) const = 0;
 };
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MessageDisplay.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MessageDisplay.h
@@ -42,7 +42,7 @@ class EXPORT_OPT_MANTIDQT_COMMON MessageDisplay : public QWidget,
 public:
   // Configurable interface
   void readSettings(const QSettings &storage) override;
-  void writeSettings(QSettings *storage) override;
+  void writeSettings(QSettings &storage) const override;
 
 public:
   /// Default constructor with optional parent

--- a/qt/widgets/common/src/AlgorithmInputHistory.cpp
+++ b/qt/widgets/common/src/AlgorithmInputHistory.cpp
@@ -93,26 +93,60 @@ const QString &AbstractAlgorithmInputHistory::getPreviousDirectory() const {
  */
 void AbstractAlgorithmInputHistory::save() const {
   QSettings settings;
-  settings.beginGroup(m_algorithmsGroup);
+  this->writeSettings(settings);
+}
+
+void AbstractAlgorithmInputHistory::readSettings(const QSettings &storage) {
+  // unfortunately QSettings does not allow const when using beginGroup and
+  // endGroup
+  m_lastInput.clear();
+  const_cast<QSettings &>(storage).beginGroup(m_algorithmsGroup);
+  //  QStringList algorithms = settings.childGroups();
+  QListIterator<QString> algNames(storage.childGroups());
+
+  // Each property is a key of the algorithm group
+  while (algNames.hasNext()) {
+    QHash<QString, QString> algorithmProperties;
+    QString group = algNames.next();
+    const_cast<QSettings &>(storage).beginGroup(group);
+    QListIterator<QString> properties(storage.childKeys());
+    while (properties.hasNext()) {
+      QString propName = properties.next();
+      QString value = storage.value(propName).toString();
+      if (!value.isEmpty())
+        algorithmProperties.insert(propName, value);
+    }
+    m_lastInput.insert(group, algorithmProperties);
+    const_cast<QSettings &>(storage).endGroup();
+  }
+
+  // The previous dir
+  m_previousDirectory = storage.value(m_dirKey).toString();
+
+  const_cast<QSettings &>(storage).endGroup();
+}
+
+void AbstractAlgorithmInputHistory::writeSettings(QSettings &storage) const {
+  storage.beginGroup(m_algorithmsGroup);
   QHashIterator<QString, QHash<QString, QString>> inputHistory(m_lastInput);
   while (inputHistory.hasNext()) {
     inputHistory.next();
-    settings.beginGroup(inputHistory.key());
+    storage.beginGroup(inputHistory.key());
     // Remove all keys for this group that exist at the moment
-    settings.remove("");
+    storage.remove("");
     QHash<QString, QString>::const_iterator iend = inputHistory.value().end();
     for (QHash<QString, QString>::const_iterator itr =
              inputHistory.value().begin();
          itr != iend; ++itr) {
-      settings.setValue(itr.key(), itr.value());
+      storage.setValue(itr.key(), itr.value());
     }
-    settings.endGroup();
+    storage.endGroup();
   }
 
   // Store the previous directory
-  settings.setValue(m_dirKey, m_previousDirectory);
+  storage.setValue(m_dirKey, m_previousDirectory);
 
-  settings.endGroup();
+  storage.endGroup();
 }
 
 //----------------------------------
@@ -124,30 +158,6 @@ void AbstractAlgorithmInputHistory::save() const {
  * clears all currently values stored
  */
 void AbstractAlgorithmInputHistory::load() {
-  m_lastInput.clear();
   QSettings settings;
-  settings.beginGroup(m_algorithmsGroup);
-  //  QStringList algorithms = settings.childGroups();
-  QListIterator<QString> algNames(settings.childGroups());
-
-  // Each property is a key of the algorithm group
-  while (algNames.hasNext()) {
-    QHash<QString, QString> algorithmProperties;
-    QString group = algNames.next();
-    settings.beginGroup(group);
-    QListIterator<QString> properties(settings.childKeys());
-    while (properties.hasNext()) {
-      QString propName = properties.next();
-      QString value = settings.value(propName).toString();
-      if (!value.isEmpty())
-        algorithmProperties.insert(propName, value);
-    }
-    m_lastInput.insert(group, algorithmProperties);
-    settings.endGroup();
-  }
-
-  // The previous dir
-  m_previousDirectory = settings.value(m_dirKey).toString();
-
-  settings.endGroup();
+  this->readSettings(settings);
 }

--- a/qt/widgets/common/src/MessageDisplay.cpp
+++ b/qt/widgets/common/src/MessageDisplay.cpp
@@ -53,9 +53,8 @@ void MessageDisplay::readSettings(const QSettings &storage) {
  * @param storage A pointer to an existing QSettings instance opened
  * at the group where the values should be stored.
  */
-void MessageDisplay::writeSettings(QSettings *storage) {
-  Q_ASSERT(storage);
-  storage->setValue("MessageDisplayPriority", Poco::Logger::root().getLevel());
+void MessageDisplay::writeSettings(QSettings &storage) const {
+  storage.setValue("MessageDisplayPriority", Poco::Logger::root().getLevel());
 }
 
 /**


### PR DESCRIPTION
Remember values in algorithm dialogs between workbench sessions.

**To test:**

1. Start the workbench
2. Run an algorithm via a dialog
3. Shutdown the workbench and start it again
4. Start the same algorithm dialog again and see the previous values are already filled in

*There is no associated issue.*

*This does not require release notes* because the new workbench is not being advertised yet.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
