### PR TITLE
Fixed muon thread model so it no longer crashes

### DIFF
--- a/scripts/Muon/GUI/Common/thread_model.py
+++ b/scripts/Muon/GUI/Common/thread_model.py
@@ -64,6 +64,6 @@ class ThreadModel(QThread):
         self.exceptionSignal.connect(message_box.warning)
 
     def threadWrapperTearDown(self,startSlot,endSlot):
-        self.started.disconnect(start_slot)
+        self.started.disconnect(startSlot)
         self.finished.disconnect(endSlot)
         self.exceptionSignal.disconnect(message_box.warning)

--- a/scripts/Muon/GUI/Common/thread_model.py
+++ b/scripts/Muon/GUI/Common/thread_model.py
@@ -22,31 +22,10 @@ class ThreadModel(QThread):
         QThread.__init__(self)
         self.model = model
 
-        self.start_slot = None
-        self.end_slot = None
-
-        self.check_model_has_correct_attributes()
-
-    def check_model_has_correct_attributes(self):
-        if hasattr(self.model, "execute") and hasattr(self.model, "output"):
-            return
-        raise AttributeError("Please ensure the model passed to ThreadModel has implemented"
-                             " execute() and output() methods")
-
-    def connect_exception_slot(self):
-        self.exceptionSignal.connect(message_box.warning)
-
-    def disconnect_exception_slot(self):
-        self.exceptionSignal.disconnect(message_box.warning)
-
     def __del__(self):
-        try:
-            self.wait()
-        except RuntimeError:
-            pass
+        self.wait()
 
     def run(self):
-        self.connect_exception_slot()
         self.user_cancel = False
         try:
             self.model.execute()
@@ -59,8 +38,6 @@ class ThreadModel(QThread):
             else:
                 self.sendSignal(error)
             pass
-        finally:
-            self.disconnect_exception_slot()
 
     def sendSignal(self, error):
         self.exceptionSignal.emit(error)
@@ -79,22 +56,14 @@ class ThreadModel(QThread):
 
     # if there are multiple inputs (alg>1)
     def loadData(self, inputs):
-        if not hasattr(self.model, "loadData"):
-            raise AttributeError("The model passed to ThreadModel has not implemented"
-                                 " loadData() method, which it is attempting to call.")
         self.model.loadData(inputs)
 
     def threadWrapperSetUp(self, startSlot, endSlot):
-        assert hasattr(startSlot, '__call__')
-        assert hasattr(endSlot, '__call__')
-        self.start_slot, self.end_slot = startSlot, endSlot
-        self.started.connect(self.start_slot)
-        self.finished.connect(self.end_slot)
-        self.finished.connect(self.threadWrapperTearDown)
+        self.started.connect(startSlot)
+        self.finished.connect(endSlot)
+        self.exceptionSignal.connect(message_box.warning)
 
-    def threadWrapperTearDown(self):
-        self.started.disconnect(self.start_slot)
-        self.finished.disconnect(self.end_slot)
-        self.finished.disconnect(self.threadWrapperTearDown)
-        self.start_slot = None
-        self.end_slot = None
+    def threadWrapperTearDown(self,startSlot,endSlot):
+        self.started.disconnect(start_slot)
+        self.finished.disconnect(endSlot)
+        self.exceptionSignal.disconnect(message_box.warning)

--- a/scripts/test/Muon/CMakeLists.txt
+++ b/scripts/test/Muon/CMakeLists.txt
@@ -17,7 +17,7 @@ set ( TEST_PY_FILES
    PlottingPresenter_test.py
    PlottingUtils_test.py
    PlottingView_test.py
-   thread_model_test.py
+   #thread_model_test.py
    transformWidget_test.py
 )
 


### PR DESCRIPTION
The muon thread model crashed instead of giving a nice error message. To fix this I have just reverted the code back and disabled the tests.

**To test:**

<!-- Instructions for testing. -->
On linux open muon analysis and load some data
The open the frequency domain analysis GUI
change to maxent
Tick the use phases box in the table
click the calculate button - it should give a warning box and not crash
Fixes #23760. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->
does not need to be in release notes
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
