### PR TITLE
Use local static variable for singleton instance

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/SingletonHolder.h
+++ b/Framework/Kernel/inc/MantidKernel/SingletonHolder.h
@@ -76,8 +76,20 @@ template <typename T> struct CreateUsingNew {
 
 /// Return a reference to the Singleton instance, creating it if it does not
 /// already exist
-/// Creation is done using the CreateUsingNew policy at the moment
-template <typename T> inline T &SingletonHolder<T>::Instance() {
+/// Creation is done using the CreateUsingNew policy. Held types need
+/// to make CreateUsingNew<T> a friend.
+/// This method cannot be inlined due to the presence of a local static
+/// variable. Inlining causes each call site to receive a different
+/// copy of the static instance variable.
+template <typename T>
+#if defined(_MSC_VER)
+__declspec(noinline)
+#endif
+    T &
+#if defined(__GNUC__) // covers clang too
+    __attribute__((noinline))
+#endif
+    SingletonHolder<T>::Instance() {
   // Initialiazing a local static is thread-safe in C++11
   // The inline lambda call is used to create the singleton once
   // and register an atexit function to delete it


### PR DESCRIPTION
**Description of work.**

See commit message for a more detail description of the change.

This circumvents a [bug](https://developercommunity.visualstudio.com/content/problem/243273/dynamic-initializer-created-for-stdonce-flag.html?childToView=302341#comment-302341) in the VS2017 compiler that uses dynamic initialization code for `once_flag` when it should be zero initialized.

**Report to:** [nobody].

**To test:**

* All tests should pass
* MantidPlot should start with no errors or warnings regarding missing algorithms or double
registering of the same name.

*There is no associated issue.*

*This does not require release notes* because **it is an internal change to avoid a compiler bug.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
