### PR TITLE
Move back to correct algorithm

### DIFF
--- a/Testing/SystemTests/lib/systemtests/stresstesting.py
+++ b/Testing/SystemTests/lib/systemtests/stresstesting.py
@@ -295,7 +295,7 @@ class MantidStressTest(unittest.TestCase):
 
     def validateWorkspaces(self, valNames=None, mismatchName=None):
         '''
-        Performs a check that two workspaces are equal using the CheckWorkspacesMatch
+        Performs a check that two workspaces are equal using the CompareWorkspaces
         algorithm. Loads one workspace from a nexus file if appropriate.
         Returns true if: the workspaces match
                       OR the validate method has not been overridden.
@@ -304,7 +304,7 @@ class MantidStressTest(unittest.TestCase):
         if valNames is None:
             valNames = self.validate()
 
-        checker = AlgorithmManager.create("CheckWorkspacesMatch")
+        checker = AlgorithmManager.create("CompareWorkspaces")
         checker.setLogging(True)
         checker.setPropertyValue("Workspace1", valNames[0])
         checker.setPropertyValue("Workspace2", valNames[1])
@@ -775,7 +775,7 @@ class TestManager(object):
         self._skippedTests = 0
         self._failedTests = 0
         self._lastTestRun = 0
-        
+
         self._tests = list_of_tests
 
     def generateMasterTestList(self):
@@ -1178,7 +1178,7 @@ def testThreadsLoop(testDir, saveDir, dataDir, options, tests_dict,
                     total_number_of_tests, maximum_name_length,
                     tests_done, process_number, lock, required_files_dict,
                     locked_files_dict):
-    
+
     reporter = XmlResultReporter(showSkipped=options.showskipped,
                                  total_number_of_tests=total_number_of_tests,
                                  maximum_name_length=maximum_name_length)
@@ -1186,7 +1186,7 @@ def testThreadsLoop(testDir, saveDir, dataDir, options, tests_dict,
     runner = TestRunner(executable=options.executable, exec_args=options.execargs,
                         escape_quotes=True, clean=options.clean)
 
-    # Make sure the status is 1 to begin with as it will be replaced 
+    # Make sure the status is 1 to begin with as it will be replaced
     res_array[process_number + 2*options.ncores] = 1
 
     # Begin loop: as long as there are still some test modules that


### PR DESCRIPTION
#23458 modified system tests to use a deprecated algorithm to validate workspaces. The result is that (on current line 316) the `Result` property which was a non-empty string evaluated to `True` so no tests would fail in the validation step.

References: [CompareWorkspaces](http://docs.mantidproject.org/nightly/algorithms/CompareWorkspaces-v1.html) and the deprecated [CheckWorkspacesMatch](http://docs.mantidproject.org/nightly/algorithms/CheckWorkspacesMatch-v1.html)

**Report to:** nobody. No one should ever speak about it.

**To test:**

*There is no associated issue.*

*This does not require release notes* because that would be telling people about it.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
