### PR TITLE
Moved groupworkspace before convertunits in ISIS Powder script

### DIFF
--- a/scripts/Diffraction/isis_powder/routines/common_output.py
+++ b/scripts/Diffraction/isis_powder/routines/common_output.py
@@ -24,20 +24,19 @@ def split_into_tof_d_spacing_groups(run_details, processed_spectra):
     tof_output = []
     run_number = str(run_details.output_run_string)
     ext = run_details.file_extension if run_details.file_extension else ""
-
-    for name_index, ws in enumerate(processed_spectra, start=1):
-        d_spacing_out_name = run_number + ext + "-ResultD_" + str(name_index)
-        tof_out_name = run_number + ext + "-ResultTOF_" + str(name_index)
-
-        d_spacing_output.append(mantid.ConvertUnits(InputWorkspace=ws, OutputWorkspace=d_spacing_out_name,
-                                                    Target="dSpacing"))
-        tof_output.append(mantid.ConvertUnits(InputWorkspace=ws, OutputWorkspace=tof_out_name, Target="TOF"))
-
-    # Group the outputs
+    input_group = mantid.GroupWorkspaces(processed_spectra)
     d_spacing_group_name = run_number + ext + "-ResultD"
-    d_spacing_group = mantid.GroupWorkspaces(InputWorkspaces=d_spacing_output, OutputWorkspace=d_spacing_group_name)
+    d_spacing_group = mantid.ConvertUnits(InputWorkspace=input_group, OutputWorkspace=d_spacing_group_name,
+                                          Target="dSpacing")
     tof_group_name = run_number + ext + "-ResultTOF"
-    tof_group = mantid.GroupWorkspaces(InputWorkspaces=tof_output, OutputWorkspace=tof_group_name)
+    tof_group = mantid.ConvertUnits(InputWorkspace=input_group, OutputWorkspace=tof_group_name, Target="TOF")
+
+    for name_index, ws in enumerate(d_spacing_group, start=1):
+        d_spacing_out_name = run_number + ext + "-ResultD_" + str(name_index)
+        mantid.RenameWorkspace(InputWorkspace=ws,OutputWorkspace=d_spacing_out_name)
+    for name_index, ws in enumerate(tof_group, start=1):
+        tof_out_name = run_number + ext + "-ResultTOF_" + str(name_index)
+        mantid.RenameWorkspace(InputWorkspace=ws,OutputWorkspace=tof_out_name)
 
     return d_spacing_group, tof_group
 

--- a/scripts/Diffraction/isis_powder/routines/common_output.py
+++ b/scripts/Diffraction/isis_powder/routines/common_output.py
@@ -20,8 +20,7 @@ def split_into_tof_d_spacing_groups(run_details, processed_spectra):
     :param processed_spectra: A list containing workspaces, one entry per focused bank.
     :return: A workspace group for dSpacing and TOF in that order
     """
-    d_spacing_output = []
-    tof_output = []
+   
     run_number = str(run_details.output_run_string)
     ext = run_details.file_extension if run_details.file_extension else ""
     input_group = mantid.GroupWorkspaces(processed_spectra)

--- a/scripts/Diffraction/isis_powder/routines/common_output.py
+++ b/scripts/Diffraction/isis_powder/routines/common_output.py
@@ -20,7 +20,7 @@ def split_into_tof_d_spacing_groups(run_details, processed_spectra):
     :param processed_spectra: A list containing workspaces, one entry per focused bank.
     :return: A workspace group for dSpacing and TOF in that order
     """
-   
+
     run_number = str(run_details.output_run_string)
     ext = run_details.file_extension if run_details.file_extension else ""
     input_group = mantid.GroupWorkspaces(processed_spectra)


### PR DESCRIPTION
**Description of work.**
To prevent duplication of history moved groupWorkspace before convertunits instead of after it.
**To test:** (Requires access to the ISIS Data Search Archive)

<!-- Instructions for testing. -->
Run The following script with these [files](https://github.com/mantidproject/mantid/files/2478177/GemTest.zip)
```
from isis_powder import Gem
config_file_path = r"Path/to/Gem_config_example.yaml"
Gem_example = Gem(config_file=config_file_path,user_name="test")
Gem_example.create_vanadium(input_mode="Individual",first_cycle_run_no="85374" )
Gem_example.focus(input_mode="Individual", run_number="85416")
```
then check the workspace history of ResultD workspaces or ResultTof workspaces for duplication in history.

Be sure to update all paths before running script



Fixes #23799 
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
