### PR TITLE
Turn off logging for Project Serialiser when saving instrument window

### DIFF
--- a/docs/source/release/v3.14.0/ui.rst
+++ b/docs/source/release/v3.14.0/ui.rst
@@ -29,6 +29,7 @@ Bugfixes
 - Workspaces with a '#' in their name will no longer cause issues in the loading of a recovered project
 - Project Recovery will actually recover fully cases where multiple workspaces were passed as a list to an algorithm (Fixes a known bug with GroupWorkspaces as well)
 - Project Recovery will now run normally when you select no or the recovery fails when recovering from a ungraceful exit.
+- When autosaving or saving a recovery checkpoint with the Instrument View open the results log would be filled with excess logging and no longer does this.
 
 MantidPlot
 ----------

--- a/qt/widgets/instrumentview/src/InstrumentActor.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentActor.cpp
@@ -758,6 +758,7 @@ Mantid::API::MatrixWorkspace_sptr InstrumentActor::extractCurrentMask() const {
                                                                 -1);
   alg->setPropertyValue("InputWorkspace", getWorkspace()->getName());
   alg->setPropertyValue("OutputWorkspace", maskName);
+  alg->setLogging(false);
   alg->execute();
 
   Mantid::API::MatrixWorkspace_sptr maskWorkspace =

--- a/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
@@ -1365,6 +1365,7 @@ bool InstrumentWidgetMaskTab::saveMaskViewToProject(
     alg->setProperty("InputWorkspace",
                      boost::dynamic_pointer_cast<Workspace>(outputWS));
     alg->setPropertyValue("OutputFile", fileName);
+    alg->setLogging(false);
     alg->execute();
 
   } catch (...) {


### PR DESCRIPTION
**Description of work.**
I turned off the logging of ExtractMask and SaveMask which would stop the spamming of the logs

**To test:**
- Start Mantid
- Load a workspace with an instrument e.g. OFFSPEC44956 (Doesn't matter what instrument)
- Right click on the workspace in the ADS and click show instrument
- Set your logging level in the log to Information
- Then run this script ```mantidplot.app.saveRecoveryCheckpoint()```
- Notice whether or not ExtractMask and SaveMask appear in the Log results
- If they don't then it is fixed.

Fixes #23518

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
