### PR TITLE
Indirect - Display error message to catch Plot Current Preview exception

### DIFF
--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -37,6 +37,8 @@ Bugfixes
 
 - The parameter values for a selected spectrum are now updated properly when a Fit is run using the Fit String 
   option in ConvFit.
+- An unexpected crash is prevented when Plot Current Preview is clicked when no data is loaded. A meaningful error
+  message is now displayed.
 
 
 Data Corrections Interface

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.cpp
@@ -162,7 +162,8 @@ void IndirectDataAnalysisTab::plotCurrentPreview() {
                             inputWs->getNumberHistograms()) {
     IndirectTab::plotSpectrum(QString::fromStdString(inputWs->getName()),
                               static_cast<int>(m_selectedSpectrum));
-  }
+  } else
+    showMessageBox("Workspace not found - data may not be loaded.");
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
@@ -304,8 +304,11 @@ void IndirectFitPlotPresenter::updateFitRangeSelector() {
 }
 
 void IndirectFitPlotPresenter::plotCurrentPreview() {
-  const auto plotString = getPlotString(m_model->getActiveSpectrum());
-  m_pythonRunner.runPythonCode(QString::fromStdString(plotString));
+  if (m_model->getWorkspace()) {
+    const auto plotString = getPlotString(m_model->getActiveSpectrum());
+    m_pythonRunner.runPythonCode(QString::fromStdString(plotString));
+  } else
+    m_view->displayMessage("Workspace not found - data may not be loaded.");
 }
 
 void IndirectFitPlotPresenter::updateGuess() {

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
@@ -4,6 +4,8 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <QMessageBox>
+
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
@@ -252,6 +254,11 @@ void IndirectFitPlotView::setBackgroundRangeVisible(bool visible) {
 
 void IndirectFitPlotView::setHWHMRangeVisible(bool visible) {
   m_plotForm->ppPlotTop->getRangeSelector("HWHM")->setVisible(visible);
+}
+
+void IndirectFitPlotView::displayMessage(const std::string &message) const {
+  QMessageBox::information(parentWidget(), "MantidPlot - Warning",
+                           QString::fromStdString(message));
 }
 
 void IndirectFitPlotView::emitSelectedFitDataChanged(int index) {

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.h
@@ -64,6 +64,8 @@ public:
   void setBackgroundRangeVisible(bool visible);
   void setHWHMRangeVisible(bool visible);
 
+  void displayMessage(const std::string &message) const;
+
 public slots:
   void clearTopPreview();
   void clearBottomPreview();


### PR DESCRIPTION
**Description of work.**
This PR ensures a meaningful error message is displayed if you click `Plot Current Preview` in Indirect Data Analysis when there is no data loaded. This prevents an unexpected exception.

**To test:**
1. `Interfaces`->`Indirect Data Analysis`-> All tabs
2. Click on `Plot Current Preview` when no data loaded
3. A meaningful error message should be displayed.
4. Load data and then ensure `Plot Current Preview` works

Fixes #23547 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
