### PR TITLE
Peak numbers unique when peak workspaces combined

### DIFF
--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -267,7 +267,8 @@ void SaveIsawPeaks::exec() {
   runMap_t::iterator runMap_it;
   for (runMap_it = runMap.begin(); runMap_it != runMap.end(); ++runMap_it) {
     // Start of a new run
-    if (maxPeakNumb > 0) appendPeakNumb += maxPeakNumb + 1;
+    if (maxPeakNumb > 0)
+      appendPeakNumb += maxPeakNumb + 1;
     int run = runMap_it->first;
     bankMap_t &bankMap = runMap_it->second;
 

--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -267,8 +267,10 @@ void SaveIsawPeaks::exec() {
   runMap_t::iterator runMap_it;
   for (runMap_it = runMap.begin(); runMap_it != runMap.end(); ++runMap_it) {
     // Start of a new run
-    if (maxPeakNumb > 0)
+    if (maxPeakNumb > 0) {
       appendPeakNumb += maxPeakNumb + 1;
+      maxPeakNumb = 0;
+    }
     int run = runMap_it->first;
     bankMap_t &bankMap = runMap_it->second;
 

--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -267,7 +267,7 @@ void SaveIsawPeaks::exec() {
   runMap_t::iterator runMap_it;
   for (runMap_it = runMap.begin(); runMap_it != runMap.end(); ++runMap_it) {
     // Start of a new run
-    appendPeakNumb += maxPeakNumb;
+    if (maxPeakNumb > 0) appendPeakNumb += maxPeakNumb + 1;
     int run = runMap_it->first;
     bankMap_t &bankMap = runMap_it->second;
 

--- a/docs/source/release/v3.14.0/diffraction.rst
+++ b/docs/source/release/v3.14.0/diffraction.rst
@@ -41,6 +41,7 @@ Bugfixes
 - :ref:`CentroidPeaksMD <algm-CentroidPeaksMD>` now updates peak bin counts.
 
 - :ref:`FindPeaksMD <algm-FindPeaksMD>` now finds peaks correctly with the crystallography convention setting and reduction with crystallography convention is tested with a system test.
+- :ref:`SaveIsawPeaks <algm-SaveIsawPeaks>` does not have duplicate peak numbers when saving PeaksWorkspaces with more than one RunNumber.
 
 Powder Diffraction
 ------------------


### PR DESCRIPTION
**Description of work.**
No duplicate peak numbers when combining orientations. Peak numbers are only used for topaz reduction.

**Report to:** [wangx@ornl.gov]/[nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**
````python
LoadIsawPeaks(Filename='/SNS/TOPAZ/IPTS-21677/shared/si-ch/si-ch_Niggli.integrate', OutputWorkspace='Niggli')
SaveIsawPeaks(Filename='~/test.integrate', InputWorkspace='Niggli')
LoadIsawPeaks(Filename='~/test.integrate', OutputWorkspace='Niggli2')
````
Check that last column (PeakNumber) is not the same for last peak of each RunNumber and first of the next RunNumber in Niggli2.

Fixes #23697 
<!-- alternative
*There is no associated issue.*
-->




---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
