### PR TITLE
HB2AReduce allow exp to be omitted

### DIFF
--- a/docs/source/algorithms/HB2AReduce-v1.rst
+++ b/docs/source/algorithms/HB2AReduce-v1.rst
@@ -11,7 +11,7 @@ Description
 
 This algorithm reduces HFIR POWDER (HB-2A) data.
 
-You can either specify the filenames of data you want to reduce or provide the IPTS, exp and scan number. *e.g.* the following are equivalent:
+You can either specify the filenames of data you want to reduce or provide the IPTS, exp and scan number. If only one experiment exists in an IPTS then exp can be omitted. *e.g.* the following are equivalent:
 
 .. code-block:: python
 


### PR DESCRIPTION
When there is only one experiment in an IPTS you now don't need to set Exp.

**To test:**
You need the HFIR mounts to test this.

This should now work
```python
ws = HB2AReduce(IPTS=21526, ScanNumbers=1)
```
This should fail with a sensible error message
```python
ws = HB2AReduce(IPTS=21073, ScanNumbers=1)
```

*There is no associated issue.



*This does not require release notes* because it was only added in this release

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
