### PR TITLE
Fix TableWorkspace constructor in Python

### DIFF
--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/DataServiceExporter.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/DataServiceExporter.h
@@ -112,12 +112,13 @@ template <typename SvcType, typename SvcPtrType> struct DataServiceExporter {
    */
   static void addItem(SvcType &self, const boost::python::object &name,
                       const boost::python::object &item) {
+    std::string namestr;
     try {
-      std::string namestr = PythonInterface::Converters::pyObjToStr(name);
-      self.add(namestr, extractCppValue(item));
+      namestr = PythonInterface::Converters::pyObjToStr(name);
     } catch (std::invalid_argument &) {
       throw std::invalid_argument("Failed to convert name to a string");
     }
+    self.add(namestr, extractCppValue(item));
   }
 
   /**
@@ -129,12 +130,13 @@ template <typename SvcType, typename SvcPtrType> struct DataServiceExporter {
    */
   static void addOrReplaceItem(SvcType &self, const boost::python::object &name,
                                const boost::python::object &item) {
+    std::string namestr;
     try {
-      std::string namestr = PythonInterface::Converters::pyObjToStr(name);
-      self.addOrReplace(namestr, extractCppValue(item));
+      namestr = PythonInterface::Converters::pyObjToStr(name);
     } catch (std::invalid_argument &) {
       throw std::invalid_argument("Failed to convert name to a string");
     }
+    self.addOrReplace(namestr, extractCppValue(item));
   }
 
   /**
@@ -148,9 +150,9 @@ template <typename SvcType, typename SvcPtrType> struct DataServiceExporter {
     if (extractWeak.check()) {
       return extractWeak().lock();
     }
-    boost::python::extract<SvcPtrType &> extractShared(pyvalue);
-    if (extractShared.check()) {
-      return extractShared();
+    boost::python::extract<SvcPtrType &> extractRefShared(pyvalue);
+    if (extractRefShared.check()) {
+      return extractRefShared();
     } else {
       throw std::invalid_argument(
           "Cannot extract pointer from Python object argument. Incorrect type");

--- a/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
@@ -476,13 +476,6 @@ bpl::dict toDict(const ITableWorkspace &self) {
   return result;
 }
 
-/** Constructor function for ITableWorkspaces */
-ITableWorkspace_sptr makeTableWorkspace() {
-  const auto ws = WorkspaceFactory::Instance().createTable();
-  Mantid::API::AnalysisDataService::Instance().add(ws->getName(), ws);
-  return ws;
-}
-
 class ITableWorkspacePickleSuite : public boost::python::pickle_suite {
 public:
   static dict getstate(const ITableWorkspace &ws) {
@@ -580,7 +573,6 @@ void export_ITableWorkspace() {
   class_<ITableWorkspace, bases<Workspace>, boost::noncopyable>(
       "ITableWorkspace", iTableWorkspace_docstring.c_str(), no_init)
       .def_pickle(ITableWorkspacePickleSuite())
-      .def("__init__", make_constructor(&makeTableWorkspace))
       .def("addColumn", &addColumnSimple,
            (arg("self"), arg("type"), arg("name")),
            "Add a named column with the given type. Recognized types are: "

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/TableWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/TableWorkspace.cpp
@@ -15,7 +15,7 @@ using namespace boost::python;
 GET_POINTER_SPECIALIZATION(TableWorkspace)
 
 namespace {
-ITableWorkspace_sptr makeTableWorkspace() {
+Mantid::API::Workspace_sptr makeTableWorkspace() {
   return WorkspaceFactory::Instance().createTable();
 }
 } // namespace

--- a/Framework/PythonInterface/test/python/mantid/api/ITableWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/ITableWorkspaceTest.py
@@ -3,7 +3,8 @@ from __future__ import (absolute_import, division, print_function)
 import unittest
 from testhelpers import run_algorithm
 from mantid.kernel import std_vector_str
-from mantid.api import WorkspaceFactory
+from mantid.api import AnalysisDataService, ITableWorkspace, WorkspaceFactory
+from mantid.dataobjects import TableWorkspace
 import numpy
 
 class ITableWorkspaceTest(unittest.TestCase):
@@ -14,6 +15,10 @@ class ITableWorkspaceTest(unittest.TestCase):
         if self._test_ws is None:
             alg = run_algorithm('RawFileInfo', Filename='LOQ48127.raw',GetRunParameters=True, child=True)
             self.__class__._test_ws = alg.getProperty('RunParameterTable').value
+
+    def test_tableworkspace_is_constructible(self):
+        table = TableWorkspace()
+        self.assertTrue(isinstance(table, ITableWorkspace))
 
     def test_meta_information_is_correct(self):
         self.assertEquals(self._test_ws.columnCount(), 19)
@@ -225,7 +230,7 @@ class ITableWorkspaceTest(unittest.TestCase):
         from mantid.kernel import V3D
         import pickle
 
-        table = WorkspaceFactory.createTable()
+        table = TableWorkspace()
         table.addColumn(type="int",name="index")
         table.addColumn(type="str",name="value")
         table.addColumn(type="V3D",name="position")
@@ -237,8 +242,13 @@ class ITableWorkspaceTest(unittest.TestCase):
 
         p = pickle.dumps(table)
         table2 = pickle.loads(p)
-
         self.assertEqual(table.toDict(), table2.toDict())
+
+        # Can we add it to the ADS
+        name = "test_pickle_table_workspace"
+        AnalysisDataService.add(name, table2)
+        self.assertTrue(name in AnalysisDataService)
+        AnalysisDataService.remove(name)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**

Moves the `__init__` for the table workspace export from `ITableWorkspace` to `TableWorkspace` as the interface should not be constructible.

**Report to:** [nobody]. 

**To test:**

* Check that a table workspace can be picked, unpickled and then added to the ADS

*There is no associated issue.*

*This does not require release notes* because **it is a minor bug fix.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
