### PR TITLE
option for renumbering in SaveIsawPeaks

### DIFF
--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -165,7 +165,7 @@ void SaveIsawPeaks::exec() {
       double three;
       ss >> three;
       if (three == 3) {
-        int peakNumber
+        int peakNumber;
         ss >> peakNumber;
         appendPeakNumb = std::max(peakNumber, appendPeakNumb);
       }

--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -156,19 +156,19 @@ void SaveIsawPeaks::exec() {
   if (append) {
     std::ifstream infile(filename.c_str());
     std::string line;
-  while (!infile.eof())      // To get you all the lines.
-  {
-    getline(infile, line); // Saves the line in STRING.
-    if (infile.eof())
-      break;
-    std::stringstream ss(line);
+    while (!infile.eof()) // To get you all the lines.
+    {
+      getline(infile, line); // Saves the line in STRING.
+      if (infile.eof())
+        break;
+      std::stringstream ss(line);
       double three;
       ss >> three;
-      if (three == 3) ss >> appendPeakNumb;
-
+      if (three == 3)
+        ss >> appendPeakNumb;
     }
 
-    std::cout << appendPeakNumb <<"\n";
+    std::cout << appendPeakNumb << "\n";
     infile.close();
     out.open(filename.c_str(), std::ios::app);
   } else {

--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -334,7 +334,7 @@ void SaveIsawPeaks::exec() {
             maxPeakNumb = std::max(maxPeakNumb, p.getPeakNumber());
             int peakNumber = p.getPeakNumber();
             if (append)
-              peakNumber = +appendPeakNumb;
+              peakNumber += appendPeakNumb;
             out << "3" << std::setw(7) << peakNumber;
           }
 

--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -332,10 +332,7 @@ void SaveIsawPeaks::exec() {
             out << "3" << std::setw(7) << sequenceNumber;
           } else {
             maxPeakNumb = std::max(maxPeakNumb, p.getPeakNumber());
-            int peakNumber = p.getPeakNumber();
-            if (append)
-              peakNumber += appendPeakNumb;
-            out << "3" << std::setw(7) << peakNumber;
+            out << "3" << std::setw(7) << p.getPeakNumber() + appendPeakNumb;
           }
 
           // HKL's are flipped by -1 because of the internal Q convention

--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -152,7 +152,24 @@ void SaveIsawPeaks::exec() {
   if (!Poco::File(filename.c_str()).exists())
     append = false;
 
+  int appendPeakNumb = 0;
   if (append) {
+    std::ifstream infile(filename.c_str());
+    std::string line;
+  while (!infile.eof())      // To get you all the lines.
+  {
+    getline(infile, line); // Saves the line in STRING.
+    if (infile.eof())
+      break;
+    std::stringstream ss(line);
+      double three;
+      ss >> three;
+      if (three == 3) ss >> appendPeakNumb;
+
+    }
+
+    std::cout << appendPeakNumb <<"\n";
+    infile.close();
     out.open(filename.c_str(), std::ios::app);
   } else {
     out.open(filename.c_str());
@@ -273,16 +290,10 @@ void SaveIsawPeaks::exec() {
   // =========================================
 
   // Go in order of run numbers
-  int maxPeakNumb = 0;
-  int appendPeakNumb = 0;
-  int sequenceNumber = 0;
+  int sequenceNumber = appendPeakNumb;
   runMap_t::iterator runMap_it;
   for (runMap_it = runMap.begin(); runMap_it != runMap.end(); ++runMap_it) {
     // Start of a new run
-    if (maxPeakNumb > 0) {
-      appendPeakNumb += maxPeakNumb + 1;
-      maxPeakNumb = 0;
-    }
     int run = runMap_it->first;
     bankMap_t &bankMap = runMap_it->second;
 
@@ -331,7 +342,6 @@ void SaveIsawPeaks::exec() {
             sequenceNumber++;
             out << "3" << std::setw(7) << sequenceNumber;
           } else {
-            maxPeakNumb = std::max(maxPeakNumb, p.getPeakNumber());
             out << "3" << std::setw(7) << p.getPeakNumber() + appendPeakNumb;
           }
 

--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -328,11 +328,11 @@ void SaveIsawPeaks::exec() {
 
           // Sequence (run) number
           if (renumber) {
-              sequenceNumber++;
-              out << "3" << std::setw(7) << sequenceNumber;
+            sequenceNumber++;
+            out << "3" << std::setw(7) << sequenceNumber;
           } else {
-              maxPeakNumb = std::max(maxPeakNumb, p.getPeakNumber());
-              out << "3" << std::setw(7) << p.getPeakNumber() + appendPeakNumb;
+            maxPeakNumb = std::max(maxPeakNumb, p.getPeakNumber());
+            out << "3" << std::setw(7) << p.getPeakNumber() + appendPeakNumb;
           }
 
           // HKL's are flipped by -1 because of the internal Q convention

--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -51,6 +51,10 @@ void SaveIsawPeaks::init() {
       make_unique<WorkspaceProperty<Workspace2D>>(
           "ProfileWorkspace", "", Direction::Input, PropertyMode::Optional),
       "An optional Workspace2D of profiles from integrating cylinder.");
+
+  declareProperty("RenumberPeaks", false,
+                  "If true, sequential peak numbers\n"
+                  "If false, keep original numbering (default).");
 }
 
 /** Execute the algorithm.
@@ -142,6 +146,7 @@ void SaveIsawPeaks::exec() {
 
   std::ofstream out;
   bool append = getProperty("AppendFile");
+  bool renumber = getProperty("RenumberPeaks");
 
   // do not append if file does not exist
   if (!Poco::File(filename.c_str()).exists())
@@ -270,6 +275,7 @@ void SaveIsawPeaks::exec() {
   // Go in order of run numbers
   int maxPeakNumb = 0;
   int appendPeakNumb = 0;
+  int sequenceNumber = 0;
   runMap_t::iterator runMap_it;
   for (runMap_it = runMap.begin(); runMap_it != runMap.end(); ++runMap_it) {
     // Start of a new run
@@ -321,8 +327,13 @@ void SaveIsawPeaks::exec() {
           Peak &p = peaks[wi];
 
           // Sequence (run) number
-          maxPeakNumb = std::max(maxPeakNumb, p.getPeakNumber());
-          out << "3" << std::setw(7) << p.getPeakNumber() + appendPeakNumb;
+          if (renumber) {
+              sequenceNumber++;
+              out << "3" << std::setw(7) << sequenceNumber;
+          } else {
+              maxPeakNumb = std::max(maxPeakNumb, p.getPeakNumber());
+              out << "3" << std::setw(7) << p.getPeakNumber() + appendPeakNumb;
+          }
 
           // HKL's are flipped by -1 because of the internal Q convention
           // unless Crystallography convention

--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -164,11 +164,13 @@ void SaveIsawPeaks::exec() {
       std::stringstream ss(line);
       double three;
       ss >> three;
-      if (three == 3)
-        ss >> appendPeakNumb;
+      if (three == 3) {
+        int peakNumber
+        ss >> peakNumber;
+        appendPeakNumb = std::max(peakNumber, appendPeakNumb);
+      }
     }
 
-    std::cout << appendPeakNumb << "\n";
     infile.close();
     out.open(filename.c_str(), std::ios::app);
   } else {

--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -332,7 +332,9 @@ void SaveIsawPeaks::exec() {
             out << "3" << std::setw(7) << sequenceNumber;
           } else {
             maxPeakNumb = std::max(maxPeakNumb, p.getPeakNumber());
-            out << "3" << std::setw(7) << p.getPeakNumber() + appendPeakNumb;
+            int peakNumber = p.getPeakNumber();
+            if (append) peakNumber =+ appendPeakNumb;
+            out << "3" << std::setw(7) << peakNumber;
           }
 
           // HKL's are flipped by -1 because of the internal Q convention

--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -333,7 +333,8 @@ void SaveIsawPeaks::exec() {
           } else {
             maxPeakNumb = std::max(maxPeakNumb, p.getPeakNumber());
             int peakNumber = p.getPeakNumber();
-            if (append) peakNumber =+ appendPeakNumb;
+            if (append)
+              peakNumber = +appendPeakNumb;
             out << "3" << std::setw(7) << peakNumber;
           }
 

--- a/docs/source/release/v3.14.0/diffraction.rst
+++ b/docs/source/release/v3.14.0/diffraction.rst
@@ -34,6 +34,7 @@ Improvements
 - :ref:`StartLiveData <algm-StartLiveData>` will load "live"
   data streaming from TOPAZ new Adara data server.
 - :ref:`IntegratePeaksMD <algm-IntegratePeaksMD>` with Cylinder=True now has improved fits using BackToBackExponential and IkedaCarpenterPV functions.
+- :ref:`SaveIsawPeaks <algm-SaveIsawPeaks>` now has option to renumber peaks sequentially.
 
 Bugfixes
 ########


### PR DESCRIPTION
**Description of work.**

**Report to:** [wangx@ornl.gov]/[nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**
````python
LoadIsawPeaks(Filename='/SNS/TOPAZ/IPTS-21677/shared/2018C/Si_32155-32238/Si2mm_Cubic_F.integrate', OutputWorkspace='Si')
SaveIsawPeaks(InputWorkspace='Si',Filename='origNumbers')
SaveIsawPeaks(InputWorkspace='Si',Filename='sequentialNumbers', RenumberPeaks=True)
SaveIsawPeaks(InputWorkspace='Si',Filename='origNumbers',AppendFile=True)
SaveIsawPeaks(InputWorkspace='Si',Filename='sequentialNumbers', RenumberPeaks=True,AppendFile=True)
````
Check that lastSEQN in sequentialNumbers file is the number of peaks in workspace.

Fixes #23784 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
