### PR TITLE
23158 auto strong peaks library

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
@@ -153,6 +153,10 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
             intensIDX = intensities < forceCutoff
             edgeIDX = np.logical_or.reduce(np.array([rows < edgeCutoff, rows > numDetRows - edgeCutoff,
                                            cols < edgeCutoff, cols > numDetCols - edgeCutoff]))
+            needsForcedProfile = np.logical_or(intensIDX, edgeIDX)
+            needsForcedProfileIDX = np.where(needsForcedProfile)[0]
+            canFitProfileIDX = np.where(~needsForcedProfile)[0]
+            numPeaksCanFit = len(canFitProfileIDX)
             # We can populate the strongPeakParams_ws now
             for row in strongPeakParams:
                 strongPeakParams_ws.addRow(row)
@@ -194,6 +198,7 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
         peaks_ws_out = peaks_ws.clone()
         np.warnings.filterwarnings('ignore') # There can be a lot of warnings for bad solutions that get rejected.
         progress = Progress(self, 0.0, 1.0, len(peaksToFit))
+        
         for fitNumber, peakNumber in enumerate(peaksToFit):#range(peaks_ws.getNumberPeaks()):
             peak = peaks_ws_out.getPeak(peakNumber)
             progress.report(' ')
@@ -271,7 +276,7 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
                 raise
 
             except:
-                raise
+                #raise
                 numerrors += 1
                 peak.setIntensity(0.0)
                 peak.setSigmaIntensity(1.0)

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
@@ -95,6 +95,7 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
         padeCoefficients = ICCFT.getModeratorCoefficients(padeFile)
 
         #UB Matrix
+        
         if UBFile == '' and peaks_ws.sample().hasOrientedLattice():
             logger.information("Using UB file already available in PeaksWorkspace")
         else:

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
@@ -153,7 +153,6 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
             intensIDX = intensities < forceCutoff
             edgeIDX = reduce(np.logical_or, [rows < edgeCutoff, rows > numDetRows - edgeCutoff,
                                              cols < edgeCutoff, cols > numDetCols - edgeCutoff])
-            needsForcedProfile = np.logical_and(intensIDX, edgeIDX)
             # We can populate the strongPeakParams_ws now
             for row in strongPeakParams:
                 strongPeakParams_ws.addRow(row)
@@ -167,13 +166,14 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
             intensIDX = intensities < forceCutoff
             edgeIDX = reduce(np.logical_or, [rows < edgeCutoff, rows > numDetRows - edgeCutoff,
                                              cols < edgeCutoff, cols > numDetCols - edgeCutoff])
-            needsForcedProfile = np.logical_and(intensIDX, edgeIDX)
+            needsForcedProfile = np.logical_or(intensIDX, edgeIDX)
             needsForcedProfileIDX = np.where(needsForcedProfile)[0]
             canFitProfileIDX = np.where(~needsForcedProfile)[0]
             numPeaksCanFit = len(canFitProfileIDX)
             peaksToFit = np.append(canFitProfileIDX, needsForcedProfileIDX) #Will fit in this order
             peaksToFit = peaksToFit[runNumbers[peaksToFit]==sampleRun]
 
+            
             #Initialize our strong peaks dictionary
             strongPeakParams = np.empty([numPeaksCanFit, 9])
 

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
@@ -52,9 +52,9 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
                              doc="File containing the Pade coefficients describing moderator emission versus energy.")
         self.declareProperty(FileProperty("StrongPeakParamsFile",defaultValue="",action=FileAction.OptionalLoad,
                              extensions=[".pkl"]),
-                             doc="File containing strong peaks profiles.  If left blank, no profiles will be enforced.")
+                             doc="File containing strong peaks profiles.  If left blank, strong peaks will be fit first and their profiles used.")
         self.declareProperty("IntensityCutoff", defaultValue=0., doc="Minimum number of counts to force a profile")
-        edgeDocString = 'Pixels within EdgeCutoff from a detector edge will be have a profile forced.  Currently for 256x256 cameras only.'
+        edgeDocString = 'Pixels within EdgeCutoff from a detector edge will be have a profile forced.'
         self.declareProperty("EdgeCutoff", defaultValue=0., doc=edgeDocString)
         self.declareProperty("FracStop", defaultValue=0.05, validator=FloatBoundedValidator(lower=0., exclusive=True),
                              doc="Fraction of max counts to include in peak selection.")
@@ -272,7 +272,7 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
                 raise
 
             except:
-                # raise
+                raise
                 numerrors += 1
                 peak.setIntensity(0.0)
                 peak.setSigmaIntensity(1.0)

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
@@ -157,6 +157,7 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
             needsForcedProfileIDX = np.where(needsForcedProfile)[0]
             canFitProfileIDX = np.where(~needsForcedProfile)[0]
             numPeaksCanFit = len(canFitProfileIDX)
+
             # We can populate the strongPeakParams_ws now
             for row in strongPeakParams:
                 strongPeakParams_ws.addRow(row)
@@ -198,7 +199,7 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
         peaks_ws_out = peaks_ws.clone()
         np.warnings.filterwarnings('ignore') # There can be a lot of warnings for bad solutions that get rejected.
         progress = Progress(self, 0.0, 1.0, len(peaksToFit))
-        
+
         for fitNumber, peakNumber in enumerate(peaksToFit):#range(peaks_ws.getNumberPeaks()):
             peak = peaks_ws_out.getPeak(peakNumber)
             progress.report(' ')

--- a/Framework/PythonInterface/plugins/functions/BivariateGaussian.py
+++ b/Framework/PythonInterface/plugins/functions/BivariateGaussian.py
@@ -124,10 +124,10 @@ class BivariateGaussian(IFunction1D):
                     constraintString = "{:4.4e} < {:s} < {:4.4e}".format(boundsDict[param][0], param, boundsDict[param][1])
                     self.addConstraints(constraintString)
                 else:
-                    self.log().information('Setting constraints on mbvg; reversing bounds')
                     self.addConstraints("{:4.4e} < A < {:4.4e}".format(boundsDict[param][1], boundsDict[param][0]))
             except ValueError:
-                self.log().warning("Cannot set parameter {:s} for mbvg.  Valid choices are " +
+                raise
+                raise UserWarning("Cannot set parameter {:s} for mbvg.  Valid choices are " +
                                    "('A', 'MuX', 'MuY', 'SigX', 'SigY', 'SigP', 'Bg')".format(param))
 
     def function2D(self, t):

--- a/Framework/PythonInterface/plugins/functions/BivariateGaussian.py
+++ b/Framework/PythonInterface/plugins/functions/BivariateGaussian.py
@@ -128,7 +128,7 @@ class BivariateGaussian(IFunction1D):
             except ValueError:
                 raise
                 raise UserWarning("Cannot set parameter {:s} for mbvg.  Valid choices are " +
-                                   "('A', 'MuX', 'MuY', 'SigX', 'SigY', 'SigP', 'Bg')".format(param))
+                                  "('A', 'MuX', 'MuY', 'SigX', 'SigY', 'SigP', 'Bg')".format(param))
 
     def function2D(self, t):
         """

--- a/docs/source/algorithms/IntegratePeaksProfileFitting-v1.rst
+++ b/docs/source/algorithms/IntegratePeaksProfileFitting-v1.rst
@@ -83,7 +83,7 @@ This histogram is in (q\ :sub:`x`\ ,  q\ :sub:`y`\, q\ :sub:`z`\) and composed o
 length **DQPixel**.  To minimize the effect of neighboring peaks on profile fitting, the variable 
 **qMask** is used to only consider a region around the peak in (h,k,l) space.  It will filter voxels
 outside of (h ± **FracHKL**, k ± **FracHKL**, l ± **FracHKL**) from calculations used for profile
-fitting. In practice, values of 0.35 < **fracHKL** < 0.5 seem to work best. 
+fitting. In practice, values of 0.25 < **fracHKL** < 0.5 seem to work best. 
 
 Fitting the Time-of-Flight Coordinate
 #####################################

--- a/docs/source/algorithms/IntegratePeaksProfileFitting-v1.rst
+++ b/docs/source/algorithms/IntegratePeaksProfileFitting-v1.rst
@@ -80,9 +80,9 @@ Constructing the Measured Intensity Distribution
 ##################################################
 To construct the measured distribution to be fit, a histogram of events is made around the peak.
 This histogram is in (q\ :sub:`x`\ ,  q\ :sub:`y`\, q\ :sub:`z`\) and composed of voxels of side
-length **dQPixel**.  To minimize the effect of neighboring peaks on profile fitting, the variable 
+length **DQPixel**.  To minimize the effect of neighboring peaks on profile fitting, the variable 
 **qMask** is used to only consider a region around the peak in (h,k,l) space.  It will filter voxels
-outside of (h ± **fracHKL**, k ± **fracHKL**, l ± **fracHKL**) from calculations used for profile
+outside of (h ± **FracHKL**, k ± **FracHKL**, l ± **FracHKL**) from calculations used for profile
 fitting. In practice, values of 0.35 < **fracHKL** < 0.5 seem to work best. 
 
 Fitting the Time-of-Flight Coordinate
@@ -95,7 +95,7 @@ The time-of-flight (TOF), t, of each voxel is determined as:
 The events are histogrammed by their `t` values to create a TOF profile.  This profile can then be fit 
 to the Ikeda Carpenter function.  To separate the peak and background, different levels of intensity are
 filtered out.  The predicted background level is determined as the average background not near the peak or off the edge
-and values within **minppl_frac** and **maxppl_frac** times the predicted value are tried.  The best fit to the expected 
+and values within **Minppl_frac** and **Maxppl_frac** times the predicted value are tried.  The best fit to the expected 
 moderator emission (determined by the moderator coefficients defined in **ModeratorCoefficientsFile**) is
 taken and these voxels are considered to be signal.
 
@@ -104,13 +104,18 @@ Fitting the Non-TOF Coordinate
 TOF goes as :math:`1/|\vec{q}|` and so it is natural to use spherical coordinate.  In that sense, the other two coordinates
 are  :math:`(q_{\theta} ,  q_{\phi_az})` - along the scattering angle and azimuthal angle, respectively.  From the
 MDHisto Workspace (filtered by **qMask** and using only the signal voxels from the TOF fight), a 2D histogram is constructed
-which is fit to a bivariate normal distribution.  The histogram has **nTheta** :math:`\times` **nPhi** bins.
+which is fit to a bivariate normal distribution.  The histogram has **NTheta** :math:`\times` **NPhi** bins.
 
 For weak peaks or peaks near detector edges, the 2D histogram likely does not reflect the full profile.  To address this, the
 profile of the nearest strong peaks is forced when doing the BVG fit.  The profile is fit (allowed to vary 10% in
 :math:`\sigma_x, \sigma_y, \rho` ) and location and amplitude are not fixed.  Weak peaks are defined as peaks with fewer 
-than **forceCutoff** counts from peak-minus-background integration or within **dEdge** pixels of the detector edge.
+than **IntensityCutoff** counts from peak-minus-background integration or within **EdgeCutoff** pixels of the detector edge.
 
+The strong peaks library can be generated in two ways.  First, it can be provided as an input file through **StrongPeakParamsFile**.
+The **StrongPeakParamsFile** should be a .pkl file which contains a Numpy array containing the parameters used for strong peaks.
+Alternatively, if no file is provided, the algorithm will go through and fit strong peaks first, building the strong peaks library
+as it goes.  After fitting all of the strong peaks, defined as peaks with spherical intensities above **IntensityCutoff** and further 
+than **EdgeCutoff** pixels from the edge, it will fit weak peaks using those profiles. 
 
 Integrating the Model
 #####################

--- a/docs/source/release/v3.14.0/diffraction.rst
+++ b/docs/source/release/v3.14.0/diffraction.rst
@@ -26,7 +26,7 @@ Single Crystal Diffraction
 Improvements
 ############
 
-- :ref:`IntegratePeaksProfileFitting <algm-IntegratePeaksProfileFitting>` now supports MaNDi, TOPAZ, and CORELLI. Other instruments can easily be added as well.
+- :ref:`IntegratePeaksProfileFitting <algm-IntegratePeaksProfileFitting>` now supports MaNDi, TOPAZ, and CORELLI. Other instruments can easily be added as well.  In addition, the algorithm can now automatically generate a strong peaks library is one is not provided.
 - :ref:`MDNormSCD <algm-MDNormSCD>` now can handle merged MD workspaces.
 
 Bugfixes

--- a/instrument/MANDI_Parameters.xml
+++ b/instrument/MANDI_Parameters.xml
@@ -10,17 +10,17 @@
 
 <!-- Need to fill in gaps for peak profile fitting -->
 <parameter name="fitConvolvedPeak" type="bool">
- <value val="true"/>
+ <value val="false"/>
 </parameter>
 
 <!-- Multiplier for profile fitting for BVG polar angle -->
 <parameter name="sigX0Scale">
- <value val="2." />
+ <value val="1." />
 </parameter>
 
 <!-- Multiplier for profile fitting for BVG azimuthal angle -->
 <parameter name="sigY0Scale">
- <value val="2." />
+ <value val="1." />
 </parameter>
 
 <!-- Number of rows between detector gaps for profile fitting -->

--- a/instrument/MANDI_Parameters_2015_08_01.xml
+++ b/instrument/MANDI_Parameters_2015_08_01.xml
@@ -6,21 +6,20 @@
 <parameter name="T0">
  <value val="-0.904000"/>
 </parameter>
-</component-link>
 
 <!-- Need to fill in gaps for peak profile fitting -->
 <parameter name="fitConvolvedPeak" type="bool">
- <value val="true"/>
+ <value val="false"/>
 </parameter>
 
 <!-- Multiplier for profile fitting for BVG polar angle -->
 <parameter name="sigX0Scale">
- <value val="2." />
+ <value val="1." />
 </parameter>
 
 <!-- Multiplier for profile fitting for BVG azimuthal angle -->
 <parameter name="sigY0Scale">
- <value val="2." />
+ <value val="1." />
 </parameter>
 
 <!-- Number of rows between detector gaps for profile fitting -->
@@ -69,4 +68,5 @@
 </parameter>
 
 
+</component-link>
 </parameter-file>

--- a/instrument/MANDI_Parameters_2016_02_01.xml
+++ b/instrument/MANDI_Parameters_2016_02_01.xml
@@ -9,17 +9,17 @@
 
 <!-- Need to fill in gaps for peak profile fitting -->
 <parameter name="fitConvolvedPeak" type="bool">
- <value val="true"/>
+ <value val="false"/>
 </parameter>
 
 <!-- Multiplier for profile fitting for BVG polar angle -->
 <parameter name="sigX0Scale">
- <value val="2." />
+ <value val="1." />
 </parameter>
 
 <!-- Multiplier for profile fitting for BVG azimuthal angle -->
 <parameter name="sigY0Scale">
- <value val="2." />
+ <value val="1." />
 </parameter>
 
 <!-- Number of rows between detector gaps for profile fitting -->

--- a/scripts/SCD_Reduction/BVGFitTools.py
+++ b/scripts/SCD_Reduction/BVGFitTools.py
@@ -489,8 +489,8 @@ def doBVGFit(box, nTheta=200, nPhi=200, zBG=1.96, fracBoxToHistogram=1.0, goodID
                              thBins[thBins.size // 2 + dth]]
         boundsDict['MuY'] = [phBins[phBins.size // 2 - dph],
                              phBins[phBins.size // 2 + dph]]
-        # boundsDict['sigX'] = [0.7*sigX0, 1.3*sigX0]
-        boundsDict['SigX'] = [0., 0.02]
+        boundsDict['SigX'] = [0.5*sigX0, 1.5*sigX0]
+        #boundsDict['SigX'] = [0., 0.02]
         boundsDict['SigY'] = [0., 0.02]
         boundsDict['SigP'] = [-1., 1.]
         boundsDict['Bg'] = [0, np.inf]
@@ -520,7 +520,6 @@ def doBVGFit(box, nTheta=200, nPhi=200, zBG=1.96, fracBoxToHistogram=1.0, goodID
         m.setAttributeValue('nX', h.shape[0])
         m.setAttributeValue('nY', h.shape[1])
         m.setConstraints(boundsDict)
-
         # Do the fit
         #bvgWS = CreateWorkspace(OutputWorkspace='bvgWS', DataX=pos.ravel(
         #), DataY=H.ravel(), DataE=np.sqrt(H.ravel()))

--- a/scripts/SCD_Reduction/BVGFitTools.py
+++ b/scripts/SCD_Reduction/BVGFitTools.py
@@ -109,10 +109,10 @@ def get3DPeak(peak, peaks_ws, box, padeCoefficients, qMask, nTheta=150, nPhi=150
         tmp = strongPeakParams[:, :2] - phthPeak
         distSq = tmp[:, 0]**2 + tmp[:, 1]**2
         nnIDX = np.argmin(distSq)
-        logger.information('Using [ph, th] = [{:2.2f},{:2.2f}] for [{:2.2f},{:2.2f}]'.format(strongPeakParams[nnIDX,0],
-                                                                                             strongPeakParams[nnIDX,1],
-                                                                                             phthPeak[0],
-                                                                                             phthPeak[1]))
+        #logger.information('Using [ph, th] = [{:2.2f},{:2.2f}] for [{:2.2f},{:2.2f}]'.format(strongPeakParams[nnIDX,0],
+        #                                                                                     strongPeakParams[nnIDX,1],
+        #                                                                                     phthPeak[0],
+        #                                                                                     phthPeak[1]))
         params, h, t, p = doBVGFit(box, nTheta=nTheta, nPhi=nPhi, fracBoxToHistogram=fracBoxToHistogram,
                                    goodIDX=goodIDX, forceParams=strongPeakParams[nnIDX],
                                    doPeakConvolution=doPeakConvolution, sigX0Scale=sigX0Scale, sigY0Scale=sigY0Scale)

--- a/scripts/SCD_Reduction/BVGFitTools.py
+++ b/scripts/SCD_Reduction/BVGFitTools.py
@@ -588,7 +588,6 @@ def doBVGFit(box, nTheta=200, nPhi=200, zBG=1.96, fracBoxToHistogram=1.0, goodID
         m.setAttributeValue('nX', h.shape[0])
         m.setAttributeValue('nY', h.shape[1])
         m.setConstraints(boundsDict)
-
         # Do the fit
         #plt.figure(18); plt.clf(); plt.imshow(m.function2D(pos)); plt.title('BVG Initial guess')
         bvgWS = CreateWorkspace(OutputWorkspace='bvgWS', DataX=pos.ravel(), DataY=H.ravel(), DataE=np.sqrt(H.ravel()))

--- a/scripts/SCD_Reduction/ICCFitTools.py
+++ b/scripts/SCD_Reduction/ICCFitTools.py
@@ -283,6 +283,11 @@ def getOptimizedGoodIDX(n_events, padeCoefficients, zBG=1.96, neigh_length_m=3, 
     pp_lambda_toCheck = pp_lambda_toCheck[pp_lambda_toCheck > minppl]
     pp_lambda_toCheck = pp_lambda_toCheck[pp_lambda_toCheck < maxppl]
 
+    if pp_lambda_toCheck == []:
+        pp_lambda_toCheck = [meanBG*1.96]
+        print('Cannot find suitable background.  Consider adjusting MinpplFrac or MaxpplFrac')
+        
+
     chiSqList = 1.0e30*np.ones_like(pp_lambda_toCheck)
     ISIGList = 1.0e-30*np.ones_like(pp_lambda_toCheck)
     IList = 1.0e-30*np.ones_like(pp_lambda_toCheck)

--- a/scripts/SCD_Reduction/ICCFitTools.py
+++ b/scripts/SCD_Reduction/ICCFitTools.py
@@ -286,7 +286,6 @@ def getOptimizedGoodIDX(n_events, padeCoefficients, zBG=1.96, neigh_length_m=3, 
     if pp_lambda_toCheck == []:
         pp_lambda_toCheck = [meanBG*1.96]
         print('Cannot find suitable background.  Consider adjusting MinpplFrac or MaxpplFrac')
-        
 
     chiSqList = 1.0e30*np.ones_like(pp_lambda_toCheck)
     ISIGList = 1.0e-30*np.ones_like(pp_lambda_toCheck)


### PR DESCRIPTION
**Description of work.**
This updates the `IntegratePeaksProfileFitting` algorithm to automatically generate a strong peaks library if one is not given.  This will make it so that users do not need to process their data a first time to generate the strong library and then again using the strong peaks library.

**To test:**
Extract [this directory](https://www.dropbox.com/s/58s2zb9akhh459w/corelli_test_autostrongpeaks.zip?dl=0) and from the folder run `doTest.py`.  It should produce the following output.
```
Peak#    Original Intens         Intens          Forced Profile?
 1       3014.0400       7588.0374
 6       8605.2800       12230.4874
 7       8530.7400       14158.3273
10       11103.2800      17355.2818
 0       1033.1900       2273.5049               *
 2       1064.6900       2425.4988               *
 3       403.7000        1502.5494               *
 4       1774.2300       4060.1520               *
 5       2044.0400       3997.8776               *
 8       1971.4300       5396.8069               *
 9       1265.3900       2772.2649               *
Intensity cutoff was 3000, intensities lower than that should be asterisked and at the bottom of the list
Peak#    Original Intens         Intens          Forced Profile?
 0       1033.1900       2271.7743
 1       3014.0400       7588.0374
 2       1064.6900       2465.5270
 3       403.7000        1501.9480
 4       1774.2300       4055.8815
 5       2044.0400       3999.1617
 6       8605.2800       12230.4874
 7       8530.7400       14158.3273
 8       1971.4300       5380.8167
 9       1265.3900       2783.7676
10       11103.2800      17355.2818
Intensity cutoff was -30000, intensities lower than that should be asterisked and at the bottom of the list
```

Note that peaks above IntensityCutoff are fit first and have different intensities then when no profile is applied.


Fixes #23158  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
