### PR TITLE
Notify user of errorreport failure

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/ErrorReporter.h
+++ b/Framework/Kernel/inc/MantidKernel/ErrorReporter.h
@@ -44,7 +44,7 @@ public:
                 std::string exitCode, bool share, std::string name,
                 std::string email);
   /// Sends an error report
-  void sendErrorReport();
+  int sendErrorReport();
 
 protected:
   /// Generates an error string in json format

--- a/Framework/Kernel/src/ErrorReporter.cpp
+++ b/Framework/Kernel/src/ErrorReporter.cpp
@@ -49,15 +49,17 @@ ErrorReporter::ErrorReporter(std::string application,
 
 /** Generates an error message and then calls an internet helper to send it
  */
-void ErrorReporter::sendErrorReport() {
+int ErrorReporter::sendErrorReport() {
   try {
     std::string message = this->generateErrorMessage();
 
     // send the report
     // Poco::ActiveResult<int> result = m_errorActiveMethod(message);
-    this->sendReport(message, m_url + "/api/error");
+    auto status = this->sendReport(message, m_url + "/api/error");
+    return status;
   } catch (std::exception &ex) {
     g_log.debug() << "Send error report failure. " << ex.what() << '\n';
+    return -1;
   }
 }
 

--- a/scripts/ErrorReporter/error_report_presenter.py
+++ b/scripts/ErrorReporter/error_report_presenter.py
@@ -10,14 +10,21 @@ class ErrorReporterPresenter(object):
         self._view.action.connect(self.error_handler)
 
     def error_handler(self, continue_working, share, name, email):
+        status = -1
         if share == 0:
             errorReporter = ErrorReporter(
                 "mantidplot", UsageService.getUpTime(), self._exit_code, True, str(name), str(email))
-            errorReporter.sendErrorReport()
+            status = errorReporter.sendErrorReport()
         elif share == 1:
             errorReporter = ErrorReporter(
                 "mantidplot", UsageService.getUpTime(), self._exit_code, False, str(name), str(email))
-            errorReporter.sendErrorReport()
+            status = errorReporter.sendErrorReport()
+
+        if status != 201:
+            self._view.display_message_box('Error contacting server','There was an error when sending the report.'
+                                           'Please contact mantid-help@mantidproject.org directly',
+                                           'http request returned with status {}'.format(status))
+            self.error_log.error("Failed to send error report http request returned status {}".format(status))
 
         if not continue_working:
             self.error_log.error("Terminated by user.")

--- a/scripts/ErrorReporter/errorreport.py
+++ b/scripts/ErrorReporter/errorreport.py
@@ -62,6 +62,21 @@ class CrashReportPage(QtGui.QWidget, ui_errorreport.Ui_Errorreport):
         else:
             self.nonIDShareButton.setEnabled(False)
 
+    def display_message_box(self, title, message, details):
+        msg = QtGui.QMessageBox()
+        msg.setIcon(QtGui.QMessageBox.Warning)
+
+        message_length = len(message)
+
+        # This is to ensure that the QMessage box if wide enough to display nicely.
+        msg.setText(10 * ' ' + message + ' ' * (30 - message_length))
+        msg.setWindowTitle(title)
+        msg.setDetailedText(details)
+        msg.setStandardButtons(QtGui.QMessageBox.Ok)
+        msg.setDefaultButton(QtGui.QMessageBox.Ok)
+        msg.setEscapeButton(QtGui.QMessageBox.Ok)
+        msg.exec_()
+
     @property
     def input_name(self):
         return self.get_simple_line_edit_field(line_edit="input_name_line_edit", expected_type=str)

--- a/scripts/ErrorReporter/errorreport.py
+++ b/scripts/ErrorReporter/errorreport.py
@@ -63,12 +63,12 @@ class CrashReportPage(QtGui.QWidget, ui_errorreport.Ui_Errorreport):
             self.nonIDShareButton.setEnabled(False)
 
     def display_message_box(self, title, message, details):
-        msg = QtGui.QMessageBox()
+        msg = QtGui.QMessageBox(self)
         msg.setIcon(QtGui.QMessageBox.Warning)
 
         message_length = len(message)
 
-        # This is to ensure that the QMessage box if wide enough to display nicely.
+        # This is to ensure that the QMessage box is wide enough to display nicely.
         msg.setText(10 * ' ' + message + ' ' * (30 - message_length))
         msg.setWindowTitle(title)
         msg.setDetailedText(details)

--- a/scripts/test/ErrorReporterPresenterTest.py
+++ b/scripts/test/ErrorReporterPresenterTest.py
@@ -22,6 +22,9 @@ class ErrorReportPresenterTest(unittest.TestCase):
 
     @mock.patch('ErrorReporter.error_report_presenter.ErrorReporter')
     def test_error_handler_sends_no_report_for_no_share(self, error_reporter_mock):
+        error_reporter_mock_instance = mock.MagicMock()
+        error_reporter_mock_instance.sendErrorReport.return_value = 201
+        error_reporter_mock.return_value = error_reporter_mock_instance
         share = 2
         continue_working = True
         name = ''
@@ -36,7 +39,12 @@ class ErrorReportPresenterTest(unittest.TestCase):
         self.assertEqual(presenter._view.quit.call_count, 0)
 
     @mock.patch('ErrorReporter.error_report_presenter.ErrorReporter')
-    def test_error_handler_sends_report_for_share(self, error_reporter_mock):
+    @mock.patch('ErrorReporter.error_report_presenter.UsageService')
+    def test_error_handler_sends_report_for_share_all(self, usage_service, error_reporter_mock):
+        usage_service.getUpTime.return_value = 'up_time'
+        error_reporter_mock_instance = mock.MagicMock()
+        error_reporter_mock_instance.sendErrorReport.return_value = 201
+        error_reporter_mock.return_value = error_reporter_mock_instance
         share = 0
         continue_working = False
         name = ''
@@ -48,6 +56,56 @@ class ErrorReportPresenterTest(unittest.TestCase):
         presenter.error_handler(continue_working, share, name, email)
 
         self.assertEqual(error_reporter_mock.call_count, 1)
+        error_reporter_mock_instance.sendErrorReport.asser_called_once_with(
+            "mantidplot", 'up_time', exit_code, False, str(name), str(email))
+        presenter._view.quit.assert_called_once_with()
+
+    @mock.patch('ErrorReporter.error_report_presenter.ErrorReporter')
+    @mock.patch('ErrorReporter.error_report_presenter.UsageService')
+    def test_error_handler_sends_report_for_share_non_id(self, usage_service, error_reporter_mock):
+        usage_service.getUpTime.return_value = 'up_time'
+        error_reporter_mock_instance = mock.MagicMock()
+        error_reporter_mock_instance.sendErrorReport.return_value = 201
+        error_reporter_mock.return_value = error_reporter_mock_instance
+        share = 1
+        continue_working = False
+        name = ''
+        email = ''
+        view = mock.MagicMock()
+        exit_code = 0
+        presenter = ErrorReporterPresenter(view, exit_code)
+
+        presenter.error_handler(continue_working, share, name, email)
+
+        self.assertEqual(error_reporter_mock.call_count, 1)
+        error_reporter_mock_instance.sendErrorReport.asser_called_once_with(
+            "mantidplot", 'up_time', exit_code, True, str(name), str(email))
+        presenter._view.quit.assert_called_once_with()
+
+    @mock.patch('ErrorReporter.error_report_presenter.ErrorReporter')
+    @mock.patch('ErrorReporter.error_report_presenter.UsageService')
+    def test_error_handler_reports_if_incorrect_http_response_sent(self, usage_service, error_reporter_mock):
+        usage_service.getUpTime.return_value = 'up_time'
+        error_reporter_mock_instance = mock.MagicMock()
+        error_reporter_mock_instance.sendErrorReport.return_value = 500
+        error_reporter_mock.return_value = error_reporter_mock_instance
+        share = 0
+        continue_working = False
+        name = ''
+        email = ''
+        view = mock.MagicMock()
+        exit_code = 0
+        presenter = ErrorReporterPresenter(view, exit_code)
+
+        presenter.error_handler(continue_working, share, name, email)
+
+        self.assertEqual(error_reporter_mock.call_count, 1)
+        error_reporter_mock_instance.sendErrorReport.asser_called_once_with(
+            "mantidplot", 'up_time', exit_code, False, str(name), str(email))
+        presenter._view.display_message_box.assert_called_once_with('Error contacting server',
+                                                                    'There was an error when sending the report.'
+                                                                    'Please contact mantid-help@mantidproject.org directly',
+                                                                    'http request returned with status 500')
         presenter._view.quit.assert_called_once_with()
 
 


### PR DESCRIPTION
**Description of work.**
Currently if the error reporter receives a server error when it attempts to send the report this is only noticeable as a Debug level log output. This should be made much clearer so users do not think they have submitted an error report when they haven't

This PR adds code to check the returned http response and inform the user if it is not 201.
**Report to:** keith <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

* Set up the error reporter to fail. The easiest way to do this is probably to change the url to something which doesn't make sense. Or to modify generateErrorMessage in ErrorReporter.cpp so it creates a bogus message i.e. by adding a new unexpected field. Trying both failure modes independently is probably best.
* Crash Mantid either using the Segfualt algorithm or the method here #18990 (The file is in the SANS2D system test data)
* When the error reporter comes up try to send a message hopefully a modal box should pop up warning you this has failed.
* In particular check the text and information given in this box are appropriate.

<!-- Instructions for testing. -->

Fixes #23389. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
