### PR TITLE
LiveData Do not rebin event data unless not already binned

### DIFF
--- a/Framework/LiveData/inc/MantidLiveData/LoadLiveData.h
+++ b/Framework/LiveData/inc/MantidLiveData/LoadLiveData.h
@@ -66,7 +66,7 @@ private:
   void appendChunk(Mantid::API::Workspace_sptr chunkWS);
   API::Workspace_sptr appendMatrixWSChunk(API::Workspace_sptr accumWS,
                                           Mantid::API::Workspace_sptr chunkWS);
-  void resetAllXToSingleBin(API::Workspace *workspace);
+  void updateDefaultBinBoundaries(API::Workspace *workspace);
 
   /// The "accumulation" workspace = after adding, but before post-processing
   Mantid::API::Workspace_sptr m_accumWS;

--- a/Framework/LiveData/src/LiveDataAlgorithm.cpp
+++ b/Framework/LiveData/src/LiveDataAlgorithm.cpp
@@ -74,10 +74,7 @@ void LiveDataAlgorithm::initProps() {
       make_unique<PropertyWithValue<std::string>>("ProcessingAlgorithm", "",
                                                   Direction::Input),
       "Name of the algorithm that will be run to process each chunk of data.\n"
-      "Optional. If blank, no processing will occur. Note that, if "
-      "PreserveEvents is enabled, any rebinning done in this step will be "
-      "lost. Use the Post-Process step for custom rebinning of "
-      "EventWorkspaces.");
+      "Optional. If blank, no processing will occur.");
 
   declareProperty(
       make_unique<PropertyWithValue<std::string>>("ProcessingProperties", "",
@@ -89,19 +86,13 @@ void LiveDataAlgorithm::initProps() {
                       "ProcessingScript", "", Direction::Input),
                   "A Python script that will be run to process each chunk of "
                   "data. Only for command line usage, does not appear on the "
-                  "user interface. Note that, if PreserveEvents is enabled, "
-                  "any rebinning done in this step will be lost. Use the "
-                  "Post-Process step for custom rebinning of "
-                  "EventWorkspaces.");
+                  "user interface.");
 
   declareProperty(make_unique<FileProperty>("ProcessingScriptFilename", "",
                                             FileProperty::OptionalLoad, "py"),
                   "A Python script that will be run to process each chunk of "
                   "data. Only for command line usage, does not appear on the "
-                  "user interface. Note that, if PreserveEvents is enabled, "
-                  "any rebinning done in this step will be lost. Use the "
-                  "Post-Process step for custom rebinning of "
-                  "EventWorkspaces.");
+                  "user interface.");
 
   std::vector<std::string> propOptions{"Add", "Replace", "Append"};
   declareProperty(

--- a/Framework/LiveData/src/LoadLiveData.cpp
+++ b/Framework/LiveData/src/LoadLiveData.cpp
@@ -426,7 +426,7 @@ bool shouldResetAllXToSingleBin(const EventWorkspace *workspace) {
   // make sure that they are sorted
   return (x.front() < x.back());
 }
-}
+} // namespace
 
 //----------------------------------------------------------------------------------------------
 /** Resets all HistogramX in given EventWorkspace(s) to a single bin.

--- a/Framework/LiveData/test/LoadLiveDataTest.h
+++ b/Framework/LiveData/test/LoadLiveDataTest.h
@@ -289,7 +289,7 @@ public:
     // Accumulated workspace: it was rebinned, but rebinning should be reset
     TS_ASSERT_EQUALS(ws_accum->getNumberHistograms(), 2);
     TS_ASSERT_EQUALS(ws_accum->getNumberEvents(), 200);
-    TS_ASSERT_EQUALS(ws_accum->blocksize(), 1);
+    TS_ASSERT_EQUALS(ws_accum->blocksize(), 40);
 
     // The post-processed workspace was rebinned starting at 40e3
     TS_ASSERT_EQUALS(ws->getNumberHistograms(), 2);

--- a/docs/source/algorithms/LoadLiveData-v1.rst
+++ b/docs/source/algorithms/LoadLiveData-v1.rst
@@ -31,26 +31,20 @@ Data Processing
 -  You have two options on how to process this workspace:
 
 Processing with an Algorithm
-############################
+++++++++++++++++++++++++++++
 
 -  Specify the name of the algorithm in the ``ProcessingAlgorithm``
    property.
 
-   -  This could be, e.g. a `Python Algorithm <Python Algorithm>`__
-      written for this purpose.
+   -  This could be a python algorithm written for this purpose
    -  The algorithm *must* have at least 2 properties: ``InputWorkspace``
       and ``OutputWorkspace``.
    -  Any other properties are set from the string in
       ``ProcessingProperties``.
-   -  The algorithm is then run, and its ``OutputWorkspace`` is saved.
-
-.. note:
-
-   When PreserveEvents is enabled, any rebinning done in this step will be
-   lost. Use the Post-Process step instead for EventWorkspaces.
+   -  The algorithm is then run, and its ``OutputWorkspace`` is saved
 
 Processing with a Python Script
-###############################
++++++++++++++++++++++++++++++++
 
 The python script is run using :ref:`algm-RunPythonScript`. Please see
 its documentation for details of how the script is run.
@@ -72,10 +66,13 @@ its documentation for details of how the script is run.
 
    - Contents of the file have the exact same rules as specifying the ``ProcessingScript``
 
-.. note:
+.. note::
 
-   When PreserveEvents is enabled, any rebinning done in this step will be
-   lost. Use the Post-Process step instead for EventWorkspaces.
+   When ``PreserveEvents`` is enabled and the data has not been binned
+   during the process step (with ``ProcessingAlgorithm``,
+   ``ProcessingScript``, or ``ProcessingScriptFilename``), the data
+   will be rebinned at the end of the step to include all events. Use
+   the Post-Process step instead for :ref:`EventWorkspaces <EventWorkspace>`.
 
 Data Accumulation
 #################
@@ -90,36 +87,31 @@ Data Accumulation
    -  If you select ``Append``, then the spectra from each chunk will be
       appended to the output workspace.
 
-A Warning About Events
-######################
+.. warning::
 
-Beware! If you select ``PreserveEvents=True`` and your processing
-keeps the data as :ref:`EventWorkspaces <EventWorkspace>`, you may end
-up creating **very large** EventWorkspaces in long runs. Most plots
-require re-sorting the events, which is an operation that gets much
-slower as the list gets bigger (Order of :math:`N * log(N)`). This
-could cause Mantid to run very slowly or to crash due to lack of
-memory.
+   Beware! If you select ``PreserveEvents=True`` and your processing
+   keeps the data as :ref:`EventWorkspaces <EventWorkspace>`, you may end
+   up creating **very large** EventWorkspaces in long runs. Most plots
+   require re-sorting the events, which is an operation that gets much
+   slower as the list gets bigger (Order of :math:`N * log(N)`). This
+   could cause Mantid to run very slowly or to crash due to lack of
+   memory.
 
-Additionally, the resulting EventWorkspaces produced when
-``PreserveEvents=True`` will have their X values reset to a single bin with
-boundaries that encompass all events currently in the workspace. This means
-that any rebinning that was done during the Process step will be lost. If
-custom binning is required, this should be done using the Post-Process step
-described below.
+   It is highly recommended that early in the PostProcessing step one
+   uses :ref:`CompressEvents <algm-CompressEvents>` if the data is going
+   to remain in events.
 
 Post-Processing Step
 ####################
 
--  Optionally, you can specify some processing to perform *after*
-   accumulation.
+- Optionally, you can specify some processing to perform *after*
+  accumulation.
 
-   -  You then need to specify the ``AccumulationWorkspace`` property.
+  -  You then need to specify the ``AccumulationWorkspace`` property.
 
-- Using either the ``PostProcessingAlgorithm``,
-   ``PostProcessingScript``, or ``PostProcessingScriptFilename`` (same
-   way as above), the ``AccumulationWorkspace`` is processed into the
-   ``OutputWorkspace``
+- Using either the ``PostProcessingAlgorithm``, ``PostProcessingScript``,
+  or ``PostProcessingScriptFilename`` (same way as above), the
+  ``AccumulationWorkspace`` is processed into the ``OutputWorkspace``
 
 Usage
 -----

--- a/docs/source/release/v3.14.0/framework.rst
+++ b/docs/source/release/v3.14.0/framework.rst
@@ -48,7 +48,7 @@ Improvements
 - :ref:`CropToComponent <algm-CropToComponent>` now supports also scanning workspaces.
 - :ref:`SumOverlappingTubes <algm-SumOverlappingTubes>` will produce histogram data, and will not split the counts between bins by default.
 - :ref:`SumSpectra <algm-SumSpectra>` has an additional option, ``MultiplyBySpectra``, which controls whether or not the output spectra are multiplied by the number of bins. This property should be set to ``False`` for summing spectra as PDFgetN does.
-- :ref:`Live Data <algm-StartLiveData>` for events in PreserveEvents mode now produces workspaces that have bin boundaries which encompass the total x-range (TOF) for all events across all spectra.
+- :ref:`Live Data <algm-StartLiveData>` for events with ``PreserveEvents=True`` now produces workspaces that have bin boundaries which encompass the total x-range (TOF) for all events across all spectra if the data was not binned during the process step.
 - Bugfix in :ref:`ConvertToMatrixWorkspace <algm-ConvertToMatrixWorkspace>` with ``Workspace2D`` as the ``InputWorkspace`` not being cloned to the ``OutputWorkspace``. Added support for ragged workspaces.
 - :ref:`RebinToWorkspace <algm-RebinToWorkspace>` now checks if the ``WorkspaceToRebin`` and ``WorkspaceToMatch`` already have the same binning. Added support for ragged workspaces.
 - :ref:`GroupWorkspaces <algm-GroupWorkspaces>` supports glob patterns for matching workspaces in the ADS.


### PR DESCRIPTION
This was a behavior introduced in #22425 to solve a problem with data
that wasn't being binned during the processing step. This changes it to
rebin only if it hadn't been during the processing.

**Report to:** [user name]/[nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

See if this works for sns (without changing the scripts) and kafka data. That is why there are two reviewers.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
