### PR TITLE
Fix memory leak in clone to numpy policy

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp
@@ -67,7 +67,7 @@ PyObject *clone1D(const std::vector<Types::Core::DateAndTime> &cvector) {
     auto scalar =
         PyArray_Scalar(reinterpret_cast<char *>(&abstime), descr, nullptr);
     PyArray_SETITEM(nparray, reinterpret_cast<char *>(itemPtr), scalar);
-    Py_DecRef(scalar);
+    Py_DECREF(scalar);
   }
   return reinterpret_cast<PyObject *>(nparray);
 }
@@ -85,9 +85,9 @@ template <> PyObject *clone1D(const std::vector<bool> &cvector) {
 
   for (Py_intptr_t i = 0; i < dims[0]; ++i) {
     void *itemPtr = PyArray_GETPTR1(nparray, i);
-    auto py_bool = PyBool_FromLong(static_cast<long int>(cvector[i]))
+    auto py_bool = PyBool_FromLong(static_cast<long int>(cvector[i]));
         PyArray_SETITEM(nparray, reinterpret_cast<char *>(itemPtr), py_bool);
-    Py_DecRef(py_bool);
+    Py_DECREF(py_bool);
   }
   return reinterpret_cast<PyObject *>(nparray);
 }

--- a/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp
@@ -86,7 +86,7 @@ template <> PyObject *clone1D(const std::vector<bool> &cvector) {
   for (Py_intptr_t i = 0; i < dims[0]; ++i) {
     void *itemPtr = PyArray_GETPTR1(nparray, i);
     auto py_bool = PyBool_FromLong(static_cast<long int>(cvector[i]));
-        PyArray_SETITEM(nparray, reinterpret_cast<char *>(itemPtr), py_bool);
+    PyArray_SETITEM(nparray, reinterpret_cast<char *>(itemPtr), py_bool);
     Py_DECREF(py_bool);
   }
   return reinterpret_cast<PyObject *>(nparray);

--- a/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp
@@ -64,10 +64,9 @@ PyObject *clone1D(const std::vector<Types::Core::DateAndTime> &cvector) {
   for (Py_intptr_t i = 0; i < dims[0]; ++i) {
     void *itemPtr = PyArray_GETPTR1(nparray, i);
     npy_datetime abstime = Converters::to_npy_datetime(cvector[i]);
-    auto scalar = PyArray_Scalar(reinterpret_cast<char *>(&abstime), descr, nullptr);
-    PyArray_SETITEM(
-        nparray, reinterpret_cast<char *>(itemPtr),
-        scalar);
+    auto scalar =
+        PyArray_Scalar(reinterpret_cast<char *>(&abstime), descr, nullptr);
+    PyArray_SETITEM(nparray, reinterpret_cast<char *>(itemPtr), scalar);
     Py_DecRef(scalar);
   }
   return reinterpret_cast<PyObject *>(nparray);
@@ -87,8 +86,7 @@ template <> PyObject *clone1D(const std::vector<bool> &cvector) {
   for (Py_intptr_t i = 0; i < dims[0]; ++i) {
     void *itemPtr = PyArray_GETPTR1(nparray, i);
     auto py_bool = PyBool_FromLong(static_cast<long int>(cvector[i]))
-    PyArray_SETITEM(nparray, reinterpret_cast<char *>(itemPtr),
-                    py_bool);
+        PyArray_SETITEM(nparray, reinterpret_cast<char *>(itemPtr), py_bool);
     Py_DecRef(py_bool);
   }
   return reinterpret_cast<PyObject *>(nparray);
@@ -174,7 +172,7 @@ INSTANTIATE_CLONE(double)
 INSTANTIATE_CLONE(float)
 // Need further 1D specialisation for string
 INSTANTIATE_CLONE1D(std::string)
-// Need further 1D specialisation for DateAndTime
+// Need further ND specialisation for DateAndTime
 INSTANTIATE_CLONEND(Types::Core::DateAndTime)
 // Need further ND specialisation for bool
 INSTANTIATE_CLONEND(bool)

--- a/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp
@@ -86,8 +86,10 @@ template <> PyObject *clone1D(const std::vector<bool> &cvector) {
 
   for (Py_intptr_t i = 0; i < dims[0]; ++i) {
     void *itemPtr = PyArray_GETPTR1(nparray, i);
+    auto py_bool = PyBool_FromLong(static_cast<long int>(cvector[i]))
     PyArray_SETITEM(nparray, reinterpret_cast<char *>(itemPtr),
-                    PyBool_FromLong(static_cast<long int>(cvector[i])));
+                    py_bool);
+    Py_DecRef(py_bool);
   }
   return reinterpret_cast<PyObject *>(nparray);
 }

--- a/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp
@@ -64,9 +64,11 @@ PyObject *clone1D(const std::vector<Types::Core::DateAndTime> &cvector) {
   for (Py_intptr_t i = 0; i < dims[0]; ++i) {
     void *itemPtr = PyArray_GETPTR1(nparray, i);
     npy_datetime abstime = Converters::to_npy_datetime(cvector[i]);
+    auto scalar = PyArray_Scalar(reinterpret_cast<char *>(&abstime), descr, nullptr);
     PyArray_SETITEM(
         nparray, reinterpret_cast<char *>(itemPtr),
-        PyArray_Scalar(reinterpret_cast<char *>(&abstime), descr, nullptr));
+        scalar);
+    Py_DecRef(scalar);
   }
   return reinterpret_cast<PyObject *>(nparray);
 }


### PR DESCRIPTION
**Description of work.**

There is a memory leak when converting C++ vectors containing DateTime objects to Numpy arrays. This is leading to some sporadically failing system tests. 

For example if you run the following script you will leak a few GB of memory.
```
workspace = Load('LARMOR00013038.nxs')
run = workspace[0].getRun()
property = run.getLogData('Bench_Rot')
size = len(property.value)
for i in range(0, size):
    dt = str(property.times)
```
**To test:**

Run the script above and ensure memory usage does not change enormously. Code review. Check that other functionality not broken.

<!-- Instructions for testing. -->

Fixes #23710  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

I have not added release notes as this is an internal issue.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
