### PR TITLE
Allow default grouping option for TOSCA

### DIFF
--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -11,6 +11,16 @@ Indirect Inelastic Changes
 
 :ref:`Release 3.14.0 <v3.14.0>`
 
+Data Analysis Interface
+-----------------------
+
+Bugfixes
+########
+
+- The parameter values for a selected spectrum are now updated properly when a Fit is run using the Fit String 
+  option in ConvFit.
+
+
 Data Corrections Interface
 --------------------------
 
@@ -22,11 +32,14 @@ Improvements
 - Added 'MaxScatterPtAttempts' spinbox to Calculate Monte Carlo Absorption. This sets the maximum number of 
   tries to be made to generate a scattering point.
 
-Data Analysis Interfaces
--------------------------
 
-Bugfixes
-########
+Data Reduction Interface
+------------------------
 
-- The parameter values for a selected spectrum are now updated properly when a Fit is run using the Fit String 
-  option in ConvFit.
+Improvements
+############
+
+- Added 'Default' detector grouping option in ISISEnergyTransfer for TOSCA, to allow a default grouping 
+  using the grouping specified in the Instrument Parameter File.
+- ISISEnergyTransfer now allows overlapping detector grouping.
+

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -57,7 +57,7 @@ getCustomGroupingNumbers(std::string const &customString) {
   // Get the numbers from customString and store them in customGroupingStrings
   boost::split(customGroupingStrings, customString, boost::is_any_of(" ,-+:"));
   for (const auto &string : customGroupingStrings)
-    if (string != "")
+    if (!string.empty())
       customGroupingNumbers.emplace_back(std::stoull(string));
   return customGroupingNumbers;
 }
@@ -268,7 +268,7 @@ QString ISISEnergyTransfer::validateDetectorGrouping() const {
   } else if (m_uiForm.cbGroupingOptions->currentText() == "Custom") {
     const std::string customString =
         m_uiForm.leCustomGroups->text().toStdString();
-    if (customString == "")
+    if (customString.empty())
       return "Please supply a custom grouping for detectors.";
     else
       return checkCustomGroupingNumbersInRange(

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -376,7 +376,7 @@ void ISISEnergyTransfer::algorithmComplete(bool error) {
 }
 
 void ISISEnergyTransfer::removeGroupingOption(const QString &option) {
-  for (auto i = 0u; i < m_uiForm.cbGroupingOptions->count(); ++i)
+  for (auto i = 0; i < m_uiForm.cbGroupingOptions->count(); ++i)
     if (m_uiForm.cbGroupingOptions->itemText(i) == option) {
       m_uiForm.cbGroupingOptions->removeItem(i);
       return;

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -47,7 +47,6 @@ std::string createDetectorGroupingString(std::size_t numberOfDetectors,
   return createDetectorGroupingString(groupSize, numberOfGroups,
                                       numberOfDetectors);
 }
-
 } // namespace
 
 namespace MantidQt {
@@ -316,6 +315,7 @@ void ISISEnergyTransfer::run() {
 
   std::pair<std::string, std::string> grouping =
       createMapFile(m_uiForm.cbGroupingOptions->currentText().toStdString());
+
   reductionAlg->setProperty("GroupingMethod", grouping.first);
 
   if (grouping.first == "File")
@@ -375,6 +375,22 @@ void ISISEnergyTransfer::algorithmComplete(bool error) {
   m_uiForm.ckSaveSPE->setEnabled(true);
 }
 
+void ISISEnergyTransfer::removeGroupingOption(const QString &option) {
+  for (auto i = 0u; i < m_uiForm.cbGroupingOptions->count(); ++i)
+    if (m_uiForm.cbGroupingOptions->itemText(i) == option) {
+      m_uiForm.cbGroupingOptions->removeItem(i);
+      return;
+    }
+}
+
+void ISISEnergyTransfer::includeExtraGroupingOption(bool includeOption,
+                                                    const QString &option) {
+  if (includeOption)
+    m_uiForm.cbGroupingOptions->addItem(option);
+  else
+    removeGroupingOption(option);
+}
+
 /**
  * Called when the instrument has changed, used to update default values.
  */
@@ -388,6 +404,12 @@ void ISISEnergyTransfer::setInstrumentDefault() {
   qens << "IRIS"
        << "OSIRIS";
   m_uiForm.spEfixed->setEnabled(qens.contains(instDetails["instrument"]));
+
+  QStringList allowDefaultGroupingInstruments;
+  allowDefaultGroupingInstruments << "TOSCA";
+  includeExtraGroupingOption(
+      allowDefaultGroupingInstruments.contains(instDetails["instrument"]),
+      "Default");
 
   if (instDetails["spectra-min"].isEmpty() ||
       instDetails["spectra-max"].isEmpty()) {

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
@@ -77,7 +77,10 @@ private:
   std::vector<std::string> getSaveFormats(); ///< get a vector of save formats
   std::vector<std::string>
       m_outputWorkspaces; ///< get a vector of workspaces to plot
-  QString validateDetectorGrouping();
+  bool numberInCorrectRange(std::size_t const &spectraNumber) const;
+  QString checkCustomGroupingNumbersInRange(
+      std::vector<std::size_t> const &customGroupingNumbers) const;
+  QString validateDetectorGrouping() const;
   std::string getDetectorGroupingString() const;
 };
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
@@ -50,6 +50,8 @@ public slots:
 
 private slots:
   void algorithmComplete(bool error);
+  void removeGroupingOption(const QString &option);
+  void includeExtraGroupingOption(bool includeOption, const QString &option);
   void
   setInstrumentDefault(); ///< Sets default parameters for current instrument
   void mappingOptionSelected(


### PR DESCRIPTION
**Description of work.**
This PR adds an option for default detector groups in ISIS Energy Transfer in the Indirect Data Reduction interface for the TOSCA instrument only. 
This PR also allows spectra numbers to be entered instead of spectra indices in the `Custom` grouping option.
The overlapping of spectra numbers in the `custom` grouping option is also now allowed.

**To test:**
**1.**
- Open Indirect > Data Reduction
- Select instrument to be TOSCA
- In the ISIS Energy Transfer tab, load the file below
[TSC10076.raw](https://files.slack.com/files-pri/T02J4MMEW-FCKLQHRFB/download/tsc10076.raw)
- In Detector Grouping, under Mode, there should be a `Default` grouping option for when the TOSCA instrument is selected (**Problem 1**)
- Click `Run`. The process should run without error and the resultant workspace should contain 3 spectra. 

**2.**
- Use the same file above. In the `Custom` grouping option, enter the following `1-70, 71-140, 1-140` 
- Click 'Run'. The process should run without error. This tests that the spectra numbers (instead of spectra indices) are allowed, and that overlapping groups are allowed. (**Problem 2 and 3**). 
- The resulting workspace should be exactly the same as the output workspace achieved during the default grouping. The algorithm `CompareWorkspaces` could be used to check that this is the case - the table produced by this algorithm should be empty.

Fixes #23321 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
