### PR TITLE
Indirect - Iqt Monte Carlo Progress bar and option to skip error calculation

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/CalculateIqt.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CalculateIqt.h
@@ -2,6 +2,7 @@
 #define MANTID_ALGORITHMS_CALCULATEIQT_H_
 
 #include "MantidAPI/Algorithm.h"
+#include "MantidAPI/MatrixWorkspace.h"
 
 namespace Mantid {
 namespace Algorithms {
@@ -45,6 +46,38 @@ private:
                              API::MatrixWorkspace_sptr resolution,
                              const std::string &rebinParams, const int seed,
                              bool calculateErrors, const int nIterations);
+
+  API::MatrixWorkspace_sptr rebin(API::MatrixWorkspace_sptr workspace,
+                                  const std::string &params);
+  API::MatrixWorkspace_sptr integration(API::MatrixWorkspace_sptr workspace);
+  API::MatrixWorkspace_sptr
+  convertToPointData(API::MatrixWorkspace_sptr workspace);
+  API::MatrixWorkspace_sptr
+  extractFFTSpectrum(API::MatrixWorkspace_sptr workspace);
+  API::MatrixWorkspace_sptr divide(API::MatrixWorkspace_sptr lhsWorkspace,
+                                   API::MatrixWorkspace_sptr rhsWorkspace);
+  API::MatrixWorkspace_sptr cropWorkspace(API::MatrixWorkspace_sptr workspace,
+                                          double xMax);
+  API::MatrixWorkspace_sptr
+  replaceSpecialValues(API::MatrixWorkspace_sptr workspace);
+
+  API::MatrixWorkspace_sptr
+  removeInvalidData(API::MatrixWorkspace_sptr workspace);
+  API::MatrixWorkspace_sptr
+  normalizedFourierTransform(API::MatrixWorkspace_sptr workspace,
+                             const std::string &rebinParams);
+  API::MatrixWorkspace_sptr
+  calculateIqt(API::MatrixWorkspace_sptr workspace,
+               API::MatrixWorkspace_sptr resolutionWorkspace,
+               const std::string &rebinParams);
+  API::MatrixWorkspace_sptr doSimulation(API::MatrixWorkspace_sptr sample,
+                                         API::MatrixWorkspace_sptr resolution,
+                                         const std::string &rebinParams,
+                                         const int seed);
+  API::MatrixWorkspace_sptr setErrorsToStandardDeviation(
+      const std::vector<API::MatrixWorkspace_sptr> &simulatedWorkspaces);
+  API::MatrixWorkspace_sptr CalculateIqt::setErrorsToZero(
+      const std::vector<API::MatrixWorkspace_sptr> &simulatedWorkspaces);
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/CalculateIqt.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CalculateIqt.h
@@ -40,9 +40,11 @@ private:
   void exec() override;
   std::map<std::string, std::string> validateInputs() override;
   std::string rebinParamsAsString();
-  API::MatrixWorkspace_sptr monteCarloErrorCalculation(
-      API::MatrixWorkspace_sptr sample, API::MatrixWorkspace_sptr resolution,
-      const std::string &rebinParams, const int seed, const int nIterations);
+  API::MatrixWorkspace_sptr
+  monteCarloErrorCalculation(API::MatrixWorkspace_sptr sample,
+                             API::MatrixWorkspace_sptr resolution,
+                             const std::string &rebinParams, const int seed,
+                             bool calculateErrors, const int nIterations);
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/CalculateIqt.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CalculateIqt.h
@@ -45,7 +45,7 @@ private:
   monteCarloErrorCalculation(API::MatrixWorkspace_sptr sample,
                              API::MatrixWorkspace_sptr resolution,
                              const std::string &rebinParams, const int seed,
-                             bool calculateErrors, const int nIterations);
+                             const bool calculateErrors, const int nIterations);
 
   API::MatrixWorkspace_sptr rebin(API::MatrixWorkspace_sptr workspace,
                                   const std::string &params);
@@ -57,7 +57,7 @@ private:
   API::MatrixWorkspace_sptr divide(API::MatrixWorkspace_sptr lhsWorkspace,
                                    API::MatrixWorkspace_sptr rhsWorkspace);
   API::MatrixWorkspace_sptr cropWorkspace(API::MatrixWorkspace_sptr workspace,
-                                          double xMax);
+                                          const double xMax);
   API::MatrixWorkspace_sptr
   replaceSpecialValues(API::MatrixWorkspace_sptr workspace);
 

--- a/Framework/Algorithms/inc/MantidAlgorithms/CalculateIqt.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CalculateIqt.h
@@ -76,7 +76,7 @@ private:
                                          const int seed);
   API::MatrixWorkspace_sptr setErrorsToStandardDeviation(
       const std::vector<API::MatrixWorkspace_sptr> &simulatedWorkspaces);
-  API::MatrixWorkspace_sptr CalculateIqt::setErrorsToZero(
+  API::MatrixWorkspace_sptr setErrorsToZero(
       const std::vector<API::MatrixWorkspace_sptr> &simulatedWorkspaces);
 };
 

--- a/Framework/Algorithms/src/CalculateIqt.cpp
+++ b/Framework/Algorithms/src/CalculateIqt.cpp
@@ -84,7 +84,7 @@ allYValuesAtIndex(const std::vector<MatrixWorkspace_sptr> &workspaces,
 }
 
 int getWorkspaceNumberOfHistograms(MatrixWorkspace_sptr workspace) {
-  return boost::numeric_cast<std::size_t>(workspace->getNumberHistograms());
+  return boost::numeric_cast<int>(workspace->getNumberHistograms());
 }
 
 } // namespace

--- a/Framework/Algorithms/src/CalculateIqt.cpp
+++ b/Framework/Algorithms/src/CalculateIqt.cpp
@@ -83,7 +83,7 @@ allYValuesAtIndex(const std::vector<MatrixWorkspace_sptr> &workspaces,
   return yValues;
 }
 
-std::size_t getWorkspaceNumberOfHistograms(MatrixWorkspace_sptr workspace) {
+int getWorkspaceNumberOfHistograms(MatrixWorkspace_sptr workspace) {
   return boost::numeric_cast<std::size_t>(workspace->getNumberHistograms());
 }
 

--- a/Framework/Algorithms/src/CalculateIqt.cpp
+++ b/Framework/Algorithms/src/CalculateIqt.cpp
@@ -127,7 +127,6 @@ void CalculateIqt::init() {
   auto positiveInt = boost::make_shared<Kernel::BoundedValidator<int>>();
   positiveInt->setLower(1);
 
-  declareProperty("CalculateErrors", true, "Calculate monte-carlo errors.");
   declareProperty("NumberOfIterations", DEFAULT_ITERATIONS, positiveInt,
                   "Number of randomised simulations within error to run.");
   declareProperty(
@@ -137,6 +136,8 @@ void CalculateIqt::init() {
   declareProperty(make_unique<WorkspaceProperty<>>("OutputWorkspace", "",
                                                    Direction::Output),
                   "The name to use for the output workspace.");
+
+  declareProperty("CalculateErrors", true, "Calculate monte-carlo errors.");
 }
 
 void CalculateIqt::exec() {
@@ -165,7 +166,7 @@ std::string CalculateIqt::rebinParamsAsString() {
 
 MatrixWorkspace_sptr CalculateIqt::monteCarloErrorCalculation(
     MatrixWorkspace_sptr sample, MatrixWorkspace_sptr resolution,
-    const std::string &rebinParams, const int seed, bool calculateErrors,
+    const std::string &rebinParams, const int seed, const bool calculateErrors,
     const int nIterations) {
   auto outputWorkspace = calculateIqt(sample, resolution, rebinParams);
   std::vector<MatrixWorkspace_sptr> simulatedWorkspaces;
@@ -258,7 +259,7 @@ MatrixWorkspace_sptr CalculateIqt::divide(MatrixWorkspace_sptr lhsWorkspace,
 }
 
 MatrixWorkspace_sptr CalculateIqt::cropWorkspace(MatrixWorkspace_sptr workspace,
-                                                 double xMax) {
+                                                 const double xMax) {
   IAlgorithm_sptr cropAlgorithm = this->createChildAlgorithm("CropWorkspace");
   cropAlgorithm->initialize();
   cropAlgorithm->setProperty("InputWorkspace", workspace);

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TransformToIqt.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TransformToIqt.py
@@ -48,8 +48,6 @@ class TransformToIqt(PythonAlgorithm):
                              doc='Decrease total number of spectrum points by this ratio through merging of '
                                  'intensities from neighbouring bins. Default=1')
 
-        self.declareProperty('CalculateErrors', defaultValue=True,
-                             doc="Calculate monte-carlo errors.")
         self.declareProperty('NumberOfIterations', DEFAULT_ITERATIONS, IntBoundedValidator(lower=1),
                              doc="Number of randomised simulations for monte-carlo error calculation.")
 
@@ -68,6 +66,8 @@ class TransformToIqt(PythonAlgorithm):
 
         self.declareProperty(name='DryRun', defaultValue=False,
                              doc='Only calculate and output the parameters')
+        self.declareProperty('CalculateErrors', defaultValue=True,
+                             doc="Calculate monte-carlo errors.")
 
     def PyExec(self):
         self._setup()

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TransformToIqt.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TransformToIqt.py
@@ -5,8 +5,6 @@ from mantid.api import (PythonAlgorithm, AlgorithmFactory, MatrixWorkspaceProper
                         ITableWorkspaceProperty, PropertyMode, Progress)
 from mantid.kernel import Direction, logger, IntBoundedValidator
 
-import time
-
 DEFAULT_ITERATIONS = 50
 DEFAULT_SEED = 89631139
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TransformToIqt.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TransformToIqt.py
@@ -19,6 +19,7 @@ class TransformToIqt(PythonAlgorithm):
     _parameter_table = None
     _output_workspace = None
     _dry_run = None
+    _calculate_errors = None
     _number_of_iterations = None
     _seed = None
 
@@ -47,6 +48,8 @@ class TransformToIqt(PythonAlgorithm):
                              doc='Decrease total number of spectrum points by this ratio through merging of '
                                  'intensities from neighbouring bins. Default=1')
 
+        self.declareProperty('CalculateErrors', defaultValue=True,
+                             doc="Calculate monte-carlo errors.")
         self.declareProperty('NumberOfIterations', DEFAULT_ITERATIONS, IntBoundedValidator(lower=1),
                              doc="Number of randomised simulations for monte-carlo error calculation.")
 
@@ -103,6 +106,7 @@ class TransformToIqt(PythonAlgorithm):
         if self._parameter_table == '':
             self._parameter_table = getWSprefix(self._sample) + 'TransformToIqtParameters'
 
+        self._calculate_errors = self.getProperty("CalculateErrors").value
         self._number_of_iterations = self.getProperty("NumberOfIterations").value
         self._seed = self.getProperty("SeedValue").value
 
@@ -213,6 +217,7 @@ class TransformToIqt(PythonAlgorithm):
         Run TransformToIqt.
         """
         from IndirectCommon import CheckHistZero, CheckHistSame, CheckAnalysers
+
         try:
             CheckAnalysers(self._sample, self._resolution)
         except ValueError:
@@ -228,9 +233,9 @@ class TransformToIqt(PythonAlgorithm):
             CheckHistSame(self._sample, 'Sample', self._resolution, 'Resolution')
 
         iqt = CalculateIqt(InputWorkspace=self._sample, ResolutionWorkspace=self._resolution, EnergyMin=self._e_min,
-                           EnergyMax=self._e_max, EnergyWidth=self._e_width,
+                           EnergyMax=self._e_max, EnergyWidth=self._e_width, CalculateErrors=self._calculate_errors,
                            NumberOfIterations=self._number_of_iterations, SeedValue=self._seed,
-                           StoreInADS=False, OutputWorkspace="__ciqt")
+                           StoreInADS=False, OutputWorkspace="__ciqt")#, startProgress=0.0, endProgress=1.0)
 
         # Set Y axis unit and label
         iqt.setYUnit('')

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TransformToIqt.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TransformToIqt.py
@@ -137,8 +137,10 @@ class TransformToIqt(PythonAlgorithm):
         """
         Calculates the TransformToIqt parameters and saves in a table workspace.
         """
-        workflow_prog = Progress(self, start=0.0, end=0.3, nreports=8)
+        end_prog = 0.3 if self._calculate_errors else 0.9
+        workflow_prog = Progress(self, start=0.0, end=end_prog, nreports=8)
         workflow_prog.report('Croping Workspace')
+        
         CropWorkspace(InputWorkspace=self._sample,
                       OutputWorkspace='__TransformToIqt_sample_cropped',
                       Xmin=self._e_min,
@@ -205,7 +207,7 @@ class TransformToIqt(PythonAlgorithm):
                        ('iqt_resolution_workspace', self._resolution),
                        ('iqt_binning', '%f,%f,%f' % (self._e_min, self._e_width, self._e_max))]
 
-        log_alg = self.createChildAlgorithm(name='AddSampleLogMultiple', startProgress=0.8,
+        log_alg = self.createChildAlgorithm(name='AddSampleLogMultiple', startProgress=0.9,
                                             endProgress=1.0, enableLogging=True)
         log_alg.setProperty('Workspace', self._output_workspace)
         log_alg.setProperty('LogNames', [item[0] for item in sample_logs])

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TransformToIqt.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TransformToIqt.py
@@ -100,14 +100,17 @@ class TransformToIqt(PythonAlgorithm):
 
         self._e_min = self.getProperty('EnergyMin').value
         self._e_max = self.getProperty('EnergyMax').value
-        self._number_points_per_bin = self.getProperty('BinReductionFactor').value
+        self._number_points_per_bin = self.getProperty(
+            'BinReductionFactor').value
 
         self._parameter_table = self.getPropertyValue('ParameterWorkspace')
         if self._parameter_table == '':
-            self._parameter_table = getWSprefix(self._sample) + 'TransformToIqtParameters'
+            self._parameter_table = getWSprefix(
+                self._sample) + 'TransformToIqtParameters'
 
         self._calculate_errors = self.getProperty("CalculateErrors").value
-        self._number_of_iterations = self.getProperty("NumberOfIterations").value
+        self._number_of_iterations = self.getProperty(
+            "NumberOfIterations").value
         self._seed = self.getProperty("SeedValue").value
 
         self._output_workspace = self.getPropertyValue('OutputWorkspace')
@@ -139,8 +142,7 @@ class TransformToIqt(PythonAlgorithm):
         """
         end_prog = 0.3 if self._calculate_errors else 0.9
         workflow_prog = Progress(self, start=0.0, end=end_prog, nreports=8)
-        workflow_prog.report('Croping Workspace')
-        
+        workflow_prog.report('Cropping Workspace')
         CropWorkspace(InputWorkspace=self._sample,
                       OutputWorkspace='__TransformToIqt_sample_cropped',
                       Xmin=self._e_min,
@@ -151,7 +153,7 @@ class TransformToIqt(PythonAlgorithm):
         num_bins = int(number_input_points / self._number_points_per_bin)
         self._e_width = (abs(self._e_min) + abs(self._e_max)) / num_bins
 
-        workflow_prog.report('Attemping to Access IPF')
+        workflow_prog.report('Attempting to Access IPF')
         try:
             workflow_prog.report('Access IPF')
             instrument = mtd[self._sample].getInstrument()
@@ -173,15 +175,19 @@ class TransformToIqt(PythonAlgorithm):
         except (AttributeError, IndexError):
             workflow_prog.report('Resorting to Default')
             resolution = 0.0175
-            logger.warning('Could not get resolution from IPF, using default value: %f' % (resolution))
+            logger.warning(
+                'Could not get resolution from IPF, using default value: %f' %
+                (resolution))
 
         resolution_bins = int(round((2 * resolution) / self._e_width))
 
         if resolution_bins < 5:
-            logger.warning('Resolution curve has <5 points. Results may be unreliable.')
+            logger.warning(
+                'Resolution curve has <5 points. Results may be unreliable.')
 
         workflow_prog.report('Creating Parameter table')
-        param_table = CreateEmptyTableWorkspace(OutputWorkspace=self._parameter_table)
+        param_table = CreateEmptyTableWorkspace(
+            OutputWorkspace=self._parameter_table)
 
         workflow_prog.report('Populating Parameter table')
         param_table.addColumn('int', 'SampleInputBins')
@@ -225,14 +231,20 @@ class TransformToIqt(PythonAlgorithm):
         except ValueError:
             # A genuine error the shows that the two runs are incompatible
             raise
-        except:
-            # Checking could not be performed due to incomplete or no instrument
-            logger.warning('Could not check for matching analyser and reflection')
+        except BaseException:
+            # Checking could not be performed due to incomplete or no
+            # instrument
+            logger.warning(
+                'Could not check for matching analyser and reflection')
 
         # Process resolution data
         num_res_hist = CheckHistZero(self._resolution)[0]
         if num_res_hist > 1:
-            CheckHistSame(self._sample, 'Sample', self._resolution, 'Resolution')
+            CheckHistSame(
+                self._sample,
+                'Sample',
+                self._resolution,
+                'Resolution')
 
         calculateiqt_alg = self.createChildAlgorithm(name='CalculateIqt', startProgress=0.3,
                                                      endProgress=1.0, enableLogging=True)

--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -29,6 +29,8 @@ Improvements
 - When the InelasticDiffSphere, InelasticDiffRotDiscreteCircle, ElasticDiffSphere or ElasticDiffRotDiscreteCircle
   Fit Types are selected in the ConvFit Tab, the Q values are retrieved from the workspaces, preventing a crash 
   when plotting a guess.
+- An option to skip the calculation of Monte Carlo Errors on the I(Q,t) Tab has been added.
+- During the calculation of Monte Carlo Errors, a progress bar is now shown.
 
 Bugfixes
 ########

--- a/qt/scientific_interfaces/Indirect/Iqt.cpp
+++ b/qt/scientific_interfaces/Indirect/Iqt.cpp
@@ -128,6 +128,8 @@ void Iqt::setup() {
   connect(m_uiForm.pbTile, SIGNAL(clicked()), this, SLOT(plotTiled()));
   connect(m_uiForm.pbPlotPreview, SIGNAL(clicked()), this,
           SLOT(plotCurrentPreview()));
+  connect(m_uiForm.cbCalculateErrors, SIGNAL(clicked()), this,
+          SLOT(errorsClicked()));
 }
 
 void Iqt::run() {
@@ -143,6 +145,7 @@ void Iqt::run() {
   QString wsName = m_uiForm.dsInput->getCurrentDataName();
   QString resName = m_uiForm.dsResolution->getCurrentDataName();
   QString nIterations = m_uiForm.spIterations->cleanText();
+  bool calculateErrors = m_uiForm.cbCalculateErrors->isChecked();
 
   double energyMin = m_dblManager->value(m_properties["ELow"]);
   double energyMax = m_dblManager->value(m_properties["EHigh"]);
@@ -155,6 +158,7 @@ void Iqt::run() {
   IqtAlg->setProperty("SampleWorkspace", wsName.toStdString());
   IqtAlg->setProperty("ResolutionWorkspace", resName.toStdString());
   IqtAlg->setProperty("NumberOfIterations", nIterations.toStdString());
+  IqtAlg->setProperty("CalculateErrors", calculateErrors);
 
   IqtAlg->setProperty("EnergyMin", energyMin);
   IqtAlg->setProperty("EnergyMax", energyMax);
@@ -195,6 +199,12 @@ void Iqt::plotClicked() {
   checkADSForPlotSaveWorkspace(m_pythonExportWsName, false);
   plotSpectrum(QString::fromStdString(m_pythonExportWsName));
 }
+
+void Iqt::errorsClicked() {
+  m_uiForm.spIterations->setEnabled(isErrorsEnabled());
+}
+
+bool Iqt::isErrorsEnabled() { return m_uiForm.cbCalculateErrors->isChecked(); }
 
 void Iqt::plotTiled() {
   MatrixWorkspace_const_sptr outWs =

--- a/qt/scientific_interfaces/Indirect/Iqt.h
+++ b/qt/scientific_interfaces/Indirect/Iqt.h
@@ -19,6 +19,8 @@ private:
   bool validate() override;
   void loadSettings(const QSettings &settings) override;
 
+  bool isErrorsEnabled();
+
 private slots:
   void algorithmComplete(bool error);
   void plotInput(const QString &wsname);
@@ -28,6 +30,7 @@ private slots:
   void updateDisplayedBinParameters();
   void saveClicked();
   void plotClicked();
+  void errorsClicked();
   void plotTiled();
 
 private:

--- a/qt/scientific_interfaces/Indirect/Iqt.ui
+++ b/qt/scientific_interfaces/Indirect/Iqt.ui
@@ -231,6 +231,29 @@
         </property>
        </widget>
       </item>
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="cbCalculateErrors">
+        <property name="text">
+         <string>Calculate Errors</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
**Description of work.**
This PR adds an checkbox in the Iqt Tab of `Indirect Data Analysis` which allows the user to skip the calculation of Monte Carlo errors.
This PR also adds a progress bar which lets the user know how far through the error calculation it is.

**To test:**
1. Go to `Interfaces`->`Indirect Data Analysis`->`I(Q, t)` Tab
2. Load in the data below
3. Uncheck `Calculate Errors` - ensure the `Number of Iterations` spinbox is disabled
4. Click `Run`
5. The calculation should be quick, and the output workspace should have zero for all their errors

- Repeat again but this time have `Calculate Errors` checked. Click `Run` and make sure a progress bar in the bottom right of the screen indicating that errors are being calculated appears at some point during the calculation. This calculation will take longer. Then check that errors are displayed in the output workspace. 

**Test Files**
[irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2374049/irs26176_graphite002_red.zip)
[irs26173_graphite002_res.zip](https://github.com/mantidproject/mantid/files/2374050/irs26173_graphite002_res.zip)


Fixes #23474

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
