### PR TITLE
Remove extra banks from 2014_08_01 MANDI IDF

### DIFF
--- a/instrument/MANDI_Definition_2014_08_01.xml
+++ b/instrument/MANDI_Definition_2014_08_01.xml
@@ -6,9 +6,10 @@
             xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
  name="MANDI" valid-from   ="2014-08-01 00:00:00"
                          valid-to     ="2015-07-31 23:59:59"
-		         last-modified="2015-08-18 12:00:00">
+		         last-modified="2018-10-04 12:00:00">
   <!--Created by Vickie Lynch-->
   <!--Modified by Vickie Lynch using the MANDI.py script from the Translation Service calibration/geometry/ code. -->
+  <!--Modified by Brendan Sullivan to remove banks not present in nxs files. -->
 
   <!--DEFAULTS-->
   <defaults>
@@ -58,13 +59,6 @@
   </rot>
 </location>
 </component>
-<component type="panel" idstart="655360" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.455000" t="31.999979" p="-90.000000" name="bank10" rot="152.080035" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="53.154399">
-    <rot val="41.466968" axis-x="0" axis-y="1" axis-z="0" />
-  </rot>
-</location>
-</component>
 <component type="panel" idstart="720896" idfillbyfirst="y" idstepbyrow="256">
 <location r="0.455000" t="46.678985" p="-46.751571" name="bank11" rot="-171.919938" axis-x="0" axis-y="1" axis-z="0">
   <rot val="53.154399">
@@ -81,27 +75,6 @@
 </component>
 <component type="panel" idstart="851968" idfillbyfirst="y" idstepbyrow="256">
 <location r="0.455000" t="105.192621" p="-33.305992" name="bank13" rot="-99.919712" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="53.154399">
-    <rot val="41.466968" axis-x="0" axis-y="1" axis-z="0" />
-  </rot>
-</location>
-</component>
-<component type="panel" idstart="917504" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.455000" t="133.320872" p="-46.751427" name="bank14" rot="-63.920201" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="53.154399">
-    <rot val="41.466968" axis-x="0" axis-y="1" axis-z="0" />
-  </rot>
-</location>
-</component>
-<component type="panel" idstart="983040" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.455000" t="148.000021" p="-89.999757" name="bank15" rot="-27.920117" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="53.154399">
-    <rot val="41.466968" axis-x="0" axis-y="1" axis-z="0" />
-  </rot>
-</location>
-</component>
-<component type="panel" idstart="1048576" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.455000" t="133.320872" p="-133.248573" name="bank16" rot="8.080272" axis-x="0" axis-y="1" axis-z="0">
   <rot val="53.154399">
     <rot val="41.466968" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
@@ -149,34 +122,6 @@
   </rot>
 </location>
 </component>
-<component type="panel" idstart="1507328" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.425000" t="124.403098" p="-19.516157" name="bank23" rot="-69.410491" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="47.178655">
-    <rot val="22.073524" axis-x="0" axis-y="1" axis-z="0" />
-  </rot>
-</location>
-</component>
-<component type="panel" idstart="1572864" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.425000" t="156.094224" p="-42.858824" name="bank24" rot="-33.410407" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="47.178655">
-    <rot val="22.073524" axis-x="0" axis-y="1" axis-z="0" />
-  </rot>
-</location>
-</component>
-<component type="panel" idstart="1638400" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.425000" t="156.094224" p="-137.141176" name="bank25" rot="2.589982" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="47.178655">
-    <rot val="22.073524" axis-x="0" axis-y="1" axis-z="0" />
-  </rot>
-</location>
-</component>
-<component type="panel" idstart="1703936" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.425000" t="124.403098" p="-160.483843" name="bank26" rot="38.590066" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="47.178655">
-    <rot val="22.073524" axis-x="0" axis-y="1" axis-z="0" />
-  </rot>
-</location>
-</component>
 <component type="panel" idstart="1769472" idfillbyfirst="y" idstepbyrow="256">
 <location r="0.425000" t="90.000202" p="-163.999982" name="bank27" rot="74.589577" axis-x="0" axis-y="1" axis-z="0">
   <rot val="47.178655">
@@ -219,29 +164,8 @@
   </rot>
 </location>
 </component>
-<component type="panel" idstart="2228224" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.395000" t="143.999764" p="0.000000" name="bank34" rot="-36.000236" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="45.000000">
-    <rot val="0.000000" axis-x="0" axis-y="1" axis-z="0" />
-  </rot>
-</location>
-</component>
-<component type="panel" idstart="2359296" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.395000" t="143.999764" p="180.000000" name="bank36" rot="36.000236" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="45.000000">
-    <rot val="0.000000" axis-x="0" axis-y="1" axis-z="0" />
-  </rot>
-</location>
-</component>
 <component type="panel" idstart="2424832" idfillbyfirst="y" idstepbyrow="256">
 <location r="0.395000" t="108.000253" p="180.000000" name="bank37" rot="71.999747" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="45.000000">
-    <rot val="0.000000" axis-x="0" axis-y="1" axis-z="0" />
-  </rot>
-</location>
-</component>
-<component type="panel" idstart="2490368" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.395000" t="72.000168" p="180.000000" name="bank38" rot="107.999832" axis-x="0" axis-y="1" axis-z="0">
   <rot val="45.000000">
     <rot val="0.000000" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
@@ -270,34 +194,6 @@
 </component>
 <component type="panel" idstart="2752512" idfillbyfirst="y" idstepbyrow="256">
 <location r="0.425000" t="90.000202" p="16.000018" name="bank42" rot="-74.589577" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="47.178655">
-    <rot val="-22.073524" axis-x="0" axis-y="1" axis-z="0" />
-  </rot>
-</location>
-</component>
-<component type="panel" idstart="2818048" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.425000" t="124.403098" p="19.516157" name="bank43" rot="-38.590066" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="47.178655">
-    <rot val="-22.073524" axis-x="0" axis-y="1" axis-z="0" />
-  </rot>
-</location>
-</component>
-<component type="panel" idstart="2883584" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.425000" t="156.094224" p="42.858824" name="bank44" rot="-2.589982" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="47.178655">
-    <rot val="-22.073524" axis-x="0" axis-y="1" axis-z="0" />
-  </rot>
-</location>
-</component>
-<component type="panel" idstart="2949120" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.425000" t="156.094224" p="137.141176" name="bank45" rot="33.410407" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="47.178655">
-    <rot val="-22.073524" axis-x="0" axis-y="1" axis-z="0" />
-  </rot>
-</location>
-</component>
-<component type="panel" idstart="3014656" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.425000" t="124.403098" p="160.483843" name="bank46" rot="69.410491" axis-x="0" axis-y="1" axis-z="0">
   <rot val="47.178655">
     <rot val="-22.073524" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
@@ -345,41 +241,6 @@
   </rot>
 </location>
 </component>
-<component type="panel" idstart="3473408" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.455000" t="105.192621" p="33.305992" name="bank53" rot="-44.079783" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="53.154399">
-    <rot val="-41.466968" axis-x="0" axis-y="1" axis-z="0" />
-  </rot>
-</location>
-</component>
-<component type="panel" idstart="3538944" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.455000" t="133.320872" p="46.751427" name="bank54" rot="-8.080272" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="53.154399">
-    <rot val="-41.466968" axis-x="0" axis-y="1" axis-z="0" />
-  </rot>
-</location>
-</component>
-<component type="panel" idstart="3604480" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.455000" t="148.000021" p="89.999757" name="bank55" rot="27.919812" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="53.154399">
-    <rot val="-41.466968" axis-x="0" axis-y="1" axis-z="0" />
-  </rot>
-</location>
-</component>
-<component type="panel" idstart="3670016" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.455000" t="133.320872" p="133.248573" name="bank56" rot="63.920201" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="53.154399">
-    <rot val="-41.466968" axis-x="0" axis-y="1" axis-z="0" />
-  </rot>
-</location>
-</component>
-<component type="panel" idstart="3735552" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.455000" t="105.192621" p="146.694008" name="bank57" rot="99.919712" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="53.154399">
-    <rot val="-41.466968" axis-x="0" axis-y="1" axis-z="0" />
-  </rot>
-</location>
-</component>
 <component type="panel" idstart="3801088" idfillbyfirst="y" idstepbyrow="256">
 <location r="0.455000" t="74.807731" p="146.694071" name="bank58" rot="135.919796" axis-x="0" axis-y="1" axis-z="0">
   <rot val="53.154399">
@@ -395,7 +256,7 @@
 </location>
 </component>
 <!-- List of all the bank names:
-bank10,bank11,bank12,bank13,bank14,bank15,bank16,bank17,bank18,bank19,bank20,bank21,bank22,bank23,bank24,bank25,bank26,bank27,bank28,bank29,bank31,bank32,bank33,bank34,bank36,bank37,bank38,bank39,bank40,bank41,bank42,bank43,bank44,bank45,bank46,bank47,bank48,bank49,bank50,bank51,bank52,bank53,bank54,bank55,bank56,bank57,bank58,bank59
+bank11,bank12,bank13,bank17,bank18,bank19,bank20,bank21,bank22,bank27,bank28,bank29,bank31,bank32,bank33,bank37,bank39,bank40,bank41,bank42,bank47,bank48,bank49,bank50,bank51,bank52,bank58,bank59
 -->
 
 <!-- NOTE: This detector is the same as the SNAP detector -->


### PR DESCRIPTION
Removes the following banks from the IDF (these banks were not installed during this period and the loader cannot load data from that period):
bank10,bank14,bank15,bank16,bank23,bank24,bank25,bank26,bank34,bank36,bank38,bank43,bank44,bank45,bank46,bank53,bank54,bank55,bank56,bank57,

To test, copy instrument/MANDI_Definition_2014_08_01.xml to where mantid is reading IDFs for loading then run 

```python
Load(Filename='/SNS/MANDI/IPTS-12697/0/4094/NeXus/MANDI_4094_event.nxs', OutputWorkspace='MANDI_4094_event', LoadMonitors=True)
```


<!-- Instructions for testing. -->

Fixes #23719 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
