### PR TITLE
Allow the option for Python interfaces to save the MantidPlot project

### DIFF
--- a/MantidPlot/src/ProjectSave.ui
+++ b/MantidPlot/src/ProjectSave.ui
@@ -16,198 +16,230 @@
   <property name="modal">
    <bool>true</bool>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_8">
-   <item>
-    <layout class="QGridLayout" name="gridLayout">
-     <property name="sizeConstraint">
-      <enum>QLayout::SetDefaultConstraint</enum>
-     </property>
-     <item row="1" column="0" colspan="3">
-      <widget class="QSplitter" name="splitter">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <layout class="QVBoxLayout" name="verticalLayout_7">
+     <item>
+      <widget class="QLabel" name="label_4">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-       <widget class="QWidget" name="verticalLayoutWidget_2">
-        <layout class="QVBoxLayout" name="verticalLayout_3">
-         <item>
-          <widget class="QLabel" name="label">
-           <property name="text">
-            <string>Workspaces</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QTreeWidget" name="workspaceList">
-           <column>
-            <property name="text">
-             <string>Name</string>
-            </property>
-           </column>
-           <column>
-            <property name="text">
-             <string>Type</string>
-            </property>
-           </column>
-           <column>
-            <property name="text">
-             <string>Size</string>
-            </property>
-           </column>
-           <item>
-            <property name="text">
-             <string>ws1</string>
-            </property>
-            <property name="checkState">
-             <enum>Checked</enum>
-            </property>
-            <property name="text">
-             <string>Matrix</string>
-            </property>
-            <property name="text">
-             <string>10mb</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-       <widget class="QWidget" name="verticalLayoutWidget">
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <item>
-          <widget class="QSplitter" name="splitter_2">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <widget class="QWidget" name="verticalLayoutWidget_3">
-            <layout class="QVBoxLayout" name="verticalLayout_5">
-             <item>
-              <widget class="QLabel" name="label_2">
-               <property name="text">
-                <string>Included Windows</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QTreeWidget" name="includedWindows">
-               <column>
-                <property name="text">
-                 <string>Name</string>
-                </property>
-               </column>
-               <column>
-                <property name="text">
-                 <string>Type</string>
-                </property>
-               </column>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-           <widget class="QWidget" name="verticalLayoutWidget_4">
-            <layout class="QVBoxLayout" name="verticalLayout_6">
-             <item>
-              <widget class="QLabel" name="label_3">
-               <property name="text">
-                <string>Excluded Windows</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QTreeWidget" name="excludedWindows">
-               <column>
-                <property name="text">
-                 <string>Name</string>
-                </property>
-               </column>
-               <column>
-                <property name="text">
-                 <string>Type</string>
-                </property>
-               </column>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </widget>
-         </item>
-        </layout>
-       </widget>
+       <property name="text">
+        <string>Project Location</string>
+       </property>
       </widget>
      </item>
-     <item row="2" column="0" colspan="3">
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
        <property name="sizeConstraint">
         <enum>QLayout::SetFixedSize</enum>
        </property>
        <item>
-        <widget class="QProgressBar" name="saveProgressBar">
-         <property name="value">
-          <number>24</number>
-         </property>
-        </widget>
+        <widget class="QLineEdit" name="projectPath"/>
        </item>
        <item>
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>0</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QPushButton" name="btnCancel">
+        <widget class="QPushButton" name="btnBrowseFilePath">
          <property name="text">
-          <string>Cancel</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="btnSave">
-         <property name="text">
-          <string>Save</string>
+          <string>Browse</string>
          </property>
         </widget>
        </item>
       </layout>
      </item>
-     <item row="0" column="0" colspan="3">
-      <layout class="QVBoxLayout" name="verticalLayout_7">
+    </layout>
+   </item>
+   <item row="1" column="0">
+    <widget class="QSplitter" name="splitter_3">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <widget class="QWidget" name="verticalLayoutWidget_6">
+      <layout class="QVBoxLayout" name="verticalLayout_10">
        <item>
-        <widget class="QLabel" name="label_4">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
+        <widget class="QSplitter" name="splitter">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
          </property>
-         <property name="text">
-          <string>Project Location</string>
-         </property>
+         <widget class="QWidget" name="verticalLayoutWidget_2">
+          <layout class="QVBoxLayout" name="verticalLayout_3">
+           <item>
+            <widget class="QLabel" name="label">
+             <property name="text">
+              <string>Workspaces</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QTreeWidget" name="workspaceList">
+             <column>
+              <property name="text">
+               <string>Name</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>Type</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>Size</string>
+              </property>
+             </column>
+             <item>
+              <property name="text">
+               <string>ws1</string>
+              </property>
+              <property name="checkState">
+               <enum>Checked</enum>
+              </property>
+              <property name="text">
+               <string>Matrix</string>
+              </property>
+              <property name="text">
+               <string>10mb</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="verticalLayoutWidget_5">
+          <layout class="QVBoxLayout" name="verticalLayout_8">
+           <item>
+            <widget class="QLabel" name="label_5">
+             <property name="text">
+              <string>Interfaces</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QTreeWidget" name="interfaceList">
+             <column>
+              <property name="text">
+               <string>Name</string>
+              </property>
+             </column>
+             <item>
+              <property name="text">
+               <string>Interface 1</string>
+              </property>
+              <property name="checkState">
+               <enum>Checked</enum>
+              </property>
+             </item>
+            </widget>
+           </item>
+          </layout>
+         </widget>
         </widget>
        </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="verticalLayoutWidget">
+      <layout class="QVBoxLayout" name="verticalLayout">
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout">
-         <property name="sizeConstraint">
-          <enum>QLayout::SetFixedSize</enum>
+        <widget class="QSplitter" name="splitter_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
          </property>
-         <item>
-          <widget class="QLineEdit" name="projectPath"/>
-         </item>
-         <item>
-          <widget class="QPushButton" name="btnBrowseFilePath">
-           <property name="text">
-            <string>Browse</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
+         <widget class="QWidget" name="verticalLayoutWidget_4">
+          <layout class="QVBoxLayout" name="verticalLayout_6">
+           <item>
+            <widget class="QLabel" name="label_3">
+             <property name="text">
+              <string>Excluded Windows</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QTreeWidget" name="excludedWindows">
+             <column>
+              <property name="text">
+               <string>Name</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>Type</string>
+              </property>
+             </column>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="verticalLayoutWidget_3">
+          <layout class="QVBoxLayout" name="verticalLayout_5">
+           <item>
+            <widget class="QLabel" name="label_2">
+             <property name="text">
+              <string>Included Windows</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QTreeWidget" name="includedWindows">
+             <column>
+              <property name="text">
+               <string>Name</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>Type</string>
+              </property>
+             </column>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
        </item>
       </layout>
+     </widget>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetFixedSize</enum>
+     </property>
+     <item>
+      <widget class="QProgressBar" name="saveProgressBar">
+       <property name="value">
+        <number>24</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>0</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnCancel">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnSave">
+       <property name="text">
+        <string>Save</string>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>

--- a/MantidPlot/src/ProjectSaveView.h
+++ b/MantidPlot/src/ProjectSaveView.h
@@ -48,14 +48,21 @@ public:
   ProjectSaveView(
       const QString &projectName, MantidQt::API::ProjectSerialiser &serialiser,
       const std::vector<MantidQt::API::IProjectSerialisable *> &windows,
+      const std::vector<std::string> &activePythonInterfaces,
       QWidget *parent = nullptr);
 
   /// Get all of the window handles passed to the view
   std::vector<MantidQt::API::IProjectSerialisable *> getWindows() override;
+  /// Get all of the python interfaces passed to the view
+  virtual std::vector<std::string> getAllPythonInterfaces() override;
   /// Get any checked workspace names on the view
   std::vector<std::string> getCheckedWorkspaceNames() override;
   /// Get any unchecked workspace names on the view
   std::vector<std::string> getUncheckedWorkspaceNames() override;
+  /// Get any checked interface names on the view
+  std::vector<std::string> getCheckedPythonInterfaces() override;
+  /// Get any unchecked workspace names on the view
+  std::vector<std::string> getUncheckedPythonInterfaces() override;
   /// Get the current path of the project
   QString getProjectPath() override;
   /// Set the current path of the project
@@ -63,6 +70,9 @@ public:
   /// Update the list of workspaces with a collection of workspace info
   void
   updateWorkspacesList(const std::vector<WorkspaceInfo> &workspaces) override;
+  /// Update the list of interfaces
+  virtual void
+  updateInterfacesList(const std::vector<std::string> &interfaces) override;
   /// Update the list of included windows with a collection of window info
   void
   updateIncludedWindowsList(const std::vector<WindowInfo> &windows) override;
@@ -91,9 +101,10 @@ private slots:
 private:
   /// Get a list of included windows names to be saved
   std::vector<std::string> getIncludedWindowNames() const;
-  /// Get the name value of all items with a given check state
+  /// Get the name value of all items with a given check state in the given tree
   std::vector<std::string>
-  getItemsWithCheckState(const Qt::CheckState state) const;
+  getItemsWithCheckState(const QTreeWidget &tree,
+                         const Qt::CheckState state) const;
   /// Remove an item from a QTreeWidget
   void removeItem(QTreeWidget *widget, const std::string &name);
   /// Add an new window item QTreeWidget
@@ -115,6 +126,8 @@ private:
 
   /// List of windows to be serialised
   std::vector<MantidQt::API::IProjectSerialisable *> m_serialisableWindows;
+  /// List of possible python interfaces to save
+  std::vector<std::string> m_allPythonInterfaces;
   /// Handle to the presenter for this view
   std::unique_ptr<ProjectSavePresenter> m_presenter;
   /// Handle to the project serialiser

--- a/MantidPlot/src/ProjectSerialiser.cpp
+++ b/MantidPlot/src/ProjectSerialiser.cpp
@@ -1,10 +1,13 @@
+// clang-format off
+#include "PythonScripting.h"
+// clang-format on
+
 #include "ProjectSerialiser.h"
 #include "ApplicationWindow.h"
 #include "Folder.h"
 #include "Graph3D.h"
 #include "Matrix.h"
 #include "Note.h"
-#include "PythonScripting.h"
 #include "ScriptingWindow.h"
 #include "TableStatistics.h"
 #include "WindowFactory.h"
@@ -69,7 +72,7 @@ PyObject *callPythonModuleAttr(const char *moduleName, const char *attrName,
     PyErr_Fetch(&exception, &value, &traceback);
     PyErr_Clear();
     auto msg = PyObject_Str(value);
-    auto msgAsCstr = PyString_AsString(msg);
+    auto msgAsCstr = TO_CSTRING(msg);
     Py_DecRef(msg);
     const auto lineno(
         reinterpret_cast<PyTracebackObject *>(traceback)->tb_lineno);
@@ -736,7 +739,7 @@ ProjectSerialiser::savePythonInterface(const QString &launcherModuleName) {
   ScopedGIL<PythonGIL> gil;
   auto state = callPythonModuleAttr(launcherModuleName.toLatin1().data(),
                                     "saveToProject", nullptr);
-  if (!PyString_Check(state)) {
+  if (!STR_CHECK(state)) {
     Py_XDECREF(state);
     throw std::runtime_error("saveToProject() did not return a string.");
   }
@@ -746,7 +749,7 @@ ProjectSerialiser::savePythonInterface(const QString &launcherModuleName) {
       .append(">\n")
       .append(launcherModuleName)
       .append("\n")
-      .append(PyString_AsString(state))
+      .append(TO_CSTRING(state))
       .append("\n")
       .append("</")
       .append(PY_INTERFACE_SECTION)

--- a/MantidPlot/src/ProjectSerialiser.cpp
+++ b/MantidPlot/src/ProjectSerialiser.cpp
@@ -90,14 +90,13 @@ PyObject *callPythonModuleAttr(const char *moduleName, const char *attrName,
     moduleAttr = throwIfPythonError(
         PyObject_GetAttrString(launcher, const_cast<char *>(attrName)));
     callResult = throwIfPythonError(PyObject_CallObject(moduleAttr, arg));
-    Py_DECREF(callResult);
-    Py_DECREF(moduleAttr);
-    Py_DECREF(launcher);
+    Py_XDECREF(moduleAttr);
+    Py_XDECREF(launcher);
     return callResult;
   } catch (std::runtime_error &) {
-    Py_DECREF(callResult);
-    Py_DECREF(moduleAttr);
-    Py_DECREF(launcher);
+    Py_XDECREF(callResult);
+    Py_XDECREF(moduleAttr);
+    Py_XDECREF(launcher);
     throw;
   }
 }
@@ -1067,13 +1066,17 @@ void ProjectSerialiser::loadPythonInterface(
 
   ScopedGIL<PythonGIL> gil;
   PyObject *fnArg = Py_BuildValue("(s)", pySection.c_str());
+  PyObject *result(nullptr);
   try {
-    callPythonModuleAttr(launcherModuleName.c_str(), "loadFromProject", fnArg);
+    result = callPythonModuleAttr(launcherModuleName.c_str(), "loadFromProject",
+                                  fnArg);
   } catch (std::runtime_error &) {
     Py_DECREF(fnArg);
+    Py_XDECREF(result);
     throw;
   }
   Py_DECREF(fnArg);
+  Py_XDECREF(result);
 }
 
 /**

--- a/MantidPlot/src/ProjectSerialiser.h
+++ b/MantidPlot/src/ProjectSerialiser.h
@@ -57,6 +57,8 @@ using groupNameToWsNamesT =
 class ProjectSerialiser : public QObject {
   Q_OBJECT
 public:
+  static QStringList serialisablePythonInterfaces();
+
   /// Create a new serialiser with the current application window
   explicit ProjectSerialiser(ApplicationWindow *window);
   explicit ProjectSerialiser(ApplicationWindow *window, Folder *folder);
@@ -67,7 +69,8 @@ public:
 
   /// Save the current state of the project to disk
   bool save(const QString &projectName, const std::vector<std::string> &wsNames,
-            const std::vector<std::string> &windowNames, bool compress = false);
+            const std::vector<std::string> &windowNames,
+            const std::vector<std::string> &interfaces, bool compress = false);
   bool save(const QString &projectName, bool compress = false,
             bool saveAll = true);
   /// Load a project file from disk
@@ -95,6 +98,8 @@ private:
   std::vector<std::string> m_windowNames;
   /// Vector of names of workspaces to save to file
   std::vector<std::string> m_workspaceNames;
+  /// Vector of names of python interfaces to save to file
+  std::vector<std::string> m_interfacesNames;
   /// Store a count of the number of windows during saving
   int m_windowCount;
   /// Flag to check if we should save all workspaces

--- a/MantidPlot/src/ProjectSerialiser.h
+++ b/MantidPlot/src/ProjectSerialiser.h
@@ -125,6 +125,10 @@ private:
   QString saveWorkspaces();
   /// Save additional windows
   QString saveAdditionalWindows();
+  /// Save Python interfaces
+  QString savePythonInterfaces();
+  /// Save Python interfaces
+  QString savePythonInterface(const QString &launcherModuleName);
 
   // Loading Functions
 

--- a/MantidPlot/src/ProjectSerialiser.h
+++ b/MantidPlot/src/ProjectSerialiser.h
@@ -155,6 +155,11 @@ private:
   void loadWsToMantidTree(const std::string &wsName);
   /// Load additional windows (e.g. slice viewer)
   void loadAdditionalWindows(const std::string &lines, const int fileVersion);
+  /// Load any PythonInterfaces in the project
+  void loadPythonInterfaces(const std::string &lines);
+  /// Load a single Python interface
+  void loadPythonInterface(const std::string &launcherModuleName,
+                           const std::string &pySection);
 
   // Misc functions
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IProjectSaveView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IProjectSaveView.h
@@ -45,10 +45,17 @@ class IProjectSaveView {
 public:
   /// Get all window handles passed to the view
   virtual std::vector<MantidQt::API::IProjectSerialisable *> getWindows() = 0;
+  /// Get all active python interfaces names passed to the view
+  virtual std::vector<std::string> getAllPythonInterfaces() = 0;
+
   /// Get the names of all checked workspaces
   virtual std::vector<std::string> getCheckedWorkspaceNames() = 0;
   /// Get the names of all unchecked workspaces
   virtual std::vector<std::string> getUncheckedWorkspaceNames() = 0;
+  /// Get any checked interface names on the view
+  virtual std::vector<std::string> getCheckedPythonInterfaces() = 0;
+  /// Get any unchecked interface names on the view
+  virtual std::vector<std::string> getUncheckedPythonInterfaces() = 0;
   /// Get the project path
   virtual QString getProjectPath() = 0;
   /// Set the project path
@@ -56,6 +63,9 @@ public:
   /// Update the workspaces list with a collection of workspace info items
   virtual void
   updateWorkspacesList(const std::vector<WorkspaceInfo> &workspaces) = 0;
+  /// Update the list of interfaces
+  virtual void
+  updateInterfacesList(const std::vector<std::string> &interfaces) = 0;
   /// Update the included windows list with a collection of window info items
   virtual void
   updateIncludedWindowsList(const std::vector<WindowInfo> &windows) = 0;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ProjectSaveModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ProjectSaveModel.h
@@ -40,7 +40,9 @@ struct WindowInfo {
 class EXPORT_OPT_MANTIDQT_COMMON ProjectSaveModel {
 public:
   /// Construct a new model instance with vector of window handles
-  ProjectSaveModel(std::vector<MantidQt::API::IProjectSerialisable *> windows);
+  ProjectSaveModel(std::vector<MantidQt::API::IProjectSerialisable *> windows,
+                   std::vector<std::string> activePythonInterfaces =
+                       std::vector<std::string>());
 
   /// Check if a workspace has any windows attached to it
   bool hasWindows(const std::string &ws) const;
@@ -49,6 +51,8 @@ public:
   getWindowNames(const std::vector<std::string> &wsNames) const;
   /// Get all workspace names
   std::vector<std::string> getWorkspaceNames() const;
+  /// Return the list of python interfaces that can be saved
+  std::vector<std::string> getAllPythonInterfaces() const;
   /// Get all window information for a collection of workspaces
   std::vector<WindowInfo>
   getWindowInformation(const std::vector<std::string> &wsNames,
@@ -80,6 +84,7 @@ private:
       m_workspaceWindows;
 
   std::vector<MantidQt::API::IProjectSerialisable *> m_unattachedWindows;
+  std::vector<std::string> m_activePythonInterfaces;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/src/ProjectSaveModel.cpp
+++ b/qt/widgets/common/src/ProjectSaveModel.cpp
@@ -14,9 +14,12 @@ using namespace MantidQt::MantidWidgets;
 /**
  * Construct a new model with a list of window handles
  * @param windows :: vector of handles to windows open in Mantid
+ * @param activePythonInterfaces The list of active Python interfaces
  */
 ProjectSaveModel::ProjectSaveModel(
-    std::vector<IProjectSerialisable *> windows) {
+    std::vector<IProjectSerialisable *> windows,
+    std::vector<std::string> activePythonInterfaces)
+    : m_activePythonInterfaces(std::move(activePythonInterfaces)) {
   auto workspaces = getWorkspaces();
   for (auto &ws : workspaces) {
     std::pair<std::string, std::vector<IProjectSerialisable *>> item(
@@ -110,6 +113,14 @@ std::vector<std::string> ProjectSaveModel::getWorkspaceNames() const {
 
   std::sort(names.begin(), names.end());
   return names;
+}
+
+/**
+ * Get all workspace names in the model
+ * @return vector of all python interfaces names in the model
+ */
+std::vector<std::string> ProjectSaveModel::getAllPythonInterfaces() const {
+  return m_activePythonInterfaces;
 }
 
 /**

--- a/qt/widgets/common/src/ProjectSavePresenter.cpp
+++ b/qt/widgets/common/src/ProjectSavePresenter.cpp
@@ -2,10 +2,12 @@
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/Workspace.h"
 
+#include <QApplication>
 #include <QDir>
 #include <QFileInfo>
 
 #include <algorithm>
+#include <iostream>
 #include <iterator>
 #include <vector>
 
@@ -17,12 +19,14 @@ using namespace Mantid::API;
  * @param view :: a handle to a view for this presenter
  */
 ProjectSavePresenter::ProjectSavePresenter(IProjectSaveView *view)
-    : m_view(view), m_model(m_view->getWindows()) {
+    : m_view(view),
+      m_model(m_view->getWindows(), m_view->getAllPythonInterfaces()) {
   auto workspaceNames = m_model.getWorkspaceNames();
   auto info = m_model.getWorkspaceInformation();
   auto winInfo = m_model.getWindowInformation(workspaceNames, true);
   m_view->updateIncludedWindowsList(winInfo);
   m_view->updateWorkspacesList(info);
+  m_view->updateInterfacesList(m_model.getAllPythonInterfaces());
 }
 
 /**

--- a/qt/widgets/common/test/ProjectSaveMockObjects.h
+++ b/qt/widgets/common/test/ProjectSaveMockObjects.h
@@ -15,11 +15,15 @@ GNU_DIAG_OFF_SUGGEST_OVERRIDE
 class MockProjectSaveView : public IProjectSaveView {
 public:
   MOCK_METHOD0(getWindows, std::vector<IProjectSerialisable *>());
+  MOCK_METHOD0(getAllPythonInterfaces, std::vector<std::string>());
   MOCK_METHOD0(getCheckedWorkspaceNames, std::vector<std::string>());
   MOCK_METHOD0(getUncheckedWorkspaceNames, std::vector<std::string>());
+  MOCK_METHOD0(getCheckedPythonInterfaces, std::vector<std::string>());
+  MOCK_METHOD0(getUncheckedPythonInterfaces, std::vector<std::string>());
   MOCK_METHOD0(getProjectPath, QString());
   MOCK_METHOD1(setProjectPath, void(const QString &));
   MOCK_METHOD1(updateWorkspacesList, void(const std::vector<WorkspaceInfo> &));
+  MOCK_METHOD1(updateInterfacesList, void(const std::vector<std::string> &));
   MOCK_METHOD1(updateIncludedWindowsList,
                void(const std::vector<WindowInfo> &));
   MOCK_METHOD1(updateExcludedWindowsList,

--- a/qt/widgets/common/test/ProjectSaveModelTest.h
+++ b/qt/widgets/common/test/ProjectSaveModelTest.h
@@ -101,6 +101,18 @@ public:
     TS_ASSERT_EQUALS(names[1], "ws2");
   }
 
+  void testGetInterfaceNames() {
+    std::vector<MantidQt::API::IProjectSerialisable *> windows;
+    std::vector<std::string> interfaces{"Test_Interface",
+                                        "Test_Python_Interface_2"};
+
+    ProjectSaveModel model(windows, interfaces);
+    auto names = model.getAllPythonInterfaces();
+    TS_ASSERT_EQUALS(2, names.size());
+    TS_ASSERT_EQUALS("Test_Interface", names[0]);
+    TS_ASSERT_EQUALS("Test_Python_Interface_2", names[1]);
+  }
+
   void testGetWindowNames() {
     std::vector<MantidQt::API::IProjectSerialisable *> windows;
 

--- a/qt/widgets/common/test/ProjectSavePresenterTest.h
+++ b/qt/widgets/common/test/ProjectSavePresenterTest.h
@@ -96,8 +96,9 @@ public:
     tearDownWorkspaces(workspaces);
   }
 
-  void testConstructWithOneWorkspaceAndOneWindow() {
+  void testConstructWithOneWorkspaceAndOneWindowOneInterface() {
     auto workspaces = setUpWorkspaces({"ws1"});
+    std::vector<std::string> interfaces{"Interface_1"};
 
     WindowInfo info;
     info.name = "WindowName1Workspace";
@@ -109,8 +110,10 @@ public:
     // View should be passed what workspaces exist and what windows
     // are currently included.
     ON_CALL(m_view, getWindows()).WillByDefault(Return(windows));
+    ON_CALL(m_view, getAllPythonInterfaces()).WillByDefault(Return(interfaces));
     EXPECT_CALL(m_view, getWindows()).WillOnce(Return(windows));
     EXPECT_CALL(m_view, updateWorkspacesList(workspaces)).Times(Exactly(1));
+    EXPECT_CALL(m_view, updateInterfacesList(interfaces)).Times(Exactly(1));
     EXPECT_CALL(m_view, updateIncludedWindowsList(winInfo)).Times(Exactly(1));
 
     ProjectSavePresenter presenter(&m_view);


### PR DESCRIPTION
**Description of work.**

Adds a mechanism for pure-Python interfaces to save to the MantidPlot project file.

Note that no interface is currently set up to save. This simply implements the hooks to allow this to be possible.

**Report to:** [nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

* Code review
* Optionally, replace the `scripts/Frequency_Domain_Analysis.py` file with the following content:

```python
#pylint: disable=invalid-name
from __future__ import (absolute_import, division, print_function)

import sys

import PyQt4.QtGui as QtGui

from Muon.GUI.FrequencyDomainAnalysis.Transform.transform_widget import TransformWidget
from Muon.GUI.Common import load_utils
from Muon.GUI.Common import message_box


class FrequencyDomainAnalysisGui(QtGui.QMainWindow):
    def __init__(self,parent=None):
        super(FrequencyDomainAnalysisGui,self).__init__(parent)

        load = load_utils.LoadUtils()
        if not load.MuonAnalysisExists:
            return
        self.transform = TransformWidget(load = load, parent = self)

        self.setCentralWidget(self.transform.widget)
        self.setWindowTitle("Frequency Domain Analysis")

    # cancel algs if window is closed
    def closeEvent(self,event):
        self.transform.closeEvent(event)


QAPP = None

def qapp():
    global QAPP
    if QAPP is None:
        QAPP = QtGui.QApplication(sys.argv)
    return QAPP


def main():
    app = qapp()
    try:
        ex= FrequencyDomainAnalysisGui()
        ex.resize(700, 700)
        ex.show()
        app.exec_()
    except RuntimeError as error:
        message_box.warning(str(error))


def saveToProject():
    return "state from interface"


def loadFromProject(section):
    print("Loading FDA")
    print(section)


if __name__ == '__main__':
    main()
```

and add `Frequency_Domain_Analysis` to the [list](https://github.com/mantidproject/mantid/compare/master...martyngigg:project-save-python-interfaces?expand=1#diff-6bd08622a7fd56fd11bc014ef19d0a66R121) and recompile. See then that project save and load prints the values from the functions.

Fixes #23234 

<!-- delete this if you added release notes
*This does not require release notes* because **it is part of a larger issue and notes will be added then.**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
