### PR TITLE
Indirect - F(Q) - Change the allowed Fit Types depending on the selected parameter

### DIFF
--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -117,7 +117,7 @@ void IndirectFitAnalysisTab::setup() {
 
   connect(m_dataPresenter.get(), SIGNAL(dataChanged()), this,
           SLOT(updateResultOptions()));
-  connect(m_dataPresenter.get(), SIGNAL(dataAdded()), this,
+  connect(m_dataPresenter.get(), SIGNAL(dataChanged()), this,
           SLOT(emitUpdateFitTypes()));
 
   connectDataAndSpectrumPresenters();
@@ -503,9 +503,12 @@ void IndirectFitAnalysisTab::addComboBoxFunctionGroup(
   m_fitPropertyBrowser->addComboBoxFunctionGroup(groupName, functions);
 }
 
-void IndirectFitAnalysisTab::removeFitTypesFromComboBox(
-    std::vector<QString> const &groupNames) {
-  m_fitPropertyBrowser->removeFitTypesFromComboBox(groupNames);
+/**
+ * Removes all options from the Fit Type combo-box apart from the 'None' option
+ *
+ */
+void IndirectFitAnalysisTab::clearFitTypeComboBox() {
+  m_fitPropertyBrowser->clearFitTypeComboBox();
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -117,6 +117,8 @@ void IndirectFitAnalysisTab::setup() {
 
   connect(m_dataPresenter.get(), SIGNAL(dataChanged()), this,
           SLOT(updateResultOptions()));
+  connect(m_dataPresenter.get(), SIGNAL(dataAdded()), this,
+          SLOT(emitUpdateFitTypes()));
 
   connectDataAndSpectrumPresenters();
   connectDataAndPlotPresenters();
@@ -967,8 +969,9 @@ void IndirectFitAnalysisTab::updateResultOptions() {
                                                      getSelectedSpectrum());
   setPlotResultEnabled(isFit);
   setSaveResultEnabled(isFit);
-  emit updateFitTypes();
 }
+
+void IndirectFitAnalysisTab::emitUpdateFitTypes() { emit updateFitTypes(); }
 
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -501,6 +501,11 @@ void IndirectFitAnalysisTab::addComboBoxFunctionGroup(
   m_fitPropertyBrowser->addComboBoxFunctionGroup(groupName, functions);
 }
 
+void IndirectFitAnalysisTab::removeFitTypesFromComboBox(
+    std::vector<QString> const &groupNames) {
+  m_fitPropertyBrowser->removeFitTypesFromComboBox(groupNames);
+}
+
 /**
  * Sets the available background options in this fit analysis tab.
  *
@@ -962,6 +967,7 @@ void IndirectFitAnalysisTab::updateResultOptions() {
                                                      getSelectedSpectrum());
   setPlotResultEnabled(isFit);
   setSaveResultEnabled(isFit);
+  emit updateFitTypes();
 }
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -198,6 +198,7 @@ protected slots:
   void updateResultOptions();
   void saveResult();
 
+private slots:
   void emitUpdateFitTypes();
 
 private:

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -74,6 +74,7 @@ public:
   void addComboBoxFunctionGroup(
       const QString &groupName,
       const std::vector<Mantid::API::IFunction_sptr> &functions);
+  void removeFitTypesFromComboBox(std::vector<QString> const &groupNames);
 
   void setBackgroundOptions(const QStringList &backgrounds);
 
@@ -157,6 +158,7 @@ signals:
   void functionChanged();
   void parameterChanged(const Mantid::API::IFunction *);
   void customBoolChanged(const QString &key, bool value);
+  void updateFitTypes();
 
 protected slots:
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -74,7 +74,7 @@ public:
   void addComboBoxFunctionGroup(
       const QString &groupName,
       const std::vector<Mantid::API::IFunction_sptr> &functions);
-  void removeFitTypesFromComboBox(std::vector<QString> const &groupNames);
+  void clearFitTypeComboBox();
 
   void setBackgroundOptions(const QStringList &backgrounds);
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -198,6 +198,8 @@ protected slots:
   void updateResultOptions();
   void saveResult();
 
+  void emitUpdateFitTypes();
+
 private:
   /// Overidden by child class.
   void setup() override;

--- a/qt/scientific_interfaces/Indirect/JumpFit.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFit.cpp
@@ -92,13 +92,11 @@ void JumpFit::addWidthFunctionsToFitTypeComboBox() {
 
 void JumpFit::updateParameterFitTypes() {
   auto const parameter = m_uiForm->cbParameterType->currentText().toStdString();
-  if (parameter == "EISF") {
-    clearFitTypeComboBox();
+  clearFitTypeComboBox();
+  if (parameter == "EISF")
     addEISFFunctionsToFitTypeComboBox();
-  } else if (parameter == "Width") {
-    clearFitTypeComboBox();
+  else if (parameter == "Width")
     addWidthFunctionsToFitTypeComboBox();
-  }
 }
 
 void JumpFit::updateModelFitTypeString() {

--- a/qt/scientific_interfaces/Indirect/JumpFit.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFit.cpp
@@ -49,8 +49,8 @@ void JumpFit::setupFitTab() {
   setSampleWSSuffices({"_Result"});
   setSampleFBSuffices({"_Result.nxs"});
 
-  addWidthFunctionsToFitType();
-  addEISFFunctionsToFitType();
+  addWidthFunctionsToFitTypeComboBox();
+  addEISFFunctionsToFitTypeComboBox();
 
   m_uiForm->cbParameter->setEnabled(false);
 
@@ -66,7 +66,7 @@ void JumpFit::setupFitTab() {
           SLOT(updateParameterFitTypes()));
 }
 
-void JumpFit::addEISFFunctionsToFitType() {
+void JumpFit::addEISFFunctionsToFitTypeComboBox() {
   auto &functionFactory = FunctionFactory::Instance();
   auto const eisfDiffCylinder =
       functionFactory.createFunction("EISFDiffCylinder");
@@ -78,7 +78,7 @@ void JumpFit::addEISFFunctionsToFitType() {
   addComboBoxFunctionGroup("EISFDiffSphereAlkyl", {eisfDiffSphereAklyl});
 }
 
-void JumpFit::addWidthFunctionsToFitType() {
+void JumpFit::addWidthFunctionsToFitTypeComboBox() {
   auto &functionFactory = FunctionFactory::Instance();
   auto const chudleyElliot = functionFactory.createFunction("ChudleyElliot");
   auto const hallRoss = functionFactory.createFunction("HallRoss");
@@ -93,15 +93,11 @@ void JumpFit::addWidthFunctionsToFitType() {
 void JumpFit::updateParameterFitTypes() {
   auto const parameter = m_uiForm->cbParameterType->currentText().toStdString();
   if (parameter == "EISF") {
-    std::vector<QString> const groupNames = {"ChudleyElliot", "HallRoss",
-                                             "FickDiffusion", "TeixeiraWater"};
-    removeFitTypesFromComboBox(groupNames);
-    addEISFFunctionsToFitType();
+    clearFitTypeComboBox();
+    addEISFFunctionsToFitTypeComboBox();
   } else if (parameter == "Width") {
-    std::vector<QString> const groupNames = {
-        "EISFDiffCylinder", "EISFDiffCylinder", "EISFDiffSphere"};
-    removeFitTypesFromComboBox(groupNames);
-    addWidthFunctionsToFitType();
+    clearFitTypeComboBox();
+    addWidthFunctionsToFitTypeComboBox();
   }
 }
 

--- a/qt/scientific_interfaces/Indirect/JumpFit.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFit.cpp
@@ -49,22 +49,8 @@ void JumpFit::setupFitTab() {
   setSampleWSSuffices({"_Result"});
   setSampleFBSuffices({"_Result.nxs"});
 
-  auto &functionFactory = FunctionFactory::Instance();
-  auto chudleyElliot = functionFactory.createFunction("ChudleyElliot");
-  auto hallRoss = functionFactory.createFunction("HallRoss");
-  auto fickDiffusion = functionFactory.createFunction("FickDiffusion");
-  auto teixeiraWater = functionFactory.createFunction("TeixeiraWater");
-  auto eisfDiffCylinder = functionFactory.createFunction("EISFDiffCylinder");
-  auto eisfDiffSphere = functionFactory.createFunction("EISFDiffSphere");
-  auto eisfDiffSphereAklyl =
-      functionFactory.createFunction("EISFDiffSphereAlkyl");
-  addComboBoxFunctionGroup("ChudleyElliot", {chudleyElliot});
-  addComboBoxFunctionGroup("HallRoss", {hallRoss});
-  addComboBoxFunctionGroup("FickDiffusion", {fickDiffusion});
-  addComboBoxFunctionGroup("TeixeiraWater", {teixeiraWater});
-  addComboBoxFunctionGroup("EISFDiffCylinder", {eisfDiffCylinder});
-  addComboBoxFunctionGroup("EISFDiffSphere", {eisfDiffSphere});
-  addComboBoxFunctionGroup("EISFDiffSphereAlkyl", {eisfDiffSphereAklyl});
+  addWidthFunctionsToFitType();
+  addEISFFunctionsToFitType();
 
   m_uiForm->cbParameter->setEnabled(false);
 
@@ -74,6 +60,49 @@ void JumpFit::setupFitTab() {
   connect(m_uiForm->pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
   connect(this, SIGNAL(functionChanged()), this,
           SLOT(updateModelFitTypeString()));
+  connect(m_uiForm->cbParameterType, SIGNAL(currentIndexChanged(int)), this,
+          SLOT(updateParameterFitTypes()));
+  connect(this, SIGNAL(updateFitTypes()), this,
+          SLOT(updateParameterFitTypes()));
+}
+
+void JumpFit::addEISFFunctionsToFitType() {
+  auto &functionFactory = FunctionFactory::Instance();
+  auto const eisfDiffCylinder =
+      functionFactory.createFunction("EISFDiffCylinder");
+  auto const eisfDiffSphere = functionFactory.createFunction("EISFDiffSphere");
+  auto const eisfDiffSphereAklyl =
+      functionFactory.createFunction("EISFDiffSphereAlkyl");
+  addComboBoxFunctionGroup("EISFDiffCylinder", {eisfDiffCylinder});
+  addComboBoxFunctionGroup("EISFDiffSphere", {eisfDiffSphere});
+  addComboBoxFunctionGroup("EISFDiffSphereAlkyl", {eisfDiffSphereAklyl});
+}
+
+void JumpFit::addWidthFunctionsToFitType() {
+  auto &functionFactory = FunctionFactory::Instance();
+  auto const chudleyElliot = functionFactory.createFunction("ChudleyElliot");
+  auto const hallRoss = functionFactory.createFunction("HallRoss");
+  auto const fickDiffusion = functionFactory.createFunction("FickDiffusion");
+  auto const teixeiraWater = functionFactory.createFunction("TeixeiraWater");
+  addComboBoxFunctionGroup("ChudleyElliot", {chudleyElliot});
+  addComboBoxFunctionGroup("HallRoss", {hallRoss});
+  addComboBoxFunctionGroup("FickDiffusion", {fickDiffusion});
+  addComboBoxFunctionGroup("TeixeiraWater", {teixeiraWater});
+}
+
+void JumpFit::updateParameterFitTypes() {
+  auto const parameter = m_uiForm->cbParameterType->currentText().toStdString();
+  if (parameter == "EISF") {
+    std::vector<QString> const groupNames = {"ChudleyElliot", "HallRoss",
+                                             "FickDiffusion", "TeixeiraWater"};
+    removeFitTypesFromComboBox(groupNames);
+    addEISFFunctionsToFitType();
+  } else if (parameter == "Width") {
+    std::vector<QString> const groupNames = {
+        "EISFDiffCylinder", "EISFDiffCylinder", "EISFDiffSphere"};
+    removeFitTypesFromComboBox(groupNames);
+    addWidthFunctionsToFitType();
+  }
 }
 
 void JumpFit::updateModelFitTypeString() {

--- a/qt/scientific_interfaces/Indirect/JumpFit.h
+++ b/qt/scientific_interfaces/Indirect/JumpFit.h
@@ -26,7 +26,6 @@ public:
   void setupFitTab() override;
 
 protected slots:
-  void updateParameterFitTypes();
   void updatePlotOptions() override;
   void updateModelFitTypeString();
   void plotClicked();
@@ -39,6 +38,9 @@ protected:
   void setSaveResultEnabled(bool enabled) override;
 
   void setRunIsRunning(bool running) override;
+
+private slots:
+  void updateParameterFitTypes();
 
 private:
   void addEISFFunctionsToFitTypeComboBox();

--- a/qt/scientific_interfaces/Indirect/JumpFit.h
+++ b/qt/scientific_interfaces/Indirect/JumpFit.h
@@ -41,8 +41,8 @@ protected:
   void setRunIsRunning(bool running) override;
 
 private:
-  void addEISFFunctionsToFitType();
-  void addWidthFunctionsToFitType();
+  void addEISFFunctionsToFitTypeComboBox();
+  void addWidthFunctionsToFitTypeComboBox();
 
   void setRunEnabled(bool enabled);
   void setFitSingleSpectrumEnabled(bool enabled);

--- a/qt/scientific_interfaces/Indirect/JumpFit.h
+++ b/qt/scientific_interfaces/Indirect/JumpFit.h
@@ -26,6 +26,7 @@ public:
   void setupFitTab() override;
 
 protected slots:
+  void updateParameterFitTypes();
   void updatePlotOptions() override;
   void updateModelFitTypeString();
   void plotClicked();
@@ -40,6 +41,9 @@ protected:
   void setRunIsRunning(bool running) override;
 
 private:
+  void addEISFFunctionsToFitType();
+  void addWidthFunctionsToFitType();
+
   void setRunEnabled(bool enabled);
   void setFitSingleSpectrumEnabled(bool enabled);
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IndirectFitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IndirectFitPropertyBrowser.h
@@ -78,7 +78,7 @@ public:
   void addComboBoxFunctionGroup(
       const QString &groupName,
       const std::vector<Mantid::API::IFunction_sptr> &functions);
-  void removeFitTypesFromComboBox(std::vector<QString> const &groupNames);
+  void clearFitTypeComboBox();
 
   void setBackgroundOptions(const QStringList &backgrounds);
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IndirectFitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IndirectFitPropertyBrowser.h
@@ -78,6 +78,7 @@ public:
   void addComboBoxFunctionGroup(
       const QString &groupName,
       const std::vector<Mantid::API::IFunction_sptr> &functions);
+  void removeFitTypesFromComboBox(std::vector<QString> const &groupNames);
 
   void setBackgroundOptions(const QStringList &backgrounds);
 

--- a/qt/widgets/common/src/IndirectFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/IndirectFitPropertyBrowser.cpp
@@ -712,6 +712,24 @@ void IndirectFitPropertyBrowser::addComboBoxFunctionGroup(
 }
 
 /**
+ * Removes all current Fit Type options from the fit type combo-box in this
+ * property browser.
+ */
+void IndirectFitPropertyBrowser::removeFitTypesFromComboBox(
+    std::vector<QString> const &groupNames) {
+  for (auto groupName : groupNames) {
+    for (auto function : m_groupToFunctionList[groupName]) {
+      auto const functionName = function->name();
+      m_customFunctionCount[functionName] -= 1;
+    }
+    m_groupToFunctionList.remove(groupName);
+  }
+  m_groupToFunctionList["None"] = {};
+  m_enumManager->setEnumNames(m_functionsInComboBox, {"None"});
+
+}
+
+/**
  * Adds a custom function group to this fit property browser, with the specified
  * name and the associated specified functions.
  *

--- a/qt/widgets/common/src/IndirectFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/IndirectFitPropertyBrowser.cpp
@@ -715,18 +715,8 @@ void IndirectFitPropertyBrowser::addComboBoxFunctionGroup(
  * Removes all current Fit Type options from the fit type combo-box in this
  * property browser.
  */
-void IndirectFitPropertyBrowser::removeFitTypesFromComboBox(
-    std::vector<QString> const &groupNames) {
-  for (auto groupName : groupNames) {
-    for (auto function : m_groupToFunctionList[groupName]) {
-      auto const functionName = function->name();
-      m_customFunctionCount[functionName] -= 1;
-    }
-    m_groupToFunctionList.remove(groupName);
-  }
-  m_groupToFunctionList["None"] = {};
+void IndirectFitPropertyBrowser::clearFitTypeComboBox() {
   m_enumManager->setEnumNames(m_functionsInComboBox, {"None"});
-
 }
 
 /**


### PR DESCRIPTION
**Description of work.**
This PR ensures that only the relevant Fit Types are available in F(Q) Fit when a specific parameter is selected.

**To test:**
1. `Interfaces`->`Indirect Data Analysis`->`F(Q)`Tab
2. Load in the data below
3. Select `Width` as the Fit Parameter
4. Check the allowed Fit Types
5. Select `EISF` as the Fit Parameter
6. Check the allowed Fit Types

Width allowed Fit types: `ChudleyElliot`, `HallRoss`, `FickDiffusion`, `TeixeiraWater`
EISF allowed Fit types: `EISFDiffCylinder`, `EISFDiffSphereAlkyl`, `EISFDiffSphere`
Note that before you load any data, when you initially enter the tab, all Fit Types should be visible.

**Data Files**
[IN16B_125878_QLd_Result.zip](https://github.com/mantidproject/mantid/files/2446298/IN16B_125878_QLd_Result.zip)

Fixes #23701 

No release notes required because this change is very small.

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
