### PR TITLE
Add custom interfaces to workbench menus

### DIFF
--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -37,7 +37,7 @@ requirements.check_qt()
 # -----------------------------------------------------------------------------
 # Qt
 # -----------------------------------------------------------------------------
-from qtpy.QtCore import (QEventLoop, Qt, QCoreApplication, QSettings, QPoint, QSize)  # noqa
+from qtpy.QtCore import (QEventLoop, Qt, QCoreApplication, QPoint, QSize)  # noqa
 from qtpy.QtGui import (QColor, QPixmap)  # noqa
 from qtpy.QtWidgets import (QApplication, QDesktopWidget, QFileDialog,
                             QMainWindow, QSplashScreen)  # noqa
@@ -131,6 +131,7 @@ class MainWindow(QMainWindow):
         self.editor_menu = None
         self.view_menu = None
         self.view_menu_actions = None
+        self.interfaces_menu = None
 
         # Allow splash screen text to be overridden in set_splash
         self.splash = SPLASH
@@ -200,6 +201,7 @@ class MainWindow(QMainWindow):
         self.file_menu = self.menuBar().addMenu("&File")
         self.editor_menu = self.menuBar().addMenu("&Editor")
         self.view_menu = self.menuBar().addMenu("&View")
+        self.interfaces_menu = self.menuBar().addMenu('&Interfaces')
 
     def create_actions(self):
         # --- general application menu options --
@@ -247,6 +249,50 @@ class MainWindow(QMainWindow):
         # Link to menus
         add_actions(self.file_menu, self.file_menu_actions)
         add_actions(self.view_menu, self.view_menu_actions)
+
+    def launchCustomGUI(self, name):
+        try:
+            importlib.import_module(name)
+        except ImportError:
+            from mantid.kernel import  logger
+            logger.error(str('Failed to load {} interface'.format(name)))  # TODO logger should accept unicode
+            raise
+
+
+    def populateAfterMantidImport(self):
+        from mantid.kernel import ConfigService, logger
+        # TODO ConfigService should accept unicode strings
+        interface_dir = ConfigService[str('mantidqt.python_interfaces_directory')]
+        items = ConfigService[str('mantidqt.python_interfaces')].split()
+
+        # list of custom interfaces that have been made qt4/qt5 compatible
+        # TODO need to make *anything* compatible
+        GUI_WHITELIST = []
+
+        # detect the python interfaces
+        interfaces = {}
+        for item in items:
+            key,scriptname = item.split('/')
+            if not os.path.exists(os.path.join(interface_dir, scriptname)):
+                logger.warning('Failed to find script "{}" in "{}"'.format(scriptname, interface_dir))
+                continue
+            if scriptname not in GUI_WHITELIST:
+                continue
+            temp = interfaces.get(key, [])
+            temp.append(scriptname)
+            interfaces[key] = temp
+
+        # add the interfaces to the menu
+        keys = list(interfaces.keys())
+        keys.sort()
+        for key in keys:
+            submenu = self.interfaces_menu.addMenu(key)
+            names = interfaces[key]
+            names.sort()
+            for name in names:
+                action = submenu.addAction(name.replace('.py', '').replace('_', ' '))
+                script = name.replace('.py', '')
+                action.triggered.connect(lambda checked, script=script:self.launchCustomGUI(script))
 
     def add_dockwidget(self, plugin):
         """Create a dockwidget around a plugin and add the dock to window"""
@@ -453,6 +499,7 @@ def start_workbench(app, command_line_options):
     # start mantid
     main_window.set_splash('Preloading mantid')
     importlib.import_module('mantid')
+    main_window.populateAfterMantidImport()
     main_window.show()
 
     if main_window.splash:

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -258,7 +258,6 @@ class MainWindow(QMainWindow):
             logger.error(str('Failed to load {} interface'.format(name)))  # TODO logger should accept unicode
             raise
 
-
     def populateAfterMantidImport(self):
         from mantid.kernel import ConfigService, logger
         # TODO ConfigService should accept unicode strings


### PR DESCRIPTION
This adds the code for introspecting the python interfaces, adding them to the menus, and launching the interfaces. Converting the interfaces to work in qt4/qt5 compatibility is a separate PR.

**To test:**

Since there are no custom interfaces in the list, you'll only see an empty menu. Comment out the whitelist check and you'll see lots of GUIs that generate exceptions when you try to launch them.

*There is no associated issue.*

*This does not require release notes* because workbench.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
