### PR TITLE
Indirect - Disable output buttons during a fit

### DIFF
--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -26,7 +26,7 @@ Data Analysis Interface
 Improvements
 ############
 
-- The Run button in the Data Analysis tabs is now above the output options, and is disabled during fitting.
+- The Run button is now above the output options, and is disabled during fitting along with the output buttons.
 - The Fit Single Spectrum buttons in the Data Analysis tabs MSDFit, ConvFit, I(Q,t)Fit and F(Q)Fit are now disabled
   during fitting.
 - When the InelasticDiffSphere, InelasticDiffRotDiscreteCircle, ElasticDiffSphere or ElasticDiffRotDiscreteCircle

--- a/qt/scientific_interfaces/Indirect/ConvFit.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFit.cpp
@@ -192,6 +192,8 @@ void ConvFit::setSaveResultEnabled(bool enabled) {
 void ConvFit::setRunIsRunning(bool running) {
   m_uiForm->pbRun->setText(running ? "Running..." : "Run");
   setRunEnabled(!running);
+  setPlotResultEnabled(!running);
+  setSaveResultEnabled(!running);
   setFitSingleSpectrumEnabled(!running);
 }
 

--- a/qt/scientific_interfaces/Indirect/Elwin.cpp
+++ b/qt/scientific_interfaces/Indirect/Elwin.cpp
@@ -526,6 +526,8 @@ void Elwin::setSaveResultEnabled(bool enabled) {
 void Elwin::setRunIsRunning(bool running) {
   m_uiForm.pbRun->setText(running ? "Running..." : "Run");
   setRunEnabled(!running);
+  setPlotResultEnabled(!running);
+  setSaveResultEnabled(!running);
 }
 
 void Elwin::setPlotResultIsPlotting(bool plotting) {

--- a/qt/scientific_interfaces/Indirect/Iqt.cpp
+++ b/qt/scientific_interfaces/Indirect/Iqt.cpp
@@ -475,6 +475,9 @@ void Iqt::setSaveResultEnabled(bool enabled) {
 void Iqt::setRunIsRunning(bool running) {
   m_uiForm.pbRun->setText(running ? "Running..." : "Run");
   setRunEnabled(!running);
+  setPlotResultEnabled(!running);
+  setSaveResultEnabled(!running);
+  setTiledPlotEnabled(!running);
 }
 
 void Iqt::setPlotResultIsPlotting(bool plotting) {

--- a/qt/scientific_interfaces/Indirect/IqtFit.cpp
+++ b/qt/scientific_interfaces/Indirect/IqtFit.cpp
@@ -149,6 +149,8 @@ void IqtFit::setSaveResultEnabled(bool enabled) {
 void IqtFit::setRunIsRunning(bool running) {
   m_uiForm->pbRun->setText(running ? "Running..." : "Run");
   setRunEnabled(!running);
+  setPlotResultEnabled(!running);
+  setSaveResultEnabled(!running);
   setFitSingleSpectrumEnabled(!running);
 }
 

--- a/qt/scientific_interfaces/Indirect/JumpFit.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFit.cpp
@@ -111,6 +111,8 @@ void JumpFit::setSaveResultEnabled(bool enabled) {
 void JumpFit::setRunIsRunning(bool running) {
   m_uiForm->pbRun->setText(running ? "Running..." : "Run");
   setRunEnabled(!running);
+  setPlotResultEnabled(!running);
+  setSaveResultEnabled(!running);
   setFitSingleSpectrumEnabled(!running);
 }
 

--- a/qt/scientific_interfaces/Indirect/MSDFit.cpp
+++ b/qt/scientific_interfaces/Indirect/MSDFit.cpp
@@ -92,6 +92,8 @@ void MSDFit::setSaveResultEnabled(bool enabled) {
 void MSDFit::setRunIsRunning(bool running) {
   m_uiForm->pbRun->setText(running ? "Running..." : "Run");
   setRunEnabled(!running);
+  setPlotResultEnabled(!running);
+  setSaveResultEnabled(!running);
   setFitSingleSpectrumEnabled(!running);
 }
 


### PR DESCRIPTION
**Description of work.**
This PR disables the output buttons `Plot Result` and `Save Result` (as well as `Tiled Plot` for the `I(Q,t)` Tab) in the Indirect Data Analysis Interface.

**To test:**
1. `Interfaces`->Indirect Data Analysis`->All tabs
2. Run a fit with the data below for each tab
3. After the first `Run`, click `Run` again and ensure the buttons stated above are disabled while running

### **Test Data**
**Elwin Tab**
Input file: [irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2361048/irs26176_graphite002_red.zip)

**MSDFit Tab**
Input file: [osi92762_graphite002_elwin_eq.zip](https://github.com/mantidproject/mantid/files/2361050/osi92762_graphite002_elwin_eq.zip)
Fit Type: `Guassian`

**Iqt Tab**
Input files: [irs26173_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2361057/irs26173_graphite002_red.zip)
[irs26173_graphite002_res.zip](https://github.com/mantidproject/mantid/files/2361058/irs26173_graphite002_res.zip)


**IqtFit Tab**
Input file: [irs26176_graphite002_iqt.zip](https://github.com/mantidproject/mantid/files/2361062/irs26176_graphite002_iqt.zip)
Exponential: `2`
Note: drag the blue line on the graph to the left a bit

**ConvFit Tab**
Input files: [irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2361070/irs26176_graphite002_red.zip)
[irs26173_graphite002_res.zip](https://github.com/mantidproject/mantid/files/2361071/irs26173_graphite002_res.zip)
Fit Type: `One Lorenztian`

**F(Q) Tab**
Input file: [IN16B_125878_QLd_Result.zip](https://github.com/mantidproject/mantid/files/2361073/IN16B_125878_QLd_Result.zip)
Fit Type: `Chudley Elliott`

Fixes #23688 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
