### PR TITLE
Fix overlaying peaks on instrument view

### DIFF
--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -886,15 +886,7 @@ void InstrumentWidget::dragEnterEvent(QDragEnterEvent *e) {
 void InstrumentWidget::dropEvent(QDropEvent *e) {
   QString name = e->mimeData()->objectName();
   if (name == "MantidWorkspace") {
-    QString text = e->mimeData()->text();
-    int endIndex = 0;
-    QStringList wsNames;
-    while (text.indexOf("[\"", endIndex) > -1) {
-      int startIndex = text.indexOf("[\"", endIndex) + 2;
-      endIndex = text.indexOf("\"]", startIndex);
-      wsNames.append(text.mid(startIndex, endIndex - startIndex));
-    }
-
+    QStringList wsNames = e->mimeData()->text().split("\n");
     foreach (const auto &wsName, wsNames) {
       if (this->overlay(wsName))
         e->accept();


### PR DESCRIPTION
The bug was caused by the changes in ad48fa635ae66dc5cfd7e5d70d091eafaeeaadb8.

**Description of work.**
A bug was introduced preventing peaks workspaces from being overlaid on the instrument view. This fixes the bug.

**Report to:** Fabio Orlandi. 

**To test:**
Follow the instructions to reproduce the bug in the issue description. Verify that these changes fix that.

Fixes #23384 

*This does not require release notes* because it is a bug only since after the 3.13 release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
