### PR TITLE
Indirect - Fix the default detector grouping option

### DIFF
--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -421,8 +421,8 @@ std::size_t ISISEnergyTransfer::getGroupingOptionIndex(QString const &option) {
 bool ISISEnergyTransfer::isOptionHidden(QString const &option) {
   for (auto i = 0; i < m_uiForm.cbGroupingOptions->count(); ++i)
     if (m_uiForm.cbGroupingOptions->itemText(i) == option)
-      return true;
-  return false;
+      return false;
+  return true;
 }
 
 void ISISEnergyTransfer::setCurrentGroupingOption(QString const &option) {

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -411,7 +411,7 @@ void ISISEnergyTransfer::algorithmComplete(bool error) {
   m_uiForm.ckSaveSPE->setEnabled(true);
 }
 
-std::size_t ISISEnergyTransfer::getGroupingOptionIndex(QString const &option) {
+int ISISEnergyTransfer::getGroupingOptionIndex(QString const &option) {
   for (auto i = 0; i < m_uiForm.cbGroupingOptions->count(); ++i)
     if (m_uiForm.cbGroupingOptions->itemText(i) == option)
       return i;

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -411,19 +411,34 @@ void ISISEnergyTransfer::algorithmComplete(bool error) {
   m_uiForm.ckSaveSPE->setEnabled(true);
 }
 
-void ISISEnergyTransfer::removeGroupingOption(const QString &option) {
+std::size_t ISISEnergyTransfer::getGroupingOptionIndex(QString const &option) {
   for (auto i = 0; i < m_uiForm.cbGroupingOptions->count(); ++i)
-    if (m_uiForm.cbGroupingOptions->itemText(i) == option) {
-      m_uiForm.cbGroupingOptions->removeItem(i);
-      return;
-    }
+    if (m_uiForm.cbGroupingOptions->itemText(i) == option)
+      return i;
+  return 0;
+}
+
+bool ISISEnergyTransfer::isOptionHidden(QString const &option) {
+  for (auto i = 0; i < m_uiForm.cbGroupingOptions->count(); ++i)
+    if (m_uiForm.cbGroupingOptions->itemText(i) == option)
+      return true;
+  return false;
+}
+
+void ISISEnergyTransfer::setCurrentGroupingOption(QString const &option) {
+  m_uiForm.cbGroupingOptions->setCurrentIndex(getGroupingOptionIndex(option));
+}
+
+void ISISEnergyTransfer::removeGroupingOption(QString const &option) {
+  m_uiForm.cbGroupingOptions->removeItem(getGroupingOptionIndex(option));
 }
 
 void ISISEnergyTransfer::includeExtraGroupingOption(bool includeOption,
-                                                    const QString &option) {
-  if (includeOption)
+                                                    QString const &option) {
+  if (includeOption && isOptionHidden(option)) {
     m_uiForm.cbGroupingOptions->addItem(option);
-  else
+    setCurrentGroupingOption(option);
+  } else if (!includeOption && !isOptionHidden(option))
     removeGroupingOption(option);
 }
 

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
@@ -50,8 +50,13 @@ public slots:
 
 private slots:
   void algorithmComplete(bool error);
-  void removeGroupingOption(const QString &option);
-  void includeExtraGroupingOption(bool includeOption, const QString &option);
+
+  void setCurrentGroupingOption(QString const &option);
+  std::size_t getGroupingOptionIndex(QString const &option);
+  bool isOptionHidden(QString const &option);
+  void removeGroupingOption(QString const &option);
+  void includeExtraGroupingOption(bool includeOption, QString const &option);
+
   void
   setInstrumentDefault(); ///< Sets default parameters for current instrument
   void mappingOptionSelected(

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
@@ -52,7 +52,7 @@ private slots:
   void algorithmComplete(bool error);
 
   void setCurrentGroupingOption(QString const &option);
-  std::size_t getGroupingOptionIndex(QString const &option);
+  int getGroupingOptionIndex(QString const &option);
   bool isOptionHidden(QString const &option);
   void removeGroupingOption(QString const &option);
   void includeExtraGroupingOption(bool includeOption, QString const &option);


### PR DESCRIPTION
**Description of work.**
This PR prevents the possibility of two default detector grouping options appearing when the TOSCA instrument is selected in the `ISISEnergyTransfer` Tab.
It also ensures the default option will be selected when you change instrument to TOSCA.

**To test:**
1. Go to `Interfaces` -> `Indirect Data Reduction` -> `ISISEnergyTransfer` Tab
2. Select the TOSCA instrument. The Detector Grouping combobox should show `Default`
3. Deselected and then reselecting the TOSCA instrument shouldn't add multiple Default options to the Detector Grouping combobox.

Fixes #23635 

No release notes needed

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
