### PR TITLE
Project Recovery: Now runs when you select no or fails

### DIFF
--- a/MantidPlot/src/ProjectRecovery.cpp
+++ b/MantidPlot/src/ProjectRecovery.cpp
@@ -182,6 +182,7 @@ void ProjectRecovery::attemptRecovery() {
 
   if (userChoice == 1) {
     // User selected no
+    this->startProjectSaving();
     return;
   }
 
@@ -362,12 +363,14 @@ void ProjectRecovery::loadRecoveryCheckpoint(const Poco::Path &recoveryFolder) {
           m_windowPtr, "loadProjectRecovery", Qt::BlockingQueuedConnection,
           Q_RETURN_ARG(bool, loadCompleted),
           Q_ARG(const std::string, projectFile.toString()))) {
+    this->startProjectSaving();
     throw std::runtime_error(
         "Project Recovery: Failed to load project windows - Qt binding failed");
   }
 
   if (!loadCompleted) {
     g_log.warning("Loading failed to recovery everything completely");
+    this->startProjectSaving();
     return;
   }
   g_log.notice("Project Recovery finished");
@@ -398,6 +401,7 @@ void ProjectRecovery::openInEditor(const Poco::Path &inputFolder,
     throw std::runtime_error("Could not get handle to scripting window");
   }
 
+  startProjectSaving();
   scriptWindow->open(QString::fromStdString(historyDest.toString()));
 }
 

--- a/docs/source/release/v3.14.0/ui.rst
+++ b/docs/source/release/v3.14.0/ui.rst
@@ -21,6 +21,7 @@ Changes
 Bugfixes
 ########
 - Workspaces with a '#' in their name will no longer cause issues in the loading of a recovered project
+- Project recovery will now run normally when you select no or the recovery fails when recvoering from a ungraceful exit.
 
 MantidPlot
 ----------

--- a/docs/source/release/v3.14.0/ui.rst
+++ b/docs/source/release/v3.14.0/ui.rst
@@ -21,7 +21,7 @@ Changes
 Bugfixes
 ########
 - Workspaces with a '#' in their name will no longer cause issues in the loading of a recovered project
-- Project recovery will now run normally when you select no or the recovery fails when recvoering from a ungraceful exit.
+- Project recovery will now run normally when you select no or the recovery fails when recovering from a ungraceful exit.
 
 MantidPlot
 ----------


### PR DESCRIPTION
**Description of work.**
Project recovery will now run normally when you select no or the recovery fails when recovering from a ungraceful exit.

**To test:**
- Load up Mantid
- Load a workspace
- Wait for the project recovery to save (make sure logging is at debug level)
- Run Segfault
- Restart Mantid
- Select "no" on project recovery popup GUI
- Load a workspace
- Wait for it to save and if it does attempt a save it is working!

And
- Load mantid
- Run this script
```python
Load(Filename='/Users/keithbutler/Documents/Mantid/Data/QENSFitTestFiles/MSDFit/irs26176_graphite002_elwin_eq.nxs', OutputWorkspace='irs26176_graphite002_elwin_eq')  # 2018-09-05 13:23:15.067225 
QENSFitSequential(Input='irs26176_graphite002_elwin_eq,i0;', OutputWorkspace='irs26176_graphite002_elwin_eq_MSDFit_Gaussian_s0_Result', OutputParameterWorkspace='irs26176_graphite002_elwin_eq_MSDFit_Gaussian_s0_Parameters', OutputWorkspaceGroup='irs26176_graphite002_elwin_eq_MSDFit_Gaussian_s0_Workspaces', Function='name=MsdGauss,Height=1,MSD=0.05', StartX=0.52531275787596388, EndX=1.8250942715026275, PassWSIndexToFunction=True, MaxIterations=400, IgnoreInvalidData=True)  # 2018-09-05 13:23:15.099078 
```
- Wait for mantid to auto-save
- Segfault mantid
- Restart mantid
- Click yes on the popup gui
- It should fail 
- Wait until it says that it is saving and then it worked!


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
