### PR TITLE
Indirect - Data Reduction - Disable run, plot and save options while processing

### DIFF
--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -70,3 +70,5 @@ Improvements
 - Added 'Default' detector grouping option in ISISEnergyTransfer for TOSCA, to allow a default grouping 
   using the grouping specified in the Instrument Parameter File.
 - ISISEnergyTransfer now allows overlapping detector grouping.
+- The Run button has been moved to be above the output options. The run button, save button and plotting options 
+  are now disabled while a tab is running or plotting.  

--- a/qt/scientific_interfaces/Indirect/ILLEnergyTransfer.ui
+++ b/qt/scientific_interfaces/Indirect/ILLEnergyTransfer.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>670</width>
-    <height>621</height>
+    <width>672</width>
+    <height>585</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -841,54 +841,6 @@
          </widget>
         </item>
        </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="gbRun">
-     <property name="title">
-      <string>Run</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_5">
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>7</number>
-      </property>
-      <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>270</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="pbRun">
-        <property name="text">
-         <string>Run</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>269</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
       </item>
      </layout>
     </widget>

--- a/qt/scientific_interfaces/Indirect/ILLEnergyTransfer.ui
+++ b/qt/scientific_interfaces/Indirect/ILLEnergyTransfer.ui
@@ -846,6 +846,54 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="gbRun">
+     <property name="title">
+      <string>Run</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_5">
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>7</number>
+      </property>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>270</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pbRun">
+        <property name="text">
+         <string>Run</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>269</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="gbOutput">
      <property name="title">
       <string>Output Options</string>

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -675,6 +675,7 @@ void ISISCalibration::runClicked() { runTab(); }
  * Handle mantid plotting
  */
 void ISISCalibration::plotClicked() {
+  setPlotIsPlotting(true);
 
   plotTimeBin(m_outputCalibrationName);
   checkADSForPlotSaveWorkspace(m_outputCalibrationName.toStdString(), true);
@@ -687,6 +688,7 @@ void ISISCalibration::plotClicked() {
       plotWorkspaces.append(m_outputResolutionName + "_pre_smooth");
   }
   plotSpectrum(plotWorkspaces);
+  setPlotIsPlotting(false);
 }
 
 void ISISCalibration::addRuntimeSmoothing(const QString &workspaceName) {
@@ -806,6 +808,13 @@ void ISISCalibration::updateRunButton(bool enabled,
   m_uiForm.pbRun->setToolTip(tooltip);
   if (enableOutputButtons != "unchanged")
     setOutputButtonsEnabled(enableOutputButtons);
+}
+
+void ISISCalibration::setPlotIsPlotting(bool plotting) {
+  m_uiForm.pbPlot->setText(plotting ? "Plotting..." : "Plot Result");
+  setPlotEnabled(!plotting);
+  setRunEnabled(!plotting);
+  setSaveEnabled(!plotting);
 }
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -173,9 +173,17 @@ ISISCalibration::ISISCalibration(IndirectDataReduction *idrUI, QWidget *parent)
 
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
           SLOT(algorithmComplete(bool)));
-  // Handle plotting and saving
+  // Handle running, plotting and saving
+  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
   connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
+
+  connect(this,
+          SIGNAL(updateRunButton(bool, std::string const &, QString const &,
+                                 QString const &)),
+          this,
+          SLOT(updateRunButton(bool, std::string const &, QString const &,
+                               QString const &)));
 }
 
 //----------------------------------------------------------------------------------------------
@@ -618,17 +626,16 @@ void ISISCalibration::resCheck(bool state) {
  * Called when a user starts to type / edit the runs to load.
  */
 void ISISCalibration::pbRunEditing() {
-  emit updateRunButton(false, "Editing...",
-                       "Run numbers are currently being edited.");
+  updateRunButton(false, "unchanged", "Editing...",
+                  "Run numbers are currently being edited.");
 }
 
 /**
  * Called when the FileFinder starts finding the files.
  */
 void ISISCalibration::pbRunFinding() {
-  emit updateRunButton(
-      false, "Finding files...",
-      "Searching for data files for the run numbers entered...");
+  updateRunButton(false, "unchanged", "Finding files...",
+                  "Searching for data files for the run numbers entered...");
   m_uiForm.leRunNo->setEnabled(false);
 }
 
@@ -636,13 +643,12 @@ void ISISCalibration::pbRunFinding() {
  * Called when the FileFinder has finished finding the files.
  */
 void ISISCalibration::pbRunFinished() {
-  if (!m_uiForm.leRunNo->isValid()) {
-    emit updateRunButton(
-        false, "Invalid Run(s)",
+  if (!m_uiForm.leRunNo->isValid())
+    updateRunButton(
+        false, "unchanged", "Invalid Run(s)",
         "Cannot find data files for some of the run numbers entered.");
-  } else {
-    emit updateRunButton();
-  }
+  else
+    updateRunButton();
 
   m_uiForm.leRunNo->setEnabled(true);
 }
@@ -659,6 +665,11 @@ void ISISCalibration::saveClicked() {
   }
   m_batchAlgoRunner->executeBatchAsync();
 }
+
+/**
+ * Handle when Run is clicked
+ */
+void ISISCalibration::runClicked() { runTab(); }
 
 /**
  * Handle mantid plotting
@@ -765,6 +776,36 @@ IAlgorithm_sptr ISISCalibration::energyTransferReductionAlgorithm(
   reductionAlg->setProperty("LoadLogFiles",
                             m_uiForm.ckLoadLogFiles->isChecked());
   return reductionAlg;
+}
+
+void ISISCalibration::setRunEnabled(bool enabled) {
+  m_uiForm.pbRun->setEnabled(enabled);
+}
+
+void ISISCalibration::setPlotEnabled(bool enabled) {
+  m_uiForm.pbPlot->setEnabled(enabled);
+}
+
+void ISISCalibration::setSaveEnabled(bool enabled) {
+  m_uiForm.pbSave->setEnabled(enabled);
+}
+
+void ISISCalibration::setOutputButtonsEnabled(
+    std::string const &enableOutputButtons) {
+  bool enable = enableOutputButtons == "enable" ? true : false;
+  setPlotEnabled(enable);
+  setSaveEnabled(enable);
+}
+
+void ISISCalibration::updateRunButton(bool enabled,
+                                      std::string const &enableOutputButtons,
+                                      QString const message,
+                                      QString const tooltip) {
+  setRunEnabled(enabled);
+  m_uiForm.pbRun->setText(message);
+  m_uiForm.pbRun->setToolTip(tooltip);
+  if (enableOutputButtons != "unchanged")
+    setOutputButtonsEnabled(enableOutputButtons);
 }
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.h
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.h
@@ -66,9 +66,19 @@ private slots:
   void pbRunFinding();  //< Called when the FileFinder starts finding the files.
   void pbRunFinished(); //< Called when the FileFinder has finished finding the
   // files.
-  /// Handles saving and plotting
+  /// Handles running, saving and plotting
+  void runClicked();
   void saveClicked();
   void plotClicked();
+
+  void setRunEnabled(bool enabled);
+  void setPlotEnabled(bool enabled);
+  void setSaveEnabled(bool enabled);
+  void setOutputButtonsEnabled(std::string const &enableOutputButtons);
+  void updateRunButton(bool enabled = true,
+                       std::string const &enableOutputButtons = "unchanged",
+                       QString const message = "Run",
+                       QString const tooltip = "");
 
 private:
   void createRESfile(const QString &file);

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.h
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.h
@@ -79,6 +79,7 @@ private slots:
                        std::string const &enableOutputButtons = "unchanged",
                        QString const message = "Run",
                        QString const tooltip = "");
+  void setPlotIsPlotting(bool plotting);
 
 private:
   void createRESfile(const QString &file);

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.ui
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>500</width>
-    <height>339</height>
+    <height>367</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -234,6 +234,54 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="gbRun">
+     <property name="title">
+      <string>Run</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>7</number>
+      </property>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>185</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pushButton">
+        <property name="text">
+         <string>Run</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>184</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="gbOutput">
      <property name="title">
       <string>Output</string>
@@ -282,15 +330,16 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>MantidQt::API::MWRunFiles</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Common/MWRunFiles.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>MantidQt::MantidWidgets::PreviewPlot</class>
    <extends>QWidget</extends>
    <header>MantidQtWidgets/LegacyQwt/PreviewPlot.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>MantidQt::API::MWRunFiles</class>
-   <extends>QWidget</extends>
-   <header>MantidQtWidgets/Common/MWRunFiles.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.ui
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.ui
@@ -259,7 +259,19 @@
        </spacer>
       </item>
       <item>
-       <widget class="QPushButton" name="pushButton">
+       <widget class="QPushButton" name="pbRun">
+        <property name="minimumSize">
+         <size>
+          <width>150</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>180</width>
+          <height>16777215</height>
+         </size>
+        </property>
         <property name="text">
          <string>Run</string>
         </property>

--- a/qt/scientific_interfaces/Indirect/ISISDiagnostics.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISDiagnostics.cpp
@@ -489,8 +489,10 @@ void ISISDiagnostics::runClicked() { runTab(); }
  * Handles mantid plotting
  */
 void ISISDiagnostics::plotClicked() {
+  setPlotIsPlotting(true);
   if (checkADSForPlotSaveWorkspace(m_pythonExportWsName, true))
     plotSpectrum(QString::fromStdString(m_pythonExportWsName));
+  setPlotIsPlotting(false);
 }
 
 /**
@@ -530,6 +532,13 @@ void ISISDiagnostics::updateRunButton(bool enabled,
   m_uiForm.pbRun->setToolTip(tooltip);
   if (enableOutputButtons != "unchanged")
     setOutputButtonsEnabled(enableOutputButtons);
+}
+
+void ISISDiagnostics::setPlotIsPlotting(bool plotting) {
+  m_uiForm.pbPlot->setText(plotting ? "Plotting..." : "Plot Result");
+  setPlotEnabled(!plotting);
+  setRunEnabled(!plotting);
+  setSaveEnabled(!plotting);
 }
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/ISISDiagnostics.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISDiagnostics.cpp
@@ -124,9 +124,17 @@ ISISDiagnostics::ISISDiagnostics(IndirectDataReduction *idrUI, QWidget *parent)
   // Reverts run button back to normal when file finding has finished
   connect(m_uiForm.dsInputFiles, SIGNAL(fileFindingFinished()), this,
           SLOT(pbRunFinished()));
-  // Handles plotting and saving
+  // Handles running, plotting and saving
+  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
   connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
+
+  connect(this,
+          SIGNAL(updateRunButton(bool, std::string const &, QString const &,
+                                 QString const &)),
+          this,
+          SLOT(updateRunButton(bool, std::string const &, QString const &,
+                               QString const &)));
 
   // Set default UI state
   sliceTwoRanges(nullptr, false);
@@ -445,17 +453,16 @@ void ISISDiagnostics::sliceAlgDone(bool error) {
  * Called when a user starts to type / edit the runs to load.
  */
 void ISISDiagnostics::pbRunEditing() {
-  emit updateRunButton(false, "Editing...",
-                       "Run numbers are curently being edited.");
+  updateRunButton(false, "unchanged", "Editing...",
+                  "Run numbers are curently being edited.");
 }
 
 /**
  * Called when the FileFinder starts finding the files.
  */
 void ISISDiagnostics::pbRunFinding() {
-  emit updateRunButton(
-      false, "Finding files...",
-      "Searchig for data files for the run numbers entered...");
+  updateRunButton(false, "unchanged", "Finding files...",
+                  "Searchig for data files for the run numbers entered...");
   m_uiForm.dsInputFiles->setEnabled(false);
 }
 
@@ -463,16 +470,20 @@ void ISISDiagnostics::pbRunFinding() {
  * Called when the FileFinder has finished finding the files.
  */
 void ISISDiagnostics::pbRunFinished() {
-  if (!m_uiForm.dsInputFiles->isValid()) {
-    emit updateRunButton(
-        false, "Invalid Run(s)",
+  if (!m_uiForm.dsInputFiles->isValid())
+    updateRunButton(
+        false, "unchanged", "Invalid Run(s)",
         "Cannot find data files for some of the run numbers enetered.");
-  } else {
-    emit updateRunButton();
-  }
+  else
+    updateRunButton();
 
   m_uiForm.dsInputFiles->setEnabled(true);
 }
+
+/**
+ * Handle when Run is clicked
+ */
+void ISISDiagnostics::runClicked() { runTab(); }
 
 /**
  * Handles mantid plotting
@@ -490,5 +501,36 @@ void ISISDiagnostics::saveClicked() {
     addSaveWorkspaceToQueue(QString::fromStdString(m_pythonExportWsName));
   m_batchAlgoRunner->executeBatchAsync();
 }
+
+void ISISDiagnostics::setRunEnabled(bool enabled) {
+  m_uiForm.pbRun->setEnabled(enabled);
+}
+
+void ISISDiagnostics::setPlotEnabled(bool enabled) {
+  m_uiForm.pbPlot->setEnabled(enabled);
+}
+
+void ISISDiagnostics::setSaveEnabled(bool enabled) {
+  m_uiForm.pbSave->setEnabled(enabled);
+}
+
+void ISISDiagnostics::setOutputButtonsEnabled(
+    std::string const &enableOutputButtons) {
+  bool enable = enableOutputButtons == "enable" ? true : false;
+  setPlotEnabled(enable);
+  setSaveEnabled(enable);
+}
+
+void ISISDiagnostics::updateRunButton(bool enabled,
+                                      std::string const &enableOutputButtons,
+                                      QString const message,
+                                      QString const tooltip) {
+  setRunEnabled(enabled);
+  m_uiForm.pbRun->setText(message);
+  m_uiForm.pbRun->setToolTip(tooltip);
+  if (enableOutputButtons != "unchanged")
+    setOutputButtonsEnabled(enableOutputButtons);
+}
+
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/ISISDiagnostics.h
+++ b/qt/scientific_interfaces/Indirect/ISISDiagnostics.h
@@ -63,8 +63,18 @@ private slots:
   void pbRunFinding();  //< Called when the FileFinder starts finding the files.
   void pbRunFinished(); //< Called when the FileFinder has finished finding the
   // files.
+  void runClicked();
   void saveClicked();
   void plotClicked();
+
+  void setRunEnabled(bool enabled);
+  void setPlotEnabled(bool enabled);
+  void setSaveEnabled(bool enabled);
+  void setOutputButtonsEnabled(std::string const &enableOutputButtons);
+  void updateRunButton(bool enabled = true,
+                       std::string const &enableOutputButtons = "unchanged",
+                       QString const message = "Run",
+                       QString const tooltip = "");
 
 private:
   Ui::ISISDiagnostics m_uiForm;

--- a/qt/scientific_interfaces/Indirect/ISISDiagnostics.h
+++ b/qt/scientific_interfaces/Indirect/ISISDiagnostics.h
@@ -75,6 +75,7 @@ private slots:
                        std::string const &enableOutputButtons = "unchanged",
                        QString const message = "Run",
                        QString const tooltip = "");
+  void setPlotIsPlotting(bool plotting);
 
 private:
   Ui::ISISDiagnostics m_uiForm;

--- a/qt/scientific_interfaces/Indirect/ISISDiagnostics.ui
+++ b/qt/scientific_interfaces/Indirect/ISISDiagnostics.ui
@@ -179,6 +179,18 @@
       </item>
       <item>
        <widget class="QPushButton" name="pbRun">
+        <property name="minimumSize">
+         <size>
+          <width>150</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>180</width>
+          <height>16777215</height>
+         </size>
+        </property>
         <property name="text">
          <string>Run</string>
         </property>
@@ -246,15 +258,15 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>MantidQt::MantidWidgets::DataSelector</class>
-   <extends>QWidget</extends>
-   <header>MantidQtWidgets/Common/DataSelector.h</header>
-  </customwidget>
-  <customwidget>
    <class>MantidQt::API::MWRunFiles</class>
    <extends>QWidget</extends>
    <header>MantidQtWidgets/Common/MWRunFiles.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::MantidWidgets::DataSelector</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Common/DataSelector.h</header>
   </customwidget>
   <customwidget>
    <class>MantidQt::MantidWidgets::PreviewPlot</class>

--- a/qt/scientific_interfaces/Indirect/ISISDiagnostics.ui
+++ b/qt/scientific_interfaces/Indirect/ISISDiagnostics.ui
@@ -147,6 +147,60 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="gbRun">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Run</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>7</number>
+      </property>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>197</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pbRun">
+        <property name="text">
+         <string>Run</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>196</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="gbOutput">
      <property name="title">
       <string>Output</string>
@@ -197,15 +251,16 @@
    <header>MantidQtWidgets/Common/DataSelector.h</header>
   </customwidget>
   <customwidget>
+   <class>MantidQt::API::MWRunFiles</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Common/MWRunFiles.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>MantidQt::MantidWidgets::PreviewPlot</class>
    <extends>QWidget</extends>
    <header>MantidQtWidgets/LegacyQwt/PreviewPlot.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>MantidQt::API::MWRunFiles</class>
-   <extends>QWidget</extends>
-   <header>MantidQtWidgets/Common/MWRunFiles.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -830,6 +830,7 @@ void ISISEnergyTransfer::runClicked() { runTab(); }
  * Handle mantid plotting of workspaces
  */
 void ISISEnergyTransfer::plotClicked() {
+  setPlotIsPlotting(true);
   for (const auto &it : m_outputWorkspaces) {
     if (checkADSForPlotSaveWorkspace(it, true)) {
       const auto plotType = m_uiForm.cbPlotType->currentText();
@@ -840,6 +841,7 @@ void ISISEnergyTransfer::plotClicked() {
       m_pythonRunner.runPythonCode(pyInput);
     }
   }
+  setPlotIsPlotting(false);
 }
 
 /**
@@ -893,6 +895,13 @@ void ISISEnergyTransfer::updateRunButton(bool enabled,
   m_uiForm.pbRun->setToolTip(tooltip);
   if (enableOutputButtons != "unchanged")
     setOutputButtonsEnabled(enableOutputButtons);
+}
+
+void ISISEnergyTransfer::setPlotIsPlotting(bool plotting) {
+  m_uiForm.pbPlot->setText(plotting ? "Plotting..." : "Plot");
+  setPlotEnabled(!plotting);
+  setRunEnabled(!plotting);
+  setSaveEnabled(!plotting);
 }
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -869,10 +869,12 @@ void ISISEnergyTransfer::setRunEnabled(bool enabled) {
 
 void ISISEnergyTransfer::setPlotEnabled(bool enabled) {
   m_uiForm.pbPlot->setEnabled(enabled);
+  m_uiForm.cbPlotType->setEnabled(enabled);
 }
 
 void ISISEnergyTransfer::setSaveEnabled(bool enabled) {
   m_uiForm.pbSave->setEnabled(enabled);
+  m_uiForm.loSaveFormats->setEnabled(enabled);
 }
 
 void ISISEnergyTransfer::setOutputButtonsEnabled(

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
@@ -54,9 +54,19 @@ private slots:
   // files.
   void plotRawComplete(
       bool error); //< Called when the Plot Raw algorithmm chain completes
-  /// Handles plotting and saving
+  /// Handles running, plotting and saving
+  void runClicked();
   void plotClicked();
   void saveClicked();
+
+  void setRunEnabled(bool enabled);
+  void setPlotEnabled(bool enabled);
+  void setSaveEnabled(bool enabled);
+  void setOutputButtonsEnabled(std::string const &enableOutputButtons);
+  void updateRunButton(bool enabled = true,
+                       std::string const &enableOutputButtons = "unchanged",
+                       QString const message = "Run",
+                       QString const tooltip = "");
 
 private:
   Ui::ISISEnergyTransfer m_uiForm;

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
@@ -67,6 +67,7 @@ private slots:
                        std::string const &enableOutputButtons = "unchanged",
                        QString const message = "Run",
                        QString const tooltip = "");
+  void setPlotIsPlotting(bool plotting);
 
 private:
   Ui::ISISEnergyTransfer m_uiForm;

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.ui
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.ui
@@ -246,7 +246,7 @@
          <number>0</number>
         </property>
         <property name="currentIndex">
-         <number>2</number>
+         <number>1</number>
         </property>
         <widget class="QWidget" name="pgMapFile">
          <layout class="QHBoxLayout" name="horizontalLayout_5">
@@ -840,6 +840,66 @@
          <string>Plot</string>
         </property>
        </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gbRun">
+     <property name="title">
+      <string>Run</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_7">
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>7</number>
+      </property>
+      <item>
+       <spacer name="horizontalSpacer_4">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pbRun">
+        <property name="minimumSize">
+         <size>
+          <width>150</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>180</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Run</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_10">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
       </item>
      </layout>
     </widget>

--- a/qt/scientific_interfaces/Indirect/IndirectDataReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReduction.cpp
@@ -95,25 +95,14 @@ void IndirectDataReduction::exportTabPython() {
 }
 
 /**
- * This is the function called when the "Run" button is clicked. It will call
- * the relevent function
- * in the subclass.
- */
-void IndirectDataReduction::runClicked() {
-  QString tabName =
-      m_uiForm.twIDRTabs->tabText(m_uiForm.twIDRTabs->currentIndex());
-  m_tabs[tabName].second->runTab();
-}
-
-/**
  * Sets up Qt UI file and connects signals, slots.
  */
 void IndirectDataReduction::initLayout() {
   m_uiForm.setupUi(this);
 
-  // Do not allow running until setup  and instrument laoding are done
-  updateRunButton(false, "Loading UI",
-                  "Initialising user interface components...");
+  // Do not allow running until setup  and instrument loading are done
+  emitUpdateRunButton(false, "disable", "Loading UI...",
+                      "Initialising user interface components...");
 
   // Create the tabs
   addTab<ISISEnergyTransfer>("ISIS Energy Transfer");
@@ -130,15 +119,13 @@ void IndirectDataReduction::initLayout() {
   // Connect the Python export buton
   connect(m_uiForm.pbPythonExport, SIGNAL(clicked()), this,
           SLOT(exportTabPython()));
-  // Connect the "Run" button
-  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
   // Connect the "Manage User Directories" Button
   connect(m_uiForm.pbManageDirectories, SIGNAL(clicked()), this,
           SLOT(openDirectoryDialog()));
 
   // Reset the Run button state when the tab is changed
   connect(m_uiForm.twIDRTabs, SIGNAL(currentChanged(int)), this,
-          SLOT(updateRunButton()));
+          SLOT(emitUpdateRunButton()));
 
   // Handle instrument configuration changes
   connect(m_uiForm.iicInstrumentConfiguration,
@@ -550,9 +537,8 @@ void IndirectDataReduction::showMessageBox(const QString &message) {
  * @param message Message shown on the button
  * @param tooltip Tooltip shown when hovering over button
  */
-void IndirectDataReduction::updateRunButton(bool enabled, QString message,
-                                            QString tooltip) {
-  m_uiForm.pbRun->setEnabled(enabled);
-  m_uiForm.pbRun->setText(message);
-  m_uiForm.pbRun->setToolTip(tooltip);
+void IndirectDataReduction::emitUpdateRunButton(
+    bool enabled, std::string const &enableOutputButtons, QString message,
+    QString tooltip) {
+  emit updateRunButton(enabled, enableOutputButtons, message, tooltip);
 }

--- a/qt/scientific_interfaces/Indirect/IndirectDataReduction.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReduction.h
@@ -72,6 +72,10 @@ public:
 signals:
   /// Emitted when the instrument setup is changed
   void newInstrumentConfiguration();
+  /// Emitted to update the state of the Run button
+  void updateRunButton(bool enabled = true,
+                       std::string const &enableOutputButtons = "unchanged",
+                       QString message = "Run", QString tooltip = "");
 
 private slots:
   /// Shows/hides tabs based on facility
@@ -80,16 +84,15 @@ private slots:
   void helpClicked();
   /// Exports the current tab algorithms as a Python script
   void exportTabPython();
-  /// Runs the current tab
-  void runClicked();
   /// Opens the manage directory dialog
   void openDirectoryDialog();
 
   /// Shows a information dialog box
   void showMessageBox(const QString &message);
   /// Updates the state of the Run button
-  void updateRunButton(bool enabled = true, QString message = "Run",
-                       QString tooltip = "");
+  void emitUpdateRunButton(bool enabled = true,
+                           std::string const &enableOutputButtons = "unchanged",
+                           QString message = "Run", QString tooltip = "");
 
   /// Called when the load instrument algorithms complete
   void instrumentLoadingDone(bool error);

--- a/qt/scientific_interfaces/Indirect/IndirectDataReduction.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReduction.ui
@@ -123,34 +123,6 @@
         </property>
        </widget>
       </item>
-      <item alignment="Qt::AlignLeft">
-       <widget class="QPushButton" name="pbRun">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>150</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>180</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>Run conversion to energy process.</string>
-        </property>
-        <property name="text">
-         <string>Run</string>
-        </property>
-       </widget>
-      </item>
       <item alignment="Qt::AlignRight|Qt::AlignVCenter">
        <widget class="QPushButton" name="pbManageDirectories">
         <property name="sizePolicy">
@@ -180,7 +152,6 @@
   <tabstop>twIDRTabs</tabstop>
   <tabstop>pbHelp</tabstop>
   <tabstop>pbPythonExport</tabstop>
-  <tabstop>pbRun</tabstop>
   <tabstop>pbManageDirectories</tabstop>
  </tabstops>
  <resources/>

--- a/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.cpp
@@ -43,7 +43,8 @@ void IndirectDataReductionTab::runTab() {
   if (validate()) {
     m_tabStartTime = DateAndTime::getCurrentTime();
     m_tabRunning = true;
-    emit updateRunButton(false, "Running...", "Running data reduction...");
+    emit updateRunButton(false, "disable", "Running...",
+                         "Running data reduction...");
     run();
   } else {
     g_log.warning("Failed to validate indirect tab input!");
@@ -60,7 +61,8 @@ void IndirectDataReductionTab::tabExecutionComplete(bool error) {
   UNUSED_ARG(error);
   if (m_tabRunning) {
     m_tabRunning = false;
-    emit updateRunButton();
+    auto const enableOutputButtons = error == false ? "enable" : "disable";
+    emit updateRunButton(true, enableOutputButtons);
   }
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.h
@@ -69,8 +69,9 @@ public slots:
 
 signals:
   /// Update the Run button on the IDR main window
-  void updateRunButton(bool enabled = true, QString message = "Run",
-                       QString tooltip = "");
+  void updateRunButton(bool enabled = true,
+                       std::string const &enableOutputButtons = "unchanged",
+                       QString message = "Run", QString tooltip = "");
   /// Emitted when the instrument setup is changed
   void newInstrumentConfiguration();
 

--- a/qt/scientific_interfaces/Indirect/IndirectMoments.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectMoments.cpp
@@ -223,11 +223,12 @@ void IndirectMoments::runClicked() { runTab(); }
  * Handle mantid plotting
  */
 void IndirectMoments::plotClicked() {
+  setPlotIsPlotting(true);
   QString outputWs =
       getWorkspaceBasename(m_uiForm.dsInput->getCurrentDataName()) + "_Moments";
-  if (checkADSForPlotSaveWorkspace(outputWs.toStdString(), true)) {
+  if (checkADSForPlotSaveWorkspace(outputWs.toStdString(), true))
     plotSpectra(outputWs, {0, 2, 4});
-  }
+  setPlotIsPlotting(false);
 }
 
 /**
@@ -267,6 +268,13 @@ void IndirectMoments::updateRunButton(bool enabled,
   m_uiForm.pbRun->setToolTip(tooltip);
   if (enableOutputButtons != "unchanged")
     setOutputButtonsEnabled(enableOutputButtons);
+}
+
+void IndirectMoments::setPlotIsPlotting(bool plotting) {
+  m_uiForm.pbPlot->setText(plotting ? "Plotting..." : "Plot Result");
+  setPlotEnabled(!plotting);
+  setRunEnabled(!plotting);
+  setSaveEnabled(!plotting);
 }
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectMoments.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectMoments.cpp
@@ -57,8 +57,16 @@ IndirectMoments::IndirectMoments(IndirectDataReduction *idrUI, QWidget *parent)
           SLOT(momentsAlgComplete(bool)));
 
   // Plot and save
+  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
   connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
+
+  connect(this,
+          SIGNAL(updateRunButton(bool, std::string const &, QString const &,
+                                 QString const &)),
+          this,
+          SLOT(updateRunButton(bool, std::string const &, QString const &,
+                               QString const &)));
 }
 
 //----------------------------------------------------------------------------------------------
@@ -207,6 +215,11 @@ void IndirectMoments::momentsAlgComplete(bool error) {
 }
 
 /**
+ * Handle when Run is clicked
+ */
+void IndirectMoments::runClicked() { runTab(); }
+
+/**
  * Handle mantid plotting
  */
 void IndirectMoments::plotClicked() {
@@ -226,6 +239,34 @@ void IndirectMoments::saveClicked() {
   if (checkADSForPlotSaveWorkspace(outputWs.toStdString(), false))
     addSaveWorkspaceToQueue(outputWs);
   m_batchAlgoRunner->executeBatchAsync();
+}
+
+void IndirectMoments::setRunEnabled(bool enabled) {
+  m_uiForm.pbRun->setEnabled(enabled);
+}
+void IndirectMoments::setPlotEnabled(bool enabled) {
+  m_uiForm.pbPlot->setEnabled(enabled);
+}
+void IndirectMoments::setSaveEnabled(bool enabled) {
+  m_uiForm.pbSave->setEnabled(enabled);
+}
+
+void IndirectMoments::setOutputButtonsEnabled(
+    std::string const &enableOutputButtons) {
+  bool enable = enableOutputButtons == "enable" ? true : false;
+  setPlotEnabled(enable);
+  setSaveEnabled(enable);
+}
+
+void IndirectMoments::updateRunButton(bool enabled,
+                                      std::string const &enableOutputButtons,
+                                      QString const message,
+                                      QString const tooltip) {
+  setRunEnabled(enabled);
+  m_uiForm.pbRun->setText(message);
+  m_uiForm.pbRun->setToolTip(tooltip);
+  if (enableOutputButtons != "unchanged")
+    setOutputButtonsEnabled(enableOutputButtons);
 }
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectMoments.h
+++ b/qt/scientific_interfaces/Indirect/IndirectMoments.h
@@ -44,8 +44,18 @@ protected slots:
   /// Called when the algorithm completes to update preview plot
   void momentsAlgComplete(bool error);
   /// Slots for plot and save
-  void saveClicked();
+  void runClicked();
   void plotClicked();
+  void saveClicked();
+
+  void setRunEnabled(bool enabled);
+  void setPlotEnabled(bool enabled);
+  void setSaveEnabled(bool enabled);
+  void setOutputButtonsEnabled(std::string const &enableOutputButtons);
+  void updateRunButton(bool enabled = true,
+                       std::string const &enableOutputButtons = "unchanged",
+                       QString const message = "Run",
+                       QString const tooltip = "");
 
 private:
   Ui::IndirectMoments m_uiForm;

--- a/qt/scientific_interfaces/Indirect/IndirectMoments.h
+++ b/qt/scientific_interfaces/Indirect/IndirectMoments.h
@@ -56,6 +56,7 @@ protected slots:
                        std::string const &enableOutputButtons = "unchanged",
                        QString const message = "Run",
                        QString const tooltip = "");
+  void setPlotIsPlotting(bool plotting);
 
 private:
   Ui::IndirectMoments m_uiForm;

--- a/qt/scientific_interfaces/Indirect/IndirectMoments.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectMoments.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>500</width>
-    <height>398</height>
+    <height>439</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -136,7 +136,16 @@
       <string>Preview</string>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_1">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>6</number>
+      </property>
+      <property name="topMargin">
+       <number>6</number>
+      </property>
+      <property name="rightMargin">
+       <number>6</number>
+      </property>
+      <property name="bottomMargin">
        <number>6</number>
       </property>
       <item>
@@ -152,6 +161,54 @@
          <bool>true</bool>
         </property>
        </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gbRun">
+     <property name="title">
+      <string>Run</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>7</number>
+      </property>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>185</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pbRun">
+        <property name="text">
+         <string>Run</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>184</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
       </item>
      </layout>
     </widget>

--- a/qt/scientific_interfaces/Indirect/IndirectMoments.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectMoments.ui
@@ -192,6 +192,18 @@
       </item>
       <item>
        <widget class="QPushButton" name="pbRun">
+        <property name="minimumSize">
+         <size>
+          <width>150</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>180</width>
+          <height>16777215</height>
+         </size>
+        </property>
         <property name="text">
          <string>Run</string>
         </property>

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
@@ -28,8 +28,16 @@ IndirectSqw::IndirectSqw(IndirectDataReduction *idrUI, QWidget *parent)
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
           SLOT(sqwAlgDone(bool)));
 
+  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
   connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
+
+  connect(this,
+          SIGNAL(updateRunButton(bool, std::string const &, QString const &,
+                                 QString const &)),
+          this,
+          SLOT(updateRunButton(bool, std::string const &, QString const &,
+                               QString const &)));
 }
 
 //----------------------------------------------------------------------------------------------
@@ -178,6 +186,11 @@ void IndirectSqw::plotContour() {
 }
 
 /**
+ * Handle when Run is clicked
+ */
+void IndirectSqw::runClicked() { runTab(); }
+
+/**
  * Handles mantid plotting
  */
 void IndirectSqw::plotClicked() {
@@ -203,5 +216,36 @@ void IndirectSqw::saveClicked() {
     addSaveWorkspaceToQueue(QString::fromStdString(m_pythonExportWsName));
   m_batchAlgoRunner->executeBatch();
 }
+
+void IndirectSqw::setRunEnabled(bool enabled) {
+  m_uiForm.pbRun->setEnabled(enabled);
+}
+
+void IndirectSqw::setPlotEnabled(bool enabled) {
+  m_uiForm.pbPlot->setEnabled(enabled);
+}
+
+void IndirectSqw::setSaveEnabled(bool enabled) {
+  m_uiForm.pbSave->setEnabled(enabled);
+}
+
+void IndirectSqw::setOutputButtonsEnabled(
+    std::string const &enableOutputButtons) {
+  bool enable = enableOutputButtons == "enable" ? true : false;
+  setPlotEnabled(enable);
+  setSaveEnabled(enable);
+}
+
+void IndirectSqw::updateRunButton(bool enabled,
+                                  std::string const &enableOutputButtons,
+                                  QString const message,
+                                  QString const tooltip) {
+  setRunEnabled(enabled);
+  m_uiForm.pbRun->setText(message);
+  m_uiForm.pbRun->setToolTip(tooltip);
+  if (enableOutputButtons != "unchanged")
+    setOutputButtonsEnabled(enableOutputButtons);
+}
+
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
@@ -223,6 +223,7 @@ void IndirectSqw::setRunEnabled(bool enabled) {
 
 void IndirectSqw::setPlotEnabled(bool enabled) {
   m_uiForm.pbPlot->setEnabled(enabled);
+  m_uiForm.cbPlotType->setEnabled(enabled);
 }
 
 void IndirectSqw::setSaveEnabled(bool enabled) {

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
@@ -194,6 +194,7 @@ void IndirectSqw::runClicked() { runTab(); }
  * Handles mantid plotting
  */
 void IndirectSqw::plotClicked() {
+  setPlotIsPlotting(true);
   QString plotType = m_uiForm.cbPlotType->currentText();
   if (plotType == "Contour" &&
       (checkADSForPlotSaveWorkspace(m_pythonExportWsName, true)))
@@ -206,6 +207,7 @@ void IndirectSqw::plotClicked() {
     int numHist = static_cast<int>(ws->getNumberHistograms());
     plotSpectrum(QString::fromStdString(m_pythonExportWsName), 0, numHist - 1);
   }
+  setPlotIsPlotting(false);
 }
 
 /**
@@ -246,6 +248,13 @@ void IndirectSqw::updateRunButton(bool enabled,
   m_uiForm.pbRun->setToolTip(tooltip);
   if (enableOutputButtons != "unchanged")
     setOutputButtonsEnabled(enableOutputButtons);
+}
+
+void IndirectSqw::setPlotIsPlotting(bool plotting) {
+  m_uiForm.pbPlot->setText(plotting ? "Plotting..." : "Plot");
+  setPlotEnabled(!plotting);
+  setRunEnabled(!plotting);
+  setSaveEnabled(!plotting);
 }
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.h
@@ -33,8 +33,19 @@ public:
 private slots:
   void plotContour();
   void sqwAlgDone(bool error);
+
+  void runClicked();
   void plotClicked();
   void saveClicked();
+
+  void setRunEnabled(bool enabled);
+  void setPlotEnabled(bool enabled);
+  void setSaveEnabled(bool enabled);
+  void setOutputButtonsEnabled(std::string const &enableOutputButtons);
+  void updateRunButton(bool enabled = true,
+                       std::string const &enableOutputButtons = "unchanged",
+                       QString const message = "Run",
+                       QString const tooltip = "");
 
 private:
   Ui::IndirectSqw m_uiForm;

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.h
@@ -46,6 +46,7 @@ private slots:
                        std::string const &enableOutputButtons = "unchanged",
                        QString const message = "Run",
                        QString const tooltip = "");
+  void setPlotIsPlotting(bool plotting);
 
 private:
   Ui::IndirectSqw m_uiForm;

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.ui
@@ -350,7 +350,91 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>45</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>45</height>
+      </size>
+     </property>
+     <property name="title">
+      <string>Run</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>7</number>
+      </property>
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>198</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pbRun">
+        <property name="minimumSize">
+         <size>
+          <width>150</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>180</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Run</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>197</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="sqw_outputOptions">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>56</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>56</height>
+      </size>
+     </property>
      <property name="title">
       <string>Output</string>
      </property>

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetrise.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetrise.cpp
@@ -538,11 +538,12 @@ void IndirectSymmetrise::runClicked() { runTab(); }
  * Handles mantid plotting
  */
 void IndirectSymmetrise::plotClicked() {
-
+  setPlotIsPlotting(true);
   QStringList workspaces;
   workspaces.append(m_uiForm.dsInput->getCurrentDataName());
   workspaces.append(QString::fromStdString(m_pythonExportWsName));
   plotSpectrum(workspaces);
+  setPlotIsPlotting(false);
 }
 
 /**
@@ -581,6 +582,13 @@ void IndirectSymmetrise::updateRunButton(bool enabled,
   m_uiForm.pbRun->setToolTip(tooltip);
   if (enableOutputButtons != "unchanged")
     setOutputButtonsEnabled(enableOutputButtons);
+}
+
+void IndirectSymmetrise::setPlotIsPlotting(bool plotting) {
+  m_uiForm.pbPlot->setText(plotting ? "Plotting..." : "Plot Result");
+  setPlotEnabled(!plotting);
+  setRunEnabled(!plotting);
+  setSaveEnabled(!plotting);
 }
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetrise.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetrise.cpp
@@ -137,9 +137,17 @@ IndirectSymmetrise::IndirectSymmetrise(IndirectDataReduction *idrUI,
           SLOT(xRangeMinChanged(double)));
   connect(negativeERaw, SIGNAL(maxValueChanged(double)), this,
           SLOT(xRangeMaxChanged(double)));
-  // Handle plotting and saving
+  // Handle running, plotting and saving
+  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
   connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
+
+  connect(this,
+          SIGNAL(updateRunButton(bool, std::string const &, QString const &,
+                                 QString const &)),
+          this,
+          SLOT(updateRunButton(bool, std::string const &, QString const &,
+                               QString const &)));
 
   // Set default X range values
   m_dblManager->setValue(m_properties["EMin"], 0.1);
@@ -520,6 +528,12 @@ void IndirectSymmetrise::xRangeMaxChanged(double value) {
     m_dblManager->setValue(m_properties["EMin"], std::abs(value));
   }
 }
+
+/**
+ * Handle when Run is clicked
+ */
+void IndirectSymmetrise::runClicked() { runTab(); }
+
 /**
  * Handles mantid plotting
  */
@@ -538,5 +552,36 @@ void IndirectSymmetrise::saveClicked() {
   if (checkADSForPlotSaveWorkspace(m_pythonExportWsName, false))
     plotSpectrum(QString::fromStdString(m_pythonExportWsName));
 }
+
+void IndirectSymmetrise::setRunEnabled(bool enabled) {
+  m_uiForm.pbRun->setEnabled(enabled);
+}
+
+void IndirectSymmetrise::setPlotEnabled(bool enabled) {
+  m_uiForm.pbPlot->setEnabled(enabled);
+}
+
+void IndirectSymmetrise::setSaveEnabled(bool enabled) {
+  m_uiForm.pbSave->setEnabled(enabled);
+}
+
+void IndirectSymmetrise::setOutputButtonsEnabled(
+    std::string const &enableOutputButtons) {
+  bool enable = enableOutputButtons == "enable" ? true : false;
+  setPlotEnabled(enable);
+  setSaveEnabled(enable);
+}
+
+void IndirectSymmetrise::updateRunButton(bool enabled,
+                                         std::string const &enableOutputButtons,
+                                         QString const message,
+                                         QString const tooltip) {
+  setRunEnabled(enabled);
+  m_uiForm.pbRun->setText(message);
+  m_uiForm.pbRun->setToolTip(tooltip);
+  if (enableOutputButtons != "unchanged")
+    setOutputButtonsEnabled(enableOutputButtons);
+}
+
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetrise.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetrise.h
@@ -60,8 +60,19 @@ private slots:
   void previewAlgDone(bool error);
   void xRangeMaxChanged(double value);
   void xRangeMinChanged(double value);
+
+  void runClicked();
   void plotClicked();
   void saveClicked();
+
+  void setRunEnabled(bool enabled);
+  void setPlotEnabled(bool enabled);
+  void setSaveEnabled(bool enabled);
+  void setOutputButtonsEnabled(std::string const &enableOutputButtons);
+  void updateRunButton(bool enabled = true,
+                       std::string const &enableOutputButtons = "unchanged",
+                       QString const message = "Run",
+                       QString const tooltip = "");
 
 private:
   Ui::IndirectSymmetrise m_uiForm;

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetrise.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetrise.h
@@ -73,6 +73,7 @@ private slots:
                        std::string const &enableOutputButtons = "unchanged",
                        QString const message = "Run",
                        QString const tooltip = "");
+  void setPlotIsPlotting(bool plotting);
 
 private:
   Ui::IndirectSymmetrise m_uiForm;

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetrise.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetrise.ui
@@ -109,12 +109,69 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="gbRun">
+     <property name="title">
+      <string>Run</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>7</number>
+      </property>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>185</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pbRun">
+        <property name="text">
+         <string>Run</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>184</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="gbOutput">
      <property name="title">
       <string>Output</string>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout1">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>6</number>
+      </property>
+      <property name="topMargin">
+       <number>6</number>
+      </property>
+      <property name="rightMargin">
+       <number>6</number>
+      </property>
+      <property name="bottomMargin">
        <number>6</number>
       </property>
       <item>

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetrise.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetrise.ui
@@ -135,6 +135,18 @@
       </item>
       <item>
        <widget class="QPushButton" name="pbRun">
+        <property name="minimumSize">
+         <size>
+          <width>150</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>180</width>
+          <height>16777215</height>
+         </size>
+        </property>
         <property name="text">
          <string>Run</string>
         </property>

--- a/qt/scientific_interfaces/Indirect/IndirectTransmission.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTransmission.cpp
@@ -32,6 +32,7 @@ IndirectTransmission::IndirectTransmission(IndirectDataReduction *idrUI,
           SLOT(dataLoaded()));
   connect(m_uiForm.dsCanInput, SIGNAL(dataReady(QString)), this,
           SLOT(dataLoaded()));
+
   connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
   connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
@@ -162,10 +163,12 @@ void IndirectTransmission::saveClicked() {
  * Handle mantid plotting
  */
 void IndirectTransmission::plotClicked() {
+  setPlotIsPlotting(true);
   QString outputWs =
       (m_uiForm.dsSampleInput->getCurrentDataName() + "_transmission");
   if (checkADSForPlotSaveWorkspace(outputWs.toStdString(), true))
     plotSpectrum(outputWs);
+  setPlotIsPlotting(false);
 }
 
 void IndirectTransmission::setRunEnabled(bool enabled) {
@@ -195,6 +198,13 @@ void IndirectTransmission::updateRunButton(
   m_uiForm.pbRun->setToolTip(tooltip);
   if (enableOutputButtons != "unchanged")
     setOutputButtonsEnabled(enableOutputButtons);
+}
+
+void IndirectTransmission::setPlotIsPlotting(bool plotting) {
+  m_uiForm.pbPlot->setText(plotting ? "Plotting..." : "Plot Result");
+  setPlotEnabled(!plotting);
+  setRunEnabled(!plotting);
+  setSaveEnabled(!plotting);
 }
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectTransmission.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTransmission.cpp
@@ -32,8 +32,16 @@ IndirectTransmission::IndirectTransmission(IndirectDataReduction *idrUI,
           SLOT(dataLoaded()));
   connect(m_uiForm.dsCanInput, SIGNAL(dataReady(QString)), this,
           SLOT(dataLoaded()));
+  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
   connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
+
+  connect(this,
+          SIGNAL(updateRunButton(bool, std::string const &, QString const &,
+                                 QString const &)),
+          this,
+          SLOT(updateRunButton(bool, std::string const &, QString const &,
+                               QString const &)));
 }
 
 //----------------------------------------------------------------------------------------------
@@ -134,6 +142,11 @@ void IndirectTransmission::instrumentSet() {
 }
 
 /**
+ * Handle when Run is clicked
+ */
+void IndirectTransmission::runClicked() { runTab(); }
+
+/**
  * Handle saving of workspace
  */
 void IndirectTransmission::saveClicked() {
@@ -154,5 +167,35 @@ void IndirectTransmission::plotClicked() {
   if (checkADSForPlotSaveWorkspace(outputWs.toStdString(), true))
     plotSpectrum(outputWs);
 }
+
+void IndirectTransmission::setRunEnabled(bool enabled) {
+  m_uiForm.pbRun->setEnabled(enabled);
+}
+
+void IndirectTransmission::setPlotEnabled(bool enabled) {
+  m_uiForm.pbPlot->setEnabled(enabled);
+}
+
+void IndirectTransmission::setSaveEnabled(bool enabled) {
+  m_uiForm.pbSave->setEnabled(enabled);
+}
+
+void IndirectTransmission::setOutputButtonsEnabled(
+    std::string const &enableOutputButtons) {
+  bool enable = enableOutputButtons == "enable" ? true : false;
+  setPlotEnabled(enable);
+  setSaveEnabled(enable);
+}
+
+void IndirectTransmission::updateRunButton(
+    bool enabled, std::string const &enableOutputButtons, QString const message,
+    QString const tooltip) {
+  setRunEnabled(enabled);
+  m_uiForm.pbRun->setText(message);
+  m_uiForm.pbRun->setToolTip(tooltip);
+  if (enableOutputButtons != "unchanged")
+    setOutputButtonsEnabled(enableOutputButtons);
+}
+
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/IndirectTransmission.h
+++ b/qt/scientific_interfaces/Indirect/IndirectTransmission.h
@@ -39,8 +39,19 @@ private slots:
   void previewPlot();
   void transAlgDone(bool error);
   void instrumentSet();
+
+  void runClicked();
   void plotClicked();
   void saveClicked();
+
+  void setRunEnabled(bool enabled);
+  void setPlotEnabled(bool enabled);
+  void setSaveEnabled(bool enabled);
+  void setOutputButtonsEnabled(std::string const &enableOutputButtons);
+  void updateRunButton(bool enabled = true,
+                       std::string const &enableOutputButtons = "unchanged",
+                       QString const message = "Run",
+                       QString const tooltip = "");
 
 private:
   Ui::IndirectTransmission m_uiForm;

--- a/qt/scientific_interfaces/Indirect/IndirectTransmission.h
+++ b/qt/scientific_interfaces/Indirect/IndirectTransmission.h
@@ -52,6 +52,7 @@ private slots:
                        std::string const &enableOutputButtons = "unchanged",
                        QString const message = "Run",
                        QString const tooltip = "");
+  void setPlotIsPlotting(bool plotting);
 
 private:
   Ui::IndirectTransmission m_uiForm;

--- a/qt/scientific_interfaces/Indirect/IndirectTransmission.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectTransmission.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>514</width>
-    <height>360</height>
+    <width>525</width>
+    <height>402</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -122,6 +122,54 @@
          <bool>true</bool>
         </property>
        </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gbRun">
+     <property name="title">
+      <string>Run</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>7</number>
+      </property>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>197</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pbRun">
+        <property name="text">
+         <string>Run</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>197</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
       </item>
      </layout>
     </widget>

--- a/qt/scientific_interfaces/Indirect/IndirectTransmission.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectTransmission.ui
@@ -153,6 +153,18 @@
       </item>
       <item>
        <widget class="QPushButton" name="pbRun">
+        <property name="minimumSize">
+         <size>
+          <width>150</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>180</width>
+          <height>16777215</height>
+         </size>
+        </property>
         <property name="text">
          <string>Run</string>
         </property>


### PR DESCRIPTION
**Description of work.**
This PR moves the Run button on the Data Reduction interface so that it is above the output options in order to remain consistent with other interfaces.
This PR also ensures the output options (Plot and Save) are disabled while the interface is running, as well as the Run button.
The Plot, Save and Run buttons are also now disabled while plotting is taking place.

**To test:**
1. `Interfaces`->`Indirect`->`Data Reduction`
2. Check that the Run button has been moved to above the output options on all of the tabs
3. Enter the data below
4. Click `Run` and make sure that Run, Plot and Save options are all disabled and then re-enabled once the running is complete.
5. Click `Plot` and make sure the Run, Plot and Save options are all disabled and then re-enabled once the plotting is complete

**Test Data**

**ISISEnergyTransfer:**
Use run-number `26176`
**ISISCalibration:**
Use run-number `26176`
**ISISDiagnostics:**
Use run-number `26176`
**Transmission**
Sample: run number `26176`
Container: run number `26174`
**Symmetrise**
Input File: [irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2486896/irs26176_graphite002_red.zip)
Move the vertical lines on the graph slightly towards 0
Click `Preview`, then click `Run`
**S(Q,w)**
Input File: [irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2486896/irs26176_graphite002_red.zip)
QLow: 0.45                      
QWidth: 0.05                     
QHigh: 1.6
ELow: -0.5                      
EWidth: 0.005                     
EHigh: 0.5
Note that the run button is disabled for this tab when running, however it may appear that it isn't.
**Moments**
Input File: [iris26176_graphite002_sqw.zip](https://github.com/mantidproject/mantid/files/2486919/iris26176_graphite002_sqw.zip)

Fixes #23774 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
