### PR TITLE
Add s1 offset option to ConvertWANDSCDtoQ

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
+++ b/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
@@ -35,6 +35,7 @@ class ConvertWANDSCDtoQ(PythonAlgorithm):
                                                direction=Direction.Input),
                              "Workspace containing the UB matrix to use")
         self.declareProperty("Wavelength", 1.488, validator=FloatBoundedValidator(0.0), doc="Wavelength to set the workspace")
+        self.declareProperty("S1Offset", 0., doc="Offset to apply (in degrees) to the s1 of the input workspace")
         self.declareProperty('NormaliseBy', 'Monitor', StringListValidator(['None', 'Time', 'Monitor']),
                              "Normalise to monitor, time or None.")
         self.declareProperty('Frame', 'Q_sample', StringListValidator(['Q_sample', 'HKL']),
@@ -153,7 +154,7 @@ class ConvertWANDSCDtoQ(PythonAlgorithm):
         progress = Progress(self, 0.0, 1.0, number_of_runs+4)
 
         # Get rotation array
-        s1 = np.deg2rad(inWS.getExperimentInfo(0).run().getProperty('s1').value)
+        s1 = np.deg2rad(inWS.getExperimentInfo(0).run().getProperty('s1').value) + np.deg2rad(self.getProperty("S1Offset").value)
 
         normaliseBy = self.getProperty("NormaliseBy").value
         if normaliseBy == "Monitor":


### PR DESCRIPTION
They want the ability to simply change the s1 when viewing particular data sets in Q space.

**Report to:** 
Matthias Frontzek

**To test:**
Load in some data and try different s1 offsets. _e.g._
```python
data=LoadWANDSCD(IPTS=7776, RunNumbers='26640-26740', Grouping='4x4')
ConvertWANDSCDtoQ(data, S1Offset=-45, OutputWorkspace='q')
```

*There is no associated issue.*

*This does not require release notes* because

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
