### PR TITLE
Stitch1DMany Validation of ScaleFactorFromPeriod fix

### DIFF
--- a/Framework/Algorithms/src/Stitch1DMany.cpp
+++ b/Framework/Algorithms/src/Stitch1DMany.cpp
@@ -183,11 +183,15 @@ std::map<std::string, std::string> Stitch1DMany::validateInputs() {
 
       int scaleFactorFromPeriod = this->getProperty("ScaleFactorFromPeriod");
       m_scaleFactorFromPeriod = static_cast<size_t>(scaleFactorFromPeriod);
-      m_scaleFactorFromPeriod--; // To account for period being indexed from
-                                 // 1
-      if (m_scaleFactorFromPeriod >= m_inputWSMatrix.size()) {
+
+      size_t maxScaleFactorFromPeriod = numStitchableWS;
+      // If workspaces are greater than entered ws then they were grouped
+      if (workspaces.size() > numStitchableWS)
+        maxScaleFactorFromPeriod = workspaces.size() / numStitchableWS;
+
+      if (m_scaleFactorFromPeriod > maxScaleFactorFromPeriod) {
         std::stringstream expectedRange;
-        expectedRange << m_inputWSMatrix.size();
+        expectedRange << maxScaleFactorFromPeriod;
         issues["ScaleFactorFromPeriod"] =
             "Period index out of range, must be smaller than " +
             expectedRange.str();
@@ -368,12 +372,11 @@ void Stitch1DMany::doStitch1DMany(const size_t period,
                                   const bool useManualScaleFactors,
                                   std::string &outName,
                                   std::vector<double> &outScaleFactors) {
-
   // List of workspaces to stitch
   std::vector<std::string> toProcess;
 
   for (const auto &ws : m_inputWSMatrix) {
-    const std::string &wsName = ws[period]->getName();
+    const std::string &wsName = ws[period - 1]->getName();
     toProcess.emplace_back(wsName);
     outName += "_" + wsName;
   }

--- a/docs/source/release/v3.14.0/reflectometry.rst
+++ b/docs/source/release/v3.14.0/reflectometry.rst
@@ -40,6 +40,7 @@ Bug fixes
 #########
 
 - Fixed the error propagation in :math:`Q` grouping in :ref:`ReflectometryILLConvertToQ <algm-ReflectometryILLConvertToQ>`
+- Fixed an issue with validation of ScaleFactorFromPeriod not allowing correct period to be given for Group Workspaces in :ref:`algm-Stitch1DMany`
 
 Liquids Reflectometer
 ---------------------


### PR DESCRIPTION
**Description of work.**
Validation has been adjusted to compensate for group workspaces when entering a ScaleFactorFromPeriod

**Report to:** Max/Andrew (ISIS). 

**To test:**
- Load POLREF00025580 and POLREF00025581(Or other Reflectometry workspaces sets that are groups and would be used in Stitch1DMany)
- Open Stitch1DMany Select the input workspaces POLREF00025580 and POLREF00025581 (not the ones with the _ and then a number.
- Tick UseManualScaleFactors
- Choose one of [1,2,3,4] and run the script
- Repeat for unchosen numbers
- If algorithm ran successfully it is ok!
<!-- Instructions for testing. -->

Fixes #23832. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
