### PR TITLE
Add support for fat events to AlignAndFocusPowder

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
@@ -17,8 +17,8 @@ PROPS_FOR_ALIGN = [CAL_FILE, GROUP_FILE,
                    MASK_WKSP, "MaskBinTable",
                    "Params", "ResampleX", "Dspacing", "DMin", "DMax",
                    "TMin", "TMax", "PreserveEvents",
-                   "RemovePromptPulseWidth", "CompressTolerance",
-                   "UnwrapRef", "LowResRef",
+                   "RemovePromptPulseWidth", "CompressTolerance", "CompressWallClockTolerance",
+                   "CompressStartTime", "UnwrapRef", "LowResRef",
                    "CropWavelengthMin", "CropWavelengthMax",
                    "LowResSpectrumOffset", "ReductionProperties"]
 PROPS_FOR_ALIGN.extend(PROPS_FOR_INSTR)

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -10,7 +10,9 @@
 #include "MantidDataObjects/TableWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidKernel/ArrayProperty.h"
+#include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/ConfigService.h"
+#include "MantidKernel/DateTimeValidator.h"
 #include "MantidKernel/EnabledWhenProperty.h"
 #include "MantidKernel/InstrumentInfo.h"
 #include "MantidKernel/PropertyManager.h"
@@ -116,10 +118,30 @@ void AlignAndFocusPowder::init() {
                   "Width of events (in "
                   "microseconds) near the prompt "
                   "pulse to remove. 0 disables");
-  declareProperty("CompressTolerance", 0.01,
+  auto mustBePositive = boost::make_shared<BoundedValidator<double>>();
+  mustBePositive->setLower(0.0);
+  declareProperty(make_unique<PropertyWithValue<double>>("CompressTolerance",
+                                                         1e-5, mustBePositive,
+                                                         Direction::Input),
                   "Compress events (in "
                   "microseconds) within this "
-                  "tolerance. (Default 0.01) ");
+                  "tolerance. (Default 0.01)");
+  declareProperty(
+      make_unique<PropertyWithValue<double>>("CompressWallClockTolerance",
+                                             EMPTY_DBL(), mustBePositive,
+                                             Direction::Input),
+      "The tolerance (in seconds) on the wall-clock time for comparison. Unset "
+      "means compressing all wall-clock times together disabling pulsetime "
+      "resolution.");
+
+  auto dateValidator = boost::make_shared<DateTimeValidator>();
+  dateValidator->allowEmpty(true);
+  declareProperty(
+      "CompressStartTime", "", dateValidator,
+      "An ISO formatted date/time string specifying the timestamp for "
+      "starting filtering. Ignored if WallClockTolerance is not specified. "
+      "Default is start of run",
+      Direction::Input);
   declareProperty("UnwrapRef", 0.,
                   "Reference total flight path for frame "
                   "unwrapping. Zero skips the correction");
@@ -358,14 +380,22 @@ void AlignAndFocusPowder::exec() {
   if (m_inputEW) {
     double tolerance = getProperty("CompressTolerance");
     if (tolerance > 0.) {
-      g_log.information() << "running CompressEvents(Tolerance=" << tolerance
-                          << ") started at "
+      double wallClockTolerance = getProperty("CompressWallClockTolerance");
+      g_log.information() << "running CompressEvents(Tolerance=" << tolerance;
+      if (!isEmpty(wallClockTolerance))
+        g_log.information() << " and WallClockTolerance=" << wallClockTolerance;
+      g_log.information() << ") started at "
                           << Types::Core::DateAndTime::getCurrentTime() << "\n";
       API::IAlgorithm_sptr compressAlg = createChildAlgorithm("CompressEvents");
       compressAlg->setProperty("InputWorkspace", m_outputEW);
       compressAlg->setProperty("OutputWorkspace", m_outputEW);
       compressAlg->setProperty("OutputWorkspace", m_outputEW);
       compressAlg->setProperty("Tolerance", tolerance);
+      if (!isEmpty(wallClockTolerance)) {
+        compressAlg->setProperty("WallClockTolerance", wallClockTolerance);
+        compressAlg->setPropertyValue("StartTime",
+                                      getPropertyValue("CompressStartTime"));
+      }
       compressAlg->executeAsChildAlg();
       m_outputEW = compressAlg->getProperty("OutputWorkspace");
       m_outputW = boost::dynamic_pointer_cast<MatrixWorkspace>(m_outputEW);
@@ -649,14 +679,22 @@ void AlignAndFocusPowder::exec() {
   double tolerance = getProperty("CompressTolerance");
   m_outputEW = boost::dynamic_pointer_cast<EventWorkspace>(m_outputW);
   if ((m_outputEW) && (tolerance > 0.)) {
-    g_log.information() << "running CompressEvents(Tolerance=" << tolerance
-                        << ") started at "
+    double wallClockTolerance = getProperty("CompressWallClockTolerance");
+    g_log.information() << "running CompressEvents(Tolerance=" << tolerance;
+    if (!isEmpty(wallClockTolerance))
+      g_log.information() << " and WallClockTolerance=" << wallClockTolerance;
+    g_log.information() << ") started at "
                         << Types::Core::DateAndTime::getCurrentTime() << "\n";
     API::IAlgorithm_sptr compressAlg = createChildAlgorithm("CompressEvents");
     compressAlg->setProperty("InputWorkspace", m_outputEW);
     compressAlg->setProperty("OutputWorkspace", m_outputEW);
     compressAlg->setProperty("OutputWorkspace", m_outputEW);
     compressAlg->setProperty("Tolerance", tolerance);
+    if (!isEmpty(wallClockTolerance)) {
+      compressAlg->setProperty("WallClockTolerance", wallClockTolerance);
+      compressAlg->setPropertyValue("StartTime",
+                                    getPropertyValue("CompressStartTime"));
+    }
     compressAlg->executeAsChildAlg();
     m_outputEW = compressAlg->getProperty("OutputWorkspace");
     m_outputW = boost::dynamic_pointer_cast<MatrixWorkspace>(m_outputEW);

--- a/docs/source/release/v3.14.0/diffraction.rst
+++ b/docs/source/release/v3.14.0/diffraction.rst
@@ -13,6 +13,7 @@ Improvements
 ############
 
 - :ref:`SNAPReduce <algm-SNAPReduce>` now has progress bar and all output workspaces have history
+- :ref:`AlignAndFocusPowder <algm-AlignAndFocusPowder>` and :ref:`AlignAndFocusPowderFromFiles <algm-AlignAndFocusPowderFromFiles>` now support weighted events (with time). This allows for event filtering **after** processing the data.
 - :ref:`LoadWAND <algm-LoadWAND>` has grouping option added and loads faster
 - Mask workspace option added to :ref:`WANDPowderReduction <algm-WANDPowderReduction>`
 
@@ -31,4 +32,3 @@ Bugfixes
 ########
 
 - :ref:`CentroidPeaksMD <algm-CentroidPeaksMD>` now updates peak bin counts.
-


### PR DESCRIPTION
This was done by adding two more properties which allow specifying the
wall-clock tolerance. If those properties aren't set then the old
behavior is retained.

**Report to:** @wdzhou and @marshallmcdonnell.

**To test:**

Run `AlignAndFocusPowderFromFiles` (or `AlignAndFocusPowder`) with and without the wall-clock tolerance specified. With a wall-clock tolerance should have more events.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
