### PR TITLE
Fix incident energy output workspace in DirectILLCollectData

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLCollectData.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLCollectData.py
@@ -520,6 +520,7 @@ class DirectILLCollectData(DataProcessorAlgorithm):
 
     def _calibrateEi(self, mainWS, monWS, monEPPWS, wsNames, wsCleanup, report, subalgLogging):
         """Perform and apply incident energy calibration."""
+        eiCalibrationWS = None
         if self._eiCalibrationEnabled(mainWS, report):
             if self.getProperty(common.PROP_INCIDENT_ENERGY_WS).isDefault:
                 detEPPWS = self._createEPPWSDet(mainWS, wsNames, wsCleanup, report, subalgLogging)
@@ -539,10 +540,15 @@ class DirectILLCollectData(DataProcessorAlgorithm):
                                                                     subalgLogging)
                 wsCleanup.cleanup(monWS)
                 monWS = eiCalibratedMonWS
-            if not self.getProperty(
-                    common.PROP_OUTPUT_INCIDENT_ENERGY_WS).isDefault:
-                self.setProperty(common.PROP_OUTPUT_INCIDENT_ENERGY_WS, eiCalibrationWS)
-            wsCleanup.cleanup(eiCalibrationWS)
+        if not self.getProperty(common.PROP_OUTPUT_INCIDENT_ENERGY_WS).isDefault:
+            if eiCalibrationWS is None:
+                eiCalibrationWSName = wsNames.withSuffix('incident_energy_from_logs')
+                Ei = mainWS.run().getProperty('Ei').value
+                eiCalibrationWS = CreateSingleValuedWorkspace(OutputWorkspace=eiCalibrationWSName,
+                                                              DataValue=Ei,
+                                                              EnableLogging=subalgLogging)
+            self.setProperty(common.PROP_OUTPUT_INCIDENT_ENERGY_WS, eiCalibrationWS)
+        wsCleanup.cleanup(eiCalibrationWS)
         return mainWS, monWS
 
     def _chooseElasticChannelMode(self, mainWS, report):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/DirectILLCollectDataTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/DirectILLCollectDataTest.py
@@ -22,7 +22,7 @@ class DirectILLCollectDataTest(unittest.TestCase):
             'InputWorkspace': self._TEST_WS,
             'OutputWorkspace': self._TEST_WS_NAME,
         }
-        run_algorithm('CloneWorkspace', **algProperties)        
+        run_algorithm('CloneWorkspace', **algProperties)
 
     def tearDown(self):
         mtd.clear()
@@ -145,6 +145,23 @@ class DirectILLCollectDataTest(unittest.TestCase):
         es = outWS.extractE()
         originalEs = inWS.extractE()
         numpy.testing.assert_almost_equal(es, originalEs[1:, :])
+
+    def testOutputIncidentEnergyWorkspaceWhenEnergyCalibrationIsOff(self):
+        outWSName = 'outWS'
+        eiWSName = 'Ei'
+        algProperties = {
+            'InputWorkspace': self._TEST_WS_NAME,
+            'OutputWorkspace': outWSName,
+            'IncidentEnergyCalibration': 'Energy Calibration OFF',
+            'OutputIncidentEnergyWorkspace': eiWSName,
+            'rethrow': True
+        }
+        run_algorithm('DirectILLCollectData', **algProperties)
+        self.assertTrue(mtd.doesExist(eiWSName))
+        eiWS = mtd[eiWSName]
+        inWS = mtd[self._TEST_WS_NAME]
+        E_i = inWS.run().getProperty('Ei').value
+        self.assertEquals(eiWS.readY(0)[0], E_i)
 
 
 if __name__ == '__main__':

--- a/docs/source/release/v3.14.0/direct_inelastic.rst
+++ b/docs/source/release/v3.14.0/direct_inelastic.rst
@@ -18,6 +18,11 @@ New Algorithms
 
 - Added a new algorithm to ILL's reduction workflow: :ref:`DirectILLTubeBackground <algm-DirectILLTubeBackground>` which can be used to calculate the time-independent backgrounds for instruments with PSD detectors such as IN5.
 
+Bugfixes
+########
+
+- Fixed a bug in :ref:`DirectILLCollectData <algm-DirectILLCollectData>` which prevented the *OutputIncidentEnergyWorkspace* being generated if *IncidentEnergyCalibration* was turned off.
+
 Interfaces
 ----------
 


### PR DESCRIPTION
**Description of work.**

This PR fixes the optional *OutputIncidentEnergyWorkspace* property of `DirectILLCollectData`. The workspace was never generated if incident energy calibration was disabled. Now, the `Ei` value in the sample logs is returned via the property.

**Report to:** Björn Fåk/ILL.

**To test:**

Make sure the unit test data directory is included in the data search directories and check the following script runs without issues:
```python
DirectILLCollectData(
    Run='ILL/IN6/164192.nxs',
    OutputWorkspace='ws',
    IncidentEnergyCalibration='Energy Calibration OFF',
    OutputIncidentEnergyWorkspace='E_i'
)

ei = mtd['ws'].run().getProperty('Ei').value
assert(mtd['E_i'].dataY(0)[0] == ei)
```

Fixes #23489.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
