### PR TITLE
Reduce copies made in RebinToWorkspace

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/RebinToWorkspace.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/RebinToWorkspace.h
@@ -66,21 +66,20 @@ protected:
       const override;
 
 private:
-  bool m_preserveEvents;
-  bool m_isEvents;
+  bool m_preserveEvents{true};
+  bool m_isEvents{true};
 
   /// Initialisation code
   void init() override;
   /// Execution code
   void exec() override;
 
+  bool needToRebin(const API::MatrixWorkspace_sptr &left,
+                   const API::MatrixWorkspace_sptr &rght);
   void rebin(API::MatrixWorkspace_sptr &toRebin,
              API::MatrixWorkspace_sptr &toMatch);
   void histogram(API::MatrixWorkspace_sptr &toRebin,
                  API::MatrixWorkspace_sptr &toMatch);
-  API::MatrixWorkspace_sptr
-  createOutputWorkspace(API::MatrixWorkspace_sptr &inputWS,
-                        const double endProgress);
 };
 } // namespace Algorithms
 } // namespace Mantid

--- a/Framework/Algorithms/inc/MantidAlgorithms/RebinToWorkspace.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/RebinToWorkspace.h
@@ -20,9 +20,6 @@ namespace Algorithms {
    <LI>OutputWorkspace - The name of the output workspace</LI>
    </UL>
 
-   @author Martyn Gigg, Tessella Support Services plc
-   @date 19/01/2009
-
    Copyright &copy; 2009 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
    National Laboratory & European Spallation Source
 
@@ -74,9 +71,11 @@ private:
   /// Execution code
   void exec() override;
 
-  /// Create the rebin paraeters
-  std::vector<double>
-  createRebinParameters(Mantid::API::MatrixWorkspace_sptr toMatch);
+  void rebin(API::MatrixWorkspace_sptr &toRebin,
+             API::MatrixWorkspace_sptr &toMatch);
+  API::MatrixWorkspace_sptr
+  createOutputWorkspace(API::MatrixWorkspace_sptr &inputWS,
+                        const double endProgress);
 };
 } // namespace Algorithms
 } // namespace Mantid

--- a/Framework/Algorithms/inc/MantidAlgorithms/RebinToWorkspace.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/RebinToWorkspace.h
@@ -66,6 +66,9 @@ protected:
       const override;
 
 private:
+  bool m_preserveEvents;
+  bool m_isEvents;
+
   /// Initialisation code
   void init() override;
   /// Execution code
@@ -73,6 +76,8 @@ private:
 
   void rebin(API::MatrixWorkspace_sptr &toRebin,
              API::MatrixWorkspace_sptr &toMatch);
+  void histogram(API::MatrixWorkspace_sptr &toRebin,
+                 API::MatrixWorkspace_sptr &toMatch);
   API::MatrixWorkspace_sptr
   createOutputWorkspace(API::MatrixWorkspace_sptr &inputWS,
                         const double endProgress);

--- a/Framework/Algorithms/src/ConvertToMatrixWorkspace.cpp
+++ b/Framework/Algorithms/src/ConvertToMatrixWorkspace.cpp
@@ -63,10 +63,17 @@ void ConvertToMatrixWorkspace::exec() {
     }
     PARALLEL_CHECK_INTERUPT_REGION
   } else {
-    g_log.information() << "Input workspace does not need converting. Pointing "
-                           "OutputWorkspace property to input.\n";
-    outputWorkspace =
-        boost::const_pointer_cast<MatrixWorkspace>(inputWorkspace);
+    outputWorkspace = getProperty("OutputWorkspace");
+    if (inputWorkspace == outputWorkspace) {
+      g_log.information("InputWorkspace does not need converting. Pointing "
+                        "OutputWorkspace property to input.");
+      outputWorkspace =
+          boost::const_pointer_cast<MatrixWorkspace>(inputWorkspace);
+    } else {
+      g_log.information(
+          "InputWorkspace does not need converting. Cloning InputWorkspace.");
+      outputWorkspace = inputWorkspace->clone();
+    }
   }
 
   setProperty("OutputWorkspace", outputWorkspace);

--- a/Framework/Algorithms/src/RebinToWorkspace.cpp
+++ b/Framework/Algorithms/src/RebinToWorkspace.cpp
@@ -82,7 +82,8 @@ void RebinToWorkspace::exec() {
     g_log.information("Rebinning");
     this->rebin(toRebin, toMatch);
   } else { // don't need to rebin
-    g_log.information("WorkspaceToRebin and WorkspaceToMatch already have matched binning");
+    g_log.information(
+        "WorkspaceToRebin and WorkspaceToMatch already have matched binning");
     auto outputWS = this->createOutputWorkspace(toRebin, 1.);
     this->setProperty("OutputWorkspace", outputWS);
   }

--- a/Framework/Algorithms/src/RebinToWorkspace.cpp
+++ b/Framework/Algorithms/src/RebinToWorkspace.cpp
@@ -53,13 +53,13 @@ void RebinToWorkspace::init() {
 
 bool RebinToWorkspace::needToRebin(const MatrixWorkspace_sptr &left,
                                    const MatrixWorkspace_sptr &rght) {
-  // if pointers match they are the same object
-  if (left == rght)
-    return false;
-
   // converting from EventWorkspace to Workspace2D is a rebin
   if (m_isEvents && (!m_preserveEvents))
     return true;
+
+  // if pointers match they are the same object
+  if (left == rght)
+    return false;
 
   // see if there is the same number of histograms
   const size_t numHist = left->getNumberHistograms();

--- a/Framework/Algorithms/src/RebinToWorkspace.cpp
+++ b/Framework/Algorithms/src/RebinToWorkspace.cpp
@@ -1,11 +1,13 @@
 #include "MantidAlgorithms/RebinToWorkspace.h"
 #include "MantidAPI/HistogramValidator.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidDataObjects/EventWorkspace.h"
 
 namespace Mantid {
 namespace Algorithms {
 
 using namespace API;
+using DataObjects::EventWorkspace;
 
 // Register the algorithm into the AlgorithmFactory
 DECLARE_ALGORITHM(RebinToWorkspace)
@@ -43,6 +45,25 @@ void RebinToWorkspace::init() {
                   "Workspace2D histogram.");
 }
 
+namespace {
+bool needToRebin(const MatrixWorkspace_sptr &left,
+                 const MatrixWorkspace_sptr &rght) {
+  // if pointers match they are the same object
+  if (left == rght)
+    return false;
+
+  // look for first non-equal x-axis between the workspaces
+  const size_t numHist = left->getNumberHistograms();
+  for (size_t i = 0; i < numHist; ++i) {
+    if (left->getSpectrum(i).readX() != rght->getSpectrum(i).readX()) {
+      return true;
+    }
+  }
+  // everything must be the same
+  return false;
+}
+} // namespace
+
 /**
  * Execute the algorithm
  */
@@ -50,22 +71,71 @@ void RebinToWorkspace::exec() {
   // The input workspaces ...
   MatrixWorkspace_sptr toRebin = getProperty("WorkspaceToRebin");
   MatrixWorkspace_sptr toMatch = getProperty("WorkspaceToMatch");
-  bool PreserveEvents = getProperty("PreserveEvents");
+  bool preserveEvents = getProperty("PreserveEvents");
 
-  // First we need to create the parameter vector from the workspace with which
-  // we are matching
-  std::vector<double> rb_params = createRebinParameters(toMatch);
+  if (needToRebin(toRebin, toMatch)) {
+    // TODO should copy code from Rebin to do the right thing spectrum by
+    // spectrum
+    if (!WorkspaceHelpers::commonBoundaries(*toMatch)) {
+      throw std::runtime_error(
+          "WorkspaceToMatch must have common bin boundaries in all spectra");
+    }
 
-  IAlgorithm_sptr runRebin = createChildAlgorithm("Rebin");
-  runRebin->setProperty<MatrixWorkspace_sptr>("InputWorkspace", toRebin);
-  runRebin->setPropertyValue("OutputWorkspace", "rebin_out");
-  runRebin->setProperty("params", rb_params);
-  runRebin->setProperty("PreserveEvents", PreserveEvents);
-  runRebin->setProperty("IgnoreBinErrors", true);
-  runRebin->executeAsChildAlg();
-  progress(1);
-  MatrixWorkspace_sptr ws = runRebin->getProperty("OutputWorkspace");
-  setProperty("OutputWorkspace", ws);
+    // First we need to create the parameter vector from the workspace with
+    // which we are matching
+    std::vector<double> rb_params = createRebinParameters(toMatch);
+
+    IAlgorithm_sptr runRebin = createChildAlgorithm("Rebin");
+    runRebin->setProperty<MatrixWorkspace_sptr>("InputWorkspace", toRebin);
+    runRebin->setPropertyValue("OutputWorkspace", "rebin_out");
+    runRebin->setProperty("params", rb_params);
+    runRebin->setProperty("PreserveEvents", preserveEvents);
+    runRebin->setProperty("IgnoreBinErrors", true);
+    runRebin->setChildStartProgress(0.);
+    runRebin->setChildStartProgress(1.);
+    runRebin->executeAsChildAlg();
+    MatrixWorkspace_sptr outputWS = runRebin->getProperty("OutputWorkspace");
+    setProperty("OutputWorkspace", outputWS);
+  } else { // don't need to rebin
+    g_log.information("Workspaces have matched binning");
+    MatrixWorkspace_sptr outputWS = getProperty("OutputWorkspace");
+
+    bool inPlace = (toRebin == outputWS);
+    bool isEvents =
+        bool(boost::dynamic_pointer_cast<const EventWorkspace>(toRebin));
+
+    if (inPlace) {
+      if (isEvents && (!preserveEvents)) {
+        // convert to a MatrixWorkspace
+        IAlgorithm_sptr convert =
+            createChildAlgorithm("ConvertToMatrixWorkspace");
+        convert->setProperty<MatrixWorkspace_sptr>("InputWorkspace", toRebin);
+        convert->setProperty<MatrixWorkspace_sptr>("OutputWorkspace", outputWS);
+        convert->setChildStartProgress(0.);
+        convert->setChildStartProgress(1.);
+        convert->executeAsChildAlg();
+        outputWS = convert->getProperty("OutputWorkspace");
+      }
+      // all other cases are already handled by not doing anything
+    } else {
+      if (isEvents && (!preserveEvents)) {
+        // convert to a MatrixWorkspace
+        // convert to a MatrixWorkspace
+        IAlgorithm_sptr convert =
+            createChildAlgorithm("ConvertToMatrixWorkspace");
+        convert->setProperty<MatrixWorkspace_sptr>("InputWorkspace", toRebin);
+        convert->setProperty<MatrixWorkspace_sptr>("OutputWorkspace", outputWS);
+        convert->setChildStartProgress(0.);
+        convert->setChildStartProgress(1.);
+        convert->executeAsChildAlg();
+        outputWS = convert->getProperty("OutputWorkspace");
+      } else {
+        outputWS = toRebin->clone();
+      }
+    }
+
+    setProperty("OutputWorkspace", outputWS);
+  }
 }
 
 /**
@@ -78,7 +148,7 @@ std::vector<double> RebinToWorkspace::createRebinParameters(
     Mantid::API::MatrixWorkspace_sptr toMatch) {
   using namespace Mantid::API;
 
-  auto &matchXdata = toMatch->x(0);
+  const auto &matchXdata = toMatch->x(0);
   // params vector should have the form [x_1, delta_1,x_2, ...
   // ,x_n-1,delta_n-1,x_n), see Rebin.cpp
   std::vector<double> rb_params;

--- a/Framework/Algorithms/src/RebinToWorkspace.cpp
+++ b/Framework/Algorithms/src/RebinToWorkspace.cpp
@@ -155,11 +155,12 @@ void RebinToWorkspace::rebin(MatrixWorkspace_sptr &toRebin,
     PARALLEL_START_INTERUPT_REGION
     const auto &edges = matchingX ? toMatch->histogram(0).binEdges()
                                   : toMatch->histogram(i).binEdges();
-    if (m_isEvents)
-      outputWSEvents->getSpectrum(i).mutableX() = edges.rawData();
-    else
+    if (m_isEvents) {
+      outputWSEvents->getSpectrum(i).setHistogram(edges);
+    } else {
       outputWS->setHistogram(
           i, HistogramData::rebin(toRebin->histogram(i), edges));
+    }
     prog.report();
     PARALLEL_END_INTERUPT_REGION
   }

--- a/Framework/HistogramData/inc/MantidHistogramData/FixedLengthVector.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/FixedLengthVector.h
@@ -109,6 +109,10 @@ public:
     return this->rawData() == rhs.rawData();
   }
 
+  bool operator!=(const FixedLengthVector<T> &rhs) const {
+    return !(*this == rhs);
+  }
+
   bool empty() const { return m_data.empty(); }
   size_t size() const { return m_data.size(); }
 

--- a/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
@@ -208,12 +208,15 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
             numSteps = 7 # one more for accumulating the unfocused workspace
         self.log().information('Processing \'{}\' in {:d} chunks'.format(filename, len(chunks)))
         prog_per_chunk_step = self.prog_per_file * 1./(numSteps*float(len(chunks)))
+        unfocusname_chunk = ''
 
         # inner loop is over chunks
         for (j, chunk) in enumerate(chunks):
             prog_start = file_prog_start + float(j) * float(numSteps - 1) * prog_per_chunk_step
             chunkname = '{}_c{:d}'.format(wkspname, j)
-            unfocusname_chunk = '{}_c{:d}'.format(unfocusname, j)
+            if unfocusname != '':  # only create unfocus chunk if needed
+                unfocusname_chunk = '{}_c{:d}'.format(unfocusname, j)
+
             Load(Filename=filename, OutputWorkspace=chunkname,
                  startProgress=prog_start, endProgress=prog_start+prog_per_chunk_step,
                  **chunk)

--- a/docs/source/release/v3.14.0/framework.rst
+++ b/docs/source/release/v3.14.0/framework.rst
@@ -49,8 +49,8 @@ Improvements
 - :ref:`SumOverlappingTubes <algm-SumOverlappingTubes>` will produce histogram data, and will not split the counts between bins by default.
 - :ref:`SumSpectra <algm-SumSpectra>` has an additional option, ``MultiplyBySpectra``, which controls whether or not the output spectra are multiplied by the number of bins. This property should be set to ``False`` for summing spectra as PDFgetN does.
 - :ref:`Live Data <algm-StartLiveData>` for events in PreserveEvents mode now produces workspaces that have bin boundaries which encompass the total x-range (TOF) for all events across all spectra.
-- Bugfix in :ref:`ConvertToMatrixWorkspace <algm-ConvertToMatrixWorkspace>` with ``Workspace2D`` as the ``InputWorkspace`` not being cloned to the ``OutputWorkspace``
-- :ref:`RebinToWorkspace <algm-RebinToWorkspace>` now checks if the ``WorkspaceToRebin`` and ``WorkspaceToMatch`` already have the same binning
+- Bugfix in :ref:`ConvertToMatrixWorkspace <algm-ConvertToMatrixWorkspace>` with ``Workspace2D`` as the ``InputWorkspace`` not being cloned to the ``OutputWorkspace``. Added support for ragged workspaces.
+- :ref:`RebinToWorkspace <algm-RebinToWorkspace>` now checks if the ``WorkspaceToRebin`` and ``WorkspaceToMatch`` already have the same binning. Added support for ragged workspaces.
 - :ref:`GroupWorkspaces <algm-GroupWorkspaces>` supports glob patterns for matching workspaces in the ADS.
 
 Bugfixes

--- a/docs/source/release/v3.14.0/framework.rst
+++ b/docs/source/release/v3.14.0/framework.rst
@@ -49,6 +49,8 @@ Improvements
 - :ref:`SumOverlappingTubes <algm-SumOverlappingTubes>` will produce histogram data, and will not split the counts between bins by default.
 - :ref:`SumSpectra <algm-SumSpectra>` has an additional option, ``MultiplyBySpectra``, which controls whether or not the output spectra are multiplied by the number of bins. This property should be set to ``False`` for summing spectra as PDFgetN does.
 - :ref:`Live Data <algm-StartLiveData>` for events in PreserveEvents mode now produces workspaces that have bin boundaries which encompass the total x-range (TOF) for all events across all spectra.
+- Bugfix in :ref:`ConvertToMatrixWorkspace <algm-ConvertToMatrixWorkspace>` with ``Workspace2D`` as the ``InputWorkspace`` not being cloned to the ``OutputWorkspace``
+- :ref:`RebinToWorkspace <algm-RebinToWorkspace>` now checks if the ``WorkspaceToRebin`` and ``WorkspaceToMatch`` already have the same binning
 
 Bugfixes
 ########

--- a/scripts/Inelastic/IndirectReductionCommon.py
+++ b/scripts/Inelastic/IndirectReductionCommon.py
@@ -966,7 +966,7 @@ def rebin_reduction(workspace_name, rebin_string, multi_frame_rebin_string, num_
     @param multi_frame_rebin_string Rebin string for multiple frame rebinning
     @param num_bins Max number of bins in input frames
     """
-    from mantid.simpleapi import (Rebin, RebinToWorkspace, SortXAxis)
+    from mantid.simpleapi import (Rebin, SortXAxis)
 
     if rebin_string is not None:
         if multi_frame_rebin_string is not None and num_bins is not None:

--- a/scripts/Inelastic/IndirectReductionCommon.py
+++ b/scripts/Inelastic/IndirectReductionCommon.py
@@ -989,9 +989,18 @@ def rebin_reduction(workspace_name, rebin_string, multi_frame_rebin_string, num_
     else:
         try:
             # If user does not want to rebin then just ensure uniform binning across spectra
-            RebinToWorkspace(WorkspaceToRebin=workspace_name,
-                             WorkspaceToMatch=workspace_name,
-                             OutputWorkspace=workspace_name)
+            # extract the binning parameters from the first spectrum.
+            # there is probably a better way to calculate the binning parameters, but this
+            # gets the right answer.
+            xaxis = mtd[workspace_name].readX(0)
+            params = []
+            for i, x in enumerate(xaxis):
+                params.append(x)
+                if i < len(xaxis) -1:
+                    params.append(xaxis[i+1] - x) # delta
+            Rebin(InputWorkspace=workspace_name,
+                  OutputWorkspace=workspace_name,
+                  Params=params)
         except RuntimeError:
             logger.warning('Rebinning failed, will try to continue anyway.')
 

--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -290,9 +290,10 @@ def fromEvent2Histogram(ws_event, ws_monitor, binning = ""):
 
     if binning != "":
         aux_hist = Rebin(ws_event, binning, False)
-        Rebin(ws_monitor, binning, False, OutputWorkspace=name)
+        Rebin(InputWorkspace=ws_monitor, Params=binning, PreserveEvents=False, OutputWorkspace=name)
     else:
-        aux_hist = RebinToWorkspace(ws_event, ws_monitor, False)
+        aux_hist = RebinToWorkspace(WorkspaceToRebin=ws_event, WorkspaceToMatch=ws_monitor,
+                                    PreserveEvents=False)
         ws_monitor.clone(OutputWorkspace=name)
 
     ConjoinWorkspaces(name, aux_hist, CheckOverlapping=True)


### PR DESCRIPTION
This adds some checks to `RebinToWorkspace` that it won't rebin if the `WorkspaceToRebin` and `WorkspaceToMatch` have the same bins already. It also fixes a bug in `ConvertToMatrixWorkspace` not creating a clone when out-of-place and fixes an accidental workspace creation in `AlignAndFocusPowderFromFiles`. The last item isn't in the release notes because it was a bug introduced during this release cycle.

**Report to:** Huq

**To test:**

Code review should be sufficient.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
