### PR TITLE
Add SampleLogs widget to workbench

### DIFF
--- a/Framework/PythonInterface/mantid/plots/__init__.py
+++ b/Framework/PythonInterface/mantid/plots/__init__.py
@@ -63,7 +63,7 @@ class MantidAxes(Axes):
 
         For keywords related to workspaces, see :func:`mantid.plots.plotfunctions.plot`.
         '''
-        if mantid.plots.helperfunctions.validate_args(*args):
+        if mantid.plots.helperfunctions.validate_args(*args, **kwargs):
             mantid.kernel.logger.debug('using mantid.plots.plotfunctions')
             return mantid.plots.plotfunctions.plot(self, *args, **kwargs)
         else:

--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -20,6 +20,7 @@ from qtpy.QtWidgets import QMessageBox, QVBoxLayout
 # local package imports
 from workbench.plugins.base import PluginWidget
 from workbench.plotting.functions import can_overplot, pcolormesh, plot_from_names
+from mantidqt.widgets.samplelogs.presenter import SampleLogs
 
 
 class WorkspaceWidget(PluginWidget):
@@ -46,6 +47,7 @@ class WorkspaceWidget(PluginWidget):
         self.workspacewidget.overplotSpectrumWithErrorsClicked.connect(functools.partial(self._do_plot_spectrum,
                                                                                          errors=True, overplot=True))
         self.workspacewidget.plotColorfillClicked.connect(self._do_plot_colorfill)
+        self.workspacewidget.sampleLogsClicked.connect(self._do_sample_logs)
 
     # ----------------- Plugin API --------------------
 
@@ -88,3 +90,7 @@ class WorkspaceWidget(PluginWidget):
         except BaseException:
             import traceback
             traceback.print_exc()
+
+    def _do_sample_logs(self, names):
+        for ws in self._ads.retrieveWorkspaces(names, unrollGroups=True):
+            SampleLogs(ws=ws, parent=self)

--- a/qt/python/CMakeLists.txt
+++ b/qt/python/CMakeLists.txt
@@ -84,6 +84,9 @@ endif ()
 
     mantidqt/widgets/test/test_jupyterconsole.py
     mantidqt/widgets/test/test_messagedisplay.py
+
+    mantidqt/widgets/samplelogs/test/test_samplelogs_model.py
+    mantidqt/widgets/samplelogs/test/test_samplelogs_presenter.py
   )
 
   # Tests

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -241,6 +241,7 @@ signals:
   void plotSpectrumWithErrorsClicked(const QStringList & workspaceNames);
   void overplotSpectrumWithErrorsClicked(const QStringList & workspaceNames);
   void plotColorfillClicked(const QStringList &workspaceNames);
+  void sampleLogsClicked(const QStringList &workspaceNames);
 };
 
 // ---------------------------------

--- a/qt/python/mantidqt/widgets/samplelogs/__init__.py
+++ b/qt/python/mantidqt/widgets/samplelogs/__init__.py
@@ -1,0 +1,13 @@
+"""
+You can run this widget independently by for example:
+
+    from workbench.widgets.samplelogs.presenter import SampleLogs
+    from mantid.simpleapi import Load
+    from qtpy.QtWidgets import QApplication
+
+    ws=Load('CNCS_7860')
+
+    app = QApplication([])
+    window = SampleLogs(ws)
+    app.exec_()
+"""

--- a/qt/python/mantidqt/widgets/samplelogs/model.py
+++ b/qt/python/mantidqt/widgets/samplelogs/model.py
@@ -1,0 +1,111 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+#
+#
+from __future__ import (absolute_import, division, print_function)
+from mantid.kernel import (BoolTimeSeriesProperty,
+                           FloatTimeSeriesProperty, Int32TimeSeriesProperty,
+                           Int64TimeSeriesProperty, StringTimeSeriesProperty)
+from mantid.api import MultipleExperimentInfos
+from qtpy.QtGui import QStandardItemModel, QStandardItem
+
+TimeSeriesProperties = (BoolTimeSeriesProperty,
+                        FloatTimeSeriesProperty, Int32TimeSeriesProperty,
+                        Int64TimeSeriesProperty, StringTimeSeriesProperty)
+
+
+def get_type(log):
+    dtype_map = {'i': 'int', 'f': 'float', 's': 'string', 'b': 'bool'}
+    if isinstance(log, TimeSeriesProperties):
+        return "{} series".format(dtype_map[log.dtype()[0].lower()])
+    else:
+        return log.type
+
+
+def get_value(log):
+    if isinstance(log, TimeSeriesProperties):
+        if log.size() > 1:
+            return "({} entries)".format(log.size())
+        else:
+            return log.firstValue()
+    else:
+        return log.value
+
+
+class SampleLogsModel(object):
+    def __init__(self, ws):
+        self._ws = ws
+        self._exp = 0
+        self._set_run()
+
+    def _set_run(self):
+        if self.isMD():
+            self.run = self._ws.getExperimentInfo(self._exp).run()
+        else:
+            self.run = self._ws.run()
+
+    def set_exp(self, exp):
+        self._exp = exp
+        self._set_run()
+
+    def get_exp(self):
+        return self._exp
+
+    def get_ws(self):
+        return self._ws
+
+    def get_name(self):
+        return self._ws.name()
+
+    def getNumExperimentInfo(self):
+        return self._ws.getNumExperimentInfo() if self.isMD() else 0
+
+    def get_log(self, LogName):
+        return self.run.getLogData(LogName)
+
+    def get_log_names(self):
+        return self.run.keys()
+
+    def get_log_display_values(self, LogName):
+        log = self.get_log(LogName)
+        return log.name, get_type(log), get_value(log), log.units
+
+    def is_log_plottable(self, LogName):
+        return isinstance(self.get_log(LogName), (FloatTimeSeriesProperty,
+                                                  Int32TimeSeriesProperty,
+                                                  Int64TimeSeriesProperty))
+
+    def get_statistics(self, LogName):
+        log = self.get_log(LogName)
+        if isinstance(log, TimeSeriesProperties):
+            return log.getStatistics()
+
+    def isMD(self):
+        return isinstance(self._ws, MultipleExperimentInfos)
+
+    def getItemModel(self):
+        model = QStandardItemModel()
+        model.setHorizontalHeaderLabels(["Name", "Type", "Value", "Units"])
+        model.setColumnCount(4)
+        for key in self.get_log_names():
+            log = self.run.getLogData(key)
+            name = QStandardItem()
+            name.setText(log.name)
+            name.setEditable(False)
+            log_type = QStandardItem()
+            log_type.setText(get_type(log))
+            log_type.setEditable(False)
+            value = QStandardItem()
+            value.setText(str(get_value(log)))
+            value.setEditable(False)
+            unit = QStandardItem()
+            unit.setText(log.units)
+            unit.setEditable(False)
+            model.appendRow((name, log_type, value, unit))
+        model.sort(0)
+        return model

--- a/qt/python/mantidqt/widgets/samplelogs/presenter.py
+++ b/qt/python/mantidqt/widgets/samplelogs/presenter.py
@@ -1,0 +1,62 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+#
+#
+from __future__ import (absolute_import, division, print_function)
+from .model import SampleLogsModel
+from .view import SampleLogsView
+
+
+class SampleLogs(object):
+    def __init__(self, ws, parent=None, model=None, view=None):
+        # Create model and view, or accept mocked versions
+        self.model = model if model else SampleLogsModel(ws)
+        self.view = view if view else SampleLogsView(self,
+                                                     parent,
+                                                     self.model.get_name(),
+                                                     self.model.isMD(),
+                                                     self.model.getNumExperimentInfo())
+        self.setup_table()
+
+    def clicked(self):
+        self.update_stats()
+        self.plot_logs()
+
+    def doubleClicked(self, i):
+        # print the log, later this should display the data in a table workspace or something
+        log_text = self.view.get_row_log_name(i.row())
+        log = self.model.get_log(log_text)
+        print('# {}'.format(log.name))
+        print(log.valueAsPrettyStr())
+
+    def changeExpInfo(self):
+        selected_rows = self.view.get_selected_row_indexes()
+        self.model.set_exp(self.view.get_exp())
+        self.setup_table()
+        self.view.set_selected_rows(selected_rows)
+        self.update_stats()
+        self.plot_logs()
+
+    def update_stats(self):
+        selected_rows = self.view.get_selected_row_indexes()
+        if len(selected_rows) == 1:
+            stats = self.model.get_statistics(self.view.get_row_log_name(selected_rows[0]))
+            if stats:
+                self.view.set_statistics(stats)
+            else:
+                self.view.clear_statistics()
+        else:
+            self.view.clear_statistics()
+
+    def plot_logs(self):
+        selected_rows = self.view.get_selected_row_indexes()
+        to_plot = [row for row in selected_rows if self.model.is_log_plottable(self.view.get_row_log_name(row))]
+        self.view.plot_selected_logs(self.model.get_ws(), self.model.get_exp(), to_plot)
+
+    def setup_table(self):
+        self.view.set_model(self.model.getItemModel())

--- a/qt/python/mantidqt/widgets/samplelogs/test/test_samplelogs_model.py
+++ b/qt/python/mantidqt/widgets/samplelogs/test/test_samplelogs_model.py
@@ -1,0 +1,90 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+#
+#
+from __future__ import (absolute_import, division, print_function)
+
+from mantid.simpleapi import LoadEventNexus, CreateMDWorkspace
+from mantidqt.widgets.samplelogs.model import SampleLogsModel
+
+import unittest
+
+
+class SampleLogsModelTest(unittest.TestCase):
+
+    def test_model(self):
+        ws = LoadEventNexus('CNCS_7860', MetaDataOnly=True)
+        model = SampleLogsModel(ws)
+
+        self.assertEqual(model.get_exp(), 0)
+        self.assertEqual(model.get_name(), 'ws')
+        self.assertEqual(model.getNumExperimentInfo(), 0)
+
+        log = model.get_log("Speed5")
+        self.assertEqual(log.name, "Speed5")
+        self.assertEqual(log.size(), 4)
+
+        log_names = model.get_log_names()
+        self.assertEqual(len(log_names), 48)
+        self.assertIn("Speed5", log_names)
+
+        values = model.get_log_display_values("Speed5")
+        self.assertEqual(values[0], "Speed5")
+        self.assertEqual(values[1], "float series")
+        self.assertEqual(values[2], "(4 entries)")
+        self.assertEqual(values[3], "Hz")
+
+        self.assertTrue(model.is_log_plottable("Speed5"))
+        self.assertFalse(model.is_log_plottable("duration"))
+
+        stats = model.get_statistics("Speed5")
+        self.assertEqual(stats.maximum, 300.0)
+
+        self.assertFalse(model.isMD())
+
+        itemModel = model.getItemModel()
+        self.assertEqual(itemModel.horizontalHeaderItem(0).text(), "Name")
+        self.assertEqual(itemModel.horizontalHeaderItem(1).text(), "Type")
+        self.assertEqual(itemModel.horizontalHeaderItem(2).text(), "Value")
+        self.assertEqual(itemModel.horizontalHeaderItem(3).text(), "Units")
+        self.assertEqual(itemModel.rowCount(), 48)
+        self.assertEqual(itemModel.item(0,0).text(), "ChopperStatus1")
+        self.assertEqual(itemModel.item(0,1).text(), "float series")
+        self.assertEqual(itemModel.item(0,2).text(), "4.0")
+        self.assertEqual(itemModel.item(0,3).text(), "")
+
+    def test_model_MD(self):
+        ws1 = LoadEventNexus("CNCS_7860", MetaDataOnly=True)
+        ws2 = LoadEventNexus("VIS_19351", MetaDataOnly=True)
+        md = CreateMDWorkspace(Dimensions=1, Extents='-1,1', Names='A', Units='U')
+        md.addExperimentInfo(ws1)
+        md.addExperimentInfo(ws2)
+        model = SampleLogsModel(md)
+
+        self.assertEqual(model.get_exp(), 0)
+        self.assertEqual(model.get_name(), 'md')
+        self.assertEqual(model.getNumExperimentInfo(), 2)
+
+        values = model.get_log_display_values("duration")
+        self.assertEqual(values[0], "duration")
+        self.assertEqual(values[1], "number")
+        self.assertEqual(values[2], 148.0)
+        self.assertEqual(values[3], "second")
+
+        # Change exp
+        model.set_exp(1)
+        self.assertEqual(model.get_exp(), 1)
+        values = model.get_log_display_values("duration")
+        self.assertEqual(values[0], "duration")
+        self.assertEqual(values[1], "number")
+        self.assertEqual(values[2], 4.616606712341309)
+        self.assertEqual(values[3], "second")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qt/python/mantidqt/widgets/samplelogs/test/test_samplelogs_presenter.py
+++ b/qt/python/mantidqt/widgets/samplelogs/test/test_samplelogs_presenter.py
@@ -1,0 +1,97 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+#
+#
+from __future__ import (absolute_import, division, print_function)
+
+import matplotlib
+matplotlib.use('Agg') # noqa: E402
+
+from mantidqt.widgets.samplelogs.model import SampleLogsModel
+from mantidqt.widgets.samplelogs.presenter import SampleLogs
+from mantidqt.widgets.samplelogs.view import SampleLogsView
+
+import unittest
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+
+class SampleLogsTest(unittest.TestCase):
+
+    def setUp(self):
+        self.view = mock.Mock(spec=SampleLogsView)
+        self.view.get_row_log_name =  mock.Mock(return_value="Speed5")
+        self.view.get_selected_row_indexes =  mock.Mock(return_value=[5])
+        self.view.get_exp = mock.Mock(return_value=1)
+
+        self.model = mock.Mock(spec=SampleLogsModel)
+        self.model.get_ws = mock.Mock(return_value='ws')
+        self.model.is_log_plottable = mock.Mock(return_value=True)
+        self.model.get_statistics = mock.Mock(return_value=[1,2,3,4])
+        self.model.get_exp = mock.Mock(return_value=0)
+
+    def test_sampleLogs(self):
+
+        presenter = SampleLogs(None, model=self.model, view=self.view)
+
+        # setup calls
+        self.assertEqual(self.view.set_model.call_count, 1)
+        self.assertEqual(self.model.getItemModel.call_count, 1)
+
+        # plot_logs
+        presenter.plot_logs()
+        self.model.is_log_plottable.assert_called_once_with("Speed5")
+        self.assertEqual(self.model.get_ws.call_count, 1)
+        self.view.plot_selected_logs.assert_called_once_with('ws', 0, [5])
+
+        # update_stats
+        presenter.update_stats()
+        self.assertEqual(self.model.get_statistics.call_count, 1)
+        self.view.get_row_log_name.assert_called_with(5)
+        self.view.set_statistics.assert_called_once_with([1,2,3,4])
+        self.assertEqual(self.view.clear_statistics.call_count, 0)
+
+        self.view.reset_mock()
+        self.view.get_selected_row_indexes =  mock.Mock(return_value=[2,5])
+        presenter.update_stats()
+        self.assertEqual(self.view.set_statistics.call_count, 0)
+        self.assertEqual(self.view.clear_statistics.call_count, 1)
+
+        # changeExpInfo
+        self.model.reset_mock()
+        self.view.reset_mock()
+
+        presenter.changeExpInfo()
+        self.assertEqual(self.view.get_selected_row_indexes.call_count, 3)
+        self.assertEqual(self.view.get_exp.call_count, 1)
+        self.model.set_exp.assert_called_once_with(1)
+        self.view.set_selected_rows.assert_called_once_with([2,5])
+
+        # clicked
+        self.model.reset_mock()
+        self.view.reset_mock()
+
+        presenter.clicked()
+        self.assertEqual(self.view.get_selected_row_indexes.call_count, 2)
+
+        # double clicked
+        self.model.reset_mock()
+        self.view.reset_mock()
+
+        index = mock.Mock()
+        index.row = mock.Mock(return_value=7)
+
+        presenter.doubleClicked(index)
+        self.view.get_row_log_name.assert_called_once_with(7)
+        self.model.get_log.assert_called_once_with("Speed5")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qt/python/mantidqt/widgets/samplelogs/view.py
+++ b/qt/python/mantidqt/widgets/samplelogs/view.py
@@ -1,0 +1,137 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+#
+#
+from __future__ import (absolute_import, division, print_function)
+from qtpy.QtWidgets import (QTableView, QHBoxLayout, QVBoxLayout,
+                            QAbstractItemView, QFormLayout, QLineEdit,
+                            QHeaderView, QLabel, QCheckBox,
+                            QSizePolicy, QSpinBox, QSplitter, QFrame)
+from qtpy.QtCore import QItemSelectionModel, Qt
+from matplotlib.backends.backend_qt5agg import FigureCanvas
+import matplotlib.pyplot as plt
+
+
+class SampleLogsView(QSplitter):
+    def __init__(self, presenter, parent = None, name = '', isMD=False, noExp = 0):
+        super(SampleLogsView, self).__init__(parent)
+
+        self.presenter = presenter
+
+        self.setWindowTitle("{} sample logs".format(name))
+        self.setWindowFlags(Qt.Window)
+
+        # Create sample log table
+        self.table = QTableView()
+        self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.table.clicked.connect(self.presenter.clicked)
+        self.table.doubleClicked.connect(self.presenter.doubleClicked)
+        self.addWidget(self.table)
+
+        frame_right = QFrame()
+        layout_right = QVBoxLayout()
+
+        #Add full_time and experimentinfo options
+        layout_options = QHBoxLayout()
+
+        if isMD:
+            layout_options.addWidget(QLabel("Experiment Info #"))
+            self.experimentInfo = QSpinBox()
+            self.experimentInfo.setMaximum(noExp-1)
+            self.experimentInfo.valueChanged.connect(self.presenter.changeExpInfo)
+            layout_options.addWidget(self.experimentInfo)
+
+        self.full_time = QCheckBox("Relative Time")
+        self.full_time.setChecked(True)
+        self.full_time.stateChanged.connect(self.presenter.plot_logs)
+        layout_options.addWidget(self.full_time)
+        layout_right.addLayout(layout_options)
+
+        # Sample log plot
+        self.fig, self.ax = plt.subplots(subplot_kw={'projection': 'mantid'})
+        self.canvas = FigureCanvas(self.fig)
+        self.canvas.setSizePolicy(QSizePolicy.Expanding,QSizePolicy.Expanding)
+        layout_right.addWidget(self.canvas)
+
+        # Sample stats
+        self.create_stats_widgets()
+        layout_stats = QFormLayout()
+        layout_stats.addRow('', QLabel("Log Statistics"))
+        layout_stats.addRow('Min:', self.stats_widgets["minimum"])
+        layout_stats.addRow('Max:', self.stats_widgets["maximum"])
+        layout_stats.addRow('Mean:', self.stats_widgets["mean"])
+        layout_stats.addRow('Median:', self.stats_widgets["median"])
+        layout_stats.addRow('Std Dev:', self.stats_widgets["standard_deviation"])
+        layout_stats.addRow('Time Avg:', self.stats_widgets["time_mean"])
+        layout_stats.addRow('Time Std Dev:', self.stats_widgets["time_standard_deviation"])
+        layout_stats.addRow('Duration:', self.stats_widgets["duration"])
+        layout_right.addLayout(layout_stats)
+        frame_right.setLayout(layout_right)
+
+        self.addWidget(frame_right)
+        self.setStretchFactor(0,1)
+
+        self.resize(1200,800)
+        self.show()
+
+    def set_model(self, model):
+        self.model = model
+        self.table.setModel(self.model)
+        self.table.resizeColumnsToContents()
+        self.table.horizontalHeader().setSectionResizeMode(2, QHeaderView.Stretch)
+
+    def plot_selected_logs(self, ws, exp, rows):
+        self.ax.clear()
+
+        for row in rows:
+            log_text = self.get_row_log_name(row)
+            self.ax.plot(ws,
+                         LogName=log_text,
+                         label=log_text,
+                         marker='.',
+                         FullTime=not self.full_time.isChecked(),
+                         ExperimentInfo=exp)
+
+        self.ax.set_ylabel('')
+        if self.ax.get_legend_handles_labels()[0]:
+            self.ax.legend()
+        self.fig.canvas.draw()
+
+    def get_row_log_name(self, i):
+        return str(self.model.item(i, 0).text())
+
+    def get_exp(self):
+        return self.experimentInfo.value()
+
+    def get_selected_row_indexes(self):
+        return [row.row() for row in self.table.selectionModel().selectedRows()]
+
+    def set_selected_rows(self, rows):
+        mode = QItemSelectionModel.Select | QItemSelectionModel.Rows
+        for row in rows:
+            self.table.selectionModel().select(self.model.index(row, 0), mode)
+
+    def create_stats_widgets(self):
+        self.stats_widgets = {"minimum": QLineEdit(),
+                              "maximum": QLineEdit(),
+                              "mean": QLineEdit(),
+                              "median": QLineEdit(),
+                              "standard_deviation": QLineEdit(),
+                              "time_mean": QLineEdit(),
+                              "time_standard_deviation": QLineEdit(),
+                              "duration": QLineEdit()}
+        for widget in self.stats_widgets.values():
+            widget.setReadOnly(True)
+
+    def set_statistics(self, stats):
+        for param in self.stats_widgets.keys():
+            self.stats_widgets[param].setText('{:.6}'.format(getattr(stats, param)))
+
+    def clear_statistics(self):
+        for widget in self.stats_widgets.values():
+            widget.clear()

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidgetSimple.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidgetSimple.h
@@ -47,6 +47,7 @@ signals:
   void plotSpectrumWithErrorsClicked(const QStringList &workspaceName);
   void overplotSpectrumWithErrorsClicked(const QStringList &workspaceName);
   void plotColorfillClicked(const QStringList &workspaceName);
+  void sampleLogsClicked(const QStringList &workspaceName);
 
 private slots:
   void onPlotSpectrumClicked();
@@ -54,10 +55,11 @@ private slots:
   void onPlotSpectrumWithErrorsClicked();
   void onOverplotSpectrumWithErrorsClicked();
   void onPlotColorfillClicked();
+  void onSampleLogsClicked();
 
 private:
   QAction *m_plotSpectrum, *m_overplotSpectrum, *m_plotSpectrumWithErrs,
-      *m_overplotSpectrumWithErrs, *m_plotColorfill;
+      *m_overplotSpectrumWithErrs, *m_plotColorfill, *m_sampleLogs;
 };
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
@@ -31,7 +31,8 @@ WorkspaceTreeWidgetSimple::WorkspaceTreeWidgetSimple(QWidget *parent)
       m_plotSpectrumWithErrs(new QAction("spectrum with errors...", this)),
       m_overplotSpectrumWithErrs(
           new QAction("overplot spectrum with errors...", this)),
-      m_plotColorfill(new QAction("colorfill", this)) {
+      m_plotColorfill(new QAction("colorfill", this)),
+      m_sampleLogs(new QAction("Sample Logs", this)) {
   // connections
   connect(m_plotSpectrum, SIGNAL(triggered()), this,
           SLOT(onPlotSpectrumClicked()));
@@ -43,6 +44,7 @@ WorkspaceTreeWidgetSimple::WorkspaceTreeWidgetSimple(QWidget *parent)
           SLOT(onOverplotSpectrumWithErrorsClicked()));
   connect(m_plotColorfill, SIGNAL(triggered()), this,
           SLOT(onPlotColorfillClicked()));
+  connect(m_sampleLogs, SIGNAL(triggered()), this, SLOT(onSampleLogsClicked()));
 }
 
 WorkspaceTreeWidgetSimple::~WorkspaceTreeWidgetSimple() {}
@@ -86,6 +88,7 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
     }
     menu->addAction(m_rename);
     menu->addAction(m_saveNexus);
+    menu->addAction(m_sampleLogs);
 
     menu->addSeparator();
     menu->addAction(m_delete);
@@ -113,6 +116,10 @@ void WorkspaceTreeWidgetSimple::onOverplotSpectrumWithErrorsClicked() {
 
 void WorkspaceTreeWidgetSimple::onPlotColorfillClicked() {
   emit plotColorfillClicked(getSelectedWorkspaceNamesAsQList());
+}
+
+void WorkspaceTreeWidgetSimple::onSampleLogsClicked() {
+  emit sampleLogsClicked(getSelectedWorkspaceNamesAsQList());
 }
 
 } // namespace MantidWidgets


### PR DESCRIPTION
This add a SampleLogs widget to the workbench. Simply right click on a workspace and select "Sample Logs."

**To test:**
Load up a workspace *e.g.*
```python
ws=Load('CNCS_7860')
```
Then open the sample logs widget.

Clicking a log will, if possible, plot and show statistics.
![samplelogs1](https://user-images.githubusercontent.com/5595210/46422855-37cfe180-c703-11e8-8e8a-24569d65c3c9.png)


Selecting multiple logs will overplot them.
![samplelogs2](https://user-images.githubusercontent.com/5595210/46422859-3acad200-c703-11e8-82c0-39db20017ba9.png)


For MD workspace a `Experiment Info #` box should appear where you can select which experiment info to use.
![samplelogs3](https://user-images.githubusercontent.com/5595210/46422863-3d2d2c00-c703-11e8-8a18-00ceb1e43479.png)

Double clicking a log will simply print the values, this should be replaced in the future to open the log in a table workspace or whatever.

Closes #23593

*This does not require release notes* because workbench

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
