### PR TITLE
Run PyQt-based unit tests sequentially

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/FractionalIndexingTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/FractionalIndexingTest.py
@@ -1,10 +1,10 @@
 import unittest
 import numpy as np
 import numpy.testing as npt
-import fractional_indexing as indexing
 
 from mantid.geometry import UnitCell
 from mantid.simpleapi import CreatePeaksWorkspace, CreateSimulationWorkspace
+import fractional_indexing as indexing
 
 
 class FractionIndexingTests(unittest.TestCase):

--- a/Framework/PythonInterface/test/testhelpers/testrunner.py
+++ b/Framework/PythonInterface/test/testhelpers/testrunner.py
@@ -128,8 +128,9 @@ def result_class(pathname):
 
 
 if __name__ == "__main__":
-    # Import mantid so that it sets up the additional paths to scripts etc
-    # It would be good to try & remove this to soften the impact on tests
-    # that don't require importing mantid at all
-    import mantid  # noqa
+    if "TESTRUNNER_IMPORT_MANTID" in os.environ:
+        # Import mantid so that it sets up the additional paths to scripts etc
+        # It would be good to try & remove this to soften the impact on tests
+        # that don't require importing mantid at all
+        import mantid  # noqa
     main(sys.argv)

--- a/buildconfig/CMake/FindPyUnitTest.cmake
+++ b/buildconfig/CMake/FindPyUnitTest.cmake
@@ -35,6 +35,9 @@ function ( PYUNITTEST_ADD_TEST _test_src_dir _testname_prefix )
   if ( PYUNITTEST_QT_API )
     list ( APPEND _test_environment "QT_API=${PYUNITTEST_QT_API}" )
   endif()
+  if ( PYUNITTEST_TESTRUNNER_IMPORT_MANTID )
+    list ( APPEND _test_environment "TESTRUNNER_IMPORT_MANTID=1" )
+  endif()
 
   # Add all of the individual tests so that they can be run in parallel
   foreach ( part ${ARGN} )

--- a/buildconfig/CMake/FindPyUnitTest.cmake
+++ b/buildconfig/CMake/FindPyUnitTest.cmake
@@ -49,6 +49,10 @@ function ( PYUNITTEST_ADD_TEST _test_src_dir _testname_prefix )
                            WORKING_DIRECTORY ${_working_dir}
                            ENVIRONMENT "${_test_environment}"
                            TIMEOUT ${TESTING_TIMEOUT} )
+    if ( PYUNITTEST_RUN_SERIAL )
+      set_tests_properties ( ${_pyunit_separate_name} PROPERTIES
+                             RUN_SERIAL 1 )
+    endif ()
   endforeach ( part ${ARGN} )
 endfunction ()
 

--- a/qt/applications/workbench/CMakeLists.txt
+++ b/qt/applications/workbench/CMakeLists.txt
@@ -27,6 +27,7 @@ set ( TEST_FILES
   workbench/widgets/plotselector/test/test_plotselector_view.py
 )
 
+set ( PYUNITTEST_RUN_SERIAL ON )
 set ( PYUNITTEST_QT_API pyqt5)
 pyunittest_add_test ( ${CMAKE_CURRENT_SOURCE_DIR}
   workbench ${TEST_FILES}

--- a/qt/applications/workbench/workbench/plugins/test/test_jupyterconsole.py
+++ b/qt/applications/workbench/workbench/plugins/test/test_jupyterconsole.py
@@ -20,15 +20,14 @@ from __future__ import (absolute_import)
 import unittest
 
 # third-party library imports
-from mantidqt.utils.qt.test import requires_qapp
+from mantidqt.utils.qt.test import GuiTest
 from qtpy.QtWidgets import QMainWindow
 
 # local package imports
 from workbench.plugins.jupyterconsole import InProcessJupyterConsole, JupyterConsole
 
 
-@requires_qapp
-class JupyterConsoleTest(unittest.TestCase):
+class JupyterConsoleTest(GuiTest):
 
     def test_construction_creates_inprocess_console_widget(self):
         main_window = QMainWindow()

--- a/qt/applications/workbench/workbench/widgets/plotselector/test/test_plotselector_view.py
+++ b/qt/applications/workbench/workbench/widgets/plotselector/test/test_plotselector_view.py
@@ -16,11 +16,10 @@
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import absolute_import, division, print_function
 
+from mantidqt.utils.qt.test import GuiTest
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QIcon
 from qtpy.QtTest import QTest
-
-from mantidqt.utils.qt.test import requires_qapp
 
 from workbench.widgets.plotselector.presenter import PlotSelectorPresenter
 from workbench.widgets.plotselector.view import EXPORT_TYPES, PlotSelectorView, Column
@@ -32,8 +31,7 @@ except ImportError:
     import mock
 
 
-@requires_qapp
-class PlotSelectorWidgetTest(unittest.TestCase):
+class PlotSelectorWidgetTest(GuiTest):
 
     def setUp(self):
         self.presenter = mock.Mock(spec=PlotSelectorPresenter)

--- a/qt/python/CMakeLists.txt
+++ b/qt/python/CMakeLists.txt
@@ -87,6 +87,7 @@ endif ()
   )
 
   # Tests
+  set ( PYUNITTEST_RUN_SERIAL ON )
   set ( PYUNITTEST_QT_API pyqt5 )
   pyunittest_add_test ( ${CMAKE_CURRENT_SOURCE_DIR}
     mantidqt_qt5 ${PYTHON_TEST_FILES}
@@ -101,6 +102,4 @@ endif ()
     mantidqt_qt4 ${PYTHON_TEST_FILES}
   )
   unset ( PYUNITTEST_QT_API )
-  # No package installation yet...
-  # Configure utils.qt.plugins file for install
 endif ()

--- a/qt/python/mantidqt/dialogs/test/test_algorithm_dialog.py
+++ b/qt/python/mantidqt/dialogs/test/test_algorithm_dialog.py
@@ -20,10 +20,10 @@ from qtpy.QtWidgets import QWidget, QLineEdit
 
 from mantid.api import AlgorithmManager, AlgorithmFactory, PythonAlgorithm
 from mantid.kernel import Direction, FloatArrayProperty
-from mantidqt.utils.qt.test import requires_qapp
 from mantidqt.dialogs.algorithmdialog import AlgorithmDialog
 from mantidqt.dialogs.genericdialog import GenericDialog
 from mantidqt.interfacemanager import InterfaceManager
+from mantidqt.utils.qt.test import GuiTest
 
 
 class AlgorithmDialogMockAlgorithm(PythonAlgorithm):
@@ -41,8 +41,7 @@ class AlgorithmDialogMockAlgorithm(PythonAlgorithm):
         pass
 
 
-@requires_qapp
-class TestAlgorithmDialog(unittest.TestCase):
+class TestAlgorithmDialog(GuiTest):
 
     def setUp(self):
         AlgorithmFactory.subscribe(AlgorithmDialogMockAlgorithm)

--- a/qt/python/mantidqt/dialogs/test/test_spectraselectiondialog.py
+++ b/qt/python/mantidqt/dialogs/test/test_spectraselectiondialog.py
@@ -28,13 +28,12 @@ from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QDialog, QDialogButtonBox
 
 # local imports
-from mantidqt.utils.qt.test import requires_qapp
+from mantidqt.utils.qt.test import GuiTest
 from mantidqt.dialogs.spectraselectordialog import (get_spectra_selection, parse_selection_str,
                                                     SpectraSelectionDialog)
 
 
-@requires_qapp
-class SpectraSelectionDialogTest(unittest.TestCase):
+class SpectraSelectionDialogTest(GuiTest):
 
     _mock_get_icon = None
     _single_spec_ws = None

--- a/qt/python/mantidqt/utils/qt/test/__init__.py
+++ b/qt/python/mantidqt/utils/qt/test/__init__.py
@@ -19,8 +19,7 @@
 """
 from __future__ import absolute_import
 
-from inspect import isfunction, ismethod
-import gc
+from unittest import TestCase
 
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QApplication
@@ -28,55 +27,23 @@ from qtpy.QtWidgets import QApplication
 from mantidqt.utils.qt.plugins import setup_library_paths
 from .modal_tester import ModalTester
 
+# Hold on to QAPP reference to avoid garbage collection
+_QAPP = None
 
-def requires_qapp(cls):
+
+class GuiTest(TestCase):
+    """Base class for tests that require a QApplication instance
+    GuiTest ensures that a QApplication exists before tests are run
     """
-    Converts a unittest.TestCase class to a GUI test case by wrapping all
-    test methods in a decorator that makes sure that a QApplication is created.
-    Qt widgets don't work without QApplication.
-
-    Note: It seems possible to segfault the Python process if the QApplication object
-    is destroyed too late. This seems nearly guaranteed if the QApplication object is stored
-    as a global variable at module scope. For this reason this decorator stores
-    its instance as an object attribute.
-
-    Usage:
-
-        @requires_qapp
-        class MyWidgetTest(unittest.TestCase):
-
-            def test_something(self):
-                ...
-
-            def test_something_else(self):
-                ...
-
-    :param cls: Class instance
-    """
-    def do_nothing(self):
-      pass
-
-    orig_setUp = getattr(cls, 'setUp', do_nothing)
-    orig_tearDown = getattr(cls, 'tearDown', do_nothing)
-
-    def setUp(self):
-        qapp = QApplication.instance()
-        if qapp is None:
+    @classmethod
+    def setUpClass(cls):
+        """Prepare for test execution.
+        Ensure that a (single copy of) QApplication has been created
+        """
+        global _QAPP
+        if _QAPP is None:
             setup_library_paths()
-            cls._qapp = QApplication([cls.__name__])
-        else:
-            self._qapp = qapp
-        orig_setUp(self)
-
-    def tearDown(self):
-      orig_tearDown(self)
-      if self._qapp is not None:
-          self._qapp.closeAllWindows()
-          gc.collect()
-
-    cls.setUp = setUp
-    cls.tearDown = tearDown
-    return cls
+            _QAPP = QApplication([cls.__name__])
 
 
 def select_item_in_tree(tree, item_label):

--- a/qt/python/mantidqt/utils/test/test_modal_tester.py
+++ b/qt/python/mantidqt/utils/test/test_modal_tester.py
@@ -22,11 +22,10 @@ import unittest
 
 from qtpy.QtWidgets import QInputDialog
 
-from mantidqt.utils.qt.test import requires_qapp, ModalTester
+from mantidqt.utils.qt.test import GuiTest, ModalTester
 
 
-@requires_qapp
-class TestModalTester(unittest.TestCase):
+class TestModalTester(GuiTest):
 
     def test_pass_widget_closed(self):
         def testing_function(widget):

--- a/qt/python/mantidqt/utils/test/test_qt_utils.py
+++ b/qt/python/mantidqt/utils/test/test_qt_utils.py
@@ -27,12 +27,11 @@ try:
 except ImportError:
     NEW_STYLE_SIGNAL = True
 
-from mantidqt.utils.qt.test import requires_qapp
+from mantidqt.utils.qt.test import GuiTest
 from mantidqt.utils.qt import add_actions, create_action
 
 
-@requires_qapp
-class CreateActionTest(unittest.TestCase):
+class CreateActionTest(GuiTest):
 
     def test_parent_and_name_only_required(self):
         class Parent(QObject):
@@ -73,8 +72,7 @@ class CreateActionTest(unittest.TestCase):
         self.assertEqual(Qt.WindowShortcut, action.shortcutContext())
 
 
-@requires_qapp
-class AddActionsTest(unittest.TestCase):
+class AddActionsTest(GuiTest):
 
     def test_add_actions_with_qmenu_target(self):
         test_act_1 = create_action(None, "Test Action 1")

--- a/qt/python/mantidqt/utils/test/test_writetosignal.py
+++ b/qt/python/mantidqt/utils/test/test_writetosignal.py
@@ -23,7 +23,7 @@ import unittest
 from qtpy.QtCore import QCoreApplication, QObject
 
 # local imports
-from mantidqt.utils.qt.test import requires_qapp
+from mantidqt.utils.qt.test import GuiTest
 from mantidqt.utils.writetosignal import WriteToSignal
 
 
@@ -34,8 +34,7 @@ class Receiver(QObject):
         self.captured_txt = txt
 
 
-@requires_qapp
-class WriteToSignalTest(unittest.TestCase):
+class WriteToSignalTest(GuiTest):
 
     def test_connected_receiver_receives_text(self):
         recv = Receiver()

--- a/qt/python/mantidqt/widgets/algorithmselector/test/test_algorithmselector.py
+++ b/qt/python/mantidqt/widgets/algorithmselector/test/test_algorithmselector.py
@@ -23,7 +23,7 @@ import unittest
 from qtpy.QtCore import Qt
 from qtpy.QtTest import QTest
 
-from mantidqt.utils.qt.test import requires_qapp,  select_item_in_combo_box, select_item_in_tree
+from mantidqt.utils.qt.test import select_item_in_combo_box, select_item_in_tree, GuiTest
 from mantidqt.widgets.algorithmselector.model import AlgorithmSelectorModel
 from mantidqt.widgets.algorithmselector.widget import AlgorithmSelectorWidget
 
@@ -80,9 +80,8 @@ class ModelTest(unittest.TestCase):
         self.assertEqual(mock_get_algorithm_descriptors.mock_calls[-1], call(True))
 
 
-@requires_qapp
 @patch('mantid.AlgorithmFactory.getDescriptors', mock_get_algorithm_descriptors)
-class WidgetTest(unittest.TestCase):
+class WidgetTest(GuiTest):
 
     def _select_in_tree(self, widget, item_label):
         select_item_in_tree(widget.tree, item_label)

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_codeeditor.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_codeeditor.py
@@ -21,13 +21,12 @@ import unittest
 
 # local imports
 from mantidqt.widgets.codeeditor.editor import CodeEditor
-from mantidqt.utils.qt.test import requires_qapp
+from mantidqt.utils.qt.test import GuiTest
 
 TEST_LANG = "Python"
 
 
-@requires_qapp
-class CodeEditorTest(unittest.TestCase):
+class CodeEditorTest(GuiTest):
 
     # ---------------------------------------------------------------
     # Success tests

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_execution.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_execution.py
@@ -23,7 +23,7 @@ import unittest
 from qtpy.QtCore import QCoreApplication, QObject
 
 # local imports
-from mantidqt.utils.qt.test import requires_qapp
+from mantidqt.utils.qt.test import GuiTest
 from mantidqt.widgets.codeeditor.execution import PythonCodeExecution
 
 
@@ -50,8 +50,7 @@ class ReceiverWithProgress(Receiver):
         self.lines_received.append(lineno)
 
 
-@requires_qapp
-class PythonCodeExecutionTest(unittest.TestCase):
+class PythonCodeExecutionTest(GuiTest):
 
     def test_default_construction_yields_empty_context(self):
         executor = PythonCodeExecution()

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_interpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_interpreter.py
@@ -24,7 +24,7 @@ import six
 
 # local imports
 from mantidqt.widgets.codeeditor.interpreter import PythonFileInterpreter
-from mantidqt.utils.qt.test import requires_qapp
+from mantidqt.utils.qt.test import GuiTest
 
 if six.PY2:
     import mock
@@ -32,8 +32,7 @@ else:
     from unittest import mock
 
 
-@requires_qapp
-class PythonFileInterpreterTest(unittest.TestCase):
+class PythonFileInterpreterTest(GuiTest):
 
     def test_construction(self):
         w = PythonFileInterpreter()

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
@@ -22,12 +22,11 @@ import unittest
 # third-party library imports
 
 # local imports
-from mantidqt.utils.qt.test import requires_qapp
+from mantidqt.utils.qt.test import GuiTest
 from mantidqt.widgets.codeeditor.multifileinterpreter import MultiPythonFileInterpreter
 
 
-@requires_qapp
-class MultiPythonFileInterpreterTest(unittest.TestCase):
+class MultiPythonFileInterpreterTest(GuiTest):
 
     def test_default_contains_single_editor(self):
         widget = MultiPythonFileInterpreter()

--- a/qt/python/mantidqt/widgets/test/test_jupyterconsole.py
+++ b/qt/python/mantidqt/widgets/test/test_jupyterconsole.py
@@ -26,15 +26,14 @@ from qtpy import QT_VERSION
 
 # local package imports
 from mantidqt.widgets.jupyterconsole import InProcessJupyterConsole
-from mantidqt.utils.qt.test import requires_qapp
+from mantidqt.utils.qt.test import GuiTest
 
 
 PRE_IPY5_PY3_QT5 = (sys.version_info.major == 3 and IPython.version_info[0] < 5 and int(QT_VERSION[0]) == 5)
 SKIP_REASON = "Segfault within readline for IPython < 5 and Python 3"
 
 
-@requires_qapp
-class InProcessJupyterConsoleTest(unittest.TestCase):
+class InProcessJupyterConsoleTest(GuiTest):
 
     @unittest.skipIf(PRE_IPY5_PY3_QT5, SKIP_REASON)
     def test_construction_raises_no_errors(self):

--- a/qt/python/mantidqt/widgets/test/test_messagedisplay.py
+++ b/qt/python/mantidqt/widgets/test/test_messagedisplay.py
@@ -20,11 +20,10 @@ from __future__ import (absolute_import, division, print_function,
 import unittest
 
 from mantidqt.widgets.messagedisplay import MessageDisplay
-from mantidqt.utils.qt.test import requires_qapp
+from mantidqt.utils.qt.test import GuiTest
 
 
-@requires_qapp
-class MessageDisplayTest(unittest.TestCase):
+class MessageDisplayTest(GuiTest):
     """Minimal testing as it is exported from C++"""
 
     def test_widget_creation(self):

--- a/qt/python/mantidqt/widgets/workspacewidget/test/test_workspacetreewidget.py
+++ b/qt/python/mantidqt/widgets/workspacewidget/test/test_workspacetreewidget.py
@@ -20,6 +20,7 @@ import unittest
 
 from mantidqt.widgets.workspacewidget.workspacetreewidget import WorkspaceTreeWidget
 from mantidqt.utils.qt.test import GuiTest
+import sip
 
 
 class WorkspaceWidgetTest(GuiTest):
@@ -28,6 +29,7 @@ class WorkspaceWidgetTest(GuiTest):
     def test_widget_creation(self):
         widget = WorkspaceTreeWidget()
         self.assertTrue(widget is not None)
+        sip.delete(widget)
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqt/widgets/workspacewidget/test/test_workspacetreewidget.py
+++ b/qt/python/mantidqt/widgets/workspacewidget/test/test_workspacetreewidget.py
@@ -19,11 +19,10 @@ from __future__ import absolute_import, print_function
 import unittest
 
 from mantidqt.widgets.workspacewidget.workspacetreewidget import WorkspaceTreeWidget
-from mantidqt.utils.qt.test import requires_qapp
+from mantidqt.utils.qt.test import GuiTest
 
 
-@requires_qapp
-class WorkspaceWidgetTest(unittest.TestCase):
+class WorkspaceWidgetTest(GuiTest):
     """Minimal testing as it is exported from C++"""
 
     def test_widget_creation(self):

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -29,9 +29,14 @@ set_property ( TARGET CompileUIErrorReporter PROPERTY FOLDER "CompilePyUI" )
 # External GUIs
 add_subdirectory ( ExternalInterfaces )
 
-# -------------------------------------------------------------------
+# --------------------------------------------------------------------
 # Testing
-# -------------------------------------------------------------------
+# --------------------------------------------------------------------
+# All of the following tests (and those in subdirectories) require the
+# test format to import mantid to setup paths to the scripts
+# directory
+set ( PYUNITTEST_TESTRUNNER_IMPORT_MANTID 1 )
+
 set ( TEST_PY_FILES
       test/AbinsAtomsDataTest.py
       test/AbinsCalculateDWSingleCrystalTest.py


### PR DESCRIPTION
**Description of work.**

It has been observed that on many pull requests and [clean builds](http://builds.mantidproject.org/view/Master%20Pipeline/job/master_clean-rhel7/788/console) some number of `mantidqt_qt5` unit tests failed randomly when the python process exited. This only appears to happen when the tests run in parallel and only affects the tests that require an active `QApplication` object. The `mantidqt` and `workbench` unit tests now run with the `RUN_SERIAL` flag to avoid these spurious failures. It is not ideal but I believe this to be better than sporadic failures that constantly confuse developers.

As part of these changes the requirement that `mantid` be imported has been removed for many of the `mantidqt` and `workbench` tests, which has resulted in these tests speeding up by ~2s per test.

**Report to:** [nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

Before these changes I was guaranteed a segfault with `ctest --force-new-ctest-process -R "mantidqt_" --schedule-random -j8 --repeat-until-fail 10` when running on RedHat 7.

*There is no associated issue.*

*This does not require release notes* because **it fixes a developer issue.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
