### PR TITLE
Fix intradocumentation links

### DIFF
--- a/docs/source/algorithms/ApplyCalibration-v1.rst
+++ b/docs/source/algorithms/ApplyCalibration-v1.rst
@@ -15,7 +15,7 @@ updated as absolute positions and so this update can be repeated.
 The PositionTable must have columns *Detector ID* and *Detector
 Position*. The entries of the *Detector ID* column are integer referring
 to the Detector ID and the enties of the *Detector Position* are
-`V3Ds <../api/python/mantid/kernel/V3D.html>`__ referring to the position of the detector whose ID is in same row.
+:py:obj:`V3Ds <mantid.kernel.V3D>` referring to the position of the detector whose ID is in same row.
 
 This algorithm is not appropriate for rectangular detectors and won't move them.
 

--- a/docs/source/algorithms/BayesStretch-v1.rst
+++ b/docs/source/algorithms/BayesStretch-v1.rst
@@ -10,12 +10,12 @@ Description
 -----------
 
 This is a variation of the stretched exponential option of
-`Quasi <http://www.mantidproject.org/IndirectBayes:Quasi>`__. For each spectrum a fit is performed
+:ref:`Quasi <algm-BayesQuasi>`. For each spectrum a fit is performed
 for a grid of :math:`\beta` and :math:`\sigma` values. The distribution of goodness of fit values
 is plotted.
 
 This routine was originally part of the MODES package. Note that this algorithm
-uses F2Py and is currently only supported on windows.
+uses F2Py and is currently only supported on Windows.
 
 Usage
 -----

--- a/docs/source/algorithms/CalculateTransmission-v1.rst
+++ b/docs/source/algorithms/CalculateTransmission-v1.rst
@@ -12,7 +12,7 @@ Description
 Calculates the probability of a neutron being transmitted through the
 sample using detected counts from two monitors, one in front and one
 behind the sample. A data workspace can be corrected for transmission by
-`dividing <http://www.mantidproject.org/Divide>`_ by the output of this algorithm.
+:ref:`dividing <algm-Divide>` by the output of this algorithm.
 
 Because the detection efficiency of the monitors can be different the
 transmission calculation is done using two runs, one run with the sample

--- a/docs/source/algorithms/ClearInstrumentParameters-v1.rst
+++ b/docs/source/algorithms/ClearInstrumentParameters-v1.rst
@@ -12,7 +12,7 @@ Description
 This algorithm clears all the parameters associated with a workspace's instrument.
 
 Parameters are used by Mantid to tweak an instrument's values without having to change
-the `instrument definition file <http://mantidproject.org/InstrumentDefinitionFile>`__ itself.
+the :ref:`instrument definition file <InstrumentDefinitionFile>` itself.
 
 Usage
 -----

--- a/docs/source/algorithms/ClearUB-v1.rst
+++ b/docs/source/algorithms/ClearUB-v1.rst
@@ -10,7 +10,7 @@ Description
 -----------
 
 Clears the :ref:`OrientedLattice <Lattice>` of each ExperimentInfo attached to the intput
-`Workspace <http://www.mantidproject.org/Workspace>`_. Works with both single ExperimentInfos and
+:ref:`Workspace <Workspace>`. Works with both single ExperimentInfos and
 MultipleExperimentInfo instances.
 
 Usage

--- a/docs/source/algorithms/CloneMDWorkspace-v1.rst
+++ b/docs/source/algorithms/CloneMDWorkspace-v1.rst
@@ -10,7 +10,7 @@ Description
 -----------
 
 This algorithm will clones an existing
-`MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_ or
+:ref:`MDEventWorkspace <MDWorkspace>` or
 :ref:`MDHistoWorkspace <MDHistoWorkspace>` into a new one.
 
 If the InputWorkspace is a file-backed MDEventWorkspace, then the

--- a/docs/source/algorithms/CloneWorkspace-v1.rst
+++ b/docs/source/algorithms/CloneWorkspace-v1.rst
@@ -12,7 +12,7 @@ Description
 This algorithm performs a deep copy of all of the information in the
 workspace. It maintains events if the input is an
 :ref:`EventWorkspace <EventWorkspace>`. It will call CloneMDWorkspace for a
-`MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_ or a
+:ref:`MDEventWorkspace <MDWorkspace>` or a
 :ref:`MDHistoWorkspace <MDHistoWorkspace>`. It can also clone a
 :ref:`PeaksWorkspace <PeaksWorkspace>`.
 

--- a/docs/source/algorithms/CompactMD-v1.rst
+++ b/docs/source/algorithms/CompactMD-v1.rst
@@ -12,8 +12,7 @@ Used to crop an n-dimensional :ref:`MDHistoWorkspace <MDHistoWorkspace>` to the 
 
 Cropping
 --------
-The cropping is done by supplying `IntegrateMDHistoWorkspace <http://docs.mantidproject.org/nightly/algorithms/IntegrateMDHistoWorkspace-v1.html>`__ with the minimum and maximum extents associated with the first non-zero
-signal values in the workspace.
+The cropping is done by supplying :ref:`IntegrateMDHistoWorkspace <algm-IntegrateMDHistoWorkspace>` with the minimum and maximum extents associated with the first non-zero signal values in the workspace.
 
 
 Usage
@@ -55,8 +54,6 @@ Output:
    :width: 400px
    :align: center
 
-   
-   
 .. categories::
 
 .. sourcelink::

--- a/docs/source/algorithms/CompareMDWorkspaces-v1.rst
+++ b/docs/source/algorithms/CompareMDWorkspaces-v1.rst
@@ -9,14 +9,14 @@
 Description
 -----------
 
-Compare two MDWorkspaces (`MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_ or
+Compare two MDWorkspaces (:ref:`MDEventWorkspace <MDWorkspace>` or
 :ref:`MDHistoWorkspace <MDHistoWorkspace>`) to see if they are the same.
 This is mostly meant for testing/debugging use by developers.
 
 **What is compared**: The dimensions, as well as the signal and error
 for each bin of each workspace will be compared.
 
-`MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_ : the events in each box will
+:ref:`MDEventWorkspace <MDWorkspace>` : the events in each box will
 be compared if the *CheckEvents* option is checked. The events would
 need to be in the same order to match.
 

--- a/docs/source/algorithms/ConvertAxisByFormula-v1.rst
+++ b/docs/source/algorithms/ConvertAxisByFormula-v1.rst
@@ -14,7 +14,8 @@ defined math formula. It will adjust the data values
 (other than in one case the X values) of a workspace, although it will 
 reverse the spectra if needed to keep the X values increasing across the workspace.
 This only works for MatrixWorkspaces, so will not work on
-Multi Dimensional Workspaces or Table Workspaces. If you specify one of the known Units from the `Unit Factory <http://www.mantidproject.org/Units>`__ then that will be the resulting unit,
+Multi Dimensional Workspaces or Table Workspaces. If you specify one of the
+known :ref:`Units <Unit Factory>` then that will be the resulting unit,
 otherwise like the
 :ref:`algm-ConvertSpectrumAxis` algorithm the result of
 this algorithm will have custom units defined for the axis you have

--- a/docs/source/algorithms/ConvertToDetectorFaceMD-v1.rst
+++ b/docs/source/algorithms/ConvertToDetectorFaceMD-v1.rst
@@ -10,7 +10,7 @@ Description
 -----------
 
 This algorithm takes a a :ref:`MatrixWorkspace <MatrixWorkspace>` and
-converts it into a `MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_ that can be
+converts it into a :ref:`MDEventWorkspace <MDWorkspace>` that can be
 viewed in the `SliceViewer <http://www.mantidproject.org/SliceViewer>`_.
 
 The algorithm currently only works for instruments with
@@ -25,7 +25,7 @@ output workspace are:
 Each MDEvent created has a weight given by the number of counts in that
 bin. Zero bins are not converted to events (saving memory).
 
-Once created, the `MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_ can be viewed
+Once created, the :ref:`MDEventWorkspace <MDWorkspace>` can be viewed
 in the `SliceViewer <http://www.mantidproject.org/SliceViewer>`_. It can also be rebinned with
 different parameters using :ref:`algm-BinMD`. This allows you to view
 the data in detector-space. For example, you might use this feature to
@@ -49,7 +49,7 @@ looks for :ref:`rectangular detectors <Creating Rectangular Area Detectors>` wit
 bank number.
 
 If you specify more than one bank number, then the algorithm will create
-a 4D `MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_. The fourth dimension will be equal to the bank
+a 4D :ref:`MDEventWorkspace <MDWorkspace>`. The fourth dimension will be equal to the bank
 number, allowing you to easily pick a bank to view.
 
 .. categories::

--- a/docs/source/algorithms/ConvertToDiffractionMDWorkspace-v1.rst
+++ b/docs/source/algorithms/ConvertToDiffractionMDWorkspace-v1.rst
@@ -9,9 +9,9 @@
 Description
 -----------
 
-This algorithm converts from a `MatrixWorkspace <http://www.mantidproject.org/MatrixWorkspace>`__ (in
+This algorithm converts from a :ref:`MatrixWorkspace <MatrixWorkspace>` (in
 detector/time-of-flight space) to a
-`MDEventWorkspace <http://www.mantidproject.org/MDWorkspace>`__ containing events in reciprocal
+:ref:`MDEventWorkspace <MDWorkspace>` containing events in reciprocal
 space.
 
 The calculations apply only to elastic diffraction experiments. The
@@ -20,8 +20,8 @@ to HKL of the crystal.
 
 If the OutputWorkspace does NOT already exist, a default one is created.
 In order to define more precisely the parameters of the
-`MDEventWorkspace <http://www.mantidproject.org/MDWorkspace>`__, use the
-:ref:`algm-CreateMDWorkspace` algorithm first.
+:ref:`MDEventWorkspace <MDWorkspace>`, use the :ref:`algm-CreateMDWorkspace`
+algorithm first.
 
 Types of Conversion
 ###################
@@ -75,9 +75,9 @@ Also, the :ref:`algm-FindPeaksMD` algorithm may not work optimally
 because it depends partly on higher density of events causing more
 finely split boxes.
 
-If your input is a `Workspace2D <http://www.mantidproject.org/Workspace2D>`__ and you do NOT check
+If your input is a :ref:`Workspace2D <Workspace2D>` and you do NOT check
 *OneEventPerBin*, then the workspace is converted to an
-`EventWorkspace <http://www.mantidproject.org/EventWorkspace>`__ but with no events for empty bins.
+:ref:`EventWorkspace <EventWorkspace>` but with no events for empty bins.
 
 Performance Notes
 #################

--- a/docs/source/algorithms/ConvertToMD-v1.rst
+++ b/docs/source/algorithms/ConvertToMD-v1.rst
@@ -11,10 +11,10 @@ Description
 
 The algorithm is used transform existing :ref:`Event <EventWorkspace>` 
 or :ref:`Matrix <MatrixWorkspace>` workspace into 
-`Multidimensional workspace <http://www.mantidproject.org/MDEventWorkspace>`__ using
+:ref:`Multidimensional workspace <MDWorkspace>` using
 `MD Transformations Factory <http://www.mantidproject.org/MD_Transformation_factory>`_. 
 
-If  the target workspace does not exist, the algorithm creates `MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`__
+If  the target workspace does not exist, the algorithm creates :ref:`MDEventWorkspace <MDWorkspace>`
 with selected dimensions, e.g. the reciprocal space of momentums **(Qx, Qy, Qz)** or momentums modules **\|Q|**, energy transfer **dE** if available 
 and any other user specified log values which can be treated as dimensions. If the target workspace do exist, 
 the **MD Events** are added to this workspace.

--- a/docs/source/algorithms/ConvertUnits-v1.rst
+++ b/docs/source/algorithms/ConvertUnits-v1.rst
@@ -10,8 +10,8 @@ Description
 -----------
 
 Changes the units in which the X values of a :ref:`workspace <Workspace>`
-are represented. The available units are those registered with the `Unit
-Factory <http://www.mantidproject.org/Units>`__. If the Y data is 'dimensioned' (i.e. has been
+are represented. The available units are those registered with the :ref:`Unit
+Factory <Unit Factory>`. If the Y data is 'dimensioned' (i.e. has been
 divided by the bin width), then this will be correctly handled, but at
 present nothing else is done to the Y data. If the sample-detector
 distance cannot be calculated then the affected spectrum will be zeroed,
@@ -20,7 +20,7 @@ service.
 
 If AlignBins is false or left at the default the output workspace may be
 a :ref:`ragged workspace <Ragged_Workspace>`. If it is set to true then the
-data is automatically `rebinned <http://www.mantidproject.org/Rebin>`__ to a regular grid so that the
+data is automatically :ref:`rebinned <algm-Rebin>` to a regular grid so that the
 maximum and minimum X values will be maintained. It uses the same number
 of bins as the input data, and divides them linearly equally between the
 minimum and maximum values.
@@ -32,14 +32,14 @@ value of EFixed will be taken, if available, from the instrument
 definition file.
 
 If ConvertFromPointData is true, an input workspace
-contains Point data will be converted using `ConvertToHistogram <http://www.mantidproject.org/ConvertToHistogram>`__
+contains Point data will be converted using :ref:`ConvertToHistogram <algm-ConvertToHistogram>`
 and then the algorithm will be run on the converted workspace.
 
 Restrictions on the input workspace
 ###################################
 
 -  Naturally, the X values must have a unit set, and that unit must be
-   known to the `Unit Factory <http://www.mantidproject.org/Units>`__.
+   known to the :ref:`Unit Factory <Unit Factory>`.
 -  Histograms and Point data can be handled.
 -  The algorithm will also fail if the source-sample distance cannot be
    calculated (i.e. the :ref:`instrument <instrument>` has not been
@@ -49,7 +49,7 @@ Available units
 ---------------
 
 The units currently available to this algorithm are listed
-`here <http://www.mantidproject.org/Units>`__, along with equations specifying exactly how the
+:ref:`here <Unit Factory>`, along with equations specifying exactly how the
 conversions are done.
 
 Usage

--- a/docs/source/algorithms/ConvertUnitsUsingDetectorTable-v1.rst
+++ b/docs/source/algorithms/ConvertUnitsUsingDetectorTable-v1.rst
@@ -12,13 +12,13 @@ Description
 
 This algorithm functions in the same basic way as :ref:`algm-ConvertUnits` but
 instead of reading the geometric parameters from the instrument, it uses values
-that are specified in a `TableWorkspace <http://www.mantidproject.org/TableWorkspace>`__
+that are specified in a :ref:`TableWorkspace <Table Workspaces>`
 
 Restrictions on the input workspace
 ###################################
 
 -  Naturally, the X values must have a unit set, and that unit must be
-   known to the `Unit Factory <http://www.mantidproject.org/Units>`__.
+   known to the :ref:`Unit Factory <Unit Factory>`.
 -  Only histograms, not point data, can be handled at present.
 -  The algorithm will also fail if the source-sample distance cannot be
    calculated (i.e. the :ref:`instrument <instrument>` has not been
@@ -28,7 +28,7 @@ Available units
 ---------------
 
 The units currently available to this algorithm are listed
-`here <http://www.mantidproject.org/Units>`__, along with equations specifying exactly how the
+:ref:`here <Unit Factory>`, along with equations specifying exactly how the
 conversions are done.
 
 Usage

--- a/docs/source/algorithms/CorrectToFile-v1.rst
+++ b/docs/source/algorithms/CorrectToFile-v1.rst
@@ -11,7 +11,7 @@ Description
 
 Use data from the supplied file, written in the RKH format, to correct
 the input data. The operations allowed for the correction are
-`multiply <http://www.mantidproject.org/multiply>`_ and `divide <http://www.mantidproject.org/divide>`_.
+:ref:`multiply <algm-Multiply>` and :ref:`divide <algm-Divide>`.
 
 Allowed correction files may contain one spectrum with many bins or many
 spectra each with one bin. If the are many bins then the

--- a/docs/source/algorithms/CreateCalFileByNames-v1.rst
+++ b/docs/source/algorithms/CreateCalFileByNames-v1.rst
@@ -14,12 +14,12 @@ Description
 
    Instrument Tree
 
-Create a `calibration file <http://www.mantidproject.org/CalFile>`_ for diffraction focusing based
+Create a :ref:`calibration file <CalFile>` for diffraction focusing based
 on list of names of the instrument tree.
 
 If a new file name is specified then offsets in the file are all sets to
 zero and all detectors are selected. If a valid calibration file already
-exists at the location specified by the `GroupingFileName <http://www.mantidproject.org/CalFile>`_
+exists at the location specified by the :ref:`GroupingFileName <CalFile>`
 then any existing offsets and selection values will be maintained and
 only the grouping values changed.
 

--- a/docs/source/algorithms/CreateDummyCalFile-v1.rst
+++ b/docs/source/algorithms/CreateDummyCalFile-v1.rst
@@ -14,7 +14,7 @@ Description
 
    Instrument Tree
 
-Create a dummy `calibration file <http://www.mantidproject.org/CalFile>`_ for diffraction focusing
+Create a dummy :ref:`calibration file <CalFile>` for diffraction focusing
 with one group.
 
 Offsets in the file are all sets to zero and all detectors are selected.

--- a/docs/source/algorithms/CreateLeBailFitInput-v1.rst
+++ b/docs/source/algorithms/CreateLeBailFitInput-v1.rst
@@ -41,7 +41,7 @@ How to use algorithm with other algorithms
 
 This algorithm is designed to work with other algorithms to do Le Bail
 fit. The introduction can be found in the wiki page of `Le Bail
-Fit <Le Bail Fit>`__.
+Fit <http://www.mantidproject.org/Le_Bail_Fit>`__.
 
 Usage
 -----

--- a/docs/source/algorithms/CreateWorkspace-v1.rst
+++ b/docs/source/algorithms/CreateWorkspace-v1.rst
@@ -13,9 +13,7 @@ This algorithm constructs a :ref:`MatrixWorkspace <MatrixWorkspace>`
 when passed a vector for each of the X, Y and optionally E and Dx values.
 The E values of the output workspace will be zero if not provided.
 The unit for the X Axis can optionally be specified as any of the units in the
-Mantid `Unit Factory <http://www.mantidproject.org/Units>`__ (see `the
-list of units currently available
-<http://www.mantidproject.org/Units>`__).  Multiple spectra may be
+Mantid :ref:`Unit Factory <Unit Factory>`.  Multiple spectra may be
 created by supplying the NSpec Property (integer, default 1). When
 this is provided the vectors are split into equal-sized spectra (all
 X, Y, E, Dx values must still be in a single vector for input).

--- a/docs/source/algorithms/DgsAbsoluteUnitsReduction-v1.rst
+++ b/docs/source/algorithms/DgsAbsoluteUnitsReduction-v1.rst
@@ -17,7 +17,7 @@ workflow. The AbsUnitsIncidentEnergy parameter needs to be passed via a
 property manager since the absolute units sample may have been measured
 at an energy different from the sample of interest. Parameters in
 italics are controlled by the
-`instrument parameter file (IPF) <http://www.mantidproject.org/InstrumentParameterFile>`_
+:ref:`instrument parameter file (IPF) <InstrumentParameterFile>`
 unless provided to the algorithm via a property manager. The mappings are given
 below.
 

--- a/docs/source/algorithms/DgsConvertToEnergyTransfer-v1.rst
+++ b/docs/source/algorithms/DgsConvertToEnergyTransfer-v1.rst
@@ -17,7 +17,7 @@ parameter to be left blank. Also, SNS instruments need to pass a monitor
 workspace to :ref:`GetEi <algm-GetEi>`
 since they are separate from the sample workspace.
 Parameters in italics are controlled by the
-`instrument parameter file (IPF) <http://www.mantidproject.org/InstrumentParameterFile>`_
+:ref:`instrument parameter file (IPF) <InstrumentParameterFile>`
 unless provided to the algorithm via a property manager. The mappings are given
 below.
 

--- a/docs/source/algorithms/DgsDiagnose-v1.rst
+++ b/docs/source/algorithms/DgsDiagnose-v1.rst
@@ -14,7 +14,7 @@ to the :ref:`DetectorDiagnostic <algm-DetectorDiagnostic>`
 algorithm. The diagram below shows the manipulations
 done by this algorithm. Workspaces that have dashed lines are optional. Parameters
 in italics are retrieved from the
-`instrument parameter file (IPF) <http://www.mantidproject.org/InstrumentParameterFile>`_
+:ref:`instrument parameter file (IPF) <InstrumentParameterFile>`
 unless they are provided to the algorithm via a property manager. The mappings for
 these parameters are shown below.
 

--- a/docs/source/algorithms/DgsPreprocessData-v1.rst
+++ b/docs/source/algorithms/DgsPreprocessData-v1.rst
@@ -14,7 +14,7 @@ beam parameter. This parameter, IncidentBeamNormalisation, is controlled
 from the reduction property manager. It can have the values *None*,
 *ByCurrent* or *ByMonitor*. For SNS, monitor workspaces need to be
 passed. Parameters in italics are controlled by the
-`instrument parameter file (IPF) <http://www.mantidproject.org/InstrumentParameterFile>`_
+:ref:`instrument parameter file (IPF) <InstrumentParameterFile>`
 unless provided to the algorithm via a property manager. The mappings are given
 below.
 

--- a/docs/source/algorithms/DgsProcessDetectorVanadium-v1.rst
+++ b/docs/source/algorithms/DgsProcessDetectorVanadium-v1.rst
@@ -12,7 +12,7 @@ Description
 This algorithm is responsible for processing the detector vanadium in
 the form required for the sample data normalisation in the convert to
 energy transfer process. Parameters in italics are controlled by the
-`instrument parameter file (IPF) <http://www.mantidproject.org/InstrumentParameterFile>`_
+:ref:`instrument parameter file (IPF) <InstrumentParameterFile>`
 unless provided to the algorithm via a property manager. The mappings are given
 below.
 

--- a/docs/source/algorithms/DiffractionFocussing-v1.rst
+++ b/docs/source/algorithms/DiffractionFocussing-v1.rst
@@ -22,7 +22,7 @@ following:
 #. All histograms are read and rebinned to the new grid for their group.
 #. A new workspace with N histograms is created.
 
-Within the `CalFile <http://www.mantidproject.org/CalFile>`_ any detectors with the 'select' flag
+Within the :ref:`CalFile <CalFile>` any detectors with the 'select' flag
 can be set to zero or with a group number of 0 or -ve groups are not
 included in the analysis.
 
@@ -34,7 +34,7 @@ Some 2D and 3D plots will not display the data correctly.
 
 The DiffractionFocussing algorithm uses GroupDetectors algorithm to
 combine data from several spectra according to GroupingFileName file
-which is a `CalFile <http://www.mantidproject.org/CalFile>`_.
+which is a :ref:`CalFile <CalFile>`.
 
 For EventWorkspaces
 ###################

--- a/docs/source/algorithms/DiffractionFocussing-v2.rst
+++ b/docs/source/algorithms/DiffractionFocussing-v2.rst
@@ -23,7 +23,7 @@ following:
 #. All histograms are read and rebinned to the new grid for their group.
 #. A new workspace with N histograms is created.
 
-Within the `CalFile <http://www.mantidproject.org/CalFile>`_ any detectors with the 'select' flag
+Within the :ref:`CalFile <CalFile>` any detectors with the 'select' flag
 can be set to zero or with a group number of 0 or -ve groups are not
 included in the analysis.
 
@@ -35,12 +35,12 @@ Some 2D and 3D plots will not display the data correctly.
 
 The DiffractionFocussing algorithm uses GroupDetectors algorithm to
 combine data from several spectra according to GroupingFileName file
-which is a `CalFile <http://www.mantidproject.org/CalFile>`_.
+which is a :ref:`CalFile <CalFile>`.
 
 For EventWorkspaces
 ###################
 
-The algorithm can be used with an `EventWorkspace <http://www.mantidproject.org/EventWorkspace>`_
+The algorithm can be used with an :ref:`EventWorkspace <EventWorkspace>`
 input, and will create an EventWorkspace output if a different workspace
 is specified.
 

--- a/docs/source/algorithms/DivideMD-v1.rst
+++ b/docs/source/algorithms/DivideMD-v1.rst
@@ -27,7 +27,7 @@ The error of :math:`f = a / b` is propagated with
 
    -  This is not allowed.
 
--  **`MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_'s**
+-  **:ref:`MDEventWorkspace <MDWorkspace>`'s**
 
    -  This operation is not supported, as it is not clear what its
       meaning would be.

--- a/docs/source/algorithms/ExponentialMD-v1.rst
+++ b/docs/source/algorithms/ExponentialMD-v1.rst
@@ -16,7 +16,7 @@ The signal :math:`a` becomes :math:`f = e^a`
 The error :math:`da` becomes :math:`df^2 = f^2 * da^2`
 
 This algorithm cannot be run on a
-`MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`__. Its equivalent on a
+:ref:`MDEventWorkspace <MDWorkspace>`. Its equivalent on a
 :ref:`MatrixWorkspace <MatrixWorkspace>` is called
 :ref:`algm-Exponential`.
 

--- a/docs/source/algorithms/FakeMDEventData-v1.rst
+++ b/docs/source/algorithms/FakeMDEventData-v1.rst
@@ -9,7 +9,7 @@
 Description
 -----------
 
-For testing `MDEventWorkspaces <http://www.mantidproject.org/MDEventWorkspace>`_,
+For testing :ref:`MDEventWorkspaces <MDWorkspace>`,
 this algorithm either creates a uniform, random distribution of events, or generates
 regular events placed in boxes, or fills peaks around given points with a given
 number of events.
@@ -17,7 +17,7 @@ number of events.
 Usage
 -----
 
-This algorithm can be run on a pre-existing `MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_
+This algorithm can be run on a pre-existing :ref:`MDEventWorkspace <MDWorkspace>`
 or a newly created one. All of the examples below will be done with newly created ones
 using :ref:`CreateMDWorkspace <algm-CreateMDWorkspace>`.
 

--- a/docs/source/algorithms/FilterEventsByLogValuePreNexus-v2.rst
+++ b/docs/source/algorithms/FilterEventsByLogValuePreNexus-v2.rst
@@ -12,7 +12,7 @@ Description
 The LoadEventPreNeXus algorithm stores data from the pre-nexus neutron
 event data file in an :ref:`EventWorkspace <EventWorkspace>`. The default
 histogram bin boundaries consist of a single bin able to hold all events
-(in all pixels), and will have their `units <http://www.mantidproject.org/units>`_ set to
+(in all pixels), and will have their :ref:`units <Unit Factory>` set to
 time-of-flight. Since it is an :ref:`EventWorkspace <EventWorkspace>`, it
 can be rebinned to finer bins with no loss of data.
 

--- a/docs/source/algorithms/FindClusterFaces-v1.rst
+++ b/docs/source/algorithms/FindClusterFaces-v1.rst
@@ -14,7 +14,7 @@ Algorithm takes an image workspace (a.k.a
 the clusters contained within the image. The image is expected to be a
 labeled image workspace outputted from
 :ref:`algm-IntegratePeaksUsingClusters`. The
-algorithm generates a `TableWorkspace <http://www.mantidproject.org/TableWorkspace>`_ as output,
+algorithm generates a :ref:`TableWorkspace <Table Workspaces>` as output,
 which contains all the cluster edge faces required to draw the outer
 edge of all clusters within the workspace.
 

--- a/docs/source/algorithms/FindEPP-v1.rst
+++ b/docs/source/algorithms/FindEPP-v1.rst
@@ -14,7 +14,7 @@ This utility algorithm attempts to search for the elastic peak position (EPP) in
 .. note::
     This algorithm uses very simple approach to search for an elastic peak: it suggests that the elastic peak has maximal intensity. This approach may fail in the case if the dataset contains Bragg peaks with higher intensities.
 
-As a result, `TableWorkspace <http://www.mantidproject.org/TableWorkspace>`_ with the following columns is produced: *WorkspaceIndex*, *PeakCentre*, *PeakCentreError*, *Sigma*, *SigmaError*, *Height*, *HeightError*, *chiSq* and *FitStatus*. Table rows correspond to the workspace indices.
+As a result, :ref:`TableWorkspace <Table Workspaces>` with the following columns is produced: *WorkspaceIndex*, *PeakCentre*, *PeakCentreError*, *Sigma*, *SigmaError*, *Height*, *HeightError*, *chiSq* and *FitStatus*. Table rows correspond to the workspace indices.
 
 Usage
 -----

--- a/docs/source/algorithms/FindEPP-v2.rst
+++ b/docs/source/algorithms/FindEPP-v2.rst
@@ -16,7 +16,7 @@ This utility algorithm attempts to search for the elastic peak position (EPP) in
 .. note::
     This algorithm uses very simple approach to search for an elastic peak: it suggests that the elastic peak has maximal intensity. This approach may fail in the case if the dataset contains Bragg peaks with higher intensities.
 
-As a result, `TableWorkspace <http://www.mantidproject.org/TableWorkspace>`_ with the following columns is produced: *WorkspaceIndex*, *PeakCentre*, *PeakCentreError*, *Sigma*, *SigmaError*, *Height*, *HeightError*, *chiSq* and *FitStatus*. Table rows correspond to the workspace indices.
+As a result, :ref:`TableWorkspace <Table Workspaces>` with the following columns is produced: *WorkspaceIndex*, *PeakCentre*, *PeakCentreError*, *Sigma*, *SigmaError*, *Height*, *HeightError*, *chiSq* and *FitStatus*. Table rows correspond to the workspace indices.
 
 Last column will contain the status of peak finding as follows:
 

--- a/docs/source/algorithms/FindPeaks-v1.rst
+++ b/docs/source/algorithms/FindPeaks-v1.rst
@@ -17,7 +17,7 @@ is then searched for patterns consistent with the presence of a peak.
 The list of candidate peaks found is passed to a fitting routine and
 those that are successfully fitted are kept and returned in the output
 workspace (and logged at information level). The output
-`TableWorkspace <http://www.mantidproject.org/TableWorkspace>`_ contains columns,
+:ref:`TableWorkspace <Table Workspaces>` contains columns,
 which reflect the fact that the peak has been fitted to a peak function atop
 a background: spectrum, centre, width, height, backgroundintercept and
 backgroundslope. Setting ``RawPeakParameters=True`` will give the actual
@@ -82,7 +82,7 @@ observed data.
    #. If peak centre is restricted to given value, then the peak range will be from 1/6 to 5/6 of the given data points;
    #. If peak centre is set to observed value, then the 3 leftmost data points will be used for background.
 
-.. seealso:: The `peak shape functions <../fitfunctions/categories/Peak.html>`_ and `background functions </fitfunctions/categories/Background.html>`_ for details on the various functions. The `documentation for minimizers <../fitminimizers/>`_.
+.. seealso:: The :ref:`list of available functions <Fit Functions List>` for details on the various functions and the :ref:`documentation for minimizers <fitminimizers>`.
 
 References
 ----------

--- a/docs/source/algorithms/FindPeaksMD-v1.rst
+++ b/docs/source/algorithms/FindPeaksMD-v1.rst
@@ -10,7 +10,7 @@ Description
 -----------
 
 This algorithm is used to find single-crystal peaks in a
-multi-dimensional workspace (`MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_ or
+multi-dimensional workspace (:ref:`MDEventWorkspace <MDWorkspace>` or
 :ref:`MDHistoWorkspace <MDHistoWorkspace>`). It looks for high signal
 density areas, and is based on an algorithm designed by Dennis Mikkelson
 for ISAW.

--- a/docs/source/algorithms/Fit-v1.rst
+++ b/docs/source/algorithms/Fit-v1.rst
@@ -45,8 +45,8 @@ no additional properties will be declared. The Function property must be
 set before any other.
 
 The function and the initial values for its parameters are set with the
-Function property. A function can be simple or composite. A `simple
-function <../fitfunctions/categories/FitFunctions.html>`__ has a name registered with Mantid
+Function property. A function can be simple or composite. A :ref:`simple
+function <Fit Functions List>` has a name registered with Mantid
 framework. The Fit algorithm creates an instance of a function by this
 name. A composite function is an arithmetic sum of two or more functions
 (simple or composite). Each function has a number of named parameters,
@@ -61,7 +61,7 @@ to perform the minimization. By default if the function's derivatives
 can be evaluated then Fit uses the GSL Levenberg-Marquardt minimizer.
 
 In Mantidplot this algorithm can be run from the `Fit Property
-Browser <MantidPlot:_Data Analysis and Curve Fitting#Simple_Peak_Fitting_with_the_Fit_Wizard>`__
+Browser <http://www.mantidproject.org/MantidPlot:_Data_Analysis_and_Curve_Fitting>`__
 which allows all the settings to be specified via its graphical user
 interface.
 
@@ -71,8 +71,8 @@ Setting a simple function
 To use a simple function for a fit set its name and initial parameter
 values using the Function property. This property is a comma separated
 list of name=value pairs. The name of the first name=value pairs must be
-"name" and it must be set equal to the name of one of a `simple
-function <../fitfunctions/categories/FitFunctions.html>`__. This name=value pair is followed
+"name" and it must be set equal to the name of one of a :ref:`simple
+function <Fit Functions List>`. This name=value pair is followed
 by name=value pairs specifying values for the parameters of this
 function. If a parameter is not set in Function it will be given its
 default value defined by the function. All names are case sensitive. For
@@ -94,7 +94,7 @@ are created when the Formula attribute is set. It is important that
 Formula is defined before initializing the parameters.
 
 A list of the available simple functions can be found
-`here <../fitfunctions/categories/FitFunctions.html>`__.
+:ref:`here <Fit Functions List>`.
 
 Setting a composite function
 ############################
@@ -255,8 +255,8 @@ replace the name of the workspace with a different name if you give a
 value to the property 'Output' which redefines the base name of the
 output workspaces.
 
-OutputParameters is is a `TableWorkspace
-<http://www.mantidproject.org/TableWorkspace>`_ with the fitted
+OutputParameters is a :ref:`TableWorkspace
+<Table Workspaces>` with the fitted
 parameter values. OutputWorkspace is a :ref:`Workspace2D
 <Workspace2D>` which compares the fit with the original data. The
 names given to these workspaces are built by appending the suffixes
@@ -274,7 +274,7 @@ spectra:
 3. The third spectrum is the difference between the first two.
 
 Also, if the function's derivatives can be evaluated an additional
-`TableWorkspace <http://www.mantidproject.org/TableWorkspace>`_ is
+:ref:`TableWorkspace <Table Workspaces>` is
 produced. If for example the property Output is set to "MyResults"
 then this TableWorkspace will have the name
 "MyResults\_NormalisedCovarianceMatrix" and it contains a calculated

--- a/docs/source/algorithms/FitPeak-v1.rst
+++ b/docs/source/algorithms/FitPeak-v1.rst
@@ -12,7 +12,7 @@ Description
 This algorithm is used to fit a single peak with some checking mechanism
 to ensure its fitting result is physical.
 
-The output `TableWorkspace <http://www.mantidproject.org/TableWorkspace>`_ contains the following
+The output :ref:`TableWorkspace <Table Workspaces>` contains the following
 columns...
 
 Peak profile

--- a/docs/source/algorithms/FitPowderDiffPeaks-v1.rst
+++ b/docs/source/algorithms/FitPowderDiffPeaks-v1.rst
@@ -16,7 +16,7 @@ The assumption is that all the peaks in the diffraction patter can be described 
 A specific peak parameter will have its values plotted by an analytical function among all the peaks. 
 
 It serves as the first step to fit/refine instrumental parameters that
-will be introduced in `Le Bail Fit <Le Bail Fit>`__. The second step is
+will be introduced in `Le Bail Fit <http://www.mantidproject.org/Le_Bail_Fit>`__. The second step is
 realized by algorithm RefinePowderInstrumentParameters.
 
 Peak Fitting Algorithms

--- a/docs/source/algorithms/GenerateEventsFilter-v1.rst
+++ b/docs/source/algorithms/GenerateEventsFilter-v1.rst
@@ -41,7 +41,7 @@ serve as an event splitter. There are two types of output workspaces for storing
 event splitters that are supported by this algorithm.
 
 -  :ref:`SplittersWorkspace`: It is a
-   `TableWorkspace <http://www.mantidproject.org/TableWorkspace>`_ that has 3 columns for start
+   :ref:`TableWorkspace <Table Workspaces>` that has 3 columns for start
    time, stop time and target workspace for events within start time and
    stop time. This type of workspace is appropriate for the case that
    the amount of generated event splitters are not huge;
@@ -54,7 +54,7 @@ event splitters that are supported by this algorithm.
    workspace is appropriate for the case that the amount of generated
    event splitters are huge, because processing a
    :ref:`MatrixWorkspace <MatrixWorkspace>` is way faster than a
-   `TableWorkspace <http://www.mantidproject.org/TableWorkspace>`_ in Mantid.
+   :ref:`TableWorkspace <Table Workspaces>` in Mantid.
 
 .. _functionalities-GenerateEventFilter-ref:
 

--- a/docs/source/algorithms/GeneratePeaks-v1.rst
+++ b/docs/source/algorithms/GeneratePeaks-v1.rst
@@ -11,7 +11,7 @@ Description
 
 Generate a workspace by summing over the peak functions and optionally background functions.
 The peaks' and background'
-parameters are either (1) given in a `TableWorkspace <http://www.mantidproject.org/TableWorkspace>`_
+parameters are either (1) given in a :ref:`TableWorkspace <Table Workspaces>`
 or (2) given by an array of doubles.
 
 Function Parameters
@@ -23,10 +23,10 @@ TableWorkspace
 ==============
 
 Peak and background parameters must have the following columns, which are case
-sensitive in input `TableWorkspace <http://www.mantidproject.org/TableWorkspace>`_
+sensitive in input :ref:`TableWorkspace <Table Workspaces>`
 
 The definition of this table workspace is consistent with the output
-peak and background parameter `TableWorkspace <http://www.mantidproject.org/TableWorkspace>`_
+peak and background parameter :ref:`TableWorkspace <Table Workspaces>`
 of algorithm FindPeaks.
 
 The following table contains the effective peak and background parameters.

--- a/docs/source/algorithms/GetDetOffsetsMultiPeaks-v1.rst
+++ b/docs/source/algorithms/GetDetOffsetsMultiPeaks-v1.rst
@@ -19,7 +19,7 @@ function (default is a :ref:`Gaussian <func-Gaussian>`) to the reference peak. T
 to calculate the centre of the fitted peak, and the offset is then
 calculated as:
 
-This is then written into a `.cal file <http://www.mantidproject.org/CalFile>`__ for every detector
+This is then written into a :ref:`.cal file <CalFile>` for every detector
 that contributes to that spectrum. All of the entries in the cal file
 are initially set to both be included, but also to all group into a
 single group on :ref:`algm-DiffractionFocussing`. The

--- a/docs/source/algorithms/GetDetectorOffsets-v1.rst
+++ b/docs/source/algorithms/GetDetectorOffsets-v1.rst
@@ -23,7 +23,7 @@ calculated as:
 
 :math:`-peakCentre*step/(dreference+PeakCentre*step)`
 
-This is then written into a `.cal file <http://www.mantidproject.org/CalFile>`__ for every detector
+This is then written into a :ref:`.cal file <CalFile>` for every detector
 that contributes to that spectrum. All of the entries in the cal file
 are initially set to both be included, but also to all group into a
 single group on :ref:`algm-DiffractionFocussing`. The

--- a/docs/source/algorithms/ImportMDEventWorkspace-v1.rst
+++ b/docs/source/algorithms/ImportMDEventWorkspace-v1.rst
@@ -9,7 +9,7 @@
 Description
 -----------
 
-Creates an `MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_
+Creates an :ref:`MDEventWorkspace <MDWorkspace>`
 from a plain ASCII file. Uses a simple
 format for the file described below. This algorithm is suitable for
 importing small volumes of data only. This algorithm does not scale well

--- a/docs/source/algorithms/IntegrateEllipsoids-v1.rst
+++ b/docs/source/algorithms/IntegrateEllipsoids-v1.rst
@@ -25,7 +25,7 @@ from :ref:`algm-IntegratePeaksMD` in several critical ways.
 
 -  This algorithm works directly with raw or weighted events
    while :ref:`algm-IntegratePeaksMD` uses **MDEvents** from
-   `MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_.
+   :ref:`MDEventWorkspace <MDWorkspace>`.
 -  This algorithm uses 3D ellipsoidal regions with aspect ratios that
    are adapted to the set of events that are near the peak center, while
    :ref:`algm-IntegratePeaksMD` uses spherical regions.

--- a/docs/source/algorithms/IntegrateEllipsoidsTwoStep-v1.rst
+++ b/docs/source/algorithms/IntegrateEllipsoidsTwoStep-v1.rst
@@ -25,7 +25,7 @@ from :ref:`algm-IntegratePeaksMD` in several critical ways.
 
 -  This algorithm works directly with raw or weighted events
    while :ref:`algm-IntegratePeaksMD` uses **MDEvents** from
-   `MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_.
+   :ref:`MDEventWorkspace <MDWorkspace>`.
 -  This algorithm uses 3D ellipsoidal regions with aspect ratios that
    are adapted to the set of events that are near the peak center, while
    :ref:`algm-IntegratePeaksMD` uses spherical regions.

--- a/docs/source/algorithms/IntegratePeaksMD-v2.rst
+++ b/docs/source/algorithms/IntegratePeaksMD-v2.rst
@@ -16,7 +16,7 @@ Similar algorithms
 ##################
 
 See :ref:`algm-IntegrateEllipsoids` for a ways of integrating peaks from data collected in
-`EventWorkspace <http://www.mantidproject.org/EventWorkspace>`_. :ref:`algm-PeakIntensityVsRadius`
+:ref:`EventWorkspace <EventWorkspace>`. :ref:`algm-PeakIntensityVsRadius`
 is meant to help determine an appropriate value for `PeakRadius`.
 
 Inputs

--- a/docs/source/algorithms/LeBailFit-v1.rst
+++ b/docs/source/algorithms/LeBailFit-v1.rst
@@ -9,7 +9,7 @@
 Description
 -----------
 
-This algorithm performs `Le Bail Fit <Le Bail Fit>`__ to powder
+This algorithm performs `Le Bail Fit <http://www.mantidproject.org/Le_Bail_Fit>`__ to powder
 diffraction data, and also supports pattern calculation. This algorithm
 will refine a specified set of the powder instrumental profile
 parameters with a previous refined background model.
@@ -61,7 +61,7 @@ Supported functionalities
 Further Information
 ###################
 
-See `Le Bail Fit <Le Bail Fit>`__.
+See `Le Bail Fit <http://www.mantidproject.org/Le_Bail_Fit>`__.
 
 .. categories::
 

--- a/docs/source/algorithms/Load-v1.rst
+++ b/docs/source/algorithms/Load-v1.rst
@@ -10,11 +10,10 @@ Description
 -----------
 
 The Load algorithm is a more intelligent algorithm than most other load
-algorithms. When passed a filename it attempts to search the existing
-load `algorithms <index.html>`__ and find the most appropriate
-to load the given file. The specific load algorithm is then run as a
-child algorithm with the exception that it logs messages to the Mantid
-logger.
+:ref:`algorithms <Algorithms List>`. When passed a filename it attempts to
+search the existing load algorithms and find the most appropriate to load the
+given file. The specific load algorithm is then run as a child algorithm with
+the exception that it logs messages to the Mantid logger.
 
 Filename Property
 #################

--- a/docs/source/algorithms/LoadAscii-v2.rst
+++ b/docs/source/algorithms/LoadAscii-v2.rst
@@ -10,7 +10,7 @@ Description
 -----------
 
 The LoadAscii2 algorithm reads in spectra data from a text file and
-stores it in a `Workspace2D <http://www.mantidproject.org/Workspace2D>`_ as data points. The data in
+stores it in a :ref:`Workspace2D <Workspace2D>` as data points. The data in
 the file must be organized in columns separated by commas, tabs, spaces,
 colons or semicolons. Only one separator type can be used throughout the
 file; use the "Separator" property to tell the algorithm which to use.

--- a/docs/source/algorithms/LoadDNSSCD-v1.rst
+++ b/docs/source/algorithms/LoadDNSSCD-v1.rst
@@ -13,7 +13,7 @@ Description
 
    This algorithm does not perform any consistency check of the input data. It is the users responsibility to choose a physically reasonable dataset.
 
-This algorithm loads a list  of DNS `.d_dat` data files into a `MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_. If the algorithm fails to process a file, this file will be ignored. In this case the algorithm produces a warning and continues to process further files. Only if no valid files are provided, the algorithm terminates with an error message.
+This algorithm loads a list  of DNS `.d_dat` data files into a :ref:`MDEventWorkspace <MDWorkspace>`. If the algorithm fails to process a file, this file will be ignored. In this case the algorithm produces a warning and continues to process further files. Only if no valid files are provided, the algorithm terminates with an error message.
 
 This algorithm is meant to replace the :ref:`algm-LoadDNSLegacy` for single crystal diffraction data.
 
@@ -44,9 +44,9 @@ Data replication
 
 For standard data (vanadium, NiCr, background) the sample rotation angle is assumed to be not important. These data are typically measured only for one sample rotation angle. The algorithm can replicate these data for the same sample rotation angles as a single crystal sample has been measured. For this purpose optional input fields *SaveHuberTo* and *LoadHuberFrom* can be used.
 
-- *SaveHuberTo* should contain a name of the `TableWorkspace <http://www.mantidproject.org/TableWorkspace>`_ where sample rotation angles (Huber) read from the data files will be saved. If the specified workspace exists, it will be overwritten.
+- *SaveHuberTo* should contain a name of the :ref:`TableWorkspace <Table Workspaces>` where sample rotation angles (Huber) read from the data files will be saved. If the specified workspace exists, it will be overwritten.
 
-- *LoadHuberFrom* should contain a name of the `TableWorkspace <http://www.mantidproject.org/TableWorkspace>`_. The workspace must exist and contain one column with the name *Huber(degrees)*, where the sample rotation angles are specified.
+- *LoadHuberFrom* should contain a name of the :ref:`TableWorkspace <Table Workspaces>`. The workspace must exist and contain one column with the name *Huber(degrees)*, where the sample rotation angles are specified.
 
 .. note::
 

--- a/docs/source/algorithms/LoadEventNexus-v1.rst
+++ b/docs/source/algorithms/LoadEventNexus-v1.rst
@@ -12,7 +12,7 @@ Description
 The LoadEventNeXus algorithm loads data from an EventNexus file into an
 :ref:`EventWorkspace <EventWorkspace>`. The default histogram bin
 boundaries consist of a single bin able to hold all events (in all
-pixels), and will have their `units <http://www.mantidproject.org/units>`_ set to time-of-flight.
+pixels), and will have their :ref:`units <Unit Factory>` set to time-of-flight.
 Since it is an :ref:`EventWorkspace <EventWorkspace>`, it can be rebinned
 to finer bins with no loss of data.
 

--- a/docs/source/algorithms/LoadEventPreNexus-v2.rst
+++ b/docs/source/algorithms/LoadEventPreNexus-v2.rst
@@ -10,10 +10,10 @@ Description
 -----------
 
 The LoadEventPreNeXus algorithm stores data from the pre-nexus neutron
-event data file in an `EventWorkspace <http://www.mantidproject.org/EventWorkspace>`_. The default
+event data file in an :ref:`EventWorkspace <EventWorkspace>`. The default
 histogram bin boundaries consist of a single bin able to hold all events
-(in all pixels), and will have their `units <http://www.mantidproject.org/units>`_ set to
-time-of-flight. Since it is an `EventWorkspace <http://www.mantidproject.org/EventWorkspace>`_, it
+(in all pixels), and will have their :ref:`units <Unit Factory>` set to
+time-of-flight. Since it is an :ref:`EventWorkspace <EventWorkspace>`, it
 can be rebinned to finer bins with no loss of data.
 
 Optional properties

--- a/docs/source/algorithms/LoadMD-v1.rst
+++ b/docs/source/algorithms/LoadMD-v1.rst
@@ -9,13 +9,13 @@
 Description
 -----------
 
-This algorithm loads a `MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_ that was
+This algorithm loads a :ref:`MDEventWorkspace <MDWorkspace>` that was
 previously saved using the :ref:`algm-SaveMD` algorithm to a .nxs file
 format.
 
 If the workspace is too large to fit into memory, You can load the
-workspace as a `file-backed
-MDWorkspace <MDWorkspace#File-Backed_MDWorkspaces>`__ by checking the
+workspace as a :ref:`file-backed
+MDWorkspace :ref:<MDWorkspace File Backed>` by checking the
 FileBackEnd option. This will load the box structure (allowing for some
 visualization with no speed penalty) but leave the events on disk until
 requested. Processing file-backed MDWorkspaces is significantly slower

--- a/docs/source/algorithms/LoadMD-v1.rst
+++ b/docs/source/algorithms/LoadMD-v1.rst
@@ -13,13 +13,12 @@ This algorithm loads a :ref:`MDEventWorkspace <MDWorkspace>` that was
 previously saved using the :ref:`algm-SaveMD` algorithm to a .nxs file
 format.
 
-If the workspace is too large to fit into memory, You can load the
-workspace as a :ref:`file-backed
-MDWorkspace :ref:<MDWorkspace File Backed>` by checking the
-FileBackEnd option. This will load the box structure (allowing for some
-visualization with no speed penalty) but leave the events on disk until
-requested. Processing file-backed MDWorkspaces is significantly slower
-than in-memory workspaces due to frequent file access!
+If the workspace is too large to fit into memory, You can load the workspace 
+as a :ref:`file-backed MDWorkspace <MDWorkspace File Backed>` by checking the 
+FileBackEnd option. This will load the box structure (allowing for some 
+visualization with no speed penalty) but leave the events on disk until 
+requested. Processing file-backed MDWorkspaces is significantly slower than 
+in-memory workspaces due to frequent file access!
 
 For file-backed workspaces, the Memory option allows you to specify a
 cache size, in MB, to keep events in memory before caching to disk.

--- a/docs/source/algorithms/LoadRaw-v3.rst
+++ b/docs/source/algorithms/LoadRaw-v3.rst
@@ -10,10 +10,10 @@ Description
 -----------
 
 The LoadRaw algorithm stores data from the :ref:`RAW file <RAW File>` in a
-`Workspace2D <http://www.mantidproject.org/Workspace2D>`__, which will naturally contain histogram
+:ref:`Workspace2D <Workspace2D>`, which will naturally contain histogram
 data with each spectrum going into a separate histogram. The time bin
 boundaries (X values) will be common to all histograms and will have
-their `units <http://www.mantidproject.org/Units>`__ set to time-of-flight. The Y values will contain
+their :ref:`units <Unit Factory>` set to time-of-flight. The Y values will contain
 the counts and will be unit-less (i.e. no division by bin width or
 normalisation of any kind). The errors, currently assumed Gaussian, will
 be set to be the square root of the number of counts in the bin.
@@ -34,9 +34,9 @@ If the RAW file contains multiple periods of data this will be detected
 and the different periods will be output as separate workspaces, which
 after the first one will have the period number appended (e.g.
 OutputWorkspace\_period). Each workspace will share the same
-`Instrument <http://www.mantidproject.org/Instrument>`__, SpectraToDetectorMap and
-`sample objects <../api/python/mantid/api/Sample.html>`__. If the optional 'spectrum' properties are
-set for a multiperiod dataset, then they will ignored.
+:ref:`Instrument <Instrument>`, SpectraToDetectorMap and
+:py:obj:`sample objects <mantid.api.Sample>`. If the optional 'spectrum'
+properties are set for a multiperiod dataset, then they will ignored.
 
 If PeriodList property isn't empty then only periods listed there will be
 loaded.
@@ -45,7 +45,7 @@ Subalgorithms used
 ##################
 
 LoadRaw runs the following algorithms as child algorithms to populate
-aspects of the output `Workspace <http://www.mantidproject.org/Workspace>`__:
+aspects of the output :ref:`Workspace <Workspace>`:
 
 -  :ref:`algm-LoadInstrument` - Looks for an instrument
    definition file named XXX\_Definition.xml, where XXX is the 3 letter
@@ -57,10 +57,10 @@ aspects of the output `Workspace <http://www.mantidproject.org/Workspace>`__:
    run instead.
 -  :ref:`algm-LoadMappingTable` - To build up the mapping
    between the spectrum numbers and the Detectors of the attached
-   `Instrument <http://www.mantidproject.org/Instrument>`__.
+   :ref:`Instrument <Instrument>`.
 -  :ref:`algm-LoadLog` - Will look for any log files in the same
    directory as the RAW file and load their data into the workspace's
-   `sample objects <../api/python/mantid/api/Sample.html>`__.
+   :py:obj:`sample objects <mantid.api.Sample>`.
 
 Previous Versions
 -----------------
@@ -75,8 +75,7 @@ Usage
 
 .. include:: ../usagedata-note.txt
 
-Example 1: using defaults
-#########################
+**Example 1: using defaults**
 
 .. testcode:: ExLoadDataDefaults
 
@@ -92,8 +91,7 @@ Example 1: using defaults
   print('Workspace contains {} logs'.format(len(run.keys())))
   print('Workspace has property INT1: {}'.format(run.hasProperty('INT1')))
 
-Output
-^^^^^^
+Output:
 
 .. testoutput:: ExLoadDataDefaults
 
@@ -103,8 +101,7 @@ Output
   Workspace has property INT1: True
 
 
-Example 2: load without the logs
-################################
+**Example 2: load without the logs**
 
 .. testcode:: ExLoadDataNoLogs
 
@@ -120,8 +117,7 @@ Example 2: load without the logs
   print('Workspace contains {} logs'.format(len(run.keys())))
   print('Workspace has property INT1: {}'.format(run.hasProperty('INT1')))
 
-Output
-^^^^^^
+Output:
 
 .. testoutput:: ExLoadDataNoLogs
 
@@ -130,8 +126,7 @@ Output
   Workspace contains 29 logs
   Workspace has property INT1: False
 
-Example 3: exclude monitors
-###########################
+**Example 3: exclude monitors**
 
 .. testcode:: ExLoadDataNoMonitors
 
@@ -147,8 +142,7 @@ Example 3: exclude monitors
   print('Workspace contains {} logs'.format(len(run.keys())))
   print('Workspace has property INT1: {}'.format(run.hasProperty('INT1')))
 
-Output
-^^^^^^
+Output:
 
 .. testoutput:: ExLoadDataNoMonitors
 
@@ -157,8 +151,7 @@ Output
   Workspace contains 35 logs
   Workspace has property INT1: True
 
-Example 4: load monitors separately
-###################################
+**Example 4: load monitors separately**
 
 .. testcode:: ExLoadDataSepMonitors
 
@@ -175,8 +168,7 @@ Example 4: load monitors separately
   detid = monitorws.getSpectrum(1).getDetectorIDs()[0]
   print('Is detector {} a monitor? {}'.format(detid, monitorws.getInstrument().getDetector(detid).isMonitor()))
 
-Output
-^^^^^^
+Output:
 
 .. testoutput:: ExLoadDataSepMonitors
 

--- a/docs/source/algorithms/LoadSQW-v1.rst
+++ b/docs/source/algorithms/LoadSQW-v1.rst
@@ -19,7 +19,7 @@ recalculated to the Crystal? frame, without HKL transformation).
 
 U matrix is set to unity but the B-matrix is read from the SQW and
 attached to the workspace which may confuse the algorithms which work
-with `MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_ produced by Mantid
+with :ref:`MDEventWorkspace <MDWorkspace>` produced by Mantid
 algorithms.
 
 Notes on Horace SQW files

--- a/docs/source/algorithms/LoadSQW-v2.rst
+++ b/docs/source/algorithms/LoadSQW-v2.rst
@@ -12,7 +12,7 @@ Description
 
 The algorithm reads the pixel information defined in an ``.sqw`` file produced
 by the `Horace <http://horace.isis.rl.ac.uk/Main_Page>`_ program and stores
-it in a `MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_.
+it in a :ref:`MDEventWorkspace <MDWorkspace>`.
 
 SQW objects in Horace can be split into 4 sections (see below for more detail):
 

--- a/docs/source/algorithms/LogarithmMD-v1.rst
+++ b/docs/source/algorithms/LogarithmMD-v1.rst
@@ -16,7 +16,7 @@ The signal :math:`a` becomes :math:`f = log(a)`
 The error :math:`da` becomes :math:`df^2 = a^2 / da^2`
 
 This algorithm cannot be run on a
-`MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`__. Its equivalent on a
+:ref:`MDEventWorkspace <MDWorkspace>`. Its equivalent on a
 :ref:`MatrixWorkspace <MatrixWorkspace>` is called
 :ref:`algm-Logarithm`.
 

--- a/docs/source/algorithms/MaskDetectors-v1.rst
+++ b/docs/source/algorithms/MaskDetectors-v1.rst
@@ -85,7 +85,7 @@ If *MaskedWorkspace* is provided, both *MaskedWorkspace* and
 
 The algorithm works differently depending on *MaskedWorkspace* property 
 being a *Mask Workspace* (SpecialWorkspace2D object) or 
-`Matrix Workspace <http://docs.mantidproject.org/nightly/concepts/MatrixWorkspace.html#matrixworkspace>`_. 
+:ref:`Matrix Workspace <MatrixWorkspace>`. 
 
 If source *MaskedWorkspace* is a *Mask Workspace* and the number of spectra in the source 
 *MaskedWorkspace* is equal to number of spectra in the target *Workspace*, the 
@@ -97,12 +97,11 @@ the algorithm extracts list of masked detector IDS from source workspace and
 uses them to mask the corresponding spectra of the target workspace. 
 
 Setting property *ForceInstrumentMasking* to true forces algorithm 
-to always use *MaskedWorkspace* detector IDs
-as the source of the masking information. 
-If a detector is masked, then the corresponding detector
+to always use *MaskedWorkspace* detector IDs as the source of the masking
+information. If a detector is masked, then the corresponding detector
 will be masked in the input *Workspace*.
 
-If the input *MaskedWorkspace* is a `Matrix Workspace <http://docs.mantidproject.org/nightly/concepts/MatrixWorkspace.html#matrixworkspace>`_ 
+If the input *MaskedWorkspace* is a :ref:`Matrix Workspace <MatrixWorkspace>` 
 and the number of spectra in the source *MaskedWorkspace* is equal to the number 
 of spectra in the target *Workspace*, then workspace indices of the source are
 used.
@@ -173,8 +172,7 @@ There are 2 operations to mask a detector and thus spectrum related
 Usage
 -----
 
-Example 1: specifying spectrum numbers
-######################################
+**Example 1: specifying spectrum numbers**
 
 .. testcode:: ExMaskSpec
 
@@ -219,8 +217,7 @@ Example 1: specifying spectrum numbers
   y = ws.readY(3)
   print('All counts in the spectrum are 0:    {}'.format(np.all( y == 0.0 )))
 
-Output
-^^^^^^
+Output:
 
 .. testoutput:: ExMaskSpec
 
@@ -238,8 +235,7 @@ Output
   All counts in the spectrum are 0:    False
 
 
-Example 2: specifying detector IDs
-##################################
+**Example 2: specifying detector IDs**
 
 .. testcode:: ExMaskIDs
 
@@ -266,8 +262,7 @@ Example 2: specifying detector IDs
   det = ws.getInstrument().getDetector(105)
   print('Detector  {}  is masked: {}'.format(det.getID(), det.isMasked()))
 
-Output
-^^^^^^
+Output:
 
 .. testoutput:: ExMaskIDs
 
@@ -278,8 +273,7 @@ Output
   Detector  105  is masked: False
 
 
-Example 3: specifying workspace indices
-#######################################
+**Example 3: specifying workspace indices**
 
 .. testcode:: ExMaskWI
 
@@ -311,8 +305,7 @@ Example 3: specifying workspace indices
   det = ws.getDetector( workspaceIndex )
   print('Detector in spectrum with workspace index  {}  is masked: {}'.format(workspaceIndex, det.isMasked()))
 
-Output
-^^^^^^
+Output:
 
 .. testoutput:: ExMaskWI
 
@@ -323,8 +316,7 @@ Output
   Detector in spectrum with workspace index  4  is masked: False
 
 
-Example 4: specifying instrument components
-###########################################
+**Example 4: specifying instrument components**
 
 .. testcode:: ExMaskComp
 
@@ -356,13 +348,14 @@ Example 4: specifying instrument components
   # Check bank2
   checkMasked(200,300)
 
+Output:
+
 .. testoutput:: ExMaskComp
 
   Detectors from 130 to 140 are masked.
   Detectors from 200 to 300 are masked.
 
-Example 5: specifying a masking workspace
-#########################################
+**Example 5: specifying a masking workspace**
 
 .. testcode:: ExMaskMask
 
@@ -401,8 +394,7 @@ Example 5: specifying a masking workspace
   print('Detector {} is masked: {}'.format(det.getID(), det.isMasked()))
 
 
-Output
-^^^^^^
+Output:
 
 .. testoutput:: ExMaskMask
 
@@ -419,8 +411,7 @@ Output
   Detector 103 is masked: True
   Detector 104 is masked: False
   
-Example 6: specifying a masking range
-#####################################
+**Example 6: specifying a masking range**
 
 .. testcode:: ExMaskInRange
 
@@ -435,8 +426,7 @@ Example 6: specifying a masking range
     print('Detector {} is masked: {}'.format(det.getID(), det.isMasked()))
 
 
-Output
-^^^^^^
+Output:
 
 .. testoutput:: ExMaskInRange
 
@@ -447,8 +437,7 @@ Output
   Detector 104 is masked: True
   Detector 105 is masked: False
   
-Example 7: constraining the masking range
-#########################################
+**Example 7: constraining the masking range**
 
 .. testcode:: ExMaskConstrainInRange
 
@@ -478,9 +467,8 @@ Example 7: constraining the masking range
   for ind in range(0,7):
     det = ws.getDetector(ind)
     print('Detector {} is masked: {}'.format(det.getID(), det.isMasked()))
-    
-Output
-^^^^^^
+
+Output:
 
 .. testoutput:: ExMaskConstrainInRange
 

--- a/docs/source/algorithms/MinusMD-v1.rst
+++ b/docs/source/algorithms/MinusMD-v1.rst
@@ -25,15 +25,15 @@ MDHistoWorkspace and a scalar.
 
    -  This is not allowed.
 
--  **`MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_ -
-   `MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_**
+-  **:ref:`MDEventWorkspace <MDWorkspace>` -
+   :ref:`MDEventWorkspace <MDWorkspace>`**
 
    -  The signal of each event on the right-hand-side is multiplied by
       -1 before the events are summed.
    -  The number of events in the output MDEventWorkspace is that of the
       LHS and RHS workspaces put together.
 
--  **`MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_ - Scalar or
+-  **:ref:`MDEventWorkspace <MDWorkspace>` - Scalar or
    MDHistoWorkspace**
 
    -  This is not possible.

--- a/docs/source/algorithms/MonitorLiveData-v1.rst
+++ b/docs/source/algorithms/MonitorLiveData-v1.rst
@@ -19,7 +19,7 @@ This algorithm simply calls :ref:`algm-LoadLiveData` at the given
 :ref:`algm-StartLiveData`.
 
 For details on the way to specify the data processing steps, see:
-`LoadLiveData <LoadLiveData#Description>`__.
+:ref:`LoadLiveData <algm-LoadLiveData>`.
 
 Usage
 -----

--- a/docs/source/algorithms/MultiplyMD-v1.rst
+++ b/docs/source/algorithms/MultiplyMD-v1.rst
@@ -23,7 +23,7 @@ The error of :math:`f = a * b` is propagated with
 
    -  Every element of the MDHistoWorkspace is multiplied by the scalar.
 
--  **`MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_'s**
+-  **:ref:`MDEventWorkspace <MDWorkspace>`'s**
 
    -  This operation is not supported, as it is not clear what its
       meaning would be.

--- a/docs/source/algorithms/NormaliseByCurrent-v1.rst
+++ b/docs/source/algorithms/NormaliseByCurrent-v1.rst
@@ -11,7 +11,7 @@ Description
 
 Normalises a workspace according to the good proton charge figure taken
 from the Input Workspace log data, which is stored in the workspace's
-`sample objects <../api/python/mantid/api/Sample.html>`__). Every data point
+:py:obj:`run object <mantid.api.Run>`. Every data point
 (and its error) is divided by that number.
 The good proton charge value is added to the normalized workspace
 as the value of *NormalizationFactor* log. 

--- a/docs/source/algorithms/NormaliseByDetector-v1.rst
+++ b/docs/source/algorithms/NormaliseByDetector-v1.rst
@@ -11,7 +11,7 @@ Description
 
 This algorithm is designed to normalise a workspace via detector
 efficiency functions. **For this algorithm to work, the Instrument
-Definition File `IDF <http://www.mantidproject.org/IDF>`_ must have fitting functions on the
+Definition File :ref:`IDF <InstrumentDefinitionFile>` must have fitting functions on the
 component tree**. The setup information for this, as well as some
 examples, are provided below.
 
@@ -45,7 +45,7 @@ Background
 In brief, the components in the IDF file form a tree structure.
 Detectors and Instruments are both types of component. Detectors are
 ultimately children of Instruments in the tree structure. For a more
-complete description see `IDF <http://www.mantidproject.org/IDF>`_. The tree structure of the
+complete description see :ref:`IDF <InstrumentDefinitionFile>`. The tree structure of the
 components, mean that fitting functions do not necessarily have to be
 assigned on a detector-by-detector basis. Applying a fit function to the
 instrument, will ensure that all subcomponents (including detectors),

--- a/docs/source/algorithms/OneStepMDEW-v1.rst
+++ b/docs/source/algorithms/OneStepMDEW-v1.rst
@@ -10,7 +10,7 @@ Description
 -----------
 
 This algorithm is used in the Paraview event nexus loader to both load
-an event nexus file and convert it into a `MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_ for use in visualization.
+an event nexus file and convert it into a :ref:`MDEventWorkspace <MDWorkspace>` for use in visualization.
 
 The :ref:`algm-LoadEventNexus` algorithm is called with default
 parameters to load into an :ref:`EventWorkspace <EventWorkspace>`.

--- a/docs/source/algorithms/PDCalibration-v1.rst
+++ b/docs/source/algorithms/PDCalibration-v1.rst
@@ -54,8 +54,8 @@ three workspaces placed in the ``DiagnosticWorkspace`` group. They are:
 * instrument resolution (delta-d/d ``_resolution``)
 
 Since multiple peak shapes can be used,
-see the documentation for the individual `fit functions
-<../fitfunctions/index.html>`_ to see how they relate to the effective
+see the documentation for the individual :ref:`fit functions
+<Fit Functions List>` to see how they relate to the effective
 values displayed in the diagnostic tables. For ``Gaussian`` and
 ``Lorentzian``, the widths and resolution are converted to values that
 can be directly compared with the results of
@@ -68,7 +68,7 @@ Usage
 
 .. code-block:: python
 
-   # If you have a old calibration it can be used as the starting point
+   # If you have an old calibration it can be used as the starting point
    oldCal = 'NOM_calibrate_d72460_2016_05_23.h5'
 
    # list of d values for diamond

--- a/docs/source/algorithms/PDDetermineCharacterizations-v1.rst
+++ b/docs/source/algorithms/PDDetermineCharacterizations-v1.rst
@@ -10,7 +10,7 @@ Description
 -----------
 
 This algorithm takes an ``InputWorkspace`` and ``Characterizations``
-`TableWorkspace <http://www.mantidproject.org/TableWorkspace>`__ and
+:ref:`TableWorkspace <Table Workspaces>` and
 creates a PropertyManager with the appropriate characterization runs.
 This is done by determining the effective accelerator frequency and
 center wavelength and choosing the appropriate row from the table.
@@ -58,14 +58,14 @@ wavelength_min      double       0
 wavelength_max      double       0
 =================== ============ ======= ============
 
-In the case of extra columns existing in the `TableWorkspace
-<TableWorkspace>`__ denoting ``SampleContainer`` information: if the
+In the case of extra columns existing in the :ref:`TableWorkspace
+<Table Workspaces>` denoting ``SampleContainer`` information: if the
 ``SampleContainer`` isn't a property on the workspace, or the value
 isn't one of the column labels, the value of the ``container`` column
-in the supplied `TableWorkspace <TableWorkspace>`__ will be used
+in the supplied :ref:`TableWorkspace <Table Workspaces>` will be used
 instead.
 
-For a description of the  `TableWorkspace <TableWorkspace>`__
+For a description of the  :ref:`TableWorkspace <Table Workspaces>`
 see :ref:`PDLoadCharacterizations <algm-PDLoadCharacterizations>`.
 
 .. categories::

--- a/docs/source/algorithms/PDFFourierTransform-v1.rst
+++ b/docs/source/algorithms/PDFFourierTransform-v1.rst
@@ -11,10 +11,10 @@ Description
 
 The algorithm transforms a single spectrum workspace containing 
 spectral density :math:`S(Q)`, :math:`S(Q)-1`, or :math:`Q[S(Q)-1]` 
-(as a function of **MomentumTransfer** or **dSpacing** `units <http://www.mantidproject.org/Units>`_ ) to a PDF 
+(as a function of **MomentumTransfer** or **dSpacing** :ref:`units <Unit Factory>`) to a PDF 
 (pair distribution function) as described below.
 
-The input Workspace spectrum should be in the Q-space (\ **MomentumTransfer**\ ) `units <http://www.mantidproject.org/Units>`_ . 
+The input Workspace spectrum should be in the Q-space (\ **MomentumTransfer**\ ) :ref:`units <Unit Factory>` .
 (d-spacing is not supported any more. Contact development team to fix that and enable **dSpacing** again)
 
 References

--- a/docs/source/algorithms/PDLoadCharacterizations-v1.rst
+++ b/docs/source/algorithms/PDLoadCharacterizations-v1.rst
@@ -10,7 +10,7 @@ Description
 -----------
 
 This algorithm loads information into a
-`TableWorkspace <http://www.mantidproject.org/TableWorkspace>`__ for the
+:ref:`TableWorkspace <Table Workspaces>` for the
 characterization information and a collection of output parameters for
 the focus positions to be used in :ref:`algm-EditInstrumentGeometry`. If
 a section is missing then those parameters will be empty. This includes an empty
@@ -52,7 +52,7 @@ specifying azimuthal angles for the focus positions is being supplied
 as it uncommon except for preferred orientation studies.
 
 The second section of the characterizations file is read into the output
-`TableWorkspace <http://www.mantidproject.org/TableWorkspace>`__ as described below.
+:ref:`TableWorkspace <Table Workspaces>` as described below.
 
 A second example from NOMAD demonstrates how to specify different
 ranges for each focused spectrum as well as the optional wavelength

--- a/docs/source/algorithms/PlusMD-v1.rst
+++ b/docs/source/algorithms/PlusMD-v1.rst
@@ -10,7 +10,7 @@ Description
 -----------
 
 This algorithm sums two :ref:`MDHistoWorkspaces <MDHistoWorkspace>` or
-merges two `MDEventWorkspaces <http://www.mantidproject.org/MDEventWorkspace>`_ together.
+merges two :ref:`MDEventWorkspaces <MDWorkspace>` together.
 
 MDHistoWorkspaces
 #################
@@ -37,7 +37,7 @@ Note for file-backed workspaces
 The algorithm uses :ref:`algm-CloneMDWorkspace` to create the
 output workspace, except when adding in place (e.g. :math:`A = A + B` ).
 See :ref:`algm-CloneMDWorkspace` for details, but note that a
-file-backed `MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_ will have its file
+file-backed :ref:`MDEventWorkspace <MDWorkspace>` will have its file
 copied.
 
 -  If A is in memory and B is file-backed, the operation

--- a/docs/source/algorithms/PowerMD-v1.rst
+++ b/docs/source/algorithms/PowerMD-v1.rst
@@ -16,7 +16,7 @@ The signal :math:`a` becomes :math:`f = a^b`
 The error :math:`da` becomes :math:`df^2 = f^2 * b^2 * (da^2 / a^2)`
 
 This algorithm cannot be run on a
-`MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`__. Its equivalent on a
+:ref:`MDEventWorkspace <MDWorkspace>`. Its equivalent on a
 :ref:`MatrixWorkspace <MatrixWorkspace>` is called :ref:`algm-Power`.
 
 .. categories::

--- a/docs/source/algorithms/Q1D-v2.rst
+++ b/docs/source/algorithms/Q1D-v2.rst
@@ -51,7 +51,7 @@ This section describes the normalisation/scaling/correction of the input
 workspace using PixelAdj, WavelengthAdj and WavePixelAdj.
 
 This :ref:`algorithm <Algorithm>` takes as input a workspace of neutron
-counts against `wavelength <http://www.mantidproject.org/Units>`_ and creates a workspace of cross
+counts against :ref:`wavelength <Unit Factory>` and creates a workspace of cross
 section against Q. The output Q bins boundaries are defined by setting
 the property OutputBinning.
 
@@ -70,7 +70,7 @@ of many, one, or no wavelength bins.)
 
 In the equation the number of counts in the input spectrum number is
 denoted by :math:`S(n)`, :math:`N(n)` is the wavelength dependent
-correction and :math:`\Omega` is the `solid angle <http://www.mantidproject.org/SolidAngle>`_ of the
+correction and :math:`\Omega` is the :ref:`solid angle <algm-SolidAngle>` of the
 detector
 
 .. math:: P_I(Q) = \frac{ \sum_{n \supset I} S(n)}{\Omega\sum_{n \supset I}N(n)}
@@ -101,7 +101,7 @@ where :math:`F` is the detector dependent (e.g. flood) scaling specified
 by the PixelAdj property, and where a :math:`\lambda` bin :math:`n`
 spans more than one :math:`Q` bin :math:`I`, it is split assuming a
 uniform distribution of the counts in :math:`\lambda`. The normalization
-takes any `bin masking <http://www.mantidproject.org/MaskBins>`_ into account.
+takes any :ref:`bin masking <algm-MaskBins>` into account.
 
 Some corrections will be both pixel and wavelength dependent, for example an
 angle transmission correction. Such corrections can be taken into account by

--- a/docs/source/algorithms/RawFileInfo-v1.rst
+++ b/docs/source/algorithms/RawFileInfo-v1.rst
@@ -11,10 +11,10 @@ Description
 
 Extracts run parameters from the :ref:`RAW <Raw File>` file given as an
 input property. If the ``GetRunParameters`` argument is ``True`` then a
-`TableWorkspace <http://www.mantidproject.org/TableWorkspace>`__ is created that contains a 
+:ref:`TableWorkspace <Table Workspaces>` is created that contains a 
 column for each value of the ``RPB_STRUCT``, i.e. column names such as ``r_dur``, ``r_goodfrm``
 etc. If the ``GetSampleParameters`` argument is ``True`` then a 
-`TableWorkspace <http://www.mantidproject.org/TableWorkspace>`__ is created that contains a 
+:ref:`TableWorkspace <Table Workspaces>` is created that contains a 
 column for each value of the ``SPB_STRUCT``, i.e. column names such as ``e_geom``, ``e_width``, etc.
 This is Mantid's version of the ``Get`` routine in `Open Genie <http://www.opengenie.org/>`__.
 

--- a/docs/source/algorithms/Rebin-v1.rst
+++ b/docs/source/algorithms/Rebin-v1.rst
@@ -49,7 +49,7 @@ Example Rebin param strings
 For EventWorkspaces
 ###################
 
-If the input is an `EventWorkspace <www.mantidproject.org/EventWorkspace>`__ and the "Preserve
+If the input is an :ref:`EventWorkspace <EventWorkspace>` and the "Preserve
 Events" property is True, the rebinning is performed in place, and only
 the X axes of the workspace are set. The actual Y histogram data will
 only be requested as needed, for example, when plotting or displaying

--- a/docs/source/algorithms/SaveMD-v1.rst
+++ b/docs/source/algorithms/SaveMD-v1.rst
@@ -9,7 +9,7 @@
 Description
 -----------
 
-Save an `MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_ or a
+Save an :ref:`MDEventWorkspace <MDWorkspace>` or a
 :ref:`MDHistoWorkspace <MDHistoWorkspace>` to a .nxs file. The
 workspace's current box structure and entire list of events is
 preserved. The resulting file can be loaded via :ref:`LoadMD <algm-LoadMD>`.

--- a/docs/source/algorithms/SaveMD-v2.rst
+++ b/docs/source/algorithms/SaveMD-v2.rst
@@ -9,7 +9,7 @@
 Description
 -----------
 
-Save an `MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_ or a
+Save an :ref:`MDEventWorkspace <MDWorkspace>` or a
 :ref:`MDHistoWorkspace <MDHistoWorkspace>` to a .nxs file. The
 workspace's current box structure and entire list of events is
 preserved. The resulting file can be loaded via :ref:`LoadMD <algm-LoadMD>`.

--- a/docs/source/algorithms/SaveNXcanSAS-v1.rst
+++ b/docs/source/algorithms/SaveNXcanSAS-v1.rst
@@ -9,7 +9,7 @@
 Description
 -----------
 
-Saves a workspace with momentum transfer units into a file adhering to the NXcanSAS format specified by NXcanSAS Data Formats Working Group schema http://cansas-org.github.io/NXcanSAS/classes/contributed_definitions/NXcanSAS.html. If the input workspace is 2D then the vertical axis needs to be a numeric axis in momentum transfer units. The created file can be reloaded using he :ref:`algm-LoadNXcanSAS` algorithm.
+Saves a workspace with momentum transfer units into a file adhering to the NXcanSAS format specified by NXcanSAS Data Formats Working Group `schema <http://cansas-org.github.io/NXcanSAS/classes/contributed_definitions/NXcanSAS.html>`__. If the input workspace is 2D then the vertical axis needs to be a numeric axis in momentum transfer units. The created file can be reloaded using the :ref:`algm-LoadNXcanSAS` algorithm.
 
 In addition it is possible to save the transmission workspaces obtain from a reduction.
 

--- a/docs/source/algorithms/SaveParameterFile-v1.rst
+++ b/docs/source/algorithms/SaveParameterFile-v1.rst
@@ -10,7 +10,7 @@ Description
 -----------
 
 This algorithm allows instrument parameters to be saved into an
-`instrument parameter file <http://www.mantidproject.org/InstrumentParameterFile>`__.
+:ref:`instrument parameter file <InstrumentParameterFile>`.
 The parameter file can then be inspected and or modified. It can also be loaded back into
 Mantid using the :ref:`algm-LoadParameterFile` algorithm.
 

--- a/docs/source/algorithms/SaveZODS-v1.rst
+++ b/docs/source/algorithms/SaveZODS-v1.rst
@@ -73,7 +73,7 @@ Description of data fields
 Usage
 -----
 
-This algorithm can be run on a pre-existing `MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_
+This algorithm can be run on a pre-existing :ref:`MDEventWorkspace <MDWorkspace>`
 or a newly created one. The example below will be done with newly created one
 using :ref:`CreateMDWorkspace <algm-CreateMDWorkspace>`.
 

--- a/docs/source/algorithms/Scale-v1.rst
+++ b/docs/source/algorithms/Scale-v1.rst
@@ -12,7 +12,7 @@ Description
 Uses the binary operation algorithms :ref:`algm-Multiply` or
 :ref:`algm-Plus` to scale the input workspace by the amount requested.
 This algorithm is provided as a simple, but less powerful, alternative
-to the python `workspace algebra <http://www.mantidproject.org/MatrixWorkspace_Attributes#Workspace_algebra>`__ functionality.
+to the python :ref:`workspace algebra <MatrixWorkspace Algebra>` functionality.
 
 
 Usage

--- a/docs/source/algorithms/SetMDUsingMask-v1.rst
+++ b/docs/source/algorithms/SetMDUsingMask-v1.rst
@@ -22,8 +22,8 @@ a a simple number to set.
 In matlab, the equivalent function call would be WS[mask] =
 OtherWS[mask]
 
-See `this page on boolean
-operations <MDHistoWorkspace#Boolean_Operations>`__ for examples of how
+See :ref:`this page on boolean
+operations <MDHistoWorkspace boolean operations>` for examples of how
 to create a mask.
 
 Usage (Python)

--- a/docs/source/algorithms/SetSpecialCoordinates-v1.rst
+++ b/docs/source/algorithms/SetSpecialCoordinates-v1.rst
@@ -9,7 +9,7 @@
 Description
 -----------
 
-`MDEventWorkspaces <http://www.mantidproject.org/MDEventWorkspace>`_ and
+:ref:`MDEventWorkspaces <MDWorkspace>` and
 :ref:`MDHistoWorkspaces <MDHistoWorkspace>` can be used with any type of
 coordinate system. On the other hand
 :ref:`PeaksWorkspaces <PeaksWorkspace>` may be plotted either in QLab,

--- a/docs/source/algorithms/SliceMD-v1.rst
+++ b/docs/source/algorithms/SliceMD-v1.rst
@@ -10,7 +10,7 @@ Description
 -----------
 
 Algorithm that can take a slice out of an original
-`MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_ while preserving all the events
+:ref:`MDEventWorkspace <MDWorkspace>` while preserving all the events
 contained therein.
 
 It uses the same parameters as :ref:`algm-BinMD` to determine a
@@ -55,7 +55,7 @@ Slicing a MDHistoWorkspace
 
 It is possible to slice a :ref:`MDHistoWorkspace <MDHistoWorkspace>`. Each
 MDHistoWorkspace holds a reference to the
-`MDEventWorkspace <http://www.mantidproject.org/MDEventWorkspace>`_ that created it, as well as the
+:ref:`MDEventWorkspace <MDWorkspace>` that created it, as well as the
 coordinate transformation that was used.
 
 In this case, the algorithm is executed on the original

--- a/docs/source/algorithms/SmoothNeighbours-v1.rst
+++ b/docs/source/algorithms/SmoothNeighbours-v1.rst
@@ -12,8 +12,8 @@ Description
 This algorithm performs a moving-average smoothing of data by summing
 spectra of nearest neighbours over the face of detectors. The output
 workspace has the same number of spectra as the input workspace. This
-works on both `EventWorkspaces <http://mantidproject.org/EventWorkspace>`__ and
-`Workspace2D <http://mantidproject.org/Workspace2D>`__'s. It has two main modes of operation.
+works on both :ref:`EventWorkspaces <EventWorkspace>` and
+:ref:`Workspace2D <Workspace2D>`'s. It has two main modes of operation.
 
 Processing Either Generically or Assuming Rectangular Detectors
 ###############################################################
@@ -34,7 +34,7 @@ section below).
 For Instruments With Rectangular Detectors
 ##########################################
 
-The algorithm looks through the `Instrument <http://mantidproject.org/Instrument>`__ to find all
+The algorithm looks through the :ref:`Instrument <Instrument>` to find all
 the :ref:`RectangularDetectors <RectangularDetector>` defined. For each
 pixel in each detector, the AdjX\*AdjY neighboring spectra are summed
 together and saved in the output workspace.

--- a/docs/source/algorithms/SofQW-v1.rst
+++ b/docs/source/algorithms/SofQW-v1.rst
@@ -10,7 +10,7 @@ Description
 -----------
 
 This algorithm is for use by inelastic instruments and takes as its
-input a workspace where the data's been reduced to be in `units <http://www.mantidproject.org/Units>`_
+input a workspace where the data's been reduced to be in :ref:`units <Unit Factory>`
 of **energy transfer** against spectrum number (which can be seen as equivalent to
 angle, with the angle being taken from the detector(s) to which the
 spectrum pertains).

--- a/docs/source/algorithms/SofQWCentre-v1.rst
+++ b/docs/source/algorithms/SofQWCentre-v1.rst
@@ -10,7 +10,7 @@ Description
 -----------
 
 This algorithm is for use by inelastic instruments and takes as its
-input a workspace where the data's been reduced to be in `units <http://www.mantidproject.org/Units>`_ 
+input a workspace where the data's been reduced to be in :ref:`units <Unit Factory>`
 of **energy transfer** against spectrum number (which can be seen as equivalent to
 angle, with the angle being taken from the detector(s) to which the
 spectrum pertains). For each detector the value of **momentum transfer**

--- a/docs/source/algorithms/UserFunction1D-v1.rst
+++ b/docs/source/algorithms/UserFunction1D-v1.rst
@@ -82,7 +82,7 @@ with 0.0. If some of the parameters should be fixed in the fit list them
 in the *Fix* property in any order, e.g. "a,c".
 
 The resulting parameters are returned in a
-`TableWorkspace <http://www.mantidproject.org/TableWorkspace>`_ set in ``OutputParameters`` property.
+:ref:`TableWorkspace <Table Workspaces>` set in ``OutputParameters`` property.
 Also for displaying purposes *OutputWorkspace* is returned. It contains
 the initial spectrum, the fitted spectrum and their difference.
 

--- a/docs/source/concepts/FittingMinimizers.rst
+++ b/docs/source/concepts/FittingMinimizers.rst
@@ -21,6 +21,8 @@ and modifications to existing minimizers.
 
 For the task of Bayesian probability sampling: this is supported with the FABADA minimizer.
 
+.. _FittingMinimizers Minimizer Comparison:
+
 Comparing Minimizers
 ====================
 
@@ -46,16 +48,16 @@ Several minimizers are included with Mantid and can be selected in the
 or when using the algorithm :ref:`Fit <algm-Fit>` The following
 options are available:
 
-- `Simplex <../fitminimizers/Simplex.html>`__
-- `SteepestDescent <../fitminimizers/GradientDescent.html>`__
-- `Conjugate gradient (Fletcher-Reeves imp.) <../fitminimizers/FletcherReeves.html>`__
-- `Conjugate gradient (Polak-Ribiere imp.) <../fitminimizers/PolakRibiere.html>`__
-- `BFGS (Broyden-Fletcher-Goldfarb-Shanno) <../fitminimizers/BFGS.html>`__
-- `Levenberg-Marquardt <../fitminimizers/LevenbergMarquardt.html>`__ (default)
-- `Levenberg-MarquardtMD <../fitminimizers/LevenbergMarquardtMD.html>`__
-- `Damped Gauss-Newton <../fitminimizers/DampedGaussNewton.html>`__
+- :ref:`Simplex <Simplex>`
+- :ref:`SteepestDescent <GradientDescent>`
+- :ref:`Conjugate gradient (Fletcher-Reeves imp.) <FletcherReeves>`
+- :ref:`Conjugate gradient (Polak-Ribiere imp.) <PolakRiberiere>`
+- :ref:`BFGS (Broyden-Fletcher-Goldfarb-Shanno) <BFGS>`
+- :ref:`Levenberg-Marquardt <LevenbergMarquardt>` (default)
+- :ref:`Levenberg-MarquardtMD <LevenbergMarquardtMD>`
+- :ref:`Damped Gauss-Newton <DampedGaussNewton>`
 - :ref:`FABADA <FABADA>`
-- `Trust region <../fitminimizers/TrustRegion.html>`__
+- :ref:`Trust region <TrustRegion>`
 
 All these algorithms are `iterative
 <https://en.wikipedia.org/wiki/Iterative_method>`__.  The *Simplex*

--- a/docs/source/concepts/HowToDefineGeometricShape.rst
+++ b/docs/source/concepts/HowToDefineGeometricShape.rst
@@ -48,19 +48,17 @@ Axes and units of measure
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 All objects are defined with respect to cartesian axes (x,y,z), and the
-`default <IDF#Using_.3Cdefaults.3E>`__ unit of all supplied values are
+:ref:`default <Using defaults>` unit of all supplied values are
 metres(m). Objects may be defined so that the origin (0,0,0) is at the
 centre, so that when rotations are applied they do not also apply an
 unexpected translation.
 
 Within instrument definitions we support the concept of defining a
-rotation by specifying what point the object is
-`facing <InstrumentDefinitionFile#Using_.3Cfacing.3E>`__. To apply that
-correctly the side of the object we consider to be the front is the xy
-plane. Hence, when planning to use
-`facing <InstrumentDefinitionFile#Using_.3Cfacing.3E>`__ the shape
-should be defined such that the positive y-axis is considered to be up,
-the x-axis the width, and the z-axis the depth of the shape.
+rotation by specifying what point the object is :ref:`facing <Using facing>`.
+To apply that correctly the side of the object we consider to be the front
+is the xy plane. Hence, when planning to use :ref:`facing <Using facing>`
+the shape should be defined such that the positive y-axis is considered
+to be up, the x-axis the width, and the z-axis the depth of the shape.
 
 To be aware of
 --------------

--- a/docs/source/concepts/MDHistoWorkspace.rst
+++ b/docs/source/concepts/MDHistoWorkspace.rst
@@ -222,6 +222,8 @@ The basic arithmetic operators are available from python. For example:
    #Compound arithmetic expressions can be made, e.g:
    E = (A - B) / (C * C)
 
+.. _MDHistoWorkspace boolean operations:
+
 Boolean Operations
 ##################
 
@@ -269,7 +271,7 @@ Using Boolean Masks
       
 The :ref:`SetMDUsingMask <algm-SetMDUsingMask>` algorithm allows you to modify
 the values in a MDHistoWorkspace using a mask created using the boolean
-operations above. See the `algorithm wiki page <algm-SetMDUsingMask>`__ for
+operations above. See the :ref:`algorithm wiki page <algm-SetMDUsingMask>` for
 more details.
 
 

--- a/docs/source/concepts/MDWorkspace.rst
+++ b/docs/source/concepts/MDWorkspace.rst
@@ -75,6 +75,8 @@ There are several algorithms that will create a MDWorkspace:
    new one.
 -  :ref:`LoadSQW <algm-LoadSQW>` converts from the SQW format.
 
+.. _MDWorkspace File Backed:
+
 File-Backed MDWorkspaces
 ------------------------
 

--- a/docs/source/concepts/MatrixWorkspace.rst
+++ b/docs/source/concepts/MatrixWorkspace.rst
@@ -371,6 +371,8 @@ The data is accessed using the ``readX()``, ``readY()`` and ``readE()`` commands
 
 There are more examples how to `Extract and manipulate workspace data here <http://www.mantidproject.org/Extracting_And_Manipulating_Data>`_.
 
+.. _MatrixWorkspace Algebra:
+
 Workspace algebra
 #################
 

--- a/docs/source/concepts/Run.rst
+++ b/docs/source/concepts/Run.rst
@@ -181,6 +181,8 @@ ISIS (not including ISIS Muon data)
 -  **mon\_sum3** - Monitor sum 3
 -  **rb\_proposal** - The proposal number
 
+.. _RunInfoOnISISMuonData:
+
 ISIS Muon data
 ##############
 

--- a/docs/source/fitting/fitfunctions/CubicSpline.rst
+++ b/docs/source/fitting/fitfunctions/CubicSpline.rst
@@ -16,13 +16,13 @@ First and second derivatives from the spline can be calculated by using
 the derivative1D function.
 
 A CubicSpline is a polynomial function :math:`f(x)` of order 3, defined between an interval :math:`a \leqslant x \leqslant b`.
-When using CubicSplines for interpolation or for fitting, we essentially chain `BSplines <http://docs.mantidproject.org/nightly/fitfunctions/BSpline.html>`__ 
+When using CubicSplines for interpolation or for fitting, we essentially chain :ref:`BSplines <func-BSpline>` 
 of order 3 together so that each spline passes through the breakpoints in that interval.
 
-A Cubic Spline is a specific case of `BSpline <http://docs.mantidproject.org/nightly/fitfunctions/BSpline.html>`__
+A Cubic Spline is a specific case of :ref:`BSpline <func-BSpline>`
 that only uses polynomials of order 3 to define the spline functions.
 
-Again, as with `BSplines <http://docs.mantidproject.org/nightly/fitfunctions/BSpline.html>`__ , there are certain conditions
+Again, as with :ref:`BSplines <func-BSpline>` , there are certain conditions
 that must be fulfilled at each breakpoint such that the overall Spline is piecewise-smooth.
 
 Example

--- a/docs/source/fitting/fitfunctions/PrimStretchedExpFT.rst
+++ b/docs/source/fitting/fitfunctions/PrimStretchedExpFT.rst
@@ -18,7 +18,7 @@ each energy bin.
 
 .. math:: S(Q,E) = \int_{E-\delta E}^{E+\delta E} dE' StretchedExpFT(E', Centre, Tau, Beta)
 
-with :math:`StretchedExpFT` is fit function `StretchedExpFT <func-StretchedExpFT>`__.
+with :math:`StretchedExpFT` is fit function :ref:`StretchedExpFT <func-StretchedExpFT>`.
 Quantity :math:`\delta E` is evaluated at run time. If we request to evaluate this
 function over a set of energy values :math:`E_0,..,E_N`,
 then :math:`2\delta E = \frac{E_N-E_0}{N}`

--- a/docs/source/fitting/fitfunctions/ProductLinearExp.rst
+++ b/docs/source/fitting/fitfunctions/ProductLinearExp.rst
@@ -10,8 +10,8 @@ Description
 -----------
 
 This fit function computes the product of a linear and exponential
-function. See `ExpDecay <ExpDecay>`__ and
-`LinearBackground <LinearBackground>`__ for details on the component
+function. See :ref:`ExpDecay <func-ExpDecay>` and
+:ref:`LinearBackground <func-LinearBackground>` for details on the component
 functions.
 
 .. math:: \left(\mbox{A}_0 + \mbox{A}_1 x\right)\cdot h\cdot e^{-\frac{x}{\tau}}

--- a/docs/source/fitting/fitfunctions/ProductQuadraticExp.rst
+++ b/docs/source/fitting/fitfunctions/ProductQuadraticExp.rst
@@ -10,7 +10,7 @@ Description
 -----------
 
 This fit function computes the product of a linear and exponential
-function. See `ExpDecay <ExpDecay>`__ and QuadraticBackground for
+function. See :ref:`ExpDecay <func-ExpDecay>` and QuadraticBackground for
 details on the component functions.
 
 .. math:: \left(\mbox{A}_0 + \mbox{A}_1 x + \mbox{A}_2 x^2\right)\cdot h \cdot e^{-\frac{x}{\tau}}
@@ -18,7 +18,7 @@ details on the component functions.
 This function may be used with the :ref:`algm-Fit` algorithm. However, it
 was originally added to Mantid as a named function for the purposes of
 detector efficiency calibration. Also see
-`ProductLinearExp <func-ProductLinearExp>`__.
+:ref:`ProductLinearExp <func-ProductLinearExp>`.
 
 .. attributes::
 

--- a/docs/source/fitting/fitfunctions/Resolution.rst
+++ b/docs/source/fitting/fitfunctions/Resolution.rst
@@ -9,9 +9,9 @@ Resolution
 Description
 -----------
 
-This is a function that has the same attributes as the `TabulatedFunction <TabulatedFunction>`__ but has no fitting
+This is a function that has the same attributes as the :ref:`TabulatedFunction <func-TabulatedFunction>` but has no fitting
 parameters. Its purpose is to represent a measured instrument resolution function. It is primarily used as the
-first member (:math:`R`) of the `Convolution <Convolution>`__ function.
+first member (:math:`R`) of the :ref:`Convolution <func-Convolution>` function.
 
 .. attributes::
 

--- a/docs/source/fitting/fitminimizers/BFGS.rst
+++ b/docs/source/fitting/fitminimizers/BFGS.rst
@@ -6,7 +6,7 @@ BFGS (Broyden-Fletcher-Goldfarb-Shanno) minimizer
 This minimizer is
 explained at `Wikipedia <https://en.wikipedia.org/wiki/Broyden–Fletcher–Goldfarb–Shanno_algorithm>`__ 
 
-It is listed in `a comparison of fitting minimizers <../concepts/FittingMinimizers.html>`__.
+It is listed in :ref:`a comparison of fitting minimizers <FittingMinimizers Minimizer Comparison>`.
 
 It makes use of the 
 `GSL (GNU Scientific Library) library

--- a/docs/source/fitting/fitminimizers/DampedGaussNewton.rst
+++ b/docs/source/fitting/fitminimizers/DampedGaussNewton.rst
@@ -7,7 +7,7 @@ This minimizer is
 explained at `Wikipedia <https://en.wikipedia.org/wiki/Gauss–Newton_algorithm#Improved_versions>`__ 
 and has damping.
 
-It is listed in `a comparison of fitting minimizers <../concepts/FittingMinimizers.html>`__.
+It is listed in :ref:`a comparison of fitting minimizers <FittingMinimizers Minimizer Comparison>`.
 
 It makes use of the 
 `GSL (GNU Scientific Library) library

--- a/docs/source/fitting/fitminimizers/FletcherReeves.rst
+++ b/docs/source/fitting/fitminimizers/FletcherReeves.rst
@@ -6,7 +6,7 @@ Conjugate Gradient Minimizer (Fletcher-Reeves imp.)
 This minimizer an implementation of the nonlinear conjugate gradient method 
 explained at `Wikipedia <https://en.wikipedia.org/wiki/Nonlinear_conjugate_gradient_method>`__ 
 
-It is listed in `a comparison of fitting minimizers <../concepts/FittingMinimizers.html>`__.
+It is listed in :ref:`a comparison of fitting minimizers <FittingMinimizers Minimizer Comparison>`.
 
 It makes use of the 
 `GSL (GNU Scientific Library) library

--- a/docs/source/fitting/fitminimizers/GradientDescent.rst
+++ b/docs/source/fitting/fitminimizers/GradientDescent.rst
@@ -4,7 +4,7 @@ Steepest Descent Minimizer
 ==========================
 
 This minimizer is explained at - `Wikipedia <https://en.wikipedia.org/wiki/Gradient_descent>`__  as the gradient descent method.
-It is listed in `a comparison of fitting minimizers <../concepts/FittingMinimizers.html>`__.
+It is listed in :ref:`a comparison of fitting minimizers <FittingMinimizers Minimizer Comparison>`.
 
 It makes use of the 
 `GSL (GNU Scientific Library) library

--- a/docs/source/fitting/fitminimizers/LevenbergMarquardt.rst
+++ b/docs/source/fitting/fitminimizers/LevenbergMarquardt.rst
@@ -4,7 +4,7 @@ Levenberg-Marquardt Minimizer
 =============================
 
 This minimizer is explained at - `Wikipedia <https://en.wikipedia.org/wiki/Levenberg-Marquardt_algorithm>`__ 
-It is the default minimizer and is listed in `a comparison of fitting minimizers <../concepts/FittingMinimizers.html>`__.
+It is the default minimizer and is listed in :ref:`a comparison of fitting minimizers <FittingMinimizers Minimizer Comparison>`.
 
 It makes use of the 
 `GSL (GNU Scientific Library) library

--- a/docs/source/fitting/fitminimizers/LevenbergMarquardtMD.rst
+++ b/docs/source/fitting/fitminimizers/LevenbergMarquardtMD.rst
@@ -3,14 +3,14 @@
 Levenberg-Marquardt MD Minimizer
 ================================
 
-This minimizer is the same as the `Levenberg-Marquardt minimizer <LevenbergMarquardt.html>`__ as explained 
+This minimizer is the same as the :ref:`Levenberg-Marquardt minimizer <LevenbergMarquardt>` as explained 
 in - `Wikipedia <https://en.wikipedia.org/wiki/Levenberg-Marquardt_algorithm>`__ , but is intended for 
-`MD workspaces <../concepts/MDWorkspace.html>`__
+:ref:`MD workspaces <MDWorkspace>`
 or for a large number of data points.
 It divides its work into chunks to achieve a greater efficiency for a large number of data points than
 can be obtained from the default Levenberg-Marquardt minimizer.
 
-It is listed in `a comparison of fitting minimizers <../concepts/FittingMinimizers.html>`__.
+It is listed in :ref:`a comparison of fitting minimizers <FittingMinimizers Minimizer Comparison>`.
 
 It makes use of the 
 `GSL (GNU Scientific Library) library

--- a/docs/source/fitting/fitminimizers/PolakRibiere.rst
+++ b/docs/source/fitting/fitminimizers/PolakRibiere.rst
@@ -6,7 +6,7 @@ Conjugate Gradient Minimizer (Polak-Ribiere imp.)
 This minimizer an implementation of the nonlinear conjugate gradient method 
 explained at `Wikipedia <https://en.wikipedia.org/wiki/Nonlinear_conjugate_gradient_method>`__ .
 
-It is listed in `a comparison of fitting minimizers <../concepts/FittingMinimizers.html>`__.
+It is listed in :ref:`a comparison of fitting minimizers <FittingMinimizers Minimizer Comparison>`.
 
 It makes use of the 
 `GSL (GNU Scientific Library) library

--- a/docs/source/fitting/fitminimizers/Simplex.rst
+++ b/docs/source/fitting/fitminimizers/Simplex.rst
@@ -4,7 +4,7 @@ Simplex Minimizer
 =================
 
 This minimizer is explained at - `Wikipedia <https://en.wikipedia.org/wiki/Nelder%E2%80%93Mead_method>`__  as the Nelder-Mead method.
-It is listed in `a comparison of fitting minimizers <../concepts/FittingMinimizers.html>`__.
+It is listed in :ref:`a comparison of fitting minimizers <FittingMinimizers Minimizer Comparison>`.
 
 It makes use of the 
 `GSL (GNU Scientific Library) library

--- a/docs/source/fitting/fitminimizers/TrustRegion.rst
+++ b/docs/source/fitting/fitminimizers/TrustRegion.rst
@@ -9,7 +9,7 @@ method, that makes use of a `trust region <https://en.wikipedia.org/wiki/Trust_r
 
 It is a reimplementation of part of `RALFit_nonlinear least squares solver <https://github.com/ralna/RALFit>`__. 
 
-It is listed in `a comparison of fitting minimizers <../concepts/FittingMinimizers.html>`__.
+It is listed in :ref:`a comparison of fitting minimizers <FittingMinimizers Minimizer Comparison>`.
 
 Reference
 ---------

--- a/docs/source/fitting/index.rst
+++ b/docs/source/fitting/index.rst
@@ -14,7 +14,7 @@ for setting up the function, as well as some examples of how to use different fu
 
 *Fitting minimizers* gives links to detailed descriptions of the various minimizers available in 
 Mantid. Choosing the right minimizer is an art as much as a science, a discussion of choosing 
-the right minimizer is provided `here. <http://docs.mantidproject.org/nightly/concepts/FittingMinimizers.html>`_
+the right minimizer is provided :ref:`here <FittingMinimizers>`.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/interfaces/Muon Analysis.rst
+++ b/docs/source/interfaces/Muon Analysis.rst
@@ -40,9 +40,8 @@ Instrument
 
 +-------+--------------------------+-----------------------------------------------------------------------------------------+
 | **1** | **Instrument**           | Selection of instrument that the experiments were run on.                               |
-|       |                          | It is an advantage if an Instrument Definition File (                                   |
-|       |                          | `IDF <http://docs.mantidproject.org/nightly/concepts/InstrumentDefinitionFile.html>`_)  |
-|       |                          | is available for the instrument selection.                                              |
+|       |                          | It is an advantage if an Instrument Definition File                                     |
+|       |                          | (:ref:`IDF <InstrumentDefinitionFile>`) is available for the instrument selection.      |
 +-------+--------------------------+-----------------------------------------------------------------------------------------+
 | **2** | **Time Zero**            | Time zero value (:math:`\mu s`). Any bins before that time will be discarded.           |
 |       |                          | If *From datafile* is checked, the value stored in the loaded Muon data file is used.   |
@@ -150,8 +149,7 @@ Run Information etc.
    :align: center
 
 +-------+--------------------------+-----------------------------------------------------------------------------------------+
-| **1** | **Run Information**      | Information about the loaded run.                                                       |
-|       |                          | See `Run <http://docs.mantidproject.org/nightly/concepts/Run.html#isis-muon-data>`_     |
+| **1** | **Run Information**      | Information about the loaded run. See :ref:`Run <RunInfoOnISISMuonData>`                |
 |       |                          | for the list of parameters which are looked up in the data files.                       |
 +-------+--------------------------+-----------------------------------------------------------------------------------------+
 | **2** | **Connected plot**       | The name of the workspace produced for the last plot, i.e. "connected" to the interface.|

--- a/docs/source/interfaces/TOF Converter.rst
+++ b/docs/source/interfaces/TOF Converter.rst
@@ -21,8 +21,8 @@ The output of the program will be the converted value produced by the input valu
 Available Conversion Units
 --------------------------
 
-Some of the units available are those registered with see: `UnitFactory <http://www.mantidproject.org/Units>`__.
-The units that are not specified in `UnitFactory <http://www.mantidproject.org/Units>`__ but are used in ToFConverter
+Some of the units available are those registered with see: :ref:`Units <Unit Factory>`.
+The units that are not specified in :ref:`Units <Unit Factory>` but are used in ToFConverter
 are: 
 
 Nu (:math:`\nu`): :math:`\frac{h}{m_{N}\lambda^2}`


### PR DESCRIPTION
**Description of work.**

This fixes broken links and some bad linking practices in the sphinx documentation. Rather than hard-linking to pages on the web or using relative paths, we should use reST labels and references and let sphinx take care of the linking.

**To test:**

Careful proofreading. Build the `docs-html` target and see if you can find more broken links, especially in sections considering fitting.

Fixes #23609.

*This does not require release notes* because **this does not introduce functional changes**.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
