### PR TITLE
output intensities should not change in StatisticsOfPeaksWorkspaces

### DIFF
--- a/Framework/Crystal/src/PeakStatisticsTools.cpp
+++ b/Framework/Crystal/src/PeakStatisticsTools.cpp
@@ -283,7 +283,6 @@ void PeaksStatistics::calculatePeaksStatistics(
         // Collect sum of intensities for R-value calculation
         intensitySumRValues +=
             std::accumulate(intensities.begin(), intensities.end(), 0.0);
-
       }
 
       const std::vector<Peak> &reflectionPeaks = outliersRemoved.getPeaks();

--- a/Framework/Crystal/src/PeakStatisticsTools.cpp
+++ b/Framework/Crystal/src/PeakStatisticsTools.cpp
@@ -284,10 +284,6 @@ void PeaksStatistics::calculatePeaksStatistics(
         intensitySumRValues +=
             std::accumulate(intensities.begin(), intensities.end(), 0.0);
 
-        // The original algorithm sets the intensities and sigmas to the mean.
-        double sqrtOfMeanSqrSigma = getRMS(sigmas);
-        outliersRemoved.setPeaksIntensityAndSigma(meanIntensity,
-                                                  sqrtOfMeanSqrSigma);
       }
 
       const std::vector<Peak> &reflectionPeaks = outliersRemoved.getPeaks();

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -1027,6 +1027,7 @@ Peak &Peak::operator=(const Peak &other) {
     m_orig_L = other.m_orig_L;
     m_detIDs = other.m_detIDs;
     convention = other.convention;
+    m_peakNumber = other.m_peakNumber;
     m_peakShape.reset(other.m_peakShape->clone());
   }
   return *this;

--- a/Testing/SystemTests/tests/analysis/SortHKLTest.py
+++ b/Testing/SystemTests/tests/analysis/SortHKLTest.py
@@ -109,7 +109,8 @@ class SortHKLTest(HKLStatisticsTestMixin, stresstesting.MantidStressTest):
             reference_statistics = self._load_reference_statistics(space_group)
 
             self._compare_statistics(statistics, reference_statistics)
-            self._check_sorted_hkls_consistency(sorted_hkls, space_group)
+            # No need to check since intensities do no change
+            #self._check_sorted_hkls_consistency(sorted_hkls, space_group)
 
     def _run_sort_hkl(self, reflections, space_group):
         point_group_name = self._get_point_group(space_group).getName()


### PR DESCRIPTION
**Description of work.**
OutputWorkspace of StatisticsOfPeaksWorkspaces should not change intensities.  Also peak numbers are now unchanged after sort.

**Report to:** [Xiaoping Wang]/[nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

LoadIsawPeaks(Filename='/SNS/TOPAZ/IPTS-20746/shared/KDP_small_find/KDP_Tetragonal_I_anvred.integrate', OutputWorkspace='peaks')
LoadIsawUB(InputWorkspace='peaks', Filename='/SNS/TOPAZ/IPTS-20746/shared/KDP_small_find/KDP_Tetragonal_I.mat')
StatisticsOfPeaksWorkspace(InputWorkspace='peaks', PointGroup='-42m (Tetragonal)', LatticeCentering='I', OutputWorkspace='out', SortBy='Overall', WeightedZScore=True)


Fixes #23603 
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
