### PR TITLE
Peak integration improvements

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/MDBox.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBox.tcc
@@ -633,7 +633,7 @@ TMDE(void MDBox)::integrateCylinder(
   for (const auto &evnt : events) {
     coord_t out[2]; // radius and length of cylinder
     radiusTransform.apply(evnt.getCenter(), out);
-    if (out[0] < radius && std::fabs(out[1]) < 0.5 * length) {
+    if (out[0] < radius && std::fabs(out[1]) < 0.5 * length + deltaQ) {
       // add event to appropriate y channel
       size_t xchannel =
           static_cast<size_t>(std::floor(out[1] / deltaQ)) + numSteps / 2;

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -521,6 +521,17 @@ void IntegratePeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
         }
 
         IFunction_sptr ifun = fitAlgorithm->getProperty("Function");
+        if (i == 0) {
+          for (size_t j = 0; j < ifun->nParams(); ++j)
+            out << std::setw(20) << ifun->parameterName(j) << " ";
+          out << "\n";
+        }
+        out << std::setw(20) << i << "\n";
+        for (size_t j = 0; j < ifun->nParams(); ++j) {
+          out << std::setw(20) << std::fixed << std::setprecision(10)
+              << ifun->getParameter(j) << " ";
+        }
+        out << "\n";
 
         /*double chi2 = fitAlgorithm->getProperty("OutputChi2overDoF");
         if (chi2 > 10.0) {

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -522,25 +522,20 @@ void IntegratePeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
 
         IFunction_sptr ifun = fitAlgorithm->getProperty("Function");
         if (i == 0) {
+          out << std::setw(20) << "spectrum" << " ";
           for (size_t j = 0; j < ifun->nParams(); ++j)
             out << std::setw(20) << ifun->parameterName(j) << " ";
+          out << std::setw(20) << "chi2" << " ";
           out << "\n";
         }
-        out << std::setw(20) << i << "\n";
+        out << std::setw(20) << i << " ";
         for (size_t j = 0; j < ifun->nParams(); ++j) {
           out << std::setw(20) << std::fixed << std::setprecision(10)
               << ifun->getParameter(j) << " ";
         }
-        out << "\n";
+        double chi2 = fitAlgorithm->getProperty("OutputChi2overDoF");
+        out << std::setw(20) << std::fixed << std::setprecision(10) << chi2 << "\n";
 
-        /*double chi2 = fitAlgorithm->getProperty("OutputChi2overDoF");
-        if (chi2 > 10.0) {
-          if (replaceIntensity) {
-            p.setIntensity(0.0);
-            p.setSigmaIntensity(0.0);
-          }
-          continue;
-        }*/
         boost::shared_ptr<const CompositeFunction> fun =
             boost::dynamic_pointer_cast<const CompositeFunction>(ifun);
 

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -522,10 +522,12 @@ void IntegratePeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
 
         IFunction_sptr ifun = fitAlgorithm->getProperty("Function");
         if (i == 0) {
-          out << std::setw(20) << "spectrum" << " ";
+          out << std::setw(20) << "spectrum"
+              << " ";
           for (size_t j = 0; j < ifun->nParams(); ++j)
             out << std::setw(20) << ifun->parameterName(j) << " ";
-          out << std::setw(20) << "chi2" << " ";
+          out << std::setw(20) << "chi2"
+              << " ";
           out << "\n";
         }
         out << std::setw(20) << i << " ";
@@ -534,7 +536,8 @@ void IntegratePeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
               << ifun->getParameter(j) << " ";
         }
         double chi2 = fitAlgorithm->getProperty("OutputChi2overDoF");
-        out << std::setw(20) << std::fixed << std::setprecision(10) << chi2 << "\n";
+        out << std::setw(20) << std::fixed << std::setprecision(10) << chi2
+            << "\n";
 
         boost::shared_ptr<const CompositeFunction> fun =
             boost::dynamic_pointer_cast<const CompositeFunction>(ifun);

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -499,9 +499,14 @@ void IntegratePeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   std::ostringstream strs;
 strs << maxPeak[0];
 std::string strMax = strs.str();
-      if (profileFunction == "Gaussian") myFunc += ", PeakCentre=50, Height="+ strMax;
-      else if (profileFunction == "BackToBackExponential") myFunc += ", X0=50, I="+ strMax;
-      else if (profileFunction == "IkedaCarpenterPV") myFunc += ", X0=50, I="+ strMax;
+      if (profileFunction == "Gaussian") {
+          myFunc += ", PeakCentre=50, Height="+ strMax;
+          fitAlgorithm->setProperty("Constraints", "40<f1.PeakCentre<60");
+      }
+      else if (profileFunction == "BackToBackExponential" || profileFunction == "IkedaCarpenterPV") {
+          myFunc += ", X0=50, I="+ strMax;
+          fitAlgorithm->setProperty("Constraints", "40<f1.X0<60");
+      }
   fitAlgorithm->setProperty("CalcErrors", true);
   fitAlgorithm->setProperty("Function", myFunc);
   fitAlgorithm->setProperty("InputWorkspace", wsProfile2D);

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -490,27 +490,29 @@ void IntegratePeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
         errorSquared = std::fabs(signal);
       } else {
 
-  IAlgorithm_sptr fitAlgorithm = createChildAlgorithm("Fit", -1, -1, false);
-  //fitAlgorithm->setProperty("CreateOutput", true);
-  //fitAlgorithm->setProperty("Output", "FitPeaks1D");
-  std::string myFunc = std::string("name=LinearBackground;name=")+profileFunction;
-  auto maxPeak = std::max_element(signal_fit.begin(), signal_fit.end());
+        IAlgorithm_sptr fitAlgorithm =
+            createChildAlgorithm("Fit", -1, -1, false);
+        // fitAlgorithm->setProperty("CreateOutput", true);
+        // fitAlgorithm->setProperty("Output", "FitPeaks1D");
+        std::string myFunc =
+            std::string("name=LinearBackground;name=") + profileFunction;
+        auto maxPeak = std::max_element(signal_fit.begin(), signal_fit.end());
 
-  std::ostringstream strs;
-strs << maxPeak[0];
-std::string strMax = strs.str();
-      if (profileFunction == "Gaussian") {
-          myFunc += ", PeakCentre=50, Height="+ strMax;
+        std::ostringstream strs;
+        strs << maxPeak[0];
+        std::string strMax = strs.str();
+        if (profileFunction == "Gaussian") {
+          myFunc += ", PeakCentre=50, Height=" + strMax;
           fitAlgorithm->setProperty("Constraints", "40<f1.PeakCentre<60");
-      }
-      else if (profileFunction == "BackToBackExponential" || profileFunction == "IkedaCarpenterPV") {
-          myFunc += ", X0=50, I="+ strMax;
+        } else if (profileFunction == "BackToBackExponential" ||
+                   profileFunction == "IkedaCarpenterPV") {
+          myFunc += ", X0=50, I=" + strMax;
           fitAlgorithm->setProperty("Constraints", "40<f1.X0<60");
-      }
-  fitAlgorithm->setProperty("CalcErrors", true);
-  fitAlgorithm->setProperty("Function", myFunc);
-  fitAlgorithm->setProperty("InputWorkspace", wsProfile2D);
-  fitAlgorithm->setProperty("WorkspaceIndex", static_cast<int>(i));
+        }
+        fitAlgorithm->setProperty("CalcErrors", true);
+        fitAlgorithm->setProperty("Function", myFunc);
+        fitAlgorithm->setProperty("InputWorkspace", wsProfile2D);
+        fitAlgorithm->setProperty("WorkspaceIndex", static_cast<int>(i));
         try {
           fitAlgorithm->executeAsChildAlg();
         } catch (...) {
@@ -518,16 +520,16 @@ std::string strMax = strs.str();
           continue;
         }
 
-     IFunction_sptr ifun = fitAlgorithm->getProperty("Function");
-     
-      /*double chi2 = fitAlgorithm->getProperty("OutputChi2overDoF");
-      if (chi2 > 10.0) {
-        if (replaceIntensity) {
-          p.setIntensity(0.0);
-          p.setSigmaIntensity(0.0);
-        }
-        continue;
-      }*/
+        IFunction_sptr ifun = fitAlgorithm->getProperty("Function");
+
+        /*double chi2 = fitAlgorithm->getProperty("OutputChi2overDoF");
+        if (chi2 > 10.0) {
+          if (replaceIntensity) {
+            p.setIntensity(0.0);
+            p.setSigmaIntensity(0.0);
+          }
+          continue;
+        }*/
         boost::shared_ptr<const CompositeFunction> fun =
             boost::dynamic_pointer_cast<const CompositeFunction>(ifun);
 
@@ -567,8 +569,8 @@ std::string strMax = strs.str();
         errorSquared = std::fabs(signal);
         // Get background counts
         for (size_t j = 0; j < numSteps; j++) {
-          double background = ifun->getParameter(0) +
-                              ifun->getParameter(1) * x[j];
+          double background =
+              ifun->getParameter(0) + ifun->getParameter(1) * x[j];
           if (j < peakMin || j > peakMax)
             background_total = background_total + background;
         }

--- a/docs/source/release/v3.14.0/diffraction.rst
+++ b/docs/source/release/v3.14.0/diffraction.rst
@@ -33,6 +33,7 @@ Improvements
 - :ref:`MDNormSCD <algm-MDNormSCD>` now can handle merged MD workspaces.
 - :ref:`StartLiveData <algm-StartLiveData>` will load "live"
   data streaming from TOPAZ new Adara data server.
+- :ref:`IntegratePeaksMD <algm-IntegratePeaksMD>` with Cylinder=True now has improved fits using BackToBackExponential and IkedaCarpenterPV functions.
 
 Bugfixes
 ########

--- a/qt/scientific_interfaces/General/MantidEV.ui
+++ b/qt/scientific_interfaces/General/MantidEV.ui
@@ -3008,7 +3008,7 @@
                 </item>
                 <item>
                  <property name="text">
-                  <string>Bk2BKExpConvPV</string>
+                  <string>Bk2BkExpConvPV</string>
                  </property>
                 </item>
                 <item>


### PR DESCRIPTION
**Description of work.**
1D Profile fitting works better with user data now. 

**Report to:** [Arthur Schultz <ajschultz2@gmail.com>]/[nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**
````python
Load(Filename='/SNS/TOPAZ/IPTS-18519/0/24554/NeXus/TOPAZ_24554_event.nxs', OutputWorkspace='TOPAZ_24554_event', FilterByTofMin=500, FilterByTofMax=16666, LoadMonitors=True)
FilterBadPulses(InputWorkspace='TOPAZ_24554_event', OutputWorkspace='TOPAZ_24554_event', LowerCutoff=25)
LoadIsawDetCal(InputWorkspace='TOPAZ_24554_event', Filename='/SNS/TOPAZ/IPTS-18519/shared/2017B/calibration/TOPAZ_2017B.DetCal')
LoadIsawPeaks(Filename='/SNS/TOPAZ/IPTS-18519/shared/2017B/2_PhMDA/100K_PhMDA_1D_profile/24554_Niggli.integrate', OutputWorkspace='TOPAZ_24554_peaks')

ConvertToMD(InputWorkspace='TOPAZ_24554_event', QDimensions='Q3D', dEAnalysisMode='Elastic', Q3DFrames='Q_sample', OutputWorkspace='MantidEVWorker_sphere_integrate_temp_MD_ws', MinValues='-30,-30,-30', MaxValues='30,30,30', SplitInto='2,2,2', SplitThreshold=200, MaxRecursionDepth=10, MinRecursionDepth=7)
IntegratePeaksMD(InputWorkspace='MantidEVWorker_sphere_integrate_temp_MD_ws', PeakRadius=0.1, BackgroundInnerRadius=0.11, BackgroundOuterRadius=0.13, PeaksWorkspace='TOPAZ_24554_peaks', 
    OutputWorkspace='TOPAZ_24554_peaks', Cylinder=False)

IntegratePeaksMD(InputWorkspace='MantidEVWorker_sphere_integrate_temp_MD_ws', PeakRadius=0.1, BackgroundInnerRadius=0.11, BackgroundOuterRadius=0.13, PeaksWorkspace='TOPAZ_24554_peaks',
    OutputWorkspace='TOPAZ_24554_Gausspeaks', Cylinder=True, CylinderLength=0.22, PercentBackground=20, ProfileFunction='Gaussian')
IntegratePeaksMD(InputWorkspace='MantidEVWorker_sphere_integrate_temp_MD_ws', PeakRadius=0.1, BackgroundInnerRadius=0.11, BackgroundOuterRadius=0.13, PeaksWorkspace='TOPAZ_24554_peaks', 
OutputWorkspace='TOPAZ_24554_B2Bpeaks', Cylinder=True, CylinderLength=0.22, PercentBackground=20, ProfileFunction='BackToBackExponential')
IntegratePeaksMD(InputWorkspace='MantidEVWorker_sphere_integrate_temp_MD_ws', PeakRadius=0.1, BackgroundInnerRadius=0.11, BackgroundOuterRadius=0.13, PeaksWorkspace='TOPAZ_24554_peaks', 
    OutputWorkspace='TOPAZ_24554_ICpeaks', Cylinder=True, CylinderLength=0.22, PercentBackground=20, ProfileFunction='IkedaCarpenterPV')
````
Plot ProfilesData spectra with same ProfilesFit spectra to compare fits.
![strong](https://user-images.githubusercontent.com/1108354/46311081-206fe780-c58f-11e8-9884-7849544e6c50.png)
![weak](https://user-images.githubusercontent.com/1108354/46311094-25cd3200-c58f-11e8-8d3e-1b05c96ec654.png)



Fixes #23614 
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
