### PR TITLE
Remove manual linking to asan library

### DIFF
--- a/Framework/API/src/WorkspaceHistory.cpp
+++ b/Framework/API/src/WorkspaceHistory.cpp
@@ -187,12 +187,8 @@ boost::shared_ptr<IAlgorithm> WorkspaceHistory::lastAlgorithm() const {
  * sub-objects
  */
 void WorkspaceHistory::printSelf(std::ostream &os, const int indent) const {
-
   os << std::string(indent, ' ') << m_environment << '\n';
-
-  AlgorithmHistories::const_iterator it;
   os << std::string(indent, ' ') << "Histories:\n";
-
   for (const auto &algorithm : m_algorithms) {
     os << '\n';
     algorithm->printSelf(os, indent + 2);

--- a/Framework/Algorithms/src/MaskNonOverlappingBins.cpp
+++ b/Framework/Algorithms/src/MaskNonOverlappingBins.cpp
@@ -33,8 +33,8 @@ std::string const NONRAGGED{"Common Bins"};
 bool isXSorted(Mantid::API::MatrixWorkspace const &ws) {
   int unsorted{0};
   PARALLEL_FOR_IF(Mantid::Kernel::threadSafe(ws))
-  for (int64_t i = 0; static_cast<size_t>(i) < ws.getNumberHistograms(); ++i) {
-    auto const &Xs = ws.x(static_cast<size_t>(i));
+  for (int64_t i = 0; i < static_cast<int64_t>(ws.getNumberHistograms()); ++i) {
+    auto const &Xs = ws.x(i);
     if (!std::is_sorted(Xs.cbegin(), Xs.cend())) {
       PARALLEL_ATOMIC
       ++unsorted;

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadSampleEnvironment.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadSampleEnvironment.h
@@ -14,18 +14,17 @@ namespace Geometry {
 class MeshObject;
 }
 namespace DataHandling {
-/**  Load Environment into the sample of a workspace, either replacing the
-   current environment, or replacing it, you may also set the material
-
-     The following file types are supported
-
-       STL file with suffix .stl
+/**
+ * Load Environment into the sample of a workspace, either replacing the
+ * current environment, or replacing it, you may also set the material
+ *
+ * The following file types are supported:
+ *   - STL file with suffix .stl
  */
-
 class DLLExport LoadSampleEnvironment : public Mantid::API::Algorithm {
 public:
   /// Algorithm's name for identification overriding a virtual method
-  const std::string name() const override { return "LoadSampleEnvironment"; };
+  const std::string name() const override { return "LoadSampleEnvironment"; }
   /// Summary of algorithms purpose
   const std::string summary() const override {
     return "The algorithm loads an Environment into the instrument of a "
@@ -34,7 +33,7 @@ public:
   }
 
   /// Algorithm's version for identification overriding a virtual method
-  int version() const override { return 1; };
+  int version() const override { return 1; }
   /// Related algorithms
   const std::vector<std::string> seeAlso() const override {
     return {"CreateSampleEnvironment", "CopySample", "SetSampleMaterial",

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadStl.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadStl.h
@@ -45,6 +45,7 @@ public:
   LoadStl(std::string filename) : m_filename(filename), m_setMaterial(false) {}
   LoadStl(std::string filename, ReadMaterial::MaterialParameters params)
       : m_filename(filename), m_setMaterial(true), m_params(params) {}
+  virtual ~LoadStl() = default;
   virtual std::unique_ptr<Geometry::MeshObject> readStl() = 0;
 
 protected:

--- a/Framework/DataHandling/src/LoadSampleEnvironment.cpp
+++ b/Framework/DataHandling/src/LoadSampleEnvironment.cpp
@@ -40,8 +40,6 @@ using namespace Geometry;
 
 void LoadSampleEnvironment::init() {
   auto wsValidator = boost::make_shared<API::InstrumentValidator>();
-  ;
-
   // input workspace
   declareProperty(make_unique<WorkspaceProperty<>>(
                       "InputWorkspace", "", Direction::Input, wsValidator),

--- a/Framework/Kernel/CMakeLists.txt
+++ b/Framework/Kernel/CMakeLists.txt
@@ -499,10 +499,6 @@ if ( GCC_COMPILER_VERSION AND GCC_COMPILER_VERSION VERSION_LESS "4.5" )
 endif()
 target_link_libraries ( Kernel LINK_PUBLIC ${NEXUS_LIBRARIES} Eigen3::Eigen LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME} ${GSL_LIBRARIES} ${MANTIDLIBS} ${NETWORK_LIBRARIES} ${JSONCPP_LIBRARIES} ${TBB_LIBRARIES} ${TBB_MALLOC_LIBRARIES})
 
-if (WITH_ASAN)
-  target_link_libraries ( Kernel LINK_PRIVATE -lasan )
-endif ()
-
 if ( WIN32 )
   target_link_libraries ( Kernel LINK_PRIVATE Psapi.lib ) # For memory usage queries
 endif()

--- a/MantidPlot/CMakeLists.txt
+++ b/MantidPlot/CMakeLists.txt
@@ -828,10 +828,6 @@ if(MAKE_VATES)
   target_link_libraries ( MantidPlot LINK_PRIVATE vtkPVClientServerCoreRendering vtkPVServerManagerRendering ${vtkjsoncpp_LIBRARIES})
 endif()
 
-if (WITH_ASAN)
-  target_link_libraries ( MantidPlot LINK_PRIVATE -lasan )
-endif ()
-
 # Plugin dependencies
 add_dependencies( MantidPlot mantidqtpython CompilePyUI )
 

--- a/buildconfig/CMake/GNUSetup.cmake
+++ b/buildconfig/CMake/GNUSetup.cmake
@@ -47,7 +47,7 @@ add_compile_options ( $<$<COMPILE_LANGUAGE:CXX>:-Woverloaded-virtual>
   $<$<COMPILE_LANGUAGE:CXX>:-fno-operator-names>
 )
 
-#Linking errors on Ubuntu 18.04 with --enable-new-dtags 
+#Linking errors on Ubuntu 18.04 with --enable-new-dtags
 if ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
   string(APPEND CMAKE_MODULE_LINKER_FLAGS " -Wl,--disable-new-dtags" )
   string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,--disable-new-dtags" )
@@ -76,9 +76,9 @@ option(WITH_ASAN "Enable address sanitizer" OFF)
 if(WITH_ASAN)
   message(STATUS "enabling address sanitizer")
   add_compile_options(-fno-omit-frame-pointer -fno-common -fsanitize=address)
-  set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fsanitize=address -lasan" )
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address -lasan" )
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fsanitize=address -lasan" )
+  set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fsanitize=address" )
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fsanitize=address")
 endif()
 
 option(WITH_UBSAN "Enable undefined behavior sanitizer" OFF)

--- a/buildconfig/CMake/LinuxPackageScripts.cmake
+++ b/buildconfig/CMake/LinuxPackageScripts.cmake
@@ -160,8 +160,17 @@ if ( TCMALLOC_FOUND )
   string( REGEX REPLACE "([0-9]+)\.[0-9]+\.[0-9]+$" "\\1" TCMALLOC_RUNTIME_LIB ${TCMALLOC_RUNTIME_LIB} )
 endif ()
 
-# definitions to preload tcmalloc
-set ( TCMALLOC_DEFINITIONS
+# definitions to preload tcmalloc but not if we are using address sanitizer as this confuses things
+if ( WITH_ASAN )
+  set ( TCMALLOC_DEFINITIONS
+"
+LOCAL_PRELOAD=\${LD_PRELOAD}
+TCM_RELEASE=\${TCMALLOC_RELEASE_RATE}
+TCM_REPORT=\${TCMALLOC_LARGE_ALLOC_REPORT_THRESHOLD}"
+)
+else ()
+  # Do not indent the string below as it messes up the formatting in the final script
+  set ( TCMALLOC_DEFINITIONS
 "# Define parameters for tcmalloc
 LOCAL_PRELOAD=${TCMALLOC_RUNTIME_LIB}
 if [ -n \"\${LD_PRELOAD}\" ]; then
@@ -186,6 +195,7 @@ if [ -z \"\${TCMALLOC_LARGE_ALLOC_REPORT_THRESHOLD}\" ]; then
 else
     TCM_REPORT=\${TCMALLOC_LARGE_ALLOC_REPORT_THRESHOLD}
 fi" )
+endif()
 
 # chunk of code for launching gdb
 set ( GDB_DEFINITIONS


### PR DESCRIPTION
**Description of work.**

If included then clang on Linux reports "incompatible ASan runtimes"
on running the executables. This lets the -fsanitize flag handle
everything, which seems to do the correct thing for gcc and clang.

**Report to:** [nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

* Build `KernelTest` with address sanitizer (`WITH_ASAN`) with clang on Linux
* Run `KernelTest` and see there are no errors about incompatible ASan runtimes

*There is no associated issue.*

*This does not require release notes* because **it is a developer change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
