### PR TITLE
Fix local links in dev-docs 

### DIFF
--- a/dev-docs/source/AlgorithmMPISupport.rst
+++ b/dev-docs/source/AlgorithmMPISupport.rst
@@ -372,7 +372,7 @@ The consequences are as follows:
   It should not be logged, written as output, or used for branching execution paths since it is meaningless.
   If the total number of spectra in a workspace is required it can be accessed via ``MatrixWorkspace::indexInfo()::globalSize()``.
 - User input providing indices or spectrum numbers in one way or another must be translated into local indices by ``IndexInfo``.
-  The most common cases are a workspace property that also accepts indices, see `IndexProperty <../concepts/IndexProperty.html>`__.
+  The most common cases are a workspace property that also accepts indices, see :ref:`IndexProperty <IndexProperty>`.
 - The distinction between local and global indices must not be exposed to the user.
   In particular, the 'global' prefix should be omitted, i.e., for the user interface we keep referring to 'workspace index', even though it is internally not what used to be the workspace index but rather a global index.
   Indices provided by a user may never be interpreted as local indices, since a local index has no fixed meaning.

--- a/dev-docs/source/GettingStartedWithPyCharm.rst
+++ b/dev-docs/source/GettingStartedWithPyCharm.rst
@@ -5,7 +5,7 @@ Getting Started with PyCharm
 
 PyCharm can be installed from `here <https://jetbrains.com/pycharm/download/>`_.
 
-This tutorial assumes you are familiar with the process of building Mantid (with separate source and build directories inside a root directory), and that you have built a working version. If you are unclear about this see `here <GettingStarted.html>`__
+This tutorial assumes you are familiar with the process of building Mantid (with separate source and build directories inside a root directory), and that you have built a working version. If you are unclear about this see :ref:`here <GettingStarted>`.
 
 .. contents::
   :local:

--- a/dev-docs/source/MVPTutorial/AddButton.rst
+++ b/dev-docs/source/MVPTutorial/AddButton.rst
@@ -1,3 +1,5 @@
+.. _AddButton:
+
 ===============
 Adding a Button
 ===============
@@ -10,7 +12,7 @@ The View
 The below code creates a QWidget containing a single button. When the
 button is pressed it will print a message to the terminal screen. It
 should be noted that in practice this should be avoided and will be
-discussed in `this section <ReceivingSignalFromView.html>`_.
+discussed in :ref:`this section <ReceivingSignalFromView>`.
 
 First we need to import the relevant packages, this includes PyQt.
 
@@ -42,10 +44,10 @@ Next we create a layout and add a button to it
 
         # connect button to signal
         self.button.clicked.connect(self.btn_click)
-	# add button to layout
-	grid.addWidget(self.button)
-	# set the layout for the view widget
-	self.setLayout(grid)
+    # add button to layout
+    grid.addWidget(self.button)
+    # set the layout for the view widget
+    self.setLayout(grid)
 
 The above connect statement means that when the button is pressed, the
 function ``btn_click`` is called:
@@ -88,9 +90,9 @@ all been saved in ``view.py``, the ``main.py`` will contain:
     def qapp():
         if QtGui.QApplication.instance():
             _app = QtGui.QApplication.instance()
-	else:
+    else:
             _app = QtGui.QApplication(sys.argv)
-	return _app
+    return _app
 
     app = qapp()
     window = demo()

--- a/dev-docs/source/MVPTutorial/AddButton.rst
+++ b/dev-docs/source/MVPTutorial/AddButton.rst
@@ -90,9 +90,9 @@ all been saved in ``view.py``, the ``main.py`` will contain:
     def qapp():
         if QtGui.QApplication.instance():
             _app = QtGui.QApplication.instance()
-    else:
+        else:
             _app = QtGui.QApplication(sys.argv)
-    return _app
+        return _app
 
     app = qapp()
     window = demo()

--- a/dev-docs/source/MVPTutorial/AddButton.rst
+++ b/dev-docs/source/MVPTutorial/AddButton.rst
@@ -38,12 +38,12 @@ Next we create a layout and add a button to it
 
 .. code-block:: python
 
-        grid = QtGui.QGridLayout()
-        self.button = QtGui.QPushButton('Hi', self)
-        self.button.setStyleSheet("background-color:lightgrey")
+    grid = QtGui.QGridLayout()
+    self.button = QtGui.QPushButton('Hi', self)
+    self.button.setStyleSheet("background-color:lightgrey")
 
-        # connect button to signal
-        self.button.clicked.connect(self.btn_click)
+    # connect button to signal
+    self.button.clicked.connect(self.btn_click)
     # add button to layout
     grid.addWidget(self.button)
     # set the layout for the view widget
@@ -54,8 +54,8 @@ function ``btn_click`` is called:
 
 .. code-block:: python
 
-        def btn_click(self):
-            print("Hello world")
+    def btn_click(self):
+        print("Hello world")
 
 The Main
 ########

--- a/dev-docs/source/MVPTutorial/AddComboBox.rst
+++ b/dev-docs/source/MVPTutorial/AddComboBox.rst
@@ -1,3 +1,5 @@
+.. _AddComboBox:
+
 ==============
 Add a ComboBox
 ==============

--- a/dev-docs/source/MVPTutorial/AddLineEdit.rst
+++ b/dev-docs/source/MVPTutorial/AddLineEdit.rst
@@ -18,6 +18,6 @@ edit (useful for tables).
 
 Care should be taken before using a line edit as it can give a user
 too much freedom. If you know that the input is an integer then a
-`spin box <AddSpinBox.html>`_ is better. If there is a finite list of
-possible options then a `combo box <AddComboBox.html>`_ would be a
+:ref:`spin box <AddSpinBox>` is better. If there is a finite list of
+possible options then a :ref:`combo box <AddComboBox>` would be a
 better choice.

--- a/dev-docs/source/MVPTutorial/AddSpinBox.rst
+++ b/dev-docs/source/MVPTutorial/AddSpinBox.rst
@@ -1,3 +1,5 @@
+.. _AddSpinBox:
+
 ==============
 Add a Spin Box
 ==============

--- a/dev-docs/source/MVPTutorial/CompleteGUI.rst
+++ b/dev-docs/source/MVPTutorial/CompleteGUI.rst
@@ -146,7 +146,7 @@ Plot Presenter
 PlotView
 ########
 
-Unchanged from `Matplotlib and MVP <Matplotlib.html>`_.
+Unchanged from :ref:`Matplotlib and MVP <Matplotlib>`.
 
 Presenter
 #########
@@ -171,9 +171,9 @@ Presenter
 View
 ####
 
-Unchanged from `Model Exercise Solution <ModelExerciseSolution.html>`_.
+Unchanged from :ref:`Model Exercise Solution <ModelExerciseSolution>`.
 
 Model
 #####
 
-Unchanged from `Model Exercise Solution <ModelExerciseSolution.html>`_.
+Unchanged from :ref:`Model Exercise Solution <ModelExerciseSolution>`.

--- a/dev-docs/source/MVPTutorial/CompleteGUI.rst
+++ b/dev-docs/source/MVPTutorial/CompleteGUI.rst
@@ -41,9 +41,9 @@ Main module
         def qapp():
             if QtGui.QApplication.instance():
                 _app = QtGui.QApplication.instance()
-	    else:
-		_app = QtGui.QApplication(sys.argv)
-	    return _app
+            else:
+                _app = QtGui.QApplication(sys.argv)
+            return _app
 
     app = qapp()
     window = demo()
@@ -82,10 +82,10 @@ Master View
 
             self.setLayout(grid)
 
-	def getOptionView(self):
+        def getOptionView(self):
             return self.options_view
 
-	def getPlotView(self):
+        def getPlotView(self):
             return self.plot_view
 
 Master Presenter
@@ -114,13 +114,13 @@ Master Presenter
         # connect statements
         self.view.getOptionView().plotSignal.connect(self.updatePlot)             
        
-	# handle signals 
-	def updatePlot(self):
-	    # only care about the colour if the button is pressed
-	    colour, freq,phi = self.presenter.getPlotInfo()
-	    grid_lines = self.presenter.getGridLines()
+        # handle signals 
+        def updatePlot(self):
+            # only care about the colour if the button is pressed
+            colour, freq,phi = self.presenter.getPlotInfo()
+            grid_lines = self.presenter.getGridLines()
  
-	    self.data_model.genData(freq,phi )
+            self.data_model.genData(freq,phi )
             x_data = self.data_model.getXData()
             y_data = self.data_model.getYData()
  
@@ -140,7 +140,7 @@ Plot Presenter
         def __init__(self, view):
             self.view = view
 
-	def plot(self, x_data, y_data, grid_lines, colour_code):
+        def plot(self, x_data, y_data, grid_lines, colour_code):
             self.view.addData(x_data, y_data, grid_lines, colour_code, "x")
 
 PlotView
@@ -160,12 +160,12 @@ Presenter
 
         def __init__(self, view, colours):
             self.view = view
-	    self.view.setColours(colours)
+            self.view.setColours(colours)
        
-	def getPlotInfo(self):
+        def getPlotInfo(self):
             return str(self.view.getColour()), self.view.getFreq(), self.view.getPhase()
 
-	def getGridLines(self):
+        def getGridLines(self):
             return self.view.getGridLines()
 
 View

--- a/dev-docs/source/MVPTutorial/ExtractInfoFromView.rst
+++ b/dev-docs/source/MVPTutorial/ExtractInfoFromView.rst
@@ -19,7 +19,7 @@ be used.
 
         doSomethingSignal = QtCore.pyqtSignal()
 
-	def __init__(self, parent=None):
+        def __init__(self, parent=None):
             super(view, self).__init__(parent)
 
             self.button = QtGui.QPushButton('Hi', self)
@@ -45,12 +45,12 @@ be used.
             # set the layout for the view widget
             self.setLayout(grid)
  
-	#send signals
-	def btn_click(self):
+        #send signals
+        def btn_click(self):
             print ("hellow from view")
-	    self.doSomethingSignal.emit()
+            self.doSomethingSignal.emit()
 
-	def getValue(self):
+            def getValue(self):
             return float(self.value.text())
 
 The last function ``getValue`` returns the value of the line

--- a/dev-docs/source/MVPTutorial/Layouts.rst
+++ b/dev-docs/source/MVPTutorial/Layouts.rst
@@ -19,15 +19,15 @@ In the View we will replace the ``__init__`` with the following:
     def __init__(self, parent=None):
         super(view, self).__init__(parent)
 
-	self.button = QtGui.QPushButton('Hi', self)
-	self.button.setStyleSheet("background-color:lightgrey")
+        self.button = QtGui.QPushButton('Hi', self)
+        self.button.setStyleSheet("background-color:lightgrey")
 
-	# connect button to signal
-	self.button.clicked.connect(self.btn_click)
+        # connect button to signal
+        self.button.clicked.connect(self.btn_click)
         self.label = QtGui.QLabel()
         self.label.setText("Button")
 
-	# add widgets to layout
+        # add widgets to layout
         self.sub_layout = QtGui.QHBoxLayout()
         self.sub_layout.addWidget(self.label)
         self.sub_layout.addWidget(self.button)
@@ -36,4 +36,4 @@ In the View we will replace the ``__init__`` with the following:
         grid.addLayout(self.sub_layout)
 
         # set the layout for the view widget
-	self.setLayout(grid)
+        self.setLayout(grid)

--- a/dev-docs/source/MVPTutorial/Matplotlib.rst
+++ b/dev-docs/source/MVPTutorial/Matplotlib.rst
@@ -1,3 +1,5 @@
+.. _Matplotlib:
+
 ==================
 Matplotlib and MVP
 ==================

--- a/dev-docs/source/MVPTutorial/Matplotlib.rst
+++ b/dev-docs/source/MVPTutorial/Matplotlib.rst
@@ -45,29 +45,29 @@ the plot and creating an empty plot (no data).
         def __init__(self, parent=None):
             super(PlotView, self).__init__(parent)
 
-	    self.figure = plt.figure()
-	    grid = QtGui.QVBoxLayout(self)
-	    self.draw() 
-	    self.canvas = self.getWidget()
-	    grid.addWidget(self.canvas)
-	    self.setLayout(grid) 
+            self.figure = plt.figure()
+            grid = QtGui.QVBoxLayout(self)
+            self.draw() 
+            self.canvas = self.getWidget()
+            grid.addWidget(self.canvas)
+            self.setLayout(grid) 
 
-	def draw(self):
+        def draw(self):
             ax = self.figure.add_subplot(111)
-	    ax.clear()
-	    ax.set_xlim([0.0, 10.5])
-	    ax.set_ylim([-1.05, 1.05])
-	    ax.set_xlabel("time ($s$)")
-	    ax.set_ylabel("$f(t)$")
-	    return ax
+            ax.clear()
+            ax.set_xlim([0.0, 10.5])
+            ax.set_ylim([-1.05, 1.05])
+            ax.set_xlabel("time ($s$)")
+            ax.set_ylabel("$f(t)$")
+            return ax
 
-	def getWidget(self):
+        def getWidget(self):
             return FigureCanvas(self.figure)
 
-	def addData(self, xvalues, yvalues, colour, marker):
+        def addData(self, xvalues, yvalues, colour, marker):
             ax = self.draw()
-	    ax.plot(xvalues, yvalues, color=colour, marker=marker, linestyle="--") 
-	    self.canvas.draw()
+            ax.plot(xvalues, yvalues, color=colour, marker=marker, linestyle="--") 
+            self.canvas.draw()
 
 The ``draw`` method creates the plot area without any data. The widget
 is obtained from the ``getWidget`` function. The final method adds

--- a/dev-docs/source/MVPTutorial/Mocking.rst
+++ b/dev-docs/source/MVPTutorial/Mocking.rst
@@ -36,14 +36,14 @@ The test class is then initialised:
 
     class presenterTest(unittest.TestCase):
         def setUp(self):
-	    self.view = mock.create_autospec(view.view)
-
-	    # mock view
-	    self.view.doSomethingSignal = mock.Mock()
-	    self.view.btn_click = mock.Mock()
-	    self.view.getValue = mock.Mock(return_value=3.14)
+            self.view = mock.create_autospec(view.view)
+        
+            # mock view
+            self.view.doSomethingSignal = mock.Mock()
+            self.view.btn_click = mock.Mock()
+            self.view.getValue = mock.Mock(return_value=3.14)
        
-	    self.presenter = presenter.Presenter(self.view)
+            self.presenter = presenter.Presenter(self.view)
 
 ``create_autospec`` mocks the class contained within the brackets. We
 then need to explicitly mock the methods using ``mock.Mock``. In

--- a/dev-docs/source/MVPTutorial/MockingExercise.rst
+++ b/dev-docs/source/MVPTutorial/MockingExercise.rst
@@ -8,4 +8,4 @@ mocked and the return values should be present only when necessary (on
 this occasion the values do not matter). The ``updatePlot`` function
 should be tested to make sure that it calls the correct methods.
 
-See `here <MockingExerciseSolution.html>`_ for the solution. 
+See :ref:`here <MockingExerciseSolution>` for the solution. 

--- a/dev-docs/source/MVPTutorial/MockingExerciseSolution.rst
+++ b/dev-docs/source/MVPTutorial/MockingExerciseSolution.rst
@@ -1,3 +1,5 @@
+.. _MockingExerciseSolution:
+
 =========================
 Mocking Exercise Solution
 =========================

--- a/dev-docs/source/MVPTutorial/MockingExerciseSolution.rst
+++ b/dev-docs/source/MVPTutorial/MockingExerciseSolution.rst
@@ -22,25 +22,25 @@ Mocking Exercise Solution
         def setUp(self):
             self.view = mock.create_autospec(view.view)
 
-	    # mock view
-	    self.view.plotSignal = mock.Mock()
-	    self.view.getColour = mock.Mock(return_value="black")
-	    self.view.getGridLines =mock.Mock(return_value=True)
-	    self.view.getFreq =mock.Mock(return_value=3.14)
-	    self.view.getPhase =mock.Mock(return_value=0.56)
-	    self.view.buttonPressed = mock.Mock()
-	    self.view.setTableRow = mock.Mock()
-	    self.view.addWidgetToTable = mock.Mock()
-	    self.view.addITemToTable = mock.Mock()
-
-	    self.presenter = presenter.Presenter(self.view)
+            # mock view
+            self.view.plotSignal = mock.Mock()
+            self.view.getColour = mock.Mock(return_value="black")
+            self.view.getGridLines =mock.Mock(return_value=True)
+            self.view.getFreq =mock.Mock(return_value=3.14)
+            self.view.getPhase =mock.Mock(return_value=0.56)
+            self.view.buttonPressed = mock.Mock()
+            self.view.setTableRow = mock.Mock()
+            self.view.addWidgetToTable = mock.Mock()
+            self.view.addITemToTable = mock.Mock()
+        
+            self.presenter = presenter.Presenter(self.view)
 
         def test_updatePlot(self):
             self.presenter.updatePlot()
-	    assert(self.view.getColour.call_count == 1)
-	    assert(self.view.getGridLines.call_count == 1)
-	    assert(self.view.getFreq.call_count == 1)
-	    assert(self.view.getPhase.call_count == 1)
+            assert(self.view.getColour.call_count == 1)
+            assert(self.view.getGridLines.call_count == 1)
+            assert(self.view.getFreq.call_count == 1)
+            assert(self.view.getPhase.call_count == 1)
 
     if __name__ == "__main__":
         unittest.main()

--- a/dev-docs/source/MVPTutorial/Model.rst
+++ b/dev-docs/source/MVPTutorial/Model.rst
@@ -17,15 +17,15 @@ The first model generates the data for the user:
 
         def __init__(self):
             self.x_data = np.linspace(0.0, 10.0, 100)
-	    self.y_data = []
- 
-	def genData(self, freq, phi):
+            self.y_data = []
+
+        def genData(self, freq, phi):
             self.y_data = np.sin(freq * self.x_data + phi)
 
-	def getXData(self):
-	    return self.x_data
+        def getXData(self):
+            return self.x_data
 
-	def getYData(self):
+        def getYData(self):
             return self.y_data
 
 The model methods can be split into three types initialisation, a

--- a/dev-docs/source/MVPTutorial/ModelExercise.rst
+++ b/dev-docs/source/MVPTutorial/ModelExercise.rst
@@ -15,4 +15,4 @@ input values
 3. In the initialisation of the Presenter get the allowed colours from
 the Model and pass them to the View
 
-See `here <ModelExerciseSolution.html>`_ for the solution. 
+See :ref:`here <ModelExerciseSolution>` for the solution. 

--- a/dev-docs/source/MVPTutorial/ModelExerciseSolution.rst
+++ b/dev-docs/source/MVPTutorial/ModelExerciseSolution.rst
@@ -1,3 +1,5 @@
+.. _ModelExerciseSolution:
+
 =======================
 Model Exercise Solution
 =======================

--- a/dev-docs/source/MVPTutorial/MultipleViews.rst
+++ b/dev-docs/source/MVPTutorial/MultipleViews.rst
@@ -74,12 +74,12 @@ The main only needs to import the masterView:
             self.setCentralWidget(my_view)
             self.setWindowTitle("view tutorial")
 
-	def qapp():
+        def qapp():
             if QtGui.QApplication.instance():
                 _app = QtGui.QApplication.instance()
-	    else:
-		_app = QtGui.QApplication(sys.argv)
-	    return _app
+            else:
+                _app = QtGui.QApplication(sys.argv)
+            return _app
 
     app = qapp()
     window = demo()

--- a/dev-docs/source/MVPTutorial/MultipleViews.rst
+++ b/dev-docs/source/MVPTutorial/MultipleViews.rst
@@ -1,3 +1,5 @@
+.. _MultipleViews:
+
 ==============
 Multiple Views
 ==============

--- a/dev-docs/source/MVPTutorial/PresenterExercise.rst
+++ b/dev-docs/source/MVPTutorial/PresenterExercise.rst
@@ -15,4 +15,4 @@ is pressed the following should be output:
 
 The ``main`` module will also need updating to handle these changes.
 
-See `here <PresenterExerciseSolution.html>`_ for the solution. 
+See :ref:`here <PresenterExerciseSolution>` for the solution. 

--- a/dev-docs/source/MVPTutorial/PresenterExerciseSolution.rst
+++ b/dev-docs/source/MVPTutorial/PresenterExerciseSolution.rst
@@ -1,3 +1,5 @@
+.. _PresenterExerciseSolution:
+
 ===========================
 Presenter Exercise Solution
 ===========================
@@ -16,7 +18,7 @@ View
 
         plotSignal = QtCore.pyqtSignal()
 
-	def __init__(self, parent=None):
+        def __init__(self, parent=None):
             super(view, self).__init__(parent)
 
             grid = QtGui.QVBoxLayout(self)
@@ -52,22 +54,22 @@ View
 
             self.plot.clicked.connect(self.buttonPressed)
 
-	def getColour(self):
+        def getColour(self):
             return self.colours.currentText()
   
-	def getGridLines(self):
+        def getGridLines(self):
             return self.grid_lines.checkState() == QtCore.Qt.Checked
 
-	def getFreq(self):
+        def getFreq(self):
             return float(self.freq.text())
 
-	def getPhase(self):
+        def getPhase(self):
             return float(self.phi.text())
 
-	def buttonPressed(self):
+        def buttonPressed(self):
             self.plotSignal.emit()
 
-	def setTableRow(self, name, row):
+        def setTableRow(self, name, row):
             text = QtGui.QTableWidgetItem(name)
             text.setFlags(QtCore.Qt.ItemIsEnabled)
             col = 0
@@ -93,18 +95,18 @@ Presenter
     class Presenter(object):
 
         # pass the view and model into the presenter
-	def __init__(self, view):
+        def __init__(self, view):
             self.view = view
 
-	    self.view.plotSignal.connect(self.updatePlot)             
+        self.view.plotSignal.connect(self.updatePlot)             
        
-	# handle signals 
-	def updatePlot(self):
+        # handle signals 
+        def updatePlot(self):
             print("The table settings are:")
-	    print("   colour     : " + str(self.view.getColour()))
-	    print("   Grid lines : " + str(self.view.getGridLines()))
-	    print("   Frequency  : " + str(self.view.getFreq()))
-	    print("   Phase      : " + str(self.view.getPhase()))
+        print("   colour     : " + str(self.view.getColour()))
+        print("   Grid lines : " + str(self.view.getGridLines()))
+        print("   Frequency  : " + str(self.view.getFreq()))
+        print("   Phase      : " + str(self.view.getPhase()))
 
 Main module
 ###########
@@ -136,12 +138,12 @@ Main module
             self.setCentralWidget(my_view)
             self.setWindowTitle("view tutorial")
 
-	def qapp():
+    def qapp():
             if QtGui.QApplication.instance():
                 _app = QtGui.QApplication.instance()
-	    else:
-		_app = QtGui.QApplication(sys.argv)
-	    return _app
+        else:
+        _app = QtGui.QApplication(sys.argv)
+        return _app
 
     app = qapp()
     window = demo()

--- a/dev-docs/source/MVPTutorial/PresenterExerciseSolution.rst
+++ b/dev-docs/source/MVPTutorial/PresenterExerciseSolution.rst
@@ -75,16 +75,16 @@ View
             col = 0
             self.table.setItem(row, col, text)
 
-     def addWidgetToTable(self, name, widget, row):
+        def addWidgetToTable(self, name, widget, row):
             self.setTableRow(name, row)
             col = 1
             self.table.setCellWidget(row, col, widget)
-
-     def addItemToTable(self, name, widget, row):
+        
+        def addItemToTable(self, name, widget, row):
             self.setTableRow(name, row)
             col = 1
             self.table.setItem(row, col, widget)
-
+    
 Presenter
 #########
 
@@ -139,10 +139,10 @@ Main module
             self.setWindowTitle("view tutorial")
 
     def qapp():
-            if QtGui.QApplication.instance():
-                _app = QtGui.QApplication.instance()
+        if QtGui.QApplication.instance():
+            _app = QtGui.QApplication.instance()
         else:
-        _app = QtGui.QApplication(sys.argv)
+            _app = QtGui.QApplication(sys.argv)
         return _app
 
     app = qapp()

--- a/dev-docs/source/MVPTutorial/PresenterExerciseSolution.rst
+++ b/dev-docs/source/MVPTutorial/PresenterExerciseSolution.rst
@@ -98,15 +98,15 @@ Presenter
         def __init__(self, view):
             self.view = view
 
-        self.view.plotSignal.connect(self.updatePlot)             
+            self.view.plotSignal.connect(self.updatePlot)             
        
         # handle signals 
         def updatePlot(self):
             print("The table settings are:")
-        print("   colour     : " + str(self.view.getColour()))
-        print("   Grid lines : " + str(self.view.getGridLines()))
-        print("   Frequency  : " + str(self.view.getFreq()))
-        print("   Phase      : " + str(self.view.getPhase()))
+            print("   colour     : " + str(self.view.getColour()))
+            print("   Grid lines : " + str(self.view.getGridLines()))
+            print("   Frequency  : " + str(self.view.getFreq()))
+            print("   Phase      : " + str(self.view.getPhase()))
 
 Main module
 ###########

--- a/dev-docs/source/MVPTutorial/ReceivingSignalFromView.rst
+++ b/dev-docs/source/MVPTutorial/ReceivingSignalFromView.rst
@@ -1,8 +1,10 @@
+.. _ReceivingSignalFromView:
+
 ================================
 Receiving a signal from the view
 ================================
 
-In the `Add Button <AddButton.html>`_ section we had the response to a button press
+In the :ref:`Add Button <AddButton>` section we had the response to a button press
 within the View. In practice this is not a good implementation. If the
 response was more complicated then it would be difficult to maintain
 the View as it would become extremely long. Furthermore creating the
@@ -23,7 +25,7 @@ pressed. First we will start with the View:
 
         doSomethingSignal = QtCore.pyqtSignal()
 
-	def __init__(self, parent=None):
+        def __init__(self, parent=None):
             super(view, self).__init__(parent)
 
             self.button = QtGui.QPushButton('Hi', self)
@@ -44,10 +46,10 @@ pressed. First we will start with the View:
             # set the layout for the view widget
             self.setLayout(grid)
  
-	#send signals
-	def btn_click(self):
+        #send signals
+        def btn_click(self):
             print ("hellow from view")
-	    self.doSomethingSignal.emit()
+            self.doSomethingSignal.emit()
 
 The above code has two new additions. The first is the creation of a
 custom signal on line eight. It is also possible to pass objects with
@@ -67,13 +69,13 @@ custom signal from the View to its own function (``handleButton``).
     class Presenter(object):
 
         # pass the view and model into the presenter
-	def __init__(self, view):
+        def __init__(self, view):
             self.view = view
 
-	    self.view.doSomethingSignal.connect(self.handleButton)             
+            self.view.doSomethingSignal.connect(self.handleButton)             
        
-	# handle signals 
-	def handleButton(self):
+        # handle signals 
+        def handleButton(self):
             print("hello world, from the presenter")
 
 The main is now:
@@ -105,12 +107,12 @@ The main is now:
             self.setCentralWidget(my_view)
             self.setWindowTitle("view tutorial")
 
-	def qapp():
+        def qapp():
             if QtGui.QApplication.instance():
                 _app = QtGui.QApplication.instance()
-	    else:
-		_app = QtGui.QApplication(sys.argv)
-	    return _app
+            else:
+                _app = QtGui.QApplication(sys.argv)
+            return _app
 
 
     app = qapp()

--- a/dev-docs/source/MVPTutorial/ViewExercise1.rst
+++ b/dev-docs/source/MVPTutorial/ViewExercise1.rst
@@ -17,7 +17,7 @@ plot. The table should include options for:
 
 The previous sections are not an exhaustive list of possible widgets.
 
-The pages `Matplotlib and MVP <Matplotlib.html>`_ and `MultipleView
-<MultipleViews.html>`_ will be useful for the exercise.
+The pages :ref:`Matplotlib and MVP <Matplotlib>` and :ref:`MultipleView
+<MultipleViews>` will be useful for the exercise.
 
-The solution can be found `here <ViewExercise1Solution.html>`_.
+The solution can be found :ref:`here <ViewExercise1Solution>`.

--- a/dev-docs/source/MVPTutorial/ViewExercise1Solution.rst
+++ b/dev-docs/source/MVPTutorial/ViewExercise1Solution.rst
@@ -1,3 +1,5 @@
+.. _ViewExercise1Solution:
+
 ========================
 View Exercise 1 Solution
 ========================
@@ -30,12 +32,12 @@ main.py
             self.setCentralWidget(my_view)
             self.setWindowTitle("view tutorial")
 
-	def qapp():
+        def qapp():
             if QtGui.QApplication.instance():
                 _app = QtGui.QApplication.instance()
-	    else:
-		_app = QtGui.QApplication(sys.argv)
-	    return _app
+            else:
+                _app = QtGui.QApplication(sys.argv)
+            return _app
 
     app = qapp()
     window = demo()

--- a/dev-docs/source/Standards/AlgorithmDocumentation.rst
+++ b/dev-docs/source/Standards/AlgorithmDocumentation.rst
@@ -121,7 +121,7 @@ As the **Description** and **Usage** of an algorithm *cannot* be obtained automa
    }
 
 ``.. relatedalgorithms::``
-   This directive obtains a list of related algorithms from the ``seeAlso`` method in the algorithm, for example, the following method is used in Rebin: 
+   This directive obtains a list of related algorithms from the ``seeAlso`` and ``alias`` methods in the algorithm, for example, the following ``seeAlso`` is used in Rebin: 
 
 .. code-block:: c++
 

--- a/dev-docs/source/Standards/AlgorithmDocumentation.rst
+++ b/dev-docs/source/Standards/AlgorithmDocumentation.rst
@@ -10,7 +10,7 @@ Algorithm Documentation
 Summary
 =======
 
-This page deals with the specifics of how to document an algorithm. For a more general guide to the Mantid documentation system see `Documentation Guide For Devs <DocumentationGuideForDevs.html>`__.
+This page deals with the specifics of how to document an algorithm. For a more general guide to the Mantid documentation system see :ref:`Documentation Guide For Devs <DocumentationGuideForDevs>`.
 
 How to Document an Algorithm
 ============================
@@ -18,7 +18,7 @@ How to Document an Algorithm
 Algorithm documentation is stored in two places.
 
 * The code (.cpp / .h / .py) files: For strings that are needed in the GUI for tooltips etc.
-* The .rst file: For all other documentation, including the algorithm description and `usage examples <AlgorithmUsageExamples.html>`__.
+* The .rst file: For all other documentation, including the algorithm description and :ref:`usage examples <AlgorithmUsageExamples>`.
 
 The Code Files
 --------------
@@ -69,7 +69,7 @@ For example:
 Workflow algorithms
 ===================
 
-There should be a flow chart for workflow algorithms. See `here <FlowchartCreation.html>`__ on how to make one.
+There should be a flow chart for workflow algorithms. See :ref:`here <FlowchartCreation>` on how to make one.
 
 Algorithm Directives
 ====================
@@ -84,7 +84,7 @@ As the **Description** and **Usage** of an algorithm *cannot* be obtained automa
 
    .. summary::
 
-   .. alias::
+   .. relatedalgorithms::
 
    .. properties::
 
@@ -120,13 +120,16 @@ As the **Description** and **Usage** of an algorithm *cannot* be obtained automa
       return "Rebins data with new X bin boundaries. For EventWorkspaces, you can very quickly rebin in-place by keeping the same output name and PreserveEvents=true.";
    }
 
-``.. alias::``
-   This directive obtains aliases from the required ``alias`` method in the algorithm, for example, the following method is used in Rebin: 
+``.. relatedalgorithms::``
+   This directive obtains a list of related algorithm from the ``seeAlso`` method in the algorithm, for example, the following method is used in Rebin: 
 
 .. code-block:: c++
 
-   /// Algorithm's aliases
-   const std::string alias() const override { return "rebin"; }
+   /// Algorithm's seeAlso
+   const std::vector<std::string> seeAlso() const override {
+    return {"RebinToWorkspace", "Rebin2D",           "Rebunch",
+            "Regroup",          "RebinByPulseTimes", "RebinByTimeAtSample"};
+   }
 
 ``.. properties::``
    As mentioned above, it is *critical* that you include a description for the properties of your algorithm. This directive obtains all of the algorithm's properties (set inside the algorithm's ``init`` method) and outputs in a table format. 
@@ -147,7 +150,7 @@ It is possible to add additional categories by passing the directive arguments, 
 
    .. categories:: Algorithms, Transforms, Rebin, Example
 
-``..sourcelink ::``
+``.. sourcelink::``
    This directive adds links to the algorithms source code.
 
 Description
@@ -175,7 +178,7 @@ where the first part outside the angle brackets defines the link text and the pa
 Usage
 =====
 
-This section *must* be manually entered. The usage is a 'code' example of the algorithm in use. The `testcode` directive must be used to verify the usage code you entered works correctly. See `here <AlgorithmUsageExamples>`__ for more information on how to write usage examples.
+This section *must* be manually entered. The usage is a 'code' example of the algorithm in use. The ``.. testcode::`` directive must be used to verify the usage code you entered works correctly. See :ref:`here <AlgorithmUsageExamples>` for more information on how to write usage examples.
 
 Building the Documentation
 ==========================

--- a/dev-docs/source/Standards/AlgorithmDocumentation.rst
+++ b/dev-docs/source/Standards/AlgorithmDocumentation.rst
@@ -121,7 +121,7 @@ As the **Description** and **Usage** of an algorithm *cannot* be obtained automa
    }
 
 ``.. relatedalgorithms::``
-   This directive obtains a list of related algorithm from the ``seeAlso`` method in the algorithm, for example, the following method is used in Rebin: 
+   This directive obtains a list of related algorithms from the ``seeAlso`` method in the algorithm, for example, the following method is used in Rebin: 
 
 .. code-block:: c++
 

--- a/dev-docs/source/Standards/AlgorithmUsageExamples.rst
+++ b/dev-docs/source/Standards/AlgorithmUsageExamples.rst
@@ -18,7 +18,7 @@ From a user's point of view, the main purposes of usage examples are:
 * Understanding the algorithm
 * Showing hints/comments etc. that help understand Mantid Python scripting in general
 
-The usage examples are written in `reStructuredText <http://docutils.sourceforge.net/rst.html>`__, which can be converted to HTML and the code in the usage examples can be tested. The image below demonstrates an example of converting reStructuredText to HTML. 
+The usage examples are written in `reStructuredText <http://docutils.sourceforge.net/rst.html>`__, which can be converted to HTML and the code in the usage examples can be tested. 
 
 Guide
 =====
@@ -75,7 +75,7 @@ What is worth keeping in mind is:
 * Use comments.
 * Use Python ``print`` to output results, which, where possible, helps to understand the algorithm.
 
-A Jenkins job tests that the usage examples are not broken, i.e. that they continue to provide a working demonstration against the current build. It is vital to stress that the purpose of usage testing is *not to replace unit testing* (or system testing). The purpose of usage testing (better described as demonstration examples), is to provide some happy-path examples, which, where this is possible, can assist the user understanding of the Python code. This is very different from the purposes of testing in general, see `here <UnitTestGoodPractice.html>`__.
+A Jenkins job tests that the usage examples are not broken, i.e. that they continue to provide a working demonstration against the current build. It is vital to stress that the purpose of usage testing is *not to replace unit testing* (or system testing). The purpose of usage testing (better described as demonstration examples), is to provide some happy-path examples, which, where this is possible, can assist the user understanding of the Python code. This is very different from the purposes of testing in general, see :ref:`here <UnitTestGoodPractice>`.
 
 Additional benefits of usage examples:
 
@@ -181,7 +181,7 @@ For a more simple use of CreateSampleWorkspace see example below (note if no arg
 When needing to load a data file
 --------------------------------
 
-Instructions to add a new data file to the repository are available `here <DataFilesForTesting.html>`__. Files from the repository will be bundled up into a .zip file, and this .zip made available for download from the Mantid download page.
+Instructions to add a new data file to the repository are available :ref:`here <DataFilesForTesting>`. Files from the repository will be bundled up into a .zip file, and this .zip made available for download from the Mantid download page.
 
 If you use files you must add the line
 
@@ -221,4 +221,4 @@ as shown in the example below. This will generate a note to the user explaining 
 Running the Tests
 =================
 
-See `here <DocumentationGuideForDevs.html>`__ for how to run and test the usage examples locally.
+See :ref:`here <DocumentationGuideForDevs>` for how to run and test the usage examples locally.

--- a/dev-docs/source/Standards/DocumentationGuideForDevs.rst
+++ b/dev-docs/source/Standards/DocumentationGuideForDevs.rst
@@ -96,12 +96,12 @@ If you wish to place comments in the reST file that will not be rendered anywher
 Algorithms
 ----------
 
-The algorithm documentation has a slightly more rigid structure and is described in more detail `here <AlgorithmDocumentation.html>`__ and `here <AlgorithmUsageExamples.html>`__.
+The algorithm documentation has a slightly more rigid structure and is described in more detail :ref:`here <AlgorithmDocumentation>` and :ref:`here <AlgorithmUsageExamples>`.
 
 Interfaces
 ----------
 
-For documenting custom interfaces, it is recommended that you consult `this <InterfaceDocumentation.html>`__  page, which explains how to document them, and which directives may be used in more detail. 
+For documenting custom interfaces, it is recommended that you consult :ref:`this <InterfaceDocumentation>`  page, which explains how to document them, and which directives may be used in more detail. 
 
 How to define titles, sections etc.
 -----------------------------------
@@ -251,6 +251,6 @@ For multi-configuration generators such as Visual Studio or XCode you will need 
 Building the HTML Development Documentation
 ===========================================
 
-The developer documentation is written as `.rst` files in the mantid source folder under ``dev-docs/``, the html files can be built using the `dev-docs-html` target. This will build all the development documentation into the mantid build folder under ``dev-docs/html/``.
+The developer documentation is written as ``.rst`` files in the mantid source folder under ``dev-docs/``, the html files can be built using the `dev-docs-html` target. This will build all the development documentation into the mantid build folder under ``dev-docs/html/``.
 
 In Visual Studio, this can be found in the "Documentation" folder in the solution explorer for the Mantid solution. Simply right click `dev-docs-html` and select build.

--- a/dev-docs/source/Standards/InterfaceDocumentation.rst
+++ b/dev-docs/source/Standards/InterfaceDocumentation.rst
@@ -10,7 +10,7 @@ Interface Documentation
 Summary
 =======
 
-This page deals with the specifics of how to document Custom Interfaces. For a more general guide to the Mantid documentation system see `Documentation Guide For Devs <DocumentationGuideForDevs.html>`__.
+This page deals with the specifics of how to document Custom Interfaces. For a more general guide to the Mantid documentation system see :ref:`Documentation Guide For Devs <DocumentationGuideForDevs>`.
 
 The ``interface`` Directive
 ===========================

--- a/dev-docs/source/Testing/ErrorReporter-ProjectRecovery/ProjectRecoveryTesting.rst
+++ b/dev-docs/source/Testing/ErrorReporter-ProjectRecovery/ProjectRecoveryTesting.rst
@@ -12,7 +12,7 @@ Project Recovery test
 *Preparation*
 
 - Before running these tests, set project recovery to run every 2 seconds. The instructions for this
-  are on the `Project Recovery concepts page <http://docs.mantidproject.org/nightly/concepts/ProjectRecovery.html>`_.
+  are on the `Project Recovery concepts page <http://docs.mantidproject.org/nightly/concepts/ProjectRecovery.html>`__.
 - Get the ISIS sample dataset from the `Downloads page <http://download.mantidproject.org/>`_.
 - `TOPAZ_3132_event.nxs` - availabe in ``/Testing/Data/SystemTest/``, get this by building the `SystemTestData` target. It should be in ``ExternalData/Testing/Data/SystemTest/``
 - The files `INTER000*` are in the ISIS sample data


### PR DESCRIPTION
**Description of work.**

Some of the pages in dev-docs were unaccessible since the `.rst` files had hard-links to the final `.html` pages. Some of this originated because the pages were created in different branches and cross-referencing would have produced warnings with the `dev-docs` target. When the pages were reorganized at some point, the hard-coded links were broken.

This PR changes the hard-coded local links within `dev-docs` to use proper sphinx cross-referencing. Also, some small 'typos' have been corrected here and there.

**Report to:** [nobody].

**To test:**

Build the *dev-docs* target and try to find broken links/broken behavior.

*There is no associated issue.*

*This does not require release notes* because **it is an internal developer documentation change**.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
