### PR TITLE
Project Recovery: Add a call to project recovery from python to call a save

### DIFF
--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -16857,6 +16857,6 @@ void ApplicationWindow::checkForProjectRecovery() {
   }
 }
 
-void ApplicationWindow::saveRecoveryCheckpoint(){
+void ApplicationWindow::saveRecoveryCheckpoint() {
   m_projectRecovery.saveAll(false);
 }

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -16856,3 +16856,7 @@ void ApplicationWindow::checkForProjectRecovery() {
     m_projectRecovery.startProjectSaving();
   }
 }
+
+void ApplicationWindow::saveRecoveryCheckpoint(){
+  m_projectRecovery.saveAll();
+}

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -16858,5 +16858,5 @@ void ApplicationWindow::checkForProjectRecovery() {
 }
 
 void ApplicationWindow::saveRecoveryCheckpoint(){
-  m_projectRecovery.saveAll();
+  m_projectRecovery.saveAll(false);
 }

--- a/MantidPlot/src/ApplicationWindow.h
+++ b/MantidPlot/src/ApplicationWindow.h
@@ -1132,6 +1132,10 @@ public slots:
   /// Checks for and attempts project recovery if required
   void checkForProjectRecovery();
 
+  /// Make a Recovery checkpoint so you don't have to wait for it to happen
+  /// normally  
+  void saveRecoveryCheckpoint();
+  
 signals:
   void modified();
   void shutting_down();

--- a/MantidPlot/src/ApplicationWindow.h
+++ b/MantidPlot/src/ApplicationWindow.h
@@ -1133,9 +1133,9 @@ public slots:
   void checkForProjectRecovery();
 
   /// Make a Recovery checkpoint so you don't have to wait for it to happen
-  /// normally  
+  /// normally
   void saveRecoveryCheckpoint();
-  
+
 signals:
   void modified();
   void shutting_down();

--- a/MantidPlot/src/ProjectRecovery.cpp
+++ b/MantidPlot/src/ProjectRecovery.cpp
@@ -174,7 +174,6 @@ void ProjectRecovery::attemptRecovery() {
       QObject::tr("Only open script in editor"), 0, 1);
 
   if (userChoice == 1) {
-    this->saveAll();
     // User selected no
     this->startProjectSaving();
     return;
@@ -444,14 +443,20 @@ void ProjectRecovery::projectSavingThread() {
  * @param projectDestFile :: The full path to write to
  * @throws If saving fails in the main GUI thread
  */
-void ProjectRecovery::saveOpenWindows(const std::string &projectDestFile) {
+void ProjectRecovery::saveOpenWindows(const std::string &projectDestFile,
+                                      bool autoSave) {
   bool saveCompleted = false;
-  if (!QMetaObject::invokeMethod(m_windowPtr, "saveProjectRecovery",
-                                 Qt::QueuedConnection,
-                                 Q_RETURN_ARG(bool, saveCompleted),
-                                 Q_ARG(const std::string, projectDestFile))) {
-    throw std::runtime_error("Project Recovery: Failed to save project "
-                             "windows - Qt binding failed");
+  if (autoSave) {
+    if (!QMetaObject::invokeMethod(m_windowPtr, "saveProjectRecovery",
+                                   Qt::BlockingQueuedConnection,
+                                   Q_RETURN_ARG(bool, saveCompleted),
+                                   Q_ARG(const std::string, projectDestFile))) {
+      throw std::runtime_error("Project Recovery: Failed to save project "
+                               "windows - Qt binding failed");
+    }
+  } else {
+    // Only use this if it is called from the python interface/error reporter
+    saveCompleted = m_windowPtr->saveProjectRecovery(projectDestFile);
   }
 
   if (!saveCompleted) {
@@ -509,13 +514,13 @@ void ProjectRecovery::saveWsHistories(const Poco::Path &historyDestFolder) {
  * This won't run if it is locked by the background thread but then it saving
  * Anyway so thats no issue.
  */
-void ProjectRecovery::saveAll() {
+void ProjectRecovery::saveAll(bool autoSave) {
   // "Timeout" - Save out again
   const auto &ads = Mantid::API::AnalysisDataService::Instance();
-  //if (ads.size() == 0) {
-  //  g_log.debug("Nothing to save");
-  //  return;
-  //}
+  if (ads.size() == 0) {
+    g_log.debug("Nothing to save");
+    return;
+  }
 
   g_log.debug("Project Recovery: Saving started");
 
@@ -524,7 +529,7 @@ void ProjectRecovery::saveAll() {
 
   saveWsHistories(basePath);
   auto projectFile = Poco::Path(basePath).append(OUTPUT_PROJ_NAME);
-  saveOpenWindows(projectFile.toString());
+  saveOpenWindows(projectFile.toString(), autoSave);
 
   // Purge any excessive folders
   deleteExistingCheckpoints(NO_OF_CHECKPOINTS);

--- a/MantidPlot/src/ProjectRecovery.h
+++ b/MantidPlot/src/ProjectRecovery.h
@@ -98,7 +98,8 @@ private:
   void projectSavingThread();
 
   /// Saves a project recovery file in Mantid
-  void saveOpenWindows(const std::string &projectDestFolder, bool autoSave = true);
+  void saveOpenWindows(const std::string &projectDestFolder,
+                       bool autoSave = true);
 
   /// Saves the current workspace's histories from Mantid
   void saveWsHistories(const Poco::Path &projectDestFile);

--- a/MantidPlot/src/ProjectRecovery.h
+++ b/MantidPlot/src/ProjectRecovery.h
@@ -67,6 +67,9 @@ public:
   /// Stops the background thread
   void stopProjectSaving();
 
+  /// Saves a project recovery checkpoint
+  void saveAll();
+
 private:
   /// Captures the current object in the background thread
   std::thread createBackgroundThread();

--- a/MantidPlot/src/ProjectRecovery.h
+++ b/MantidPlot/src/ProjectRecovery.h
@@ -68,7 +68,7 @@ public:
   void stopProjectSaving();
 
   /// Saves a project recovery checkpoint
-  void saveAll();
+  void saveAll(bool autoSave = true);
 
 private:
   /// Captures the current object in the background thread
@@ -98,7 +98,7 @@ private:
   void projectSavingThread();
 
   /// Saves a project recovery file in Mantid
-  void saveOpenWindows(const std::string &projectDestFolder);
+  void saveOpenWindows(const std::string &projectDestFolder, bool autoSave = true);
 
   /// Saves the current workspace's histories from Mantid
   void saveWsHistories(const Poco::Path &projectDestFile);

--- a/MantidPlot/src/qti.sip
+++ b/MantidPlot/src/qti.sip
@@ -1240,6 +1240,8 @@ public:
 
   QString stemPlot(Table *t, const QString& colName, int power = 1001, int startRow = 0, int endRow = -1);
 
+  void saveRecoveryCheckpoint();
+  
   //---- Mantid
   MantidUI* mantidUI;
   void addUserMenu(const QString &);

--- a/docs/source/release/v3.14.0/ui.rst
+++ b/docs/source/release/v3.14.0/ui.rst
@@ -13,6 +13,9 @@ UI & Usability Changes
 
 Project Recovery
 ----------------
+New
+###
+-Project recovery can now make a recovery checkpoint on command using mantidplot.app.saveRecoveryCheckpoint() in either the interpreter or script windows in python
 
 Changes
 #######


### PR DESCRIPTION
**Description of work.**
I added the ability to call a project recovery save at a given moment instead of waiting for it to tick over.

**To test:**
- Load a workspace and open a plot
- In the python interpreter or script window use the line mantidplot.app.saveRecoveryCheckpoint() before it has a chance to autosave
- Then run Segfault
- Then reload mantid and click yes on the recovery
- If everything looks like it was then it worked.

Fixes #23468  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
