### PR TITLE
Save message window log level in user settings

### DIFF
--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -64,7 +64,7 @@ def qapplication():
     if app is None:
         QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
         argv = sys.argv[:]
-        argv[0] = APPNAME # replace application name
+        argv[0] = APPNAME  # replace application name
         app = QApplication(argv)
         app.setOrganizationName(ORGANIZATION)
         app.setOrganizationDomain(ORG_DOMAIN)
@@ -328,11 +328,11 @@ class MainWindow(QMainWindow):
     def closeEvent(self, event):
         # Close editors
         if self.editor.app_closing():
-            self.writeSettings(CONF) # write current window information to global settings object
+            self.writeSettings(CONF)  # write current window information to global settings object
 
             # Close all open plots
             # We don't want this at module scope here
-            import matplotlib.pyplot as plt  #noqa
+            import matplotlib.pyplot as plt  # noqa
             plt.close('all')
 
             event.accept()
@@ -360,13 +360,13 @@ class MainWindow(QMainWindow):
         qapp = QApplication.instance()
         qapp.setAttribute(Qt.AA_UseHighDpiPixmaps)
         if hasattr(Qt, 'AA_EnableHighDpiScaling'):
-            qapp.setAttribute(Qt.AA_EnableHighDpiScaling, settings.get('main/high_dpi_scaling'))
+            qapp.setAttribute(Qt.AA_EnableHighDpiScaling, settings.get('high_dpi_scaling'))
 
         # get the saved window geometry
-        window_size = settings.get('main/window/size')
+        window_size = settings.get('MainWindow/size')
         if not isinstance(window_size, QSize):
             window_size = QSize(*window_size)
-        window_pos = settings.get('main/window/position')
+        window_pos = settings.get('MainWindow/position')
         if not isinstance(window_pos, QPoint):
             window_pos = QPoint(*window_pos)
 
@@ -392,8 +392,8 @@ class MainWindow(QMainWindow):
         self.move(window_pos)
 
         # restore window state
-        if settings.has('main/window/state'):
-            self.restoreState(settings.get('main/window/state'))
+        if settings.has('MainWindow/state'):
+            self.restoreState(settings.get('MainWindow/state'))
         else:
             self.setWindowState(Qt.WindowMaximized)
 
@@ -404,9 +404,9 @@ class MainWindow(QMainWindow):
                 widget.readSettings(settings)
 
     def writeSettings(self, settings):
-        settings.set('main/window/size', self.size()) # QSize
-        settings.set('main/window/position', self.pos()) # QPoint
-        settings.set('main/window/state', self.saveState()) # QByteArray
+        settings.set('MainWindow/size', self.size())        # QSize
+        settings.set('MainWindow/position', self.pos())     # QPoint
+        settings.set('MainWindow/state', self.saveState())  # QByteArray
 
         # write out settings for children
         AlgorithmInputHistory().writeSettings(settings)

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -113,9 +113,6 @@ class MainWindow(QMainWindow):
         # -- instance attributes --
         self.setWindowTitle("Mantid Workbench")
 
-        # uses default configuration as necessary
-        self.readSettings(CONF)
-
         # widgets
         self.messagedisplay = None
         self.ipythonconsole = None
@@ -183,6 +180,9 @@ class MainWindow(QMainWindow):
         self.workspacewidget = WorkspaceWidget(self)
         self.workspacewidget.register_plugin()
         self.widgets.append(self.workspacewidget)
+
+        # uses default configuration as necessary
+        self.readSettings(CONF)
 
         self.setup_layout()
         self.create_actions()
@@ -397,16 +397,22 @@ class MainWindow(QMainWindow):
         else:
             self.setWindowState(Qt.WindowMaximized)
 
-        # have algorithm dialogs do their thing
+        # read in settings for children
         AlgorithmInputHistory().readSettings(settings)
+        for widget in self.widgets:
+            if hasattr(widget, 'readSettings'):
+                widget.readSettings(settings)
 
     def writeSettings(self, settings):
         settings.set('main/window/size', self.size()) # QSize
         settings.set('main/window/position', self.pos()) # QPoint
         settings.set('main/window/state', self.saveState()) # QByteArray
 
-        # have algorithm dialogs do their thing
+        # write out settings for children
         AlgorithmInputHistory().writeSettings(settings)
+        for widget in self.widgets:
+            if hasattr(widget, 'writeSettings'):
+                widget.writeSettings(settings)
 
 
 def initialize():

--- a/qt/applications/workbench/workbench/config/__init__.py
+++ b/qt/applications/workbench/workbench/config/__init__.py
@@ -30,10 +30,10 @@ APPNAME = 'mantidworkbench'
 # Iterable containing defaults for each configurable section of the code
 # General application settings are in the main section
 DEFAULTS = {
-    'main': {
-      'high_dpi_scaling': True,
-      'window/size': (1260, 740),
-      'window/position': (10, 10),
+    'high_dpi_scaling': True,
+    'MainWindow': {
+        'size': (1260, 740),
+        'position': (10, 10),
     }
 }
 

--- a/qt/applications/workbench/workbench/plugins/algorithmselectorwidget.py
+++ b/qt/applications/workbench/workbench/plugins/algorithmselectorwidget.py
@@ -17,6 +17,7 @@ from qtpy.QtWidgets import QVBoxLayout
 
 # local package imports
 from workbench.plugins.base import PluginWidget
+# from mantidqt.utils.qt import toQSettings when readSettings/writeSettings are implemented
 
 
 class AlgorithmSelector(PluginWidget):
@@ -39,5 +40,8 @@ class AlgorithmSelector(PluginWidget):
     def get_plugin_title(self):
         return "Algorithms"
 
-    def read_user_settings(self, _):
+    def readSettings(self, _):
+        pass
+
+    def writeSettings(self, _):
         pass

--- a/qt/applications/workbench/workbench/plugins/base.py
+++ b/qt/applications/workbench/workbench/plugins/base.py
@@ -36,9 +36,14 @@ class PluginWidget(QWidget):
     def get_plugin_title(self):
         raise NotImplementedError()
 
-    def read_user_settings(self, qsettings):
+    def readSettings(self, qsettings):
         """Called by the main window to ask the plugin to
         load user configuration"""
+        raise NotImplementedError()
+
+    def writeSettings(self, qsettings):
+        """Called by the main window to ask the plugin to
+        save user configuration"""
         raise NotImplementedError()
 
     def register_plugin(self, menu=None):

--- a/qt/applications/workbench/workbench/plugins/editor.py
+++ b/qt/applications/workbench/workbench/plugins/editor.py
@@ -19,6 +19,7 @@ from qtpy.QtWidgets import QVBoxLayout
 
 # local package imports
 from workbench.plugins.base import PluginWidget
+# from mantidqt.utils.qt import toQSettings when readSettings/writeSettings are implemented
 
 
 # Initial content
@@ -75,7 +76,10 @@ class MultiFileEditor(PluginWidget):
     def get_plugin_title(self):
         return "Editor"
 
-    def read_user_settings(self, _):
+    def readSettings(self, _):
+        pass
+
+    def writeSettings(self, _):
         pass
 
     def register_plugin(self):

--- a/qt/applications/workbench/workbench/plugins/jupyterconsole.py
+++ b/qt/applications/workbench/workbench/plugins/jupyterconsole.py
@@ -16,7 +16,7 @@ import sys
 from mantidqt.widgets.jupyterconsole import InProcessJupyterConsole
 try:
     from IPython.core.usage import quick_guide
-except ImportError: # quick_guide was removed in IPython 6.0
+except ImportError:  # quick_guide was removed in IPython 6.0
     quick_guide = ''
 from IPython.core.usage import release as ipy_release
 from matplotlib import __version__ as mpl_version
@@ -25,6 +25,7 @@ from qtpy.QtWidgets import QVBoxLayout
 
 # local package imports
 from workbench.plugins.base import PluginWidget
+# from mantidqt.utils.qt import toQSettings when readSettings/writeSettings are implemented
 
 DEFAULT_BANNER_PARTS = [
     'IPython {version} -- An enhanced Interactive Python.\n'.format(
@@ -63,7 +64,10 @@ class JupyterConsole(PluginWidget):
     def get_plugin_title(self):
         return "IPython"
 
-    def read_user_settings(self, _):
+    def readSettings(self, _):
+        pass
+
+    def writeSettings(self, _):
         pass
 
     def register_plugin(self, menu=None):

--- a/qt/applications/workbench/workbench/plugins/logmessagedisplay.py
+++ b/qt/applications/workbench/workbench/plugins/logmessagedisplay.py
@@ -19,6 +19,7 @@ from qtpy.QtWidgets import QHBoxLayout
 
 # local imports
 from workbench.plugins.base import PluginWidget
+from mantidqt.utils.qt import toQSettings
 
 # Default logs at notice
 DEFAULT_LOG_PRIORITY = 5
@@ -47,8 +48,11 @@ class LogMessageDisplay(PluginWidget):
     def get_plugin_title(self):
         return "Messages"
 
-    def read_user_settings(self, qsettings):
-        self.display.readSettings(qsettings)
+    def readSettings(self, settings):
+        self.display.readSettings(toQSettings(settings))
+
+    def writeSettings(self, settings):
+        self.display.writeSettings(toQSettings(settings))
 
     def register_plugin(self, menu=None):
         self.display.attachLoggingChannel(DEFAULT_LOG_PRIORITY)

--- a/qt/applications/workbench/workbench/plugins/plotselectorwidget.py
+++ b/qt/applications/workbench/workbench/plugins/plotselectorwidget.py
@@ -18,6 +18,7 @@ from qtpy.QtWidgets import QVBoxLayout
 from workbench.plugins.base import PluginWidget
 from workbench.plotting.globalfiguremanager import GlobalFigureManager
 from workbench.widgets.plotselector.presenter import PlotSelectorPresenter
+# from mantidqt.utils.qt import toQSettings when readSettings/writeSettings are implemented
 
 
 class PlotSelector(PluginWidget):
@@ -42,5 +43,8 @@ class PlotSelector(PluginWidget):
     def get_plugin_title(self):
         return "Plots"
 
-    def read_user_settings(self, _):
+    def readSettings(self, _):
+        pass
+
+    def writeSettings(self, _):
         pass

--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -20,6 +20,7 @@ from qtpy.QtWidgets import QMessageBox, QVBoxLayout
 # local package imports
 from workbench.plugins.base import PluginWidget
 from workbench.plotting.functions import can_overplot, pcolormesh, plot_from_names
+# from mantidqt.utils.qt import toQSettings when readSettings/writeSettings are implemented
 
 
 class WorkspaceWidget(PluginWidget):
@@ -55,7 +56,10 @@ class WorkspaceWidget(PluginWidget):
     def get_plugin_title(self):
         return "Workspaces"
 
-    def read_user_settings(self, _):
+    def readSettings(self, _):
+        pass
+
+    def writeSettings(self, _):
         pass
 
     # ----------------- Behaviour --------------------

--- a/qt/python/mantidqt/algorithminputhistory.py
+++ b/qt/python/mantidqt/algorithminputhistory.py
@@ -9,19 +9,10 @@
 #
 from __future__ import (absolute_import)
 
-from mantidqt.utils.qt import import_qt
+from mantidqt.utils.qt import import_qt, toQSettings
 
 
 _AlgorithmInputHistory = import_qt('._common', 'mantidqt', 'AlgorithmInputHistory')
-
-
-def _toQSettings(settings):
-    '''Utility function to convert supplied settings object to a qtpy.QtCore.QSettings
-    '''
-    try: # workbench.config.user
-        return settings.qsettings
-    except: # must be a QSettings already
-        return settings
 
 
 class AlgorithmInputHistory(object):
@@ -33,7 +24,7 @@ class AlgorithmInputHistory(object):
         pass
 
     def readSettings(self, settings):
-        self._singleton.readSettings(_toQSettings(settings))
+        self._singleton.readSettings(toQSettings(settings))
 
     def writeSettings(self, settings):
-        self._singleton.writeSettings(_toQSettings(settings))
+        self._singleton.writeSettings(toQSettings(settings))

--- a/qt/python/mantidqt/utils/qt/__init__.py
+++ b/qt/python/mantidqt/utils/qt/__init__.py
@@ -152,3 +152,12 @@ def add_actions(target, actions):
         else:
             raise ValueError("Unexpected action type. "
                              "Expected one of (QAction,QMenu) but found '{}'".format(type(action)))
+
+
+def toQSettings(settings):
+    '''Utility function to convert supplied settings object to a qtpy.QtCore.QSettings
+    '''
+    if hasattr(settings, 'qsettings'):  # workbench.config.user
+        return settings.qsettings
+    else:  # must be a QSettings already
+        return settings


### PR DESCRIPTION
Also changes the initialization sequence so the settings aren't read in until the widgets are created. Now any widget in main window that supports saving and loading from settings will do so automatically.

Since this also changes the names of various settings, it will forget those settings the first time it is started after merging.

**To test:**

1. Startup the workbench
2. Change the log level in the message window
3. Shutdown the workbench and start it again

*There is no associated issue.*

*This does not require release notes* because this is part of the workbench.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
