### PR TITLE
Indirect - MSD Fit - Add option to choose which output parameter to plot

### DIFF
--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -32,8 +32,9 @@ Improvements
 - When the InelasticDiffSphere, InelasticDiffRotDiscreteCircle, ElasticDiffSphere or ElasticDiffRotDiscreteCircle
   Fit Types are selected in the ConvFit Tab, the Q values are retrieved from the workspaces, preventing a crash 
   when plotting a guess.
-- The Plot Result buttons in MSDFit and F(Q)Fit are disabled after a Run when the result workspace only has one
+- The Plot buttons in MSDFit and F(Q)Fit are disabled after a Run when the result workspace only has one
   data point to plot.
+- There is now an option to choose which output parameter to plot in MSDFit.
 - An option to skip the calculation of Monte Carlo Errors on the I(Q,t) Tab has been added.
 - During the calculation of Monte Carlo Errors, a progress bar is now shown.
 

--- a/qt/scientific_interfaces/Indirect/JumpFit.ui
+++ b/qt/scientific_interfaces/Indirect/JumpFit.ui
@@ -223,6 +223,9 @@
              </item>
              <item>
               <widget class="QComboBox" name="cbPlotType">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
                <property name="minimumSize">
                 <size>
                  <width>100</width>
@@ -244,6 +247,9 @@
              </item>
              <item>
               <widget class="QPushButton" name="pbPlot">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
                <property name="text">
                 <string>Plot</string>
                </property>

--- a/qt/scientific_interfaces/Indirect/MSDFit.cpp
+++ b/qt/scientific_interfaces/Indirect/MSDFit.cpp
@@ -58,11 +58,13 @@ void MSDFit::updateModelFitTypeString() {
   m_msdFittingModel->setFitType(selectedFitType().toStdString());
 }
 
-void MSDFit::updatePlotOptions() {}
+void MSDFit::updatePlotOptions() {
+  IndirectFitAnalysisTab::updatePlotOptions(m_uiForm->cbPlotType);
+}
 
 void MSDFit::plotClicked() {
   setPlotResultIsPlotting(true);
-  IndirectFitAnalysisTab::plotResult("All");
+  IndirectFitAnalysisTab::plotResult(m_uiForm->cbPlotType->currentText());
   setPlotResultIsPlotting(false);
 }
 
@@ -79,6 +81,7 @@ void MSDFit::setRunEnabled(bool enabled) {
 
 void MSDFit::setPlotResultEnabled(bool enabled) {
   m_uiForm->pbPlot->setEnabled(enabled);
+  m_uiForm->cbPlotType->setEnabled(enabled);
 }
 
 void MSDFit::setFitSingleSpectrumEnabled(bool enabled) {
@@ -96,7 +99,7 @@ void MSDFit::setRunIsRunning(bool running) {
 }
 
 void MSDFit::setPlotResultIsPlotting(bool plotting) {
-  m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot Result");
+  m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot");
   setPlotResultEnabled(!plotting);
 }
 

--- a/qt/scientific_interfaces/Indirect/MSDFit.ui
+++ b/qt/scientific_interfaces/Indirect/MSDFit.ui
@@ -122,12 +122,43 @@
             </property>
             <layout class="QHBoxLayout" name="horizontalLayout_8">
              <item>
+              <widget class="QLabel" name="label">
+               <property name="text">
+                <string>Plot Output:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QComboBox" name="cbPlotType">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>100</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>100</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+               <item>
+                <property name="text">
+                 <string>All</string>
+                </property>
+               </item>
+              </widget>
+             </item>
+             <item>
               <widget class="QPushButton" name="pbPlot">
                <property name="enabled">
                 <bool>false</bool>
                </property>
                <property name="text">
-                <string>Plot Result</string>
+                <string>Plot</string>
                </property>
                <property name="checked">
                 <bool>false</bool>


### PR DESCRIPTION
**Description of work.**
This PR introduces an option which allows you to select which output parameter you want to `Plot` in MSD Fit. This option should work like the one in `F(Q) Fit`.

**To test:**
1. `Interfaces`->`Indirect Data Analysis`->`MSD Fit` tab
2. Load the data below
3. Select `Fit Type` to be Gaussian
4. Click `Run` and wait
5. There should be options for `All`, `MSD` and `Height` in the Plot Output combo box
6. Select each option in turn and click `Plot`. The relevant graphs should be plotted

**Data Files**
[osi104367-104371_graphite002_red_elwin_eq.zip](https://github.com/mantidproject/mantid/files/2441714/osi104367-104371_graphite002_red_elwin_eq.zip)

Fixes #23699 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
