### PR TITLE
Change figure creation in SampleLogs

### DIFF
--- a/qt/python/mantidqt/widgets/samplelogs/__init__.py
+++ b/qt/python/mantidqt/widgets/samplelogs/__init__.py
@@ -1,7 +1,7 @@
 """
 You can run this widget independently by for example:
 
-    from workbench.widgets.samplelogs.presenter import SampleLogs
+    from mantidqt.widgets.samplelogs.presenter import SampleLogs
     from mantid.simpleapi import Load
     from qtpy.QtWidgets import QApplication
 

--- a/qt/python/mantidqt/widgets/samplelogs/presenter.py
+++ b/qt/python/mantidqt/widgets/samplelogs/presenter.py
@@ -33,6 +33,8 @@ class SampleLogs(object):
         log = self.model.get_log(log_text)
         print('# {}'.format(log.name))
         print(log.valueAsPrettyStr())
+        if self.model.is_log_plottable(log_text):
+            self.view.new_plot_log(self.model.get_ws(), self.model.get_exp(), log_text)
 
     def changeExpInfo(self):
         selected_rows = self.view.get_selected_row_indexes()

--- a/qt/python/mantidqt/widgets/samplelogs/view.py
+++ b/qt/python/mantidqt/widgets/samplelogs/view.py
@@ -14,6 +14,7 @@ from qtpy.QtWidgets import (QTableView, QHBoxLayout, QVBoxLayout,
                             QSizePolicy, QSpinBox, QSplitter, QFrame)
 from qtpy.QtCore import QItemSelectionModel, Qt
 from matplotlib.backends.backend_qt5agg import FigureCanvas
+from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
 
 
@@ -53,9 +54,10 @@ class SampleLogsView(QSplitter):
         layout_right.addLayout(layout_options)
 
         # Sample log plot
-        self.fig, self.ax = plt.subplots(subplot_kw={'projection': 'mantid'})
+        self.fig = Figure()
         self.canvas = FigureCanvas(self.fig)
         self.canvas.setSizePolicy(QSizePolicy.Expanding,QSizePolicy.Expanding)
+        self.ax = self.fig.add_subplot(111, projection='mantid')
         layout_right.addWidget(self.canvas)
 
         # Sample stats
@@ -101,6 +103,14 @@ class SampleLogsView(QSplitter):
         if self.ax.get_legend_handles_labels()[0]:
             self.ax.legend()
         self.fig.canvas.draw()
+
+    def new_plot_log(self, ws, exp, log_text):
+        fig, ax = plt.subplots(subplot_kw={'projection': 'mantid'})
+        ax.plot(ws,
+                LogName=log_text,
+                FullTime=not self.full_time.isChecked(),
+                ExperimentInfo=exp)
+        fig.show()
 
     def get_row_log_name(self, i):
         return str(self.model.item(i, 0).text())


### PR DESCRIPTION
Change figure creation in SampleLogs so it doesn't appear in plot selector. And now double clicking will create a new figure with a plot of that log.

**To test:**

* Load some data and open the sample logs.
* See that no plot appear in the plot selector.
* Double click a log and a new separate plot should be created.



*This does not require release notes* because workbench


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
