### PR TITLE
Expose WorkspaceGroup Constructor and addWorkspace Method

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceGroup.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceGroup.cpp
@@ -38,8 +38,8 @@ std::vector<Workspace_sptr>::iterator group_end(WorkspaceGroup &self) {
 }
 
 /** Constructor function for WorkspaceGroup */
-WorkspaceGroup_sptr makeWorkspaceGroup() {
-	WorkspaceGroup_sptr wsGroup = boost::make_shared<WorkspaceGroup>();
+Workspace_sptr makeWorkspaceGroup() {
+	Workspace_sptr wsGroup = boost::make_shared<WorkspaceGroup>();
 	return wsGroup;
 }
 
@@ -60,6 +60,8 @@ void export_WorkspaceGroup() {
            "Sort members by name")
       .def("add", &WorkspaceGroup::add, (arg("self"), arg("workspace_name")),
            "Add a name to the group")
+	  .def("addWorkspace", &WorkspaceGroup::addWorkspace, (arg("self"), arg("workspace")), 
+		  "Add a workspace to the group.")
       .def("size", &WorkspaceGroup::size, arg("self"),
            "Returns the number of workspaces contained in the group")
       .def("remove", &WorkspaceGroup::remove,

--- a/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceGroup.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceGroup.cpp
@@ -6,6 +6,7 @@
 #include <boost/python/class.hpp>
 #include <boost/python/copy_non_const_reference.hpp>
 #include <boost/python/iterator.hpp>
+#include <boost/python/make_constructor.hpp>
 #include <boost/python/return_value_policy.hpp>
 
 using namespace Mantid::API;
@@ -36,9 +37,16 @@ std::vector<Workspace_sptr>::iterator group_end(WorkspaceGroup &self) {
   return self.end();
 }
 
+/** Constructor function for WorkspaceGroup */
+WorkspaceGroup_sptr makeWorkspaceGroup() {
+	WorkspaceGroup_sptr wsGroup = boost::make_shared<WorkspaceGroup>();
+	return wsGroup;
+}
+
 void export_WorkspaceGroup() {
   class_<WorkspaceGroup, bases<Workspace>, boost::noncopyable>("WorkspaceGroup",
                                                                no_init)
+	  .def("__init__", make_constructor(&makeWorkspaceGroup))
       .def("getNumberOfEntries", &WorkspaceGroup::getNumberOfEntries,
            arg("self"), "Returns the number of entries in the group")
       .def("getNames", &WorkspaceGroup::getNames, arg("self"),

--- a/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceGroup.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceGroup.cpp
@@ -2,6 +2,8 @@
 #include "MantidPythonInterface/kernel/GetPointer.h"
 #include "MantidPythonInterface/kernel/Policies/ToWeakPtr.h"
 #include "MantidPythonInterface/kernel/Registry/RegisterWorkspacePtrToPython.h"
+#include "MantidPythonInterface/kernel/DataServiceExporter.h"
+#include "MantidAPI/AnalysisDataService.h"
 
 #include <boost/python/class.hpp>
 #include <boost/python/copy_non_const_reference.hpp>
@@ -43,6 +45,10 @@ Workspace_sptr makeWorkspaceGroup() {
 	return wsGroup;
 }
 
+void addWorkspace(WorkspaceGroup &self, const boost::python::object& pyobj) {
+	self.addWorkspace(DataServiceExporter<AnalysisDataServiceImpl, Workspace_sptr >::extractCppValue(pyobj));
+}
+
 void export_WorkspaceGroup() {
   class_<WorkspaceGroup, bases<Workspace>, boost::noncopyable>("WorkspaceGroup",
                                                                no_init)
@@ -60,7 +66,7 @@ void export_WorkspaceGroup() {
            "Sort members by name")
       .def("add", &WorkspaceGroup::add, (arg("self"), arg("workspace_name")),
            "Add a name to the group")
-	  .def("addWorkspace", &WorkspaceGroup::addWorkspace, (arg("self"), arg("workspace")), 
+	  .def("addWorkspace", addWorkspace, (arg("self"), arg("workspace")), 
 		  "Add a workspace to the group.")
       .def("size", &WorkspaceGroup::size, arg("self"),
            "Returns the number of workspaces contained in the group")

--- a/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceGroup.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceGroup.cpp
@@ -1,9 +1,9 @@
 #include "MantidAPI/WorkspaceGroup.h"
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidPythonInterface/kernel/DataServiceExporter.h"
 #include "MantidPythonInterface/kernel/GetPointer.h"
 #include "MantidPythonInterface/kernel/Policies/ToWeakPtr.h"
 #include "MantidPythonInterface/kernel/Registry/RegisterWorkspacePtrToPython.h"
-#include "MantidPythonInterface/kernel/DataServiceExporter.h"
-#include "MantidAPI/AnalysisDataService.h"
 
 #include <boost/python/class.hpp>
 #include <boost/python/copy_non_const_reference.hpp>
@@ -41,18 +41,20 @@ std::vector<Workspace_sptr>::iterator group_end(WorkspaceGroup &self) {
 
 /** Constructor function for WorkspaceGroup */
 Workspace_sptr makeWorkspaceGroup() {
-	Workspace_sptr wsGroup = boost::make_shared<WorkspaceGroup>();
-	return wsGroup;
+  Workspace_sptr wsGroup = boost::make_shared<WorkspaceGroup>();
+  return wsGroup;
 }
 
-void addWorkspace(WorkspaceGroup &self, const boost::python::object& pyobj) {
-	self.addWorkspace(DataServiceExporter<AnalysisDataServiceImpl, Workspace_sptr >::extractCppValue(pyobj));
+void addWorkspace(WorkspaceGroup &self, const boost::python::object &pyobj) {
+  self.addWorkspace(
+      DataServiceExporter<AnalysisDataServiceImpl,
+                          Workspace_sptr>::extractCppValue(pyobj));
 }
 
 void export_WorkspaceGroup() {
   class_<WorkspaceGroup, bases<Workspace>, boost::noncopyable>("WorkspaceGroup",
                                                                no_init)
-	  .def("__init__", make_constructor(&makeWorkspaceGroup))
+      .def("__init__", make_constructor(&makeWorkspaceGroup))
       .def("getNumberOfEntries", &WorkspaceGroup::getNumberOfEntries,
            arg("self"), "Returns the number of entries in the group")
       .def("getNames", &WorkspaceGroup::getNames, arg("self"),
@@ -66,8 +68,8 @@ void export_WorkspaceGroup() {
            "Sort members by name")
       .def("add", &WorkspaceGroup::add, (arg("self"), arg("workspace_name")),
            "Add a name to the group")
-	  .def("addWorkspace", addWorkspace, (arg("self"), arg("workspace")), 
-		  "Add a workspace to the group.")
+      .def("addWorkspace", addWorkspace, (arg("self"), arg("workspace")),
+           "Add a workspace to the group.")
       .def("size", &WorkspaceGroup::size, arg("self"),
            "Returns the number of workspaces contained in the group")
       .def("remove", &WorkspaceGroup::remove,

--- a/Framework/PythonInterface/test/python/mantid/api/WorkspaceGroupTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/WorkspaceGroupTest.py
@@ -2,14 +2,74 @@ from __future__ import (absolute_import, division, print_function)
 
 import unittest
 from testhelpers import run_algorithm
-from mantid.api import mtd, WorkspaceGroup, MatrixWorkspace
+from mantid.api import mtd, WorkspaceGroup, MatrixWorkspace, AnalysisDataService, WorkspaceFactory
+
 
 class WorkspaceGroupTest(unittest.TestCase):
 
+    def create_matrix_workspace_in_ADS(self, name):
+        run_algorithm('CreateWorkspace', OutputWorkspace=name, DataX=[1., 2., 3.], DataY=[2., 3.], DataE=[2., 3.],
+                      UnitX='TOF')
+
+    # ------------------------------------------------------------------------------------------------------------------
+    # TESTS
+    # ------------------------------------------------------------------------------------------------------------------
+
+    def test_WorkspaceGroup_can_be_instantiated(self):
+        ws_group = WorkspaceGroup()
+        self.assertIsNotNone(ws_group)
+        self.assertIsInstance(ws_group, WorkspaceGroup)
+
+    def test_that_instantiated_WorkspaceGroup_is_not_added_to_the_ADS(self):
+        AnalysisDataService.clear()
+
+        ws_group = WorkspaceGroup()
+
+        self.assertEqual(len(AnalysisDataService.getObjectNames()), 0)
+
+    def test_that_instantiated_WorkspaceGroup_can_be_added_to_the_ADS(self):
+        AnalysisDataService.clear()
+
+        ws_group = WorkspaceGroup()
+        mtd.add("group1", ws_group)
+
+        self.assertEqual(AnalysisDataService.getObjectNames(), ["group1"])
+        self.assertIsInstance(mtd["group1"], WorkspaceGroup)
+
+    def test_that_can_add_workspaces_to_WorkspaceGroup_when_in_ADS(self):
+        AnalysisDataService.clear()
+
+        self.create_matrix_workspace_in_ADS("ws1")
+        self.create_matrix_workspace_in_ADS("ws2")
+
+        ws_group = WorkspaceGroup()
+        mtd.add("group1", ws_group)
+
+        ws_group.add("ws1")
+        ws_group.add("ws2")
+
+        self.assertTrue("ws1" in mtd["group1"])
+        self.assertTrue("ws2" in mtd["group1"])
+
+    def test_that_can_add_workspaces_to_WorkspaceGroup_when_not_in_ADS(self):
+        AnalysisDataService.clear()
+
+        ws1 = WorkspaceFactory.create("Workspace2D", 2, 2, 2)
+        ws2 = WorkspaceFactory.create("Workspace2D", 2, 2, 2)
+
+        ws_group = WorkspaceGroup()
+
+        ws_group.addWorkspace(ws1)
+        ws_group.addWorkspace(ws2)
+
+        self.assertEqual(ws_group.size(), 2)
+
     def test_group_interface(self):
-        run_algorithm('CreateWorkspace', OutputWorkspace='First',DataX=[1.,2.,3.], DataY=[2.,3.], DataE=[2.,3.],UnitX='TOF')
-        run_algorithm('CreateWorkspace', OutputWorkspace='Second',DataX=[1.,2.,3.], DataY=[2.,3.], DataE=[2.,3.],UnitX='TOF')
-        run_algorithm('GroupWorkspaces',InputWorkspaces='First,Second',OutputWorkspace='grouped')
+        run_algorithm('CreateWorkspace', OutputWorkspace='First', DataX=[1., 2., 3.], DataY=[2., 3.], DataE=[2., 3.],
+                      UnitX='TOF')
+        run_algorithm('CreateWorkspace', OutputWorkspace='Second', DataX=[1., 2., 3.], DataY=[2., 3.], DataE=[2., 3.],
+                      UnitX='TOF')
+        run_algorithm('GroupWorkspaces', InputWorkspaces='First,Second', OutputWorkspace='grouped')
         grouped = mtd['grouped']
         self.assertEquals(type(grouped), WorkspaceGroup)
         self.assertEquals(2, grouped.size())
@@ -28,18 +88,22 @@ class WorkspaceGroupTest(unittest.TestCase):
         mtd.clear()
         try:
             grouped.getNames()
-            self.fail("WorkspaceGroup handle is still usable after ADS has been cleared, it should be a weak reference and raise an error.")
+            self.fail(
+                "WorkspaceGroup handle is still usable after ADS has been cleared, it should be a weak reference and raise an error.")
         except RuntimeError as exc:
             self.assertEquals(str(exc), 'Variable invalidated, data has been deleted.')
 
     def test_group_index_access_returns_correct_workspace(self):
-        run_algorithm('CreateWorkspace', OutputWorkspace='First',DataX=[1.,2.,3.], DataY=[2.,3.], DataE=[2.,3.],UnitX='TOF')
-        run_algorithm('CreateWorkspace', OutputWorkspace='Second',DataX=[4.,5.,6.], DataY=[4.,5.], DataE=[2.,3.],UnitX='TOF')
-        run_algorithm('CreateWorkspace', OutputWorkspace='Third',DataX=[7.,8.,9.], DataY=[6.,7.], DataE=[2.,3.],UnitX='TOF')
-        run_algorithm('GroupWorkspaces',InputWorkspaces='First,Second,Third',OutputWorkspace='grouped')
+        run_algorithm('CreateWorkspace', OutputWorkspace='First', DataX=[1., 2., 3.], DataY=[2., 3.], DataE=[2., 3.],
+                      UnitX='TOF')
+        run_algorithm('CreateWorkspace', OutputWorkspace='Second', DataX=[4., 5., 6.], DataY=[4., 5.], DataE=[2., 3.],
+                      UnitX='TOF')
+        run_algorithm('CreateWorkspace', OutputWorkspace='Third', DataX=[7., 8., 9.], DataY=[6., 7.], DataE=[2., 3.],
+                      UnitX='TOF')
+        run_algorithm('GroupWorkspaces', InputWorkspaces='First,Second,Third', OutputWorkspace='grouped')
         group = mtd['grouped']
 
-        self.assertRaises(IndexError, group.__getitem__, 3) # Index out of bounds
+        self.assertRaises(IndexError, group.__getitem__, 3)  # Index out of bounds
         for i in range(3):
             member = group[i]
             self.assertTrue(isinstance(member, MatrixWorkspace))
@@ -49,16 +113,19 @@ class WorkspaceGroupTest(unittest.TestCase):
         mtd.remove("First")
         try:
             member.name()
-            self.fail("Handle for item extracted from WorkspaceGroup is still usable after ADS has been cleared, it should be a weak reference and raise an error.")
+            self.fail(
+                "Handle for item extracted from WorkspaceGroup is still usable after ADS has been cleared, it should be a weak reference and raise an error.")
         except RuntimeError as exc:
             self.assertEquals(str(exc), 'Variable invalidated, data has been deleted.')
 
     def test_SimpleAlgorithm_Accepts_Group_Handle(self):
         from mantid.simpleapi import Scale
 
-        run_algorithm('CreateWorkspace', OutputWorkspace='First',DataX=[1.,2.,3.], DataY=[2.,3.], DataE=[2.,3.],UnitX='TOF')
-        run_algorithm('CreateWorkspace', OutputWorkspace='Second',DataX=[1.,2.,3.], DataY=[2.,3.], DataE=[2.,3.],UnitX='TOF')
-        run_algorithm('GroupWorkspaces',InputWorkspaces='First,Second',OutputWorkspace='group')
+        run_algorithm('CreateWorkspace', OutputWorkspace='First', DataX=[1., 2., 3.], DataY=[2., 3.], DataE=[2., 3.],
+                      UnitX='TOF')
+        run_algorithm('CreateWorkspace', OutputWorkspace='Second', DataX=[1., 2., 3.], DataY=[2., 3.], DataE=[2., 3.],
+                      UnitX='TOF')
+        run_algorithm('GroupWorkspaces', InputWorkspaces='First,Second', OutputWorkspace='group')
         group = mtd['group']
         self.assertEquals(group.name(), "group")
         self.assertEquals(type(group), WorkspaceGroup)
@@ -70,11 +137,13 @@ class WorkspaceGroupTest(unittest.TestCase):
         mtd.remove(str(group))
 
     def test_complex_binary_operations_with_group_do_not_leave_temporary_workspaces_in_ADS(self):
-        run_algorithm('CreateWorkspace', OutputWorkspace='grouped_1',DataX=[1.,2.,3.], DataY=[2.,3.], DataE=[2.,3.],UnitX='TOF')
-        run_algorithm('CreateWorkspace', OutputWorkspace='grouped_2',DataX=[1.,2.,3.], DataY=[2.,3.], DataE=[2.,3.],UnitX='TOF')
-        run_algorithm('GroupWorkspaces',InputWorkspaces='grouped_1,grouped_2',OutputWorkspace='grouped')
+        run_algorithm('CreateWorkspace', OutputWorkspace='grouped_1', DataX=[1., 2., 3.], DataY=[2., 3.],
+                      DataE=[2., 3.], UnitX='TOF')
+        run_algorithm('CreateWorkspace', OutputWorkspace='grouped_2', DataX=[1., 2., 3.], DataY=[2., 3.],
+                      DataE=[2., 3.], UnitX='TOF')
+        run_algorithm('GroupWorkspaces', InputWorkspaces='grouped_1,grouped_2', OutputWorkspace='grouped')
 
-        w1=(mtd['grouped']*0.0)+1.0
+        w1 = (mtd['grouped'] * 0.0) + 1.0
 
         self.assertTrue('w1' in mtd)
         self.assertTrue('grouped' in mtd)
@@ -92,14 +161,14 @@ class WorkspaceGroupTest(unittest.TestCase):
     def test_sortByName(self):
         run_algorithm('CreateSingleValuedWorkspace', OutputWorkspace="w1")
         run_algorithm('CreateSingleValuedWorkspace', OutputWorkspace="w4")
-        run_algorithm('GroupWorkspaces',InputWorkspaces='w4,w1',
+        run_algorithm('GroupWorkspaces', InputWorkspaces='w4,w1',
                       OutputWorkspace='group')
         group = mtd['group']
         names = ' '.join(list(group.getNames()))
-        self.assertTrue("w4 w1"==names)
+        self.assertTrue("w4 w1" == names)
         group.sortByName()
         names = ' '.join(list(group.getNames()))
-        self.assertTrue("w1 w4"==names)
+        self.assertTrue("w1 w4" == names)
 
 
 if __name__ == '__main__':

--- a/docs/source/concepts/WorkspaceGroup.rst
+++ b/docs/source/concepts/WorkspaceGroup.rst
@@ -16,9 +16,30 @@ algorithm on each workspace contained within.
 Creating a Workspace Group
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  Select a few workspaces in MantidPlot and click the "Group" button
-   above the list of workspaces.
--  Use the :ref:`GroupWorkspaces <algm-GroupWorkspaces>` algorithm.
+Workspace groups can be created through the MantidPlot interface;
+
+- Select a few workspaces from the ADS in MantidPlot and click the "Group" button
+   above the list of workspaces. The group will be named "NewGroup".
+
+Workspace groups can be created in a more flexible way in the Python script window using the Python API;
+
+- Use the :ref:`GroupWorkspaces <algm-GroupWorkspaces>` algorithm. This will place a workspace group directly into the ADS, and requires at least one workspace to be added to the group.
+
+- To avoid interaction with the ADS, a `WorkspaceGroup` object can be instantiated using
+
+.. code::
+
+    import mantid.api as api
+
+    ws_group = api.WorkspaceGroup()
+
+This **will not** be automatically added to the list of workspaces, to do so, using the following line
+
+.. code::
+
+    AnalysisDataService.add("name", ws_group)
+
+the group should then appear with the given name.
 
 Un-grouping Workspaces
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -31,6 +52,8 @@ Working with Event Workspaces in Python
 
 Creating and splitting groups
 #############################
+
+Creating groups via the :ref:`GroupWorkspaces <algm-GroupWorkspaces>` algorithm
 
 .. testcode:: CreatingWorkspaceGroups
 
@@ -59,6 +82,63 @@ Creating and splitting groups
     :options: +NORMALIZE_WHITESPACE
 
     ['ws1','ws2','ws3']
+
+Creating groups via direct instantiation;
+
+.. testcode:: CreatingWorkspaceGroupsInstantiated
+
+    ws1 = CreateSampleWorkspace()
+    ws2 = CreateSampleWorkspace()
+    ws3 = CreateSampleWorkspace()
+
+
+    # Create a group workspace and add to the ADS
+    ws_group = api.WorkspaceGroup()
+    mtd.add("group1", ws_group)
+
+    ws_group.add(ws1)
+    ws_group.add(ws2)
+    ws_group.add(ws3)
+
+    print(ws_group.getNames())
+
+
+.. testoutput:: CreatingWorkspaceGroupsInstantiated
+    :hide:
+    :options: +NORMALIZE_WHITESPACE
+
+    ['ws1','ws2','ws3']
+
+Workspace groups can be created without using the ADS, and fed workspaces which are also not in the ADS (in this case the `addWorkspace` method is used rather than `add` because `add` requires a name, and since the workspaces are not in the ADS they may not have a name)
+
+.. testcode:: CreatingWorkspaceGroupsNoADS
+
+    ws1 = WorkspaceFactory.create("Workspace2D", 2, 2, 2)
+    ws2 = WorkspaceFactory.create("Workspace2D", 2, 2, 2)
+    ws3 = WorkspaceFactory.create("Workspace2D", 2, 2, 2)
+
+    # Create a group workspace
+    ws_group = api.WorkspaceGroup()
+
+    ws_group.addWorkspace(ws1)
+    ws_group.addWorkspace(ws2)
+    ws_group.addWorkspace(ws3)
+
+    print(ws_group.getNames())
+
+    mtd.add("group1", ws_group)
+
+    print(ws_group.getNmes())
+
+
+.. testoutput:: CreatingWorkspaceGroupsNoADS
+    :hide:
+    :options: +NORMALIZE_WHITESPACE
+
+    ['','','']
+    ['1','2','3']
+
+when adding the group to the ADS, the workspaces will also be added, and given default names. It is not recommended to add workspace to groups in this way, as much of the functionality of groups depends on workspaces having names; for example the "in" keyword.
 
 Accessing Workspace Groups
 ##########################

--- a/docs/source/concepts/WorkspaceGroup.rst
+++ b/docs/source/concepts/WorkspaceGroup.rst
@@ -214,6 +214,42 @@ You can pass workspace groups into any algorithm and Mantid will run that algori
     # You can still of course refer to members of a group directly
     ws1 = Rebin(ws1, Params=100)
 
+Using Nested Workspace Groups
+#############################
+
+It is possible to have groups within groups, the inner group can simply be added to the outer group in the usual way. For example
+
+.. testcode:: WorkspaceGroupNesting
+    # create the following structure
+    # group1/
+    #       ws1
+    #       ws2
+    #       group2/
+    #               ws3
+    #               ws4
+
+    ws1 = CreateSampleWorkspace()
+    ws2 = CreateSampleWorkspace()
+    ws3 = CreateSampleWorkspace()
+    ws4 = CreateSampleWorkspace()
+
+    group1 = WorkspaceGroup()
+    group2 = WorkspaceGroup()
+
+    group1.add("ws1")
+    group1.add("ws2")
+    group2.add("ws3")
+    group2.add("ws4")
+
+    mtd.add("group1", group1)
+    mtd.add("group2", group2)
+
+    group1.add("group2")
+
+Be careful when creating nested groups; every single group and workspace must have a unique name, if not workspaces with the same name will be overwritten. Do not be tempted to make duplicate named workspaces and put them into different folders; this will result in data being deleted without warning.
+
+One final note; it is best to add all workspaces to the ADS before configuring the grouping structure (as in the above code); otherwise you will only be able to name the top level group when you add the structure to the ADS. All the sub-groups and workspaces not already in the ADS will be given default names which you will then have to change manually, it is much easier to name them as you go (and putting them in the ADS is the only way to name them).
+
 .. include:: WorkspaceNavigation.txt
 
 

--- a/docs/source/concepts/WorkspaceGroup.rst
+++ b/docs/source/concepts/WorkspaceGroup.rst
@@ -8,18 +8,16 @@ Workspace Group
 .. contents::
   :local:
 
-A WorkspaceGroup is a group of workspaces.
+A WorkspaceGroup is a group of workspaces. The WorkspaceGroup object does not hold any data itself, but instead holds a like of Workspace objects. They appear as an expandable list of workspaces in the MantidPlot interface (the list of workspace is also called the ADS or *AnalysisDataService*). Thus, their primary function is to add structure to the ADS and make it more readable.
 
-Most algorithms will execute on a WorkspaceGroup by simply executing the
-algorithm on each workspace contained within.
+Most algorithms can be passed a WorkspaceGroup in place of a normal workspace input, and will simply execute the algorithm on each workspace contained within the group.
 
 Creating a Workspace Group
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Workspace groups can be created through the MantidPlot interface;
 
-- Select a few workspaces from the ADS in MantidPlot and click the "Group" button
-   above the list of workspaces. The group will be named "NewGroup".
+- Select a few workspaces from the ADS in MantidPlot and click the "Group" button above the list of workspaces. The group will be named "NewGroup".
 
 Workspace groups can be created in a more flexible way in the Python script window using the Python API;
 
@@ -33,7 +31,7 @@ Workspace groups can be created in a more flexible way in the Python script wind
 
     ws_group = api.WorkspaceGroup()
 
-This **will not** be automatically added to the list of workspaces, to do so, using the following line
+This **will not** be automatically added to the ADS, to do so, using the following line
 
 .. code::
 
@@ -76,9 +74,9 @@ Creating groups via the :ref:`GroupWorkspaces <algm-GroupWorkspaces>` algorithm
     # Using wsGroup now will cause a runtime error
     # RuntimeError: Variable invalidated, data has been deleted.
 
+Output:
 
 .. testoutput:: CreatingWorkspaceGroups
-    :hide:
     :options: +NORMALIZE_WHITESPACE
 
     ['ws1','ws2','ws3']
@@ -102,9 +100,9 @@ Creating groups via direct instantiation;
 
     print(ws_group.getNames())
 
+Output:
 
 .. testoutput:: CreatingWorkspaceGroupsInstantiated
-    :hide:
     :options: +NORMALIZE_WHITESPACE
 
     ['ws1','ws2','ws3']
@@ -128,11 +126,11 @@ Workspace groups can be created without using the ADS, and fed workspaces which 
 
     mtd.add("group1", ws_group)
 
-    print(ws_group.getNmes())
+    print(ws_group.getNames())
 
+Output:
 
 .. testoutput:: CreatingWorkspaceGroupsNoADS
-    :hide:
     :options: +NORMALIZE_WHITESPACE
 
     ['','','']
@@ -219,7 +217,8 @@ Using Nested Workspace Groups
 
 It is possible to have groups within groups, the inner group can simply be added to the outer group in the usual way. For example
 
-.. testcode:: WorkspaceGroupNesting
+.. code::
+
     # create the following structure
     # group1/
     #       ws1

--- a/docs/source/concepts/WorkspaceGroup.rst
+++ b/docs/source/concepts/WorkspaceGroup.rst
@@ -8,7 +8,7 @@ Workspace Group
 .. contents::
   :local:
 
-A WorkspaceGroup is a group of workspaces. The WorkspaceGroup object does not hold any data itself, but instead holds a like of Workspace objects. They appear as an expandable list of workspaces in the MantidPlot interface (the list of workspace is also called the ADS or *AnalysisDataService*). Thus, their primary function is to add structure to the ADS and make it more readable.
+A WorkspaceGroup is a group of workspaces. The WorkspaceGroup object does not hold any data itself, but instead holds a list of Workspace objects. They appear as an expandable list of workspaces in the MantidPlot interface (the list of workspaces is also called the ADS or *AnalysisDataService*). Thus, their primary function is to add structure to the ADS and make it more readable.
 
 Most algorithms can be passed a WorkspaceGroup in place of a normal workspace input, and will simply execute the algorithm on each workspace contained within the group.
 
@@ -91,7 +91,7 @@ Creating groups via direct instantiation;
 
 
     # Create a group workspace and add to the ADS
-    ws_group = api.WorkspaceGroup()
+    ws_group = WorkspaceGroup()
     mtd.add("group1", ws_group)
 
     ws_group.add(ws1)
@@ -116,7 +116,7 @@ Workspace groups can be created without using the ADS, and fed workspaces which 
     ws3 = WorkspaceFactory.create("Workspace2D", 2, 2, 2)
 
     # Create a group workspace
-    ws_group = api.WorkspaceGroup()
+    ws_group = WorkspaceGroup()
 
     ws_group.addWorkspace(ws1)
     ws_group.addWorkspace(ws2)

--- a/docs/source/concepts/WorkspaceGroup.rst
+++ b/docs/source/concepts/WorkspaceGroup.rst
@@ -8,42 +8,9 @@ Workspace Group
 .. contents::
   :local:
 
-A WorkspaceGroup is a group of workspaces. The WorkspaceGroup object does not hold any data itself, but instead holds a list of Workspace objects. They appear as an expandable list of workspaces in the MantidPlot interface (the list of workspaces is also called the ADS or *AnalysisDataService*). Thus, their primary function is to add structure to the ADS and make it more readable.
+A WorkspaceGroup is a group of workspaces. The WorkspaceGroup object does not hold any data itself, but instead holds a list of Workspace objects. They appear as an expandable list of workspaces in the MantidPlot interface (the list of workspaces is also called the ADS or *AnalysisDataService*). Thus, workspace groups add structure to the ADS and make it more readable and also allow algorithms to be executed over a list of workspaces contained within the group but passing the group to the algorithm.
 
 Most algorithms can be passed a WorkspaceGroup in place of a normal workspace input, and will simply execute the algorithm on each workspace contained within the group.
-
-Creating a Workspace Group
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Workspace groups can be created through the MantidPlot interface;
-
-- Select a few workspaces from the ADS in MantidPlot and click the "Group" button above the list of workspaces. The group will be named "NewGroup".
-
-Workspace groups can be created in a more flexible way in the Python script window using the Python API;
-
-- Use the :ref:`GroupWorkspaces <algm-GroupWorkspaces>` algorithm. This will place a workspace group directly into the ADS, and requires at least one workspace to be added to the group.
-
-- To avoid interaction with the ADS, a `WorkspaceGroup` object can be instantiated using
-
-.. code::
-
-    import mantid.api as api
-
-    ws_group = api.WorkspaceGroup()
-
-This **will not** be automatically added to the ADS, to do so, use the following line
-
-.. code::
-
-    AnalysisDataService.add("name", ws_group)
-
-the group should then appear in the ADS with the given name.
-
-Un-grouping Workspaces
-~~~~~~~~~~~~~~~~~~~~~~
-
--  Select the WorkspaceGroup and click "Ungroup".
--  Use the :ref:`UnGroupWorkspace <algm-UnGroupWorkspace>` algorithm.
 
 Working with Event Workspaces in Python
 ----------------------------------------
@@ -51,7 +18,11 @@ Working with Event Workspaces in Python
 Creating and splitting groups
 #############################
 
-Creating groups via the :ref:`GroupWorkspaces <algm-GroupWorkspaces>` algorithm
+Workspace groups can be created through the MantidPlot interface;
+
+- Select a few workspaces from the ADS in MantidPlot and click the "Group" button above the list of workspaces. The group will be named "NewGroup".
+
+Workspace groups can be created in a more flexible way in the Python script window using the Python API. Groups may be created via the :ref:`GroupWorkspaces <algm-GroupWorkspaces>` algorithm,  This will place a workspace group directly into the ADS, and requires at least one workspace to be added to the group.
 
 .. testcode:: CreatingWorkspaceGroups
 
@@ -81,7 +52,21 @@ Output:
 
     ['ws1','ws2','ws3']
 
-Creating groups via direct instantiation;
+To avoid interaction with the ADS, a `WorkspaceGroup` object can be instantiated using
+
+.. code::
+
+    import mantid.api as api
+
+    ws_group = api.WorkspaceGroup()
+
+This **will not** be automatically added to the ADS, to do so, use the following line
+
+.. code::
+
+    AnalysisDataService.add("name", ws_group)
+
+the group should then appear in the ADS with the given name. Using direct instantiation; groups can be added to the ADS and then workspaces added to the group via their name and the `add` method;
 
 .. testcode:: CreatingWorkspaceGroupsInstantiated
 
@@ -108,7 +93,7 @@ Output:
 
     ['ws1','ws2','ws3']
 
-Workspace groups can be created without using the ADS, and fed workspaces which are also not in the ADS (in this case the `addWorkspace` method is used rather than `add` because `add` requires a name, and since the workspaces are not in the ADS they may not have a name)
+Alternatively, workspace group objects can be fed workspaces which are not in the ADS (in this case the `addWorkspace` method is used rather than `add` because `add` requires a name, and since the workspaces are not in the ADS they may not have a name)
 
 .. testcode:: CreatingWorkspaceGroupsNoADS
 

--- a/docs/source/concepts/WorkspaceGroup.rst
+++ b/docs/source/concepts/WorkspaceGroup.rst
@@ -85,10 +85,11 @@ Creating groups via direct instantiation;
 
 .. testcode:: CreatingWorkspaceGroupsInstantiated
 
+    from mantid.api import WorkspaceGroup
+
     ws1 = CreateSampleWorkspace()
     ws2 = CreateSampleWorkspace()
     ws3 = CreateSampleWorkspace()
-
 
     # Create a group workspace and add to the ADS
     ws_group = WorkspaceGroup()
@@ -110,6 +111,8 @@ Output:
 Workspace groups can be created without using the ADS, and fed workspaces which are also not in the ADS (in this case the `addWorkspace` method is used rather than `add` because `add` requires a name, and since the workspaces are not in the ADS they may not have a name)
 
 .. testcode:: CreatingWorkspaceGroupsNoADS
+
+    from mantid.api import WorkspaceGroup
 
     ws1 = WorkspaceFactory.create("Workspace2D", 2, 2, 2)
     ws2 = WorkspaceFactory.create("Workspace2D", 2, 2, 2)

--- a/docs/source/concepts/WorkspaceGroup.rst
+++ b/docs/source/concepts/WorkspaceGroup.rst
@@ -31,13 +31,13 @@ Workspace groups can be created in a more flexible way in the Python script wind
 
     ws_group = api.WorkspaceGroup()
 
-This **will not** be automatically added to the ADS, to do so, using the following line
+This **will not** be automatically added to the ADS, to do so, use the following line
 
 .. code::
 
     AnalysisDataService.add("name", ws_group)
 
-the group should then appear with the given name.
+the group should then appear in the ADS with the given name.
 
 Un-grouping Workspaces
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -95,9 +95,9 @@ Creating groups via direct instantiation;
     ws_group = WorkspaceGroup()
     mtd.add("group1", ws_group)
 
-    ws_group.add(ws1)
-    ws_group.add(ws2)
-    ws_group.add(ws3)
+    ws_group.add("ws1")
+    ws_group.add("ws2")
+    ws_group.add("ws3")
 
     print(ws_group.getNames())
 
@@ -137,7 +137,7 @@ Output:
     :options: +NORMALIZE_WHITESPACE
 
     ['','','']
-    ['1','2','3']
+    ['group1_1','group1_2','group1_3']
 
 when adding the group to the ADS, the workspaces will also be added, and given default names. It is not recommended to add workspace to groups in this way, as much of the functionality of groups depends on workspaces having names; for example the "in" keyword.
 


### PR DESCRIPTION
closes #23448 

This PR adds functionality to the Python API related to WorkspaceGroup objects. 

Specifically, the constructor has been exposed, allowing python to instantiate `WorkspaceGroup` objects without adding them to the ADS.

The `addWorkspace` method has also been exposed, which allows workspaces to be added to the group which also aren't in the ADS. When adding the group to the ADS, these are added with default names.

This brings the Python API closer to the C++ API, but more importantly for projects like the new Muon GUI (see e.g. https://github.com/mantidproject/documents/pull/63), allows us to create nested grouping structures in a simple way (see #23448). 

The new functionality is unit tested, and the appropriate documentation has been updated to give examples of its usage. See the documented test code for examples of ways to test/use the new functionality.

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
