### PR TITLE
Fix class descriptions in Python API documentation

### DIFF
--- a/docs/source/api/python/mantid/api/Algorithm.rst
+++ b/docs/source/api/python/mantid/api/Algorithm.rst
@@ -2,7 +2,7 @@
  Algorithm
 ===========
 
-This a python binding to the C++ class Mantid::API::Algorithm.
+This is a Python binding to the C++ class Mantid::API::Algorithm.
 
 *bases:* :py:obj:`mantid.api.IAlgorithm`
 

--- a/docs/source/api/python/mantid/api/AlgorithmFactoryImpl.rst
+++ b/docs/source/api/python/mantid/api/AlgorithmFactoryImpl.rst
@@ -2,7 +2,7 @@
  AlgorithmFactoryImpl
 ======================
 
-This a python binding to the C++ class Mantid::API::AlgorithmFactoryImpl.
+This is a Python binding to the C++ class Mantid::API::AlgorithmFactoryImpl.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/AlgorithmHistory.rst
+++ b/docs/source/api/python/mantid/api/AlgorithmHistory.rst
@@ -2,7 +2,7 @@
  AlgorithmHistory
 ==================
 
-This a python binding to the C++ class Mantid::API::AlgorithmHistory.
+This is a Python binding to the C++ class Mantid::API::AlgorithmHistory.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/AlgorithmID.rst
+++ b/docs/source/api/python/mantid/api/AlgorithmID.rst
@@ -2,7 +2,7 @@
  AlgorithmID
 =============
 
-This a python binding to the C++ class Mantid::API::AlgorithmID.
+This is a Python binding to the C++ class Mantid::API::AlgorithmID.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/AlgorithmManagerImpl.rst
+++ b/docs/source/api/python/mantid/api/AlgorithmManagerImpl.rst
@@ -2,7 +2,7 @@
  AlgorithmManagerImpl
 ======================
 
-This a python binding to the C++ class Mantid::API::AlgorithmManagerImpl.
+This is a Python binding to the C++ class Mantid::API::AlgorithmManagerImpl.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/AlgorithmProperty.rst
+++ b/docs/source/api/python/mantid/api/AlgorithmProperty.rst
@@ -2,7 +2,7 @@
  AlgorithmProperty
 ===================
 
-This a python binding to the C++ class Mantid::API::AlgorithmProperty.
+This is a Python binding to the C++ class Mantid::API::AlgorithmProperty.
 
 *bases:* :py:obj:`mantid.api.AlgorithmPropertyWithValue`
 

--- a/docs/source/api/python/mantid/api/AlgorithmPropertyWithValue.rst
+++ b/docs/source/api/python/mantid/api/AlgorithmPropertyWithValue.rst
@@ -2,7 +2,7 @@
  AlgorithmPropertyWithValue
 ============================
 
-This a python binding to the C++ class Mantid::API::AlgorithmPropertyWithValue.
+This is a Python binding to the C++ class Mantid::API::AlgorithmPropertyWithValue.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/api/AlgorithmProxy.rst
+++ b/docs/source/api/python/mantid/api/AlgorithmProxy.rst
@@ -2,7 +2,7 @@
  AlgorithmProxy
 ================
 
-This a python binding to the C++ class Mantid::API::AlgorithmProxy.
+This is a Python binding to the C++ class Mantid::API::AlgorithmProxy.
 
 *bases:* :py:obj:`mantid.api.IAlgorithm`
 

--- a/docs/source/api/python/mantid/api/AnalysisDataServiceImpl.rst
+++ b/docs/source/api/python/mantid/api/AnalysisDataServiceImpl.rst
@@ -2,7 +2,7 @@
  AnalysisDataServiceImpl
 =========================
 
-This a python binding to the C++ class Mantid::API::AnalysisDataServiceImpl.
+This is a Python binding to the C++ class Mantid::API::AnalysisDataServiceImpl.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/BinEdgeAxis.rst
+++ b/docs/source/api/python/mantid/api/BinEdgeAxis.rst
@@ -2,7 +2,7 @@
  BinEdgeAxis
 =============
 
-This a python binding to the C++ class Mantid::API::BinEdgeAxis.
+This is a Python binding to the C++ class Mantid::API::BinEdgeAxis.
 
 *bases:* :py:obj:`mantid.api.NumericAxis`
 

--- a/docs/source/api/python/mantid/api/BoxController.rst
+++ b/docs/source/api/python/mantid/api/BoxController.rst
@@ -2,7 +2,7 @@
  BoxController
 ===============
 
-This a python binding to the C++ class Mantid::API::BoxController.
+This is a Python binding to the C++ class Mantid::API::BoxController.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/CommonBinsValidator.rst
+++ b/docs/source/api/python/mantid/api/CommonBinsValidator.rst
@@ -2,7 +2,7 @@
  CommonBinsValidator
 =====================
 
-This a python binding to the C++ class Mantid::API::CommonBinsValidator.
+This is a Python binding to the C++ class Mantid::API::CommonBinsValidator.
 
 *bases:* :py:obj:`mantid.api.MatrixWorkspaceValidator`
 

--- a/docs/source/api/python/mantid/api/DataProcessorAlgorithm.rst
+++ b/docs/source/api/python/mantid/api/DataProcessorAlgorithm.rst
@@ -2,7 +2,7 @@
  DataProcessorAlgorithm
 ========================
 
-This a python binding to the C++ class Mantid::API::DataProcessorAlgorithm.
+This is a Python binding to the C++ class Mantid::API::DataProcessorAlgorithm.
 
 *bases:* :py:obj:`mantid.api.Algorithm`
 

--- a/docs/source/api/python/mantid/api/DeprecatedAlgorithmChecker.rst
+++ b/docs/source/api/python/mantid/api/DeprecatedAlgorithmChecker.rst
@@ -2,7 +2,7 @@
  DeprecatedAlgorithmChecker
 ============================
 
-This a python binding to the C++ class Mantid::API::DeprecatedAlgorithm.
+This is a Python binding to the C++ class Mantid::API::DeprecatedAlgorithm.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/EventType.rst
+++ b/docs/source/api/python/mantid/api/EventType.rst
@@ -2,7 +2,7 @@
  EventType
 ===========
 
-This a python binding to the C++ class Mantid::API::EventType.
+This is a Python binding to the C++ class Mantid::API::EventType.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/ExperimentInfo.rst
+++ b/docs/source/api/python/mantid/api/ExperimentInfo.rst
@@ -2,7 +2,7 @@
  ExperimentInfo
 ================
 
-This a python binding to the C++ class Mantid::API::ExperimentInfo.
+This is a Python binding to the C++ class Mantid::API::ExperimentInfo.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/ExperimentInfoValidator.rst
+++ b/docs/source/api/python/mantid/api/ExperimentInfoValidator.rst
@@ -2,7 +2,7 @@
  ExperimentInfoValidator
 =========================
 
-This a python binding to the C++ class Mantid::API::ExperimentInfoValidator.
+This is a Python binding to the C++ class Mantid::API::ExperimentInfoValidator.
 
 *bases:* :py:obj:`mantid.kernel.IValidator`
 

--- a/docs/source/api/python/mantid/api/FileAction.rst
+++ b/docs/source/api/python/mantid/api/FileAction.rst
@@ -2,7 +2,7 @@
  FileAction
 ============
 
-This a python binding to the C++ class Mantid::API::FileProperty.
+This is a Python binding to the C++ class Mantid::API::FileProperty.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/FileFinderImpl.rst
+++ b/docs/source/api/python/mantid/api/FileFinderImpl.rst
@@ -2,7 +2,7 @@
  FileFinderImpl
 ================
 
-This a python binding to the C++ class Mantid::API::FileFinderImpl.
+This is a Python binding to the C++ class Mantid::API::FileFinderImpl.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/FileProperty.rst
+++ b/docs/source/api/python/mantid/api/FileProperty.rst
@@ -2,7 +2,7 @@
  FileProperty
 ==============
 
-This a python binding to the C++ class Mantid::API::FileProperty.
+This is a Python binding to the C++ class Mantid::API::FileProperty.
 
 *bases:* :py:obj:`mantid.kernel.StringPropertyWithValue`
 

--- a/docs/source/api/python/mantid/api/FrameworkManagerImpl.rst
+++ b/docs/source/api/python/mantid/api/FrameworkManagerImpl.rst
@@ -2,7 +2,7 @@
  FrameworkManagerImpl
 ======================
 
-This a python binding to the C++ class Mantid::API::FrameworkManagerImpl.
+This is a Python binding to the C++ class Mantid::API::FrameworkManagerImpl.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/FunctionFactoryImpl.rst
+++ b/docs/source/api/python/mantid/api/FunctionFactoryImpl.rst
@@ -2,7 +2,7 @@
  FunctionFactoryImpl
 =====================
 
-This a python binding to the C++ class Mantid::API::FunctionFactoryImpl.
+This is a Python binding to the C++ class Mantid::API::FunctionFactoryImpl.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/FunctionProperty.rst
+++ b/docs/source/api/python/mantid/api/FunctionProperty.rst
@@ -2,7 +2,7 @@
  FunctionProperty
 ==================
 
-This a python binding to the C++ class Mantid::API::FunctionProperty.
+This is a Python binding to the C++ class Mantid::API::FunctionProperty.
 
 *bases:* :py:obj:`mantid.api.FunctionPropertyWithValue`
 

--- a/docs/source/api/python/mantid/api/FunctionPropertyWithValue.rst
+++ b/docs/source/api/python/mantid/api/FunctionPropertyWithValue.rst
@@ -2,7 +2,7 @@
  FunctionPropertyWithValue
 ===========================
 
-This a python binding to the C++ class Mantid::API::FunctionPropertyWithValue.
+This is a Python binding to the C++ class Mantid::API::FunctionPropertyWithValue.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/api/HistogramValidator.rst
+++ b/docs/source/api/python/mantid/api/HistogramValidator.rst
@@ -2,7 +2,7 @@
  HistogramValidator
 ====================
 
-This a python binding to the C++ class Mantid::API::HistogramValidator.
+This is a Python binding to the C++ class Mantid::API::HistogramValidator.
 
 *bases:* :py:obj:`mantid.api.MatrixWorkspaceValidator`
 

--- a/docs/source/api/python/mantid/api/IAlgorithm.rst
+++ b/docs/source/api/python/mantid/api/IAlgorithm.rst
@@ -2,7 +2,7 @@
  IAlgorithm
 ============
 
-This a python binding to the C++ class Mantid::API::IAlgorithm.
+This is a Python binding to the C++ class Mantid::API::IAlgorithm.
 
 *bases:* :py:obj:`mantid.kernel.IPropertyManager`
 

--- a/docs/source/api/python/mantid/api/IEventList.rst
+++ b/docs/source/api/python/mantid/api/IEventList.rst
@@ -2,7 +2,7 @@
  IEventList
 ============
 
-This a python binding to the C++ class Mantid::API::IEventList.
+This is a Python binding to the C++ class Mantid::API::IEventList.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/IEventWorkspace.rst
+++ b/docs/source/api/python/mantid/api/IEventWorkspace.rst
@@ -4,7 +4,7 @@
  IEventWorkspace
 =================
 
-This a python binding to the C++ class Mantid::API::IEventWorkspace.
+This is a Python binding to the C++ class Mantid::API::IEventWorkspace.
 
 *bases:* :py:obj:`mantid.api.MatrixWorkspace`
 

--- a/docs/source/api/python/mantid/api/IEventWorkspaceProperty.rst
+++ b/docs/source/api/python/mantid/api/IEventWorkspaceProperty.rst
@@ -2,7 +2,7 @@
  IEventWorkspaceProperty
 =========================
 
-This a python binding to the C++ class Mantid::API::WorkspaceProperty.
+This is a Python binding to the C++ class Mantid::API::WorkspaceProperty.
 
 *bases:* :py:obj:`mantid.api.IEventWorkspacePropertyPropertyWithValue`, :py:obj:`mantid.api.IWorkspaceProperty`
 

--- a/docs/source/api/python/mantid/api/IEventWorkspacePropertyPropertyWithValue.rst
+++ b/docs/source/api/python/mantid/api/IEventWorkspacePropertyPropertyWithValue.rst
@@ -2,7 +2,7 @@
  IEventWorkspacePropertyPropertyWithValue
 ==========================================
 
-This a python binding to the C++ class Mantid::API::IEventWorkspacePropertyPropertyWithValue.
+This is a Python binding to the C++ class Mantid::API::IEventWorkspacePropertyPropertyWithValue.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/api/IFunction.rst
+++ b/docs/source/api/python/mantid/api/IFunction.rst
@@ -2,7 +2,7 @@
  IFunction
 ===========
 
-This a python binding to the C++ class Mantid::API::IFunction.
+This is a Python binding to the C++ class Mantid::API::IFunction.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/IFunction1D.rst
+++ b/docs/source/api/python/mantid/api/IFunction1D.rst
@@ -2,7 +2,7 @@
  IFunction1D
 =============
 
-This a python binding to the C++ class Mantid::API::IFunction1D.
+This is a Python binding to the C++ class Mantid::API::IFunction1D.
 
 *bases:* :py:obj:`mantid.api.IFunction`
 

--- a/docs/source/api/python/mantid/api/IMDEventWorkspace.rst
+++ b/docs/source/api/python/mantid/api/IMDEventWorkspace.rst
@@ -2,7 +2,7 @@
  IMDEventWorkspace
 ===================
 
-This a python binding to the C++ class Mantid::API::IMDEventWorkspace.
+This is a Python binding to the C++ class Mantid::API::IMDEventWorkspace.
 
 *bases:* :py:obj:`mantid.api.IMDWorkspace`, :py:obj:`mantid.api.MultipleExperimentInfos`
 

--- a/docs/source/api/python/mantid/api/IMDHistoWorkspace.rst
+++ b/docs/source/api/python/mantid/api/IMDHistoWorkspace.rst
@@ -2,7 +2,7 @@
  IMDHistoWorkspace
 ===================
 
-This a python binding to the C++ class Mantid::API::IMDHistoWorkspace.
+This is a Python binding to the C++ class Mantid::API::IMDHistoWorkspace.
 
 *bases:* :py:obj:`mantid.api.IMDWorkspace`, :py:obj:`mantid.api.MultipleExperimentInfos`
 

--- a/docs/source/api/python/mantid/api/IMDHistoWorkspaceProperty.rst
+++ b/docs/source/api/python/mantid/api/IMDHistoWorkspaceProperty.rst
@@ -2,7 +2,7 @@
  IMDHistoWorkspaceProperty
 ===========================
 
-This a python binding to the C++ class Mantid::API::WorkspaceProperty.
+This is a Python binding to the C++ class Mantid::API::WorkspaceProperty.
 
 *bases:* :py:obj:`mantid.api.IMDHistoWorkspacePropertyPropertyWithValue`, :py:obj:`mantid.api.IWorkspaceProperty`
 

--- a/docs/source/api/python/mantid/api/IMDHistoWorkspacePropertyPropertyWithValue.rst
+++ b/docs/source/api/python/mantid/api/IMDHistoWorkspacePropertyPropertyWithValue.rst
@@ -2,7 +2,7 @@
  IMDHistoWorkspacePropertyPropertyWithValue
 ============================================
 
-This a python binding to the C++ class Mantid::API::IMDHistoWorkspacePropertyPropertyWithValue.
+This is a Python binding to the C++ class Mantid::API::IMDHistoWorkspacePropertyPropertyWithValue.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/api/IMDWorkspace.rst
+++ b/docs/source/api/python/mantid/api/IMDWorkspace.rst
@@ -2,7 +2,7 @@
  IMDWorkspace
 ==============
 
-This a python binding to the C++ class Mantid::API::IMDWorkspace.
+This is a Python binding to the C++ class Mantid::API::IMDWorkspace.
 
 *bases:* :py:obj:`mantid.api.Workspace`, :py:obj:`mantid.api.MDGeometry`
 

--- a/docs/source/api/python/mantid/api/IPeak.rst
+++ b/docs/source/api/python/mantid/api/IPeak.rst
@@ -2,7 +2,7 @@
  IPeak
 =======
 
-This a python binding to the C++ class Mantid::API::IPeak.
+This is a Python binding to the C++ class Mantid::API::IPeak.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/IPeakFunction.rst
+++ b/docs/source/api/python/mantid/api/IPeakFunction.rst
@@ -2,7 +2,7 @@
  IPeakFunction
 ===============
 
-This a python binding to the C++ class Mantid::API::IPeakFunction.
+This is a Python binding to the C++ class Mantid::API::IPeakFunction.
 
 *bases:* :py:obj:`mantid.api.IFunction1D`
 

--- a/docs/source/api/python/mantid/api/IPeaksWorkspace.rst
+++ b/docs/source/api/python/mantid/api/IPeaksWorkspace.rst
@@ -2,7 +2,7 @@
  IPeaksWorkspace
 =================
 
-This a python binding to the C++ class Mantid::API::IPeaksWorkspace.
+This is a Python binding to the C++ class Mantid::API::IPeaksWorkspace.
 
 *bases:* :py:obj:`mantid.api.ITableWorkspace`, :py:obj:`mantid.api.ExperimentInfo`
 

--- a/docs/source/api/python/mantid/api/ISpectrum.rst
+++ b/docs/source/api/python/mantid/api/ISpectrum.rst
@@ -2,7 +2,7 @@
  ISpectrum
 ===========
 
-This a python binding to the C++ class Mantid::API::ISpectrum.
+This is a Python binding to the C++ class Mantid::API::ISpectrum.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/ITableWorkspace.rst
+++ b/docs/source/api/python/mantid/api/ITableWorkspace.rst
@@ -2,7 +2,7 @@
  ITableWorkspace
 =================
 
-This a python binding to the C++ class Mantid::API::ITableWorkspace.
+This is a Python binding to the C++ class Mantid::API::ITableWorkspace.
 
 *bases:* :py:obj:`mantid.api.Workspace`
 

--- a/docs/source/api/python/mantid/api/ITableWorkspaceProperty.rst
+++ b/docs/source/api/python/mantid/api/ITableWorkspaceProperty.rst
@@ -2,7 +2,7 @@
  ITableWorkspaceProperty
 =========================
 
-This a python binding to the C++ class Mantid::API::WorkspaceProperty.
+This is a Python binding to the C++ class Mantid::API::WorkspaceProperty.
 
 *bases:* :py:obj:`mantid.api.ITableWorkspacePropertyPropertyWithValue`, :py:obj:`mantid.api.IWorkspaceProperty`
 

--- a/docs/source/api/python/mantid/api/ITableWorkspacePropertyPropertyWithValue.rst
+++ b/docs/source/api/python/mantid/api/ITableWorkspacePropertyPropertyWithValue.rst
@@ -2,7 +2,7 @@
  ITableWorkspacePropertyPropertyWithValue
 ==========================================
 
-This a python binding to the C++ class Mantid::API::ITableWorkspacePropertyPropertyWithValue.
+This is a Python binding to the C++ class Mantid::API::ITableWorkspacePropertyPropertyWithValue.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/api/IWorkspaceProperty.rst
+++ b/docs/source/api/python/mantid/api/IWorkspaceProperty.rst
@@ -2,7 +2,7 @@
  IWorkspaceProperty
 ====================
 
-This a python binding to the C++ class Mantid::API::WorkspaceProperty.
+This is a Python binding to the C++ class Mantid::API::WorkspaceProperty.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/InstrumentValidator.rst
+++ b/docs/source/api/python/mantid/api/InstrumentValidator.rst
@@ -2,7 +2,7 @@
  InstrumentValidator
 =====================
 
-This a python binding to the C++ class Mantid::API::InstrumentValidator.
+This is a Python binding to the C++ class Mantid::API::InstrumentValidator.
 
 *bases:* :py:obj:`mantid.api.ExperimentInfoValidator`
 

--- a/docs/source/api/python/mantid/api/Jacobian.rst
+++ b/docs/source/api/python/mantid/api/Jacobian.rst
@@ -2,7 +2,7 @@
  Jacobian
 ==========
 
-This a python binding to the C++ class Mantid::API::Jacobian.
+This is a Python binding to the C++ class Mantid::API::Jacobian.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/LockMode.rst
+++ b/docs/source/api/python/mantid/api/LockMode.rst
@@ -2,7 +2,7 @@
  LockMode
 ==========
 
-This a python binding to the C++ class Mantid::API::LockMode.
+This is a Python binding to the C++ class Mantid::API::LockMode.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/MDGeometry.rst
+++ b/docs/source/api/python/mantid/api/MDGeometry.rst
@@ -2,7 +2,7 @@
  MDGeometry
 ============
 
-This a python binding to the C++ class Mantid::API::MDGeometry.
+This is a Python binding to the C++ class Mantid::API::MDGeometry.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/MDNormalization.rst
+++ b/docs/source/api/python/mantid/api/MDNormalization.rst
@@ -2,7 +2,7 @@
  MDNormalization
 =================
 
-This a python binding to the C++ class Mantid::API::MDNormalization.
+This is a Python binding to the C++ class Mantid::API::MDNormalization.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/MantidAxis.rst
+++ b/docs/source/api/python/mantid/api/MantidAxis.rst
@@ -2,7 +2,7 @@
  MantidAxis
 ============
 
-This a python binding to the C++ class Mantid::API::MantidAxis.
+This is a Python binding to the C++ class Mantid::API::MantidAxis.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/MatrixWorkspace.rst
+++ b/docs/source/api/python/mantid/api/MatrixWorkspace.rst
@@ -4,7 +4,7 @@
  MatrixWorkspace
 =================
 
-This a python binding to the C++ class Mantid::API::MatrixWorkspace.
+This is a Python binding to the C++ class Mantid::API::MatrixWorkspace.
 
 *bases:* :py:obj:`mantid.api.ExperimentInfo`, :py:obj:`mantid.api.IMDWorkspace`
 

--- a/docs/source/api/python/mantid/api/MatrixWorkspaceProperty.rst
+++ b/docs/source/api/python/mantid/api/MatrixWorkspaceProperty.rst
@@ -2,7 +2,7 @@
  MatrixWorkspaceProperty
 =========================
 
-This a python binding to the C++ class Mantid::API::WorkspaceProperty.
+This is a Python binding to the C++ class Mantid::API::WorkspaceProperty.
 
 *bases:* :py:obj:`mantid.api.MatrixWorkspacePropertyPropertyWithValue`, :py:obj:`mantid.api.IWorkspaceProperty`
 

--- a/docs/source/api/python/mantid/api/MatrixWorkspacePropertyPropertyWithValue.rst
+++ b/docs/source/api/python/mantid/api/MatrixWorkspacePropertyPropertyWithValue.rst
@@ -2,7 +2,7 @@
  MatrixWorkspacePropertyPropertyWithValue
 ==========================================
 
-This a python binding to the C++ class Mantid::API::MatrixWorkspacePropertyPropertyWithValue.
+This is a Python binding to the C++ class Mantid::API::MatrixWorkspacePropertyPropertyWithValue.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/api/MatrixWorkspaceValidator.rst
+++ b/docs/source/api/python/mantid/api/MatrixWorkspaceValidator.rst
@@ -2,7 +2,7 @@
  MatrixWorkspaceValidator
 ==========================
 
-This a python binding to the C++ class Mantid::API::MatrixWorkspaceValidator.
+This is a Python binding to the C++ class Mantid::API::MatrixWorkspaceValidator.
 
 *bases:* :py:obj:`mantid.api.MatrixWorkspaceValidator`
 

--- a/docs/source/api/python/mantid/api/MultipleExperimentInfos.rst
+++ b/docs/source/api/python/mantid/api/MultipleExperimentInfos.rst
@@ -2,7 +2,7 @@
  MultipleExperimentInfos
 =========================
 
-This a python binding to the C++ class Mantid::API::MultipleExperimentInfos.
+This is a Python binding to the C++ class Mantid::API::MultipleExperimentInfos.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/MultipleFileProperty.rst
+++ b/docs/source/api/python/mantid/api/MultipleFileProperty.rst
@@ -2,7 +2,7 @@
  MultipleFileProperty
 ======================
 
-This a python binding to the C++ class
+This is a Python binding to the C++ class
 ``Mantid::API::MultipleFileProperty``.
 
 .. contents::

--- a/docs/source/api/python/mantid/api/NumericAxis.rst
+++ b/docs/source/api/python/mantid/api/NumericAxis.rst
@@ -2,7 +2,7 @@
  NumericAxis
 =============
 
-This a python binding to the C++ class Mantid::API::NumericAxis.
+This is a Python binding to the C++ class Mantid::API::NumericAxis.
 
 *bases:* :py:obj:`mantid.api.MantidAxis`
 

--- a/docs/source/api/python/mantid/api/NumericAxisValidator.rst
+++ b/docs/source/api/python/mantid/api/NumericAxisValidator.rst
@@ -2,7 +2,7 @@
  NumericAxisValidator
 ======================
 
-This a python binding to the C++ class Mantid::API::NumericAxisValidator.
+This is a Python binding to the C++ class Mantid::API::NumericAxisValidator.
 
 *bases:* :py:obj:`mantid.api.MatrixWorkspaceValidator`
 

--- a/docs/source/api/python/mantid/api/Progress.rst
+++ b/docs/source/api/python/mantid/api/Progress.rst
@@ -2,7 +2,7 @@
  Progress
 ==========
 
-This a python binding to the C++ class Mantid::API::Progress.
+This is a Python binding to the C++ class Mantid::API::Progress.
 
 *bases:* :py:obj:`mantid.kernel.ProgressBase`
 

--- a/docs/source/api/python/mantid/api/PropertyMode.rst
+++ b/docs/source/api/python/mantid/api/PropertyMode.rst
@@ -2,7 +2,7 @@
  PropertyMode
 ==============
 
-This a python binding to the C++ class Mantid::API::PropertyMode.
+This is a Python binding to the C++ class Mantid::API::PropertyMode.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/RawCountValidator.rst
+++ b/docs/source/api/python/mantid/api/RawCountValidator.rst
@@ -2,7 +2,7 @@
  RawCountValidator
 ===================
 
-This a python binding to the C++ class Mantid::API::RawCountValidator.
+This is a Python binding to the C++ class Mantid::API::RawCountValidator.
 
 *bases:* :py:obj:`mantid.api.MatrixWorkspaceValidator`
 

--- a/docs/source/api/python/mantid/api/Run.rst
+++ b/docs/source/api/python/mantid/api/Run.rst
@@ -4,7 +4,7 @@
  Run
 =====
 
-This a python binding to the C++ class Mantid::API::Run.
+This is a Python binding to the C++ class Mantid::API::Run.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/Sample.rst
+++ b/docs/source/api/python/mantid/api/Sample.rst
@@ -4,7 +4,7 @@
  Sample
 ========
 
-This a python binding to the C++ class Mantid::API::Sample.
+This is a Python binding to the C++ class Mantid::API::Sample.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/ScriptRepository.rst
+++ b/docs/source/api/python/mantid/api/ScriptRepository.rst
@@ -2,7 +2,7 @@
  ScriptRepository
 ==================
 
-This a python binding to the C++ class Mantid::API::ScriptRepository.
+This is a Python binding to the C++ class Mantid::API::ScriptRepository.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/ScriptRepositoryFactory.rst
+++ b/docs/source/api/python/mantid/api/ScriptRepositoryFactory.rst
@@ -2,7 +2,7 @@
  ScriptRepositoryFactory
 =========================
 
-This a python binding to the C++ class Mantid::API::ScriptRepositoryFactory.
+This is a Python binding to the C++ class Mantid::API::ScriptRepositoryFactory.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/SpectraAxisValidator.rst
+++ b/docs/source/api/python/mantid/api/SpectraAxisValidator.rst
@@ -2,7 +2,7 @@
  SpectraAxisValidator
 ======================
 
-This a python binding to the C++ class Mantid::API::SpectraAxisValidator.
+This is a Python binding to the C++ class Mantid::API::SpectraAxisValidator.
 
 *bases:* :py:obj:`mantid.api.MatrixWorkspaceValidator`
 

--- a/docs/source/api/python/mantid/api/TextAxis.rst
+++ b/docs/source/api/python/mantid/api/TextAxis.rst
@@ -2,7 +2,7 @@
  TextAxis
 ==========
 
-This a python binding to the C++ class Mantid::API::TextAxis.
+This is a Python binding to the C++ class Mantid::API::TextAxis.
 
 *bases:* :py:obj:`mantid.api.MantidAxis`
 

--- a/docs/source/api/python/mantid/api/VectorVectorStringPropertyWithValue.rst
+++ b/docs/source/api/python/mantid/api/VectorVectorStringPropertyWithValue.rst
@@ -2,7 +2,7 @@
  VectorVectorStringPropertyWithValue
 =====================================
 
-This a python binding to the C++ class Mantid::API::VectorVectorStringPropertyWithValue.
+This is a Python binding to the C++ class Mantid::API::VectorVectorStringPropertyWithValue.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/api/Workspace.rst
+++ b/docs/source/api/python/mantid/api/Workspace.rst
@@ -4,7 +4,7 @@
  Workspace
 ===========
 
-This a python binding to the C++ class Mantid::API::Workspace.
+This is a Python binding to the C++ class Mantid::API::Workspace.
 
 *bases:* :py:obj:`mantid.kernel.DataItem`
 

--- a/docs/source/api/python/mantid/api/WorkspaceFactoryImpl.rst
+++ b/docs/source/api/python/mantid/api/WorkspaceFactoryImpl.rst
@@ -2,7 +2,7 @@
  WorkspaceFactoryImpl
 ======================
 
-This a python binding to the C++ class Mantid::API::WorkspaceFactoryImpl.
+This is a Python binding to the C++ class Mantid::API::WorkspaceFactoryImpl.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/WorkspaceGroup.rst
+++ b/docs/source/api/python/mantid/api/WorkspaceGroup.rst
@@ -2,7 +2,7 @@
  WorkspaceGroup
 ================
 
-This a python binding to the C++ class Mantid::API::WorkspaceGroup.
+This is a Python binding to the C++ class Mantid::API::WorkspaceGroup.
 
 *bases:* :py:obj:`mantid.api.Workspace`
 

--- a/docs/source/api/python/mantid/api/WorkspaceGroupProperty.rst
+++ b/docs/source/api/python/mantid/api/WorkspaceGroupProperty.rst
@@ -2,7 +2,7 @@
  WorkspaceGroupProperty
 ========================
 
-This a python binding to the C++ class Mantid::API::WorkspaceGroupProperty.
+This is a Python binding to the C++ class Mantid::API::WorkspaceGroupProperty.
 
 *bases:* :py:obj:`mantid.api.WorkspaceGroupPropertyPropertyWithValue`, :py:obj:`mantid.api.IWorkspaceProperty`
 

--- a/docs/source/api/python/mantid/api/WorkspaceGroupPropertyPropertyWithValue.rst
+++ b/docs/source/api/python/mantid/api/WorkspaceGroupPropertyPropertyWithValue.rst
@@ -2,7 +2,7 @@
  WorkspaceGroupPropertyPropertyWithValue
 =========================================
 
-This a python binding to the C++ class Mantid::API::WorkspaceGroupPropertyPropertyWithValue.
+This is a Python binding to the C++ class Mantid::API::WorkspaceGroupPropertyPropertyWithValue.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/api/WorkspaceHistory.rst
+++ b/docs/source/api/python/mantid/api/WorkspaceHistory.rst
@@ -2,7 +2,7 @@
  WorkspaceHistory
 ==================
 
-This a python binding to the C++ class Mantid::API::WorkspaceHistory.
+This is a Python binding to the C++ class Mantid::API::WorkspaceHistory.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/api/WorkspaceProperty.rst
+++ b/docs/source/api/python/mantid/api/WorkspaceProperty.rst
@@ -2,7 +2,7 @@
  WorkspaceProperty
 ===================
 
-This a python binding to the C++ class Mantid::API::WorkspaceProperty.
+This is a Python binding to the C++ class Mantid::API::WorkspaceProperty.
 
 *bases:* :py:obj:`mantid.api.WorkspacePropertyPropertyWithValue`, :py:obj:`mantid.api.IWorkspaceProperty`
 

--- a/docs/source/api/python/mantid/api/WorkspacePropertyPropertyWithValue.rst
+++ b/docs/source/api/python/mantid/api/WorkspacePropertyPropertyWithValue.rst
@@ -2,7 +2,7 @@
  WorkspacePropertyPropertyWithValue
 ====================================
 
-This a python binding to the C++ class Mantid::API::WorkspacePropertyPropertyWithValue.
+This is a Python binding to the C++ class Mantid::API::WorkspacePropertyPropertyWithValue.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/api/WorkspaceUnitValidator.rst
+++ b/docs/source/api/python/mantid/api/WorkspaceUnitValidator.rst
@@ -2,7 +2,7 @@
  WorkspaceUnitValidator
 ========================
 
-This a python binding to the C++ class Mantid::API::WorkspaceUnitValidator.
+This is a Python binding to the C++ class Mantid::API::WorkspaceUnitValidator.
 
 *bases:* :py:obj:`mantid.api.MatrixWorkspaceValidator`
 

--- a/docs/source/api/python/mantid/geometry/AngleUnits.rst
+++ b/docs/source/api/python/mantid/geometry/AngleUnits.rst
@@ -2,7 +2,7 @@
  AngleUnits
 ============
 
-This a python binding to the C++ class Mantid::Geometry::AngleUnits.
+This is a Python binding to the C++ class Mantid::Geometry::AngleUnits.
 
 
 .. module:`mantid.geometry`

--- a/docs/source/api/python/mantid/geometry/BoundingBox.rst
+++ b/docs/source/api/python/mantid/geometry/BoundingBox.rst
@@ -2,7 +2,7 @@
  BoundingBox
 =============
 
-This a python binding to the C++ class Mantid::Geometry::BoundingBox.
+This is a Python binding to the C++ class Mantid::Geometry::BoundingBox.
 
 
 .. module:`mantid.geometry`

--- a/docs/source/api/python/mantid/geometry/CompAssembly.rst
+++ b/docs/source/api/python/mantid/geometry/CompAssembly.rst
@@ -2,7 +2,7 @@
  CompAssembly
 ==============
 
-This a python binding to the C++ class Mantid::Geometry::CompAssembly.
+This is a Python binding to the C++ class Mantid::Geometry::CompAssembly.
 
 *bases:* :py:obj:`mantid.geometry.ICompAssembly`, :py:obj:`mantid.geometry.Component`
 

--- a/docs/source/api/python/mantid/geometry/Component.rst
+++ b/docs/source/api/python/mantid/geometry/Component.rst
@@ -2,7 +2,7 @@
  Component
 ===========
 
-This a python binding to the C++ class Mantid::Geometry::Component.
+This is a Python binding to the C++ class Mantid::Geometry::Component.
 
 *bases:* :py:obj:`mantid.geometry.IComponent`
 

--- a/docs/source/api/python/mantid/geometry/Detector.rst
+++ b/docs/source/api/python/mantid/geometry/Detector.rst
@@ -2,7 +2,7 @@
  Detector
 ==========
 
-This a python binding to the C++ class Mantid::Geometry::Detector.
+This is a Python binding to the C++ class Mantid::Geometry::Detector.
 
 *bases:* :py:obj:`mantid.geometry.IDetector`, :py:obj:`mantid.geometry.ObjComponent`
 

--- a/docs/source/api/python/mantid/geometry/DetectorGroup.rst
+++ b/docs/source/api/python/mantid/geometry/DetectorGroup.rst
@@ -2,7 +2,7 @@
  DetectorGroup
 ===============
 
-This a python binding to the C++ class Mantid::Geometry::DetectorGroup.
+This is a Python binding to the C++ class Mantid::Geometry::DetectorGroup.
 
 *bases:* :py:obj:`mantid.geometry.IDetector`
 

--- a/docs/source/api/python/mantid/geometry/Goniometer.rst
+++ b/docs/source/api/python/mantid/geometry/Goniometer.rst
@@ -2,7 +2,7 @@
  Goniometer
 ============
 
-This a python binding to the C++ class Mantid::Geometry::Goniometer.
+This is a Python binding to the C++ class Mantid::Geometry::Goniometer.
 
 
 .. module:`mantid.geometry`

--- a/docs/source/api/python/mantid/geometry/GridDetectorPixel.rst
+++ b/docs/source/api/python/mantid/geometry/GridDetectorPixel.rst
@@ -2,7 +2,7 @@
  GridDetectorPixel
 ==========================
 
-This a python binding to the C++ class Mantid::Geometry::GridDetectorPixel.
+This is a Python binding to the C++ class Mantid::Geometry::GridDetectorPixel.
 
 *bases:* :py:obj:`mantid.geometry.Detector`
 

--- a/docs/source/api/python/mantid/geometry/ICompAssembly.rst
+++ b/docs/source/api/python/mantid/geometry/ICompAssembly.rst
@@ -2,7 +2,7 @@
  ICompAssembly
 ===============
 
-This a python binding to the C++ class Mantid::Geometry::ICompAssembly.
+This is a Python binding to the C++ class Mantid::Geometry::ICompAssembly.
 
 *bases:* :py:obj:`mantid.geometry.IComponent`
 

--- a/docs/source/api/python/mantid/geometry/IComponent.rst
+++ b/docs/source/api/python/mantid/geometry/IComponent.rst
@@ -2,7 +2,7 @@
  IComponent
 ============
 
-This a python binding to the C++ class Mantid::Geometry::IComponent.
+This is a Python binding to the C++ class Mantid::Geometry::IComponent.
 
 
 .. module:`mantid.geometry`

--- a/docs/source/api/python/mantid/geometry/IDetector.rst
+++ b/docs/source/api/python/mantid/geometry/IDetector.rst
@@ -2,7 +2,7 @@
  IDetector
 ===========
 
-This a python binding to the C++ class Mantid::Geometry::IDetector.
+This is a Python binding to the C++ class Mantid::Geometry::IDetector.
 
 *bases:* :py:obj:`mantid.geometry.IObjComponent`
 

--- a/docs/source/api/python/mantid/geometry/IMDDimension.rst
+++ b/docs/source/api/python/mantid/geometry/IMDDimension.rst
@@ -2,7 +2,7 @@
  IMDDimension
 ==============
 
-This a python binding to the C++ class Mantid::Geometry::IMDDimension.
+This is a Python binding to the C++ class Mantid::Geometry::IMDDimension.
 
 
 .. module:`mantid.geometry`

--- a/docs/source/api/python/mantid/geometry/IObjCompAssembly.rst
+++ b/docs/source/api/python/mantid/geometry/IObjCompAssembly.rst
@@ -2,7 +2,7 @@
  IObjCompAssembly
 ==================
 
-This a python binding to the C++ class Mantid::Geometry::ObjCompAssembly.
+This is a Python binding to the C++ class Mantid::Geometry::ObjCompAssembly.
 
 *bases:* :py:obj:`mantid.geometry.ICompAssembly`, :py:obj:`mantid.geometry.ObjComponent`
 

--- a/docs/source/api/python/mantid/geometry/IObjComponent.rst
+++ b/docs/source/api/python/mantid/geometry/IObjComponent.rst
@@ -2,7 +2,7 @@
  IObjComponent
 ===============
 
-This a python binding to the C++ class Mantid::Geometry::IObjComponent.
+This is a Python binding to the C++ class Mantid::Geometry::IObjComponent.
 
 *bases:* :py:obj:`mantid.geometry.IComponent`
 

--- a/docs/source/api/python/mantid/geometry/IObject.rst
+++ b/docs/source/api/python/mantid/geometry/IObject.rst
@@ -2,7 +2,7 @@
  Object
 ========
 
-This a python binding to the C++ class Mantid::Geometry::Object.
+This is a Python binding to the C++ class Mantid::Geometry::Object.
 
 
 .. module:`mantid.geometry`

--- a/docs/source/api/python/mantid/geometry/Instrument.rst
+++ b/docs/source/api/python/mantid/geometry/Instrument.rst
@@ -2,7 +2,7 @@
  Instrument
 ============
 
-This a python binding to the C++ class Mantid::Geometry::Instrument.
+This is a Python binding to the C++ class Mantid::Geometry::Instrument.
 
 *bases:* :py:obj:`mantid.geometry.CompAssembly`
 

--- a/docs/source/api/python/mantid/geometry/ObjComponent.rst
+++ b/docs/source/api/python/mantid/geometry/ObjComponent.rst
@@ -2,7 +2,7 @@
  ObjComponent
 ==============
 
-This a python binding to the C++ class Mantid::Geometry::ObjComponent.
+This is a Python binding to the C++ class Mantid::Geometry::ObjComponent.
 
 *bases:* :py:obj:`mantid.geometry.IObjComponent`, :py:obj:`mantid.geometry.Component`
 

--- a/docs/source/api/python/mantid/geometry/OrientedLattice.rst
+++ b/docs/source/api/python/mantid/geometry/OrientedLattice.rst
@@ -2,7 +2,7 @@
  OrientedLattice
 =================
 
-This a python binding to the C++ class Mantid::Geometry::OrientedLattice. The
+This is a Python binding to the C++ class Mantid::Geometry::OrientedLattice. The
 methods on this class follow naming conventions for parameters as defined in
 the `International Tables for Crystallography
 <http://it.iucr.org/Ba/ch1o1v0001/>`__. See also the

--- a/docs/source/api/python/mantid/geometry/PointingAlong.rst
+++ b/docs/source/api/python/mantid/geometry/PointingAlong.rst
@@ -2,7 +2,7 @@
  PointingAlong
 ===============
 
-This a python binding to the C++ class Mantid::Geometry::PointingAlong.
+This is a Python binding to the C++ class Mantid::Geometry::PointingAlong.
 
 
 .. module:`mantid.geometry`

--- a/docs/source/api/python/mantid/geometry/RectangularDetector.rst
+++ b/docs/source/api/python/mantid/geometry/RectangularDetector.rst
@@ -2,7 +2,7 @@
  RectangularDetector
 =====================
 
-This a python binding to the C++ class Mantid::Geometry::RectangularDetector.
+This is a Python binding to the C++ class Mantid::Geometry::RectangularDetector.
 
 *bases:* :py:obj:`mantid.geometry.CompAssembly`, :py:obj:`mantid.geometry.IObjComponent`
 

--- a/docs/source/api/python/mantid/geometry/ReferenceFrame.rst
+++ b/docs/source/api/python/mantid/geometry/ReferenceFrame.rst
@@ -2,7 +2,7 @@
  ReferenceFrame
 ================
 
-This a python binding to the C++ class Mantid::Geometry::ReferenceFrame.
+This is a Python binding to the C++ class Mantid::Geometry::ReferenceFrame.
 
 
 .. module:`mantid.geometry`

--- a/docs/source/api/python/mantid/geometry/UnitCell.rst
+++ b/docs/source/api/python/mantid/geometry/UnitCell.rst
@@ -2,7 +2,7 @@
  UnitCell
 ==========
 
-This a python binding to the C++ class Mantid::Geometry::UnitCell. The methods
+This is a Python binding to the C++ class Mantid::Geometry::UnitCell. The methods
 on this class follow naming conventions for parameters as defined in the
 `International Tables for Crystallography <http://it.iucr.org/Ba/ch1o1v0001/>`__.
 

--- a/docs/source/api/python/mantid/kernel/Atom.rst
+++ b/docs/source/api/python/mantid/kernel/Atom.rst
@@ -2,7 +2,7 @@
  Atom
 ======
 
-This a python binding to the C++ class Mantid::PhysicalConstants::Atom.
+This is a Python binding to the C++ class Mantid::PhysicalConstants::Atom.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/BoolFilteredTimeSeriesProperty.rst
+++ b/docs/source/api/python/mantid/kernel/BoolFilteredTimeSeriesProperty.rst
@@ -2,7 +2,7 @@
  BoolFilteredTimeSeriesProperty
 ================================
 
-This a python binding to the C++ class Mantid::Kernel::FilteredTimeSeriesProperty.
+This is a Python binding to the C++ class Mantid::Kernel::FilteredTimeSeriesProperty.
 
 *bases:* :py:obj:`mantid.kernel.BoolTimeSeriesProperty`
 

--- a/docs/source/api/python/mantid/kernel/BoolPropertyWithValue.rst
+++ b/docs/source/api/python/mantid/kernel/BoolPropertyWithValue.rst
@@ -2,7 +2,7 @@
  BoolPropertyWithValue
 =======================
 
-This a python binding to the C++ class Mantid::Kernel::BoolPropertyWithValue.
+This is a Python binding to the C++ class Mantid::Kernel::BoolPropertyWithValue.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/kernel/BoolTimeSeriesProperty.rst
+++ b/docs/source/api/python/mantid/kernel/BoolTimeSeriesProperty.rst
@@ -2,7 +2,7 @@
  BoolTimeSeriesProperty
 ========================
 
-This a python binding to the C++ class Mantid::Kernel::TimeSeriesProperty.
+This is a Python binding to the C++ class Mantid::Kernel::TimeSeriesProperty.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/kernel/CIntArrayProperty.rst
+++ b/docs/source/api/python/mantid/kernel/CIntArrayProperty.rst
@@ -2,7 +2,7 @@
  CIntArrayProperty
 ===================
 
-This a python binding to the C++ class Mantid::Kernel::ArrayProperty.
+This is a Python binding to the C++ class Mantid::Kernel::ArrayProperty.
 
 *bases:* :py:obj:`mantid.kernel.VectorIntPropertyWithValue`
 

--- a/docs/source/api/python/mantid/kernel/CompositeValidator.rst
+++ b/docs/source/api/python/mantid/kernel/CompositeValidator.rst
@@ -2,7 +2,7 @@
  CompositeValidator
 ====================
 
-This a python binding to the C++ class Mantid::Kernel::CompositeValidator.
+This is a Python binding to the C++ class Mantid::Kernel::CompositeValidator.
 
 *bases:* :py:obj:`mantid.kernel.IValidator`
 

--- a/docs/source/api/python/mantid/kernel/ConfigObserver.rst
+++ b/docs/source/api/python/mantid/kernel/ConfigObserver.rst
@@ -2,7 +2,7 @@
  ConfigObserver
 ===================
 
-This a python binding to the C++ class Mantid::Kernel::ConfigObserver.
+This is a Python binding to the C++ class Mantid::Kernel::ConfigObserver.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/ConfigPropertyObserver.rst
+++ b/docs/source/api/python/mantid/kernel/ConfigPropertyObserver.rst
@@ -2,7 +2,7 @@
  ConfigPropertyObserver
 ========================
 
-This a python binding to the C++ class Mantid::Kernel::ConfigPropertyObserver.
+This is a Python binding to the C++ class Mantid::Kernel::ConfigPropertyObserver.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/ConfigServiceImpl.rst
+++ b/docs/source/api/python/mantid/kernel/ConfigServiceImpl.rst
@@ -2,7 +2,7 @@
  ConfigServiceImpl
 ===================
 
-This a python binding to the C++ class Mantid::Kernel::ConfigServiceImpl.
+This is a Python binding to the C++ class Mantid::Kernel::ConfigServiceImpl.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/DataItem.rst
+++ b/docs/source/api/python/mantid/kernel/DataItem.rst
@@ -2,7 +2,7 @@
  DataItem
 ==========
 
-This a python binding to the C++ class Mantid::Kernel::DataItem.
+This is a Python binding to the C++ class Mantid::Kernel::DataItem.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/DateAndTime.rst
+++ b/docs/source/api/python/mantid/kernel/DateAndTime.rst
@@ -2,7 +2,7 @@
  DateAndTime
 =============
 
-This a python binding to the C++ class Mantid::Kernel::DateAndTime.
+This is a Python binding to the C++ class Mantid::Kernel::DateAndTime.
 
 The equivalent object in python is :class:`numpy.datetime64`. The two
 classes have a different EPOCH. Note that

--- a/docs/source/api/python/mantid/kernel/DeltaEMode.rst
+++ b/docs/source/api/python/mantid/kernel/DeltaEMode.rst
@@ -2,7 +2,7 @@
  DeltaEMode
 ============
 
-This a python binding to the C++ class Mantid::Kernel::DeltaEMode.
+This is a Python binding to the C++ class Mantid::Kernel::DeltaEMode.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/DeltaEModeType.rst
+++ b/docs/source/api/python/mantid/kernel/DeltaEModeType.rst
@@ -2,7 +2,7 @@
  DeltaEModeType
 ================
 
-This a python binding to the C++ class Mantid::Kernel::DeltaEMode.
+This is a Python binding to the C++ class Mantid::Kernel::DeltaEMode.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/Direction.rst
+++ b/docs/source/api/python/mantid/kernel/Direction.rst
@@ -2,7 +2,7 @@
  Direction
 ===========
 
-This a python binding to the C++ class Mantid::Kernel::Direction.
+This is a Python binding to the C++ class Mantid::Kernel::Direction.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/EnabledWhenProperty.rst
+++ b/docs/source/api/python/mantid/kernel/EnabledWhenProperty.rst
@@ -2,7 +2,7 @@
  EnabledWhenProperty
 =====================
 
-This a python binding to the C++ class Mantid::Kernel::EnabledWhenProperty.
+This is a Python binding to the C++ class Mantid::Kernel::EnabledWhenProperty.
 
 *bases:* :py:obj:`mantid.kernel.IPropertySettings`
 

--- a/docs/source/api/python/mantid/kernel/FacilityInfo.rst
+++ b/docs/source/api/python/mantid/kernel/FacilityInfo.rst
@@ -2,7 +2,7 @@
  FacilityInfo
 ==============
 
-This a python binding to the C++ class Mantid::Kernel::FacilityInfo.
+This is a Python binding to the C++ class Mantid::Kernel::FacilityInfo.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/FloatArrayBoundedValidator.rst
+++ b/docs/source/api/python/mantid/kernel/FloatArrayBoundedValidator.rst
@@ -2,7 +2,7 @@
  FloatArrayBoundedValidator
 ============================
 
-This a python binding to the C++ class Mantid::Kernel::ArrayBoundedValidator.
+This is a Python binding to the C++ class Mantid::Kernel::ArrayBoundedValidator.
 
 *bases:* :py:obj:`mantid.kernel.IValidator`
 

--- a/docs/source/api/python/mantid/kernel/FloatArrayLengthValidator.rst
+++ b/docs/source/api/python/mantid/kernel/FloatArrayLengthValidator.rst
@@ -2,7 +2,7 @@
  FloatArrayLengthValidator
 ===========================
 
-This a python binding to the C++ class Mantid::Kernel::ArrayLengthValidator.
+This is a Python binding to the C++ class Mantid::Kernel::ArrayLengthValidator.
 
 *bases:* :py:obj:`mantid.kernel.IValidator`
 

--- a/docs/source/api/python/mantid/kernel/FloatArrayMandatoryValidator.rst
+++ b/docs/source/api/python/mantid/kernel/FloatArrayMandatoryValidator.rst
@@ -2,7 +2,7 @@
  FloatArrayMandatoryValidator
 ==============================
 
-This a python binding to the C++ class Mantid::Kernel::MandatoryValidator.
+This is a Python binding to the C++ class Mantid::Kernel::MandatoryValidator.
 
 *bases:* :py:obj:`mantid.kernel.IValidator`
 

--- a/docs/source/api/python/mantid/kernel/FloatArrayProperty.rst
+++ b/docs/source/api/python/mantid/kernel/FloatArrayProperty.rst
@@ -2,7 +2,7 @@
  FloatArrayProperty
 ====================
 
-This a python binding to the C++ class Mantid::Kernel::ArrayProperty.
+This is a Python binding to the C++ class Mantid::Kernel::ArrayProperty.
 
 *bases:* :py:obj:`mantid.kernel.VectorFloatPropertyWithValue`
 

--- a/docs/source/api/python/mantid/kernel/FloatBoundedValidator.rst
+++ b/docs/source/api/python/mantid/kernel/FloatBoundedValidator.rst
@@ -2,7 +2,7 @@
  FloatBoundedValidator
 =======================
 
-This a python binding to the C++ class Mantid::Kernel::FloatBoundedValidator.
+This is a Python binding to the C++ class Mantid::Kernel::FloatBoundedValidator.
 
 *bases:* :py:obj:`mantid.kernel.IValidator`
 

--- a/docs/source/api/python/mantid/kernel/FloatFilteredTimeSeriesProperty.rst
+++ b/docs/source/api/python/mantid/kernel/FloatFilteredTimeSeriesProperty.rst
@@ -2,7 +2,7 @@
  FloatFilteredTimeSeriesProperty
 =================================
 
-This a python binding to the C++ class Mantid::Kernel::FilteredTimeSeriesProperty.
+This is a Python binding to the C++ class Mantid::Kernel::FilteredTimeSeriesProperty.
 
 *bases:* :py:obj:`mantid.kernel.FloatTimeSeriesProperty`
 

--- a/docs/source/api/python/mantid/kernel/FloatMandatoryValidator.rst
+++ b/docs/source/api/python/mantid/kernel/FloatMandatoryValidator.rst
@@ -2,7 +2,7 @@
  FloatMandatoryValidator
 =========================
 
-This a python binding to the C++ class Mantid::Kernel::MandatoryValidator.
+This is a Python binding to the C++ class Mantid::Kernel::MandatoryValidator.
 
 *bases:* :py:obj:`mantid.kernel.IValidator`
 

--- a/docs/source/api/python/mantid/kernel/FloatPropertyWithValue.rst
+++ b/docs/source/api/python/mantid/kernel/FloatPropertyWithValue.rst
@@ -2,7 +2,7 @@
  FloatPropertyWithValue
 ========================
 
-This a python binding to the C++ class Mantid::Kernel::FloatPropertyWithValue.
+This is a Python binding to the C++ class Mantid::Kernel::FloatPropertyWithValue.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/kernel/FloatTimeSeriesProperty.rst
+++ b/docs/source/api/python/mantid/kernel/FloatTimeSeriesProperty.rst
@@ -2,7 +2,7 @@
  FloatTimeSeriesProperty
 =========================
 
-This a python binding to the C++ class Mantid::Kernel::TimeSeriesProperty.
+This is a Python binding to the C++ class Mantid::Kernel::TimeSeriesProperty.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/kernel/IPropertyManager.rst
+++ b/docs/source/api/python/mantid/kernel/IPropertyManager.rst
@@ -2,7 +2,7 @@
  IPropertyManager
 ==================
 
-This a python binding to the C++ class Mantid::Kernel::IPropertyManager.
+This is a Python binding to the C++ class Mantid::Kernel::IPropertyManager.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/IPropertySettings.rst
+++ b/docs/source/api/python/mantid/kernel/IPropertySettings.rst
@@ -2,7 +2,7 @@
  IPropertySettings
 ===================
 
-This a python binding to the C++ class Mantid::Kernel::IPropertySettings.
+This is a Python binding to the C++ class Mantid::Kernel::IPropertySettings.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/IValidator.rst
+++ b/docs/source/api/python/mantid/kernel/IValidator.rst
@@ -2,7 +2,7 @@
  IValidator
 ============
 
-This a python binding to the C++ class Mantid::Kernel::IValidator.
+This is a Python binding to the C++ class Mantid::Kernel::IValidator.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/InstrumentInfo.rst
+++ b/docs/source/api/python/mantid/kernel/InstrumentInfo.rst
@@ -2,7 +2,7 @@
  InstrumentInfo
 ================
 
-This a python binding to the C++ class Mantid::Kernel::InstrumentInfo.
+This is a Python binding to the C++ class Mantid::Kernel::InstrumentInfo.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/Int32FilteredTimeSeriesProperty.rst
+++ b/docs/source/api/python/mantid/kernel/Int32FilteredTimeSeriesProperty.rst
@@ -2,7 +2,7 @@
  Int32FilteredTimeSeriesProperty
 =================================
 
-This a python binding to the C++ class Mantid::Kernel::FilteredTimeSeriesProperty.
+This is a Python binding to the C++ class Mantid::Kernel::FilteredTimeSeriesProperty.
 
 *bases:* :py:obj:`mantid.kernel.Int32TimeSeriesProperty`
 

--- a/docs/source/api/python/mantid/kernel/Int32TimeSeriesProperty.rst
+++ b/docs/source/api/python/mantid/kernel/Int32TimeSeriesProperty.rst
@@ -2,7 +2,7 @@
  Int32TimeSeriesProperty
 =========================
 
-This a python binding to the C++ class Mantid::Kernel::TimeSeriesProperty.
+This is a Python binding to the C++ class Mantid::Kernel::TimeSeriesProperty.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/kernel/Int64FilteredTimeSeriesProperty.rst
+++ b/docs/source/api/python/mantid/kernel/Int64FilteredTimeSeriesProperty.rst
@@ -2,7 +2,7 @@
  Int64FilteredTimeSeriesProperty
 =================================
 
-This a python binding to the C++ class Mantid::Kernel::FilteredTimeSeriesProperty.
+This is a Python binding to the C++ class Mantid::Kernel::FilteredTimeSeriesProperty.
 
 *bases:* :py:obj:`mantid.kernel.Int64TimeSeriesProperty`
 

--- a/docs/source/api/python/mantid/kernel/Int64TimeSeriesProperty.rst
+++ b/docs/source/api/python/mantid/kernel/Int64TimeSeriesProperty.rst
@@ -2,7 +2,7 @@
  Int64TimeSeriesProperty
 =========================
 
-This a python binding to the C++ class Mantid::Kernel::TimeSeriesProperty.
+This is a Python binding to the C++ class Mantid::Kernel::TimeSeriesProperty.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/kernel/IntArrayBoundedValidator.rst
+++ b/docs/source/api/python/mantid/kernel/IntArrayBoundedValidator.rst
@@ -2,7 +2,7 @@
  IntArrayBoundedValidator
 ==========================
 
-This a python binding to the C++ class Mantid::Kernel::ArrayBoundedValidator.
+This is a Python binding to the C++ class Mantid::Kernel::ArrayBoundedValidator.
 
 *bases:* :py:obj:`mantid.kernel.IValidator`
 

--- a/docs/source/api/python/mantid/kernel/IntArrayLengthValidator.rst
+++ b/docs/source/api/python/mantid/kernel/IntArrayLengthValidator.rst
@@ -2,7 +2,7 @@
  IntArrayLengthValidator
 =========================
 
-This a python binding to the C++ class Mantid::Kernel::ArrayLengthValidator.
+This is a Python binding to the C++ class Mantid::Kernel::ArrayLengthValidator.
 
 *bases:* :py:obj:`mantid.kernel.IValidator`
 

--- a/docs/source/api/python/mantid/kernel/IntArrayMandatoryValidator.rst
+++ b/docs/source/api/python/mantid/kernel/IntArrayMandatoryValidator.rst
@@ -2,7 +2,7 @@
  IntArrayMandatoryValidator
 ============================
 
-This a python binding to the C++ class Mantid::Kernel::MandatoryValidator.
+This is a Python binding to the C++ class Mantid::Kernel::MandatoryValidator.
 
 *bases:* :py:obj:`mantid.kernel.IValidator`
 

--- a/docs/source/api/python/mantid/kernel/IntArrayProperty.rst
+++ b/docs/source/api/python/mantid/kernel/IntArrayProperty.rst
@@ -2,7 +2,7 @@
  IntArrayProperty
 ==================
 
-This a python binding to the C++ class Mantid::Kernel::ArrayProperty.
+This is a Python binding to the C++ class Mantid::Kernel::ArrayProperty.
 
 *bases:* :py:obj:`mantid.kernel.VectorLongPropertyWithValue`
 

--- a/docs/source/api/python/mantid/kernel/IntBoundedValidator.rst
+++ b/docs/source/api/python/mantid/kernel/IntBoundedValidator.rst
@@ -2,7 +2,7 @@
  IntBoundedValidator
 =====================
 
-This a python binding to the C++ class Mantid::Kernel::IntBoundedValidator.
+This is a Python binding to the C++ class Mantid::Kernel::IntBoundedValidator.
 
 *bases:* :py:obj:`mantid.kernel.IValidator`
 

--- a/docs/source/api/python/mantid/kernel/IntListValidator.rst
+++ b/docs/source/api/python/mantid/kernel/IntListValidator.rst
@@ -2,7 +2,7 @@
  IntListValidator
 ==================
 
-This a python binding to the C++ class Mantid::Kernel::IntListValidator.
+This is a Python binding to the C++ class Mantid::Kernel::IntListValidator.
 
 *bases:* :py:obj:`mantid.kernel.IValidator`
 

--- a/docs/source/api/python/mantid/kernel/IntMandatoryValidator.rst
+++ b/docs/source/api/python/mantid/kernel/IntMandatoryValidator.rst
@@ -2,7 +2,7 @@
  IntMandatoryValidator
 =======================
 
-This a python binding to the C++ class Mantid::Kernel::MandatoryValidator.
+This is a Python binding to the C++ class Mantid::Kernel::MandatoryValidator.
 
 *bases:* :py:obj:`mantid.kernel.IValidator`
 

--- a/docs/source/api/python/mantid/kernel/IntPropertyWithValue.rst
+++ b/docs/source/api/python/mantid/kernel/IntPropertyWithValue.rst
@@ -2,7 +2,7 @@
  IntPropertyWithValue
 ======================
 
-This a python binding to the C++ class Mantid::Kernel::IntPropertyWithValue.
+This is a Python binding to the C++ class Mantid::Kernel::IntPropertyWithValue.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/kernel/Label.rst
+++ b/docs/source/api/python/mantid/kernel/Label.rst
@@ -2,7 +2,7 @@
  Label
 =======
 
-This a python binding to the C++ class Mantid::Kernel::Label.
+This is a Python binding to the C++ class Mantid::Kernel::Label.
 
 *bases:* :py:obj:`mantid.kernel.Unit`
 

--- a/docs/source/api/python/mantid/kernel/LiveListenerInfo.rst
+++ b/docs/source/api/python/mantid/kernel/LiveListenerInfo.rst
@@ -2,7 +2,7 @@
  LiveListenerInfo
 ==================
 
-This a python binding to the C++ class Mantid::Kernel::LiveListenerInfo.
+This is a Python binding to the C++ class Mantid::Kernel::LiveListenerInfo.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/LogFilter.rst
+++ b/docs/source/api/python/mantid/kernel/LogFilter.rst
@@ -2,7 +2,7 @@
  LogFilter
 ===========
 
-This a python binding to the C++ class Mantid::Kernel::LogFilter.
+This is a Python binding to the C++ class Mantid::Kernel::LogFilter.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/Logger.rst
+++ b/docs/source/api/python/mantid/kernel/Logger.rst
@@ -2,7 +2,7 @@
  Logger
 ========
 
-This a python binding to the C++ class Mantid::Kernel::Logger.
+This is a Python binding to the C++ class Mantid::Kernel::Logger.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/LongLongPropertyWithValue.rst
+++ b/docs/source/api/python/mantid/kernel/LongLongPropertyWithValue.rst
@@ -2,7 +2,7 @@
  LongLongPropertyWithValue
 ===========================
 
-This a python binding to the C++ class Mantid::Kernel::LongLongPropertyWithValue.
+This is a Python binding to the C++ class Mantid::Kernel::LongLongPropertyWithValue.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/kernel/LongPropertyWithValue.rst
+++ b/docs/source/api/python/mantid/kernel/LongPropertyWithValue.rst
@@ -2,7 +2,7 @@
  LongPropertyWithValue
 =======================
 
-This a python binding to the C++ class Mantid::Kernel::LongPropertyWithValue.
+This is a Python binding to the C++ class Mantid::Kernel::LongPropertyWithValue.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/kernel/Material.rst
+++ b/docs/source/api/python/mantid/kernel/Material.rst
@@ -2,7 +2,7 @@
  Material
 ==========
 
-This a python binding to the C++ class Mantid::Kernel::Material.
+This is a Python binding to the C++ class Mantid::Kernel::Material.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/MaterialBuilder.rst
+++ b/docs/source/api/python/mantid/kernel/MaterialBuilder.rst
@@ -2,7 +2,7 @@
  MaterialBuilder
 =================
 
-This a python binding to the C++ class
+This is a Python binding to the C++ class
 Mantid::Kernel::MaterialBuilder. It provides an interface for
 generating :py:obj:`mantid.kernel.Material` objects.
 

--- a/docs/source/api/python/mantid/kernel/MemoryStats.rst
+++ b/docs/source/api/python/mantid/kernel/MemoryStats.rst
@@ -2,7 +2,7 @@
  MemoryStats
 =============
 
-This a python binding to the C++ class Mantid::Kernel::MemoryStats.
+This is a Python binding to the C++ class Mantid::Kernel::MemoryStats.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/NullValidator.rst
+++ b/docs/source/api/python/mantid/kernel/NullValidator.rst
@@ -2,7 +2,7 @@
  NullValidator
 ===============
 
-This a python binding to the C++ class Mantid::Kernel::NullValidator.
+This is a Python binding to the C++ class Mantid::Kernel::NullValidator.
 
 *bases:* :py:obj:`mantid.kernel.IValidator`
 

--- a/docs/source/api/python/mantid/kernel/ProgressBase.rst
+++ b/docs/source/api/python/mantid/kernel/ProgressBase.rst
@@ -2,7 +2,7 @@
  ProgressBase
 ==============
 
-This a python binding to the C++ class Mantid::Kernel::ProgressBase.
+This is a Python binding to the C++ class Mantid::Kernel::ProgressBase.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/Property.rst
+++ b/docs/source/api/python/mantid/kernel/Property.rst
@@ -2,7 +2,7 @@
  Property
 ==========
 
-This a python binding to the C++ class Mantid::Kernel::Property.
+This is a Python binding to the C++ class Mantid::Kernel::Property.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/PropertyCriterion.rst
+++ b/docs/source/api/python/mantid/kernel/PropertyCriterion.rst
@@ -2,7 +2,7 @@
  PropertyCriterion
 ===================
 
-This a python binding to the C++ class Mantid::Kernel::PropertyCriterion.
+This is a Python binding to the C++ class Mantid::Kernel::PropertyCriterion.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/PropertyHistory.rst
+++ b/docs/source/api/python/mantid/kernel/PropertyHistory.rst
@@ -2,7 +2,7 @@
  PropertyHistory
 =================
 
-This a python binding to the C++ class Mantid::Kernel::PropertyHistory.
+This is a Python binding to the C++ class Mantid::Kernel::PropertyHistory.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/PropertyManager.rst
+++ b/docs/source/api/python/mantid/kernel/PropertyManager.rst
@@ -2,7 +2,7 @@
  PropertyManager
 =================
 
-This a python binding to the C++ class Mantid::Kernel::PropertyManager.
+This is a Python binding to the C++ class Mantid::Kernel::PropertyManager.
 
 *bases:* :py:obj:`mantid.kernel.IPropertyManager`
 

--- a/docs/source/api/python/mantid/kernel/PropertyManagerDataServiceImpl.rst
+++ b/docs/source/api/python/mantid/kernel/PropertyManagerDataServiceImpl.rst
@@ -2,7 +2,7 @@
  PropertyManagerDataServiceImpl
 ================================
 
-This a python binding to the C++ class Mantid::Kernel::PropertyManagerDataServiceImpl.
+This is a Python binding to the C++ class Mantid::Kernel::PropertyManagerDataServiceImpl.
 
 
 .. module:`mantid.api`

--- a/docs/source/api/python/mantid/kernel/Quat.rst
+++ b/docs/source/api/python/mantid/kernel/Quat.rst
@@ -2,7 +2,7 @@
  Quat
 ======
 
-This a python binding to the C++ class Mantid::Kernel::Quat.
+This is a Python binding to the C++ class Mantid::Kernel::Quat.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/Stats.rst
+++ b/docs/source/api/python/mantid/kernel/Stats.rst
@@ -2,7 +2,7 @@
  Stats
 =======
 
-This a python binding to the C++ class Mantid::Kernel::Stats.
+This is a Python binding to the C++ class Mantid::Kernel::Stats.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/StringArrayLengthValidator.rst
+++ b/docs/source/api/python/mantid/kernel/StringArrayLengthValidator.rst
@@ -2,7 +2,7 @@
  StringArrayLengthValidator
 ============================
 
-This a python binding to the C++ class Mantid::Kernel::ArrayLengthValidator.
+This is a Python binding to the C++ class Mantid::Kernel::ArrayLengthValidator.
 
 *bases:* :py:obj:`mantid.kernel.IValidator`
 

--- a/docs/source/api/python/mantid/kernel/StringArrayMandatoryValidator.rst
+++ b/docs/source/api/python/mantid/kernel/StringArrayMandatoryValidator.rst
@@ -2,7 +2,7 @@
  StringArrayMandatoryValidator
 ===============================
 
-This a python binding to the C++ class Mantid::Kernel::MandatoryValidator.
+This is a Python binding to the C++ class Mantid::Kernel::MandatoryValidator.
 
 *bases:* :py:obj:`mantid.kernel.IValidator`
 

--- a/docs/source/api/python/mantid/kernel/StringArrayProperty.rst
+++ b/docs/source/api/python/mantid/kernel/StringArrayProperty.rst
@@ -2,7 +2,7 @@
  StringArrayProperty
 =====================
 
-This a python binding to the C++ class Mantid::Kernel::ArrayProperty.
+This is a Python binding to the C++ class Mantid::Kernel::ArrayProperty.
 
 *bases:* :py:obj:`mantid.kernel.VectorStringPropertyWithValue`
 

--- a/docs/source/api/python/mantid/kernel/StringContainsValidator.rst
+++ b/docs/source/api/python/mantid/kernel/StringContainsValidator.rst
@@ -2,7 +2,7 @@
 StringContainsValidator
 =======================
 
-This a python binding to the C++ class Mantid::Kernel::StringContainsValidator.
+This is a Python binding to the C++ class Mantid::Kernel::StringContainsValidator.
 
 *bases:* :py:obj:`mantid.kernel.IValidator`
 

--- a/docs/source/api/python/mantid/kernel/StringFilteredTimeSeriesProperty.rst
+++ b/docs/source/api/python/mantid/kernel/StringFilteredTimeSeriesProperty.rst
@@ -2,7 +2,7 @@
  StringFilteredTimeSeriesProperty
 ==================================
 
-This a python binding to the C++ class Mantid::Kernel::FilteredTimeSeriesProperty.
+This is a Python binding to the C++ class Mantid::Kernel::FilteredTimeSeriesProperty.
 
 *bases:* :py:obj:`mantid.kernel.StringTimeSeriesProperty`
 

--- a/docs/source/api/python/mantid/kernel/StringListValidator.rst
+++ b/docs/source/api/python/mantid/kernel/StringListValidator.rst
@@ -2,7 +2,7 @@
  StringListValidator
 =====================
 
-This a python binding to the C++ class Mantid::Kernel::StringListValidator.
+This is a Python binding to the C++ class Mantid::Kernel::StringListValidator.
 
 *bases:* :py:obj:`mantid.kernel.IValidator`
 

--- a/docs/source/api/python/mantid/kernel/StringMandatoryValidator.rst
+++ b/docs/source/api/python/mantid/kernel/StringMandatoryValidator.rst
@@ -2,7 +2,7 @@
  StringMandatoryValidator
 ==========================
 
-This a python binding to the C++ class Mantid::Kernel::MandatoryValidator.
+This is a Python binding to the C++ class Mantid::Kernel::MandatoryValidator.
 
 *bases:* :py:obj:`mantid.kernel.IValidator`
 

--- a/docs/source/api/python/mantid/kernel/StringPropertyWithValue.rst
+++ b/docs/source/api/python/mantid/kernel/StringPropertyWithValue.rst
@@ -2,7 +2,7 @@
  StringPropertyWithValue
 =========================
 
-This a python binding to the C++ class Mantid::Kernel::StringPropertyWithValue.
+This is a Python binding to the C++ class Mantid::Kernel::StringPropertyWithValue.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/kernel/StringTimeSeriesProperty.rst
+++ b/docs/source/api/python/mantid/kernel/StringTimeSeriesProperty.rst
@@ -2,7 +2,7 @@
  StringTimeSeriesProperty
 ==========================
 
-This a python binding to the C++ class Mantid::Kernel::TimeSeriesProperty.
+This is a Python binding to the C++ class Mantid::Kernel::TimeSeriesProperty.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/kernel/TimeSeriesPropertyStatistics.rst
+++ b/docs/source/api/python/mantid/kernel/TimeSeriesPropertyStatistics.rst
@@ -2,7 +2,7 @@
  TimeSeriesPropertyStatistics
 ==============================
 
-This a python binding to the C++ class Mantid::Kernel::TimeSeriesPropertyStatistics.
+This is a Python binding to the C++ class Mantid::Kernel::TimeSeriesPropertyStatistics.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/UIntPropertyWithValue.rst
+++ b/docs/source/api/python/mantid/kernel/UIntPropertyWithValue.rst
@@ -2,7 +2,7 @@
  UIntPropertyWithValue
 =======================
 
-This a python binding to the C++ class Mantid::Kernel::UIntPropertyWithValue.
+This is a Python binding to the C++ class Mantid::Kernel::UIntPropertyWithValue.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/kernel/ULongLongPropertyWithValue.rst
+++ b/docs/source/api/python/mantid/kernel/ULongLongPropertyWithValue.rst
@@ -2,7 +2,7 @@
  ULongLongPropertyWithValue
 ============================
 
-This a python binding to the C++ class Mantid::Kernel::ULongLongPropertyWithValue.
+This is a Python binding to the C++ class Mantid::Kernel::ULongLongPropertyWithValue.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/kernel/ULongPropertyWithValue.rst
+++ b/docs/source/api/python/mantid/kernel/ULongPropertyWithValue.rst
@@ -2,7 +2,7 @@
  ULongPropertyWithValue
 ========================
 
-This a python binding to the C++ class Mantid::Kernel::ULongPropertyWithValue.
+This is a Python binding to the C++ class Mantid::Kernel::ULongPropertyWithValue.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/kernel/Unit.rst
+++ b/docs/source/api/python/mantid/kernel/Unit.rst
@@ -2,7 +2,7 @@
  Unit
 ======
 
-This a python binding to the C++ class Mantid::Kernel::Unit.
+This is a Python binding to the C++ class Mantid::Kernel::Unit.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/UnitConversion.rst
+++ b/docs/source/api/python/mantid/kernel/UnitConversion.rst
@@ -2,7 +2,7 @@
  UnitConversion
 ================
 
-This a python binding to the C++ class Mantid::Kernel::UnitConversion.
+This is a Python binding to the C++ class Mantid::Kernel::UnitConversion.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/UnitFactoryImpl.rst
+++ b/docs/source/api/python/mantid/kernel/UnitFactoryImpl.rst
@@ -2,7 +2,7 @@
  UnitFactoryImpl
 =================
 
-This a python binding to the C++ class Mantid::Kernel::UnitFactoryImpl.
+This is a Python binding to the C++ class Mantid::Kernel::UnitFactoryImpl.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/UnitLabel.rst
+++ b/docs/source/api/python/mantid/kernel/UnitLabel.rst
@@ -2,7 +2,7 @@
  UnitLabel
 ===========
 
-This a python binding to the C++ class Mantid::Kernel::UnitLabel.
+This is a Python binding to the C++ class Mantid::Kernel::UnitLabel.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/UnsignedIntArrayProperty.rst
+++ b/docs/source/api/python/mantid/kernel/UnsignedIntArrayProperty.rst
@@ -2,7 +2,7 @@
  UnsignedIntArrayProperty
 ==========================
 
-This a python binding to the C++ class Mantid::Kernel::ArrayProperty.
+This is a Python binding to the C++ class Mantid::Kernel::ArrayProperty.
 
 *bases:* :py:obj:`mantid.kernel.VectorULongPropertyWithValue`
 

--- a/docs/source/api/python/mantid/kernel/V3D.rst
+++ b/docs/source/api/python/mantid/kernel/V3D.rst
@@ -2,7 +2,7 @@
  V3D
 =====
 
-This a python binding to the C++ class Mantid::Kernel::V3D.
+This is a Python binding to the C++ class Mantid::Kernel::V3D.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/VMD.rst
+++ b/docs/source/api/python/mantid/kernel/VMD.rst
@@ -2,7 +2,7 @@
  VMD
 =====
 
-This a python binding to the C++ class Mantid::Kernel::VMD.
+This is a Python binding to the C++ class Mantid::Kernel::VMD.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/VectorBoolPropertyWithValue.rst
+++ b/docs/source/api/python/mantid/kernel/VectorBoolPropertyWithValue.rst
@@ -2,7 +2,7 @@
  VectorBoolPropertyWithValue
 =============================
 
-This a python binding to the C++ class Mantid::Kernel::VectorBoolPropertyWithValue.
+This is a Python binding to the C++ class Mantid::Kernel::VectorBoolPropertyWithValue.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/kernel/VectorFloatPropertyWithValue.rst
+++ b/docs/source/api/python/mantid/kernel/VectorFloatPropertyWithValue.rst
@@ -2,7 +2,7 @@
  VectorFloatPropertyWithValue
 ==============================
 
-This a python binding to the C++ class Mantid::Kernel::VectorFloatPropertyWithValue.
+This is a Python binding to the C++ class Mantid::Kernel::VectorFloatPropertyWithValue.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/kernel/VectorIntPropertyWithValue.rst
+++ b/docs/source/api/python/mantid/kernel/VectorIntPropertyWithValue.rst
@@ -2,7 +2,7 @@
  VectorIntPropertyWithValue
 ============================
 
-This a python binding to the C++ class Mantid::Kernel::VectorIntPropertyWithValue.
+This is a Python binding to the C++ class Mantid::Kernel::VectorIntPropertyWithValue.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/kernel/VectorLongLongPropertyWithValue.rst
+++ b/docs/source/api/python/mantid/kernel/VectorLongLongPropertyWithValue.rst
@@ -2,7 +2,7 @@
  VectorLongLongPropertyWithValue
 =================================
 
-This a python binding to the C++ class Mantid::Kernel::VectorLongLongPropertyWithValue.
+This is a Python binding to the C++ class Mantid::Kernel::VectorLongLongPropertyWithValue.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/kernel/VectorLongPropertyWithValue.rst
+++ b/docs/source/api/python/mantid/kernel/VectorLongPropertyWithValue.rst
@@ -2,7 +2,7 @@
  VectorLongPropertyWithValue
 =============================
 
-This a python binding to the C++ class Mantid::Kernel::VectorLongPropertyWithValue.
+This is a Python binding to the C++ class Mantid::Kernel::VectorLongPropertyWithValue.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/kernel/VectorStringPropertyWithValue.rst
+++ b/docs/source/api/python/mantid/kernel/VectorStringPropertyWithValue.rst
@@ -2,7 +2,7 @@
  VectorStringPropertyWithValue
 ===============================
 
-This a python binding to the C++ class Mantid::Kernel::VectorStringPropertyWithValue.
+This is a Python binding to the C++ class Mantid::Kernel::VectorStringPropertyWithValue.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/kernel/VectorUIntPropertyWithValue.rst
+++ b/docs/source/api/python/mantid/kernel/VectorUIntPropertyWithValue.rst
@@ -2,7 +2,7 @@
  VectorUIntPropertyWithValue
 =============================
 
-This a python binding to the C++ class Mantid::Kernel::VectorUIntPropertyWithValue.
+This is a Python binding to the C++ class Mantid::Kernel::VectorUIntPropertyWithValue.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/kernel/VectorULongLongPropertyWithValue.rst
+++ b/docs/source/api/python/mantid/kernel/VectorULongLongPropertyWithValue.rst
@@ -2,7 +2,7 @@
  VectorULongLongPropertyWithValue
 ==================================
 
-This a python binding to the C++ class Mantid::Kernel::VectorULongLongPropertyWithValue.
+This is a Python binding to the C++ class Mantid::Kernel::VectorULongLongPropertyWithValue.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/kernel/VectorULongPropertyWithValue.rst
+++ b/docs/source/api/python/mantid/kernel/VectorULongPropertyWithValue.rst
@@ -2,7 +2,7 @@
  VectorULongPropertyWithValue
 ==============================
 
-This a python binding to the C++ class Mantid::Kernel::VectorULongPropertyWithValue.
+This is a Python binding to the C++ class Mantid::Kernel::VectorULongPropertyWithValue.
 
 *bases:* :py:obj:`mantid.kernel.Property`
 

--- a/docs/source/api/python/mantid/kernel/VisibleWhenProperty.rst
+++ b/docs/source/api/python/mantid/kernel/VisibleWhenProperty.rst
@@ -2,7 +2,7 @@
  VisibleWhenProperty
 =====================
 
-This a python binding to the C++ class Mantid::Kernel::VisibleWhenProperty.
+This is a Python binding to the C++ class Mantid::Kernel::VisibleWhenProperty.
 
 *bases:* :py:obj:`mantid.kernel.EnabledWhenProperty`
 

--- a/docs/source/api/python/mantid/kernel/std_set_int.rst
+++ b/docs/source/api/python/mantid/kernel/std_set_int.rst
@@ -2,7 +2,7 @@
  std_set_int
 =============
 
-This a python binding to the C++ class Mantid::Kernel::std_set_int.
+This is a Python binding to the C++ class Mantid::Kernel::std_set_int.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/std_set_str.rst
+++ b/docs/source/api/python/mantid/kernel/std_set_str.rst
@@ -2,7 +2,7 @@
  std_set_str
 =============
 
-This a python binding to the C++ class Mantid::Kernel::std_set_str.
+This is a Python binding to the C++ class Mantid::Kernel::std_set_str.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/std_vector_InstrumentInfo.rst
+++ b/docs/source/api/python/mantid/kernel/std_vector_InstrumentInfo.rst
@@ -2,7 +2,7 @@
  std_vector_InstrumentInfo
 ===========================
 
-This a python binding to the C++ class Mantid::Kernel::std_vector_InstrumentInfo.
+This is a Python binding to the C++ class Mantid::Kernel::std_vector_InstrumentInfo.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/std_vector_bool.rst
+++ b/docs/source/api/python/mantid/kernel/std_vector_bool.rst
@@ -2,7 +2,7 @@
  std_vector_bool
 =================
 
-This a python binding to the C++ class Mantid::Kernel::std_vector_bool.
+This is a Python binding to the C++ class Mantid::Kernel::std_vector_bool.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/std_vector_dateandtime.rst
+++ b/docs/source/api/python/mantid/kernel/std_vector_dateandtime.rst
@@ -2,7 +2,7 @@
  std_vector_dateandtime
 ========================
 
-This a python binding to the C++ class Mantid::Kernel::std_vector_dateandtime.
+This is a Python binding to the C++ class Mantid::Kernel::std_vector_dateandtime.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/std_vector_dbl.rst
+++ b/docs/source/api/python/mantid/kernel/std_vector_dbl.rst
@@ -2,7 +2,7 @@
  std_vector_dbl
 ================
 
-This a python binding to the C++ class Mantid::Kernel::std_vector_dbl.
+This is a Python binding to the C++ class Mantid::Kernel::std_vector_dbl.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/std_vector_facilityinfo.rst
+++ b/docs/source/api/python/mantid/kernel/std_vector_facilityinfo.rst
@@ -2,7 +2,7 @@
  std_vector_facilityinfo
 =========================
 
-This a python binding to the C++ class Mantid::Kernel::std_vector_facilityinfo.
+This is a Python binding to the C++ class Mantid::Kernel::std_vector_facilityinfo.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/std_vector_int.rst
+++ b/docs/source/api/python/mantid/kernel/std_vector_int.rst
@@ -2,7 +2,7 @@
  std_vector_int
 ================
 
-This a python binding to the C++ class Mantid::Kernel::std_vector_int.
+This is a Python binding to the C++ class Mantid::Kernel::std_vector_int.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/std_vector_long.rst
+++ b/docs/source/api/python/mantid/kernel/std_vector_long.rst
@@ -2,7 +2,7 @@
  std_vector_long
 =================
 
-This a python binding to the C++ class Mantid::Kernel::std_vector_long.
+This is a Python binding to the C++ class Mantid::Kernel::std_vector_long.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/std_vector_property.rst
+++ b/docs/source/api/python/mantid/kernel/std_vector_property.rst
@@ -2,7 +2,7 @@
  std_vector_property
 =====================
 
-This a python binding to the C++ class Mantid::Kernel::std_vector_property.
+This is a Python binding to the C++ class Mantid::Kernel::std_vector_property.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/std_vector_size_t.rst
+++ b/docs/source/api/python/mantid/kernel/std_vector_size_t.rst
@@ -2,7 +2,7 @@
  std_vector_size_t
 ===================
 
-This a python binding to the C++ class Mantid::Kernel::std_vector_size_t.
+This is a Python binding to the C++ class Mantid::Kernel::std_vector_size_t.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/std_vector_str.rst
+++ b/docs/source/api/python/mantid/kernel/std_vector_str.rst
@@ -2,7 +2,7 @@
  std_vector_str
 ================
 
-This a python binding to the C++ class Mantid::Kernel::std_vector_str.
+This is a Python binding to the C++ class Mantid::Kernel::std_vector_str.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantid/kernel/time_duration.rst
+++ b/docs/source/api/python/mantid/kernel/time_duration.rst
@@ -2,7 +2,7 @@
  time_duration
 ===============
 
-This a python binding to the C++ class Mantid::Kernel::time_duration.
+This is a Python binding to the C++ class Mantid::Kernel::time_duration.
 
 
 .. module:`mantid.kernel`

--- a/docs/source/api/python/mantidplot/ArrowMarker.rst
+++ b/docs/source/api/python/mantidplot/ArrowMarker.rst
@@ -2,7 +2,7 @@
  ArrowMarker
 =============
 
-This a python binding to the C++ class Mantidplot::ArrowMarker.
+This is a Python binding to the C++ class Mantidplot::ArrowMarker.
 
 
 .. module:`mantidplot`

--- a/docs/source/api/python/mantidplot/GraphOptions.rst
+++ b/docs/source/api/python/mantidplot/GraphOptions.rst
@@ -2,7 +2,7 @@
  GraphOptions
 ==============
 
-This a python binding to the C++ class Mantidplot::GraphOptions.
+This is a Python binding to the C++ class Mantidplot::GraphOptions.
 
 
 .. module:`mantidplot`

--- a/docs/source/api/python/mantidplot/ImageMarker.rst
+++ b/docs/source/api/python/mantidplot/ImageMarker.rst
@@ -2,7 +2,7 @@
  ImageMarker
 =============
 
-This a python binding to the C++ class Mantidplot::ImageMarker.
+This is a Python binding to the C++ class Mantidplot::ImageMarker.
 
 
 .. module:`mantidplot`

--- a/docs/source/api/python/mantidplot/ImageSymbol.rst
+++ b/docs/source/api/python/mantidplot/ImageSymbol.rst
@@ -2,7 +2,7 @@
  ImageSymbol
 =============
 
-This a python binding to the C++ class Mantidplot::ImageSymbol.
+This is a Python binding to the C++ class Mantidplot::ImageSymbol.
 
 *bases:* :py:obj:`mantidplot.PlotSymbol`
 

--- a/docs/source/api/python/mantidplot/InstrumentView.rst
+++ b/docs/source/api/python/mantidplot/InstrumentView.rst
@@ -2,7 +2,7 @@
  InstrumentView
 ================
 
-This a python binding to the C++ class Mantidplot::InstrumentView.
+This is a Python binding to the C++ class Mantidplot::InstrumentView.
 
 *bases:* :py:obj:`mantidplot.MDIWindow`
 

--- a/docs/source/api/python/mantidplot/InstrumentViewMaskTab.rst
+++ b/docs/source/api/python/mantidplot/InstrumentViewMaskTab.rst
@@ -2,7 +2,7 @@
  InstrumentViewMaskTab
 =======================
 
-This a python binding to the C++ class Mantidplot::InstrumentViewMaskTab.
+This is a Python binding to the C++ class Mantidplot::InstrumentViewMaskTab.
 
 *bases:* :py:obj:`mantidplot.InstrumentViewTab`
 

--- a/docs/source/api/python/mantidplot/InstrumentViewPickTab.rst
+++ b/docs/source/api/python/mantidplot/InstrumentViewPickTab.rst
@@ -2,7 +2,7 @@
  InstrumentViewPickTab
 =======================
 
-This a python binding to the C++ class Mantidplot::InstrumentViewPickTab.
+This is a Python binding to the C++ class Mantidplot::InstrumentViewPickTab.
 
 *bases:* :py:obj:`mantidplot.InstrumentViewTab`
 

--- a/docs/source/api/python/mantidplot/Layer.rst
+++ b/docs/source/api/python/mantidplot/Layer.rst
@@ -2,7 +2,7 @@
  Layer
 =======
 
-This a python binding to the C++ class Mantidplot::Layer.
+This is a Python binding to the C++ class Mantidplot::Layer.
 
 
 .. module:`mantidplot`

--- a/docs/source/api/python/mantidplot/PlotSymbol.rst
+++ b/docs/source/api/python/mantidplot/PlotSymbol.rst
@@ -2,7 +2,7 @@
  PlotSymbol
 ============
 
-This a python binding to the C++ class Mantidplot::PlotSymbol.
+This is a Python binding to the C++ class Mantidplot::PlotSymbol.
 
 
 .. module:`mantidplot`

--- a/docs/source/api/python/mantidplot/Qt.rst
+++ b/docs/source/api/python/mantidplot/Qt.rst
@@ -2,7 +2,7 @@
  Qt
 ====
 
-This a python binding to the C++ class PyQt4::QtCore::Qt.
+This is a Python binding to the C++ class PyQt4::QtCore::Qt.
 
 
 .. module:`PyQt4.QtCore`

--- a/docs/source/api/python/mantidplot/Screenshot.rst
+++ b/docs/source/api/python/mantidplot/Screenshot.rst
@@ -2,7 +2,7 @@
  Screenshot
 ============
 
-This a python binding to the C++ class Mantidplot::Screenshot.
+This is a Python binding to the C++ class Mantidplot::Screenshot.
 
 
 .. module:`mantidplot`


### PR DESCRIPTION
**Description of work.**

This PR replaces numerous phrases starting with 'This a Python binding to the C++ class...' with 'This is a Python binding to the C++ class...' in the Python API docs.

**Report to:** [nobody].

**To test:**

Check that the documentation looks more professional. If the starting phrase still looks clunky (especially for a native speaker), suggestions for better wording will be appreciated.

Fixes #23753. 

*This does not require release notes* because **there are no functional changes, just docs**.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
