### PR TITLE
FindReflectometryLines version 2

### DIFF
--- a/Framework/Algorithms/CMakeLists.txt
+++ b/Framework/Algorithms/CMakeLists.txt
@@ -137,6 +137,7 @@ set ( SRC_FILES
 	src/FindEPP.cpp
 	src/FindPeakBackground.cpp
 	src/FindPeaks.cpp
+	src/FindReflectometryLines2.cpp
 	src/FitPeak.cpp
 	src/FitPeaks.cpp
 	src/FixGSASInstrumentFile.cpp
@@ -462,6 +463,7 @@ set ( INC_FILES
 	inc/MantidAlgorithms/FindEPP.h
 	inc/MantidAlgorithms/FindPeakBackground.h
 	inc/MantidAlgorithms/FindPeaks.h
+	inc/MantidAlgorithms/FindReflectometryLines2.h
 	inc/MantidAlgorithms/FitPeak.h
 	inc/MantidAlgorithms/FitPeaks.h
 	inc/MantidAlgorithms/FixGSASInstrumentFile.h
@@ -799,6 +801,7 @@ set ( TEST_FILES
 	FindEPPTest.h
 	FindPeakBackgroundTest.h
 	FindPeaksTest.h
+	FindReflectometryLines2Test.h
 	FitPeakTest.h
 	FitPeaksTest.h
 	FixGSASInstrumentFileTest.h

--- a/Framework/Algorithms/inc/MantidAlgorithms/FindReflectometryLines2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FindReflectometryLines2.h
@@ -1,8 +1,8 @@
 #ifndef MANTID_ALGORITHMS_FINDREFLECTOMETRYLINES2_H_
 #define MANTID_ALGORITHMS_FINDREFLECTOMETRYLINES2_H_
 
-#include "MantidAlgorithms/DllConfig.h"
 #include "MantidAPI/Algorithm.h"
+#include "MantidAlgorithms/DllConfig.h"
 
 namespace Mantid {
 namespace Algorithms {

--- a/Framework/Algorithms/inc/MantidAlgorithms/FindReflectometryLines2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FindReflectometryLines2.h
@@ -1,0 +1,53 @@
+#ifndef MANTID_ALGORITHMS_FINDREFLECTOMETRYLINES2_H_
+#define MANTID_ALGORITHMS_FINDREFLECTOMETRYLINES2_H_
+
+#include "MantidAlgorithms/DllConfig.h"
+#include "MantidAPI/Algorithm.h"
+
+namespace Mantid {
+namespace Algorithms {
+
+/** FindReflectometryLines2 : Finds fractional workspace index
+  corresponding to reflected or direct line in a line detector workspace.
+
+  Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class MANTID_ALGORITHMS_DLL FindReflectometryLines2 : public API::Algorithm {
+public:
+  const std::string name() const override;
+  int version() const override;
+  const std::string category() const override;
+  const std::string summary() const override;
+
+private:
+  void init() override;
+  std::map<std::string, std::string> validateInputs() override;
+  void exec() override;
+  double findPeak(API::MatrixWorkspace_sptr &ws);
+  API::MatrixWorkspace_sptr integrate(API::MatrixWorkspace_sptr &ws);
+  API::MatrixWorkspace_sptr transpose(API::MatrixWorkspace_sptr &ws);
+};
+
+} // namespace Algorithms
+} // namespace Mantid
+
+#endif /* MANTID_ALGORITHMS_FINDREFLECTOMETRYLINES2_H_ */

--- a/Framework/Algorithms/src/FindReflectometryLines2.cpp
+++ b/Framework/Algorithms/src/FindReflectometryLines2.cpp
@@ -107,7 +107,7 @@ std::map<std::string, std::string> FindReflectometryLines2::validateInputs() {
   std::map<std::string, std::string> issues;
   if (!isDefault(Prop::RANGE_LOWER) && !isDefault(Prop::RANGE_UPPER)) {
     double const lower = getProperty(Prop::RANGE_LOWER);
-    double const upper = getProperty(Prop::RANGE_LOWER);
+    double const upper = getProperty(Prop::RANGE_UPPER);
     if (lower >= upper) {
       issues[Prop::RANGE_UPPER] = "The upper limit is smaller than the lower.";
     }
@@ -157,18 +157,19 @@ double FindReflectometryLines2::findPeak(API::MatrixWorkspace_sptr &ws) {
   double const centreIndex = static_cast<double>(maxIndex);
   int const startIndex = getProperty(Prop::START_INDEX);
   double const centreByMax = static_cast<double>(startIndex) + centreIndex;
-  g_log.debug() << "Peak maximum position: " << centreByMax << '\n';
+  g_log.debug() << "Line maximum position: " << centreByMax << '\n';
   // determine sigma
-  auto lessThanHalfMax =
-      [height, medianY](double const x) { return x - medianY < 0.5 * (height - medianY); };
+  auto lessThanHalfMax = [height, medianY](double const x) {
+    return x - medianY < 0.5 * (height - medianY);
+  };
   using IterType = HistogramData::HistogramY::const_iterator;
   std::reverse_iterator<IterType> revMaxValueIt{maxValueIt};
   auto revMinFwhmIt = std::find_if(revMaxValueIt, Ys.crend(), lessThanHalfMax);
   auto maxFwhmIt = std::find_if(maxValueIt, Ys.cend(), lessThanHalfMax);
   std::reverse_iterator<IterType> revMaxFwhmIt{maxFwhmIt};
   if (revMinFwhmIt == Ys.crend() || maxFwhmIt == Ys.cend()) {
-    g_log.warning() << "Couldn't determine fwhm of beam, using position of max "
-                       "value as beam center.\n";
+    g_log.warning() << "Couldn't determine fwhm of line, using position of max "
+                       "value as line center.\n";
     return centreByMax;
   }
   double const fwhm =
@@ -204,7 +205,7 @@ double FindReflectometryLines2::findPeak(API::MatrixWorkspace_sptr &ws) {
   }
   auto const centreByFit = gaussian->centre() + static_cast<double>(startIndex);
   g_log.debug() << "Sigma: " << gaussian->fwhm() << '\n';
-  g_log.debug() << "Estimated peak position: " << centreByFit << '\n';
+  g_log.debug() << "Estimated line position: " << centreByFit << '\n';
   return centreByFit;
 }
 

--- a/Framework/Algorithms/src/FindReflectometryLines2.cpp
+++ b/Framework/Algorithms/src/FindReflectometryLines2.cpp
@@ -1,0 +1,235 @@
+#include "MantidAlgorithms/FindReflectometryLines2.h"
+
+#include "MantidAPI/CompositeFunction.h"
+#include "MantidAPI/FunctionFactory.h"
+#include "MantidAPI/IPeakFunction.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidDataObjects/WorkspaceSingleValue.h"
+#include "MantidKernel/BoundedValidator.h"
+
+namespace {
+namespace Prop {
+std::string const END_INDEX{"EndWorkspaceIndex"};
+std::string const INPUT_WS{"InputWorkspace"};
+std::string const LINE_CENTRE{"LineCentre"};
+std::string const OUTPUT_WS{"OutputWorkspace"};
+std::string const RANGE_LOWER{"RangeLower"};
+std::string const RANGE_UPPER{"RangeUpper"};
+std::string const START_INDEX{"StartWorkspaceIndex"};
+}
+
+void clearIntegrationLimits(Mantid::API::MatrixWorkspace &ws) {
+  for (size_t i = 0; i < ws.getNumberHistograms(); ++i) {
+    auto &Xs = ws.mutableX(i);
+    Xs.front() = 0.;
+    Xs.back() = 1.;
+  }
+}
+
+/** Fill the X values of the first histogram of ws with workspace indices.
+ *  @param ws a workspace to modify
+ */
+void convertXToWorkspaceIndex(Mantid::API::MatrixWorkspace &ws) {
+  auto &xs = ws.mutableX(0);
+  std::iota(xs.begin(), xs.end(), 0.);
+}
+
+Mantid::API::MatrixWorkspace_sptr makeOutput(double const x) {
+  auto ws = boost::make_shared<Mantid::DataObjects::WorkspaceSingleValue>(x);
+  return boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(ws);
+}
+}
+
+namespace Mantid {
+namespace Algorithms {
+
+using Mantid::Kernel::Direction;
+using Mantid::API::WorkspaceProperty;
+
+// Register the algorithm into the AlgorithmFactory
+DECLARE_ALGORITHM(FindReflectometryLines2)
+
+/// Algorithms name for identification. @see Algorithm::name
+const std::string FindReflectometryLines2::name() const {
+  return "FindReflectometryLines";
+}
+
+/// Algorithm's version for identification. @see Algorithm::version
+int FindReflectometryLines2::version() const { return 2; }
+
+/// Algorithm's category for identification. @see Algorithm::category
+const std::string FindReflectometryLines2::category() const {
+  return "Reflectometry;ILL\\Reflectometry";
+}
+
+/// Algorithm's summary for use in the GUI and help. @see Algorithm::summary
+const std::string FindReflectometryLines2::summary() const {
+  return "Finds fractional workspace index corresponding to reflected or "
+         "direct line in a line detector workspace.";
+}
+
+/** Initialize the algorithm's properties.
+ */
+void FindReflectometryLines2::init() {
+  declareProperty(Kernel::make_unique<WorkspaceProperty<API::MatrixWorkspace>>(
+                      Prop::INPUT_WS, "", Direction::Input),
+                  "A reflectometry workspace.");
+  declareProperty(
+      Kernel::make_unique<WorkspaceProperty<API::MatrixWorkspace>>(
+          Prop::OUTPUT_WS, "", Direction::Output, API::PropertyMode::Optional),
+      "A workspaced containing the fractional workspace index of "
+      "the line centre.");
+  declareProperty(Prop::LINE_CENTRE, EMPTY_DBL(),
+                  "The fractional workspace index of the line centre",
+                  Direction::Output);
+  declareProperty(Prop::RANGE_LOWER, EMPTY_DBL(),
+                  "The lower peak search limit (an X value).");
+  declareProperty(Prop::RANGE_UPPER, EMPTY_DBL(),
+                  "The upper peak search limit (an X value).");
+  auto mustBePositive = boost::make_shared<Kernel::BoundedValidator<int>>();
+  mustBePositive->setLower(0);
+  declareProperty(
+      Prop::START_INDEX, 0, mustBePositive,
+      "Index of the first histogram to include in the peak search.");
+  declareProperty(Prop::END_INDEX, EMPTY_INT(), mustBePositive,
+                  "Index of the last histogram to include in the peak search.");
+}
+
+std::map<std::string, std::string> FindReflectometryLines2::validateInputs() {
+  std::map<std::string, std::string> issues;
+  if (!isDefault(Prop::RANGE_LOWER) && !isDefault(Prop::RANGE_UPPER)) {
+    double const lower = getProperty(Prop::RANGE_LOWER);
+    double const upper = getProperty(Prop::RANGE_LOWER);
+    if (lower >= upper) {
+      issues[Prop::RANGE_UPPER] = "The upper limit is smaller than the lower.";
+    }
+  }
+  if (!isDefault(Prop::END_INDEX)) {
+    int const start = getProperty(Prop::START_INDEX);
+    int const end = getProperty(Prop::END_INDEX);
+    if (start > end) {
+      issues[Prop::END_INDEX] = "The index is smaller than the start.";
+    }
+  }
+  return issues;
+}
+
+/** Execute the algorithm.
+ */
+void FindReflectometryLines2::exec() {
+  API::MatrixWorkspace_sptr inputWS = getProperty(Prop::INPUT_WS);
+  double const peakWSIndex = findPeak(inputWS);
+  setProperty(Prop::LINE_CENTRE, peakWSIndex);
+  if (!isDefault(Prop::OUTPUT_WS)) {
+    auto outputWS = makeOutput(peakWSIndex);
+    setProperty(Prop::OUTPUT_WS, outputWS);
+  }
+}
+
+/**
+  * Gaussian fit to determine peak position if no user position given.
+  *
+  * @return :: detector position of the peak: Gaussian fit and position
+  * of the maximum (serves as start value for the optimization)
+  */
+double FindReflectometryLines2::findPeak(API::MatrixWorkspace_sptr &ws) {
+  auto integralWS = integrate(ws);
+  // integralWS may be ragged due to different integration limits for each
+  // histogram. We don't really care but Transpose does.
+  clearIntegrationLimits(*integralWS);
+  auto transposedWS = transpose(integralWS);
+  convertXToWorkspaceIndex(*transposedWS);
+  // determine initial height: maximum value
+  auto const &Ys = transposedWS->y(0);
+  auto const maxValueIt = std::max_element(Ys.cbegin(), Ys.cend());
+  double const height = *maxValueIt;
+  // determine initial centre: index of the maximum value
+  size_t const maxIndex = std::distance(Ys.cbegin(), maxValueIt);
+  double const centreIndex = static_cast<double>(maxIndex);
+  int const startIndex = getProperty(Prop::START_INDEX);
+  double const centreByMax = static_cast<double>(startIndex) + centreIndex;
+  g_log.debug() << "Peak maximum position: " << centreByMax << '\n';
+  // determine sigma
+  auto lessThanHalfMax = [height](double const x) { return x < 0.5 * height; };
+  using IterType = HistogramData::HistogramY::const_iterator;
+  std::reverse_iterator<IterType> revMaxValueIt{maxValueIt};
+  auto revMinFwhmIt = std::find_if(revMaxValueIt, Ys.crend(), lessThanHalfMax);
+  auto maxFwhmIt = std::find_if(maxValueIt, Ys.cend(), lessThanHalfMax);
+  std::reverse_iterator<IterType> revMaxFwhmIt{maxFwhmIt};
+  if (revMinFwhmIt == Ys.crend() || maxFwhmIt == Ys.cend()) {
+    g_log.warning() << "Couldn't determine fwhm of beam, using position of max "
+                       "value as beam center.\n";
+    return centreByMax;
+  }
+  double const fwhm =
+      static_cast<double>(std::distance(revMaxFwhmIt, revMinFwhmIt) + 1);
+  g_log.debug() << "Initial fwhm (full width at half maximum): " << fwhm
+                << '\n';
+  auto func =
+      API::FunctionFactory::Instance().createFunction("CompositeFunction");
+  auto sum = boost::dynamic_pointer_cast<API::CompositeFunction>(func);
+  func = API::FunctionFactory::Instance().createFunction("Gaussian");
+  auto gaussian = boost::dynamic_pointer_cast<API::IPeakFunction>(func);
+  gaussian->setHeight(height);
+  gaussian->setCentre(centreIndex);
+  gaussian->setFwhm(fwhm);
+  sum->addFunction(gaussian);
+  func = API::FunctionFactory::Instance().createFunction("LinearBackground");
+  func->setParameter("A0", 0.);
+  func->setParameter("A1", 0.);
+  sum->addFunction(func);
+  // call Fit child algorithm
+  API::IAlgorithm_sptr fit = createChildAlgorithm("Fit");
+  fit->initialize();
+  fit->setProperty("Function",
+                   boost::dynamic_pointer_cast<API::IFunction>(sum));
+  fit->setProperty("InputWorkspace", transposedWS);
+  fit->setProperty("StartX", centreIndex - 3 * fwhm);
+  fit->setProperty("EndX", centreIndex + 3 * fwhm);
+  fit->execute();
+  std::string const fitStatus = fit->getProperty("OutputStatus");
+  if (fitStatus != "success") {
+    g_log.warning("Fit not successful, using position of max value.\n");
+    return centreByMax;
+  }
+  auto const centreByFit = gaussian->centre() + static_cast<double>(startIndex);
+  g_log.debug() << "Sigma: " << gaussian->fwhm() << '\n';
+  g_log.debug() << "Estimated peak position: " << centreByFit << '\n';
+  return centreByFit;
+}
+
+API::MatrixWorkspace_sptr
+FindReflectometryLines2::integrate(API::MatrixWorkspace_sptr &ws) {
+  int const startIndex = getProperty(Prop::START_INDEX);
+  int const endIndex = getProperty(Prop::END_INDEX);
+  double const startX = getProperty(Prop::RANGE_LOWER);
+  double const endX = getProperty(Prop::RANGE_UPPER);
+  API::IAlgorithm_sptr integration = createChildAlgorithm("Integration");
+  integration->initialize();
+  integration->setProperty("InputWorkspace", ws);
+  integration->setProperty("OutputWorkspace", "__unused_for_child");
+  integration->setProperty("RangeLower", startX);
+  integration->setProperty("RangeUpper", endX);
+  integration->setProperty("StartWorkspaceIndex", startIndex);
+  integration->setProperty("EndWorkspaceIndex", endIndex);
+  integration->execute();
+  API::MatrixWorkspace_sptr integralWS =
+      integration->getProperty("OutputWorkspace");
+  return integralWS;
+}
+
+API::MatrixWorkspace_sptr
+FindReflectometryLines2::transpose(API::MatrixWorkspace_sptr &ws) {
+  API::IAlgorithm_sptr transpose = createChildAlgorithm("Transpose");
+  transpose->initialize();
+  transpose->setProperty("InputWorkspace", ws);
+  transpose->setProperty("OutputWorkspace", "__unused_for_child");
+  transpose->execute();
+  API::MatrixWorkspace_sptr transposedWS =
+      transpose->getProperty("OutputWorkspace");
+  return transposedWS;
+}
+
+} // namespace Algorithms
+} // namespace Mantid

--- a/Framework/Algorithms/src/FindReflectometryLines2.cpp
+++ b/Framework/Algorithms/src/FindReflectometryLines2.cpp
@@ -19,7 +19,7 @@ std::string const OUTPUT_WS{"OutputWorkspace"};
 std::string const RANGE_LOWER{"RangeLower"};
 std::string const RANGE_UPPER{"RangeUpper"};
 std::string const START_INDEX{"StartWorkspaceIndex"};
-}
+} // namespace Prop
 
 /** Set the first bin edge to 0 and last to 1.
  *  @param ws a preferably single bin workspace
@@ -58,7 +58,7 @@ Mantid::API::MatrixWorkspace_sptr makeOutput(double const x) {
   auto ws = boost::make_shared<Mantid::DataObjects::WorkspaceSingleValue>(x);
   return boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(ws);
 }
-}
+} // namespace
 
 namespace Mantid {
 namespace Algorithms {
@@ -87,12 +87,14 @@ const std::string FindReflectometryLines2::summary() const {
 
 /// Initialize the algorithm's properties.
 void FindReflectometryLines2::init() {
-  declareProperty(Kernel::make_unique<API::WorkspaceProperty<API::MatrixWorkspace>>(
-                      Prop::INPUT_WS, "", Kernel::Direction::Input),
-                  "A reflectometry workspace.");
   declareProperty(
       Kernel::make_unique<API::WorkspaceProperty<API::MatrixWorkspace>>(
-          Prop::OUTPUT_WS, "", Kernel::Direction::Output, API::PropertyMode::Optional),
+          Prop::INPUT_WS, "", Kernel::Direction::Input),
+      "A reflectometry workspace.");
+  declareProperty(
+      Kernel::make_unique<API::WorkspaceProperty<API::MatrixWorkspace>>(
+          Prop::OUTPUT_WS, "", Kernel::Direction::Output,
+          API::PropertyMode::Optional),
       "A workspaced containing the fractional workspace index of "
       "the line centre.");
   declareProperty(Prop::LINE_CENTRE, EMPTY_DBL(),

--- a/Framework/Algorithms/test/FindReflectometryLines2Test.h
+++ b/Framework/Algorithms/test/FindReflectometryLines2Test.h
@@ -1,0 +1,57 @@
+#ifndef MANTID_ALGORITHMS_FINDREFLECTOMETRYLINES2TEST_H_
+#define MANTID_ALGORITHMS_FINDREFLECTOMETRYLINES2TEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAlgorithms/FindReflectometryLines2.h"
+
+using Mantid::Algorithms::FindReflectometryLines2;
+
+class FindReflectometryLines2Test : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static FindReflectometryLines2Test *createSuite() { return new FindReflectometryLines2Test(); }
+  static void destroySuite( FindReflectometryLines2Test *suite ) { delete suite; }
+
+
+  void test_Init()
+  {
+    FindReflectometryLines2 alg;
+    TS_ASSERT_THROWS_NOTHING( alg.initialize() )
+    TS_ASSERT( alg.isInitialized() )
+  }
+
+  void test_exec()
+  {
+    /*// Create test input if necessary
+    MatrixWorkspace_sptr inputWS = //-- Fill in appropriate code. Consider using TestHelpers/WorkspaceCreationHelpers.h --
+
+    FindReflectometryLines2 alg;
+    // Don't put output in ADS by default
+    alg.setChild(true);
+    TS_ASSERT_THROWS_NOTHING( alg.initialize() )
+    TS_ASSERT( alg.isInitialized() )
+    TS_ASSERT_THROWS_NOTHING( alg.setProperty("InputWorkspace", inputWS) );
+    TS_ASSERT_THROWS_NOTHING( alg.setPropertyValue("OutputWorkspace", "_unused_for_child") );
+    TS_ASSERT_THROWS_NOTHING( alg.execute(); );
+    TS_ASSERT( alg.isExecuted() );
+
+    // Retrieve the workspace from the algorithm. The type here will probably need to change. It should
+    // be the type using in declareProperty for the "OutputWorkspace" type.
+    // We can't use auto as it's an implicit conversion.
+    Workspace_sptr outputWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outputWS);*/
+    TS_FAIL("TODO: Check the results and remove this line");
+  }
+  
+  void test_Something()
+  {
+    TS_FAIL( "You forgot to write a test!");
+  }
+
+
+};
+
+
+#endif /* MANTID_ALGORITHMS_FINDREFLECTOMETRYLINES2TEST_H_ */

--- a/Framework/Algorithms/test/FindReflectometryLines2Test.h
+++ b/Framework/Algorithms/test/FindReflectometryLines2Test.h
@@ -5,53 +5,218 @@
 
 #include "MantidAlgorithms/FindReflectometryLines2.h"
 
-using Mantid::Algorithms::FindReflectometryLines2;
+#include "MantidAPI/FrameworkManager.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidHistogramData/LinearGenerator.h"
+
+using namespace Mantid;
 
 class FindReflectometryLines2Test : public CxxTest::TestSuite {
 public:
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests
-  static FindReflectometryLines2Test *createSuite() { return new FindReflectometryLines2Test(); }
-  static void destroySuite( FindReflectometryLines2Test *suite ) { delete suite; }
+  static FindReflectometryLines2Test *createSuite() {
+    return new FindReflectometryLines2Test();
+  }
+  static void destroySuite(FindReflectometryLines2Test *suite) { delete suite; }
 
-
-  void test_Init()
-  {
-    FindReflectometryLines2 alg;
-    TS_ASSERT_THROWS_NOTHING( alg.initialize() )
-    TS_ASSERT( alg.isInitialized() )
+  FindReflectometryLines2Test() : CxxTest::TestSuite() {
+    API::FrameworkManager::Instance();
   }
 
-  void test_exec()
-  {
-    /*// Create test input if necessary
-    MatrixWorkspace_sptr inputWS = //-- Fill in appropriate code. Consider using TestHelpers/WorkspaceCreationHelpers.h --
+  void test_init() {
+    Algorithms::FindReflectometryLines2 alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+  }
 
-    FindReflectometryLines2 alg;
-    // Don't put output in ADS by default
+  void test_simplePeakSucceeds() {
+    constexpr size_t nBins{256};
+    constexpr size_t nHisto{128};
+    auto ws = emptyWorkspace(nHisto, nBins);
+    constexpr double verticalCentre = static_cast<double>(nHisto) / 3.4;
+    constexpr double verticalWidth = static_cast<double>(nHisto) / 20.;
+    double const horizontalCentre = ws->x(0).back() / 1.5;
+    double const horizontalWidth = ws->x(0).back() / 2.5;
+    addReflectometryLine(*ws, horizontalCentre, horizontalWidth, verticalCentre,
+                         verticalWidth);
+    Algorithms::FindReflectometryLines2 alg;
     alg.setChild(true);
-    TS_ASSERT_THROWS_NOTHING( alg.initialize() )
-    TS_ASSERT( alg.isInitialized() )
-    TS_ASSERT_THROWS_NOTHING( alg.setProperty("InputWorkspace", inputWS) );
-    TS_ASSERT_THROWS_NOTHING( alg.setPropertyValue("OutputWorkspace", "_unused_for_child") );
-    TS_ASSERT_THROWS_NOTHING( alg.execute(); );
-    TS_ASSERT( alg.isExecuted() );
-
-    // Retrieve the workspace from the algorithm. The type here will probably need to change. It should
-    // be the type using in declareProperty for the "OutputWorkspace" type.
-    // We can't use auto as it's an implicit conversion.
-    Workspace_sptr outputWS = alg.getProperty("OutputWorkspace");
-    TS_ASSERT(outputWS);*/
-    TS_FAIL("TODO: Check the results and remove this line");
-  }
-  
-  void test_Something()
-  {
-    TS_FAIL( "You forgot to write a test!");
+    alg.setRethrows(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", ws))
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", "_unused_for_child"))
+    TS_ASSERT_THROWS_NOTHING(alg.execute())
+    TS_ASSERT(alg.isExecuted())
+    API::MatrixWorkspace_sptr outputWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outputWS);
+    double const lineCentre = alg.getProperty("LineCentre");
+    TS_ASSERT_EQUALS(outputWS->y(0)[0], lineCentre)
+    TS_ASSERT_DELTA(lineCentre, verticalCentre, 1e-8)
   }
 
+  void test_StartEndWorkspaceIndicesWithTwoPeaks() {
+    constexpr size_t nBins{256};
+    constexpr size_t nHisto{128};
+    auto ws = emptyWorkspace(nHisto, nBins);
+    std::array<double, 2> const verticalCentres{
+        {static_cast<double>(nHisto) / 3.,
+         static_cast<double>(nHisto) * 2. / 3.}};
+    constexpr double verticalWidth = static_cast<double>(nHisto) / 20.;
+    double const horizontalCentre = ws->x(0).back() / 1.5;
+    double const horizontalWidth = ws->x(0).back() / 2.5;
+    addReflectometryLine(*ws, horizontalCentre, horizontalWidth,
+                         verticalCentres.front(), verticalWidth);
+    addReflectometryLine(*ws, horizontalCentre, horizontalWidth,
+                         verticalCentres.back(), verticalWidth);
+    for (auto const centre : verticalCentres) {
+      Algorithms::FindReflectometryLines2 alg;
+      alg.setChild(true);
+      alg.setRethrows(true);
+      TS_ASSERT_THROWS_NOTHING(alg.initialize())
+      TS_ASSERT(alg.isInitialized())
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", ws))
+      TS_ASSERT_THROWS_NOTHING(
+          alg.setPropertyValue("OutputWorkspace", "_unused_for_child"))
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty(
+          "StartWorkspaceIndex", static_cast<int>(centre - 2 * verticalWidth)))
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty(
+          "EndWorkspaceIndex", static_cast<int>(centre + 2 * verticalWidth)))
+      TS_ASSERT_THROWS_NOTHING(alg.execute())
+      TS_ASSERT(alg.isExecuted())
+      API::MatrixWorkspace_sptr outputWS = alg.getProperty("OutputWorkspace");
+      TS_ASSERT(outputWS);
+      double const lineCentre = alg.getProperty("LineCentre");
+      TS_ASSERT_EQUALS(outputWS->y(0)[0], lineCentre)
+      TS_ASSERT_DELTA(lineCentre, centre, 1e-8)
+    }
+  }
 
+  void test_RangeLowerAndUpperWithTwoPeaks() {
+    constexpr size_t nBins{256};
+    constexpr size_t nHisto{128};
+    auto ws = emptyWorkspace(nHisto, nBins);
+    std::array<double, 2> const verticalCentres{
+        {static_cast<double>(nHisto) / 3.,
+         static_cast<double>(nHisto) * 2. / 3.}};
+    constexpr double verticalWidth = static_cast<double>(nHisto) / 20.;
+    std::array<double, 2> const horizontalCentres{
+        {ws->x(0).back() / 4., ws->x(0).back() * 3. / 4.}};
+    double const horizontalWidth = ws->x(0).back() / 6.;
+    for (size_t i = 0; i < 2; ++i) {
+      addReflectometryLine(*ws, horizontalCentres[i], horizontalWidth,
+                           verticalCentres[i], verticalWidth);
+      addReflectometryLine(*ws, horizontalCentres[i], horizontalWidth,
+                           verticalCentres[i], verticalWidth);
+    }
+    std::array<double, 2> const lower{{0., 0.5 * ws->x(0).back()}};
+    std::array<double, 2> const upper{{0.5 * ws->x(0).back(), ws->x(0).back()}};
+    for (size_t i = 0; i < 2; ++i) {
+      Algorithms::FindReflectometryLines2 alg;
+      alg.setChild(true);
+      alg.setRethrows(true);
+      TS_ASSERT_THROWS_NOTHING(alg.initialize())
+      TS_ASSERT(alg.isInitialized())
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", ws))
+      TS_ASSERT_THROWS_NOTHING(
+          alg.setPropertyValue("OutputWorkspace", "_unused_for_child"))
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty("RangeLower", lower[i]))
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty("RangeUpper", upper[i]))
+      TS_ASSERT_THROWS_NOTHING(alg.execute())
+      TS_ASSERT(alg.isExecuted())
+      API::MatrixWorkspace_sptr outputWS = alg.getProperty("OutputWorkspace");
+      TS_ASSERT(outputWS);
+      double const lineCentre = alg.getProperty("LineCentre");
+      TS_ASSERT_EQUALS(outputWS->y(0)[0], lineCentre)
+      TS_ASSERT_DELTA(lineCentre, verticalCentres[i], 1e-8)
+    }
+  }
+
+  void test_invalidRangeLowerAndUpperThrows() {
+    constexpr size_t nBins{256};
+    constexpr size_t nHisto{128};
+    auto ws = emptyWorkspace(nHisto, nBins);
+    Algorithms::FindReflectometryLines2 alg;
+    alg.setChild(true);
+    alg.setRethrows(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", ws))
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", "_unused_for_child"))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("RangeLower", 2.))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("RangeUpper", 1.))
+    TS_ASSERT_THROWS_EQUALS(alg.execute(), std::runtime_error const &e,
+                            e.what(), std::string("Some invalid Properties found"))
+  }
+
+  void test_invalidEndAndStartIndicesThrows() {
+    constexpr size_t nBins{256};
+    constexpr size_t nHisto{128};
+    auto ws = emptyWorkspace(nHisto, nBins);
+    Algorithms::FindReflectometryLines2 alg;
+    alg.setChild(true);
+    alg.setRethrows(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", ws))
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", "_unused_for_child"))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("StartWorkspaceIndex", 2))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("EndWorkspaceIndex", 1))
+    TS_ASSERT_THROWS_EQUALS(alg.execute(), std::runtime_error const &e,
+                            e.what(), std::string("Some invalid Properties found"))
+  }
+
+private:
+  static void addReflectometryLine(API::MatrixWorkspace &ws,
+                                   double const horizontalCentre,
+                                   double const horizontalWidth,
+                                   double const verticalCentre,
+                                   double const verticalWidth) {
+    auto verticalFunction = [verticalCentre, verticalWidth](double const x) {
+      // Simple Gaussian ___.-^-.___
+      auto const arg = (x - verticalCentre) / verticalWidth;
+      return std::exp(-arg * arg);
+    };
+    auto horizontalFunction =
+        [horizontalCentre, horizontalWidth](double const x) {
+          // Ugly box function ___|^^^^|___
+          if (x >= horizontalCentre - horizontalWidth / 2. &&
+              x < horizontalCentre + horizontalWidth / 2.) {
+            return 1.;
+          } else {
+            return 0.;
+          }
+        };
+    for (size_t wsIndex = 0; wsIndex < ws.getNumberHistograms(); ++wsIndex) {
+      auto const &Xs = ws.x(wsIndex);
+      auto &Ys = ws.mutableY(wsIndex);
+      auto &Es = ws.mutableE(wsIndex);
+      for (size_t binIndex = 0; binIndex < Ys.size(); ++binIndex) {
+        auto const y = verticalFunction(static_cast<double>(wsIndex)) *
+                       horizontalFunction(Xs[binIndex]);
+        Ys[binIndex] += y;
+        auto const e = Es[binIndex];
+        Es[binIndex] = std::sqrt(e * e + y);
+      }
+    }
+  }
+
+  static API::MatrixWorkspace_sptr emptyWorkspace(size_t const nHisto,
+                                                 size_t const nBins) {
+    HistogramData::BinEdges const edges{
+        nBins + 1, HistogramData::LinearGenerator(0., 2.3)};
+    HistogramData::Counts const counts(nBins, 0.);
+    API::MatrixWorkspace_sptr ws =
+        DataObjects::create<DataObjects::Workspace2D>(
+            nHisto, HistogramData::Histogram(edges, counts));
+    return ws;
+  }
 };
-
 
 #endif /* MANTID_ALGORITHMS_FINDREFLECTOMETRYLINES2TEST_H_ */

--- a/Framework/Algorithms/test/FindReflectometryLines2Test.h
+++ b/Framework/Algorithms/test/FindReflectometryLines2Test.h
@@ -151,7 +151,8 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("RangeLower", 2.))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("RangeUpper", 1.))
     TS_ASSERT_THROWS_EQUALS(alg.execute(), std::runtime_error const &e,
-                            e.what(), std::string("Some invalid Properties found"))
+                            e.what(),
+                            std::string("Some invalid Properties found"))
   }
 
   void test_invalidEndAndStartIndicesThrows() {
@@ -169,7 +170,8 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("StartWorkspaceIndex", 2))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("EndWorkspaceIndex", 1))
     TS_ASSERT_THROWS_EQUALS(alg.execute(), std::runtime_error const &e,
-                            e.what(), std::string("Some invalid Properties found"))
+                            e.what(),
+                            std::string("Some invalid Properties found"))
   }
 
 private:
@@ -183,16 +185,16 @@ private:
       auto const arg = (x - verticalCentre) / verticalWidth;
       return std::exp(-arg * arg);
     };
-    auto horizontalFunction =
-        [horizontalCentre, horizontalWidth](double const x) {
-          // Ugly box function ___|^^^^|___
-          if (x >= horizontalCentre - horizontalWidth / 2. &&
-              x < horizontalCentre + horizontalWidth / 2.) {
-            return 1.;
-          } else {
-            return 0.;
-          }
-        };
+    auto horizontalFunction = [horizontalCentre,
+                               horizontalWidth](double const x) {
+      // Ugly box function ___|^^^^|___
+      if (x >= horizontalCentre - horizontalWidth / 2. &&
+          x < horizontalCentre + horizontalWidth / 2.) {
+        return 1.;
+      } else {
+        return 0.;
+      }
+    };
     for (size_t wsIndex = 0; wsIndex < ws.getNumberHistograms(); ++wsIndex) {
       auto const &Xs = ws.x(wsIndex);
       auto &Ys = ws.mutableY(wsIndex);
@@ -208,7 +210,7 @@ private:
   }
 
   static API::MatrixWorkspace_sptr emptyWorkspace(size_t const nHisto,
-                                                 size_t const nBins) {
+                                                  size_t const nBins) {
     HistogramData::BinEdges const edges{
         nBins + 1, HistogramData::LinearGenerator(0., 2.3)};
     HistogramData::Counts const counts(nBins, 0.);

--- a/Framework/Algorithms/test/FindReflectometryLines2Test.h
+++ b/Framework/Algorithms/test/FindReflectometryLines2Test.h
@@ -11,6 +11,8 @@
 #include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidHistogramData/LinearGenerator.h"
 
+#include <array>
+
 using namespace Mantid;
 
 class FindReflectometryLines2Test : public CxxTest::TestSuite {

--- a/Framework/HistogramData/inc/MantidHistogramData/LinearGenerator.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/LinearGenerator.h
@@ -6,7 +6,8 @@
 namespace Mantid {
 namespace HistogramData {
 
-/** LinearGenerator : TODO: DESCRIPTION
+/** LinearGenerator : A helper functor to generate linearly increasing
+  series of double values.
 
   Copyright &copy; 2016 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
   National Laboratory & European Spallation Source

--- a/Framework/PythonInterface/plugins/algorithms/FindReflectometryLines.py
+++ b/Framework/PythonInterface/plugins/algorithms/FindReflectometryLines.py
@@ -65,6 +65,8 @@ class FindReflectometryLines(PythonAlgorithm):
     def PyExec(self):
         import mantid.simpleapi as ms
 
+        self.log().warning('FindReflectometryLines algorithm version 1 has been deprecated and will be removed in a future release.')
+
         in_ws = self.getPropertyValue("InputWorkspace")
         min_wavelength = self.getPropertyValue("StartWavelength")
         keep_workspaces = self.getPropertyValue("KeepIntermediateWorkspaces")

--- a/Framework/PythonInterface/test/python/plugins/algorithms/FindReflectometryLinesTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/FindReflectometryLinesTest.py
@@ -52,7 +52,7 @@ class FindReflectometryLinesTest(unittest.TestCase):
         run_algorithm("CreateWorkspace", DataX=[0, 1], DataY=[0], DataE=[0], NSpec=1, UnitX=units, VerticalAxisUnit="SpectraNumber", OutputWorkspace="in_tof")
         try:
             # This should throw, because input units are in TOF, not wavelength!
-            alg = run_algorithm('FindReflectometryLines', InputWorkspace='in_tof' , OutputWorkspace='spectrum_numbers', child=True)
+            alg = run_algorithm('FindReflectometryLines', Version=1, InputWorkspace='in_tof' , OutputWorkspace='spectrum_numbers', child=True)
         except ValueError:
             self.assertTrue(True)
         else:
@@ -61,14 +61,14 @@ class FindReflectometryLinesTest(unittest.TestCase):
     def test_start_wavlength_too_low(self):
         try:
             # Negative value choosen for start wavelength, should throw!
-            alg = run_algorithm('FindReflectometryLines', InputWorkspace=self.__class__._two_peak_ws , OutputWorkspace='spectrum_numbers', StartWavelength=-1, child=True)
+            alg = run_algorithm('FindReflectometryLines', Version=1, InputWorkspace=self.__class__._two_peak_ws , OutputWorkspace='spectrum_numbers', StartWavelength=-1, child=True)
         except ValueError:
             self.assertTrue(True)
         else:
             self.assertTrue(False)
 
     def test_keep_intermeidate_workspaces_off_by_default(self):
-        alg = run_algorithm('FindReflectometryLines', InputWorkspace=self.__class__._two_peak_ws , OutputWorkspace='spectrum_numbers')
+        alg = run_algorithm('FindReflectometryLines', Version=1, InputWorkspace=self.__class__._two_peak_ws , OutputWorkspace='spectrum_numbers')
         keep_workspaces = alg.getPropertyValue("KeepIntermediateWorkspaces")
         # Should have requested that no intermediate workspaces have been kept, these should then have all been deleted too.
         self.assertEquals("0", keep_workspaces)
@@ -78,7 +78,7 @@ class FindReflectometryLinesTest(unittest.TestCase):
         mtd.remove('spectrum_numbers')
 
     def test_switch_intermediate_workspaces_on(self):
-        alg = run_algorithm('FindReflectometryLines', InputWorkspace=self.__class__._two_peak_ws , OutputWorkspace='spectrum_numbers', KeepIntermediateWorkspaces=True)
+        alg = run_algorithm('FindReflectometryLines', Version=1, InputWorkspace=self.__class__._two_peak_ws , OutputWorkspace='spectrum_numbers', KeepIntermediateWorkspaces=True)
         self.assertTrue(mtd.doesExist('spectrum_numbers'))
         self.assertTrue(mtd.doesExist('cropped_ws'))
         self.assertTrue(mtd.doesExist('summed_ws'))
@@ -89,7 +89,7 @@ class FindReflectometryLinesTest(unittest.TestCase):
 
     def test_find_no_peaks_throws(self):
         try:
-            alg = run_algorithm('FindReflectometryLines', InputWorkspace=self.__class__._no_peak_ws , OutputWorkspace='spectrum_numbers', child=True)
+            alg = run_algorithm('FindReflectometryLines', Version=1, InputWorkspace=self.__class__._no_peak_ws , OutputWorkspace='spectrum_numbers', child=True)
         except RuntimeError as error:
             self.assertTrue(True) #We expect the algorithm to fail if no peaks are found.
         else:
@@ -97,14 +97,14 @@ class FindReflectometryLinesTest(unittest.TestCase):
 
     def test_find_three_peaks_throws(self):
         try:
-            alg = run_algorithm('FindReflectometryLines', InputWorkspace=self.__class__._three_peak_ws , OutputWorkspace='spectrum_numbers', child=True)
+            alg = run_algorithm('FindReflectometryLines', Version=1, InputWorkspace=self.__class__._three_peak_ws , OutputWorkspace='spectrum_numbers', child=True)
         except RuntimeError as error:
             self.assertTrue(True) #We expect the algorithm to fail if three peaks are found.
         else:
             self.assertTrue(False)
 
     def test_find_one_peaks(self):
-        alg = run_algorithm('FindReflectometryLines', InputWorkspace=self.__class__._one_peak_ws, OutputWorkspace='spectrum_numbers')
+        alg = run_algorithm('FindReflectometryLines', Version=1, InputWorkspace=self.__class__._one_peak_ws, OutputWorkspace='spectrum_numbers')
         spectrum_workspace = mtd.retrieve('spectrum_numbers')
 
         # Should create a table with a SINGLE column (reflected spectra #) and one row.
@@ -113,7 +113,7 @@ class FindReflectometryLinesTest(unittest.TestCase):
         self.assertEquals(2, spectrum_workspace.cell(0,0)) # Match of exact spectrum that should be found
 
     def test_find_two_peaks(self):
-        alg = run_algorithm('FindReflectometryLines', InputWorkspace=self.__class__._two_peak_ws, OutputWorkspace='spectrum_numbers')
+        alg = run_algorithm('FindReflectometryLines', Version=1, InputWorkspace=self.__class__._two_peak_ws, OutputWorkspace='spectrum_numbers')
         spectrum_workspace = mtd.retrieve('spectrum_numbers')
 
         # Should create a table with a TWO columns (reflected spectra #, transmission spectra #) and one row.

--- a/Testing/SystemTests/tests/analysis/ReflectometryISIS.py
+++ b/Testing/SystemTests/tests/analysis/ReflectometryISIS.py
@@ -42,7 +42,7 @@ class ReflectometryISIS(with_metaclass(ABCMeta, stresstesting.MantidStressTest))
         I=mtd['I'][0]
 
         # Automatically determine the SC and averageDB
-        FindReflectometryLines(InputWorkspace=I, StartWavelength=10, OutputWorkspace='spectrum_numbers')
+        FindReflectometryLines(InputWorkspace=I, StartWavelength=10, OutputWorkspace='spectrum_numbers', Version=1)
         spectrum_table = mtd['spectrum_numbers']
         self.assertTrue(2 == spectrum_table.columnCount())
         self.assertTrue(1 == spectrum_table.rowCount())

--- a/docs/source/algorithms/FindReflectometryLines-v1.rst
+++ b/docs/source/algorithms/FindReflectometryLines-v1.rst
@@ -33,7 +33,7 @@ Usage
     ws = CreateWorkspace(DataX=dataX, DataY=dataY, DataE=dataE, NSpec=nSpec, UnitX="Wavelength", 
         VerticalAxisUnit="SpectraNumber")
             
-    wsOut = FindReflectometryLines(ws)
+    wsOut = FindReflectometryLines(ws, Version=1)
 
     for i in range(wsOut.columnCount()):
         print("{} {}".format(wsOut.getColumnNames()[i], wsOut.column(i)[0]))

--- a/docs/source/algorithms/FindReflectometryLines-v2.rst
+++ b/docs/source/algorithms/FindReflectometryLines-v2.rst
@@ -1,0 +1,51 @@
+
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+This algorithm finds the line position in a line detector reflectometry dataset. It integrates *InputWorkspace* over the :math:`X` axis and fits the sum of a Gaussian and a linear background to the integral. The center of the Gaussian, a fractional workspace index to the *InputWorkspace*, is returned as a single valued workspace in *OutputWorkspace* and as a plain number in the *LineCentre* output property.
+
+The integration region can be constrained by *RangeLower* and *RangeUpper* which restrict the :math:`X` range. Further, the peak fitting can be controlled by *StartWorkspaceIndex* and *EndWorkspaceIndex* which limit the workspace index range.
+
+If the peak fitting fails, the algorithm logs a warning and returns the workspace index of the integral maximum.
+
+Usage
+-----
+
+.. include:: ../usagedata-note.txt
+
+**Example - FindReflectometryLines2**
+
+.. testcode:: FindReflectometryLines2Example
+
+   LoadISISNexus('POLREF00004699.nxs', OutputWorkspace='ws', LoadMonitors='Exclude')
+   # 'ws' is a group workspace -> OutputWorkspace is a group as well
+   FindReflectometryLines('ws', OutputWorkspace='pos')
+   # Access individual outputs
+   pos1 = mtd['pos_1']
+   pos2 = mtd['pos_2']
+   print('Line position in the 1st workspace: {:.3}'.format(pos1.readY(0)[0]))
+   print('Line position in the 2nd workspace: {:.3}'.format(pos2.readY(0)[0]))
+   # With single workspaces one can use the named tuple output
+   out = FindReflectometryLines('ws_1')
+   print('Line position from the returned tuple: {:.3}'.format(out.LineCentre))
+
+Output:
+
+.. testoutput:: FindReflectometryLines2Example
+
+   Line position in the 1st workspace: 25.7
+   Line position in the 2nd workspace: 25.7
+   Line position from the returned tuple: 25.7
+
+.. categories::
+
+.. sourcelink::
+

--- a/docs/source/release/v3.14.0/reflectometry.rst
+++ b/docs/source/release/v3.14.0/reflectometry.rst
@@ -9,6 +9,14 @@ Reflectometry Changes
     putting new features at the top of the section, followed by
     improvements, followed by bug fixes.
 
+Algorithms
+----------
+
+New Algorithms
+##############
+
+- :ref:`FindReflectometryLines <algm-FindReflectometryLines-v2>` has been rewritten and updated to version 2. The new version finds a single line by a Gaussian fit. Version 1 has been deprecated and will be removed in a future release.
+
 Liquids Reflectometer
 ---------------------
 


### PR DESCRIPTION
**Description of work.**

This PR introduces version 2 of the `FindReflectometryLines` algorithm deprecating the old version. Version 2 is a complete rewrite implementing the peak fitting procedure from `LoadILLReflectometry` with some enhancements.

**Report to nobody.** Let's keep this one secret!

**To test:**

The algorithm is supposed to find the (fractional) workspace index of the peak center in a reflectometry dataset. The following script illustrates the usage with some unit test data:
```python
ws = LoadILLReflectometry('ILL/D17/317369.nxs')
ExtractMonitors(ws, DetectorWorkspace='ws')
pos = FindReflectometryLines('ws')
print(pos.LineCentre)
```

Check that the `pos.LineCentre` and the single valued workspace *out* contain the same fractional workspace index and that this corresponds to the peak centre in *314369*. There are other sample reflectometry files available in the unit/doc test data directories.

Try out the *RangeLower*, *RangeUpper*, *StartWorkspaceIndex* and *EndWorkspaceIndex* properties. Can you break the algorithm?

Implements the peak finding part of #22734.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
