### PR TITLE
Add parameter name to exception

### DIFF
--- a/Framework/API/test/FilePropertyTest.h
+++ b/Framework/API/test/FilePropertyTest.h
@@ -166,7 +166,11 @@ public:
     std::string TestDir("my_nonexistent_folder");
     std::string msg = fp.setValue(TestDir);
     // It gives an error message starting "Directory "X" not found".
-    TS_ASSERT_EQUALS(msg.substr(0, 3), "Dir");
+    auto pos = msg.find("Directory");
+    TS_ASSERT(pos != std::string::npos);
+    // "not found" comes after "Directory"
+    TS_ASSERT(msg.find("not found", pos) !=
+              std::string::npos); //.substr(0, 3), "Dir");
   }
 
   void testDirectoryPasses() {

--- a/Framework/API/test/IndexPropertyTest.h
+++ b/Framework/API/test/IndexPropertyTest.h
@@ -125,8 +125,9 @@ public:
 
     auto error = indexProp.setValue("30:35");
 
-    TS_ASSERT_EQUALS(error,
-                     "Indices provided to IndexProperty are out of range.");
+    TS_ASSERT(
+        error.find("Indices provided to IndexProperty are out of range.") !=
+        std::string::npos);
   }
 
   void testIndexAccessWithOperator() {

--- a/Framework/Kernel/inc/MantidKernel/PropertyWithValue.tcc
+++ b/Framework/Kernel/inc/MantidKernel/PropertyWithValue.tcc
@@ -278,7 +278,7 @@ PropertyWithValue<TYPE> &PropertyWithValue<TYPE>::operator=(const TYPE &value) {
     return *this;
   } else {
     m_value = oldValue;
-    throw std::invalid_argument(problem);
+    throw std::invalid_argument("When setting value of property \"" + this->name() + "\": " + problem);
   }
 }
 

--- a/Framework/Kernel/test/PropertyWithValueTest.h
+++ b/Framework/Kernel/test/PropertyWithValueTest.h
@@ -445,8 +445,9 @@ public:
     TS_ASSERT_EQUALS(p.isValid(), "A value must be entered for this parameter");
     TS_ASSERT_EQUALS(p.setValue("I'm here"), "");
     TS_ASSERT_EQUALS(p.isValid(), "");
-    TS_ASSERT_EQUALS(p.setValue(""),
-                     "A value must be entered for this parameter");
+    TS_ASSERT(
+        p.setValue("").find("A value must be entered for this parameter") !=
+        std::string::npos);
     TS_ASSERT_EQUALS(p.value(), "I'm here");
   }
 
@@ -459,15 +460,16 @@ public:
     PropertyWithValue<int> pi("test", 11,
                               boost::make_shared<BoundedValidator<int>>(1, 10));
     TS_ASSERT_EQUALS(pi.isValid(), start + "11" + greaterThan + "10" + end);
-    TS_ASSERT_EQUALS(pi.setValue("0"), start + "0" + lessThan + "1" + end);
+    TS_ASSERT(pi.setValue("0").find(start + "0" + lessThan + "1" + end) !=
+              std::string::npos);
     TS_ASSERT_EQUALS(pi.value(), "11");
     TS_ASSERT_EQUALS(pi.isValid(), start + "11" + greaterThan + "10" + end);
     TS_ASSERT_EQUALS(pi.setValue("1"), "");
     TS_ASSERT_EQUALS(pi.isValid(), "");
     TS_ASSERT_EQUALS(pi.setValue("10"), "");
     TS_ASSERT_EQUALS(pi.isValid(), "");
-    TS_ASSERT_EQUALS(pi.setValue("11"),
-                     start + "11" + greaterThan + "10" + end);
+    TS_ASSERT(pi.setValue("11").find(start + "11" + greaterThan + "10" + end) !=
+              std::string::npos);
     TS_ASSERT_EQUALS(pi.value(), "10");
     TS_ASSERT_EQUALS(pi.isValid(), "");
     std::string errorMsg = pi.setValue("");
@@ -482,15 +484,16 @@ public:
     PropertyWithValue<double> pd(
         "test", 11.0, boost::make_shared<BoundedValidator<double>>(1.0, 10.0));
     TS_ASSERT_EQUALS(pd.isValid(), start + "11" + greaterThan + "10" + end);
-    TS_ASSERT_EQUALS(pd.setValue("0.9"), start + "0.9" + lessThan + "1" + end);
+    TS_ASSERT(pd.setValue("0.9").find(start + "0.9" + lessThan + "1" + end) !=
+              std::string::npos);
     TS_ASSERT_EQUALS(pd.value(), "11");
     TS_ASSERT_EQUALS(pd.isValid(), start + "11" + greaterThan + "10" + end);
     TS_ASSERT_EQUALS(pd.setValue("1"), "");
     TS_ASSERT_EQUALS(pd.isValid(), "");
     TS_ASSERT_EQUALS(pd.setValue("10"), "");
     TS_ASSERT_EQUALS(pd.isValid(), "");
-    TS_ASSERT_EQUALS(pd.setValue("10.1"),
-                     start + "10.1" + greaterThan + "10" + end);
+    TS_ASSERT(pd.setValue("10.1").find(start + "10.1" + greaterThan + "10" +
+                                       end) != std::string::npos);
     TS_ASSERT_EQUALS(pd.value(), "10");
     TS_ASSERT_EQUALS(pd.isValid(), "");
 
@@ -499,14 +502,16 @@ public:
         "test", "",
         boost::make_shared<BoundedValidator<std::string>>("B", "T"));
     TS_ASSERT_EQUALS(ps.isValid(), start + "" + lessThan + "B" + end);
-    TS_ASSERT_EQUALS(ps.setValue("AZ"), start + "AZ" + lessThan + "B" + end);
+    TS_ASSERT(ps.setValue("AZ").find(start + "AZ" + lessThan + "B" + end) !=
+              std::string::npos);
     TS_ASSERT_EQUALS(ps.value(), "");
     TS_ASSERT_EQUALS(ps.isValid(), start + "" + lessThan + "B" + end);
     TS_ASSERT_EQUALS(ps.setValue("B"), "");
     TS_ASSERT_EQUALS(ps.isValid(), "");
     TS_ASSERT_EQUALS(ps.setValue("T"), "");
     TS_ASSERT_EQUALS(ps.isValid(), "");
-    TS_ASSERT_EQUALS(ps.setValue("TA"), start + "TA" + greaterThan + "T" + end);
+    TS_ASSERT(ps.setValue("TA").find(start + "TA" + greaterThan + "T" + end) !=
+              std::string::npos);
     TS_ASSERT_EQUALS(ps.value(), "T");
     TS_ASSERT_EQUALS(ps.isValid(), "");
 
@@ -516,15 +521,16 @@ public:
         boost::make_shared<BoundedValidator<int64_t>>(0, 789789789789LL));
     TS_ASSERT_EQUALS(pl.isValid(), start + "987987987987" + greaterThan +
                                        "789789789789" + end);
-    TS_ASSERT_EQUALS(pl.setValue("-1"), start + "-1" + lessThan + "0" + end);
+    TS_ASSERT(pl.setValue("-1").find(start + "-1" + lessThan + "0" + end) !=
+              std::string::npos);
     TS_ASSERT_EQUALS(pl.value(), "987987987987");
     TS_ASSERT_EQUALS(pl.setValue("0"), "");
     TS_ASSERT_EQUALS(pl.isValid(), "");
     TS_ASSERT_EQUALS(pl.setValue("789789789789"), "");
     TS_ASSERT_EQUALS(pl.isValid(), "");
-    TS_ASSERT_EQUALS(pl.setValue("789789789790"), start + "789789789790" +
-                                                      greaterThan +
-                                                      "789789789789" + end);
+    TS_ASSERT(pl.setValue("789789789790")
+                  .find(start + "789789789790" + greaterThan + "789789789789" +
+                        end) != std::string::npos);
     TS_ASSERT_EQUALS(pl.value(), "789789789789");
   }
 
@@ -545,9 +551,9 @@ public:
     TS_ASSERT_EQUALS(p.isValid(), "");
     TS_ASSERT_EQUALS(p.setValue("two"), "");
     TS_ASSERT_EQUALS(p.isValid(), "");
-    TS_ASSERT_EQUALS(
-        p.setValue("three"),
-        "The value \"three\" is not in the list of allowed values");
+    TS_ASSERT(p.setValue("three").find(
+                  "The value \"three\" is not in the list of allowed values") !=
+              std::string::npos);
     TS_ASSERT_EQUALS(p.value(), "two");
     TS_ASSERT_EQUALS(p.isValid(), "");
     std::vector<std::string> s;


### PR DESCRIPTION
**Description of work.**

**To test:**

Run the script
```python
#!/usr/bin/env python

from mantid.simpleapi import *
wksp = Load(Filename="NOM_107566", MetaDataOnly=True)
PDLoadCharacterizations(Filename="/SNS/NOM/shared/CALIBRATION/2018_2_1B_CAL/NOM_char_2018_05_29-rietveld.txt",
                        OutputWorkspace="characterizations")
PDDetermineCharacterizations(InputWorkspace=wksp, Characterizations="characterizations", 
                             ReductionProperties="__snspowderreduction")
AlignAndFocusPowderFromFiles(Filename="NOM_107566", MaxChunkSize=8,
                             Characterizations="characterizations",
                             CalFilename="/SNS/NOM/shared/CALIBRATION/2018_2_1B_CAL/NOM_d107566_2018_05_29_shifter.h5",
                             OutputWorkspace="out_wksp")
```
and see that it errors with a slightly more helpful message about which property has an issue.

*There is no associated issue.*

*This does not require release notes* because users should never see an error in setting property values. ;)

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
