### PR TITLE
Made detector names consistent

### DIFF
--- a/scripts/Interface/ui/sans_isis/beam_centre.py
+++ b/scripts/Interface/ui/sans_isis/beam_centre.py
@@ -97,14 +97,21 @@ class BeamCentre(QtGui.QWidget, ui_beam_centre.Ui_BeamCentre):
         self.instrument = instrument
         component_list = get_detector_strings_for_gui(self.instrument)
         self.set_component_options(component_list)
+        self.lab_centre_label.setText('Centre Position {}'.format(component_list[0]))
+        self.update_lab_check_box.setText('Update {}'.format(component_list[0]))
         if len(component_list) < 2:
             self.hab_pos_1_line_edit.setEnabled(False)
             self.hab_pos_2_line_edit.setEnabled(False)
             self.update_hab_check_box.setEnabled(False)
+            self.hab_centre_label.setText('Centre Position HAB')
+            self.update_hab_check_box.setText('Update HAB')
         else:
             self.hab_pos_1_line_edit.setEnabled(True)
             self.hab_pos_2_line_edit.setEnabled(True)
             self.update_hab_check_box.setEnabled(True)
+            self.hab_centre_label.setText('Centre Position {}'.format(component_list[1]))
+            self.update_hab_check_box.setText('Update {}'.format(component_list[1]))
+
 
     # ------------------------------------------------------------------------------------------------------------------
     # Actions

--- a/scripts/Interface/ui/sans_isis/beam_centre.py
+++ b/scripts/Interface/ui/sans_isis/beam_centre.py
@@ -112,7 +112,6 @@ class BeamCentre(QtGui.QWidget, ui_beam_centre.Ui_BeamCentre):
             self.hab_centre_label.setText('Centre Position {}'.format(component_list[1]))
             self.update_hab_check_box.setText('Update {}'.format(component_list[1]))
 
-
     # ------------------------------------------------------------------------------------------------------------------
     # Actions
     # ------------------------------------------------------------------------------------------------------------------

--- a/scripts/Interface/ui/sans_isis/diagnostics_page.py
+++ b/scripts/Interface/ui/sans_isis/diagnostics_page.py
@@ -49,6 +49,7 @@ class DiagnosticsPage(QtGui.QWidget, ui_diagnostics_page.Ui_DiagnosticsPage):
         # Q Settings
         self.__generic_settings = GENERIC_SETTINGS
         self.__path_key = "sans_path"
+        self.detector_combo_box.currentIndexChanged.connect(self.combo_box_changed)
 
     def update_simple_line_edit_field(self, line_edit, value):
         gui_element = getattr(self, line_edit)
@@ -103,6 +104,10 @@ class DiagnosticsPage(QtGui.QWidget, ui_diagnostics_page.Ui_DiagnosticsPage):
         self.detector_combo_box.clear()
         for element in detector_list:
             self.detector_combo_box.addItem(element)
+
+    def combo_box_changed(self, index):
+        current_detector_name = self.detector_combo_box.currentText()
+        self.detector_group_box.setTitle(current_detector_name)
 
     # ------------------------------------------------------------------------------------------------------------------
     # Properties

--- a/scripts/Interface/ui/sans_isis/diagnostics_page.ui
+++ b/scripts/Interface/ui/sans_isis/diagnostics_page.ui
@@ -108,7 +108,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox_2">
+    <widget class="QGroupBox" name="detector_group_box">
      <property name="title">
       <string>Detector1</string>
      </property>

--- a/scripts/SANS/sans/gui_logic/presenter/beam_centre_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/beam_centre_presenter.py
@@ -6,7 +6,6 @@ from mantid.kernel import Logger
 from ui.sans_isis.beam_centre import BeamCentre
 from ui.sans_isis.work_handler import WorkHandler
 
-
 class BeamCentrePresenter(object):
     class ConcreteBeamCentreListener(BeamCentre.BeamCentreListener):
         def __init__(self, presenter):

--- a/scripts/SANS/sans/gui_logic/presenter/beam_centre_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/beam_centre_presenter.py
@@ -6,6 +6,7 @@ from mantid.kernel import Logger
 from ui.sans_isis.beam_centre import BeamCentre
 from ui.sans_isis.work_handler import WorkHandler
 
+
 class BeamCentrePresenter(object):
     class ConcreteBeamCentreListener(BeamCentre.BeamCentreListener):
         def __init__(self, presenter):


### PR DESCRIPTION
**Description of work.**

The different SANS instruments at ISIS have different names for their low angle and high angle banks. This updates the GUI so that the correct names are used for each instrument when it is selected.

**Report to:** steve <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**
Open the new GUI and check the Settings tab, the BeamCentre tab and the diagnostic tab to ensure that the correct names are used for the detector banks as the instrument is changed.

The detector names for the various instruments are:
 * Larmor: DetectorBench
 * LOQ: main-detector, HAB
 * SANS2D: rear, front
 * ZOOM: rear-detector
<!-- Instructions for testing. -->

Partially Fixes #23209  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
