### PR TITLE
InstrumentMaskTab Exception Fix

### DIFF
--- a/qt/widgets/instrumentview/src/InstrumentActor.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentActor.cpp
@@ -1063,14 +1063,19 @@ void InstrumentActor::setDataIntegrationRange(const double &xmin,
 
 /// Add a range of bins for masking
 void InstrumentActor::addMaskBinsData(const std::vector<size_t> &indices) {
-  std::vector<size_t> wsIndices;
-  wsIndices.reserve(indices.size());
+  // Ensure we do not have duplicate workspace indices.
+  std::set<size_t> wi;
   for (auto det : indices) {
     auto index = getWorkspaceIndex(det);
     if (index == INVALID_INDEX)
       continue;
-    wsIndices.emplace_back(index);
+    wi.insert(index);
   }
+
+  // We will be able to do this more efficiently in C++17
+  std::vector<size_t> wsIndices(wi.size());
+  std::copy(wi.begin(), wi.end(), wsIndices.begin());
+
   if (!indices.empty()) {
     m_maskBinsData.addXRange(m_BinMinValue, m_BinMaxValue, wsIndices);
     auto workspace = getWorkspace();

--- a/qt/widgets/instrumentview/src/InstrumentActor.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentActor.cpp
@@ -1073,8 +1073,7 @@ void InstrumentActor::addMaskBinsData(const std::vector<size_t> &indices) {
   }
 
   // We will be able to do this more efficiently in C++17
-  std::vector<size_t> wsIndices(wi.size());
-  std::copy(wi.begin(), wi.end(), wsIndices.begin());
+  std::vector<size_t> wsIndices(wi.cbegin(), wi.cend());
 
   if (!indices.empty()) {
     m_maskBinsData.addXRange(m_BinMinValue, m_BinMaxValue, wsIndices);


### PR DESCRIPTION
**Description of work.**

Detector masking in the `InstrumentView` was broken after the introduction of the `InputWorkspaceIndexProperty` in `MaskBins` which no longer allowed duplicate workspace indices. When extracting workspace indices from the detector mask, a set is not used to ensure that no duplicates exist.

**Report to:** [user name]/[nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

See the original issue for details on how to test.

Fixes #23548. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
