### PR TITLE
Modified Systemtests to show more failures

### DIFF
--- a/Testing/SystemTests/lib/systemtests/stresstesting.py
+++ b/Testing/SystemTests/lib/systemtests/stresstesting.py
@@ -521,7 +521,10 @@ class ResultReporter(object):
                                                                       self._total_number_of_tests)
                 console_output += '{:.<{}} ({}: {}s)'.format(result.name+" ", self._maximum_name_length+2,
                                                              result.status, time_taken)
-            if ((self._output_on_failure and (result.status.count('fail') > 0)) or (not self._quiet)):
+            if ((self._output_on_failure
+                 and (result.status != 'success')
+                 and (result.status != 'skipped'))
+                 or (not self._quiet)):
                 nstars = 80
                 console_output += '\n' + ('*' * nstars) + '\n'
                 print_list = ['test_name', 'filename', 'test_date', 'host_name', 'environment',

--- a/Testing/SystemTests/lib/systemtests/stresstesting.py
+++ b/Testing/SystemTests/lib/systemtests/stresstesting.py
@@ -522,9 +522,9 @@ class ResultReporter(object):
                 console_output += '{:.<{}} ({}: {}s)'.format(result.name+" ", self._maximum_name_length+2,
                                                              result.status, time_taken)
             if ((self._output_on_failure
-                 and (result.status != 'success')
-                 and (result.status != 'skipped'))
-                 or (not self._quiet)):
+                and (result.status != 'success')
+                and (result.status != 'skipped'))
+                or (not self._quiet)):
                 nstars = 80
                 console_output += '\n' + ('*' * nstars) + '\n'
                 print_list = ['test_name', 'filename', 'test_date', 'host_name', 'environment',


### PR DESCRIPTION
**Description of work.**

Changed the requirements for output-on-failure to be triggered in systemtests.

Before, it was only writing the full log to console if the test status contained `fail` which would apply to `failed` and `algorithm failure`, but it was missing statuses like 'hung'.

Now the output is always printed unless the status is `success` or `skipped`.

**To test:**

`./systemtest -j 8 --showskipped --output-on-failure -q`


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
