### PR TITLE
Add first round of command line arguments

### DIFF
--- a/qt/applications/workbench/workbench/plugins/editor.py
+++ b/qt/applications/workbench/workbench/plugins/editor.py
@@ -66,6 +66,10 @@ class MultiFileEditor(PluginWidget):
 
         self.editor_actions = [self.run_action, self.abort_action]
 
+    def execute_current(self):
+        '''This is used by MainWindow to execute a file after opening it'''
+        return self.editors.execute_current()
+
     # ----------- Plugin API --------------------
 
     def app_closing(self):


### PR DESCRIPTION
This is the first pass at making command line arguments work in mantidworkbench. There is missing functionality from the framework and workbench to make the rest of the old command line arguments work. However, this is the first round which includes `--help`, `--execute`, and `--quit`

**To test:**

Create a script that can actually run in mantidworkbench (not all can for reasons that I haven't discovered yet) and try it out.

*There is no associated issue.*
*This does not require release notes* because the workbench hasn't been announced to general users yet.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
