### PR TITLE
Fix workbench plotting test for matplotlib >= v2

### DIFF
--- a/qt/applications/workbench/workbench/plotting/test/test_functions.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_functions.py
@@ -112,7 +112,7 @@ class FunctionsTest(TestCase):
     def test_plot_from_names_produces_single_error_plot_for_valid_name(self, get_spectra_selection_mock):
         fig = self._do_plot_from_names_test(get_spectra_selection_mock,
                                             # matplotlib does not set labels on the lines for error plots
-                                            expected_labels=[None, None, None],
+                                            expected_labels=[],
                                             wksp_indices=[0], errors=True, overplot=False)
         self.assertEqual(1, len(fig.gca().containers))
 
@@ -184,7 +184,7 @@ class FunctionsTest(TestCase):
         if target_fig is not None:
             self.assertEqual(target_fig, fig)
 
-        plotted_lines = fig.gca().get_lines()
+        plotted_lines = fig.gca().get_legend().get_lines()
         self.assertEqual(len(expected_labels), len(plotted_lines))
         for label_part, line in zip(expected_labels, plotted_lines):
             if label_part is not None:


### PR DESCRIPTION
**Description of work.**

See commit message.

**Report to:** [nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

* If you wish to check locally then you can install matplotlib in a `virtualenv`:

```
virtualenv --system-site-packages mpl2 ~/.virtualenvs/mpl2
. ~/.virtualenvs/mpl2/bin/activate
pip install matplotlib
``` 


*There is no associated issue.*

*This does not require release notes* because **it fixes a development issue**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
