### PR TITLE
macOS bundle h5py

### DIFF
--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -338,6 +338,11 @@ end
 path = "/Library/Python/2.7/site-packages"
 directories = ["sphinx","sphinx_bootstrap_theme","IPython","zmq","pygments","backports", "qtawesome", "qtpy",
                "certifi","tornado","markupsafe","jinja2","jsonschema","functools32","ptyprocess","CifFile","yaml"]
+if Dir.exists?(path + "/h5py")
+  directories.push("h5py")
+else
+  addPythonLibrary("/usr/local/lib/python2.7/site-packages/h5py","Contents/MacOS/")
+end
 directories.each do |directory|
   addPythonLibrary("#{path}/#{directory}","Contents/MacOS/")
 end
@@ -359,15 +364,8 @@ end
 # ---------------------------------------------
 # H5Py section
 # ---------------------------------------------
-h5py_path = "/usr/local/lib/python2.7/site-packages"
-h5py_directories = ["h5py"]
-h5py_directories.each do |directory|
-  addPythonLibrary("#{h5py_path}/#{directory}","Contents/MacOS/")
-end
-
 h5py_patterns = ["**/h5py/*.so"]
 change_id(h5py_patterns, "Contents/MacOS/h5py/")
-
 h5py_linking_dir = find_linking_directories(h5py_patterns, 'lib/libhdf5', '/usr/local/opt/hdf5/lib')
 
 h5py_patterns.each do |pattern|


### PR DESCRIPTION
**Description of work.**

This PR makes packaging of `h5py` a bit more flexible; now it can be in brew site packages or system python site packages.

**To test:**
- [x] Believe that packaging works on my machine
- [ ] Make package, install and make sure it works on your macOS machine
- [ ] Rebuild the macOS build on the server with make package ON, download and install the artefact, make sure it works as well. (Note that `ill-mac` will fail the packaging (for different reasons), so might need to rebuild until it is picked up by another mac server).

<!-- Instructions for testing. -->

Fixes #23552 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->


*This does not require release notes, internal issue.*


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
