### PR TITLE
Duplicate print statements to the console

### DIFF
--- a/qt/applications/workbench/workbench/plugins/logmessagedisplay.py
+++ b/qt/applications/workbench/workbench/plugins/logmessagedisplay.py
@@ -29,6 +29,8 @@ from workbench.plugins.base import PluginWidget
 
 # Default logs at notice
 DEFAULT_LOG_PRIORITY = 5
+ORIGINAL_STDOUT = sys.stdout
+ORIGINAL_STDERR = sys.stderr
 
 
 class LogMessageDisplay(PluginWidget):
@@ -44,10 +46,10 @@ class LogMessageDisplay(PluginWidget):
         self.setWindowTitle(self.get_plugin_title())
 
         # output capture
-        stdout_capture, stderr_capture = WriteToSignal(), WriteToSignal()
-        stdout_capture.sig_write_received.connect(self.display.appendNotice)
-        stderr_capture.sig_write_received.connect(self.display.appendError)
-        self.stdout, self.stderr = stdout_capture, stderr_capture
+        self.stdout = WriteToSignal(ORIGINAL_STDOUT)
+        self.stdout.sig_write_received.connect(self.display.appendNotice)
+        self.stderr = WriteToSignal(ORIGINAL_STDERR)
+        self.stderr.sig_write_received.connect(self.display.appendError)
 
     def get_plugin_title(self):
         return "Messages"

--- a/qt/python/mantidqt/utils/test/test_writetosignal.py
+++ b/qt/python/mantidqt/utils/test/test_writetosignal.py
@@ -18,6 +18,7 @@ from __future__ import (absolute_import)
 
 # std imports
 import unittest
+import sys
 
 # 3rdparty
 from qtpy.QtCore import QCoreApplication, QObject
@@ -38,7 +39,7 @@ class WriteToSignalTest(GuiTest):
 
     def test_connected_receiver_receives_text(self):
         recv = Receiver()
-        writer = WriteToSignal()
+        writer = WriteToSignal(sys.stdout)
         writer.sig_write_received.connect(recv.capture_text)
         txt = "I expect to see this"
         writer.write(txt)

--- a/qt/python/mantidqt/utils/writetosignal.py
+++ b/qt/python/mantidqt/utils/writetosignal.py
@@ -27,6 +27,9 @@ class WriteToSignal(QObject):
     used to transform write requests to
     Qt-signals. Mainly used to communicate
     stdout/stderr across threads"""
+    def __init__(self, original_out):
+        QObject.__init__(self)
+        self.__original_out = original_out
 
     sig_write_received = Signal(str)
 
@@ -40,4 +43,7 @@ class WriteToSignal(QObject):
         return False
 
     def write(self, txt):
+        # write to the console
+        self.__original_out.write(txt)
+        # emit the signal which will write to logging
         self.sig_write_received.emit(txt)


### PR DESCRIPTION
The capture of print statements to the message display is useful, but
makes debuging crashes difficult because the message display disappears
before anything can be read. The solution is to write the print
statements to both places.

**To test:**

Try a simple script of `print('hello')` in the editor window. It will print in both the messages display and the console. `print` statements in the ipython window don't appear to use the same code. It is an open question as to if it should print to console as well.

*There is no associated issue.*

*This does not require release notes* because workbench.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
