### PR TITLE
Remove unused includes

### DIFF
--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -27,7 +27,6 @@
 
 #include "MantidParallel/Communicator.h"
 
-#include <boost/algorithm/string/regex.hpp>
 #include <boost/weak_ptr.hpp>
 
 #include <MantidKernel/StringTokenizer.h>

--- a/Framework/API/test/ImplicitFunctionFactoryTest.h
+++ b/Framework/API/test/ImplicitFunctionFactoryTest.h
@@ -14,7 +14,6 @@
 #include "MantidGeometry/MDGeometry/MDImplicitFunction.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/WarningSuppressions.h"
-#include <boost/scoped_ptr.hpp>
 #include <boost/shared_ptr.hpp>
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>

--- a/Framework/Algorithms/src/PerformIndexOperations.cpp
+++ b/Framework/Algorithms/src/PerformIndexOperations.cpp
@@ -10,7 +10,6 @@
 #include "MantidKernel/Strings.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/regex.hpp>
-#include <boost/scoped_ptr.hpp>
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;

--- a/Framework/Algorithms/src/SmoothNeighbours.cpp
+++ b/Framework/Algorithms/src/SmoothNeighbours.cpp
@@ -23,7 +23,6 @@
 #include "MantidKernel/ListValidator.h"
 
 #include <boost/algorithm/string.hpp>
-#include <boost/regex.hpp>
 
 using namespace Mantid::Kernel;
 using namespace Mantid::Geometry;

--- a/Framework/Algorithms/test/GenerateIPythonNotebookTest.h
+++ b/Framework/Algorithms/test/GenerateIPythonNotebookTest.h
@@ -9,7 +9,6 @@
 
 #include "MantidKernel/System.h"
 #include "MantidKernel/Timer.h"
-#include <boost/regex.hpp>
 #include <cxxtest/TestSuite.h>
 #include <fstream>
 

--- a/Framework/Algorithms/test/GeneratePythonScriptTest.h
+++ b/Framework/Algorithms/test/GeneratePythonScriptTest.h
@@ -27,7 +27,6 @@
 #include "MantidKernel/make_unique.h"
 
 #include <Poco/File.h>
-#include <boost/regex.hpp>
 
 #include <fstream>
 

--- a/Framework/DataHandling/src/LoadLog.cpp
+++ b/Framework/DataHandling/src/LoadLog.cpp
@@ -26,7 +26,6 @@
 #include <Poco/File.h>
 #include <Poco/Path.h>
 #include <boost/algorithm/string.hpp>
-#include <boost/regex.hpp>
 #include <fstream> // used to get ifstream
 #include <sstream>
 

--- a/Framework/DataHandling/src/SaveNexusProcessed.cpp
+++ b/Framework/DataHandling/src/SaveNexusProcessed.cpp
@@ -21,7 +21,6 @@
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidNexus/NexusFileIO.h"
 #include <Poco/File.h>
-#include <boost/regex.hpp>
 #include <boost/shared_ptr.hpp>
 
 using namespace Mantid::API;

--- a/Framework/DataObjects/inc/MantidDataObjects/CoordTransformDistance.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/CoordTransformDistance.h
@@ -12,7 +12,6 @@
 #include "MantidGeometry/MDGeometry/IMDDimension.h"
 #include "MantidKernel/Matrix.h"
 #include "MantidKernel/System.h"
-#include <boost/scoped_ptr.hpp>
 
 namespace Mantid {
 namespace DataObjects {

--- a/Framework/DataObjects/test/MDBoxSaveableTest.h
+++ b/Framework/DataObjects/test/MDBoxSaveableTest.h
@@ -21,7 +21,6 @@
 #include "MantidTestHelpers/BoxControllerDummyIO.h"
 #include "MantidTestHelpers/MDEventsTestHelper.h"
 #include <Poco/File.h>
-#include <boost/scoped_ptr.hpp>
 #include <cxxtest/TestSuite.h>
 #include <map>
 #include <memory>

--- a/Framework/Geometry/test/PeakTransformSelectorTest.h
+++ b/Framework/Geometry/test/PeakTransformSelectorTest.h
@@ -16,7 +16,6 @@
 using namespace Mantid::Geometry;
 using namespace Mantid;
 using namespace testing;
-using boost::regex;
 
 class PeakTransformSelectorTest : public CxxTest::TestSuite {
 private:

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -51,7 +51,6 @@
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/optional/optional.hpp>
-#include <boost/regex.hpp>
 
 #include <algorithm>
 #include <cctype>

--- a/Framework/Kernel/src/Material.cpp
+++ b/Framework/Kernel/src/Material.cpp
@@ -10,7 +10,6 @@
 #include <NeXusFile.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/make_shared.hpp>
-#include <boost/regex.hpp>
 #include <numeric>
 
 namespace Mantid {

--- a/Framework/Kernel/test/LogParserTest.h
+++ b/Framework/Kernel/test/LogParserTest.h
@@ -17,7 +17,6 @@
 #include "MantidKernel/TimeSeriesProperty.h"
 #include "MantidKernel/make_unique.h"
 #include <boost/lexical_cast.hpp>
-#include <boost/scoped_ptr.hpp>
 
 #include <Poco/File.h>
 

--- a/Framework/Kernel/test/NDRandomNumberGeneratorTest.h
+++ b/Framework/Kernel/test/NDRandomNumberGeneratorTest.h
@@ -11,7 +11,6 @@
 #include "MantidKernel/WarningSuppressions.h"
 #include <cxxtest/TestSuite.h>
 
-#include <boost/scoped_ptr.hpp>
 #include <gmock/gmock.h>
 
 class NDRandomNumberGeneratorTest : public CxxTest::TestSuite {

--- a/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
@@ -24,7 +24,6 @@
 #include <utility>
 
 #include <boost/make_shared.hpp>
-#include <boost/scoped_ptr.hpp>
 
 using namespace Mantid::API;
 using namespace Mantid::Kernel;

--- a/Framework/MDAlgorithms/src/SmoothMD.cpp
+++ b/Framework/MDAlgorithms/src/SmoothMD.cpp
@@ -20,7 +20,6 @@
 #include <boost/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/make_shared.hpp>
-#include <boost/scoped_ptr.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <limits>
 #include <map>

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -181,7 +181,6 @@
 #include <gsl/gsl_sort.h>
 
 #include <boost/regex.hpp>
-#include <boost/scoped_ptr.hpp>
 
 #include <Poco/Path.h>
 

--- a/MantidPlot/src/Script.cpp
+++ b/MantidPlot/src/Script.cpp
@@ -29,7 +29,6 @@
 #include "Script.h"
 #include "ScriptingEnv.h"
 
-#include <QRegExp>
 #include <stdexcept>
 
 //--------------------------------------------------------------------------------------------------

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -22,8 +22,6 @@
 #include "ui_EnggDiffractionQtTabPreproc.h"
 #include "ui_EnggDiffractionQtTabSettings.h"
 
-#include <boost/scoped_ptr.hpp>
-
 // Qt classes forward declarations
 class QMessageBox;
 class QMutex;

--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
@@ -29,7 +29,6 @@
 
 #include <QStringList>
 #include <algorithm>
-#include <boost/regex.hpp>
 #include <boost/tokenizer.hpp>
 #include <fstream>
 #include <iterator>

--- a/qt/widgets/common/src/DataProcessorUI/GenerateNotebook.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/GenerateNotebook.cpp
@@ -14,7 +14,6 @@
 #include "MantidQtWidgets/Common/ParseKeyValueString.h"
 
 #include <boost/algorithm/string.hpp>
-#include <boost/regex.hpp>
 #include <boost/tokenizer.hpp>
 #include <fstream>
 #include <memory>

--- a/qt/widgets/common/src/FindDialog.cpp
+++ b/qt/widgets/common/src/FindDialog.cpp
@@ -16,7 +16,6 @@
 #include <QGroupBox>
 #include <QLabel>
 #include <QPushButton>
-#include <QRegExp>
 #include <QVBoxLayout>
 
 FindDialog::FindDialog(ScriptEditor *editor, Qt::WindowFlags flags)

--- a/qt/widgets/common/src/FindFilesThreadPoolManager.cpp
+++ b/qt/widgets/common/src/FindFilesThreadPoolManager.cpp
@@ -18,7 +18,6 @@
 #include <QCoreApplication>
 #include <QSharedPointer>
 #include <boost/algorithm/string.hpp>
-#include <boost/regex.hpp>
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;

--- a/qt/widgets/common/src/FindFilesWorker.cpp
+++ b/qt/widgets/common/src/FindFilesWorker.cpp
@@ -16,7 +16,6 @@
 #include <Poco/File.h>
 #include <QApplication>
 #include <boost/algorithm/string.hpp>
-#include <boost/regex.hpp>
 
 #include <utility>
 

--- a/qt/widgets/common/src/MdSettings.cpp
+++ b/qt/widgets/common/src/MdSettings.cpp
@@ -6,7 +6,6 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidQtWidgets/Common/MdSettings.h"
 #include "MantidQtWidgets/Common/MdConstants.h"
-#include "boost/scoped_ptr.hpp"
 #include <QSettings>
 #include <QString>
 

--- a/qt/widgets/common/src/SelectFunctionDialog.cpp
+++ b/qt/widgets/common/src/SelectFunctionDialog.cpp
@@ -22,7 +22,6 @@
 #include <QGroupBox>
 #include <QLabel>
 #include <QPushButton>
-#include <QRegExp>
 #include <QVBoxLayout>
 
 /**

--- a/qt/widgets/common/test/AlgorithmHintStrategyTest.h
+++ b/qt/widgets/common/test/AlgorithmHintStrategyTest.h
@@ -16,8 +16,6 @@
 #include "MantidQtWidgets/Common/HintStrategy.h"
 #include <cxxtest/TestSuite.h>
 
-#include <boost/scoped_ptr.hpp>
-
 using namespace MantidQt::MantidWidgets;
 using namespace Mantid::API;
 

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Projection3D.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Projection3D.h
@@ -15,7 +15,6 @@
 #include <QGLWidget>
 #include <QString>
 
-#include <boost/scoped_ptr.hpp>
 #include <boost/shared_ptr.hpp>
 
 namespace MantidQt {

--- a/qt/widgets/instrumentview/src/Projection3D.cpp
+++ b/qt/widgets/instrumentview/src/Projection3D.cpp
@@ -19,7 +19,6 @@
 #include "MantidQtWidgets/Common/InputController.h"
 #include "MantidQtWidgets/Common/TSVSerialiser.h"
 
-#include <boost/scoped_ptr.hpp>
 #include <boost/shared_ptr.hpp>
 
 #include <QApplication>

--- a/qt/widgets/sliceviewer/src/ConcretePeaksPresenter.cpp
+++ b/qt/widgets/sliceviewer/src/ConcretePeaksPresenter.cpp
@@ -21,7 +21,6 @@
 #include "MantidQtWidgets/SliceViewer/UpdateableOnDemand.h"
 #include "MantidQtWidgets/SliceViewer/ZoomableOnDemand.h"
 #include <boost/regex.hpp>
-#include <boost/scoped_ptr.hpp>
 
 using namespace Mantid::API;
 using namespace Mantid::Kernel;

--- a/qt/widgets/sliceviewer/test/ConcretePeaksPresenterTest.h
+++ b/qt/widgets/sliceviewer/test/ConcretePeaksPresenterTest.h
@@ -29,7 +29,6 @@ using namespace Mantid::API;
 using namespace Mantid::Geometry;
 using namespace Mantid::Kernel;
 using namespace testing;
-using boost::regex;
 
 // Alias.
 using MDGeometry_sptr = boost::shared_ptr<Mantid::API::MDGeometry>;


### PR DESCRIPTION
**Description of work.**

This PR removes some unused `boost/regex`, `QRegExp` and `boost/scoped_ptr` includes and `using` directives.

**Report to:** [nobody].

**To test:**

Check that the builds pass.

*There is no associated issue.*

*This does not require release notes* because **there are no functional changes**.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
