### PR TITLE
Obey skipTests method in dynamic CxxTest test suites

### DIFF
--- a/Testing/Tools/cxxtest/cxxtest/RealDescriptions.h
+++ b/Testing/Tools/cxxtest/cxxtest/RealDescriptions.h
@@ -181,7 +181,7 @@ namespace CxxTest
         }
         _TS_CATCH_ABORT( { return false; } );
 
-        return (suite() != 0);
+        return (suite() != 0) && !suite()->skipTests();
     }
 
     template<class S>


### PR DESCRIPTION
**Description of work.**

The `skipTests` method was being ignored for any unit test suite that contained `createSuite/destroySuite` methods. This fixes the issue in our copy of `cxxtest` as apparently we added the `skipTests` behaviour. This was found after #23287 was merged and some ICat tests failed on a machine that is unable to connect to the ISIS server.

**Report to:** [nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

* Build the ICat test suite
* disconnect network cable/wireless
*  Run the ICat tests (`ctest -R ICat -V`) and they should all record as passed. The verbose output should say they were skipped.

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **this is a developer issue**.
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
