### PR TITLE
Set constraintPenaltyFactor in IntegratePeaksProfileFitting

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
@@ -270,7 +270,7 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
                                                                   forceCutoff=forceCutoff, edgeCutoff=edgeCutoff,
                                                                   peakMaskSize=peakMaskSize,
                                                                   iccFitDict=iccFitDict, sigX0Params=sigX0Params,
-                                                                  sigY0=sigY0, sigP0Params=sigP0Params)
+                                                                  sigY0=sigY0, sigP0Params=sigP0Params, fitPenalty=1.e7)
                 # First we get the peak intensity
                 peakIDX = Y3D/Y3D.max() > fracStop
                 intensity = np.sum(Y3D[peakIDX])

--- a/Framework/PythonInterface/plugins/functions/BivariateGaussian.py
+++ b/Framework/PythonInterface/plugins/functions/BivariateGaussian.py
@@ -116,7 +116,7 @@ class BivariateGaussian(IFunction1D):
     def getMuSigma(self):
         return self.getMu(), self.getSigma()
 
-    def setConstraints(self, boundsDict):
+    def setConstraints(self, boundsDict, penalty=None):
         """
         setConstraints sets fitting constraints for the mbvg function.
         Intput:
@@ -130,9 +130,10 @@ class BivariateGaussian(IFunction1D):
                     constraintString = "{:4.4e} < {:s} < {:4.4e}".format(boundsDict[param][0], param, boundsDict[param][1])
                     self.addConstraints(constraintString)
                 else:
-                    self.addConstraints("{:4.4e} < A < {:4.4e}".format(boundsDict[param][1], boundsDict[param][0]))
+                    self.addConstraints("{:4.4e} < {:s} < {:4.4e}".format(boundsDict[param][1], param, boundsDict[param][0]))
+                if penalty is not None:
+                    self.setConstraintPenaltyFactor(param, penalty)
             except ValueError:
-                raise
                 raise UserWarning("Cannot set parameter {:s} for mbvg.  Valid choices are " +
                                   "('A', 'MuX', 'MuY', 'SigX', 'SigY', 'SigP', 'Bg')".format(param))
 

--- a/Framework/PythonInterface/plugins/functions/ICConvoluted.py
+++ b/Framework/PythonInterface/plugins/functions/ICConvoluted.py
@@ -26,8 +26,8 @@ class IkedaCarpenterConvoluted(IFunction1D):
         self.declareParameter("HatWidth") #width of square wave
         self.declareParameter("KConv") #KConv for Gaussian
 
-    #n.b. pass penalty=None to not use default mantid penalty - useful for development
-    def setPenalizedConstraints(self, A0=None, B0=None, R0=None, T00=None, Scale0=None, HatWidth0=None, KConv0=None, penalty=1.0e20):
+    #use penalty=None to not use default mantid penalty
+    def setPenalizedConstraints(self, A0=None, B0=None, R0=None, T00=None, Scale0=None, HatWidth0=None, KConv0=None, penalty=None):
         if A0 is not None:
             self.addConstraints("{:4.4e} < A < {:4.4e}".format(A0[0], A0[1]))
             if penalty is not None:

--- a/scripts/SCD_Reduction/BVGFitTools.py
+++ b/scripts/SCD_Reduction/BVGFitTools.py
@@ -22,7 +22,7 @@ def get3DPeak(peak, peaks_ws, box, padeCoefficients, qMask, nTheta=150, nPhi=150
               strongPeakParams=None, forceCutoff=250, edgeCutoff=15,
               neigh_length_m=3, q_frame='sample', dtSpread=0.03, pplmin_frac=0.8, pplmax_frac=1.5, mindtBinWidth=1,
               maxdtBinWidth=50, figureNumber=2, peakMaskSize=5, iccFitDict=None,
-              sigX0Params=None, sigY0=None, sigP0Params=None):
+              sigX0Params=None, sigY0=None, sigP0Params=None, fitPenalty=None):
     n_events = box.getNumEventsArray()
 
     if q_frame == 'lab':
@@ -43,7 +43,7 @@ def get3DPeak(peak, peaks_ws, box, padeCoefficients, qMask, nTheta=150, nPhi=150
                     box, peak, padeCoefficients, dtSpread=dtSpread, qMask=qMask, bgPolyOrder=bgPolyOrder, zBG=zBG,
                     plotResults=plotResults, pp_lambda=pp_lambda, neigh_length_m=neigh_length_m, pplmin_frac=pplmin_frac,
                     pplmax_frac=pplmax_frac, mindtBinWidth=mindtBinWidth, maxdtBinWidth=maxdtBinWidth,
-                    peakMaskSize=peakMaskSize, iccFitDict=iccFitDict)
+                    peakMaskSize=peakMaskSize, iccFitDict=iccFitDict, fitPenalty=fitPenalty)
         chiSqTOF = mtd['fit_Parameters'].column(1)[-1]
     else:  # we already did I-C profile, so we'll just read the parameters
         pp_lambda = fICCParams[-1]
@@ -107,11 +107,12 @@ def get3DPeak(peak, peaks_ws, box, padeCoefficients, qMask, nTheta=150, nPhi=150
         params, h, t, p = doBVGFit(box, nTheta=nTheta, nPhi=nPhi, fracBoxToHistogram=fracBoxToHistogram,
                                    goodIDX=goodIDX, forceParams=strongPeakParams[nnIDX],
                                    doPeakConvolution=doPeakConvolution, sigX0Params=sigX0Params,
-                                   sigY0=sigY0, sigP0Params=sigP0Params)
+                                   sigY0=sigY0, sigP0Params=sigP0Params, fitPenalty=fitPenalty)
     else:  # Just do the fit - no nearest neighbor assumptions
         params, h, t, p = doBVGFit(
             box, nTheta=nTheta, nPhi=nPhi, fracBoxToHistogram=fracBoxToHistogram, goodIDX=goodIDX,
-            doPeakConvolution=doPeakConvolution, sigX0Params=sigX0Params, sigY0=sigY0, sigP0Params=sigP0Params)
+            doPeakConvolution=doPeakConvolution, sigX0Params=sigX0Params, sigY0=sigY0, sigP0Params=sigP0Params,
+            fitPenalty=fitPenalty)
 
     if plotResults:
         compareBVGFitData(
@@ -284,7 +285,7 @@ def getXTOF(box, peak):
 def fitTOFCoordinate(box, peak, padeCoefficients, dtSpread=0.03, minFracPixels=0.01,
                      neigh_length_m=3, zBG=1.96, bgPolyOrder=1, qMask=None, plotResults=False,
                      fracStop=0.01, pp_lambda=None, pplmin_frac=0.8, pplmax_frac=1.5, mindtBinWidth=1,
-                     maxdtBinWidth=50, peakMaskSize=5, iccFitDict=None):
+                     maxdtBinWidth=50, peakMaskSize=5, iccFitDict=None, fitPenalty=None):
 
     # Get info from the peak
     tof = peak.getTOF()  # in us
@@ -308,7 +309,7 @@ def fitTOFCoordinate(box, peak, padeCoefficients, dtSpread=0.03, minFracPixels=0
 
     fitResults, fICC = ICCFT.doICCFit(tofWS, energy, flightPath,
                                       padeCoefficients, fitOrder=bgPolyOrder, constraintScheme=1,
-                                      iccFitDict=iccFitDict)
+                                      iccFitDict=iccFitDict, fitPenalty=fitPenalty)
 
     for i, param in enumerate(['A', 'B', 'R', 'T0', 'Scale', 'HatWidth', 'KConv']):
         fICC[param] = mtd['fit_Parameters'].row(i)['Value']
@@ -463,7 +464,7 @@ def compareBVGFitData(box, params, nTheta=200, nPhi=200, figNumber=2, fracBoxToH
 def doBVGFit(box, nTheta=200, nPhi=200, zBG=1.96, fracBoxToHistogram=1.0, goodIDX=None,
              forceParams=None, forceTolerance=0.1, dth=10, dph=10,
              doPeakConvolution=False, sigX0Params=[5.68860816e-06, 7.63702849e-01, 8.31642225e-02, 3.06656383e-03],
-             sigY0=0.0025, sigP0Params=[0.1460775, 1.85816592, 0.26850086, -0.00725352]):
+             sigY0=0.0025, sigP0Params=[0.1460775, 1.85816592, 0.26850086, -0.00725352], fitPenalty=None):
     """
     doBVGFit takes a binned MDbox and returns the fit of the peak shape along the non-TOF direction.  This is done in one of two ways:
         1) Standard least squares fit of the 2D histogram.
@@ -538,8 +539,6 @@ def doBVGFit(box, nTheta=200, nPhi=200, zBG=1.96, fracBoxToHistogram=1.0, goodID
         m = BivariateGaussian.BivariateGaussian()
         m.init()
         m['A'] = 1.
-        #m['MuX'] = meanTH
-        #m['MuY'] = meanPH
         m['MuX'] = TH[np.unravel_index(h.argmax(), h.shape)]
         m['MuY'] = PH[np.unravel_index(h.argmax(), h.shape)]
         m['SigX'] = sigX0
@@ -547,9 +546,8 @@ def doBVGFit(box, nTheta=200, nPhi=200, zBG=1.96, fracBoxToHistogram=1.0, goodID
         m['SigP'] = sigP0
         m.setAttributeValue('nX', h.shape[0])
         m.setAttributeValue('nY', h.shape[1])
-        m.setConstraints(boundsDict)
+        m.setConstraints(boundsDict, penalty=fitPenalty)
         # Do the fit
-
         CreateWorkspace(OutputWorkspace='__bvgWS', DataX=pos.ravel(
         ), DataY=H.ravel(), DataE=np.sqrt(H.ravel()))
         fitResults = Fit(Function=m, InputWorkspace='__bvgWS', Output='__bvgfit',
@@ -602,11 +600,6 @@ def doBVGFit(box, nTheta=200, nPhi=200, zBG=1.96, fracBoxToHistogram=1.0, goodID
         m = BivariateGaussian.BivariateGaussian()
         m.init()
         m['A'] = 0.1
-        #m['muX'] = np.average(thCenters,weights=np.sum(h,axis=1))
-        #m['muY'] = np.average(phCenters,weights=np.sum(h,axis=0))
-
-        #m['muX'] = TH.mean()
-        #m['muY'] = PH.mean()
         m['MuX'] = TH[np.unravel_index(h.argmax(), h.shape)]
         m['MuY'] = PH[np.unravel_index(h.argmax(), h.shape)]
         m['SigX'] = forceParams[5]
@@ -614,7 +607,7 @@ def doBVGFit(box, nTheta=200, nPhi=200, zBG=1.96, fracBoxToHistogram=1.0, goodID
         m['SigP'] = forceParams[7]
         m.setAttributeValue('nX', h.shape[0])
         m.setAttributeValue('nY', h.shape[1])
-        m.setConstraints(boundsDict)
+        m.setConstraints(boundsDict, penalty=fitPenalty)
         # Do the fit
         CreateWorkspace(OutputWorkspace='__bvgWS', DataX=pos.ravel(), DataY=H.ravel(), DataE=np.sqrt(H.ravel()))
         fitFun = m

--- a/scripts/SCD_Reduction/ICCFitTools.py
+++ b/scripts/SCD_Reduction/ICCFitTools.py
@@ -836,7 +836,7 @@ def getBoxFracHKL(peak, peaks_ws, MDdata, UBMatrix, peakNumber, dQ, dQPixel=0.00
 
 
 def doICCFit(tofWS, energy, flightPath, padeCoefficients, constraintScheme=None, outputWSName='fit', fitOrder=1,
-             iccFitDict=None):
+             iccFitDict=None, fitPenalty=None):
     """
     doICCFit - Carries out the actual least squares fit for the TOF workspace.
     Intput:
@@ -889,9 +889,7 @@ def doICCFit(tofWS, energy, flightPath, padeCoefficients, constraintScheme=None,
         KConv0 = [100, 140]
         # Now we see what instrument specific parameters we have
         if iccFitDict is not None:
-            #TODO This is only a temporary fix to not fix iccB - need to update parameters files
             possibleKeys = ['iccA', 'iccB', 'iccR', 'iccT0', 'iccScale0', 'iccHatWidth', 'iccKConv']
-            #possibleKeys = ['iccA', 'iccR', 'iccT0', 'iccScale0', 'iccHatWidth', 'iccKConv']
             for keyIDX, (key, bounds) in enumerate(zip(possibleKeys, [A0, B0, R0, T00, Scale0, HatWidth0, KConv0])):
                 if key in iccFitDict:
                     bounds[0] = iccFitDict[key][0]
@@ -899,17 +897,10 @@ def doICCFit(tofWS, energy, flightPath, padeCoefficients, constraintScheme=None,
                     if len(iccFitDict[key] == 3):
                         x0[keyIDX] = iccFitDict[key][2]
                         fICC.setParameter(keyIDX, x0[keyIDX])
-        try:
-            fICC.setPenalizedConstraints(A0=A0, B0=B0, R0=R0, T00=T00, KConv0=KConv0, penalty=1.0e10)
-        except:
-            fICC.setPenalizedConstraints(A0=A0, B0=B0, R0=R0, T00=T00, KConv0=KConv0, penalty=None)
+        fICC.setPenalizedConstraints(A0=A0, B0=B0, R0=R0, T00=T00, KConv0=KConv0, penalty=fitPenalty)
     if constraintScheme == 2:
-        try:
-            fICC.setPenalizedConstraints(A0=[0.0001, 1.0], B0=[0.005, 1.5], R0=[0.00, 1.], Scale0=[
-                                         0.0, 1.0e10], T00=[0, 1.0e10], KConv0=[100., 140.], penalty=1.0e20)
-        except:
-            fICC.setPenalizedConstraints(A0=[0.0001, 1.0], B0=[0.005, 1.5], R0=[0.00, 1.], Scale0=[
-                                         0.0, 1.0e10], T00=[0, 1.0e10], KConv0=[100, 140.], penalty=None)
+        fICC.setPenalizedConstraints(A0=[0.0001, 1.0], B0=[0.005, 1.5], R0=[0.00, 1.], Scale0=[
+                                         0.0, 1.0e10], T00=[0, 1.0e10], KConv0=[100., 140.], penalty=fitPenalty)
     f = FunctionWrapper(fICC)
     bg = Polynomial(n=fitOrder)
 


### PR DESCRIPTION
**Description of work.**
Provides strong constraint penalty for fitting in `IntegratePeaksProfileFitting`.  

**To test:**
Extract [this directory from Dropbox](https://www.dropbox.com/s/wargm3g5hz56n5t/test_constraints.zip?dl=0) and cd into it from Mantid.  Then run the following:
```python
from mantid.simpleapi import *
import matplotlib.pyplot as plt
plt.ion()
import numpy as np
import pickle
import sys
import ICCFitTools as ICCFT
import BVGFitTools as BVGFT

#beta lac july 2018 second xtal
peaksFile = 'beta_lac_july2018_secondxtal.integrate'
UBFile = 'beta_lac_july2018_secondxtal.mat'
DetCalFile = 'MANDI_June2018.DetCal'
workDir = None
nxsTemplate = '/SNS/MANDI/IPTS-8776/nexus/MANDI_%i.nxs.h5'
dQPixel=0.003
q_frame = 'lab'
pplmin_frac=0.9; pplmax_frac=1.1; mindtBinWidth=15; maxdtBinWidth=50
moderatorFile = 'bl11_moderatorCoefficients_2018.dat'
strongPeaksParamsFile = 'strongPeaksParams_betalac_july2018_secondxtal.pkl'
peakToGet=14

#Load stuff
peaks_ws = LoadIsawPeaks(Filename = peaksFile)
LoadIsawUB(InputWorkspace=peaks_ws, FileName=UBFile)
UBMatrix = peaks_ws.sample().getOrientedLattice().getUB()
peak = peaks_ws.getPeak(peakToGet)
fileName = nxsTemplate%peak.getRunNumber()
MDdata = ICCFT.getSample(peak.getRunNumber(), DetCalFile, workDir, fileName, q_frame=q_frame)

dQ = np.abs(ICCFT.getDQFracHKL(UBMatrix, frac=0.5))
dQ[dQ>0.25]=0.25
dQPixel = peaks_ws.getInstrument().getNumberParameter("dQPixel")[0]
Box = ICCFT.getBoxFracHKL(peak, peaks_ws, MDdata, UBMatrix, peakToGet, dQ, fracHKL=0.5,dQPixel=dQPixel,  q_frame=q_frame)
box = Box
qMask = ICCFT.getHKLMask(UBMatrix, frac=0.25, dQPixel=dQPixel, dQ=dQ)
strongPeakParams = pickle.load(open(strongPeaksParamsFile, 'rb'))
padeCoefficients = ICCFT.getModeratorCoefficients(moderatorFile)
mindtBinWidth = peaks_ws.getInstrument().getNumberParameter("minDTBinWidth")[0]
maxdtBinWidth = peaks_ws.getInstrument().getNumberParameter("maxDTBinWidth")[0]
nTheta = peaks_ws.getInstrument().getIntParameter("numBinsTheta")[0]
nPhi   = peaks_ws.getInstrument().getIntParameter("numBinsPhi")[0]
iccFitDict = ICCFT.parseConstraints(peaks_ws)

# Default penalty
Y3D, gIDX, pp_lambda, params = BVGFT.get3DPeak(peak, peaks_ws, box, padeCoefficients,qMask,nTheta=nTheta, nPhi=nPhi, plotResults=False, zBG=1.96,fracBoxToHistogram=1.0,bgPolyOrder=1, strongPeakParams=strongPeakParams, q_frame=q_frame, mindtBinWidth=mindtBinWidth, pplmin_frac=pplmin_frac, pplmax_frac=pplmax_frac,forceCutoff=200,edgeCutoff=3,maxdtBinWidth=maxdtBinWidth, iccFitDict=iccFitDict)

X = mtd['__bvgfit_Workspace'].readX(0).reshape([49,49,2])
Ymeas = mtd['__bvgfit_Workspace'].readY(0).reshape([49,49,2])
Yfit = mtd['__bvgfit_Workspace'].readY(1).reshape([49,49,2])
plt.figure(10); plt.clf();
plt.subplot(2,2,1); plt.imshow(Ymeas[:,:,0]); plt.title('Default Penalty Data');
plt.subplot(2,2,3); plt.imshow(Yfit[:,:,0]); plt.title('Default Penalty Fit');
sigXDefault = mtd['__bvgfit_Parameters'].row(3)['Value']

# High Penalty
Y3D, gIDX, pp_lambda, params = BVGFT.get3DPeak(peak, peaks_ws, box, padeCoefficients,qMask,nTheta=nTheta, nPhi=nPhi, plotResults=False, zBG=1.96,fracBoxToHistogram=1.0,bgPolyOrder=1, strongPeakParams=strongPeakParams, q_frame=q_frame, mindtBinWidth=mindtBinWidth, pplmin_frac=pplmin_frac, pplmax_frac=pplmax_frac,forceCutoff=200,edgeCutoff=3,maxdtBinWidth=maxdtBinWidth, iccFitDict=iccFitDict, fitPenalty=1.e7)

plt.figure(10);
X = mtd['__bvgfit_Workspace'].readX(0).reshape([49,49,2])
Ymeas = mtd['__bvgfit_Workspace'].readY(0).reshape([49,49,2])
Yfit = mtd['__bvgfit_Workspace'].readY(1).reshape([49,49,2])
plt.subplot(2,2,4); plt.imshow(Yfit[:,:,0]); plt.title('High Penalty Fit');
sigXHighPenalty = mtd['__bvgfit_Parameters'].row(3)['Value']

# Forced Profile
q0 = peak.getQLabFrame()
ph = np.arctan2(q0[1], q0[0])
th = np.arctan2(q0[2], np.hypot(q0[0], q0[1]))
phthPeak = np.array([ph, th])
tmp = strongPeakParams[:, :2] - phthPeak
distSq = tmp[:, 0]**2 + tmp[:, 1]**2
nnIDX = np.argmin(distSq)
h = Ymeas[:,:,0]
m = BivariateGaussian()
m['A'] = 0.1
m['MuX'] = X[:,:,0][np.unravel_index(h.argmax(), h.shape)]
m['MuY'] = X[:,:,1][np.unravel_index(h.argmax(), h.shape)]
m['SigX'] = strongPeakParams[nnIDX][5]
m['SigY'] = strongPeakParams[nnIDX][6]
m['SigP'] = strongPeakParams[nnIDX][7]
m['Bg'] = 0.0
m.setAttributeValue("nX", 49)
m.setAttributeValue("nY", 49)
YProfile = m(X.ravel()).reshape(X.shape)
plt.subplot(2,2,2); plt.imshow(YProfile[:,:,0]); plt.title('Strong Neighbor Profile');

#Check we get the same answer through the algorithm
IntegratePeaksProfileFitting(OutputPeaksWorkspace='peaks_ws_out', OutputParamsWorkspace='params_ws', InputWorkspace='MDdata', 
                             PeaksWorkspace='peaks_ws', ModeratorCoefficientsFile=moderatorFile, DQMax=0.2,
                             MinpplFrac=0.9, MaxpplFrac=1.1, FracStop=0.05, EdgeCutoff=15,
                             IntensityCutoff=200, StrongPeakParamsFile=strongPeaksParamsFile,PeakNumber=peakToGet)
sigXAlgo = mtd['params_ws'].column('SigX')[0]

print('SigX Default penalty:\t%4.4f\n'%sigXDefault)
print('SigX High penalty:\t%4.4f\n'%sigXHighPenalty)
print('SigX from Algorithm:\t%4.4f\n'%sigXAlgo)
print('The algorithm uses the high penalty, so the last two should be the same')
```
You can see the high penalty fit (bottom right) agrees with the strong peak profile we are trying to force (top right) while the default penalty (bottom left) allows the fit to converge to a minimum that does not reflect the profile we're trying to force.
![image](https://user-images.githubusercontent.com/30410059/47100008-7b971080-d204-11e8-9878-83927f23d092.png)




Fixes #23835 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
