### PR TITLE
Changes the behaviour of QCompleter to MatchContains on Qt5

### DIFF
--- a/qt/python/mantidqt/widgets/algorithmselector/test/test_algorithmselector.py
+++ b/qt/python/mantidqt/widgets/algorithmselector/test/test_algorithmselector.py
@@ -17,6 +17,8 @@
 from __future__ import absolute_import
 
 from collections import Counter, namedtuple
+
+import qtpy
 from mock import Mock, patch, call
 import unittest
 
@@ -26,7 +28,6 @@ from qtpy.QtTest import QTest
 from mantidqt.utils.qt.test import select_item_in_combo_box, select_item_in_tree, GuiTest
 from mantidqt.widgets.algorithmselector.model import AlgorithmSelectorModel
 from mantidqt.widgets.algorithmselector.widget import AlgorithmSelectorWidget
-
 
 AlgorithmDescriptorMock = namedtuple('AlgorithmDescriptorMock', ['name', 'alias', 'category', 'version'])
 mock_get_algorithm_descriptors = Mock()
@@ -119,6 +120,14 @@ class WidgetTest(GuiTest):
         selected_algorithm = widget.get_selected_algorithm()
         self.assertEqual(selected_algorithm.name, 'DoStuff')
         self.assertEqual(selected_algorithm.version, -1)
+
+    def test_search_box_selection_filter_mode_on_qt5(self):
+        if not qtpy.PYQT5:
+            self.skipTest("Versions below Qt5 do not support the following functionality, "
+                          "and the default Qt behaviour is used")
+        else:
+            widget = AlgorithmSelectorWidget()
+            self.assertEquals(widget.search_box.completer().filterMode(), Qt.MatchContains)
 
     def test_search_box_selection_ignores_tree_selection(self):
         widget = AlgorithmSelectorWidget()

--- a/qt/python/mantidqt/widgets/algorithmselector/widget.py
+++ b/qt/python/mantidqt/widgets/algorithmselector/widget.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function
 
 import re
 
+import qtpy
 from qtpy.QtCore import QModelIndex, Qt
 from qtpy.QtWidgets import (QWidget, QPushButton, QComboBox, QTreeWidget, QVBoxLayout,
                             QHBoxLayout, QCompleter, QTreeWidgetItem)
@@ -64,7 +65,9 @@ class AlgorithmSelectorWidget(IAlgorithmSelectorView, QWidget):
         search_box = QComboBox(self)
         search_box.setEditable(True)
         search_box.completer().setCompletionMode(QCompleter.PopupCompletion)
-        search_box.completer().setFilterMode(Qt.MatchContains)
+        # setFilterMode behaviour changing is only available on Qt5, if this check is not present the Qt4 tests fail
+        if qtpy.PYQT5:
+            search_box.completer().setFilterMode(Qt.MatchContains)
         search_box.setInsertPolicy(QComboBox.NoInsert)
         search_box.editTextChanged.connect(self._on_search_box_selection_changed)
         search_box.lineEdit().returnPressed.connect(self.execute_algorithm)

--- a/qt/python/mantidqt/widgets/algorithmselector/widget.py
+++ b/qt/python/mantidqt/widgets/algorithmselector/widget.py
@@ -5,10 +5,12 @@ import re
 from qtpy.QtCore import QModelIndex
 from qtpy.QtWidgets import (QWidget, QPushButton, QComboBox, QTreeWidget, QVBoxLayout,
                             QHBoxLayout, QCompleter, QTreeWidgetItem)
+from qtpy import QtCore
 
 from mantidqt.interfacemanager import InterfaceManager
 from mantidqt.utils.qt import block_signals
 from mantidqt.widgets.algorithmprogress import AlgorithmProgressWidget
+from mantidqt.widgets.algorithmselector.fuzzyqcompleter import CustomQCompleter
 
 from .presenter import IAlgorithmSelectorView, SelectedAlgorithm
 
@@ -34,6 +36,7 @@ class AlgorithmSelectorWidget(IAlgorithmSelectorView, QWidget):
     """
     An algorithm selector view implemented with qtpy.
     """
+
     def __init__(self, parent=None, include_hidden=False):
         """
         Initialise a new instance of AlgorithmSelectorWidget
@@ -57,12 +60,13 @@ class AlgorithmSelectorWidget(IAlgorithmSelectorView, QWidget):
 
     def _make_search_box(self):
         """
-        Make a algorithm search box.
+        Make an algorithm search box.
         :return: A QComboBox
         """
         search_box = QComboBox(self)
         search_box.setEditable(True)
         search_box.completer().setCompletionMode(QCompleter.PopupCompletion)
+        search_box.completer().setFilterMode(QtCore.Qt.MatchContains)
         search_box.setInsertPolicy(QComboBox.NoInsert)
         search_box.editTextChanged.connect(self._on_search_box_selection_changed)
         search_box.lineEdit().returnPressed.connect(self.execute_algorithm)
@@ -133,6 +137,10 @@ class AlgorithmSelectorWidget(IAlgorithmSelectorView, QWidget):
         Called when text in the search box is changed by the user or script.
         :param text: New text in the search box.
         """
+        # if the function is called without text, avoid doing anything
+        if text == '':
+            return
+
         with block_signals(self.tree):
             self.tree.setCurrentIndex(QModelIndex())
         with block_signals(self.search_box):

--- a/qt/python/mantidqt/widgets/algorithmselector/widget.py
+++ b/qt/python/mantidqt/widgets/algorithmselector/widget.py
@@ -2,15 +2,13 @@ from __future__ import absolute_import, print_function
 
 import re
 
-from qtpy.QtCore import QModelIndex
+from qtpy.QtCore import QModelIndex, Qt
 from qtpy.QtWidgets import (QWidget, QPushButton, QComboBox, QTreeWidget, QVBoxLayout,
                             QHBoxLayout, QCompleter, QTreeWidgetItem)
-from qtpy import QtCore
 
 from mantidqt.interfacemanager import InterfaceManager
 from mantidqt.utils.qt import block_signals
 from mantidqt.widgets.algorithmprogress import AlgorithmProgressWidget
-from mantidqt.widgets.algorithmselector.fuzzyqcompleter import CustomQCompleter
 
 from .presenter import IAlgorithmSelectorView, SelectedAlgorithm
 
@@ -66,7 +64,7 @@ class AlgorithmSelectorWidget(IAlgorithmSelectorView, QWidget):
         search_box = QComboBox(self)
         search_box.setEditable(True)
         search_box.completer().setCompletionMode(QCompleter.PopupCompletion)
-        search_box.completer().setFilterMode(QtCore.Qt.MatchContains)
+        search_box.completer().setFilterMode(Qt.MatchContains)
         search_box.setInsertPolicy(QComboBox.NoInsert)
         search_box.editTextChanged.connect(self._on_search_box_selection_changed)
         search_box.lineEdit().returnPressed.connect(self.execute_algorithm)


### PR DESCRIPTION
**Description of work.**
Note: This is Qt5 *ONLY* change.

The `filterMode` of the `QComboBox`'s `QCompleter` (that searches through all `QComboBox` entries while the user types) has been changed to `MatchContains`. Now when the user types in something, it is checked whether the string they typed is contained within _any_ algorithm's name.

[Qt Docs for QCompleter's `filterMode`](http://doc.qt.io/qt-5/qcompleter.html#filterMode-prop)

**Report and discussion to:** @dtasev

**To test:**
Build the Mantid workbench and try out the new algorithm selection logic. This changes a Qt property so no new tests have been added.

Fixes #23372

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
