### PR TITLE
MR: Minor fix to MagnetismReflectometryReduction

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/MagnetismReflectometryReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/MagnetismReflectometryReduction.py
@@ -370,7 +370,7 @@ class MagnetismReflectometryReduction(PythonAlgorithm):
                                   ParentWorkspace=workspace, OutputWorkspace=name_output_ws)
 
         # At this point we still have a histogram, and we need to convert to point data
-        q_rebin = ConvertToPointData(InputWorkspace=q_rebin)
+        q_rebin = ConvertToPointData(InputWorkspace=q_rebin, OutputWorkspace=name_output_ws)
         return q_rebin
 
     def convert_to_q(self, workspace):


### PR DESCRIPTION
**Description of work.**
The MagnetismReflectometryReduction algorithm works fine, but the naming of the output workspaces for the constant-q option creates usage issues. The output workspace name should be specified when calling child algorithms.

**Report to:** nobody

**To test:**
- make sure tests pass
- inspect code

*There is no associated issue.*

*This does not require release notes* because this is a small bug fix.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
