### PR TITLE
Fix Plot All in workbench with python 3

### DIFF
--- a/qt/applications/workbench/workbench/plotting/functions.py
+++ b/qt/applications/workbench/workbench/plotting/functions.py
@@ -284,7 +284,7 @@ def _raise_if_not_sequence(value, seq_name, element_type=None):
     is an instance of this type
     :raises ValueError: if the conditions are not met
     """
-    accepted_types = (list, tuple)
+    accepted_types = (list, tuple, range)
     if type(value) not in accepted_types:
         raise ValueError("{} should be a list or tuple".format(seq_name))
     if element_type is not None:


### PR DESCRIPTION
Add `range` as accepted sequence type for plotting functions. The "Plot All" spectrum option wasn't working in the workbench when using python 3 because it was passing a range not a list.


**To test:**
In the workbench and using python 3`ws=CreateSampleWorkspace()` then `Plot->spectrum...->Plot All` should now work.

*This does not require release notes* because nobody is using the workbench

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
