### PR TITLE
Mantidplot/ Testing/ buildconfig/ misc. typos

### DIFF
--- a/MantidPlot/CMakeLists.txt
+++ b/MantidPlot/CMakeLists.txt
@@ -909,7 +909,7 @@ endif ()
 # Add an environment property MANTID_SOURCE so that the script can find the source of xmlrunner
 if ( ${CMAKE_SYSTEM_NAME} STREQUAL "Windows" )
   set ( _python_path $ENV{PYTHONPATH};${PYTHON_XMLRUNNER_DIR} )
-  # cmake list separator and Windows environment seprator are the same so escape the cmake one
+  # cmake list separator and Windows environment separator are the same so escape the cmake one
   string ( REPLACE ";" "\\;" _python_path "${_python_path}" )
 else()
   set ( _python_path $ENV{PYTHONPATH}:${PYTHON_XMLRUNNER_DIR} )

--- a/MantidPlot/mantidplotrc.py
+++ b/MantidPlot/mantidplotrc.py
@@ -38,7 +38,7 @@ if __name__ == '__main__':
     from mantid.api import *
     from mantid.simpleapi import *
 
-    # Common imports (here for backwards compatability)
+    # Common imports (here for backwards compatibility)
     import os
     import sys
 

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -3130,7 +3130,7 @@ Table *ApplicationWindow::newHiddenTable(const QString &name,
   return w;
 }
 
-/* Perfom initialization on a Table?
+/* Perform initialization on a Table?
  * @param w :: table that was created
  * @param caption :: title to set
  */
@@ -4404,7 +4404,7 @@ void ApplicationWindow::open() {
       QString pn = fi.absoluteFilePath();
       if (fn == pn) {
         QMessageBox::warning(
-            this, tr("MantidPlot - File openning error"), // Mantid
+            this, tr("MantidPlot - File opening error"), // Mantid
             tr("The file: <b>%1</b> is the current file!").arg(fn));
         return;
       }
@@ -4421,7 +4421,7 @@ void ApplicationWindow::open() {
         fn.endsWith(".mantid~", Qt::CaseInsensitive)) {
       if (!fi.exists()) {
         QMessageBox::critical(this,
-                              tr("MantidPlot - File openning error"), // Mantid
+                              tr("MantidPlot - File opening error"), // Mantid
                               tr("The file: <b>%1</b> doesn't exist!").arg(fn));
         return;
       }
@@ -4440,7 +4440,7 @@ void ApplicationWindow::open() {
       }
     } else {
       QMessageBox::critical(
-          this, tr("MantidPlot - File openning error"), // Mantid
+          this, tr("MantidPlot - File opening error"), // Mantid
           tr("The file: <b>%1</b> is not a MantidPlot or Origin project file!")
               .arg(fn));
       return;
@@ -5276,7 +5276,7 @@ void ApplicationWindow::readSettings() {
     settings.endGroup();
   }
 
-  // Mantid - Remember which interfaces the user explicitely removed
+  // Mantid - Remember which interfaces the user explicitly removed
   // from the Interfaces menu
   removed_interfaces = settings.value("RemovedInterfaces").toStringList();
 
@@ -5652,7 +5652,7 @@ void ApplicationWindow::saveSettings() {
     settings.endGroup();
   }
 
-  // Mantid - Remember which interfaces the user explicitely removed
+  // Mantid - Remember which interfaces the user explicitly removed
   // from the Interfaces menu
   settings.setValue("RemovedInterfaces", removed_interfaces);
 
@@ -9187,7 +9187,7 @@ void ApplicationWindow::closeWindow(MdiSubWindow *window) {
  * @param window :: the window to add
  */
 void ApplicationWindow::addSerialisableWindow(QObject *window) {
-  // Here we must store the window as a QObject to avoid multiple inheritence
+  // Here we must store the window as a QObject to avoid multiple inheritance
   // issues with Qt and the IProjectSerialisable class as well as being able
   // to respond to the destroyed signal
   // We can still check here that the window conforms to the interface and
@@ -9196,8 +9196,8 @@ void ApplicationWindow::addSerialisableWindow(QObject *window) {
     return;
 
   m_serialisableWindows.push_back(window);
-  // Note that destoryed is emitted directly before the QObject itself
-  // is destoryed. This means the destructor of the specific window type
+  // Note that destroyed is emitted directly before the QObject itself
+  // is destroyed. This means the destructor of the specific window type
   // will have already been called.
   connect(window, SIGNAL(destroyed(QObject *)), this,
           SLOT(removeSerialisableWindow(QObject *)));
@@ -11583,7 +11583,7 @@ void ApplicationWindow::setUpdateCurvesFromTable(Table *table, bool on) {
   }
 }
 
-/** Fixes the colour pallete so that the hints are readable.
+/** Fixes the colour palette so that the hints are readable.
 
   On Linux Fedora 26+ and Ubuntu 14.4+ the palette colour for
   ToolTipBase has no effect on the colour of tooltips, but does change
@@ -11591,7 +11591,7 @@ void ApplicationWindow::setUpdateCurvesFromTable(Table *table, bool on) {
   colour for ToolTipText on the other hand affects all three of
   these.
 
-  The default pallete shows light text on a pale background which, although
+  The default palette shows light text on a pale background which, although
   not affecting tooltips, makes LineEdit hints and 'What's This' boxes
   difficuilt if not impossible to read.
 
@@ -13850,7 +13850,7 @@ void ApplicationWindow::showBugTracker() {
 
 /*
 @param arg: command argument
-@return TRUE if argument suggests execution and quiting
+@return TRUE if argument suggests execution and quitting
 */
 bool ApplicationWindow::shouldExecuteAndQuit(const QString &arg) {
   return arg.endsWith("--execandquit") || arg.endsWith("-xq");
@@ -15943,7 +15943,7 @@ void ApplicationWindow::tileMdiWindows() {
   shakeViewport();
   // QMdiArea::tileSubWindows() aranges the windows and enables automatic
   // tiling after subsequent resizing of the mdi area until a window is moved
-  // or resized separatly. Unfortunately Graph behaves badly during this. The
+  // or resized separately. Unfortunately Graph behaves badly during this. The
   // following code disables automatic tiling.
   auto winList = d_workspace->subWindowList();
   if (!winList.isEmpty()) {
@@ -16025,8 +16025,8 @@ void ApplicationWindow::customMultilayerToolButtons(MultiLayer *w) {
     btnPointer->setChecked(true);
 }
 /**  save workspace data in nexus format
- *   @param wsName :: name of the ouput file.
- *   @param fileName :: name of the ouput file.
+ *   @param wsName :: name of the output file.
+ *   @param fileName :: name of the output file.
  */
 void ApplicationWindow::savedatainNexusFormat(const std::string &wsName,
                                               const std::string &fileName) {
@@ -16294,7 +16294,7 @@ QPoint ApplicationWindow::positionNewFloatingWindow(QSize sz) const {
     // Get window which was added last
     FloatingWindow *lastWindow = m_floatingWindows.last();
 
-    if (lastWindow->isVisible()) { // If it is still visibile - can't use it's
+    if (lastWindow->isVisible()) { // If it is still visible - can't use it's
                                    // location, so need to find a new one
 
       QPoint diff = lastWindow->pos() - lastPoint;

--- a/MantidPlot/src/ApplicationWindow.h
+++ b/MantidPlot/src/ApplicationWindow.h
@@ -279,7 +279,7 @@ public slots:
   /// Update application window post save
   void postSaveProject();
 
-  //! Set the project status to modifed
+  //! Set the project status to modified
   void modifiedProject();
   //! Set the project status to saved (not modified)
   void savedProject();
@@ -462,7 +462,7 @@ public slots:
    * @param label :: window label (compare MdiSubWindow::MdiSubWindow)
    * @param r :: number of rows
    * @param c :: number of columns
-   * @param text :: tab/newline - seperated initial content; may be empty
+   * @param text :: tab/newline - separated initial content; may be empty
    */
   Table *newHiddenTable(const QString &name, const QString &label, int r, int c,
                         const QString &text = QString());
@@ -974,11 +974,11 @@ public slots:
   //! Show the currently selected windows from the list view #lv.
   void showSelectedWindows();
 
-  //! Sets all items in the folders list view to be desactivated (QPixmap =
+  //! Sets all items in the folders list view to be deactivated (QPixmap =
   // folder_closed_xpm)
   void desactivateFolders();
 
-  //! Changes the current folder. Returns true if successfull
+  //! Changes the current folder. Returns true if successful
   bool changeFolder(Folder *newFolder, bool force = false);
 
   //! Changes the current folder when the user changes the current item in the
@@ -1009,7 +1009,7 @@ public slots:
   // depending on the user's viewing policy
   void showAllFolderWindows();
 
-  //!  forces hidding all windows in the current folder and subfolders,
+  //!  forces hiding all windows in the current folder and subfolders,
   // depending on the user's viewing policy
   void hideAllFolderWindows();
 
@@ -1428,7 +1428,7 @@ public:
   ImageMarker *d_image_copy;
   //@}
 
-  //! Equals true if an automatical search for updates was performed on start-up
+  //! Equals true if an automatic search for updates was performed on start-up
   // otherwise is set to false;
   bool autoSearchUpdatesRequest;
 

--- a/MantidPlot/src/AxesDialog.cpp
+++ b/MantidPlot/src/AxesDialog.cpp
@@ -1512,8 +1512,8 @@ AxesDialog::AxesDialog(ApplicationWindow *app, Graph *g, Qt::WFlags fl)
   initGridPage();
   initGeneralPage();
 
-  // Connect scale details to axis details in order to disable scale options when
-  // an axis is not shown
+  // Connect scale details to axis details in order to disable scale options
+  // when an axis is not shown
   auto scaleIter = m_Scale_list.begin();
   auto axisIter = m_Axis_list.begin();
   while ((scaleIter != m_Scale_list.end()) && (axisIter != m_Axis_list.end())) {

--- a/MantidPlot/src/AxesDialog.cpp
+++ b/MantidPlot/src/AxesDialog.cpp
@@ -1494,7 +1494,7 @@ Mantid::Kernel::Logger g_log("AxisDialog");
  * scale of an axis.
  *  @param app :: the containing application window
  *  @param g :: the graph the dialog is settign the options for
- *  @param fl :: The QT flags fro thsi window
+ *  @param fl :: The QT flags for this window
  */
 AxesDialog::AxesDialog(ApplicationWindow *app, Graph *g, Qt::WFlags fl)
     : QDialog(g, fl), m_app(app), m_graph(g) {
@@ -1512,7 +1512,7 @@ AxesDialog::AxesDialog(ApplicationWindow *app, Graph *g, Qt::WFlags fl)
   initGridPage();
   initGeneralPage();
 
-  // Connect scale details to axis details in order to diable scale options when
+  // Connect scale details to axis details in order to disable scale options when
   // an axis is not shown
   auto scaleIter = m_Scale_list.begin();
   auto axisIter = m_Axis_list.begin();
@@ -1562,7 +1562,7 @@ void AxesDialog::accept() {
   if (pressToGraph())
     close();
 }
-/** Applys the changes to the graph without closing the window
+/** Applies the changes to the graph without closing the window
  *
  */
 void AxesDialog::apply() {

--- a/MantidPlot/src/AxisDetails.cpp
+++ b/MantidPlot/src/AxisDetails.cpp
@@ -39,7 +39,7 @@
  *  @param graph :: the graph the dialog is settign the options for
  *  @param mappedaxis :: the QwtPlot::axis value that corresponds to this axis
  *  @param parent :: the QWidget that acts as this widget's parent in the
- * hierachy
+ * hierarchy
  */
 AxisDetails::AxisDetails(ApplicationWindow *app, Graph *graph, int mappedaxis,
                          QWidget *parent)
@@ -336,7 +336,7 @@ void AxisDetails::initWidgets() {
   }
 }
 
-/** Sets the modifed flag to true so that the changes may be applied.
+/** Sets the modified flag to true so that the changes may be applied.
  *
  */
 void AxisDetails::setModified() { m_modified = true; }
@@ -374,7 +374,7 @@ bool AxisDetails::valid() {
            !w);
 }
 
-/** Applies the grid paremeters to the graphs
+/** Applies the grid parameters to the graphs
  *
  */
 void AxisDetails::apply() {
@@ -413,7 +413,7 @@ void AxisDetails::apply() {
   }
 }
 
-/** Applies the grid paremeters to the graphs
+/** Applies the grid parameters to the graphs
  *
  */
 void AxisDetails::showAxis() {
@@ -431,7 +431,7 @@ void AxisDetails::showAxis() {
     m_txtFormula->setEnabled(labels);
 
     // this should so the work of the below IF but on one line and slightly more
-    // efficently as i assume setDisabled negates that given to it
+    // efficiently as i assume setDisabled negates that given to it
     m_spnAngle->setEnabled(
         (m_mappedaxis == QwtPlot::xBottom || m_mappedaxis == QwtPlot::xTop) &&
         labels);
@@ -445,7 +445,7 @@ void AxisDetails::showAxis() {
   emit axisShowChanged(shown);
 }
 
-/** Enables, Disables, Hides or Shows widgets apropriate to the current Axis
+/** Enables, Disables, Hides or Shows widgets appropriate to the current Axis
  *Format
  *
  */

--- a/MantidPlot/src/Bar.cpp
+++ b/MantidPlot/src/Bar.cpp
@@ -5,7 +5,7 @@
     Copyright            : (C) 2006 by Ion Vasilief, Tilman Hoener zu
  Siederdissen
     Email (use @ for *)  : ion_vasilief*yahoo.fr, thzs*gmx.net
-    Description          : 3D bars (modifed enrichment from QwtPlot3D)
+    Description          : 3D bars (modified enrichment from QwtPlot3D)
 
  ***************************************************************************/
 

--- a/MantidPlot/src/Bar.h
+++ b/MantidPlot/src/Bar.h
@@ -5,7 +5,7 @@
     Copyright            : (C) 2006 by Ion Vasilief, Tilman Hoener zu
  Siederdissen
     Email (use @ for *)  : ion_vasilief*yahoo.fr, thzs*gmx.net
-    Description          : 3D bars (modifed enrichment from QwtPlot3D)
+    Description          : 3D bars (modified enrichment from QwtPlot3D)
 
  ***************************************************************************/
 
@@ -32,7 +32,7 @@
 
 #include <qwt3d_plot.h>
 
-//! 3D bars (modifed enrichment from QwtPlot3D)
+//! 3D bars (modified enrichment from QwtPlot3D)
 class Bar : public Qwt3D::VertexEnrichment {
 public:
   Bar();

--- a/MantidPlot/src/CanvasPicker.h
+++ b/MantidPlot/src/CanvasPicker.h
@@ -93,7 +93,7 @@ signals:
 private:
   bool pointSelected;
   /**\brief The marker that is currently being edited, or NULL.
-   * Editing does explicitly _not_ inlude moving and resizing, which are being
+   * Editing does explicitly _not_ include moving and resizing, which are being
    * handled by SelectionMoveResizer (see Graph::d_markers_selector).
    * Currently, only ArrowMarker provides any other form of editing, but this
    * really

--- a/MantidPlot/src/ConfigDialog.cpp
+++ b/MantidPlot/src/ConfigDialog.cpp
@@ -2436,9 +2436,10 @@ void ConfigDialog::languageChange() {
 
   mdPlottingGeneralFrame->setTitle(
       "Use same default color map for Slice Viewer and VSI");
-  mdPlottingGeneralFrame->setToolTip("The specified color map will be available "
-                                     "for the Slice Viewer and the VSI when a "
-                                     "new instance of either is started.");
+  mdPlottingGeneralFrame->setToolTip(
+      "The specified color map will be available "
+      "for the Slice Viewer and the VSI when a "
+      "new instance of either is started.");
 }
 
 void ConfigDialog::accept() {

--- a/MantidPlot/src/ConfigDialog.cpp
+++ b/MantidPlot/src/ConfigDialog.cpp
@@ -1192,7 +1192,7 @@ void ConfigDialog::populateProgramTree() {
 void ConfigDialog::updateProgramTree() {
   // Store into a map ready to go into config service when apply is clicked
   for (const auto &itr : m_sendToSettings) {
-    // creating the map of kvps needs to happen first as createing the item
+    // creating the map of kvps needs to happen first as creating the item
     // requires them.
     std::map<std::string, std::string> programKeysAndDetails = itr.second;
 
@@ -2436,7 +2436,7 @@ void ConfigDialog::languageChange() {
 
   mdPlottingGeneralFrame->setTitle(
       "Use same default color map for Slice Viewer and VSI");
-  mdPlottingGeneralFrame->setToolTip("The specifed color map will be available "
+  mdPlottingGeneralFrame->setToolTip("The specified color map will be available "
                                      "for the Slice Viewer and the VSI when a "
                                      "new instance of either is started.");
 }

--- a/MantidPlot/src/Convolution.h
+++ b/MantidPlot/src/Convolution.h
@@ -49,7 +49,7 @@ public:
 protected:
   //! Handles the graphical output
   void addResultCurve();
-  //! Performes the convolution of the two data sets and stores the result in
+  //! Performs the convolution of the two data sets and stores the result in
   // the signal data set
   void convlv(double *sig, int n, double *dres, int m, int sign);
 

--- a/MantidPlot/src/CurvesDialog.cpp
+++ b/MantidPlot/src/CurvesDialog.cpp
@@ -476,7 +476,7 @@ void CurvesDialog::enableAddBtn() {
                      !available->selectedItems().isEmpty());
 }
 
-/** Enables or disables the button when appopriate number of graphs are in graph
+/** Enables or disables the button when appropriate number of graphs are in graph
  *contents
  *
  */

--- a/MantidPlot/src/CurvesDialog.cpp
+++ b/MantidPlot/src/CurvesDialog.cpp
@@ -476,8 +476,8 @@ void CurvesDialog::enableAddBtn() {
                      !available->selectedItems().isEmpty());
 }
 
-/** Enables or disables the button when appropriate number of graphs are in graph
- *contents
+/** Enables or disables the button when appropriate number of graphs are in
+ *graph contents
  *
  */
 void CurvesDialog::enableRemoveBtn() {

--- a/MantidPlot/src/DataPickerTool.h
+++ b/MantidPlot/src/DataPickerTool.h
@@ -59,7 +59,7 @@ public:
 signals:
   /** Emitted whenever a new message should be presented to the user.
    *
-   * You don't have to connect to this signal if you alreay specified a reciever
+   * You don't have to connect to this signal if you already specified a receiver
    *during initialization.
    */
   void statusText(const QString &);

--- a/MantidPlot/src/DataPickerTool.h
+++ b/MantidPlot/src/DataPickerTool.h
@@ -59,8 +59,8 @@ public:
 signals:
   /** Emitted whenever a new message should be presented to the user.
    *
-   * You don't have to connect to this signal if you already specified a receiver
-   *during initialization.
+   * You don't have to connect to this signal if you already specified a
+   *receiver during initialization.
    */
   void statusText(const QString &);
   //! Emitted whenever a new data point has been selected.

--- a/MantidPlot/src/FFTFilter.cpp
+++ b/MantidPlot/src/FFTFilter.cpp
@@ -157,7 +157,7 @@ void FFTFilter::calculateOutputData(double *x, double *y) {
     d_explanation += tr("Band Block FFT Filter");
 
     if (!d_offset)
-      y[0] = 0; // substract DC offset
+      y[0] = 0; // subtract DC offset
 
     for (int i = 1; i < d_n; i++)
       y[i] = ((i * df > d_low_freq) && (i * df < d_high_freq)) ? 0 : y[i];

--- a/MantidPlot/src/FFTFilter.h
+++ b/MantidPlot/src/FFTFilter.h
@@ -72,7 +72,7 @@ private:
   //! Upper edge of the band for Band Pass and Band block filters.
   double d_high_freq;
 
-  //! Flag telling if the DC offset must be added/substracted when applying a
+  //! Flag telling if the DC offset must be added/subtracted when applying a
   // Band Pass/Band block filter respectively.
   bool d_offset;
 };

--- a/MantidPlot/src/FilterDialog.cpp
+++ b/MantidPlot/src/FilterDialog.cpp
@@ -79,7 +79,7 @@ FilterDialog::FilterDialog(int type, QWidget *parent, Qt::WFlags fl)
     if (type == FFTFilter::BandPass)
       gl1->addWidget(new QLabel(tr("Add DC Offset")), 3, 0);
     else
-      gl1->addWidget(new QLabel(tr("Substract DC Offset")), 3, 0);
+      gl1->addWidget(new QLabel(tr("Subtract DC Offset")), 3, 0);
 
     boxOffset = new QCheckBox();
     gl1->addWidget(boxOffset, 3, 1);

--- a/MantidPlot/src/Fit.h
+++ b/MantidPlot/src/Fit.h
@@ -122,7 +122,7 @@ public:
   //! Returns R^2
   double rSquare();
 
-  //! Specifies wheather the errors must be scaled with sqrt(chi_2/dof)
+  //! Specifies whether the errors must be scaled with sqrt(chi_2/dof)
   void scaleErrors(bool yes = true) { d_scale_errors = yes; };
 
   Table *parametersTable(const QString &tableName);
@@ -239,7 +239,7 @@ protected:
   //! The sum of squares of the residuals from the best-fit line
   double chi_2;
 
-  //! Specifies wheather the errors must be scaled with sqrt(chi_2/dof)
+  //! Specifies whether the errors must be scaled with sqrt(chi_2/dof)
   bool d_scale_errors;
 
   //! Table window used for the output of fit parameters

--- a/MantidPlot/src/FloatingWindow.cpp
+++ b/MantidPlot/src/FloatingWindow.cpp
@@ -84,7 +84,7 @@ bool FloatingWindow::event(QEvent *e) {
   } else if (e->type() == QEvent::WindowStateChange) {
     if (this->isMinimized()) {
 #ifdef Q_OS_WIN
-      // set parent to NULL wich makes it minimize nicely into a program bar
+      // set parent to NULL which makes it minimize nicely into a program bar
       // icon
       this->setParent(NULL);
       this->showMinimized();

--- a/MantidPlot/src/Folder.h
+++ b/MantidPlot/src/Folder.h
@@ -134,7 +134,7 @@ private:
   /// Recursively save subwindows and subfolders
   QString saveFolderSubWindows(ApplicationWindow *app, Folder *,
                                int &windowCount);
-  /// Save footer infromation about the folder
+  /// Save footer information about the folder
   QString saveFolderFooter();
 
 public slots:

--- a/MantidPlot/src/FunctionCurve.cpp
+++ b/MantidPlot/src/FunctionCurve.cpp
@@ -50,7 +50,7 @@ FunctionCurve::FunctionCurve(const FunctionType &t, const QString &name)
 }
 
 /**
- * This constractor creates a function curve from a Mantid IFunction and uses a
+ * This constructor creates a function curve from a Mantid IFunction and uses a
  * workspace for x values
  * @param fun :: A pointer to a Mantid function
  * @param wsName :: A name of a workspace to provide x values and to be passed

--- a/MantidPlot/src/Graph.cpp
+++ b/MantidPlot/src/Graph.cpp
@@ -2644,7 +2644,7 @@ bool Graph::addCurves(Table *w, const QStringList &names, int style,
         // If X column is given - use it
         xColName = xColNameGiven;
       else
-        // Otherise, use associated one
+        // Otherwise, use associated one
         xColName = w->colName(w->colX(colIndex));
 
       if (xColName.isEmpty() || yColName.isEmpty())

--- a/MantidPlot/src/Graph.h
+++ b/MantidPlot/src/Graph.h
@@ -668,7 +668,7 @@ public slots:
   void setCurveTitle(int index, const QString &title);
   //@}
 
-  //! \name Modifing insertCurve Data
+  //! \name Modifying insertCurve Data
   //@{
   int selectedCurveID();
   int selectedCurveIndex() { return curveIndex(selectedCurveID()); }

--- a/MantidPlot/src/Graph3D.cpp
+++ b/MantidPlot/src/Graph3D.cpp
@@ -687,7 +687,7 @@ void Graph3D::resetNonEmptyStyle() {
   if (sp->plotStyle() != Qwt3D::NOPLOT)
     return; // the plot was not previousely emptied
 
-  if (style_ == Qwt3D::USER) { // reseting the right user plot style
+  if (style_ == Qwt3D::USER) { // resetting the right user plot style
     switch (pointStyle) {
     case None:
       break;
@@ -2868,7 +2868,7 @@ int Graph3D::read3DPlotStyle(MantidQt::API::TSVSerialiser &tsv) {
 
 Graph3D::SurfaceFunctionParams
 Graph3D::readSurfaceFunction(MantidQt::API::TSVSerialiser &tsv) {
-  // We cant use {0} to zero initialise as GCC incorrectly thinks
+  // We can't use {0} to zero initialise as GCC incorrectly thinks
   // the members are still uninitialised
   SurfaceFunctionParams params = SurfaceFunctionParams();
   tsv >> params.formula;

--- a/MantidPlot/src/GridDetails.cpp
+++ b/MantidPlot/src/GridDetails.cpp
@@ -20,12 +20,12 @@
 #include <QWidget>
 
 /** The constructor for a single set of widgets containing parameters for a
- * sigle direction of gridlines.
+ * single direction of gridlines.
  *  @param app :: the containing application window
  *  @param graph :: the graph the dialog is settign the options for
  *  @param mappedaxis :: the QwtPlot::axis value that corresponds to this axis
  *  @param parent :: the QWidget that acts as this widget's parent in the
- * hierachy
+ * hierarchy
  */
 GridDetails::GridDetails(ApplicationWindow *app, Graph *graph, int alignment,
                          QWidget *parent)
@@ -202,14 +202,14 @@ void GridDetails::initWidgets() {
   }
 }
 
-/** Sets the modifed flag to true so that the changes may be applied.
+/** Sets the modified flag to true so that the changes may be applied.
  *
  */
 void GridDetails::setModified() { m_modified = true; }
 
-/** Applies the grid paremeters to the graphs
+/** Applies the grid parameters to the graphs
 *
-@param grid :: the gird to apply this formatting to
+@param grid :: the grid to apply this formatting to
 @bool antialias :: apply antialias to this formatting or not
 @bool multirun :: this will run multiple times for this dialog, and forces even
 if no modified

--- a/MantidPlot/src/GridDetails.h
+++ b/MantidPlot/src/GridDetails.h
@@ -68,6 +68,7 @@ private:
 
   ApplicationWindow *m_app;
   Graph *m_graph;
-  int m_alignment; // 0 = horizontal, 1 = vertical, anything else sets this to 0;
+  int m_alignment; // 0 = horizontal, 1 = vertical, anything else sets this to
+                   // 0;
 };
 #endif /* GRIDDETAILS_H_ */

--- a/MantidPlot/src/GridDetails.h
+++ b/MantidPlot/src/GridDetails.h
@@ -68,6 +68,6 @@ private:
 
   ApplicationWindow *m_app;
   Graph *m_graph;
-  int m_alignment; // 0 = horzontal, 1 = vertical, anything else sets this to 0;
+  int m_alignment; // 0 = horizontal, 1 = vertical, anything else sets this to 0;
 };
 #endif /* GRIDDETAILS_H_ */

--- a/MantidPlot/src/ImageExportDialog.h
+++ b/MantidPlot/src/ImageExportDialog.h
@@ -79,7 +79,7 @@ public:
   //! For vector formats: returns the output resolution the user selected,
   // defaulting to the screen resolution.
   int resolution() const { return d_resolution->value(); }
-  //! For vector formats: returns whether colors should be enabled for ouput
+  //! For vector formats: returns whether colors should be enabled for output
   //(default: true).
   bool color() const { return d_color->isChecked(); }
   //! For vector formats: returns whether the output should preserve aspect

--- a/MantidPlot/src/ImportASCIIDialog.cpp
+++ b/MantidPlot/src/ImportASCIIDialog.cpp
@@ -432,7 +432,7 @@ void ImportASCIIDialog::displayHelp() {
           "single space.");
 
   s += "\n\n" +
-       tr("Warning: using these two last options leads to column overlaping if "
+       tr("Warning: using these two last options leads to column overlapping if "
           "the columns in the ASCII file don't have the same number of rows.");
   s += "\n" + tr("To avoid this problem you should precisely define the column "
                  "separator using TAB and SPACE characters.");
@@ -577,7 +577,7 @@ void ImportASCIIDialog::changePreviewFile(const QString &path) {
 
   if (!fi.isReadable()) {
     QMessageBox::critical(
-        this, tr("MantidPlot - File openning error"),
+        this, tr("MantidPlot - File opening error"),
         tr("You don't have the permission to open this file: <b>%1</b>")
             .arg(path));
     return;

--- a/MantidPlot/src/ImportASCIIDialog.cpp
+++ b/MantidPlot/src/ImportASCIIDialog.cpp
@@ -431,9 +431,10 @@ void ImportASCIIDialog::displayHelp() {
           "whitespaces (including the TAB character) will be replaced with a "
           "single space.");
 
-  s += "\n\n" +
-       tr("Warning: using these two last options leads to column overlapping if "
-          "the columns in the ASCII file don't have the same number of rows.");
+  s +=
+      "\n\n" +
+      tr("Warning: using these two last options leads to column overlapping if "
+         "the columns in the ASCII file don't have the same number of rows.");
   s += "\n" + tr("To avoid this problem you should precisely define the column "
                  "separator using TAB and SPACE characters.");
 

--- a/MantidPlot/src/ImportASCIIDialog.h
+++ b/MantidPlot/src/ImportASCIIDialog.h
@@ -132,7 +132,7 @@ public:
   int ignoredLines() const { return d_ignored_lines->value(); }
   //! Whether to rename columns based on the first (non-skipped) line.
   bool renameColumns() const { return d_rename_columns->isChecked(); }
-  //! Whether to replace sequences of whitespace charecters with a single space.
+  //! Whether to replace sequences of whitespace characters with a single space.
   bool simplifySpaces() const { return d_simplify_spaces->isChecked(); }
   //! Whether to remove whitespace from beginning and end of lines.
   bool stripSpaces() const { return d_strip_spaces->isChecked(); }

--- a/MantidPlot/src/LineProfileTool.h
+++ b/MantidPlot/src/LineProfileTool.h
@@ -82,7 +82,7 @@ public:
 signals:
   /** Emitted whenever a new message should be presented to the user.
    *
-   * You don't have to connect to this signal if you alreay specified a reciever
+   * You don't have to connect to this signal if you already specified a receiver
    *during initialization.
    */
   void statusText(const QString &);

--- a/MantidPlot/src/LineProfileTool.h
+++ b/MantidPlot/src/LineProfileTool.h
@@ -82,8 +82,8 @@ public:
 signals:
   /** Emitted whenever a new message should be presented to the user.
    *
-   * You don't have to connect to this signal if you already specified a receiver
-   *during initialization.
+   * You don't have to connect to this signal if you already specified a
+   *receiver during initialization.
    */
   void statusText(const QString &);
 

--- a/MantidPlot/src/Mantid/AlgorithmHistoryWindow.cpp
+++ b/MantidPlot/src/Mantid/AlgorithmHistoryWindow.cpp
@@ -449,7 +449,7 @@ void AlgorithmHistoryWindow::updateAlgHistoryProperties(
 
 void AlgorithmHistoryWindow::updateExecSummaryGrpBox(
     AlgorithmHistory_const_sptr algHistory) {
-  // getting the selcted algorithm at pos from History vector
+  // getting the selected algorithm at pos from History vector
   double duration = algHistory->executionDuration();
   Mantid::Types::Core::DateAndTime date = algHistory->executionDate();
   if (m_execSumGrpBox)

--- a/MantidPlot/src/Mantid/FirstTimeSetup.cpp
+++ b/MantidPlot/src/Mantid/FirstTimeSetup.cpp
@@ -86,7 +86,7 @@ void FirstTimeSetup::initLayout() {
 
   QString stlyeName = QApplication::style()->metaObject()->className();
   if ((stlyeName == "QMotifStyle") || (stlyeName == "QCDEStyle")) {
-    // add stylesheet formatting for other environemnts
+    // add stylesheet formatting for other environments
     QString ss = this->styleSheet();
     ss += "\n"
           "QDialog#FirstTimeSetup QCommandLinkButton {"

--- a/MantidPlot/src/Mantid/FitParameterTie.cpp
+++ b/MantidPlot/src/Mantid/FitParameterTie.cpp
@@ -106,10 +106,10 @@ QString FitParameterTie::exprRHS() const {
 }
 
 /**
- * When a new function is added the function indeces in the tying expression
+ * When a new function is added the function indices in the tying expression
  * must
  * be changed.
- * @param i :: The index at wich the function is inserted. All old indeces
+ * @param i :: The index at which the function is inserted. All old indices
  * starting
  *   from i (inclusive) must be incremented.
  */
@@ -122,10 +122,10 @@ void FitParameterTie::functionInserted(int i) {
 }
 
 /**
- * When a function is deleted the function indeces in the tying expression must
+ * When a function is deleted the function indices in the tying expression must
  * be changed or the tie may become invalid if the deleted function is used in
  * the tie.
- * @param i :: The index of the deleted function. All old indeces starting
+ * @param i :: The index of the deleted function. All old indices starting
  *   from i+1 must be decremented.
  * @return true if the tie remains valid and false otherwise.
  */

--- a/MantidPlot/src/Mantid/FitParameterTie.h
+++ b/MantidPlot/src/Mantid/FitParameterTie.h
@@ -31,11 +31,11 @@ public:
   QString parName() const;
   /// Returns the right-hand side of the expression
   QString exprRHS() const;
-  /// Mofifies the function indeces in response to insertion of a new function
+  /// Modifies the function indeces in response to insertion of a new function
   /// into
   /// the composite function
   void functionInserted(int i);
-  /// Mofifies the function indeces in response to deletion of a function from
+  /// Modifies the function indeces in response to deletion of a function from
   /// the composite function
   bool functionDeleted(int i);
   /// Set property

--- a/MantidPlot/src/Mantid/IFunctionWrapper.h
+++ b/MantidPlot/src/Mantid/IFunctionWrapper.h
@@ -14,7 +14,7 @@ class IPeakFunction;
 
 /**
  * IFunctionWrapper is a wrapper for IFunction pointer which is a QObject
- * and can send and recieve signals.
+ * and can send and receive signals.
  */
 class IFunctionWrapper : public QObject {
   Q_OBJECT

--- a/MantidPlot/src/Mantid/MantidCurve.h
+++ b/MantidPlot/src/Mantid/MantidCurve.h
@@ -48,7 +48,7 @@ public:
   virtual const MantidQwtWorkspaceData *mantidData() const = 0;
   /// Get mantid data
   virtual MantidQwtWorkspaceData *mantidData() = 0;
-  /// Overriden virtual method
+  /// Overridden virtual method
   void itemChanged() override;
 
   /// Returns whether the curve has error bars

--- a/MantidPlot/src/Mantid/MantidMDCurve.h
+++ b/MantidPlot/src/Mantid/MantidMDCurve.h
@@ -107,7 +107,7 @@ private:
       const std::string &wsName,
       const boost::shared_ptr<Mantid::API::Workspace> ws) override;
 
-  /// Handle an ADS clear notificiation
+  /// Handle an ADS clear notification
   void clearADSHandle() override { emit removeMe(this); }
 
 signals:

--- a/MantidPlot/src/Mantid/MantidMatrix.cpp
+++ b/MantidPlot/src/Mantid/MantidMatrix.cpp
@@ -41,7 +41,7 @@ Logger g_log("MantidMatrix");
 
 namespace {
 /**
- * Converts an interger value to the corrsponding enum
+ * Converts an integer value to the corrsponding enum
  * @param i: the integer to check
  * @returns the corresponding model type
  */
@@ -133,7 +133,7 @@ MantidMatrix::MantidMatrix(Mantid::API::MatrixWorkspace_const_sptr ws,
 
   setWidget(m_tabs);
   // for synchronizing the views
-  // index is zero for the defualt view
+  // index is zero for the default view
   m_PrevIndex = 0;
   // install event filter on  these objects
   m_table_viewY->installEventFilter(this);
@@ -445,7 +445,7 @@ void MantidMatrix::copySelection() {
 }
 
 /**  Returns minimum and maximum values in the matrix.
-If setRange(...) has not been called it returns the true smalles ang largest
+If setRange(...) has not been called it returns the true smallest and largest
 Y-values in the matrix,
 otherwise the values set with setRange(...) are returned. These are needed in
 plotGraph2D to set

--- a/MantidPlot/src/Mantid/MantidMatrix.h
+++ b/MantidPlot/src/Mantid/MantidMatrix.h
@@ -326,7 +326,7 @@ private:
   /// Update the existing extensions
   void updateExtensions(Mantid::API::MatrixWorkspace_sptr ws);
 
-  /// ExtensioRequest handleer
+  /// ExtensioRequest handler
   MantidMatrixExtensionRequest m_extensionRequest;
 
   friend class MantidMatrixFunction;

--- a/MantidPlot/src/Mantid/MantidMatrixCurve.h
+++ b/MantidPlot/src/Mantid/MantidMatrixCurve.h
@@ -112,7 +112,7 @@ public:
   void draw(QPainter *p, const QwtScaleMap &xMap, const QwtScaleMap &yMap,
             const QRect &) const override;
 
-  /// Overriden virtual method
+  /// Overridden virtual method
   void itemChanged() override;
 
   /// saves the MantidMatrixCurve details to project file.
@@ -147,7 +147,7 @@ private:
       const std::string &wsName,
       const boost::shared_ptr<Mantid::API::Workspace> ws) override;
 
-  /// Handle an ADS clear notificiation
+  /// Handle an ADS clear notification
   void clearADSHandle() override { emit removeMe(this); }
 
 signals:

--- a/MantidPlot/src/Mantid/MantidMatrixExtensionRequest.cpp
+++ b/MantidPlot/src/Mantid/MantidMatrixExtensionRequest.cpp
@@ -116,7 +116,7 @@ QChar MantidMatrixExtensionRequest::getFormat(
  * Get the preicson for the requested type
  * @param type: the type
  * @param extensions: the extensions
- * @param defaultValue: a defaut value
+ * @param defaultValue: a default value
  * @returns the precision
  */
 int MantidMatrixExtensionRequest::getPrecision(

--- a/MantidPlot/src/Mantid/MantidMatrixModel.cpp
+++ b/MantidPlot/src/Mantid/MantidMatrixModel.cpp
@@ -235,7 +235,7 @@ QVariant MantidMatrixModel::headerData(int section, Qt::Orientation orientation,
 }
 
 Qt::ItemFlags MantidMatrixModel::flags(const QModelIndex &index) const {
-  // MG: For item selection to work correclty in later Qt versions it must be
+  // MG: For item selection to work correctly in later Qt versions it must be
   // marked as enabled
   if (index.isValid())
     return Qt::ItemIsSelectable | Qt::ItemIsEnabled;

--- a/MantidPlot/src/Mantid/MantidMatrixModel.h
+++ b/MantidPlot/src/Mantid/MantidMatrixModel.h
@@ -68,10 +68,10 @@ public slots:
 
 private:
   bool checkMonitorCache(
-      int row) const; // check the monitor cache and add to it if neccessary
+      int row) const; // check the monitor cache and add to it if necessary
 
   bool checkMaskedCache(
-      int row) const; // check the masked cache and add to it if neccessary
+      int row) const; // check the masked cache and add to it if necessary
 
   bool checkMaskedBinCache(int row, int bin) const;
 

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -227,7 +227,7 @@ MantidUI::MantidUI(ApplicationWindow *aw)
     qRegisterMetaType<Mantid::API::Workspace_sptr>();
     qRegisterMetaType<Mantid::API::MatrixWorkspace_sptr>();
     qRegisterMetaType<Mantid::API::MatrixWorkspace_const_sptr>();
-    // Register std::string as well as we use it alot
+    // Register std::string as well as we use it a lot
     qRegisterMetaType<std::string>();
   }
 
@@ -1629,7 +1629,7 @@ void MantidUI::executeSaveNexus() {
  *
  * @param algName :: name of the algorithm
  * @param version :: version number, -1 for latest
- * @return true if sucessful.
+ * @return true if successful.
  */
 void MantidUI::showAlgorithmDialog(const QString &algName, int version) {
   Mantid::API::IAlgorithm_sptr alg = this->createAlgorithm(algName, version);
@@ -1882,7 +1882,7 @@ void MantidUI::groupWorkspaces() {
     // get selected workspaces
     auto selectedItems = m_exploreMantid->getSelectedWorkspaceNames();
     if (selectedItems.size() < 2) {
-      throw std::runtime_error("Select atleast two workspaces to group ");
+      throw std::runtime_error("Select at least two workspaces to group ");
     }
     if (Mantid::API::AnalysisDataService::Instance().doesExist(sgrpName)) {
       if (QMessageBox::question(
@@ -2394,7 +2394,7 @@ void MantidUI::importString(const QString &logName, const QString &data) {
 /** Displays a string in a Qtiplot table
  *  @param logName :: the title of the table is based on this
  *  @param data :: the string to display
- *  @param sep :: the seperator character
+ *  @param sep :: the separator character
  *  @param wsName :: add workspace name to the table window title bar, defaults
  * to logname if left blank
  */
@@ -3214,7 +3214,7 @@ MultiLayer *MantidUI::plot1D(const QMultiMap<QString, int> &toPlot,
 
 /* Get the log values and put into a curve spec list in preparation of
  *  the creation of the curves
- *  @param curveSpecList :: list of curve specs to recieve the logs
+ *  @param curveSpecList :: list of curve specs to receive the logs
  *  @param toPlot :: workspaces to plot
  *  @param log :: log value
  *  @param customLogValues :: custom log values
@@ -3887,7 +3887,7 @@ struct mem_block {
   int state;
 };
 
-///  Assess the virtual memeory of the current process.
+///  Assess the virtual memory of the current process.
 void countVirtual(vector<mem_block> &mem, int &total) {
 
   MEMORYSTATUSEX memStatus;
@@ -3899,14 +3899,14 @@ void countVirtual(vector<mem_block> &mem, int &total) {
   char *addr = 0;
   size_t free = 0;      // total free space
   size_t reserved = 0;  // total reserved space
-  size_t committed = 0; // total commited (used) space
+  size_t committed = 0; // total committed (used) space
   size_t size = 0;
   size_t free_max = 0;      // maximum contiguous block of free memory
   size_t reserved_max = 0;  // maximum contiguous block of reserved memory
   size_t committed_max = 0; // maximum contiguous block of committed memory
 
   size_t GB2 =
-      memStatus.ullTotalVirtual; // Maximum memeory available to the process
+      memStatus.ullTotalVirtual; // Maximum memory available to the process
   total = static_cast<int>(GB2);
 
   // Loop over all virtual memory to find out the status of every block.
@@ -4024,7 +4024,7 @@ void MantidUI::memoryImage2() {
 
 #endif
   //=======================================================================
-  // End of Windows specfic stuff
+  // End of Windows specific stuff
   //=======================================================================
 
 #include "MantidGeometry/Instrument.h"

--- a/MantidPlot/src/Mantid/MantidUI.h
+++ b/MantidPlot/src/Mantid/MantidUI.h
@@ -579,7 +579,7 @@ public:
 #endif
 
 private slots:
-  // respond to the global Mantid properties being modifed
+  // respond to the global Mantid properties being modified
   void configModified();
 
   // slot for file open dialogs created from the main app menu, or the

--- a/MantidPlot/src/Mantid/PeakPickerTool.h
+++ b/MantidPlot/src/Mantid/PeakPickerTool.h
@@ -94,7 +94,7 @@ public:
   Graph *graph() const { return d_graph; }
   /// Prepare a context menu
   void prepareContextMenu(QMenu &menu);
-  /// Was the tool created successfuly?
+  /// Was the tool created successfully?
   bool isInitialized() const { return m_init; }
 
 public slots:

--- a/MantidPlot/src/Mantid/SampleLogDialogBase.h
+++ b/MantidPlot/src/Mantid/SampleLogDialogBase.h
@@ -91,7 +91,7 @@ protected slots:
 protected:
   /// This function is not virtual because it is called from derived classes
   /// without overriding
-  /// This function initalises everything in the tree widget
+  /// This function initialises everything in the tree widget
   void init();
 
   /// Sets the dialog's window title
@@ -144,7 +144,7 @@ protected:
   /// these values are used to specify the format of the log file, all of which
   /// are stored as strings
   enum logType {
-    string,        ///< indicates the log is a string, no other known formating
+    string,        ///< indicates the log is a string, no other known formatting
     numTSeries,    ///< for time series properties that contain numbers
     stringTSeries, ///< for logs that are string time series properties
     numeric,       ///< for logs that are single numeric values (int or double)

--- a/MantidPlot/src/Mantid/UserFitFunctionDialog.cpp
+++ b/MantidPlot/src/Mantid/UserFitFunctionDialog.cpp
@@ -43,7 +43,7 @@ void UserFitFunctionDialog::addFunction(const QString &op, bool brackets) {
   QTreeWidgetItem *parentItem = item->parent();
 
   if (parentItem == nullptr)
-    return; // this sould never happen, just in case
+    return; // this should never happen, just in case
 
   if (parentItem->parent() != nullptr)
     item = parentItem;

--- a/MantidPlot/src/Matrix.h
+++ b/MantidPlot/src/Matrix.h
@@ -252,7 +252,7 @@ public slots:
 
   //! Return the matrix formula
   QString formula() { return formula_str; };
-  //! Set the matrix forumla
+  //! Set the matrix formula
   void setFormula(const QString &s) { formula_str = s; };
 
   //! Load the matrix from a string list (i.e. lines from a project file)
@@ -284,7 +284,7 @@ public slots:
 
   //! Insert a column before the current cell
   void insertColumn();
-  //! Delte the selected columns
+  //! Delete the selected columns
   void deleteSelectedColumns();
   //! Return the number of selected columns
   int numSelectedColumns();

--- a/MantidPlot/src/MdPlottingCmapsProvider.h
+++ b/MantidPlot/src/MdPlottingCmapsProvider.h
@@ -73,7 +73,7 @@ private:
 
   /**
    * Compare the colormap names of the Slice Viewer and the VSI and extract all
-   * indicees of the list of Slice Viewer color maps
+   * indices of the list of Slice Viewer color maps
    * which also exist in the list of the VSI color maps.
    * @param colorMapNamesSliceViewer A list of color maps of the Slice Viewer.
    * @param colorMapNamesVsi A list of color maps for the VSI.

--- a/MantidPlot/src/MdiSubWindow.h
+++ b/MantidPlot/src/MdiSubWindow.h
@@ -136,7 +136,7 @@ public:
   //! Possible window captions.
   enum CaptionPolicy {
     Name = 0,  //!< caption determined by the window name
-    Label = 1, //!< caption detemined by the window label
+    Label = 1, //!< caption determined by the window label
     Both = 2   //!< caption = "name - label"
   };
   enum Status { Hidden = -1, Normal = 0, Minimized = 1, Maximized = 2 };
@@ -234,7 +234,7 @@ public slots:
    * lines to be ignored.
    * It creates a temporary file with '\n' terminated lines which can be
    * correctly read by QTextStream
-   * and returnes a path to this file.
+   * and returns a path to this file.
    */
   static QString parseAsciiFile(const QString &fname,
                                 const QString &commentString, int endLine,
@@ -307,7 +307,7 @@ signals:
   void dockToMDIArea(MdiSubWindow *);
   //! Emitted when the window wants to undock
   void undockFromMDIArea(MdiSubWindow *);
-  /// Emited to detach this window from any parent - docked or floating
+  /// Emitted to detach this window from any parent - docked or floating
   void detachFromParent(MdiSubWindow *);
 
   void dragMousePress(QPoint);

--- a/MantidPlot/src/MultiLayer.cpp
+++ b/MantidPlot/src/MultiLayer.cpp
@@ -1298,7 +1298,7 @@ void MultiLayer::dropEvent(QDropEvent *event) {
   }
 }
 
-/** Drop a workspace onto an exisiting MantidMDCurve (plot of a MDWorkspace)
+/** Drop a workspace onto an existing MantidMDCurve (plot of a MDWorkspace)
 @param g : Graph object
 @param originalCurve : the original MantidMDCurve onto which the new
 workspace(s) are to be dropped
@@ -1350,7 +1350,7 @@ void MultiLayer::dropOntoMDCurve(Graph *g, MantidMDCurve *originalCurve,
 }
 
 /*
-Drop a workspace onto an exisiting matrix curve
+Drop a workspace onto an existing matrix curve
 @param g : Graph object
 @param originalCurve : the original MantidMatrixCurve onto which the new
 workspace(s) are to be dropped
@@ -1477,7 +1477,7 @@ void MultiLayer::convertToWaterfall() {
 }
 
 /**
- * Assume we have a waterfall 1D plot and convert it to a standard overlayed
+ * Assume we have a waterfall 1D plot and convert it to a standard overlaid
  * layout
  */
 void MultiLayer::convertFromWaterfall() {
@@ -1788,7 +1788,7 @@ MultiLayer::loadFromProject(const std::string &lines, ApplicationWindow *app,
     multiLayer->setLayerCanvasSize(width, height);
   }
 
-  if (tsv.selectLine("Alignement")) {
+  if (tsv.selectLine("Alignment")) {
     int hor = 0, vert = 0;
     tsv >> hor >> vert;
     multiLayer->setAlignement(hor, vert);
@@ -1851,7 +1851,7 @@ std::string MultiLayer::saveToProject(ApplicationWindow *app) {
                            << bottom_margin;
   tsv.writeLine("Spacing") << rowsSpace << colsSpace;
   tsv.writeLine("LayerCanvasSize") << l_canvas_width << l_canvas_height;
-  tsv.writeLine("Alignement") << hor_align << vert_align;
+  tsv.writeLine("Alignment") << hor_align << vert_align;
 
   foreach (Graph *g, graphsList)
     tsv.writeSection("graph", g->saveToProject());

--- a/MantidPlot/src/MultiPeakFitTool.h
+++ b/MantidPlot/src/MultiPeakFitTool.h
@@ -61,7 +61,7 @@ public:
 signals:
   /** Emitted whenever a new message should be presented to the user.
    *
-   * You don't have to connect to this signal if you alreay specified a reciever
+   * You don't have to connect to this signal if you already specified a receiver
    *during initialization.
    */
   void statusText(const QString &);

--- a/MantidPlot/src/MultiPeakFitTool.h
+++ b/MantidPlot/src/MultiPeakFitTool.h
@@ -61,8 +61,8 @@ public:
 signals:
   /** Emitted whenever a new message should be presented to the user.
    *
-   * You don't have to connect to this signal if you already specified a receiver
-   *during initialization.
+   * You don't have to connect to this signal if you already specified a
+   *receiver during initialization.
    */
   void statusText(const QString &);
 protected slots:

--- a/MantidPlot/src/MultiTabScriptInterpreter.cpp
+++ b/MantidPlot/src/MultiTabScriptInterpreter.cpp
@@ -660,7 +660,7 @@ void MultiTabScriptInterpreter::contextMenuEvent(QContextMenuEvent *event) {
 /**
  * A custom event handler, which in this case monitors for ScriptChangeEvent
  * signals
- * @param event :: The custome event
+ * @param event :: The custom event
  */
 void MultiTabScriptInterpreter::customEvent(QEvent *event) {
   if (!isExecuting() && event->type() == SCRIPTING_CHANGE_EVENT) {

--- a/MantidPlot/src/PlotDialog.cpp
+++ b/MantidPlot/src/PlotDialog.cpp
@@ -449,7 +449,7 @@ void PlotDialog::changePlotType(int plotType) {
 }
 
 /**
- * Changes the graph's plot stlye from somewhere other than the plot dialog.
+ * Changes the graph's plot style from somewhere other than the plot dialog.
  *
  * @params plotType :: This is the plot style number. i.e line is 0 and scatter
  *is 1.
@@ -2820,11 +2820,11 @@ void PlotDialog::customVectorsPage(bool angleMag) {
 }
 
 /**
- This slot gets called on clicking slect colormap button
+ This slot gets called on clicking select colormap button
  */
 void PlotDialog::changeColormap(const QString &filename) {
   // loads the settings to get the colormap file name.
-  // as theres is no spectrgram valid pointer here i'm directly using Qsetting
+  // as there's no spectrgram valid pointer here i'm directly using Qsetting
   // instead of Spectrogram::loadSettings()
   // mCurrentColorMap gives the last selected colormap file name
   QSettings settings;

--- a/MantidPlot/src/PlotToolInterface.h
+++ b/MantidPlot/src/PlotToolInterface.h
@@ -57,7 +57,7 @@ class Graph;
  * when they are finished and to generalize the statusText signal provided by
  *most tools, but having
  * PlotToolInterface inherit from QObject would make it impossible for
- * plot tools to also inherit from other QObject decendants (such as
+ * plot tools to also inherit from other QObject descendants (such as
  *QwtPlotPicker).
  * As a workaround, plot tools can call Graph::setActiveTool(), carefully noting
  *that they are deleted

--- a/MantidPlot/src/ProjectRecovery.cpp
+++ b/MantidPlot/src/ProjectRecovery.cpp
@@ -510,9 +510,9 @@ void ProjectRecovery::saveWsHistories(const Poco::Path &historyDestFolder) {
 }
 
 /**
- * @brief A function that brings the two seperate save methods together
+ * @brief A function that brings the two separate save methods together
  * This won't run if it is locked by the background thread but then it saving
- * Anyway so thats no issue.
+ * Anyway so that's no issue.
  */
 void ProjectRecovery::saveAll(bool autoSave) {
   // "Timeout" - Save out again

--- a/MantidPlot/src/ProjectSaveView.cpp
+++ b/MantidPlot/src/ProjectSaveView.cpp
@@ -231,7 +231,7 @@ void ProjectSaveView::workspaceItemChanged(QTreeWidgetItem *item, int column) {
  * then only a subset of the workspaces/windows will be passed to the project
  * serialiser.
  *
- * @param checked :: unused arguement
+ * @param checked :: unused argument
  */
 void ProjectSaveView::save(bool checked) {
   UNUSED_ARG(checked);

--- a/MantidPlot/src/ProjectSaveView.h
+++ b/MantidPlot/src/ProjectSaveView.h
@@ -18,7 +18,7 @@ namespace MantidWidgets {
 
 /** @class ProjectSaveView
 
-ProjectSaveView is the interaces for defining the functions that the project
+ProjectSaveView is the interfaces for defining the functions that the project
 save view needs to implement.
 
 Copyright &copy; 2011-14 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
@@ -117,7 +117,7 @@ private:
   bool checkIfNewProject(const QString &projectName) const;
   /// Resize a QTreeWidgets columns to fit text correctly
   void resizeWidgetColumns(QTreeWidget *widget);
-  /// Connect up signals to the interface on initilisation
+  /// Connect up signals to the interface on initialisation
   void connectSignals();
   /// Update the checked state of the tree when an item is updated
   void updateWorkspaceListCheckState(QTreeWidgetItem *item);

--- a/MantidPlot/src/PythonScript.cpp
+++ b/MantidPlot/src/PythonScript.cpp
@@ -148,7 +148,7 @@ PyObject *PythonScript::createSipInstanceFromMe() {
 
 /**
  * @param code A lump of python code
- * @return True if the code forms a complete statment
+ * @return True if the code forms a complete statement
  */
 bool PythonScript::compilesToCompleteStatement(const QString &code) const {
   bool result(false);
@@ -263,7 +263,7 @@ void PythonScript::emit_error() {
     filename = TO_CSTRING(tb->tb_frame->f_code->co_filename);
   }
 
-  // the error message is the full (formated) traceback
+  // the error message is the full (formatted) traceback
   PyObject *str_repr = PyObject_Str(value);
   QString message;
   QTextStream msgStream(&message);

--- a/MantidPlot/src/PythonScript.h
+++ b/MantidPlot/src/PythonScript.h
@@ -161,7 +161,7 @@ private:
   //        mantidplot.runPythonScript('test=CreateSampleWorkspace()', True)
   //
   // To circumvent this we must release the GIL on the main thread
-  // before starting the async thread and then reaquire it when that thread
+  // before starting the async thread and then reacquire it when that thread
   // has finished and the main thread must keep executing. These methods
   // are used for this purpose and are NOT used by the general executeAsync
   // methods where the GILState API functions can cope and there is no

--- a/MantidPlot/src/PythonScripting.h
+++ b/MantidPlot/src/PythonScripting.h
@@ -64,7 +64,7 @@ public:
   /// Set the argv attribute on the sys module
   void setSysArgs(const QStringList &args) override;
 
-  /// Create a new script object that can execute code within this enviroment
+  /// Create a new script object that can execute code within this environment
   Script *newScript(const QString &name, QObject *context,
                     const Script::InteractionType interact) const override;
 
@@ -77,7 +77,7 @@ public:
   /// Does this support abort requests?
   bool supportsAbortRequests() const override { return true; }
 
-  /// Return a string represenation of the given object
+  /// Return a string representation of the given object
   QString toString(PyObject *object, bool decref = false);
   /// Convert a Python list object to a Qt QStringList
   QStringList toStringList(PyObject *py_seq);

--- a/MantidPlot/src/RangeSelectorTool.h
+++ b/MantidPlot/src/RangeSelectorTool.h
@@ -49,7 +49,7 @@ class QEvent;
  * active in parallel and possibly depending on each other should be generalized
  *somehow.
  *
- * In any case, gathering the code specific to range selection in a seperate
+ * In any case, gathering the code specific to range selection in a separate
  *class makes Graph/CanvasPicker
  * more manageable; maybe something similar can be done for zooming.
  */
@@ -88,7 +88,7 @@ public slots:
 signals:
   /** Emitted whenever a new message should be presented to the user.
    *
-   * You don't have to connect to this signal if you alreay specified a reciever
+   * You don't have to connect to this signal if you already specified a receiver
    *during initialization.
    */
   void statusText(const QString &);

--- a/MantidPlot/src/RangeSelectorTool.h
+++ b/MantidPlot/src/RangeSelectorTool.h
@@ -88,8 +88,8 @@ public slots:
 signals:
   /** Emitted whenever a new message should be presented to the user.
    *
-   * You don't have to connect to this signal if you already specified a receiver
-   *during initialization.
+   * You don't have to connect to this signal if you already specified a
+   *receiver during initialization.
    */
   void statusText(const QString &);
   //! Emitted whenever the selected curve and/or range have changed.

--- a/MantidPlot/src/ScaleDetails.cpp
+++ b/MantidPlot/src/ScaleDetails.cpp
@@ -28,7 +28,7 @@ Mantid::Kernel::Logger g_log("ScaleDetails");
  *  @param graph :: the graph the dialog is settign the options for
  *  @param mappedaxis :: the QwtPlot::axis value that corresponds to this axis
  *  @param parent :: the QWidget that acts as this widget's parent in the
- * hierachy
+ * hierarchy
  */
 ScaleDetails::ScaleDetails(ApplicationWindow *app, Graph *graph, int mappedaxis,
                            QWidget *parent)
@@ -581,7 +581,7 @@ void ScaleDetails::apply() {
   }
 }
 
-/** Sets the modifed flag to true so that the changes may be applied.
+/** Sets the modified flag to true so that the changes may be applied.
  *
  */
 void ScaleDetails::setModified() { m_modified = true; }

--- a/MantidPlot/src/ScreenPickerTool.h
+++ b/MantidPlot/src/ScreenPickerTool.h
@@ -56,7 +56,7 @@ public:
 signals:
   /** Emitted whenever a new message should be presented to the user.
    *
-   * You don't have to connect to this signal if you alreay specified a reciever
+   * You don't have to connect to this signal if you already specified a receiver
    *during initialization.
    */
   void statusText(const QString &);

--- a/MantidPlot/src/ScreenPickerTool.h
+++ b/MantidPlot/src/ScreenPickerTool.h
@@ -56,8 +56,8 @@ public:
 signals:
   /** Emitted whenever a new message should be presented to the user.
    *
-   * You don't have to connect to this signal if you already specified a receiver
-   *during initialization.
+   * You don't have to connect to this signal if you already specified a
+   *receiver during initialization.
    */
   void statusText(const QString &);
 

--- a/MantidPlot/src/Script.h
+++ b/MantidPlot/src/Script.h
@@ -65,7 +65,7 @@ public:
          QObject *context = nullptr);
   /// Destructor
   ~Script() override;
-  /// Returns the envirnoment this script is tied to
+  /// Returns the environment this script is tied to
   inline ScriptingEnv *environment() { return m_env; }
   /// Returns the identifier for the script.
   inline const std::string &identifier() const { return m_name; }

--- a/MantidPlot/src/ScriptingEnv.h
+++ b/MantidPlot/src/ScriptingEnv.h
@@ -71,7 +71,8 @@ public:
   virtual Script *newScript(const QString &name, QObject *context,
                             const Script::InteractionType interact) const = 0;
 
-  //! If an exception / error occurred, return a nicely formatted stack backtrace.
+  //! If an exception / error occurred, return a nicely formatted stack
+  //! backtrace.
   virtual QString stackTraceString() { return QString::null; }
   /// Return a list of supported mathematical functions. These should be
   /// imported into the global namespace.

--- a/MantidPlot/src/ScriptingEnv.h
+++ b/MantidPlot/src/ScriptingEnv.h
@@ -71,7 +71,7 @@ public:
   virtual Script *newScript(const QString &name, QObject *context,
                             const Script::InteractionType interact) const = 0;
 
-  //! If an exception / error occured, return a nicely formated stack backtrace.
+  //! If an exception / error occurred, return a nicely formatted stack backtrace.
   virtual QString stackTraceString() { return QString::null; }
   /// Return a list of supported mathematical functions. These should be
   /// imported into the global namespace.

--- a/MantidPlot/src/ScriptingWindow.cpp
+++ b/MantidPlot/src/ScriptingWindow.cpp
@@ -183,7 +183,7 @@ void ScriptingWindow::showEvent(QShowEvent *event) {
 }
 
 /**
- * Open a script directly. This is here for backwards compatability with the old
+ * Open a script directly. This is here for backwards compatibility with the old
  * ScriptWindow
  * class
  * @param filename :: The file name

--- a/MantidPlot/src/ScriptingWindow.h
+++ b/MantidPlot/src/ScriptingWindow.h
@@ -25,7 +25,7 @@ class QShowEvent;
 class QHideEvent;
 
 /** @class ScriptingWindow
-    This class displays a seperate window for editing and executing scripts
+    This class displays a separate window for editing and executing scripts
 */
 class ScriptingWindow : public QMainWindow {
   /// Qt macro

--- a/MantidPlot/src/SelectionMoveResizer.h
+++ b/MantidPlot/src/SelectionMoveResizer.h
@@ -73,7 +73,7 @@ class ImageMarker;
  *
  * \section design Design Ideas
  *   - Keep as much of the select/move/resize code as possible in one class to
- *ease maintanance.
+ *ease maintenance.
  *   - Use the same class for layer and marker handling to avoid duplicating
  *code.
  *     Good for bugfixing and for maintaining a consistent user interface.
@@ -144,16 +144,16 @@ public slots:
   //! Add target to the list of items to be moved/resized together.
   void add(QWidget *target);
   //! Remove target from the list of items to be moved/resized together and
-  // returns the number of occurences removed.
+  // returns the number of occurrences removed.
   int removeAll(LegendWidget *target);
   //! Remove target from the list of items to be moved/resized together and
-  // returns the number of occurences removed.
+  // returns the number of occurrences removed.
   int removeAll(ArrowMarker *target);
   //! Remove target from the list of items to be moved/resized together and
-  // returns the number of occurences removed.
+  // returns the number of occurrences removed.
   int removeAll(ImageMarker *target);
   //! Remove target from the list of items to be moved/resized together and
-  // returns the number of occurences removed.
+  // returns the number of occurrences removed.
   int removeAll(QWidget *target);
   //! Calculate #d_bounding_rect based on the bounding rectangles of all
   // targets.

--- a/MantidPlot/src/Spectrogram.cpp
+++ b/MantidPlot/src/Spectrogram.cpp
@@ -883,7 +883,7 @@ void Spectrogram::updateLabels(
   }
 }
 /**
-     for setting the lables color on contour lines
+     for setting the labels color on contour lines
  */
 void Spectrogram::setLabelsColor(const QColor &c) {
   if (c == d_labels_color)

--- a/MantidPlot/src/Spectrogram.h
+++ b/MantidPlot/src/Spectrogram.h
@@ -84,7 +84,7 @@ public:
   void afterReplaceHandle(
       const std::string &wsName,
       const boost::shared_ptr<Mantid::API::Workspace> ws) override;
-  /// Handle an ADS clear notificiation
+  /// Handle an ADS clear notification
   void clearADSHandle() override;
 
   enum ColorMapPolicy { GrayScale, Default, Custom };

--- a/MantidPlot/src/Table.cpp
+++ b/MantidPlot/src/Table.cpp
@@ -1078,7 +1078,7 @@ void Table::clearSelection() {
     }
     if (lstReadOnly.count() > 0) {
       QMessageBox::warning(this, tr("MantidPlot - Error"),
-                           tr("The folowing columns") + ":\n" +
+                           tr("The following columns") + ":\n" +
                                lstReadOnly.join("\n") + "\n" +
                                tr("are read only!"));
     }
@@ -1115,7 +1115,7 @@ void Table::clearSelection() {
       }
       if (lstReadOnly.count() > 0) {
         QMessageBox::warning(this, tr("MantidPlot - Error"),
-                             tr("The folowing columns") + ":\n" +
+                             tr("The following columns") + ":\n" +
                                  lstReadOnly.join("\n") + "\n" +
                                  tr("are read only!"));
       }
@@ -1234,7 +1234,7 @@ void Table::pasteSelection() {
   }
   if (lstReadOnly.count() > 0) {
     QMessageBox::warning(this, tr("MantidPlot - Error"),
-                         tr("The folowing columns") + ":\n" +
+                         tr("The following columns") + ":\n" +
                              lstReadOnly.join("\n") + "\n" +
                              tr("are read only!"));
   }
@@ -1289,7 +1289,7 @@ void Table::removeCol(const QStringList &list) {
 
   if (lstReadOnly.count() > 0) {
     QMessageBox::warning(this, tr("MantidPlot - Error"),
-                         tr("The folowing columns") + ":\n" +
+                         tr("The following columns") + ":\n" +
                              lstReadOnly.join("\n") + "\n" +
                              tr("are read only!"));
   }
@@ -1339,7 +1339,7 @@ void Table::normalizeSelection() {
 
   if (lstReadOnly.count() > 0) {
     QMessageBox::warning(this, tr("MantidPlot - Error"),
-                         tr("The folowing columns") + ":\n" +
+                         tr("The following columns") + ":\n" +
                              lstReadOnly.join("\n") + "\n" +
                              tr("are read only!"));
   }
@@ -1359,7 +1359,7 @@ void Table::normalize() {
 
   if (lstReadOnly.count() > 0) {
     QMessageBox::warning(this, tr("MantidPlot - Error"),
-                         tr("The folowing columns") + ":\n" +
+                         tr("The following columns") + ":\n" +
                              lstReadOnly.join("\n") + "\n" +
                              tr("are read only!"));
   }
@@ -1936,7 +1936,7 @@ void Table::setRandomValues() {
 
   if (lstReadOnly.count() > 0) {
     QMessageBox::warning(this, tr("MantidPlot - Error"),
-                         tr("The folowing columns") + ":\n" +
+                         tr("The following columns") + ":\n" +
                              lstReadOnly.join("\n") + "\n" +
                              tr("are read only!"));
   }
@@ -2091,7 +2091,7 @@ void Table::setAscValues() {
 
   if (lstReadOnly.count() > 0) {
     QMessageBox::warning(this, tr("MantidPlot - Error"),
-                         tr("The folowing columns") + ":\n" +
+                         tr("The following columns") + ":\n" +
                              lstReadOnly.join("\n") + "\n" +
                              tr("are read only!"));
   }
@@ -2398,7 +2398,7 @@ bool Table::exportASCII(const QString &fname, const QString &separator,
         text += "C" + header[cols - 1] + eol;
       }
     }
-  } // finished writting labels
+  } // finished writing labels
 
   if (exportComments) {
     if (exportSelection) {

--- a/MantidPlot/src/Table.h
+++ b/MantidPlot/src/Table.h
@@ -85,7 +85,7 @@ private:
  *
  * \section future Future Plans
  * Port to the Model/View approach used in Qt4 and get rid of the Qt3Support
- * dependancy.
+ * dependency.
  * [ assigned to thzs ]
  */
 class Table : public MdiSubWindow, public Scripted {

--- a/MantidPlot/src/TextDialog.cpp
+++ b/MantidPlot/src/TextDialog.cpp
@@ -110,7 +110,7 @@ TextDialog::TextDialog(TextType type, QWidget *parent, Qt::WFlags fl)
   buttonDefault = nullptr;
   boxBackgroundTransparency = nullptr;
   if (textType == TextMarker) { // TODO: Sometime background features for axes
-                                // lables should be implemented
+                                // labels should be implemented
     topLayout->addWidget(new QLabel(tr("Opacity")), 3, 0);
     boxBackgroundTransparency = new QSpinBox();
     boxBackgroundTransparency->setRange(0, 255);

--- a/MantidPlot/src/TiledWindow.cpp
+++ b/MantidPlot/src/TiledWindow.cpp
@@ -728,7 +728,7 @@ void TiledWindow::addToSelection(Tile *tile, bool append) {
 }
 
 /**
- * Add a range of tiles to the selection. One of the ends of tha range
+ * Add a range of tiles to the selection. One of the ends of the range
  * is given by an already selected tile with the lowest flat index (see
  * calcFlatIndex).
  * The other end is the tile in the argument.
@@ -912,7 +912,7 @@ void TiledWindow::removeSelectionTo(TiledWindow::RemoveDestination to) {
   foreach (Tile *tile, m_selection) {
     MdiSubWindow *widget = removeTile(tile);
     if (widget == nullptr) {
-      throw std::logic_error("TiledWindow: Empty tile is found in slection.");
+      throw std::logic_error("TiledWindow: Empty tile is found in selection.");
     }
     sendWidgetTo(widget, to);
   }

--- a/MantidPlot/src/TranslateCurveTool.h
+++ b/MantidPlot/src/TranslateCurveTool.h
@@ -66,7 +66,7 @@ public:
 signals:
   /**\brief Emitted whenever a new message should be presented to the user.
    *
-   * You don't have to connect to this signal if you alreay specified a reciever
+   * You don't have to connect to this signal if you already specified a receiver
    *during initialization.
    */
   void statusText(const QString &);

--- a/MantidPlot/src/TranslateCurveTool.h
+++ b/MantidPlot/src/TranslateCurveTool.h
@@ -66,8 +66,8 @@ public:
 signals:
   /**\brief Emitted whenever a new message should be presented to the user.
    *
-   * You don't have to connect to this signal if you already specified a receiver
-   *during initialization.
+   * You don't have to connect to this signal if you already specified a
+   *receiver during initialization.
    */
   void statusText(const QString &);
 public slots:

--- a/MantidPlot/src/cursors.h
+++ b/MantidPlot/src/cursors.h
@@ -2,7 +2,7 @@
     File                 : cursors.h
     Project              : QtiPlot
     --------------------------------------------------------------------
-    This file has been superceded by pixmaps.h, which holds ALL xpm
+    This file has been superseded by pixmaps.h, which holds ALL xpm
     char arrays.
 
  ***************************************************************************/

--- a/MantidPlot/src/importOPJ.cpp
+++ b/MantidPlot/src/importOPJ.cpp
@@ -253,7 +253,7 @@ bool ImportOPJ::importTables(const OPJFile &opj) {
           case 1: // Scientific
             f = 2;
             break;
-          case 2: // Engeneering
+          case 2: // Engineering
           case 3: // Decimal 1,000
             f = 0;
             break;
@@ -460,7 +460,7 @@ bool ImportOPJ::importTables(const OPJFile &opj) {
     case 1: // Scientific
       format = 'e';
       break;
-    case 2: // Engeneering
+    case 2: // Engineering
     case 3: // Decimal 1,000
       format = 'g';
       break;
@@ -1073,7 +1073,7 @@ bool ImportOPJ::importGraphs(const OPJFile &opj) {
           case 1: // Scientific
             format = 2;
             break;
-          case 2: // Engeneering
+          case 2: // Engineering
           case 3: // Decimal 1,000
             format = 0;
             break;
@@ -1107,7 +1107,7 @@ bool ImportOPJ::importGraphs(const OPJFile &opj) {
           case 1: // Scientific
             format = 2;
             break;
-          case 2: // Engeneering
+          case 2: // Engineering
           case 3: // Decimal 1,000
             format = 0;
             break;
@@ -1461,4 +1461,4 @@ QString ImportOPJ::parseOriginTags(const QString &str) {
 // TODO: bug in grid dialog
 //		scale/minor ticks checkbox
 //		histogram: autobin export
-//		if prec not setted - automac+4digits
+//		if prec not set - automac+4digits

--- a/MantidPlot/src/lib/include/TextFormatButtons.h
+++ b/MantidPlot/src/lib/include/TextFormatButtons.h
@@ -63,19 +63,19 @@ private:
   void init(Buttons btns);
 
 private slots:
-  //! Format seleted text to fraction
+  //! Format selected text to fraction
   void addFraction();
-  //! Format seleted text to square root
+  //! Format selected text to square root
   void addSquareRoot();
-  //! Format seleted text to subscript
+  //! Format selected text to subscript
   void addSubscript();
-  //! Format seleted text to superscript
+  //! Format selected text to superscript
   void addSuperscript();
-  //! Format seleted text to underlined
+  //! Format selected text to underlined
   void addUnderline();
-  //! Format seleted text to italics
+  //! Format selected text to italics
   void addItalics();
-  //! Format seleted text to bold
+  //! Format selected text to bold
   void addBold();
   //! Insert curve marker into the text
   void addCurve();

--- a/MantidPlot/src/main.cpp
+++ b/MantidPlot/src/main.cpp
@@ -114,7 +114,7 @@ scripts.
   %Note about modularization: this is mainly about internal reorganizations.
   Most of the current features should remain part of the main executable, but
 use interfaces similar or
-  identical to those used by plug-ins. This should ease maintanance and make
+  identical to those used by plug-ins. This should ease maintenance and make
 adding new features
   to the core application a no-brainer once they're available as plug-ins.
   Support for Python, liborigin and zlib could be real, external plug-ins since

--- a/MantidPlot/src/origin/OPJFile.cpp
+++ b/MantidPlot/src/origin/OPJFile.cpp
@@ -1576,8 +1576,8 @@ void OPJFile::readSpreadInfo(FILE *f, int file_size, FILE *debug) {
       case 0x09: // Text&Numeric - Dec1000
       case 0x10: // Numeric    - Scientific
       case 0x19: // Text&Numeric - Scientific
-      case 0x20: // Numeric    - Engeneering
-      case 0x29: // Text&Numeric - Engeneering
+      case 0x20: // Numeric    - Engineering
+      case 0x29: // Text&Numeric - Engineering
       case 0x30: // Numeric    - Dec1,000
       case 0x39: // Text&Numeric - Dec1,000
         SPREADSHEET[spread].column[col_index].value_type =
@@ -1825,8 +1825,8 @@ void OPJFile::readExcelInfo(FILE *f, int file_size, FILE *debug) {
         case 0x09: // Text&Numeric - Dec1000
         case 0x10: // Numeric    - Scientific
         case 0x19: // Text&Numeric - Scientific
-        case 0x20: // Numeric    - Engeneering
-        case 0x29: // Text&Numeric - Engeneering
+        case 0x20: // Numeric    - Engineering
+        case 0x29: // Text&Numeric - Engineering
         case 0x30: // Numeric    - Dec1,000
         case 0x39: // Text&Numeric - Dec1,000
           EXCEL[iexcel].sheet[isheet].column[col_index].value_type =

--- a/MantidPlot/src/origin/readme
+++ b/MantidPlot/src/origin/readme
@@ -48,7 +48,7 @@ Changelog :
 
 06-07-06	* read size of matrix	
 06-02-06	* replaced arrays with vectors and char* with strings
-06-01-06	* fixed convertion of 4.1 projects
+06-01-06	* fixed conversion of 4.1 projects
 05-30-06	* read matrix tables (testing)
 05-29-06	* read column type if names are not matching (seems to be ok)
 05-26-06	* compare only 11 chars of col label in header section

--- a/MantidPlot/test/MantidPlotProjectSerialiseTest.py
+++ b/MantidPlot/test/MantidPlotProjectSerialiseTest.py
@@ -55,7 +55,7 @@ class MantidPlotProjectSerialiseTest(unittest.TestCase):
         self.assert_project_files_saved(workspace_name)
         contents = read_project_file(self._project_folder)
 
-        # Check corrent number of windows
+        # Check current number of windows
         self.assertEqual(int(contents['<windows>']), 1)
 
         # Check workspace list was written
@@ -86,7 +86,7 @@ class MantidPlotProjectSerialiseTest(unittest.TestCase):
         self.assert_project_files_saved(workspace_name)
         contents = read_project_file(self._project_folder)
 
-        # Check corrent number of windows
+        # Check current number of windows
         self.assertEqual(int(contents['<windows>']), 1)
 
         # Check plot title is correct

--- a/MantidPlot/test/squish_test_suites/refl_gui_tests/tst_basic_operation/test.py
+++ b/MantidPlot/test/squish_test_suites/refl_gui_tests/tst_basic_operation/test.py
@@ -215,7 +215,7 @@ def do_test_three_runs(test_harness):
     # Set the second run number
     tbl.item(row_index, 5).setText(str(run_number2))
     
-    # Set the thrid run number
+    # Set the third run number
     tbl.item(row_index, 10).setText(str(run_number3))
     # Give the third run a theta value
     tbl.item(row_index, 11).setText(str(1.0))

--- a/Testing/PerformanceTests/Mantid.systemtests.properties.template
+++ b/Testing/PerformanceTests/Mantid.systemtests.properties.template
@@ -1,6 +1,6 @@
 # This file can be used to override any properties for this installation.
 # Any properties found in this file will override any that are found in the Mantid.Properties file
-# As this file will not be replaced with futher installations of Mantid it is a safe place to put 
+# As this file will not be replaced with further installations of Mantid it is a safe place to put 
 # properties that suit your particular installation.
 
 # Where to find mantid plugin libraries

--- a/Testing/PerformanceTests/analysis.py
+++ b/Testing/PerformanceTests/analysis.py
@@ -1,5 +1,5 @@
 """ Module containing functions for test
-performance analyis, plotting, and saving
+performance analysis, plotting, and saving
 to other formats (CSV, PDF) """
 
 import testresult

--- a/Testing/PerformanceTests/analysis_mpl.py
+++ b/Testing/PerformanceTests/analysis_mpl.py
@@ -1,5 +1,5 @@
 """ Module containing functions for test
-performance analyis, plotting, and saving
+performance analysis, plotting, and saving
 to other formats (CSV, PDF) """
 from __future__ import (absolute_import, division, print_function)
 from six.moves import range

--- a/Testing/PerformanceTests/make_report.py
+++ b/Testing/PerformanceTests/make_report.py
@@ -48,7 +48,7 @@ if __name__ == "__main__":
 
     parser.add_argument('--path', dest='path',
                         default="./Report",
-                        help='Path to the ouput HTML. Default "./Report".')
+                        help='Path to the output HTML. Default "./Report".')
 
     parser.add_argument('--x_field', dest='x_field',
                         default="revision",

--- a/Testing/PerformanceTests/sqlresults.py
+++ b/Testing/PerformanceTests/sqlresults.py
@@ -260,7 +260,7 @@ class SQLResultReporter(reporters.ResultReporter):
 
     def dispatchResults(self, result):
         '''
-        Construct the SQL commands and send them to the databse
+        Construct the SQL commands and send them to the database
         '''
         dbcxn = SQLgetConnection()
         cur = dbcxn.cursor()

--- a/Testing/SystemTests/lib/systemtests/stresstesting.py
+++ b/Testing/SystemTests/lib/systemtests/stresstesting.py
@@ -614,7 +614,7 @@ class TestRunner(object):
 
 
 #########################################################################
-# Encapsulate the script for runnning a single test
+# Encapsulate the script for running a single test
 #########################################################################
 class TestScript(object):
 
@@ -1124,7 +1124,7 @@ class MantidFrameworkConfig:
 
         # datasearch
         if self.__datasearch:
-            # turn on for 'all' facilties, 'on' is only for default facility
+            # turn on for 'all' facilities, 'on' is only for default facility
             config["datasearch.searcharchive"] = 'all'
             config['network.default.timeout'] = '5'
 
@@ -1253,7 +1253,7 @@ def testThreadsLoop(testDir, saveDir, dataDir, options, tests_dict,
             except KeyboardInterrupt:
                 mgr.markSkipped("KeyboardInterrupt", tests_done.value)
 
-            # Update the test results in the array shared accross cores
+            # Update the test results in the array shared across cores
             res_array[process_number] += mgr._skippedTests
             res_array[process_number + options.ncores] += mgr._failedTests
             res_array[process_number + 2*options.ncores] = min(int(reporter.reportStatus()),\

--- a/Testing/SystemTests/scripts/performance/analysis.py
+++ b/Testing/SystemTests/scripts/performance/analysis.py
@@ -1,5 +1,5 @@
 """ Module containing functions for test
-performance analyis, plotting, and saving
+performance analysis, plotting, and saving
 to other formats (CSV, PDF) """
 from __future__ import (absolute_import, division, print_function)
 from six.moves import range

--- a/Testing/SystemTests/scripts/performance/make_report.py
+++ b/Testing/SystemTests/scripts/performance/make_report.py
@@ -48,7 +48,7 @@ if __name__ == "__main__":
 
     parser.add_argument('--path', dest='path', 
                         default="./Report",
-                        help='Path to the ouput HTML. Default "./Report".' )
+                        help='Path to the output HTML. Default "./Report".' )
 
     parser.add_argument('--x_field', dest='x_field', 
                         default="revision",

--- a/Testing/SystemTests/scripts/performance/sqlresults.py
+++ b/Testing/SystemTests/scripts/performance/sqlresults.py
@@ -260,7 +260,7 @@ class SQLResultReporter(reporters.ResultReporter):
 
     def dispatchResults(self, result):
         '''
-        Construct the SQL commands and send them to the databse
+        Construct the SQL commands and send them to the database
         '''
         dbcxn = SQLgetConnection()
         cur = dbcxn.cursor()

--- a/Testing/SystemTests/tests/analysis/HRPDPowderDiffraction.py
+++ b/Testing/SystemTests/tests/analysis/HRPDPowderDiffraction.py
@@ -70,7 +70,7 @@ class HRPDPowderDiffraction(stresstesting.MantidStressTest):
                            CylinderSampleRadius="0.4",AttenuationXSection="5.1",ScatteringXSection="5.08",
                            SampleNumberDensity="0.072",NumberOfSlices="10",NumberOfAnnuli="10",NumberOfWavelengthPoints="100")
         Divide(LHSWorkspace="Vanadium",RHSWorkspace="Transmission",OutputWorkspace="Vanadium")
-        #convert to dspacing and focus
+        #convert to dspacing and focuss
         ConvertUnits(InputWorkspace="Vanadium",OutputWorkspace="Vanadium",Target="dSpacing")
         DiffractionFocussing(InputWorkspace="Vanadium",OutputWorkspace="Vanadium",GroupingFileName="hrpd_new_072_01_corr.cal")
 

--- a/Testing/SystemTests/tests/analysis/HRPDPowderDiffraction.py
+++ b/Testing/SystemTests/tests/analysis/HRPDPowderDiffraction.py
@@ -70,7 +70,7 @@ class HRPDPowderDiffraction(stresstesting.MantidStressTest):
                            CylinderSampleRadius="0.4",AttenuationXSection="5.1",ScatteringXSection="5.08",
                            SampleNumberDensity="0.072",NumberOfSlices="10",NumberOfAnnuli="10",NumberOfWavelengthPoints="100")
         Divide(LHSWorkspace="Vanadium",RHSWorkspace="Transmission",OutputWorkspace="Vanadium")
-        #convert to dspacing and focuss
+        #convert to dspacing and focus
         ConvertUnits(InputWorkspace="Vanadium",OutputWorkspace="Vanadium",Target="dSpacing")
         DiffractionFocussing(InputWorkspace="Vanadium",OutputWorkspace="Vanadium",GroupingFileName="hrpd_new_072_01_corr.cal")
 

--- a/Testing/SystemTests/tests/analysis/ISISIndirectInelastic.py
+++ b/Testing/SystemTests/tests/analysis/ISISIndirectInelastic.py
@@ -412,7 +412,7 @@ class ISISIndirectInelasticResolution(with_metaclass(ABCMeta, ISISIndirectInelas
     The workflow is defined in the _run() method, simply
     define an __init__ method and set the following properties
     on the object
-        - self.instrument: a string giving the intrument name
+        - self.instrument: a string giving the instrument name
         - self.analyser: a string giving the name of the analyser
         - self.reflection: a string giving the name of the reflection
         - self.detector_range: a list of two integers, giving the range of detectors

--- a/Testing/SystemTests/tests/analysis/ISISLoadingEventData.py
+++ b/Testing/SystemTests/tests/analysis/ISISLoadingEventData.py
@@ -17,7 +17,7 @@ class ISISLoadingEventData(stresstesting.MantidStressTest):
         ev_ws = LoadEventNexus('LET00006278.nxs')
         # isis_vms_compat/SPB[2]
         self.assertEqual(ev_ws.sample().getGeometryFlag(), 1,
-                         "Geometry flag mimatch. vms_compat block not read correctly")
+                         "Geometry flag mismatch. vms_compat block not read correctly")
         # Isis correct the tof using loadTimeOfFlight method.
         self.assertDelta(ev_ws.getSpectrum(10).getTofs()[1], 1041.81, 0.01,
                          "The ISIS event correction is incorrect (check LoadEventNexus::loadTimeOfFlight)")

--- a/Testing/SystemTests/tests/analysis/ISISReflectometryAutoreductionTest.py
+++ b/Testing/SystemTests/tests/analysis/ISISReflectometryAutoreductionTest.py
@@ -373,7 +373,7 @@ def MakeTuples(rlist):
 
 
 def SortRuns(tupsort):
-    # sort tuples of runs into groups beloning to one sample title
+    # sort tuples of runs into groups belonging to one sample title
     row = 0
     complete_list = []
     for _key, group in itertools.groupby(

--- a/Testing/SystemTests/tests/analysis/LOQTransFitWorkspace2D.py
+++ b/Testing/SystemTests/tests/analysis/LOQTransFitWorkspace2D.py
@@ -23,7 +23,7 @@ class LOQTransFitWorkspace2D(stresstesting.MantidStressTest):
         #run the reduction
         WavRangeReduction(3, 4, False, '_suff')
 
-        #save the results, we'll use them later, remove the other tempory workspaces
+        #save the results, we'll use them later, remove the other temporary workspaces
         RenameWorkspace(InputWorkspace='54435_trans_sample_3.0_8.0',OutputWorkspace= 'samp')
         RenameWorkspace(InputWorkspace='54434_trans_can_3.0_8.0',OutputWorkspace= 'can')
         DeleteWorkspace(Workspace='54435_trans_sample_3.0_8.0_unfitted')

--- a/Testing/SystemTests/tests/analysis/LoadMuonNexusTest.py
+++ b/Testing/SystemTests/tests/analysis/LoadMuonNexusTest.py
@@ -7,7 +7,7 @@ class LoadMuonNexusTest(stresstesting.MantidStressTest):
 
     def runTest(self):
       # EMU03087 is an old data file produced by CONVERT_NEXUS from MCS binary files.
-      # Checked specifically because stores resulution (used to calculate FirstGoodData)
+      # Checked specifically because stores resolution (used to calculate FirstGoodData)
       # as NX_FLOAT32 opposed to NX_INT32 in other Muon files.
         loadResult = LoadMuonNexus(Filename = "EMU03087.nxs",
                                    OutputWorkspace = "EMU03087")

--- a/Testing/SystemTests/tests/analysis/PolrefExample.py
+++ b/Testing/SystemTests/tests/analysis/PolrefExample.py
@@ -9,7 +9,7 @@ class PolrefExample(stresstesting.MantidStressTest):
     Owen Arnold
     29/06/2012
     The analysis performed here is a subset of what is done in ReflectometryISIS.py.
-    We may want to remove this test in the furture to avoid duplication. However,
+    We may want to remove this test in the future to avoid duplication. However,
 
     I'm leaving this in here for now because Tim Charlton suggests making the ReflectometryISIS.py
     test more generic for every reflectometry instrument.

--- a/Testing/SystemTests/tests/analysis/ReflectometryISIS.py
+++ b/Testing/SystemTests/tests/analysis/ReflectometryISIS.py
@@ -36,7 +36,7 @@ class ReflectometryISIS(with_metaclass(ABCMeta, stresstesting.MantidStressTest))
         Io=mtd['Io']
         D=mtd['D']
 
-        # Peform the normaisation step
+        # Perform the normaisation step
         Divide(LHSWorkspace=D,RHSWorkspace=Io,OutputWorkspace='I',
                AllowDifferentNumberSpectra='1',ClearRHSWorkspace='1')
         I=mtd['I'][0]
@@ -55,7 +55,7 @@ class ReflectometryISIS(with_metaclass(ABCMeta, stresstesting.MantidStressTest))
         # Should now have signed theta vs Lambda
         ConvertSpectrumAxis(InputWorkspace=I,OutputWorkspace='SignedTheta_vs_Wavelength',Target='signed_theta')
 
-        # Check that signed two theta is being caluclated correctly (not normalised)
+        # Check that signed two theta is being calculated correctly (not normalised)
         ws1 = mtd['SignedTheta_vs_Wavelength']
         upperHistogram = ws1.getNumberHistograms()-1
         for i in range(0, upperHistogram):

--- a/Testing/SystemTests/tests/analysis/ReflectometryQuickCombineMulti.py
+++ b/Testing/SystemTests/tests/analysis/ReflectometryQuickCombineMulti.py
@@ -48,7 +48,7 @@ class ReflectometryQuickCombineMulti(stresstesting.MantidStressTest):
         IvsQ2 = self.doQuickOnRun(runNumber=13462, transmissionNumbers=[13463,13464], instrument='INTER', incidentAngle=2.3)
         IvsQ2Binned = Rebin(InputWorkspace=IvsQ2, Params=self.createBinningParam(run2QLow, -step, run2QHigh))
 
-        # Peform the stitching
+        # Perform the stitching
         combineMulti.combineDataMulti([IvsQ1Binned.name(), IvsQ2Binned.name()], self.__stitchedWorkspaceName,
                                       [run1QLow, run2QLow], [run1QHigh, run2QHigh], run1QLow, run2QHigh, -step, 1)
 

--- a/Testing/SystemTests/tests/analysis/SANS2DBatch.py
+++ b/Testing/SystemTests/tests/analysis/SANS2DBatch.py
@@ -52,11 +52,11 @@ class SANS2DNewSettingsCarriedAcrossInBatchMode(stresstesting.MantidStressTest):
         SANS2D()
         Set1D()
         Detector("rear-detector")
-        # This contains two MASKFILE commands, each resulting in a seperate call to MaskDetectors.
+        # This contains two MASKFILE commands, each resulting in a separate call to MaskDetectors.
         MaskFile('MaskSANS2DReductionGUI_MaskFiles.txt')
         Gravity(True)
 
-        # This does 2 seperate reductions of the same data, but saving the result of each to a different workspace.
+        # This does 2 separate reductions of the same data, but saving the result of each to a different workspace.
         csv_file = FileFinder.getFullPath("SANS2D_mask_batch.csv")
         BatchReduce(csv_file, 'nxs', plotresults=False)
 
@@ -78,7 +78,7 @@ class SANS2DTUBESBatchWithZeroErrorCorrection(stresstesting.MantidStressTest):
         SANS2DTUBES()
         Set1D()
         Detector("rear-detector")
-        # This contains two MASKFILE commands, each resulting in a seperate call to MaskDetectors.
+        # This contains two MASKFILE commands, each resulting in a separate call to MaskDetectors.
         MaskFile('SANS2DTube_ZerroErrorFreeTest.txt')
 
         # Saves a file which produces an output file which does not contain any zero errors

--- a/Testing/SystemTests/tests/analysis/SANS2DBatchTest_V2.py
+++ b/Testing/SystemTests/tests/analysis/SANS2DBatchTest_V2.py
@@ -83,7 +83,7 @@ class SANS2DTUBESBatchWithZeroErrorCorrectionTest_V2(stresstesting.MantidStressT
         SANS2DTUBES()
         Set1D()
         Detector("rear-detector")
-        # This contains two MASKFILE commands, each resulting in a seperate call to MaskDetectors.
+        # This contains two MASKFILE commands, each resulting in a separate call to MaskDetectors.
         MaskFile('SANS2DTube_ZerroErrorFreeTest.txt')
 
         # Saves a file which produces an output file which does not contain any zero errors

--- a/Testing/SystemTests/tests/analysis/SANS2DLOQReloadWorkspaces.py
+++ b/Testing/SystemTests/tests/analysis/SANS2DLOQReloadWorkspaces.py
@@ -78,7 +78,7 @@ class LOQReductionShouldAcceptLoadedWorkspace(unittest.TestCase):
 
         ws_name = ReductionSingleton().get_sample().get_wksp_name()
         # it is different, because, it will compose the name using its rule,
-        # wich, for sure, will be different of my_workspace.
+        # which, for sure, will be different of my_workspace.
         self.assertFalse(ws_name==my_workspace.name())
         self.assertFalse(mtd[ws_name].dataY(0)[10]==5)
         # it is not necessary to ensure the Reduce occurs
@@ -97,7 +97,7 @@ class LOQReductionShouldAcceptLoadedWorkspace(unittest.TestCase):
         ws_name = ReductionSingleton().get_sample().get_wksp_name()
         # the workspace is renamed, so it seems another workspace
         my_workspace = RenameWorkspace(ws_name)
-        ## trying to assing it again to AssingSample must fail
+        ## trying to assign it again to AssingSample must fail
         self.assertRaises(RuntimeError, AssignSample, my_workspace, False)
 
 

--- a/Testing/SystemTests/tests/analysis/SANSDarkRunSubtractionTest.py
+++ b/Testing/SystemTests/tests/analysis/SANSDarkRunSubtractionTest.py
@@ -412,7 +412,7 @@ class DarkRunSubtractionTest(unittest.TestCase):
 
         # Execute the dark_run_subtractor - let exceptions flow to help track down errors
         start_spec = 9
-        end_spec = 20 # Full specturm length
+        end_spec = 20 # Full spectrum length
         scatter_workspace, monitor_workspace = dark_run_subtractor.execute(scatter_workspace, monitor_workspace,
                                                                            start_spec, end_spec, is_input_event)
 

--- a/Testing/SystemTests/tests/analysis/SEQUOIAreduction.py
+++ b/Testing/SystemTests/tests/analysis/SEQUOIAreduction.py
@@ -169,7 +169,7 @@ class DirectInelaticSNSTest(stresstesting.MantidStressTest):
         flag_spe=False                                                  #flag to generate an spe file
         flag_nxspe=True                                                 #flag to generate an nxspe file
         do_powder=True                                                  #group detectors by angle
-        anglemin=0.				                                        #minumum angle
+        anglemin=0.				                                        #minimum angle
         anglemax=70.				                                    #maximum angle
         anglestep=1.				                                    #angle step - this can be fine tuned for pixel arc over detectors
 

--- a/Testing/SystemTests/tests/analysis/SXDAnalysis.py
+++ b/Testing/SystemTests/tests/analysis/SXDAnalysis.py
@@ -40,16 +40,16 @@ class SXDAnalysis(stresstesting.MantidStressTest):
         unitcell_angle = 90
         length_tolerance = 0.1
         #
-        angle_tolelerance = 0.25  # Actual tolernce seems is 0.17
+        angle_tolerance = 0.25  # Actual tolerance seems is 0.17
         #
         # Check results.
         latt = peaks_qLab.sample().getOrientedLattice()
         self.assertDelta( latt.a(), unitcell_length, length_tolerance, "a length is different from expected")
         self.assertDelta( latt.b(), unitcell_length, length_tolerance, "b length is different from expected")
         self.assertDelta( latt.c(), unitcell_length, length_tolerance, "c length is different from expected")
-        self.assertDelta( latt.alpha(), unitcell_angle, angle_tolelerance, "alpha angle is different from expected")
-        self.assertDelta( latt.beta(), unitcell_angle, angle_tolelerance, "beta angle is different from expected")
-        self.assertDelta( latt.gamma(), unitcell_angle, angle_tolelerance, "gamma angle length is different from expected")
+        self.assertDelta( latt.alpha(), unitcell_angle, angle_tolerance, "alpha angle is different from expected")
+        self.assertDelta( latt.beta(), unitcell_angle, angle_tolerance, "beta angle is different from expected")
+        self.assertDelta( latt.gamma(), unitcell_angle, angle_tolerance, "gamma angle length is different from expected")
 
     def doValidation(self):
         # If we reach here, no validation failed

--- a/Testing/SystemTests/tests/analysis/ValidateFacilitiesFile.py
+++ b/Testing/SystemTests/tests/analysis/ValidateFacilitiesFile.py
@@ -41,4 +41,4 @@ class ValidateFacilitiesFile(stresstesting.MantidStressTest):
             print("SUMMARY OF FAILED FILES")
             raise RuntimeError("Failed Validation of Facilities.xml")
         else:
-            print("Succesfully Validated Facilities.xml")
+            print("Successfully Validated Facilities.xml")

--- a/Testing/SystemTests/tests/analysis/ValidateGroupingFiles.py
+++ b/Testing/SystemTests/tests/analysis/ValidateGroupingFiles.py
@@ -61,4 +61,4 @@ class ValidateGroupingFiles(stresstesting.MantidStressTest):
             raise RuntimeError("Failed Validation for %d of %d files"
                                % (len(failed), len(files)))
         else:
-            print("Succesfully Validated %d files" % len(files))
+            print("Successfully Validated %d files" % len(files))

--- a/Testing/SystemTests/tests/analysis/ValidateInstrumentDefinitionFiles.py
+++ b/Testing/SystemTests/tests/analysis/ValidateInstrumentDefinitionFiles.py
@@ -96,7 +96,7 @@ class ValidateInstrumentDefinitionFiles(stresstesting.MantidStressTest):
             raise RuntimeError("Failed Validation for %d of %d files"
                                % (len(failed), len(files)))
         else:
-            print("Succesfully Validated %d files" % len(files))
+            print("Successfully Validated %d files" % len(files))
 
 
 if __name__ == '__main__':

--- a/Testing/SystemTests/tests/analysis/ValidateParameterFiles.py
+++ b/Testing/SystemTests/tests/analysis/ValidateParameterFiles.py
@@ -62,7 +62,7 @@ class ValidateParameterFiles(stresstesting.MantidStressTest):
             raise RuntimeError("Failed Validation for %d of %d files"
                                % (len(failed), len(files)))
         else:
-            print("Succesfully Validated %d files" % len(files))
+            print("Successfully Validated %d files" % len(files))
 
 
 if __name__ == '__main__':

--- a/Testing/SystemTests/tests/analysis/WeightedLeastSquaresTest.py
+++ b/Testing/SystemTests/tests/analysis/WeightedLeastSquaresTest.py
@@ -153,7 +153,7 @@ class SineLikeMuonExperimentAsymmetry(unittest.TestCase):
     rubbish results. This happens even with 0 noise.
 
     Initial values of w approximately <=5.25 or >=6.75 will make the minimizer fail.
-    This is very sensitive to inital conditions. The goodness of fit is highly non-convex on w.
+    This is very sensitive to initial conditions. The goodness of fit is highly non-convex on w.
     Any local minimizer should be very sensitive to the initial guess.
     """
     filename = 'sine_fitting_test_muon_asymmetry.txt'

--- a/Testing/SystemTests/tests/analysis/WishAnalysis.py
+++ b/Testing/SystemTests/tests/analysis/WishAnalysis.py
@@ -51,7 +51,7 @@ class WishAnalysis(stresstesting.MantidStressTest):
         RebinToWorkspace(WorkspaceToRebin="vana",WorkspaceToMatch="w16748-1foc",OutputWorkspace="vana")
         Divide(LHSWorkspace="w16748-1foc",RHSWorkspace="vana",OutputWorkspace="w16748-1foc")
         DeleteWorkspace(Workspace="vana")
-        #convert back to TOF for ouput to GSAS/Fullprof
+        #convert back to TOF for output to GSAS/Fullprof
         ConvertUnits(InputWorkspace="w16748-1foc",OutputWorkspace="w16748-1foc",Target="TOF")
 
     def validate(self):

--- a/Testing/SystemTests/tests/analysis/WishCalibrate.py
+++ b/Testing/SystemTests/tests/analysis/WishCalibrate.py
@@ -112,7 +112,7 @@ class WishCalibration(stresstesting.MantidStressTest):
 
             @param peakTable: the table containing fitted peak centers
             @param threshold: the tolerance on the difference from the mean value
-            @return A list of expected peak positions and a list of indicies of tubes
+            @return A list of expected peak positions and a list of indices of tubes
             to correct
             """
             n = len(peaksTable)
@@ -150,7 +150,7 @@ class WishCalibration(stresstesting.MantidStressTest):
             tube are recalculated.
 
             @param ws: the workspace to get the tube geometry from
-            @param calibrationTable: the calibration table ouput from running calibration
+            @param calibrationTable: the calibration table output from running calibration
             @param peaksTable: the table containing the fitted peak centers from calibration
             @param spec: the tube spec for the instrument
             @param idealTube: the ideal tube for the instrument

--- a/Testing/SystemTests/tests/analysis/WishMasking.py
+++ b/Testing/SystemTests/tests/analysis/WishMasking.py
@@ -29,9 +29,9 @@ class WishMasking(stresstesting.MantidStressTest):
                 continue
 
     # Tests that the cal file is being created in the expected way.
-        #  1) Uses the masks to create a cal file
-        #  2) Read the cal file
-        #  3) Use the known masking boundaries to determine whether the cal file has been created propertly according to the function inputs.
+        # 1) Uses the masks to create a cal file
+        # 2) Read the cal file
+        # 3) Use the known masking boundaries to determine whether the cal file has been created propertly according to the function inputs.
         #pylint: disable=too-many-arguments
     def do_test_cal_file(self, masked_workspace, should_invert, expected_masking_identifier, expected_not_masking_identifier, masking_edge):
 

--- a/Testing/SystemTests/tests/analysis/WishMasking.py
+++ b/Testing/SystemTests/tests/analysis/WishMasking.py
@@ -31,7 +31,7 @@ class WishMasking(stresstesting.MantidStressTest):
     # Tests that the cal file is being created in the expected way.
         #  1) Uses the masks to create a cal file
         #  2) Read the cal file
-        #  3) Use the known masking boundaries to determine whether the cal file has been created propertly accoring to the function inputs.
+        #  3) Use the known masking boundaries to determine whether the cal file has been created propertly according to the function inputs.
         #pylint: disable=too-many-arguments
     def do_test_cal_file(self, masked_workspace, should_invert, expected_masking_identifier, expected_not_masking_identifier, masking_edge):
 

--- a/Testing/Tools/cxxtest/TODO
+++ b/Testing/Tools/cxxtest/TODO
@@ -8,7 +8,7 @@ It is not meant to be "human readable".
 Write some mocks
 
 *** Distribution
-Seperate packages (w/ binaries)?  How would that be used?
+Separate packages (w/ binaries)?  How would that be used?
 For Windows: .lib for "Real" and "Mock" parts.
 For Linux: Maybe. Different compilers etc.
 So probably only source release with Makefiles and .ds[pw]?  Or just Win32 binary.

--- a/Testing/Tools/cxxtest/cxxtest/Gui.h
+++ b/Testing/Tools/cxxtest/cxxtest/Gui.h
@@ -2,7 +2,7 @@
 #define __CXXTEST__GUI_H
 
 //
-// GuiListener is a simple base class for the differes GUIs
+// GuiListener is a simple base class for the different GUIs
 // GuiTuiRunner<GuiT, TuiT> combines a GUI with a text-mode error formatter
 //
 
@@ -20,15 +20,15 @@ namespace CxxTest
         {
             enterGui( argc, argv );
             TestRunner::runAllTests( listener );
-            leaveGui();            
+            leaveGui();
         }
 
         virtual void enterGui( int & /*argc*/, char ** /*argv*/ ) {}
         virtual void leaveGui() {}
-        
+
         //
         // The easy way is to implement these functions:
-        //      
+        //
         virtual void guiEnterWorld( unsigned /*numTotalTests*/ ) {}
         virtual void guiEnterSuite( const char * /*suiteName*/ ) {}
         virtual void guiEnterTest( const char * /*suiteName*/, const char * /*testName*/ ) {}
@@ -44,22 +44,22 @@ namespace CxxTest
         void leaveTest( const TestDescription & ) {}
         void leaveSuite( const SuiteDescription & ) {}
         void leaveWorld( const WorldDescription & ) {}
-        
+
         void warning( const char * /*file*/, unsigned /*line*/, const char * /*expression*/ )
         {
             yellowBarSafe();
         }
-        
+
         void failedTest( const char * /*file*/, unsigned /*line*/, const char * /*expression*/ )
         {
             redBarSafe();
         }
-        
+
         void failedAssert( const char * /*file*/, unsigned /*line*/, const char * /*expression*/ )
         {
             redBarSafe();
         }
-        
+
         void failedAssertEquals( const char * /*file*/, unsigned /*line*/,
                                  const char * /*xStr*/, const char * /*yStr*/,
                                  const char * /*x*/, const char * /*y*/ )
@@ -74,55 +74,55 @@ namespace CxxTest
         {
             redBarSafe();
         }
-        
+
         void failedAssertDelta( const char * /*file*/, unsigned /*line*/,
                                 const char * /*xStr*/, const char * /*yStr*/, const char * /*dStr*/,
                                 const char * /*x*/, const char * /*y*/, const char * /*d*/ )
         {
             redBarSafe();
         }
-        
+
         void failedAssertDiffers( const char * /*file*/, unsigned /*line*/,
                                   const char * /*xStr*/, const char * /*yStr*/,
                                   const char * /*value*/ )
         {
             redBarSafe();
         }
-        
+
         void failedAssertLessThan( const char * /*file*/, unsigned /*line*/,
                                    const char * /*xStr*/, const char * /*yStr*/,
                                    const char * /*x*/, const char * /*y*/ )
         {
             redBarSafe();
         }
-        
+
         void failedAssertLessThanEquals( const char * /*file*/, unsigned /*line*/,
                                          const char * /*xStr*/, const char * /*yStr*/,
                                          const char * /*x*/, const char * /*y*/ )
         {
             redBarSafe();
         }
-        
+
         void failedAssertPredicate( const char * /*file*/, unsigned /*line*/,
                                     const char * /*predicate*/, const char * /*xStr*/, const char * /*x*/ )
         {
             redBarSafe();
         }
-        
+
         void failedAssertRelation( const char * /*file*/, unsigned /*line*/,
                                    const char * /*relation*/, const char * /*xStr*/, const char * /*yStr*/,
                                    const char * /*x*/, const char * /*y*/ )
         {
             redBarSafe();
         }
-        
+
         void failedAssertThrows( const char * /*file*/, unsigned /*line*/,
                                  const char * /*expression*/, const char * /*type*/,
                                  bool /*otherThrown*/ )
         {
             redBarSafe();
         }
-        
+
         void failedAssertThrowsNot( const char * /*file*/, unsigned /*line*/,
                                     const char * /*expression*/ )
         {
@@ -145,7 +145,7 @@ namespace CxxTest
                 _state = RED_BAR;
             }
         }
-        
+
     private:
         enum { GREEN_BAR, YELLOW_BAR, RED_BAR } _state;
     };
@@ -157,12 +157,12 @@ namespace CxxTest
         char **_argv;
         GuiT _gui;
         TuiT _tui;
-        
+
     public:
         GuiTuiRunner() : _argc(0), _argv(0) {}
 
         void process_commandline( int& argc, char** argv )
-        {  
+        {
             _argc=&argc;
             _argv=argv;
             setFirst( _gui );
@@ -182,4 +182,3 @@ namespace CxxTest
 // Copyright 2008 Sandia Corporation. Under the terms of Contract
 // DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
 // retains certain rights in this software.
-

--- a/Testing/Tools/cxxtest/cxxtest/MantidFormatter.h
+++ b/Testing/Tools/cxxtest/cxxtest/MantidFormatter.h
@@ -57,7 +57,7 @@ namespace CxxTest
             std::ostringstream o;
             o << ticksElapsed;
             std::string s = o.str();
-            //ouput it
+            //output it
             (*_o) << "Elapsed: " << s.c_str() << " seconds"<< endl;
             return tracker().failedTests();
         }

--- a/Testing/Tools/cxxtest/cxxtest/XmlFormatter.h
+++ b/Testing/Tools/cxxtest/cxxtest/XmlFormatter.h
@@ -230,7 +230,7 @@ namespace CxxTest
 
             // Add the CPU fraction measurement
             o << "> <measurement><name>CPUFraction</name><value>" << CPUFraction_stream.str().c_str() << "</value></measurement>";
-            elts = true; // force there to alway be elements, since I just wrote one
+            elts = true; // force there to always be elements, since I just wrote one
 
             element_t curr = elements.begin();
             element_t end  = elements.end();

--- a/Testing/Tools/cxxtest/docs/guide.texi
+++ b/Testing/Tools/cxxtest/docs/guide.texi
@@ -278,7 +278,7 @@ Success rate: 50%
 @end smallexample
 
 
-Fixing the bug is left as an excercise to the reader.
+Fixing the bug is left as an exercise to the reader.
 
 
 @section Graphical user interface
@@ -705,7 +705,7 @@ CxxTest comes with some samples in the @file{sample/} subdirectory of
 the distribution.  If you look in that directory, you will see three
 Makefiles: @file{Makefile.unix}, @file{Makefile.msvc} and
 @file{Makefile.bcc32} which are for Linux/Unix, MS Visual C++ and
-Borland C++, repectively.  These files are provided as a starting point,
+Borland C++, respectively.  These files are provided as a starting point,
 and some options may need to be tweaked in them for your system.
 
 If you are running under Windows, a good guess would be to run
@@ -1436,7 +1436,7 @@ Sometimes your code needs to call functions which are not available when
 testing. This happens for example when you test driver code using a
 user-mode test runner, and you need to call kernel functions.  You can
 use CxxTest's mock framework to provide testable implementations for the
-test code, while maintaing the original functions for the real code.
+test code, while maintaining the original functions for the real code.
 This you do with @code{CXXTEST_SUPPLY_GLOBAL} (and
 @code{CXXTEST_SUPPLY_VOID_GLOBAL}).  For example, say you want to supply
 your code with the Win32 kernel function @code{IoCallDriver}:
@@ -1541,7 +1541,7 @@ test listener of your fancy.
 
 @subsubsection The @code{stdio} printer
 If the @code{ErrorPrinter}'s usage of @code{std::cout} clashes
-with your environment or is unsupported by your compiler, don't dispair!
+with your environment or is unsupported by your compiler, don't despair!
 You may still be able to use the @code{StdioPrinter}, which does the
 exact same thing but uses good old @code{printf()}.
 
@@ -1637,7 +1637,7 @@ The currently available runners are:
 This is the standard error printer, which formats its output to @code{std::cout}.
 
 @item --runner=ParenPrinter
-Identical to @code{ErrorPrinter} except that it prints line numbers in parantheses.
+Identical to @code{ErrorPrinter} except that it prints line numbers in parentheses.
 This is the way Visual Studio expects it.
 
 @item --runner=StdioPrinter

--- a/Testing/Tools/cxxtest/python/cxxtest/__init__.py
+++ b/Testing/Tools/cxxtest/python/cxxtest/__init__.py
@@ -2,7 +2,7 @@
 
 .. _CxxTest: http://cxxtest.tigris.org/
 
-The _CxxTest testing framework is focussed on being a lightweight
+The _CxxTest testing framework is focused on being a lightweight
 framework that is well suited for integration into embedded systems
 development projects.
 

--- a/Testing/Tools/cxxtest/python/cxxtest/__init__.py
+++ b/Testing/Tools/cxxtest/python/cxxtest/__init__.py
@@ -2,7 +2,7 @@
 
 .. _CxxTest: http://cxxtest.tigris.org/
 
-The _CxxTest testing framework is focused on being a lightweight
+The _CxxTest testing framework is focussed on being a lightweight
 framework that is well suited for integration into embedded systems
 development projects.
 

--- a/Testing/Tools/cxxtest/sample/SCons/SConstruct
+++ b/Testing/Tools/cxxtest/sample/SCons/SConstruct
@@ -17,18 +17,18 @@ env.Append(CPPPATH=['include'])
 libtested = env.StaticLibrary('build/embedded_platform/tested', 
                               env.Glob('build/embedded_platform/*.c'))
 
-# Now create a seperate build environment for the tests so we can keep any
-# options that are specific to testing  seperate from the 'production' build
+# Now create a separate build environment for the tests so we can keep any
+# options that are specific to testing  separate from the 'production' build
 # environment. For simplicity I am just copying the production environment.
 # If we are cross compiling for the "real" library, then this 
-# environement might be using the normal compiler.
+# environment might be using the normal compiler.
 env_test = env.Clone()
 
 # Add the CxxTestBuilder to our testing build environment.
 cxxtest.generate(env_test, CXXTEST_INSTALL_DIR = cxxtest_path)
 
 # If we were working with an embedded platform we may want to create a 
-# seperate version of our library that runs on our development box in 
+# separate version of our library that runs on our development box in 
 # order to do our initial unit testing. This version may also include 
 # any special preprocessor defines needed for testing e.g. -DTESTING
 env_test.BuildDir('build/dev_platform', 'src')

--- a/Testing/Tools/cxxtest/test/GoodSuite.h
+++ b/Testing/Tools/cxxtest/test/GoodSuite.h
@@ -105,7 +105,7 @@ public:
 
     void testThrowsNothingMessage()
     {
-        TSM_ASSERT_THROWS_NOTHING( "Empty functions dosn't throw", throwNothing() );
+        TSM_ASSERT_THROWS_NOTHING( "Empty functions doesn't throw", throwNothing() );
     }
 
     void throwNothing()

--- a/Testing/Tools/cxxtest/www/cn-project-pages/snippets/HtmlSnippet1.html
+++ b/Testing/Tools/cxxtest/www/cn-project-pages/snippets/HtmlSnippet1.html
@@ -3,7 +3,7 @@
 <p><b>This is the new home of CxxTest. The old pages on SourceForge.net do not contain the new releases or any new developments.</b>
 
 <p>CxxTest is a JUnit/CppUnit/xUnit-like framework for C/C++.
-<p> It is focused on being a lightweight framework that is well suited for integration into embedded systems development projects.
+<p> It is focussed on being a lightweight framework that is well suited for integration into embedded systems development projects.
 
 <p>CxxTest's advantages over existing alternatives are that it:
 <ul>

--- a/Testing/Tools/cxxtest/www/cn-project-pages/snippets/HtmlSnippet1.html
+++ b/Testing/Tools/cxxtest/www/cn-project-pages/snippets/HtmlSnippet1.html
@@ -3,7 +3,7 @@
 <p><b>This is the new home of CxxTest. The old pages on SourceForge.net do not contain the new releases or any new developments.</b>
 
 <p>CxxTest is a JUnit/CppUnit/xUnit-like framework for C/C++.
-<p> It is focussed on being a lightweight framework that is well suited for integration into embedded systems development projects.
+<p> It is focused on being a lightweight framework that is well suited for integration into embedded systems development projects.
 
 <p>CxxTest's advantages over existing alternatives are that it:
 <ul>
@@ -15,12 +15,10 @@
 <li>Doesn't require the user to manually register tests and test suites
 </ul>
 
-<p>This makes it extremely portable and usable. 
+<p>This makes it extremely portable and usable.
 
 <p> Currently CxxTest is about to get a major update. The stable version (3.10.1) is available in the documents and files section.
 
 <p> For more information you may visit our <a href="http://cxxtest.com">wiki</a>.
 
-If you are interested in helping this project you can start by <a href="http://cxxtest.tigris.org/source/browse/cxxtest/">browsing the code</a> and looking at the currently <a href="http://cxxtest.tigris.org/issues/buglist.cgi?issue_status=UNCONFIRMED&issue_status=NEW&issue_status=STARTED&issue_status=REOPENED">open issues</a>. 
-              
-              
+If you are interested in helping this project you can start by <a href="http://cxxtest.tigris.org/source/browse/cxxtest/">browsing the code</a> and looking at the currently <a href="http://cxxtest.tigris.org/issues/buglist.cgi?issue_status=UNCONFIRMED&issue_status=NEW&issue_status=STARTED&issue_status=REOPENED">open issues</a>.

--- a/Testing/Tools/generatetestmain.py
+++ b/Testing/Tools/generatetestmain.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
     if len(args) <= 0:
         parser.error("Must specify an output file")
     if len(args) > 1:
-        parser.error("Can only produce a single ouput file")
+        parser.error("Can only produce a single output file")
     filename = args[0]
     if not filename.endswith(".cpp"):
         parser.error("Filename '%s' must end with '.cpp'" % filename)

--- a/buildconfig/CMake/CppCheck_Suppressions.txt
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt
@@ -5,7 +5,7 @@
 // memsetClassFloat:/Users/builder/Jenkins/workspace/cppcheck-1.72/Framework/DataHandling/src/LoadRaw/isisraw.h
 
 
-// suppress in all files - BE CAREFULL not to leave trailing spaces after the rule id. or empty lines
+// suppress in all files - BE CAREFUL not to leave trailing spaces after the rule id. or empty lines
 // For a library this is not a problem per se
 // unusedFunction
 // cppcheck has problems handling the number of pre-processor definitions used in the DLL_EXPORTs

--- a/buildconfig/CMake/FindLibRDKafka.cmake
+++ b/buildconfig/CMake/FindLibRDKafka.cmake
@@ -37,7 +37,7 @@ macro(HEXCHAR2DEC VAR VAL)
     elseif(${VAL} MATCHES "[fF]")
         SET(${VAR} 15)
     else()
-        MESSAGE(FATAL_ERROR "Invalid format for hexidecimal character")
+        MESSAGE(FATAL_ERROR "Invalid format for hexadecimal character")
     endif()
 
 endmacro(HEXCHAR2DEC)

--- a/buildconfig/CMake/FindOpenCL.cmake
+++ b/buildconfig/CMake/FindOpenCL.cmake
@@ -1,6 +1,6 @@
 # - Try to find OpenCL
 # This module tries to find an OpenCL implementation on your system. It supports
-# AMD / ATI, Apple and NVIDIA implementations, but shoudl work, too.
+# AMD / ATI, Apple and NVIDIA implementations, but should work, too.
 #
 # Once done this will define
 #  OPENCL_FOUND        - system has OpenCL

--- a/buildconfig/CMake/FindPoco.cmake
+++ b/buildconfig/CMake/FindPoco.cmake
@@ -65,7 +65,7 @@ if( POCO_INCLUDE_DIR )
   set ( POCO_VERSION "${POCO_VERSION_MAJOR}.${POCO_VERSION_MINOR}.${POCO_VERSION_PATCH}" )
 endif()
 
-# Also set a shared libarary version number. This is different to the main version number
+# Also set a shared library version number. This is different to the main version number
 # and can form part of the package name on some Linux systems
 if( POCO_LIB_FOUNDATION )
   set ( POCO_SOLIB_VERSION "" )

--- a/buildconfig/CMake/FindPyQt4.cmake
+++ b/buildconfig/CMake/FindPyQt4.cmake
@@ -6,7 +6,7 @@
 # Find the installed version of PyQt4. FindPyQt4 should only be called after
 # Python has been found.
 #
-# This file defines the following variables, which can also be overriden by
+# This file defines the following variables, which can also be overridden by
 # users:
 #
 # PYQT4_VERSION - The version of PyQt4 found expressed as a 6 digit hex number

--- a/buildconfig/CMake/FindPyQt5.cmake
+++ b/buildconfig/CMake/FindPyQt5.cmake
@@ -6,7 +6,7 @@
 # Find the installed version of PyQt5. FindPyQt5 should only be called after
 # Python has been found.
 #
-# This file defines the following variables, which can also be overriden by
+# This file defines the following variables, which can also be overridden by
 # users:
 #
 # PYQT5_VERSION - The version of PyQt5 found expressed as a 6 digit hex number

--- a/buildconfig/CMake/FindPyUnitTest.cmake
+++ b/buildconfig/CMake/FindPyUnitTest.cmake
@@ -25,7 +25,7 @@ function ( PYUNITTEST_ADD_TEST _test_src_dir _testname_prefix )
   # Environment
   if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
     set ( _python_path ${PYTHON_XMLRUNNER_DIR};${_test_src_dir};$ENV{PYTHONPATH} )
-    # cmake list separator and Windows environment seprator are the same so escape the cmake one
+    # cmake list separator and Windows environment separator are the same so escape the cmake one
     string ( REPLACE ";" "\\;" _python_path "${_python_path}" )
   else()
     set ( _python_path ${PYTHON_XMLRUNNER_DIR}:${_test_src_dir}:$ENV{PYTHONPATH} )

--- a/buildconfig/CMake/FindSIP.cmake
+++ b/buildconfig/CMake/FindSIP.cmake
@@ -9,7 +9,7 @@
 # This file defines the following variables:
 #
 # SIP_VERSION - The version of SIP found expressed as a 6 digit hex number
-#     suitable for comparision as a string.
+#     suitable for comparison as a string.
 #
 # SIP_VERSION_STR - The version of SIP found as a human readable string.
 #

--- a/buildconfig/CMake/FindTBB.cmake
+++ b/buildconfig/CMake/FindTBB.cmake
@@ -160,7 +160,7 @@ endif ()
 # will never adequately match the user's setup, so there is no feasible way
 # to detect the "best" version to use. The user will have to manually
 # select the right files. (Chances are the distributions are shipping their
-# custom version of tbb, anyway, so the problem is probably nonexistant.)
+# custom version of tbb, anyway, so the problem is probably nonexistent.)
 if (WIN32 AND MSVC)
   set(COMPILER_PREFIX "vc7.1")
   if (MSVC_VERSION EQUAL 1400)

--- a/buildconfig/CMake/NSIS.template.in
+++ b/buildconfig/CMake/NSIS.template.in
@@ -885,7 +885,7 @@ Section "Uninstall"
 @CPACK_NSIS_DELETE_ICONS@
 @CPACK_NSIS_DELETE_ICONS_EXTRA@
 
-  ;Delete empty start menu parent diretories
+  ;Delete empty start menu parent directories
   StrCpy $MUI_TEMP "$SMPROGRAMS\$MUI_TEMP"
 
   startMenuDeleteLoop:
@@ -904,7 +904,7 @@ Section "Uninstall"
   Delete "$SMPROGRAMS\$MUI_TEMP\Uninstall.lnk"
 @CPACK_NSIS_DELETE_ICONS_EXTRA@
 
-  ;Delete empty start menu parent diretories
+  ;Delete empty start menu parent directories
   StrCpy $MUI_TEMP "$SMPROGRAMS\$MUI_TEMP"
 
   secondStartMenuDeleteLoop:

--- a/buildconfig/CMake/PyQtFindImpl.cmake
+++ b/buildconfig/CMake/PyQtFindImpl.cmake
@@ -45,7 +45,7 @@ function (find_pyqt major_version)
         "FindPyQt.py config gave:\n${_pyqt_config}")
     endif()
   else ()
-    message (FATAL_ERROR "Error encountered while determing PyQt confguration:\n${_pyqt_config_err}")
+    message (FATAL_ERROR "Error encountered while determining PyQt confguration:\n${_pyqt_config_err}")
   endif()
 
   find_package_handle_standard_args( PyQt${major_version}

--- a/buildconfig/CMake/PythonPackageTargetFunctions.cmake
+++ b/buildconfig/CMake/PythonPackageTargetFunctions.cmake
@@ -62,7 +62,7 @@ CustomInstallLib = patch_setuptools_command('install_lib')
   if ( ${PACKAGE_WORKBENCH} )
     # setuptools by default wants to build into a directory called 'build' relative the to the working directory. We have overridden
     # commands in setup.py.in to force the build directory to take place out of source. The install directory is specified here and then
-    # --install-scripts=bin --install-lib=lib removes any of the plaform/distribution specific install directories so we can have a flat
+    # --install-scripts=bin --install-lib=lib removes any of the platform/distribution specific install directories so we can have a flat
     # structure
     install(CODE "execute_process(COMMAND ${PYTHON_EXECUTABLE} ${_setup_py} install -O1 --single-version-externally-managed --root=${_setup_py_build_root}/install --install-scripts=bin --install-lib=lib WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})")
     # register the "installed" components with cmake so it will carry them over

--- a/buildconfig/CMake/QtTargetFunctions.cmake
+++ b/buildconfig/CMake/QtTargetFunctions.cmake
@@ -7,7 +7,7 @@
 # is created.
 # The global ENABLE_WORKBENCH option controls if a Qt5 target
 # is created.
-# To limit the Qt version for a specfic library use
+# To limit the Qt version for a specific library use
 # QT_VERSION, e.g.
 #
 # mtd_add_qt_library ( QT_VERSION 5
@@ -35,7 +35,7 @@ endfunction()
 # is created.
 # The global ENABLE_WORKBENCH option controls if a Qt5 target
 # is created.
-# To limit the Qt version for a specfic library use
+# To limit the Qt version for a specific library use
 # QT_VERSION, e.g.
 #
 # mtd_add_qt_executable ( QT_VERSION 5
@@ -51,7 +51,7 @@ function (mtd_add_qt_executable)
       mtd_add_qt_target (EXECUTABLE QT_VERSION ${_ver} ${ARGN})
     endif ()
     if (_ver EQUAL 5 AND ENABLE_WORKBENCH)
-      mtd_add_qt_target (EXCUTABLE QT_VERSION ${_ver} ${ARGN})
+      mtd_add_qt_target (EXECUTABLE QT_VERSION ${_ver} ${ARGN})
     endif ()
   endforeach()
 endfunction()

--- a/buildconfig/CMake/SetMantidSubprojects.cmake
+++ b/buildconfig/CMake/SetMantidSubprojects.cmake
@@ -7,7 +7,7 @@
 #
 # EX: Framework/Kernel
 #
-# Thie macro the calls include_directories for each path and creates the 
+# This macro calls include_directories for each path and creates the
 # MANTID_SUBPROJECT_LIBS variable with the given subproject library names.
 #
 ################################################################################

--- a/buildconfig/Jenkins/pylint-buildscript
+++ b/buildconfig/Jenkins/pylint-buildscript
@@ -24,7 +24,7 @@ then
         # Copy "reference" results from master to keep numbers stable across builds
         REF_RESULTS=$WORKSPACE/master_pylint-logs.zip
         if [[ -f "$REF_RESULTS" ]] && [[ -d "$PYLINT_OUTPUT_DIR" ]]; then
-          echo "extracting refererence results from master build"
+          echo "extracting reference results from master build"
           cd $PYLINT_OUTPUT_DIR
           unzip $REF_RESULTS
         fi

--- a/buildconfig/doxygen_to_sip.py
+++ b/buildconfig/doxygen_to_sip.py
@@ -72,7 +72,7 @@ def start_python_doc_section(out, line, look_for, section_header):
 def doxygen_to_docstring(doxygen, method):
     """ Takes an array of DOXYGEN lines, and converts
     them to a more pleasing python docstring format
-    @param doxygen :: list of strings contaning the doxygen
+    @param doxygen :: list of strings containing the doxygen
     @param method :: method declaration string """
     out = []
     if doxygen is None:

--- a/buildconfig/move_class.py
+++ b/buildconfig/move_class.py
@@ -40,7 +40,7 @@ def move_one(subproject, classname, newproject, newclassname, oldfilename, newfi
 
         # Replace the namespace declaration
         text = text.replace("namespace " + subproject, "namespace " + newproject)
-        # Replace the conents
+        # Replace the contents
         f = open(newfilename, 'w')
         f.write(text)
     except RuntimeError as err:

--- a/buildconfig/python_export_maker.py
+++ b/buildconfig/python_export_maker.py
@@ -76,7 +76,7 @@ def get_include(headerfile):
         includefile = matches.group(2)
     else:
         raise RuntimeError("Unable to determine include path from given header")
-    # Make sure the include only has forward slases
+    # Make sure the include only has forward slashes
     includefile = includefile.replace("\\", "/")
     return includefile
 def get_modulepath(frameworkdir, submodule):

--- a/buildconfig/wrap_pyui.py
+++ b/buildconfig/wrap_pyui.py
@@ -9,7 +9,7 @@ import sys
 
 def lines_to_pre_append():
     lines = list()
-    # PYLINT ingnore flags
+    # PYLINT ignore flags
     lines.append(u"#pylint: skip-file\n")
     return lines
 


### PR DESCRIPTION
Found via `codespell -q 3 -I ../mantid-word-whitelist.txt` where whitelist consists of  
```
alloced
allws
amin
ang
ans
arithmetics
dum
focussed
dur
iff
isnt
ith
lod
minimise
mut
mye
nd
originaly
realy
sav
splitted
te
tim
uint
vertexes
```