### PR TITLE
PDLoadCharacterizations throw exception when there is unmatch column count

### DIFF
--- a/Framework/DataHandling/src/PDLoadCharacterizations.cpp
+++ b/Framework/DataHandling/src/PDLoadCharacterizations.cpp
@@ -33,6 +33,9 @@ static const std::string ZERO("0.");
 static const std::string EXP_INI_VAN_KEY("Vana");
 static const std::string EXP_INI_EMPTY_KEY("VanaBg");
 static const std::string EXP_INI_CAN_KEY("MTc");
+/// the offset difference between the information in the table and the the
+/// information in version=1 files
+static const size_t INFO_OFFSET_V1(6);
 // in the filenames vector, each index has a unique location
 static const int F_INDEX_V0 = 0;
 static const int F_INDEX_V1 = 1;
@@ -493,7 +496,7 @@ void updateRow(API::ITableWorkspace_sptr &wksp, const size_t rowNum,
   wksp->getRef<std::string>("empty_instrument", rowNum) = values[5];
   for (size_t i = 0; i < names.size(); ++i) {
     const auto name = names[i];
-    wksp->getRef<std::string>(name, rowNum) = values[i + 6];
+    wksp->getRef<std::string>(name, rowNum) = values[i + INFO_OFFSET_V1];
   }
 }
 } // namespace
@@ -557,11 +560,11 @@ void PDLoadCharacterizations::readVersion1(const std::string &filename,
       for (const auto &token : tokenizer) {
         valuesAsStr.push_back(token);
       }
-      if (valuesAsStr.size() < columnNames.size() + 6) {
+      if (valuesAsStr.size() < columnNames.size() + INFO_OFFSET_V1) {
         std::stringstream msg;
         msg << "Number of data columns (" << valuesAsStr.size()
             << ") not compatible with number of column labels ("
-            << (columnNames.size() + 6) << ")";
+            << (columnNames.size() + INFO_OFFSET_V1) << ")";
         throw Exception::ParseError(msg.str(), filename, linenum);
       }
 
@@ -589,7 +592,7 @@ void PDLoadCharacterizations::readVersion1(const std::string &filename,
         row << 0.;                              // wavelength_min
         row << 0.;                              // wavelength_max
         // insert all the extras
-        for (size_t i = 6; i < valuesAsStr.size(); ++i) {
+        for (size_t i = INFO_OFFSET_V1; i < valuesAsStr.size(); ++i) {
           row << valuesAsStr[i];
         }
       }

--- a/Framework/DataHandling/src/PDLoadCharacterizations.cpp
+++ b/Framework/DataHandling/src/PDLoadCharacterizations.cpp
@@ -70,7 +70,7 @@ extra_columns(const std::vector<std::string> &filenames) {
       if (result.size() == 2) {
         line = Strings::strip(result[1]);
         Kernel::StringTokenizer tokenizer(
-            line, " ", Kernel::StringTokenizer::TOK_IGNORE_EMPTY);
+            line, " \t", Kernel::StringTokenizer::TOK_IGNORE_EMPTY);
         for (const auto &token : tokenizer) {
           columnSet.insert(token);
         }
@@ -541,7 +541,7 @@ void PDLoadCharacterizations::readVersion1(const std::string &filename,
       if (result.size() == 2) {
         line = Strings::strip(result[1]);
         Kernel::StringTokenizer tokenizer(
-            line, " ", Kernel::StringTokenizer::TOK_IGNORE_EMPTY);
+            line, " \t", Kernel::StringTokenizer::TOK_IGNORE_EMPTY);
         for (const auto &token : tokenizer) {
           columnNames.push_back(token);
         }
@@ -552,7 +552,7 @@ void PDLoadCharacterizations::readVersion1(const std::string &filename,
 
       line = Strings::strip(line);
       Kernel::StringTokenizer tokenizer(
-          line, " ", Kernel::StringTokenizer::TOK_IGNORE_EMPTY);
+          line, " \t", Kernel::StringTokenizer::TOK_IGNORE_EMPTY);
       std::vector<std::string> valuesAsStr;
       for (const auto &token : tokenizer) {
         valuesAsStr.push_back(token);


### PR DESCRIPTION
The `version=1` file parsing assumed that there were more column labels
than values in a given row. This caused a segfault when reading past the
end of a vector. The code now checks for the values and labels to have
compatible lengths for each row and reports mismatch to the user. There
are also several changes in what particular exceptions are thrown
elsewhere in the algorithm.

**Report to:** Huq

**To test:**
Create a file `PG3_char_2018_05_26.txt` with the contents
```
Instrument parameter file: 
1 3.18 90.0000 
L1 60.0
#S 1 characterization runs
#L frequency(Hz) center_wavelength(angstrom) bank_num vanadium_run empty_run vanadium_back d_min(angstrom) d_max(angstrom) t_min(microsec) t_min(microsec) lamda_min(angstrom) lambda_max(angstrom)
60	0.800	1	0	0 	0	0.15  	 8.75  	   4500.00  	21000.00 	0.267 	1.333
60	1.500	2	0	0 	0 	0.50 	13.00     15400.00  	32500.00 	0.967 	2.033
60	2.665	3	0	0 	0 	1.08 	21.00     33500.33  	51500.00 	2.132 	3.198
60	4.797	4	0	0 	0 	2.14 	38.00     66666.67      83333.67 	4.264 	5.330
60	0.533	5	0	0 	0	0.05  	 7.50  	    800.00  	16600.00 	0.050 	1.066
10      3.198   1       0       0       0       0.10    40.00      2500.00      98500.00        0.050   6.396
20      1.599   1       0       0       0       0.10    20.00      1250.00      49000.00        0.050   3.198
30      1.066   1       0       0       0       0.10    15.00      1200.00      33300.00        0.050   2.132
```
and a file `PG3_char_2018_06_11-HighRes-PAC.txt` with the contents
```
version=1
freq wl     van   van_back mt_env mt_instr PAC03 PAC06 PAC08 PAC10  	Quartz Basket
60 0.533   40266  0       0      0        0      0         0         0     0
60 0.800   40521  40519   0      0        0      40515     40517     0     0
60 1.500   40506  40502   0      0        0      40494     40498     0     0
60 2.665   40507  40503   0      0        0      40495     40499     0     0
60 4.797   40508  0       0      0        0      0         0         0     0
10 3.198   40314  0       0      0        0      0         0         0     0
20 1.599   40315  0       0      0        0      0         0         0     0
30 1.066   40516  0       0      0        0      0         0         0     0
```
Then run it through `PDLoadCharacterizations` in the `Filename` argument (comma separated). Without this PR mantid will segfault. Once it is merged, you'll get an error message that the second file has errors in it.

*There is no associated issue.*

*This does not require release notes* because it is a change in how the code errors (exception rather than segfault).

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
