### PR TITLE
Add missing UI files to workbench CMakeLists

### DIFF
--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -167,6 +167,7 @@ set ( QT5_INC_FILES
 
 set ( QT5_UI_FILES
   inc/MantidQtWidgets/Common/DataSelector.ui
+  inc/MantidQtWidgets/Common/ManageUserDirectories.ui
   inc/MantidQtWidgets/Common/MWRunFiles.ui
   inc/MantidQtWidgets/Common/ProcessingAlgoWidget.ui
   inc/MantidQtWidgets/Common/RenameParDialog.ui

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -171,6 +171,7 @@ set ( QT5_UI_FILES
   inc/MantidQtWidgets/Common/ProcessingAlgoWidget.ui
   inc/MantidQtWidgets/Common/RenameParDialog.ui
   inc/MantidQtWidgets/Common/SelectFunctionDialog.ui
+  inc/MantidQtWidgets/Common/UserFunctionDialog.ui
 )
 
 set ( SRC_FILES


### PR DESCRIPTION
**Description of work.**
Adds the two missing UI files that cause Mantid to fail compilation.

**Report to:** @DTasev 

**To test:**
- Delete `build/qt/widgets/common` or do a clean
- Build Mantid
- The build should be successful

<!-- Instructions for testing. -->

No associated issue. Fixes missing includes from #23668

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
