### PR TITLE
Update to PyQt5 in scripts/Muon

### DIFF
--- a/scripts/Muon/GUI/Common/dock/dock_view.py
+++ b/scripts/Muon/GUI/Common/dock/dock_view.py
@@ -1,6 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 
-from qtpy import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtWidgets
 
 
 class DockView(QtWidgets.QMainWindow):

--- a/scripts/Muon/GUI/Common/dock/dock_view.py
+++ b/scripts/Muon/GUI/Common/dock/dock_view.py
@@ -1,10 +1,9 @@
 from __future__ import (absolute_import, division, print_function)
 
-from PyQt4 import QtCore
-from PyQt4 import QtGui
+from qtpy import QtCore, QtGui, QtWidgets
 
 
-class DockView(QtGui.QMainWindow):
+class DockView(QtWidgets.QMainWindow):
 
     def __init__(self, parent=None):
         super(DockView, self).__init__(parent)
@@ -31,7 +30,7 @@ class DockView(QtGui.QMainWindow):
         # put tabs on the top of the page
         self.setTabPosition(
             QtCore.Qt.LeftDockWidgetArea,
-            QtGui.QTabWidget.North)
+            QtWidgets.QTabWidget.North)
         # open to first tab
         self.docks[0].show()
         self.docks[0].raise_()
@@ -39,7 +38,7 @@ class DockView(QtGui.QMainWindow):
     def keepDocksOpen(self):
         for j in range(0, len(self.docks), 1):
             self.docks[j].setFeatures(
-                QtGui.QDockWidget.DockWidgetClosable and QtGui.QDockWidget.DockWidgetFloatable)
+                QtWidgets.QDockWidget.DockWidgetClosable and QtWidgets.QDockWidget.DockWidgetFloatable)
 
     def closeEvent(self, event):
         for j in range(len(self.docks) - 1, -1, -1):

--- a/scripts/Muon/GUI/Common/dock/dock_view.py
+++ b/scripts/Muon/GUI/Common/dock/dock_view.py
@@ -14,7 +14,7 @@ class DockView(QtWidgets.QMainWindow):
         # add widget
         self.widgets.append(widget)
         # make an empty dock for widget
-        self.docks.append(QtGui.QDockWidget(name))
+        self.docks.append(QtWidgets.QDockWidget(name))
         # add widget to dock
         self.docks[-1].setWidget(self.widgets[-1])
         # add dock to view

--- a/scripts/Muon/GUI/Common/dummy/dummy_view.py
+++ b/scripts/Muon/GUI/Common/dummy/dummy_view.py
@@ -1,19 +1,17 @@
 from __future__ import (absolute_import, division, print_function)
 
+from qtpy import QtWidgets
+from qtpy.QtCore import Signal
 
-from PyQt4 import QtCore
-from PyQt4 import QtGui
 
-
-class DummyView(QtGui.QWidget):
-
-    buttonSignal = QtCore.pyqtSignal(object)
+class DummyView(QtWidgets.QWidget):
+    buttonSignal = Signal(object)
 
     def __init__(self, name, parent=None):
         super(DummyView, self).__init__(parent)
-        self.grid = QtGui.QGridLayout(self)
+        self.grid = QtWidgets.QGridLayout(self)
         self.message = name
-        btn = QtGui.QPushButton(name, self)
+        btn = QtWidgets.QPushButton(name, self)
         self.grid.addWidget(btn)
         btn.clicked.connect(self.buttonClick)
 

--- a/scripts/Muon/GUI/Common/dummy/dummy_widget.py
+++ b/scripts/Muon/GUI/Common/dummy/dummy_widget.py
@@ -1,6 +1,5 @@
 from __future__ import (absolute_import, division, print_function)
 
-
 from Muon.GUI.Common.dummy.dummy_view import DummyView
 from Muon.GUI.Common.dummy.dummy_presenter import DummyPresenter
 
@@ -8,10 +7,11 @@ from Muon.GUI.Common.dummy.dummy_presenter import DummyPresenter
 class DummyWidget(object):
     """
     """
-    def __init__(self,name,parent=None):
-        view=DummyView(name,parent)
-        model=None
-        self._presenter = DummyPresenter(view,model)
+
+    def __init__(self, name, parent=None):
+        view = DummyView(name, parent)
+        model = None
+        self._presenter = DummyPresenter(view, model)
 
     @property
     def presenter(self):
@@ -21,6 +21,6 @@ class DummyWidget(object):
     def widget(self):
         return self._presenter.widget
 
-    def setButtonConnection(self,slot):
-        view=self._presenter.widget
+    def setButtonConnection(self, slot):
+        view = self._presenter.widget
         view.buttonSignal.connect(slot)

--- a/scripts/Muon/GUI/Common/dummy_label/dummy_label_presenter.py
+++ b/scripts/Muon/GUI/Common/dummy_label/dummy_label_presenter.py
@@ -4,13 +4,14 @@ from __future__ import (absolute_import, division, print_function)
 class DummyLabelPresenter(object):
     """
     """
-    def __init__(self,view,model):
-        self.view=view
-        self.model=model
+
+    def __init__(self, view, model):
+        self.view = view
+        self.model = model
 
     @property
     def widget(self):
         return self.view
 
-    def updateLabel(self,message):
+    def updateLabel(self, message):
         self.view.updateLabel(message)

--- a/scripts/Muon/GUI/Common/dummy_label/dummy_label_view.py
+++ b/scripts/Muon/GUI/Common/dummy_label/dummy_label_view.py
@@ -1,16 +1,15 @@
 from __future__ import (absolute_import, division, print_function)
 
+from qtpy import QtWidgets
 
-from PyQt4 import QtGui
 
-
-class DummyLabelView(QtGui.QWidget):
+class DummyLabelView(QtWidgets.QWidget):
 
     def __init__(self, name, parent=None):
         super(DummyLabelView, self).__init__(parent)
-        self.grid = QtGui.QGridLayout(self)
+        self.grid = QtWidgets.QGridLayout(self)
 
-        self.label = QtGui.QLabel(name)
+        self.label = QtWidgets.QLabel(name)
         self.grid.addWidget(self.label)
 
     def getLayout(self):

--- a/scripts/Muon/GUI/Common/load_widget/load_view.py
+++ b/scripts/Muon/GUI/Common/load_widget/load_view.py
@@ -1,26 +1,26 @@
 from __future__ import absolute_import
 
-from PyQt4 import QtGui
+from qtpy import QtWidgets
 
 from mantidqtpython import MantidQt
 
 
-class LoadView(QtGui.QWidget):
+class LoadView(QtWidgets.QWidget):
     def __init__(self, parent=None):
         super(LoadView, self).__init__(parent)
 
-        self.browse_button = QtGui.QPushButton("User Dirs", self)
+        self.browse_button = QtWidgets.QPushButton("User Dirs", self)
         self.browse_button.clicked.connect(self.show_directory_manager)
 
-        self.co_button = QtGui.QPushButton("Co-Add", self)
-        self.load_button = QtGui.QPushButton("Load", self)
+        self.co_button = QtWidgets.QPushButton("Co-Add", self)
+        self.load_button = QtWidgets.QPushButton("Load", self)
 
-        self.spinbox = QtGui.QSpinBox(self)
+        self.spinbox = QtWidgets.QSpinBox(self)
         self.spinbox.setRange(0, 99999)
         self.spinbox.setValue(0)
         self.last_spinbox_val = 0
 
-        self.grid = QtGui.QVBoxLayout()
+        self.grid = QtWidgets.QVBoxLayout()
         self.grid.addWidget(self.spinbox)
         self.grid.addWidget(self.load_button)
         self.grid.addWidget(self.co_button)

--- a/scripts/Muon/GUI/Common/load_widget/load_view.py
+++ b/scripts/Muon/GUI/Common/load_widget/load_view.py
@@ -1,27 +1,27 @@
 from __future__ import absolute_import
 
-from qtpy import QtWidgets
+from PyQt4 import QtGui
 
 
-# from mantidqtpython import MantidQt
+from mantidqtpython import MantidQt
 
 
-class LoadView(QtWidgets.QWidget):
+class LoadView(QtGui.QWidget):
     def __init__(self, parent=None):
         super(LoadView, self).__init__(parent)
 
-        self.browse_button = QtWidgets.QPushButton("User Dirs", self)
+        self.browse_button = QtGui.QPushButton("User Dirs", self)
         self.browse_button.clicked.connect(self.show_directory_manager)
 
-        self.co_button = QtWidgets.QPushButton("Co-Add", self)
-        self.load_button = QtWidgets.QPushButton("Load", self)
+        self.co_button = QtGui.QPushButton("Co-Add", self)
+        self.load_button = QtGui.QPushButton("Load", self)
 
-        self.spinbox = QtWidgets.QSpinBox(self)
+        self.spinbox = QtGui.QSpinBox(self)
         self.spinbox.setRange(0, 99999)
         self.spinbox.setValue(0)
         self.last_spinbox_val = 0
 
-        self.grid = QtWidgets.QVBoxLayout()
+        self.grid = QtGui.QVBoxLayout()
         self.grid.addWidget(self.spinbox)
         self.grid.addWidget(self.load_button)
         self.grid.addWidget(self.co_button)

--- a/scripts/Muon/GUI/Common/load_widget/load_view.py
+++ b/scripts/Muon/GUI/Common/load_widget/load_view.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import
 
 from qtpy import QtWidgets
 
-from mantidqtpython import MantidQt
+
+# from mantidqtpython import MantidQt
 
 
 class LoadView(QtWidgets.QWidget):

--- a/scripts/Muon/GUI/Common/message_box.py
+++ b/scripts/Muon/GUI/Common/message_box.py
@@ -1,7 +1,6 @@
-import PyQt4.QtGui as QtGui
+from qtpy import QtWidgets
 
 
 def warning(error):
-
-    ex = QtGui.QWidget()
-    QtGui.QMessageBox.warning(ex, "Error", str(error))
+    ex = QtWidgets.QWidget()
+    QtWidgets.QMessageBox.warning(ex, "Error", str(error))

--- a/scripts/Muon/GUI/Common/mock_widget.py
+++ b/scripts/Muon/GUI/Common/mock_widget.py
@@ -1,6 +1,5 @@
 from qtpy import QtWidgets
 
-
 def mockQapp():
     qapp = QtWidgets.QApplication.instance()
     if qapp is None:

--- a/scripts/Muon/GUI/Common/mock_widget.py
+++ b/scripts/Muon/GUI/Common/mock_widget.py
@@ -1,10 +1,9 @@
-
-import PyQt4.QtGui as QtGui
+from qtpy import QtWidgets
 
 
 def mockQapp():
-    qapp = QtGui.QApplication.instance()
+    qapp = QtWidgets.QApplication.instance()
     if qapp is None:
-        return QtGui.QApplication([''])
+        return QtWidgets.QApplication([''])
     else:
         return qapp

--- a/scripts/Muon/GUI/Common/mock_widget.py
+++ b/scripts/Muon/GUI/Common/mock_widget.py
@@ -1,5 +1,6 @@
 from qtpy import QtWidgets
 
+
 def mockQapp():
     qapp = QtWidgets.QApplication.instance()
     if qapp is None:

--- a/scripts/Muon/GUI/Common/mock_widget.py
+++ b/scripts/Muon/GUI/Common/mock_widget.py
@@ -1,9 +1,9 @@
-from qtpy import QtWidgets
+import PyQt4.QtGui as QtGui
 
 
 def mockQapp():
-    qapp = QtWidgets.QApplication.instance()
+    qapp = QtGui.QApplication.instance()
     if qapp is None:
-        return QtWidgets.QApplication([''])
+        return QtGui.QApplication([''])
     else:
         return qapp

--- a/scripts/Muon/GUI/Common/table_utils.py
+++ b/scripts/Muon/GUI/Common/table_utils.py
@@ -1,7 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
-from PyQt4 import QtCore, QtGui
+from qtpy import QtCore, QtGui, QtWidgets
 import os
-
 
 """
 This module contains the methods for
@@ -9,43 +8,43 @@ adding information to tables.
 """
 
 
-def setRowName(table,row,name):
-    text = QtGui.QTableWidgetItem((name))
+def setRowName(table, row, name):
+    text = QtWidgets.QTableWidgetItem((name))
     text.setFlags(QtCore.Qt.ItemIsEnabled)
-    table.setItem(row,0, text)
+    table.setItem(row, 0, text)
 
 
-def addComboToTable(table,row,options):
-    combo=QtGui.QComboBox()
+def addComboToTable(table, row, options):
+    combo = QtWidgets.QComboBox()
     combo.addItems(options)
-    table.setCellWidget(row,1,combo)
+    table.setCellWidget(row, 1, combo)
     return combo
 
 
-def addDoubleToTable(table,value,row):
-    numberWidget = QtGui.QTableWidgetItem(str(value))
-    table.setItem(row,1, numberWidget)
+def addDoubleToTable(table, value, row):
+    numberWidget = QtWidgets.QTableWidgetItem(str(value))
+    table.setItem(row, 1, numberWidget)
     return numberWidget
 
 
-def addCheckBoxToTable(table,state,row):
-    box = QtGui.QTableWidgetItem()
-    box.setFlags(QtCore.Qt.ItemIsUserCheckable |QtCore.Qt.ItemIsEnabled)
+def addCheckBoxToTable(table, state, row):
+    box = QtWidgets.QTableWidgetItem()
+    box.setFlags(QtCore.Qt.ItemIsUserCheckable | QtCore.Qt.ItemIsEnabled)
     if state:
         box.setCheckState(QtCore.Qt.Checked)
     else:
         box.setCheckState(QtCore.Qt.Unchecked)
 
-    table.setItem(row,1, box)
+    table.setItem(row, 1, box)
     return box
 
 
-def addSpinBoxToTable(table,default,row):
-    box = QtGui.QSpinBox()
+def addSpinBoxToTable(table, default, row):
+    box = QtWidgets.QSpinBox()
     if default > 99:
-        box.setMaximum(default*10)
+        box.setMaximum(default * 10)
     box.setValue(default)
-    table.setCellWidget(row,1,box)
+    table.setCellWidget(row, 1, box)
     return box
 
 
@@ -53,28 +52,28 @@ def addSpinBoxToTable(table,default,row):
 # bug that stops tables having underlines for
 # the headers.
 def setTableHeaders(table):
-        # is it not windows
-        if os.name != "nt":
-            return
-        version=QtCore.QSysInfo.WindowsVersion
-        WINDOWS_10=160
-        if(version==WINDOWS_10):
-            styleSheet= \
-                "QHeaderView::section{"\
-                +"border-top:0px solid #D8D8D8;"\
-                +"border-left:0px solid #D8D8D8;"\
-                +"border-right:1px solid #D8D8D8;"\
-                +"border-bottom: 1px solid #D8D8D8;"\
-                +"background-color:white;"\
-                +"padding:4px;"\
-                +"}"\
-                +"QTableCornerButton::section{"\
-                +"border-top:0px solid #D8D8D8;"\
-                +"border-left:0px solid #D8D8D8;"\
-                +"border-right:1px solid #D8D8D8;"\
-                +"border-bottom: 1px solid #D8D8D8;"\
-                +"background-color:white;"\
-                +"}"
-            table.setStyleSheet(styleSheet)
-            return styleSheet
+    # is it not windows
+    if os.name != "nt":
         return
+    version = QtCore.QSysInfo.WindowsVersion
+    WINDOWS_10 = 160
+    if (version == WINDOWS_10):
+        styleSheet = \
+            "QHeaderView::section{" \
+            + "border-top:0px solid #D8D8D8;" \
+            + "border-left:0px solid #D8D8D8;" \
+            + "border-right:1px solid #D8D8D8;" \
+            + "border-bottom: 1px solid #D8D8D8;" \
+            + "background-color:white;" \
+            + "padding:4px;" \
+            + "}" \
+            + "QTableCornerButton::section{" \
+            + "border-top:0px solid #D8D8D8;" \
+            + "border-left:0px solid #D8D8D8;" \
+            + "border-right:1px solid #D8D8D8;" \
+            + "border-bottom: 1px solid #D8D8D8;" \
+            + "background-color:white;" \
+            + "}"
+        table.setStyleSheet(styleSheet)
+        return styleSheet
+    return

--- a/scripts/Muon/GUI/Common/table_utils.py
+++ b/scripts/Muon/GUI/Common/table_utils.py
@@ -1,5 +1,5 @@
 from __future__ import (absolute_import, division, print_function)
-from qtpy import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtWidgets
 import os
 
 """

--- a/scripts/Muon/GUI/Common/thread_model.py
+++ b/scripts/Muon/GUI/Common/thread_model.py
@@ -1,17 +1,15 @@
 from __future__ import (absolute_import, division, print_function)
 
-from PyQt4.QtCore import QThread
-from PyQt4 import QtCore
+from qtpy.QtCore import QThread, Signal
 from Muon.GUI.Common import message_box
 
 
 class ThreadModel(QThread):
-
     """
     A wrapper to allow threading with
     the MaxEnt models.
     """
-    exceptionSignal = QtCore.pyqtSignal(object)
+    exceptionSignal = Signal(object)
 
     def __init__(self, model):
         QThread.__init__(self)

--- a/scripts/Muon/GUI/ElementalAnalysis/PeriodicTable/periodic_table.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/PeriodicTable/periodic_table.py
@@ -6,8 +6,10 @@
 
 from collections import OrderedDict
 import logging
-from PyQt4 import QtCore
-from PyQt4 import QtGui as qt
+from qtpy import QtCore
+from qtpy.QtCore import Signal
+from qtpy import QtWidgets as qt
+from qtpy import QtGui
 
 # coding: utf-8
 # /*##########################################################################
@@ -256,13 +258,13 @@ _defaultTableItems = [ColoredPeriodicTableItem(*info) for info in _elements]
 class _ElementButton(qt.QPushButton):
     """Atomic element button, used as a cell in the periodic table
     """
-    sigElementEnter = QtCore.pyqtSignal(object)
+    sigElementEnter = Signal(object)
     """Signal emitted as the cursor enters the widget"""
-    sigElementLeave = QtCore.pyqtSignal(object)
+    sigElementLeave = Signal(object)
     """Signal emitted as the cursor leaves the widget"""
-    sigElementLeftClicked = QtCore.pyqtSignal(object)
+    sigElementLeftClicked = Signal(object)
     """Signal emitted when the widget is left clicked"""
-    sigElementRightClicked = QtCore.pyqtSignal(object)
+    sigElementRightClicked = Signal(object)
     """Signal emitted when the widget is right clicked"""
 
     def __init__(self, item, parent=None):
@@ -287,18 +289,18 @@ class _ElementButton(qt.QPushButton):
         self.current = False
 
         # selection colors
-        self.selected_color = qt.QColor(QtCore.Qt.yellow)
-        self.current_color = qt.QColor(QtCore.Qt.gray)
-        self.selected_current_color = qt.QColor(QtCore.Qt.darkYellow)
+        self.selected_color = QtGui.QColor(QtCore.Qt.yellow)
+        self.current_color = QtGui.QColor(QtCore.Qt.gray)
+        self.selected_current_color = QtGui.QColor(QtCore.Qt.darkYellow)
 
         # element colors
 
         if hasattr(item, "bgcolor"):
-            self.bgcolor = qt.QColor(item.bgcolor)
+            self.bgcolor = QtGui.QColor(item.bgcolor)
         else:
-            self.bgcolor = qt.QColor("#FFFFFF")
+            self.bgcolor = QtGui.QColor("#FFFFFF")
 
-        self.brush = qt.QBrush()
+        self.brush = QtGui.QBrush()
         self.__setBrush()
 
         self.clicked.connect(self.leftClickedSlot)
@@ -346,16 +348,16 @@ class _ElementButton(qt.QPushButton):
         instantiation (:attr:`bgcolor`)"""
         palette = self.palette()
         # if self.current and self.selected:
-        #     self.brush = qt.QBrush(self.selected_current_color)
+        #     self.brush = QtGui.QBrush(self.selected_current_color)
         # el
         if self.selected:
-            self.brush = qt.QBrush(self.selected_color)
+            self.brush = QtGui.QBrush(self.selected_color)
         # elif self.current:
-        #     self.brush = qt.QBrush(self.current_color)
+        #     self.brush = QtGui.QBrush(self.current_color)
         elif self.bgcolor is not None:
-            self.brush = qt.QBrush(self.bgcolor)
+            self.brush = QtGui.QBrush(self.bgcolor)
         else:
-            self.brush = qt.QBrush()
+            self.brush = QtGui.QBrush()
         palette.setBrush(self.backgroundRole(),
                          self.brush)
         self.setPalette(palette)
@@ -370,11 +372,11 @@ class _ElementButton(qt.QPushButton):
                                  widgGeom.height() - 2)
 
         # paint background color
-        painter = qt.QPainter(self)
+        painter = QtGui.QPainter(self)
         if self.brush is not None:
             painter.fillRect(paintGeom, self.brush)
         # paint frame
-        pen = qt.QPen(QtCore.Qt.black)
+        pen = QtGui.QPen(QtCore.Qt.black)
         pen.setWidth(1 if not self.isCurrent() else 5)
         painter.setPen(pen)
         painter.drawRect(paintGeom)
@@ -426,16 +428,16 @@ class PeriodicTable(qt.QWidget):
         pt.sigElementClicked.connect(my_slot)
 
     """
-    sigElementLeftClicked = QtCore.pyqtSignal(object)
+    sigElementLeftClicked = Signal(object)
     """When any element is clicked in the table, the widget emits
     this signal and sends a :class:`PeriodicTableItem` object.
     """
-    sigElementRightClicked = QtCore.pyqtSignal(object)
+    sigElementRightClicked = Signal(object)
     """When any element is clicked in the table, the widget emits
     this signal and sends a :class:`PeriodicTableItem` object.
     """
 
-    sigSelectionChanged = QtCore.pyqtSignal(object)
+    sigSelectionChanged = Signal(object)
     """When any element is selected/unselected in the table, the widget emits
     this signal and sends a list of :class:`PeriodicTableItem` objects.
 
@@ -639,7 +641,7 @@ class PeriodicCombo(qt.QComboBox):
         a predefined list with minimal information (symbol, atomic number,
         name, mass).
     """
-    sigSelectionChanged = QtCore.pyqtSignal(object)
+    sigSelectionChanged = Signal(object)
     """Signal emitted when the selection changes. Send
     :class:`PeriodicTableItem` object representing selected
     element
@@ -695,7 +697,7 @@ class PeriodicList(qt.QTreeWidget):
     :param single: *True* for single element selection with mouse click,
         *False* for multiple element selection mode.
     """
-    sigSelectionChanged = QtCore.pyqtSignal(object)
+    sigSelectionChanged = Signal(object)
     """When any element is selected/unselected in the widget, it emits
     this signal and sends a list of currently selected
     :class:`PeriodicTableItem` objects.

--- a/scripts/Muon/GUI/ElementalAnalysis/PeriodicTable/periodic_table_view.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/PeriodicTable/periodic_table_view.py
@@ -1,16 +1,16 @@
 from __future__ import absolute_import
 
-from PyQt4 import QtGui
+from qtpy import QtWidgets
 
 from Muon.GUI.ElementalAnalysis.PeriodicTable import periodic_table
 
 
-class PeriodicTableView(QtGui.QWidget):
+class PeriodicTableView(QtWidgets.QWidget):
     def __init__(self, parent=None):
         super(PeriodicTableView, self).__init__(parent)
         self.ptable = periodic_table.PeriodicTable(self, selectable=True)
 
-        self.grid = QtGui.QGridLayout()
+        self.grid = QtWidgets.QGridLayout()
         self.grid.addWidget(self.ptable)
         self.setLayout(self.grid)
 

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/FFT/fft_view.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/FFT/fft_view.py
@@ -1,31 +1,32 @@
 from __future__ import (absolute_import, division, print_function)
 
-from PyQt4 import QtCore, QtGui
+from qtpy import QtCore, QtWidgets
+from qtpy.QtCore import Signal
 
 import mantid.simpleapi as mantid
 
 from Muon.GUI.Common import table_utils
 
 
-class FFTView(QtGui.QWidget):
+class FFTView(QtWidgets.QWidget):
 
     """
     creates the layout for the FFT GUI
     """
     # signals
-    buttonSignal = QtCore.pyqtSignal()
-    tableClickSignal = QtCore.pyqtSignal(object, object)
-    phaseCheckSignal = QtCore.pyqtSignal()
+    buttonSignal = Signal()
+    tableClickSignal = Signal(object, object)
+    phaseCheckSignal = Signal()
 
     def __init__(self, parent=None):
         super(FFTView, self).__init__(parent)
-        self.grid = QtGui.QGridLayout(self)
+        self.grid = QtWidgets.QGridLayout(self)
 
         # add splitter for resizing
-        splitter = QtGui.QSplitter(QtCore.Qt.Vertical)
+        splitter = QtWidgets.QSplitter(QtCore.Qt.Vertical)
 
         # make table
-        self.FFTTable = QtGui.QTableWidget(self)
+        self.FFTTable = QtWidgets.QTableWidget(self)
         self.FFTTable.resize(800, 800)
         self.FFTTable.setRowCount(9)
         self.FFTTable.setColumnCount(2)
@@ -78,8 +79,8 @@ class FFTView(QtGui.QWidget):
 
         self.FFTTable.resizeRowsToContents()
         # make advanced table options
-        self.advancedLabel = QtGui.QLabel("\n Advanced Options")
-        self.FFTTableA = QtGui.QTableWidget(self)
+        self.advancedLabel = QtWidgets.QLabel("\n Advanced Options")
+        self.FFTTableA = QtWidgets.QTableWidget(self)
         self.FFTTableA.resize(800, 800)
         self.FFTTableA.setRowCount(4)
         self.FFTTableA.setColumnCount(2)
@@ -110,7 +111,7 @@ class FFTView(QtGui.QWidget):
         self.FFTTableA.resizeRowsToContents()
 
         # make button
-        self.button = QtGui.QPushButton('Calculate FFT', self)
+        self.button = QtWidgets.QPushButton('Calculate FFT', self)
         self.button.setStyleSheet("background-color:lightgrey")
         # connects
         self.FFTTable.cellClicked.connect(self.tableClick)

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/FFT/fft_widget.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/FFT/fft_widget.py
@@ -4,10 +4,10 @@ from Muon.GUI.FrequencyDomainAnalysis.FFT.fft_view import FFTView
 from Muon.GUI.FrequencyDomainAnalysis.FFT.fft_presenter import FFTPresenter
 from Muon.GUI.FrequencyDomainAnalysis.FFT.fft_model import FFTModel, FFTWrapper
 
-from PyQt4 import QtGui
+from qtpy import QtWidgets
 
 
-class FFTWidget(QtGui.QWidget):
+class FFTWidget(QtWidgets.QWidget):
 
     def __init__(self, load, parent=None):
         super(FFTWidget, self).__init__(parent)

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_view.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_view.py
@@ -1,31 +1,32 @@
 from __future__ import (absolute_import, division, print_function)
 
-from PyQt4 import QtCore, QtGui
+from qtpy import QtCore, QtGui, QtWidgets
+from qtpy.QtCore import Signal
 
 from Muon.GUI.Common import table_utils
 
 
-class MaxEntView(QtGui.QWidget):
+class MaxEntView(QtWidgets.QWidget):
 
     """
     The view for the MaxEnt widget. This
     creates the look of the widget
     """
     # signals
-    maxEntButtonSignal = QtCore.pyqtSignal()
-    cancelSignal = QtCore.pyqtSignal()
-    phaseSignal = QtCore.pyqtSignal(object, object)
+    maxEntButtonSignal = Signal()
+    cancelSignal = Signal()
+    phaseSignal = Signal(object, object)
 
     def __init__(self, parent=None):
         super(MaxEntView, self).__init__(parent)
-        self.grid = QtGui.QVBoxLayout(self)
+        self.grid = QtWidgets.QVBoxLayout(self)
 
         # add splitter for resizing
-        splitter = QtGui.QSplitter(QtCore.Qt.Vertical)
+        splitter = QtWidgets.QSplitter(QtCore.Qt.Vertical)
 
         self.run = None
         # make table
-        self.table = QtGui.QTableWidget(self)
+        self.table = QtWidgets.QTableWidget(self)
         self.table.resize(800, 800)
 
         self.table.setRowCount(11)
@@ -87,9 +88,9 @@ class MaxEntView(QtGui.QWidget):
         self.table.resizeRowsToContents()
 
         # advanced options table
-        self.advancedLabel = QtGui.QLabel("\n  Advanced Options")
+        self.advancedLabel = QtWidgets.QLabel("\n  Advanced Options")
         # make table
-        self.tableA = QtGui.QTableWidget(self)
+        self.tableA = QtWidgets.QTableWidget(self)
         self.tableA.resize(800, 800)
 
         self.tableA.setRowCount(7)
@@ -132,9 +133,9 @@ class MaxEntView(QtGui.QWidget):
         self.tableA.setMinimumSize(40, 207)
 
         # make buttons
-        self.button = QtGui.QPushButton('Calculate MaxEnt', self)
+        self.button = QtWidgets.QPushButton('Calculate MaxEnt', self)
         self.button.setStyleSheet("background-color:lightgrey")
-        self.cancel = QtGui.QPushButton('Cancel', self)
+        self.cancel = QtWidgets.QPushButton('Cancel', self)
         self.cancel.setStyleSheet("background-color:lightgrey")
         self.cancel.setEnabled(False)
         # connects
@@ -142,7 +143,7 @@ class MaxEntView(QtGui.QWidget):
         self.cancel.clicked.connect(self.cancelClick)
         self.table.cellClicked.connect(self.phaseBoxClick)
         # button layout
-        self.buttonLayout = QtGui.QHBoxLayout()
+        self.buttonLayout = QtWidgets.QHBoxLayout()
         self.buttonLayout.addWidget(self.button)
         self.buttonLayout.addWidget(self.cancel)
         # add to layout

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_view.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_view.py
@@ -1,6 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 
-from qtpy import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtWidgets
 from qtpy.QtCore import Signal
 
 from Muon.GUI.Common import table_utils

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_widget.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_widget.py
@@ -4,10 +4,10 @@ from Muon.GUI.FrequencyDomainAnalysis.MaxEnt.maxent_view import MaxEntView
 from Muon.GUI.FrequencyDomainAnalysis.MaxEnt.maxent_presenter import MaxEntPresenter
 from Muon.GUI.FrequencyDomainAnalysis.MaxEnt.maxent_model import MaxEntModel, MaxEntWrapper
 
-from PyQt4 import QtGui
+from qtpy import QtWidgets
 
 
-class MaxEntWidget(QtGui.QWidget):
+class MaxEntWidget(QtWidgets.QWidget):
 
     def __init__(self, load, parent=None):
         super(MaxEntWidget, self).__init__(parent)

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/Transform/transform_view.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/Transform/transform_view.py
@@ -1,9 +1,9 @@
 from __future__ import (absolute_import, division, print_function)
 
-from PyQt4 import QtGui
+from qtpy import QtWidgets
 
 
-class TransformView(QtGui.QWidget):
+class TransformView(QtWidgets.QWidget):
 
     """
     Creates the view for the transformation tab.
@@ -15,7 +15,7 @@ class TransformView(QtGui.QWidget):
         super(TransformView, self).__init__(parent)
         # set selector
         self.selection = selectorView
-        self.Layout = QtGui.QGridLayout()
+        self.Layout = QtWidgets.QGridLayout()
         self.Layout.addWidget(self.selection, 1, 0)
         # add the transform widgets to the tab
         self.methods = groupedViews

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/Transform/transform_widget.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/Transform/transform_widget.py
@@ -6,19 +6,19 @@ from Muon.GUI.FrequencyDomainAnalysis.FFT.fft_widget import FFTWidget
 from Muon.GUI.FrequencyDomainAnalysis.MaxEnt.maxent_widget import MaxEntWidget
 from Muon.GUI.FrequencyDomainAnalysis.TransformSelection.transform_selection_widget import TransformSelectionWidget
 
-from PyQt4 import QtGui
+from qtpy import QtWidgets
 
 
-class TransformWidget(QtGui.QWidget):
+class TransformWidget(QtWidgets.QWidget):
     def __init__(self, load, parent=None):
-        super(TransformWidget,self).__init__(parent)
-        self._fft = FFTWidget(load=load,parent=self)
-        self._maxent = MaxEntWidget(load=load,parent=self)
+        super(TransformWidget, self).__init__(parent)
+        self._fft = FFTWidget(load=load, parent=self)
+        self._maxent = MaxEntWidget(load=load, parent=self)
         self._selector = TransformSelectionWidget(parent=self)
 
         groupedViews = self.getViews()
 
-        self._view = TransformView(self._selector.widget, groupedViews,parent)
+        self._view = TransformView(self._selector.widget, groupedViews, parent)
 
         self._selector.setSelectionConnection(self.updateDisplay)
 
@@ -29,12 +29,12 @@ class TransformWidget(QtGui.QWidget):
     def mockWidget(self, mockView):
         self._view = mockView
 
-    def closeEvent(self,event):
+    def closeEvent(self, event):
         self._selector.closeEvent(event)
         self._fft.closeEvent(event)
         self._maxent.closeEvent(event)
 
-    def updateDisplay(self,method):
+    def updateDisplay(self, method):
         self._view.hideAll()
         self._view.show(method)
 

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/TransformSelection/transform_selection_view.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/TransformSelection/transform_selection_view.py
@@ -1,20 +1,21 @@
 from __future__ import (absolute_import, division, print_function)
 
-from PyQt4 import QtCore, QtGui
+from qtpy import QtWidgets
+from qtpy.QtCore import Signal
 
 
-class TransformSelectionView(QtGui.QWidget):
+class TransformSelectionView(QtWidgets.QWidget):
 
     """
     Create the transformation selection widget's appearance
     """
     # signals
-    changeMethodSignal = QtCore.pyqtSignal(object)
+    changeMethodSignal = Signal(object)
 
     def __init__(self, parent=None):
         super(TransformSelectionView, self).__init__(parent)
-        self.grid = QtGui.QGridLayout(self)
-        self.methods = QtGui.QComboBox()
+        self.grid = QtWidgets.QGridLayout(self)
+        self.methods = QtWidgets.QComboBox()
         # default to FFT
         options = ["FFT", "MaxEnt"]
         self.methods.addItems(options)

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/TransformSelection/transform_selection_widget.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/TransformSelection/transform_selection_widget.py
@@ -3,10 +3,10 @@ from __future__ import (absolute_import, division, print_function)
 from Muon.GUI.FrequencyDomainAnalysis.TransformSelection.transform_selection_view import TransformSelectionView
 from Muon.GUI.FrequencyDomainAnalysis.TransformSelection.transform_selection_presenter import TransformSelectionPresenter
 
-from PyQt4 import QtGui
+from qtpy import QtWidgets
 
 
-class TransformSelectionWidget(QtGui.QWidget):
+class TransformSelectionWidget(QtWidgets.QWidget):
 
     def __init__(self, parent=None):
         super(TransformSelectionWidget, self).__init__(parent)

--- a/scripts/Muon/GUI/MuonAnalysis/dock/dock_widget.py
+++ b/scripts/Muon/GUI/MuonAnalysis/dock/dock_widget.py
@@ -1,6 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 
-from qtpy import QtGui, QtWidgets
+from qtpy import QtWidgets
 
 from Muon.GUI.Common.dummy.dummy_widget import DummyWidget
 from Muon.GUI.Common.dummy_label.dummy_label_widget import DummyLabelWidget

--- a/scripts/Muon/GUI/MuonAnalysis/dock/dock_widget.py
+++ b/scripts/Muon/GUI/MuonAnalysis/dock/dock_widget.py
@@ -1,14 +1,13 @@
 from __future__ import (absolute_import, division, print_function)
 
-from PyQt4 import QtGui
+from qtpy import QtGui, QtWidgets
 
 from Muon.GUI.Common.dummy.dummy_widget import DummyWidget
 from Muon.GUI.Common.dummy_label.dummy_label_widget import DummyLabelWidget
 from Muon.GUI.Common.dock.dock_view import DockView
 
 
-class DockWidget(QtGui.QWidget):
-
+class DockWidget(QtWidgets.QWidget):
     """
     This is a special case of the widget class structure.
     Normally we would only store the presenter and would
@@ -20,7 +19,7 @@ class DockWidget(QtGui.QWidget):
 
     def __init__(self, parent=None):
         super(DockWidget, self).__init__(parent)
-        self.dockWidget = QtGui.QWidget()
+        self.dockWidget = QtWidgets.QWidget()
 
         self.dock_view = DockView(self)
 
@@ -38,7 +37,7 @@ class DockWidget(QtGui.QWidget):
         self.dock_view.makeTabs()
         self.dock_view.keepDocksOpen()
 
-        QHbox = QtGui.QHBoxLayout()
+        QHbox = QtWidgets.QHBoxLayout()
         QHbox.addWidget(self.dock_view)
 
         self.dockWidget.setLayout(QHbox)


### PR DESCRIPTION
Closes #23335 

This PR updates all the current Muon code written in Python (i.e. `scripts/Muon`) to PyQt5 by using the `QtPy` module.

Essentially this amounts to using `from qtpy import <module>`, where `module` is the same as it would be in PyQt5. However this means that a lot of classes which were previously in `QtGui` are now in `QtWidgets`. 

Additionally, when using signals, these should be imported as `from qtpy.QtCore import Signal` and used as `my_sig = Signal()`.

##### Code Review #####

- Does the FDA, MaxEnt GUI open and function as before?
- Does the Elemental Analysis code still run correctly?
- Does the Muon Analysis 2 GUI still open and function?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
