### PR TITLE
Correct workbench window location

### DIFF
--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -378,14 +378,20 @@ class MainWindow(QMainWindow):
             window_pos = QPoint(*window_pos)
 
         # make sure main window is smaller than the desktop
-        desktop_size = QDesktopWidget().screenGeometry().size()
-        w = min(desktop_size.width(), window_size.width())
-        h = min(desktop_size.height(), window_size.height())
+        desktop = QDesktopWidget()
+
+        # this gives the maximum screen number if the position is off screen
+        screen = desktop.screenNumber(window_pos)
+
+        # recalculate the window size
+        desktop_geom = desktop.screenGeometry(screen)
+        w = min(desktop_geom.size().width(), window_size.width())
+        h = min(desktop_geom.size().height(), window_size.height())
         window_size = QSize(w, h)
 
-        # and that it will be painted on screen
-        x = min(window_pos.x(), desktop_size.width() - window_size.width())
-        y = min(window_pos.y(), desktop_size.height() - window_size.height())
+        # and position it on the supplied desktop screen
+        x = max(window_pos.x(), desktop_geom.left())
+        y = max(window_pos.y(), desktop_geom.top())
         window_pos = QPoint(x, y)
 
         # set the geometry


### PR DESCRIPTION
The workbench is not restored to the correct place. This fixes that issue and will remember the location on multi-monitor configurations.

This does not fully work on [awesome](https://awesomewm.org/) or [i3](https://i3wm.org/). They always place the window on the active screen.

**To test:**

Startup the workbench, move the window, shut it down, start it, etc. Repeat until it feels like it works.

Fixes #23284.

*This does not require release notes* because the workbench is not being advertised yet.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
