### PR TITLE
Prevent Plot Guess Crash on ConvFit by Reading Q Values

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ElasticDiffRotDiscreteCircle.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ElasticDiffRotDiscreteCircle.h
@@ -5,6 +5,7 @@
 // Mantid Headers from the same project
 #include "DeltaFunction.h"
 // Mantid headers from other projects (N/A)
+#include "MantidCurveFitting/Functions/FunctionQDepends.h"
 // 3rd party library headers (N/A)
 // standard library (N/A)
 
@@ -40,7 +41,8 @@ Code Documentation is available at: <http://doxygen.mantidproject.org>
 /* Class representing the elastic portion of DiffRotDiscreteCircle
  * Contains a Delta Dirac.
  */
-class DLLExport ElasticDiffRotDiscreteCircle : public DeltaFunction {
+class DLLExport ElasticDiffRotDiscreteCircle : public DeltaFunction,
+                                               public FunctionQDepends {
 public:
   /// Constructor
   ElasticDiffRotDiscreteCircle();

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ElasticDiffSphere.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ElasticDiffSphere.h
@@ -4,6 +4,7 @@
 // Mantid Coding standars <http://www.mantidproject.org/Coding_Standards>
 // Mantid Headers from the same project
 #include "MantidCurveFitting/Functions/DeltaFunction.h"
+#include "MantidCurveFitting/Functions/FunctionQDepends.h"
 // Mantid headers from other projects (N/A)
 // 3rd party library headers (N/A)
 // standard library headers (N/A)
@@ -40,7 +41,8 @@ Code Documentation is available at: <http://doxygen.mantidproject.org>
 /**
  * @brief Elastic part of the DiffSphere function
  */
-class DLLExport ElasticDiffSphere : public DeltaFunction {
+class DLLExport ElasticDiffSphere : public DeltaFunction,
+                                    public FunctionQDepends {
 public:
   /// Constructor
   ElasticDiffSphere();

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/FunctionQDepends.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/FunctionQDepends.h
@@ -51,8 +51,8 @@ namespace Functions {
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
 
-class DLLExport FunctionQDepends : public Mantid::API::IFunction1D,
-                                   public Mantid::API::ParamFunction {
+class DLLExport FunctionQDepends : virtual public Mantid::API::IFunction1D,
+                                   virtual public Mantid::API::ParamFunction {
 
 public:
   /* -------------------

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/InelasticDiffRotDiscreteCircle.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/InelasticDiffRotDiscreteCircle.h
@@ -2,11 +2,10 @@
 #define MANTID_INELASTICDIFFROTDISCRETECIRCLE_H_
 
 // Mantid Coding standards <http://www.mantidproject.org/Coding_Standards>
-// Mantid Headers from the same project (N/A)
+// Mantid Headers from the same project
+#include "MantidCurveFitting/Functions/FunctionQDepends.h"
 // Mantid headers from other projects
-#include "MantidAPI/IFunction1D.h"
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidAPI/ParamFunction.h"
 // 3rd party library headers (N/A)
 // standard library (N/A)
 
@@ -42,8 +41,7 @@ Code Documentation is available at: <http://doxygen.mantidproject.org>
 /* Class representing the inelastic portion of DiffRotDiscreteCircle
  * Contains a linear combination of Lorentzians.
  */
-class DLLExport InelasticDiffRotDiscreteCircle : public API::ParamFunction,
-                                                 public API::IFunction1D {
+class DLLExport InelasticDiffRotDiscreteCircle : public FunctionQDepends {
 public:
   /// Constructor
   InelasticDiffRotDiscreteCircle();

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/InelasticDiffSphere.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/InelasticDiffSphere.h
@@ -4,10 +4,9 @@
 // Mantid Coding standars <http://www.mantidproject.org/Coding_Standards>
 // Mantid Headers from the same project
 #include "MantidCurveFitting/Functions/DeltaFunction.h"
+#include "MantidCurveFitting/Functions/FunctionQDepends.h"
 // Mantid headers from other projects
-#include "MantidAPI/IFunction1D.h"
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidAPI/ParamFunction.h"
 // 3rd party library headers (N/A)
 // standard library headers (N/A)
 
@@ -58,8 +57,7 @@ struct linearJ {
  * @brief Inelastic part of the DiffSphere function. Contains the 98
  * Lorentzians.
  */
-class DLLExport InelasticDiffSphere : public API::ParamFunction,
-                                      public API::IFunction1D {
+class DLLExport InelasticDiffSphere : public FunctionQDepends {
 public:
   InelasticDiffSphere();
 

--- a/Framework/CurveFitting/src/Functions/ElasticDiffRotDiscreteCircle.cpp
+++ b/Framework/CurveFitting/src/Functions/ElasticDiffRotDiscreteCircle.cpp
@@ -31,8 +31,8 @@ ElasticDiffRotDiscreteCircle::ElasticDiffRotDiscreteCircle() {
   // declareParameter("Height", 1.0); //parameter "Height" already declared in
   // constructor of base class DeltaFunction
   this->declareParameter("Radius", 1.0, "Circle radius [Angstroms] ");
-  this->declareAttribute("Q", API::IFunction::Attribute(0.5));
   this->declareAttribute("N", API::IFunction::Attribute(3));
+  FunctionQDepends::declareAttributes();
 }
 
 /**

--- a/Framework/CurveFitting/src/Functions/ElasticDiffSphere.cpp
+++ b/Framework/CurveFitting/src/Functions/ElasticDiffSphere.cpp
@@ -32,7 +32,7 @@ ElasticDiffSphere::ElasticDiffSphere() {
   // parameter "Height" declared in parent DeltaFunction constructor
   // declareParameter("Height", 1.0);
   declareParameter("Radius", 2.0, "Sphere radius");
-  declareAttribute("Q", API::IFunction::Attribute(1.0));
+  FunctionQDepends::declareAttributes();
 }
 
 /**

--- a/Framework/CurveFitting/src/Functions/InelasticDiffRotDiscreteCircle.cpp
+++ b/Framework/CurveFitting/src/Functions/InelasticDiffRotDiscreteCircle.cpp
@@ -41,9 +41,8 @@ InelasticDiffRotDiscreteCircle::InelasticDiffRotDiscreteCircle()
                          "energy in mili-eV");
   this->declareParameter("Shift", 0.0, "Shift in the centre of the peak");
 
-  this->declareAttribute("Q", API::IFunction::Attribute(EMPTY_DBL()));
-  this->declareAttribute("WorkspaceIndex", API::IFunction::Attribute(0));
   this->declareAttribute("N", API::IFunction::Attribute(3));
+  declareAttributes();
 }
 
 /**

--- a/Framework/CurveFitting/src/Functions/InelasticDiffSphere.cpp
+++ b/Framework/CurveFitting/src/Functions/InelasticDiffSphere.cpp
@@ -38,8 +38,7 @@ InelasticDiffSphere::InelasticDiffSphere()
                          "if energy in ueV");
   this->declareParameter("Shift", 0.0, "Shift in domain");
 
-  this->declareAttribute("Q", API::IFunction::Attribute(EMPTY_DBL()));
-  this->declareAttribute("WorkspaceIndex", API::IFunction::Attribute(0));
+  declareAttributes();
 }
 
 /**

--- a/Framework/CurveFitting/test/Functions/DiffRotDiscreteCircleTest.h
+++ b/Framework/CurveFitting/test/Functions/DiffRotDiscreteCircleTest.h
@@ -236,7 +236,8 @@ public:
     std::string funtion_string =
         "(composite=Convolution,FixResolution=true,NumDeriv=true;name=Gaussian,"
         "Height=1,PeakCentre=0,Sigma=20,ties=(Height=1,PeakCentre=0,Sigma=20);("
-        "name=DiffRotDiscreteCircle,N=3,NumDeriv=true,Q=0.5,Intensity=47.014,"
+        "name=DiffRotDiscreteCircle,N=3,NumDeriv=true,Q=0.20092,Intensity=47."
+        "014,"
         "Radius=1.567,Decay=0.07567))";
 
     // Initialize the fit function in the Fit algorithm
@@ -252,11 +253,12 @@ public:
     // purposes only
 
     // override the function with new parameters, then do the Fit
-    funtion_string = "(composite=Convolution,FixResolution=true,NumDeriv=true;"
-                     "name=Gaussian,Height=1,PeakCentre=0,Sigma=20,ties=("
-                     "Height=1,PeakCentre=0,Sigma=20);(name="
-                     "DiffRotDiscreteCircle,N=3,NumDeriv=true,Q=0.5,Intensity="
-                     "20.0,Radius=1.567,Decay=0.1))";
+    funtion_string =
+        "(composite=Convolution,FixResolution=true,NumDeriv=true;"
+        "name=Gaussian,Height=1,PeakCentre=0,Sigma=20,ties=("
+        "Height=1,PeakCentre=0,Sigma=20);(name="
+        "DiffRotDiscreteCircle,N=3,NumDeriv=true,Q=0.20092,Intensity="
+        "20.0,Radius=1.567,Decay=0.1))";
     fitalg.setProperty("Function", funtion_string);
     fitalg.setProperty("InputWorkspace", data_workspace);
     fitalg.setPropertyValue("WorkspaceIndex", "0");

--- a/Framework/CurveFitting/test/Functions/DiffSphereTest.h
+++ b/Framework/CurveFitting/test/Functions/DiffSphereTest.h
@@ -43,7 +43,8 @@ public:
     std::string funtion_string =
         "(composite=Convolution,FixResolution=true,NumDeriv=true;name=Gaussian,"
         "Height=1.0,PeakCentre=0.0,Sigma=0.002,ties=(Height=1.0,PeakCentre=0.0,"
-        "Sigma=0.002);name=ElasticDiffSphere,Q=0.5,Height=47.014,Radius=3.567)";
+        "Sigma=0.002);name=ElasticDiffSphere,Q=0.20092,Height=47.014,Radius="
+        "3.567)";
 
     // Initialize the fit function in the Fit algorithm
     Algorithms::Fit fitalg;
@@ -66,10 +67,11 @@ public:
      * and thus no unique fit exists. Thus, we fix parameter height and fit the
      * radius.
      */
-    funtion_string = "(composite=Convolution,NumDeriv=true;name=Gaussian,"
-                     "Height=1.0,PeakCentre=0.0,Sigma=0.002,ties=(Height=1.0,"
-                     "PeakCentre=0.0,Sigma=0.002);name=ElasticDiffSphere,Q=0.5,"
-                     "Height=47.014,Radius=6.0,ties=(Height=47.014,Centre=0))";
+    funtion_string =
+        "(composite=Convolution,NumDeriv=true;name=Gaussian,"
+        "Height=1.0,PeakCentre=0.0,Sigma=0.002,ties=(Height=1.0,"
+        "PeakCentre=0.0,Sigma=0.002);name=ElasticDiffSphere,Q=0.20092,"
+        "Height=47.014,Radius=6.0,ties=(Height=47.014,Centre=0))";
     fitalg.setProperty("Function", funtion_string);
     fitalg.setProperty("InputWorkspace", data_workspace);
     fitalg.setPropertyValue("WorkspaceIndex", "0");

--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -14,6 +14,13 @@ Indirect Inelastic Changes
 Data Analysis Interface
 -----------------------
 
+Improvements
+############
+
+- When the InelasticDiffSphere, InelasticDiffRotDiscreteCircle, ElasticDiffSphere or ElasticDiffRotDiscreteCircle
+  Fit Types are selected in the ConvFit Tab, the Q values are retrieved from the workspaces, preventing a crash 
+  when plotting a guess.
+
 Bugfixes
 ########
 
@@ -42,4 +49,5 @@ Improvements
 - Added 'Default' detector grouping option in ISISEnergyTransfer for TOSCA, to allow a default grouping 
   using the grouping specified in the Instrument Parameter File.
 - ISISEnergyTransfer now allows overlapping detector grouping.
+
 


### PR DESCRIPTION
**Description of work.**
This PR prevents a crash when Plot Guess is clicked for the Fit Types `InelasticDiffSphere` and `InelasticDiffRotDiscreteCircle`. The Q values were missing, and so they had to be retrieved from the workspaces in order to fix this (like with `Teixeira Water`).
This PR also makes sure the Q values for `ElasticDiffSphere` and `ElasticDiffRotDiscreteCircle` are retrieved from the workspace.

**To test:**
1. `Indirect`->`Data Analysis` ->`ConvFit` Tab
2. Load in the data below
3. Select `InelasticDiffSphere` as Fit Type
4. Check for a reasonable Q value in the FitPropertyBrowser
5. Check the `Plot Guess` box
6. There should be no crash, and a guess plotted (note: the guess may be poor)

- Repeat these steps for `InelasticDiffRotDiscreteCircle`
- Check that the Q values for `ElasticDiffSphere` and `ElasticDiffRotDiscreteCircle` look reasonable. When you change the WorkspaceIndex in the FitPropertyBrowser, these Q values should change slightly.

**Test Files**
[irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2374624/irs26176_graphite002_red.zip)
[irs26173_graphite002_res.zip](https://github.com/mantidproject/mantid/files/2374625/irs26173_graphite002_res.zip)

Fixes #23229 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
