### PR TITLE
Bugfix for DeltaE>Ei in DgsPlanner

### DIFF
--- a/Framework/MDAlgorithms/src/CalculateCoverageDGS.cpp
+++ b/Framework/MDAlgorithms/src/CalculateCoverageDGS.cpp
@@ -261,8 +261,17 @@ void CalculateCoverageDGS::exec() {
 
   // Qmax is at  kf=kfmin or kf=kfmax
   m_ki = std::sqrt(energyToK * m_Ei);
-  m_kfmin = std::sqrt(energyToK * (m_Ei - m_dEmin));
-  m_kfmax = std::sqrt(energyToK * (m_Ei - m_dEmax));
+  if (m_Ei > m_dEmin) {
+    m_kfmin = std::sqrt(energyToK * (m_Ei - m_dEmin));
+  } else {
+    m_kfmin=0.;
+  }
+  if (m_Ei > m_dEmax) {
+    m_kfmax = std::sqrt(energyToK * (m_Ei - m_dEmax));
+  } else {
+    m_kfmax =0;
+  }
+
   double QmaxTemp =
       sqrt(m_ki * m_ki + m_kfmin * m_kfmin - 2 * m_ki * m_kfmin * cos(ttmax));
   double Qmax = QmaxTemp;

--- a/Framework/MDAlgorithms/src/CalculateCoverageDGS.cpp
+++ b/Framework/MDAlgorithms/src/CalculateCoverageDGS.cpp
@@ -264,12 +264,12 @@ void CalculateCoverageDGS::exec() {
   if (m_Ei > m_dEmin) {
     m_kfmin = std::sqrt(energyToK * (m_Ei - m_dEmin));
   } else {
-    m_kfmin=0.;
+    m_kfmin = 0.;
   }
   if (m_Ei > m_dEmax) {
     m_kfmax = std::sqrt(energyToK * (m_Ei - m_dEmax));
   } else {
-    m_kfmax =0;
+    m_kfmax = 0;
   }
 
   double QmaxTemp =


### PR DESCRIPTION
**Description of work.**
Fixed an error where setting the DeltaE limit at something larger that Ei yields no picture

**Report to:** Matt Stone. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**
Start DgsPlanner, slect SEQUOIA, with incident energy 100. Select to plot `[H,0,0]` and `DeltaE`
If no limits are selected, you get something like 
![planner_no_limits](https://user-images.githubusercontent.com/1128952/45831184-bc1a7180-bccc-11e8-95c5-39f4e90dfcdf.png)

If you select the upper limit for DeltaE as 200, the plot is empty
![planner_wrong_limits](https://user-images.githubusercontent.com/1128952/45831227-d48a8c00-bccc-11e8-9715-63ec38e97eb3.png)

With this change, the answer is
![planner_fixed_limits](https://user-images.githubusercontent.com/1128952/45831256-e8ce8900-bccc-11e8-865b-daf5c92dc91d.png)


<!-- Instructions for testing. -->


*There is no associated issue.*


*This does not require release notes* because **most users (99%) would not select such limits**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
