### PR TITLE
Fix problem with const-Q

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/MagnetismReflectometryReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/MagnetismReflectometryReduction.py
@@ -572,7 +572,7 @@ class MagnetismReflectometryReduction(PythonAlgorithm):
         """
         if self._tof_range is not None:
             self.validate_tof_range(ws_event_data)
-            return self._tof_range
+            return
 
         tof_step = self.getProperty("TimeAxisStep").value
         crop_TOF = self.getProperty("CutTimeAxis").value
@@ -593,8 +593,6 @@ class MagnetismReflectometryReduction(PythonAlgorithm):
             self._tof_range = [tof_min, tof_max]
             logger.notice("Determining range: %g %g" % (tof_min, tof_max))
 
-        return self._tof_range
-
     def validate_tof_range(self, ws_event_data):
         """
             Validate that the TOF range we previously stored is consistent with
@@ -610,7 +608,6 @@ class MagnetismReflectometryReduction(PythonAlgorithm):
                 error_msg += "[%g, %g] found [%g, %g]" % (self._tof_range[0], self._tof_range[1],
                                                           tof_min, tof_max)
                 raise RuntimeError(error_msg)
-        return True
 
     def write_meta_data(self, workspace):
         """

--- a/Testing/SystemTests/tests/analysis/MagnetismReflectometryReductionTest.py
+++ b/Testing/SystemTests/tests/analysis/MagnetismReflectometryReductionTest.py
@@ -41,6 +41,68 @@ class MagnetismReflectometryReductionTest(stresstesting.MantidStressTest):
         return "r_24949", 'MagnetismReflectometryReductionTest.nxs'
 
 
+class MagnetismReflectometryReductionConstQTest(stresstesting.MantidStressTest):
+    def runTest(self):
+        wsg = MRFilterCrossSections(Filename="REF_M_24949")
+        MagnetismReflectometryReduction(InputWorkspace=wsg[0],
+                                        NormalizationRunNumber=24945,
+                                        SignalPeakPixelRange=[125, 129],
+                                        SubtractSignalBackground=True,
+                                        SignalBackgroundPixelRange=[15, 105],
+                                        ApplyNormalization=True,
+                                        NormPeakPixelRange=[201, 205],
+                                        SubtractNormBackground=True,
+                                        NormBackgroundPixelRange=[10,127],
+                                        CutLowResDataAxis=True,
+                                        LowResDataAxisPixelRange=[91, 161],
+                                        CutLowResNormAxis=True,
+                                        LowResNormAxisPixelRange=[86, 174],
+                                        CutTimeAxis=True,
+                                        UseWLTimeAxis=False,
+                                        QMin=0.005,
+                                        QStep=-0.01,
+                                        TimeAxisStep=40,
+                                        TimeAxisRange=[25000, 54000],
+                                        SpecularPixel=126.9,
+                                        ConstantQBinning=True,
+                                        OutputWorkspace="r_24949")
+
+    def validate(self):
+        refl = mtd["r_24949"].dataY(0)
+        return math.fabs(refl[1] - 0.648596877775159) < 0.002
+
+
+class MagnetismReflectometryReductionConstQWLCutTest(stresstesting.MantidStressTest):
+    def runTest(self):
+        wsg = MRFilterCrossSections(Filename="REF_M_24949")
+        MagnetismReflectometryReduction(InputWorkspace=wsg[0],
+                                        NormalizationRunNumber=24945,
+                                        SignalPeakPixelRange=[125, 129],
+                                        SubtractSignalBackground=True,
+                                        SignalBackgroundPixelRange=[15, 105],
+                                        ApplyNormalization=True,
+                                        NormPeakPixelRange=[201, 205],
+                                        SubtractNormBackground=True,
+                                        NormBackgroundPixelRange=[10,127],
+                                        CutLowResDataAxis=True,
+                                        LowResDataAxisPixelRange=[91, 161],
+                                        CutLowResNormAxis=True,
+                                        LowResNormAxisPixelRange=[86, 174],
+                                        CutTimeAxis=True,
+                                        UseWLTimeAxis=True,
+                                        QMin=0.005,
+                                        QStep=-0.01,
+                                        TimeAxisStep=0.007,
+                                        TimeAxisRange=[4.5, 10.5],
+                                        SpecularPixel=126.9,
+                                        ConstantQBinning=True,
+                                        OutputWorkspace="r_24949")
+
+    def validate(self):
+        refl = mtd["r_24949"].dataY(0)
+        return math.fabs(refl[1] - 0.648596877775159) < 0.002
+
+
 class MRFilterCrossSectionsTest(stresstesting.MantidStressTest):
     """ Test data loading and cross-section extraction """
     def runTest(self):


### PR DESCRIPTION
**Description of work.**
A problem was found with the constant-Q option of the `MagnetismReflectometryReduction` algorithm. A unit conversion was missing before a rebinning.

While fixing this, also add system tests that will exercise the constant-Q option.

**To test:**
- Inspect code
- Make sure tests pass

*There is no associated issue.*

*This does not require release notes* because **it doesn't add functionality and relates to functionality that wasn't yet used in production.**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
