### PR TITLE
Learning peak shapes for SCD Profile fitting

### DIFF
--- a/Framework/CurveFitting/src/Constraints/BoundaryConstraint.cpp
+++ b/Framework/CurveFitting/src/Constraints/BoundaryConstraint.cpp
@@ -25,13 +25,13 @@ using namespace API;
 
 /// Default constructor
 BoundaryConstraint::BoundaryConstraint()
-    : API::IConstraint(), m_penaltyFactor(1000.0), m_hasLowerBound(false),
+    : API::IConstraint(), m_penaltyFactor(10000000.0), m_hasLowerBound(false),
       m_hasUpperBound(false), m_lowerBound(DBL_MAX), m_upperBound(-DBL_MAX) {}
 
 /// Constructor with no boundary arguments
 /// @param paramName :: The parameter name
 BoundaryConstraint::BoundaryConstraint(const std::string &paramName)
-    : API::IConstraint(), m_penaltyFactor(1000.0), m_hasLowerBound(false),
+    : API::IConstraint(), m_penaltyFactor(10000000.0), m_hasLowerBound(false),
       m_hasUpperBound(false) {
   UNUSED_ARG(paramName);
 }
@@ -49,7 +49,7 @@ BoundaryConstraint::BoundaryConstraint(API::IFunction *fun,
                                        const std::string paramName,
                                        const double lowerBound,
                                        const double upperBound, bool isDefault)
-    : m_penaltyFactor(1000.0), m_hasLowerBound(true), m_hasUpperBound(true),
+    : m_penaltyFactor(10000000.0), m_hasLowerBound(true), m_hasUpperBound(true),
       m_lowerBound(lowerBound), m_upperBound(upperBound) {
   reset(fun, fun->parameterIndex(paramName), isDefault);
 }
@@ -57,7 +57,7 @@ BoundaryConstraint::BoundaryConstraint(API::IFunction *fun,
 BoundaryConstraint::BoundaryConstraint(API::IFunction *fun,
                                        const std::string paramName,
                                        const double lowerBound, bool isDefault)
-    : m_penaltyFactor(1000.0), m_hasLowerBound(true), m_hasUpperBound(false),
+    : m_penaltyFactor(10000000.0), m_hasLowerBound(true), m_hasUpperBound(false),
       m_lowerBound(lowerBound), m_upperBound(-DBL_MAX) {
   reset(fun, fun->parameterIndex(paramName), isDefault);
 }

--- a/Framework/CurveFitting/src/Constraints/BoundaryConstraint.cpp
+++ b/Framework/CurveFitting/src/Constraints/BoundaryConstraint.cpp
@@ -25,13 +25,13 @@ using namespace API;
 
 /// Default constructor
 BoundaryConstraint::BoundaryConstraint()
-    : API::IConstraint(), m_penaltyFactor(10000000.0), m_hasLowerBound(false),
+    : API::IConstraint(), m_penaltyFactor(1000.0), m_hasLowerBound(false),
       m_hasUpperBound(false), m_lowerBound(DBL_MAX), m_upperBound(-DBL_MAX) {}
 
 /// Constructor with no boundary arguments
 /// @param paramName :: The parameter name
 BoundaryConstraint::BoundaryConstraint(const std::string &paramName)
-    : API::IConstraint(), m_penaltyFactor(10000000.0), m_hasLowerBound(false),
+    : API::IConstraint(), m_penaltyFactor(1000.0), m_hasLowerBound(false),
       m_hasUpperBound(false) {
   UNUSED_ARG(paramName);
 }
@@ -49,7 +49,7 @@ BoundaryConstraint::BoundaryConstraint(API::IFunction *fun,
                                        const std::string paramName,
                                        const double lowerBound,
                                        const double upperBound, bool isDefault)
-    : m_penaltyFactor(10000000.0), m_hasLowerBound(true), m_hasUpperBound(true),
+    : m_penaltyFactor(1000.0), m_hasLowerBound(true), m_hasUpperBound(true),
       m_lowerBound(lowerBound), m_upperBound(upperBound) {
   reset(fun, fun->parameterIndex(paramName), isDefault);
 }
@@ -57,7 +57,7 @@ BoundaryConstraint::BoundaryConstraint(API::IFunction *fun,
 BoundaryConstraint::BoundaryConstraint(API::IFunction *fun,
                                        const std::string paramName,
                                        const double lowerBound, bool isDefault)
-    : m_penaltyFactor(10000000.0), m_hasLowerBound(true), m_hasUpperBound(false),
+    : m_penaltyFactor(1000.0), m_hasLowerBound(true), m_hasUpperBound(false),
       m_lowerBound(lowerBound), m_upperBound(-DBL_MAX) {
   reset(fun, fun->parameterIndex(paramName), isDefault);
 }

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
@@ -207,7 +207,7 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
             peaksToFit = peaksToFit[runNumbers[peaksToFit]==sampleRun]
 
             # Initialize our strong peaks dictionary.  Set BVG Params to be None so that we fall back on
-            # instrument defaults until we have fit >=100 peaks.
+            # instrument defaults until we have fit >=30 peaks.
             strongPeakParams = np.empty([numPeaksCanFit, 9])
             sigX0Params, sigY0, sigP0Params = None, None, None
 

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
@@ -308,6 +308,7 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
 
             except:
                 #raise
+                logger.warning('Error fitting peak number ' + str(peakNumber))
                 peak.setIntensity(0.0)
                 peak.setSigmaIntensity(1.0)
 

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
@@ -97,8 +97,6 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
     def PyExec(self):
         import ICCFitTools as ICCFT
         import BVGFitTools as BVGFT
-        reload(ICCFT)
-        reload(BVGFT)
         from mantid.simpleapi import LoadIsawUB
         import pickle
         from scipy.ndimage.filters import convolve

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
@@ -242,6 +242,8 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
                     strongPeakParamsToSend = strongPeakParams
 
                 # Will allow forced weak and edge peaks to be fit using a neighboring peak profile
+                print(sigX0Params, sigY0)
+
                 Y3D, goodIDX, pp_lambda, params = BVGFT.get3DPeak(peak, peaks_ws, box, padeCoefficients,qMask,
                                                                   nTheta=nTheta, nPhi=nPhi, plotResults=False,
                                                                   zBG=zBG,fracBoxToHistogram=1.0,bgPolyOrder=1,
@@ -319,7 +321,7 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
                 raise
 
             except:
-                #raise
+                raise
                 logger.warning('Error fitting peak number ' + str(peakNumber))
                 peak.setIntensity(0.0)
                 peak.setSigmaIntensity(1.0)

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
@@ -292,7 +292,7 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
                         qPeak = peak.getQLabFrame()
                         theta = np.arctan2(qPeak[2], np.hypot(qPeak[0],qPeak[1])) #2theta
                         try:
-                            p = mtd['fitSigX0_Parameters'].column(1)[:-1]
+                            p = mtd['__fitSigX0_Parameters'].column(1)[:-1]
                             tol = 0.2 #We should have a good idea now - only allow 20% variation
                         except:
                             p = peaks_ws.getInstrument().getStringParameter("sigSC0Params")

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
@@ -41,8 +41,6 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
                              direction=Direction.Input),
                              doc='PeaksWorkspace with peaks to be integrated.')
 
-        self.declareProperty("RunNumber", defaultValue=0,
-                             doc="Run Number to integrate")
         self.declareProperty(FileProperty(name="UBFile",defaultValue="",action=FileAction.OptionalLoad,
                              extensions=[".mat"]),
                              doc="File containing the UB Matrix in ISAW format. Leave blank to use loaded UB Matrix.")
@@ -65,98 +63,9 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
         self.declareProperty("DQMax", defaultValue=0.15, doc="Largest total side length (in Angstrom) to consider for profile fitting.")
         self.declareProperty("PeakNumber", defaultValue=-1,  doc="Which Peak to fit.  Leave negative for all.")
 
-    def getBVGInitialGuesses(self, peaks_ws, strongPeakParams_ws, minNumberPeaks=30):
-        """
-        Returns initial guesses for the BVG fit if strongPeakParams_ws contains more than
-        minNumberPeaks entries.  If not, we return all None, which will fall back to the
-        instrument defaults.
-        """
-        if strongPeakParams_ws.rowCount() > minNumberPeaks:
-            # First, along the scattering direction
-            theta = np.abs(strongPeakParams_ws.column('Theta'))
-            sigma_theta = np.abs(strongPeakParams_ws.column('SigTheta'))
-
-            CreateWorkspace(DataX=theta, DataY=sigma_theta, OutputWorkspace='__ws_bvg0_scat')
-            Fit(Function='name=UserFunction,Formula=A/2.0*(exp(((x-x0)/b))+exp( -((x-x0)/b)))+BG,A=0.0025,x0=1.54,b=1,BG=-1.26408e-15',
-                InputWorkspace='__ws_bvg0_scat', Output='__fitSigX0', StartX=np.min(theta), EndX=np.max(theta))
-            sigX0Params = mtd['__fitSigX0_Parameters'].column(1)[:-1]
-            # Second, along the azimuthal.  This is just a constant.
-            sigY0 = np.median(strongPeakParams_ws.column('SigPhi'))
-            # Finally, the interaction term.  This we just get from the instrument file.
-            try:
-                sigP0Params = peaks_ws.getInstrument().getStringParameter("sigP0Params")
-                sigP0Params = np.array(str(sigP0Params).strip('[]\'').split(),dtype=float)
-            except:
-                logger.warning('Cannot find sigP0Params.  Will use defaults.')
-                sigP0Params = [0.1460775, 1.85816592, 0.26850086, -0.00725352]
-            return sigX0Params, sigY0, sigP0Params
-        else:
-            return None, None, None
-
-    def getUBMatrix(self, peaks_ws, UBFile):
-        # Load the UB Matrix if one is not already loaded
-        if UBFile == '' and peaks_ws.sample().hasOrientedLattice():
-            logger.information("Using UB file already available in PeaksWorkspace")
-        else:
-            try:
-                from mantid.simpleapi import LoadIsawUB
-                LoadIsawUB(InputWorkspace=peaks_ws, FileName=UBFile)
-            except:
-                logger.error("peaks_ws does not have a UB matrix loaded.  Must provide a file")
-        UBMatrix = peaks_ws.sample().getOrientedLattice().getUB()
-        return UBMatrix
-
-    def PyExec(self):
-        import ICCFitTools as ICCFT
-        import BVGFitTools as BVGFT
+    def initializeStrongPeakSettings(self, strongPeaksParamsFile, peaks_ws, sampleRun, forceCutoff, edgeCutoff, numDetRows,
+                                     numDetCols):
         import pickle
-        from scipy.ndimage.filters import convolve
-        MDdata = self.getProperty('InputWorkspace').value
-        peaks_ws = self.getProperty('PeaksWorkspace').value
-        fracStop = self.getProperty('FracStop').value
-        dQMax = self.getProperty('DQMax').value
-        UBFile = self.getProperty('UBFile').value
-        padeFile = self.getProperty('ModeratorCoefficientsFile').value
-        strongPeaksParamsFile = self.getProperty('StrongPeakParamsFile').value
-        forceCutoff = self.getProperty('IntensityCutoff').value
-        edgeCutoff = self.getProperty('EdgeCutoff').value
-        peakNumberToFit = self.getProperty('PeakNumber').value
-        pplmin_frac = self.getProperty('MinpplFrac').value
-        pplmax_frac = self.getProperty('MaxpplFrac').value
-        sampleRun = self.getProperty('RunNumber').value
-
-        q_frame='lab'
-        mtd['MDdata'] = MDdata
-        zBG = 1.96
-        neigh_length_m=3
-        iccFitDict = ICCFT.parseConstraints(peaks_ws) #Contains constraints and guesses for ICC Fitting
-        padeCoefficients = ICCFT.getModeratorCoefficients(padeFile)
-
-        # There are a few instrument specific parameters that we define here.  In some cases,
-        # it may improve fitting to set tweak these parameters, but for simplicity we define these here
-        # The default values are good for MaNDi - new instruments can be added by adding a different elif
-        # statement.
-        # If you change these values or add an instrument, documentation should also be changed.
-        try:
-            numDetRows = peaks_ws.getInstrument().getIntParameter("numDetRows")[0]
-            numDetCols = peaks_ws.getInstrument().getIntParameter("numDetCols")[0]
-            nPhi = peaks_ws.getInstrument().getIntParameter("numBinsPhi")[0]
-            nTheta = peaks_ws.getInstrument().getIntParameter("numBinsTheta")[0]
-            nPhi = peaks_ws.getInstrument().getIntParameter("numBinsPhi")[0]
-            mindtBinWidth = peaks_ws.getInstrument().getNumberParameter("mindtBinWidth")[0]
-            maxdtBinWidth = peaks_ws.getInstrument().getNumberParameter("maxdtBinWidth")[0]
-            fracHKL = peaks_ws.getInstrument().getNumberParameter("fracHKL")[0]
-            dQPixel = peaks_ws.getInstrument().getNumberParameter("dQPixel")[0]
-            peakMaskSize = peaks_ws.getInstrument().getIntParameter("peakMaskSize")[0]
-        except:
-            logger.error("Cannot find all parameters in instrument parameters file.")
-            raise
-
-        UBMatrix = self.getUBMatrix(peaks_ws, UBFile)
-        dQ = np.abs(ICCFT.getDQFracHKL(UBMatrix, frac=0.5))
-        dQ[dQ>dQMax] = dQMax
-        qMask = ICCFT.getHKLMask(UBMatrix, frac=fracHKL, dQPixel=dQPixel,dQ=dQ)
-
         # Strong peak profiles - we set up the workspace and determine which peaks we'll fit.
         strongPeakKeys =  ['Phi', 'Theta', 'Scale3d', 'FitPhi', 'FitTheta', 'SigTheta', 'SigPhi', 'SigP', 'PeakNumber']
         strongPeakDatatypes = ['float']*len(strongPeakKeys)
@@ -210,8 +119,107 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
             # Initialize our strong peaks dictionary.  Set BVG Params to be None so that we fall back on
             # instrument defaults until we have fit >=30 peaks.
             strongPeakParams = np.empty([numPeaksCanFit, 9])
-            sigX0Params, sigY0, sigP0Params = None, None, None
+            #sigX0Params, sigY0, sigP0Params = None, None, None
+        peaksToFit = np.append(peaksToFit, np.where(runNumbers!=sampleRun)[0])
+        return generateStrongPeakParams, strongPeakParams, strongPeakParams_ws, needsForcedProfile,\
+            needsForcedProfileIDX, canFitProfileIDX, numPeaksCanFit, peaksToFit
 
+    def getBVGInitialGuesses(self, peaks_ws, strongPeakParams_ws, minNumberPeaks=30):
+        """
+        Returns initial guesses for the BVG fit if strongPeakParams_ws contains more than
+        minNumberPeaks entries.  If not, we return all None, which will fall back to the
+        instrument defaults.
+        """
+        if strongPeakParams_ws.rowCount() > minNumberPeaks:
+            # First, along the scattering direction
+            theta = np.abs(strongPeakParams_ws.column('Theta'))
+            sigma_theta = np.abs(strongPeakParams_ws.column('SigTheta'))
+
+            CreateWorkspace(DataX=theta, DataY=sigma_theta, OutputWorkspace='__ws_bvg0_scat')
+            Fit(Function='name=UserFunction,Formula=A/2.0*(exp(((x-x0)/b))+exp( -((x-x0)/b)))+BG,A=0.0025,x0=1.54,b=1,BG=-1.26408e-15',
+                InputWorkspace='__ws_bvg0_scat', Output='__fitSigX0', StartX=np.min(theta), EndX=np.max(theta))
+            sigX0Params = mtd['__fitSigX0_Parameters'].column(1)[:-1]
+            # Second, along the azimuthal.  This is just a constant.
+            sigY0 = np.median(strongPeakParams_ws.column('SigPhi'))
+            # Finally, the interaction term.  This we just get from the instrument file.
+            try:
+                sigP0Params = peaks_ws.getInstrument().getStringParameter("sigP0Params")
+                sigP0Params = np.array(str(sigP0Params).strip('[]\'').split(),dtype=float)
+            except:
+                logger.warning('Cannot find sigP0Params.  Will use defaults.')
+                sigP0Params = [0.1460775, 1.85816592, 0.26850086, -0.00725352]
+            return sigX0Params, sigY0, sigP0Params
+        else:
+            return None, None, None
+
+    def getUBMatrix(self, peaks_ws, UBFile):
+        # Load the UB Matrix if one is not already loaded
+        if UBFile == '' and peaks_ws.sample().hasOrientedLattice():
+            logger.information("Using UB file already available in PeaksWorkspace")
+        else:
+            try:
+                from mantid.simpleapi import LoadIsawUB
+                LoadIsawUB(InputWorkspace=peaks_ws, FileName=UBFile)
+            except:
+                logger.error("peaks_ws does not have a UB matrix loaded.  Must provide a file")
+        UBMatrix = peaks_ws.sample().getOrientedLattice().getUB()
+        return UBMatrix
+
+    def PyExec(self):
+        import ICCFitTools as ICCFT
+        import BVGFitTools as BVGFT
+        from scipy.ndimage.filters import convolve
+        MDdata = self.getProperty('InputWorkspace').value
+        peaks_ws = self.getProperty('PeaksWorkspace').value
+        fracStop = self.getProperty('FracStop').value
+        dQMax = self.getProperty('DQMax').value
+        UBFile = self.getProperty('UBFile').value
+        padeFile = self.getProperty('ModeratorCoefficientsFile').value
+        strongPeaksParamsFile = self.getProperty('StrongPeakParamsFile').value
+        forceCutoff = self.getProperty('IntensityCutoff').value
+        edgeCutoff = self.getProperty('EdgeCutoff').value
+        peakNumberToFit = self.getProperty('PeakNumber').value
+        pplmin_frac = self.getProperty('MinpplFrac').value
+        pplmax_frac = self.getProperty('MaxpplFrac').value
+        sampleRun = peaks_ws.getPeak(0).getRunNumber()
+
+        q_frame='lab'
+        mtd['MDdata'] = MDdata
+        zBG = 1.96
+        neigh_length_m=3
+        iccFitDict = ICCFT.parseConstraints(peaks_ws) #Contains constraints and guesses for ICC Fitting
+        padeCoefficients = ICCFT.getModeratorCoefficients(padeFile)
+
+        # There are a few instrument specific parameters that we define here.  In some cases,
+        # it may improve fitting to set tweak these parameters, but for simplicity we define these here
+        # The default values are good for MaNDi - new instruments can be added by adding a different elif
+        # statement.
+        # If you change these values or add an instrument, documentation should also be changed.
+        try:
+            numDetRows = peaks_ws.getInstrument().getIntParameter("numDetRows")[0]
+            numDetCols = peaks_ws.getInstrument().getIntParameter("numDetCols")[0]
+            nPhi = peaks_ws.getInstrument().getIntParameter("numBinsPhi")[0]
+            nTheta = peaks_ws.getInstrument().getIntParameter("numBinsTheta")[0]
+            nPhi = peaks_ws.getInstrument().getIntParameter("numBinsPhi")[0]
+            mindtBinWidth = peaks_ws.getInstrument().getNumberParameter("mindtBinWidth")[0]
+            maxdtBinWidth = peaks_ws.getInstrument().getNumberParameter("maxdtBinWidth")[0]
+            fracHKL = peaks_ws.getInstrument().getNumberParameter("fracHKL")[0]
+            dQPixel = peaks_ws.getInstrument().getNumberParameter("dQPixel")[0]
+            peakMaskSize = peaks_ws.getInstrument().getIntParameter("peakMaskSize")[0]
+        except:
+            logger.error("Cannot find all parameters in instrument parameters file.")
+            raise
+
+        UBMatrix = self.getUBMatrix(peaks_ws, UBFile)
+        dQ = np.abs(ICCFT.getDQFracHKL(UBMatrix, frac=0.5))
+        dQ[dQ>dQMax] = dQMax
+        qMask = ICCFT.getHKLMask(UBMatrix, frac=fracHKL, dQPixel=dQPixel,dQ=dQ)
+
+        generateStrongPeakParams, strongPeakParams, strongPeakParams_ws, needsForcedProfile, \
+            needsForcedProfileIDX, canFitProfileIDX, numPeaksCanFit, peaksToFit = \
+            self.initializeStrongPeakSettings(strongPeaksParamsFile, peaks_ws, sampleRun, forceCutoff, edgeCutoff, numDetRows,
+                                              numDetCols)
+        
         if peakNumberToFit>-1:
             peaksToFit = [peakNumberToFit]
 
@@ -233,6 +241,10 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
         for fitNumber, peakNumber in enumerate(peaksToFit):#range(peaks_ws.getNumberPeaks()):
             peak = peaks_ws_out.getPeak(peakNumber)
             progress.report(' ')
+            if peak.getRunNumber() != MDdata.getExperimentInfo(0).getRunNumber():
+                logger.warning('Peak number %i has run number %i but MDWorkspace is from run number %i.  Skipping this peak.'%(
+                                           peakNumber, peak.getRunNumber(), MDdata.getExperimentInfo(0).getRunNumber()))
+                continue
             try:
                 box = ICCFT.getBoxFracHKL(peak, peaks_ws, MDdata, UBMatrix, peakNumber,
                                           dQ, fracHKL=0.5, dQPixel=dQPixel, q_frame=q_frame)
@@ -318,6 +330,7 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
                 raise
 
             except:
+                #raise
                 logger.warning('Error fitting peak number ' + str(peakNumber))
                 peak.setIntensity(0.0)
                 peak.setSigmaIntensity(1.0)

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
@@ -78,8 +78,8 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
 
             CreateWorkspace(DataX=theta, DataY=sigma_theta, OutputWorkspace='__ws_bvg0_scat')
             Fit(Function='name=UserFunction,Formula=A/2.0*(exp(((x-x0)/b))+exp( -((x-x0)/b)))+BG,A=0.0025,x0=1.54,b=1,BG=-1.26408e-15',
-                InputWorkspace='__ws_bvg0_scat', Output='fitSigX0', StartX=np.min(theta), EndX=np.max(theta))
-            sigX0Params = mtd['fitSigX0_Parameters'].column(1)[:-1]
+                InputWorkspace='__ws_bvg0_scat', Output='__fitSigX0', StartX=np.min(theta), EndX=np.max(theta))
+            sigX0Params = mtd['__fitSigX0_Parameters'].column(1)[:-1]
             # Second, along the azimuthal.  This is just a constant.
             sigY0 = np.median(strongPeakParams_ws.column('SigPhi'))
             # Finally, the interaction term.  This we just get from the instrument file.
@@ -253,7 +253,6 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
                                                                   peakMaskSize=peakMaskSize,
                                                                   iccFitDict=iccFitDict, sigX0Params=sigX0Params,
                                                                   sigY0=sigY0, sigP0Params=sigP0Params)
-                print(pp_lambda, '=pp_lambda')
                 # First we get the peak intensity
                 peakIDX = Y3D/Y3D.max() > fracStop
                 intensity = np.sum(Y3D[peakIDX])

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
@@ -77,7 +77,7 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
             sigma_theta = np.abs(strongPeakParams_ws.column('SigTheta'))
 
             CreateWorkspace(DataX=theta, DataY=sigma_theta, OutputWorkspace='__ws_bvg0_scat')
-            Fit(Function='name=UserFunction,Formula=A*(exp(((x-x0)/b))+exp( -((x-x0)/b)))+BG,A=0.0025,x0=1.54,b=1,BG=-1.26408e-15',
+            Fit(Function='name=UserFunction,Formula=A/2.0*(exp(((x-x0)/b))+exp( -((x-x0)/b)))+BG,A=0.0025,x0=1.54,b=1,BG=-1.26408e-15',
                 InputWorkspace='__ws_bvg0_scat', Output='fitSigX0', StartX=np.min(theta), EndX=np.max(theta))
             sigX0Params = mtd['fitSigX0_Parameters'].column(1)[:-1]
             # Second, along the azimuthal.  This is just a constant.
@@ -242,8 +242,6 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
                     strongPeakParamsToSend = strongPeakParams
 
                 # Will allow forced weak and edge peaks to be fit using a neighboring peak profile
-                print(sigX0Params, sigY0)
-
                 Y3D, goodIDX, pp_lambda, params = BVGFT.get3DPeak(peak, peaks_ws, box, padeCoefficients,qMask,
                                                                   nTheta=nTheta, nPhi=nPhi, plotResults=False,
                                                                   zBG=zBG,fracBoxToHistogram=1.0,bgPolyOrder=1,
@@ -255,7 +253,7 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
                                                                   peakMaskSize=peakMaskSize,
                                                                   iccFitDict=iccFitDict, sigX0Params=sigX0Params,
                                                                   sigY0=sigY0, sigP0Params=sigP0Params)
-
+                print(pp_lambda, '=pp_lambda')
                 # First we get the peak intensity
                 peakIDX = Y3D/Y3D.max() > fracStop
                 intensity = np.sum(Y3D[peakIDX])
@@ -321,7 +319,7 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
                 raise
 
             except:
-                raise
+                #raise
                 logger.warning('Error fitting peak number ' + str(peakNumber))
                 peak.setIntensity(0.0)
                 peak.setSigmaIntensity(1.0)

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
@@ -219,7 +219,7 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
             needsForcedProfileIDX, canFitProfileIDX, numPeaksCanFit, peaksToFit = \
             self.initializeStrongPeakSettings(strongPeaksParamsFile, peaks_ws, sampleRun, forceCutoff, edgeCutoff, numDetRows,
                                               numDetCols)
-        
+
         if peakNumberToFit>-1:
             peaksToFit = [peakNumberToFit]
 

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
@@ -68,6 +68,8 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
     def PyExec(self):
         import ICCFitTools as ICCFT
         import BVGFitTools as BVGFT
+        reload(ICCFT)
+        reload(BVGFT)
         from mantid.simpleapi import LoadIsawUB
         import pickle
         from scipy.ndimage.filters import convolve

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
@@ -93,7 +93,7 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
         else:
             return None, None, None
 
-    def getUBMatrix(peaks_ws, UBFile):
+    def getUBMatrix(self, peaks_ws, UBFile):
         # Load the UB Matrix if one is not already loaded
         if UBFile == '' and peaks_ws.sample().hasOrientedLattice():
             logger.information("Using UB file already available in PeaksWorkspace")
@@ -152,7 +152,7 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
             logger.error("Cannot find all parameters in instrument parameters file.")
             raise
 
-        UBMatrix = getUBMatrix(peaks_ws, UBFile)
+        UBMatrix = self.getUBMatrix(peaks_ws, UBFile)
         dQ = np.abs(ICCFT.getDQFracHKL(UBMatrix, frac=0.5))
         dQ[dQ>dQMax] = dQMax
         qMask = ICCFT.getHKLMask(UBMatrix, frac=fracHKL, dQPixel=dQPixel,dQ=dQ)

--- a/docs/source/algorithms/IntegratePeaksProfileFitting-v1.rst
+++ b/docs/source/algorithms/IntegratePeaksProfileFitting-v1.rst
@@ -115,7 +115,8 @@ The strong peaks library can be generated in two ways.  First, it can be provide
 The **StrongPeakParamsFile** should be a .pkl file which contains a Numpy array containing the parameters used for strong peaks.
 Alternatively, if no file is provided, the algorithm will go through and fit strong peaks first, building the strong peaks library
 as it goes.  After fitting all of the strong peaks, defined as peaks with spherical intensities above **IntensityCutoff** and further 
-than **EdgeCutoff** pixels from the edge, it will fit weak peaks using those profiles. 
+than **EdgeCutoff** pixels from the edge, it will fit weak peaks using those profiles. For initial guesses, the algorithm will fit
+the first 30 peaks using the instrument default parameters.  After that, it will use already fit peaks to determine initial guesses.
 
 Integrating the Model
 #####################

--- a/docs/source/algorithms/IntegratePeaksProfileFitting-v1.rst
+++ b/docs/source/algorithms/IntegratePeaksProfileFitting-v1.rst
@@ -28,7 +28,8 @@ The algorithms takes two input workspaces:
    This would be the output of
    :ref:`algm-ConvertToMD`.
 -  As well as a PeaksWorkspace containing single-crystal peak locations.
-   This could be the output of :ref:`algm-FindPeaksMD` or :ref:`algm-PredictPeaks`
+   This could be the output of :ref:`algm-FindPeaksMD` or :ref:`algm-PredictPeaks`.  All peaks should
+   be from the same run.
 -  The OutputPeaksWorkspace will contain a copy of the input PeaksWorkspace,
    with the integrated intensities and errors changed.
 -  The OutputParamsWorkspace is a TableWorkspace containing the fit parameters.
@@ -46,11 +47,11 @@ values are below:
 | Parameter    |  Description               |  MaNDi   |  TOPAZ   | CORELLI |
 +==============+============================+==========+==========+=========+
 | DQPixel      | The side length for each   |          |          |         |
-|              | voxel used for fitting.    | 0.003    | 0.01     | 0.007   |
+|              | voxel used for fitting.    | 0.003    | 0.006    | 0.007   |
 |              | Units: 1/Angstrom          |          |          |         |
 +--------------+----------------------------+----------+----------+---------+
 | FracHKL      | The distance between peaks |          |          |         |
-|              | (in fraction of hkl) that  | 0.4      | 0.4      | 0.4     |
+|              | (in fraction of hkl) that  | 0.25     | 0.25     | 0.25    |
 |              | is used for fitting.       |          |          |         |
 +--------------+----------------------------+----------+----------+---------+
 | MinDtBinWidth| The smallest time bin used |          |          |         |
@@ -157,7 +158,7 @@ Usage
     LoadIsawPeaks(Filename='/SNS/MANDI/shared/ProfileFitting/demo_5921.integrate', OutputWorkspace='peaks_ws')
 
     IntegratePeaksProfileFitting(OutputPeaksWorkspace='peaks_ws_out', OutputParamsWorkspace='params_ws',
-            InputWorkspace='MANDI_5921_md', PeaksWorkspace='peaks_ws', RunNumber=5921,
+            InputWorkspace='MANDI_5921_md', PeaksWorkspace='peaks_ws',
             UBFile='/SNS/MANDI/shared/ProfileFitting/demo_5921.mat', MinpplFrac=0.9, MaxpplFrac=1.1,
             ModeratorCoefficientsFile='/SNS/MANDI/shared/ProfileFitting/franz_coefficients_2017.dat',
             StrongPeakParamsFile='/SNS/MANDI/shared/ProfileFitting/strongPeakParams_beta_lac_mut_mbvg.pkl',

--- a/docs/source/release/v3.14.0/diffraction.rst
+++ b/docs/source/release/v3.14.0/diffraction.rst
@@ -21,7 +21,7 @@ Improvements
 - :ref:`AlignAndFocusPowder <algm-AlignAndFocusPowder>` and :ref:`AlignAndFocusPowderFromFiles <algm-AlignAndFocusPowderFromFiles>` now support outputting the unfocussed data and weighted events (with time). This allows for event filtering **after** processing the data.
 - :ref:`LoadWAND <algm-LoadWAND>` has grouping option added and loads faster
 - Mask workspace option added to :ref:`WANDPowderReduction <algm-WANDPowderReduction>`
-
+- :ref:`Le Bail concept page <Le Bail Fit>` moved from mediawiki
 
 Single Crystal Diffraction
 --------------------------
@@ -29,10 +29,12 @@ Single Crystal Diffraction
 Improvements
 ############
 
-- :ref:`IntegratePeaksProfileFitting <algm-IntegratePeaksProfileFitting>` now supports MaNDi, TOPAZ, and CORELLI. Other instruments can easily be added as well.  In addition, the algorithm can now automatically generate a strong peaks library is one is not provided.
+- :ref:`IntegratePeaksProfileFitting <algm-IntegratePeaksProfileFitting>` now supports MaNDi, TOPAZ, and CORELLI. Other instruments can easily be added as well.  In addition, the algorithm can now automatically generate a strong peaks library is one is not provided.  Peakshapes will be learned to improve initial guesses as the strong peak library is generated.
 - :ref:`MDNormSCD <algm-MDNormSCD>` now can handle merged MD workspaces.
 - :ref:`StartLiveData <algm-StartLiveData>` will load "live"
   data streaming from TOPAZ new Adara data server.
+- :ref:`IntegratePeaksMD <algm-IntegratePeaksMD>` with Cylinder=True now has improved fits using BackToBackExponential and IkedaCarpenterPV functions.
+- :ref:`SaveIsawPeaks <algm-SaveIsawPeaks>` now has option to renumber peaks sequentially.
 
 Bugfixes
 ########
@@ -40,6 +42,7 @@ Bugfixes
 - :ref:`CentroidPeaksMD <algm-CentroidPeaksMD>` now updates peak bin counts.
 
 - :ref:`FindPeaksMD <algm-FindPeaksMD>` now finds peaks correctly with the crystallography convention setting and reduction with crystallography convention is tested with a system test.
+- :ref:`SaveIsawPeaks <algm-SaveIsawPeaks>` does not have duplicate peak numbers when saving PeaksWorkspaces with more than one RunNumber.
 
 Powder Diffraction
 ------------------

--- a/instrument/CORELLI_Parameters.xml
+++ b/instrument/CORELLI_Parameters.xml
@@ -80,27 +80,6 @@
      <value val="0.1460775 1.85816592 0.26850086 -0.00725352" />
     </parameter>
 
-    <!-- Constraints for ICC fitting.  Valid names are iccA, iccB, iccR, iccT0, iccScale0
-         iccHatWidth and iccKConv.  Inputs are strings with values separated by
-         spaces which are prased by the IntegratePeaksProfileFitting algorithm.  
-         If two values are given they are treated as the lower and upper bounds. If 
-         three are given they are the lower bound, upper bound, and initial guess.-->
-    <parameter name="iccA" type="string">
-     <value val="0.25 0.75 0.5" />
-    </parameter>
-
-    <parameter name="iccB" type="string">
-     <value val="0.001 0.3 0.005" />
-    </parameter>
-
-    <parameter name="iccR" type="string">
-     <value val="0.05 0.15 0.1" />
-    </parameter>
-
-    <parameter name="iccKConv" type="string">
-     <value val="10.0 800.0 100.0" />
-    </parameter>
-
   </component-link>
 
 </parameter-file>

--- a/instrument/CORELLI_Parameters.xml
+++ b/instrument/CORELLI_Parameters.xml
@@ -75,6 +75,21 @@
      <value val="10" />
     </parameter>
 
+    <!-- Initial guess parameters for coshPeakWidthModel -->
+    <parameter name="sigSC0Params" type="string">
+     <value val="0.00413132 1.54103839 1.0 -0.00266634" />
+    </parameter>
+
+    <!-- Initial guess for sigma along the azimuthal direction (rad) -->
+    <parameter name="sigAZ0">
+     <value val="0.0025" />
+    </parameter>
+
+    <!-- Initial guess parameters for fsigP (BVG covariance) -->
+    <parameter name="sigP0Params" type="string">
+     <value val="0.1460775 1.85816592 0.26850086 -0.00725352" />
+    </parameter>
+
     <!-- Constraints for ICC fitting.  Valid names are iccA, iccB, iccR, iccT0, iccScale0
          iccHatWidth and iccKConv.  Inputs are strings with values separated by
          spaces which are prased by the IntegratePeaksProfileFitting algorithm.  

--- a/instrument/CORELLI_Parameters.xml
+++ b/instrument/CORELLI_Parameters.xml
@@ -20,16 +20,6 @@
      <value val="true"/>
     </parameter>
 
-    <!-- Multiplier for profile fitting for BVG polar angle -->
-    <parameter name="sigX0Scale">
-     <value val="2." />
-    </parameter>
-
-    <!-- Multiplier for profile fitting for BVG azimuthal angle -->
-    <parameter name="sigY0Scale">
-     <value val="2." />
-    </parameter>
-
     <!-- Number of rows between detector gaps for profile fitting -->
     <parameter name="numDetRows" type="int">
      <value val="255" />
@@ -52,7 +42,7 @@
 
     <!-- Fraction along (h,k,l) to use for profile fitting. 0.5 is the next peak. -->
     <parameter name="fracHKL">
-     <value val="0.4" />
+     <value val="0.25" />
     </parameter>
 
     <!-- Side length of each voxel for fitting in units of angstrom^-1 -->

--- a/instrument/MANDI_Parameters.xml
+++ b/instrument/MANDI_Parameters.xml
@@ -68,6 +68,21 @@
  <value val="5" />
 </parameter>
 
+<!-- Initial guess parameters for coshPeakWidthModel -->
+<parameter name="sigSC0Params" type="string">
+ <value val="0.00413132 1.54103839 1.0 -0.00266634" />
+</parameter>
+
+<!-- Initial guess for sigma along the azimuthal direction (rad) -->
+<parameter name="sigAZ0">
+ <value val="0.0025" />
+</parameter>
+
+<!-- Initial guess parameters for fsigP (BVG covariance) -->
+<parameter name="sigP0Params" type="string">
+ <value val="0.1460775 1.85816592 0.26850086 -0.00725352" />
+</parameter>
+
 </component-link>
 
 </parameter-file>

--- a/instrument/MANDI_Parameters.xml
+++ b/instrument/MANDI_Parameters.xml
@@ -45,7 +45,7 @@
 
 <!-- Fraction along (h,k,l) to use for profile fitting. 0.5 is the next peak. -->
 <parameter name="fracHKL">
- <value val="0.4" />
+ <value val="0.25" />
 </parameter>
 
 <!-- Side length of each voxel for fitting in units of angstrom^-1 -->

--- a/instrument/MANDI_Parameters_2015_08_01.xml
+++ b/instrument/MANDI_Parameters_2015_08_01.xml
@@ -67,5 +67,20 @@
  <value val="5" />
 </parameter>
 
+<!-- Initial guess parameters for coshPeakWidthModel -->
+<parameter name="sigSC0Params" type="string">
+ <value val="0.00413132 1.54103839 1.0 -0.00266634" />
+</parameter>
+
+<!-- Initial guess for sigma along the azimuthal direction (rad) -->
+<parameter name="sigAZ0">
+ <value val="0.0025" />
+</parameter>
+
+<!-- Initial guess parameters for fsigP (BVG covariance) -->
+<parameter name="sigP0Params" type="string">
+ <value val="0.1460775 1.85816592 0.26850086 -0.00725352" />
+</parameter>
+
 </component-link>
 </parameter-file>

--- a/instrument/MANDI_Parameters_2015_08_01.xml
+++ b/instrument/MANDI_Parameters_2015_08_01.xml
@@ -44,7 +44,7 @@
 
 <!-- Fraction along (h,k,l) to use for profile fitting. 0.5 is the next peak. -->
 <parameter name="fracHKL">
- <value val="0.4" />
+ <value val="0.25" />
 </parameter>
 
 <!-- Side length of each voxel for fitting in units of angstrom^-1 -->

--- a/instrument/MANDI_Parameters_2016_02_01.xml
+++ b/instrument/MANDI_Parameters_2016_02_01.xml
@@ -67,5 +67,20 @@
  <value val="5" />
 </parameter>
 
+<!-- Initial guess parameters for coshPeakWidthModel -->
+<parameter name="sigSC0Params" type="string">
+ <value val="0.00413132 1.54103839 1.0 -0.00266634" />
+</parameter>
+
+<!-- Initial guess for sigma along the azimuthal direction (rad) -->
+<parameter name="sigAZ0">
+ <value val="0.0025" />
+</parameter>
+
+<!-- Initial guess parameters for fsigP (BVG covariance) -->
+<parameter name="sigP0Params" type="string">
+ <value val="0.1460775 1.85816592 0.26850086 -0.00725352" />
+</parameter>
+
 </component-link>
 </parameter-file>

--- a/instrument/MANDI_Parameters_2016_02_01.xml
+++ b/instrument/MANDI_Parameters_2016_02_01.xml
@@ -44,7 +44,7 @@
 
 <!-- Fraction along (h,k,l) to use for profile fitting. 0.5 is the next peak. -->
 <parameter name="fracHKL">
- <value val="0.4" />
+ <value val="0.25" />
 </parameter>
 
 <!-- Side length of each voxel for fitting in units of angstrom^-1 -->

--- a/instrument/TOPAZ_Parameters.xml
+++ b/instrument/TOPAZ_Parameters.xml
@@ -121,12 +121,12 @@ detScale={13:1.046504,14:1.259293,16:1.02449,17:1.18898,18:0.88014,19:0.98665,\
 
 <!-- Fraction along (h,k,l) to use for profile fitting. 0.5 is the next peak. -->
 <parameter name="fracHKL">
- <value val="0.4" />
+ <value val="0.25" />
 </parameter>
 
 <!-- Side length of each voxel for fitting in units of angstrom^-1 -->
 <parameter name="dQPixel">
- <value val="0.01" />
+ <value val="0.006" />
 </parameter>
 
 <!-- Minimum spacing for profile fitting the TOF profile. Units of microseconds -->
@@ -141,7 +141,7 @@ detScale={13:1.046504,14:1.259293,16:1.02449,17:1.18898,18:0.88014,19:0.98665,\
 
 <!-- Size of peak mask for background calculation in units of dQPixel -->
 <parameter name="peakMaskSize" type="int">
- <value val="15" />
+ <value val="6" />
 </parameter>
 
 <!-- Initial guess parameters for coshPeakWidthModel -->

--- a/instrument/TOPAZ_Parameters.xml
+++ b/instrument/TOPAZ_Parameters.xml
@@ -164,15 +164,11 @@ detScale={13:1.046504,14:1.259293,16:1.02449,17:1.18898,18:0.88014,19:0.98665,\
      spaces which are prased by the IntegratePeaksProfileFitting algorithm.  
      If two values are given they are treated as the lower and upper bounds. If 
      three are given they are the lower bound, upper bound, and initial guess.-->
-<parameter name="iccB" type="string">
- <value val="0.001 0.3 0.005" />
-</parameter>
 
 <parameter name="iccKConv" type="string">
  <value val="10.0 800.0 100.0" />
 </parameter>
 </component-link>
-
 
 
 </parameter-file>

--- a/instrument/TOPAZ_Parameters.xml
+++ b/instrument/TOPAZ_Parameters.xml
@@ -144,6 +144,21 @@ detScale={13:1.046504,14:1.259293,16:1.02449,17:1.18898,18:0.88014,19:0.98665,\
  <value val="15" />
 </parameter>
 
+<!-- Initial guess parameters for coshPeakWidthModel -->
+<parameter name="sigSC0Params" type="string">
+ <value val="0.00413132 1.54103839 1.0 -0.00266634" />
+</parameter>
+
+<!-- Initial guess for sigma along the azimuthal direction (rad) -->
+<parameter name="sigAZ0">
+ <value val="0.0025" />
+</parameter>
+
+<!-- Initial guess parameters for fsigP (BVG covariance) -->
+<parameter name="sigP0Params" type="string">
+ <value val="0.1460775 1.85816592 0.26850086 -0.00725352" />
+</parameter>
+
 <!-- Constraints for ICC fitting.  Valid names are iccA, iccB, iccR, iccT0, iccScale0
      iccHatWidth and iccKConv.  Inputs are strings with values separated by
      spaces which are prased by the IntegratePeaksProfileFitting algorithm.  
@@ -157,6 +172,8 @@ detScale={13:1.046504,14:1.259293,16:1.02449,17:1.18898,18:0.88014,19:0.98665,\
  <value val="10.0 800.0 100.0" />
 </parameter>
 </component-link>
+
+
 
 </parameter-file>
  

--- a/scripts/SCD_Reduction/BVGFitTools.py
+++ b/scripts/SCD_Reduction/BVGFitTools.py
@@ -180,6 +180,16 @@ def get3DPeak(peak, peaks_ws, box, padeCoefficients, qMask, nTheta=150, nPhi=150
     return Y2, goodIDX, pp_lambda, retParams
 
 
+def coshPeakWidthModel(x,A,x0,b,BG):
+    """
+    coshPeakWidthModel: returns A*cosh((x-x0)/b) + BG
+    This phenomenologically describes the peak width along the scattering
+    direction.
+    """
+    y = (x-x0)/b
+    return A*(np.exp(y)+np.exp(-y)) + BG
+
+
 def boxToTOFThetaPhi(box, peak):
     QX, QY, QZ = ICCFT.getQXQYQZ(box)
     R, THETA, PHI = ICCFT.cart2sph(QX, QY, QZ)
@@ -474,10 +484,9 @@ def doBVGFit(box, nTheta=200, nPhi=200, zBG=1.96, fracBoxToHistogram=1.0, goodID
     if forceParams is None:
         meanTH = TH.mean()
         meanPH = PH.mean()
-        # sigX0 = 0.0018
-        # sigX0 = 0.002#ICCFT.oldScatFun(meanPH, 1.71151521e-02,   6.37218400e+00,   3.39439675e-03)
-        sigX0 = ICCFT.oldScatFun(
-            meanPH, 1.71151521e-02, 6.37218400e+00, 3.39439675e-03)
+        sigX0 = coshPeakWidthModel(meanPH,  0.00413132, 1.54103839, 1.0, -0.00266634) #TOPAZ
+        #sigX0 = coshPeakWidthModel(meanPH, 0.09191742, 0.41444781, 1.0, -0.17877383) #MaNDi
+        print(sigX0)
         sigY0 = 0.0025
         sigP0 = fSigP(meanTH, 0.1460775, 1.85816592,
                       0.26850086, -0.00725352)

--- a/scripts/SCD_Reduction/BVGFitTools.py
+++ b/scripts/SCD_Reduction/BVGFitTools.py
@@ -184,16 +184,16 @@ def getBVGGuesses(peaks_ws, sigX0Params, sigY0, sigP0Params):
     # If we're not given initial guesses for the BVG, then we try to find instrument defaults.  If those are not
     # available we use default values.
     if sigX0Params is None:
-        if peaks_ws.getInstrument().hasParameter("sigX0Params"):
-            sigX0Params = np.array(peaks_ws.getInstrument().getStringParameter("sigX0Params")[0].split(),dtype=float)
+        if peaks_ws.getInstrument().hasParameter("sigSC0Params"):
+            sigX0Params = np.array(peaks_ws.getInstrument().getStringParameter("sigSC0Params")[0].split(),dtype=float)
         else:
             sigX0Params=[0.00413132, 1.54103839, 1.0, -0.00266634]
     
     if sigY0 is None:
-        if peaks_ws.getInstrument().hasParameter("sigY0"):
-            sigY0 = peaks_ws.getInstrument().getNumberParameter("sigY0")[0]
+        if peaks_ws.getInstrument().hasParameter("sigAZ0"):
+            sigY0 = peaks_ws.getInstrument().getNumberParameter("sigAZ0")[0]
         else:
-            sigY0=0.025
+            sigY0=0.0025
     if sigP0Params is None:
         if peaks_ws.getInstrument().hasParameter("sigP0Params"):
             sigP0Params = np.array(peaks_ws.getInstrument().getStringParameter("sigP0Params")[0].split(),dtype=float)

--- a/scripts/SCD_Reduction/BVGFitTools.py
+++ b/scripts/SCD_Reduction/BVGFitTools.py
@@ -623,7 +623,6 @@ def doBVGFit(box, nTheta=200, nPhi=200, zBG=1.96, fracBoxToHistogram=1.0, goodID
         #plt.figure(18); plt.clf(); plt.imshow(m.function2D(pos)); plt.title('BVG Initial guess')
         bvgWS = CreateWorkspace(OutputWorkspace='bvgWS', DataX=pos.ravel(), DataY=H.ravel(), DataE=np.sqrt(H.ravel()))
         fitFun = m
-        print(m)
         fitResults = Fit(Function=fitFun, InputWorkspace=bvgWS,
                          Output='bvgfit', Minimizer='Levenberg-MarquardtMD')
     # Recover the result

--- a/scripts/SCD_Reduction/BVGFitTools.py
+++ b/scripts/SCD_Reduction/BVGFitTools.py
@@ -238,6 +238,13 @@ def fitScaling(n_events, box, YTOF, YBVG, goodIDX=None, neigh_length_m=3):
                 max(fitMaxIDX[1] - dP, 0):min(fitMaxIDX[1] + dP, goodIDX.shape[1]),
                 max(fitMaxIDX[2] - dP, 0):min(fitMaxIDX[2] + dP, goodIDX.shape[2])] = True
     goodIDX = np.logical_and(goodIDX, conv_n_events > 0)
+    plt.figure(19); plt.clf()
+    plt.imshow(n_events[:,:,n_events.shape[2]//2])
+    plt.figure(20); plt.clf()
+    plt.imshow(goodIDX[:,:,n_events.shape[2]//2])
+    TOF = 1./np.sqrt(QX*QX+QY*QY+QZ*QZ)
+    plt.figure(21); plt.clf()
+    plt.imshow(TOF[:,:,n_events.shape[2]//2])
     # A1 = slope, A0 = offset
     scaleLinear = Polynomial(n=1)
     scaleLinear.constrain("A1>0")
@@ -616,9 +623,9 @@ def doBVGFit(box, nTheta=200, nPhi=200, zBG=1.96, fracBoxToHistogram=1.0, goodID
         #plt.figure(18); plt.clf(); plt.imshow(m.function2D(pos)); plt.title('BVG Initial guess')
         bvgWS = CreateWorkspace(OutputWorkspace='bvgWS', DataX=pos.ravel(), DataY=H.ravel(), DataE=np.sqrt(H.ravel()))
         fitFun = m
+        print(m)
         fitResults = Fit(Function=fitFun, InputWorkspace=bvgWS,
                          Output='bvgfit', Minimizer='Levenberg-MarquardtMD')
-
     # Recover the result
     m = BivariateGaussian.BivariateGaussian()
     m.init()

--- a/scripts/SCD_Reduction/BVGFitTools.py
+++ b/scripts/SCD_Reduction/BVGFitTools.py
@@ -247,7 +247,6 @@ def fitScaling(n_events, box, YTOF, YBVG, goodIDX=None, neigh_length_m=3):
     scaleLinear.constrain("A1>0")
     scaleX = YJOINT[goodIDX]
     scaleY = n_events[goodIDX]
-    # , dataE=np.sqrt(scaleY))
     CreateWorkspace(OutputWorkspace='__scaleWS', dataX=scaleX, dataY=scaleY)
     fitResultsScaling = Fit(Function=scaleLinear, InputWorkspace='__scaleWS',
                             Output='__scalefit', CostFunction='Unweighted least squares')

--- a/scripts/SCD_Reduction/BVGFitTools.py
+++ b/scripts/SCD_Reduction/BVGFitTools.py
@@ -90,7 +90,6 @@ def get3DPeak(peak, peaks_ws, box, padeCoefficients, qMask, nTheta=150, nPhi=150
     ) >= nPixels[0] - dEdge or peak.getCol() <= dEdge or peak.getCol() >= nPixels[1] - dEdge
 
     sigX0Params, sigY0, sigP0Params, doPeakConvolution = getBVGGuesses(peaks_ws, sigX0Params, sigY0, sigP0Params)
-
     if strongPeakParams is not None and useForceParams:  # We will force parameters on this fit
         ph = np.arctan2(q0[1], q0[0])
         th = np.arctan2(q0[2], np.hypot(q0[0], q0[1]))
@@ -201,7 +200,7 @@ def getBVGGuesses(peaks_ws, sigX0Params, sigY0, sigP0Params):
         else:
             sigP0Params = [0.1460775, 1.85816592, 0.26850086, -0.00725352]
 
-    if peaks_ws.getInstrument().hasParameter("fitConvolutedPeak"):
+    if peaks_ws.getInstrument().hasParameter("fitConvolvedPeak"):
         doPeakConvolution = peaks_ws.getInstrument().getBoolParameter("fitConvolvedPeak")[0]
     else:
         doPeakConvolution = False
@@ -549,6 +548,7 @@ def doBVGFit(box, nTheta=200, nPhi=200, zBG=1.96, fracBoxToHistogram=1.0, goodID
         ), DataY=H.ravel(), DataE=np.sqrt(H.ravel()))
         fitResults = Fit(Function=m, InputWorkspace='__bvgWS', Output='__bvgfit',
                          Minimizer='Levenberg-MarquardtMD')
+
     elif forceParams is not None:
         p0 = np.zeros(7)
         p0[0] = np.max(h)

--- a/scripts/SCD_Reduction/BVGFitTools.py
+++ b/scripts/SCD_Reduction/BVGFitTools.py
@@ -459,7 +459,7 @@ def compareBVGFitData(box, params, nTheta=200, nPhi=200, figNumber=2, fracBoxToH
 def doBVGFit(box, nTheta=200, nPhi=200, zBG=1.96, fracBoxToHistogram=1.0, goodIDX=None,
              forceParams=None, forceTolerance=0.1, dth=10, dph=10,
              doPeakConvolution=False, sigX0Params=[0.00413132, 1.54103839, 1.0, -0.00266634],
-             sigY0=0.025, sigP0Params = [0.1460775, 1.85816592, 0.26850086, -0.00725352]):
+             sigY0=0.0025, sigP0Params=[0.1460775, 1.85816592, 0.26850086, -0.00725352]):
     """
     doBVGFit takes a binned MDbox and returns the fit of the peak shape along the non-TOF direction.  This is done in one of two ways:
         1) Standard least squares fit of the 2D histogram.
@@ -550,7 +550,7 @@ def doBVGFit(box, nTheta=200, nPhi=200, zBG=1.96, fracBoxToHistogram=1.0, goodID
 
         CreateWorkspace(OutputWorkspace='__bvgWS', DataX=pos.ravel(
         ), DataY=H.ravel(), DataE=np.sqrt(H.ravel()))
-
+        print(m)
         fitResults = Fit(Function=m, InputWorkspace='__bvgWS', Output='__bvgfit',
                          Minimizer='Levenberg-MarquardtMD')
     elif forceParams is not None:
@@ -634,6 +634,7 @@ def doBVGFit(box, nTheta=200, nPhi=200, zBG=1.96, fracBoxToHistogram=1.0, goodID
     chiSq = fitResults[1]
     params = [[m['A'], m['MuX'], m['MuY'], m['SigX'],
                m['SigY'], m['SigP'], m['Bg']], chiSq]
+    print('after'+str(m))
     return params, h, thBins, phBins
 
 

--- a/scripts/SCD_Reduction/BVGFitTools.py
+++ b/scripts/SCD_Reduction/BVGFitTools.py
@@ -174,7 +174,7 @@ def coshPeakWidthModel(x,A,x0,b,BG):
     direction.
     """
     y = (x-x0)/b
-    return A*(np.exp(y)+np.exp(-y)) + BG
+    return A/2.0*(np.exp(y)+np.exp(-y)) + BG
 
 
 def getBVGGuesses(peaks_ws, sigX0Params, sigY0, sigP0Params):
@@ -188,8 +188,7 @@ def getBVGGuesses(peaks_ws, sigX0Params, sigY0, sigP0Params):
         if peaks_ws.getInstrument().hasParameter("sigSC0Params"):
             sigX0Params = np.array(peaks_ws.getInstrument().getStringParameter("sigSC0Params")[0].split(),dtype=float)
         else:
-            sigX0Params=[0.00413132, 1.54103839, 1.0, -0.00266634]
-
+            sigX0Params=[5.68860816e-06, 7.63702849e-01, 8.31642225e-02, 3.06656383e-03]
     if sigY0 is None:
         if peaks_ws.getInstrument().hasParameter("sigAZ0"):
             sigY0 = peaks_ws.getInstrument().getNumberParameter("sigAZ0")[0]
@@ -458,7 +457,7 @@ def compareBVGFitData(box, params, nTheta=200, nPhi=200, figNumber=2, fracBoxToH
 
 def doBVGFit(box, nTheta=200, nPhi=200, zBG=1.96, fracBoxToHistogram=1.0, goodIDX=None,
              forceParams=None, forceTolerance=0.1, dth=10, dph=10,
-             doPeakConvolution=False, sigX0Params=[0.00413132, 1.54103839, 1.0, -0.00266634],
+             doPeakConvolution=False, sigX0Params=[5.68860816e-06, 7.63702849e-01, 8.31642225e-02, 3.06656383e-03],
              sigY0=0.0025, sigP0Params=[0.1460775, 1.85816592, 0.26850086, -0.00725352]):
     """
     doBVGFit takes a binned MDbox and returns the fit of the peak shape along the non-TOF direction.  This is done in one of two ways:
@@ -509,7 +508,6 @@ def doBVGFit(box, nTheta=200, nPhi=200, zBG=1.96, fracBoxToHistogram=1.0, goodID
         meanPH = PH.mean()
         sigX0 = coshPeakWidthModel(meanPH,  sigX0Params[0], sigX0Params[1], sigX0Params[2], sigX0Params[3])
         sigP0 = fSigP(meanTH, sigP0Params[0], sigP0Params[1], sigP0Params[2], sigP0Params[3])
-
         # Set some constraints
         boundsDict = {}
         boundsDict['A'] = [0.0, np.inf]
@@ -517,8 +515,7 @@ def doBVGFit(box, nTheta=200, nPhi=200, zBG=1.96, fracBoxToHistogram=1.0, goodID
                              thBins[thBins.size // 2 + dth]]
         boundsDict['MuY'] = [phBins[phBins.size // 2 - dph],
                              phBins[phBins.size // 2 + dph]]
-        boundsDict['SigX'] = [0.5*sigX0, 1.5*sigX0]
-        #boundsDict['SigX'] = [0., 0.02]
+        boundsDict['SigX'] = [0., 0.02]
         boundsDict['SigY'] = [0., 0.02]
         boundsDict['SigP'] = [-1., 1.]
         boundsDict['Bg'] = [0, np.inf]
@@ -550,7 +547,6 @@ def doBVGFit(box, nTheta=200, nPhi=200, zBG=1.96, fracBoxToHistogram=1.0, goodID
 
         CreateWorkspace(OutputWorkspace='__bvgWS', DataX=pos.ravel(
         ), DataY=H.ravel(), DataE=np.sqrt(H.ravel()))
-        print(m)
         fitResults = Fit(Function=m, InputWorkspace='__bvgWS', Output='__bvgfit',
                          Minimizer='Levenberg-MarquardtMD')
     elif forceParams is not None:
@@ -634,7 +630,6 @@ def doBVGFit(box, nTheta=200, nPhi=200, zBG=1.96, fracBoxToHistogram=1.0, goodID
     chiSq = fitResults[1]
     params = [[m['A'], m['MuX'], m['MuY'], m['SigX'],
                m['SigY'], m['SigP'], m['Bg']], chiSq]
-    print('after'+str(m))
     return params, h, thBins, phBins
 
 

--- a/scripts/SCD_Reduction/BVGFitTools.py
+++ b/scripts/SCD_Reduction/BVGFitTools.py
@@ -243,16 +243,6 @@ def fitScaling(n_events, box, YTOF, YBVG, goodIDX=None, neigh_length_m=3):
                 max(fitMaxIDX[2] - dP, 0):min(fitMaxIDX[2] + dP, goodIDX.shape[2])] = True
     goodIDX = np.logical_and(goodIDX, conv_n_events > 0)
 
-    #Remove these - debugging plots
-    #plt.figure(19); plt.clf()
-    #plt.imshow(n_events[:,:,n_events.shape[2]//2])
-    #plt.figure(20); plt.clf()
-    #plt.imshow(goodIDX[:,:,n_events.shape[2]//2])
-    #TOF = 1./np.sqrt(QX*QX+QY*QY+QZ*QZ)
-    #plt.figure(21); plt.clf()
-    #plt.imshow(TOF[:,:,n_events.shape[2]//2])
-    # A1 = slope, A0 = offset
-
     scaleLinear = Polynomial(n=1)
     scaleLinear.constrain("A1>0")
     scaleX = YJOINT[goodIDX]
@@ -625,7 +615,6 @@ def doBVGFit(box, nTheta=200, nPhi=200, zBG=1.96, fracBoxToHistogram=1.0, goodID
         m.setAttributeValue('nY', h.shape[1])
         m.setConstraints(boundsDict)
         # Do the fit
-        #plt.figure(18); plt.clf(); plt.imshow(m.function2D(pos)); plt.title('BVG Initial guess')
         CreateWorkspace(OutputWorkspace='__bvgWS', DataX=pos.ravel(), DataY=H.ravel(), DataE=np.sqrt(H.ravel()))
         fitFun = m
         fitResults = Fit(Function=fitFun, InputWorkspace='__bvgWS',

--- a/scripts/SCD_Reduction/ICCFitTools.py
+++ b/scripts/SCD_Reduction/ICCFitTools.py
@@ -999,7 +999,6 @@ def integrateSample(run, MDdata, peaks_ws, paramList, UBMatrix, dQ, qMask, padeC
                                                          pplmin_frac=minpplfrac, pplmax_frac=maxpplfrac,
                                                          constraintScheme=constraintScheme,
                                                          peakMaskSize=peakMaskSize, iccFitDict=iccFitDict)
-                # --IN PRINCIPLE!!! WE CALCULATE THIS BEFORE GETTING HERE
                 tofWS = mtd['__tofWS']
 
                 fitResults, fICC = doICCFit(

--- a/scripts/SCD_Reduction/ICCFitTools.py
+++ b/scripts/SCD_Reduction/ICCFitTools.py
@@ -861,7 +861,6 @@ def doICCFit(tofWS, energy, flightPath, padeCoefficients, constraintScheme=None,
     x0 = getInitialGuess(tofWS, paramNames, energy,
                          flightPath, padeCoefficients)
     [fICC.setParameter(iii, v) for iii, v in enumerate(x0[:fICC.numParams()])]
-    print(fICC)
     x = tofWS.readX(0)
     y = tofWS.readY(0)
     bgx0 = np.polyfit(x[np.r_[0:15, -15:0]], y[np.r_[0:15, -15:0]], fitOrder)
@@ -882,7 +881,6 @@ def doICCFit(tofWS, energy, flightPath, padeCoefficients, constraintScheme=None,
         HatWidth0 = [0., 5.]
         Scale0 = [0., np.inf]
         KConv0 = [100, 140]
-        print(B0)
         # Now we see what instrument specific parameters we have
         if iccFitDict is not None:
             #TODO This is only a temporary fix to not fix iccB - need to update parameters files

--- a/scripts/SCD_Reduction/ICCFitTools.py
+++ b/scripts/SCD_Reduction/ICCFitTools.py
@@ -282,7 +282,6 @@ def getOptimizedGoodIDX(n_events, padeCoefficients, zBG=1.96, neigh_length_m=3, 
     maxppl = maxppl_frac*pred_ppl
     pp_lambda_toCheck = pp_lambda_toCheck[pp_lambda_toCheck > minppl]
     pp_lambda_toCheck = pp_lambda_toCheck[pp_lambda_toCheck < maxppl]
-
     if pp_lambda_toCheck == []:
         pp_lambda_toCheck = [meanBG*1.96]
         print('Cannot find suitable background.  Consider adjusting MinpplFrac or MaxpplFrac')
@@ -862,6 +861,7 @@ def doICCFit(tofWS, energy, flightPath, padeCoefficients, constraintScheme=None,
     x0 = getInitialGuess(tofWS, paramNames, energy,
                          flightPath, padeCoefficients)
     [fICC.setParameter(iii, v) for iii, v in enumerate(x0[:fICC.numParams()])]
+    print(fICC)
     x = tofWS.readX(0)
     y = tofWS.readY(0)
     bgx0 = np.polyfit(x[np.r_[0:15, -15:0]], y[np.r_[0:15, -15:0]], fitOrder)
@@ -882,10 +882,12 @@ def doICCFit(tofWS, energy, flightPath, padeCoefficients, constraintScheme=None,
         HatWidth0 = [0., 5.]
         Scale0 = [0., np.inf]
         KConv0 = [100, 140]
-
+        print(B0)
         # Now we see what instrument specific parameters we have
         if iccFitDict is not None:
+            #TODO This is only a temporary fix to not fix iccB - need to update parameters files
             possibleKeys = ['iccA', 'iccB', 'iccR', 'iccT0', 'iccScale0', 'iccHatWidth', 'iccKConv']
+            #possibleKeys = ['iccA', 'iccR', 'iccT0', 'iccScale0', 'iccHatWidth', 'iccKConv']
             for keyIDX, (key, bounds) in enumerate(zip(possibleKeys, [A0, B0, R0, T00, Scale0, HatWidth0, KConv0])):
                 if key in iccFitDict:
                     bounds[0] = iccFitDict[key][0]

--- a/scripts/SCD_Reduction/ICCFitTools.py
+++ b/scripts/SCD_Reduction/ICCFitTools.py
@@ -655,7 +655,7 @@ def getTOFWS(box, flightPath, scatteringHalfAngle, tofPeak, peak, qMask, zBG=-1.
 
     if workspaceNumber is None:
         tofWS = CreateWorkspace(
-            OutputWorkspace='tofWS', DataX=tPoints, DataY=yPoints, DataE=np.sqrt(yPoints))
+            OutputWorkspace='__tofWS', DataX=tPoints, DataY=yPoints, DataE=np.sqrt(yPoints))
     else:
         tofWS = CreateWorkspace(OutputWorkspace='tofWS%i' % workspaceNumber,
                                 DataX=tPoints, DataY=yPoints, DataE=np.sqrt(yPoints))
@@ -911,7 +911,7 @@ def doICCFit(tofWS, energy, flightPath, padeCoefficients, constraintScheme=None,
         bg['A'+str(fitOrder-i)] = bgx0[i]
     bg.constrain('-1.0 < A%i < 1.0' % fitOrder)
     fitFun = f + bg
-    fitResults = Fit(Function=fitFun, InputWorkspace='tofWS',
+    fitResults = Fit(Function=fitFun, InputWorkspace='__tofWS',
                      Output=outputWSName)
     return fitResults, fICC
 
@@ -1000,7 +1000,7 @@ def integrateSample(run, MDdata, peaks_ws, paramList, UBMatrix, dQ, qMask, padeC
                                                          constraintScheme=constraintScheme,
                                                          peakMaskSize=peakMaskSize, iccFitDict=iccFitDict)
                 # --IN PRINCIPLE!!! WE CALCULATE THIS BEFORE GETTING HERE
-                tofWS = mtd['tofWS']
+                tofWS = mtd['__tofWS']
 
                 fitResults, fICC = doICCFit(
                     tofWS, energy, flightPath, padeCoefficients, fitOrder=bgPolyOrder, constraintScheme=constraintScheme,
@@ -1009,7 +1009,7 @@ def integrateSample(run, MDdata, peaks_ws, paramList, UBMatrix, dQ, qMask, padeC
 
                 r = mtd['fit_Workspace']
                 param = mtd['fit_Parameters']
-                tofWS = mtd['tofWS']
+                tofWS = mtd['__tofWS']
 
                 iii = fICC.numParams() - 1
                 fitBG = [param.row(int(iii+bgIDX+1))['Value']


### PR DESCRIPTION
**Description of work.**
Changes the `IntegratePeaksProfileFitting` algorithm to automatically learn peak shapes.

**To test:**
```python
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
plt.ion()

event_ws = Load(Filename='/SNS/MANDI/IPTS-8776/nexus/MANDI_9113.nxs.h5', OutputWorkspace='event_ws')
MDdata = ConvertToMD(InputWorkspace='event_ws', QDimensions='Q3D', dEAnalysisMode='Elastic', Q3DFrames='Q_lab', OutputWorkspace='MDdata', MinValues='-5,-5,-5', MaxValues='5,5,5', MaxRecursionDepth=10)
mtd.remove('event_ws') #Free up memory

peaks_ws = FindPeaksMD(InputWorkspace='MDdata', MaxPeaks=150, DensityThresholdFactor=5000, OutputWorkspace='peaks_ws')
FindUBUsingFFT(PeaksWorkspace='peaks_ws', MinD=65, MaxD=120, Tolerance=0.15, Iterations=10, DegreesPerStep=1.0)
IndexPeaks(PeaksWorkspace='peaks_ws')

IntegratePeaksMD(InputWorkspace='MDdata', PeakRadius=0.019, BackgroundInnerRadius=0.020, BackgroundOuterRadius=0.021, 
                 PeaksWorkspace='peaks_ws', OutputWorkspace='peaks_ws', CylinderLength=0.4, PercentBackground=20,
                 ProfileFunction='IkedaCarpenterPV')
mtd.remove('event_ws') #Free up memory

moderatorFile = '/SNS/MANDI/shared/ProfileFitting/franz_coefficients_2017.dat'

#These are temporary until Parameters files are updated.
SetInstrumentParameter(Workspace='peaks_ws', ParameterName='fitConvolvedPeak', ParameterType='Bool', Value='False')
SetInstrumentParameter(Workspace='peaks_ws', ParameterName='sigX0Scale', ParameterType='Number', Value='1.0')
SetInstrumentParameter(Workspace='peaks_ws', ParameterName='sigY0Scale', ParameterType='Number', Value='1.0')
SetInstrumentParameter(Workspace='peaks_ws', ParameterName='numDetRows', ParameterType='Number', Value='255')
SetInstrumentParameter(Workspace='peaks_ws', ParameterName='numDetCols', ParameterType='Number', Value='255')
SetInstrumentParameter(Workspace='peaks_ws', ParameterName='numBinsTheta', ParameterType='Number', Value='50')
SetInstrumentParameter(Workspace='peaks_ws', ParameterName='numBinsPhi', ParameterType='Number', Value='50')
SetInstrumentParameter(Workspace='peaks_ws', ParameterName='fracHKL', ParameterType='Number', Value='0.25')
SetInstrumentParameter(Workspace='peaks_ws', ParameterName='dQPixel', ParameterType='Number', Value='0.003')
SetInstrumentParameter(Workspace='peaks_ws', ParameterName='mindtBinWidth', ParameterType='Number', Value='15.0')
SetInstrumentParameter(Workspace='peaks_ws', ParameterName='maxdtBinWidth', ParameterType='Number', Value='50.0')
SetInstrumentParameter(Workspace='peaks_ws', ParameterName='peakMaskSize', ParameterType='Number', Value='5')
SetInstrumentParameter(Workspace='peaks_ws', ParameterName='sigSC0Params', ParameterType='String', 
                       Value='5.68860816e-06 7.63702849e-01 8.31642225e-02 3.06656383e-03')
SetInstrumentParameter(Workspace='peaks_ws', ParameterName='sigAZ0', ParameterType='Number', Value='0.0025')
SetInstrumentParameter(Workspace='peaks_ws', ParameterName='sigP0Params', ParameterType='String', 
                       Value='0.1460775 1.85816592 0.26850086 -0.00725352')


IntegratePeaksProfileFitting(OutputPeaksWorkspace='peaks_ws_out', OutputParamsWorkspace='params_ws', InputWorkspace='MDdata', 
                             PeaksWorkspace='peaks_ws', RunNumber=9113, ModeratorCoefficientsFile=moderatorFile, DQMax=0.2,
                             IntensityCutoff=np.median((mtd['peaks_ws'].column('Intens'))))
                             

plt.plot(mtd['__fitSigX0_Workspace'].readX(0), mtd['__fitSigX0_Workspace'].readY(0),'.',label='Fit Peaks')
xLearned = np.array(mtd['__fitSigX0_Workspace'].readX(1))
yLearned = np.array(mtd['__fitSigX0_Workspace'].readY(1))
sIDX = np.argsort(xLearned)
plt.plot(xLearned[sIDX], yLearned[sIDX],label='Learned Peak Shape')
plt.legend(loc='best')
plt.xlabel('Theta (rad)')
plt.ylabel('sig_theta (rad)')

```
<!-- Instructions for testing. -->

Fixes #23470 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
