### PR TITLE
Fix typo in PolarizationCorrectionWildes docs

### DIFF
--- a/docs/source/algorithms/PolarizationCorrectionWildes-v1.rst
+++ b/docs/source/algorithms/PolarizationCorrectionWildes-v1.rst
@@ -40,7 +40,7 @@ Flipper configurations
    Polarization corrections with the assumption that the corrected count rates :math:`\Sigma^{+-} = \Sigma^{-+}`. In this case the intensity of the missing flipper configuration (01 or 10) can be solved from the other intensities. Workspaces in the input group should be in the following order: both flippers off, one flipper on, both flippers on.
 
 :literal:`'00, 11'`
-   Polarization corrections with the assumption that the corrected count rates :math:`\Sigma^{+-} = \Sigma^{-+} = 0`. In this case the intensities of the missing flipper configurations (01 and 11) can be solved from the other intensities. Workspaces in the input group should be in the following order: both flippers off, both flippers on.
+   Polarization corrections with the assumption that the corrected count rates :math:`\Sigma^{+-} = \Sigma^{-+} = 0`. In this case the intensities of the missing flipper configurations (01 and 10) can be solved from the other intensities. Workspaces in the input group should be in the following order: both flippers off, both flippers on.
 
 :literal:`'0, 1'`
    Polarization corrections when no analyzer has been used. Workspaces in the input group should be in the following order: polarizer flipper off, polarizer flipper on.


### PR DESCRIPTION
**Description of work.**

Fix a small typo in the documentation of `PolarizationCorrectionWildes`

**Report to:**[nobody].

**To test:**

Code review

Fixes #23327.

*This does not require release notes* because **no functionality has been changed**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
