### PR TITLE
fix conda build problem with direct calls of std::make_unique

### DIFF
--- a/Framework/DataHandling/src/LoadBankFromDiskTask.cpp
+++ b/Framework/DataHandling/src/LoadBankFromDiskTask.cpp
@@ -3,6 +3,7 @@
 #include "MantidDataHandling/DefaultEventLoader.h"
 #include "MantidDataHandling/LoadEventNexus.h"
 #include "MantidDataHandling/ProcessBankData.h"
+#include "MantidKernel/make_unique.h"
 
 namespace Mantid {
 namespace DataHandling {
@@ -188,7 +189,7 @@ LoadBankFromDiskTask::loadEventId(::NeXus::File &file) {
   int64_t dim0 = recalculateDataSize(id_info.dims[0]);
 
   // Now we allocate the required arrays
-  auto event_id = std::make_unique<uint32_t[]>(m_loadSize[0]);
+  auto event_id = Mantid::Kernel::make_unique<uint32_t[]>(m_loadSize[0]);
 
   // Check that the required space is there in the file.
   if (dim0 < m_loadSize[0] + m_loadStart[0]) {
@@ -251,7 +252,7 @@ LoadBankFromDiskTask::loadEventId(::NeXus::File &file) {
  */
 std::unique_ptr<float[]> LoadBankFromDiskTask::loadTof(::NeXus::File &file) {
   // Allocate the array
-  auto event_time_of_flight = std::make_unique<float[]>(m_loadSize[0]);
+  auto event_time_of_flight = Mantid::Kernel::make_unique<float[]>(m_loadSize[0]);
 
   // Get the list of event_time_of_flight's
   if (!m_oldNexusFileNames)
@@ -314,7 +315,7 @@ LoadBankFromDiskTask::loadEventWeights(::NeXus::File &file) {
   m_have_weight = true;
 
   // Allocate the array
-  auto event_weight = std::make_unique<float[]>(m_loadSize[0]);
+  auto event_weight = Mantid::Kernel::make_unique<float[]>(m_loadSize[0]);
 
   ::NeXus::Info weight_info = file.getInfo();
   int64_t weight_dim0 = recalculateDataSize(weight_info.dims[0]);

--- a/Framework/DataHandling/src/LoadBankFromDiskTask.cpp
+++ b/Framework/DataHandling/src/LoadBankFromDiskTask.cpp
@@ -252,7 +252,8 @@ LoadBankFromDiskTask::loadEventId(::NeXus::File &file) {
  */
 std::unique_ptr<float[]> LoadBankFromDiskTask::loadTof(::NeXus::File &file) {
   // Allocate the array
-  auto event_time_of_flight = Mantid::Kernel::make_unique<float[]>(m_loadSize[0]);
+  auto event_time_of_flight =
+      Mantid::Kernel::make_unique<float[]>(m_loadSize[0]);
 
   // Get the list of event_time_of_flight's
   if (!m_oldNexusFileNames)

--- a/Framework/NexusGeometry/src/InstrumentBuilder.cpp
+++ b/Framework/NexusGeometry/src/InstrumentBuilder.cpp
@@ -5,6 +5,7 @@
 #include "MantidGeometry/Instrument/ObjCompAssembly.h"
 #include "MantidGeometry/Instrument/ReferenceFrame.h"
 #include "MantidKernel/EigenConversionHelpers.h"
+#include "MantidKernel/make_unique.h"
 #include "MantidNexusGeometry/NexusShapeFactory.h"
 #include <boost/make_shared.hpp>
 #include <memory>
@@ -14,7 +15,7 @@ namespace NexusGeometry {
 
 /// Constructor
 InstrumentBuilder::InstrumentBuilder(const std::string &instrumentName)
-    : m_instrument(std::make_unique<Geometry::Instrument>(instrumentName)) {
+  : m_instrument(Mantid::Kernel::make_unique<Geometry::Instrument>(instrumentName)) {
   // Default view
   std::string defaultViewAxis = "z";
   Geometry::PointingAlong pointingUp(Geometry::Y), alongBeam(Geometry::Z),
@@ -160,7 +161,7 @@ std::unique_ptr<const Geometry::Instrument>
 InstrumentBuilder::createInstrument() {
   sortDetectors();
   // Create the new replacement first incase it throws
-  auto temp = std::make_unique<Geometry::Instrument>(m_instrument->getName());
+  auto temp = Mantid::Kernel::make_unique<Geometry::Instrument>(m_instrument->getName());
   auto *product = m_instrument.release();
   m_instrument = std::move(temp);
   // Some older compilers (Apple clang 7) don't support copy construction

--- a/Framework/NexusGeometry/src/InstrumentBuilder.cpp
+++ b/Framework/NexusGeometry/src/InstrumentBuilder.cpp
@@ -8,7 +8,6 @@
 #include "MantidKernel/make_unique.h"
 #include "MantidNexusGeometry/NexusShapeFactory.h"
 #include <boost/make_shared.hpp>
-#include <memory>
 
 namespace Mantid {
 namespace NexusGeometry {

--- a/Framework/NexusGeometry/src/InstrumentBuilder.cpp
+++ b/Framework/NexusGeometry/src/InstrumentBuilder.cpp
@@ -14,7 +14,8 @@ namespace NexusGeometry {
 
 /// Constructor
 InstrumentBuilder::InstrumentBuilder(const std::string &instrumentName)
-  : m_instrument(Mantid::Kernel::make_unique<Geometry::Instrument>(instrumentName)) {
+    : m_instrument(
+          Mantid::Kernel::make_unique<Geometry::Instrument>(instrumentName)) {
   // Default view
   std::string defaultViewAxis = "z";
   Geometry::PointingAlong pointingUp(Geometry::Y), alongBeam(Geometry::Z),
@@ -160,7 +161,8 @@ std::unique_ptr<const Geometry::Instrument>
 InstrumentBuilder::createInstrument() {
   sortDetectors();
   // Create the new replacement first incase it throws
-  auto temp = Mantid::Kernel::make_unique<Geometry::Instrument>(m_instrument->getName());
+  auto temp = Mantid::Kernel::make_unique<Geometry::Instrument>(
+      m_instrument->getName());
   auto *product = m_instrument.release();
   m_instrument = std::move(temp);
   // Some older compilers (Apple clang 7) don't support copy construction


### PR DESCRIPTION
**Description of work.**
Fixes conda build (linux). It now fails due to direct calls to std::make_unique instead of Mantid::Kernel::make_unique

**To test:**
Run conda build

Fixes #23418 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
