### PR TITLE
Disable Plot Result for MSD and F(Q) Fit for one spectra

### DIFF
--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -32,6 +32,8 @@ Improvements
 - When the InelasticDiffSphere, InelasticDiffRotDiscreteCircle, ElasticDiffSphere or ElasticDiffRotDiscreteCircle
   Fit Types are selected in the ConvFit Tab, the Q values are retrieved from the workspaces, preventing a crash 
   when plotting a guess.
+- The Plot Result buttons in MSDFit and F(Q)Fit are disabled after a Run when the result workspace only has one
+  data point to plot.
 - An option to skip the calculation of Monte Carlo Errors on the I(Q,t) Tab has been added.
 - During the calculation of Monte Carlo Errors, a progress bar is now shown.
 

--- a/qt/scientific_interfaces/Indirect/ConvFit.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFit.cpp
@@ -139,7 +139,9 @@ void ConvFit::saveClicked() { IndirectFitAnalysisTab::saveResult(); }
  * Handles plotting the workspace when plot is clicked
  */
 void ConvFit::plotClicked() {
+  setPlotResultIsPlotting(true);
   IndirectFitAnalysisTab::plotResult(m_uiForm->cbPlotType->currentText());
+  setPlotResultIsPlotting(false);
 }
 
 void ConvFit::updatePlotOptions() {
@@ -170,19 +172,32 @@ std::string ConvFit::fitTypeString() const {
   return fitType;
 }
 
+void ConvFit::setRunEnabled(bool enabled) {
+  m_uiForm->pbRun->setEnabled(enabled);
+}
+
 void ConvFit::setPlotResultEnabled(bool enabled) {
   m_uiForm->pbPlot->setEnabled(enabled);
   m_uiForm->cbPlotType->setEnabled(enabled);
+}
+
+void ConvFit::setFitSingleSpectrumEnabled(bool enabled) {
+  m_uiForm->pvFitPlotView->enableFitSingleSpectrum(enabled);
 }
 
 void ConvFit::setSaveResultEnabled(bool enabled) {
   m_uiForm->pbSave->setEnabled(enabled);
 }
 
-void ConvFit::setRunEnabled(bool enabled) {
-  m_uiForm->pvFitPlotView->enableFitSingleSpectrum(enabled);
-  m_uiForm->pbRun->setEnabled(enabled);
-  m_uiForm->pbRun->setText(!enabled ? "Running..." : "Run");
+void ConvFit::setRunIsRunning(bool running) {
+  m_uiForm->pbRun->setText(running ? "Running..." : "Run");
+  setRunEnabled(!running);
+  setFitSingleSpectrumEnabled(!running);
+}
+
+void ConvFit::setPlotResultIsPlotting(bool plotting) {
+  m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot Result");
+  setPlotResultEnabled(!plotting);
 }
 
 void ConvFit::runClicked() { runTab(); }

--- a/qt/scientific_interfaces/Indirect/ConvFit.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFit.cpp
@@ -196,7 +196,7 @@ void ConvFit::setRunIsRunning(bool running) {
 }
 
 void ConvFit::setPlotResultIsPlotting(bool plotting) {
-  m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot Result");
+  m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot");
   setPlotResultEnabled(!plotting);
 }
 

--- a/qt/scientific_interfaces/Indirect/ConvFit.h
+++ b/qt/scientific_interfaces/Indirect/ConvFit.h
@@ -19,6 +19,8 @@ public:
   ConvFit(QWidget *parent = nullptr);
 
 protected:
+  bool shouldEnablePlotResult() override { return true; };
+
   void setRunEnabled(bool enabled) override;
   void setPlotResultEnabled(bool enabled) override;
   void setSaveResultEnabled(bool enabled) override;

--- a/qt/scientific_interfaces/Indirect/ConvFit.h
+++ b/qt/scientific_interfaces/Indirect/ConvFit.h
@@ -18,17 +18,6 @@ class DLLExport ConvFit : public IndirectFitAnalysisTab {
 public:
   ConvFit(QWidget *parent = nullptr);
 
-protected:
-  bool shouldEnablePlotResult() override { return true; };
-
-  void setRunEnabled(bool enabled) override;
-  void setPlotResultEnabled(bool enabled) override;
-  void setSaveResultEnabled(bool enabled) override;
-
-private:
-  void setupFitTab() override;
-  void setupFit(Mantid::API::IAlgorithm_sptr fitAlgorithm) override;
-
 protected slots:
   void setModelResolution(const QString &resolutionName);
   void runClicked();
@@ -37,7 +26,23 @@ protected slots:
   void updatePlotOptions() override;
   void fitFunctionChanged();
 
+protected:
+  bool shouldEnablePlotResult() override { return true; };
+
+  void setPlotResultEnabled(bool enabled) override;
+  void setSaveResultEnabled(bool enabled) override;
+
+  void setRunIsRunning(bool running) override;
+
 private:
+  void setupFitTab() override;
+  void setupFit(Mantid::API::IAlgorithm_sptr fitAlgorithm) override;
+
+  void setRunEnabled(bool enabled);
+  void setFitSingleSpectrumEnabled(bool enabled);
+
+  void setPlotResultIsPlotting(bool plotting);
+
   std::string fitTypeString() const;
 
   std::unique_ptr<Ui::ConvFit> m_uiForm;

--- a/qt/scientific_interfaces/Indirect/ConvFit.ui
+++ b/qt/scientific_interfaces/Indirect/ConvFit.ui
@@ -198,7 +198,7 @@
                 <bool>false</bool>
                </property>
                <property name="text">
-                <string>Plot Result</string>
+                <string>Plot</string>
                </property>
               </widget>
              </item>

--- a/qt/scientific_interfaces/Indirect/ConvFit.ui
+++ b/qt/scientific_interfaces/Indirect/ConvFit.ui
@@ -165,8 +165,14 @@
                </property>
                <property name="minimumSize">
                 <size>
-                 <width>120</width>
+                 <width>100</width>
                  <height>0</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>100</width>
+                 <height>16777215</height>
                 </size>
                </property>
                <item>
@@ -192,7 +198,7 @@
                 <bool>false</bool>
                </property>
                <property name="text">
-                <string>Plot</string>
+                <string>Plot Result</string>
                </property>
               </widget>
              </item>

--- a/qt/scientific_interfaces/Indirect/Elwin.cpp
+++ b/qt/scientific_interfaces/Indirect/Elwin.cpp
@@ -117,7 +117,7 @@ void Elwin::setup() {
 }
 
 void Elwin::run() {
-  setRunEnabled(false);
+  setRunIsRunning(true);
 
   QStringList inputFilenames = m_uiForm.dsInputFiles->getFilenames();
   inputFilenames.sort();
@@ -240,20 +240,19 @@ void Elwin::run() {
 void Elwin::unGroupInput(bool error) {
   disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
              SLOT(unGroupInput(bool)));
-  if (error)
-    return;
-  if (!m_uiForm.ckGroupInput->isChecked()) {
-    IAlgorithm_sptr ungroupAlg =
-        AlgorithmManager::Instance().create("UnGroupWorkspace");
-    ungroupAlg->initialize();
-    ungroupAlg->setProperty("InputWorkspace", "IDA_Elwin_Input");
-    ungroupAlg->execute();
-  }
+  setRunIsRunning(false);
 
-  // Enable run, plot and save
-  setRunEnabled(true);
-  m_uiForm.pbPlot->setEnabled(true);
-  m_uiForm.pbSave->setEnabled(true);
+  if (!error) {
+    if (!m_uiForm.ckGroupInput->isChecked()) {
+      IAlgorithm_sptr ungroupAlg =
+          AlgorithmManager::Instance().create("UnGroupWorkspace");
+      ungroupAlg->initialize();
+      ungroupAlg->setProperty("InputWorkspace", "IDA_Elwin_Input");
+      ungroupAlg->execute();
+    }
+    setPlotResultEnabled(true);
+    setSaveResultEnabled(true);
+  }
 }
 
 bool Elwin::validate() {
@@ -464,6 +463,7 @@ void Elwin::updateRS(QtProperty *prop, double val) {
  * Handles mantid plotting
  */
 void Elwin::plotClicked() {
+  setPlotResultIsPlotting(true);
 
   auto workspaceBaseName =
       getWorkspaceBasename(QString::fromStdString(m_pythonExportWsName));
@@ -483,13 +483,14 @@ void Elwin::plotClicked() {
   if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_elt").toStdString(),
                                    true, false))
     plotSpectrum(workspaceBaseName + "_elt");
+
+  setPlotResultIsPlotting(false);
 }
 
 /**
  * Handles saving of workspaces
  */
 void Elwin::saveClicked() {
-
   auto workspaceBaseName =
       getWorkspaceBasename(QString::fromStdString(m_pythonExportWsName));
 
@@ -512,9 +513,24 @@ void Elwin::saveClicked() {
   m_batchAlgoRunner->executeBatchAsync();
 }
 
-void Elwin::setRunEnabled(bool enabled) {
-  m_uiForm.pbRun->setEnabled(enabled);
-  m_uiForm.pbRun->setText(!enabled ? "Running..." : "Run");
+void Elwin::setRunEnabled(bool enabled) { m_uiForm.pbRun->setEnabled(enabled); }
+
+void Elwin::setPlotResultEnabled(bool enabled) {
+  m_uiForm.pbPlot->setEnabled(enabled);
+}
+
+void Elwin::setSaveResultEnabled(bool enabled) {
+  m_uiForm.pbSave->setEnabled(enabled);
+}
+
+void Elwin::setRunIsRunning(bool running) {
+  m_uiForm.pbRun->setText(running ? "Running..." : "Run");
+  setRunEnabled(!running);
+}
+
+void Elwin::setPlotResultIsPlotting(bool plotting) {
+  m_uiForm.pbPlot->setText(plotting ? "Plotting..." : "Plot Result");
+  setPlotResultEnabled(!plotting);
 }
 
 void Elwin::runClicked() { runTab(); }

--- a/qt/scientific_interfaces/Indirect/Elwin.h
+++ b/qt/scientific_interfaces/Indirect/Elwin.h
@@ -14,9 +14,6 @@ class DLLExport Elwin : public IndirectDataAnalysisTab {
 public:
   Elwin(QWidget *parent = nullptr);
 
-protected:
-  void setRunEnabled(bool enabled) override;
-
 private:
   void run() override;
   void setup() override;
@@ -25,6 +22,13 @@ private:
   void setDefaultResolution(Mantid::API::MatrixWorkspace_const_sptr ws,
                             const QPair<double, double> &range);
   void setDefaultSampleLog(Mantid::API::MatrixWorkspace_const_sptr ws);
+
+  void setRunEnabled(bool enabled);
+  void setPlotResultEnabled(bool enabled);
+  void setSaveResultEnabled(bool enabled);
+
+  void setRunIsRunning(bool running);
+  void setPlotResultIsPlotting(bool plotting);
 
 private slots:
   void newInputFiles();

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.h
@@ -111,8 +111,6 @@ protected:
                        const QString &startRangePropName = "",
                        const QString &endRangePropName = "");
 
-  virtual void setRunEnabled(bool enabled) = 0;
-
   /// DoubleEditorFactory
   DoubleEditorFactory *m_dblEdFac;
   /// QtCheckBoxFactory

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -664,9 +664,9 @@ void IndirectFitAnalysisTab::updateSingleFitOutput(bool error) {
  * and completed within this interface.
  */
 void IndirectFitAnalysisTab::fitAlgorithmComplete(bool error) {
-  setSaveResultEnabled(!error);
-  setRunEnabled(true);
+  setRunIsRunning(false);
   enablePlotResult(error);
+  setSaveResultEnabled(!error);
   updateParameterValues();
   m_spectrumPresenter->enableView();
   m_plotPresenter->updatePlots();
@@ -839,7 +839,7 @@ bool IndirectFitAnalysisTab::validate() {
  * Called when the 'Run' button is called in the IndirectTab.
  */
 void IndirectFitAnalysisTab::run() {
-  setRunEnabled(false);
+  setRunIsRunning(true);
   runFitAlgorithm(m_fittingModel->getFittingAlgorithm());
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -759,8 +759,11 @@ void IndirectFitAnalysisTab::plotAll(
     Mantid::API::MatrixWorkspace_sptr workspace, const std::size_t &index) {
   const std::size_t numberOfSpectra =
       m_fittingModel->getWorkspace(index)->getNumberHistograms();
-  if (numberOfSpectra != 1 || allowPlotResultWithOneSpectra())
+  if (numberOfSpectra > 1)
     plotSpectrum(workspace);
+  else
+    showMessageBox(QString("Unable to plot result for a workspace:\n\n Cannot "
+                           "plot a single data point"));
 }
 
 void IndirectFitAnalysisTab::plotParameter(
@@ -768,8 +771,11 @@ void IndirectFitAnalysisTab::plotParameter(
     const std::string &parameterToPlot, const std::size_t &index) {
   const std::size_t numberOfSpectra =
       m_fittingModel->getWorkspace(index)->getNumberHistograms();
-  if (numberOfSpectra != 1 || allowPlotResultWithOneSpectra())
+  if (numberOfSpectra > 1)
     plotSpectrum(workspace, parameterToPlot);
+  else
+    showMessageBox(QString("Unable to plot result for a workspace:\n\n Cannot "
+                           "plot a single data point"));
 }
 
 void IndirectFitAnalysisTab::plotSpectrum(

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -762,8 +762,8 @@ void IndirectFitAnalysisTab::plotAll(
   if (numberOfSpectra > 1)
     plotSpectrum(workspace);
   else
-    showMessageBox(QString("Unable to plot result for a workspace:\n\n Cannot "
-                           "plot a single data point"));
+    showMessageBox(QString("Plotting the result of a workspace failed:\n\n "
+                           "Workspace result has only one data point"));
 }
 
 void IndirectFitAnalysisTab::plotParameter(
@@ -774,8 +774,8 @@ void IndirectFitAnalysisTab::plotParameter(
   if (numberOfSpectra > 1)
     plotSpectrum(workspace, parameterToPlot);
   else
-    showMessageBox(QString("Unable to plot result for a workspace:\n\n Cannot "
-                           "plot a single data point"));
+    showMessageBox(QString("Plotting the result of a workspace failed:\n\n "
+                           "Workspace result has only one data point"));
 }
 
 void IndirectFitAnalysisTab::plotSpectrum(

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -741,30 +741,42 @@ void IndirectFitAnalysisTab::plotResult(const QString &plotType) {
 
 void IndirectFitAnalysisTab::plotAll(
     Mantid::API::WorkspaceGroup_sptr workspaces) {
-  for (auto &&workspace : *workspaces)
-    plotAll(boost::dynamic_pointer_cast<MatrixWorkspace>(workspace));
+  for (auto index = 0u; index < workspaces->size(); ++index)
+    plotAll(boost::dynamic_pointer_cast<MatrixWorkspace>(
+                workspaces->getItem(index)),
+            index);
 }
 
 void IndirectFitAnalysisTab::plotParameter(
     Mantid::API::WorkspaceGroup_sptr workspaces, const std::string &parameter) {
-  for (auto &&workspace : *workspaces)
-    plotParameter(boost::dynamic_pointer_cast<MatrixWorkspace>(workspace),
-                  parameter);
+  for (auto index = 0u; index < workspaces->size(); ++index)
+    plotParameter(boost::dynamic_pointer_cast<MatrixWorkspace>(
+                      workspaces->getItem(index)),
+                  parameter, index);
 }
 
 void IndirectFitAnalysisTab::plotAll(
-    Mantid::API::MatrixWorkspace_sptr workspace) {
-  const auto name = QString::fromStdString(workspace->getName());
-  for (auto i = 0u; i < workspace->getNumberHistograms(); ++i)
-    IndirectTab::plotSpectrum(name, static_cast<int>(i));
+    Mantid::API::MatrixWorkspace_sptr workspace, const std::size_t &index) {
+  const std::size_t numberOfSpectra =
+      m_fittingModel->getWorkspace(index)->getNumberHistograms();
+  if (numberOfSpectra != 1 || allowPlotResultWithOneSpectra())
+    plotSpectrum(workspace);
 }
 
 void IndirectFitAnalysisTab::plotParameter(
     Mantid::API::MatrixWorkspace_sptr workspace,
+    const std::string &parameterToPlot, const std::size_t &index) {
+  const std::size_t numberOfSpectra =
+      m_fittingModel->getWorkspace(index)->getNumberHistograms();
+  if (numberOfSpectra != 1 || allowPlotResultWithOneSpectra())
+    plotSpectrum(workspace, parameterToPlot);
+}
+
+void IndirectFitAnalysisTab::plotSpectrum(
+    Mantid::API::MatrixWorkspace_sptr workspace,
     const std::string &parameterToPlot) {
   const auto name = QString::fromStdString(workspace->getName());
   const auto labels = IndirectTab::extractAxisLabels(workspace, 1);
-
   for (const auto &parameter : m_fittingModel->getFitParameterNames()) {
     if (boost::contains(parameter, parameterToPlot)) {
       auto it = labels.find(parameter);
@@ -772,6 +784,13 @@ void IndirectFitAnalysisTab::plotParameter(
         IndirectTab::plotSpectrum(name, static_cast<int>(it->second));
     }
   }
+}
+
+void IndirectFitAnalysisTab::plotSpectrum(
+    Mantid::API::MatrixWorkspace_sptr workspace) {
+  const auto name = QString::fromStdString(workspace->getName());
+  for (auto i = 0u; i < workspace->getNumberHistograms(); ++i)
+    IndirectTab::plotSpectrum(name, static_cast<int>(i));
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -665,8 +665,8 @@ void IndirectFitAnalysisTab::updateSingleFitOutput(bool error) {
  */
 void IndirectFitAnalysisTab::fitAlgorithmComplete(bool error) {
   setSaveResultEnabled(!error);
-  setPlotResultEnabled(!error);
   setRunEnabled(true);
+  enablePlotResult(error);
   updateParameterValues();
   m_spectrumPresenter->enableView();
   m_plotPresenter->updatePlots();
@@ -878,6 +878,10 @@ void IndirectFitAnalysisTab::setupFit(IAlgorithm_sptr fitAlgorithm) {
  */
 void IndirectFitAnalysisTab::updatePlotOptions(QComboBox *cbPlotType) {
   setPlotOptions(cbPlotType, m_fittingModel->getFitParameterNames());
+}
+
+void IndirectFitAnalysisTab::enablePlotResult(bool error) {
+  setPlotResultEnabled(!shouldEnablePlotResult() ? false : !error);
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -141,8 +141,11 @@ protected:
                       const QSet<QString> &options) const;
 
   virtual bool shouldEnablePlotResult() = 0;
+
   virtual void setPlotResultEnabled(bool enabled) = 0;
   virtual void setSaveResultEnabled(bool enabled) = 0;
+
+  virtual void setRunIsRunning(bool running) = 0;
 
 signals:
   void functionChanged();

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -118,9 +118,13 @@ protected:
   void plotAll(Mantid::API::WorkspaceGroup_sptr workspaces);
   void plotParameter(Mantid::API::WorkspaceGroup_sptr workspace,
                      const std::string &parameter);
-  void plotAll(Mantid::API::MatrixWorkspace_sptr workspace);
+  void plotAll(Mantid::API::MatrixWorkspace_sptr workspace,
+               const std::size_t &index);
   void plotParameter(Mantid::API::MatrixWorkspace_sptr workspace,
-                     const std::string &parameter);
+                     const std::string &parameter, const std::size_t &index);
+  void plotSpectrum(Mantid::API::MatrixWorkspace_sptr workspace);
+  void plotSpectrum(Mantid::API::MatrixWorkspace_sptr workspace,
+                    const std::string &parameterToPlot);
 
   void setAlgorithmProperties(Mantid::API::IAlgorithm_sptr fitAlgorithm) const;
   void runFitAlgorithm(Mantid::API::IAlgorithm_sptr fitAlgorithm);
@@ -137,6 +141,7 @@ protected:
                       const QSet<QString> &options) const;
 
   virtual bool shouldEnablePlotResult() = 0;
+  virtual bool allowPlotResultWithOneSpectra() = 0;
   virtual void setPlotResultEnabled(bool enabled) = 0;
   virtual void setSaveResultEnabled(bool enabled) = 0;
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -141,7 +141,6 @@ protected:
                       const QSet<QString> &options) const;
 
   virtual bool shouldEnablePlotResult() = 0;
-  virtual bool allowPlotResultWithOneSpectra() = 0;
   virtual void setPlotResultEnabled(bool enabled) = 0;
   virtual void setSaveResultEnabled(bool enabled) = 0;
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -128,6 +128,7 @@ protected:
   virtual void setupFit(Mantid::API::IAlgorithm_sptr fitAlgorithm);
 
   void updatePlotOptions(QComboBox *cbPlotType);
+  void enablePlotResult(bool error);
 
   void setPlotOptions(QComboBox *cbPlotType,
                       const std::vector<std::string> &parameters) const;
@@ -135,6 +136,7 @@ protected:
   void setPlotOptions(QComboBox *cbPlotType,
                       const QSet<QString> &options) const;
 
+  virtual bool shouldEnablePlotResult() = 0;
   virtual void setPlotResultEnabled(bool enabled) = 0;
   virtual void setSaveResultEnabled(bool enabled) = 0;
 

--- a/qt/scientific_interfaces/Indirect/Iqt.cpp
+++ b/qt/scientific_interfaces/Indirect/Iqt.cpp
@@ -136,7 +136,7 @@ void Iqt::setup() {
 void Iqt::run() {
   using namespace Mantid::API;
 
-  setRunEnabled(false);
+  setRunIsRunning(true);
 
   updateDisplayedBinParameters();
 
@@ -180,12 +180,12 @@ void Iqt::run() {
  * @param error If the algorithm failed
  */
 void Iqt::algorithmComplete(bool error) {
-  if (error)
-    return;
-  setRunEnabled(true);
-  m_uiForm.pbPlot->setEnabled(true);
-  m_uiForm.pbSave->setEnabled(true);
-  m_uiForm.pbTile->setEnabled(true);
+  setRunIsRunning(false);
+  if (!error) {
+    setPlotResultEnabled(true);
+    setTiledPlotEnabled(true);
+    setSaveResultEnabled(true);
+  }
 }
 /**
  * Handle saving of workspace
@@ -201,7 +201,9 @@ void Iqt::saveClicked() {
  */
 void Iqt::plotClicked() {
   checkADSForPlotSaveWorkspace(m_pythonExportWsName, false);
+  setPlotResultIsPlotting(true);
   plotSpectrum(QString::fromStdString(m_pythonExportWsName));
+  setPlotResultIsPlotting(false);
 }
 
 void Iqt::errorsClicked() {
@@ -211,6 +213,8 @@ void Iqt::errorsClicked() {
 bool Iqt::isErrorsEnabled() { return m_uiForm.cbCalculateErrors->isChecked(); }
 
 void Iqt::plotTiled() {
+  setTiledPlotIsPlotting(true);
+
   MatrixWorkspace_const_sptr outWs =
       AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
           m_pythonExportWsName);
@@ -262,6 +266,8 @@ void Iqt::plotTiled() {
   }
   pyInput += "])\n";
   runPythonCode(pyInput);
+
+  setTiledPlotIsPlotting(false);
 }
 
 /**
@@ -452,9 +458,33 @@ void Iqt::updateRS(QtProperty *prop, double val) {
     xRangeSelector->setMaximum(val);
 }
 
-void Iqt::setRunEnabled(bool enabled) {
-  m_uiForm.pbRun->setEnabled(enabled);
-  m_uiForm.pbRun->setText(!enabled ? "Running..." : "Run");
+void Iqt::setRunEnabled(bool enabled) { m_uiForm.pbRun->setEnabled(enabled); }
+
+void Iqt::setPlotResultEnabled(bool enabled) {
+  m_uiForm.pbPlot->setEnabled(enabled);
+}
+
+void Iqt::setTiledPlotEnabled(bool enabled) {
+  m_uiForm.pbTile->setEnabled(enabled);
+}
+
+void Iqt::setSaveResultEnabled(bool enabled) {
+  m_uiForm.pbSave->setEnabled(enabled);
+}
+
+void Iqt::setRunIsRunning(bool running) {
+  m_uiForm.pbRun->setText(running ? "Running..." : "Run");
+  setRunEnabled(!running);
+}
+
+void Iqt::setPlotResultIsPlotting(bool plotting) {
+  m_uiForm.pbPlot->setText(plotting ? "Plotting..." : "Plot Result");
+  setPlotResultEnabled(!plotting);
+}
+
+void Iqt::setTiledPlotIsPlotting(bool plotting) {
+  m_uiForm.pbTile->setText(plotting ? "Plotting..." : "Tiled Plot");
+  setTiledPlotEnabled(!plotting);
 }
 
 void Iqt::runClicked() { runTab(); }

--- a/qt/scientific_interfaces/Indirect/Iqt.h
+++ b/qt/scientific_interfaces/Indirect/Iqt.h
@@ -13,9 +13,6 @@ class DLLExport Iqt : public IndirectDataAnalysisTab {
 public:
   Iqt(QWidget *parent = nullptr);
 
-protected:
-  void setRunEnabled(bool enabled) override;
-
 private:
   void run() override;
   void setup() override;
@@ -23,6 +20,15 @@ private:
   void loadSettings(const QSettings &settings) override;
 
   bool isErrorsEnabled();
+
+  void setRunEnabled(bool enabled);
+  void setPlotResultEnabled(bool enabled);
+  void setTiledPlotEnabled(bool enabled);
+  void setSaveResultEnabled(bool enabled);
+
+  void setRunIsRunning(bool running);
+  void setPlotResultIsPlotting(bool plotting);
+  void setTiledPlotIsPlotting(bool plotting);
 
 private slots:
   void algorithmComplete(bool error);

--- a/qt/scientific_interfaces/Indirect/Iqt.ui
+++ b/qt/scientific_interfaces/Indirect/Iqt.ui
@@ -236,6 +236,32 @@
           <number>7</number>
          </property>
          <item>
+          <widget class="QCheckBox" name="cbCalculateErrors">
+           <property name="text">
+            <string>Calculate Errors</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_5">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>30</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
           <widget class="QLabel" name="label">
            <property name="maximumSize">
             <size>
@@ -279,16 +305,6 @@
             </size>
            </property>
           </spacer>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="cbCalculateErrors">
-           <property name="text">
-            <string>Calculate Errors</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
          </item>
         </layout>
        </widget>

--- a/qt/scientific_interfaces/Indirect/IqtFit.cpp
+++ b/qt/scientific_interfaces/Indirect/IqtFit.cpp
@@ -117,15 +117,6 @@ void IqtFit::updatePlotOptions() {
   IndirectFitAnalysisTab::updatePlotOptions(m_uiForm->cbPlotType);
 }
 
-void IqtFit::setPlotResultEnabled(bool enabled) {
-  m_uiForm->pbPlot->setEnabled(enabled);
-  m_uiForm->cbPlotType->setEnabled(enabled);
-}
-
-void IqtFit::setSaveResultEnabled(bool enabled) {
-  m_uiForm->pbSave->setEnabled(enabled);
-}
-
 void IqtFit::setupFit(Mantid::API::IAlgorithm_sptr fitAlgorithm) {
   fitAlgorithm->setProperty("ExtractMembers",
                             boolSettingValue("ExtractMembers"));
@@ -133,13 +124,37 @@ void IqtFit::setupFit(Mantid::API::IAlgorithm_sptr fitAlgorithm) {
 }
 
 void IqtFit::plotResult() {
+  setPlotResultIsPlotting(true);
   IndirectFitAnalysisTab::plotResult(m_uiForm->cbPlotType->currentText());
+  setPlotResultIsPlotting(false);
 }
 
 void IqtFit::setRunEnabled(bool enabled) {
-  m_uiForm->pvFitPlotView->enableFitSingleSpectrum(enabled);
   m_uiForm->pbRun->setEnabled(enabled);
-  m_uiForm->pbRun->setText(!enabled ? "Running..." : "Run");
+}
+
+void IqtFit::setPlotResultEnabled(bool enabled) {
+  m_uiForm->pbPlot->setEnabled(enabled);
+  m_uiForm->cbPlotType->setEnabled(enabled);
+}
+
+void IqtFit::setFitSingleSpectrumEnabled(bool enabled) {
+  m_uiForm->pvFitPlotView->enableFitSingleSpectrum(enabled);
+}
+
+void IqtFit::setSaveResultEnabled(bool enabled) {
+  m_uiForm->pbSave->setEnabled(enabled);
+}
+
+void IqtFit::setRunIsRunning(bool running) {
+  m_uiForm->pbRun->setText(running ? "Running..." : "Run");
+  setRunEnabled(!running);
+  setFitSingleSpectrumEnabled(!running);
+}
+
+void IqtFit::setPlotResultIsPlotting(bool plotting) {
+  m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot Result");
+  setPlotResultEnabled(!plotting);
 }
 
 void IqtFit::runClicked() { runTab(); }

--- a/qt/scientific_interfaces/Indirect/IqtFit.cpp
+++ b/qt/scientific_interfaces/Indirect/IqtFit.cpp
@@ -153,7 +153,7 @@ void IqtFit::setRunIsRunning(bool running) {
 }
 
 void IqtFit::setPlotResultIsPlotting(bool plotting) {
-  m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot Result");
+  m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot");
   setPlotResultEnabled(!plotting);
 }
 

--- a/qt/scientific_interfaces/Indirect/IqtFit.h
+++ b/qt/scientific_interfaces/Indirect/IqtFit.h
@@ -33,10 +33,13 @@ private:
 protected:
   bool shouldEnablePlotResult() override { return true; };
 <<<<<<< HEAD
+<<<<<<< HEAD
 
   void setRunEnabled(bool enabled) override;
 =======
   bool allowPlotResultWithOneSpectra() override { return true; }
+=======
+>>>>>>> Show message box if one spectra in Multiple Input Refs #23164
 
 >>>>>>> Plot Result only for workspaces with multiple spectra Refs #23164
   void setPlotResultEnabled(bool enabled) override;

--- a/qt/scientific_interfaces/Indirect/IqtFit.h
+++ b/qt/scientific_interfaces/Indirect/IqtFit.h
@@ -32,16 +32,8 @@ private:
 
 protected:
   bool shouldEnablePlotResult() override { return true; };
-<<<<<<< HEAD
-<<<<<<< HEAD
 
   void setRunEnabled(bool enabled) override;
-=======
-  bool allowPlotResultWithOneSpectra() override { return true; }
-=======
->>>>>>> Show message box if one spectra in Multiple Input Refs #23164
-
->>>>>>> Plot Result only for workspaces with multiple spectra Refs #23164
   void setPlotResultEnabled(bool enabled) override;
   void setSaveResultEnabled(bool enabled) override;
 

--- a/qt/scientific_interfaces/Indirect/IqtFit.h
+++ b/qt/scientific_interfaces/Indirect/IqtFit.h
@@ -31,6 +31,8 @@ private:
   void setupFitTab() override;
 
 protected:
+  bool shouldEnablePlotResult() override { return true; };
+
   void setRunEnabled(bool enabled) override;
   void setPlotResultEnabled(bool enabled) override;
   void setSaveResultEnabled(bool enabled) override;

--- a/qt/scientific_interfaces/Indirect/IqtFit.h
+++ b/qt/scientific_interfaces/Indirect/IqtFit.h
@@ -32,8 +32,13 @@ private:
 
 protected:
   bool shouldEnablePlotResult() override { return true; };
+<<<<<<< HEAD
 
   void setRunEnabled(bool enabled) override;
+=======
+  bool allowPlotResultWithOneSpectra() override { return true; }
+
+>>>>>>> Plot Result only for workspaces with multiple spectra Refs #23164
   void setPlotResultEnabled(bool enabled) override;
   void setSaveResultEnabled(bool enabled) override;
 

--- a/qt/scientific_interfaces/Indirect/IqtFit.h
+++ b/qt/scientific_interfaces/Indirect/IqtFit.h
@@ -27,16 +27,6 @@ class DLLExport IqtFit : public IndirectFitAnalysisTab {
 public:
   IqtFit(QWidget *parent = nullptr);
 
-private:
-  void setupFitTab() override;
-
-protected:
-  bool shouldEnablePlotResult() override { return true; };
-
-  void setRunEnabled(bool enabled) override;
-  void setPlotResultEnabled(bool enabled) override;
-  void setSaveResultEnabled(bool enabled) override;
-
 protected slots:
   void setupFit(Mantid::API::IAlgorithm_sptr fitAlgorithm) override;
   void updatePlotOptions() override;
@@ -45,9 +35,24 @@ protected slots:
   void plotResult();
   void runClicked();
 
+protected:
+  bool shouldEnablePlotResult() override { return true; };
+
+  void setPlotResultEnabled(bool enabled) override;
+  void setSaveResultEnabled(bool enabled) override;
+
+  void setRunIsRunning(bool running) override;
+
 private:
   void setConstrainIntensitiesEnabled(bool enabled);
   std::string fitTypeString() const;
+
+  void setupFitTab() override;
+
+  void setRunEnabled(bool enabled);
+  void setFitSingleSpectrumEnabled(bool enabled);
+
+  void setPlotResultIsPlotting(bool plotting);
 
   IqtFitModel *m_iqtFittingModel;
   std::unique_ptr<Ui::IqtFit> m_uiForm;

--- a/qt/scientific_interfaces/Indirect/IqtFit.ui
+++ b/qt/scientific_interfaces/Indirect/IqtFit.ui
@@ -127,7 +127,7 @@
              <item>
               <widget class="QLabel" name="lbPlotType">
                <property name="text">
-                <string>Plot Output: </string>
+                <string>Plot Output:</string>
                </property>
               </widget>
              </item>
@@ -135,6 +135,18 @@
               <widget class="QComboBox" name="cbPlotType">
                <property name="enabled">
                 <bool>false</bool>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>100</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>100</width>
+                 <height>16777215</height>
+                </size>
                </property>
                <item>
                 <property name="text">

--- a/qt/scientific_interfaces/Indirect/IqtFit.ui
+++ b/qt/scientific_interfaces/Indirect/IqtFit.ui
@@ -181,7 +181,7 @@
                 <bool>false</bool>
                </property>
                <property name="text">
-                <string>Plot Result</string>
+                <string>Plot</string>
                </property>
               </widget>
              </item>

--- a/qt/scientific_interfaces/Indirect/JumpFit.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFit.cpp
@@ -80,7 +80,7 @@ void JumpFit::updatePlotOptions() {
 
 bool JumpFit::shouldEnablePlotResult() {
   for (auto i = 0u; i < m_jumpFittingModel->numberOfWorkspaces(); ++i)
-    if (m_jumpFittingModel->getNumberOfSpectra(i) != 1)
+    if (m_jumpFittingModel->getNumberOfSpectra(i) > 1)
       return true;
   return false;
 }

--- a/qt/scientific_interfaces/Indirect/JumpFit.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFit.cpp
@@ -78,6 +78,13 @@ void JumpFit::updatePlotOptions() {
   IndirectFitAnalysisTab::updatePlotOptions(m_uiForm->cbPlotType);
 }
 
+bool JumpFit::shouldEnablePlotResult() {
+  for (auto i = 0u; i < m_jumpFittingModel->numberOfWorkspaces(); ++i)
+    if (m_jumpFittingModel->getNumberOfSpectra(i) != 1)
+      return true;
+  return false;
+}
+
 void JumpFit::setPlotResultEnabled(bool enabled) {
   m_uiForm->pbPlot->setEnabled(enabled);
   m_uiForm->cbPlotType->setEnabled(enabled);

--- a/qt/scientific_interfaces/Indirect/JumpFit.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFit.cpp
@@ -78,6 +78,12 @@ void JumpFit::updatePlotOptions() {
   IndirectFitAnalysisTab::updatePlotOptions(m_uiForm->cbPlotType);
 }
 
+void JumpFit::plotClicked() {
+  setPlotResultIsPlotting(true);
+  IndirectFitAnalysisTab::plotResult(m_uiForm->cbPlotType->currentText());
+  setPlotResultIsPlotting(false);
+}
+
 bool JumpFit::shouldEnablePlotResult() {
   for (auto i = 0u; i < m_jumpFittingModel->numberOfWorkspaces(); ++i)
     if (m_jumpFittingModel->getNumberOfSpectra(i) > 1)
@@ -85,23 +91,32 @@ bool JumpFit::shouldEnablePlotResult() {
   return false;
 }
 
+void JumpFit::setRunEnabled(bool enabled) {
+  m_uiForm->pbRun->setEnabled(enabled);
+}
+
 void JumpFit::setPlotResultEnabled(bool enabled) {
   m_uiForm->pbPlot->setEnabled(enabled);
   m_uiForm->cbPlotType->setEnabled(enabled);
+}
+
+void JumpFit::setFitSingleSpectrumEnabled(bool enabled) {
+  m_uiForm->pvFitPlotView->enableFitSingleSpectrum(enabled);
 }
 
 void JumpFit::setSaveResultEnabled(bool enabled) {
   m_uiForm->pbSave->setEnabled(enabled);
 }
 
-void JumpFit::plotClicked() {
-  IndirectFitAnalysisTab::plotResult(m_uiForm->cbPlotType->currentText());
+void JumpFit::setRunIsRunning(bool running) {
+  m_uiForm->pbRun->setText(running ? "Running..." : "Run");
+  setRunEnabled(!running);
+  setFitSingleSpectrumEnabled(!running);
 }
 
-void JumpFit::setRunEnabled(bool enabled) {
-  m_uiForm->pvFitPlotView->enableFitSingleSpectrum(enabled);
-  m_uiForm->pbRun->setEnabled(enabled);
-  m_uiForm->pbRun->setText(!enabled ? "Running..." : "Run");
+void JumpFit::setPlotResultIsPlotting(bool plotting) {
+  m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot Result");
+  setPlotResultEnabled(!plotting);
 }
 
 void JumpFit::runClicked() { runTab(); }

--- a/qt/scientific_interfaces/Indirect/JumpFit.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFit.cpp
@@ -115,7 +115,7 @@ void JumpFit::setRunIsRunning(bool running) {
 }
 
 void JumpFit::setPlotResultIsPlotting(bool plotting) {
-  m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot Result");
+  m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot");
   setPlotResultEnabled(!plotting);
 }
 

--- a/qt/scientific_interfaces/Indirect/JumpFit.h
+++ b/qt/scientific_interfaces/Indirect/JumpFit.h
@@ -28,10 +28,13 @@ protected slots:
 protected:
   bool shouldEnablePlotResult() override;
 <<<<<<< HEAD
+<<<<<<< HEAD
 
   void setRunEnabled(bool enabled) override;
 =======
   bool allowPlotResultWithOneSpectra() override { return false; }
+=======
+>>>>>>> Show message box if one spectra in Multiple Input Refs #23164
 
 >>>>>>> Plot Result only for workspaces with multiple spectra Refs #23164
   void setPlotResultEnabled(bool enabled) override;

--- a/qt/scientific_interfaces/Indirect/JumpFit.h
+++ b/qt/scientific_interfaces/Indirect/JumpFit.h
@@ -28,11 +28,17 @@ protected slots:
 protected:
   bool shouldEnablePlotResult() override;
 
-  void setRunEnabled(bool enabled) override;
   void setPlotResultEnabled(bool enabled) override;
   void setSaveResultEnabled(bool enabled) override;
 
+  void setRunIsRunning(bool running) override;
+
 private:
+  void setRunEnabled(bool enabled);
+  void setFitSingleSpectrumEnabled(bool enabled);
+
+  void setPlotResultIsPlotting(bool plotting);
+
   JumpFitModel *m_jumpFittingModel;
   std::unique_ptr<Ui::JumpFit> m_uiForm;
 };

--- a/qt/scientific_interfaces/Indirect/JumpFit.h
+++ b/qt/scientific_interfaces/Indirect/JumpFit.h
@@ -26,6 +26,8 @@ protected slots:
   void runClicked();
 
 protected:
+  bool shouldEnablePlotResult() override;
+
   void setRunEnabled(bool enabled) override;
   void setPlotResultEnabled(bool enabled) override;
   void setSaveResultEnabled(bool enabled) override;

--- a/qt/scientific_interfaces/Indirect/JumpFit.h
+++ b/qt/scientific_interfaces/Indirect/JumpFit.h
@@ -27,16 +27,8 @@ protected slots:
 
 protected:
   bool shouldEnablePlotResult() override;
-<<<<<<< HEAD
-<<<<<<< HEAD
 
   void setRunEnabled(bool enabled) override;
-=======
-  bool allowPlotResultWithOneSpectra() override { return false; }
-=======
->>>>>>> Show message box if one spectra in Multiple Input Refs #23164
-
->>>>>>> Plot Result only for workspaces with multiple spectra Refs #23164
   void setPlotResultEnabled(bool enabled) override;
   void setSaveResultEnabled(bool enabled) override;
 

--- a/qt/scientific_interfaces/Indirect/JumpFit.h
+++ b/qt/scientific_interfaces/Indirect/JumpFit.h
@@ -27,8 +27,13 @@ protected slots:
 
 protected:
   bool shouldEnablePlotResult() override;
+<<<<<<< HEAD
 
   void setRunEnabled(bool enabled) override;
+=======
+  bool allowPlotResultWithOneSpectra() override { return false; }
+
+>>>>>>> Plot Result only for workspaces with multiple spectra Refs #23164
   void setPlotResultEnabled(bool enabled) override;
   void setSaveResultEnabled(bool enabled) override;
 

--- a/qt/scientific_interfaces/Indirect/JumpFit.ui
+++ b/qt/scientific_interfaces/Indirect/JumpFit.ui
@@ -223,6 +223,18 @@
              </item>
              <item>
               <widget class="QComboBox" name="cbPlotType">
+               <property name="minimumSize">
+                <size>
+                 <width>100</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>100</width>
+                 <height>16777215</height>
+                </size>
+               </property>
                <item>
                 <property name="text">
                  <string>All</string>
@@ -233,7 +245,7 @@
              <item>
               <widget class="QPushButton" name="pbPlot">
                <property name="text">
-                <string>Plot</string>
+                <string>Plot Result</string>
                </property>
               </widget>
              </item>

--- a/qt/scientific_interfaces/Indirect/JumpFit.ui
+++ b/qt/scientific_interfaces/Indirect/JumpFit.ui
@@ -245,7 +245,7 @@
              <item>
               <widget class="QPushButton" name="pbPlot">
                <property name="text">
-                <string>Plot Result</string>
+                <string>Plot</string>
                </property>
               </widget>
              </item>

--- a/qt/scientific_interfaces/Indirect/MSDFit.cpp
+++ b/qt/scientific_interfaces/Indirect/MSDFit.cpp
@@ -60,7 +60,11 @@ void MSDFit::updateModelFitTypeString() {
 
 void MSDFit::updatePlotOptions() {}
 
-void MSDFit::plotClicked() { IndirectFitAnalysisTab::plotResult("All"); }
+void MSDFit::plotClicked() {
+  setPlotResultIsPlotting(true);
+  IndirectFitAnalysisTab::plotResult("All");
+  setPlotResultIsPlotting(false);
+}
 
 bool MSDFit::shouldEnablePlotResult() {
   for (auto i = 0u; i < m_msdFittingModel->numberOfWorkspaces(); ++i)
@@ -69,18 +73,31 @@ bool MSDFit::shouldEnablePlotResult() {
   return false;
 }
 
+void MSDFit::setRunEnabled(bool enabled) {
+  m_uiForm->pbRun->setEnabled(enabled);
+}
+
 void MSDFit::setPlotResultEnabled(bool enabled) {
   m_uiForm->pbPlot->setEnabled(enabled);
+}
+
+void MSDFit::setFitSingleSpectrumEnabled(bool enabled) {
+  m_uiForm->pvFitPlotView->enableFitSingleSpectrum(enabled);
 }
 
 void MSDFit::setSaveResultEnabled(bool enabled) {
   m_uiForm->pbSave->setEnabled(enabled);
 }
 
-void MSDFit::setRunEnabled(bool enabled) {
-  m_uiForm->pvFitPlotView->enableFitSingleSpectrum(enabled);
-  m_uiForm->pbRun->setEnabled(enabled);
-  m_uiForm->pbRun->setText(!enabled ? "Running..." : "Run");
+void MSDFit::setRunIsRunning(bool running) {
+  m_uiForm->pbRun->setText(running ? "Running..." : "Run");
+  setRunEnabled(!running);
+  setFitSingleSpectrumEnabled(!running);
+}
+
+void MSDFit::setPlotResultIsPlotting(bool plotting) {
+  m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot Result");
+  setPlotResultEnabled(!plotting);
 }
 
 void MSDFit::runClicked() { runTab(); }

--- a/qt/scientific_interfaces/Indirect/MSDFit.cpp
+++ b/qt/scientific_interfaces/Indirect/MSDFit.cpp
@@ -62,6 +62,13 @@ void MSDFit::updatePlotOptions() {}
 
 void MSDFit::plotClicked() { IndirectFitAnalysisTab::plotResult("All"); }
 
+bool MSDFit::shouldEnablePlotResult() {
+  for (auto i = 0u; i < m_msdFittingModel->numberOfWorkspaces(); ++i)
+    if (m_msdFittingModel->getNumberOfSpectra(i) != 1)
+      return true;
+  return false;
+}
+
 void MSDFit::setPlotResultEnabled(bool enabled) {
   m_uiForm->pbPlot->setEnabled(enabled);
 }

--- a/qt/scientific_interfaces/Indirect/MSDFit.cpp
+++ b/qt/scientific_interfaces/Indirect/MSDFit.cpp
@@ -64,7 +64,7 @@ void MSDFit::plotClicked() { IndirectFitAnalysisTab::plotResult("All"); }
 
 bool MSDFit::shouldEnablePlotResult() {
   for (auto i = 0u; i < m_msdFittingModel->numberOfWorkspaces(); ++i)
-    if (m_msdFittingModel->getNumberOfSpectra(i) != 1)
+    if (m_msdFittingModel->getNumberOfSpectra(i) > 1)
       return true;
   return false;
 }

--- a/qt/scientific_interfaces/Indirect/MSDFit.h
+++ b/qt/scientific_interfaces/Indirect/MSDFit.h
@@ -28,10 +28,13 @@ protected slots:
 protected:
   bool shouldEnablePlotResult() override;
 <<<<<<< HEAD
+<<<<<<< HEAD
 
   void setRunEnabled(bool enabled) override;
 =======
   bool allowPlotResultWithOneSpectra() override { return false; }
+=======
+>>>>>>> Show message box if one spectra in Multiple Input Refs #23164
 
 >>>>>>> Plot Result only for workspaces with multiple spectra Refs #23164
   void setPlotResultEnabled(bool enabled) override;

--- a/qt/scientific_interfaces/Indirect/MSDFit.h
+++ b/qt/scientific_interfaces/Indirect/MSDFit.h
@@ -27,16 +27,8 @@ protected slots:
 
 protected:
   bool shouldEnablePlotResult() override;
-<<<<<<< HEAD
-<<<<<<< HEAD
 
   void setRunEnabled(bool enabled) override;
-=======
-  bool allowPlotResultWithOneSpectra() override { return false; }
-=======
->>>>>>> Show message box if one spectra in Multiple Input Refs #23164
-
->>>>>>> Plot Result only for workspaces with multiple spectra Refs #23164
   void setPlotResultEnabled(bool enabled) override;
   void setSaveResultEnabled(bool enabled) override;
 

--- a/qt/scientific_interfaces/Indirect/MSDFit.h
+++ b/qt/scientific_interfaces/Indirect/MSDFit.h
@@ -27,8 +27,13 @@ protected slots:
 
 protected:
   bool shouldEnablePlotResult() override;
+<<<<<<< HEAD
 
   void setRunEnabled(bool enabled) override;
+=======
+  bool allowPlotResultWithOneSpectra() override { return false; }
+
+>>>>>>> Plot Result only for workspaces with multiple spectra Refs #23164
   void setPlotResultEnabled(bool enabled) override;
   void setSaveResultEnabled(bool enabled) override;
 

--- a/qt/scientific_interfaces/Indirect/MSDFit.h
+++ b/qt/scientific_interfaces/Indirect/MSDFit.h
@@ -26,6 +26,8 @@ protected slots:
   void updateModelFitTypeString();
 
 protected:
+  bool shouldEnablePlotResult() override;
+
   void setRunEnabled(bool enabled) override;
   void setPlotResultEnabled(bool enabled) override;
   void setSaveResultEnabled(bool enabled) override;

--- a/qt/scientific_interfaces/Indirect/MSDFit.h
+++ b/qt/scientific_interfaces/Indirect/MSDFit.h
@@ -16,9 +16,6 @@ class DLLExport MSDFit : public IndirectFitAnalysisTab {
 public:
   MSDFit(QWidget *parent = nullptr);
 
-private:
-  void setupFitTab() override;
-
 protected slots:
   void plotClicked();
   void runClicked();
@@ -28,11 +25,19 @@ protected slots:
 protected:
   bool shouldEnablePlotResult() override;
 
-  void setRunEnabled(bool enabled) override;
   void setPlotResultEnabled(bool enabled) override;
   void setSaveResultEnabled(bool enabled) override;
 
+  void setRunIsRunning(bool running) override;
+
 private:
+  void setupFitTab() override;
+
+  void setRunEnabled(bool enabled);
+  void setFitSingleSpectrumEnabled(bool enabled);
+
+  void setPlotResultIsPlotting(bool plotting);
+
   MSDFitModel *m_msdFittingModel;
   std::unique_ptr<Ui::MSDFit> m_uiForm;
 };


### PR DESCRIPTION
**Description of work.**
This PR ensures that the `Plot Result` button is disabled for a workspace containing only one spectra for both MSD Fit and F(Q) Fit on the Data Analysis Interface of Indirect .
This PR also makes sure an informative error message is displayed when trying to plot a workspace with a single spectra from MultipleInput. The other workspaces with more than one spectra in the MultipleInput will be plotted.
This PR also ensures that the `Plot Result` button on each tab of Data analysis is disabled while plotting is taking place.
The `Calculate Errors` checkbox in the I(Q,t) Tab has been moved to the left of `Number of Iterations`.

**To test:**
1. `Indirect Data Analysis` -> `MSD Fit` Tab (or `F(Q) Fit` Tab)
2. Load the data provided below
3. Selected Plot type `Gaussian`
4. Click `Run`
5. Check that the `Plot Result` (or `Plot`) button is disabled/enabled for the relevant data

- Repeat this but for F(Q) Fit

1. In `MSD Fit`, load both the files below into `Multiple Input` by clicking `Add Workspace`, browsing to the file location and selecting `All Spectra`.
2. Select Plot type `Gaussian` and click `Run`
3. Click `Plot Result` - two graphs should be displayed, and then an informative error message (which corresponds to the last workspace of the two below)

- While plotting is being undertaken, the `Plot Result` button should also be disabled.

**Test Data**
MSD Fit:
[osi104367-104371_graphite002_red_elwin_eq.zip](https://github.com/mantidproject/mantid/files/2352781/osi104367-104371_graphite002_red_elwin_eq.zip) - button should be enabled
[osi92762_graphite002_elwin_eq.zip](https://github.com/mantidproject/mantid/files/2352782/osi92762_graphite002_elwin_eq.zip) - button should be disabled

F(Q) Fit:
[IN16B_125878_QLd_Result.zip](https://github.com/mantidproject/mantid/files/2352784/IN16B_125878_QLd_Result.zip) - button should be disabled
[iris26174_graphite002_s0-17_Result.zip](https://github.com/mantidproject/mantid/files/2379723/iris26174_graphite002_s0-17_Result.zip) - button should be disabled

--------------------------------------------------------

Fixes #23164 and #23496

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

