### PR TITLE
Fixing unscripted tests for project recovery

### DIFF
--- a/dev-docs/source/Testing/ErrorReporter-ProjectRecovery/ProjectRecoveryTesting.rst
+++ b/dev-docs/source/Testing/ErrorReporter-ProjectRecovery/ProjectRecoveryTesting.rst
@@ -65,25 +65,12 @@ Project Recovery test
    GroupWorkspaces(InputWorkspaces='Rename3_fit_Workspace_1_Workspace,Rename1_fit_Workspace_1_Workspace', OutputWorkspace='Rename3_fit_Workspaces') 
    RenameWorkspace(InputWorkspace='Rename3_fit_Workspace_1_Workspace', OutputWorkspace='Sequential5')
    RenameWorkspace(InputWorkspace='Rename1_fit_Workspace_1_Workspace', OutputWorkspace='Sequential6')
-   SaveCSV(InputWorkspace='Sequential4', Filename=testing_directory + '/Sequence4.csv')
-   SaveCSV(InputWorkspace='Sequential5', Filename=testing_directory + '/Sequence5.csv')
-   SaveCSV(InputWorkspace='Sequential6', Filename=testing_directory + '/Sequence6.csv') 
 
 - Wait a few seconds, then provoke a crash by running `Segfault` from the algorithm window
 - Re-start MantidPlot
 - You should be presented with the Project Recovery dialog
 - Choose `Yes`
 - This should re-populate your workspace dialog and pop up a recovery script in the script window
-- Run the following script:
-
-.. code-block:: python
-
-    testing_directory=<path-to-test>
-    SaveCSV(InputWorkspace='Sequential4', Filename=testing_directory + '/Sequence4r.csv')
-    SaveCSV(InputWorkspace='Sequential5', Filename=testing_directory + '/Sequence5r.csv')
-    SaveCSV(InputWorkspace='Sequential6', Filename=testing_directory + '/Sequence6r.csv')
-
-- Compare the contents of the `SequenceX.csv` and `SequenceXr.csv` files, they should be the same
 
 -------- 
 
@@ -98,7 +85,7 @@ Project Recovery test
    CreateWorkspace(DataX=range(12), DataY=range(12), DataE=range(12), NSpec=4, OutputWorkspace='0Rebinned')
    for i in range(100):
        RenameWorkspace(InputWorkspace='%sRebinned'%str(i), OutputWorkspace='%sRebinned'%str(i+1))
-   for i in range(3000):
+   for i in range(300):
        CloneWorkspace(InputWorkspace='100Rebinned', OutputWorkspace='%sClone'%str(i))
    SaveCSV(InputWorkspace='2999Clone', Filename=testing_directory + 'Clone.csv')
 
@@ -112,7 +99,7 @@ Project Recovery test
 .. code-block:: python
 
    testing_directory=<path-to-test>
-   SaveCSV(InputWorkspace='2999Clone', Filename=testing_directory +'Cloner.csv')
+   SaveCSV(InputWorkspace='299Clone', Filename=testing_directory +'Cloner.csv')
 
 - Compare the contents of `Clone.csv` and `Cloner.csv`, they should be the same
 
@@ -172,33 +159,6 @@ Project Recovery test
 
 - Compare the contents of ``/test_binary_operators_r.csv`` and ``/test_binary_operators.csv``, they should be the same
 - Compare the contents of ``/method_test_r.csv`` and ``/method_test_r.csv``, they should be the same
-
---------
-
-4. Multiple instances of Mantid
-
-- Open up MantidPlot, ensure that only one instance is running
-- Right-click in the Results Log and set `Log level` to `Debug`
-- The Results Log should be printing `Nothing to save`
-- Run the following script:
-
-.. code-block:: python
-
-  CreateWorkspace(DataX=range(12), DataY=range(12), DataE=range(12), NSpec=4, OutputWorkspace='NewWorkspace')
-
-- The Results Log should now be printing `Project Recovery: Saving started` and `Project Recovery: Saving finished` on alternate lines
-- Now start a second instance of Mantid - note on OSX this has to be done from the command line, as OSX will not allow two instances of an executable to be run using the `open` command
-- Set `Log level` to `Debug`
-- Watch the `Results log` for 30 seconds (or longer than your interval for project recovery saving, see the `Preparation` section)
-- No message about saving should be printed
-- Now, crash the first instance of Mantid with `Segfault` from the algorithm window
-- Start a new instance of Mantid
-- This should also have no messages about saving
-- Close both instances of Mantid gracefully
-- Start a new instance of Mantid
-- You should be presented with the Project Recovery dialog
-- Choose `Yes`
-- This should repopulate your workspace window
 
 --------
 
@@ -292,8 +252,10 @@ Project Recovery test
   RenameWorkspace(InputWorkspace='NewWorkspace', OutputWorkspace='Rename2')  
 
 - Save the workspace as a `.nxs` file
-- Delete the workspace
+- Close Mantid normally
+- Re-open Mantid
 - Re-open the workspace from the saved `.nxs` file
+- Wait for saving
 - Crash Mantid with `Segfault` from the algorithm window
 - Reopen Mantid
 - Choose `Only open in script editor`

--- a/dev-docs/source/Testing/ErrorReporter-ProjectRecovery/ProjectRecoveryTesting.rst
+++ b/dev-docs/source/Testing/ErrorReporter-ProjectRecovery/ProjectRecoveryTesting.rst
@@ -86,7 +86,7 @@ Project Recovery test
        RenameWorkspace(InputWorkspace='%sRebinned'%str(i), OutputWorkspace='%sRebinned'%str(i+1))
    for i in range(300):
        CloneWorkspace(InputWorkspace='100Rebinned', OutputWorkspace='%sClone'%str(i))
-   SaveCSV(InputWorkspace='2999Clone', Filename=testing_directory + 'Clone.csv')
+   SaveCSV(InputWorkspace='299Clone', Filename=testing_directory + 'Clone.csv')
 
 - Wait a few seconds, then provoke a crash by running `Segfault` from the algorithm window
 - Re-start MantidPlot

--- a/dev-docs/source/Testing/ErrorReporter-ProjectRecovery/ProjectRecoveryTesting.rst
+++ b/dev-docs/source/Testing/ErrorReporter-ProjectRecovery/ProjectRecoveryTesting.rst
@@ -40,7 +40,6 @@ Project Recovery test
 
 .. code-block:: python
 
-   testing_directory=<path-to-test>
    Load(Filename='INTER00013464.nxs', OutputWorkspace='INTER1')
    Load(Filename='INTER00013469.nxs', OutputWorkspace='INTER2')  
    Load(Filename='INTER00013469.nxs', OutputWorkspace='INTER3')  
@@ -81,7 +80,7 @@ Project Recovery test
 
 .. code-block:: python
 
-   testing_directory=<path-to-test>
+   testing_directory=<path-to-test>   # <path-to-test> is the location of a directory for saving workspaces for comparison later
    CreateWorkspace(DataX=range(12), DataY=range(12), DataE=range(12), NSpec=4, OutputWorkspace='0Rebinned')
    for i in range(100):
        RenameWorkspace(InputWorkspace='%sRebinned'%str(i), OutputWorkspace='%sRebinned'%str(i+1))


### PR DESCRIPTION
**Description of work.**

There were a few tests in the unscripted testing of project recovery which no longer worked and also one of the tests took an unreasonably long time to run.

I have edited the tests to address this



**To test:**

Build the developer docs
 
`make dev-docs-html`

Try tests 1, 2 and 8 of `Testing/ErrorReporter-ProjectRecovery/ProjectRecoveryTesting.html`

*This does not require release notes* because  it is not user-facing

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
