### PR TITLE
ALC interface bug

### DIFF
--- a/docs/source/release/v3.14.0/muon.rst
+++ b/docs/source/release/v3.14.0/muon.rst
@@ -12,6 +12,7 @@ Improvements
 ############
 - Elemental Analysis added to Muon Interfaces: Includes a selectable Periodic Table.
 - TF Asymmetry mode now displays the chi squared value at the top of the browser.
+- ALC interface now sorts the data into ascending order.
 
 Bugfixes
 ########

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
@@ -192,12 +192,12 @@ void ALCDataLoadingPresenter::load(const std::string &lastFile) {
       throw std::runtime_error(result.error());
     }
 
-    m_loadedData = alg->getProperty("OutputWorkspace");
+    MatrixWorkspace_sptr tmp = alg->getProperty("OutputWorkspace");
 
 	IAlgorithm_sptr sortAlg =
 		AlgorithmManager::Instance().create("SortXAxis");
 	sortAlg->setChild(true); // Don't want workspaces in the ADS
-	sortAlg->setProperty("InputWorkspace", m_loadedData);
+	sortAlg->setProperty("InputWorkspace", tmp);
 	sortAlg->setProperty("Ordering", "Ascending");
 	sortAlg->setProperty("OutputWorkspace", "__NotUsed__");
 

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
@@ -194,6 +194,17 @@ void ALCDataLoadingPresenter::load(const std::string &lastFile) {
 
     m_loadedData = alg->getProperty("OutputWorkspace");
 
+	IAlgorithm_sptr sortAlg =
+		AlgorithmManager::Instance().create("SortXAxis");
+	sortAlg->setChild(true); // Don't want workspaces in the ADS
+	sortAlg->setProperty("InputWorkspace", m_loadedData);
+	sortAlg->setProperty("Ordering", "Ascending");
+	sortAlg->setProperty("OutputWorkspace", "__NotUsed__");
+
+	sortAlg->execute();
+	m_loadedData = sortAlg->getProperty("OutputWorkspace");
+
+
     // If errors are properly caught, shouldn't happen
     assert(m_loadedData);
     // If subtract is not checked, only one spectrum,

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
@@ -194,15 +194,14 @@ void ALCDataLoadingPresenter::load(const std::string &lastFile) {
 
     MatrixWorkspace_sptr tmp = alg->getProperty("OutputWorkspace");
 
-	IAlgorithm_sptr sortAlg =
-		AlgorithmManager::Instance().create("SortXAxis");
-	sortAlg->setChild(true); // Don't want workspaces in the ADS
-	sortAlg->setProperty("InputWorkspace", tmp);
-	sortAlg->setProperty("Ordering", "Ascending");
-	sortAlg->setProperty("OutputWorkspace", "__NotUsed__");
+    IAlgorithm_sptr sortAlg = AlgorithmManager::Instance().create("SortXAxis");
+    sortAlg->setChild(true); // Don't want workspaces in the ADS
+    sortAlg->setProperty("InputWorkspace", tmp);
+    sortAlg->setProperty("Ordering", "Ascending");
+    sortAlg->setProperty("OutputWorkspace", "__NotUsed__");
 
-	sortAlg->execute();
-	m_loadedData = sortAlg->getProperty("OutputWorkspace");
+    sortAlg->execute();
+    m_loadedData = sortAlg->getProperty("OutputWorkspace");
 
     // If errors are properly caught, shouldn't happen
     assert(m_loadedData);

--- a/qt/scientific_interfaces/test/ALCDataLoadingPresenterTest.h
+++ b/qt/scientific_interfaces/test/ALCDataLoadingPresenterTest.h
@@ -360,7 +360,7 @@ public:
             AllOf(Property(&QwtData::size, 3), QwtDataX(0, 1360.200, 1E-3),
                   QwtDataX(1, 1364.520, 1E-3), QwtDataX(2, 1398.090, 1E-3),
                   QwtDataY(0, 0.14289, 1E-5), QwtDataY(1, 0.12837, 1E-5),
-                  QwtDataY(2, 0.15004, 1E-5)), 
+                  QwtDataY(2, 0.15004, 1E-5)),
             AllOf(Property(&std::vector<double>::size, 3),
                   VectorValue(0, 1.284E-3, 1E-6),
                   VectorValue(1, 1.280E-3, 1E-6),

--- a/qt/scientific_interfaces/test/ALCDataLoadingPresenterTest.h
+++ b/qt/scientific_interfaces/test/ALCDataLoadingPresenterTest.h
@@ -357,14 +357,14 @@ public:
     EXPECT_CALL(
         *m_view,
         setDataCurve(
-            AllOf(Property(&QwtData::size, 3), QwtDataX(0, 1398.090, 1E-3),
-                  QwtDataX(1, 1360.200, 1E-3), QwtDataX(2, 1364.520, 1E-3),
-                  QwtDataY(0, 0.15004, 1E-5), QwtDataY(1, 0.14289, 1E-5),
-                  QwtDataY(2, 0.12837, 1E-5)),
+            AllOf(Property(&QwtData::size, 3), QwtDataX(0, 1360.200, 1E-3),
+                  QwtDataX(1, 1364.520, 1E-3), QwtDataX(2, 1398.090, 1E-3),
+                  QwtDataY(0, 0.14289, 1E-5), QwtDataY(1, 0.12837, 1E-5),
+                  QwtDataY(2, 0.15004, 1E-5)), 
             AllOf(Property(&std::vector<double>::size, 3),
-                  VectorValue(0, 1.285E-3, 1E-6),
-                  VectorValue(1, 1.284E-3, 1E-6),
-                  VectorValue(2, 1.280E-3, 1E-6))));
+                  VectorValue(0, 1.284E-3, 1E-6),
+                  VectorValue(1, 1.280E-3, 1E-6),
+                  VectorValue(2, 1.285E-3, 1E-6))));
     m_view->requestLoading();
   }
 


### PR DESCRIPTION
The ALC interface had a bug that caused the fitting range to be shorter than the data range and for the plot to look like a mess.


**To test:**

<!-- Instructions for testing. -->
Open mantid and set the default instrument to EMU
Tuyrn on search the data archieve
Open the ALC interface (in Muon)
For the first data put 81061 and for last put 81142
Select field_danfysik for the log value
tick the subtract box in the periods section and set the second combo box to 2.
In calculation set the max to 16
Click run and wait for the data to load

Click baseline modelling
Add a linear background fit function
Add 2 fitting regions
Set one to before the peak and one to after peak
You should be able to go up to the largest x value (this was bug 1)
Do the fit

Go to the curve fitting
Add a Gaussian (put sigma = 1, centre = 2100 and height  =0.1)
Do a fit
The fitted result should make sense (and not be a jumbled mess).

Fixes #23359. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
