### PR TITLE
Fix some HB2AReduce bugs

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/HB2AReduce.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB2AReduce.py
@@ -133,6 +133,14 @@ class HB2AReduce(PythonAlgorithm):
         twotheta = data['2theta']
         monitor = data['monitor']
 
+        # Remove points with zero monitor count
+        monitor_mask = np.nonzero(monitor)[0]
+        if len(monitor_mask) == 0:
+            raise RuntimeError("{} has all zero monitor counts".format(filename))
+        monitor = monitor[monitor_mask]
+        counts = counts[:, monitor_mask]
+        twotheta = twotheta[monitor_mask]
+
         # Get either vcorr file or vanadium data
         vanadium_count, vanadium_monitor, vcorr = self.get_vanadium(detector_mask,
                                                                     data['m1'][0], data['colltrans'][0],
@@ -150,7 +158,7 @@ class HB2AReduce(PythonAlgorithm):
             x = twotheta+self._gaps[:, np.newaxis][detector_mask]
             UnitX='Degrees'
         else:
-            x = np.tile(data[def_x], (44,1))[detector_mask]
+            x = np.tile(data[def_x], (44,1))[detector_mask][:, monitor_mask]
             UnitX=def_x
 
         if self.getProperty("IndividualDetectors").value:
@@ -235,12 +243,14 @@ class HB2AReduce(PythonAlgorithm):
 
     def process(self, counts, scale, monitor, vanadium_count=None, vanadium_monitor=None, vcorr=None):
         """Reduce data not binning"""
+        old_settings = np.seterr(all='ignore') # otherwise it will complain about divide by zero
         if vcorr is not None:
             y = counts/vcorr[:, np.newaxis]/monitor
             e = np.sqrt(counts)/vcorr[:, np.newaxis]/monitor
         else:
             y = counts/vanadium_count[:, np.newaxis]*vanadium_monitor/monitor
             e = np.sqrt(1/counts + 1/vanadium_count[:, np.newaxis] + 1/vanadium_monitor + 1/monitor)*y
+        np.seterr(**old_settings)
         return np.nan_to_num(y*scale), np.nan_to_num(e*scale)
 
     def process_binned(self, counts, x, scale, monitor, vanadium_count=None, vanadium_monitor=None, vcorr=None):
@@ -249,16 +259,15 @@ class HB2AReduce(PythonAlgorithm):
         bins = np.arange(x.min(), x.max()+binWidth, binWidth) # calculate bin boundaries
         inds = np.digitize(x, bins) # get bin indices
 
-        # because np.broadcast_to is not in numpy 1.7.1 we use stride_tricks
         if vcorr is not None:
-            vcorr=np.lib.stride_tricks.as_strided(vcorr, shape=counts.shape, strides=(vcorr.strides[0],0))
+            vcorr = np.tile(vcorr, (counts.shape[1], 1)).T
             vcorr_binned = np.bincount(inds, weights=vcorr.ravel(), minlength=len(bins))
         else:
-            vanadium_count=np.lib.stride_tricks.as_strided(vanadium_count, shape=counts.shape, strides=(vanadium_count.strides[0],0))
+            vanadium_count = np.tile(vanadium_count, (counts.shape[1], 1)).T
             vanadium_binned = np.bincount(inds, weights=vanadium_count.ravel(), minlength=len(bins))
             vanadium_monitor_binned = np.bincount(inds, minlength=len(bins))*vanadium_monitor
 
-        monitor=np.lib.stride_tricks.as_strided(monitor, shape=counts.shape, strides=(monitor.strides[0],0))
+        monitor = np.tile(monitor, (counts.shape[0], 1))
 
         counts_binned = np.bincount(inds, weights=counts.ravel(), minlength=len(bins))
         monitor_binned = np.bincount(inds, weights=monitor.ravel(), minlength=len(bins))
@@ -273,6 +282,7 @@ class HB2AReduce(PythonAlgorithm):
             e = (np.sqrt(1/counts_binned + 1/vanadium_binned + 1/vanadium_monitor + 1/monitor_binned)[1:])*y
         np.seterr(**old_settings)
         x = bins
+
         return x, np.nan_to_num(y*scale), np.nan_to_num(e*scale)
 
     def add_metadata(self, ws, metadata, data):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/HB2AReduceTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/HB2AReduceTest.py
@@ -31,7 +31,7 @@ class HB2AReduceTest(unittest.TestCase):
         self.assertEquals(HB2AReduce_ws.getNumberHistograms(), 1)
         self.assertEquals(HB2AReduce_ws.blocksize(), 2439)
         self.assertEquals(np.argmax(HB2AReduce_ws.extractY()), 2203)
-        self.assertAlmostEquals(np.max(HB2AReduce_ws.extractY()), 2.7863608266)
+        self.assertAlmostEquals(np.max(HB2AReduce_ws.extractY()), 2.788603131)
         HB2AReduce_ws.delete()
 
     def test_TwoFiles(self):
@@ -40,7 +40,7 @@ class HB2AReduceTest(unittest.TestCase):
         self.assertEquals(HB2AReduce_ws.getNumberHistograms(), 1)
         self.assertEquals(HB2AReduce_ws.blocksize(), 2439)
         self.assertEquals(np.argmax(HB2AReduce_ws.extractY()), 2203)
-        self.assertAlmostEquals(np.max(HB2AReduce_ws.extractY()), 2.8059953301)
+        self.assertAlmostEquals(np.max(HB2AReduce_ws.extractY()), 2.780263137)
         HB2AReduce_ws.delete()
 
     def test_Vanadium(self):
@@ -50,7 +50,7 @@ class HB2AReduceTest(unittest.TestCase):
         self.assertEquals(HB2AReduce_ws.getNumberHistograms(), 1)
         self.assertEquals(HB2AReduce_ws.blocksize(), 2439)
         self.assertEquals(np.argmax(HB2AReduce_ws.extractY()), 2203)
-        self.assertAlmostEquals(np.max(HB2AReduce_ws.extractY()), 78.4374673238)
+        self.assertAlmostEquals(np.max(HB2AReduce_ws.extractY()), 78.50058933)
         HB2AReduce_ws.delete()
 
     def test_ExcludeDetectors(self):
@@ -60,7 +60,7 @@ class HB2AReduceTest(unittest.TestCase):
         self.assertEquals(HB2AReduce_ws.getNumberHistograms(), 1)
         self.assertEquals(HB2AReduce_ws.blocksize(), 1360)
         self.assertEquals(np.argmax(HB2AReduce_ws.extractY()), 283)
-        self.assertAlmostEquals(np.max(HB2AReduce_ws.extractY()), 0.8336013246)
+        self.assertAlmostEquals(np.max(HB2AReduce_ws.extractY()), 0.826432392)
         HB2AReduce_ws.delete()
 
     def test_anode_vs_temp(self):


### PR DESCRIPTION
1. Scan points with monitor counts of 0 are now removed before processing data, this was causing many inf's in the data
2. The monitor was broadcasted incorrectly causing incorrect normalization, this was fixed and changed to np.tile to make the code more readable

**To test:**
```python
ws=HB2AReduce('/HFIR/HB2A/IPTS-21229/exp671/Datafiles/HB2A_exp0671_scan0034.dat')
```
should now produce a nice plot, previously it looks like [this](https://monitor.sns.gov/report/hb2a/167/)


*There is no associated issue.*

*This does not require release notes* because this algorithm was only added this release.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
