### PR TITLE
Centralise icon access in mantidqt and workbench

### DIFF
--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -22,7 +22,7 @@ from __future__ import (absolute_import, division, print_function,
 
 # third-party library imports
 from matplotlib.backends.backend_qt5 import NavigationToolbar2QT
-import qtawesome as qta
+from mantidqt.icons import get_icon
 from qtpy import QtCore, QtGui, QtPrintSupport, QtWidgets
 
 # local package imports
@@ -52,7 +52,7 @@ class WorkbenchNavigationToolbar(NavigationToolbar2QT):
                 self.addSeparator()
             else:
                 if fa_icon:
-                    a = self.addAction(qta.icon(fa_icon),
+                    a = self.addAction(get_icon(fa_icon),
                                        text, getattr(self, callback))
                 else:
                     a = self.addAction(text, getattr(self, callback))

--- a/qt/applications/workbench/workbench/widgets/plotselector/test/test_plotselector_view.py
+++ b/qt/applications/workbench/workbench/widgets/plotselector/test/test_plotselector_view.py
@@ -17,9 +17,8 @@
 from __future__ import absolute_import, division, print_function
 
 from qtpy.QtCore import Qt
+from qtpy.QtGui import QIcon
 from qtpy.QtTest import QTest
-
-import qtawesome as qta
 
 from mantidqt.utils.qt.test import requires_qapp
 
@@ -41,6 +40,11 @@ class PlotSelectorWidgetTest(unittest.TestCase):
         self.presenter.get_plot_name_from_number = mock.Mock(side_effect=self.se_plot_name)
         self.presenter.get_initial_last_active_value = mock.Mock(side_effect=self.se_get_initial_last_active_value)
         self.presenter.is_shown_by_filter = mock.Mock(side_effect=self.se_is_shown_by_filter)
+
+        patcher = mock.patch('workbench.widgets.plotselector.view.get_icon')
+        self.mock_get_icon = patcher.start()
+        self.mock_get_icon.return_value = QIcon()
+        self.addCleanup(patcher.stop)
 
         self.view = PlotSelectorView(self.presenter)
         self.view.table_widget.setSortingEnabled(False)
@@ -285,24 +289,18 @@ class PlotSelectorWidgetTest(unittest.TestCase):
     def test_set_visibility_icon_to_visible(self):
         plot_numbers = [0, 1, 2]
         self.view.set_plot_list(plot_numbers)
-
+        self.mock_get_icon.reset_mock()
         self.view.set_visibility_icon(0, True)
 
-        name_widget = self.view.table_widget.cellWidget(0, Column.Name)
-        icon = name_widget.hide_button.icon()
-        self.assertEqual(icon.pixmap(50, 50).toImage(),
-                         qta.icon('fa.eye').pixmap(50, 50).toImage())
+        self.mock_get_icon.assert_called_once_with('fa.eye')
 
     def test_set_visibility_icon_to_hidden(self):
         plot_numbers = [0, 1, 2]
         self.view.set_plot_list(plot_numbers)
-
+        self.mock_get_icon.reset_mock()
         self.view.set_visibility_icon(0, False)
 
-        name_widget = self.view.table_widget.cellWidget(0, Column.Name)
-        icon = name_widget.hide_button.icon()
-        self.assertEqual(icon.pixmap(50, 50).toImage(),
-                         qta.icon('fa.eye', color='lightgrey').pixmap(50, 50).toImage())
+        self.mock_get_icon.assert_called_once_with('fa.eye', color='lightgrey')
 
     # ------------------------ Plot Renaming ------------------------
 

--- a/qt/applications/workbench/workbench/widgets/plotselector/view.py
+++ b/qt/applications/workbench/workbench/widgets/plotselector/view.py
@@ -22,8 +22,7 @@ from qtpy.QtCore import Qt, Signal, QMutex, QMutexLocker
 from qtpy.QtWidgets import (QAbstractItemView, QAction, QActionGroup, QFileDialog, QHBoxLayout, QHeaderView, QLineEdit,
                             QMenu, QPushButton, QTableWidget, QTableWidgetItem, QVBoxLayout, QWidget)
 
-import qtawesome as qta
-
+from mantidqt.icons import get_icon
 from mantidqt.utils.flowlayout import FlowLayout
 from mantidqt.py3compat.enum import IntEnum
 from workbench.plotting.qappthreadcall import QAppThreadCall
@@ -629,14 +628,14 @@ class PlotNameWidget(QWidget):
         self.line_edit.setAttribute(Qt.WA_TransparentForMouseEvents, True)
         self.line_edit.editingFinished.connect(self.rename_plot)
 
-        shown_icon = qta.icon('fa.eye')
+        shown_icon = get_icon('fa.eye')
         self.hide_button = QPushButton(shown_icon, "")
         self.hide_button.setToolTip('Hide')
         self.hide_button.setFlat(True)
         self.hide_button.setMaximumWidth(self.hide_button.iconSize().width() * 5 / 3)
         self.hide_button.clicked.connect(self.toggle_visibility)
 
-        rename_icon = qta.icon('fa.edit')
+        rename_icon = get_icon('fa.edit')
         self.rename_button = QPushButton(rename_icon, "")
         self.rename_button.setToolTip('Rename')
         self.rename_button.setFlat(True)
@@ -644,7 +643,7 @@ class PlotNameWidget(QWidget):
         self.rename_button.setCheckable(True)
         self.rename_button.toggled.connect(self.rename_button_toggled)
 
-        close_icon = qta.icon('fa.close')
+        close_icon = get_icon('fa.close')
         self.close_button = QPushButton(close_icon, "")
         self.close_button.setToolTip('Delete')
         self.close_button.setFlat(True)
@@ -729,10 +728,10 @@ class PlotNameWidget(QWidget):
         :param is_shown: True if plot is shown, false if hidden
         """
         if is_shown:
-            self.hide_button.setIcon(qta.icon('fa.eye'))
+            self.hide_button.setIcon(get_icon('fa.eye'))
             self.hide_button.setToolTip('Hide')
         else:
-            self.hide_button.setIcon(qta.icon('fa.eye', color='lightgrey'))
+            self.hide_button.setIcon(get_icon('fa.eye', color='lightgrey'))
             self.hide_button.setToolTip('Show')
 
     def rename_plot(self):

--- a/qt/python/mantidqt/dialogs/spectraselectordialog.py
+++ b/qt/python/mantidqt/dialogs/spectraselectordialog.py
@@ -20,10 +20,10 @@ from __future__ import (absolute_import, unicode_literals)
 
 # 3rd party imports
 from mantid.api import MatrixWorkspace
-import qtawesome as qta
 from qtpy.QtWidgets import QDialogButtonBox
 
 # local imports
+from mantidqt.icons import get_icon
 from mantidqt.utils.qt import load_ui
 
 # Constants
@@ -35,7 +35,7 @@ RED_ASTERISK = None
 def red_asterisk():
     global RED_ASTERISK
     if RED_ASTERISK is None:
-        RED_ASTERISK = qta.icon('fa.asterisk', color='red', scale_factor=0.6)
+        RED_ASTERISK = get_icon('fa.asterisk', color='red', scale_factor=0.6)
     return RED_ASTERISK
 
 

--- a/qt/python/mantidqt/dialogs/test/test_spectraselectiondialog.py
+++ b/qt/python/mantidqt/dialogs/test/test_spectraselectiondialog.py
@@ -24,6 +24,7 @@ except ImportError:
 
 # 3rdparty imports
 from mantid.api import WorkspaceFactory
+from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QDialog, QDialogButtonBox
 
 # local imports
@@ -35,10 +36,17 @@ from mantidqt.dialogs.spectraselectordialog import (get_spectra_selection, parse
 @requires_qapp
 class SpectraSelectionDialogTest(unittest.TestCase):
 
+    _mock_get_icon = None
     _single_spec_ws = None
     _multi_spec_ws = None
 
     def setUp(self):
+        # patch away getting a real icon as it can hit a race condition when running tests
+        # in parallel
+        patcher = mock.patch('mantidqt.dialogs.spectraselectordialog.get_icon')
+        self._mock_get_icon = patcher.start()
+        self._mock_get_icon.return_value = QIcon()
+        self.addCleanup(patcher.stop)
         if self._single_spec_ws is None:
             self.__class__._single_spec_ws = WorkspaceFactory.Instance().create("Workspace2D", NVectors=1,
                                                                                 XLength=1, YLength=1)
@@ -104,6 +112,7 @@ class SpectraSelectionDialogTest(unittest.TestCase):
         dlg._ui.wkspIndices.setText("50-60")
         dlg._ui.buttonBox.button(QDialogButtonBox.Ok).click()
 
+        self._mock_get_icon.assert_called_once_with('fa.asterisk', color='red', scale_factor=0.6)
         self.assertTrue(dlg.selection is not None)
         self.assertTrue(dlg.selection.spectra is None)
         self.assertEqual(list(range(50, 61)), dlg.selection.wksp_indices)

--- a/qt/python/mantidqt/icons.py
+++ b/qt/python/mantidqt/icons.py
@@ -1,0 +1,32 @@
+#  This file is part of the mantid workbench.
+#
+#  Copyright (C) 2018 mantidproject
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Icon access. Icons are provided by qtawesome.
+"""
+from __future__ import absolute_import
+
+# std imports
+
+# third party imports
+import qtawesome as qta
+
+
+def get_icon(*names, **kwargs):
+    """Return a QIcon corresponding to the icon name.
+    See qtawesome.icon documentation for a full list of options.
+    """
+    return qta.icon(*names, **kwargs)

--- a/qt/python/mantidqt/utils/qt/__init__.py
+++ b/qt/python/mantidqt/utils/qt/__init__.py
@@ -24,10 +24,12 @@ from importlib import import_module
 import os.path as osp
 
 # 3rd-party modules
-import qtawesome as qta
 from qtpy import QT_VERSION
 from qtpy.uic import loadUi, loadUiType
 from qtpy.QtWidgets import QAction, QMenu
+
+# local modules
+from ...icons import get_icon
 
 LIB_SUFFIX = 'qt' + QT_VERSION[0]
 
@@ -135,7 +137,7 @@ def create_action(parent, text, on_triggered=None, shortcut=None,
         if shortcut_context is not None:
             action.setShortcutContext(shortcut_context)
     if icon_name is not None:
-        action.setIcon(qta.icon(icon_name))
+        action.setIcon(get_icon(icon_name))
 
     return action
 


### PR DESCRIPTION
**Description of work.**

Defines a central location for accessing icons in the new `mantidqt` package. See commit message for full details.

**Report to:** [nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

Code review unless you can reproduce the race condition mentioned in the commit message.

*There is no associated issue.*

*This does not require release notes* because it **fixes random unit test failures.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
