### PR TITLE
ISIS Powder Gem Removed intermediate workspaces

### DIFF
--- a/scripts/Diffraction/isis_powder/routines/focus.py
+++ b/scripts/Diffraction/isis_powder/routines/focus.py
@@ -79,6 +79,7 @@ def _focus_one_ws(input_workspace, run_number, instrument, perform_vanadium_norm
     # Tidy workspaces from Mantid
     common.remove_intermediate_workspace(input_workspace)
     common.remove_intermediate_workspace(aligned_ws)
+    print(("Remove " + str(focused_ws)))
     common.remove_intermediate_workspace(focused_ws)
     common.remove_intermediate_workspace(output_spectra)
 
@@ -120,8 +121,10 @@ def _divide_one_spectrum_by_spline(spectrum, spline, instrument):
     if instrument.get_instrument_prefix() == "GEM":
         divided = mantid.Divide(LHSWorkspace=spectrum, RHSWorkspace=rebinned_spline, OutputWorkspace=spectrum,
                                 StoreInADS=False)
-        return _crop_spline_to_percent_of_max(rebinned_spline, divided, spectrum)
-
+        output =_crop_spline_to_percent_of_max(rebinned_spline, divided, spectrum)
+        mantid.mtd['output'] = output
+        common.remove_intermediate_workspace(divided)
+        return output
     divided = mantid.Divide(LHSWorkspace=spectrum, RHSWorkspace=rebinned_spline, OutputWorkspace=spectrum)
     return divided
 
@@ -169,7 +172,7 @@ def _test_splined_vanadium_exists(instrument, run_details):
 def _crop_spline_to_percent_of_max(spline, input_ws, output_workspace):
     spline_spectrum = spline.readY(0)
     y_val = numpy.amax(spline_spectrum)
-    y_val = y_val / 100
+    y_val = y_val / 50
     x_list = input_ws.readX(0)
     small_spline_indecies = numpy.nonzero(spline_spectrum > y_val)[0]
     x_max = x_list[small_spline_indecies[-1]]

--- a/scripts/Diffraction/isis_powder/routines/focus.py
+++ b/scripts/Diffraction/isis_powder/routines/focus.py
@@ -79,6 +79,7 @@ def _focus_one_ws(input_workspace, run_number, instrument, perform_vanadium_norm
     # Tidy workspaces from Mantid
     common.remove_intermediate_workspace(input_workspace)
     common.remove_intermediate_workspace(aligned_ws)
+    print(("Remove " + str(focused_ws)))
     common.remove_intermediate_workspace(focused_ws)
     common.remove_intermediate_workspace(output_spectra)
 
@@ -120,10 +121,7 @@ def _divide_one_spectrum_by_spline(spectrum, spline, instrument):
     if instrument.get_instrument_prefix() == "GEM":
         divided = mantid.Divide(LHSWorkspace=spectrum, RHSWorkspace=rebinned_spline, OutputWorkspace=spectrum,
                                 StoreInADS=False)
-        output =_crop_spline_to_percent_of_max(rebinned_spline, divided, spectrum)
-        mantid.mtd['output'] = output
-        common.remove_intermediate_workspace(divided)
-        return output
+        return _crop_spline_to_percent_of_max(rebinned_spline, divided, spectrum)
     divided = mantid.Divide(LHSWorkspace=spectrum, RHSWorkspace=rebinned_spline, OutputWorkspace=spectrum)
     return divided
 
@@ -171,7 +169,7 @@ def _test_splined_vanadium_exists(instrument, run_details):
 def _crop_spline_to_percent_of_max(spline, input_ws, output_workspace):
     spline_spectrum = spline.readY(0)
     y_val = numpy.amax(spline_spectrum)
-    y_val = y_val / 100
+    y_val = y_val / 50
     x_list = input_ws.readX(0)
     small_spline_indecies = numpy.nonzero(spline_spectrum > y_val)[0]
     x_max = x_list[small_spline_indecies[-1]]

--- a/scripts/Diffraction/isis_powder/routines/focus.py
+++ b/scripts/Diffraction/isis_powder/routines/focus.py
@@ -79,7 +79,6 @@ def _focus_one_ws(input_workspace, run_number, instrument, perform_vanadium_norm
     # Tidy workspaces from Mantid
     common.remove_intermediate_workspace(input_workspace)
     common.remove_intermediate_workspace(aligned_ws)
-    print(("Remove " + str(focused_ws)))
     common.remove_intermediate_workspace(focused_ws)
     common.remove_intermediate_workspace(output_spectra)
 
@@ -172,7 +171,7 @@ def _test_splined_vanadium_exists(instrument, run_details):
 def _crop_spline_to_percent_of_max(spline, input_ws, output_workspace):
     spline_spectrum = spline.readY(0)
     y_val = numpy.amax(spline_spectrum)
-    y_val = y_val / 50
+    y_val = y_val / 100
     x_list = input_ws.readX(0)
     small_spline_indecies = numpy.nonzero(spline_spectrum > y_val)[0]
     x_max = x_list[small_spline_indecies[-1]]


### PR DESCRIPTION
**Description of work.**
added a step to remove intermediate workspaces created during vanadium normalization.

**To test:**
*This test will only run on the ISIS Data Search archive*
Run the following script
```
from isis_powder import Gem

config_file_path = r"Path/To/Gem_config_example.yaml"
Gem_example = Gem(config_file=config_file_path,user_name="test")
Gem_example.create_vanadium(input_mode="Individual",first_cycle_run_no=85374,texture_mode=True)
Gem_example.focus(input_mode="Individual", run_number="85374",texture_mode=True)
``` 
with the following [files](https://github.com/mantidproject/mantid/files/2437921/GemTest.zip) (be sure to update paths)

there should be no workspaces not in groups  in the ADS when the script finishes.

Fixes #23685 


This does not require release notes as it merely addresses a bug that has only existed between releases.




---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
