### PR TITLE
Fix bug when reducing a series of files

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SNAPReduce.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNAPReduce.py
@@ -262,8 +262,8 @@ class SNAPReduce(DataProcessorAlgorithm):
             maskFile = self.getProperty('MaskingFilename').value
         # TODO not reading the correct mask file geometry
         elif masking == 'Horizontal' or masking == 'Vertical':
-            maskWSname = masking + 'Mask' # append the work 'Mask' for the wksp name
-            if not mtd.doesExist(maskWSname): # only load if it isn't already loaded
+            maskWSname = masking + 'Mask'  # append the work 'Mask' for the wksp name
+            if not mtd.doesExist(maskWSname):  # only load if it isn't already loaded
                 maskFile = '/SNS/SNAP/shared/libs/%s_Mask.xml' % masking
 
         if maskFile is not None:
@@ -308,7 +308,7 @@ class SNAPReduce(DataProcessorAlgorithm):
                 peak_clip_WS.setY(h, self.peak_clip(peak_clip_WS.readY(h), win=window, decrese=True,
                                                     LLS=True, smooth_window=smooth_range))
             return str(peak_clip_WS)
-        else: # other values are already held in normWS
+        else:  # other values are already held in normWS
             return normWS
 
     def _save(self, saveDir, basename, outputWksp):
@@ -342,20 +342,16 @@ class SNAPReduce(DataProcessorAlgorithm):
         return wsname
 
     def PyExec(self):
-        # Retrieve all relevant notice
-
         in_Runs = self.getProperty("RunNumbers").value
-
         maskWSname = self._getMaskWSname()
-
         progress = Progress(self, 0., .25, 3)
 
         # default arguments for AlignAndFocusPowder
-        alignAndFocusArgs={'TMax':50000,
-                           'RemovePromptPulseWidth':1600,
-                           'PreserveEvents':False,
-                           'Dspacing':True,  # binning parameters in d-space
-                           'Params':self.getProperty("Binning").value}
+        alignAndFocusArgs = {'TMax': 50000,
+                             'RemovePromptPulseWidth': 1600,
+                             'PreserveEvents': False,
+                             'Dspacing': True,  # binning parameters in d-space
+                             'Params': self.getProperty("Binning").value}
 
         # workspace for loading metadata only to be used in LoadDiffCal and
         # CreateGroupingWorkspace
@@ -406,7 +402,7 @@ class SNAPReduce(DataProcessorAlgorithm):
 
         progStart = .25
         progDelta = (1.-progStart)/len(in_Runs)
-        for runnumber in in_Runs:
+        for i, runnumber in enumerate(in_Runs):
             self.log().notice("processing run %s" % runnumber)
             self.log().information(str(self.get_IPTS_Local(runnumber)))
 
@@ -438,8 +434,8 @@ class SNAPReduce(DataProcessorAlgorithm):
                                 MaskWorkspace=maskWSname,  # can be empty string
                                 GroupingWorkspace=group,
                                 UnfocussedWorkspace=unfocussedWksp,  # can be empty string
-                                startProgress = progStart,
-                                endProgress = progStart + .5 * progDelta,
+                                startProgress=progStart,
+                                endProgress=progStart + .5 * progDelta,
                                 **alignAndFocusArgs)
             progStart += .5 * progDelta
 
@@ -505,12 +501,17 @@ class SNAPReduce(DataProcessorAlgorithm):
             self.setProperty(propertyName, outputWksp)
 
             # declare some things as extra outputs in set-up
-            if Process_Mode != "Production":  # TODO set them as workspace properties
-                propNames = ['OuputWorkspace_'+str(it) for it in ['d', 'norm', 'normalizer']]
-                wkspNames = ['%s_%s_d' % (new_Tag, runnumber), basename + '_red', '%s_%s_normalizer' % (new_Tag, runnumber)]
+            if Process_Mode != "Production":
+                prefix = 'OuputWorkspace_{:d}_'.format(i)
+                propNames = [prefix + it for it in ['d', 'norm', 'normalizer']]
+                wkspNames = ['%s_%s_d' % (new_Tag, runnumber),
+                             basename + '_red',
+                             '%s_%s_normalizer' % (new_Tag, runnumber)]
                 for (propName, wkspName) in zip(propNames, wkspNames):
                     if mtd.doesExist(wkspName):
-                        self.declareProperty(WorkspaceProperty(propName, wkspName, Direction.Output))
+                        self.declareProperty(WorkspaceProperty(propName,
+                                                               wkspName,
+                                                               Direction.Output))
                         self.setProperty(propName, wkspName)
 
 


### PR DESCRIPTION
The problem was in the creation of optional output workspace on-the-fly in `SNAPReduce`. The fix was to create unique property names. Additional minor pep8 fixes were implemented as well.

**Report to:** Moreira Dos Santos

**To test:**

Reduce a single SNAP run and a series.

*There is no associated issue.*

*This does not require release notes* because it is a fix to functionality that most people don't notice.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
