### PR TITLE
Add missing options to Calculate Monte Carlo Absorption

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/CalculateMonteCarloAbsorption.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/CalculateMonteCarloAbsorption.py
@@ -100,10 +100,14 @@ class CalculateMonteCarloAbsorption(DataProcessorAlgorithm):
                              validator=StringListValidator(
                                  ['Linear', 'CSpline']),
                              doc='Type of interpolation')
+        self.declareProperty(name='MaxScatterPtAttempts', defaultValue=5000,
+                             validator=IntBoundedValidator(0),
+                             doc='Maximum number of tries made to generate a scattering point')
 
         self.setPropertyGroup('NumberOfWavelengthPoints', 'Monte Carlo Options')
         self.setPropertyGroup('EventsPerPoint', 'Monte Carlo Options')
         self.setPropertyGroup('Interpolation', 'Monte Carlo Options')
+        self.setPropertyGroup('MaxScatterPtAttempts', 'Monte Carlo Options')
 
         # Container options
         self.declareProperty(WorkspaceProperty('ContainerWorkspace', '', direction=Direction.Input,
@@ -381,7 +385,8 @@ class CalculateMonteCarloAbsorption(DataProcessorAlgorithm):
                                 'BeamWidth': self.getProperty('BeamWidth').value,
                                 'NumberOfWavelengthPoints': self.getProperty('NumberOfWavelengthPoints').value,
                                 'EventsPerPoint': self.getProperty('EventsPerPoint').value,
-                                'Interpolation': self.getProperty('Interpolation').value}
+                                'Interpolation': self.getProperty('Interpolation').value,
+                                'MaxScatterPtAttempts': self.getProperty('MaxScatterPtAttempts').value}
 
         self._shape = self.getProperty('Shape').value
         self._height = self.getProperty('Height').value

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SimpleShapeMonteCarloAbsorption.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SimpleShapeMonteCarloAbsorption.py
@@ -84,6 +84,10 @@ class SimpleShapeMonteCarloAbsorption(DataProcessorAlgorithm):
                              validator=StringListValidator(['Linear', 'CSpline']),
                              doc='Type of interpolation')
 
+        self.declareProperty(name='MaxScatterPtAttempts', defaultValue=5000,
+                             validator=IntBoundedValidator(0),
+                             doc='Maximum number of tries made to generate a scattering point')
+
         # -------------------------------------------------------------------------------------------
 
         # Beam size
@@ -230,6 +234,7 @@ class SimpleShapeMonteCarloAbsorption(DataProcessorAlgorithm):
         monte_carlo_alg.setProperty("EventsPerPoint", self._events)
         monte_carlo_alg.setProperty("NumberOfWavelengthPoints", self._number_wavelengths)
         monte_carlo_alg.setProperty("Interpolation", self._interpolation)
+        monte_carlo_alg.setProperty("MaxScatterPtAttempts", self._max_scatter_attempts)
         monte_carlo_alg.execute()
 
         output_ws = monte_carlo_alg.getProperty("OutputWorkspace").value
@@ -265,6 +270,7 @@ class SimpleShapeMonteCarloAbsorption(DataProcessorAlgorithm):
         self._number_wavelengths = self.getProperty('NumberOfWavelengthPoints').value
         self._events = self.getProperty('EventsPerPoint').value
         self._interpolation = self.getProperty('Interpolation').value
+        self._max_scatter_attempts = self.getProperty('MaxScatterPtAttempts').value
 
         # beam options
         self._beam_height = self.getProperty('BeamHeight').value

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SimpleShapeMonteCarloAbsorptionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SimpleShapeMonteCarloAbsorptionTest.py
@@ -50,7 +50,7 @@ class SimpleShapeMonteCarloAbsorptionTest(unittest.TestCase):
         self.assertEquals(y_unit, 'Attenuation factor')
 
         num_hists = corr_ws.getNumberHistograms()
-        self.assertEquals(num_hists, 51)
+        self.assertEquals(num_hists, 10)
 
         blocksize = corr_ws.blocksize()
         self.assertEquals(blocksize, 1905)

--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -10,3 +10,14 @@ Indirect Inelastic Changes
     improvements, followed by bug fixes.
 
 :ref:`Release 3.14.0 <v3.14.0>`
+
+Data Corrections Interface
+--------------------------
+
+Improvements
+############
+
+- Added 'Interpolation' combobox to Calculate Monte Carlo Absorption. This allows the method of interpolation 
+  to be selected. Allowed values: ['Linear', 'CSpline'].
+- Added 'MaxScatterPtAttempts' spinbox to Calculate Monte Carlo Absorption. This sets the maximum number of 
+  tries to be made to generate a scattering point.

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
@@ -143,6 +143,12 @@ void AbsorptionCorrections::run() {
   monteCarloAbsCor->setProperty("NumberOfWavelengthPoints", wave);
   long events = static_cast<long>(m_uiForm.spNumberEvents->value());
   monteCarloAbsCor->setProperty("EventsPerPoint", events);
+  auto const interpolation =
+      m_uiForm.cbInterpolation->currentText().toStdString();
+  monteCarloAbsCor->setProperty("Interpolation", interpolation);
+  long maxAttempts =
+      static_cast<long>(m_uiForm.spMaxScatterPtAttempts->value());
+  monteCarloAbsCor->setProperty("MaxScatterPtAttempts", maxAttempts);
 
   // Can details
   bool useCan = m_uiForm.ckUseCan->isChecked();

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.ui
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.ui
@@ -190,6 +190,9 @@
       </item>
       <item row="2" column="4">
        <widget class="QSpinBox" name="spMaxScatterPtAttempts">
+        <property name="minimum">
+         <number>1</number>
+        </property>
         <property name="maximum">
          <number>1000000</number>
         </property>

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.ui
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.ui
@@ -114,14 +114,14 @@
       <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
-      <item row="0" column="2">
+      <item row="1" column="2">
        <widget class="QLabel" name="lbNumberEvents">
         <property name="text">
          <string>Events:</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
+      <item row="1" column="1">
        <widget class="QSpinBox" name="spNumberWavelengths">
         <property name="minimum">
          <number>1</number>
@@ -137,20 +137,64 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="0">
+      <item row="1" column="0">
        <widget class="QLabel" name="lbNumberWavelengths">
         <property name="text">
          <string>Number Wavelengths:</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="4">
+      <item row="1" column="4">
        <widget class="QSpinBox" name="spNumberEvents">
         <property name="maximum">
          <number>1000000</number>
         </property>
         <property name="singleStep">
          <number>10</number>
+        </property>
+        <property name="value">
+         <number>5000</number>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Interpolation:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Maximum Scatter Point Attempts:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QComboBox" name="cbInterpolation">
+        <property name="currentIndex">
+         <number>0</number>
+        </property>
+        <item>
+         <property name="text">
+          <string>Linear</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>CSpline</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="2" column="4">
+       <widget class="QSpinBox" name="spMaxScatterPtAttempts">
+        <property name="maximum">
+         <number>1000000</number>
+        </property>
+        <property name="singleStep">
+         <number>100</number>
         </property>
         <property name="value">
          <number>5000</number>


### PR DESCRIPTION
**Description of work.**
Add options to select the Interpolation (Linear or CSpline) and MaxScatterPtAttempts in the  Calculate Monte Carlo Absorption tab. 

**To test:**
1. Interfaces -> Indirect -> Corrections
2. Go to Calculate Monte Carlo Absorption tab
3. Check that the Interpolation and MaxScatterPtAttempts options are available. Interpolation should have a combobox with default value Linear. MaxScatterPtAttempts should have a default value of 5000.
4. Load in the sample file below
5. Set sample Height, thickness and width to 0.1cm
6. Set the chemical formula to be H2-O
7. Click run and wait for it to finish
8. Check the log to make sure the parameters Interpolation and MaxScatterPtAttempts have been retrieved. It should look something like this:
```  
Name: Interpolation, Value: Linear, Default?: Yes, Direction: Input
Name: MaxScatterPtAttempts, Value: 5000, Default?: Yes, Direction: Input
```

**Files**
[iris26184_multi_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2302852/iris26184_multi_graphite002_red.zip)

Fixes #22054 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
