### PR TITLE
Add optional output UnfocussedWorkspace to AlignAndFocusPowder

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
@@ -96,6 +96,18 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
         self.copyProperties("AlignAndFocusPowder", PROPS_FOR_ALIGN)
         self.copyProperties('PDDetermineCharacterizations', PROPS_FOR_PD_CHARACTER)
 
+    def validateInputs(self):
+        errors = dict()
+
+        unfocusname = self.getPropertyValue('UnfocussedWorkspace')
+        if len(unfocusname) > 0:
+            finalname = self.getPropertyValue('OutputWorkspace')
+            if unfocusname == finalname:
+                errors["OutputWorkspace"] = "Cannot be the same as UnfocussedWorkspace"
+                errors["UnfocussedWorkspace"] = "Cannot be the same as OutputWorkspace"
+
+        return errors
+
     def _getLinearizedFilenames(self, propertyName):
         runnumbers = self.getProperty(propertyName).value
         linearizedRuns = []
@@ -258,7 +270,7 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
         self.chunkSize = self.getProperty('MaxChunkSize').value
         self.absorption = self.getProperty('AbsorptionWorkspace').value
         self.charac = self.getProperty('Characterizations').value
-        finalname = self.getProperty('OutputWorkspace').valueAsStr
+        finalname = self.getPropertyValue('OutputWorkspace')
         useCaching = len(self.getProperty('CacheDir').value) > 0
 
         # accumulate the unfocused workspace if it was requested

--- a/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
@@ -87,6 +87,7 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
         self.declareProperty(MatrixWorkspaceProperty('OutputWorkspace', '',
                                                      Direction.Output),
                              doc='Combined output workspace')
+        self.copyProperties('AlignAndFocusPowder', ['UnfocussedWorkspace'])
 
         self.declareProperty(ITableWorkspaceProperty('Characterizations', '',
                                                      Direction.Input, PropertyMode.Optional),
@@ -188,15 +189,19 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
                                    OtherProperties=alignandfocusargs,
                                    CacheDir=cachedir).OutputFilename
 
-    def __processFile(self, filename, wkspname, file_prog_start, determineCharacterizations):
+    def __processFile(self, filename, wkspname, unfocusname, file_prog_start, determineCharacterizations):
         chunks = determineChunking(filename, self.chunkSize)
-        self.log().information('Processing \'%s\' in %d chunks' % (filename, len(chunks)))
-        prog_per_chunk_step = self.prog_per_file * 1./(6.*float(len(chunks))) # for better progress reporting - 6 steps per chunk
+        numSteps = 6 # for better progress reporting - 6 steps per chunk
+        if unfocusname != '':
+            numSteps = 7 # one more for accumulating the unfocused workspace
+        self.log().information('Processing \'{}\' in {:d} chunks'.format(filename, len(chunks)))
+        prog_per_chunk_step = self.prog_per_file * 1./(numSteps*float(len(chunks)))
 
         # inner loop is over chunks
         for (j, chunk) in enumerate(chunks):
-            prog_start = file_prog_start + float(j) * 5. * prog_per_chunk_step
-            chunkname = "%s_c%d" % (wkspname, j)
+            prog_start = file_prog_start + float(j) * float(numSteps - 1) * prog_per_chunk_step
+            chunkname = '{}_c{:d}'.format(wkspname, j)
+            unfocusname_chunk = '{}_c{:d}'.format(unfocusname, j)
             Load(Filename=filename, OutputWorkspace=chunkname,
                  startProgress=prog_start, endProgress=prog_start+prog_per_chunk_step,
                  **chunk)
@@ -221,7 +226,7 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
                              Target='TOF', EMode='Elastic')
             prog_start += prog_per_chunk_step
 
-            AlignAndFocusPowder(InputWorkspace=chunkname, OutputWorkspace=chunkname,
+            AlignAndFocusPowder(InputWorkspace=chunkname, OutputWorkspace=chunkname, UnfocussedWorkspace=unfocusname_chunk,
                                 startProgress=prog_start, endProgress=prog_start+2.*prog_per_chunk_step,
                                 **self.kwargs)
             prog_start += 2.*prog_per_chunk_step # AlignAndFocusPowder counts for two steps
@@ -229,11 +234,20 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
             if j == 0:
                 self.__updateAlignAndFocusArgs(chunkname)
                 RenameWorkspace(InputWorkspace=chunkname, OutputWorkspace=wkspname)
+                if unfocusname != '':
+                    RenameWorkspace(InputWorkspace=unfocusname_chunk, OutputWorkspace=unfocusname)
             else:
                 Plus(LHSWorkspace=wkspname, RHSWorkspace=chunkname, OutputWorkspace=wkspname,
                      ClearRHSWorkspace=self.kwargs['PreserveEvents'],
                      startProgress=prog_start, endProgress=prog_start+prog_per_chunk_step)
                 DeleteWorkspace(Workspace=chunkname)
+
+                if unfocusname != '':
+                    Plus(LHSWorkspace=unfocusname, RHSWorkspace=unfocusname_chunk, OutputWorkspace=unfocusname,
+                         ClearRHSWorkspace=self.kwargs['PreserveEvents'],
+                         startProgress=prog_start, endProgress=prog_start + prog_per_chunk_step)
+                    DeleteWorkspace(Workspace=unfocusname_chunk)
+
                 if self.kwargs['PreserveEvents']:
                     CompressEvents(InputWorkspace=wkspname, OutputWorkspace=wkspname)
         # end of inner loop
@@ -247,7 +261,18 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
         finalname = self.getProperty('OutputWorkspace').valueAsStr
         useCaching = len(self.getProperty('CacheDir').value) > 0
 
-        if not useCaching:
+        # accumulate the unfocused workspace if it was requested
+        # empty string means it is not used
+        unfocusname = self.getPropertyValue('UnfocussedWorkspace')
+        unfocusname_file = ''
+        if len(unfocusname) > 0:
+            unfocusname_file = '__{}_partial'.format(unfocusname)
+
+        if useCaching:
+            # unfocus check only matters if caching is requested
+            if unfocusname != '':
+                self.log().warning('CacheDir is specified with "UnfocussedWorkspace" - reading cache files disabled')
+        else:
             self.log().warning('CacheDir is not specified - functionality disabled')
 
         self.prog_per_file = 1./float(len(filenames)) # for better progress reporting
@@ -269,7 +294,9 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
 
             wkspname += '_f%d' % i # add file number to be unique
 
-            if useCaching and os.path.exists(cachefile):
+            # if the unfocussed data is requested, don't read it from disk
+            # because of the extra complication of the unfocussed workspace
+            if useCaching and os.path.exists(cachefile) and unfocusname == '':
                 LoadNexusProcessed(Filename=cachefile, OutputWorkspace=wkspname)
                 # TODO LoadNexusProcessed has a bug. When it finds the
                 # instrument name without xml it reads in from an IDF
@@ -282,8 +309,10 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
                 if editinstrargs:
                     EditInstrumentGeometry(Workspace=wkspname, **editinstrargs)
             else:
-                self.__processFile(filename, wkspname, self.prog_per_file*float(i), not useCaching)
+                self.__processFile(filename, wkspname, unfocusname_file, self.prog_per_file*float(i), not useCaching)
 
+                # write out the cachefile for the main reduced data independent of whether
+                # the unfocussed workspace was requested
                 if useCaching:
                     SaveNexusProcessed(InputWorkspace=wkspname, Filename=cachefile)
 
@@ -291,12 +320,22 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
             if i == 0:
                 if wkspname != finalname:
                     RenameWorkspace(InputWorkspace=wkspname, OutputWorkspace=finalname)
+                if unfocusname != '':
+                    RenameWorkspace(InputWorkspace=unfocusname_file, OutputWorkspace=unfocusname)
             else:
                 Plus(LHSWorkspace=finalname, RHSWorkspace=wkspname, OutputWorkspace=finalname,
                      ClearRHSWorkspace=self.kwargs['PreserveEvents'])
                 DeleteWorkspace(Workspace=wkspname)
+
+                if unfocusname != '':
+                    Plus(LHSWorkspace=unfocusname, RHSWorkspace=unfocusname_file, OutputWorkspace=unfocusname,
+                         ClearRHSWorkspace=self.kwargs['PreserveEvents'])
+                    DeleteWorkspace(Workspace=unfocusname_file)
+
                 if self.kwargs['PreserveEvents']:
                     CompressEvents(InputWorkspace=finalname, OutputWorkspace=finalname)
+                    # not compressing unfocussed workspace because it is in d-spacing
+                    # and is likely to be from a different part of the instrument
 
         # with more than one chunk or file the integrated proton charge is
         # generically wrong
@@ -304,6 +343,8 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
 
         # set the output workspace
         self.setProperty('OutputWorkspace', mtd[finalname])
+        if unfocusname != '':
+            self.setProperty('UnfocussedWorkspace', mtd[unfocusname])
 
 
 # Register algorithm with Mantid.

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/AlignAndFocusPowder.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/AlignAndFocusPowder.h
@@ -81,6 +81,8 @@ public:
            "according to a grouping scheme defined in a CalFile.";
   }
 
+  std::map<std::string, std::string> validateInputs() override;
+
 private:
   // Overridden Algorithm methods
   void init() override;

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -44,6 +44,11 @@ void AlignAndFocusPowder::init() {
   declareProperty(make_unique<WorkspaceProperty<MatrixWorkspace>>(
                       "OutputWorkspace", "", Direction::Output),
                   "The result of diffraction focussing of InputWorkspace");
+  declareProperty(
+      make_unique<WorkspaceProperty<MatrixWorkspace>>(
+          "UnfocussedWorkspace", "", Direction::Output, PropertyMode::Optional),
+      "Treated data in d-spacing before focussing (optional). This will likely "
+      "need rebinning.");
   // declareProperty(
   //   new WorkspaceProperty<MatrixWorkspace>("LowResTOFWorkspace", "",
   //   Direction::Output, PropertyMode::Optional),
@@ -157,6 +162,20 @@ void AlignAndFocusPowder::init() {
                   "Otherwise, the low resolution spectra will have spectrum "
                   "IDs offset from normal ones. ");
   declareProperty("ReductionProperties", "__powdereduction", Direction::Input);
+}
+
+std::map<std::string, std::string> AlignAndFocusPowder::validateInputs() {
+  std::map<std::string, std::string> result;
+
+  if (!isDefault("UnfocussedWorkspace")) {
+    if (getPropertyValue("OutputWorkspace") ==
+        getPropertyValue("UnfocussedWorkspace")) {
+      result["OutputWorkspace"] = "Cannot be the same as UnfocussedWorkspace";
+      result["UnfocussedWorkspace"] = "Cannot be the same as OutputWorkspace";
+    }
+  }
+
+  return result;
 }
 
 template <typename NumT> struct RegLowVectorPair {
@@ -587,6 +606,13 @@ void AlignAndFocusPowder::exec() {
   if (m_processLowResTOF)
     doSortEvents(m_lowResW);
   m_progress->report();
+
+  // copy the output workspace just before `DiffractionFocusing`
+  // this probably should be binned by callers before inspecting
+  if (!isDefault("UnfocussedWorkspace")) {
+    auto wkspCopy = m_outputW->clone();
+    setProperty("UnfocussedWorkspace", std::move(wkspCopy));
+  }
 
   // Diffraction focus
   m_outputW = diffractionFocus(m_outputW);

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -130,7 +130,7 @@ void AlignAndFocusPowder::init() {
                                                          Direction::Input),
                   "Compress events (in "
                   "microseconds) within this "
-                  "tolerance. (Default 0.01)");
+                  "tolerance. (Default 1e-5)");
   declareProperty(
       make_unique<PropertyWithValue<double>>("CompressWallClockTolerance",
                                              EMPTY_DBL(), mustBePositive,

--- a/docs/source/release/v3.14.0/diffraction.rst
+++ b/docs/source/release/v3.14.0/diffraction.rst
@@ -13,6 +13,7 @@ Improvements
 ############
 
 - :ref:`SNAPReduce <algm-SNAPReduce>` now has progress bar and all output workspaces have history
+- :ref:`AlignAndFocusPowder <algm-AlignAndFocusPowder>` and :ref:`AlignAndFocusPowderFromFiles <algm-AlignAndFocusPowderFromFiles>` now support outputting the unfocussed data.
 - :ref:`LoadWAND <algm-LoadWAND>` has grouping option added and loads faster
 - Mask workspace option added to :ref:`WANDPowderReduction <algm-WANDPowderReduction>`
 


### PR DESCRIPTION
This is in preparation of refactoring `SNAPReduce` to use `AlignAndFocusPowder` as an underlying algorithm. One of the big features that is missing from the algorithms is the ability to get the corrected, unfocussed data out of the algorithm. Rather than running the algorithm twice (once with and without grouping), just output the intermediate workspace.

**To test:**

Reduce data using `AlignAndFocusPowder` and `AlignAndFocusPowderFromFiles` with and without specifying the `UnfocussedWorkspace`. The extra workspace should have spectra for every detector (in d-spacing), where the `OutputWorkspace` should only have the grouped spectra (in time-of-flight).

*There is no associated issue.*

Do not merge into `master` before ~~#23312~~.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
