### PR TITLE
Fix multiple file filters in save dialogs

### DIFF
--- a/qt/widgets/common/src/FileDialogHandler.cpp
+++ b/qt/widgets/common/src/FileDialogHandler.cpp
@@ -12,35 +12,24 @@
 #include <sstream>
 
 namespace { // anonymous namespace
-const boost::regex FILE_EXT_REG_EXP{R"(^.+\s+\((\S+)\)$)"};
 const QString ALL_FILES("All Files (*)");
 
 QString getExtensionFromFilter(const QString &selectedFilter) {
-  // empty returns empty
-  if (selectedFilter.isEmpty()) {
-    return QString("");
-  }
-
+  QString extension;
   // search for single extension
+  static const boost::regex FILE_EXT_REG_EXP{R"(\*\.[[:word:]]+)"};
   boost::smatch result;
-  if (boost::regex_search(selectedFilter.toStdString(), result,
-                          FILE_EXT_REG_EXP) &&
-      result.size() == 2) {
+  const auto filter = selectedFilter.toStdString();
+  if (boost::regex_search(filter, result, FILE_EXT_REG_EXP)) {
     // clang fails to cast result[1] to std::string.
-    std::string output = result[1];
-    auto extension = QString::fromStdString(output);
+    const std::string output = result.str(0);
+    extension = QString::fromStdString(output);
     if (extension.startsWith("*"))
-      return extension.remove(0, 1);
-    else
-      return extension;
-  } else {
-    // failure to match suggests multi-extension filter
-    std::stringstream msg;
-    msg << "Failed to determine single extension from \""
-        << selectedFilter.toStdString() << "\"";
-    throw std::runtime_error(msg.str());
+      extension.remove(0, 1);
   }
+  return extension;
 }
+
 } // anonymous namespace
 
 namespace MantidQt {
@@ -60,10 +49,9 @@ QString getSaveFileName(QWidget *parent,
   QString selectedFilter;
 
   // create the file browser
-  QString filename = QFileDialog::getSaveFileName(
+  const QString filename = QFileDialog::getSaveFileName(
       parent, caption, AlgorithmInputHistory::Instance().getPreviousDirectory(),
       filter, &selectedFilter, options);
-
   return addExtension(filename, selectedFilter);
 }
 
@@ -91,22 +79,22 @@ QString getFilter(const Mantid::Kernel::Property *baseProp) {
   // multiple file version
   const auto *multiProp =
       dynamic_cast<const Mantid::API::MultipleFileProperty *>(baseProp);
-  if (bool(multiProp))
+  if (multiProp)
     return getFilter(multiProp->getExts());
 
   // regular file version
   const auto *singleProp =
       dynamic_cast<const Mantid::API::FileProperty *>(baseProp);
   // The allowed values in this context are file extensions
-  if (bool(singleProp))
+  if (singleProp)
     return getFilter(singleProp->allowedValues());
 
   // otherwise only the all files exists
   return ALL_FILES;
 }
 
-/** For file dialogs. Have each filter on a separate line with the default as
- * the first.
+/** For file dialogs. Have each filter on a separate line with Data Files
+ * as the first and All Files as the last
  *
  * @param exts :: vector of extensions
  * @return a string that filters files by extenstions

--- a/qt/widgets/common/test/FileDialogHandlerTest.h
+++ b/qt/widgets/common/test/FileDialogHandlerTest.h
@@ -17,37 +17,46 @@ public:
     const QString singleExt(".nxs (*.nxs)");
     const QString nexusResult("/tmp/testing.nxs");
 
-    auto result1 = MantidQt::API::FileDialogHandler::addExtension(
+    auto result = MantidQt::API::FileDialogHandler::addExtension(
         QString::fromStdString("/tmp/testing"), singleExt);
-    TS_ASSERT_EQUALS(nexusResult.toStdString(), result1.toStdString());
+    TS_ASSERT_EQUALS(nexusResult.toStdString(), result.toStdString());
 
-    auto result2 = MantidQt::API::FileDialogHandler::addExtension(
+    result = MantidQt::API::FileDialogHandler::addExtension(
         QString::fromStdString("/tmp/testing."), singleExt);
-    TS_ASSERT_EQUALS(nexusResult.toStdString(), result2.toStdString());
+    TS_ASSERT_EQUALS(nexusResult.toStdString(), result.toStdString());
 
-    auto result3 =
+    result =
         MantidQt::API::FileDialogHandler::addExtension(nexusResult, singleExt);
-    TS_ASSERT_EQUALS(nexusResult.toStdString(), result3.toStdString());
+    TS_ASSERT_EQUALS(nexusResult.toStdString(), result.toStdString());
 
     // don't override if it is already specified
     const QString singleH5("/tmp/testing.h5");
-    auto result4 =
+    result =
         MantidQt::API::FileDialogHandler::addExtension(singleH5, singleExt);
-    TS_ASSERT_EQUALS(singleH5.toStdString(), result4.toStdString());
+    TS_ASSERT_EQUALS(singleH5.toStdString(), result.toStdString());
 
     // --- double extensions
     const QString doubleExt("JPEG (*.jpg *.jpeg)");
     const QString jpegResult("/tmp/testing.jpg");
 
-    // this can't work because you can't determine one extension
-    TS_ASSERT_THROWS(MantidQt::API::FileDialogHandler::addExtension(
-                         QString::fromStdString("/tmp/testing"), doubleExt),
-                     std::runtime_error);
+    // this picks the first extension in doubleExt
+    result = MantidQt::API::FileDialogHandler::addExtension(
+        QString::fromStdString("/tmp/testing"), doubleExt);
+    TS_ASSERT_EQUALS(jpegResult.toStdString(), result.toStdString());
 
     // this shouldn't do anything
-    auto result5 =
+    result =
         MantidQt::API::FileDialogHandler::addExtension(jpegResult, doubleExt);
-    TS_ASSERT_EQUALS(jpegResult.toStdString(), result5.toStdString());
+    TS_ASSERT_EQUALS(jpegResult.toStdString(), result.toStdString());
+
+    // Just the wildcard *
+    const QString wildcardExt("All files (*)");
+    const QString wildcardResult("/tmp/testing");
+
+    // this shouldn't do anything
+    result = MantidQt::API::FileDialogHandler::addExtension(
+        QString::fromStdString("/tmp/testing"), wildcardExt);
+    TS_ASSERT_EQUALS(wildcardResult.toStdString(), result.toStdString());
   }
 
   void test_getFileDialogFilter() {


### PR DESCRIPTION
**Description of work.**

Save file dialogs use a filter that shows all 'good' file extensions by default. Unfortunately this breaks the machinery that chooses a suitable extension for the file. This PR fixes the bug by choosing the first extension listed in multiple extension filters. This is probably the 'preferred' extension in most cases.

**Report to:** [nobody].

**To test:**

1. Get a workspace from somewhere
2. Select the workspace
3. Click on save, select the Nexus format, for instance
4. From the algorithm dialog, click Browse
5. Give a name to the file, select some option from the file filter combo box
6. Click Save - the dialog should close without issues
7. Observe the Filename property - is the filename (extension included) sound?
8. Repeat from 4 trying different option in the combo box until satisfied.

Fixes #23756.

*This does not require release notes* because **this bug was introduced after the last official release.**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
