### PR TITLE
Indirect - Move the run button in Data Corrections and disable when running

### DIFF
--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
@@ -495,28 +495,14 @@ void AbsorptionCorrections::plotClicked() {
 
 void AbsorptionCorrections::runClicked() { runTab(); }
 
-/**
- * Handle changing of the sample density unit
- */
 void AbsorptionCorrections::changeSampleDensityUnit(int index) {
-
-  if (index == 0) {
-    m_uiForm.spSampleDensity->setSuffix(" g/cm3");
-  } else {
-    m_uiForm.spSampleDensity->setSuffix(" 1/A3");
-  }
+  QString const suffix = index == 0 ? " g/cm3" : " 1/A3";
+  m_uiForm.spSampleDensity->setSuffix(suffix);
 }
 
-/**
- * Handle changing of the container density unit
- */
 void AbsorptionCorrections::changeCanDensityUnit(int index) {
-
-  if (index == 0) {
-    m_uiForm.spCanDensity->setSuffix(" g/cm3");
-  } else {
-    m_uiForm.spCanDensity->setSuffix(" 1/A3");
-  }
+  QString const suffix = index == 0 ? " g/cm3" : " 1/A3";
+  m_uiForm.spCanDensity->setSuffix(suffix);
 }
 
 void AbsorptionCorrections::setRunEnabled(bool enabled) {

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
@@ -16,7 +16,7 @@ namespace {
 Mantid::Kernel::Logger g_log("AbsorptionCorrections");
 
 MatrixWorkspace_sptr convertUnits(MatrixWorkspace_sptr workspace,
-                                  const std::string &target) {
+                                  std::string const &target) {
   auto convertAlg = AlgorithmManager::Instance().create("ConvertUnits");
   convertAlg->initialize();
   convertAlg->setChild(true);
@@ -32,7 +32,7 @@ MatrixWorkspace_sptr convertUnits(MatrixWorkspace_sptr workspace,
 }
 
 WorkspaceGroup_sptr
-groupWorkspaces(const std::vector<std::string> &workspaceNames) {
+groupWorkspaces(std::vector<std::string> const &workspaceNames) {
   auto groupAlg = AlgorithmManager::Instance().create("GroupWorkspaces");
   groupAlg->initialize();
   groupAlg->setChild(true);
@@ -43,13 +43,13 @@ groupWorkspaces(const std::vector<std::string> &workspaceNames) {
 }
 
 WorkspaceGroup_sptr convertUnits(WorkspaceGroup_sptr workspaceGroup,
-                                 const std::string &target) {
+                                 std::string const &target) {
   std::vector<std::string> convertedNames;
   convertedNames.reserve(workspaceGroup->size());
 
-  for (const auto &workspace : *workspaceGroup) {
-    const auto name = "__" + workspace->getName() + "_" + target;
-    const auto wavelengthWorkspace = convertUnits(
+  for (auto const &workspace : *workspaceGroup) {
+    auto const name = "__" + workspace->getName() + "_" + target;
+    auto const wavelengthWorkspace = convertUnits(
         boost::dynamic_pointer_cast<MatrixWorkspace>(workspace), target);
     AnalysisDataService::Instance().addOrReplace(name, wavelengthWorkspace);
     convertedNames.emplace_back(name);
@@ -99,7 +99,7 @@ AbsorptionCorrections::~AbsorptionCorrections() {
 }
 
 MatrixWorkspace_sptr AbsorptionCorrections::sampleWorkspace() const {
-  const auto sampleWSName =
+  auto const sampleWSName =
       m_uiForm.dsSampleInput->getCurrentDataName().toStdString();
 
   if (AnalysisDataService::Instance().doesExist(sampleWSName))
@@ -114,7 +114,7 @@ void AbsorptionCorrections::run() {
   setRunIsRunning(true);
 
   // Get correct corrections algorithm
-  QString sampleShape = m_uiForm.cbShape->currentText().replace(" ", "");
+  QString const sampleShape = m_uiForm.cbShape->currentText().replace(" ", "");
 
   IAlgorithm_sptr monteCarloAbsCor =
       AlgorithmManager::Instance().create("CalculateMonteCarloAbsorption");
@@ -125,7 +125,7 @@ void AbsorptionCorrections::run() {
   addShapeSpecificSampleOptions(monteCarloAbsCor, sampleShape);
 
   // Sample details
-  QString sampleWsName = m_uiForm.dsSampleInput->getCurrentDataName();
+  QString const sampleWsName = m_uiForm.dsSampleInput->getCurrentDataName();
   monteCarloAbsCor->setProperty("SampleWorkspace", sampleWsName.toStdString());
 
   monteCarloAbsCor->setProperty(
@@ -134,28 +134,29 @@ void AbsorptionCorrections::run() {
   monteCarloAbsCor->setProperty("SampleDensity",
                                 m_uiForm.spSampleDensity->value());
 
-  QString sampleChemicalFormula = m_uiForm.leSampleChemicalFormula->text();
+  QString const sampleChemicalFormula =
+      m_uiForm.leSampleChemicalFormula->text();
   monteCarloAbsCor->setProperty("SampleChemicalFormula",
                                 sampleChemicalFormula.toStdString());
 
   // General details
   monteCarloAbsCor->setProperty("BeamHeight", m_uiForm.spBeamHeight->value());
   monteCarloAbsCor->setProperty("BeamWidth", m_uiForm.spBeamWidth->value());
-  long wave = static_cast<long>(m_uiForm.spNumberWavelengths->value());
+  long const wave = static_cast<long>(m_uiForm.spNumberWavelengths->value());
   monteCarloAbsCor->setProperty("NumberOfWavelengthPoints", wave);
-  long events = static_cast<long>(m_uiForm.spNumberEvents->value());
+  long const events = static_cast<long>(m_uiForm.spNumberEvents->value());
   monteCarloAbsCor->setProperty("EventsPerPoint", events);
   auto const interpolation =
       m_uiForm.cbInterpolation->currentText().toStdString();
   monteCarloAbsCor->setProperty("Interpolation", interpolation);
-  long maxAttempts =
+  long const maxAttempts =
       static_cast<long>(m_uiForm.spMaxScatterPtAttempts->value());
   monteCarloAbsCor->setProperty("MaxScatterPtAttempts", maxAttempts);
 
   // Can details
-  bool useCan = m_uiForm.ckUseCan->isChecked();
+  bool const useCan = m_uiForm.ckUseCan->isChecked();
   if (useCan) {
-    std::string canWsName =
+    std::string const canWsName =
         m_uiForm.dsCanInput->getCurrentDataName().toStdString();
     monteCarloAbsCor->setProperty("ContainerWorkspace", canWsName);
 
@@ -165,7 +166,7 @@ void AbsorptionCorrections::run() {
     monteCarloAbsCor->setProperty("ContainerDensity",
                                   m_uiForm.spCanDensity->value());
 
-    const auto canChemicalFormula = m_uiForm.leCanChemicalFormula->text();
+    auto const canChemicalFormula = m_uiForm.leCanChemicalFormula->text();
     monteCarloAbsCor->setProperty("ContainerChemicalFormula",
                                   canChemicalFormula.toStdString());
 
@@ -177,7 +178,7 @@ void AbsorptionCorrections::run() {
   if (nameCutIndex == -1)
     nameCutIndex = sampleWsName.length();
 
-  const auto outputWsName =
+  auto const outputWsName =
       sampleWsName.left(nameCutIndex) + "_" + sampleShape + "_MC_Corrections";
 
   monteCarloAbsCor->setProperty("CorrectionsWorkspace",
@@ -205,33 +206,33 @@ void AbsorptionCorrections::addShapeSpecificSampleOptions(IAlgorithm_sptr alg,
                                                           QString shape) {
 
   if (shape == "FlatPlate") {
-    double sampleHeight = m_uiForm.spFlatSampleHeight->value();
+    double const sampleHeight = m_uiForm.spFlatSampleHeight->value();
     alg->setProperty("Height", sampleHeight);
 
-    double sampleWidth = m_uiForm.spFlatSampleWidth->value();
+    double const sampleWidth = m_uiForm.spFlatSampleWidth->value();
     alg->setProperty("SampleWidth", sampleWidth);
 
-    double sampleThickness = m_uiForm.spFlatSampleThickness->value();
+    double const sampleThickness = m_uiForm.spFlatSampleThickness->value();
     alg->setProperty("SampleThickness", sampleThickness);
 
-    double sampleAngle = m_uiForm.spFlatSampleAngle->value();
+    double const sampleAngle = m_uiForm.spFlatSampleAngle->value();
     alg->setProperty("SampleAngle", sampleAngle);
 
   } else if (shape == "Annulus") {
-    double sampleHeight = m_uiForm.spAnnSampleHeight->value();
+    double const sampleHeight = m_uiForm.spAnnSampleHeight->value();
     alg->setProperty("Height", sampleHeight);
 
-    double sampleInnerRadius = m_uiForm.spAnnSampleInnerRadius->value();
+    double const sampleInnerRadius = m_uiForm.spAnnSampleInnerRadius->value();
     alg->setProperty("SampleInnerRadius", sampleInnerRadius);
 
-    double sampleOuterRadius = m_uiForm.spAnnSampleOuterRadius->value();
+    double const sampleOuterRadius = m_uiForm.spAnnSampleOuterRadius->value();
     alg->setProperty("SampleOuterRadius", sampleOuterRadius);
 
   } else if (shape == "Cylinder") {
-    double sampleRadius = m_uiForm.spCylSampleRadius->value();
+    double const sampleRadius = m_uiForm.spCylSampleRadius->value();
     alg->setProperty("SampleRadius", sampleRadius);
 
-    double sampleHeight = m_uiForm.spCylSampleHeight->value();
+    double const sampleHeight = m_uiForm.spCylSampleHeight->value();
     alg->setProperty("Height", sampleHeight);
   }
 }
@@ -245,7 +246,7 @@ void AbsorptionCorrections::addShapeSpecificSampleOptions(IAlgorithm_sptr alg,
  * @param shape Sample shape
  */
 void AbsorptionCorrections::addShapeSpecificCanOptions(IAlgorithm_sptr alg,
-                                                       QString shape) {
+                                                       QString const &shape) {
   if (shape == "FlatPlate") {
     double const canFrontThickness = m_uiForm.spFlatCanFrontThickness->value();
     alg->setProperty("ContainerFrontThickness", canFrontThickness);
@@ -273,10 +274,9 @@ bool AbsorptionCorrections::validate() {
 
   // Give error for failed validation
   if (!uiv.isAllInputValid()) {
-    QString error = uiv.generateErrorMessage();
+    auto const error = uiv.generateErrorMessage();
     showMessageBox(error);
   }
-
   return uiv.isAllInputValid();
 }
 
@@ -348,11 +348,11 @@ void AbsorptionCorrections::loadSettings(const QSettings &settings) {
 }
 
 void AbsorptionCorrections::processWavelengthWorkspace() {
-  auto correctionsWorkspace =
+  auto const correctionsWs =
       AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
           m_pythonExportWsName);
-  if (correctionsWorkspace) {
-    auto wavelengthWorkspace = convertUnits(correctionsWorkspace, "Wavelength");
+  if (correctionsWs) {
+    auto const wavelengthWorkspace = convertUnits(correctionsWs, "Wavelength");
     AnalysisDataService::Instance().addOrReplace("__mc_corrections_wavelength",
                                                  wavelengthWorkspace);
   }
@@ -376,23 +376,19 @@ void AbsorptionCorrections::algorithmComplete(bool error) {
 }
 
 void AbsorptionCorrections::getParameterDefaults(QString const &dataName) {
-  auto sampleWs = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
-      dataName.toStdString());
-  if (sampleWs) {
-    auto instrument = sampleWs->getInstrument();
-    getBeamDefaults(instrument);
-    getMonteCarloDefaults(instrument);
-  } else
+  auto const sampleWs =
+      AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+          dataName.toStdString());
+  if (sampleWs)
+    getParameterDefaults(sampleWs->getInstrument());
+  else
     displayInvalidWorkspaceTypeError(dataName.toStdString(), g_log);
 }
 
-void AbsorptionCorrections::getBeamDefaults(Instrument_const_sptr instrument) {
+void AbsorptionCorrections::getParameterDefaults(
+    Instrument_const_sptr instrument) {
   setBeamWidthValue(instrument, "Workflow.beam-width");
   setBeamHeightValue(instrument, "Workflow.beam-height");
-}
-
-void AbsorptionCorrections::getMonteCarloDefaults(
-    Instrument_const_sptr instrument) {
   setWavelengthsValue(instrument, "Workflow.absorption-wavelengths");
   setEventsValue(instrument, "Workflow.absorption-events");
   setInterpolationValue(instrument, "Workflow.absorption-interpolation");
@@ -466,16 +462,15 @@ void AbsorptionCorrections::setMaxAttemptsValue(
   }
 }
 
+void AbsorptionCorrections::addSaveWorkspace(std::string const &workspaceName) {
+  if (checkADSForPlotSaveWorkspace(workspaceName, false))
+    addSaveWorkspaceToQueue(QString::fromStdString(workspaceName));
+}
+
 void AbsorptionCorrections::saveClicked() {
-
-  if (checkADSForPlotSaveWorkspace(m_pythonExportWsName, false))
-    addSaveWorkspaceToQueue(QString::fromStdString(m_pythonExportWsName));
-
-  std::string factorsWs =
-      m_absCorAlgo->getPropertyValue("CorrectionsWorkspace");
-  if (checkADSForPlotSaveWorkspace(factorsWs, false))
-    addSaveWorkspaceToQueue(QString::fromStdString(factorsWs));
-
+  auto const factorsWs = m_absCorAlgo->getPropertyValue("CorrectionsWorkspace");
+  addSaveWorkspace(m_pythonExportWsName);
+  addSaveWorkspace(factorsWs);
   m_batchAlgoRunner->executeBatchAsync();
 }
 

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
@@ -542,6 +542,7 @@ void AbsorptionCorrections::setRunIsRunning(bool running) {
 void AbsorptionCorrections::setPlotResultIsPlotting(bool plotting) {
   m_uiForm.pbPlot->setText(plotting ? "Plotting..." : "Plot");
   setPlotResultEnabled(!plotting);
+  setRunEnabled(!plotting);
   setSaveResultEnabled(!plotting);
 }
 

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
@@ -367,9 +367,12 @@ void AbsorptionCorrections::algorithmComplete(bool error) {
   setRunIsRunning(false);
   if (!error)
     processWavelengthWorkspace();
-  else
+  else {
+    setPlotResultEnabled(false);
+    setSaveResultEnabled(false);
     emit showMessageBox(
         "Could not run absorption corrections.\nSee Results Log for details.");
+  }
 }
 
 void AbsorptionCorrections::getParameterDefaults(QString const &dataName) {

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
@@ -78,9 +78,10 @@ AbsorptionCorrections::AbsorptionCorrections(QWidget *parent)
   // Handle algorithm completion
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
           SLOT(algorithmComplete(bool)));
-  // Handle plotting and saving
+  // Handle running, plotting and saving
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
   connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
+  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
 
   // Handle density units
   connect(m_uiForm.cbSampleDensity, SIGNAL(currentIndexChanged(int)), this,
@@ -463,9 +464,6 @@ void AbsorptionCorrections::setMaxAttemptsValue(
   }
 }
 
-/**
- * Handle saving of workspace
- */
 void AbsorptionCorrections::saveClicked() {
 
   if (checkADSForPlotSaveWorkspace(m_pythonExportWsName, false))
@@ -479,9 +477,6 @@ void AbsorptionCorrections::saveClicked() {
   m_batchAlgoRunner->executeBatchAsync();
 }
 
-/**
- * Handle mantid plotting
- */
 void AbsorptionCorrections::plotClicked() {
   const auto plotType = m_uiForm.cbPlotOutput->currentText();
 
@@ -493,6 +488,8 @@ void AbsorptionCorrections::plotClicked() {
       plotTimeBin(QString::fromStdString("__mc_corrections_wavelength"));
   }
 }
+
+void AbsorptionCorrections::runClicked() { runTab(); }
 
 /**
  * Handle changing of the sample density unit

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.h
@@ -33,17 +33,15 @@ private:
   bool validate() override;
   void loadSettings(const QSettings &settings) override;
 
-  void addSaveWorkspace(QString wsName);
+  void addSaveWorkspace(std::string const &wsName);
   void addShapeSpecificSampleOptions(Mantid::API::IAlgorithm_sptr alg,
                                      QString shape);
   void addShapeSpecificCanOptions(Mantid::API::IAlgorithm_sptr alg,
-                                  QString shape);
+                                  QString const &shape);
 
   void processWavelengthWorkspace();
 
-  void getBeamDefaults(Mantid::Geometry::Instrument_const_sptr instrument);
-  void
-  getMonteCarloDefaults(Mantid::Geometry::Instrument_const_sptr instrument);
+  void getParameterDefaults(Mantid::Geometry::Instrument_const_sptr instrument);
   void setBeamWidthValue(Mantid::Geometry::Instrument_const_sptr instrument,
                          std::string const &beamWidthParamName) const;
   void setBeamHeightValue(Mantid::Geometry::Instrument_const_sptr instrument,

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.h
@@ -17,11 +17,44 @@ public:
 
   Mantid::API::MatrixWorkspace_sptr sampleWorkspace() const;
 
+private slots:
+  virtual void algorithmComplete(bool error);
+  void saveClicked();
+  void plotClicked();
+  void runClicked();
+  void getParameterDefaults(QString const &dataName);
+  void changeSampleDensityUnit(int);
+  void changeCanDensityUnit(int);
+  UserInputValidator doValidation();
+
 private:
   void setup() override;
   void run() override;
   bool validate() override;
   void loadSettings(const QSettings &settings) override;
+
+  void addSaveWorkspace(QString wsName);
+  void addShapeSpecificSampleOptions(Mantid::API::IAlgorithm_sptr alg,
+                                     QString shape);
+  void addShapeSpecificCanOptions(Mantid::API::IAlgorithm_sptr alg,
+                                  QString shape);
+
+  void processWavelengthWorkspace();
+
+  void getBeamDefaults(Instrument_const_sptr instrument);
+  void getMonteCarloDefaults(Instrument_const_sptr instrument);
+  void setBeamWidthValue(Instrument_const_sptr instrument,
+                         std::string const &beamWidthParamName) const;
+  void setBeamHeightValue(Instrument_const_sptr instrument,
+                          std::string const &beamHeightParamName) const;
+  void setWavelengthsValue(Mantid::Geometry::Instrument_const_sptr instrument,
+                           std::string const &wavelengthsParamName) const;
+  void setEventsValue(Mantid::Geometry::Instrument_const_sptr instrument,
+                      std::string const &eventsParamName) const;
+  void setInterpolationValue(Mantid::Geometry::Instrument_const_sptr instrument,
+                             std::string const &interpolationParamName) const;
+  void setMaxAttemptsValue(Mantid::Geometry::Instrument_const_sptr instrument,
+                           std::string const &maxAttemptsParamName) const;
 
   void setRunEnabled(bool enabled);
   void setPlotResultEnabled(bool enabled);
@@ -29,32 +62,6 @@ private:
 
   void setRunIsRunning(bool running);
   void setPlotResultIsPlotting(bool plotting);
-
-private slots:
-  virtual void algorithmComplete(bool error);
-  void saveClicked();
-  void plotClicked();
-  void runClicked();
-  void getBeamDefaults(const QString &dataName);
-  void getMonteCarloDefaults(const QString &dataName);
-  void setWavelengthsValue(Mantid::Geometry::Instrument_const_sptr instrument,
-                           const std::string &wavelengthsParamName) const;
-  void setEventsValue(Mantid::Geometry::Instrument_const_sptr instrument,
-                      const std::string &eventsParamName) const;
-  void setInterpolationValue(Mantid::Geometry::Instrument_const_sptr instrument,
-                             const std::string &interpolationParamName) const;
-  void setMaxAttemptsValue(Mantid::Geometry::Instrument_const_sptr instrument,
-                           const std::string &maxAttemptsParamName) const;
-  void changeSampleDensityUnit(int);
-  void changeCanDensityUnit(int);
-  UserInputValidator doValidation();
-
-private:
-  void addSaveWorkspace(QString wsName);
-  void addShapeSpecificSampleOptions(Mantid::API::IAlgorithm_sptr alg,
-                                     QString shape);
-  void addShapeSpecificCanOptions(Mantid::API::IAlgorithm_sptr alg,
-                                  QString shape);
 
   Ui::AbsorptionCorrections m_uiForm;
   /// alg

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.h
@@ -60,7 +60,6 @@ private:
   void setRunEnabled(bool enabled);
   void setPlotResultEnabled(bool enabled);
   void setSaveResultEnabled(bool enabled);
-
   void setRunIsRunning(bool running);
   void setPlotResultIsPlotting(bool plotting);
 

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.h
@@ -41,11 +41,12 @@ private:
 
   void processWavelengthWorkspace();
 
-  void getBeamDefaults(Instrument_const_sptr instrument);
-  void getMonteCarloDefaults(Instrument_const_sptr instrument);
-  void setBeamWidthValue(Instrument_const_sptr instrument,
+  void getBeamDefaults(Mantid::Geometry::Instrument_const_sptr instrument);
+  void
+  getMonteCarloDefaults(Mantid::Geometry::Instrument_const_sptr instrument);
+  void setBeamWidthValue(Mantid::Geometry::Instrument_const_sptr instrument,
                          std::string const &beamWidthParamName) const;
-  void setBeamHeightValue(Instrument_const_sptr instrument,
+  void setBeamHeightValue(Mantid::Geometry::Instrument_const_sptr instrument,
                           std::string const &beamHeightParamName) const;
   void setWavelengthsValue(Mantid::Geometry::Instrument_const_sptr instrument,
                            std::string const &wavelengthsParamName) const;

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.h
@@ -27,6 +27,7 @@ private slots:
   virtual void algorithmComplete(bool error);
   void saveClicked();
   void plotClicked();
+  void runClicked();
   void getBeamDefaults(const QString &dataName);
   void getMonteCarloDefaults(const QString &dataName);
   void setWavelengthsValue(Mantid::Geometry::Instrument_const_sptr instrument,

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.h
@@ -23,6 +23,13 @@ private:
   bool validate() override;
   void loadSettings(const QSettings &settings) override;
 
+  void setRunEnabled(bool enabled);
+  void setPlotResultEnabled(bool enabled);
+  void setSaveResultEnabled(bool enabled);
+
+  void setRunIsRunning(bool running);
+  void setPlotResultIsPlotting(bool plotting);
+
 private slots:
   virtual void algorithmComplete(bool error);
   void saveClicked();

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.ui
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.ui
@@ -844,6 +844,66 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="gbRun">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>45</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>45</height>
+      </size>
+     </property>
+     <property name="title">
+      <string>Run</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>7</number>
+      </property>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>348</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pbRun">
+        <property name="text">
+         <string>Run</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>348</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="gbOutput">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
@@ -651,6 +651,7 @@ void ApplyAbsorptionCorrections::setRunIsRunning(bool running) {
 void ApplyAbsorptionCorrections::setPlotResultIsPlotting(bool plotting) {
   m_uiForm.pbPlot->setText(plotting ? "Plotting..." : "Plot");
   setPlotResultEnabled(!plotting);
+  setRunEnabled(!plotting);
   setSaveResultEnabled(!plotting);
 }
 

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
@@ -392,9 +392,13 @@ void ApplyAbsorptionCorrections::absCorComplete(bool error) {
     connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
             SLOT(postProcessComplete(bool)));
     m_batchAlgoRunner->executeBatchAsync();
-  } else
+  } else {
+    setRunIsRunning(false);
+    setPlotResultEnabled(false);
+    setSaveResultEnabled(false);
     emit showMessageBox(
         "Unable to apply corrections.\nSee Results Log for more details.");
+  }
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
@@ -19,6 +19,7 @@ ApplyAbsorptionCorrections::ApplyAbsorptionCorrections(QWidget *parent)
     : CorrectionsTab(parent) {
   m_spectra = 0;
   m_uiForm.setupUi(parent);
+
   connect(m_uiForm.cbGeometry, SIGNAL(currentIndexChanged(int)), this,
           SLOT(handleGeometryChange(int)));
   connect(m_uiForm.dsSample, SIGNAL(dataReady(const QString &)), this,
@@ -41,6 +42,7 @@ ApplyAbsorptionCorrections::ApplyAbsorptionCorrections(QWidget *parent)
           SLOT(updateContainer()));
   connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
+  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
   connect(m_uiForm.pbPlotPreview, SIGNAL(clicked()), this,
           SLOT(plotCurrentPreview()));
 
@@ -543,9 +545,7 @@ void ApplyAbsorptionCorrections::plotPreview(int wsIndex) {
 
   m_spectra = boost::numeric_cast<size_t>(wsIndex);
 }
-/**
- * Handles saving of the workspace
- */
+
 void ApplyAbsorptionCorrections::saveClicked() {
 
   if (checkADSForPlotSaveWorkspace(m_pythonExportWsName, false))
@@ -553,9 +553,6 @@ void ApplyAbsorptionCorrections::saveClicked() {
   m_batchAlgoRunner->executeBatchAsync();
 }
 
-/**
- * Handles mantid plotting of workspace
- */
 void ApplyAbsorptionCorrections::plotClicked() {
 
   QString plotType = m_uiForm.cbPlotOutput->currentText();
@@ -569,6 +566,8 @@ void ApplyAbsorptionCorrections::plotClicked() {
       plot2D(QString::fromStdString(m_pythonExportWsName));
   }
 }
+
+void ApplyAbsorptionCorrections::runClicked() { runTab(); }
 
 /**
  * Plots the current spectrum displayed in the preview plot

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.h
@@ -47,6 +47,13 @@ private:
                      Mantid::API::MatrixWorkspace_sptr &ws,
                      const QColor &curveColor);
 
+  void setRunEnabled(bool enabled);
+  void setPlotResultEnabled(bool enabled);
+  void setSaveResultEnabled(bool enabled);
+
+  void setRunIsRunning(bool running);
+  void setPlotResultIsPlotting(bool plotting);
+
   Ui::ApplyAbsorptionCorrections m_uiForm;
 
   std::string m_originalSampleUnits;

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.h
@@ -32,6 +32,7 @@ private slots:
   /// Handles mantid plot and save
   void saveClicked();
   void plotClicked();
+  void runClicked();
   void plotCurrentPreview();
 
 private:

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.h
@@ -50,7 +50,6 @@ private:
   void setRunEnabled(bool enabled);
   void setPlotResultEnabled(bool enabled);
   void setSaveResultEnabled(bool enabled);
-
   void setRunIsRunning(bool running);
   void setPlotResultIsPlotting(bool plotting);
 

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.ui
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.ui
@@ -257,7 +257,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="gbPreview">
      <property name="title">
       <string>Preview</string>
      </property>
@@ -298,6 +298,66 @@
          </widget>
         </item>
        </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gbRun">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>45</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>45</height>
+      </size>
+     </property>
+     <property name="title">
+      <string>Run</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>7</number>
+      </property>
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>311</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pbRun">
+        <property name="text">
+         <string>Run</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>310</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
       </item>
      </layout>
     </widget>

--- a/qt/scientific_interfaces/Indirect/CalculatePaalmanPings.cpp
+++ b/qt/scientific_interfaces/Indirect/CalculatePaalmanPings.cpp
@@ -41,9 +41,10 @@ CalculatePaalmanPings::CalculatePaalmanPings(QWidget *parent)
           SLOT(validateChemical()));
   connect(m_uiForm.leCanChemicalFormula, SIGNAL(editingFinished()), this,
           SLOT(validateChemical()));
-  // Connect slots for plot and save
+  // Connect slots for run, plot and save
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
   connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
+  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
 
   // Connect slots for toggling the mass/number density unit
   connect(m_uiForm.cbSampleDensity, SIGNAL(currentIndexChanged(int)), this,
@@ -538,9 +539,6 @@ void CalculatePaalmanPings::addShapeSpecificCanOptions(IAlgorithm_sptr alg,
   }
 }
 
-/**
- * Handles saving of workspace
- */
 void CalculatePaalmanPings::saveClicked() {
 
   if (checkADSForPlotSaveWorkspace(m_pythonExportWsName, false))
@@ -548,9 +546,6 @@ void CalculatePaalmanPings::saveClicked() {
   m_batchAlgoRunner->executeBatchAsync();
 }
 
-/**
- * Handles mantid plotting of workspace
- */
 void CalculatePaalmanPings::plotClicked() {
 
   QString plotType = m_uiForm.cbPlotOutput->currentText();
@@ -564,6 +559,8 @@ void CalculatePaalmanPings::plotClicked() {
       plotTimeBin(QString::fromStdString(m_pythonExportWsName));
   }
 }
+
+void CalculatePaalmanPings::runClicked() { runTab(); }
 
 /**
  * Handle changing of the sample density unit

--- a/qt/scientific_interfaces/Indirect/CalculatePaalmanPings.h
+++ b/qt/scientific_interfaces/Indirect/CalculatePaalmanPings.h
@@ -14,14 +14,6 @@ class DLLExport CalculatePaalmanPings : public CorrectionsTab {
 public:
   CalculatePaalmanPings(QWidget *parent = nullptr);
 
-private:
-  void setup() override;
-  void run() override;
-  bool validate() override;
-  void loadSettings(const QSettings &settings) override;
-
-  bool doValidation(bool silent = false);
-
 private slots:
   void absCorComplete(bool error);
   void postProcessComplete(bool error);
@@ -35,10 +27,24 @@ private slots:
   void changeCanDensityUnit(int);
 
 private:
+  void setup() override;
+  void run() override;
+  bool validate() override;
+  void loadSettings(const QSettings &settings) override;
+
+  bool doValidation(bool silent = false);
+
   void addShapeSpecificSampleOptions(Mantid::API::IAlgorithm_sptr alg,
                                      QString shape);
   void addShapeSpecificCanOptions(Mantid::API::IAlgorithm_sptr alg,
                                   QString shape);
+
+  void setRunEnabled(bool enabled);
+  void setPlotResultEnabled(bool enabled);
+  void setSaveResultEnabled(bool enabled);
+  void setRunIsRunning(bool running);
+  void setPlotResultIsPlotting(bool plotting);
+
   boost::optional<double>
   getInstrumentParameter(Mantid::Geometry::Instrument_const_sptr instrument,
                          const std::string &parameterName);

--- a/qt/scientific_interfaces/Indirect/CalculatePaalmanPings.h
+++ b/qt/scientific_interfaces/Indirect/CalculatePaalmanPings.h
@@ -30,6 +30,7 @@ private slots:
   void validateChemical();
   void saveClicked();
   void plotClicked();
+  void runClicked();
   void changeSampleDensityUnit(int);
   void changeCanDensityUnit(int);
 

--- a/qt/scientific_interfaces/Indirect/CalculatePaalmanPings.ui
+++ b/qt/scientific_interfaces/Indirect/CalculatePaalmanPings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>661</width>
-    <height>575</height>
+    <height>662</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,12 +16,6 @@
   <layout class="QVBoxLayout" name="layoutAbsF2P">
    <item>
     <widget class="QGroupBox" name="gbInput">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
      <property name="title">
       <string>Input</string>
      </property>
@@ -110,11 +104,11 @@
    </item>
    <item>
     <widget class="QGroupBox" name="corrDetails">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>93</height>
+      </size>
      </property>
      <property name="toolTip">
       <string>Correction computation details. By default will be set automatically from the instrument parameters of the input workspace. Modify to override.</string>
@@ -235,12 +229,6 @@
    </item>
    <item>
     <widget class="QGroupBox" name="gbShapeDetails">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
      <property name="title">
       <string>Shape Details</string>
      </property>
@@ -282,23 +270,31 @@
         </property>
         <widget class="QWidget" name="pgFlatPlate">
          <layout class="QGridLayout" name="gridLayout_2">
-          <property name="margin">
+          <property name="leftMargin">
            <number>0</number>
           </property>
-          <item row="0" column="2">
-           <widget class="QLabel" name="lbFlatSampleAngle">
-            <property name="text">
-             <string>Sample Angle:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="lbFlatCanFrontThickness">
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item row="3" column="1">
+           <widget class="QDoubleSpinBox" name="spFlatCanFrontThickness">
             <property name="enabled">
              <bool>false</bool>
             </property>
-            <property name="text">
-             <string>Container Front Thickness:</string>
+            <property name="suffix">
+             <string> cm</string>
+            </property>
+            <property name="decimals">
+             <number>3</number>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
             </property>
            </widget>
           </item>
@@ -309,6 +305,23 @@
             </property>
             <property name="text">
              <string>Container Back Thickness:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="lbFlatSampleThickness">
+            <property name="text">
+             <string>Sample Thickness:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="lbFlatCanFrontThickness">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="text">
+             <string>Container Front Thickness:</string>
             </property>
            </widget>
           </item>
@@ -328,18 +341,8 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="lbFlatSampleThickness">
-            <property name="text">
-             <string>Sample Thickness:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QDoubleSpinBox" name="spFlatCanFrontThickness">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
+          <item row="0" column="1">
+           <widget class="QDoubleSpinBox" name="spFlatSampleThickness">
             <property name="suffix">
              <string> cm</string>
             </property>
@@ -358,16 +361,10 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
-           <widget class="QDoubleSpinBox" name="spFlatSampleThickness">
-            <property name="suffix">
-             <string> cm</string>
-            </property>
-            <property name="decimals">
-             <number>3</number>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
+          <item row="0" column="2">
+           <widget class="QLabel" name="lbFlatSampleAngle">
+            <property name="text">
+             <string>Sample Angle:</string>
             </property>
            </widget>
           </item>
@@ -375,7 +372,16 @@
         </widget>
         <widget class="QWidget" name="pgCylinder">
          <layout class="QGridLayout" name="gridLayout_4">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
            <number>0</number>
           </property>
           <item row="5" column="3">
@@ -494,7 +500,16 @@
         </widget>
         <widget class="QWidget" name="pgAnnulus">
          <layout class="QGridLayout" name="gridLayout_5">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
            <number>0</number>
           </property>
           <item row="5" column="3">
@@ -641,11 +656,11 @@
    </item>
    <item>
     <widget class="QGroupBox" name="gbSampleDetails">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>93</height>
+      </size>
      </property>
      <property name="title">
       <string>Sample Details</string>
@@ -719,11 +734,11 @@
      <property name="enabled">
       <bool>false</bool>
      </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>93</height>
+      </size>
      </property>
      <property name="title">
       <string>Can Details</string>
@@ -790,13 +805,67 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="gbOutput">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+    <widget class="QGroupBox" name="gbRun">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>45</height>
+      </size>
      </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>45</height>
+      </size>
+     </property>
+     <property name="title">
+      <string>Run</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>7</number>
+      </property>
+      <item>
+       <spacer name="horizontalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>265</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pbRun">
+        <property name="text">
+         <string>Run</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_4">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>265</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gbOutput">
      <property name="title">
       <string>Output Options</string>
      </property>

--- a/qt/scientific_interfaces/Indirect/ContainerSubtraction.cpp
+++ b/qt/scientific_interfaces/Indirect/ContainerSubtraction.cpp
@@ -58,39 +58,39 @@ void ContainerSubtraction::setTransformedContainer(
 void ContainerSubtraction::setup() {}
 
 void ContainerSubtraction::run() {
-  if (!m_csSampleWS)
-    return;
-  if (!m_csContainerWS)
-    return;
+  setRunIsRunning(true);
 
-  m_originalSampleUnits = m_csSampleWS->getAxis(0)->unit()->unitID();
+  if (m_csSampleWS && m_csContainerWS) {
+    m_originalSampleUnits = m_csSampleWS->getAxis(0)->unit()->unitID();
 
-  // Check if using shift / scale
-  const bool shift = m_uiForm.ckShiftCan->isChecked();
-  const bool scale = m_uiForm.ckScaleCan->isChecked();
+    // Check if using shift / scale
+    const bool shift = m_uiForm.ckShiftCan->isChecked();
+    const bool scale = m_uiForm.ckScaleCan->isChecked();
 
-  auto containerWs = m_csContainerWS;
-  if (shift) {
-    containerWs = shiftWorkspace(containerWs, m_uiForm.spShift->value());
-    containerWs = rebinToWorkspace(containerWs, m_csSampleWS);
-  } else if (!checkWorkspaceBinningMatches(m_csSampleWS, containerWs)) {
-    containerWs = requestRebinToSample(containerWs);
+    auto containerWs = m_csContainerWS;
+    if (shift) {
+      containerWs = shiftWorkspace(containerWs, m_uiForm.spShift->value());
+      containerWs = rebinToWorkspace(containerWs, m_csSampleWS);
+    } else if (!checkWorkspaceBinningMatches(m_csSampleWS, containerWs)) {
+      containerWs = requestRebinToSample(containerWs);
 
-    if (!checkWorkspaceBinningMatches(m_csSampleWS, containerWs)) {
-      g_log.error("Cannot apply container corrections using a sample and "
-                  "container with different binning.");
-      return;
+      if (!checkWorkspaceBinningMatches(m_csSampleWS, containerWs)) {
+        g_log.error("Cannot apply container corrections using a sample and "
+                    "container with different binning.");
+        return;
+      }
     }
+
+    if (scale)
+      containerWs = scaleWorkspace(containerWs, m_uiForm.spCanScale->value());
+
+    m_csSubtractedWS = minusWorkspace(m_csSampleWS, containerWs);
+    m_pythonExportWsName = createOutputName();
+    AnalysisDataService::Instance().addOrReplace(m_pythonExportWsName,
+                                                 m_csSubtractedWS);
+    containerSubtractionComplete();
   }
-
-  if (scale)
-    containerWs = scaleWorkspace(containerWs, m_uiForm.spCanScale->value());
-
-  m_csSubtractedWS = minusWorkspace(m_csSampleWS, containerWs);
-  m_pythonExportWsName = createOutputName();
-  AnalysisDataService::Instance().addOrReplace(m_pythonExportWsName,
-                                               m_csSubtractedWS);
-  containerSubtractionComplete();
+  setRunIsRunning(false);
 }
 
 std::string ContainerSubtraction::createOutputName() {
@@ -314,11 +314,6 @@ void ContainerSubtraction::containerSubtractionComplete() {
                                           "Number", logText);
     m_batchAlgoRunner->addAlgorithm(shiftLog);
   }
-
-  // Enable post process plotting and saving
-  m_uiForm.cbPlotOutput->setEnabled(true);
-  m_uiForm.pbPlot->setEnabled(true);
-  m_uiForm.pbSave->setEnabled(true);
 }
 
 void ContainerSubtraction::saveClicked() {
@@ -330,8 +325,9 @@ void ContainerSubtraction::saveClicked() {
 }
 
 void ContainerSubtraction::plotClicked() {
-  QString plotType = m_uiForm.cbPlotOutput->currentText();
+  setPlotResultIsPlotting(true);
 
+  QString plotType = m_uiForm.cbPlotOutput->currentText();
   if (checkADSForPlotSaveWorkspace(m_pythonExportWsName, true)) {
 
     if (plotType == "Spectra" || plotType == "Both")
@@ -340,6 +336,7 @@ void ContainerSubtraction::plotClicked() {
     if (plotType == "Contour" || plotType == "Both")
       plot2D(QString::fromStdString(m_pythonExportWsName));
   }
+  setPlotResultIsPlotting(false);
 }
 
 void ContainerSubtraction::runClicked() { runTab(); }
@@ -536,6 +533,33 @@ IAlgorithm_sptr ContainerSubtraction::addSampleLogAlgorithm(
   shiftLog->setProperty("LogType", type);
   shiftLog->setProperty("LogText", value);
   return shiftLog;
+}
+
+void ContainerSubtraction::setRunEnabled(bool enabled) {
+  m_uiForm.pbRun->setEnabled(enabled);
+}
+
+void ContainerSubtraction::setPlotResultEnabled(bool enabled) {
+  m_uiForm.pbPlot->setEnabled(enabled);
+  m_uiForm.cbPlotOutput->setEnabled(enabled);
+}
+
+void ContainerSubtraction::setSaveResultEnabled(bool enabled) {
+  m_uiForm.pbSave->setEnabled(enabled);
+}
+
+void ContainerSubtraction::setRunIsRunning(bool running) {
+  m_uiForm.pbRun->setText(running ? "Running..." : "Run");
+  setRunEnabled(!running);
+  setPlotResultEnabled(!running);
+  setSaveResultEnabled(!running);
+}
+
+void ContainerSubtraction::setPlotResultIsPlotting(bool plotting) {
+  m_uiForm.pbPlot->setText(plotting ? "Plotting..." : "Plot");
+  setPlotResultEnabled(!plotting);
+  setRunEnabled(!plotting);
+  setSaveResultEnabled(!plotting);
 }
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/ContainerSubtraction.cpp
+++ b/qt/scientific_interfaces/Indirect/ContainerSubtraction.cpp
@@ -17,7 +17,6 @@ ContainerSubtraction::ContainerSubtraction(QWidget *parent)
     : CorrectionsTab(parent), m_spectra(0) {
   m_uiForm.setupUi(parent);
 
-  // Connect slots
   connect(m_uiForm.dsSample, SIGNAL(dataReady(const QString &)), this,
           SLOT(newSample(const QString &)));
   connect(m_uiForm.dsContainer, SIGNAL(dataReady(const QString &)), this,
@@ -30,6 +29,7 @@ ContainerSubtraction::ContainerSubtraction(QWidget *parent)
           SLOT(updateCan()));
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
   connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
+  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
   connect(m_uiForm.pbPlotPreview, SIGNAL(clicked()), this,
           SLOT(plotCurrentPreview()));
 
@@ -321,9 +321,6 @@ void ContainerSubtraction::containerSubtractionComplete() {
   m_uiForm.pbSave->setEnabled(true);
 }
 
-/**
- * Handles saving of workspace
- */
 void ContainerSubtraction::saveClicked() {
 
   // Check workspace exists
@@ -332,9 +329,6 @@ void ContainerSubtraction::saveClicked() {
   m_batchAlgoRunner->executeBatchAsync();
 }
 
-/**
- * Handles Mantid plotting of workspace
- */
 void ContainerSubtraction::plotClicked() {
   QString plotType = m_uiForm.cbPlotOutput->currentText();
 
@@ -347,6 +341,8 @@ void ContainerSubtraction::plotClicked() {
       plot2D(QString::fromStdString(m_pythonExportWsName));
   }
 }
+
+void ContainerSubtraction::runClicked() { runTab(); }
 
 /**
  * Plots the current spectrum displayed in the preview plot

--- a/qt/scientific_interfaces/Indirect/ContainerSubtraction.h
+++ b/qt/scientific_interfaces/Indirect/ContainerSubtraction.h
@@ -28,12 +28,12 @@ private slots:
   void plotPreview(int wsIndex);
   /// Handle abs. correction algorithm completion
   void containerSubtractionComplete();
-  /// Handles saving workspace
-  void saveClicked();
-  /// Handles mantid plotting
-  void plotClicked();
   /// Handles plotting the preview.
   void plotCurrentPreview();
+
+  void saveClicked();
+  void plotClicked();
+  void runClicked();
 
 private:
   void setup() override;

--- a/qt/scientific_interfaces/Indirect/ContainerSubtraction.h
+++ b/qt/scientific_interfaces/Indirect/ContainerSubtraction.h
@@ -84,6 +84,12 @@ private:
                         const std::string &name, const std::string &type,
                         const std::string &value) const;
 
+  void setRunEnabled(bool enabled);
+  void setPlotResultEnabled(bool enabled);
+  void setSaveResultEnabled(bool enabled);
+  void setRunIsRunning(bool running);
+  void setPlotResultIsPlotting(bool plotting);
+
   Ui::ContainerSubtraction m_uiForm;
   std::string m_originalSampleUnits;
 

--- a/qt/scientific_interfaces/Indirect/ContainerSubtraction.ui
+++ b/qt/scientific_interfaces/Indirect/ContainerSubtraction.ui
@@ -254,6 +254,60 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="gbRun">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>45</height>
+      </size>
+     </property>
+     <property name="title">
+      <string>Run</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>7</number>
+      </property>
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>439</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pbRun">
+        <property name="text">
+         <string>Run</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>439</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="gbOutput">
      <property name="title">
       <string>Output Options</string>

--- a/qt/scientific_interfaces/Indirect/IndirectCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectCorrections.cpp
@@ -84,7 +84,7 @@ void IndirectCorrections::initLayout() {
   connect(m_uiForm.pbPythonExport, SIGNAL(clicked()), this,
           SLOT(exportTabPython()));
   connect(m_uiForm.pbHelp, SIGNAL(clicked()), this, SLOT(help()));
-  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(run()));
+  //connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(run()));
   connect(m_uiForm.pbManageDirs, SIGNAL(clicked()), this,
           SLOT(openDirectoryDialog()));
 }
@@ -117,14 +117,6 @@ void IndirectCorrections::loadSettings() {
     tab->second->loadTabSettings(settings);
 
   settings.endGroup();
-}
-
-/**
- * Private slot, called when the Run button is pressed.  Runs current tab.
- */
-void IndirectCorrections::run() {
-  const unsigned int currentTab = m_uiForm.twTabs->currentIndex();
-  m_tabs[currentTab]->runTab();
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/IndirectCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectCorrections.cpp
@@ -84,7 +84,7 @@ void IndirectCorrections::initLayout() {
   connect(m_uiForm.pbPythonExport, SIGNAL(clicked()), this,
           SLOT(exportTabPython()));
   connect(m_uiForm.pbHelp, SIGNAL(clicked()), this, SLOT(help()));
-  //connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(run()));
+  // connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(run()));
   connect(m_uiForm.pbManageDirs, SIGNAL(clicked()), this,
           SLOT(openDirectoryDialog()));
 }

--- a/qt/scientific_interfaces/Indirect/IndirectCorrections.h
+++ b/qt/scientific_interfaces/Indirect/IndirectCorrections.h
@@ -68,8 +68,6 @@ private:
 private slots:
   /// Called when the user clicks the Py button
   void exportTabPython();
-  /// Called when the Run button is pressed.  Runs current tab.
-  void run();
   /// Opens a directory dialog.
   void openDirectoryDialog();
   /// Opens the Mantid Wiki web page of the current tab.

--- a/qt/scientific_interfaces/Indirect/IndirectCorrections.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectCorrections.ui
@@ -114,26 +114,6 @@
        </spacer>
       </item>
       <item>
-       <widget class="QPushButton" name="pbRun">
-        <property name="text">
-         <string>Run</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_11">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
        <widget class="QPushButton" name="pbManageDirs">
         <property name="text">
          <string>Manage Directories</string>
@@ -148,7 +128,6 @@
  <tabstops>
   <tabstop>twTabs</tabstop>
   <tabstop>pbHelp</tabstop>
-  <tabstop>pbRun</tabstop>
   <tabstop>pbManageDirs</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
**Description of work.**
This PR moves the `Run` button in the Indirect `Data Corrections` interface so that it is above the `Output` options. This allows the `Run` button to be disabled while a process is running.
The `Plot` button is also now disabled while plotting is being done.

**To test:**
1. `Interfaces`->`Indirect`->`Data Corrections`-> All Tabs
2. Load and enter the data below for the respective tabs.
3. You should try observe several things:
- Click Run: The `Run`, `Plot` and `Save` buttons should all be disabled while running. The text on the `Run` button should also change to `Running...`
                     
- Click Plot: The `Run`, `Plot` and `Save` buttons should all be disabled while plotting (If the plotting is quick this may be hard to notice). The text on the `Plot` button should also change to `Plotting...`
                    

#### **Data** ####
**Note**: the data provided may not be the best, but we just need to check how the `Run` and `Plot` buttons  behave

**Container Subtraction:**
Sample: [irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2460924/irs26176_graphite002_red.zip)
Container: [irs26174_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2460923/irs26174_graphite002_red.zip)

**Calculate Paalman Pings:**
Sample: [irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2460924/irs26176_graphite002_red.zip)
Sample Thickness: `0.1cm`
Chemical Formula: `H2-O`

**Calculate Monte Carlo Absorption:**
Sample: `26176` (on the system)
Container: `26174` (on the system)
Shape: `FlatPlate`
Sample and Container Height & width: `1.0`
Sample and Container Thickness: `0.1`
Sample mass density: `1`
Sample Formula: `H2-O`
Container mass density: `6`
Container Formula: `V`
It may be a long wait when running! The output workspace named 

**Apply Absorption Corrections:**
Sample: [irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2460924/irs26176_graphite002_red.zip)
Corrections: [irs26176_graphite002_FlatPlate_MC_Corrections.zip](https://github.com/mantidproject/mantid/files/2464168/irs26176_graphite002_FlatPlate_MC_Corrections.zip)
Tick `Use Container`
Container: [irs26174_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2460923/irs26174_graphite002_red.zip)

Fixes #23700 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
