### PR TITLE
Allow SANS systemtest to be run on Ubuntu

### DIFF
--- a/Testing/SystemTests/tests/analysis/SANSWorkspaceTypeTest.py
+++ b/Testing/SystemTests/tests/analysis/SANSWorkspaceTypeTest.py
@@ -11,14 +11,6 @@ from mantid.simpleapi import *
 from SANSUtility import can_load_as_event_workspace
 import os
 
-# WORKAROUND FOR IMPORT ISSUE IN UBUNTU --- START
-CAN_IMPORT_NXS_TEST = True
-try:
-    import nxs # pylint: disable=unused-import # noqa
-except ImportError:
-    CAN_IMPORT_NXS_TEST = False
-# WORKAROUND FOR IMPORT ISSUE IN UBUNTU --- STOP
-
 
 def create_file_name(base_name):
     temp_save_dir = config['defaultsave.directory']
@@ -50,24 +42,21 @@ class SANSProcessedEventWorkspaceInFile(stresstesting.MantidStressTest):
         self._success = False
 
     def runTest(self):
-        if CAN_IMPORT_NXS_TEST:
-            # Arrange
-            base_name = "processed_event"
-            filename = create_file_name(base_name)
-            ws = CreateSampleWorkspace("Event")
-            SaveNexusProcessed(InputWorkspace=ws, Filename = filename)
-            # Act
-            can_load = can_load_as_event_workspace(filename)
-            # Assert
-            if can_load:
-                self._success = True
-            else:
-                self._success = False
-            # Clean up
-            remove_temporary_file(filename)
-            clean_up_workspaces()
-        else:
+        # Arrange
+        base_name = "processed_event"
+        filename = create_file_name(base_name)
+        ws = CreateSampleWorkspace("Event")
+        SaveNexusProcessed(InputWorkspace=ws, Filename = filename)
+        # Act
+        can_load = can_load_as_event_workspace(filename)
+        # Assert
+        if can_load:
             self._success = True
+        else:
+            self._success = False
+        # Clean up
+        remove_temporary_file(filename)
+        clean_up_workspaces()
 
     def validate(self):
         return self._success
@@ -84,24 +73,21 @@ class SANSProcessedHistoWorkspaceInFile(stresstesting.MantidStressTest):
         self._success = False
 
     def runTest(self):
-        if CAN_IMPORT_NXS_TEST:
-            # Arrange
-            base_name = "processed_histo"
-            filename = create_file_name(base_name)
-            ws = CreateSampleWorkspace()
-            SaveNexusProcessed(InputWorkspace=ws, Filename = filename)
-            # Act
-            can_load = can_load_as_event_workspace(filename)
-            # Assert
-            if not can_load:
-                self._success = True
-            else:
-                self._success = False
-            # Clean up
-            remove_temporary_file(filename)
-            clean_up_workspaces()
-        else:
+        # Arrange
+        base_name = "processed_histo"
+        filename = create_file_name(base_name)
+        ws = CreateSampleWorkspace()
+        SaveNexusProcessed(InputWorkspace=ws, Filename = filename)
+        # Act
+        can_load = can_load_as_event_workspace(filename)
+        # Assert
+        if not can_load:
             self._success = True
+        else:
+            self._success = False
+        # Clean up
+        remove_temporary_file(filename)
+        clean_up_workspaces()
 
     def validate(self):
         return self._success

--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -1548,7 +1548,7 @@ def can_load_as_event_workspace(filename):
             # and check for event_eventworkspace in the next level
             with h5.File(filename) as h5f:
                 try:
-                    rootKeys = h5f.keys()
+                    rootKeys = list(h5f.keys()) # python3 fix
                     entry0 = h5f[rootKeys[0]]
                     ew = entry0['event_workspace']
                     is_event_workspace = ew is not None


### PR DESCRIPTION
**Description of work.**

Since we use h5py instead of the python nxs library in the code, the system test should be able to run on Ubuntu. Also fixed the code to run with python3.
 
**To test:**
Code review. All test should pass.

*There is no associated issue.*

*This does not require release notes* because **minor internal change**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
