### PR TITLE
Avoid documentation warnings

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/HB2AReduce.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB2AReduce.py
@@ -25,7 +25,7 @@ class HB2AReduce(PythonAlgorithm):
         return 'Diffraction\\Reduction'
 
     def seeAlso(self):
-        return [ "" ]
+        return []
 
     def name(self):
         return 'HB2AReduce'

--- a/docs/source/algorithms/SaveReflectometryAscii-v1.rst
+++ b/docs/source/algorithms/SaveReflectometryAscii-v1.rst
@@ -23,7 +23,7 @@ Computation of resolution values
 
 For the `Custom File Format (Empty Field)`_ and the `TXT File Format`_ file format, the option `WriteResolution` enables the computation of the resolution values from existing x-values (points):
 
-:math:`x_i \dot \frac{x_{1} - x_{0}}{x_{1}}`,
+:math:`x_i \cdot \frac{x_1 - x_0}{x_1}`,
 
 where the bin centre :math:`x_i` will be multiplied by the qutient of first and second bin centre :math:`x_{0}` and :math:`x_{1}`, respectively.
 


### PR DESCRIPTION
Observed the following warnings and tried to fix them:

- WARNING: relatedalgorithms - Could not find algorithm "" listed in the seeAlso for HB2AReduce.v1

- writing output... [ 51%] algorithms/SaveReflectometryAscii-v1
WARNING: display latex u'x_i \\dot \\frac{x_{1} - x_{0}}{x_{1}}': latex exited with error
! Argument of \frac  has an extra }.


**To test:**

Build the documentation (targets docs-html and docs-qthelp) for the mentioned algorithms, observe warnings and errors.

Fixes #22486 

*This does not require release notes*


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
