### PR TITLE
Disable tests on macOS until a solution can be found

### DIFF
--- a/qt/widgets/mplcpp/test/CMakeLists.txt
+++ b/qt/widgets/mplcpp/test/CMakeLists.txt
@@ -4,15 +4,20 @@
 set ( TEST_FILES
   ArtistTest.h
   AxesTest.h
-  ColorsTest.h
   ColormapTest.h
   FigureTest.h
-  FigureCanvasQtTest.h
   Line2DTest.h
   ScalarMappableTest.h
-  SipTest.h
 )
 
+if ( NOT APPLE )
+  list ( APPEND TEST_FILES
+    ColorsTest.h
+    FigureCanvasQtTest.h
+    SipTest.h
+  )
+endif()
+  
 set (CXXTEST_EXTRA_HEADER_INCLUDE ${CMAKE_CURRENT_LIST_DIR}/MplCppTestInitialization.h)
 
 mtd_add_qt_tests (TARGET_NAME MantidQtWidgetsMplCppTest


### PR DESCRIPTION
**Description of work.**

These 3 tests run and segfault at the end but only on macOS. To avoid impacting other work
they are disabled on this platform until a proper fix can be found.

**Report to:**  [nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

Check macOS build passes

*There is no associated issue.*

*This does not require release notes* because **it is a developer issue.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
