### PR TITLE
Updated default settings in GUI 

### DIFF
--- a/docs/source/release/v3.14.0/sans.rst
+++ b/docs/source/release/v3.14.0/sans.rst
@@ -6,7 +6,7 @@ SANS Changes
    :local:
 
 ISIS SANS Interface
-----------------------------
+-------------------
 New
 ###
 
@@ -17,5 +17,6 @@ Bug fixes
 #########
 * Fixed an issue where the run tab was difficult to select.
 * Changed the geometry names from CylinderAxisUP, Cuboid and CylinderAxisAlong to Cylinder, FlatPlate and Disc
+* The GUI now correctly resets to default values when a new user file is loaded.
 
 :ref:`Release 3.14.0 <v3.14.0>`

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -1693,6 +1693,7 @@ class SANSDataProcessorGui(QtGui.QMainWindow, ui_sans_data_processor_window.Ui_S
         self.merged_shift_use_fit_check_box.setChecked(False)
         self.merged_scale_use_fit_check_box.setChecked(False)
 
+        self.event_binning_group_box.setChecked(False)
         self.slice_event_line_edit.setText("")
         self.event_binning_line_edit.setText("")
 
@@ -1724,17 +1725,48 @@ class SANSDataProcessorGui(QtGui.QMainWindow, ui_sans_data_processor_window.Ui_S
         self.transmission_roi_files_line_edit.setText("")
         self.transmission_mask_files_line_edit.setText("")
 
+        self.fit_selection_combo_box.setCurrentIndex(0)
+        self.fit_sample_use_fit_check_box.setChecked(False)
+        self.fit_sample_fit_type_combo_box.setCurrentIndex(0)
+        self.fit_sample_polynomial_order_spin_box.setValue(2)
+        self.fit_sample_wavelength_combo_box.setChecked(False)
+        self.fit_sample_wavelength_min_line_edit.setText("")
+        self.fit_sample_wavelength_max_line_edit.setText("")
+
+        self.fit_can_use_fit_check_box.setChecked(False)
+        self.fit_can_fit_type_combo_box.setCurrentIndex(0)
+        self.fit_can_polynomial_order_spin_box.setValue(2)
+        self.fit_can_wavelength_combo_box.setChecked(False)
+        self.fit_can_wavelength_min_line_edit.setText("")
+        self.fit_can_wavelength_max_line_edit.setText("")
+
+        self.show_transmission_view.setChecked(True)
+
         self.pixel_adjustment_det_1_line_edit.setText("")
         self.pixel_adjustment_det_2_line_edit.setText("")
 
         self.wavelength_adjustment_det_1_line_edit.setText("")
         self.wavelength_adjustment_det_2_line_edit.setText("")
-
-        self.show_transmission_view.setChecked(True)
-
         # --------------------------------
         # Q tab
         # --------------------------------
+
+        self.radius_limit_min_line_edit.setText("")
+        self.radius_limit_max_line_edit.setText("")
+
+        self.phi_limit_min_line_edit.setText("-90")
+        self.phi_limit_max_line_edit.setText("90")
+        self.phi_limit_use_mirror_check_box.setChecked(True)
+
+        self.wavelength_min_line_edit.setText("")
+        self.wavelength_max_line_edit.setText("")
+        self.wavelength_slices_line_edit.setText("")
+        self.wavelength_step_line_edit.setText("")
+        self.wavelength_step_type_combo_box.setCurrentIndex(0)
+
+        self.r_cut_line_edit.setText("")
+        self.w_cut_line_edit.setText("")
+
         self.q_1d_min_line_edit.setText("")
         self.q_1d_max_line_edit.setText("")
         self.q_1d_step_line_edit.setText("")
@@ -1758,6 +1790,8 @@ class SANSDataProcessorGui(QtGui.QMainWindow, ui_sans_data_processor_window.Ui_S
         self.q_resolution_delta_r_line_edit.setText("")
         self.q_resolution_collimation_length_line_edit.setText("")
         self.q_resolution_moderator_file_line_edit.setText("")
+
+        self.mask_file_input_line_edit.setText("")
 
     # ------------------------------------------------------------------------------------------------------------------
     # Table interaction

--- a/scripts/SANS/sans/gui_logic/models/state_gui_model.py
+++ b/scripts/SANS/sans/gui_logic/models/state_gui_model.py
@@ -1059,7 +1059,7 @@ class StateGuiModel(object):
 
     @property
     def phi_limit_min(self):
-        return self.get_simple_element_with_attribute(element_id=LimitsId.angle, attribute="min", default_value="")
+        return self.get_simple_element_with_attribute(element_id=LimitsId.angle, attribute="min", default_value="-90")
 
     @phi_limit_min.setter
     def phi_limit_min(self, value):
@@ -1067,7 +1067,7 @@ class StateGuiModel(object):
 
     @property
     def phi_limit_max(self):
-        return self.get_simple_element_with_attribute(element_id=LimitsId.angle, attribute="max", default_value="")
+        return self.get_simple_element_with_attribute(element_id=LimitsId.angle, attribute="max", default_value="90")
 
     @phi_limit_max.setter
     def phi_limit_max(self, value):
@@ -1075,7 +1075,7 @@ class StateGuiModel(object):
 
     @property
     def phi_limit_use_mirror(self):
-        return self.get_simple_element_with_attribute(element_id=LimitsId.angle, attribute="use_mirror", default_value=False)  # noqa
+        return self.get_simple_element_with_attribute(element_id=LimitsId.angle, attribute="use_mirror", default_value=True)  # noqa
 
     @phi_limit_use_mirror.setter
     def phi_limit_use_mirror(self, value):

--- a/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
@@ -122,7 +122,7 @@ class RunTabPresenterTest(unittest.TestCase):
         self.assertTrue(view.q_resolution_delta_r == 11.)
         self.assertTrue(view.q_resolution_collimation_length == 12.)
         self.assertTrue(view.q_resolution_moderator_file == "moderator_rkh_file.txt")
-        self.assertFalse(view.phi_limit_use_mirror)
+        self.assertTrue(view.phi_limit_use_mirror)
         self.assertTrue(view.radius_limit_min == 12.)
         self.assertTrue(view.radius_limit_min == 12.)
         self.assertTrue(view.radius_limit_max == 15.)

--- a/scripts/test/SANS/gui_logic/state_gui_model_test.py
+++ b/scripts/test/SANS/gui_logic/state_gui_model_test.py
@@ -512,11 +512,11 @@ class StateGuiModelTest(unittest.TestCase):
     # ------------------------------------------------------------------------------------------------------------------
     # Phi mask
     # ------------------------------------------------------------------------------------------------------------------
-    def test_that_phi_mask_defaults_to_empty_and_false_for_use_mirror(self):
+    def test_that_phi_mask_defaults_to_90_and_true_for_use_mirror(self):
         state_gui_model = StateGuiModel({"test": [1]})
-        self.assertTrue(state_gui_model.phi_limit_min == "")
-        self.assertTrue(state_gui_model.phi_limit_max == "")
-        self.assertFalse(state_gui_model.phi_limit_use_mirror)
+        self.assertTrue(state_gui_model.phi_limit_min == "-90")
+        self.assertTrue(state_gui_model.phi_limit_max == "90")
+        self.assertTrue(state_gui_model.phi_limit_use_mirror)
 
     def test_that_phi_mask_can_be_set(self):
         state_gui_model = StateGuiModel({"test": [1]})


### PR DESCRIPTION
**Description of work.**
The ISIS SANS GUI was not resetting some of its fields back to their defaults when a new user file was loaded. The default for phi masking was also wrong.

**Report to:** sarah<!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**
* Open the SANS GUI
* Go to the settings tab and check the options in the adjustment tab check that the phi values are set to -90, 90 with mirror segments ticked.
* Set the instrument to LOQ and load MaskFile.txt from below as the user file.
[loqdemo.zip](https://github.com/mantidproject/mantid/files/2306664/loqdemo.zip)
* Go to the settings tab and change a load of stuff
* Reload the user file and check that all the values you had changed reset.


<!-- Instructions for testing. -->

Fixes #23295 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->
This change has been added to the release notes as a bug fix
<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
