### PR TITLE
Fix segfault in MantidPlot

### DIFF
--- a/docs/source/release/v3.14.0/ui.rst
+++ b/docs/source/release/v3.14.0/ui.rst
@@ -33,5 +33,6 @@ BugFixes
 ########
 
 - Fixed issue where an open set of data from ITableWorkspace wouldn't update if the data was changed via python
+- Fixed an issue where MantidPlot would crash when renaming workspaces.
 
 :ref:`Release 3.14.0 <v3.14.0>`

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidget.h
@@ -18,6 +18,7 @@
 #include <QHash>
 #include <QMap>
 #include <QMetaType>
+#include <QMutex>
 #include <boost/shared_ptr.hpp>
 #include <map>
 
@@ -278,6 +279,8 @@ private:
   QStringList m_selectedNames;
   /// Keep a map of renamed workspaces between updates
   QHash<QString, QString> m_renameMap;
+  /// A mutex to lock m_renameMap and m_selectedNames for reading/writing
+  mutable QMutex m_mutex;
 
 private slots:
   void handleUpdateTree(const TopLevelItems &);


### PR DESCRIPTION
**Description of work.**

This PR adds locking in `WorkspaceTreeWidget` preventing race conditions which would happen when workspaces were renamed in quick succession. In that case two threads could try to read and write fields in `WorkspaceTreeWidget` at the same time.

**Report to:** Stephan Rols/ILL.

**To test:**

Code review. Run the following script on master; it should segfault at some point. You may need to run it a few times. Then switch to this branch, rebuild and try the script again. It should not segfault. You may want to run the script a few times to convince yourself.

```python
for i in range(10000):
    group_names = ''
    separator = ''
    for j in range(5):
        name = '__ws{}'.format(j)
        CreateSampleWorkspace(OutputWorkspace=name)
        group_names += separator + name
        separator = ','
    GroupWorkspaces(InputWorkspaces=group_names, OutputWorkspace='g')
    for j in range(5):
        newname = '__g{}'.format(j)
        RenameWorkspace('__ws{}'.format(j), newname)
    if i % 100 == 0:
        print('at iteration {}'.format(i))
```

Fixes #23513.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
