### PR TITLE
macOS: source environment before running executables

### DIFF
--- a/buildconfig/CMake/DarwinSetup.cmake
+++ b/buildconfig/CMake/DarwinSetup.cmake
@@ -124,6 +124,11 @@ set ( INBUNDLE MantidPlot.app/ )
 configure_file ( ${CMAKE_MODULE_PATH}/Packaging/osx/Mantid_osx_launcher 
                  ${CMAKE_BINARY_DIR}/bin/MantidPlot.app/Contents/MacOS/Mantid_osx_launcher COPYONLY )
 
+# Copy also the environment setter
+# This is needed when launching the application from finder
+configure_file ( ${CMAKE_MODULE_PATH}/Packaging/osx/environment
+                 ${CMAKE_BINARY_DIR}/bin/MantidPlot.app/Contents/MacOS/environment COPYONLY )
+
 # We know exactly where this has to be on Darwin, but separate whether we have
 # kit build or a regular build.
 if ( ENABLE_CPACK AND MAKE_VATES )
@@ -214,7 +219,6 @@ install ( FILES ${CMAKE_MODULE_PATH}/Packaging/osx/mantidnotebook_Info.plist
           RENAME Info.plist )
 install ( FILES ${CMAKE_SOURCE_DIR}/images/MantidNotebook.icns
           DESTINATION MantidNotebook\ \(optional\).app/Contents/Resources/ )
-
 
 set ( CPACK_DMG_BACKGROUND_IMAGE ${CMAKE_SOURCE_DIR}/images/osx-bundle-background.png )
 set ( CPACK_DMG_DS_STORE_SETUP_SCRIPT ${CMAKE_SOURCE_DIR}/installers/MacInstaller/CMakeDMGSetup.scpt )

--- a/buildconfig/CMake/DarwinSetup.cmake
+++ b/buildconfig/CMake/DarwinSetup.cmake
@@ -219,6 +219,9 @@ install ( FILES ${CMAKE_MODULE_PATH}/Packaging/osx/mantidnotebook_Info.plist
           RENAME Info.plist )
 install ( FILES ${CMAKE_SOURCE_DIR}/images/MantidNotebook.icns
           DESTINATION MantidNotebook\ \(optional\).app/Contents/Resources/ )
+# Add the script that sources the system and user defined environment before launching executables
+install ( FILES ${CMAKE_MODULE_PATH}/Packaging/osx/environment
+          DESTINATION MantidPlot.app/Contents/MacOS )
 
 set ( CPACK_DMG_BACKGROUND_IMAGE ${CMAKE_SOURCE_DIR}/images/osx-bundle-background.png )
 set ( CPACK_DMG_DS_STORE_SETUP_SCRIPT ${CMAKE_SOURCE_DIR}/installers/MacInstaller/CMakeDMGSetup.scpt )

--- a/buildconfig/CMake/Packaging/osx/MantidNotebook_osx_launcher
+++ b/buildconfig/CMake/Packaging/osx/MantidNotebook_osx_launcher
@@ -17,4 +17,5 @@ popd  > /dev/null
 
 MANTID_PATH=${SCRIPT_PATH}/../../../MantidPlot.app/Contents/MacOS
 
+source "${MANTID_PATH}"/environment
 ."${MANTID_PATH}"/mantidpython notebook --notebook-dir=$HOME

--- a/buildconfig/CMake/Packaging/osx/MantidPython_osx_launcher
+++ b/buildconfig/CMake/Packaging/osx/MantidPython_osx_launcher
@@ -17,4 +17,5 @@ popd  > /dev/null
 
 MANTID_PATH=${SCRIPT_PATH}/../../../MantidPlot.app/Contents/MacOS
 
+source "${MANTID_PATH}"/environment
 ."${MANTID_PATH}"/mantidpython qtconsole

--- a/buildconfig/CMake/Packaging/osx/Mantid_osx_launcher
+++ b/buildconfig/CMake/Packaging/osx/Mantid_osx_launcher
@@ -2,4 +2,5 @@
 
 INSTALLDIR=$(cd "$(dirname "$0")"; pwd)
 cd $INSTALLDIR
+source ./environment
 ./MantidPlot || /usr/bin/python ../../scripts/ErrorReporter/error_dialog_app.py --exitcode=$1 --directory=$INSTALLDIR --qtdir=$INSTALLDIR/../PlugIns

--- a/buildconfig/CMake/Packaging/osx/environment
+++ b/buildconfig/CMake/Packaging/osx/environment
@@ -1,0 +1,5 @@
+source /etc/profile
+
+if [ -f ~/.profile ]; then
+    source ~/.profile
+fi

--- a/docs/source/release/v3.14.0/framework.rst
+++ b/docs/source/release/v3.14.0/framework.rst
@@ -12,7 +12,7 @@ Framework Changes
 Logging
 -------
 
-- We have changed the logging in Mantid to stop writing the a high level version of the log to a file.  This had been causing numerous problems including inconsistent behaviour with multiple instances of Mantid, performance problems when logging at detailed levels, and excessive network usage in some scenarios.  This does not change the rest of the logging that you see in the message display in Mantidplot or the console window. A warning message will appear if configuration for the removed componets of logging is found.
+- We have changed the logging in Mantid to stop writing the a high level version of the log to a file.  This had been causing numerous problems including inconsistent behaviour with multiple instances of Mantid, performance problems when logging at detailed levels, and excessive network usage in some scenarios.  This does not change the rest of the logging that you see in the message display in Mantidplot or the console window. A warning message will appear if configuration for the removed components of logging is found.
 
   - Associated with this we have also simplified the python methods used to control logging.
 
@@ -32,6 +32,9 @@ Nexus Geometry Loading
 Stability
 ---------
 
+Bugfixes
+--------
+- The macOS bundle has been fixed to pick up the system and user defined environment of the host machine, when starting the application from launcher.
 
 Algorithms
 ----------


### PR DESCRIPTION
**Description of work.**

This PR adds a script that sources the system and user defined environments in the host machine when starting the macOS applications (MantidPlot, MantidPython, MantidNotebook) from launcher, and not from terminal. See the issue for more details.

**To test:**
<!-- Instructions for testing. -->
1. Build MantidPlot on macOS
2. Start MantidPlot.app from finder, not from terminal
3. In mantid, run 
```
import os
os.environ['PATH']
```
This should have the full PATH that you set up in your `.profile`. 
This should also include `/Library/TeX/texbin` from system wide path.
4. This should run without errors.:
```
import matplotlib
import matplotlib.pyplot as plt
matplotlib.rcParams.update({'text.usetex':True})
fig, ax = plt.subplots()
ax.plot([0,1], [2, -3])
ax.set_xlabel('$a$')
fig.show()
```
5. Build the package (or download from the macOS build artefacts)
6. Install the package
7. Repeat 1-4 also for the installed MantidPlot
8. Repeat 1-4 also for MantidNotebook and MantidPython apps.

Fixes #23540 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.