### PR TITLE
Speedup DateAndTime construction

### DIFF
--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -632,6 +632,7 @@ FileFinderImpl::findRuns(const std::string &hintstr) const {
       hint, ",",
       Mantid::Kernel::StringTokenizer::TOK_TRIM |
           Mantid::Kernel::StringTokenizer::TOK_IGNORE_EMPTY);
+  static const boost::regex digits("[0-9]+");
   auto h = hints.begin();
 
   for (; h != hints.end(); ++h) {
@@ -669,7 +670,6 @@ FileFinderImpl::findRuns(const std::string &hintstr) const {
       runEnd.replace(runEnd.end() - range[1].size(), runEnd.end(), range[1]);
 
       // Throw if runEnd contains something else other than a digit.
-      boost::regex digits("[0-9]+");
       if (!boost::regex_match(runEnd, digits))
         throw std::invalid_argument("Malformed range of runs: Part of the run "
                                     "has a non-digit character in it.");

--- a/Framework/API/src/ParameterTie.cpp
+++ b/Framework/API/src/ParameterTie.cpp
@@ -87,7 +87,8 @@ void ParameterTie::set(const std::string &expr) {
   }
 
   // Create the template m_expression
-  boost::regex rx(R"(\b(([[:alpha:]]|_)([[:alnum:]]|_|\.)*)\b(?!(\s*\()))");
+  static const boost::regex rx(
+      R"(\b(([[:alpha:]]|_)([[:alnum:]]|_|\.)*)\b(?!(\s*\()))");
   std::string input = expr;
   boost::smatch res;
   std::string::const_iterator start = input.begin();
@@ -148,7 +149,7 @@ std::string ParameterTie::asString(const IFunction *fun) const {
       ;
     }
 
-    boost::regex rx(std::string("#(\\d+)"));
+    static const boost::regex rx(std::string("#(\\d+)"));
     boost::smatch res;
     std::string::const_iterator start = m_expression.begin();
     std::string::const_iterator end = m_expression.end();

--- a/Framework/Algorithms/src/PerformIndexOperations.cpp
+++ b/Framework/Algorithms/src/PerformIndexOperations.cpp
@@ -178,7 +178,8 @@ class AdditionParserRange : public CommandParserBase<AdditionCommand> {
 public:
 private:
   boost::regex getRegex() const override {
-    return boost::regex(R"(^\s*[0-9]+\s*\-\s*[0-9]+\s*$)");
+    static const boost::regex r(R"(^\s*[0-9]+\s*\-\s*[0-9]+\s*$)");
+    return r;
   }
   std::string getSeparator() const override { return "-"; }
 };
@@ -190,7 +191,7 @@ class AdditionParser : public CommandParser {
 public:
   Command *interpret(const std::string &instruction) const override {
     Command *command = nullptr;
-    boost::regex ex(R"(^\s*[0-9]+\s*\+\s*[0-9]+\s*$)");
+    static const boost::regex ex(R"(^\s*[0-9]+\s*\+\s*[0-9]+\s*$)");
     if (boost::regex_match(instruction, ex)) {
       std::vector<std::string> arguments;
       boost::split(arguments, instruction, boost::is_any_of("+"));
@@ -216,7 +217,8 @@ class CropParserRange : public CommandParserBase<CropCommand> {
 public:
 private:
   boost::regex getRegex() const override {
-    return boost::regex(R"(^\s*[0-9]+\s*:\s*[0-9]+\s*$)");
+    static const boost::regex r(R"(^\s*[0-9]+\s*:\s*[0-9]+\s*$)");
+    return r;
   }
   std::string getSeparator() const override { return ":"; }
 };
@@ -228,7 +230,7 @@ class CropParserIndex : public CommandParser {
 public:
   Command *interpret(const std::string &instruction) const override {
     Command *command = nullptr;
-    boost::regex ex("^\\s*[0-9]+\\s*$");
+    static const boost::regex ex("^\\s*[0-9]+\\s*$");
     if (boost::regex_match(instruction, ex)) {
       int index = -1;
       Mantid::Kernel::Strings::convert<int>(instruction, index);

--- a/Framework/DataHandling/src/GroupDetectors2.cpp
+++ b/Framework/DataHandling/src/GroupDetectors2.cpp
@@ -1256,7 +1256,7 @@ std::map<std::string, std::string> GroupDetectors2::validateInputs() {
 
   const std::string pattern = getPropertyValue("GroupingPattern");
 
-  boost::regex re(
+  static const boost::regex re(
       R"(^\s*[0-9]+\s*$|^(\s*,*[0-9]+(\s*(,|:|\+|\-)\s*)*[0-9]*)*$)");
 
   try {

--- a/Framework/Geometry/src/Instrument/XMLInstrumentParameter.cpp
+++ b/Framework/Geometry/src/Instrument/XMLInstrumentParameter.cpp
@@ -68,7 +68,7 @@ XMLInstrumentParameter::XMLInstrumentParameter(
       m_extractSingleValueAs(extractSingleValueAs), m_eq(eq), m_component(comp),
       m_angleConvertConst(angleConvertConst), m_description("") {
   if (!description.empty()) { // remove multiple spaces
-    boost::regex re("\\s+");
+    static const boost::regex re("\\s+");
     std::string desc = boost::regex_replace(description, re, " ");
     (const_cast<std::string *>(&m_description))->assign(desc);
   }

--- a/Framework/Geometry/src/Objects/CSGObject.cpp
+++ b/Framework/Geometry/src/Objects/CSGObject.cpp
@@ -140,7 +140,8 @@ bool CSGObject::hasValidShape() const {
  */
 int CSGObject::setObject(const int ON, const std::string &Ln) {
   // Split line
-  const boost::regex letters("[a-zA-Z]"); // Does the string now contain junk...
+  // Does the string now contain junk...
+  static const boost::regex letters("[a-zA-Z]");
   if (Mantid::Kernel::Strings::StrLook(Ln, letters))
     return 0;
 

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -1959,7 +1959,8 @@ template <typename TYPE> void TimeSeriesProperty<TYPE>::countSize() const {
  */
 template <typename TYPE>
 bool TimeSeriesProperty<TYPE>::isTimeString(const std::string &str) {
-  boost::regex re("^[0-9]{4}.[0-9]{2}.[0-9]{2}.[0-9]{2}.[0-9]{2}.[0-9]{2}");
+  static const boost::regex re(
+      "^[0-9]{4}.[0-9]{2}.[0-9]{2}.[0-9]{2}.[0-9]{2}.[0-9]{2}");
   return boost::regex_search(str.begin(), str.end(), re);
 }
 

--- a/Framework/Types/src/Core/DateAndTimeHelpers.cpp
+++ b/Framework/Types/src/Core/DateAndTimeHelpers.cpp
@@ -20,11 +20,10 @@ namespace DateAndTimeHelpers {
 bool stringIsISO8601(const std::string &date) {
   // Expecting most of Mantid's time stamp strings to be in the
   // extended format --- check it first.
-  // On Ubuntu 14.04, std::regex seems to be broken, thus boost.
-  const boost::regex extendedFormat(
+  static const boost::regex extendedFormat(
       R"(^\d{4}-[01]\d-[0-3]\d([T\s][0-2]\d:[0-5]\d(:\d{2})?(.\d+)?(Z|[+-]\d{2}(:?\d{2})?)?)?$)");
   if (!boost::regex_match(date, extendedFormat)) {
-    const boost::regex basicFormat(
+    static const boost::regex basicFormat(
         R"(^\d{4}[01]\d[0-3]\d([T\s][0-2]\d[0-5]\d(\d{2})?(.\d+)?(Z|[+-]\d{2}(:?\d{2})?)?)?$)");
     return boost::regex_match(date, basicFormat);
   }
@@ -38,7 +37,7 @@ bool stringIsISO8601(const std::string &date) {
  */
 bool stringIsPosix(const std::string &date) {
   // Formatting taken from boost::to_simple_string.
-  const boost::regex format(
+  static const boost::regex format(
       R"(^\d{4}-[A-Z][a-z]{2}-[0-3]\d\s[0-2]\d:[0-5]\d:\d{2}(.\d+)?$)");
   return boost::regex_match(date, format);
 }

--- a/Framework/Types/test/DateAndTimeTest.h
+++ b/Framework/Types/test/DateAndTimeTest.h
@@ -461,4 +461,14 @@ public:
   }
 };
 
+class DateAndTimeTestPerformance : public CxxTest::TestSuite {
+public:
+  void test_construction_from_iso8601_string() {
+    for (size_t i = 0; i < 500000; ++i) {
+      DateAndTime d("2010-03-24T14:12:51.562Z");
+      d.totalNanoseconds();
+    }
+  }
+};
+
 #endif /* DATEANDTIMETEST_H_ */


### PR DESCRIPTION
**Description of work.**

Constructing `boost::regex` is very expensive. Declaring the regular expression used to check the input string of `DateAndTime` as `static const` decreased the run time of the new `DateAndTime` performance test from 9.4s to 1.2s. Encouraged by this, some additional constant regexes were declare to be constructed at startup as well.

**Report to:** [nobody].

**To test:**

Code review.

*There is no associated issue.*

*This does not require release notes* because there are no functional changes and the performance increase is probably unnoticeable to the average user.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
