### PR TITLE
Uninitialized variable in ReflectometryReductionOneLiveData

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
+++ b/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
@@ -25,28 +25,30 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
         return 'Run the reflectometry reduction algorithm on live data'
 
     def seeAlso(self):
-        return [ "ReflectometryReductionOneAuto", "StartLiveData" ]
+        return ["ReflectometryReductionOneAuto", "StartLiveData"]
 
     def PyInit(self):
         instruments = ['CRISP', 'INTER', 'OFFSPEC', 'POLREF', 'SURF']
-        instrument = defaultInstrument if config.getInstrument() in instruments else ''
-        self.declareProperty(name='Instrument', defaultValue=instrument, direction=Direction.Input,
+        defaultInstrument = str(config.getInstrument())
+        defaultInstrument = defaultInstrument if defaultInstrument in instruments else instruments[0]
+        self.declareProperty(name='Instrument', defaultValue=defaultInstrument, direction=Direction.Input,
                              validator=StringListValidator(instruments),
                              doc='Instrument to find live value for.')
-        self.declareProperty(name='GetLiveValueAlgorithm', defaultValue='GetLiveInstrumentValue', direction=Direction.Input,
+        self.declareProperty(name='GetLiveValueAlgorithm', defaultValue='GetLiveInstrumentValue',
+                             direction=Direction.Input,
                              doc='The algorithm to use to get live values from the instrument')
 
         self._child_properties = [
-            'InputWorkspace', 'SummationType', 'ReductionType','IncludePartialBins', 'AnalysisMode',
-            'ProcessingInstructions','CorrectDetectors',
-            'DetectorCorrectionType','WavelengthMin','WavelengthMax','I0MonitorIndex',
-            'MonitorBackgroundWavelengthMin','MonitorBackgroundWavelengthMax',
-            'MonitorIntegrationWavelengthMin','MonitorIntegrationWavelengthMax',
-            'NormalizeByIntegratedMonitors','FirstTransmissionRun',
-            'SecondTransmissionRun','Params','StartOverlap','EndOverlap',
-            'StrictSpectrumChecking','CorrectionAlgorithm','Polynomial','C0','C1',
-            'MomentumTransferMin','MomentumTransferStep','MomentumTransferMax',
-            'PolarizationAnalysis','Pp','Ap','Rho','Alpha','Debug','OutputWorkspace']
+            'InputWorkspace', 'SummationType', 'ReductionType', 'IncludePartialBins',
+            'AnalysisMode', 'ProcessingInstructions', 'CorrectDetectors',
+            'DetectorCorrectionType', 'WavelengthMin', 'WavelengthMax', 'I0MonitorIndex',
+            'MonitorBackgroundWavelengthMin', 'MonitorBackgroundWavelengthMax',
+            'MonitorIntegrationWavelengthMin', 'MonitorIntegrationWavelengthMax',
+            'NormalizeByIntegratedMonitors', 'FirstTransmissionRun',
+            'SecondTransmissionRun', 'Params', 'StartOverlap', 'EndOverlap',
+            'StrictSpectrumChecking', 'CorrectionAlgorithm', 'Polynomial', 'C0', 'C1',
+            'MomentumTransferMin', 'MomentumTransferStep', 'MomentumTransferMax',
+            'PolarizationAnalysis', 'Pp', 'Ap', 'Rho', 'Alpha', 'Debug', 'OutputWorkspace']
         self.copyProperties('ReflectometryReductionOneAuto', self._child_properties)
 
     def PyExec(self):
@@ -83,20 +85,21 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
         """Create a workspace for the input/output to the reduction algorithm"""
         in_ws_name = self.getProperty("InputWorkspace").value.getName()
         self._ws_name = self.getPropertyValue("OutputWorkspace")
-        CloneWorkspace(InputWorkspace=in_ws_name,OutputWorkspace=self._ws_name)
+        CloneWorkspace(InputWorkspace=in_ws_name, OutputWorkspace=self._ws_name)
 
     def _setup_instrument(self):
         """Sets the instrument name and loads the instrument on the workspace"""
         self._instrument = self.getProperty('Instrument').value
-        LoadInstrument(Workspace=self._ws_name,RewriteSpectraMap=True,InstrumentName=self._instrument)
+        LoadInstrument(Workspace=self._ws_name, RewriteSpectraMap=True,
+                       InstrumentName=self._instrument)
 
     def _setup_sample_logs(self, liveValues):
         """Set up the sample logs based on live values from the instrument"""
         logNames = [key for key in liveValues]
         logValues = [liveValues[key].value for key in liveValues]
         logUnits = [liveValues[key].unit for key in liveValues]
-        AddSampleLogMultiple(Workspace=self._ws_name,LogNames=logNames,LogValues=logValues,
-                             LogUnits=logUnits)
+        AddSampleLogMultiple(Workspace=self._ws_name, LogNames=logNames,
+                             LogValues=logValues, LogUnits=logUnits)
 
     def _setup_slits(self, liveValues):
         """Set up instrument parameters for the slits"""
@@ -152,9 +155,9 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
 
     def _live_value_list(self):
         """Get the list of required live value names and their unit type"""
-        liveValues =  {'Theta' : LiveValue(None, 'deg'),
-                       self._s1vg_name() : LiveValue(None, 'm'),
-                       self._s2vg_name() : LiveValue(None, 'm')}
+        liveValues = {'Theta': LiveValue(None, 'deg'),
+                      self._s1vg_name(): LiveValue(None, 'm'),
+                      self._s2vg_name(): LiveValue(None, 'm')}
         return liveValues
 
     def _get_block_value_from_instrument(self, logName):


### PR DESCRIPTION
The bug was never seen because it was also comparing `InstrumentInfo` to `str` which was always returning `False`. This PR fixes both of those issues and reduces pep8 warnings.

**To test:**

Review the changes in `PyInit` lines 31-36. Everything else is whitespace changes for pep8.

*There is no associated issue.*

*This does not require release notes* because it is mostly hidden from users.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
