### PR TITLE
Muon - Core Code; Modifications for New Algorithms

### DIFF
--- a/Framework/Muon/inc/MantidMuon/MuonAlgorithmHelper.h
+++ b/Framework/Muon/inc/MantidMuon/MuonAlgorithmHelper.h
@@ -117,6 +117,22 @@ DLLExport bool checkValidPair(const std::string &name1,
 
 /// Check whether a group or pair name is valid
 DLLExport bool checkValidGroupPairName(const std::string &name);
+
+DLLExport Mantid::API::MatrixWorkspace_sptr
+sumPeriods(const Mantid::API::WorkspaceGroup_sptr &inputWS,
+           const std::vector<int> &periodsToSum);
+
+DLLExport Mantid::API::MatrixWorkspace_sptr
+subtractWorkspaces(const Mantid::API::MatrixWorkspace_sptr &lhs,
+                   const Mantid::API::MatrixWorkspace_sptr &rhs);
+
+DLLExport Mantid::API::MatrixWorkspace_sptr
+extractSpectrum(const Mantid::API::Workspace_sptr &inputWS, const int index);
+
+DLLExport void addSampleLog(Mantid::API::MatrixWorkspace_sptr workspace,
+                            const std::string &logName,
+                            const std::string &logValue);
+
 //
 ///// Saves grouping to the XML file specified
 // DLLExport std::string groupingToXML(const Mantid::API::Grouping &grouping);

--- a/Framework/Muon/src/AsymmetryCalc.cpp
+++ b/Framework/Muon/src/AsymmetryCalc.cpp
@@ -129,14 +129,13 @@ void AsymmetryCalc::exec() {
   // Create a point data workspace with only one spectra for forward
   std::unique_ptr<Mantid::API::HistoWorkspace> outputWS;
   if (inputWS->isHistogramData()) {
-	  outputWS = DataObjects::create<API::HistoWorkspace>(
-		  *inputWS, 1, tmpWS->binEdges(forward));
+    outputWS = DataObjects::create<API::HistoWorkspace>(
+        *inputWS, 1, tmpWS->binEdges(forward));
+  } else {
+    outputWS = DataObjects::create<API::HistoWorkspace>(*inputWS, 1,
+                                                        tmpWS->points(forward));
   }
-  else {
-	  outputWS = DataObjects::create<API::HistoWorkspace>(
-		  *inputWS, 1, tmpWS->points(forward));
-  }
-  
+
   outputWS->getSpectrum(0).setDetectorID(static_cast<detid_t>(1));
 
   // Calculate asymmetry for each time bin
@@ -168,7 +167,7 @@ void AsymmetryCalc::exec() {
   }
 
   // Removed this assert which checks point vs bin edges
-  //assert(outputWS->x(0).size() == blocksize);
+  // assert(outputWS->x(0).size() == blocksize);
 
   // Update Y axis units
   outputWS->setYUnit("Asymmetry");

--- a/Framework/Muon/src/AsymmetryCalc.cpp
+++ b/Framework/Muon/src/AsymmetryCalc.cpp
@@ -1,3 +1,9 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
 //----------------------------------------------------------------------
 // Includes
 //----------------------------------------------------------------------
@@ -127,15 +133,8 @@ void AsymmetryCalc::exec() {
   assert(tmpWS->blocksize() == blocksize);
 
   // Create a point data workspace with only one spectra for forward
-  std::unique_ptr<Mantid::API::HistoWorkspace> outputWS;
-  if (inputWS->isHistogramData()) {
-    outputWS = DataObjects::create<API::HistoWorkspace>(
-        *inputWS, 1, tmpWS->binEdges(forward));
-  } else {
-    outputWS = DataObjects::create<API::HistoWorkspace>(*inputWS, 1,
-                                                        tmpWS->points(forward));
-  }
-
+  auto outputWS = DataObjects::create<API::HistoWorkspace>(
+      *inputWS, 1, tmpWS->points(forward));
   outputWS->getSpectrum(0).setDetectorID(static_cast<detid_t>(1));
 
   // Calculate asymmetry for each time bin
@@ -166,8 +165,7 @@ void AsymmetryCalc::exec() {
     prog.report();
   }
 
-  // Removed this assert which checks point vs bin edges
-  // assert(outputWS->x(0).size() == blocksize);
+  assert(outputWS->x(0).size() == blocksize);
 
   // Update Y axis units
   outputWS->setYUnit("Asymmetry");

--- a/Framework/Muon/src/AsymmetryCalc.cpp
+++ b/Framework/Muon/src/AsymmetryCalc.cpp
@@ -127,8 +127,16 @@ void AsymmetryCalc::exec() {
   assert(tmpWS->blocksize() == blocksize);
 
   // Create a point data workspace with only one spectra for forward
-  auto outputWS = DataObjects::create<API::HistoWorkspace>(
-      *inputWS, 1, tmpWS->points(forward));
+  std::unique_ptr<Mantid::API::HistoWorkspace> outputWS;
+  if (inputWS->isHistogramData()) {
+	  outputWS = DataObjects::create<API::HistoWorkspace>(
+		  *inputWS, 1, tmpWS->binEdges(forward));
+  }
+  else {
+	  outputWS = DataObjects::create<API::HistoWorkspace>(
+		  *inputWS, 1, tmpWS->points(forward));
+  }
+  
   outputWS->getSpectrum(0).setDetectorID(static_cast<detid_t>(1));
 
   // Calculate asymmetry for each time bin
@@ -159,7 +167,8 @@ void AsymmetryCalc::exec() {
     prog.report();
   }
 
-  assert(outputWS->x(0).size() == blocksize);
+  // Removed this assert which checks point vs bin edges
+  //assert(outputWS->x(0).size() == blocksize);
 
   // Update Y axis units
   outputWS->setYUnit("Asymmetry");

--- a/Framework/Muon/src/CalMuonDetectorPhases.cpp
+++ b/Framework/Muon/src/CalMuonDetectorPhases.cpp
@@ -511,7 +511,12 @@ API::MatrixWorkspace_sptr CalMuonDetectorPhases::getAsymmetry(
   alg->setProperty("Alpha", alpha);
   alg->executeAsChildAlg();
   API::MatrixWorkspace_sptr wsAsym = alg->getProperty("OutputWorkspace");
-  return wsAsym;
+  auto alg2 = createChildAlgorithm("ConvertToPointData");
+  alg2->setProperty("InputWorkspace", wsAsym);
+  alg2->setProperty("OutputWorkspace", "__NotUsed");
+  alg2->execute();
+  API::MatrixWorkspace_sptr wsAsym2 = alg2->getProperty("OutputWorkspace");
+  return wsAsym2;
 }
 
 /**

--- a/Framework/Muon/src/CalMuonDetectorPhases.cpp
+++ b/Framework/Muon/src/CalMuonDetectorPhases.cpp
@@ -1,3 +1,9 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidMuon/CalMuonDetectorPhases.h"
 
 #include "MantidAPI/Axis.h"
@@ -511,12 +517,7 @@ API::MatrixWorkspace_sptr CalMuonDetectorPhases::getAsymmetry(
   alg->setProperty("Alpha", alpha);
   alg->executeAsChildAlg();
   API::MatrixWorkspace_sptr wsAsym = alg->getProperty("OutputWorkspace");
-  auto alg2 = createChildAlgorithm("ConvertToPointData");
-  alg2->setProperty("InputWorkspace", wsAsym);
-  alg2->setProperty("OutputWorkspace", "__NotUsed");
-  alg2->execute();
-  API::MatrixWorkspace_sptr wsAsym2 = alg2->getProperty("OutputWorkspace");
-  return wsAsym2;
+  return wsAsym;
 }
 
 /**

--- a/Framework/Muon/src/EstimateMuonAsymmetryFromCounts.cpp
+++ b/Framework/Muon/src/EstimateMuonAsymmetryFromCounts.cpp
@@ -9,9 +9,9 @@
 #include "MantidAPI/Run.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/Workspace_fwd.h"
-
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/PhysicalConstants.h"
+#include "MantidMuon/MuonAlgorithmHelper.h"
 
 #include <cmath>
 #include <numeric>
@@ -68,7 +68,8 @@ void EstimateMuonAsymmetryFromCounts::init() {
 
   declareProperty(
       make_unique<API::WorkspaceProperty<API::ITableWorkspace>>(
-          "NormalizationTable", "", Direction::InOut),
+          "NormalizationTable", "", Direction::InOut,
+          API::PropertyMode::Optional),
       "Name of the table containing the normalizations for the asymmetries.");
 }
 
@@ -207,10 +208,20 @@ void EstimateMuonAsymmetryFromCounts::exec() {
   }
   // update table
   Mantid::API::ITableWorkspace_sptr table = getProperty("NormalizationTable");
-  updateNormalizationTable(table, wsNames, norm, methods);
-  setProperty("NormalizationTable", table);
+  if (table) {
+    updateNormalizationTable(table, wsNames, norm, methods);
+    setProperty("NormalizationTable", table);
+  }
   // Update Y axis units
   outputWS->setYUnit("Asymmetry");
+
+  std::string normString =
+      std::accumulate(norm.begin() + 1, norm.end(), std::to_string(norm[0]),
+                      [](const std::string &a, double b) {
+                        return a + ',' + std::to_string(b);
+                      });
+  MuonAlgorithmHelper::addSampleLog(outputWS, "analysis_asymmetry_norm",
+                                    normString);
 
   setProperty("OutputWorkspace", outputWS);
 }

--- a/Framework/Muon/src/EstimateMuonAsymmetryFromCounts.cpp
+++ b/Framework/Muon/src/EstimateMuonAsymmetryFromCounts.cpp
@@ -215,11 +215,11 @@ void EstimateMuonAsymmetryFromCounts::exec() {
   // Update Y axis units
   outputWS->setYUnit("Asymmetry");
 
-  std::string normString =
-      std::accumulate(norm.begin() + 1, norm.end(), std::to_string(norm[0]),
-                      [](const std::string &currentString, double valueToAppend) {
-                        return currentString + ',' + std::to_string(valueToAppend);
-                      });
+  std::string normString = std::accumulate(
+      norm.begin() + 1, norm.end(), std::to_string(norm[0]),
+      [](const std::string &currentString, double valueToAppend) {
+        return currentString + ',' + std::to_string(valueToAppend);
+      });
   MuonAlgorithmHelper::addSampleLog(outputWS, "analysis_asymmetry_norm",
                                     normString);
 

--- a/Framework/Muon/src/EstimateMuonAsymmetryFromCounts.cpp
+++ b/Framework/Muon/src/EstimateMuonAsymmetryFromCounts.cpp
@@ -217,8 +217,8 @@ void EstimateMuonAsymmetryFromCounts::exec() {
 
   std::string normString =
       std::accumulate(norm.begin() + 1, norm.end(), std::to_string(norm[0]),
-                      [](const std::string &a, double b) {
-                        return a + ',' + std::to_string(b);
+                      [](const std::string &currentString, double valueToAppend) {
+                        return currentString + ',' + std::to_string(valueToAppend);
                       });
   MuonAlgorithmHelper::addSampleLog(outputWS, "analysis_asymmetry_norm",
                                     normString);

--- a/Framework/Muon/src/MuonAlgorithmHelper.cpp
+++ b/Framework/Muon/src/MuonAlgorithmHelper.cpp
@@ -587,16 +587,15 @@ MatrixWorkspace_sptr extractSpectrum(const Workspace_sptr &inputWS,
   return outWS;
 }
 
-void addSampleLog(MatrixWorkspace_sptr workspace, const std::string& logName, const std::string& logValue) {
-	IAlgorithm_sptr alg = AlgorithmManager::Instance().create("AddSampleLog");
-	alg->setChild(true);
-	alg->setProperty("Workspace", workspace);
-	alg->setProperty("LogName", logName);
-	alg->setProperty("LogText", logValue);
-	alg->execute();
-
+void addSampleLog(MatrixWorkspace_sptr workspace, const std::string &logName,
+                  const std::string &logValue) {
+  IAlgorithm_sptr alg = AlgorithmManager::Instance().create("AddSampleLog");
+  alg->setChild(true);
+  alg->setProperty("Workspace", workspace);
+  alg->setProperty("LogName", logName);
+  alg->setProperty("LogText", logValue);
+  alg->execute();
 }
-
 
 } // namespace MuonAlgorithmHelper
 } // namespace Mantid

--- a/Framework/Muon/src/MuonAlgorithmHelper.cpp
+++ b/Framework/Muon/src/MuonAlgorithmHelper.cpp
@@ -533,6 +533,7 @@ MatrixWorkspace_sptr sumPeriods(const WorkspaceGroup_sptr &inputWS,
         auto RHSWorkspace = inputWS->getItem(periodsToSum[i] - 1);
         IAlgorithm_sptr alg = AlgorithmManager::Instance().create("Plus");
         alg->setChild(true);
+        alg->setRethrows(true);
         alg->setProperty("LHSWorkspace", outWS);
         alg->setProperty("RHSWorkspace", RHSWorkspace);
         alg->setProperty("OutputWorkspace", "__NotUsed__");
@@ -556,6 +557,7 @@ MatrixWorkspace_sptr subtractWorkspaces(const MatrixWorkspace_sptr &lhs,
   if (lhs && rhs) {
     IAlgorithm_sptr alg = AlgorithmManager::Instance().create("Minus");
     alg->setChild(true);
+    alg->setRethrows(true);
     alg->setProperty("LHSWorkspace", lhs);
     alg->setProperty("RHSWorkspace", rhs);
     alg->setProperty("OutputWorkspace", "__NotUsed__");
@@ -578,6 +580,7 @@ MatrixWorkspace_sptr extractSpectrum(const Workspace_sptr &inputWS,
     IAlgorithm_sptr alg =
         AlgorithmManager::Instance().create("ExtractSingleSpectrum");
     alg->setChild(true);
+    alg->setRethrows(true);
     alg->setProperty("InputWorkspace", inputWS);
     alg->setProperty("WorkspaceIndex", index);
     alg->setProperty("OutputWorkspace", "__NotUsed__");
@@ -587,14 +590,15 @@ MatrixWorkspace_sptr extractSpectrum(const Workspace_sptr &inputWS,
   return outWS;
 }
 
-void addSampleLog(MatrixWorkspace_sptr workspace, const std::string &logName,
-                  const std::string &logValue) {
-  IAlgorithm_sptr alg = AlgorithmManager::Instance().create("AddSampleLog");
-  alg->setChild(true);
-  alg->setProperty("Workspace", workspace);
-  alg->setProperty("LogName", logName);
-  alg->setProperty("LogText", logValue);
-  alg->execute();
+void addSampleLog(MatrixWorkspace_sptr workspace, const std::string& logName, const std::string& logValue) {
+	IAlgorithm_sptr alg = AlgorithmManager::Instance().create("AddSampleLog");
+	alg->setChild(true);
+  alg->setRethrows(true);
+	alg->setProperty("Workspace", workspace);
+	alg->setProperty("LogName", logName);
+	alg->setProperty("LogText", logValue);
+	alg->execute();
+
 }
 
 } // namespace MuonAlgorithmHelper

--- a/Framework/Muon/src/MuonAlgorithmHelper.cpp
+++ b/Framework/Muon/src/MuonAlgorithmHelper.cpp
@@ -516,5 +516,87 @@ bool checkValidGroupPairName(const std::string &name) {
   return true;
 }
 
+/**
+ * Sums the specified periods of the input workspace group
+ * @param periodsToSum :: [input] List of period indexes (1-based) to be summed
+ * @returns Workspace containing the sum
+ */
+MatrixWorkspace_sptr sumPeriods(const WorkspaceGroup_sptr &inputWS,
+                                const std::vector<int> &periodsToSum) {
+  MatrixWorkspace_sptr outWS;
+  if (!periodsToSum.empty()) {
+    auto LHSWorkspace = inputWS->getItem(periodsToSum[0] - 1);
+    outWS = boost::dynamic_pointer_cast<MatrixWorkspace>(LHSWorkspace);
+    if (outWS != nullptr && periodsToSum.size() > 1) {
+      int numPeriods = static_cast<int>(periodsToSum.size());
+      for (int i = 1; i < numPeriods; i++) {
+        auto RHSWorkspace = inputWS->getItem(periodsToSum[i] - 1);
+        IAlgorithm_sptr alg = AlgorithmManager::Instance().create("Plus");
+        alg->setChild(true);
+        alg->setProperty("LHSWorkspace", outWS);
+        alg->setProperty("RHSWorkspace", RHSWorkspace);
+        alg->setProperty("OutputWorkspace", "__NotUsed__");
+        alg->execute();
+        outWS = alg->getProperty("OutputWorkspace");
+      }
+    }
+  }
+  return outWS;
+}
+
+/**
+ * Subtracts one workspace from another: lhs - rhs.
+ * @param lhs :: [input] Workspace on LHS of subtraction
+ * @param rhs :: [input] Workspace on RHS of subtraction
+ * @returns Result of the subtraction
+ */
+MatrixWorkspace_sptr subtractWorkspaces(const MatrixWorkspace_sptr &lhs,
+                                        const MatrixWorkspace_sptr &rhs) {
+  MatrixWorkspace_sptr outWS;
+  if (lhs && rhs) {
+    IAlgorithm_sptr alg = AlgorithmManager::Instance().create("Minus");
+    alg->setChild(true);
+    alg->setProperty("LHSWorkspace", lhs);
+    alg->setProperty("RHSWorkspace", rhs);
+    alg->setProperty("OutputWorkspace", "__NotUsed__");
+    alg->execute();
+    outWS = alg->getProperty("OutputWorkspace");
+  }
+  return outWS;
+}
+
+/**
+ * Extracts a single spectrum from the given workspace.
+ * @param inputWS :: [input] Workspace to extract spectrum from
+ * @param index :: [input] Index of spectrum to extract
+ * @returns Result of the extraction
+ */
+MatrixWorkspace_sptr extractSpectrum(const Workspace_sptr &inputWS,
+                                     const int index) {
+  MatrixWorkspace_sptr outWS;
+  if (inputWS) {
+    IAlgorithm_sptr alg =
+        AlgorithmManager::Instance().create("ExtractSingleSpectrum");
+    alg->setChild(true);
+    alg->setProperty("InputWorkspace", inputWS);
+    alg->setProperty("WorkspaceIndex", index);
+    alg->setProperty("OutputWorkspace", "__NotUsed__");
+    alg->execute();
+    outWS = alg->getProperty("OutputWorkspace");
+  }
+  return outWS;
+}
+
+void addSampleLog(MatrixWorkspace_sptr workspace, const std::string& logName, const std::string& logValue) {
+	IAlgorithm_sptr alg = AlgorithmManager::Instance().create("AddSampleLog");
+	alg->setChild(true);
+	alg->setProperty("Workspace", workspace);
+	alg->setProperty("LogName", logName);
+	alg->setProperty("LogText", logValue);
+	alg->execute();
+
+}
+
+
 } // namespace MuonAlgorithmHelper
 } // namespace Mantid

--- a/Framework/Muon/src/MuonAlgorithmHelper.cpp
+++ b/Framework/Muon/src/MuonAlgorithmHelper.cpp
@@ -590,15 +590,15 @@ MatrixWorkspace_sptr extractSpectrum(const Workspace_sptr &inputWS,
   return outWS;
 }
 
-void addSampleLog(MatrixWorkspace_sptr workspace, const std::string& logName, const std::string& logValue) {
-	IAlgorithm_sptr alg = AlgorithmManager::Instance().create("AddSampleLog");
-	alg->setChild(true);
+void addSampleLog(MatrixWorkspace_sptr workspace, const std::string &logName,
+                  const std::string &logValue) {
+  IAlgorithm_sptr alg = AlgorithmManager::Instance().create("AddSampleLog");
+  alg->setChild(true);
   alg->setRethrows(true);
-	alg->setProperty("Workspace", workspace);
-	alg->setProperty("LogName", logName);
-	alg->setProperty("LogText", logValue);
-	alg->execute();
-
+  alg->setProperty("Workspace", workspace);
+  alg->setProperty("LogName", logName);
+  alg->setProperty("LogText", logValue);
+  alg->execute();
 }
 
 } // namespace MuonAlgorithmHelper

--- a/Framework/Muon/src/MuonAsymmetryHelper.cpp
+++ b/Framework/Muon/src/MuonAsymmetryHelper.cpp
@@ -6,6 +6,7 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Progress.h"
 #include "MantidAPI/Run.h"
+#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/Workspace_fwd.h"
 
 #include "MantidAPI/AnalysisDataService.h"
@@ -115,7 +116,7 @@ size_t startIndexFromTime(const HistogramData::BinEdges &xData,
                           const double startX) {
   auto upper =
       std::lower_bound(xData.rawData().begin(), xData.rawData().end(), startX);
-  return std::distance(xData.rawData().begin(), upper + 1);
+  return std::distance(xData.rawData().begin(), upper);
 }
 /**
  * find the first index in bin edges that is after

--- a/Framework/Muon/src/MuonAsymmetryHelper.cpp
+++ b/Framework/Muon/src/MuonAsymmetryHelper.cpp
@@ -116,7 +116,7 @@ size_t startIndexFromTime(const HistogramData::BinEdges &xData,
                           const double startX) {
   auto upper =
       std::lower_bound(xData.rawData().begin(), xData.rawData().end(), startX);
-  return std::distance(xData.rawData().begin(), upper);
+  return std::distance(xData.rawData().begin(), upper + 1);
 }
 /**
  * find the first index in bin edges that is after

--- a/Framework/Muon/src/PlotAsymmetryByLogValue.cpp
+++ b/Framework/Muon/src/PlotAsymmetryByLogValue.cpp
@@ -701,11 +701,11 @@ void PlotAsymmetryByLogValue::calcIntAsymmetry(MatrixWorkspace_sptr ws,
     asym->setProperty("InputWorkspace", ws);
     asym->execute();
     MatrixWorkspace_sptr asymWS2 = asym->getProperty("OutputWorkspace");
-	auto alg2 = createChildAlgorithm("ConvertToPointData");
-	alg2->setProperty("InputWorkspace", asymWS2);
-	alg2->setProperty("OutputWorkspace", "__NotUsed");
-	alg2->execute();
-	MatrixWorkspace_sptr asymWS = alg2->getProperty("OutputWorkspace");
+    auto alg2 = createChildAlgorithm("ConvertToPointData");
+    alg2->setProperty("InputWorkspace", asymWS2);
+    alg2->setProperty("OutputWorkspace", "__NotUsed");
+    alg2->execute();
+    MatrixWorkspace_sptr asymWS = alg2->getProperty("OutputWorkspace");
 
     IAlgorithm_sptr integr = createChildAlgorithm("Integration");
     integr->setLogging(false);
@@ -730,11 +730,11 @@ void PlotAsymmetryByLogValue::calcIntAsymmetry(MatrixWorkspace_sptr ws,
     asym->setProperty("InputWorkspace", intWS);
     asym->execute();
     MatrixWorkspace_sptr tmp = asym->getProperty("OutputWorkspace");
-	auto alg2 = createChildAlgorithm("ConvertToPointData");
-	alg2->setProperty("InputWorkspace", tmp);
-	alg2->setProperty("OutputWorkspace", "__NotUsed");
-	alg2->execute();
-	out = alg2->getProperty("OutputWorkspace");
+    auto alg2 = createChildAlgorithm("ConvertToPointData");
+    alg2->setProperty("InputWorkspace", tmp);
+    alg2->setProperty("OutputWorkspace", "__NotUsed");
+    alg2->execute();
+    out = alg2->getProperty("OutputWorkspace");
   }
 
   Y = out->y(0)[0];

--- a/Framework/Muon/src/PlotAsymmetryByLogValue.cpp
+++ b/Framework/Muon/src/PlotAsymmetryByLogValue.cpp
@@ -1,3 +1,9 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
 #include <cmath>
 #include <vector>
 
@@ -700,12 +706,7 @@ void PlotAsymmetryByLogValue::calcIntAsymmetry(MatrixWorkspace_sptr ws,
     asym->setLogging(false);
     asym->setProperty("InputWorkspace", ws);
     asym->execute();
-    MatrixWorkspace_sptr asymWS2 = asym->getProperty("OutputWorkspace");
-    auto alg2 = createChildAlgorithm("ConvertToPointData");
-    alg2->setProperty("InputWorkspace", asymWS2);
-    alg2->setProperty("OutputWorkspace", "__NotUsed");
-    alg2->execute();
-    MatrixWorkspace_sptr asymWS = alg2->getProperty("OutputWorkspace");
+    MatrixWorkspace_sptr asymWS = asym->getProperty("OutputWorkspace");
 
     IAlgorithm_sptr integr = createChildAlgorithm("Integration");
     integr->setLogging(false);
@@ -729,12 +730,7 @@ void PlotAsymmetryByLogValue::calcIntAsymmetry(MatrixWorkspace_sptr ws,
     asym->setLogging(false);
     asym->setProperty("InputWorkspace", intWS);
     asym->execute();
-    MatrixWorkspace_sptr tmp = asym->getProperty("OutputWorkspace");
-    auto alg2 = createChildAlgorithm("ConvertToPointData");
-    alg2->setProperty("InputWorkspace", tmp);
-    alg2->setProperty("OutputWorkspace", "__NotUsed");
-    alg2->execute();
-    out = alg2->getProperty("OutputWorkspace");
+    out = asym->getProperty("OutputWorkspace");
   }
 
   Y = out->y(0)[0];

--- a/Framework/Muon/src/PlotAsymmetryByLogValue.cpp
+++ b/Framework/Muon/src/PlotAsymmetryByLogValue.cpp
@@ -700,7 +700,12 @@ void PlotAsymmetryByLogValue::calcIntAsymmetry(MatrixWorkspace_sptr ws,
     asym->setLogging(false);
     asym->setProperty("InputWorkspace", ws);
     asym->execute();
-    MatrixWorkspace_sptr asymWS = asym->getProperty("OutputWorkspace");
+    MatrixWorkspace_sptr asymWS2 = asym->getProperty("OutputWorkspace");
+	auto alg2 = createChildAlgorithm("ConvertToPointData");
+	alg2->setProperty("InputWorkspace", asymWS2);
+	alg2->setProperty("OutputWorkspace", "__NotUsed");
+	alg2->execute();
+	MatrixWorkspace_sptr asymWS = alg2->getProperty("OutputWorkspace");
 
     IAlgorithm_sptr integr = createChildAlgorithm("Integration");
     integr->setLogging(false);
@@ -724,7 +729,12 @@ void PlotAsymmetryByLogValue::calcIntAsymmetry(MatrixWorkspace_sptr ws,
     asym->setLogging(false);
     asym->setProperty("InputWorkspace", intWS);
     asym->execute();
-    out = asym->getProperty("OutputWorkspace");
+    MatrixWorkspace_sptr tmp = asym->getProperty("OutputWorkspace");
+	auto alg2 = createChildAlgorithm("ConvertToPointData");
+	alg2->setProperty("InputWorkspace", tmp);
+	alg2->setProperty("OutputWorkspace", "__NotUsed");
+	alg2->execute();
+	out = alg2->getProperty("OutputWorkspace");
   }
 
   Y = out->y(0)[0];

--- a/Framework/Muon/test/ApplyMuonDetectorGroupPairingTest.h
+++ b/Framework/Muon/test/ApplyMuonDetectorGroupPairingTest.h
@@ -274,7 +274,7 @@ public:
         setup.wsGroup->getItem("inputGroup; Pair; test; Asym; #1_Raw"));
 
     // Account for the bin edges to point data conversion
-    double shift = 0.2 + 0.05;
+    double shift = 0.2;
     TS_ASSERT_DELTA(wsOut->readX(0)[0], ws->readX(0)[0] + shift, 0.001);
     TS_ASSERT_DELTA(wsOut->readX(0)[4], ws->readX(0)[4] + shift, 0.001);
     TS_ASSERT_DELTA(wsOut->readX(0)[9], ws->readX(0)[9] + shift, 0.001);

--- a/Framework/Muon/test/ApplyMuonDetectorGroupPairingTest.h
+++ b/Framework/Muon/test/ApplyMuonDetectorGroupPairingTest.h
@@ -247,11 +247,9 @@ public:
     auto wsOut = boost::dynamic_pointer_cast<MatrixWorkspace>(
         setup.wsGroup->getItem("inputGroup; Pair; test; Asym; #1_Raw"));
 
-    // Current behaviour is to convert bin edge x-values to bin centre x-values
-    // (point data) so there is on fewer x-value now.
-    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.050, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.450, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[9], 0.950, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.00, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.40, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[9], 0.90, 0.001);
 
     TS_ASSERT_DELTA(wsOut->readY(0)[0], -0.4692, 0.0001);
     TS_ASSERT_DELTA(wsOut->readY(0)[4], 1.0000, 0.0001);
@@ -311,9 +309,9 @@ public:
         setup.wsGroup->getItem("inputGroup; Pair; test; Asym; #1_Raw"));
 
     // Summation of periods occurs before asymmetry calculation
-    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.050, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.450, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[9], 0.950, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.00, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.40, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[9], 0.90, 0.001);
 
     TS_ASSERT_DELTA(wsOut->readY(0)[0], -0.5755, 0.0001);
     TS_ASSERT_DELTA(wsOut->readY(0)[4], -0.5368, 0.0001);
@@ -342,9 +340,9 @@ public:
 
     // Summation of periods occurs before asymmetry calculation
     // Subtraction of periods occurs AFTER asymmetry calculation
-    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.050, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.450, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[9], 0.950, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.00, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.40, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[9], 0.90, 0.001);
 
     TS_ASSERT_DELTA(wsOut->readY(0)[0], -0.0153, 0.0001);
     TS_ASSERT_DELTA(wsOut->readY(0)[4], -0.0130, 0.0001);
@@ -380,9 +378,9 @@ public:
     auto wsOut = boost::dynamic_pointer_cast<MatrixWorkspace>(
         setup.wsGroup->getItem("inputGroup; Pair; test; Asym; #1_Raw"));
 
-    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.050, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.450, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[9], 0.950, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.00, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.40, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[9], 0.90, 0.001);
 
     // Dead time applied before asymmetry
     TS_ASSERT_DELTA(wsOut->readY(0)[0], -0.5181, 0.0001);
@@ -421,9 +419,9 @@ public:
     auto wsOut = boost::dynamic_pointer_cast<MatrixWorkspace>(
         setup.wsGroup->getItem("inputGroup; Pair; test; Asym; #1_Raw"));
 
-    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.050, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.450, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[9], 0.950, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.00, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.40, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[9], 0.90, 0.001);
 
     TS_ASSERT_DELTA(wsOut->readY(0)[0], -0.1388, 0.001);
     TS_ASSERT_DELTA(wsOut->readY(0)[4], 0.2900, 0.001);

--- a/Framework/Muon/test/ApplyMuonDetectorGroupPairingTest.h
+++ b/Framework/Muon/test/ApplyMuonDetectorGroupPairingTest.h
@@ -1,3 +1,9 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
 #ifndef MANTID_MUON_APPLYMUONDETECTORGROUPPAIRINGTEST_H_
 #define MANTID_MUON_APPLYMUONDETECTORGROUPPAIRINGTEST_H_
 
@@ -247,9 +253,11 @@ public:
     auto wsOut = boost::dynamic_pointer_cast<MatrixWorkspace>(
         setup.wsGroup->getItem("inputGroup; Pair; test; Asym; #1_Raw"));
 
-    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.00, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.40, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[9], 0.90, 0.001);
+    // Current behaviour is to convert bin edge x-values to bin centre x-values
+    // (point data) so there is on fewer x-value now.
+    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.050, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.450, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[9], 0.950, 0.001);
 
     TS_ASSERT_DELTA(wsOut->readY(0)[0], -0.4692, 0.0001);
     TS_ASSERT_DELTA(wsOut->readY(0)[4], 1.0000, 0.0001);
@@ -274,7 +282,7 @@ public:
         setup.wsGroup->getItem("inputGroup; Pair; test; Asym; #1_Raw"));
 
     // Account for the bin edges to point data conversion
-    double shift = 0.2;
+    double shift = 0.2 + 0.05;
     TS_ASSERT_DELTA(wsOut->readX(0)[0], ws->readX(0)[0] + shift, 0.001);
     TS_ASSERT_DELTA(wsOut->readX(0)[4], ws->readX(0)[4] + shift, 0.001);
     TS_ASSERT_DELTA(wsOut->readX(0)[9], ws->readX(0)[9] + shift, 0.001);
@@ -309,9 +317,9 @@ public:
         setup.wsGroup->getItem("inputGroup; Pair; test; Asym; #1_Raw"));
 
     // Summation of periods occurs before asymmetry calculation
-    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.00, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.40, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[9], 0.90, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.050, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.450, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[9], 0.950, 0.001);
 
     TS_ASSERT_DELTA(wsOut->readY(0)[0], -0.5755, 0.0001);
     TS_ASSERT_DELTA(wsOut->readY(0)[4], -0.5368, 0.0001);
@@ -340,9 +348,9 @@ public:
 
     // Summation of periods occurs before asymmetry calculation
     // Subtraction of periods occurs AFTER asymmetry calculation
-    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.00, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.40, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[9], 0.90, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.050, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.450, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[9], 0.950, 0.001);
 
     TS_ASSERT_DELTA(wsOut->readY(0)[0], -0.0153, 0.0001);
     TS_ASSERT_DELTA(wsOut->readY(0)[4], -0.0130, 0.0001);
@@ -378,9 +386,9 @@ public:
     auto wsOut = boost::dynamic_pointer_cast<MatrixWorkspace>(
         setup.wsGroup->getItem("inputGroup; Pair; test; Asym; #1_Raw"));
 
-    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.00, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.40, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[9], 0.90, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.050, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.450, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[9], 0.950, 0.001);
 
     // Dead time applied before asymmetry
     TS_ASSERT_DELTA(wsOut->readY(0)[0], -0.5181, 0.0001);
@@ -419,9 +427,9 @@ public:
     auto wsOut = boost::dynamic_pointer_cast<MatrixWorkspace>(
         setup.wsGroup->getItem("inputGroup; Pair; test; Asym; #1_Raw"));
 
-    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.00, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.40, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[9], 0.90, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.050, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.450, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[9], 0.950, 0.001);
 
     TS_ASSERT_DELTA(wsOut->readY(0)[0], -0.1388, 0.001);
     TS_ASSERT_DELTA(wsOut->readY(0)[4], 0.2900, 0.001);

--- a/Framework/Muon/test/AsymmetryCalcTest.h
+++ b/Framework/Muon/test/AsymmetryCalcTest.h
@@ -78,7 +78,6 @@ public:
     MatrixWorkspace_const_sptr outputWS =
         asymCalc.getProperty("OutputWorkspace");
     TS_ASSERT_DELTA(outputWS->y(0)[100], 0.2965, 0.005);
-    TS_ASSERT(!outputWS->isHistogramData());
   }
 
   void test_single_spectra() {
@@ -101,7 +100,6 @@ public:
     TS_ASSERT_EQUALS(outputWS->y(0)[0], -0.5); // == (1 - 3)/(1 + 3)
     TS_ASSERT_EQUALS(outputWS->y(0)[6], -0.5); // == (1 - 3)/(1 + 3)
     TS_ASSERT_EQUALS(outputWS->y(0)[9], -0.5); // == (1 - 3)/(1 + 3)
-    TS_ASSERT(!outputWS->isHistogramData());
   }
 
   void test_yUnitLabel() {

--- a/Framework/Muon/test/AsymmetryCalcTest.h
+++ b/Framework/Muon/test/AsymmetryCalcTest.h
@@ -1,3 +1,9 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
 #ifndef ASYMMETRYCALCTEST_H_
 #define ASYMMETRYCALCTEST_H_
 
@@ -78,6 +84,7 @@ public:
     MatrixWorkspace_const_sptr outputWS =
         asymCalc.getProperty("OutputWorkspace");
     TS_ASSERT_DELTA(outputWS->y(0)[100], 0.2965, 0.005);
+    TS_ASSERT(!outputWS->isHistogramData());
   }
 
   void test_single_spectra() {
@@ -100,6 +107,7 @@ public:
     TS_ASSERT_EQUALS(outputWS->y(0)[0], -0.5); // == (1 - 3)/(1 + 3)
     TS_ASSERT_EQUALS(outputWS->y(0)[6], -0.5); // == (1 - 3)/(1 + 3)
     TS_ASSERT_EQUALS(outputWS->y(0)[9], -0.5); // == (1 - 3)/(1 + 3)
+    TS_ASSERT(!outputWS->isHistogramData());
   }
 
   void test_yUnitLabel() {

--- a/Framework/Muon/test/LoadAndApplyMuonDetectorGroupingTest.h
+++ b/Framework/Muon/test/LoadAndApplyMuonDetectorGroupingTest.h
@@ -190,10 +190,9 @@ public:
     wsOut = boost::dynamic_pointer_cast<MatrixWorkspace>(
         wsGroup->getItem("EMU00012345; Pair; pair1; Asym; #1_Raw"));
 
-    // Asymmetry converts bin width to point data
-    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.050, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.450, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[9], 0.950, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.00, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.40, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[9], 0.90, 0.001);
 
     TS_ASSERT_DELTA(wsOut->readY(0)[0], -0.3928, 0.0001);
     TS_ASSERT_DELTA(wsOut->readY(0)[4], 0.44885, 0.0001);
@@ -358,9 +357,9 @@ public:
     wsOut = boost::dynamic_pointer_cast<MatrixWorkspace>(
         wsGroup->getItem("EMU00012345; Pair; pair1; Asym; #1_Raw"));
     // Asymmetry converted to point data
-    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.050, 0.0001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[1], 0.150, 0.0001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.450, 0.0001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.0, 0.0001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[1], 0.10, 0.0001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.40, 0.0001);
 
     wsOut = boost::dynamic_pointer_cast<MatrixWorkspace>(
         wsGroup->getItem("EMU00012345; Pair; pair1; Asym; #1"));
@@ -401,9 +400,9 @@ public:
     wsOut = boost::dynamic_pointer_cast<MatrixWorkspace>(
         wsGroup->getItem("EMU00012345; Pair; pair1; Asym; #1_Raw"));
 
-    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.550, 0.0001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[1], 0.650, 0.0001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.950, 0.0001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.50, 0.0001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[1], 0.60, 0.0001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.90, 0.0001);
 
     wsOut = boost::dynamic_pointer_cast<MatrixWorkspace>(
         wsGroup->getItem("EMU00012345; Pair; pair1; Asym; #1"));

--- a/Framework/Muon/test/LoadAndApplyMuonDetectorGroupingTest.h
+++ b/Framework/Muon/test/LoadAndApplyMuonDetectorGroupingTest.h
@@ -364,9 +364,9 @@ public:
     wsOut = boost::dynamic_pointer_cast<MatrixWorkspace>(
         wsGroup->getItem("EMU00012345; Pair; pair1; Asym; #1"));
     // Rebinning happens before conversion to point data
-    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.100, 0.0001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[1], 0.300, 0.0001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.900, 0.0001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.00, 0.0001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[1], 0.200, 0.0001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.800, 0.0001);
   }
 
   void test_TimeOffset_applied_correctly() {
@@ -407,9 +407,9 @@ public:
     wsOut = boost::dynamic_pointer_cast<MatrixWorkspace>(
         wsGroup->getItem("EMU00012345; Pair; pair1; Asym; #1"));
 
-    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.550, 0.0001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[1], 0.650, 0.0001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.950, 0.0001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.50, 0.0001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[1], 0.60, 0.0001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.90, 0.0001);
   }
 
   void test_multiple_period_data_summing_periods_gives_correct_result() {
@@ -553,9 +553,9 @@ public:
     wsOut = boost::dynamic_pointer_cast<MatrixWorkspace>(
         wsGroup->getItem("EMU00012345; Pair; pair1; Asym; #1_Raw"));
 
-    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.25, delta);
-    TS_ASSERT_DELTA(wsOut->readX(0)[1], 0.35, delta);
-    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.65, delta);
+    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.2, delta);
+    TS_ASSERT_DELTA(wsOut->readX(0)[1], 0.3, delta);
+    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.6, delta);
   }
 
   void test_group_asymmetry_range_applied_correctly() {}

--- a/Framework/Muon/test/LoadAndApplyMuonDetectorGroupingTest.h
+++ b/Framework/Muon/test/LoadAndApplyMuonDetectorGroupingTest.h
@@ -1,3 +1,9 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
 #ifndef MANTID_MUON_LOADANDAPPLYMUONDETECTORGROUPINGTEST_H_
 #define MANTID_MUON_LOADANDAPPLYMUONDETECTORGROUPINGTEST_H_
 
@@ -190,9 +196,10 @@ public:
     wsOut = boost::dynamic_pointer_cast<MatrixWorkspace>(
         wsGroup->getItem("EMU00012345; Pair; pair1; Asym; #1_Raw"));
 
-    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.00, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.40, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[9], 0.90, 0.001);
+    // Asymmetry converts bin width to point data
+    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.050, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.450, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[9], 0.950, 0.001);
 
     TS_ASSERT_DELTA(wsOut->readY(0)[0], -0.3928, 0.0001);
     TS_ASSERT_DELTA(wsOut->readY(0)[4], 0.44885, 0.0001);
@@ -357,16 +364,16 @@ public:
     wsOut = boost::dynamic_pointer_cast<MatrixWorkspace>(
         wsGroup->getItem("EMU00012345; Pair; pair1; Asym; #1_Raw"));
     // Asymmetry converted to point data
-    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.0, 0.0001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[1], 0.10, 0.0001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.40, 0.0001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.050, 0.0001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[1], 0.150, 0.0001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.450, 0.0001);
 
     wsOut = boost::dynamic_pointer_cast<MatrixWorkspace>(
         wsGroup->getItem("EMU00012345; Pair; pair1; Asym; #1"));
     // Rebinning happens before conversion to point data
-    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.00, 0.0001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[1], 0.200, 0.0001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.800, 0.0001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.100, 0.0001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[1], 0.300, 0.0001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.900, 0.0001);
   }
 
   void test_TimeOffset_applied_correctly() {
@@ -400,16 +407,16 @@ public:
     wsOut = boost::dynamic_pointer_cast<MatrixWorkspace>(
         wsGroup->getItem("EMU00012345; Pair; pair1; Asym; #1_Raw"));
 
-    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.50, 0.0001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[1], 0.60, 0.0001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.90, 0.0001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.550, 0.0001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[1], 0.650, 0.0001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.950, 0.0001);
 
     wsOut = boost::dynamic_pointer_cast<MatrixWorkspace>(
         wsGroup->getItem("EMU00012345; Pair; pair1; Asym; #1"));
 
-    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.50, 0.0001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[1], 0.60, 0.0001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.90, 0.0001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.550, 0.0001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[1], 0.650, 0.0001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.950, 0.0001);
   }
 
   void test_multiple_period_data_summing_periods_gives_correct_result() {
@@ -553,9 +560,9 @@ public:
     wsOut = boost::dynamic_pointer_cast<MatrixWorkspace>(
         wsGroup->getItem("EMU00012345; Pair; pair1; Asym; #1_Raw"));
 
-    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.2, delta);
-    TS_ASSERT_DELTA(wsOut->readX(0)[1], 0.3, delta);
-    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.6, delta);
+    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.25, delta);
+    TS_ASSERT_DELTA(wsOut->readX(0)[1], 0.35, delta);
+    TS_ASSERT_DELTA(wsOut->readX(0)[4], 0.65, delta);
   }
 
   void test_group_asymmetry_range_applied_correctly() {}

--- a/Framework/TestHelpers/inc/MantidTestHelpers/MuonWorkspaceCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/MuonWorkspaceCreationHelper.h
@@ -86,18 +86,27 @@ Mantid::API::MatrixWorkspace_sptr
 createCountsWorkspace(size_t nspec, size_t maxt, double seed,
                       size_t detectorIDseed = 1);
 
+Mantid::API::MatrixWorkspace_sptr
+createCountsWorkspace(size_t nspec, size_t maxt, double seed,
+                      size_t detectorIDseed, bool hist, double xStart,
+                      double xEnd);
+
 /**
- * Create a WorkspaceGroup and add to the ADS, populate with MatrixWorkspaces
- * simulating periods as used in muon analysis. Workspace for period i has a
- * name ending _i.
+ * Create a WorkspaceGroup and add to the ADS, populate with
+ * MatrixWorkspaces simulating periods as used in muon analysis. Workspace
+ * for period i has a name ending _i.
  */
 Mantid::API::WorkspaceGroup_sptr
 createMultiPeriodWorkspaceGroup(const int &nPeriods, size_t nspec, size_t maxt,
                                 const std::string &wsGroupName);
 
+Mantid::API::WorkspaceGroup_sptr
+createMultiPeriodAsymmetryData(const int &nPeriods, size_t nspec, size_t maxt,
+                               const std::string &wsGroupName);
+
 /**
- * Create a simple dead time TableWorkspace with two columns (spectrum number
- * and dead time).
+ * Create a simple dead time TableWorkspace with two columns (spectrum
+ * number and dead time).
  */
 Mantid::API::ITableWorkspace_sptr
 createDeadTimeTable(const size_t &nspec, std::vector<double> &deadTimes);

--- a/Framework/TestHelpers/src/MuonWorkspaceCreationHelper.cpp
+++ b/Framework/TestHelpers/src/MuonWorkspaceCreationHelper.cpp
@@ -59,12 +59,14 @@ double eData::operator()(const double, size_t) { return 0.005; }
  * Number of bins = maxt - 1 .
  * @param seed :: Number added to all y-values.
  * @param detectorIDseed :: detector IDs starting from this number.
+ * @param hist :: Whether to output histogram data or not
+ * @param xStart :: The start value of the x-axis.
+ * @param xEnd :: The end value of the x-axis.
  * @return Pointer to the workspace.
  */
 MatrixWorkspace_sptr createCountsWorkspace(size_t nspec, size_t maxt,
                                            double seed, size_t detectorIDseed,
-                                           bool hist, double xStart,
-                                           double xEnd) {
+                                           bool hist, double xStart, double xEnd) {
 
   MatrixWorkspace_sptr ws =
       WorkspaceCreationHelper::create2DWorkspaceFromFunction(
@@ -95,8 +97,7 @@ MatrixWorkspace_sptr createCountsWorkspace(size_t nspec, size_t maxt,
 
 MatrixWorkspace_sptr createCountsWorkspace(size_t nspec, size_t maxt,
                                            double seed, size_t detectorIDseed) {
-  return createCountsWorkspace(nspec, maxt, seed, detectorIDseed, true, 0.0,
-                               1.0);
+  return createCountsWorkspace(nspec, maxt, seed, detectorIDseed, true, 0.0, 1.0);
 }
 
 /**
@@ -140,29 +141,29 @@ createMultiPeriodWorkspaceGroup(const int &nPeriods, size_t nspec, size_t maxt,
 
 Mantid::API::WorkspaceGroup_sptr
 createMultiPeriodAsymmetryData(const int &nPeriods, size_t nspec, size_t maxt,
-                               const std::string &wsGroupName) {
-  Mantid::API::WorkspaceGroup_sptr wsGroup =
-      boost::make_shared<Mantid::API::WorkspaceGroup>();
-  Mantid::API::AnalysisDataService::Instance().addOrReplace(wsGroupName,
-                                                            wsGroup);
+	const std::string &wsGroupName) {
+	Mantid::API::WorkspaceGroup_sptr wsGroup =
+		boost::make_shared<Mantid::API::WorkspaceGroup>();
+	Mantid::API::AnalysisDataService::Instance().addOrReplace(wsGroupName,
+		wsGroup);
 
-  std::string wsNameStem = "MuonDataPeriod_";
-  std::string wsName;
+	std::string wsNameStem = "MuonDataPeriod_";
+	std::string wsName;
 
-  boost::shared_ptr<Mantid::Geometry::Instrument> inst1 =
-      boost::make_shared<Mantid::Geometry::Instrument>();
-  inst1->setName("EMU");
+	boost::shared_ptr<Mantid::Geometry::Instrument> inst1 =
+		boost::make_shared<Mantid::Geometry::Instrument>();
+	inst1->setName("EMU");
 
-  for (int period = 1; period < nPeriods + 1; period++) {
-    Mantid::API::MatrixWorkspace_sptr ws = createAsymmetryWorkspace(
-        nspec, maxt, yDataAsymmetry(10.0 * period, 0.1 * period));
+	for (int period = 1; period < nPeriods + 1; period++) {
+		Mantid::API::MatrixWorkspace_sptr ws =
+			createAsymmetryWorkspace(nspec, maxt, yDataAsymmetry(10.0 * period, 0.1 * period));
 
-    wsGroup->addWorkspace(ws);
-    wsName = wsNameStem + std::to_string(period);
-    Mantid::API::AnalysisDataService::Instance().addOrReplace(wsName, ws);
-  }
+		wsGroup->addWorkspace(ws);
+		wsName = wsNameStem + std::to_string(period);
+		Mantid::API::AnalysisDataService::Instance().addOrReplace(wsName, ws);
+	}
 
-  return wsGroup;
+	return wsGroup;
 }
 
 /**

--- a/Framework/TestHelpers/src/MuonWorkspaceCreationHelper.cpp
+++ b/Framework/TestHelpers/src/MuonWorkspaceCreationHelper.cpp
@@ -66,7 +66,8 @@ double eData::operator()(const double, size_t) { return 0.005; }
  */
 MatrixWorkspace_sptr createCountsWorkspace(size_t nspec, size_t maxt,
                                            double seed, size_t detectorIDseed,
-                                           bool isHist, double xStart, double xEnd) {
+                                           bool isHist, double xStart,
+                                           double xEnd) {
 
   MatrixWorkspace_sptr ws =
       WorkspaceCreationHelper::create2DWorkspaceFromFunction(

--- a/Framework/TestHelpers/src/MuonWorkspaceCreationHelper.cpp
+++ b/Framework/TestHelpers/src/MuonWorkspaceCreationHelper.cpp
@@ -62,12 +62,13 @@ double eData::operator()(const double, size_t) { return 0.005; }
  * @return Pointer to the workspace.
  */
 MatrixWorkspace_sptr createCountsWorkspace(size_t nspec, size_t maxt,
-                                           double seed, size_t detectorIDseed) {
+                                           double seed, size_t detectorIDseed,
+                                           bool hist, double xStart, double xEnd) {
 
   MatrixWorkspace_sptr ws =
       WorkspaceCreationHelper::create2DWorkspaceFromFunction(
-          yDataCounts(), static_cast<int>(nspec), 0.0, 1.0,
-          (1.0 / static_cast<double>(maxt)), true, eData());
+          yDataCounts(), static_cast<int>(nspec), xStart, xEnd,
+          (1.0 / static_cast<double>(maxt)), hist, eData());
 
   ws->setInstrument(ComponentCreationHelper::createTestInstrumentCylindrical(
       static_cast<int>(nspec)));
@@ -89,6 +90,11 @@ MatrixWorkspace_sptr createCountsWorkspace(size_t nspec, size_t maxt,
   ws->mutableRun().addProperty("run_number", 12345);
 
   return ws;
+}
+
+MatrixWorkspace_sptr createCountsWorkspace(size_t nspec, size_t maxt,
+                                           double seed, size_t detectorIDseed) {
+  return createCountsWorkspace(nspec, maxt, seed, detectorIDseed, true, 0.0, 1.0);
 }
 
 /**
@@ -128,6 +134,33 @@ createMultiPeriodWorkspaceGroup(const int &nPeriods, size_t nspec, size_t maxt,
   }
 
   return wsGroup;
+}
+
+Mantid::API::WorkspaceGroup_sptr
+createMultiPeriodAsymmetryData(const int &nPeriods, size_t nspec, size_t maxt,
+	const std::string &wsGroupName) {
+	Mantid::API::WorkspaceGroup_sptr wsGroup =
+		boost::make_shared<Mantid::API::WorkspaceGroup>();
+	Mantid::API::AnalysisDataService::Instance().addOrReplace(wsGroupName,
+		wsGroup);
+
+	std::string wsNameStem = "MuonDataPeriod_";
+	std::string wsName;
+
+	boost::shared_ptr<Mantid::Geometry::Instrument> inst1 =
+		boost::make_shared<Mantid::Geometry::Instrument>();
+	inst1->setName("EMU");
+
+	for (int period = 1; period < nPeriods + 1; period++) {
+		Mantid::API::MatrixWorkspace_sptr ws =
+			createAsymmetryWorkspace(nspec, maxt, yDataAsymmetry(10.0 * period, 0.1 * period));
+
+		wsGroup->addWorkspace(ws);
+		wsName = wsNameStem + std::to_string(period);
+		Mantid::API::AnalysisDataService::Instance().addOrReplace(wsName, ws);
+	}
+
+	return wsGroup;
 }
 
 /**

--- a/Framework/TestHelpers/src/MuonWorkspaceCreationHelper.cpp
+++ b/Framework/TestHelpers/src/MuonWorkspaceCreationHelper.cpp
@@ -66,7 +66,8 @@ double eData::operator()(const double, size_t) { return 0.005; }
  */
 MatrixWorkspace_sptr createCountsWorkspace(size_t nspec, size_t maxt,
                                            double seed, size_t detectorIDseed,
-                                           bool hist, double xStart, double xEnd) {
+                                           bool hist, double xStart,
+                                           double xEnd) {
 
   MatrixWorkspace_sptr ws =
       WorkspaceCreationHelper::create2DWorkspaceFromFunction(
@@ -97,7 +98,8 @@ MatrixWorkspace_sptr createCountsWorkspace(size_t nspec, size_t maxt,
 
 MatrixWorkspace_sptr createCountsWorkspace(size_t nspec, size_t maxt,
                                            double seed, size_t detectorIDseed) {
-  return createCountsWorkspace(nspec, maxt, seed, detectorIDseed, true, 0.0, 1.0);
+  return createCountsWorkspace(nspec, maxt, seed, detectorIDseed, true, 0.0,
+                               1.0);
 }
 
 /**
@@ -141,29 +143,29 @@ createMultiPeriodWorkspaceGroup(const int &nPeriods, size_t nspec, size_t maxt,
 
 Mantid::API::WorkspaceGroup_sptr
 createMultiPeriodAsymmetryData(const int &nPeriods, size_t nspec, size_t maxt,
-	const std::string &wsGroupName) {
-	Mantid::API::WorkspaceGroup_sptr wsGroup =
-		boost::make_shared<Mantid::API::WorkspaceGroup>();
-	Mantid::API::AnalysisDataService::Instance().addOrReplace(wsGroupName,
-		wsGroup);
+                               const std::string &wsGroupName) {
+  Mantid::API::WorkspaceGroup_sptr wsGroup =
+      boost::make_shared<Mantid::API::WorkspaceGroup>();
+  Mantid::API::AnalysisDataService::Instance().addOrReplace(wsGroupName,
+                                                            wsGroup);
 
-	std::string wsNameStem = "MuonDataPeriod_";
-	std::string wsName;
+  std::string wsNameStem = "MuonDataPeriod_";
+  std::string wsName;
 
-	boost::shared_ptr<Mantid::Geometry::Instrument> inst1 =
-		boost::make_shared<Mantid::Geometry::Instrument>();
-	inst1->setName("EMU");
+  boost::shared_ptr<Mantid::Geometry::Instrument> inst1 =
+      boost::make_shared<Mantid::Geometry::Instrument>();
+  inst1->setName("EMU");
 
-	for (int period = 1; period < nPeriods + 1; period++) {
-		Mantid::API::MatrixWorkspace_sptr ws =
-			createAsymmetryWorkspace(nspec, maxt, yDataAsymmetry(10.0 * period, 0.1 * period));
+  for (int period = 1; period < nPeriods + 1; period++) {
+    Mantid::API::MatrixWorkspace_sptr ws = createAsymmetryWorkspace(
+        nspec, maxt, yDataAsymmetry(10.0 * period, 0.1 * period));
 
-		wsGroup->addWorkspace(ws);
-		wsName = wsNameStem + std::to_string(period);
-		Mantid::API::AnalysisDataService::Instance().addOrReplace(wsName, ws);
-	}
+    wsGroup->addWorkspace(ws);
+    wsName = wsNameStem + std::to_string(period);
+    Mantid::API::AnalysisDataService::Instance().addOrReplace(wsName, ws);
+  }
 
-	return wsGroup;
+  return wsGroup;
 }
 
 /**

--- a/Framework/TestHelpers/src/MuonWorkspaceCreationHelper.cpp
+++ b/Framework/TestHelpers/src/MuonWorkspaceCreationHelper.cpp
@@ -63,7 +63,8 @@ double eData::operator()(const double, size_t) { return 0.005; }
  */
 MatrixWorkspace_sptr createCountsWorkspace(size_t nspec, size_t maxt,
                                            double seed, size_t detectorIDseed,
-                                           bool hist, double xStart, double xEnd) {
+                                           bool hist, double xStart,
+                                           double xEnd) {
 
   MatrixWorkspace_sptr ws =
       WorkspaceCreationHelper::create2DWorkspaceFromFunction(
@@ -94,7 +95,8 @@ MatrixWorkspace_sptr createCountsWorkspace(size_t nspec, size_t maxt,
 
 MatrixWorkspace_sptr createCountsWorkspace(size_t nspec, size_t maxt,
                                            double seed, size_t detectorIDseed) {
-  return createCountsWorkspace(nspec, maxt, seed, detectorIDseed, true, 0.0, 1.0);
+  return createCountsWorkspace(nspec, maxt, seed, detectorIDseed, true, 0.0,
+                               1.0);
 }
 
 /**
@@ -138,29 +140,29 @@ createMultiPeriodWorkspaceGroup(const int &nPeriods, size_t nspec, size_t maxt,
 
 Mantid::API::WorkspaceGroup_sptr
 createMultiPeriodAsymmetryData(const int &nPeriods, size_t nspec, size_t maxt,
-	const std::string &wsGroupName) {
-	Mantid::API::WorkspaceGroup_sptr wsGroup =
-		boost::make_shared<Mantid::API::WorkspaceGroup>();
-	Mantid::API::AnalysisDataService::Instance().addOrReplace(wsGroupName,
-		wsGroup);
+                               const std::string &wsGroupName) {
+  Mantid::API::WorkspaceGroup_sptr wsGroup =
+      boost::make_shared<Mantid::API::WorkspaceGroup>();
+  Mantid::API::AnalysisDataService::Instance().addOrReplace(wsGroupName,
+                                                            wsGroup);
 
-	std::string wsNameStem = "MuonDataPeriod_";
-	std::string wsName;
+  std::string wsNameStem = "MuonDataPeriod_";
+  std::string wsName;
 
-	boost::shared_ptr<Mantid::Geometry::Instrument> inst1 =
-		boost::make_shared<Mantid::Geometry::Instrument>();
-	inst1->setName("EMU");
+  boost::shared_ptr<Mantid::Geometry::Instrument> inst1 =
+      boost::make_shared<Mantid::Geometry::Instrument>();
+  inst1->setName("EMU");
 
-	for (int period = 1; period < nPeriods + 1; period++) {
-		Mantid::API::MatrixWorkspace_sptr ws =
-			createAsymmetryWorkspace(nspec, maxt, yDataAsymmetry(10.0 * period, 0.1 * period));
+  for (int period = 1; period < nPeriods + 1; period++) {
+    Mantid::API::MatrixWorkspace_sptr ws = createAsymmetryWorkspace(
+        nspec, maxt, yDataAsymmetry(10.0 * period, 0.1 * period));
 
-		wsGroup->addWorkspace(ws);
-		wsName = wsNameStem + std::to_string(period);
-		Mantid::API::AnalysisDataService::Instance().addOrReplace(wsName, ws);
-	}
+    wsGroup->addWorkspace(ws);
+    wsName = wsNameStem + std::to_string(period);
+    Mantid::API::AnalysisDataService::Instance().addOrReplace(wsName, ws);
+  }
 
-	return wsGroup;
+  return wsGroup;
 }
 
 /**

--- a/Framework/TestHelpers/src/MuonWorkspaceCreationHelper.cpp
+++ b/Framework/TestHelpers/src/MuonWorkspaceCreationHelper.cpp
@@ -59,20 +59,19 @@ double eData::operator()(const double, size_t) { return 0.005; }
  * Number of bins = maxt - 1 .
  * @param seed :: Number added to all y-values.
  * @param detectorIDseed :: detector IDs starting from this number.
- * @param hist :: Whether to output histogram data or not
+ * @param isHist :: Whether to output histogram data or not
  * @param xStart :: The start value of the x-axis.
  * @param xEnd :: The end value of the x-axis.
  * @return Pointer to the workspace.
  */
 MatrixWorkspace_sptr createCountsWorkspace(size_t nspec, size_t maxt,
                                            double seed, size_t detectorIDseed,
-                                           bool hist, double xStart,
-                                           double xEnd) {
+                                           bool isHist, double xStart, double xEnd) {
 
   MatrixWorkspace_sptr ws =
       WorkspaceCreationHelper::create2DWorkspaceFromFunction(
           yDataCounts(), static_cast<int>(nspec), xStart, xEnd,
-          (1.0 / static_cast<double>(maxt)), hist, eData());
+          (1.0 / static_cast<double>(maxt)), isHist, eData());
 
   ws->setInstrument(ComponentCreationHelper::createTestInstrumentCylindrical(
       static_cast<int>(nspec)));

--- a/Framework/WorkflowAlgorithms/test/IMuonAsymmetryCalculatorTest.h
+++ b/Framework/WorkflowAlgorithms/test/IMuonAsymmetryCalculatorTest.h
@@ -446,8 +446,8 @@ public:
       TS_ASSERT_DELTA(ws->readY(0)[1], 0.778, 0.001);
       TS_ASSERT_DELTA(ws->readY(0)[2], 0.714, 0.001);
 
-      TS_ASSERT_EQUALS(ws->readX(0)[0], 1.5);
-      TS_ASSERT_EQUALS(ws->readX(0)[1], 2.5);
+      TS_ASSERT_EQUALS(ws->readX(0)[0], 1);
+      TS_ASSERT_EQUALS(ws->readX(0)[1], 2);
       TS_ASSERT_EQUALS(ws->readX(0)[2], 3);
 
       TS_ASSERT_DELTA(ws->readE(0)[0], 0.475, 0.01);
@@ -481,8 +481,8 @@ public:
       TS_ASSERT_DELTA(ws->readY(0)[1], -0.2250, 0.0001);
       TS_ASSERT_DELTA(ws->readY(0)[2], -0.1666, 0.0001);
 
-      TS_ASSERT_EQUALS(ws->readX(0)[0], 1.5);
-      TS_ASSERT_EQUALS(ws->readX(0)[1], 2.5);
+      TS_ASSERT_EQUALS(ws->readX(0)[0], 1);
+      TS_ASSERT_EQUALS(ws->readX(0)[1], 2);
       TS_ASSERT_EQUALS(ws->readX(0)[2], 3);
 
       TS_ASSERT_DELTA(ws->readE(0)[0], 0.5290, 0.001);
@@ -512,8 +512,8 @@ public:
       TS_ASSERT_EQUALS(ws->getNumberHistograms(), 1);
       TS_ASSERT_EQUALS(ws->blocksize(), 3);
 
-      TS_ASSERT_EQUALS(ws->readX(0)[0], 1.5);
-      TS_ASSERT_EQUALS(ws->readX(0)[1], 2.5);
+      TS_ASSERT_EQUALS(ws->readX(0)[0], 1);
+      TS_ASSERT_EQUALS(ws->readX(0)[1], 2);
       TS_ASSERT_EQUALS(ws->readX(0)[2], 3);
 
       TS_ASSERT_DELTA(ws->readY(0)[0], -0.5454, 0.0001);
@@ -553,8 +553,8 @@ public:
       TS_ASSERT_DELTA(ws->readY(0)[1], 0.0330, 0.0001);
       TS_ASSERT_DELTA(ws->readY(0)[2], 0.0250, 0.0001);
 
-      TS_ASSERT_EQUALS(ws->readX(0)[0], 1.5);
-      TS_ASSERT_EQUALS(ws->readX(0)[1], 2.5);
+      TS_ASSERT_EQUALS(ws->readX(0)[0], 1);
+      TS_ASSERT_EQUALS(ws->readX(0)[1], 2);
       TS_ASSERT_EQUALS(ws->readX(0)[2], 3);
 
       TS_ASSERT_DELTA(ws->readE(0)[0], 0.4039, 0.001);
@@ -590,8 +590,8 @@ public:
       TS_ASSERT_DELTA(ws->readY(0)[1], 0.4500, 0.0001);
       TS_ASSERT_DELTA(ws->readY(0)[2], 0.3913, 0.0001);
 
-      TS_ASSERT_EQUALS(ws->readX(0)[0], 1.5);
-      TS_ASSERT_EQUALS(ws->readX(0)[1], 2.5);
+      TS_ASSERT_EQUALS(ws->readX(0)[0], 1);
+      TS_ASSERT_EQUALS(ws->readX(0)[1], 2);
       TS_ASSERT_EQUALS(ws->readX(0)[2], 3);
 
       TS_ASSERT_DELTA(ws->readE(0)[0], 0.1940, 0.001);

--- a/Framework/WorkflowAlgorithms/test/IMuonAsymmetryCalculatorTest.h
+++ b/Framework/WorkflowAlgorithms/test/IMuonAsymmetryCalculatorTest.h
@@ -1,3 +1,9 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
 #ifndef MANTID_WORKFLOWALGORITHMS_IMUONASYMMETRYCALCULATORTEST_H_
 #define MANTID_WORKFLOWALGORITHMS_IMUONASYMMETRYCALCULATORTEST_H_
 
@@ -446,8 +452,8 @@ public:
       TS_ASSERT_DELTA(ws->readY(0)[1], 0.778, 0.001);
       TS_ASSERT_DELTA(ws->readY(0)[2], 0.714, 0.001);
 
-      TS_ASSERT_EQUALS(ws->readX(0)[0], 1);
-      TS_ASSERT_EQUALS(ws->readX(0)[1], 2);
+      TS_ASSERT_EQUALS(ws->readX(0)[0], 1.5);
+      TS_ASSERT_EQUALS(ws->readX(0)[1], 2.5);
       TS_ASSERT_EQUALS(ws->readX(0)[2], 3);
 
       TS_ASSERT_DELTA(ws->readE(0)[0], 0.475, 0.01);
@@ -481,8 +487,8 @@ public:
       TS_ASSERT_DELTA(ws->readY(0)[1], -0.2250, 0.0001);
       TS_ASSERT_DELTA(ws->readY(0)[2], -0.1666, 0.0001);
 
-      TS_ASSERT_EQUALS(ws->readX(0)[0], 1);
-      TS_ASSERT_EQUALS(ws->readX(0)[1], 2);
+      TS_ASSERT_EQUALS(ws->readX(0)[0], 1.5);
+      TS_ASSERT_EQUALS(ws->readX(0)[1], 2.5);
       TS_ASSERT_EQUALS(ws->readX(0)[2], 3);
 
       TS_ASSERT_DELTA(ws->readE(0)[0], 0.5290, 0.001);
@@ -512,8 +518,8 @@ public:
       TS_ASSERT_EQUALS(ws->getNumberHistograms(), 1);
       TS_ASSERT_EQUALS(ws->blocksize(), 3);
 
-      TS_ASSERT_EQUALS(ws->readX(0)[0], 1);
-      TS_ASSERT_EQUALS(ws->readX(0)[1], 2);
+      TS_ASSERT_EQUALS(ws->readX(0)[0], 1.5);
+      TS_ASSERT_EQUALS(ws->readX(0)[1], 2.5);
       TS_ASSERT_EQUALS(ws->readX(0)[2], 3);
 
       TS_ASSERT_DELTA(ws->readY(0)[0], -0.5454, 0.0001);
@@ -553,8 +559,8 @@ public:
       TS_ASSERT_DELTA(ws->readY(0)[1], 0.0330, 0.0001);
       TS_ASSERT_DELTA(ws->readY(0)[2], 0.0250, 0.0001);
 
-      TS_ASSERT_EQUALS(ws->readX(0)[0], 1);
-      TS_ASSERT_EQUALS(ws->readX(0)[1], 2);
+      TS_ASSERT_EQUALS(ws->readX(0)[0], 1.5);
+      TS_ASSERT_EQUALS(ws->readX(0)[1], 2.5);
       TS_ASSERT_EQUALS(ws->readX(0)[2], 3);
 
       TS_ASSERT_DELTA(ws->readE(0)[0], 0.4039, 0.001);
@@ -590,8 +596,8 @@ public:
       TS_ASSERT_DELTA(ws->readY(0)[1], 0.4500, 0.0001);
       TS_ASSERT_DELTA(ws->readY(0)[2], 0.3913, 0.0001);
 
-      TS_ASSERT_EQUALS(ws->readX(0)[0], 1);
-      TS_ASSERT_EQUALS(ws->readX(0)[1], 2);
+      TS_ASSERT_EQUALS(ws->readX(0)[0], 1.5);
+      TS_ASSERT_EQUALS(ws->readX(0)[1], 2.5);
       TS_ASSERT_EQUALS(ws->readX(0)[2], 3);
 
       TS_ASSERT_DELTA(ws->readE(0)[0], 0.1940, 0.001);


### PR DESCRIPTION
Refs #23642

### Summary

This short PR establishes some small modifications required for the new Muon algorithms to work correctly.

Specifically;

- Three new functions are added to the muon algorithm helper file, to do some common operations which are used by the new muon algorithms (#23678, #23679, #23680, #23681).
- The `EstimateMuonAsymmetryFromCounts` has been modified to accept a NormalizationTable optionally (rather than mandatory as before); as in my use cases it is not required; plus making it mandatory enforces that the algorithm uses the ADS; in my use cases this is also unwanted. The `NormalizationTable` is itself a very recent addition to the algorithm, and so correcting its behaviour should not affect any current usages of it (it just simply allows the caller not to supply a normalization table if they don't need to).

### Unit Tests

As per instruction; unit tests have not been written yet, to focus on the functionality. Unit tests on the three new functions should be added at some point.

-----------------------------------

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
