### PR TITLE
Fix algorithm History on passed lists of workspaces

### DIFF
--- a/Framework/API/inc/MantidAPI/Algorithm.h
+++ b/Framework/API/inc/MantidAPI/Algorithm.h
@@ -6,6 +6,7 @@
 #include "MantidAPI/DllConfig.h"
 #include "MantidAPI/IAlgorithm.h"
 #include "MantidAPI/IndexTypeProperty.h"
+#include "MantidKernel/IValidator.h"
 #include "MantidKernel/PropertyManagerOwner.h"
 
 // -- These headers will (most-likely) be used by every inheriting algorithm
@@ -445,6 +446,8 @@ private:
   void setupSkipValidationMasterOnly();
 
   bool isCompoundProperty(const std::string &name) const;
+
+  bool hasAnADSValidator(const Mantid::Kernel::IValidator_sptr propProp) const;
 
   // --------------------- Private Members -----------------------------------
   /// Poco::ActiveMethod used to implement asynchronous execution.

--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -1,4 +1,5 @@
 #include "MantidAPI/Algorithm.h"
+#include "MantidAPI/ADSValidator.h"
 #include "MantidAPI/AlgorithmHistory.h"
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/AlgorithmProxy.h"
@@ -8,10 +9,12 @@
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidAPI/WorkspaceHistory.h"
 
+#include "MantidKernel/CompositeValidator.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/DateAndTime.h"
 #include "MantidKernel/EmptyValues.h"
 #include "MantidKernel/MultiThreaded.h"
+#include "MantidKernel/PropertyWithValue.h"
 #include "MantidKernel/Strings.h"
 #include "MantidKernel/Timer.h"
 #include "MantidKernel/UsageService.h"
@@ -509,9 +512,8 @@ bool Algorithm::execute() {
   // ----- Perform validation of the whole set of properties -------------
   if ((!callProcessGroups) &&
       (executionMode != Parallel::ExecutionMode::MasterOnly ||
-       communicator().rank() ==
-           0)) // for groups this is called on each workspace
-               // separately
+       communicator().rank() == 0)) // for groups this is called on each
+                                    // workspace separately
   {
     std::map<std::string, std::string> errors = this->validateInputs();
     if (!errors.empty()) {
@@ -1093,7 +1095,58 @@ void Algorithm::findWorkspaceProperties(
         outputWorkspaces.push_back(workspace);
       }
     }
+    // If it is a list of strings of workspace names make sure to add history
+    const Mantid::Kernel::PropertyWithValue<std::vector<std::string>>
+        *propProp = dynamic_cast<
+            Mantid::Kernel::PropertyWithValue<std::vector<std::string>> *>(*it);
+    if (propProp && hasAnADSValidator(propProp->getValidator())) {
+      const auto &ADS = AnalysisDataService::Instance();
+      const auto direction = propProp->direction();
+      const auto propPropValue = propProp->value();
+      std::string currentWS = "";
+      for (auto i = 0u; i < propPropValue.size(); ++i) {
+        if (propPropValue[i] == ',') {
+          if (direction == Direction::Input || direction == Direction::InOut) {
+            inputWorkspaces.push_back(ADS.retrieveWS<Workspace>(currentWS));
+          }
+          if (direction == Direction::Output || direction == Direction::InOut) {
+            outputWorkspaces.push_back(ADS.retrieveWS<Workspace>(currentWS));
+          }
+          currentWS = "";
+        } else {
+          currentWS.push_back(propPropValue[i]);
+        }
+      }
+      if (direction == Direction::Input || direction == Direction::InOut) {
+        inputWorkspaces.push_back(ADS.retrieveWS<Workspace>(currentWS));
+      }
+      if (direction == Direction::Output || direction == Direction::InOut) {
+        outputWorkspaces.push_back(ADS.retrieveWS<Workspace>(currentWS));
+      }
+      currentWS = "";
+    }
   }
+}
+
+bool Algorithm::hasAnADSValidator(const IValidator_sptr propProp) const {
+  const Mantid::API::ADSValidator *ADSPropPropValidator =
+      dynamic_cast<Mantid::API::ADSValidator *>(propProp.get());
+  if (ADSPropPropValidator) {
+    return true;
+  }
+
+  const Mantid::Kernel::CompositeValidator *propPropCompValidator =
+      dynamic_cast<Mantid::Kernel::CompositeValidator *>(propProp.get());
+  if (propPropCompValidator) {
+    const std::list<IValidator_sptr> validatorList =
+        propPropCompValidator->getChildren();
+    for (IValidator_sptr i : validatorList) {
+      if (hasAnADSValidator(i) == true) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 /** Sends out algorithm parameter information to the logger */
@@ -1105,8 +1158,8 @@ void Algorithm::logAlgorithmInfo() const {
     if (this->isChild())
       logger.notice() << " (child)";
     logger.notice() << '\n';
-    // Make use of the AlgorithmHistory class, which holds all the info we want
-    // here
+    // Make use of the AlgorithmHistory class, which holds all the info we
+    // want here
     AlgorithmHistory algHistory(this);
     size_t maxPropertyLength = 40;
     if (logger.is(Logger::Priority::PRIO_DEBUG)) {
@@ -1159,9 +1212,9 @@ bool Algorithm::checkGroups() {
     WorkspaceGroup_sptr wsGroup =
         boost::dynamic_pointer_cast<WorkspaceGroup>(ws);
 
-    // Workspace groups are NOT returned by IWP->getWorkspace() most of the time
-    // because WorkspaceProperty is templated by <MatrixWorkspace>
-    // and WorkspaceGroup does not subclass <MatrixWorkspace>
+    // Workspace groups are NOT returned by IWP->getWorkspace() most of the
+    // time because WorkspaceProperty is templated by <MatrixWorkspace> and
+    // WorkspaceGroup does not subclass <MatrixWorkspace>
     if (!wsGroup && prop && !prop->value().empty()) {
       // So try to use the name in the AnalysisDataService
       try {
@@ -1425,8 +1478,8 @@ bool Algorithm::processGroups() {
 
         outputWSNames[owp] = outName;
       } else {
-        throw std::logic_error(
-            "Found a Workspace property which doesn't inherit from Property.");
+        throw std::logic_error("Found a Workspace property which doesn't "
+                               "inherit from Property.");
       }
     } // for each OutputWorkspace property
 
@@ -1645,8 +1698,8 @@ void Algorithm::interruption_point() {
   // contravene the OpenMP standard
   // that defines that all loops must complete, and no exception can leave an
   // OpenMP section
-  // openmp cancel handling is performed using the ??, ?? and ?? macros in each
-  // algrothim
+  // openmp cancel handling is performed using the ??, ?? and ?? macros in
+  // each algrothim
   IF_NOT_PARALLEL
   if (m_cancel)
     throw CancelException();
@@ -1746,11 +1799,11 @@ void Algorithm::execDistributed() { exec(); }
 /** Runs the algorithm in `master-only` execution mode.
  *
  * The default implementation runs the normal exec() method on rank 0 and
- * nothing on all other ranks. As a consequence all output properties will have
- * their default values, such as a nullptr for output workspaces. Classes
+ * nothing on all other ranks. As a consequence all output properties will
+ * have their default values, such as a nullptr for output workspaces. Classes
  * inheriting from Algorithm can re-implement this if they support execution
- * with multiple MPI ranks and require a special implementation for master-only
- * execution. */
+ * with multiple MPI ranks and require a special implementation for
+ * master-only execution. */
 void Algorithm::execMasterOnly() {
   if (communicator().rank() == 0)
     exec();
@@ -1813,10 +1866,10 @@ Algorithm::getInputWorkspaceStorageModes() const {
 
 /** Get correct execution mode based on input storage modes for an MPI run.
  *
- * The default implementation returns ExecutionMode::Invalid. Classes inheriting
- * from Algorithm can re-implement this if they support execution with multiple
- * MPI ranks. May not return ExecutionMode::Serial, because that is not a
- * "parallel" execution mode. */
+ * The default implementation returns ExecutionMode::Invalid. Classes
+ * inheriting from Algorithm can re-implement this if they support execution
+ * with multiple MPI ranks. May not return ExecutionMode::Serial, because that
+ * is not a "parallel" execution mode. */
 Parallel::ExecutionMode Algorithm::getParallelExecutionMode(
     const std::map<std::string, Parallel::StorageMode> &storageModes) const {
   UNUSED_ARG(storageModes)
@@ -1827,9 +1880,10 @@ Parallel::ExecutionMode Algorithm::getParallelExecutionMode(
 /// Sets up skipping workspace validation on non-master ranks for
 /// StorageMode::MasterOnly.
 void Algorithm::setupSkipValidationMasterOnly() {
-  // If workspaces have StorageMode::MasterOnly, validation on non-master ranks
-  // would usually fail. Therefore, WorkspaceProperty needs to skip validation.
-  // Thus, we must notify it whether or not it is on the master rank or not.
+  // If workspaces have StorageMode::MasterOnly, validation on non-master
+  // ranks would usually fail. Therefore, WorkspaceProperty needs to skip
+  // validation. Thus, we must notify it whether or not it is on the master
+  // rank or not.
   if (communicator().rank() != 0)
     for (auto *prop : getProperties())
       if (auto *wsProp = dynamic_cast<IWorkspaceProperty *>(prop))

--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -1123,7 +1123,6 @@ void Algorithm::findWorkspaceProperties(
       if (direction == Direction::Output || direction == Direction::InOut) {
         outputWorkspaces.push_back(ADS.retrieveWS<Workspace>(currentWS));
       }
-      currentWS = "";
     }
   }
 }

--- a/Framework/Kernel/inc/MantidKernel/CompositeValidator.h
+++ b/Framework/Kernel/inc/MantidKernel/CompositeValidator.h
@@ -67,7 +67,7 @@ public:
   template <typename T, typename U> void add(const U &arg) {
     this->add(boost::make_shared<T>(arg));
   }
-  std::list<IValidator_sptr> getChildren() const {return m_children;};
+  std::list<IValidator_sptr> getChildren() const { return m_children; };
 
 private:
   /// Verify the value with the child validators

--- a/Framework/Kernel/inc/MantidKernel/CompositeValidator.h
+++ b/Framework/Kernel/inc/MantidKernel/CompositeValidator.h
@@ -67,6 +67,7 @@ public:
   template <typename T, typename U> void add(const U &arg) {
     this->add(boost::make_shared<T>(arg));
   }
+  std::list<IValidator_sptr> getChildren() const {return m_children;};
 
 private:
   /// Verify the value with the child validators

--- a/Framework/Kernel/inc/MantidKernel/PropertyWithValue.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyWithValue.h
@@ -84,6 +84,7 @@ public:
   std::vector<std::string> allowedValues() const override;
   bool isMultipleSelectionAllowed() override;
   virtual void replaceValidator(IValidator_sptr newValidator);
+  IValidator_sptr getValidator() const;
 
 protected:
   /// The value of the property

--- a/Framework/Kernel/inc/MantidKernel/PropertyWithValue.tcc
+++ b/Framework/Kernel/inc/MantidKernel/PropertyWithValue.tcc
@@ -426,5 +426,13 @@ const TYPE PropertyWithValue<TYPE>::getValueForAlias(const TYPE &alias) const {
   return value;
 }
 
+/**Returns the validator as a constant variable so it cannot be changed
+ * @tparam TYPE :: The type of the property value
+ * @return IValidator_sptr :: the validator
+ */
+template <typename TYPE>
+IValidator_sptr PropertyWithValue<TYPE>::getValidator() const {
+  return m_validator;
+}
 } // namespace Kernel
 } // namespace Mantid

--- a/docs/source/release/v3.14.0/framework.rst
+++ b/docs/source/release/v3.14.0/framework.rst
@@ -52,7 +52,7 @@ Improvements
 Bugfixes
 ########
 - :ref:`FilterEvents <algm-FilterEvents-v1>` output workspaces now contain the goniometer.
-
+- Fixed an issue where if a workspace's history wouldn't update for some algorithms
 - Fixed a ``std::bad_cast`` error in :ref:`algm-LoadLiveData` when the data size changes.
 
 


### PR DESCRIPTION
**Description of work.**
I added the ability to check an algorithm for if it is a vector<strings> being passed as a property and it also uses the ADS Validator thus implying that it is a list of workspaces, then I made sure that the workspaces would get the correct history for all other used workspaces added to it.

**To test:**
Use GroupWorkspaces on two workspaces and then check the history of one of those workspaces it should have what ever happened to the other two workspaces previously also in it.

Fixes #23450

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
