### PR TITLE
Removed setting of total phi mask 

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinderCore.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinderCore.py
@@ -101,10 +101,9 @@ class SANSBeamCentreFinderCore(DataProcessorAlgorithm):
         # Change cloned state
         # --------
         # Remove phi Masking
-        if state.mask.phi_min:
-            state.mask.phi_min = 0.0
-        if state.mask.phi_max:
-            state.mask.phi_max = 0.0
+        state.mask.phi_min = 90.0
+        state.mask.phi_max = -90.0
+        state.mask.use_mask_phi_mirror = True
 
         # Set compatibility mode
         #state.compatibility.use_compatibility_mode = self.getProperty('CompatibilityMode').value

--- a/docs/source/release/v3.14.0/sans.rst
+++ b/docs/source/release/v3.14.0/sans.rst
@@ -19,6 +19,7 @@ Bug fixes
 * Fixed an issue where the run tab was difficult to select.
 * Changed the geometry names from CylinderAxisUP, Cuboid and CylinderAxisAlong to Cylinder, FlatPlate and Disc
 * The GUI now correctly resets to default values when a new user file is loaded.
+* Fixed a bug which crashed the beam centre finder if a phi mask was set.
 
 Improvements
 ############

--- a/scripts/SANS/sans/state/mask.py
+++ b/scripts/SANS/sans/state/mask.py
@@ -202,6 +202,9 @@ class StateMask(StateBase):
         super(StateMask, self).__init__()
         # IDF Path
         self.idf_path = ""
+        self.phi_min = -90.0
+        self.phi_max = 90.0
+        self.use_mask_phi_mirror = True
 
     def validate(self):
         is_invalid = dict()

--- a/scripts/test/SANS/gui_logic/masking_table_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/masking_table_presenter_test.py
@@ -32,7 +32,8 @@ class MaskingTablePresenterTest(unittest.TestCase):
         self.assertTrue(view.set_table.call_count == 2)
         first_call = mock.call([])
         second_call = mock.call([masking_information(first='Beam stop', second='', third='infinite-cylinder, r = 10.0'),
-                                 masking_information(first='Corners', second='', third='infinite-cylinder, r = 20.0')])  # noqa
+                                 masking_information(first='Corners', second='', third='infinite-cylinder, r = 20.0'),
+                                 masking_information(first='Phi', second='', third='L/PHI -90.0 90.0')])  # noqa
         view.set_table.assert_has_calls([first_call, second_call])
 
 


### PR DESCRIPTION
**Description of work.**

This PR fixes an issue with the BeamCentreFinder where it was masking the whole workspace and therefore producing an output made entirely of NANS.

**To test:**

Get the data from #23511. 
Open up the new SANS GUI and load the MaskFile.txt as the user file and batch_mode_reduction.csv as the batch file
Go to the Beam Centre Tab and click run it should do so without any errors.

<!-- Instructions for testing. -->

Fixes #23585 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
