### PR TITLE
Force progress messages to be str

### DIFF
--- a/qt/python/mantidqt/widgets/algorithmprogress/model.py
+++ b/qt/python/mantidqt/widgets/algorithmprogress/model.py
@@ -12,7 +12,7 @@ class ProgressObserver(AlgorithmObserver):
         super(ProgressObserver, self).__init__()
         self.model = model
         self.algorithm = alg
-        self.message = None
+        self.message = ''
         self.progress = 0.0
 
     def name(self):
@@ -30,10 +30,7 @@ class ProgressObserver(AlgorithmObserver):
 
     def progressHandle(self, p, message):
         self.progress = p
-        if len(message) > 0:
-            self.message = message
-        else:
-            self.message = None
+        self.message = message
         self.model.update_progress(self)
 
     def errorHandle(self, message):

--- a/qt/python/mantidqt/widgets/algorithmprogress/presenter.py
+++ b/qt/python/mantidqt/widgets/algorithmprogress/presenter.py
@@ -23,7 +23,11 @@ class AlgorithmProgressPresenter(AlgorithmProgressPresenterBase):
         :param message: A message that may come from the algorithm.
         """
         if algorithm is self.algorithm:
-            self.need_update_progress_bar.emit(self.view.progress_bar, progress, message)
+            if message is None:
+                message = ''
+            else:
+                message = str(message)
+            self.need_update_progress_bar.emit(self.view.progress_bar, float(progress), message)
 
     def update_gui(self):
         """


### PR DESCRIPTION
The problem was that empty progress messages were being converted to
`None` which `AlgorithmObserver` did not have the proper overloaded
methods to convert to an empty string. The fix is to convert them to a
string before calling the binding. For extra measure, the progress
percentage is converted to a float as well.

**To test:**

Run an algorithm that updates the progress bar with an empty message.

Fixes #23632


*This does not require release notes* because workbench.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
