### PR TITLE
Display all valid file extensions first

### DIFF
--- a/docs/source/release/v3.14.0/ui.rst
+++ b/docs/source/release/v3.14.0/ui.rst
@@ -29,6 +29,11 @@ Bugfixes
 MantidPlot
 ----------
 
+Changes
+#######
+
+- All File Browser dialog boxes will now (by default) display all valid file extensions as the first file filter.
+
 BugFixes
 ########
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FileDialogHandler.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FileDialogHandler.h
@@ -72,8 +72,7 @@ DLLExport QString getFilter(const Mantid::Kernel::Property *baseProp);
  * @param defaultExt :: default extension to use
  * @return a string that filters files by extenstions
  */
-DLLExport QString getFilter(const std::vector<std::string> &exts,
-                            const std::string &defaultExt);
+DLLExport QString getFilter(const std::vector<std::string> &exts);
 
 DLLExport QString getCaption(const std::string &dialogName,
                              const Mantid::Kernel::Property *prop);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FileDialogHandler.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FileDialogHandler.h
@@ -58,8 +58,7 @@ getSaveFileName(QWidget *parent = nullptr,
 
 /**
  * For file dialogs. This will add the selected extension if an extension
- * doesn't
- * already exist.
+ * doesn't already exist.
  */
 DLLExport QString addExtension(const QString &filename,
                                const QString &selectedFilter);
@@ -69,10 +68,16 @@ DLLExport QString getFilter(const Mantid::Kernel::Property *baseProp);
 /** For file dialogs
  *
  * @param exts :: vector of extensions
- * @param defaultExt :: default extension to use
  * @return a string that filters files by extenstions
  */
 DLLExport QString getFilter(const std::vector<std::string> &exts);
+
+/** Format extension into expected form (*.ext)
+ *
+ * @param extension :: extension to be formatted
+ * @return a QString of the expected form
+ */
+DLLExport QString formatExtension(const std::string &extension);
 
 DLLExport QString getCaption(const std::string &dialogName,
                              const Mantid::Kernel::Property *prop);

--- a/qt/widgets/common/src/FileDialogHandler.cpp
+++ b/qt/widgets/common/src/FileDialogHandler.cpp
@@ -125,7 +125,6 @@ QString getFilter(const Mantid::Kernel::Property *baseProp) {
  * the first.
  *
  * @param exts :: vector of extensions
- * @param defaultExt :: default extension to use
  * @return a string that filters files by extenstions
  */
 QString getFilter(const std::vector<std::string> &exts) {
@@ -136,7 +135,9 @@ QString getFilter(const std::vector<std::string> &exts) {
     if (exts.size() > 1) {
       QString displayAllFilter = "Data Files (";
       for (auto &itr : exts) {
-        displayAllFilter.append(" *" + QString::fromStdString(itr));
+		  // Add a space to between each extension
+		  displayAllFilter.append(" ");
+		  displayAllFilter.append(formatExtension(itr));
       }
       displayAllFilter.append(" );;");
       filter.append(displayAllFilter);
@@ -151,6 +152,30 @@ QString getFilter(const std::vector<std::string> &exts) {
   }
   filter.append(ALL_FILES);
   return filter;
+}
+
+/** Format extension into expected form (*.ext)
+ *
+ * @param extension :: extension to be formatted
+ * @return a QString of the expected form
+ */
+QString formatExtension(const std::string &extension) {
+	QString formattedExtension = QString::fromStdString(extension);
+	if (extension.at(0) == '*' && extension.at(1) == '.') {
+		return formattedExtension;
+	}
+	else {
+		if (extension.at(0) == '*') {
+			formattedExtension.insert(1, ".");
+		} 
+		else if (extension.at(0) == '.') {
+			formattedExtension.prepend("*");
+		}
+		else {
+			formattedExtension.prepend("*.");
+		}
+	}
+	return formattedExtension;
 }
 
 QString getCaption(const std::string &dialogName,

--- a/qt/widgets/common/src/FileDialogHandler.cpp
+++ b/qt/widgets/common/src/FileDialogHandler.cpp
@@ -135,9 +135,9 @@ QString getFilter(const std::vector<std::string> &exts) {
     if (exts.size() > 1) {
       QString displayAllFilter = "Data Files (";
       for (auto &itr : exts) {
-		  // Add a space to between each extension
-		  displayAllFilter.append(" ");
-		  displayAllFilter.append(formatExtension(itr));
+        // Add a space to between each extension
+        displayAllFilter.append(" ");
+        displayAllFilter.append(formatExtension(itr));
       }
       displayAllFilter.append(" );;");
       filter.append(displayAllFilter);
@@ -160,22 +160,19 @@ QString getFilter(const std::vector<std::string> &exts) {
  * @return a QString of the expected form
  */
 QString formatExtension(const std::string &extension) {
-	QString formattedExtension = QString::fromStdString(extension);
-	if (extension.at(0) == '*' && extension.at(1) == '.') {
-		return formattedExtension;
-	}
-	else {
-		if (extension.at(0) == '*') {
-			formattedExtension.insert(1, ".");
-		} 
-		else if (extension.at(0) == '.') {
-			formattedExtension.prepend("*");
-		}
-		else {
-			formattedExtension.prepend("*.");
-		}
-	}
-	return formattedExtension;
+  QString formattedExtension = QString::fromStdString(extension);
+  if (extension.at(0) == '*' && extension.at(1) == '.') {
+    return formattedExtension;
+  } else {
+    if (extension.at(0) == '*') {
+      formattedExtension.insert(1, ".");
+    } else if (extension.at(0) == '.') {
+      formattedExtension.prepend("*");
+    } else {
+      formattedExtension.prepend("*.");
+    }
+  }
+  return formattedExtension;
 }
 
 QString getCaption(const std::string &dialogName,

--- a/qt/widgets/common/src/FileDialogHandler.cpp
+++ b/qt/widgets/common/src/FileDialogHandler.cpp
@@ -108,14 +108,14 @@ QString getFilter(const Mantid::Kernel::Property *baseProp) {
   const auto *multiProp =
       dynamic_cast<const Mantid::API::MultipleFileProperty *>(baseProp);
   if (bool(multiProp))
-    return getFilter(multiProp->getExts(), multiProp->getDefaultExt());
+    return getFilter(multiProp->getExts());
 
   // regular file version
   const auto *singleProp =
       dynamic_cast<const Mantid::API::FileProperty *>(baseProp);
   // The allowed values in this context are file extensions
   if (bool(singleProp))
-    return getFilter(singleProp->allowedValues(), singleProp->getDefaultExt());
+    return getFilter(singleProp->allowedValues());
 
   // otherwise only the all files exists
   return ALL_FILES;
@@ -128,22 +128,24 @@ QString getFilter(const Mantid::Kernel::Property *baseProp) {
  * @param defaultExt :: default extension to use
  * @return a string that filters files by extenstions
  */
-QString getFilter(const std::vector<std::string> &exts,
-                  const std::string &defaultExt) {
+QString getFilter(const std::vector<std::string> &exts) {
   QString filter("");
 
-  if (!defaultExt.empty()) {
-    filter.append(QString::fromStdString(defaultExt) + " (*" +
-                  QString::fromStdString(defaultExt) + ");;");
-  }
-
   if (!exts.empty()) {
-    // Push a wild-card onto the front of each file suffix
-    for (auto &itr : exts) {
-      if (itr != defaultExt) {
-        filter.append(QString::fromStdString(itr) + " (*" +
-                      QString::fromStdString(itr) + ");;");
+    // Generate the display all filter
+    if (exts.size() > 1) {
+      QString displayAllFilter = "Data Files (";
+      for (auto &itr : exts) {
+        displayAllFilter.append(" *" + QString::fromStdString(itr));
       }
+      displayAllFilter.append(" );;");
+      filter.append(displayAllFilter);
+    }
+
+    // Append individual file filters
+    for (auto &itr : exts) {
+      filter.append(QString::fromStdString(itr) + " (*" +
+                    QString::fromStdString(itr) + ");;");
     }
     filter = filter.trimmed();
   }

--- a/qt/widgets/common/test/FileDialogHandlerTest.h
+++ b/qt/widgets/common/test/FileDialogHandlerTest.h
@@ -52,12 +52,29 @@ public:
     TS_ASSERT_EQUALS(std::string("All Files (*)"), result1.toStdString());
 
     const auto result2 = MantidQt::API::FileDialogHandler::getFilter(exts);
-    TS_ASSERT_EQUALS(std::string("*.h5 (**.h5);;*.nxs (**.nxs);;All Files (*)"),
+	TS_ASSERT_EQUALS(std::string("Data Files ( *.h5 *.nxs );;*.h5 (**.h5);;*.nxs (**.nxs);;All Files (*)"),
                      result2.toStdString());
+  }
 
-    const auto result3 = MantidQt::API::FileDialogHandler::getFilter(exts);
-    TS_ASSERT_EQUALS(std::string("*.nxs (**.nxs);;*.h5 (**.h5);;All Files (*)"),
-                     result3.toStdString());
+  void test_formatExtension() {
+	  const std::string bare_ext = "ext";
+	  const std::string no_star = ".ext";
+	  const std::string no_dot = "*ext";
+	  const std::string valid = "*.ext";
+	  const QString expected("*.ext");
+
+	  const auto result1 = MantidQt::API::FileDialogHandler::formatExtension(bare_ext);
+	  TS_ASSERT_EQUALS(expected, result1);
+
+	  const auto result2 = MantidQt::API::FileDialogHandler::formatExtension(no_star);
+	  TS_ASSERT_EQUALS(expected, result2);
+
+	  const auto result3 = MantidQt::API::FileDialogHandler::formatExtension(no_dot);
+	  TS_ASSERT_EQUALS(expected, result3);
+
+	  const auto result4 = MantidQt::API::FileDialogHandler::formatExtension(valid);
+	  TS_ASSERT_EQUALS(expected, result4);
+
   }
 };
 

--- a/qt/widgets/common/test/FileDialogHandlerTest.h
+++ b/qt/widgets/common/test/FileDialogHandlerTest.h
@@ -47,17 +47,15 @@ public:
   void test_getFileDialogFilter() {
     std::vector<std::string> exts({"*.h5", "*.nxs"});
 
-    const auto result1 = MantidQt::API::FileDialogHandler::getFilter(
-        std::vector<std::string>(), std::string(""));
+    const auto result1 =
+        MantidQt::API::FileDialogHandler::getFilter(std::vector<std::string>());
     TS_ASSERT_EQUALS(std::string("All Files (*)"), result1.toStdString());
 
-    const auto result2 =
-        MantidQt::API::FileDialogHandler::getFilter(exts, std::string(""));
+    const auto result2 = MantidQt::API::FileDialogHandler::getFilter(exts);
     TS_ASSERT_EQUALS(std::string("*.h5 (**.h5);;*.nxs (**.nxs);;All Files (*)"),
                      result2.toStdString());
 
-    const auto result3 =
-        MantidQt::API::FileDialogHandler::getFilter(exts, std::string("*.nxs"));
+    const auto result3 = MantidQt::API::FileDialogHandler::getFilter(exts);
     TS_ASSERT_EQUALS(std::string("*.nxs (**.nxs);;*.h5 (**.h5);;All Files (*)"),
                      result3.toStdString());
   }

--- a/qt/widgets/common/test/FileDialogHandlerTest.h
+++ b/qt/widgets/common/test/FileDialogHandlerTest.h
@@ -52,29 +52,33 @@ public:
     TS_ASSERT_EQUALS(std::string("All Files (*)"), result1.toStdString());
 
     const auto result2 = MantidQt::API::FileDialogHandler::getFilter(exts);
-	TS_ASSERT_EQUALS(std::string("Data Files ( *.h5 *.nxs );;*.h5 (**.h5);;*.nxs (**.nxs);;All Files (*)"),
+    TS_ASSERT_EQUALS(std::string("Data Files ( *.h5 *.nxs );;*.h5 "
+                                 "(**.h5);;*.nxs (**.nxs);;All Files (*)"),
                      result2.toStdString());
   }
 
   void test_formatExtension() {
-	  const std::string bare_ext = "ext";
-	  const std::string no_star = ".ext";
-	  const std::string no_dot = "*ext";
-	  const std::string valid = "*.ext";
-	  const QString expected("*.ext");
+    const std::string bare_ext = "ext";
+    const std::string no_star = ".ext";
+    const std::string no_dot = "*ext";
+    const std::string valid = "*.ext";
+    const QString expected("*.ext");
 
-	  const auto result1 = MantidQt::API::FileDialogHandler::formatExtension(bare_ext);
-	  TS_ASSERT_EQUALS(expected, result1);
+    const auto result1 =
+        MantidQt::API::FileDialogHandler::formatExtension(bare_ext);
+    TS_ASSERT_EQUALS(expected, result1);
 
-	  const auto result2 = MantidQt::API::FileDialogHandler::formatExtension(no_star);
-	  TS_ASSERT_EQUALS(expected, result2);
+    const auto result2 =
+        MantidQt::API::FileDialogHandler::formatExtension(no_star);
+    TS_ASSERT_EQUALS(expected, result2);
 
-	  const auto result3 = MantidQt::API::FileDialogHandler::formatExtension(no_dot);
-	  TS_ASSERT_EQUALS(expected, result3);
+    const auto result3 =
+        MantidQt::API::FileDialogHandler::formatExtension(no_dot);
+    TS_ASSERT_EQUALS(expected, result3);
 
-	  const auto result4 = MantidQt::API::FileDialogHandler::formatExtension(valid);
-	  TS_ASSERT_EQUALS(expected, result4);
-
+    const auto result4 =
+        MantidQt::API::FileDialogHandler::formatExtension(valid);
+    TS_ASSERT_EQUALS(expected, result4);
   }
 };
 


### PR DESCRIPTION
**Description of work.**

When opening the browse files dialog the default extension filtering option should be to show all the valid extensions for a file. e.g. if a loader expects `.nxs` or `.raw` the first file extensions filter will be `Data Files ( *.nxs *.raw)`

**To test:**

* Check any Load algorithms to see if the File extension filters are working as expected. 
  * Note that this will not affect the algorithms that create custom dialogs e.g. Load.cpp
* The new expected file extensions should be of the form:
```
Data Files ( *.a *.b *.c *.d)
*.a
*.b
*.c
*.d
```

Fixes #23519 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
