### PR TITLE
Indirect - Read Monte Carlo defaults from IPF's in Corrections

### DIFF
--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -49,6 +49,8 @@ Improvements
   to be selected. Allowed values: ['Linear', 'CSpline'].
 - Added 'MaxScatterPtAttempts' spinbox to Calculate Monte Carlo Absorption. This sets the maximum number of 
   tries to be made to generate a scattering point.
+- In the Calculate Monte Carlo Absorption Tab, all of the options in the Monte Carlo section are now read from
+  an instrument parameter files once a file has been loaded.
 
 
 Data Reduction Interface

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
@@ -10,6 +10,7 @@
 #include <QRegExpValidator>
 
 using namespace Mantid::API;
+using namespace Mantid::Geometry;
 
 namespace {
 Mantid::Kernel::Logger g_log("AbsorptionCorrections");
@@ -71,6 +72,8 @@ AbsorptionCorrections::AbsorptionCorrections(QWidget *parent)
   // Change of input
   connect(m_uiForm.dsSampleInput, SIGNAL(dataReady(const QString &)), this,
           SLOT(getBeamDefaults(const QString &)));
+  connect(m_uiForm.dsSampleInput, SIGNAL(dataReady(const QString &)), this,
+          SLOT(getMonteCarloDefaults(const QString &)));
 
   // Handle algorithm completion
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
@@ -398,6 +401,65 @@ void AbsorptionCorrections::getBeamDefaults(const QString &dataName) {
     const auto beamHeightValue = beamHeight.toDouble();
 
     m_uiForm.spBeamHeight->setValue(beamHeightValue);
+  }
+}
+
+void AbsorptionCorrections::getMonteCarloDefaults(const QString &dataName) {
+  auto sampleWs = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+      dataName.toStdString());
+
+  if (sampleWs) {
+    auto instrument = sampleWs->getInstrument();
+    setWavelengthsValue(instrument, "Workflow.absorption-wavelengths");
+    setEventsValue(instrument, "Workflow.absorption-events");
+    setInterpolationValue(instrument, "Workflow.absorption-interpolation");
+    setMaxAttemptsValue(instrument, "Workflow.absorption-attempts");
+  } else
+    displayInvalidWorkspaceTypeError(dataName.toStdString(), g_log);
+}
+
+void AbsorptionCorrections::setWavelengthsValue(
+    Instrument_const_sptr instrument,
+    const std::string &wavelengthsParamName) const {
+  if (instrument->hasParameter(wavelengthsParamName)) {
+    const auto wavelengths = QString::fromStdString(
+        instrument->getStringParameter(wavelengthsParamName)[0]);
+    const auto wavelengthsValue = wavelengths.toInt();
+    m_uiForm.spNumberWavelengths->setValue(wavelengthsValue);
+  }
+}
+
+void AbsorptionCorrections::setEventsValue(
+    Instrument_const_sptr instrument,
+    const std::string &eventsParamName) const {
+  if (instrument->hasParameter(eventsParamName)) {
+    const auto events = QString::fromStdString(
+        instrument->getStringParameter(eventsParamName)[0]);
+    const auto eventsValue = events.toInt();
+    m_uiForm.spNumberEvents->setValue(eventsValue);
+  }
+}
+
+void AbsorptionCorrections::setInterpolationValue(
+    Instrument_const_sptr instrument,
+    const std::string &interpolationParamName) const {
+  if (instrument->hasParameter(interpolationParamName)) {
+    const auto interpolation = QString::fromStdString(
+        instrument->getStringParameter(interpolationParamName)[0]);
+    const auto interpolationValue = interpolation.toStdString();
+    m_uiForm.cbInterpolation->setCurrentIndex(
+        interpolationValue == "CSpline" ? 1 : 0);
+  }
+}
+
+void AbsorptionCorrections::setMaxAttemptsValue(
+    Instrument_const_sptr instrument,
+    const std::string &maxAttemptsParamName) const {
+  if (instrument->hasParameter(maxAttemptsParamName)) {
+    const auto maxScatterAttempts = QString::fromStdString(
+        instrument->getStringParameter(maxAttemptsParamName)[0]);
+    const auto maxScatterAttemptsValue = maxScatterAttempts.toInt();
+    m_uiForm.spMaxScatterPtAttempts->setValue(maxScatterAttemptsValue);
   }
 }
 

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.h
@@ -28,6 +28,15 @@ private slots:
   void saveClicked();
   void plotClicked();
   void getBeamDefaults(const QString &dataName);
+  void getMonteCarloDefaults(const QString &dataName);
+  void setWavelengthsValue(Mantid::Geometry::Instrument_const_sptr instrument,
+                           const std::string &wavelengthsParamName) const;
+  void setEventsValue(Mantid::Geometry::Instrument_const_sptr instrument,
+                      const std::string &eventsParamName) const;
+  void setInterpolationValue(Mantid::Geometry::Instrument_const_sptr instrument,
+                             const std::string &interpolationParamName) const;
+  void setMaxAttemptsValue(Mantid::Geometry::Instrument_const_sptr instrument,
+                           const std::string &maxAttemptsParamName) const;
   void changeSampleDensityUnit(int);
   void changeCanDensityUnit(int);
   UserInputValidator doValidation();


### PR DESCRIPTION
**Description of work.**
This PR ensures that the Monte Carlo values in `Indirect Data Corrections` -> `Calculate Monte Carlo Absorption` are read from the instrument parameter files when a file is loaded.

**To test:**
1. `Interfaces`->`Indirect Data Corrections`->`Calculate Monte Carlo Absorption` Tab
2. Take a look at the Monte Carlo section - most of the values (apart from Interpolation) will stay the same
3. Type `iris26176`  into the Sample Input box and press enter
4. When it has loaded, the following values should be loaded in:
`Wavelengths` : 10
`Events`: 5000
`Interpolation`: CSpline
`MaxScatterPtAttempts`: 5000

- The same should be true if you entered `osiris26176`

Fixes #23545 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
