### PR TITLE
Get selected spectrum number not combobox index

### DIFF
--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -21,3 +21,12 @@ Improvements
   to be selected. Allowed values: ['Linear', 'CSpline'].
 - Added 'MaxScatterPtAttempts' spinbox to Calculate Monte Carlo Absorption. This sets the maximum number of 
   tries to be made to generate a scattering point.
+
+Data Analysis Interfaces
+-------------------------
+
+Bugfixes
+########
+
+- The parameter values for a selected spectrum are now updated properly when a Fit is run using the Fit String 
+  option in ConvFit.

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
@@ -3,7 +3,6 @@
 #include "MantidQtWidgets/Common/SignalBlocker.h"
 
 #include <boost/numeric/conversion/cast.hpp>
-#include <string>
 
 namespace MantidQt {
 namespace CustomInterfaces {

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
@@ -3,6 +3,7 @@
 #include "MantidQtWidgets/Common/SignalBlocker.h"
 
 #include <boost/numeric/conversion/cast.hpp>
+#include <string>
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -37,7 +38,10 @@ IndirectFitPlotView::~IndirectFitPlotView() {}
 std::size_t IndirectFitPlotView::getSelectedSpectrum() const {
   if (m_plotForm->swPlotSpectrum->currentIndex() == 0)
     return m_plotForm->spPlotSpectrum->value();
-  return m_plotForm->cbPlotSpectrum->currentIndex();
+  if (m_plotForm->cbPlotSpectrum->count() != 0)
+    return boost::numeric_cast<std::size_t>(
+        std::stoi(m_plotForm->cbPlotSpectrum->currentText().toStdString()));
+  return 0;
 }
 
 int IndirectFitPlotView::getSelectedSpectrumIndex() const {

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
@@ -35,12 +35,15 @@ IndirectFitPlotView::IndirectFitPlotView(QWidget *parent)
 
 IndirectFitPlotView::~IndirectFitPlotView() {}
 
+std::string IndirectFitPlotView::getSpectrumText() const {
+  return m_plotForm->cbPlotSpectrum->currentText().toStdString();
+}
+
 std::size_t IndirectFitPlotView::getSelectedSpectrum() const {
   if (m_plotForm->swPlotSpectrum->currentIndex() == 0)
     return m_plotForm->spPlotSpectrum->value();
-  if (m_plotForm->cbPlotSpectrum->count() != 0)
-    return boost::numeric_cast<std::size_t>(
-        std::stoi(m_plotForm->cbPlotSpectrum->currentText().toStdString()));
+  else if (m_plotForm->cbPlotSpectrum->count() != 0)
+    return std::stoull(getSpectrumText());
   return 0;
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.h
@@ -92,6 +92,8 @@ private slots:
   void emitPlotGuessChanged(int);
 
 private:
+  std::string getSpectrumText() const;
+
   void addFitRangeSelector();
   void addBackgroundRangeSelector();
   void addHWHMRangeSelector();


### PR DESCRIPTION
**Description of work.**
This PR fixes an issue where the parameter values are not updated for a selected spectrum when you use the  `Fit String` option in ConvFit.
The problem was that the selected spectrum number was wrong and so an update of the parameter values did not occur. Instead of retrieving the selected spectrum number, the currently selected Combobox index was returned instead.

**To test:**
- Go to Interfaces > Indirect > Data Analysis
- Go to the Conv Fit tab
- Load the reduced and resolution files below
- Set `Fit spectra` to String 3
- Set `Fit type` to Two Lorentzian's
- Set `Max iterations` to 100
- Expand the function f0-Lorentzian - note the parameters
- Click `Run`
- Check the parameters of f0-Lorentzian are updated

- `Run` the fit for other `Fit spectra` Strings, and change between each fitted spectra to ensure that the parameter values are updating

**Test Files**
[irs26173_graphite002_res.zip](https://github.com/mantidproject/mantid/files/2339793/irs26173_graphite002_res.zip)
[irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2339794/irs26176_graphite002_red.zip)

Fixes #23225 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
