### PR TITLE
Ignore syntax errors on startup

### DIFF
--- a/qt/python/mantidqt/widgets/codeeditor/execution.py
+++ b/qt/python/mantidqt/widgets/codeeditor/execution.py
@@ -116,8 +116,8 @@ class PythonCodeExecution(QObject):
 
         self.reset_context()
 
-        if startup_code:
-            self.execute(startup_code)
+        # the code is not executed initially so code completion won't work
+        # on variables until part is executed
 
     @property
     def globals_ns(self):

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_execution.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_execution.py
@@ -64,9 +64,9 @@ class PythonCodeExecutionTest(GuiTest):
         executor.reset_context()
         self.assertEqual(0, len(executor.globals_ns))
 
-    def test_startup_code_executed_by_default(self):
+    def test_startup_code_not_executed_by_default(self):
         executor = PythonCodeExecution(startup_code="x=100")
-        self.assertEqual(100, executor.globals_ns['x'])
+        self.assertFalse('x' in executor.globals_ns)
 
     # ---------------------------------------------------------------------------
     # Successful execution tests


### PR DESCRIPTION
There was an uncaught exception in parsing the file on startup.

**To test:**

Try the two test scripts from the original issue as well as
```python
from mantid.simpleapi import Load  # comment out for a different error below
print('hello')
Load(Filename='PG3_12345', OutputWorkspace='PG3_12345')  # any file will do
raise RuntimeError('hi')
```

Fixes #23555.

*This does not require release notes* because it is a bugfix in the (unreleased) workbench.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
