### PR TITLE
Sort peak numbers by detector banks

### DIFF
--- a/Framework/Crystal/inc/MantidCrystal/PredictPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/PredictPeaks.h
@@ -67,8 +67,7 @@ private:
 
   void calculateQAndAddToOutput(const Kernel::V3D &hkl,
                                 const Kernel::DblMatrix &orientedUB,
-                                const Kernel::DblMatrix &goniometerMatrix,
-                                int &seqNum);
+                                const Kernel::DblMatrix &goniometerMatrix);
 
 private:
   /// Get the predicted detector direction from Q

--- a/Framework/Crystal/src/PredictPeaks.cpp
+++ b/Framework/Crystal/src/PredictPeaks.cpp
@@ -366,7 +366,7 @@ void PredictPeaks::exec() {
   // adjacent
   std::vector<std::pair<std::string, bool>> criteria;
   criteria.push_back(std::pair<std::string, bool>("RunNumber", true));
-  criteria.push_back(std::pair<std::string, bool>("PeakNumber", true));
+  criteria.push_back(std::pair<std::string, bool>("BankName", true));
   m_pw->sort(criteria);
 
   auto &peaks = m_pw->getPeaks();

--- a/Framework/Crystal/src/PredictPeaks.cpp
+++ b/Framework/Crystal/src/PredictPeaks.cpp
@@ -296,7 +296,6 @@ void PredictPeaks::exec() {
 
   if (getProperty("CalculateGoniometerForCW")) {
     size_t allowedPeakCount = 0;
-    int seqNum = 1;
 
     double wavelength = getProperty("Wavelength");
     if (wavelength == DBL_MAX) {
@@ -324,8 +323,7 @@ void PredictPeaks::exec() {
         g_log.information() << "Found goniometer rotation to be "
                             << goniometer.getEulerAngles()[0]
                             << " degrees for HKL = " << possibleHKL << "\n";
-        calculateQAndAddToOutput(possibleHKL, orientedUB, goniometer.getR(),
-                                 seqNum);
+        calculateQAndAddToOutput(possibleHKL, orientedUB, goniometer.getR());
         ++allowedPeakCount;
       }
       prog.report();
@@ -343,7 +341,6 @@ void PredictPeaks::exec() {
       HKLFilterWavelength lambdaFilter(orientedUB, lambdaMin, lambdaMax);
 
       size_t allowedPeakCount = 0;
-      int seqNum = 1;
 
       bool useExtendedDetectorSpace =
           getProperty("PredictPeaksOutsideDetectors");
@@ -355,8 +352,7 @@ void PredictPeaks::exec() {
 
       for (auto &possibleHKL : possibleHKLs) {
         if (lambdaFilter.isAllowed(possibleHKL)) {
-          calculateQAndAddToOutput(possibleHKL, orientedUB, goniometerMatrix,
-                                   seqNum);
+          calculateQAndAddToOutput(possibleHKL, orientedUB, goniometerMatrix);
           ++allowedPeakCount;
         }
         prog.report();
@@ -366,6 +362,17 @@ void PredictPeaks::exec() {
     }
   }
 
+  // Sort peaks by run number so that peaks with equal goniometer matrices are
+  // adjacent
+  std::vector<std::pair<std::string, bool>> criteria;
+  criteria.push_back(std::pair<std::string, bool>("RunNumber", true));
+  criteria.push_back(std::pair<std::string, bool>("PeakNumber", true));
+  m_pw->sort(criteria);
+
+  auto &peaks = m_pw->getPeaks();
+  for (int i = 0; i < static_cast<int>(m_pw->getNumberPeaks()); ++i) {
+    peaks[i].setPeakNumber(i);
+  }
   setProperty<PeaksWorkspace_sptr>("OutputWorkspace", m_pw);
 }
 
@@ -544,12 +551,10 @@ void PredictPeaks::setStructureFactorCalculatorFromSample(
  * @param hkl
  * @param orientedUB
  * @param goniometerMatrix
- * @param seqNum
  */
 void PredictPeaks::calculateQAndAddToOutput(const V3D &hkl,
                                             const DblMatrix &orientedUB,
-                                            const DblMatrix &goniometerMatrix,
-                                            int &seqNum) {
+                                            const DblMatrix &goniometerMatrix) {
   // The q-vector direction of the peak is = goniometer * ub * hkl_vector
   // This is in inelastic convention: momentum transfer of the LATTICE!
   // Also, q does have a 2pi factor = it is equal to 2pi/wavelength.
@@ -610,8 +615,6 @@ void PredictPeaks::calculateQAndAddToOutput(const V3D &hkl,
   // Save the run number found before.
   peak->setRunNumber(m_runNumber);
   peak->setHKL(hkl * m_qConventionFactor);
-  peak->setPeakNumber(seqNum);
-  seqNum++;
 
   if (m_sfCalculator) {
     peak->setIntensity(m_sfCalculator->getFSquared(hkl));

--- a/docs/source/algorithms/PredictPeaks-v1.rst
+++ b/docs/source/algorithms/PredictPeaks-v1.rst
@@ -80,7 +80,7 @@ with predicted structure factor very close to 0, which are absent:
     Maximum intensity: 6101.93
     Peaks with relative intensity < 1%: 94
     Number of absences: 16
-    Absent HKLs: [[2,0,-1], [3,0,-1], [4,0,-1], [5,0,-1], [6,0,-3], [6,0,-1], [7,0,-3], [7,0,-1], [8,0,-3], [8,0,-1], [9,-1,0], [9,0,-3], [9,0,-1], [10,0,-5], [10,0,-3], [10,0,-1]]
+    Absent HKLs: [[2,0,-1], [6,0,-3], [10,0,-5], [3,0,-1], [4,0,-1], [5,0,-1], [6,0,-1], [7,0,-3], [7,0,-1], [8,0,-3], [8,0,-1], [9,-1,0], [9,0,-3], [9,0,-1], [10,0,-3], [10,0,-1]]
 
 All absent HKLs have the form H0L with odd L. This fits with the reflection
 conditions given for :math:`Pbca` in the International Tables for Crystallography A.


### PR DESCRIPTION
**Description of work.**

PredictPeaks should sort by detector banks before numbering peaks.

**To test:**
````python
LoadIsawPeaks(OutputWorkspace='peaks', Filename='~/mantid/release/ExternalData/Testing/Data/DocTest/TOPAZ_3007.peaks')
LoadIsawUB(InputWorkspace='peaks', Filename='~/mantid/release/ExternalData/Testing/Data/DocTest/TOPAZ_3007.mat')
PredictPeaks(InputWorkspace='peaks', WavelengthMin=1, WavelengthMax=2, MinDSpacing=0.5, MaxDSpacing=5, OutputWorkspace='predicted', EdgePixels=20)
````
Look at BankName and PeakNumber columns to see that it is sorted by bank and the numbers are sequential.

Fixes #23301 
<!-- alternative
*There is no associated issue.*
-->


*This does not require release notes* because **it is minor bug**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
