### PR TITLE
Fix instrument default view

### DIFF
--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -265,8 +265,8 @@ void InstrumentWidget::init(bool resetGeometry, bool autoscaling,
           QString::fromStdString(m_instrumentActor->getDefaultView());
       if (defaultView == "3D" &&
           !Mantid::Kernel::ConfigService::Instance()
-              .getValue<bool>("MantidOptions.InstrumentView.UseOpenGL")
-              .get_value_or(true)) {
+               .getValue<bool>("MantidOptions.InstrumentView.UseOpenGL")
+               .get_value_or(true)) {
         // if OpenGL is switched off don't open the 3D view at start up
         defaultView = "CYLINDRICAL_Y";
       }

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -264,9 +264,9 @@ void InstrumentWidget::init(bool resetGeometry, bool autoscaling,
       QString defaultView =
           QString::fromStdString(m_instrumentActor->getDefaultView());
       if (defaultView == "3D" &&
-          Mantid::Kernel::ConfigService::Instance()
+          !Mantid::Kernel::ConfigService::Instance()
               .getValue<bool>("MantidOptions.InstrumentView.UseOpenGL")
-              .get_value_or(false)) {
+              .get_value_or(true)) {
         // if OpenGL is switched off don't open the 3D view at start up
         defaultView = "CYLINDRICAL_Y";
       }

--- a/qt/widgets/instrumentview/src/RotationSurface.cpp
+++ b/qt/widgets/instrumentview/src/RotationSurface.cpp
@@ -211,8 +211,9 @@ void RotationSurface::findAndCorrectUGap() {
   double bin_width = fabs(m_u_max - m_u_min) / (nbins - 1);
   if (bin_width == 0.0) {
     QApplication::setOverrideCursor(QCursor(Qt::ArrowCursor));
-    QMessageBox::warning(nullptr, tr("MantidPlot - Instrument view warning"),
-                         tr("Rotation surface: failed to build unwrapped surface"));
+    QMessageBox::warning(
+        nullptr, tr("MantidPlot - Instrument view warning"),
+        tr("Rotation surface: failed to build unwrapped surface"));
     QApplication::restoreOverrideCursor();
     m_u_min = 0.0;
     m_u_max = 1.0;

--- a/qt/widgets/instrumentview/src/RotationSurface.cpp
+++ b/qt/widgets/instrumentview/src/RotationSurface.cpp
@@ -211,7 +211,7 @@ void RotationSurface::findAndCorrectUGap() {
   double bin_width = fabs(m_u_max - m_u_min) / (nbins - 1);
   if (bin_width == 0.0) {
     QApplication::setOverrideCursor(QCursor(Qt::ArrowCursor));
-    QMessageBox::warning(nullptr, tr("MantidPLot - Instrument view error"),
+    QMessageBox::warning(nullptr, tr("MantidPlot - Instrument view error"),
                          tr("Failed to build unwrapped surface"));
     QApplication::restoreOverrideCursor();
     m_u_min = 0.0;

--- a/qt/widgets/instrumentview/src/RotationSurface.cpp
+++ b/qt/widgets/instrumentview/src/RotationSurface.cpp
@@ -211,8 +211,8 @@ void RotationSurface::findAndCorrectUGap() {
   double bin_width = fabs(m_u_max - m_u_min) / (nbins - 1);
   if (bin_width == 0.0) {
     QApplication::setOverrideCursor(QCursor(Qt::ArrowCursor));
-    QMessageBox::warning(nullptr, tr("MantidPlot - Instrument view error"),
-                         tr("Failed to build unwrapped surface"));
+    QMessageBox::warning(nullptr, tr("MantidPlot - Instrument view warning"),
+                         tr("Rotation surface: failed to build unwrapped surface"));
     QApplication::restoreOverrideCursor();
     m_u_min = 0.0;
     m_u_max = 1.0;


### PR DESCRIPTION
The instrument default view got broken https://github.com/mantidproject/mantid/commit/c2a4655e6cf3a34f0e8693be0ab9961f6d5f9025?diff=unified.

**To test:**

Read the documentation about the instrument definition file -> default-view meaning
Should be:
- 3D is default except OpenGL is explicitly switched off

On master:
Enable OpenGL: View->Preferences->Mantid->Options->UseOpenGL in Instrument View
Try `LoadEmptyInstrument` for an instrument and you will not get the Full 3D view.

Fixes #23486.

No release notes since not yet released.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
