### PR TITLE
Project Recovery: Add lock file whilst saving

### DIFF
--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -16808,7 +16808,7 @@ void ApplicationWindow::checkForProjectRecovery() {
   m_projectRecoveryRunOnStart = true;
 
   m_projectRecovery.removeOlderCheckpoints();
-  
+
   // Mantid crashed during writing to this checkpoint so remove it
   m_projectRecovery.removeLockedCheckpoints();
 

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -16808,6 +16808,9 @@ void ApplicationWindow::checkForProjectRecovery() {
   m_projectRecoveryRunOnStart = true;
 
   m_projectRecovery.removeOlderCheckpoints();
+  
+  // Mantid crashed during writing to this checkpoint so remove it
+  m_projectRecovery.removeLockedCheckpoints();
 
   if (!m_projectRecovery.checkForRecovery()) {
     m_projectRecovery.startProjectSaving();

--- a/MantidPlot/src/ProjectRecovery.cpp
+++ b/MantidPlot/src/ProjectRecovery.cpp
@@ -222,7 +222,7 @@ getRecoveryFolderCheckpoints(const std::string &recoveryFolderPath) {
   return folderPaths;
 }
 
-void removeEmptyFolders(std::vector<Poco::Path> checkpointPaths) {
+void removeEmptyFolders(std::vector<Poco::Path> &checkpointPaths) {
   for (auto i = 0u; i < checkpointPaths.size(); ++i) {
     const auto listOfFolders =
         getListOfFoldersInDirectory(checkpointPaths[i].toString());

--- a/MantidPlot/src/ProjectRecovery.h
+++ b/MantidPlot/src/ProjectRecovery.h
@@ -37,6 +37,7 @@ class ProjectRecovery {
 public:
   /// Constructor
   explicit ProjectRecovery(ApplicationWindow *windowHandle);
+
   /// Destructor the ensures background thread stops
   ~ProjectRecovery();
 
@@ -56,6 +57,7 @@ public:
 
   /// Starts the background thread
   void startProjectSaving();
+
   /// Stops the background thread
   void stopProjectSaving();
 
@@ -67,6 +69,9 @@ public:
 
   /// get Recovery Folder location
   std::string getRecoveryFolderOutputPR();
+
+  /// Remove checkpoints if it has lock file
+  void removeLockedCheckpoints();
 
 private:
   /// Captures the current object in the background thread
@@ -117,8 +122,10 @@ private:
 
   /// Mutex for conditional variable and background thread flag
   std::mutex m_notifierMutex;
+
   /// Flag to indicate to the thread to exit
   std::atomic<bool> m_stopBackgroundThread;
+
   /// Atomic to detect when the thread should fire or exit
   std::condition_variable m_threadNotifier;
 

--- a/docs/source/release/v3.14.0/ui.rst
+++ b/docs/source/release/v3.14.0/ui.rst
@@ -15,7 +15,8 @@ Project Recovery
 ----------------
 New
 ###
--Project recovery can now make a recovery checkpoint on command using mantidplot.app.saveRecoveryCheckpoint() in either the interpreter or script windows in python
+- Project Recovery can now make a recovery checkpoint on command using mantidplot.app.saveRecoveryCheckpoint() in either the interpreter or script windows in python
+- Project Recovery now adds a lock file at the start of saving so if MantidPlot crashes when saving it will no longer use that checkpoint as it is incomplete.
 
 Changes
 #######


### PR DESCRIPTION
**Description of work.**
Add a lock file for the duration of the saving that will stop Project Recovery running on broken checkpoints which didn't finish writing.

Potential issue with this: - You will likely need more than 16gb of RAM for the script here to work

**To test:**
- Run this script in MantidPlot
```python
for ii in range(0,10000):
    string = 'workspace_' + str(ii)
    CreateSampleWorkspace(OutputWorkspace=string)
```
- Once completed wait for a checkpoint to start saving out, you can see this in the results log
- Once it has started saving and before it finishes run the script
```python
Segfault(0)
```
- Then check the most recently created checkpoint in your `%APPDATA%/mantidproject/recovery/YOURCOMPUTERNAME/highestPIDNumber/`folder for windows or `~/.mantid/recovery/YOURCOMPUTERNAME/highestPIDNumber/` folder for Linux/MacOS. Then in this folder look for the most recent folder, then in that folder look for a file called projectrecovery.lock, if it exists you were successful otherwise you may need to start the test again.
- Start mantid but keep an eye on the folder containing the checkpoint folder e.g. `%APPDATA%/mantidproject/recovery/YOURCOMPUTERNAME/highestPIDNumber/` if that folder that had the projectrecovery.lock folder disappears then this code works.

<!-- Instructions for testing. -->

Fixes #23728 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
